### PR TITLE
Mobile Theme: Fix spacing for comment reply heading

### DIFF
--- a/modules/minileven/theme/pub/minileven/style.css
+++ b/modules/minileven/theme/pub/minileven/style.css
@@ -1411,7 +1411,6 @@ a.comment-reply-link > span {
 }
 #reply-title {
 	font-size: 1.5em;
-	line-height: 0.733;
 }
 .comment #reply-title {
 	margin-top: 1em;


### PR DESCRIPTION
The "Leave A Reply" heading needs spacing before the comment-form. Removing the specified `line-height` handles this nicely.

Before and after:
https://cloudup.com/cVpzDdy8oNT
