### PR TITLE
Sharing: Respect a blank Sharing Title.

### DIFF
--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -166,7 +166,7 @@ class Sharing_Admin {
 		if ( isset( $_GET['update'] ) && $_GET['update'] == 'saved' )
 			echo '<div class="updated"><p>'.__( 'Settings have been saved', 'jetpack' ).'</p></div>';
 
-		if( !isset( $global['sharing_label'] ) || '' == $global['sharing_label']  ) {
+		if( !isset( $global['sharing_label'] ) ) {
 			$global['sharing_label'] = __( 'Share this:', 'jetpack' );
 		}
 ?>


### PR DESCRIPTION
The Settings->Sharing page previously will override a blank sharing title with the default.
Fixes Automattic/jetpack#764
Props @norcross
