### PR TITLE
Gravatar Profile: use p instead of h4 for profile link

### DIFF
--- a/modules/widgets/gravatar-profile.php
+++ b/modules/widgets/gravatar-profile.php
@@ -92,7 +92,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 
 			?>
 
-			<h4><a href="<?php echo esc_url( $profile['profileUrl'] ); ?>" class="grofile-full-link"><?php echo esc_html( apply_filters( 'jetpack_gravatar_full_profile_title', __( 'View Full Profile &rarr;', 'jetpack' ) ) ); ?></a></h4>
+			<p><a href="<?php echo esc_url( $profile['profileUrl'] ); ?>" class="grofile-full-link"><?php echo esc_html( apply_filters( 'jetpack_gravatar_full_profile_title', __( 'View Full Profile &rarr;', 'jetpack' ) ) ); ?></a></p>
 
 			<?php
 


### PR DESCRIPTION
`h4` can cause styling issues when a theme uses `h4` for all sidebar widget titles
