### PR TITLE
ShareDaddy: No double @'s.

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -344,6 +344,9 @@ class Share_Twitter extends Sharing_Source {
 	function sharing_twitter_via( $post ) {
 		// Allow themes to customize the via
 		$twitter_site_tag_value = apply_filters( 'jetpack_twitter_cards_site_tag', '' );
+		// Strip out anything other than a letter, number, or underscore.
+		// This will prevent the inadvertent inclusion of an extra @, as well as normalizing the handle.
+		$twitter_site_tag_value = preg_replace( '/[^\da-z_]+/i', '', $twitter_site_tag_value );
 		return apply_filters( 'jetpack_sharing_twitter_via', $twitter_site_tag_value, $post->ID );
 	}
 


### PR DESCRIPTION
This will prevent a tweet from looking like `via @@Viper007Bond` if the
via parameter is prefixed with an @.
