### PR TITLE
Unit Tests: Use official git mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 # Clones WordPress and configures our testing environment.
 before_script:
     - export PLUGIN_SLUG=$(basename $(pwd))
-    - git clone https://github.com/tierra/wordpress.git /tmp/wordpress
+    - git clone git://develop.git.wordpress.org/ /tmp/wordpress
 # - git clone . "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
     - cd ..
     - mv $PLUGIN_SLUG "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"


### PR DESCRIPTION
We can use the official git mirror for running unit tests.

https://make.wordpress.org/core/2014/01/15/git-mirrors-for-wordpress/
