### PR TITLE
Issue 585: Add whitespace to admin body class

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -173,7 +173,7 @@ class Jetpack_Network {
 	 * @since 2.9
 	 */
 	public function body_class( $classes ) {
-		return 'network-admin';
+		return ' network-admin ';
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1766,11 +1766,13 @@ p {
 			$classes[] = 'pre-mp6';
 		}
 
-		return implode( ' ', array_unique( $classes ) );
+		$admin_body_class = implode( ' ', array_unique( $classes ) );
+
+		return ' ' . $admin_body_class . ' ';
 	}
 
 	static function add_jetpack_pagestyles( $admin_body_class = '' ) {
-		return $admin_body_class . ' jetpack-pagestyles';
+		return $admin_body_class . ' jetpack-pagestyles ';
 	}
 
 	function prepare_connect_notice() {


### PR DESCRIPTION
This resolves potential (and existing) conflicts with plugins that use the `admin_body_class` filter, but don't add whitespace to the class that they add.

Resolves #585 .
