### PR TITLE
VideoPress: update module description wording

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -138,7 +138,7 @@ _x( 'Verify your site or domain with Google Webmaster Tools, Pinterest, and othe
 
 // modules/videopress.php
 _x( 'VideoPress', 'Module Name', 'jetpack' );
-_x( 'Upload and host video right on your site. (Subscription required.)', 'Module Description', 'jetpack' );
+_x( 'Upload and embed videos right on your site. (Subscription required.)', 'Module Description', 'jetpack' );
 
 // modules/widget-visibility.php
 _x( 'Widget Visibility', 'Module Name', 'jetpack' );

--- a/modules/videopress.php
+++ b/modules/videopress.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: VideoPress
- * Module Description: Upload and host video right on your site. (Subscription required.)
+ * Module Description: Upload and embed videos right on your site. (Subscription required.)
  * First Introduced: 2.5
  * Free: false
  * Requires Connection: Yes


### PR DESCRIPTION
"host" makes it sound like the videos are hosted on your site,
while they're hosted on WordPress.com.
