### PR TITLE
Sync: Force privacy check before bulk syncs

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -720,6 +720,9 @@ class Jetpack_Sync {
 	public function reindex_trigger() {
 		$response = array( 'status' => 'ERROR' );
 
+		// Force a privacy check
+		Jetpack::check_privacy( __FILE__ );
+
 		Jetpack::load_xml_rpc_client();
 		$client = new Jetpack_IXR_Client( array(
 			'user_id' => JETPACK_MASTER_USER,


### PR DESCRIPTION
The publicly accessible status of sites is checked only when requested and then cached. This is sometimes a problem with a site changes from private to public. If we are going to reindex the site we should make sure that we have the most up-to-date setting.

This resolves #817
