### PR TITLE
Custom CSS: Solves the issue #402, prevents the stripping of

### DIFF
--- a/modules/custom-css/csstidy/data-wp.inc.php
+++ b/modules/custom-css/csstidy/data-wp.inc.php
@@ -81,4 +81,5 @@ $GLOBALS['csstidy']['all_properties']['object-position'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['text-overflow'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['zoom'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['pointer-events'] = 'CSS3.0';
+$GLOBALS['csstidy']['all_properties']['-moz-osx-font-smoothing'] = 'CSS3.0';
 


### PR DESCRIPTION
Added support for -moz-osx-font-smoothing css property. Don't know if this also needs to be merged upstream.
