### PR TITLE
Bandcamp: Switch to esc_attr instead of int for album and track IDs

### DIFF
--- a/modules/shortcodes/bandcamp.php
+++ b/modules/shortcodes/bandcamp.php
@@ -51,14 +51,14 @@ function shortcode_handler_bandcamp( $atts ) {
 	// to contain no querystring
 
 	$url = "http://bandcamp.com/EmbeddedPlayer/v=2/";
-	if ( isset( $attributes['track'] ) ) {
+	if ( isset( $attributes['track'] ) && is_numeric( $attributes['track'] ) ) {
 		$track = esc_attr( $attributes['track'] );
 		$url .= "track={$track}";
 
 		if ( $sizekey == 'tall' ) {
 			$sizekey .= '_track';
 		}
-	} elseif ( isset( $attributes['album'] ) ) {
+	} elseif ( isset( $attributes['album'] ) && is_numeric( $attributes['album'] ) ) {
 		$album = esc_attr( $attributes['album'] );
 		$url .= "album={$album}";
 		$type = 'album';


### PR DESCRIPTION
Bandcamp Album and track IDs can be larger than `PHP_INT_MAX`, thus causing issues in embeds.

View original trac ticket here:
http://plugins.trac.wordpress.org/ticket/2051
