### PR TITLE
Expose bulk sync queued status to end user

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -761,7 +761,7 @@ class Jetpack_Sync {
 		$strings = json_encode( array(
 			'WAITING' => array(
 				'action' => __( 'Refresh Status', 'jetpack' ),
-				'status' => __( 'Indexing posts&hellip;', 'jetpack' ),
+				'status' => __( 'Indexing request queued and waiting&hellip;', 'jetpack' ),
 			),
 			'INDEXING' => array(
 				'action' => __( 'Refresh Status', 'jetpack' ),


### PR DESCRIPTION
Make it clear to the user that we have received the bulk index request and have not gotten to it yet for cases when there is a backlog.
