### PR TITLE
Enable Freshly Pressed for Jetpack Blogs

### DIFF
--- a/modules/enhanced-distribution.php
+++ b/modules/enhanced-distribution.php
@@ -31,3 +31,23 @@ function jetpack_enhanced_distribution_before_activate_default_modules() {
 
 add_action( 'jetpack_activate_module_enhanced-distribution', 'jetpack_enhanced_distribution_activate' );
 add_action( 'jetpack_before_activate_default_modules', 'jetpack_enhanced_distribution_before_activate_default_modules' );
+
+/**
+ * If a request has ?get_freshly_pressed_data=true appended
+ * to the end, then let's provide the necessary data back via JSON.
+ */
+if ( isset( $_GET['get_freshly_pressed_data'] ) ) {
+	add_action( 'template_redirect', 'jetpack_get_freshly_pressed_data' );
+	function jetpack_maybe_freshly_pressed() {
+		if ( is_single() ) {
+			wp_send_json_success( array(
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
+				'post_id' => get_the_ID(),
+			) );
+		} else {
+			wp_send_json_error( array(
+				'message' => 'Not Singular',
+			) );
+		}
+	}
+}


### PR DESCRIPTION
Enhanced Distribution: Add a server-side catch that will return JSON
data if ?get_freshly_pressed_data=true
-- will return the WPCOM Blog ID and Post ID (both of which are
probably accessible on the page already, but
this simplifies things and confirms that the Enhanced Distribution
module is enabled (as we wouldn't want to
Freshly Pressed a post otherwise).
