### PR TITLE
Likes: hide the reblog settings in Jetpack

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -288,6 +288,7 @@ class Jetpack_Likes {
 				<div>
 			</td>
 		</tr>
+		<?php if ( ! $this->in_jetpack ) : ?>
 		<tr>
 			<th scope="row">
 				<label><?php esc_html_e( 'WordPress.com Reblog Button', 'jetpack' ); ?></label>
@@ -307,7 +308,6 @@ class Jetpack_Likes {
 				<div>
 			</td>
 		</tr>
-		<?php if ( ! $this->in_jetpack ) : ?>
 		<tr>
 			<th scope="row">
 				<label><?php esc_html_e( 'Comment Likes are', 'jetpack' ); ?></label>


### PR DESCRIPTION
Reblogs are not part of Jetpack yet. The Reblog settings should consequently be removed from Jetpack.
