### PR TITLE
i18n: change the priority of where plugin_textdomain is hooked

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -159,7 +159,7 @@ class Jetpack {
 			if ( did_action( 'plugins_loaded' ) )
 				self::plugin_textdomain();
 			else
-				add_action( 'plugins_loaded', array( __CLASS__, 'plugin_textdomain' ) );
+				add_action( 'plugins_loaded', array( __CLASS__, 'plugin_textdomain' ), 100 );
 
 			self::$instance = new Jetpack;
 


### PR DESCRIPTION
Props @michelwppi:

"The modification is not perfect and the enqueuing in 'plugins_loaded' filters must set at level 100 and not 10 by default (too soon). Because other plugins can enqueue their own filter between 10 and the 100 level of jetpack 'Plugins_loaded'. (more logical because jetpack choose the 100 level)"

See original trac ticket:
https://plugins.trac.wordpress.org/ticket/1764
