### PR TITLE
Sharing: Apply style changes to hidden items

### DIFF
--- a/modules/sharedaddy/admin-sharing.js
+++ b/modules/sharedaddy/admin-sharing.js
@@ -119,10 +119,10 @@
 
 			// Button style
 			if ( 'icon' === button_style ) {
-				$( '#live-preview ul.preview div span' ).html( '&nbsp;' ).parent().addClass( 'no-text' ); // Remove text label
+				$( '#live-preview ul.preview div span, .sharing-hidden .inner ul div span' ).html( '&nbsp;' ).parent().addClass( 'no-text' );
 				$( '#live-preview div.sharedaddy' ).addClass( 'sd-social-icon' );
 			} else if ( 'official' === button_style ) {
-				$( '#live-preview ul.preview .advanced' ).each( function( /*i*/ ) {
+				$( '#live-preview ul.preview .advanced, .sharing-hidden .inner ul .advanced' ).each( function( /*i*/ ) {
 					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'share-custom' ) ) {
 						$( this ).find( '.option a span' ).html( '' ).parent().removeClass( 'sd-button' ).parent().attr( 'class', 'option option-smart-on' );
 					}


### PR DESCRIPTION
Before:
![2014-09-12 21 41 32](https://cloud.githubusercontent.com/assets/3660715/4249743/3188d746-3a7b-11e4-917c-ee26a58f41f8.png)

After:
![2014-09-12 21 43 04](https://cloud.githubusercontent.com/assets/3660715/4249745/33ec5512-3a7b-11e4-9190-314c67480eba.png)

In sharing preview, hidden sharing items doesn't have correct class names.
