### PR TITLE
Contact Form: Ensure contact forms fit properly in text widgets.

### DIFF
--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -7,4 +7,4 @@
 .contact-form label.checkbox, .contact-form label.radio { margin-bottom: 3px; float: none; font-weight: bold; display: inline-block; }
 .contact-form label span { color: #AAA; margin-left: 4px; font-weight: normal; }
 .form-errors .form-error-message { color: red; }
-.textwidget input[type='text'], .textwidget input[type='email'], .textwidget textarea { width: 250px; max-width: 98%; }
+.textwidget input[type='text'], .textwidget input[type='email'], .textwidget textarea { width: 250px; max-width: 100%; box-sizing: border-box; }


### PR DESCRIPTION
Fixes #themes2665.

Merges r104666-wpcom.
