### PR TITLE
Gravatar Hovercards: add check if avatars are disabled

### DIFF
--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -171,8 +171,15 @@ function grofiles_get_avatar( $avatar, $author ) {
 function grofiles_attach_cards() {
 	global $blog_id;
 
-	if ( 'disabled' == get_option( 'gravatar_disable_hovercards' ) )
+	// Is the display of Avatars disabled?
+	if ( ! get_option( 'show_avatars' ) ) {
 		return;
+	}
+
+	// Is the display of Gravatar Hovercards disabled?
+	if ( 'disabled' == get_option( 'gravatar_disable_hovercards' ) ) {
+		return;
+	}
 
 	wp_enqueue_script( 'grofiles-cards', ( is_ssl() ? 'https://secure' : 'http://s' ) . '.gravatar.com/js/gprofiles.js', array( 'jquery' ), GROFILES__CACHE_BUSTER, true );
 	wp_enqueue_script( 'wpgroho', plugins_url( 'wpgroho.js', __FILE__ ), array( 'grofiles-cards' ), false, true );


### PR DESCRIPTION
Until now, Gravatar Hovercards scripts could be enqueued even if you didn't display any avatars on your site
