### PR TITLE
Publicize: update wording for account linking notice

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -68,7 +68,7 @@ class Publicize extends Publicize_Base {
 				<div class="jetpack-text-container">
 					<h4>
 					<p><?php printf(
-						esc_html( wptexturize( __( "To use Publicize, you'll need to link your %s account to your WordPress.com account using the button to the right.", 'jetpack' ) ) ),
+						esc_html( wptexturize( __( "To use Publicize, you'll need to link your %s account to your WordPress.com account using the link below.", 'jetpack' ) ) ),
 						'<strong>' . esc_html( $blog_name ) . '</strong>'
 					); ?></p>
 					<p><?php echo esc_html( wptexturize( __( "If you don't have a WordPress.com account yet, you can sign up for free in just a few seconds.", 'jetpack' ) ) ); ?></p>


### PR DESCRIPTION
We stopped using the Connect button on the right, so we need to update the wording as well:

![screen shot 2014-06-18 at 2 31 43 pm](https://cloud.githubusercontent.com/assets/426388/3313529/cef6d06c-f6e4-11e3-8f74-642b5a3acc3b.png)
