### PR TITLE
CSS Tidy: Add Opera prefix for keyframes at rules.

### DIFF
--- a/modules/custom-css/csstidy/data-wp.inc.php
+++ b/modules/custom-css/csstidy/data-wp.inc.php
@@ -49,6 +49,7 @@ foreach ( $GLOBALS['csstidy']['multiple_properties'] as $property ) {
 $GLOBALS['csstidy']['at_rules']['-webkit-keyframes'] = 'at';
 $GLOBALS['csstidy']['at_rules']['-moz-keyframes'] = 'at';
 $GLOBALS['csstidy']['at_rules']['-ms-keyframes'] = 'at';
+$GLOBALS['csstidy']['at_rules']['-o-keyframes'] = 'at';
 
 /**
  * Non-standard viewport rule.


### PR DESCRIPTION
Ref: http://www.opera.com/docs/specs/presto2.11/css/animations/

Reported in http://wordpress.org/support/topic/custom-css-deleting-o-tags?replies=1
