### PR TITLE
Featured Content: Remove old settings validation.

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -395,7 +395,6 @@ class Featured_Content {
 	 */
 	public static function register_setting() {
 		add_settings_field( 'featured-content', __( 'Featured Content', 'jetpack' ), array( __class__, 'render_form' ), 'reading' );
-		register_setting( 'reading', 'featured-content', array( __class__, 'validate_settings' ) );
 	}
 
 	/**


### PR DESCRIPTION
When we moved settings to the Customizer in 57fbe204410b9fd5279184b0eacefaf3e7e84a9c, we should have also removed the sanitization callback from the readings settings screen.

Currently it will cause Featured Content to reset since we don't send any values to it, when updating the Reading settings.

There is also an Automattic-internal Trac ticket for this issue: #6653-wpcom.
