### PR TITLE
Sharedaddy: Style on Admin Page

### DIFF
--- a/modules/sharedaddy/admin-sharing.css
+++ b/modules/sharedaddy/admin-sharing.css
@@ -165,7 +165,8 @@ body.settings_page_sharing ul.preview li.preview-item, body.settings_page_sharin
 	text-decoration: none;
 }
 
-div.sd-social-icon ul.preview li.preview-item a span {
+div.sd-social-icon ul.preview li.preview-item a span,
+div.sd-social-icon .inner li.preview-item a span {
 	display: none;
 }
 


### PR DESCRIPTION
At wp-admin/options-general.php?page=sharing, some icon previews are broken.
Before:
![sharedaddy-before](https://cloud.githubusercontent.com/assets/3660715/4063411/6c47ac34-2e07-11e4-9ca9-25025c3f6dce.png)
After:
![sharedaddy-after](https://cloud.githubusercontent.com/assets/3660715/4063415/70be2c16-2e07-11e4-96aa-05de72a2db79.png)
