### PR TITLE
Tiled Gallery: Fix image meta encoding.

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -309,7 +309,7 @@ class Jetpack_Tiled_Gallery {
 				esc_url( wp_get_attachment_url( $attachment_id ) ),
 				esc_attr( $size ),
 				esc_attr( $comments_opened ),
-				esc_attr( json_encode( array_map( 'esc_attr', $img_meta ) ) ),
+				esc_attr( json_encode( array_map( 'strval', $img_meta ) ) ),
 				esc_attr( $attachment_title ),
 				esc_attr( $attachment_desc ),
 				esc_url( $medium_file ),


### PR DESCRIPTION
Image meta is now encoded by calling `esc_attr` on the result of mapping strval over the image meta attributes, instead of mapping `esc_attr`. This way `json_encode` can properly escape any quotes inside the attribute, before being attr encoded.

This is also how Carousel handles image meta.
