### PR TITLE
Display Posts widget: reorganize before_widget and after_widget

### DIFF
--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -47,14 +47,15 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		}
 
 		$site_info = json_decode( $response ['body'] );
-		
+
+		echo $args['before_widget'];
+
 		if ( empty( $site_info->ID ) ) {
 			echo "<p>" . __( 'We cannot load blog data at this time.', 'jetpack' ) . "</p>";
 			echo $args['after_widget'];
 			return;
 		}
 
-		echo $args['before_widget'];
 		if ( ! empty( $title ) ) {
 			echo $args['before_title'] . esc_html( $title . ": " . $site_info->name ) . $args['after_title'];
 		}
@@ -77,7 +78,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			echo $args['after_widget'];
 			return;
 		}
-		
+
 		$posts_info = json_decode( $response['body'] );
 
 		echo "<div class='jetpack-display-remote-posts'>";
@@ -96,7 +97,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			if ( ( $instance['featured_image'] == true ) && ( ! empty ( $single_post->featured_image) ) ) {
 				$featured_image = ( $single_post->featured_image ) ? $single_post->featured_image  : '';
 				echo "<img src='" . $featured_image . "'>";
-			}		
+			}
 
 			if ( $instance['show_excerpts'] == true ) {
 				$post_excerpt = ( $single_post->excerpt ) ? $single_post->excerpt  : '';
@@ -106,6 +107,8 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		}
 
 		echo "</div>";
+
+		echo $args['after_widget'];
 	}
 
 	public function form( $instance ) {


### PR DESCRIPTION
Both args should always be displayed.

In some cases, `before_widget` and `after_widget` were not properly displayed around the Display Posts widget. This commit fixes the problem.

Here is a screenshot with 3 different Display Posts widgets, with 3 different status (error, success, error). I added the words `BEFORE WIDGET` and `AFTER WIDGET` to show where the args were displayed.
- Before the fix:
  ![screen shot 2014-01-02 at 3 21 46 pm](https://f.cloud.github.com/assets/426388/1832613/dd6aae92-73b9-11e3-86ac-0d3df777075b.png)
- After the fix:
  ![screen shot 2014-01-02 at 3 21 14 pm](https://f.cloud.github.com/assets/426388/1832615/e6783e78-73b9-11e3-9c84-ebf2e88512b0.png)

Reported here:
- http://wordpress.org/support/topic/wordpress-post-widgetphp-misses-echo-argsafter_widget-invalidating-html?replies=1
