### PR TITLE
Shortcodes: add the Recipes shortcode

### DIFF
--- a/modules/shortcodes/css/recipes-print.css
+++ b/modules/shortcodes/css/recipes-print.css
@@ -1,0 +1,3 @@
+.jetpack-recipe-meta li.jetpack-recipe-print {
+	display: none;
+}

--- a/modules/shortcodes/css/recipes.css
+++ b/modules/shortcodes/css/recipes.css
@@ -1,0 +1,33 @@
+.jetpack-recipe {
+	border: 1px solid #f2f2f2;
+	border-radius: 1px;
+	clear: both;
+	margin: 1.5em 1%;
+	padding: 1% 2%;
+}
+.jetpack-recipe-title {
+	border-bottom: 1px solid #ccc;
+	margin: .25em 0;
+	padding: .25em 0;
+}
+.jetpack-recipe .jetpack-recipe-meta {
+	display: block;
+	font-size: .9em;
+	list-style-type: none;
+	margin-right: 0;
+	margin-left: 0;
+	padding: 0;
+	overflow: hidden;
+	width: 100%;
+}
+.jetpack-recipe .jetpack-recipe-meta li {
+	float: left;
+	list-style-type: none;
+	margin: 0;
+	padding: 0 5% 0 0;
+}
+.jetpack-recipe-meta li.jetpack-recipe-print {
+	float: right;
+	padding-right: 0;
+	text-align: right;
+}

--- a/modules/shortcodes/css/rtl/recipes-rtl.css
+++ b/modules/shortcodes/css/rtl/recipes-rtl.css
@@ -1,0 +1,35 @@
+/* This file was automatically generated on Feb 24 2014 16:44:25 */
+
+.jetpack-recipe {
+	border: 1px solid #f2f2f2;
+	border-radius: 1px;
+	clear: both;
+	margin: 1.5em 1%;
+	padding: 1% 2%;
+}
+.jetpack-recipe-title {
+	border-bottom: 1px solid #ccc;
+	margin: .25em 0;
+	padding: .25em 0;
+}
+.jetpack-recipe .jetpack-recipe-meta {
+	display: block;
+	font-size: .9em;
+	list-style-type: none;
+	margin-left: 0;
+	margin-right: 0;
+	padding: 0;
+	overflow: hidden;
+	width: 100%;
+}
+.jetpack-recipe .jetpack-recipe-meta li {
+	float: right;
+	list-style-type: none;
+	margin: 0;
+	padding: 0 0 0 5%;
+}
+.jetpack-recipe-meta li.jetpack-recipe-print {
+	float: left;
+	padding-left: 0;
+	text-align: left;
+}

