### PR TITLE
Stats: Update JS and GIF domains

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2803,7 +2803,7 @@ p {
 		$args     = wp_parse_args( $args, $defaults );
 		$base_url = apply_filters(
 			'jetpack_stats_base_url',
-			set_url_scheme( 'http://stats.wordpress.com/g.gif' )
+			set_url_scheme( 'http://pixel.wp.com/g.gif' )
 		);
 		$url      = add_query_arg( $args, $base_url );
 		return $url;

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -314,7 +314,7 @@ Scroller.prototype.refresh = function() {
 
 				// Record pageview in WP Stats, if available.
 				if ( stats )
-					new Image().src = document.location.protocol + '//stats.wordpress.com/g.gif?' + stats + '&post=0&baba=' + Math.random();
+					new Image().src = document.location.protocol + '//pixel.wp.com/g.gif?' + stats + '&post=0&baba=' + Math.random();
 
 				// Add new posts to the postflair object
 				if ( 'object' == typeof response.postflair && 'object' == typeof WPCOM_sharing_counts )

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -158,7 +158,7 @@ class Jetpack_Likes {
 		// site like setting.
 		if ( ( $this->is_enabled_sitewide() && empty( $_POST['wpl_enable_post_likes'] ) ) || ( ! $this->is_enabled_sitewide() && !empty( $_POST['wpl_enable_post_likes'] ) ) ) {
 			update_post_meta( $post_id, 'switch_like_status', 1 );
-			//$g_gif = file_get_contents( 'http://stats.wordpress.com/g.gif?v=wpcom-no-pv&x_likes=switched_post_like_status' ); @todo stat
+			//$g_gif = file_get_contents( 'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_likes=switched_post_like_status' ); @todo stat
 		} else {
 			delete_post_meta( $post_id, 'switch_like_status' );
 		}
@@ -419,14 +419,14 @@ class Jetpack_Likes {
 		switch( $new_state ) {
 			case 'off' :
 				if ( true == $db_state && ! $this->in_jetpack ) {
-					$g_gif = file_get_contents( 'http://stats.wordpress.com/g.gif?v=wpcom-no-pv&x_likes=disabled_likes' );
+					$g_gif = file_get_contents( 'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_likes=disabled_likes' );
 				}
 				update_option( 'disabled_likes', 1 );
 				break;
 			case 'on'  :
 			default:
 				if ( false == $db_state && ! $this->in_jetpack ) {
-					$g_gif = file_get_contents( 'http://stats.wordpress.com/g.gif?v=wpcom-no-pv&x_likes=reenabled_likes' );
+					$g_gif = file_get_contents( 'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_likes=reenabled_likes' );
 				}
 				delete_option( 'disabled_likes' );
 				break;
@@ -435,14 +435,14 @@ class Jetpack_Likes {
 		switch( $reblogs_new_state ) {
 			case 'off' :
 				if ( true == $reblogs_db_state && ! $this->in_jetpack ) {
-					$g_gif = file_get_contents( 'http://stats.wordpress.com/g.gif?v=wpcom-no-pv&x_reblogs=disabled_reblogs' );
+					$g_gif = file_get_contents( 'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_reblogs=disabled_reblogs' );
 				}
 				update_option( 'disabled_reblogs', 1 );
 				break;
 			case 'on'  :
 			default:
 				if ( false == $reblogs_db_state && ! $this->in_jetpack ) {
-					$g_gif = file_get_contents( 'http://stats.wordpress.com/g.gif?v=wpcom-no-pv&x_reblogs=reenabled_reblogs' );
+					$g_gif = file_get_contents( 'http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_reblogs=reenabled_reblogs' );
 				}
 				delete_option( 'disabled_reblogs' );
 				break;

--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -160,7 +160,7 @@ JetpackSlideshow.prototype.onCyclePrevNextClick_ = function( isNext, i/*, slideE
 	var postid = this.images[i].id;
 	var stats = new Image();
 	stats.src = document.location.protocol +
-		'//stats.wordpress.com/g.gif?host=' +
+		'//pixel.wp.com/g.gif?host=' +
 		escape( document.location.host ) +
 		'&rand=' + Math.random() +
 		'&blog=' + jetpackSlideshowSettings.blog_id +

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -152,7 +152,7 @@ function stats_template_redirect() {
 
 	$stats_footer = <<<END
 
-	<script src="$http://stats.wordpress.com/e-$week.js" type="text/javascript"></script>
+	<script src="$http://stats.wp.com/e-$week.js" type="text/javascript"></script>
 	<script type="text/javascript">
 	st_go({{$data}});
 	var load_cmc = function(){linktracker_init($blog,$post,2);};


### PR DESCRIPTION
Load stats files from cookie-less stats.wp.com and pixel.wp.com domains to
speed up page load.
