### PR TITLE
Refining the setting of site_tag when twitter:creator is present.

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -208,7 +208,7 @@ class Jetpack_Twitter_Cards {
 		add_filter( 'jetpack_open_graph_tags',        array( __CLASS__, 'twitter_cards_tags' ) );
 		add_filter( 'jetpack_open_graph_output',      array( __CLASS__, 'twitter_cards_output' ) );
 		add_filter( 'jetpack_twitter_cards_site_tag', array( __CLASS__, 'site_tag' ), -99 );
-		add_filter( 'jetpack_twitter_cards_site_tag', array( __CLASS__, 'prioritize_creator_over_default_site' ), -99 );
+		add_filter( 'jetpack_twitter_cards_site_tag', array( __CLASS__, 'prioritize_creator_over_default_site' ), 99 );
 		add_action( 'admin_init',                     array( __CLASS__, 'settings_init' ) );
 		add_action( 'sharing_global_options',         array( __CLASS__, 'sharing_global_options' ) );
 		add_action( 'sharing_admin_update',           array( __CLASS__, 'settings_validate' ) );


### PR DESCRIPTION
This is an attempt to close #935. I added a class method that
will take in the current value for site_tag and og_tags and
return a new value for site_tag if twitter:creator is set in
og_tags. If nothing is set, it returns the original value of
site_tag.
