### PR TITLE
Updating fb likebox dimensions to reflect new specs

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -17,10 +17,10 @@ function jetpack_facebook_likebox_init() {
 class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 
 	private $default_height       = 432;
-	private $default_width        = 200;
-	private $max_width            = 400;
-	private $min_width            = 0;
-	private $max_height           = 999;
+	private $default_width        = 300;
+	private $max_width            = 9999;
+	private $min_width            = 292;
+	private $max_height           = 9999;
 	private $min_height           = 100;
 	private $default_colorscheme  = 'light';
 	private $allowed_colorschemes = array( 'light', 'dark' );


### PR DESCRIPTION
In response to: https://github.com/Automattic/jetpack/issues/103

The Facebook like box has new dimension specs. There is no longer a max
width, the default width is 300, the min width is 292.

Here are the new specs:
https://developers.facebook.com/docs/plugins/like-box-for-pages
