### PR TITLE
Sharing: improve the fallbacks for "via" on twitter sharing button

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -678,9 +678,6 @@ class Publicize extends Publicize_Base {
 
 	function get_publicized_twitter_account( $account, $post_id ) {
 		$account = get_post_meta( $post_id, 'publicize_twitter_user', true );
-		if ( empty( $account ) ) {
-			$account = get_option( 'jetpack-twitter-cards-site-tag' );
-		}
 		if ( ! empty( $account ) ) {
 			return preg_replace( '/^@/', '', $account );
 		}


### PR DESCRIPTION
Before, the button always outputted "@jetpack"
I believe this was caused by the extra `if ( ! empty( $account ) )` check before to look for a `publicize_twitter_user` custom field.

This commit introduces 2 fallback levels:
- Was the post created by an author with a connected Publicize account?
- If not, did the site admin enter a jetpack-twitter-cards-site-tag value?
- If not, fallback to "@jetpack"
