### PR TITLE
Update tiled-gallery.js

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery.js
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery.js
@@ -58,7 +58,7 @@ TiledGallery.prototype.Captions = function() {
 };
 
 TiledGallery.prototype.resize = function() {
-	var resizeableElements = '.gallery-row, .gallery-group, .tiled-gallery-item img';
+	var resizeableElements = '.gallery-row, .gallery-group';
 
 	this.gallery.each( function ( galleryIndex, galleryElement ) {
 		var thisGallery = $( galleryElement );


### PR DESCRIPTION
The images widget itself may not be updated, if there are no parent element with style attr width and height, e.g. the widget is placed on the page (not on sidebar). Otherwise the width and height is set to zero pixels.
