### PR TITLE
Featured Content: Don't remove setting validation.

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -395,6 +395,9 @@ class Featured_Content {
 	 */
 	public static function register_setting() {
 		add_settings_field( 'featured-content', __( 'Featured Content', 'jetpack' ), array( __class__, 'render_form' ), 'reading' );
+		
+		// Register sanitization callback for the Customizer.
+		register_setting( 'featured-content', 'featured-content', array( __class__, 'validate_settings' ) );
 	}
 
 	/**
@@ -410,7 +413,11 @@ class Featured_Content {
 			'theme_supports' => 'featured-content',
 		) );
 
-		// Add Featured Content settings.
+		/* Add Featured Content settings.
+		 *
+		 * Sanitization callback registered in Featured_Content::validate_settings().
+		 * See http://themeshaper.com/2013/04/29/validation-sanitization-in-customizer/comment-page-1/#comment-12374
+		 */
 		$wp_customize->add_setting( 'featured-content[tag-name]', array(
 			'type'                 => 'option',
 			'sanitize_js_callback' => array( __CLASS__, 'delete_transient' ),


### PR DESCRIPTION
Erroneously removed in a66a7e9245c4dedef1f655c81e0366df0a40d6a6.

For option-type customizations, sanitization callbacks are registered through `register_setting()`.
To avoid the callback being triggered on the Reading settings page, give it its own option-group parameter.

/cc @kovshenin
