### PR TITLE
Add Official Bitly plugin to list of OG Meta conflicts

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -686,6 +686,7 @@ class Jetpack {
 			'facebook-revised-open-graph-meta-tag/index.php',					// Facebook Revised Open Graph Meta Tag
 			'facebook-and-digg-thumbnail-generator/facebook-and-digg-thumbnail-generator.php',	// Fedmich's Facebook Open Graph Meta
 			'facebook-meta-tags/facebook-metatags.php',						// Facebook Meta Tags
+			'bitly/bitly.php',												// Official Bitly for WordPress
 		);
 
 		foreach ( $conflicting_plugins as $plugin ) {


### PR DESCRIPTION
The [Official Bitly plugin for WordPress](http://wordpress.org/plugins/bitly/) adds the following meta tags, which result in duplicate tags when active alongside Jetpack:
`
<meta property="bitly:url" content="http://example.com" />
<meta property="og:url" content="http://example.com" />
`
