### PR TITLE
Publicize: Change 'Edit' to 'Edit Details' and add line break in Meta Box

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -680,10 +680,10 @@ jQuery( function($) {
 			endif;
 			?>
 
-			<span id="publicize-defaults"><strong><?php echo join( '</strong>, <strong>', array_map( 'esc_html', $active ) ); ?></strong></span>
+			<span id="publicize-defaults"><strong><?php echo join( '</strong>, <strong>', array_map( 'esc_html', $active ) ); ?></strong></span><br />
 
 			<?php if ( 0 < count( $services ) ) : ?>
-				<a href="#" id="publicize-form-edit"><?php _e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo admin_url( 'options-general.php?page=sharing' ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
+				<a href="#" id="publicize-form-edit"><?php _e( 'Edit Details', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo admin_url( 'options-general.php?page=sharing' ); ?>" target="_blank"><?php _e( 'Settings', 'jetpack' ); ?></a><br />
 			<?php else : ?>
 				<a href="#" id="publicize-disconnected-form-show"><?php _e( 'Show', 'jetpack' ); ?></a><br />
 			<?php endif; ?>


### PR DESCRIPTION
Right now it kind of looks like "Edit Settings", so this change makes it a little more obvious that it's two different options and it also places them in a new line under the social networks:

![screen shot 2014-09-08 at 9 04 11 am](https://cloud.githubusercontent.com/assets/3220162/4188399/2ed5e342-3772-11e4-9b32-ddf6117f0f8f.png)
