### PR TITLE
Shortcodes / Facebook: update regex to support valid Facebook content URLs

### DIFF
--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -4,7 +4,7 @@
  * Facebook embeds
  */
 
-define( 'JETPACK_FACEBOOK_EMBED_REGEX', '#^https?://(www.)?facebook\.com/([^/]+)/posts/([^/]+)?#' );
+define( 'JETPACK_FACEBOOK_EMBED_REGEX', '#^https?://(www.)?facebook\.com/([^/]+)/(posts|photos)/([^/]+)?#' );
 define( 'JETPACK_FACEBOOK_ALTERNATE_EMBED_REGEX', '#^https?://(www.)?facebook\.com/permalink.php\?([^\s]+)#' );
 define( 'JETPACK_FACEBOOK_PHOTO_EMBED_REGEX', '#^https?://(www.)?facebook\.com/photo.php\?([^\s]+)#' );
 


### PR DESCRIPTION
The regular expression here is updated to support valid Facebook URLs that can be embedded, such as:

https://www.facebook.com/TheAcademy/photos/a.212963591405.141172.83574526405/10152040500621406
https://www.facebook.com/115099421882868/photos/a.116098101783000.15816.115099421882868/655027811223357/?type=1
https://www.facebook.com/ellentv/photos/a.182755292239.124686.26012002239/10152299789332240/?type=1
