### PR TITLE
Check if ignore_user_abort exists before to run it

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -74,7 +74,9 @@ class Jetpack_Sync {
 	function register( $object, $id = false, array $settings = null ) {
 		// Since we've registered something for sync, hook it up to execute on shutdown if we haven't already
 		if ( !$this->sync ) {
-			ignore_user_abort( true );
+			if ( function_exists( 'ignore_user_abort' ) ) {
+				ignore_user_abort( true );
+			}
 			add_action( 'shutdown', array( $this, 'sync' ), 9 ); // Right before async XML-RPC
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3765,7 +3765,9 @@ p {
 		if ( ! isset( $clients[$client_blog_id] ) ) {
 			Jetpack::load_xml_rpc_client();
 			$clients[$client_blog_id] = new Jetpack_IXR_ClientMulticall( array( 'user_id' => JETPACK_MASTER_USER, ) );
-			ignore_user_abort( true );
+			if ( function_exists( 'ignore_user_abort' ) ) {
+				ignore_user_abort( true );
+			}
 			add_action( 'shutdown', array( 'Jetpack', 'xmlrpc_async_call' ) );
 		}
 


### PR DESCRIPTION
Some hosts disable `ignore_user_abort`, thus creating issues when a blog owner enables Jetpack.

For more details, see original ticket:
- http://plugins.trac.wordpress.org/ticket/2041
