### PR TITLE
Tiled Gallery: Fix carousel when grayscale set.

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -162,7 +162,7 @@ class Jetpack_Tiled_Gallery {
 						if ( $add_link ) {
 							$output .= '<a href="'. esc_url( $link ) . '">';
 						}
-						$output .= '<img ' . $orig_dimensions . $this->generate_carousel_image_args( $image ) . ' class="grayscale" src="' . esc_url( $img_src_grayscale ) . '" width="' . esc_attr( $image->width ) . '" height="' . esc_attr( $image->height ) . '" style="width:' . esc_attr( $image->width ) . 'px; " height:' . esc_attr( $image->height ) . 'px;" align="left" title="' . esc_attr( $image_title ) . '" alt="' . esc_attr( $image_alt ) . '" />';
+						$output .= '<img ' . $orig_dimensions . ' class="grayscale" src="' . esc_url( $img_src_grayscale ) . '" width="' . esc_attr( $image->width ) . '" height="' . esc_attr( $image->height ) . '" style="width:' . esc_attr( $image->width ) . 'px; " height:' . esc_attr( $image->height ) . 'px;" align="left" title="' . esc_attr( $image_title ) . '" alt="' . esc_attr( $image_alt ) . '" />';
 						if ( $add_link ) {
 							$output .= '</a>';
 						}
@@ -226,7 +226,7 @@ class Jetpack_Tiled_Gallery {
 				if ( $add_link ) {
 					$output .= '<a border="0" href="' . esc_url( $link ) . '">';
 				}
-				$output .= '<img ' . $orig_dimensions . $this->generate_carousel_image_args( $image ) . ' class="grayscale" src="' . esc_url( 'http://en.wordpress.com/imgpress?url=' . urlencode( $image->guid ) . '&resize=' . $img_size . ',' . $img_size . '&filter=grayscale' ) . '" width="' . esc_attr( $img_size ) . '" height="' . esc_attr( $img_size ) . '" style=width:' . esc_attr( $img_size ) . 'px; height:' . esc_attr( $img_size ) . 'px; margin: 2px;" title="' . esc_attr( $image_title ) . '" />';
+				$output .= '<img ' . $orig_dimensions . ' class="grayscale" src="' . esc_url( 'http://en.wordpress.com/imgpress?url=' . urlencode( $image->guid ) . '&resize=' . $img_size . ',' . $img_size . '&filter=grayscale' ) . '" width="' . esc_attr( $img_size ) . '" height="' . esc_attr( $img_size ) . '" style=width:' . esc_attr( $img_size ) . 'px; height:' . esc_attr( $img_size ) . 'px; margin: 2px;" title="' . esc_attr( $image_title ) . '" />';
 				if ( $add_link ) {
 					$output .= '</a>';
 				}


### PR DESCRIPTION
Images were added twice to Carousel when grayscale was set to true, because carousel image arguments were set both to the actual image, and the grayscale overlay. I believe this is not wanted behaviour. If we don't set the attributes in grayscale images, the images are found in Carousel only once.

The problem described can be seen in action [here](https://cloudup.com/cl_Wti9KPBC). The gallery that is clicked is shown on the right, and the Carousel view is shown on the left. If you pay close attention to the partial image shown in the left edge of the screen in the screen capture, you notice that it is the same image that is currently being viewed.
