### PR TITLE
Swap invisible DOM nodes in and out based on scrolls.

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -401,20 +401,7 @@ Scroller.prototype.determineURL = function () {
 
     $.each(setsHidden, function() {
 		var $set = $('#' + this.id);
-		if( $set.hasClass('is--replaced') || $set.hasClass('is--ignored') ) {
-			return;
-		}
-
-		// Check the node for <video>, <audio>, <object>, and <iframe> elements. If any
-		// are present, mark the page to be ignored.
-		// We really shouldn't yank these elements from the page, as they may contain
-		// playing media.
-		//
-		// We use the is--ignored class as a shortcut to avoid having to look at all
-		// the elements in the page more than once.
-
-		if ( $set.find('video,audio,object,iframe') ) {
-			$set.addClass('is--ignored');
+		if( $set.hasClass( 'is--replaced' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This patch teaches the infinite scroll system how to pull DOM nodes out of
nodes outside the current viewport and stash them in a cache. It does this
by hooking into determineURL and walking all of the pages that were determined
to be hidden. It pulls all of the child nodes out of the page and stashes them
in a DocumentFragment. It also updates the min-height of the page wrapper to
match the old height when all the children were present.

When a user scrolls a page back into view, the children are reinserted into
the wrapper and the min-height and class marker are removed.

All that said, I'm not sure this had much impact on the overall memory usage of the
browser. Since we're stashing the actual DOM nodes, that memory can't be saved,
but we are likely saving some render memory, as the DOM should be substantially smaller
in most cases. Need to do some more testing with a bigger, more complex set of posts.
