### PR TITLE
AtD: use HTTPS for requests to afterthedeadline.com when SSL is on

### DIFF
--- a/modules/after-the-deadline/proxy.php
+++ b/modules/after-the-deadline/proxy.php
@@ -21,7 +21,7 @@ function AtD_http_post( $request, $host, $path, $port = 80 ) {
 
 	// Strip any / off the begining so we can add it back and protect against SSRF
 	$path = ltrim( $path, '/' );
-	$AtD_url = "http://{$host}/{$path}";
+	$AtD_url = set_url_scheme( "http://{$host}/{$path}" );
 	$response = wp_remote_post( $AtD_url, $http_args );
 	$code = (int) wp_remote_retrieve_response_code( $response );
 


### PR DESCRIPTION
The initial proofread works fine and underlines words. But if you try to use Explain which makes a remote request Firefox blocks this by default without making an exception.
Here is the error:

```
Blocked loading mixed active content "http://service.afterthedeadline.com/info.slp?text=has+been+tested&tags=VBZ%2FVBN%2FVBN&engine=3&theme=tinymce&ver=358-24485"
```

If you just changed this to https://service.afterthedeadline.com/info.slp that should fix it.
Reported here:
- http://wordpress.org/support/topic/jetpack-proofread-explain-and-admin-ssl?replies=1

Original trac ticket: 
- https://plugins.trac.wordpress.org/ticket/1886
