### PR TITLE
Change validation function in install plugin test.

### DIFF
--- a/tests/test_class.json-api-jetpack-endpoints.php
+++ b/tests/test_class.json-api-jetpack-endpoints.php
@@ -137,9 +137,9 @@ u0		 */
 		$plugins_property->setAccessible( true );
 		$plugins_property->setValue ( $endpoint , array( $the_plugin_file ) );
 
-		$validate_input_method = $class->getMethod( 'validate_input' );
-		$validate_input_method->setAccessible( true );
-		$result = $validate_input_method->invoke( $endpoint, $the_plugin_file );
+		$validate_plugins_method = $class->getMethod( 'validate_plugins' );
+		$validate_plugins_method->setAccessible( true );
+		$result = $validate_plugins_method->invoke( $endpoint );
 		$this->assertTrue( $result );
 
 		$install_plugin_method = $class->getMethod( 'install' );


### PR DESCRIPTION
Changed the used validation function in tests, which had been forgotten after a rename for the install plugin endpoint.
