### PR TITLE
Network Admin: Apply New Style

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -517,11 +517,11 @@ class Jetpack_Network {
 
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-		if( is_rtl() ) {
-			wp_enqueue_style( 'jetpack-admin', plugins_url( "_inc/jetpack-admin-rtl{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons' ), JETPACK__VERSION . '-20121016' );
-		} else {
-			wp_enqueue_style( 'jetpack-admin', plugins_url( "_inc/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons' ), JETPACK__VERSION . '-20121016' );
-		}
+		wp_enqueue_style( 'jetpack-google-fonts', '//fonts.googleapis.com/css?family=Open+Sans:400italic,400,700,600,800' );
+
+		wp_enqueue_style( 'jetpack-admin', plugins_url( "css/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons' ), JETPACK__VERSION . '-20121016' );
+		wp_style_add_data( 'jetpack-admin', 'rtl', 'replace' );
+		wp_style_add_data( 'jetpack-admin', 'suffix', $min );
 	}
 
 	/**

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -557,57 +557,8 @@ class Jetpack_Network {
 		}
 
 		require_once( 'class.jetpack-network-sites-list-table.php' );
-		$list_table = new Jetpack_Network_Sites_List_Table();
-		$list_table->prepare_items();
-		?>
-		<div class="clouds-sm"></div>
-		<?php 
-			Jetpack::init()->load_view( 'admin/network-activated-notice.php' );
-			do_action( 'jetpack_notices' ); 
-		?>
-		<div class="page-content configure">
-			<div class="frame top hide-if-no-js">
-				<div class="wrap">
-					<table class="table table-bordered fixed-top">
-						<thead>
-							<tr>
-								<th class="check-column"><input type="checkbox" class="checkall"></th>
-								<th colspan="2">
-									<?php $list_table->display_tablenav( 'top' ); ?>
-									<span class="filter-search">
-										<button type="button" class="button">Filter</button>
-									</span>
-								</th>
-							</tr>
-						</thead>
-					</table>
-				</div><!-- /.wrap -->
-			</div><!-- /.frame -->
-			<div class="frame bottom">
-				<div class="wrap">
-					<form class="jetpack-modules-list-table-form" onsubmit="return false;">
-						<table class="<?php echo implode( ' ', $list_table->get_table_classes() ); ?>">
-							<thead>
-								<tr>
-									<?php $list_table->print_column_headers(); ?>
-								</tr>
-							</thead>
 
-							<tbody id="the-list">
-								<?php $list_table->display_rows_or_placeholder(); ?>
-							</tbody>
-
-							<tfoot>
-								<tr>
-									<?php $list_table->print_column_headers( false ); ?>
-								</tr>
-							</tfoot>
-						</table>
-					</form>
-				</div><!-- /.wrap -->
-			</div><!-- /.frame -->
-		</div><!-- /.content -->
-		<?php
+		Jetpack::init()->load_view( 'admin/network-admin-page.php' );
 
 		$this->network_admin_page_footer();
 	}

--- a/views/admin/network-admin-alert.php
+++ b/views/admin/network-admin-alert.php
@@ -1,9 +1,5 @@
-<div id="message" class="updated jetpack-message jp-connect" style="display:block !important;">
-		<div class="jetpack-wrap-container">
-			<div class="jetpack-text-container">
-				<h4>
-					<p><?php echo $data['notice']; ?></p>
-				</h4>
-			</div>
-		</div>
+<div id="message" class="jetpack-message">
+	<div class="squeezer">
+		<h4><?php echo $data['notice']; ?></h4>
+	</div>
 </div>

--- a/views/admin/network-admin-footer.php
+++ b/views/admin/network-admin-footer.php
@@ -1,26 +1,61 @@
-		<div id="survey" class="jp-survey">
-				<div class="jp-survey-container">
-					<div class="jp-survey-text">
-						<h4><?php _e( 'Have feedback on Jetpack?', 'jetpack' ); ?></h4>
-						<br />
-						<?php _e( 'Answer a short survey to let us know how we&#8217;re doing and what to add in the future.', 'jetpack' ); ?>
-					</div>
-					<div class="jp-survey-button-container">
-						<p class="submit"><?php printf( '<a id="jp-survey-button" class="button-primary" target="_blank" href="%1$s">%2$s</a>', 'http://jetpack.me/survey/?rel=' . JETPACK__VERSION, __( 'Take Survey', 'jetpack' ) ); ?></p>
-					</div>
-				</div>
-			</div>
+<?php
+global $current_user;
+$is_active         = Jetpack::is_active();
+$user_token        = Jetpack_Data::get_access_token( $current_user->ID );
+$is_user_connected = $user_token && ! is_wp_error( $user_token );
+$is_master_user    = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
+?>
+			<div class="footer">
+				<?php if ( ! $is_active && current_user_can( 'jetpack_connect' ) ) : ?>
+					<a href="<?php echo $this->jetpack->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect to Get Started', 'jetpack' ); ?></a>
+				<?php elseif ( $is_active && ! $is_user_connected && current_user_can( 'jetpack_connect_user' ) ) : ?>
+					<a href="<?php echo $this->jetpack->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to WordPress.com', 'jetpack' ); ?></a>
+				<?php endif; ?>
 
-			<div id="jp-footer">
-				<p class="automattic"><?php _e( 'An <span>Automattic</span> Airline', 'jetpack' ) ?></p>
-				<p class="small">
-					<a href="http://jetpack.me/" target="_blank">Jetpack <?php echo esc_html( JETPACK__VERSION ); ?></a> |
-					<a href="http://automattic.com/privacy/" target="_blank"><?php _e( 'Privacy Policy', 'jetpack' ); ?></a> |
-					<a href="http://wordpress.com/tos/" target="_blank"><?php _e( 'Terms of Service', 'jetpack' ); ?></a> |
-<?php if ( current_user_can( 'manage_options' ) ) : ?>
-					<a href="<?php echo Jetpack::admin_url( array(	'page' => 'jetpack-debugger' ) ); ?>"><?php _e( 'Debug', 'jetpack' ); ?></a> |
-<?php endif; ?>
-					<a href="http://jetpack.me/support/" target="_blank"><?php _e( 'Support', 'jetpack' ); ?></a>
-				</p>
-			</div>
+				<nav class="primary nav-horizontal">
+					<div class="a8c-attribution">
+						<span>
+							<?php echo sprintf( __( 'An %s Airline', 'jetpack' ),
+							'<a href="http://automattic.com/" class="a8c-logo">Automattic</a>'
+							); ?>
+						</span>
+					</div>
+				</nav><!-- .primary -->
+
+				<nav class="secondary nav-horizontal">
+					<div class="secondary-footer">
+						<a href="http://jetpack.me">Jetpack <?php echo JETPACK__VERSION; ?></a>
+						<a href="http://wordpress.com/tos/"><?php esc_html_e( 'Terms', 'jetpack' ); ?></a>
+						<a href="http://automattic.com/privacy/"><?php esc_html_e( 'Privacy', 'jetpack' ); ?></a>
+						<a href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack-debugger' ) ); ?>" title="<?php esc_attr_e( 'Test your site&#8217;s compatibility with Jetpack.', 'jetpack' ); ?>"><?php _e( 'Debug', 'jetpack' ); ?></a>
+						<a href="http://jetpack.me/contact-support/" title="<?php esc_attr_e( 'Contact the Jetpack Happiness Squad.', 'jetpack' ); ?>"><?php _e( 'Support', 'jetpack' ); ?></a>
+						<a href="http://jetpack.me/survey/?rel=<?php echo JETPACK__VERSION; ?>" title="<?php esc_attr_e( 'Take a survey.  Tell us how we&#8217;re doing.', 'jetpack' ); ?>"><?php _e( 'Give Us Feedback', 'jetpack' ); ?></a>
+
+						<?php if ( $is_active && current_user_can( 'jetpack_disconnect' ) ) : ?>
+							<a href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=disconnect' ), 'jetpack-disconnect' ); ?>"><?php esc_html_e( 'Disconnect from WordPress.com', 'jetpack' ); ?></a>
+						<?php endif; ?>
+						<?php if ( $is_active && $is_user_connected && ! $is_master_user ) : ?>
+							<a href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=unlink' ), 'jetpack-unlink' ); ?>"><?php esc_html_e( 'Unlink your user account', 'jetpack' ); ?></a>
+						<?php endif; ?>
+
+					</div>
+				</nav><!-- .secondary -->
+			</div><!-- .footer -->
+		</div><!-- .wrapper -->
+
+		<div class="modal">
+			<header>
+				<a href="#" class="close">&times;</a>
+				<ul>
+					<li class="learn-more"><a href="javascript:;" data-tab="learn-more"><?php esc_html_e( 'Learn More', 'jetpack' ); ?></a></li>
+					<li class="config"><a href="javascript:;" data-tab="config"><?php esc_html_e( 'Config', 'jetpack' ); ?></a></li>
+				</ul>
+			</header>
+			<div class="content-container"><div class="content"></div></div>
 		</div>
+		<div class="shade" />
+
+	</div><!-- .jp-frame -->
+</div><!-- .jp-content -->
+
+<?php if ( 'jetpack_modules' == $_GET['page'] ) return; ?>

--- a/views/admin/network-admin-header.php
+++ b/views/admin/network-admin-header.php
@@ -1,13 +1,18 @@
-	<div class="wrap" id="jetpack-settings">
+<?php $current = $_GET['page']; ?>
+<div class="jp-content">
+	<div class="jp-frame">
+		<div class="header">
+			<nav role="navigation" class="header-nav drawer-nav nav-horizontal">
 
-			<div id="jp-header"<?php if ( $data['is_connected'] ) : ?> class="small"<?php endif; ?>>
-				<div id="jp-clouds">
-					<h3><?php _e( 'Jetpack by WordPress.com', 'jetpack' ) ?></h3>
-				</div>
-			</div>
+				<ul class="main-nav">
+					<li class="jetpack-logo"><a href="<?php echo Jetpack_Network::network_admin_url(); ?>" title="<?php esc_attr_e( 'Home', 'jetpack' ); ?>" <?php if ( 'jetpack' == $current ) { echo 'class="current"'; } ?>><span><?php esc_html_e( 'Jetpack', 'jetpack' ); ?></span></a></li>
+					<?php if ( Jetpack::is_active() || Jetpack::is_development_mode() ) : ?>
+					<li class="jetpack-settings">
+						<a href="<?php echo Jetpack_Network::network_admin_url( 'page=jetpack-settings' ); ?>" class="jp-button--settings <?php if ( 'jetpack-settings' == $current ) { echo 'current'; } ?>"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a>
+					</li>
+					<?php endif; ?>
+				</ul>
 
-			<h2 style="display: none"></h2> <!-- For WP JS message relocation -->
-
-			<?php 
-				Jetpack::init()->load_view( 'admin/network-activated-notice.php' );
-				do_action( 'jetpack_notices' ); 
+			</nav>
+		</div><!-- .header -->
+		<div class="wrapper">

--- a/views/admin/network-admin-page.php
+++ b/views/admin/network-admin-page.php
@@ -1,0 +1,52 @@
+<?php
+$list_table = new Jetpack_Network_Sites_List_Table();
+$list_table->prepare_items();
+?>
+		<div class="clouds-sm"></div>
+
+		<?php Jetpack::init()->load_view( 'admin/network-activated-notice.php' ); ?>
+
+		<?php do_action( 'jetpack_notices' ); ?>
+
+		<div class="page-content configure">
+			<div class="frame top hide-if-no-js">
+				<div class="wrap">
+					<table class="table table-bordered fixed-top">
+						<thead>
+							<tr>
+								<th class="check-column"><input type="checkbox" class="checkall"></th>
+								<th colspan="2">
+									<?php $list_table->display_tablenav( 'top' ); ?>
+									<span class="filter-search">
+										<button type="button" class="button">Filter</button>
+									</span>
+								</th>
+							</tr>
+						</thead>
+					</table>
+				</div><!-- /.wrap -->
+			</div><!-- /.frame -->
+			<div class="frame bottom">
+				<div class="wrap">
+					<form class="jetpack-modules-list-table-form" onsubmit="return false;">
+						<table class="<?php echo implode( ' ', $list_table->get_table_classes() ); ?>">
+							<thead>
+								<tr>
+									<?php $list_table->print_column_headers(); ?>
+								</tr>
+							</thead>
+
+							<tbody id="the-list">
+								<?php $list_table->display_rows_or_placeholder(); ?>
+							</tbody>
+
+							<tfoot>
+								<tr>
+									<?php $list_table->print_column_headers( false ); ?>
+								</tr>
+							</tfoot>
+						</table>
+					</form>
+				</div><!-- /.wrap -->
+			</div><!-- /.frame -->
+		</div><!-- /.content -->

--- a/views/admin/network-settings.php
+++ b/views/admin/network-settings.php
@@ -1,18 +1,18 @@
 <?php
 	extract( $data );
-
-
-if( isset( $_GET['updated'] ) && 'true' == $_GET['updated'] ) {
 ?>
+<div class="clouds-sm"></div>
+<?php 
+	Jetpack::init()->load_view( 'admin/network-activated-notice.php' );
 
-<div class="updated"><?php esc_html_e( 'Jetpack Network Settings Updated!', 'jetpack' ); ?></div>
+	if( isset( $_GET['updated'] ) && 'true' == $_GET['updated'] ) {
+		$notice = esc_html__( 'Jetpack Network Settings Updated!', 'jetpack' );
+		Jetpack::init()->load_view( 'admin/network-admin-alert.php', array( 'notice' => $notice ) );
+	}
 
-<?php
-}
+	do_action( 'jetpack_notices' );
 ?>
-
-<div class="wrap">
-	<h2><?php _e( 'Network Settings', 'jetpack' ); ?></h2>
+<div class="page-content configure">
 	<form action="edit.php?action=jetpack-network-settings" method="POST">
 		<h3><?php _e( 'Global', 'jetpack' ); ?></h3>
 		<p><?php _e( 'These settings affect all sites on the network.', 'jetpack' ); ?></p>


### PR DESCRIPTION
Jetpack Network Admin Pages(`wp-admin/network/admin.php?page=jetpack`, `wp-admin/network/admin.php?page=jetpack-settings`) seems stale.
This patch applies same style as `wp-admin/admin.php?page=jetpack`.