### PR TITLE
Shortcodes: Module Info updates

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -109,6 +109,7 @@ function jetpack_shortcodes_more_info_connected() { ?>
 		'dailymotion' => 'http://support.wordpress.com/videos/dailymotion/',
 		'facebook' => 'http://en.support.wordpress.com/facebook-integration/facebook-embeds/',
 		'flickr' => 'http://support.wordpress.com/videos/flickr-video/',
+		'gist' => 'http://en.support.wordpress.com/gist/',
 		'googlemaps' => 'http://support.wordpress.com/google-maps/',
 		'jetpack_subscription_form' => 'http://jetpack.me/support/subscriptions/#display',
 		'polldaddy' => 'http://support.polldaddy.com/wordpress-shortcodes/',


### PR DESCRIPTION
The module info included references to `[audio]` and `[upcomingevents]` that shouldn't be there and didn't include the `[gist]` shortcode.

There are a few others that Jetpack has, but there isn't WP.com documentation to point to, so punting those until later.
