### PR TITLE
Sharing: prevent duplicate @ in shared Tweets

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -352,17 +352,20 @@ class Share_Twitter extends Sharing_Source {
 
 		/*
 		 * Hack to remove the unwanted behavior of adding 'via @jetpack' which
-		 * was introduced with the adding of the Twitter cards. 
+		 * was introduced with the adding of the Twitter cards.
 		 * This should be a temporary solution until a better method is setup.
 		 */
 		if( 'jetpack' == $twitter_site_tag_value ) {
 			$twitter_site_tag_value = '';
 		}
 
+		$twitter_site_tag_value = apply_filters( 'jetpack_sharing_twitter_via', $twitter_site_tag_value, $post->ID );
+
 		// Strip out anything other than a letter, number, or underscore.
 		// This will prevent the inadvertent inclusion of an extra @, as well as normalizing the handle.
 		$twitter_site_tag_value = preg_replace( '/[^\da-z_]+/i', '', $twitter_site_tag_value );
-		return apply_filters( 'jetpack_sharing_twitter_via', $twitter_site_tag_value, $post->ID );
+
+		return $twitter_site_tag_value;
 	}
 
 	public function get_related_accounts( $post ) {


### PR DESCRIPTION
This used to happen because Publicize's Twitter Connection Data saves the Twitter handle with an "@". The attached commit makes sure we always remove extra @, even after `jetpack_sharing_twitter_via` overwrote the previous `$twitter_site_tag_value` value.

cc @kraftbj since we discussed about it last week.
