### PR TITLE
Make CPT rewrite slugs translatable

### DIFF
--- a/modules/custom-post-types/comics.php
+++ b/modules/custom-post-types/comics.php
@@ -1,5 +1,5 @@
 <?php
- 
+
 class Jetpack_Comic {
 	const POST_TYPE = 'jetpack-comic';
 
@@ -171,7 +171,7 @@ class Jetpack_Comic {
 		} else {
 			wp_enqueue_style( 'jetpack-comics-style', plugins_url( 'comics/comics.css', __FILE__ ) );
 		}
-		
+
 		wp_enqueue_script( 'jetpack-comics', plugins_url( 'comics/comics.js', __FILE__ ), array( 'jquery', 'jquery.spin' ) );
 
 		$options = array(
@@ -226,7 +226,7 @@ class Jetpack_Comic {
 				'shortlinks', // Jetpack
 			),
 			'rewrite' => array(
-				'slug'       => 'comic',
+				'slug'       => _x( 'comic', 'custom post type slug', 'jetpack' ),
 				'with_front' => false,
 			),
 			'taxonomies' => array(
@@ -312,8 +312,8 @@ class Jetpack_Comic {
 			// so check manually whether the target blog supports comics.
 			switch_to_blog( $_SERVER['argv'][1] );
 			// The add_theme_support( 'jetpack-comic' ) won't fire on switch_to_blog, so check for Panel manually.
-			$supports_comics = ( ( function_exists( 'site_vertical' ) && 'comics' == site_vertical() ) 
-								|| current_theme_supports( self::POST_TYPE ) 
+			$supports_comics = ( ( function_exists( 'site_vertical' ) && 'comics' == site_vertical() )
+								|| current_theme_supports( self::POST_TYPE )
 								|| get_stylesheet() == 'pub/panel' );
 			restore_current_blog();
 			return (bool) apply_filters( 'jetpack_enable_cpt', $supports_comics, self::POST_TYPE );

--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -155,7 +155,7 @@ class Nova_Restaurant {
 				'new_item_name'      => __( 'New Menu Sections Name', 'jetpack' ),
 			),
 			'rewrite' => array(
-				'slug'         => 'menu',
+				'slug'         => _x( 'menu', 'custom taxonomy slug', 'jetpack' ),
 				'with_front'   => false,
 				'hierarchical' => true,
 			),
@@ -191,7 +191,7 @@ class Nova_Restaurant {
 				'excerpt',
 			),
 			'rewrite' => array(
-				'slug'       => 'item',
+				'slug'       => _x( 'item', 'custom post type slug', 'jetpack' ),
 				'with_front' => false,
 				'feeds'      => false,
 				'pages'      => false,

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -290,7 +290,7 @@ class Jetpack_Portfolio {
 				'wpcom-markdown',
 			),
 			'rewrite' => array(
-				'slug'       => 'portfolio',
+				'slug'       => _x( 'portfolio', 'custom post type slug', 'jetpack' ),
 				'with_front' => false,
 				'feeds'      => true,
 				'pages'      => true,
@@ -327,7 +327,7 @@ class Jetpack_Portfolio {
 			'show_in_nav_menus' => true,
 			'show_admin_column' => true,
 			'query_var'         => true,
-			'rewrite'           => array( 'slug' => 'project-type' ),
+			'rewrite'           => array( 'slug' => _x( 'project-type', 'custom taxonomy slug', 'jetpack' ) ),
 		) );
 
 		register_taxonomy( self::CUSTOM_TAXONOMY_TAG, self::CUSTOM_POST_TYPE, array(
@@ -354,7 +354,7 @@ class Jetpack_Portfolio {
 			'show_in_nav_menus' => true,
 			'show_admin_column' => true,
 			'query_var'         => true,
-			'rewrite'           => array( 'slug' => 'project-tag' ),
+			'rewrite'           => array( 'slug' => _x( 'project-tag', 'custom taxonomy slug', 'jetpack' ) ),
 		) );
 	}
 

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -92,7 +92,7 @@ class Jetpack_Testimonial {
 				'page-attributes',
 			),
 			'rewrite' => array(
-				'slug'       => 'testimonial',
+				'slug'       => _x( 'testimonial', 'custom post type slug', 'jetpack' ),
 				'with_front' => false,
 				'feeds'      => false,
 				'pages'      => false,


### PR DESCRIPTION
Makes all custom post type and taxonomy `$rewrite['slug']` arguments contextually translatable. Fixes #980
