### PR TITLE
Gravatar Hovercards: change configure link

### DIFF
--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -27,7 +27,7 @@ function grofiles_hovercards_init() {
 }
 
 function gravatar_hovercards_configuration_load() {
-	wp_safe_redirect( admin_url( 'options-discussion.php#gravatar-hovercard-options' ) );
+	wp_safe_redirect( admin_url( 'options-discussion.php#show_avatars' ) );
 	exit;
 }
 


### PR DESCRIPTION
Now linking to an anchor higher on the page
To make sure the Hovercard options are not hidden by admin bar
