### PR TITLE
Omnisearch: change heading color back to black

### DIFF
--- a/modules/omnisearch/omnisearch-jetpack.css
+++ b/modules/omnisearch/omnisearch-jetpack.css
@@ -19,17 +19,6 @@ ul#adminmenu > li.current > a.current:after {
 	display: none;
 }
 
-h2.page-title {
-	color: #fff;
-	text-shadow: 0 1px 1px rgba(0,0,0,0.5);
-}
-
-#results-title,
-.jump-to {
-	color: #fff;
-	text-shadow: 0 1px 1px rgba(0,0,0,0.5);
-}
-
 .omnisearch-results > li:first-child > h2 {
 	text-shadow: none;
 }


### PR DESCRIPTION
We do not need white headings now that we do not add bg clouds anymore.
