### PR TITLE
Respect `t` parameter in YouTube URLs.

### DIFF
--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -195,7 +195,14 @@ function youtube_id( $url ) {
 	if ( ! isset( $url['query'] ) )
 		return false;
 
-	parse_str( $url['query'], $qargs );
+	if ( isset( $url['fragment'] ) ) {
+		wp_parse_str( $url['fragment'], $fargs );
+	} else {
+		$fargs = array();
+	}
+	wp_parse_str( $url['query'], $qargs );
+
+	$qargs = array_merge( $fargs, $qargs );
 
 	// calculate the width and height, taking content_width into consideration
 	global $content_width;


### PR DESCRIPTION
We currently parse the `start` and `end` parameters in YouTube URLs when creating the embed.

The `t` parameter is more popular, however.  It's the URL generated by inline time links in YouTube comments and by tools like http://www.youtubetime.com/.

https://www.youtube.com/watch?v=mdQK_odgedk&t=6m50s
