### PR TITLE
Carousel: Fixes issue with selected image being aligned right in IE 11

### DIFF
--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -184,7 +184,7 @@ div.jp-carousel-buttons a:hover {
 }
 
 .jp-carousel-slide.selected {
-	position: absolute;
+	position: absolute !important;
 	filter: alpha(opacity=100);
 	opacity: 1;
 }


### PR DESCRIPTION
In IE 11, the selected image in a carousel is aligned right, instead of the expected center. This is due to the inline style that is used for all carousel images being applied instead of the specific .jp-carousel-slide.selected, which is what happens in previous versions of IE and all other browsers.

PR tested on Windows 8 IE 11 to resolve the issue. Also tested on OS X, Firefox, Chrome, and Safari latest and IE 9 on Win 7 to ensure no unexpected changes. (thanks @richardmtl and @csonnek for assistance in testing).

Fixes wpcom/6150 (issuing impacting both JP and WPcom sites).
