### PR TITLE
Contact Form: fix Uninitialized string notice

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -319,7 +319,7 @@ class Grunion_Contact_Form_Plugin {
 
 		$response = akismet_http_post( $query_string, $akismet_api_host, '/1.1/comment-check', $akismet_api_port );
 		$result = false;
-		if ( 'true' == trim( $response[1] ) ) // 'true' is spam
+		if ( isset( $response[1] ) && 'true' == trim( $response[1] ) ) // 'true' is spam
 			$result = true;
 		return apply_filters( 'contact_form_is_spam_akismet', $result, $form );
 	}


### PR DESCRIPTION
Props @iandunn

Submitting a contact form with `WP_DEBUG` enabled and Akismet activated produces this PHP notice on a local install:

`( ! ) Notice: Uninitialized string offset: 1 in plugins/jetpack/modules/contact-form/grunion-contact-form.php on line 318`

That's because `akismet_http_post()` returns an empty string on failure, but the Contact Form is expecting it to always be an array.

Original ticket:
http://plugins.trac.wordpress.org/ticket/2010
