### PR TITLE
Before attempting to load any modules make sure Jetpack is connected

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -698,7 +698,7 @@ class Jetpack {
 	 * Loads the currently active modules.
 	 */
 	public static function load_modules() {
-		if( !self::is_active() ) {
+		if( !self::is_active() && !self::is_development_mode() ) {
 			return;
 		}
 


### PR DESCRIPTION
A key conditional checking to see if Jetpack is connected before loading any module was
removed in fc16302fe65c561af685cc689cb68e36e6dc0480. This commit re-adds that check but
before Jetpack even attempts to load any modules at all.

Fixes #1047
