### PR TITLE
Likes: display below excerpts as well

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -835,7 +835,6 @@ class Jetpack_Likes {
 	 */
 	function is_likes_visible() {
 
-		global $wp_current_filter; // Used to check 'get_the_excerpt' filter
 		global $post;              // Used to apply 'sharing_show' filter
 
 		// Never show on feeds or previews


### PR DESCRIPTION
Before this commit, Likes were only displayed below `the_content`
Sharing buttons, on the other hand, are displayed everywhere:
https://github.com/Automattic/jetpack/blob/2.9.3/modules/sharedaddy/sharing-service.php#L607

Both modules should have the same behaviour in my opinion.
