### PR TITLE
Custom Content Types: add comments to Portfolio CPT

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -285,6 +285,7 @@ class Jetpack_Portfolio {
 				'title',
 				'editor',
 				'thumbnail',
+				'comments',
 				'publicize',
 				'wpcom-markdown',
 			),


### PR DESCRIPTION
The Portfolio Custom Post Type doesn't support Comments yet. I think it'd be nice to leave the choice to the user to use comments or not. If they don't want comments, they can always disable them in the post editor.
