### PR TITLE
Carousel: Confirms an avatar is returned by get_avatar before displaying

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -283,7 +283,7 @@ class Jetpack_Carousel {
 		// Can't just send the results, they contain the commenter's email address.
 		foreach ( $comments as $comment ) {
 			$avatar = '';
-			if (get_avatar( $comment->comment_author_email, 64 )) {
+			if (get_option( 'show_avatars' )) {
 				$avatar = get_avatar( $comment->comment_author_email, 64 );
 			}
 			$out[] = array(


### PR DESCRIPTION
Corrects behavior when Settings->Discussion is set to not use an avatar. Previously, displayed "false" in gravatar_markup. Fixes Automattic/jetpack#438
