### PR TITLE
Sharing: update function to properly handle the sharing module

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4509,8 +4509,18 @@ p {
 
 		$do_implode = apply_filters( 'jetpack_implode_frontend_css', true );
 
-		if( Jetpack::is_development_mode() || ! $do_implode ) {
-			// We do not want to use the imploded file in dev mode
+		// Do not use the imploded file when default behaviour was altered through the filter
+		if ( ! $do_implode ) {
+			return;
+		}
+
+		// We do not want to use the imploded file in dev mode
+		if ( Jetpack::is_development_mode() ) {
+			return;
+		}
+
+		// Do not use the imploded file if sharing css was dequeued via the sharing settings screen
+		if ( get_option( 'sharedaddy_disable_resources' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
1. Concatenate the frontend sharing stylesheet
   - `sharing` is the stylesheet added to the sharing settings screen
   - `sharedaddy` is added to the frontend
2. Add a conditional to handle disabled sharing css option
   - The option can be set under Settings > Sharing, and uses the `sharedaddy_disable_resources` option

cc @blobaugh and @MichaelArestad
