### PR TITLE
Featured Content: Correct check for whether or not the front page is the...

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -254,10 +254,8 @@ class Featured_Content {
 			return;
 		}
 
-		$page_on_front = get_option( 'page_on_front' );
-
 		// Bail if the blog page is not the front page.
-		if ( ! empty( $page_on_front ) ) {
+		if ( 'posts' !== get_option( 'show_on_front' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
... blog page.

Checking if `page_on_front` is empty can cause problems, since it's no longer empty as soon as a page is set once - even when the user changes back to using the blog as the front page, `page_on_front` retains the page ID. `show_on_front` is a more accurate way of determining if the blog is the front page or not.
