### PR TITLE
Update featured-content.php

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -102,6 +102,7 @@ class Featured_Content {
 		add_action( 'customize_controls_enqueue_scripts', array( __CLASS__, 'enqueue_scripts'    )    );
 		add_action( 'pre_get_posts',                      array( __CLASS__, 'pre_get_posts'      )    );
 		add_action( 'switch_theme',                       array( __CLASS__, 'switch_theme'       )    );
+		add_action( 'switch_theme',                       array( __CLASS__, 'delete_transient'   )    );
 		add_action( 'wp_loaded',                          array( __CLASS__, 'wp_loaded'          )    );
 
 		if ( isset( $theme_support[0]['additional_post_types'] ) ) {


### PR DESCRIPTION
clear featured_post_ids transient on switch theme.

Different themes can have different max_posts properties but because of the transient max_posts doesn't get honoured. Clearing the max_posts when you switch_themes fixes this.
