### PR TITLE
Fix PHP notice in Jetpack_PostImages::from_attachment method

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -194,13 +194,19 @@ class Jetpack_PostImages {
 		* We can load up all the images found in the HTML source and then
 		* compare URLs to see if an image is attached AND inserted.
 		*/
-		$html_images = array();
 		$html_images = self::from_html( $post_id );
 		$inserted_images = array();
 
 		foreach( $html_images as $html_image ) {
 			$src = parse_url( $html_image['src'] );
-			$inserted_images[] = $src['scheme'] . '://' . $src['host'] . $src['path']; // strip off any query strings
+			// strip off any query strings from src
+			if( ! empty($src['scheme']) && ! empty($src['host']) ) {
+				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . $src['path'];
+			} elseif( ! empty($src['host']) ) {
+				$inserted_images[] = '//' . $src['host'] . $src['path'];
+			} else {
+				$inserted_images[] = WP_HOME . $src['path'];
+			}
 		}
 		foreach( $images as $i => $image ) {
 			if ( !in_array( $image['src'], $inserted_images ) )


### PR DESCRIPTION
Add logic to cope with images in posts with protocol independent and root relative urls. The URLs returned are always absolute, using WP_HOME if the image src in the post was a root relative URL. This method is used by the Jetpack OpenGraph functions, and the og:image property should be absolute (apparently... though the documentation does not seem to explicitly state this).