### PR TITLE
Jetpack: Photon: Prevent avatars from loading from Photon on avatar chan...

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -1,0 +1,8 @@
+<?php
+
+/*
+ * Placeholder to load 3rd party plugin tweaks until a legit system
+ * is architected
+ */
+
+require_once( 'buddypress.php' );

--- a/3rd-party/buddypress.php
+++ b/3rd-party/buddypress.php
@@ -1,0 +1,9 @@
+<?php
+
+add_filter( 'bp_core_pre_avatar_handle_upload', 'blobphoto' );
+function blobphoto( $bool ) {
+
+	add_filter( 'jetpack_photon_skip_image', '__return_true' );
+
+	return $bool;
+}

--- a/jetpack.php
+++ b/jetpack.php
@@ -81,3 +81,5 @@ if ( is_admin() && ! Jetpack::check_identity_crisis() ) {
 	Jetpack_Sync::sync_options( __FILE__, 'db_version', 'jetpack_active_modules', 'active_plugins' );
 }
 */
+
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php' );


### PR DESCRIPTION
...ge

Currently when changing an avatar the photo is sent to Photon before the image cropping
step. This causes cropping to fail. This commit disables Photon before cropping the image.
See https://github.com/Automattic/jetpack/pull/57
