### PR TITLE
Proper endpoints paths

### DIFF
--- a/json-endpoints/class.json-api-jetpack-endpoints.php
+++ b/json-endpoints/class.json-api-jetpack-endpoints.php
@@ -757,6 +757,9 @@ new Jetpack_JSON_API_Modify_Module_Endpoint( array(
 		'$site'   => '(int|string) The site ID, The site domain',
 		'$module' => '(string) The module name',
 	),
+	'request_format' => array(
+		'active'   => '(bool) The module activation status',
+	),
 	'response_format' => Jetpack_JSON_API_Jetpack_Modules_Endpoint::$_response_format,
 	'example_request_data' => array(
 		'headers' => array(


### PR DESCRIPTION
Adds:

GET /sites/%s/plugins/%p  (get plugin p info on
site s)
GET /sites/%s/jetpack/modules/%m (get module m info on site
s)

Fixes:

POST /sites/%s/plugins/%p { active: false } (deactivates plugin p on
site s)
POST /sites/%s/jetpack/modules/%m { active: true } (activates module m on site
s)
