### PR TITLE
Media Extractor: avoid notices when preg_match fails

### DIFF
--- a/class.media-extractor.php
+++ b/class.media-extractor.php
@@ -377,7 +377,7 @@ class Jetpack_Media_Meta_Extractor {
 		if ( !empty( $from_html ) ) {
 			$srcs = wp_list_pluck( $from_html, 'src' );
 			foreach( $srcs as $image_url ) {
-				if ( $src = parse_url( $image_url ) && isset($src['scheme']) && isset($src['host']) && isset($src['path']) ) {
+				if ( ( $src = parse_url( $image_url ) ) && isset( $src['scheme'], $src['host'], $src['path'] ) ) {
 					// Rebuild the URL without the query string
 					$queryless = $src['scheme'] . '://' . $src['host'] . $src['path'];
 				} elseif ( $length = strpos( $image_url, '?' ) ) {


### PR DESCRIPTION
`preg_match` sometimes fails to return all the necessary information that help us rebuild the URL. In such cases, it throws a warning. This commit fixes it.

More details here:
http://wordpress.org/support/topic/non-robust-code-in-jetpack_media_meta_extractorget_images_from_html
