### PR TITLE
Carousel: Fix issue with multiple galleries on one page (see #417)

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1377,11 +1377,13 @@ jQuery(document).ready(function($) {
 		var hashRegExp = /jp-carousel-(\d+)/,
 			matches, attachmentId, galleries, selectedThumbnail;
 
-		if ( ! hashRegExp.test( window.location.hash ) )
+		if ( ! hashRegExp.test( window.location.hash ) ) {
 			return;
+		}
 
-		if ( window.location.hash == last_known_location_hash )
+		if ( window.location.hash == last_known_location_hash ) {
 			return;
+		}
 
 		last_known_location_hash = window.location.hash;
 		matches = window.location.hash.match( hashRegExp );
@@ -1406,8 +1408,9 @@ jQuery(document).ready(function($) {
 		});
 	});
 
-	if ( window.location.hash )
+	if ( window.location.hash ) {
 		$( window ).trigger( 'hashchange' );
+	}
 });
 
 /**


### PR DESCRIPTION
See issue #417. This pull request includes a fix to use the correct thumbnail index in the `hashchange` event, even when there are multiple galleries on the page.
