### PR TITLE
Fix post_content notice when the safe post is empty

### DIFF
--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -483,7 +483,6 @@ class Jetpack_Custom_CSS {
 			// Don't bother checking for a migrated 'safecss' option if it never existed.
 			if ( false === get_option( 'safecss' ) || get_option( 'safecss_revision_migrated' ) ) {
 				$safecss_post = Jetpack_Custom_CSS::get_post();
-                
 				if ( ! empty( $safecss_post ) ) {
 					$css = ( $compressed && $safecss_post['post_content_filtered'] ) ? $safecss_post['post_content_filtered'] : $safecss_post['post_content'];
 				}


### PR DESCRIPTION
When installing Jetpack for the first time, heading to Edit CSS triggers a notice for missing `post_content` since the safecss_post is an empty array. The first validation for that happens after these conditionals, so adding an extra check to prevent from further notices.
