### PR TITLE
Replace register_activation_hook with jetpack_activate_module.

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -713,6 +713,4 @@ class Jetpack_Portfolio {
 add_action( 'init', array( 'Jetpack_Portfolio', 'init' ) );
 
 // Check on plugin activation if theme supports CPT
-add_action( 'jetpack_activate_module_custom-content-types',
-            array( 'Jetpack_Portfolio',
-                   'plugin_activation_post_type_support' ) );
+add_action( 'jetpack_activate_module_custom-content-types', array( 'Jetpack_Portfolio', 'plugin_activation_post_type_support' ) );


### PR DESCRIPTION
As mentioned by blobaugh, to trigger the callback, we need to use
the proper action. Changed the callback function to static, and made
sure we're calling properly on activation.
https://github.com/Automattic/jetpack/issues/882
