### PR TITLE
Pass Infinite Scroll response data in the 'post-load' event.

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -111,7 +111,7 @@ Scroller.prototype.render = function( response ) {
 	// Check if we can wrap the html
 	this.element.append( response.html );
 
-	this.body.trigger( 'post-load' );
+	this.body.trigger( 'post-load', response );
 	this.ready = true;
 };
 


### PR DESCRIPTION
Passing the response data object to the `post-load` event is helpful for a little more advanced integration.

For instance, the `.infinity-end` class is never added to the body when using the "click" IS type. With access to the response object, a theme author can check `response.lastbatch` and adjust things accordingly.
