### PR TITLE
Modifies the Image Widget to allow basic HTML in the caption.

### DIFF
--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -86,7 +86,7 @@ class Jetpack_Image_Widget extends WP_Widget {
 		$img_url    = esc_url( $instance['img_url'], null, 'display' );
 		$alt_text   = esc_attr( $instance['alt_text'] );
 		$img_title  = esc_attr( $instance['img_title'] );
-		$caption 	= esc_textarea( $instance['caption'] );
+		$caption    = esc_textarea( $instance['caption'] );
 		$align      = esc_attr( $instance['align'] );
 		$img_width  = esc_attr( $instance['img_width'] );
 		$img_height = esc_attr( $instance['img_height'] );


### PR DESCRIPTION
WP 3.6 added ability to use HTML in captions. Commit enables this in the widget. 
Output is mimics the text widget output method. wp_kses on save using custom list.

Allowed HTML: a[href, title], b, em, i, p, strong
