### PR TITLE
Add jetpack_notices to the Settings page

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -419,6 +419,7 @@ class Jetpack_Admin {
 		$this->admin_page_top();
 		?>
 		<div class="clouds-sm"></div>
+		<?php do_action( 'jetpack_notices' ) ?>
 		<div class="page-content configure">
 			<div class="frame top hide-if-no-js">
 				<div class="wrap">


### PR DESCRIPTION
Currently, `do_action( 'jetpack_notices' );` only fires on the main Jetpack page. This adds it to the Settings page as well.

Long term, would it make sense to remove both instances from /class.jetpack-admin.php and move it to _inc/header.php? That would impact the styling more than I'd prefer to push up in a PR without more consultation.
