### PR TITLE
Fix landing page featured module modals.

### DIFF
--- a/_inc/jp.js
+++ b/_inc/jp.js
@@ -224,7 +224,7 @@
 		} else {
 			// Array of featured modules
 			$( '.feature a.f-img' ).each(function() {
-				featuredModules.push($( this ).data( 'name' ));
+				featuredModules.push($( this ).data( 'module' ));
 			});
 
 			// About page
@@ -234,7 +234,7 @@
 				}
 
 				// Add data-index to featured modules
-				featuredModulesIndex = featuredModules.indexOf( modules[i].name );
+				featuredModulesIndex = featuredModules.indexOf( modules[i].module );
 				if ( featuredModulesIndex > -1 ) {
 					$( '.feature' ).eq( featuredModulesIndex ).find( 'a' ).data( 'index', i );
 				}

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -41,24 +41,24 @@
 
 			<div class="features">
 				<div class="feature">
-					<a href="http://jetpack.me/support/custom-css/" data-name="Custom CSS" class="f-img"><div class="feature-img custom-css"></div></a>
-					<a href="http://jetpack.me/support/custom-css/" data-name="Custom CSS" class="feature-description">
+					<a href="http://jetpack.me/support/custom-css/" data-module="custom-css" class="f-img"><div class="feature-img custom-css"></div></a>
+					<a href="http://jetpack.me/support/custom-css/" data-module="custom-css" class="feature-description">
 						<h3><?php _e('Custom CSS', 'jetpack' ); ?></h3>
 						<p><?php _e('Customize the look of your site, without modifying your theme.', 'jetpack' ); ?></p>
 					</a>
 				</div>
 
 				<div class="feature">
-					<a href="http://jetpack.me/support/sso/" data-name="Jetpack Single Sign On" class="f-img"><div class="feature-img wordpress-connect no-border"></div></a>
-					<a href="http://jetpack.me/support/sso/" data-name="Jetpack Single Sign On" class="feature-description">
+					<a href="http://jetpack.me/support/sso/" data-module="sso" class="f-img"><div class="feature-img wordpress-connect no-border"></div></a>
+					<a href="http://jetpack.me/support/sso/" data-module="sso" class="feature-description">
 						<h3><?php _e('Single Sign On', 'jetpack' ); ?></h3>
 						<p><?php _e('Let users log in through WordPress.com with one click.', 'jetpack' ); ?></p>
 					</a>
 				</div>
 
 				<div class="feature">
-					<a href="http://jetpack.me/support/wordpress-com-stats/" data-name="WordPress.com Stats" class="f-img"><div class="feature-img wordpress-stats"></div></a>
-					<a href="http://jetpack.me/support/wordpress-com-stats/" data-name="WordPress.com Stats" class="feature-description">
+					<a href="http://jetpack.me/support/wordpress-com-stats/" data-module="stats" class="f-img"><div class="feature-img wordpress-stats"></div></a>
+					<a href="http://jetpack.me/support/wordpress-com-stats/" data-module="stats" class="feature-description">
 						<h3><?php _e('WordPress.com Stats', 'jetpack' ); ?></h3>
 						<p><?php _e('Simple, concise site stats with no additional load on your server.', 'jetpack' ); ?></p>
 					</a>


### PR DESCRIPTION
The landing page featured module modals didn't show any content when using
translations, because the contents were found using the module name string
embedded untranslated in the HTML to find the matching module from a list of
modules.

By using the module string (like custom-css) instead of the name of the module
we can find a match regardles of translation or escaping done by json_encode
for example on some Spanish translations.
