### PR TITLE
Centralize whitelisting for domains used by Jetpack services with wp_safe_redirect()

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -310,7 +310,6 @@ class Jetpack_SSO {
 			$this->wants_to_login()
 			&& apply_filters( 'jetpack_sso_bypass_login_forward_wpcom', false ) 
 		) {
-			add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 			wp_safe_redirect( $this->build_sso_url() );
 		}
 
@@ -338,7 +337,6 @@ class Jetpack_SSO {
 				} else {
 					$this->maybe_save_cookie_redirect();
 					// Is it wiser to just use wp_redirect than do this runaround to wp_safe_redirect?
-					add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 					wp_safe_redirect( $this->build_sso_url() );
 				}
 			}
@@ -601,15 +599,6 @@ class Jetpack_SSO {
 	static function new_user_override() {
 		$new_user_override = defined( 'WPCC_NEW_USER_OVERRIDE' ) ? WPCC_NEW_USER_OVERRIDE : false;
 		return apply_filters( 'jetpack_sso_new_user_override', $new_user_override );
-	}
-
-	function allowed_redirect_hosts( $hosts ) {
-		if ( empty( $hosts ) ) {
-			$hosts = array();
-		}
-		$hosts[] = 'wordpress.com';
-
-		return array_unique( $hosts );
 	}
 
 	function button( $args = array() ) {


### PR DESCRIPTION
Commit e8d9e676b4ee7d558eed6537dcdd63e8787bf18a introduced an additional two places
where a call to allowed_redirect_hosts is used and one additional function duplicating
the domain whitelisting efforts. This commit removes the need to repeatedly call and load
the whitelisted domains and centralizes it into one easy to manage method in the Jetpack
class thus removing the possibility for even more potential code duplication.
