### PR TITLE
Tiled Gallery: No more carousel when it is off.

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -232,7 +232,7 @@ class Jetpack_Tiled_Gallery {
 			$likes_blog_id = Jetpack_Options::get_option( 'id' );
 		}
 
-		if ( in_array( 'carousel', Jetpack::get_active_modules() ) ) {
+		if ( in_array( 'carousel', Jetpack::get_active_modules() ) || 'carousel' == $this->atts['link'] ) {
 			$extra_data = array( 'data-carousel-extra' => array( 'blog_id' => $blog_id, 'permalink' => get_permalink( isset( $post->ID ) ? $post->ID : 0 ), 'likes_blog_id' => $likes_blog_id ) );
 		} else {
 			$extra_data = array();


### PR DESCRIPTION
Carousel is no longer shown for Tiled Galleries when clicking a gallery item, when it is turned off in the Jetpack settings. Addressess https://github.com/Automattic/jetpack/issues/516.

To accomplish this, we simply need to make the gallery container have the data-carousel-extra attribute only if carousel is found in the Jetpack active modules, since [this](https://github.com/Automattic/jetpack/blob/master/modules/carousel/jetpack-carousel.js#L430) is how carousel identifies proper carousel containers, used [here](https://github.com/Automattic/jetpack/blob/master/modules/carousel/jetpack-carousel.js#L1366).
