### PR TITLE
id variable might not have been defined

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -12,6 +12,7 @@
 function jetpack_shortcode_get_vimeo_id( $atts ) {
 	if ( isset( $atts[0] ) ) {
 		$atts[0] = trim( $atts[0] , '=' );
+		$id = false;
 		if ( is_numeric( $atts[0] ) )
 			$id = (int) $atts[0];
 		elseif ( preg_match( '|vimeo\.com/(\d+)/?$|i', $atts[0], $match ) )


### PR DESCRIPTION
If passed a non-vimeo URL, this produces an error as ID variable does not have a fallback value / is not set.
