### PR TITLE
Custom CSS: different approach to fixing revisions

### DIFF
--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -889,8 +889,12 @@ class Jetpack_Custom_CSS {
 	static function revisions_meta_box( $safecss_post ) {
 
 		$show_all_revisions = isset( $_GET['show_all_rev'] );
-		
-		$max_revisions = defined( 'WP_POST_REVISIONS' ) && is_numeric( WP_POST_REVISIONS ) ? (int) WP_POST_REVISIONS : 25;
+
+		if ( function_exists( 'wp_revisions_to_keep' ) ) {
+			$max_revisions = wp_revisions_to_keep( (object) $safecss_post );
+		} else {
+			$max_revisions = defined( 'WP_POST_REVISIONS' ) && is_numeric( WP_POST_REVISIONS ) ? (int) WP_POST_REVISIONS : 25;
+		}
 
 		$posts_per_page = $show_all_revisions ? $max_revisions : 6;
 


### PR DESCRIPTION
re-introduced the use of wp_revisions_to_keep, but cast the argument as
an object to avoid notice
fixes #119
