### PR TITLE
Force display:block on Likes to prevent wrapping

### DIFF
--- a/modules/likes/style.css
+++ b/modules/likes/style.css
@@ -137,6 +137,7 @@ div.sd-box {
 .comment-likes-widget {
 	margin: 0;
 	border-width: 0;
+	display: block;
 }
 
 


### PR DESCRIPTION
In iOS8 and Safari 7.1, a weird wrapping issue appeared with the Likes
widget (most obvious in responsive scenarios, where it messed up
layout). The Likes block would wrap around to the right of the “Like
this” title, which is not intended. Including display:block pushes it
back down below the title, where it’s meant to be.
