### PR TITLE
Sharing: display sharing buttons on CPT archive pages

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -503,7 +503,7 @@ function sharing_display( $text = '', $echo = false ) {
 	if ( !is_feed() ) {
 		if ( is_singular() && in_array( get_post_type(), $global['show'] ) ) {
 			$show = true;
-		} elseif ( in_array( 'index', $global['show'] ) && ( is_home() || is_archive() || is_search() ) ) {
+		} elseif ( in_array( 'index', $global['show'] ) && ( is_home() || is_archive() || is_search() || in_array( get_post_type(), $global['show'] ) ) ) {
 			$show = true;
 		}
 	}


### PR DESCRIPTION
when selected in Sharing settings:

![events](https://f.cloud.github.com/assets/426388/1777279/57fdc542-6823-11e3-9623-3abee1363e53.png)

For more details, see original ticket:
http://plugins.trac.wordpress.org/ticket/2068
