### PR TITLE
Add subscription widget wildcard

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -612,7 +612,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 					<p class="error"><?php esc_html_e( 'You have already subscribed to this site, please check your inbox.', 'jetpack' ); ?></p>
 				<?php break;
 				case 'success' :
-					echo wpautop( $subscribe_text );
+					echo wpautop( str_replace( '%d', number_format_i18n( $subscribers_total['value'] ), $subscribe_text ) );
 					break;
 				default : ?>
 					<p class="error"><?php esc_html_e( 'There was an error when subscribing, please try again.', 'jetpack' ) ?></p>
@@ -624,7 +624,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		<form action="#" method="post" accept-charset="utf-8" id="subscribe-blog-<?php echo $widget_id; ?>">
 			<?php
 			if ( ! isset ( $_GET['subscribe'] ) ) {
-				?><p id="subscribe-text"><?php echo $subscribe_text ?></p><?php
+				echo wpautop( str_replace( '%d', number_format_i18n( $subscribers_total['value'] ), $subscribe_text ) );
 			}
 
 			if ( $show_subscribers_total && 0 < $subscribers_total['value'] ) {


### PR DESCRIPTION
Replaces “%d” in the subscriptions widget text with the total number of subscribers to the site. This allows users to show this info however they want and not only  using the pre-written message that is currently available.
This can be supported by some nice UI in the widget editor or left as a hidden feature.
If this gets in, removing the current option to display the number of subscribers should be considered.