### PR TITLE
Contact Form: Add filter to allow more than 5 new fields

### DIFF
--- a/modules/contact-form/grunion-form-view.php
+++ b/modules/contact-form/grunion-form-view.php
@@ -20,6 +20,7 @@ wp_localize_script( 'grunion', 'GrunionFB_i18n', array(
 	'savedMessage' => esc_attr__( 'Saved successfully', 'jetpack' ),
 	'requiredLabel' => esc_attr( _x( '(required)', 'This HTML form field is marked as required by the user in contact form builder', 'jetpack' ) ),
 	'exitConfirmMessage' => esc_attr__( 'Are you sure you want to exit the form editor without saving?  Any changes you have made will be lost.', 'jetpack' ),
+	'maxNewFields' => intval( apply_filters( 'grunion_max_new_fields', 5 ) ),
 ) );
 
 ?>

--- a/modules/contact-form/js/grunion.js
+++ b/modules/contact-form/js/grunion.js
@@ -20,7 +20,8 @@ GrunionFB_i18n = jQuery.extend( {
 	editLabel: 'edit',
 	savedMessage: 'Saved successfully',
 	requiredLabel: '(required)',
-	exitConfirmMessage: 'Are you sure you want to exit the form editor without saving?  Any changes you have made will be lost.'
+	exitConfirmMessage: 'Are you sure you want to exit the form editor without saving?  Any changes you have made will be lost.',
+	maxNewFields: 5
 }, GrunionFB_i18n );
 
 GrunionFB_i18n.moveInstructions = GrunionFB_i18n.moveInstructions.replace( '\n', '<br />' );
@@ -75,7 +76,7 @@ FB.ContactForm = (function() {
 	};
 	var debug = false; // will print errors to log if true
 	var grunionNewCount = 0; // increment for new fields
-	var maxNewFields = 5;  // Limits number of new fields available
+	var maxNewFields = GrunionFB_i18n.maxNewFields;  // See filter in ../grunion-form-view.php
 	var optionsCache = {};
 	var optionsCount = 0; // increment for options
 	var shortcode;


### PR DESCRIPTION
Adds `grunion_max_new_fields` filter to modify the currently hard-coded limit of 5 additional contact form fields.
