### PR TITLE
Update slideshow-shortcode.css

### DIFF
--- a/modules/shortcodes/css/slideshow-shortcode.css
+++ b/modules/shortcodes/css/slideshow-shortcode.css
@@ -54,7 +54,7 @@ body div.slideshow-window * img {
 }
 
 .slideshow-line-height-hack {
-	overflow: hide;
+	overflow: hidden;
 	width: 0px;
 	font-size: 0px;
 }
@@ -99,7 +99,7 @@ body div div.slideshow-controls a:hover {
 	margin: 0 5px !important;
 	padding: 0 !important;
 	display: inline-block !important;
-	*display: inline;
+	/* display: inline; */
 	zoom: 1;
 	height: 32px !important;
 	width: 32px !important;


### PR DESCRIPTION
Examinating the style sheet file slideshow-shortcode.css I noticed 2 errors:

line 57 .slideshow-line-height-hack {
overflow:hide;
...
}

the correct value for overflow property is "hidden".

line 102 body div div.slideshow-controls a:hover {
....
*display: inline;
....
}

Removing character \* put property "display" between /\* and */
