### PR TITLE
Sharing: add Sender data to share by email

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -15,7 +15,9 @@ function sharing_email_send_post( $data ) {
 	$content .= $data['post']->post_title."\n";
 	$content .= get_permalink( $data['post']->ID )."\n";
 
-	wp_mail( $data['target'], '['.__( 'Shared Post', 'jetpack' ).'] '.$data['post']->post_title, $content );
+	$headers[] = sprintf( 'From: %1$s <%2$s>', $data['name'], $data['source'] );
+
+	wp_mail( $data['target'], '['.__( 'Shared Post', 'jetpack' ).'] '.$data['post']->post_title, $content, $headers );
 }
 
 function sharing_add_meta_box() {


### PR DESCRIPTION
This makes conversations a bit easier, since users can now reply to a shared email
It also removes the default
From: WordPress WordPress@domain.com

Suggested here:
- http://wordpress.org/support/topic/sent-by-wordpress-message-on-emails?replies=1
