### PR TITLE
Jetpack: Resolve modules not autoactivating glitch

### DIFF
--- a/_inc/jetpack-modules.js
+++ b/_inc/jetpack-modules.js
@@ -50,7 +50,7 @@
 	 * The modal details.
 	 */
 
-	show_modal = function( module, tab ) {
+	show_modal = function( module ) {
 		$jp_frame.children( '.modal, .shade' ).show();
 		$( '.modal ').empty().html( wp.template( 'modal' )( items[ module ] ) );
 	};


### PR DESCRIPTION
If the ‘version’ option was set to an old version after registration
completed, modules would get gimmicked internally, and only auto
activate ‘new’ modules.  By making sure the version is set correctly
before the connection mechanism runs, we can avoid this.

To duplicate the problem, revert this change set (or make the
`maybe_set_version_option` function return without doing anything), run
the following via wpcli, and reconnect:

```
wp plugin deactivate jetpack
wp option delete jetpack_active_modules
wp option set jetpack_activated 1
wp option delete jetpack_log
wp option update jetpack_options '{"version":"2.9.3:1404065229","old_version":"2.9.3:1404065229"}' --format=json
wp plugin activate jetpack
```
