### PR TITLE
Contact form: fix a typo in grunion_ajax_spam().

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -577,7 +577,7 @@ function grunion_ajax_spam() {
 		$email = get_post_meta( $post_id, '_feedback_email', TRUE );
 		$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post_id );
 		
-		if ( !empty( $emails ) && !empty( $content_fields ) ) {
+		if ( !empty( $email ) && !empty( $content_fields ) ) {
 			if ( isset( $content_fields['_feedback_author_email'] ) )
 				$comment_author_email = $content_fields['_feedback_author_email'];
 				


### PR DESCRIPTION
Hello,

due to a typo introduced in @2e0258037fb contact form no longer sends an email notification when a message is recovered from spam.

Thanks,
Piotr
