### PR TITLE
Tiled Galleries: update jQuery mouseover caption effect

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery.js
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery.js
@@ -52,8 +52,8 @@ TiledGallery.prototype.Captions = function() {
 	this.caption.hide();
 
 	this.item.hover(
-		function() { $( this ).find( '.tiled-gallery-caption' ).slideDown( 'fast' ); },
-		function() { $( this ).find( '.tiled-gallery-caption' ).slideUp( 'fast' ); }
+		function() { $( this ).find( '.tiled-gallery-caption' ).stop(true, true).slideDown( 'fast' ); },
+		function() { $( this ).find( '.tiled-gallery-caption' ).stop(true, true).slideUp( 'fast' ); }
 	);
 };
 


### PR DESCRIPTION
Props @magi182

The hover effect for the tiled gallery annoyingly stacks up the tweens. If you mouse over and back several times in quick succession, the current script will execute an animation on the caption for every mouseover/mouseout. A more desireable effect would be to have the animation animate to the current state of the mouse, and if extra tweens are fired, to discard them.

More details in original trac ticket:
http://plugins.trac.wordpress.org/ticket/1966
