### PR TITLE
Open Graph: add AIOSEO back to the list of conflicting plugins

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -130,7 +130,7 @@ class Jetpack {
 	/**
 	 * Plugins for which we turn off our Facebook OG Tags implementation.
 	 *
-	 * Note: WordPress SEO by Yoast, WordPress SEO Premium by Yoast, All in One SEO Pack and All in One SEO Pack Pro automatically deactivate
+	 * Note: WordPress SEO by Yoast and WordPress SEO Premium by Yoast automatically deactivate
 	 * Jetpack's Open Graph tags via filter when their Social Meta modules are active.
 	 *
 	 * Plugin authors: If you'd like to prevent Jetpack's Open Graph tag generation in your plugin, you can do so via this filter:
@@ -141,6 +141,7 @@ class Jetpack {
 		                                                         // 2 Click Social Media Buttons
 		'add-link-to-facebook/add-link-to-facebook.php',         // Add Link to Facebook
 		'add-meta-tags/add-meta-tags.php',                       // Add Meta Tags
+		'all-in-one-seo-pack/all_in_one_seo_pack.php',           // All in One SEO Pack
 		'easy-facebook-share-thumbnails/esft.php',               // Easy Facebook Share Thumbnail
 		'facebook/facebook.php',                                 // Facebook (official plugin)
 		'facebook-awd/AWD_facebook.php',                         // Facebook AWD All in one


### PR DESCRIPTION
A few months ago, we removed All In One SEO from our list of conflicting plugins in 48573a9f0d4616e22ea8c11ce197570c656b2fda, since the plugin authors had added a check for our OG Tags and Twitter Cards, allowing site owners to deactivate Jetpack's OG tags from the AIOSEO plugin options.

Unfortunately, that option doesn't seem to work. That consequently creates a duplicate set of tags when both Jetpack and AIOSEO are active and set to output OG Tags and Twitter Cards.

I've contacted the AIOSEO team to let them know about the issue, and proposed a patch. 
- https://plugins.trac.wordpress.org/ticket/2304
- https://twitter.com/jeherve/status/523394507594031104

Until that patch is released, I think we should add AIOSEO back to the list of conflicting plugins to remove our tags when the plugin is active, and avoid any issues.
