### PR TITLE
Updating PHPUnit annotations in unit tests

### DIFF
--- a/tests/test_class.functions.compat.php
+++ b/tests/test_class.functions.compat.php
@@ -5,6 +5,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers youtube_sanitize_url
+	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_valid_url() {
 
@@ -18,6 +19,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers youtube_sanitize_url
+	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_shortened_url() {
 
@@ -32,6 +34,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers youtube_sanitize_url
+	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_slash_v_slash() {
 
@@ -46,6 +49,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers youtube_sanitize_url
+	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_hashbang() {
 
@@ -60,6 +64,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers youtube_sanitize_url
+	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_amp_ampersand() {
 
@@ -74,6 +79,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers youtube_sanitize_url
+	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_encoded_ampersand() {
 
@@ -88,6 +94,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers youtube_sanitize_url
+	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_playlist() {
 
@@ -102,6 +109,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers youtube_sanitize_url
+	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_extra_question_mark() {
 
@@ -116,6 +124,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers jetpack_get_youtube_id
+	 * @since 3.2
 	 */
 	public function test_jetpack_get_youtube_id_with_single_video_url() {
 
@@ -130,6 +139,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers jetpack_get_youtube_id
+	 * @since 3.2
 	 */
 	public function test_jetpack_get_youtube_id_with_playlist_url() {
 

--- a/tests/test_class.jetpack-network.php
+++ b/tests/test_class.jetpack-network.php
@@ -10,7 +10,9 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @since 2.5
+	 * @author enkrates
+	 * @covers Jetpack_Network::get_url
+	 * @since 3.2
 	 */
 	public function test_get_url_returns_correct_string_for_network_admin_page() {
 		$jpms = Jetpack_Network::init();
@@ -24,7 +26,9 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @since 2.5
+	 * @author enkrates
+	 * @covers Jetpack_Network::get_url
+	 * @since 3.2
 	 */
 	public function test_get_url_returns_null_for_invalid_input() {
 		$jpms = Jetpack_Network::init();
@@ -33,7 +37,9 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @since 2.5
+	 * @author enkrates
+	 * @covers Jetpack_Network::get_url
+	 * @since 3.2
 	 */
 	public function test_get_url_returns_correct_string_for_subsiteregister() {
 		$jpms = Jetpack_Network::init();
@@ -47,7 +53,9 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @since 2.5
+	 * @author enkrates
+	 * @covers Jetpack_Network::get_url
+	 * @since 3.2
 	 */
 	public function test_get_url_returns_null_for_underspecified_subsiteregister() {
 		$jpms = Jetpack_Network::init();
@@ -56,7 +64,9 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @since 2.5
+	 * @author enkrates
+	 * @covers Jetpack_Network::get_url
+	 * @since 3.2
 	 */
 	public function test_get_url_returns_correct_string_for_subsitedisconnect() {
 		$jpms = Jetpack_Network::init();
@@ -70,7 +80,9 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @since 2.5
+	 * @author enkrates
+	 * @covers Jetpack_Network::get_url
+	 * @since 3.2
 	 */
 	public function test_get_url_returns_null_for_underspecified_subsitedisconnect() {
 		$jpms = Jetpack_Network::init();

--- a/tests/test_class.jetpack.php
+++ b/tests/test_class.jetpack.php
@@ -13,6 +13,7 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers Jetpack::sort_modules
+	 * @since 3.2
 	 */
 	public function test_sort_modules_with_equal_sort_values() {
 
@@ -26,6 +27,7 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 		/**
 	 * @author enkrates
 	 * @covers Jetpack::sort_modules
+	 * @since 3.2
 	 */
 	public function test_sort_modules_with_different_sort_values() {
 


### PR DESCRIPTION
I've been omitting and misstating some of the annotations on the
unit tests I've been committing, and this commit should fix those
annotations.

I believe that this brings all the tests I've touched up to date, but if I've made any mistakes I am perfectly happy to try again with another commit.
