### PR TITLE
prevent error in post_login_form_to_signed_url

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4091,7 +4091,7 @@ p {
 		$url = strtok( $url, '?' );
 		$url = "$url?{$_SERVER['QUERY_STRING']}";
 		if ( ! empty( $parsed_url['query'] ) )
-			$url = "&{$parsed_url['query']}";
+			$url .= "&{$parsed_url['query']}";
 		
 		return $url;
 	}


### PR DESCRIPTION
In some instances, when the `$parsed_url` doesn't have a `query`, the `post_login_form_to_signed_url()` function would emit a php notice and thus return an invalid result, which would then fail the signature checking process and thus the authentication flow would fail.

This prevents the "Someone may be trying to trick you..." notice to appear in the wrong context.

Discovered this bug while helping one of our API users debug an issue (see https://github.com/snarfed/bridgy/issues/161#issuecomment-45287830)
