### PR TITLE
Carousel: Make slide titles visible in all viewport sizes

### DIFF
--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -68,13 +68,14 @@ only screen and (min-device-pixel-ratio: 1.5) {
 }
 
 .jp-carousel-info h2 {
+	height: 1.25em;
 	background: none !important;
 	border: none !important;
 	color: #999;
 	display: block !important;
 	font: normal 13px/1.25em "Helvetica Neue", sans-serif !important;
 	letter-spacing: 0 !important;
-	margin: 7px 0 0 0 !important;
+	margin: 0 !important;
 	padding: 10px 0 0 !important;
 	overflow: hidden;
 	text-align: left;
@@ -1132,5 +1133,16 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	.jp-carousel-photo-info {
 		left: 0 !important;
 		width: 100% !important;
+	}
+}
+
+@media only screen and (device-width: 768px) and (device-height: 1024px) and (orientation: landscape) {
+	.jp-carousel-titleanddesc {
+		margin-top: 12px !important;
+		padding-top: 13px !important;
+	}
+
+	.jp-carousel-left-column-wrapper {
+		margin-top: 12px !important;
 	}
 }

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -5,9 +5,9 @@ jQuery(document).ready(function($) {
 	var overlay, comments, gallery, container, nextButton, previousButton, info, title, transitionBegin,
 	caption, resizeTimeout, mouseTimeout, photo_info, close_hint, commentInterval,
 	screenPadding = 110, originalOverflow = $('body').css('overflow'), originalHOverflow = $('html').css('overflow'), proportion = 85,
-	last_known_location_hash = '';
+	last_known_location_hash = '', isSmallScreen = (window.innerWidth <= 760);
 
-	if ( window.innerWidth <= 760 ) {
+	if ( isSmallScreen ) {
 		screenPadding = Math.round( ( window.innerWidth / 760 ) * 110 );
 
 		if ( screenPadding < 40 && ( ( 'ontouchstart' in window ) || window.DocumentTouch && document instanceof DocumentTouch ) )
@@ -169,7 +169,7 @@ jQuery(document).ready(function($) {
 				.append(photo_info)
 				.append(imageMeta);
 
-			if ( window.innerWidth <= 760 ) {
+			if ( isSmallScreen ) {
 				photo_info.remove().insertAfter( titleAndDescription );
 				info.prepend( leftColWrapper );
 			}
@@ -727,7 +727,30 @@ jQuery(document).ready(function($) {
 		},
 
 		fitMeta : function(animated){
-			var newInfoTop   = { top: Math.floor( $(window).height() / 100 * proportion + 5 ) + 'px' };
+			var current = this.jp_carousel('selectedSlide'),
+				titleAndDescriptionTitle = titleAndDescription.find('.jp-carousel-titleanddesc-title'),
+				smallScreenPadding = 18,
+				bigScreenPadding = 10,
+				topValue, proportionOffset, edgeOffset;
+
+			var visibleHeight = (
+				parseInt(leftColWrapper.css('margin-top'), 10) +
+				parseInt(titleAndDescription.css('padding-top'), 10) +
+				parseInt(titleAndDescription.css('margin-top'), 10) +
+				parseInt(titleAndDescription.css('border-top-width'), 10) +
+				( titleAndDescriptionTitle ? parseInt(titleAndDescriptionTitle.css('line-height'), 10) : 0 )
+			);
+
+			if ( isSmallScreen ) {
+				topValue = ( $(window).height() - visibleHeight - smallScreenPadding );
+			} else {
+				proportionOffset = Math.floor( $(window).height() / 100 * proportion + 5 );
+				edgeOffset = ( $(window).height() - photo_info.outerHeight() -
+				               visibleHeight - bigScreenPadding );
+				topValue = Math.min( proportionOffset, edgeOffset );
+			}
+
+			var newInfoTop = { top: topValue };
 			var newLeftWidth = { width: ( info.width() - (imageMeta.width() + 80) ) + 'px' };
 
 			if (animated) {


### PR DESCRIPTION
Before this change the slide titles would be cut off or missing on iPhone and iPad in landscape orientation. See issue #336. The slide title is currently positioned as a percentage of the current window height. Since the title itself is a fixed height, I wasn't able to find a percentage that worked for all device resolutions. My fix is to check the actual height of the slide title and make sure it will be positioned with enough space to show the first line regardless of the resolution.

This solution makes the `fitMeta` method a little more complex, but I think the result looks better. I made a page of before and after screenshots here: https://dl.dropboxusercontent.com/u/249607/jetpack/titles/index.html

I'd be glad to hear any suggestions on a better way to do this. Another way would be to manually set the positions of the title for specific resolutions, but this way is more general.