### PR TITLE
Open Graph: Fixes get_post_meta lacking an argument to return a single string

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -72,7 +72,7 @@ function jetpack_og_tags() {
 		$tags['article:published_time'] = date( 'c', strtotime( $data->post_date_gmt ) );
 		$tags['article:modified_time'] = date( 'c', strtotime( $data->post_modified_gmt ) );
 		if ( post_type_supports( get_post_type( $data ), 'author' ) && isset( $data->post_author ) ) {
-			$publicize_facebook_user = get_post_meta( $data->ID, '_publicize_facebook_user' );
+			$publicize_facebook_user = get_post_meta( $data->ID, '_publicize_facebook_user', true );
 			if ( ! empty( $publicize_facebook_user ) ) {
 				$tags['article:author'] = esc_url( $publicize_facebook_user );
 			} else {


### PR DESCRIPTION
In Automattic/jetpack#364, we added using a Facebook publicize user to the article:author OG tag, if connection exists. The `get_post_meta` lacked the true argument to return a string instead of an array, which caused "http://Array" to be returned as the OG tag.
