### PR TITLE
Subscription widget subscribers total placeholder

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -212,6 +212,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			'greeting_reply'       => apply_filters( 'jetpack_comment_form_prompt_reply', __( 'Leave a Reply to %s' , 'jetpack' ) ),
 			'color_scheme'         => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
 			'lang'                 => get_bloginfo( 'language' ),
+			'rtl'                  => ( is_rtl()                             ? '1' : '0' ),
 			'jetpack_version'      => JETPACK__VERSION,
 		);
 


### PR DESCRIPTION
Replaces “%d” in the subscription widget’s text with the total number
of subscribers to the site to allow showing this number without using
the predefined text.
This change can be documented or as a hidden option. Some nice UI in the widget edit window might be nice, but this is a start.
If this makes it in, removing the current option to insert the current number of subscribers should be considered.
