### PR TITLE
Prevent markdown links conflicting with shortcodes

### DIFF
--- a/_inc/lib/markdown/gfm.php
+++ b/_inc/lib/markdown/gfm.php
@@ -264,6 +264,10 @@ class WPCom_GHF_Markdown_Parser extends MarkdownExtra_Parser {
 	 */
 	protected function get_shortcode_regex() {
 		$pattern = get_shortcode_regex();
+		
+		// don't match markdown link anchors that could be mistaken for shortcodes.
+		$pattern .= '(?!\()'; 
+		
 		return "/$pattern/s";
 	}
 


### PR DESCRIPTION
This fixes issue #433.
