### PR TITLE
PHP 5.3 crashes in some instances with Related Posts

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -11,7 +11,7 @@ class Jetpack_RelatedPosts {
 		static $instance = NULL;
 
 		if ( ! $instance ) {
-			if ( method_exists( 'WPCOM_RelatedPosts', 'init' ) ) {
+			if ( class_exists('WPCOM_RelatedPosts') && method_exists( 'WPCOM_RelatedPosts', 'init' ) ) {
 				$instance = WPCOM_RelatedPosts::init();
 			} else {
 				$instance = new Jetpack_RelatedPosts(
@@ -32,7 +32,7 @@ class Jetpack_RelatedPosts {
 		static $instance = NULL;
 
 		if ( ! $instance ) {
-			if ( method_exists( 'WPCOM_RelatedPosts', 'init_raw' ) ) {
+			if ( class_exists('WPCOM_RelatedPosts') && method_exists( 'WPCOM_RelatedPosts', 'init_raw' ) ) {
 				$instance = WPCOM_RelatedPosts::init_raw();
 			} else {
 				$instance = new Jetpack_RelatedPosts_Raw(


### PR DESCRIPTION
If `method_exists()` is called on a class that does not exist PHP 5.3 will crash. Use `class_exists()` to test for class before testing for a method within a class. Props @gibrown
