### PR TITLE
Update codemirror.css

### DIFF
--- a/modules/custom-css/custom-css/css/codemirror.css
+++ b/modules/custom-css/custom-css/css/codemirror.css
@@ -5,6 +5,7 @@
   /* Set height, width, borders, and global font properties here */
   font-family: monospace;
   height: 300px;
+  direction: ltr !important;
 }
 .CodeMirror-scroll {
   /* Set scrolling behaviour here */


### PR DESCRIPTION
I added "Direction" property to .CodeMirror class
Because without it, the CSS editor is RTL.

direction: ltr !important;
