### PR TITLE
Carousel: make the X larger

### DIFF
--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -238,13 +238,13 @@ div.jp-carousel-buttons a:hover {
 	background-color: black;
 	background-color: rgba(0,0,0,0.8);
 	display: block;
-	height: 22px;
-	font: 400 24px/1 "Helvetica Neue", sans-serif !important;
-	line-height: 22px;
+	height: 50px;
+	font: 400 36px/1 "Helvetica Neue", sans-serif !important;
+	line-height: 36px;
 	margin: 0 0 0 0.4em;
 	text-align: center;
 	vertical-align: middle;
-	width: 22px;
+	width: 50px;
 	-moz-border-radius: 4px;
 	-webkit-border-radius: 4px;
 	border-radius: 4px;


### PR DESCRIPTION
This was originally marked as wontfix in https://plugins.trac.wordpress.org/ticket/1693

However, I'd like to revisit it again. I think making the X larger makes it an easier target and less frustrating to hit (yes, I know you can hit anywhere and it'll close the Carousel, but not everyone knows that so users may be getting frustrated while trying to click the tiny little X). We also had a request to make it larger for mobile viewing (on an iPad), here: http://wordpress.org/support/topic/making-x-on-carousel-a-little-larger?replies=1

I think it doesn't do much harm to make the X any larger, hence my request to consider this PR once again.

If you want to tweak the numbers somewhat, feel free!
