### PR TITLE
Trigger change event when clearing module search

### DIFF
--- a/_inc/jetpack-modules.js
+++ b/_inc/jetpack-modules.js
@@ -110,7 +110,7 @@
 		modules.trigger( 'change' );
 	} );
 
-	$the_search.on( 'keyup', function() {
+	$the_search.on( 'keyup search', function() {
 		modules.trigger( 'change' );
 	} );
 


### PR DESCRIPTION
This ensures that the modules get re-filtered when the user clicks the little (x) in the module search box to clear their search.

fixes #613
