### PR TITLE
Image Widget: hanging /wp-admin dashboard Widget page

### DIFF
--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -92,7 +92,7 @@ class Jetpack_Image_Widget extends WP_Widget {
 		$img_height = esc_attr( $instance['img_height'] );
 
 		if ( !empty( $instance['img_url'] ) ) {
-			// Download the url to a local temp file and then process it with getimagesize so we can filter out domains which are blocking us
+			// Download the url to a local temp file and then process it with getimagesize so we can optimize browser layout
 			$tmp_file = download_url( $instance['img_url'], 10 );
 			if ( ! is_wp_error( $tmp_file ) ) {
 				$size = getimagesize( $tmp_file );

--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -93,7 +93,7 @@ class Jetpack_Image_Widget extends WP_Widget {
 
 		if ( !empty( $instance['img_url'] ) ) {
 			// Download the url to a local temp file and then process it with getimagesize so we can filter out domains which are blocking us
-			$tmp_file = download_url( $instance['img_url'], 30 );
+			$tmp_file = download_url( $instance['img_url'], 10 );
 			if ( ! is_wp_error( $tmp_file ) ) {
 				$size = getimagesize( $tmp_file );
 


### PR DESCRIPTION
The JP Image Widget can potentially hang the /wp-admin dashboard Widget page if the source URLs are tardy enough and/or there are a lot of image widgets on the page.

Shared hosts in particular have strict request timeouts and when the conditions are right the Image Widget appears to have notable potential to overrun them. I think we should err on the side of a low timeout since the code looks to be for optimizing browser layout and it seems to work fine even if we don't have dimensions ahead of time.