### PR TITLE
Prevents error from array_shift in mobile theme

### DIFF
--- a/modules/minileven/theme/pub/minileven/header.php
+++ b/modules/minileven/theme/pub/minileven/header.php
@@ -29,6 +29,7 @@
 				<div class="skip-link"><a class="assistive-text" href="#content"><?php _e( 'Skip to primary content', 'minileven' , 'jetpack'); ?></a></div>
 				<?php /* Our navigation menu.  If one isn't filled out, wp_nav_menu falls back to wp_page_menu. The menu assiged to the primary position is the one used. If none is assigned, the menu with the lowest ID is used. */
 					if ( false !== $location ) :
+						$location = array_values( $location );
 						$menu_id = array_shift( array_values( $location ) ); // acccess the ID of the menu assigned to that location. Using only the first menu ID returned in the array.
 						wp_nav_menu( array( 'theme_location' => 'primary', 'container_class' => '', 'menu_class' => 'nav-menu', 'menu' => $menu_id ) );
 					else: // if the $location variable is false, wp_page_menu() is shown instead.


### PR DESCRIPTION
On PHP 5.4.24, the follow error is displayed when using the mobile theme:
`Strict Standards: Only variables should be passed by reference in /wp-content/plugins/jetpack/modules/minileven/theme/pub/minileven/header.php on line 33`

Reported in http://wordpress.org/support/topic/headerphp-call-by-reference-php-error-in-mobile-minileven-jetpack-theme
