### PR TITLE
Carousel: fix Version Check for IE11

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -150,10 +150,14 @@ class Jetpack_Carousel {
 			global $is_IE;
 			if( $is_IE )
 			{
-				$msie = strpos( $_SERVER['HTTP_USER_AGENT'], 'MSIE' ) + 4;
-				$version = (float) substr( $_SERVER['HTTP_USER_AGENT'], $msie, strpos( $_SERVER['HTTP_USER_AGENT'], ';', $msie ) - $msie );
-				if( $version < 9 )
-					wp_enqueue_style( 'jetpack-carousel-ie8fix', plugins_url( 'jetpack-carousel-ie8fix.css', __FILE__ ), array(), $this->asset_version( '20121024' ) );
+				$msie = strpos( $_SERVER['HTTP_USER_AGENT'], 'MSIE' );
+				if ($msie == False)
+				{
+					$msie += 4;
+					$version = (float) substr( $_SERVER['HTTP_USER_AGENT'], $msie, strpos( $_SERVER['HTTP_USER_AGENT'], ';', $msie ) - $msie );
+					if( $version < 9 )
+						wp_enqueue_style( 'jetpack-carousel-ie8fix', plugins_url( 'jetpack-carousel-ie8fix.css', __FILE__ ), array(), $this->asset_version( '20121024' ) );
+				}
 			}
 			do_action( 'jp_carousel_enqueue_assets', $this->first_run, $localize_strings );
 


### PR DESCRIPTION
IE 11 does not have MSIE string in user agent, so check for IE 8 causes it to break pages showing on IE 11. Check makes sure MSIE before comparing against IE 8
