### PR TITLE
Feature/widget conditions extra hooks (second time lucky)

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -12,8 +12,7 @@ class Jetpack_Widget_Conditions {
 			add_filter( 'widget_update_callback', array( __CLASS__, 'widget_update' ), 10, 3 );
 			add_action( 'in_widget_form', array( __CLASS__, 'widget_conditions_admin' ), 10, 3 );
 			add_action( 'wp_ajax_widget_conditions_options', array( __CLASS__, 'widget_conditions_options' ) );
-		}
-		else {
+		} else {
 			add_action( 'widget_display_callback', array( __CLASS__, 'filter_widget' ) );
 			add_action( 'sidebars_widgets', array( __CLASS__, 'sidebars_widgets' ) );
 		}
@@ -42,7 +41,7 @@ class Jetpack_Widget_Conditions {
 					<option value="<?php echo esc_attr( $category->term_id ); ?>" <?php selected( $category->term_id, $minor ); ?>><?php echo esc_html( $category->name ); ?></option>
 					<?php
 				}
-			break;
+				break;
 			case 'author':
 				?>
 				<option value=""><?php _e( 'All author pages', 'jetpack' ); ?></option>
@@ -53,7 +52,7 @@ class Jetpack_Widget_Conditions {
 					<option value="<?php echo esc_attr( $author->ID ); ?>" <?php selected( $author->ID, $minor ); ?>><?php echo esc_html( $author->display_name ); ?></option>
 					<?php
 				}
-			break;
+				break;
 			case 'tag':
 				?>
 				<option value=""><?php _e( 'All tag pages', 'jetpack' ); ?></option>
@@ -67,7 +66,7 @@ class Jetpack_Widget_Conditions {
 					<option value="<?php echo esc_attr($tag->term_id ); ?>" <?php selected( $tag->term_id, $minor ); ?>><?php echo esc_html( $tag->name ); ?></option>
 					<?php
 				}
-			break;
+				break;
 			case 'date':
 				?>
 				<option value="" <?php selected( '', $minor ); ?>><?php _e( 'All date archives', 'jetpack' ); ?></option>
