### PR TITLE
Added row and group containers to square and circle Tiled Galleries

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -214,9 +214,11 @@ class Jetpack_Tiled_Gallery {
 
 			$img_src = add_query_arg( array( 'w' => $img_size, 'h' => $img_size, 'crop' => 1 ), $orig_file );
 
-			$output .= '<div class="tiled-gallery-item">';
-
 			$add_link = 'none' !== $this->atts['link'];
+			$orig_dimensions = ' data-original-width="' . esc_attr( $img_size + 2 * $margin ) . '" data-original-height="' . esc_attr( $img_size + 2 * $margin ) . '" ';
+
+			$output .= '<div class="gallery-group"' . $orig_dimensions . '><div class="tiled-gallery-item">';
+
 			$orig_dimensions = ' data-original-width="' . esc_attr( $img_size ) . '" data-original-height="' . esc_attr( $img_size ) . '" ';
 
 			if ( $add_link ) {
@@ -242,7 +244,7 @@ class Jetpack_Tiled_Gallery {
 			// Captions
 			if ( trim( $image->post_excerpt ) )
 				$output .= '<div class="tiled-gallery-caption">' . wptexturize( $image->post_excerpt ) . '</div>';
-			$output .= '</div>';
+			$output .= '</div></div>';
 
 			$c ++;
 			$items_in_row ++;


### PR DESCRIPTION
This addition will make square and circle galleries deal more gracefully (like rectangular galleries do) in situations where there is an unexpected overflow of a pixel or two. Before images would sometimes overflow to next rows, and the layout would be totally murdered in some browser zoom levels while resizing. By adding row and group containers images don't overflow to next rows, removing a noticeable and irritating overflow effect.  

Adding row and group containers to square and circle galleries too gives a new opportunity to share even more code between the rectangular and the other gallery layouts. I suggest that if this PR is merged, I would update https://github.com/Automattic/jetpack/pull/526 to accomplish this.

Addresses issues https://github.com/Automattic/jetpack/issues/556 and https://github.com/Automattic/jetpack/issues/551.
