### PR TITLE
Remove Date Filter for Related Posts

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -372,10 +372,7 @@ EOT;
 			'size' => (int)$options['size'],
 			'post_type' => get_post_type( $post_id ),
 			'has_terms' => array(),
-			'date_range' => array(
-				'from' => strtotime( '-2 year' ),
-				'to' => time()
-			),
+			'date_range' => array(),
 			'exclude_post_id' => 0,
 		);
 		$args = wp_parse_args( $args, $defaults );
@@ -440,7 +437,7 @@ EOT;
 		}
 
 		$args['date_range'] = apply_filters( 'jetpack_relatedposts_filter_date_range', $args['date_range'], $post_id );
-		if ( is_array( $args['date_range'] ) ) {
+		if ( is_array( $args['date_range'] ) && ! empty( $args['date_range'] ) ) {
 			$args['date_range'] = array_map( 'intval', $args['date_range'] );
 			if ( !empty( $args['date_range']['from'] ) && !empty( $args['date_range']['to'] ) ) {
 				$filters[] = array(


### PR DESCRIPTION
Allow related posts to load posts from entire blog instead of just most recent 2 years.
