### PR TITLE
Infinite: Only load new pages when within two screens of the bottom.

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -83,9 +83,7 @@ Scroller = function( settings ) {
  */
 Scroller.prototype.check = function() {
 	var bottom = this.window.scrollTop() + this.window.height(),
-		threshold = this.element.offset().top + this.element.outerHeight(false) - this.window.height();
-
-	threshold = Math.round( threshold * 0.75 );
+	    threshold = this.element.offset().top + this.element.outerHeight(false) - (this.window.height() * 2);
 
 	return bottom > threshold;
 };
@@ -455,8 +453,9 @@ Scroller.prototype.updateURL = function( page ) {
 		offset = self.offset > 0 ? self.offset - 1 : 0,
 		pageSlug = -1 == page ? self.origURL : window.location.protocol + '//' + self.history.host + self.history.path.replace( /%d/, page + offset ) + self.history.parameters;
 
-	if ( window.location.href != pageSlug )
+	if ( window.location.href != pageSlug ) {
 		history.pushState( null, null, pageSlug );
+	}
 }
 
 /**


### PR DESCRIPTION
The current infinite scroll code loads a new page when the browser is
within 25% of the bottom of the page. On very long IS pages, this leads
to loading an increasing number of unnecessary pages, as the bottom 25%
of the page increases in size as the user loads more and more pages.

This patch makes IS less aggressive in loading new pages. Two screens was
chosen as a starting point and is obviously open to tweaking.
