### PR TITLE
Use correct object reference to find click_handle

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -75,7 +75,7 @@ Scroller = function( settings ) {
 
 		this.body.delegate( '#infinite-handle', 'click.infinity', function() {
 			// Handle the handle
-			if ( this.click_handle ) {
+			if ( self.click_handle ) {
 				$( '#infinite-handle' ).remove();
 			}
 


### PR DESCRIPTION
Within the context of `this.body.delegate`, `this.click_handle` doesn't exist, so the `#infinite-handle` element doesn't get removed.
