### PR TITLE
SSO: Adjust size of WP logo on forced SSO button.

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -438,9 +438,9 @@ class Jetpack_SSO {
 			}
 			.forced-sso .jetpack-sso.button:before {
 				font-size: 28px !important;
-				height: 28px;
+				height: 37px;
 				padding: 5px 5px 4px;
-				width: 28px;
+				width: 37px;
 			}
 			<?php endif; ?>
 		</style>


### PR DESCRIPTION
The last time I tried to adjust an SSO button, it wasn't as perfect as it should be. I _think_ this one does a better job. Fixes #1166 
![screen shot 2014-10-08 at 22 05 53](https://cloud.githubusercontent.com/assets/88897/4570581/3803c7fc-4f61-11e4-8699-f093b6cef718.png)
