### PR TITLE
Post By Email: declare static function

### DIFF
--- a/modules/post-by-email.php
+++ b/modules/post-by-email.php
@@ -42,7 +42,7 @@ class Jetpack_Post_By_Email {
 		add_action( 'init', array( &$this, 'action_init' ) );
 	}
 
-	function module_toggle() {
+	static function module_toggle() {
 		$jetpack = Jetpack::init();
 		$jetpack->sync->register( 'noop' );
 	}


### PR DESCRIPTION
Fixes PHP warnings of non-static method called dynamically

`PHP Strict Standards: call_user_func_array() expects
parameter 1 to be a valid callback, non-static method
Jetpack_Post_By_Email::module_toggle() should not be called statically in
/wp-includes/plugin.php on line 470".`
