### PR TITLE
Featured content tag name and url hard-coded

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -398,6 +398,8 @@ class Featured_Content {
 		
 		$term = get_term_by( 'id', self::get_setting( 'tag-id' ), 'post_tag' );
 		
+		$term->name = $term ? $term->name : 'featured';
+		
 		$wp_customize->add_section( 'featured_content', array(
 			'title'          => __( 'Featured Content', 'jetpack' ),
 			'description'    => sprintf( __( 'Easily feature all posts with the <a href="%1$s">"'.$term->name.'" tag</a> or a tag of your choice. Your theme supports up to %2$s posts in its featured content area.', 'jetpack' ), admin_url( '/edit.php?tag='.$term->name ), absint( self::$max_posts ) ),
@@ -407,7 +409,7 @@ class Featured_Content {
 
 		// Add Featured Content settings.
 		$wp_customize->add_setting( 'featured-content[tag-name]', array(
-			'default'              => $term ? $term->name : 'featured',
+			'default'              => $term->name,
 			'type'                 => 'option',
 			'sanitize_js_callback' => array( __CLASS__, 'delete_transient' ),
 		) );


### PR DESCRIPTION
JetPack: Featured content tag name and url hard-coded in Appearance ->
Customize -> Featured Content. The featured tag name and url does not
change even when you update the default 'featured' tag to something
else. This commit fixes this problem.
