### PR TITLE
Adds notice to Jetpack page describing trigger for JP Development Mode.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -657,9 +657,9 @@ class Jetpack {
 			if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
 				$notice = __( 'In Development Mode, via the JETPACK_DEV_DEBUG constant being defined in wp-config.php or elsewhere.', 'jetpack' );
 			} elseif ( site_url() && false === strpos( site_url(), '.' ) ) {
-				$notice = __( 'In Development Mode, via site URL lacking a dot (e.g. http://localhost)', 'jetpack' );
+				$notice = __( 'In Development Mode, via site URL lacking a dot (e.g. http://localhost).', 'jetpack' );
 			} else {
-				$notice = __( 'In Development Mode, via an add_filter call in a plugin.', 'jetpack' );
+				$notice = __( 'In Development Mode, via the jetpack_development_mode filter.', 'jetpack' );
 			}
 
 			$output = '<div class="error"><p>' . $notice . '</p></div>';


### PR DESCRIPTION
When Development Mode is enabled, it can be confusing to users who are not expecting/aware of this feature of Jetpack. This PR adds a notice to the Jetpack page informing that Development Mode is enabled as well as what trigger (JETPACK_DEV_DEBUG, a filter, site URL) enabled it.
