### PR TITLE
Adding three tests to class.jetpack for sort_modules

### DIFF
--- a/tests/test_class.jetpack.php
+++ b/tests/test_class.jetpack.php
@@ -10,4 +10,32 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 	public function test_init() {
 		$this->assertInstanceOf( 'Jetpack', Jetpack::init() );
 	}
+		/**
+	 * @author enkrates
+	 * @covers Jetpack::sort_modules
+	 */
+	public function test_sort_modules_with_equal_sort_values() {
+
+		$first_file  = array( 'sort' => 5 );
+		$second_file = array( 'sort' => 5 );
+
+		$sort_value = Jetpack::sort_modules( $first_file, $second_file );
+
+		$this->assertEquals( 0, $sort_value );
+	}
+		/**
+	 * @author enkrates
+	 * @covers Jetpack::sort_modules
+	 */
+	public function test_sort_modules_with_different_sort_values() {
+
+		$first_file  = array( 'sort' => 10 );
+		$second_file = array( 'sort' => 5 );
+
+		$sort_value = Jetpack::sort_modules( $first_file, $second_file );
+		$reversed_sort_value = Jetpack::sort_modules( $second_file, $first_file );
+
+		$this->assertEquals( 1, $sort_value );
+		$this->assertEquals( -1, $reversed_sort_value );
+	}
 } // end class


### PR DESCRIPTION
This commit adds three tests covering the sort_modules class method,
which is both simple and would cause trouble if unintentionally
changed. I did not include a @since tag as I do not know when the
method was introduced. If the @since tag is important, I'd be happy to
figure out when it was introduced and submit an update to this pull request. 
