### PR TITLE
Tiled Galleries: Don't require Photon in dev mode.

### DIFF
--- a/modules/tiled-gallery.php
+++ b/modules/tiled-gallery.php
@@ -4,7 +4,7 @@
  * Module Name: Tiled Galleries
  * Module Description: Display your image galleries in a variety of sleek, graphic arrangements.
  * First Introduced: 2.1
- * Requires Connection: Yes
+ * Requires Connection: No
  * Auto Activate: No
  * Module Tags: Photos and Videos
  */

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -108,7 +108,7 @@ class Jetpack_Tiled_Gallery {
 			if ( $gallery_html && class_exists( 'Jetpack' ) && class_exists( 'Jetpack_Photon' ) ) {
 				// Tiled Galleries in Jetpack require that Photon be active.
 				// If it's not active, run it just on the gallery output.
-				if ( ! in_array( 'photon', Jetpack::get_active_modules() ) )
+				if ( ! in_array( 'photon', Jetpack::get_active_modules() ) && ! Jetpack::is_development_mode() )
 					$gallery_html = Jetpack_Photon::filter_the_content( $gallery_html );
 			}
 


### PR DESCRIPTION
We might want to let Tiled Galleries work without Photon in development mode as discussed in https://github.com/Automattic/jetpack/issues/427.

This should do it, since the production environment will always require a connection, right?
