### PR TITLE
Contact Form: do not display the logged in user's details

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1560,10 +1560,8 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 			$this->value = stripslashes( (string) $_POST[$field_id] );
 		} elseif (
 			is_user_logged_in()
-		&&
-			(
-				( defined( 'IS_WPCOM' ) && IS_WPCOM )
-				|| true === apply_filters( 'jetpack_auto_fill_logged_in_user', false )
+			&& ( ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+			     || true === apply_filters( 'jetpack_auto_fill_logged_in_user', false )
 			)
 		) {
 			// Special defaults for logged-in users


### PR DESCRIPTION
Can be overwritten with the `jetpack_auto_fill_logged_in_user` filter

Fixes #694
