### PR TITLE
CSS: avoid notices to be displayed over WP submenus

### DIFF
--- a/_inc/jetpack.css
+++ b/_inc/jetpack.css
@@ -1063,7 +1063,6 @@ p#news-sub {
 .error,
 .updated {
 	position: relative;
-	z-index: 100;
 }
 
 .toplevel_page_jetpack .wrap {


### PR DESCRIPTION
I couldn't always reproduce, but here is what sometimes happens with Updated messages when Jetpack is active:

![screen shot 2014-01-02 at 5 09 18 pm](https://f.cloud.github.com/assets/426388/1833461/3784508a-73ca-11e3-912a-fe51b3fe9c58.png)

It seems to be caused by an old `z-index` rule that's been in Jetpack from the beginning. I ran a few tests after removing it and it doesn't seem to break anything, but I'm no CSS expert and my tests didn't include older browsers.

The problem was reported here:
- http://wordpress.org/support/topic/admin-submenu-flies-out-behind-update-messages?replies=4
- http://core.trac.wordpress.org/ticket/26612

We should also keep an eye on [26567-core](http://core.trac.wordpress.org/ticket/26567), since it's a related issue.
