### PR TITLE
Tiled Gallery: Remove extra quote in HTML.

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -215,7 +215,7 @@ class Jetpack_Tiled_Gallery {
 			if ( $add_link ) {
 				$output .= '<a border="0" href="' . esc_url( $link ) . '">';
 			}
-			$output .= '<img ' . $orig_dimensions . $this->generate_carousel_image_args( $image ) . '" src="' . esc_url( $img_src ) . '" width="' . esc_attr( $img_size ) . '" height="' . esc_attr( $img_size ) . '" style="width:' . esc_attr( $img_size ) . 'px; height:' . esc_attr( $img_size ) . 'px; margin: ' . esc_attr( $margin ) . 'px;" title="' . esc_attr( $image_title ) . '" />';
+			$output .= '<img ' . $orig_dimensions . $this->generate_carousel_image_args( $image ) . ' src="' . esc_url( $img_src ) . '" width="' . esc_attr( $img_size ) . '" height="' . esc_attr( $img_size ) . '" style="width:' . esc_attr( $img_size ) . 'px; height:' . esc_attr( $img_size ) . 'px; margin: ' . esc_attr( $margin ) . 'px;" title="' . esc_attr( $image_title ) . '" />';
 			if ( $add_link ) {
 				$output .= '</a>';
 			}


### PR DESCRIPTION
HTML for square and circle galleries currently has an extra quote, which shows in the [generated markup](https://cloudup.com/cTYznzfJ868). Even though browsers can handle it, we'd be better of without.
