### PR TITLE
Feedback download filters

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -429,7 +429,7 @@ class Grunion_Contact_Form_Plugin {
 		$output = fopen( 'php://output', 'w' );
 
 		// Prints the header
-		fputcsv( $output, $fields );
+		fputcsv( $output, apply_filters( 'grunion_feedback_field_headers', $fields, $feedbacks ) );
 
 		// Create the csv string from the array of post ids
 		foreach ( $feedbacks as $feedback ) {
@@ -514,6 +514,9 @@ class Grunion_Contact_Form_Plugin {
 			else
 				$row_items[] = '';
 		}
+
+		// Allow filtering of feedback form fields
+		$row_items = apply_filters( 'grunion_feedback_fields', $row_items, $post_id, $fields );
 
 		return $row_items;
 	}


### PR DESCRIPTION
Add filters to allow custom management of Grunion Feedback CSV Download fields. Currently there is no way to add custom fields to the csv download (such as date).
