### PR TITLE
Multisite: Correct URL to avoid a 404 of the loading spinner

### DIFF
--- a/views/admin/network-admin-footer.php
+++ b/views/admin/network-admin-footer.php
@@ -23,9 +23,4 @@
 					<a href="http://jetpack.me/support/" target="_blank"><?php _e( 'Support', 'jetpack' ); ?></a>
 				</p>
 			</div>
-
-			<div id="jetpack-configuration" style="display:none;">
-				<p><img width="16" src="<?php echo esc_url( plugins_url( 'jetpack/_inc/images/wpspin_light-2x.gif' ) ); ?>" alt="Loading ..." /></p>
-			</div>
 		</div>
-


### PR DESCRIPTION
In views/admin/network-admin-footer.php, the loading spinner is loaded from views/admin/_inc/images/... which does not exist. 

I'm not sure the best way to call on this without hardcoding in the slug, unless we had a constant in jetpack.php similar to JETPACK__PLUGIN_DIR. If that's a better route, I can modify the PR to do that.
