### PR TITLE
Contact Form: Fix a data destruction bug for dropdowns and radio buttons...

### DIFF
--- a/modules/contact-form/js/grunion.js
+++ b/modules/contact-form/js/grunion.js
@@ -114,7 +114,7 @@ FB.ContactForm = function() {
 	}
 	function addOption () {
 		try {
-			optionsCount++;
+			optionsCount = jQuery( '#fb-new-options .fb-new-fields' ).length;
 			var thisId = jQuery('#fb-field-id').val();
 			var thisType = jQuery('#fb-new-type').val();
 			if (thisType === "radio") {


### PR DESCRIPTION
....

Simply incrementing optionsCount here when it is unitialized sets it to 1 and causes new items to be added to the list of options or radio buttons in the second slot (the 1st element in the array), overwriting any option that previously existed in that slot.

In this commit I count the number of elements currently in the list and use that to initialize optionsCount so that the new item is added to the end of the list.

There's no need to increment once initialized because the fact that we're using the length of the zero-indexed array auto-increments the count for us.

I've tested this a bit for both radio buttons and select boxes, and it seems to work well.
