### PR TITLE
Close modal when ESC key pressed

### DIFF
--- a/_inc/jetpack-modules.js
+++ b/_inc/jetpack-modules.js
@@ -35,6 +35,18 @@
 	$( '.subsubsub a' ).on( 'click', { modules : modules }, handle_module_tag_click );
 
 	/**
+	 * Attach event listener for ESC key to close modal
+	 */
+
+	$( window ).on( 'keydown', function( e ) {
+		// If pressing ESC close the modal
+		if ( 27 === e.keyCode ) {
+			$( '.shade, .modal' ).hide();
+			$( '.manage-right' ).removeClass( 'show' );
+		}
+	});
+
+	/**
 	 * The modal details.
 	 */
 

--- a/_inc/jp.js
+++ b/_inc/jp.js
@@ -24,6 +24,14 @@
 			$( '.manage-right' ).removeClass( 'show' );
 			return false;
 		});
+
+		$( window ).on( 'keydown', function( e ) {
+			// If pressing ESC close the modal
+			if ( 27 === e.keyCode ) {
+				$( '.shade, .modal' ).hide();
+				$( '.manage-right' ).removeClass( 'show' );
+			}
+		});
 	}
 
 	function filterModules( prop ) {


### PR DESCRIPTION
Both landing page and settings page modals can be closed via the ESC key.

Not optimal to duplicate the function, but it's also not optimal to create a shared script just for the one function.

There is a lot of duplicate logic that the landing page and settings page could share and a refactor is on the way, but until then we can add this in to get that ESC key working.
