### PR TITLE
Hide infinite-scroll class if the option is disabled

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -355,10 +355,14 @@ class The_Neverending_Home_Page {
 	 * Adds an 'infinite-scroll' class to the body.
 	 */
 	function body_class( $classes ) {
-		$classes[] = 'infinite-scroll';
-
-		if ( 'scroll' == self::get_settings()->type )
-			$classes[] = 'neverending';
+		// Do not add infinity-scroll class if disabled through the Reading page
+		$disabled = '' === get_option( self::$option_name_enabled ) ? true : false;
+		if ( ! $disabled ) {
+			$classes[] = 'infinite-scroll';
+	
+			if ( 'scroll' == self::get_settings()->type )
+				$classes[] = 'neverending';
+		}
 
 		return $classes;
 	}


### PR DESCRIPTION
The [Jetpack support page](http://jetpack.me/support/infinite-scroll/) says that the infinite-scroll class should be used in a theme to hide the navigation links. However, even when disabled in the Reading page, the class is still visible and the CSS is applied just as if the scroll is enabled.

Adding an option check before filtering the `body_class` classes.