### PR TITLE
Related Posts: Move bulk resync button to debugger page.

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -152,6 +152,9 @@ class Jetpack_Debugger {
 				<p class="jetpack-show-contact-form"><?php _e( 'If none of these help you find a solution, <a href="#">click here to contact Jetpack support</a>. Tell us as much as you can about the issue and what steps you\'ve tried to resolve it, and one of our Happiness Engineers will be in touch to help.', 'jetpack' ); ?>
 				</p>
 				<?php endif; ?>
+				<hr />
+				<p><?php echo esc_html__( 'Some features of Jetpack uses the WordPress.com infrastructure and requires that your public content be mirrored there. If you see intermittent issues only affecting certain posts, please try requesting a reindex of your posts.', 'jetpack' ); ?></p>
+				<?php echo Jetpack::init()->sync->reindex_ui() ?>
 			</div>
 			<div id="contact-message" style="display:none">
 			<?php if ( self::is_jetpack_support_open() ): ?>

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -906,7 +906,6 @@ function jetpack_related_posts_more_info() {
 		<p>&rarr; <a href="http://jetpack.me/support/related-posts/">%s</a></p>
 		<hr />
 		<p>%s</p>
-		%s
 EOT;
 	printf(
 		$template,
@@ -915,8 +914,7 @@ EOT;
 		esc_html__( 'Related Posts', 'jetpack' ),
 		esc_html__( '"Related Posts" shows additional relevant links from your site under your posts. If the feature is enabled, links appear underneath your Sharing Buttons and WordPress.com Likes (if you’ve turned these on).', 'jetpack' ),
 		esc_html__( 'More information on using Related Posts.', 'jetpack' ),
-		esc_html__( 'This feature uses the WordPress.com infrastructure and requires that your public content be mirrored there. If you see intermittent issues only affecting certain posts, request a reindex of your posts.', 'jetpack' ),
-		Jetpack::init()->sync->reindex_ui()
+		__( 'This feature uses the WordPress.com infrastructure and requires that your public content be mirrored there. If you see intermittent issues only affecting certain posts, please try request a reindex of your posts via the <a href="' . Jetpack::admin_url( array( 'page' => 'jetpack-debugger' ) ) . '">debugger page</a>.', 'jetpack' )
 	);
 }
 add_action( 'jetpack_module_more_info_related-posts', 'jetpack_related_posts_more_info' );


### PR DESCRIPTION
Related Posts is just one module that relies on synced data so move bulk
resync request UI to JP debugger page instead.

This works around the issue in #478 as well.