--- a/modules/shortcodes/js/recipes-printthis.js
+++ b/modules/shortcodes/js/recipes-printthis.js
@@ -1,0 +1,170 @@
+/*
+* printThis v1.3
+* @desc Printing plug-in for jQuery
+* @author Jason Day
+*
+* Resources (based on) :
+*              jPrintArea: http://plugins.jquery.com/project/jPrintArea
+*              jqPrint: https://github.com/permanenttourist/jquery.jqprint
+*              Ben Nadal: http://www.bennadel.com/blog/1591-Ask-Ben-Print-Part-Of-A-Web-Page-With-jQuery.htm
+*
+* Dual licensed under the MIT and GPL licenses:
+*              http://www.opensource.org/licenses/mit-license.php
+*              http://www.gnu.org/licenses/gpl.html
+*
+* (c) Jason Day 2013
+*
+* Usage:
+*
+*  $("#mySelector").printThis({
+*      debug: false,              * show the iframe for debugging
+*      importCSS: true,           * import page CSS
+*      printContainer: true,      * grab outer container as well as the contents of the selector
+*      loadCSS: "path/to/my.css", * path to additional css file
+*      pageTitle: "",             * add title to print page
+*      removeInline: false,       * remove all inline styles from print elements
+*      printDelay: 333,           * variable print delay S. Vance
+*      header: null               * prefix to html
+*  });
+*
+* Notes:
+*  - the loadCSS will load additional css (with or without @media print) into the iframe, adjusting layout
+*/
+/* jshint onevar: false, smarttabs: true, devel: true */
+;(function ($) {
+	var opt;
+	$.fn.printThis = function (options) {
+		opt = $.extend({}, $.fn.printThis.defaults, options);
+		var $element = this instanceof jQuery ? this : $(this);
+
+			var strFrameName = 'printThis-' + (new Date()).getTime();
+
+			if(window.location.hostname !== document.domain && navigator.userAgent.match(/msie/i)){
+				// Ugly IE hacks due to IE not inheriting document.domain from parent
+				// checks if document.domain is set by comparing the host name against document.domain
+				var iframeContents = '<head><script>document.domain=\\\'' + document.domain + '\\\';</script></head><body></body>';
+				var iframeSrc = 'data:text/html;charset=utf-8,' + encodeURI(iframeContents);
+				var printI= document.createElement('iframe');
+				printI.name = 'printIframe';
+				printI.id = strFrameName;
+				printI.className = 'MSIE';
+				document.body.appendChild(printI);
+				printI.src = iframeSrc;
+
+			} else {
+				// other browsers inherit document.domain, and IE works if document.domain is not explicitly set
+				var $frame = $('<iframe id="' + strFrameName +'" name="printIframe" />');
+				$frame.appendTo('body');
+			}
+
+
+			var $iframe = $('#' + strFrameName);
+
+			// show frame if in debug mode
+			if (!opt.debug) {
+				$iframe.css({
+					position: 'absolute',
+					width: '0px',
+					height: '0px',
+					left: '-600px',
+					top: '-600px'
+				});
+			}
+
+
+		// $iframe.ready() and $iframe.load were inconsistent between browsers
+		setTimeout ( function () {
+
+			var $doc = $iframe.contents();
+
+			// import page stylesheets
+			if (opt.importCSS) {
+				$('link[rel=stylesheet]').each(function () {
+					var href = $(this).attr('href');
+					if (href) {
+						var media = $(this).attr('media') || 'all';
+						$doc.find('head').append('<link type="text/css" rel="stylesheet" href="' + href + '" media="' + media + '">');
+					}
+				});
+			}
+
+			//add title of the page
+			if (opt.pageTitle) {
+				$doc.find('head').append('<title>' + opt.pageTitle + '</title>');
+			}
+
+			// import additional stylesheet
+			if (opt.loadCSS) {
+				$doc.find('head').append('<link type="text/css" rel="stylesheet" href="' + opt.loadCSS + '">');
+			}
+
+			// print header
+			if (opt.header) {
+				$doc.find('body').append(opt.header);
+			}
+
+			// grab $.selector as container
+			if (opt.printContainer) {
+				$doc.find('body').append($element.outer());
+			}
+
+			// otherwise just print interior elements of container
+			else {
+				$element.each(function () {
+					$doc.find('body').append($(this).html());
+				});
+			}
+
+			// remove inline styles
+			if (opt.removeInline) {
+				// $.removeAttr available jQuery 1.7+
+				if ($.isFunction($.removeAttr)) {
+					$doc.find('body *').removeAttr('style');
+				} else {
+					$doc.find('body *').attr('style', '');
+				}
+			}
+
+			setTimeout(function () {
+				if($iframe.hasClass('MSIE')){
+					// check if the iframe was created with the ugly hack
+					// and perform another ugly hack out of neccessity
+					window.frames.printIframe.focus();
+					$doc.find('head').append('<script>  window.print(); </script>');
+				} else {
+					// proper method
+					$iframe[0].contentWindow.focus();
+					$iframe[0].contentWindow.print();
+				}
+
+				$element.trigger( 'done');
+				//remove iframe after print
+				if (!opt.debug) {
+					setTimeout(function () {
+						$iframe.remove();
+					}, 1000);
+				}
+
+			}, opt.printDelay);
+
+		}, 333 );
+
+	};
+
+	// defaults
+	$.fn.printThis.defaults = {
+		debug: false,            // show the iframe for debugging
+		importCSS: false,       // import parent page css
+		printContainer: true,   // print outer container/$.selector
+		loadCSS: '',            // load an additional css file
+		pageTitle: '',          // add title to print page
+		removeInline: false,    // remove all inline styles
+		printDelay: 333,        // variable print delay S. Vance
+		header: null            // prefix to html
+	};
+
+	// $.selector container
+	jQuery.fn.outer = function () {
+		return $($('<div></div>').html(this.clone())).html();
+	};
+})(jQuery);

