### PR TITLE
Update Jetpack_SSO to be a proper singleton

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -18,10 +18,7 @@ function module_configure_button_clicked() {
 class Jetpack_SSO {
 	static $instance = null;
 
-	function __construct() {
-		if ( self::$instance ) {
-			return self::$instance;
-		}
+	private function __construct() {
 
 		self::$instance = $this;
 
@@ -809,4 +806,4 @@ class Jetpack_SSO {
 	}
 }
 
-new Jetpack_SSO;
+Jetpack_SSO::get_instance();


### PR DESCRIPTION
Remove usage of ‘new Jetpack_SSO’ in favor of Jetpack_SSO::get_instance
to emphasize that Jetpack_SSO is a singleton. Made the constructor
private.

Resolves: https://github.com/Automattic/jetpack/issues/95