@@ -75,13 +74,14 @@ class Jetpack_Widget_Conditions {
 				<option value="month"<?php selected( 'month', $minor ); ?>><?php _e( 'Monthly archives', 'jetpack' ); ?></option>
 				<option value="year"<?php selected( 'year', $minor ); ?>><?php _e( 'Yearly archives', 'jetpack' ); ?></option>
 				<?php
-			break;
+				break;
 			case 'page':
 				// Previously hardcoded post type options.
-				if ( ! $minor )
+				if ( ! $minor ) {
 					$minor = 'post_type-page';
-				else if ( 'post' == $minor )
+				} else if ( 'post' == $minor ) {
 					$minor = 'post_type-post';
+				}
 
 				?>
 				<option value="front" <?php selected( 'front', $minor ); ?>><?php _e( 'Front page', 'jetpack' ); ?></option>
@@ -160,14 +160,17 @@ class Jetpack_Widget_Conditions {
 	public static function widget_conditions_admin( $widget, $return, $instance ) {
 		$conditions = array();
 
-		if ( isset( $instance['conditions'] ) )
+		if ( isset( $instance['conditions'] ) ) {
 			$conditions = $instance['conditions'];
+		}
 
-		if ( ! isset( $conditions['action'] ) )
+		if ( ! isset( $conditions['action'] ) ) {
 			$conditions['action'] = 'show';
+		}
 
-		if ( empty( $conditions['rules'] ) )
+		if ( empty( $conditions['rules'] ) ) {
 			$conditions['rules'][] = array( 'major' => '', 'minor' => '' );
+		}
 
 		?>
 		<div class="widget-conditional <?php if ( empty( $_POST['widget-conditions-visible'] ) || $_POST['widget-conditions-visible'] == '0' ) { ?>widget-conditional-hide<?php } ?>">
@@ -232,8 +235,9 @@ class Jetpack_Widget_Conditions {
 
 		$conditions[ 'active' ] = false;
 		foreach ( $_POST['conditions']['rules_major'] as $index => $major_rule ) {
-			if ( ! $major_rule )
+			if ( ! $major_rule ) {
 				continue;
+			}
 
 			$conditions['rules'][] = array(
 				'major' => $major_rule,
@@ -245,10 +249,11 @@ class Jetpack_Widget_Conditions {
 
 		$conditions = apply_filters( 'widget_conditions_update', $conditions, $instance, $new_instance, $old_instance );
 
-		if ( $conditions[ 'active' ] )
+		if ( $conditions[ 'active' ] ) {
 			$instance['conditions'] = $conditions;
-		else
+		} else {
 			unset( $instance['conditions'] );
+		}
 
 		if (
 				( isset( $instance['conditions'] ) && ! isset( $old_instance['conditions'] ) )
@@ -260,8 +265,7 @@ class Jetpack_Widget_Conditions {
 				)
 			) {
 			do_action( 'widget_conditions_save' );
-		}
-		else if ( ! isset( $instance['conditions'] ) && isset( $old_instance['conditions'] ) ) {
+		} else if ( ! isset( $instance['conditions'] ) && isset( $old_instance['conditions'] ) ) {
 			do_action( 'widget_conditions_delete' );
 		}
 
@@ -278,19 +282,20 @@ class Jetpack_Widget_Conditions {
 		$settings = array();
 
 		foreach ( $widget_areas as $widget_area => $widgets ) {
-			if ( empty( $widgets ) )
+			if ( empty( $widgets ) ) {
 				continue;
+			}
 
-			if ( 'wp_inactive_widgets' == $widget_area )
+			if ( 'wp_inactive_widgets' == $widget_area ) {
 				continue;
+			}
 
 			foreach ( $widgets as $position => $widget_id ) {
 				// Find the conditions for this widget.
 				if ( preg_match( '/^(.+?)-(\d+)$/', $widget_id, $matches ) ) {
 					$id_base = $matches[1];
 					$widget_number = intval( $matches[2] );
-				}
-				else {
+				} else {
 					$id_base = $widget_id;
 					$widget_number = null;
 				}
@@ -299,15 +304,13 @@ class Jetpack_Widget_Conditions {
 					$settings[$id_base] = get_option( 'widget_' . $id_base );
 				}
 
-				// New multi widget (WP_Widget)
 				if ( ! is_null( $widget_number ) ) {
+					// New multi widget (WP_Widget)
 					if ( isset( $settings[$id_base][$widget_number] ) && false === self::filter_widget( $settings[$id_base][$widget_number] ) ) {
 						unset( $widget_areas[$widget_area][$position] );
 					}
-				}
-
-				// Old single widget
-				else if ( ! empty( $settings[ $id_base ] ) && false === self::filter_widget( $settings[$id_base] ) ) {
+				} else if ( ! empty( $settings[ $id_base ] ) && false === self::filter_widget( $settings[$id_base] ) ) {
+					// Old single widget
 					unset( $widget_areas[$widget_area][$position] );
 				}
 			}
@@ -327,112 +330,119 @@ class Jetpack_Widget_Conditions {
 
 		$condition_result = true;
 
-		foreach ( $instance['conditions']['rules'] as $rule ) {
-			switch ( $rule['major'] ) {
-				case 'date':
-					switch ( $rule['minor'] ) {
-						case '':
-							$condition_result = is_date();
+		if ( is_array( $instance['conditions']['rules'] ) ) {
+			foreach ( $instance['conditions']['rules'] as $rule ) {
+				switch ( $rule['major'] ) {
+					case 'date':
+						switch ( $rule['minor'] ) {
+							case '':
+								$condition_result = is_date();
+							break;
+							case 'month':
+								$condition_result = is_month();
+							break;
+							case 'day':
+								$condition_result = is_day();
+							break;
+							case 'year':
+								$condition_result = is_year();
+							break;
+						}
 						break;
-						case 'month':
-							$condition_result = is_month();
-						break;
-						case 'day':
-							$condition_result = is_day();
-						break;
-						case 'year':
-							$condition_result = is_year();
-						break;
-					}
-				break;
-				case 'page':
-					// Previously hardcoded post type options.
-					if ( 'post' == $rule['minor'] )
-						$rule['minor'] = 'post_type-post';
-					else if ( ! $rule['minor'] )
-						$rule['minor'] = 'post_type-page';
+					case 'page':
+						// Previously hardcoded post type options.
+						if ( 'post' == $rule['minor'] ) {
+							$rule['minor'] = 'post_type-post';
+						} else if ( ! $rule['minor'] ) {
+							$rule['minor'] = 'post_type-page';
+						}
 
-					switch ( $rule['minor'] ) {
-						case '404':
-							$condition_result = is_404();
-						break;
-						case 'search':
-							$condition_result = is_search();
-						break;
-						case 'archive':
-							$condition_result = is_archive();
-						break;
-						case 'posts':
-							$condition_result = $wp_query->is_posts_page;
-						break;
-						case 'home':
-							$condition_result = is_home();
-						break;
-						case 'front':
+						switch ( $rule['minor'] ) {
+							case '404':
+								$condition_result = is_404();
+							break;
+							case 'search':
+								$condition_result = is_search();
+							break;
+							case 'archive':
+								$condition_result = is_archive();
+							break;
+							case 'posts':
+								$condition_result = $wp_query->is_posts_page;
+							break;
+							case 'home':
+								$condition_result = is_home();
+							break;
+							case 'front':
 								if ( current_theme_supports( 'infinite-scroll' ) ) {
-								$condition_result = is_front_page();
+									$condition_result = is_front_page();
 								} else {
-								$condition_result = is_front_page() && !is_paged();
-							}
-						break;
-						default:
+									$condition_result = is_front_page() && !is_paged();
+								}
+							break;
+							default:
 								if ( substr( $rule['minor'], 0, 10 ) == 'post_type-' ) {
-								$condition_result = is_singular( substr( $rule['minor'], 10 ) );
+									$condition_result = is_singular( substr( $rule['minor'], 10 ) );
 								} else {
-								// $rule['minor'] is a page ID -- check if we're either looking at that particular page itself OR looking at the posts page, with the correct conditions
+									// $rule['minor'] is a page ID -- check if we're either looking at that particular page itself OR looking at the posts page, with the correct conditions
 									$condition_result = is_page( $rule['minor'] );
-							}
+								}
+							break;
+						}
 						break;
-					}
-				break;
-				case 'tag':
+					case 'tag':
 						if ( ! $rule['minor'] && is_tag() ) {
-						$condition_result = true;
-						} else if ( is_singular() && $rule['minor'] && has_tag( $rule['minor'] ) ) {
-						$condition_result = true;
-						} else {
-						$tag = get_tag( $rule['minor'] );
-
-						if ( $tag && is_tag( $tag->slug ) )
 							$condition_result = true;
+						} else if ( is_singular() && $rule['minor'] && has_tag( $rule['minor'] ) ) {
+							$condition_result = true;
+						} else {
+							$tag = get_tag( $rule['minor'] );
+
+							if ( $tag && is_tag( $tag->slug ) )
+								$condition_result = true;
 							else
 								$condition_result = false;
-					}
-				break;
-				case 'category':
-					if ( ! $rule['minor'] && is_category() )
-						$condition_result = true;
-					else if ( is_category( $rule['minor'] ) )
-						$condition_result = true;
-					else if ( is_singular() && $rule['minor'] && in_array( 'category', get_post_taxonomies() ) &&  has_category( $rule['minor'] ) )
-						$condition_result = true;
-						else
+						}
+						break;
+					case 'category':
+						if ( ! $rule['minor'] && is_category() ) {
+							$condition_result = true;
+						} else if ( is_category( $rule['minor'] ) ) {
+							$condition_result = true;
+						} else if ( is_singular() && $rule['minor'] && in_array( 'category', get_post_taxonomies() ) &&  has_category( $rule['minor'] ) ) {
+							$condition_result = true;
+						} else {
 							$condition_result = false;
-				break;
-				case 'author':
-					if ( ! $rule['minor'] && is_author() )
-						$condition_result = true;
-					else if ( $rule['minor'] && is_author( $rule['minor'] ) )
-						$condition_result = true;
-					else if ( is_singular() && $rule['minor'] && $rule['minor'] == $post->post_author )
-						$condition_result = true;
-						else
+						}
+						break;
+					case 'author':
+						if ( ! $rule['minor'] && is_author() ) {
+							$condition_result = true;
+						} else if ( $rule['minor'] && is_author( $rule['minor'] ) ) {
+							$condition_result = true;
+						} else if ( is_singular() && $rule['minor'] && $rule['minor'] == $post->post_author ) {
+							$condition_result = true;
+						} else {
 							$condition_result = false;	
-				break;
-				case 'taxonomy':
-					$term = explode( '_tax_', $rule['minor'] ); // $term[0] = taxonomy name; $term[1] = term id
-					$terms = get_the_terms( $post->ID, $rule['minor'] ); // Does post have terms in taxonomy?
-					if ( is_tax( $term[0], $term[1] ) )
-						$condition_result = true;
-					else if ( is_singular() && $term[1] && has_term( $term[1], $term[0] ) )
-						$condition_result = true;
-					else if ( is_singular() && $terms & !is_wp_error( $terms ) )
-						$condition_result = true;
-				break;
-			}
+						}
+						break;
+					case 'taxonomy':
+						$term = explode( '_tax_', $rule['minor'] ); // $term[0] = taxonomy name; $term[1] = term id
+						$terms = get_the_terms( $post->ID, $rule['minor'] ); // Does post have terms in taxonomy?
+						if ( is_tax( $term[0], $term[1] ) ) {
+							$condition_result = true;
+						} else if ( is_singular() && $term[1] && has_term( $term[1], $term[0] ) ) {
+							$condition_result = true;
+						} else if ( is_singular() && $terms & !is_wp_error( $terms ) ) {
+							$condition_result = true;
+						}
+						break;
+				}
 
-			if ( $condition_result )
-				break;
+				if ( $condition_result ) {
+					break;
+				}
+			}
 		}
 
 		// No point filtering if the condition is already false, we don't want someone
@@ -441,8 +451,9 @@ class Jetpack_Widget_Conditions {
 			$condition_result = apply_filters( 'widget_conditions_condition_result', $condition_result, $instance );
 		}
 
-		if ( ( 'show' == $instance['conditions']['action'] && ! $condition_result ) || ( 'hide' == $instance['conditions']['action'] && $condition_result ) )
+		if ( ( 'show' == $instance['conditions']['action'] && ! $condition_result ) || ( 'hide' == $instance['conditions']['action'] && $condition_result ) ) {
 			return false;
+		}
 
 		return $instance;
 	}

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -179,6 +179,7 @@ class Jetpack_Widget_Conditions {
 				</div><!-- .condition-top -->
 
 				<div class="conditions">
+					<?php do_action( 'widget_conditions_before_admin_form', $instance, $return, $widget ); ?>
 					<?php
 
 					foreach ( $conditions['rules'] as $rule ) {
@@ -207,6 +208,8 @@ class Jetpack_Widget_Conditions {
 						</div><!-- .condition -->
 						<?php
 					}
+					
+					do_action( 'widget_conditions_after_admin_form', $instance, $return, $widget );
 
 					?>
 				</div><!-- .conditions -->
@@ -227,6 +230,7 @@ class Jetpack_Widget_Conditions {
 		$conditions['action'] = $_POST['conditions']['action'];
 		$conditions['rules'] = array();
 
+		$conditions[ 'active' ] = false;
 		foreach ( $_POST['conditions']['rules_major'] as $index => $major_rule ) {
 			if ( ! $major_rule )
 				continue;
@@ -235,9 +239,13 @@ class Jetpack_Widget_Conditions {
 				'major' => $major_rule,
 				'minor' => isset( $_POST['conditions']['rules_minor'][$index] ) ? $_POST['conditions']['rules_minor'][$index] : ''
 			);
+
+			$conditions[ 'active' ] = true;
 		}
 
-		if ( ! empty( $conditions['rules'] ) )
+		$conditions = apply_filters( 'widget_conditions_update', $conditions, $instance, $new_instance, $old_instance );
+
+		if ( $conditions[ 'active' ] )
 			$instance['conditions'] = $conditions;
 		else
 			unset( $instance['conditions'] );
@@ -424,6 +432,8 @@ class Jetpack_Widget_Conditions {
 			if ( $condition_result )
 				break;
 		}
+
+		apply_filters( 'widget_conditions_condition_result', $condition_result, $instance );
 
 		if ( ( 'show' == $instance['conditions']['action'] && ! $condition_result ) || ( 'hide' == $instance['conditions']['action'] && $condition_result ) )
 			return false;


### PR DESCRIPTION
See previous Pull Request: https://github.com/Automattic/jetpack/pull/167 (I got too far your repo with my delay, and a new branch/PR was the quickest cleanest way to catch up)

Copy paste of #167 follows:

These hooks would allow us to add in more type conditions to Widget Visibility, save them, and process them on the front end.

Here's the addition of a "type" control:

![140203-185953](https://f.cloud.github.com/assets/233434/2068106/697c9580-8d05-11e3-9158-38eedd96514c.png)

![140203-190032](https://f.cloud.github.com/assets/233434/2068115/841b7064-8d05-11e3-8a9f-911de98389b1.png)

Here's the code to add it:

``` php
/**
 * 
 * 
 * @package 
 **/
class Widget_Visibility_Types {

    /**
     * Singleton stuff.
     * 
     * @access @static
     * 
     * @return Widget_Visibility_Types object
     */
    static public function init() {
        static $instance = false;

        if ( ! $instance )
            $instance = new Widget_Visibility_Types;

        return $instance;

    }

    /**
     * Class constructor
     *
     * @return null
     */
    public function __construct() {
        add_action( 'widget_conditions_before_admin_form', array( $this, 'action_widget_conditions_before_admin_form' ), 10, 3 );
        add_filter( 'widget_conditions_condition_result', array( $this, 'filter_widget_conditions_condition_result' ), 10, 2 );
        add_filter( 'widget_conditions_update', array( $this, 'filter_widget_conditions_update' ), 10, 4 );
    }

    // HOOKS
    // =====

    /**
     * Hooks the Widget Conditions action widget_conditions_before_admin_form
     * Adds the additional type condition UI.
     *
     * @action widget_conditions_before_admin_form
     * 
     * @param array $instance
     * @param $return not used
     * @param $widget not used
     *
     * @return void
     * @author Simon Wheatley
     **/
    public function action_widget_conditions_before_admin_form( $instance, $return, $widget ) {
        $type = '';
        if ( isset( $instance['conditions']['type'] ) )
            $type = $instance['conditions']['type'];

        ?>
        <div class="condition">
            <div class="alignleft">
                <select class="conditions-rule-type" name="conditions[type]">
                    <option value="" <?php selected( "", $type ); ?>><?php echo esc_html_x( 'on any type (i.e. everywhere)', 'Used as the default option in a dropdown list', 'jetpack' ); ?></option>
                    <option value="is_front_page" <?php selected( "is_front_page", $type ); ?>><?php esc_html_e( 'on the front page only', 'jetpack' ); ?></option>
                    <option value="is_home" <?php selected( "is_home", $type ); ?>><?php esc_html_e( 'on the news page only', 'jetpack' ); ?></option>
                    <option value="is_archive" <?php selected( "is_archive", $type ); ?>><?php esc_html_e( 'on an archive page only', 'jetpack' ); ?></option>
                    <option value="is_singular" <?php selected( "is_singular", $type ); ?>><?php esc_html_e( 'on single posts (or pages, etc) only', 'jetpack' ); ?></option>
                </select>
            </div>
            <span class="condition-conjunction"><?php echo esc_html_x( 'and', 'Shown between widget visibility conditions.', 'jetpack' ); ?></span>
            <br class="clear" />
        </div><!-- .condition -->
        <?php
    }

    /**
     * Hooks the Widget Conditions filter widget_conditions_update
     * Save the type condition on the widget instance
     *
     * @filter widget_conditions_update
     * 
     * @param array $conditions The current widget conditions, to be returned
     * @param array $instance The current widget settings instance
     * @param array $new_instance The new widget settings as was
     * @param array $old_instance The old widget settings as were
     *
     * @return void
     * @author Simon Wheatley
     **/
    public function filter_widget_conditions_update( $conditions, $instance, $new_instance, $old_instance ) {

        $conditions['type'] = '';

        if ( isset( $_POST['conditions']['type'] ) ) {
            $conditions['type'] = $_POST['conditions']['type'];
            $conditions[ 'active' ] = true;
        }

        return $conditions;
    }

    /**
     * Hooks the Widget Conditions filter widget_conditions_before_admin_form
     * Checks the additional `type` condition allows widget display.
     *
     * @filter widget_conditions_condition_result
     * 
     * @param bool $condition_result Whether to show the widget
     * @param array $instance The widget settings for this instance
     *
     * @return void
     * @author Simon Wheatley
     **/
    public function filter_widget_conditions_condition_result( $condition_result, $instance ) {

        if ( $instance['conditions']['type'] ) {
            switch ( $instance['conditions']['type'] ) {
                case 'is_front_page':
                    $condition_result = is_front_page();
                break;
                case 'is_singular':
                    $condition_result = is_singular();
                break;
                case 'is_home':
                    $condition_result = is_home();
                break;
                case 'is_archive':
                    $condition_result = is_archive();
                break;
            }
        }

        return $condition_result;
    }

}


// Initiate the singleton
Widget_Visibility_Types::init();
```
