### PR TITLE
Mobile Theme: Close head element

### DIFF
--- a/modules/minileven/theme/pub/minileven/header.php
+++ b/modules/minileven/theme/pub/minileven/header.php
@@ -15,6 +15,7 @@
 <link rel="profile" href="http://gmpg.org/xfn/11" />
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
 <?php wp_head(); ?>
+</head>
 
 <body <?php body_class(); ?>>
 <div id="wrapper">


### PR DESCRIPTION
The `head` element is never closed. While this is acceptable per the HTML5 spec, it's cleaner to include it for those using source code viewers/parsers not smart enough to handle the omission.
