### PR TITLE
Prepend "s." to stats JS link in $stats_footer

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -152,7 +152,7 @@ function stats_template_redirect() {
 
 	$stats_footer = <<<END
 
-	<script src="$http://stats.wordpress.com/e-$week.js" type="text/javascript"></script>
+	<script src="$http://s.stats.wordpress.com/e-$week.js" type="text/javascript"></script>
 	<script type="text/javascript">
 	st_go({{$data}});
 	var load_cmc = function(){linktracker_init($blog,$post,2);};


### PR DESCRIPTION
Stats JS link in $stats_footer needs "s." prepended to resolve.
https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L155

Compare
http://s.stats.wordpress.com/e-201420.js
to
http://stats.wordpress.com/e-201420.js (current output)

From the looks of
http://en.wordpress.com/stats/
could also do http://s.stats.wordpress.com/w.js?21 format, but without knowing the inner workings or file naming conventions at work, included fix seems simplest option.

Cursory search through issues turned up https://github.com/Automattic/jetpack/issues/401 about Photon which seems unrelated, paging @skeltoac who seemed to know the most about wpcom and stats JS.
