### PR TITLE
Define disconnect as common abstract function

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -82,6 +82,21 @@ class Publicize extends Publicize_Base {
 		<?php
 	}
 
+	/**
+	 * Remove a Publicize connection
+	 */
+	function disconnect( $service_name, $connection_id, $_blog_id = false, $_user_id = false, $force_delete = false ) {
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client();
+		$xml->query( 'jetpack.deletePublicizeConnection', $connection_id );
+
+		if ( ! $xml->isError() ) {
+			Jetpack_Options::update_option( 'publicize_connections', $xml->getResponse() );
+		} else {
+			return false;
+		}
+	}
+
 	function get_connections( $service_name, $_blog_id = false, $_user_id = false ) {
 		$connections = Jetpack_Options::get_option( 'publicize_connections' );
 		$connections_to_return = array();
@@ -161,14 +176,8 @@ class Publicize extends Publicize_Base {
 				check_admin_referer( 'keyring-request', 'kr_nonce' );
 				check_admin_referer( "keyring-request-$service_name", 'nonce' );
 
-				Jetpack::load_xml_rpc_client();
-				$xml = new Jetpack_IXR_Client();
-				$xml->query( 'jetpack.deletePublicizeConnection', $id );
+				$this->disconnect( $service_name, $id );
 
-				if ( !$xml->isError() ) {
-					$response = $xml->getResponse();
-					Jetpack_Options::update_option( 'publicize_connections', $response );
-				}
 				add_action( 'admin_notices', array( $this, 'display_disconnected' ) );
 				break;
 			}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -84,6 +84,7 @@ abstract class Publicize_Base {
 	abstract function get_connection( $service, $id, $_blog_id = false, $_user_id = false );
 	abstract function flag_post_for_publicize( $new_status, $old_status, $post );
 	abstract function test_connection( $service_name, $connection );
+	abstract function disconnect( $service, $connection_id, $_blog_id = false, $_user_id = false, $force_delete = false );
 
 	/**
 	* Shared Functions


### PR DESCRIPTION
Enables option to remove a publicize connection common to all publicize
environments.
