### PR TITLE
Contact Form: Submit location must respect current scheme

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -985,7 +985,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			}
 
 			// For SSL/TLS page. See RFC 3986 Section 4.2
-			$url = str_replace( parse_url( $url, PHP_URL_SCHEME ) . ':', '', $url );
+			$url = set_url_scheme( $url );
 
 			// May eventually want to send this to admin-post.php...
 			$url = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id );


### PR DESCRIPTION
Using Jetpack with [WordPress HTTPS (SSL)](https://github.com/Mvied/wordpress-https), I got an warning from User-agent(Chrome).

> The page at 'https://www.extendwings.com/contact/en/' was loaded over HTTPS, but is submitting data to an insecure location at 'http://www.extendwings.com/contact/en/#contact-form-3142': this content should also be submitted over HTTPS.

I think using relative reference(defined at [RFC 3986 Section 4.2](http://tools.ietf.org/html/rfc3986#section-4.2)) for scheme is good.

So, this remove scheme from URL.
