### PR TITLE
Adding several tests to jetpack network tests

### DIFF
--- a/tests/test_class.jetpack-network.php
+++ b/tests/test_class.jetpack-network.php
@@ -2,102 +2,102 @@
 
 class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 
-    /**
-     * @since 2.5
-     */
-    public function test_jetpack_network_init_returns_jetpack_network() {
-        $this->assertInstanceOf( 'Jetpack_Network', Jetpack_Network::init() );
-    }
+	/**
+	 * @since 2.5
+	 */
+	public function test_jetpack_network_init_returns_jetpack_network() {
+		$this->assertInstanceOf( 'Jetpack_Network', Jetpack_Network::init() );
+	}
 
-    /**
-     * @since 2.5
-     */
-    public function test_get_url_returns_correct_string_for_network_admin_page() {
-        $jpms = Jetpack_Network::init();
+	/**
+	 * @since 2.5
+	 */
+	public function test_get_url_returns_correct_string_for_network_admin_page() {
+		$jpms = Jetpack_Network::init();
 
-        $url = $jpms->get_url( 'network_admin_page' );
+		$url = $jpms->get_url( 'network_admin_page' );
 
-        $expected_url = 'http://example.org/wp-admin/admin.php?page=jetpack';
+		$expected_url = 'http://example.org/wp-admin/admin.php?page=jetpack';
 
-        $this->assertInternalType( 'string', $url );
-        $this->assertEquals( $expected_url, $url );
-    }
+		$this->assertInternalType( 'string', $url );
+		$this->assertEquals( $expected_url, $url );
+	}
 
-    /**
-     * @since 2.5
-     */
-    public function test_get_url_returns_null_for_invalid_input() {
-        $jpms = Jetpack_Network::init();
+	/**
+	 * @since 2.5
+	 */
+	public function test_get_url_returns_null_for_invalid_input() {
+		$jpms = Jetpack_Network::init();
 
-        $this->assertNull( $jpms->get_url( 1234 ) );
-    }
+		$this->assertNull( $jpms->get_url( 1234 ) );
+	}
 
-    /**
-     * @since 2.5
-     */
-    public function test_get_url_returns_correct_string_for_subsiteregister() {
-        $jpms = Jetpack_Network::init();
+	/**
+	 * @since 2.5
+	 */
+	public function test_get_url_returns_correct_string_for_subsiteregister() {
+		$jpms = Jetpack_Network::init();
 
-        $url = $jpms->get_url(  array( 'name' => 'subsiteregister', 'site_id' => 123 ) );
+		$url = $jpms->get_url(  array( 'name' => 'subsiteregister', 'site_id' => 123 ) );
 
-        $expected_url = 'http://example.org/wp-admin/admin.php?page=jetpack&action=subsiteregister&site_id=123';
+		$expected_url = 'http://example.org/wp-admin/admin.php?page=jetpack&action=subsiteregister&site_id=123';
 
-        $this->assertInternalType( 'string', $url );
-        $this->assertEquals( $expected_url, $url );
-    }
+		$this->assertInternalType( 'string', $url );
+		$this->assertEquals( $expected_url, $url );
+	}
 
-    /**
-     * @since 2.5
-     */
-    public function test_get_url_returns_null_for_underspecified_subsiteregister() {
-        $jpms = Jetpack_Network::init();
+	/**
+	 * @since 2.5
+	 */
+	public function test_get_url_returns_null_for_underspecified_subsiteregister() {
+		$jpms = Jetpack_Network::init();
 
-        $this->assertNull( $jpms->get_url(  array( 'name' => 'subsiteregister' ) ) );
-    }
+		$this->assertNull( $jpms->get_url(  array( 'name' => 'subsiteregister' ) ) );
+	}
 
-    /**
-     * @since 2.5
-     */
-    public function test_get_url_returns_correct_string_for_subsitedisconnect() {
-        $jpms = Jetpack_Network::init();
+	/**
+	 * @since 2.5
+	 */
+	public function test_get_url_returns_correct_string_for_subsitedisconnect() {
+		$jpms = Jetpack_Network::init();
 
-        $url = $jpms->get_url(  array( 'name' => 'subsitedisconnect', 'site_id' => 123 ) );
+		$url = $jpms->get_url(  array( 'name' => 'subsitedisconnect', 'site_id' => 123 ) );
 
-        $expected_url = 'http://example.org/wp-admin/admin.php?page=jetpack&action=subsitedisconnect&site_id=123';
+		$expected_url = 'http://example.org/wp-admin/admin.php?page=jetpack&action=subsitedisconnect&site_id=123';
 
-        $this->assertInternalType( 'string', $url );
-        $this->assertEquals( $expected_url, $url );
-    }
+		$this->assertInternalType( 'string', $url );
+		$this->assertEquals( $expected_url, $url );
+	}
 
-    /**
-     * @since 2.5
-     */
-    public function test_get_url_returns_null_for_underspecified_subsitedisconnect() {
-        $jpms = Jetpack_Network::init();
+	/**
+	 * @since 2.5
+	 */
+	public function test_get_url_returns_null_for_underspecified_subsitedisconnect() {
+		$jpms = Jetpack_Network::init();
 
-        $this->assertNull( $jpms->get_url(  array( 'name' => 'subsitedisconnect' ) ) );
-    }
+		$this->assertNull( $jpms->get_url(  array( 'name' => 'subsitedisconnect' ) ) );
+	}
 
-    /**
-     * @since 2.8
-     **/
-    public function test_set_auto_activated_modules_returns_array() {
-        $jpms = Jetpack_Network::init();
+	/**
+	 * @since 2.8
+	 **/
+	public function test_set_auto_activated_modules_returns_array() {
+		$jpms = Jetpack_Network::init();
 
-        $this->assertInternalType( 'array', $jpms->set_auto_activated_modules( array() ) );
-    }
+		$this->assertInternalType( 'array', $jpms->set_auto_activated_modules( array() ) );
+	}
 
-    /**
-     * @since 2.8
-     **/
-    public function test_body_class_contains_network_admin() {
-        $jpms = Jetpack_Network::init();
+	/**
+	 * @since 2.8
+	 **/
+	public function test_body_class_contains_network_admin() {
+		$jpms = Jetpack_Network::init();
 
-        $classes = $jpms->body_class( array() );
+		$classes = $jpms->body_class( array() );
 
-        //$this->assertTrue( in_array( 'network-admin', $classes ) );
-        $this->assertInternalType( 'string', $classes );
-    }
+		//$this->assertTrue( in_array( 'network-admin', $classes ) );
+		$this->assertInternalType( 'string', $classes );
+	}
 
 
 } // end class


### PR DESCRIPTION
This commit adds several unit tests to the jetpack-network
tests and updates two existing tests (one update is trivial).
get_url() is tested in more depth, as its return values are
very specific and can be tested very specifically.

This commit is made to begin work on issue #952.
