### PR TITLE
Photon: do not apply Photon on BuddyPress avatar change pages

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -333,7 +333,7 @@ class Jetpack_Photon {
 	 * @return string|bool
 	 */
 	public function filter_image_downsize( $image, $attachment_id, $size ) {
-		// Don't foul up the admin side of things, and provide plugins a way of preventing Photon from being applied to images.
+		// Don't foul up the admin side of things, don't break BuddyPress' avatar cropping process, and provide plugins a way of preventing Photon from being applied to images.
 		if ( is_admin() || bp_is_user_change_avatar() || bp_is_group_admin_page( 'group-avatar' ) || apply_filters( 'jetpack_photon_override_image_downsize', false, compact( 'image', 'attachment_id', 'size' ) ) )
 			return $image;
 


### PR DESCRIPTION
We would need to disable Photon on BuddyPress Pages that allow you to change your avatar; Photon does indeed break the avatar cropping process. 

![photon-running](https://f.cloud.github.com/assets/426388/1861326/ae5dfd60-77c0-11e3-8e3c-93c80f6e7cee.jpg)

See [this thread](http://wordpress.org/support/topic/jetpack-tiled-mosaic-gallery-not-loading-all-images-1) for more details.
