### PR TITLE
Add compatibility for WP 3.9 Widget Customizer

### DIFF
--- a/modules/widget-visibility/widget-conditions/widget-conditions.css
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.css
@@ -9,6 +9,9 @@
 	border: 1px solid #DFDFDF;
 	padding: 12px 12px 0;
 }
+.widget-conditional {
+	margin-bottom: 12px;
+}
 .widget-conditional .condition,
 .widget-conditional .condition-top {
 	margin-bottom: 12px;
@@ -36,4 +39,12 @@
 }
 .wp-core-ui .button.display-options:hover {
 	text-decoration: none;
+}
+.wp-customizer .wide-widget-control .widget-conditional {
+	width: 400px;
+}
+.wp-customizer .widget-conditional select {
+	min-width: 0;
+	max-width: none;
+	height: auto;
 }

--- a/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -1,5 +1,9 @@
 jQuery( function( $ ) {
 	function setWidgetMargin( $widget ) {
+		if ( $( 'body' ).hasClass( 'wp-customizer' ) ) {
+			return;
+		}
+
 		if ( $widget.hasClass( 'expanded' ) ) {
 			// The expanded widget must be at least 400px wide in order to
 			// contain the visibility settings. IE wasn't handling the


### PR DESCRIPTION
The Widget Visibility module tries to force narrow widgets to be wide in order to make enough room for the `.widget-conditional` element. In WordPress 3.9, we're introducing the Widget Customizer into core. The method that Widget Visibility uses to force a widget wide, however, does not work in the customizer, since widgets cannot be left-overhanging.

Note that Widget Visibility currently does not work in 3.9 Beta 1 because the Widget Customizer script is being loaded in the header when it needs to be in the footer. For the corresponding Core patch to go along with this Jetpack patch, see https://github.com/x-team/wordpress-develop/compare/master...customizer-widget-visibility
# Narrow widget before

![widget visibility before narrow widget](https://f.cloud.github.com/assets/134745/2406383/f20d9f3c-aa6c-11e3-9648-3c5cbcd00dd4.png)
# Narrow widget after

![widget visibility after narrow widget](https://f.cloud.github.com/assets/134745/2406385/f87e708a-aa6c-11e3-9126-dbfd89e16a3c.png)
# Wide widget before

![widget visibility before wide widget](https://f.cloud.github.com/assets/134745/2406388/007fe3e0-aa6d-11e3-8201-b3d476183677.png)
# Wide widget after

![widget visibility after wide widget](https://f.cloud.github.com/assets/134745/2406391/04984698-aa6d-11e3-9b61-76cfe5addf5a.png)
