### PR TITLE
Tiled Gallery: Remove 5 px width adjustment.

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -470,7 +470,7 @@ class Jetpack_Tiled_Gallery_Grouper {
 		$this->last_shape = '';
 		$this->images = $this->get_images_with_sizes( $attachments );
 		$this->grouped_images = $this->get_grouped_images();
-		$this->apply_content_width( $content_width - 5 ); //reduce the margin hack to 5px. It will be further reduced when we fix more themes and the rounding error.
+		$this->apply_content_width( $content_width );
 	}
 
 	public function get_current_row_size() {


### PR DESCRIPTION
The grouper used in computing the layout for rectangular galleries initially had a 5 pixel adjustment in it's content width: `$content_width - 5`, which was documented to be there for broken themes and rounding errors. After some discussion in #443, @ethitter concluded that it should be safe to remove the adjustment.
