### PR TITLE
Google maps shortcode

### DIFF
--- a/modules/shortcodes/googlemaps.php
+++ b/modules/shortcodes/googlemaps.php
@@ -28,14 +28,14 @@ function jetpack_googlemaps_embed_to_short_code_callback( $match ) {
 
 	if ( preg_match( '/\bwidth=[\'"](\d+)(%)?/', $match[0], $width ) ) {
 		$percent = ! empty( $width[2] ) ? '%' : '';
-		$width = $width[1] . $percent;
+		$width = (int)$width[1] . $percent;
 	} else {
 		$width = 425;
 	}
 
 	if ( preg_match( '/\bheight=[\'"](\d+)(%)?/', $match[0], $height ) ) {
 		$percent = ! empty( $height[2] ) ? '%' : '';
-		$height = $height[1] . $percent;
+		$height = (int)$height[1] . $percent;
 	} else {
 		$height = 350;
 	}


### PR DESCRIPTION
Original report from editorial:

```
Paste in <iframe src="https://mapsengine.google.com/map/u/0/embed?mid=zI1R9jeSBMgk.kSy-zcZPHrw8" width="100%" height="550"></iframe>

Get [googlemaps https://mapsengine.google.com/map/u/0/embed?mid=zI1R9jeSBMgk.kSy-zcZPHrw8&amp;w=100&amp;h=550]

Note the width=100 pixels instead of 100% responsive
```

All of these shortcodes should probably have unit test coverage.
