### PR TITLE
Widget visibility: widget should not appear on paginated home page

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -319,7 +319,11 @@ class Jetpack_Widget_Conditions {
 							$condition_result = is_home();
 						break;
 						case 'front':
-							$condition_result = is_front_page();
+							if ( current_theme_supports( 'infinite-scroll' ) )
+								$condition_result = is_front_page();
+							else {
+								$condition_result = is_front_page() && !is_paged();
+							}
 						break;
 						default:
 							if ( substr( $rule['minor'], 0, 10 ) == 'post_type-' )


### PR DESCRIPTION
Unless a theme supports Infinite Scroll, hide widgets on paginated home page

You can read more about it in the original ticket here:
http://plugins.trac.wordpress.org/ticket/1989
