### PR TITLE
Correct ordering for email form fields

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1143,6 +1143,38 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$extra_values[$label] = $value;
 		}
 
+
+		$message_fields = array();
+
+		foreach ( $field_ids['all'] as $field_id ) {
+
+			switch( $field_id ){
+				case "name":
+					$message_fields[$comment_author_label] = $comment_author;
+					break;
+				case "email":
+					$message_fields[$comment_author_email_label] = $comment_author_email;
+					break;
+				case "url":
+					$message_fields[$comment_author_url_label] = $comment_author_url;
+					break;
+				case "textarea":
+					$message_fields[$comment_content_label] = $comment_content;
+					break;
+				case "subject":
+					$field = $this->fields[$field_id];
+					$label = $field->get_attribute( 'label' );
+					$message_fields[$label] = $contact_form_subject;
+					break;
+				default:
+					$field = $this->fields[$field_id];
+					$label = $field->get_attribute( 'label' );
+					$value = $field->value;
+					$message_fields[$label] = $value;
+			}
+
+		}
+
 		$contact_form_subject = trim( $contact_form_subject );
 
 		$comment_author_IP = Grunion_Contact_Form_Plugin::strip_tags( $_SERVER['REMOTE_ADDR'] );
@@ -1188,23 +1220,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		$date_time_format = sprintf( $date_time_format, get_option( 'date_format' ), get_option( 'time_format' ) );
 		$time = date_i18n( $date_time_format, current_time( 'timestamp' ) );
 
-		$extra_content = '';
+		$message = '';
 
-		foreach ( $extra_values as $label => $value ) {
-			$extra_content .= $label . ': ' . trim( $value ) . "\n";
+		foreach ( $message_fields as $label => $value ) {
+			$message .= $label . ': ' . trim( $value ) . "\n";
 		}
-
-		$message = "$comment_author_label: $comment_author\n";
-		if ( !empty( $comment_author_email ) ) {
-			$message .= "$comment_author_email_label: $comment_author_email\n";
-		}
-		if ( !empty( $comment_author_url ) ) {
-			$message .= "$comment_author_url_label: $comment_author_url\n";
-		}
-		if ( !empty( $comment_content_label ) ) {
-			$message .= "$comment_content_label: $comment_content\n";
-		}
-		$message .= $extra_content . "\n";
 
 		$message .= __( 'Time:', 'jetpack' ) . ' ' . $time . "\n";
 		$message .= __( 'IP Address:', 'jetpack' ) . ' ' . $comment_author_IP . "\n";


### PR DESCRIPTION
The email sent by the jetpack contact form now lists the form fields in
the order specified by the user.

Previously, the default form fields (“name”, “email”, “website” and
“comment”) always appeared first followed by any custom fields.

In response to: https://github.com/Automattic/jetpack/issues/49
