### PR TITLE
Remove audio from keeper_shortcodes array as no longer supported.

### DIFF
--- a/class.media-extractor.php
+++ b/class.media-extractor.php
@@ -23,7 +23,6 @@ class Jetpack_Media_Meta_Extractor {
 		'vimeo',
 		'hulu',
 		'ted',
-		'audio',
 		'wpvideo',
 	);
 


### PR DESCRIPTION
The audio shortcode from Jetpack is only used pre-3.6. This instance of the audio shortcode being added to the `$KEEPER_SHORTCODES` array is causing PHP to crash on some hosting environments.

Since we no longer support pre-3.6 (or pre-3.7 actually), removing this outright should be fine. 

I'd think the whole shortcode could be removed since we use core for all supported versions, but this is the bare minimum to fix fatal issues with currently-updated users.
