### PR TITLE
Top Posts: Strip HTML from post titles

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -212,7 +212,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		default :
 			echo '<ul>';
 			foreach ( $posts as $post ) {
-				echo '<li><a href="' . esc_url( $post['permalink'] ) . '" class="bump-view" data-bump-view="tp">' . esc_html( $post['title'] ) . "</a></li>\n";
+				echo '<li><a href="' . esc_url( $post['permalink'] ) . '" class="bump-view" data-bump-view="tp">' . esc_html( wp_kses( $post['title'], array() ) ) . "</a></li>\n";
 			}
 			echo '</ul>';
 		}


### PR DESCRIPTION
Prevents tags from being output along with the rest of the title:

https://github.com/Automattic/jetpack/issues/525
