### PR TITLE
restore "normal" scrolling behavior to the jetpack control panel

### DIFF
--- a/_inc/jetpack.css
+++ b/_inc/jetpack.css
@@ -32,10 +32,19 @@
 /* Force the menu not to be sticky, so we can color the arrow. */
 .toplevel_page_jetpack.sticky-menu #adminmenuwrap,
 .jetpack-pagestyles.sticky-menu #adminmenuwrap {
-	position: relative;
+	position: fixed;
 	z-index: auto;
-	top: 0;
 }
+
+/* the arrow disappears under certain conditions involving scrolling */
+
+body.jetpack_scrolled.toplevel_page_jetpack ul#adminmenu a.wp-has-current-submenu:after,
+body.jetpack_scrolled.toplevel_page_jetpack ul#adminmenu > li.current > a.current:after,
+body.jetpack_scrolled.jetpack-pagestyles ul#adminmenu a.wp-has-current-submenu:after,
+body.jetpack_scrolled.jetpack-pagestyles ul#adminmenu > li.current > a.current:after {
+	display: none;
+}
+
 
 .toplevel_page_jetpack ul#adminmenu a.wp-has-current-submenu:after,
 .toplevel_page_jetpack ul#adminmenu > li.current > a.current:after,

--- a/_inc/jetpack.js
+++ b/_inc/jetpack.js
@@ -9,6 +9,8 @@ jetpack = {
 	resizeTimeout: null,
 	resizeTimer: null,
 	shadowTimer: null,
+	scrollTimer: null,
+	scrollFlip: 60,			//how far down the menu must we scroll (in px) before the triangle flips?
 	statusText: null,
 	isRTL: !( 'undefined' == typeof isRtl || !isRtl ),
 	didDebug: false,
@@ -42,6 +44,14 @@ jetpack = {
 
 			clearTimeout( jetpack.shadowTimer );
 			jetpack.shadowTimer = setTimeout( function() { jetpack.show_shadows(); }, 200 );
+		});
+
+		jQuery( window ).bind( 'scroll', function() {
+			
+			if ( !jetpack.scrollTimer ) {
+				jetpack.scrollTimer = setTimeout( function() { jetpack.adjust_triangle(); }, 50 );	
+			}
+
 		});
 
 		jQuery( 'a#jp-debug' ).bind( 'click', function(e) {
@@ -244,6 +254,17 @@ jetpack = {
 	show_shadows: function() {
 		jQuery( 'div.jetpack-module' ).css( { '-webkit-box-shadow': 'inset 0 1px 0 #fff, inset 0 0 20px rgba(0,0,0,0.05), 0 1px 2px rgba( 0,0,0,0.1 )' } );
 		jQuery( 'div.more-info' ).css( { '-webkit-box-shadow': 'inset 0 0 20px rgba(0,0,0,0.05), 0 1px 2px rgba( 0,0,0,0.1 )' } );
+	},
+
+	adjust_triangle: function() { 
+
+		if ( jQuery( window ).scrollTop() > jetpack.scrollFlip ) {
+			jQuery( 'body' ).addClass( 'jetpack_scrolled' );
+		} else {
+			jQuery( 'body' ).removeClass( 'jetpack_scrolled' );
+		}
+		clearTimeout( jetpack.scrollTimer );	
+		jetpack.scrollTimer = null;
 	}
 }
 jQuery( function() { jetpack.init(); } );


### PR DESCRIPTION
- LH menu is now fixed if the window is taller than it, scrolls
  otherwise (this is the same as all other menus)
- Green triangle behaves in a non-offensive way
  related to #105
