### PR TITLE
JSON API: Return Whitelisted CPTs when querying for 'all'

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1898,10 +1898,11 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 
 		// Normalize post_type
 		if ( 'any' == $args['type'] ) {
-			if ( version_compare( $this->api->version, '1.1', '<' ) )
+			if ( version_compare( $this->api->version, '1.1', '<' ) ) {
 				$args['type'] = array( 'post', 'page' );
-			else // 1.1+
+			} else { // 1.1+
 				$args['type'] = $this->_get_whitelisted_post_types();
+			}
 		}
 
 		$query = array(


### PR DESCRIPTION
Currently when querying for 'all' via the get posts endpoint only `post` and `page` types are returned; CPTs whitelisted by the `rest_api_allowed_post_types` filter can be queried for explicitly by passing the type in via query params however are not included in "all".

This change bumps the minor version of the get posts endpoint to 1.1 and returns all whitelisted CPTs along with `post` and `page` when "all" is passed in as the type.
