### PR TITLE
Shortcodes: Fix [googlemaps] shortcode reversal false positive.

### DIFF
--- a/modules/shortcodes/googlemaps.php
+++ b/modules/shortcodes/googlemaps.php
@@ -6,7 +6,7 @@
  * into the [googlemaps http://...] shortcode format
  */
 function jetpack_googlemaps_embed_to_short_code( $content ) {
-	if ( false === strpos( $content, 'maps.google.' ) && false === preg_match( '@google\.[^/]+/maps@', $content ) )
+	if ( false === strpos( $content, 'maps.google.' ) && 1 !== preg_match( '@google\.[^/]+/maps@', $content ) )
 		return $content;
 
 	// IE and TinyMCE format things differently


### PR DESCRIPTION
`jetpack_googlemaps_embed_to_short_code()` is intended to only reverse URLs in
the format of `https://maps.google.com` or `https://google.com/maps/`, but it
is matching any `google.com` domain.

For example, the following tag will be reversed into a `[googlemaps]` shortcode
even though it should not be:

``` HTML
<iframe src="https://docs.google.com/spreadsheets/d/19FacgevvN-GGS8SOlbMRVKkWDYSMDQEBfRmkwqaA9z8/pubhtml?widget=true&amp;headers=false"></iframe>
```

The problem is that the code mistakeningly tests for a `false` return from
`preg_match()` instead of `0` or `false`. Unlike `strpos()`, `preg_match()`
returns `0` if the pattern is not matched, and `false` if there is an error.
Because of this, the condition evaluates to true, and the function
doesn't returns early.

This bug was introduced in 7d5c5a77b25474798554fba4e8f72c853f96b507.
