### PR TITLE
Testimonial CPT

### DIFF
--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -200,6 +200,7 @@ class Jetpack_Testimonial {
 		$wp_customize->add_section( 'jetpack_testimonials', array(
 			'title'          => esc_html__( 'Testimonials', 'jetpack' ),
 			'theme_supports' => 'jetpack-testimonial',
+			'priority'       => 130,
 		) );
 
 		$wp_customize->add_setting( 'jetpack_testimonials[page-title]', array(


### PR DESCRIPTION
Two small edits to the Testimonial CPT to address the issues in #538 - adjusting the priority of the testimonial Customizer section to below the core sections and using the `theme_supports` argument instead of a `current_theme_supports` conditional.
