### PR TITLE
Use protocol-relative URL for Google Web Fonts

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -242,7 +242,7 @@ class Jetpack_Admin {
 	function admin_styles() {
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-		wp_enqueue_style( 'jetpack-google-fonts', 'http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700,600,800' );
+		wp_enqueue_style( 'jetpack-google-fonts', '//fonts.googleapis.com/css?family=Open+Sans:400italic,400,700,600,800' );
 		wp_enqueue_style( 'jetpack-admin', plugins_url( "_inc/jetpack-admin{$min}.css", __FILE__ ), array( 'genericons' ), JETPACK__VERSION . '-20121016' );
 	}
 


### PR DESCRIPTION
This is causing a mixed content warning.
