### PR TITLE
Make backspace in carousel view functional in Chrome and Firefox.

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -30,6 +30,7 @@ jQuery(document).ready(function($) {
 				gallery.jp_carousel('next');
 				break;
 			case 37: // left
+			case 8: // backspace
 				e.preventDefault();
 				gallery.jp_carousel('clearCommentTextAreaValue');
 				gallery.jp_carousel('previous');


### PR DESCRIPTION
Currently, utilizing backspace will cause the page URL to update properly, but the actual image does not change. This corrects this behavior in Chrome and Firefox on Windows and OS/X--pressing backspace will now return to the previous image, as expected.
