### PR TITLE
Google Authorship: support apostrophe in author names

### DIFF
--- a/modules/gplus-authorship.php
+++ b/modules/gplus-authorship.php
@@ -89,7 +89,7 @@ class GPlus_Authorship {
 		if ( !is_numeric( $_POST['id'] ) )
 			return;
 		$connections = get_option( 'gplus_authors', array() );
-		$connections[ $current_user->ID ]['name'] = $_POST['name'];
+		$connections[ $current_user->ID ]['name'] = stripslashes( $_POST['name'] );
 		$connections[ $current_user->ID ]['id'] = $_POST['id'];
 		$connections[ $current_user->ID ]['url'] = esc_url_raw( $_POST['url'] );
 		$connections[ $current_user->ID ]['profile_image'] = esc_url_raw( $_POST['profile_image'] );


### PR DESCRIPTION
On the Sharing -> Settings page, if there is an apostrophe in the Google+ profile name (e.g. `Darrell O'Donnell`) the name will show with a `\` (`Darrell O\'Donnell`). This commit fixes it.

For more details, see original trac ticket:
http://plugins.trac.wordpress.org/ticket/2066
