### PR TITLE
Widget Visibility: remove get_the_terms from taxonomy check

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -458,7 +458,7 @@ class Jetpack_Widget_Conditions {
 					$term = explode( '_tax_', $rule['minor'] ); // $term[0] = taxonomy name; $term[1] = term id
 					if ( isset( $term[1] ) && is_tax( $term[0], $term[1] ) ) {
 						$condition_result = true;
-					} else if ( isset( $term[1] ) && is_singular() && has_term( $term[1], $term[0] ) ) {
+					} else if ( isset( $term[1] ) && is_singular() && $term[1] && has_term( $term[1], $term[0] ) ) {
 						$condition_result = true;
 					}
 				break;


### PR DESCRIPTION
`$post->ID` always returns null, creating a notice
That check doesn't seem needed, since we already check if we're on a taxonomy archive page or a singular page using the taxonomy

See #223 where the taxonomy check was originally added
