### PR TITLE
Carousel: Switch slide when pressing back/forward buttons

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -440,6 +440,20 @@ jQuery(document).ready(function($) {
 			return false;
 		},
 
+		openOrSelectSlide: function( index ) {
+			// The `open` method triggers an asynchronous effect, so we will get an
+			// error if we try to use `open` then `selectSlideAtIndex` immediately
+			// after it. We can only use `selectSlideAtIndex` if the carousel is
+			// already open.
+			if ( ! $( this ).jp_carousel( 'testIfOpened' ) ) {
+				// The `open` method selects the correct slide during the
+				// initialization.
+				$( this ).jp_carousel( 'open', { start_index: index } );
+			} else {
+				gallery.jp_carousel( 'selectSlideAtIndex', index );
+			}
+		},
+
 		open: function(options) {
 			var settings = {
 				'items_selector' : ".gallery-item [data-attachment-id], .tiled-gallery-item [data-attachment-id]",
@@ -484,14 +498,14 @@ jQuery(document).ready(function($) {
 					container.trigger('jp_carousel.afterOpen');
 					gallery
 						.jp_carousel('initSlides', $this.find(settings.items_selector), settings.start_index)
-						.jp_carousel('start', settings.start_index);
+						.jp_carousel('selectSlideAtIndex', settings.start_index);
 				});
 				gallery.html('');
 			});
 		},
 
-		start : function(start_index){
-			var slides = this.jp_carousel('slides'), selected = slides.eq(start_index);
+		selectSlideAtIndex : function(index){
+			var slides = this.jp_carousel('slides'), selected = slides.eq(index);
 
 			if ( 0 === selected.length )
 				selected = slides.eq(0);
@@ -1361,7 +1375,7 @@ jQuery(document).ready(function($) {
 		});
 
 		if ( index != -1 )
-			gallery.jp_carousel('open', {start_index: index}); // open method checks if already opened
+			gallery.jp_carousel('openOrSelectSlide', index);
 	});
 
 	if ( window.location.hash )


### PR DESCRIPTION
Before this change, the browser's back and forward buttons would update the URL with the ID of the desired slide, but the UI would not actually update.

The problem was that the `open` method was getting called for `onhashchange` events, but it would do nothing if the carousel was already activated.  This patch adds a new method that will switch the slide even if the carousel is already open.

Steps to reproduce:
1. Go to a post that contains a gallery.
2. Click on an image in the gallery.
3. Click the back or forward buttons _in the carousel UI, not the browser_.
4. Click the back or forward buttons _in the browser_.

On step 4, the URL should change, but the UI will stay the same.
