### PR TITLE
Contact Form: Add filter to set from address

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1295,6 +1295,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		$blog_url = parse_url( site_url() );
 		$from_email_addr = 'wordpress@' . $blog_url['host'];
+		$from_email_addr = apply_filters( 'jetpack_contact_form_from', $from_email_addr );
 
 		$reply_to_addr = $to[0];
 		if ( ! empty( $comment_author_email ) ) {


### PR DESCRIPTION
The `from` address is hardcoded to wordpress@[site domain]. Adding a filter to allow this to be set.

Originally requested: http://wordpress.org/support/topic/provide-a-filter-to-override-the-default-from-address-used-by-jetpack-contact?replies=1
