### PR TITLE
Refactor out code duplication on module activation/deactivation

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1459,7 +1459,7 @@ class Jetpack {
 	}
 
 	function activate_module_actions( $module ) {
-		do_action( "jetpack_activate_module_$module" );
+		do_action( "jetpack_activate_module_$module", $module );
 
 		$this->sync->sync_all_module_options( $module );
 	}
@@ -1470,7 +1470,7 @@ class Jetpack {
 		$active = Jetpack::get_active_modules();
 		$new    = array_filter( array_diff( $active, (array) $module ) );
 
-		do_action( "jetpack_deactivate_module_$module" );
+		do_action( "jetpack_deactivate_module_$module", $module );
 		return Jetpack_Options::update_option( 'active_modules', array_unique( $new ) );
 	}
 
@@ -4419,11 +4419,11 @@ p {
 	 *
 	 * @param string $module_slug
 	 */
-	public function toggle_module_on_wpcom() {
+	public function toggle_module_on_wpcom( $module_slug ) {
 		Jetpack::init()->sync->register( 'noop' );
 
 		if ( false !== strpos( current_filter(), 'jetpack_activate_module_' ) ) {
-			self::check_privacy( str_replace( 'jetpack_activate_module_', '', current_filter() ) );
+			self::check_privacy( $module_slug );
 		}
 	}
 }

--- a/modules/json-api.php
+++ b/modules/json-api.php
@@ -9,5 +9,5 @@
  * Module Tags: Writing, Developers
  */
 
-add_action( 'jetpack_activate_module_json-api',   array( 'Jetpack', 'toggle_module_on_wpcom' ) );
-add_action( 'jetpack_deactivate_module_json-api', array( 'Jetpack', 'toggle_module_on_wpcom' ) );
+add_action( 'jetpack_activate_module_json-api',   array( Jetpack::init(), 'toggle_module_on_wpcom' ) );
+add_action( 'jetpack_deactivate_module_json-api', array( Jetpack::init(), 'toggle_module_on_wpcom' ) );

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -8,8 +8,8 @@
  * Auto Activate: No
  */
 
-add_action( 'jetpack_activate_module_monitor', array( 'Jetpack', 'toggle_module_on_wpcom' ) );
-add_action( 'jetpack_deactivate_module_monitor', array( 'Jetpack', 'toggle_module_on_wpcom' )  );
+add_action( 'jetpack_activate_module_monitor', array( Jetpack::init(), 'toggle_module_on_wpcom' ) );
+add_action( 'jetpack_deactivate_module_monitor', array( Jetpack::init(), 'toggle_module_on_wpcom' )  );
 
 class Jetpack_Monitor {
 


### PR DESCRIPTION
When enabling/disabling a module there is duplicate code that pings WordPress.com with
the update. Abstracting this out into a method in Jetpack::toggle_module_on_wpcom().
This allows the dev on a module to simply do something such as:
add_action( 'jetpack_activate_module_monitor', array( 'Jetpack', 'toggle_module_on_wpcom' ) );
add_action( 'jetpack_deactivate_module_monitor', array( 'Jetpack', 'toggle_module_on_wpcom' )  );

This update seems to work fine. Can I get some other eyes on it before merging?
