### PR TITLE
Check for array input in AtD_change_mce_settings, and unit tests.

### DIFF
--- a/modules/after-the-deadline.php
+++ b/modules/after-the-deadline.php
@@ -139,6 +139,9 @@ function AtD_change_mce_settings( $init_array ) {
 	if ( ! AtD_is_allowed() )
 		return $init_array;
 
+	if ( ! is_array( $init_array ) )
+		$init_array = array();
+
 	$user = wp_get_current_user();
 
 	$init_array['atd_rpc_url']        = admin_url( 'admin-ajax.php?action=proxy_atd&_wpnonce=' . wp_create_nonce( 'proxy_atd' ) . '&url=' );

--- a/tests/modules/test_class.after_the_deadline.php
+++ b/tests/modules/test_class.after_the_deadline.php
@@ -1,0 +1,42 @@
+<?php
+
+class WP_Test_Jetpack_Modules_After_The_Deadline extends WP_UnitTestCase {
+
+ 	public function setUp() {
+		parent::setUp();
+
+  		$author_id = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+		wp_set_current_user( $author_id );
+
+		require_once dirname( __FILE__ ) . '/../../modules/after-the-deadline.php';
+	}
+
+	/**
+	 * @author scotchfield
+	 * @covers AtD_change_mce_settings
+	 * @since 3.2
+	 */
+	public function test_change_mce_settings_array() {
+		$init_array = array();
+
+		$result = AtD_change_mce_settings( $init_array );
+
+		$this->assertInternalType( 'array', $result );
+	}
+
+	/**
+	 * @author scotchfield
+	 * @covers AtD_change_mce_settings
+	 * @since 3.2
+	 */
+	public function test_change_mce_settings_invalid_string() {
+		$input = 'test string';
+
+		$result = AtD_change_mce_settings( $input );
+
+		$this->assertInternalType( 'array', $result );
+	}
+
+}


### PR DESCRIPTION
Should the function fix an invalid input variable as proposed here? The rest of the mce code is expecting an array, so we could at least do this. Another fix for this is to just return the unexpected input, like a string, unchanged.
https://github.com/Automattic/jetpack/issues/1056
