### PR TITLE
Publicize: hide the new publicize_twitter_user custom field

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -669,9 +669,9 @@ class Publicize extends Publicize_Base {
 	function save_publicized_twitter_account( $submit_post, $post_id, $service_name, $connection ) {
 		if ( 'twitter' == $service_name && $submit_post ) {
 			$connection_meta = $this->get_connection_meta( $connection );
-			$publicize_twitter_user = get_post_meta( $post_id, 'publicize_twitter_user' );
+			$publicize_twitter_user = get_post_meta( $post_id, '_publicize_twitter_user' );
 			if ( empty( $publicize_twitter_user ) || 0 != $connection_meta['connection_data']['user_id'] ) {
-				update_post_meta( $post_id, 'publicize_twitter_user', $this->get_display_name( 'twitter', $connection ) );
+				update_post_meta( $post_id, '_publicize_twitter_user', $this->get_display_name( 'twitter', $connection ) );
 			}
 		}
 	}
@@ -680,7 +680,7 @@ class Publicize extends Publicize_Base {
 		if ( ! empty( $account ) ) {
 			return $account;
 		}
-		$account = get_post_meta( $post_id, 'publicize_twitter_user', true );
+		$account = get_post_meta( $post_id, '_publicize_twitter_user', true );
 		if ( ! empty( $account ) ) {
 			return $account;
 		}


### PR DESCRIPTION
The other custom fields created by Jetpack are hidden. Shouldn't we do the same with the `publicize_twitter_user` custom field?
