### PR TITLE
Resolve cross-domain error causing infinite-scroll to fail on HTTPS

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -10,6 +10,11 @@ if ( isIE ) {
 	var IEVersion = parseInt( IEVersion[1] );
 }
 
+// HTTP ajaxurl when site is HTTPS causes Access-Control-Allow-Origin failure in Desktop and iOS Safari
+if ( "https:" == document.location.protocol ) {
+	infiniteScroll.settings.ajaxurl = infiniteScroll.settings.ajaxurl.replace( "http://", "https://" );
+}
+
 /**
  * Loads new posts when users scroll near the bottom of the page.
  */


### PR DESCRIPTION
Safari on Desktop and iOS consider HTTPS to HTTP requests as cross-domain.
So, for example, if a site is accessed via HTTPS on iOS Safari, infinite scroll will fail.

This bug effects many more users on wordpress.com, where all logged-in users
are switched to HTTPS.

The issue is resolved by checking the current protocol in infinity.js,
then switching http:// out for https:// in ajaxurl if needed.

This method is preferred over changing ajaxurl on the PHP side, because
server-side caching may cause protocol detection to be unreliable.

Video of bug in action: https://www.youtube.com/watch?v=253litAe1sg
