### PR TITLE
Don't load module-extras.php if Jetpack is not active

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -569,7 +569,8 @@ class Jetpack {
 		do_action( 'jetpack_modules_loaded' );
 
 		// Load module-specific code that is needed even when a module isn't active. Loaded here because code contained therein may need actions such as setup_theme.
-		require_once( JETPACK__PLUGIN_DIR . 'modules/module-extras.php' );
+		if ( Jetpack::is_active() || Jetpack::is_development_mode() )
+			require_once( JETPACK__PLUGIN_DIR . 'modules/module-extras.php' );
 	}
 
 	/**


### PR DESCRIPTION
If Jetpack is not active and not in development mode, we don't really need module-extras.php, otherwise some things (like Featured Content) still work despite Jetpack not being connected to WordPress.com, which may not be the desired behavior. This was broken in 5761feaae0adb66fca66cc64080553d60b3852b7.
