### PR TITLE
Contact Form: add help message to explain to send to multiple emails

### DIFF
--- a/modules/contact-form/grunion-form-view.php
+++ b/modules/contact-form/grunion-form-view.php
@@ -140,6 +140,8 @@ wp_localize_script( 'grunion', 'GrunionFB_i18n', array(
 		<div id="fb-email-desc" class="fb-desc" style="display: none;">
 			<h3><?php esc_html_e( 'Do I need to fill this out?', 'jetpack' ); ?></h3>
 			<p><?php esc_html_e( 'Nope.  However, if you&#8217;d like to modify where your feedback is sent, or the subject line you can.  If you don&#8217;t make any changes here, feedback will be sent to the author of the page/post and the subject will be the name of this page/post.', 'jetpack' ); ?></p>
+			<h3 style="margin-top: 21px;"><?php esc_html_e( 'Can I send a notification to more than one person?', 'jetpack' ); ?></h3>
+			<p><?php esc_html_e( 'Yep. You can enter multiple email addresses in the Email address field, and separate them with commas. A notification email will then be sent to each email address.', 'jetpack' ); ?></h3>
 			<div class="clear"></div>
 		</div>
 		<div id="fb-add-field" style="display: none;">


### PR DESCRIPTION
It's currently possible to send out notification emails to multiple email addresses by separating email addresses with commas in the form builder. But we don't mention this anywhere in the docs. This commit adds an extra help field to the right of the form builder:

![screen shot 2014-03-10 at 10 14 29 am](https://f.cloud.github.com/assets/426388/2372059/d4599a16-a834-11e3-8668-6165421c0774.png)

Reported here:
- https://twitter.com/jeffr0/status/441332282058887169
