### PR TITLE
Nonces: add ORDER BY when deleting nonces

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3677,7 +3677,7 @@ p {
 	public static function clean_nonces( $all = false ) {
 		global $wpdb;
 
-		$sql = "DELETE FROM `$wpdb->options` WHERE `option_name` LIKE %s";
+		$sql = "DELETE FROM `$wpdb->options` WHERE `option_name` LIKE %s ORDER BY ASC";
 		$sql_args = array( like_escape( 'jetpack_nonce_' ) . '%' );
 
 		if ( true !== $all ) {


### PR DESCRIPTION
It seems it should avoid the following error:

```
mysqld: 140131 0:07:13 [Warning] Statement may not be safe to log in statement format. Statement: DELETE FROMwp_optionsWHEREoption_nameLIKE 'jetpack\\_nonce\\_%' AND CAST(option_valueAS UNSIGNED ) < 1391119633 LIMIT 100
```

This seems to come from an issue with mySQL:
- https://dev.mysql.com/doc/refman/5.1/en/replication-features-limit.html

Reported here:
- http://wordpress.org/support/topic/mysql-warning-statement-may-not-be-safe-to-log-in-statement-format?replies=1

I'd be happy to have a second set of eyes on this as mySQL is not my strong suit. :)
