### PR TITLE
Related Posts: Add caching to results

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1,6 +1,6 @@
 <?php
 class Jetpack_RelatedPosts {
-	const VERSION = '20140307';
+	const VERSION = '20140611';
 	const SHORTCODE = 'jetpack-related-posts';
 
 	/**
@@ -810,16 +810,32 @@ EOT;
 	 * @param int $post_id
 	 * @param int $size
 	 * @param array $filters
-	 * @uses wp_remote_post, is_wp_error, wp_remote_retrieve_body
+	 * @uses wp_remote_post, is_wp_error, wp_remote_retrieve_body, get_post_meta, update_post_meta
 	 * @return array
 	 */
 	protected function _get_related_post_ids( $post_id, $size, array $filters ) {
+		$now_ts = time();
+		$cache_meta_key = '_jetpack_related_posts_cache';
+
 		$body = array(
 			'size' => (int) $size,
 		);
 
 		if ( !empty( $filters ) )
 			$body['filter'] = array( 'and' => $filters );
+
+		// Load all cached values
+		$cache = get_post_meta( $post_id, $cache_meta_key, true );
+		if ( empty( $cache ) )
+			$cache = array();
+
+		// Build cache key
+		$cache_key = md5( serialize( $body ) );
+
+		// Cache is valid! Return cacheed value.
+		if ( is_array( $cache[ $cache_key ] ) && $cache[ $cache_key ][ 'expires' ] > $now_ts ) {
+			return $cache[ $cache_key ][ 'payload' ];
+		}
 
 		$response = wp_remote_post(
 			"https://public-api.wordpress.com/rest/v1/sites/{$this->_blog_id_wpcom}/posts/$post_id/related/",
@@ -831,6 +847,7 @@ EOT;
 			)
 		);
 
+		// Oh no... return nothing don't cache errors.
 		if ( is_wp_error( $response ) ) {
 			return array();
 		}
@@ -844,6 +861,24 @@ EOT;
 				);
 			}
 		}
+
+		// Copy all valid cache values
+		$new_cache = array();
+		foreach ( $cache as $k => $v ) {
+			if ( is_array( $v ) && $v[ 'expires' ] > $now_ts ) {
+				$new_cache[ $k ] = $v;
+			}
+		}
+
+		// Set new cache value
+		$new_cache[ $cache_key ] = array(
+			'expires' => 12 * HOUR_IN_SECONDS + $now_ts,
+			'payload' => $related_posts,
+		);
+
+		// Update cache
+		update_post_meta( $post_id, $cache_meta_key, $new_cache );
+
 		return $related_posts;
 	}
 


### PR DESCRIPTION
Cache results for related posts in post_meta for 12 hours so that we don't
have to keep hitting WPCOM to get results.
