### PR TITLE
Accessible share links

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -78,7 +78,7 @@ abstract class Sharing_Source {
 			( $this->open_links == 'new' ) ? ' target="_blank"' : '',
 			$title,
 			( $id ? ' id="' . esc_attr( $id ) . '"' : '' ),
-			( $this->button_style == 'icon' ) ? ' class="screen-reader-text"' : '',
+			( $this->button_style == 'icon' ) ? ' class="sharing-screen-reader-text"' : '',
 			$text
 		);
 	}

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -568,7 +568,7 @@ body .sd-social-icon .sd-content li.share-custom a span {
  * Screen Reader Text for "Icon Only" option
  */
 
-.screen-reader-text {
+.sharing-screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
 	position: absolute !important;
 	height: 1px;
@@ -576,9 +576,9 @@ body .sd-social-icon .sd-content li.share-custom a span {
 	overflow: hidden;
 }
 
-.screen-reader-text:hover,
-.screen-reader-text:active,
-.screen-reader-text:focus {
+.sharing-screen-reader-text:hover,
+.sharing-screen-reader-text:active,
+.sharing-screen-reader-text:focus {
 	background-color: #f1f1f1;
 	border-radius: 3px;
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
Hello, following on from issue #1069 this pull request adds hidden screen reader text to icon only sharing links. The title attributes on these links already offer good descriptions (example: Click to share on Google+) so I'm using this as a basis, and adding '(Opens in new window)' when that option is also selected. I've also added the .screen-reader-text styles from _s into sharing.css as this won't be present in every theme.
## Possible areas for expansion
1. At the moment this doesn't change the previews shown when setting sharing up in admin, I can look into this if desired.
2. The other types of sharing links include text as wel as icons, but not as descriptive. It could be worth adding some form of screen reader text to them as well as the visible text.

Happy to hear any thoughts people might have.
