### PR TITLE
TravisCI: Only 'shallow clone' the WordPress develop repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 # Clones WordPress and configures our testing environment.
 before_script:
     - export PLUGIN_SLUG=$(basename $(pwd))
-    - git clone --depth=50 git://develop.git.wordpress.org/ /tmp/wordpress
+    - git clone --depth=1 git://develop.git.wordpress.org/ /tmp/wordpress
 # - git clone . "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
     - cd ..
     - mv $PLUGIN_SLUG "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"


### PR DESCRIPTION
There is no need to checkout the entire history of the WordPress develop Git repo.

Using `--depth=50` reduces the checkout time by ~75%

http://git-scm.com/docs/git-clone

> --depth <depth> Create a shallow clone with a history truncated to the specified number of revisions.

Time, size, objects stats: WordPress Git develop repo 'shallow clone' vs 'full clone'
https://gist.github.com/ntwb/36ad2a31cb87e7411c28

This resulted in 'my' build on Travis CI taking 22 seconds vs the previous Jetpack build taking 1min33secs
https://travis-ci.org/ntwb/jetpack/builds
https://travis-ci.org/Automattic/jetpack/builds
