### PR TITLE
Module Related Posts: IE9 Compat Fix

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1,6 +1,6 @@
 <?php
 class Jetpack_RelatedPosts {
-	const VERSION = '20140305.1';
+	const VERSION = '20140306';
 
 	/**
 	 * Creates and returns a static instance of Jetpack_RelatedPosts.

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -109,6 +109,10 @@
 		},
 
 		cleanupTrackedUrl: function() {
+			if ( 'function' != typeof history.replaceState ) {
+				return;
+			}
+
 			var cleaned_search = document.location.search.replace( /\brelatedposts_[a-z]+=[0-9]*&?\b/gi, '' );
 			if ( '?' == cleaned_search ) {
 				cleaned_search = '';


### PR DESCRIPTION
IE9 does not support `history.replaceState()` which breaks rendering of the
related posts section. Abort trying to cleaning up the URL if we cannot
rewrite state. (Sadly this leaves cruft on the URL of older browsers.)
