### PR TITLE
Tiled Gallery: Pass Carousel URLs through Photon.

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -243,7 +243,9 @@ class Jetpack_Tiled_Gallery {
 
 	function generate_carousel_image_args( $image ) {
 		$attachment_id = $image->ID;
-		$orig_file       = wp_get_attachment_url( $attachment_id );
+		$orig_file       = wp_get_attachment_image_src( $attachment_id, 'full' );
+		$orig_file       = isset( $orig_file[0] ) ? $orig_file[0] : wp_get_attachment_url( $attachment_id );
+
 		$meta            = wp_get_attachment_metadata( $attachment_id );
 		$size            = isset( $meta['width'] ) ? intval( $meta['width'] ) . ',' . intval( $meta['height'] ) : '';
 		$img_meta        = ( ! empty( $meta['image_meta'] ) ) ? (array) $meta['image_meta'] : array();
@@ -270,7 +272,7 @@ class Jetpack_Tiled_Gallery {
 		$output = sprintf(
 				'data-attachment-id="%1$d" data-orig-file="%2$s" data-orig-size="%3$s" data-comments-opened="%4$s" data-image-meta="%5$s" data-image-title="%6$s" data-image-description="%7$s" data-medium-file="%8$s" data-large-file="%9$s"',
 				esc_attr( $attachment_id ),
-				esc_url( wp_get_attachment_url( $attachment_id ) ),
+				esc_url( $orig_file ),
 				esc_attr( $size ),
 				esc_attr( $comments_opened ),
 				esc_attr( $img_meta ),


### PR DESCRIPTION
Use `wp_get_attachment_image_src` instead of `wp_get_attachment_url` for `data-orig-file` in Tiled Galleries to trigger `filter_image_downsize` in Photon. This way the full image link in Carousel will point to an image served by Photon.

Addresses https://github.com/Automattic/jetpack/issues/522.
