### PR TITLE
Contact Form: add Mullet to the list of conflicting plugins

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -36,6 +36,7 @@ class Jetpack {
 		'twitter-widget'      => array( 'wickett-twitter-widget/wickett-twitter-widget.php', 'Wickett Twitter Widget' ),
 		'after-the-deadline'  => array( 'after-the-deadline/after-the-deadline.php', 'After The Deadline' ),
 		'contact-form'        => array( 'grunion-contact-form/grunion-contact-form.php', 'Grunion Contact Form' ),
+		'contact-form'        => array( 'mullet/mullet-contact-form.php', 'Mullet Contact Form' ),
 		'custom-css'          => array( 'safecss/safecss.php', 'WordPress.com Custom CSS' ),
 		'random-redirect'     => array( 'random-redirect/random-redirect.php', 'Random Redirect' ),
 		'videopress'          => array( 'video/video.php', 'VideoPress' ),


### PR DESCRIPTION
The contact form module won't be activated when [Mullet](https://github.com/justintadlock/mullet/) is active
