### PR TITLE
Top Posts: add "width: 100%" to images in CSS

### DIFF
--- a/modules/widgets/wordpress-post-widget/style.css
+++ b/modules/widgets/wordpress-post-widget/style.css
@@ -20,5 +20,5 @@
 }
 
 .jetpack-display-remote-posts img {
-	width: 100%;
+	max-width: 100%;
 }


### PR DESCRIPTION
Added "width: 100%" to images in CSS for the Display WordPress Posts widget to prevent larger featured images from escaping the containing element.
