### PR TITLE
Rename jetpack_get_youtube_id to jetpack_shortcode_get_youtube_id

### DIFF
--- a/functions.compat.php
+++ b/functions.compat.php
@@ -1,6 +1,17 @@
 <?php
 
 /**
+* Required for class.media-extractor.php to match expected function naming convention.
+*
+* @param $url Can be just the $url or the whole $atts array
+* @return bool|mixed The Youtube video ID via jetpack_get_youtube_id
+*/
+
+function jetpack_shortcode_get_youtube_id( $url ) {
+    return jetpack_get_youtube_id( $url );
+}
+
+/**
 * @param $url Can be just the $url or the whole $atts array
 * @return bool|mixed The Youtube video ID
 */


### PR DESCRIPTION
https://github.com/Automattic/jetpack/blob/master/class.media-extractor.php#L161 is expecting all "special" shortcodes to have a get ID function in the format of `jetpack_shortcode_get_{shortcode}_id`.

91a3bdd3 named the function `jetpack_get_youtube_id`. Since the extractor couldn't get the ID, this created Automattic/Jetpack#930 since the media summary didn't have the expected ID ( https://github.com/Automattic/jetpack/blob/master/class.media-summary.php#L69 ).

Renaming all instances to jetpack_shortcode_get_youtube_id resolves this. Sure there are other ways too. 

Fixes Automattic/jetpack#930.
