### PR TITLE
Better Cacheing for Related Posts

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -887,11 +887,13 @@ EOT;
 			}
 		}
 
-		// Set new cache value
-		$new_cache[ $cache_key ] = array(
-			'expires' => 12 * HOUR_IN_SECONDS + $now_ts,
-			'payload' => $related_posts,
-		);
+		// Set new cache value if valid
+		if ( !empty( $related_posts ) ) {
+			$new_cache[ $cache_key ] = array(
+				'expires' => 12 * HOUR_IN_SECONDS + $now_ts,
+				'payload' => $related_posts,
+			);
+		}
 
 		// Update cache
 		update_post_meta( $post_id, $cache_meta_key, $new_cache );


### PR DESCRIPTION
Make sure we don't cache empty results and add logic to return stale cached results incase the WordPress.com endpoint goes down.
