### PR TITLE
Photon: Filter image source if it seems to be a resized version of a larger image

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -15,6 +15,8 @@ class Jetpack_Options {
 				'publicize',
 				'widget_twitter',
 				'wpcc_options',
+				'photon_valid_sources',
+				'photon_invalid_sources',
 			);
 		}
 


### PR DESCRIPTION
Props @georgestephanis

See original trac ticket here:
https://plugins.trac.wordpress.org/ticket/1766

---

Issue: **Photon doesn't recognize images using a filename similar to WordPress' default resized images**
Steps to reproduce:
1. Activate Jetpack and Photon on your site
2. Upload and insert an image in a new post, using the following filename: `my-image-500x500.jpg`
3. Publish your post.
4. Photon will replace the image path by `my-image.jpg?resize=500%2C500`, although `my-image.jpg` doesn't exist.

If we don't get a response when querying for the "original image", we should try to load the resized image instead.
