### PR TITLE
Fix phpunit @covers tags for coverage output.

### DIFF
--- a/tests/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/modules/contact-form/test_class.grunion-contact-form.php
@@ -395,7 +395,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers grunion_delete_old_spam
+	 * @covers ::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_deletes_an_old_post_marked_as_spam() {
 		$post_id = $this->factory->post->create( array(
@@ -410,7 +410,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers grunion_delete_old_spam
+	 * @covers ::grunion_delete_old_spam
 	 */
 	public function test_grunion_delete_old_spam_does_not_delete_a_new_post_marked_as_spam() {
 		$post_id = $this->factory->post->create( array(

--- a/tests/modules/shortcodes/test_class.archives.php
+++ b/tests/modules/shortcodes/test_class.archives.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_type_default() {
@@ -37,7 +37,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_format_option() {
@@ -53,7 +53,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_format_html() {
@@ -69,7 +69,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_type_yearly() {
@@ -87,7 +87,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_type_monthly() {
@@ -105,7 +105,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_type_weekly() {
@@ -123,7 +123,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_type_daily() {
@@ -141,7 +141,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_limit_one() {
@@ -159,7 +159,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_limit_zero_is_all() {
@@ -177,7 +177,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_showcount() {
@@ -199,7 +199,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_before() {
@@ -218,7 +218,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_after() {
@@ -237,7 +237,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_order_asc() {
@@ -260,7 +260,7 @@ class WP_Test_Jetpack_Shortcodes_Archives extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers archives_shortcode
+	 * @covers ::archives_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_archives_order_desc() {

--- a/tests/modules/shortcodes/test_class.audio.php
+++ b/tests/modules/shortcodes/test_class.audio.php
@@ -4,7 +4,6 @@ class WP_Test_Jetpack_Shortcodes_Audio extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers AudioShortcode::__construct
 	 * @since 3.2
 	 */
 	public function test_shortcodes_audio_exists() {
@@ -13,7 +12,6 @@ class WP_Test_Jetpack_Shortcodes_Audio extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers AudioShortcode::audio_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_audio() {
@@ -26,7 +24,6 @@ class WP_Test_Jetpack_Shortcodes_Audio extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers AudioShortcode::audio_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_audio_single_file() {

--- a/tests/modules/shortcodes/test_class.bandcamp.php
+++ b/tests/modules/shortcodes/test_class.bandcamp.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Bandcamp extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers shortcode_handler_bandcamp
+	 * @covers ::shortcode_handler_bandcamp
 	 * @since 3.2
 	 */
 	public function test_shortcodes_bandcamp_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Bandcamp extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers shortcode_handler_bandcamp
+	 * @covers ::shortcode_handler_bandcamp
 	 * @since 3.2
 	 */
 	public function test_shortcodes_bandcamp() {

--- a/tests/modules/shortcodes/test_class.blip.php
+++ b/tests/modules/shortcodes/test_class.blip.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Blip extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers blip_shortcode
+	 * @covers ::blip_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_blip_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Blip extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers blip_shortcode
+	 * @covers ::blip_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_blip() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_Blip extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers blip_shortcode
+	 * @covers ::blip_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_blip_empty() {
@@ -39,7 +39,7 @@ class WP_Test_Jetpack_Shortcodes_Blip extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers blip_shortcode
+	 * @covers ::blip_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_blip_posts_id_and_dest() {
@@ -55,7 +55,7 @@ class WP_Test_Jetpack_Shortcodes_Blip extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers blip_shortcode
+	 * @covers ::blip_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_blip_http_url() {

--- a/tests/modules/shortcodes/test_class.dailymotion.php
+++ b/tests/modules/shortcodes/test_class.dailymotion.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers dailymotion_shortcode
+	 * @covers ::dailymotion_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_dailymotion_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers dailymotion_shortcode
+	 * @covers ::dailymotion_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_dailymotion() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers dailymotion_shortcode
+	 * @covers ::dailymotion_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_dailymotion_id() {
@@ -40,7 +40,7 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers dailymotion_shortcode
+	 * @covers ::dailymotion_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_dailymotion_missing_id() {
@@ -53,7 +53,7 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers dailymotion_shortcode
+	 * @covers ::dailymotion_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_dailymotion_title() {
@@ -68,7 +68,7 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers dailymotion_shortcode
+	 * @covers ::dailymotion_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_dailymotion_user() {
@@ -83,7 +83,7 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers dailymotion_shortcode
+	 * @covers ::dailymotion_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_dailymotion_video() {

--- a/tests/modules/shortcodes/test_class.facebook.php
+++ b/tests/modules/shortcodes/test_class.facebook.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers jetpack_facebook_shortcode_handler
+	 * @covers ::jetpack_facebook_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_facebook_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Facebook extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers jetpack_facebook_shortcode_handler
+	 * @covers ::jetpack_facebook_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_facebook() {

--- a/tests/modules/shortcodes/test_class.flickr.php
+++ b/tests/modules/shortcodes/test_class.flickr.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers flickr_shortcode_handler
+	 * @covers ::flickr_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_flickr_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers flickr_shortcode_handler
+	 * @covers ::flickr_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_flickr() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers flickr_shortcode_handler
+	 * @covers ::flickr_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_flickr_video_http() {
@@ -41,7 +41,7 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers flickr_shortcode_handler
+	 * @covers ::flickr_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_flickr_video_id() {
@@ -55,7 +55,7 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers flickr_shortcode_handler
+	 * @covers ::flickr_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_flickr_video_id_show_info() {
@@ -70,7 +70,7 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers flickr_shortcode_handler
+	 * @covers ::flickr_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_flickr_video_id_width_height() {
@@ -88,7 +88,7 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers flickr_shortcode_handler
+	 * @covers ::flickr_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_flickr_video_id_show_info_secret() {

--- a/tests/modules/shortcodes/test_class.googlemaps.php
+++ b/tests/modules/shortcodes/test_class.googlemaps.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Googlemaps extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers jetpack_googlemaps_shortcode
+	 * @covers ::jetpack_googlemaps_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_googlemaps_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Googlemaps extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers jetpack_googlemaps_shortcode
+	 * @covers ::jetpack_googlemaps_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_googlemaps() {

--- a/tests/modules/shortcodes/test_class.scribd.php
+++ b/tests/modules/shortcodes/test_class.scribd.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Scribd extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers scribd_shortcode_handler
+	 * @covers ::scribd_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_scribd_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Scribd extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers scribd_shortcode_handler
+	 * @covers ::scribd_shortcode_handler
 	 * @since 3.2
 	 */
 	public function test_shortcodes_scribd() {

--- a/tests/modules/shortcodes/test_class.slideshare.php
+++ b/tests/modules/shortcodes/test_class.slideshare.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Slideshare extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers slideshare_shortcode
+	 * @covers ::slideshare_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_slideshare_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Slideshare extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers slideshare_shortcode
+	 * @covers ::slideshare_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_slideshare() {

--- a/tests/modules/shortcodes/test_class.soundcloud.php
+++ b/tests/modules/shortcodes/test_class.soundcloud.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers soundcloud_shortcode
+	 * @covers ::soundcloud_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_soundcloud_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers soundcloud_shortcode
+	 * @covers ::soundcloud_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_soundcloud() {

--- a/tests/modules/shortcodes/test_class.ted.php
+++ b/tests/modules/shortcodes/test_class.ted.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Ted extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers shortcode_ted
+	 * @covers ::shortcode_ted
 	 * @since 3.2
 	 */
 	public function test_shortcodes_ted_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Ted extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers shortcode_ted
+	 * @covers ::shortcode_ted
 	 * @since 3.2
 	 */
 	public function test_shortcodes_ted() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_Ted extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers shortcode_ted
+	 * @covers ::shortcode_ted
 	 * @since 3.2
 	 */
 	public function test_shortcodes_ted_id() {
@@ -48,7 +48,7 @@ class WP_Test_Jetpack_Shortcodes_Ted extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers shortcode_ted
+	 * @covers ::shortcode_ted
 	 * @since 3.2
 	 */
 	public function test_shortcodes_ted_width_height() {
@@ -72,7 +72,7 @@ class WP_Test_Jetpack_Shortcodes_Ted extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers shortcode_ted
+	 * @covers ::shortcode_ted
 	 * @since 3.2
 	 */
 	public function test_shortcodes_ted_lang() {

--- a/tests/modules/shortcodes/test_class.twitter-timeline.php
+++ b/tests/modules/shortcodes/test_class.twitter-timeline.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers twitter_timeline_shortcode
+	 * @covers ::twitter_timeline_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_twitter_timeline_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers twitter_timeline_shortcode
+	 * @covers ::twitter_timeline_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_twitter_timeline() {

--- a/tests/modules/shortcodes/test_class.vimeo.php
+++ b/tests/modules/shortcodes/test_class.vimeo.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vimeo_shortcode
+	 * @covers ::vimeo_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vimeo_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vimeo_shortcode
+	 * @covers ::vimeo_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vimeo() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vimeo_shortcode
+	 * @covers ::vimeo_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vimeo_id() {
@@ -40,7 +40,7 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vimeo_shortcode
+	 * @covers ::vimeo_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vimeo_url() {
@@ -55,7 +55,7 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vimeo_shortcode
+	 * @covers ::vimeo_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_w_h() {
@@ -73,7 +73,7 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vimeo_shortcode
+	 * @covers ::vimeo_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_width_height() {

--- a/tests/modules/shortcodes/test_class.vine.php
+++ b/tests/modules/shortcodes/test_class.vine.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Vine extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vine_shortcode
+	 * @covers ::vine_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vine_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Vine extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vine_shortcode
+	 * @covers ::vine_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vine() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_Vine extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vine_shortcode
+	 * @covers ::vine_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vine_url() {
@@ -40,7 +40,7 @@ class WP_Test_Jetpack_Shortcodes_Vine extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vine_shortcode
+	 * @covers ::vine_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vine_inappropriate_url() {
@@ -54,7 +54,7 @@ class WP_Test_Jetpack_Shortcodes_Vine extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vine_shortcode
+	 * @covers ::vine_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vine_url_width_height() {
@@ -72,7 +72,7 @@ class WP_Test_Jetpack_Shortcodes_Vine extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers vine_shortcode
+	 * @covers ::vine_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_vine_url_postcard() {

--- a/tests/modules/shortcodes/test_class.youtube.php
+++ b/tests/modules/shortcodes/test_class.youtube.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers youtube_shortcode
+	 * @covers ::youtube_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_youtube_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers youtube_shortcode
+	 * @covers ::youtube_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_youtube() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers youtube_shortcode
+	 * @covers ::youtube_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_youtube_url() {

--- a/tests/modules/test_class.after_the_deadline.php
+++ b/tests/modules/test_class.after_the_deadline.php
@@ -15,7 +15,7 @@ class WP_Test_Jetpack_Modules_After_The_Deadline extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers AtD_change_mce_settings
+	 * @covers ::AtD_change_mce_settings
 	 * @since 3.2
 	 */
 	public function test_change_mce_settings_array() {
@@ -28,7 +28,7 @@ class WP_Test_Jetpack_Modules_After_The_Deadline extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers AtD_change_mce_settings
+	 * @covers ::AtD_change_mce_settings
 	 * @since 3.2
 	 */
 	public function test_change_mce_settings_invalid_string() {

--- a/tests/test_class.functions.compat.php
+++ b/tests/test_class.functions.compat.php
@@ -4,7 +4,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers youtube_sanitize_url
+	 * @covers ::youtube_sanitize_url
 	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_valid_url() {
@@ -18,7 +18,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers youtube_sanitize_url
+	 * @covers ::youtube_sanitize_url
 	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_shortened_url() {
@@ -33,7 +33,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers youtube_sanitize_url
+	 * @covers ::youtube_sanitize_url
 	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_slash_v_slash() {
@@ -48,7 +48,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers youtube_sanitize_url
+	 * @covers ::youtube_sanitize_url
 	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_hashbang() {
@@ -63,7 +63,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers youtube_sanitize_url
+	 * @covers ::youtube_sanitize_url
 	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_amp_ampersand() {
@@ -78,7 +78,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers youtube_sanitize_url
+	 * @covers ::youtube_sanitize_url
 	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_encoded_ampersand() {
@@ -93,7 +93,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers youtube_sanitize_url
+	 * @covers ::youtube_sanitize_url
 	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_playlist() {
@@ -108,7 +108,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers youtube_sanitize_url
+	 * @covers ::youtube_sanitize_url
 	 * @since 3.2
 	 */
 	public function test_youtube_sanitize_url_with_extra_question_mark() {
@@ -123,7 +123,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers jetpack_get_youtube_id
+	 * @covers ::jetpack_get_youtube_id
 	 * @since 3.2
 	 */
 	public function test_jetpack_get_youtube_id_with_single_video_url() {
@@ -138,7 +138,7 @@ class WP_Test_Functions_Compat extends WP_UnitTestCase {
 
 	/**
 	 * @author enkrates
-	 * @covers jetpack_get_youtube_id
+	 * @covers ::jetpack_get_youtube_id
 	 * @since 3.2
 	 */
 	public function test_jetpack_get_youtube_id_with_playlist_url() {


### PR DESCRIPTION
Unfortunately, there are some bogus @covers tags in the test suite that prevent neat things like `phpunit --coverage-html` from working. With this fix, we can view the testing coverage, and have a better view on what to fix in the future.
(Sorry, a lot of these are mine from a recent push! ack.) :(
See https://phpunit.de/manual/3.7/en/appendixes.annotations.html#appendixes.annotations.covers for details on the expected format. (most notably, the double-colon for functions defined outside of a class)
