### PR TITLE
Updated Response Format -- API Changed

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -130,7 +130,7 @@ class Jetpack_RelatedPosts {
 
 		if ( $options['show_headline'] ) {
 			$headline = sprintf(
-				'<p class="jp-relatedposts-headline"><em>%s</em></p>',
+				'<h3 class="jp-relatedposts-headline"><em>%s</em></h3>',
 				esc_html__( 'Related', 'jetpack' )
 			);
 		} else {

--- a/modules/related-posts/related-posts.css
+++ b/modules/related-posts/related-posts.css
@@ -25,6 +25,9 @@ div.jp-relatedposts .jp-relatedposts-headline {
 	margin: 0 0 1em 0;
 	display: inline-block;
 	float: left;
+	font-weight: bold;
+	font-family: inherit;
+	font-size: 9pt;
 }
 
 div.jp-relatedposts .jp-relatedposts-headline em:before {

--- a/modules/related-posts/rtl/related-posts-rtl.css
+++ b/modules/related-posts/rtl/related-posts-rtl.css
@@ -1,4 +1,4 @@
-/* This file was automatically generated on Jan 14 2014 19:04:19 */
+/* This file was automatically generated on Jan 23 2014 11:00:06 */
 
 /**
  * Styles for Jetpack related posts
@@ -27,6 +27,9 @@ div.jp-relatedposts .jp-relatedposts-headline {
 	margin: 0 0 1em 0;
 	display: inline-block;
 	float: right;
+	font-weight: bold;
+	font-family: inherit;
+	font-size: 9pt;
 }
 
 div.jp-relatedposts .jp-relatedposts-headline em:before {


### PR DESCRIPTION
The WPCOM JSON related posts endpoint changed to no longer return everything encapsulated in an extraneous "response" element.
