### PR TITLE
Sharing: update LinkedIn Sharing URL for non-official button

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -574,12 +574,9 @@ class Share_LinkedIn extends Sharing_Source {
 
 		$post_link = $this->get_share_url( $post->ID );
 
-		// Using the same URL as the official button, which is *not* LinkedIn's documented sharing link
-		// http://www.linkedin.com/cws/share?url={url}&token=&isFramed=false
-
 		$linkedin_url = add_query_arg( array(
 			'url' => rawurlencode( $post_link ),
-		), $this->http() . '://www.linkedin.com/cws/share?token=&isFramed=false' );
+		), $this->http() . '://www.linkedin.com/shareArticle?mini=true' );
 
 		// Record stats
 		parent::process_request( $post, $post_data );


### PR DESCRIPTION
The old URL now creates a redirect loop

Fixes #1081
