### PR TITLE
Add third parameter to preg_match_all

### DIFF
--- a/class.media-summary.php
+++ b/class.media-summary.php
@@ -267,6 +267,6 @@ class Jetpack_Media_Summary {
 	}
 
 	static function get_link_count( $post_content ) {
-		return preg_match_all( '/\<a[\> ]/', $post_content );
+		return preg_match_all( '/\<a[\> ]/', $post_content, $matches );
 	}
 }


### PR DESCRIPTION
Sorry, I didn't realize this was a mandatory parameter in older PHP versions. Adding the parameter, and the tests pass for me.
https://github.com/Automattic/jetpack/issues/1160
