### PR TITLE
Fix for shutter speed values from EXIF data

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -998,10 +998,12 @@ jQuery(document).ready(function($) {
 
 		shutterSpeed: function(d) {
 			if (d >= 1) {
-				return Math.round(d*10)/10 + 's';
+				return Math.round(d*10)/10 + 's'; // round to one decimal if value > 1s by multiplying it by 10, rounding, then dividing by 10 again
 			}
 			var df = 1, top = 1, bot = 1;
 			var tol = 1e-8;
+			// iterate while value not reached and difference (positive or negative, hence the Math.abs) between value 
+			// and approximated value greater than given tolerance
 			while (df !== d && Math.abs(df-d) > tol) {
 				if (df < d) {
 					top += 1;


### PR DESCRIPTION
Shutter speeds were not displayed correctly, depending on their value (see https://github.com/Automattic/jetpack/issues/692). With this fix, shutter speeds up to 1/10000 s should be displayed correctly. Also now allows for one digit when shutter speed is greater than 1 s.
Not tested for performance issues on mobile terminals.
