### PR TITLE
Sharing / Minileven: fix translation functions

### DIFF
--- a/modules/minileven/theme/pub/minileven/image.php
+++ b/modules/minileven/theme/pub/minileven/image.php
@@ -84,7 +84,7 @@ get_header(); ?>
 				</article><!-- #post-<?php the_ID(); ?> -->
 
 				<nav id="nav-single">
-					<h3 class="assistive-text"><?php _e( 'Image navigation', 'next-saturday' , 'jetpack' ); ?></h3>
+					<h3 class="assistive-text"><?php _ex( 'Image navigation', 'next-saturday' , 'jetpack' ); ?></h3>
 					<span class="nav-previous"><?php previous_image_link( false, __( '&laquo; Previous' , 'jetpack' ) ); ?></span>
 					<span class="nav-next"><?php next_image_link( false, __( 'Next &raquo; ' , 'jetpack' ) ); ?></span>
 				</nav><!-- #nav-single -->

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -496,7 +496,7 @@ class Share_Reddit extends Sharing_Source {
 		if ( $this->smart )
 			return '<div class="reddit_button"><iframe src="http://www.reddit.com/static/button/button1.html?width=120&amp;url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&amp;title=' . rawurlencode( $post->post_title ) . '" height="22" width="120" scrolling="no" frameborder="0"></iframe></div>';
 		else
-			return $this->get_link( get_permalink( $post->ID ), __( 'Reddit', 'share to', 'jetpack' ), __( 'Click to share on Reddit', 'jetpack' ), 'share=reddit' );
+			return $this->get_link( get_permalink( $post->ID ), _x( 'Reddit', 'share to', 'jetpack' ), __( 'Click to share on Reddit', 'jetpack' ), 'share=reddit' );
 	}
 
 	public function process_request( $post, array $post_data ) {


### PR DESCRIPTION
props @deckerweb

2 Textdomains were missing context/ context translation functions

More information here:
http://plugins.trac.wordpress.org/ticket/2088
