### PR TITLE
Use class_exists() guard for Featured_Content.

### DIFF
--- a/modules/theme-tools.php
+++ b/modules/theme-tools.php
@@ -19,7 +19,10 @@ function jetpack_load_theme_tools() {
 add_action( 'init', 'jetpack_load_theme_tools', 30 );
 
 // Featured Content has an internal check for theme support in the constructor.
-require_once( JETPACK__PLUGIN_DIR . 'modules/theme-tools/featured-content.php' );
+// This could already be defined by Twenty Fourteen if it's loaded first.
+if ( ! class_exists( 'Featured_Content' ) ) {
+	require_once( JETPACK__PLUGIN_DIR . 'modules/theme-tools/featured-content.php' );
+}
 
 /**
  * INFINITE SCROLL


### PR DESCRIPTION
This is a work-around to the problem exhibited by wp-cli/wp-cli#917, where the Twenty Fourteen theme manages to define the `Featured_Content` class first (as plugins are activated _after_ the theme is loaded rather than before like core does).

This should ideally still be fixed in WP-CLI, but this workaround would still be helpful in the mean time.