--- a/modules/shortcodes/js/recipes.js
+++ b/modules/shortcodes/js/recipes.js
@@ -1,0 +1,11 @@
+/* global jetpack_recipes_vars */
+( function( $ ) {
+	$( window ).load( function() {
+		$( '.jetpack-recipe-print a' ).click( function( event ) {
+			event.preventDefault();
+
+			// Print the DIV.
+			$( this ).closest( '.jetpack-recipe' ).printThis( { pageTitle: jetpack_recipes_vars.pageTitle, loadCSS: jetpack_recipes_vars.loadCSS } );
+		} );
+	} );
+} )( jQuery );

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Embed recipe 'cards' in post, with basic styling and print functionality
+ *
+ */
+
+class Jetpack_Recipes {
+
+	private $scripts_and_style_included = false;
+
+	function __construct() {
+		add_action( 'init', array( $this, 'action_init' ) );
+	}
+
+	function action_init() {
+		// Enqueue styles if [recipe] exists
+		add_action( 'wp_head', array( $this, 'add_scripts' ), 1 );
+
+		// Render [recipe]
+		add_shortcode( 'recipe', array( $this, 'recipe_shortcode' ) );
+	}
+
+	/**
+	 * Enqueue scripts and styles
+	 */
+	function add_scripts() {
+		if ( empty( $GLOBALS['posts'] ) || ! is_array( $GLOBALS['posts'] ) ) {
+			return;
+		}
+
+		foreach ( $GLOBALS['posts'] as $p ) {
+			if ( has_shortcode( $p->post_content, 'recipe' ) ) {
+				$this->scripts_and_style_included = true;
+				break;
+			}
+		}
+
+		if ( ! $this->scripts_and_style_included ) {
+			return;
+		}
+
+		if( is_rtl() ) {
+			wp_enqueue_style( 'jetpack-recipes-style',  plugins_url( '/css/rtl/recipes-rtl.css',  __FILE__ ), array(), '20130919' );
+		} else {
+			wp_enqueue_style( 'jetpack-recipes-style',  plugins_url( '/css/recipes.css',  __FILE__ ), array(), '20130919' );
+		}
+
+
+		wp_enqueue_script( 'jetpack-recipes-printthis', plugins_url( '/js/recipes-printthis.js', __FILE__ ), array( 'jquery' ), '20131230' );
+		wp_enqueue_script( 'jetpack-recipes-js',        plugins_url( '/js/recipes.js', __FILE__ ),   array( 'jquery', 'jetpack-recipes-printthis' ), '20131230' );
+
+		$title_var = wp_title( '|', false, 'right' );
+		$print_css_var = plugins_url( '/css/recipes-print.css', __FILE__ );
+
+		wp_localize_script( 'jetpack-recipes-js', 'jetpack_recipes_vars', array(
+			'pageTitle' => $title_var,
+			'loadCSS'   => $print_css_var
+		) );
+	}
+
+	/**
+	 * Our [recipe] shortcode.
+	 * Prints recipe data styled to look good on *any* theme.
+	 *
+	 * @return resume_shortcode_html
+	 */
+	static function recipe_shortcode( $atts, $content = '' ) {
+		$atts = shortcode_atts( array(
+			'title'      => '', //string
+			'servings'   => '', //intval
+			'time'       => '', //string
+			'difficulty' => '', //string
+			'print'      => '', //string
+		), $atts, 'recipe' );
+
+		return self::recipe_shortcode_html( $atts, $content );
+	}
+
+	/**
+	 * The recipe output
+	 *
+	 * @return Html
+	 */
+	static function recipe_shortcode_html( $atts, $content = '' ) {
+		$html = false;
+
+		$html = '<div class="hrecipe jetpack-recipe" itemscope itemtype="http://schema.org/Recipe">';
+
+		// Print the recipe title if exists
+		if ( '' != $atts['title'] ) {
+			$html .= '<h3 class="jetpack-recipe-title" itemprop="name">' . esc_html( $atts['title'] ) . '</h3>';
+		}
+
+		// Print the recipe meta if exists
+		if ( '' != $atts['servings'] || '' != $atts['time'] || '' != $atts['difficulty'] || '' != $atts['print'] ) {
+			$html .= '<ul class="jetpack-recipe-meta">';
+
+			if ( '' != $atts['servings'] ) {
+				$html .= sprintf( '<li class="jetpack-recipe-servings" itemprop="recipeYield"><strong>%1s: </strong>%2s</li>',
+					__( 'Servings', 'jetpack' ),
+					esc_html( $atts['servings'] )
+				);
+			}
+
+			if ( '' != $atts['time'] ) {
+				$html .= sprintf( '<li class="jetpack-recipe-time" itemprop="totalTime"><strong>%1s: </strong>%2s</li>',
+					__( 'Time', 'jetpack' ),
+					esc_html( $atts['time'] )
+				);
+			}
+
+			if ( '' != $atts['difficulty'] ) {
+				$html .= sprintf( '<li class="jetpack-recipe-difficulty"><strong>%1s: </strong>%2s</li>',
+					__( 'Difficulty', 'jetpack' ),
+					esc_html( $atts['difficulty'] )
+				);
+			}
+
+			if ( 'false' != $atts['print'] ) {
+				$html .= sprintf( '<li class="jetpack-recipe-print"><a href="#">%1s</a></li>',
+					__( 'Print', 'jetpack' )
+				);
+			}
+
+			$html .= '</ul>';
+		}
+
+		// Print content between codes
+		$html .= '<div class="jetpack-recipe-content">' . do_shortcode( $content ) . '</div>';
+
+		// Close it up
+		$html .= '</div>';
+
+		// If there is a recipe within a recipe, remove the shortcode
+		if ( has_shortcode( $html, 'recipe' ) ) {
+			remove_shortcode( 'recipe' );
+		}
+
+		// Sanitize html
+		$html = wp_kses_post( $html );
+
+		// Return the HTML block
+		return $html;
+	}
+}
+
+new Jetpack_Recipes();


### PR DESCRIPTION
See http://en.support.wordpress.com/recipes/
Fixes #605

Before the merge, I'd be happy to get a second set of eyes on `recipes/printthis.js`. It's a bit different from [the original](https://github.com/jasonday/printThis/blob/master/printThis.js) because I had to make some changes to pass JSHint tests. While most of them were harmless, @rase- had to jump in and help me with the IE hack on line 42 ([ref](https://github.com/jeherve/jetpack/blob/ec0e6266579e36dd14c2f9351c650517152f4a3b/modules/shortcodes/js/recipes-printthis.js#L42)).

The shortcode seems to work properly in all browsers in my tests.
