### PR TITLE
Comments RTL support

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -212,6 +212,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			'greeting_reply'       => apply_filters( 'jetpack_comment_form_prompt_reply', __( 'Leave a Reply to %s' , 'jetpack' ) ),
 			'color_scheme'         => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
 			'lang'                 => get_bloginfo( 'language' ),
+			'rtl'                  => ( is_rtl()                             ? '1' : '0' ),
 			'jetpack_version'      => JETPACK__VERSION,
 		);
 


### PR DESCRIPTION
Add an RTL (right-to-left text) parameter to the comments request allowing the application of RTL styles to the comments.
This is just a small part of the required change. In order to achieve full RTL support, an RTL stylesheet must be added server-side when the RTL parameter is present.
I've uploaded the required CSS as a gist [here](https://gist.github.com/yelly/11090252).
