### PR TITLE
Plugin install endpoint: slug should never be empty

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -11,31 +11,36 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 	protected $download_links      = array();
 
 	protected function install() {
-		foreach ( $this->plugins as $plugin ) {
+		foreach ( $this->plugins as $index => $slug ) {
 
 			$skin      = new Automatic_Upgrader_Skin();
 			$upgrader  = new Plugin_Upgrader( $skin );
 
-			$result = $upgrader->install( $this->download_links[$plugin] );
+			$result = $upgrader->install( $this->download_links[ $slug ] );
 
 			if ( ! $this->bulk && is_wp_error( $result ) ) {
 				return $result;
 			}
 
-			if ( ! $this->bulk && ! $result ) {
-				$error = $this->log[ $plugin ]['error'] = __( 'An unknown error occurred during installation', 'jetpack' );
+			$plugin = $this::get_plugin_id_by_slug( $slug );
+
+			if ( ! $plugin ) {
+				$error = $this->log[ $slug ]['error'] = __( 'There was an error installing your plugin', 'jetpack' );
 			}
 
-			if ( ! $this::is_installed_plugin( $plugin ) ) {
-				$error = $this->log[ $plugin ]['error'] = __( 'There was an error installing your plugin', 'jetpack' );
+			if ( ! $this->bulk && ! $result ) {
+				$error = $this->log[ $slug ]['error'] = __( 'An unknown error occurred during installation', 'jetpack' );
 			}
 
 			$this->log[ $plugin ][] = $upgrader->skin->get_upgrade_messages();
 		}
 
 		if ( ! $this->bulk && isset( $error ) ) {
-			return  new WP_Error( 'install_error', $this->log[ $plugin ]['error'], 400 );
+			return  new WP_Error( 'install_error', $this->log[ $slug ]['error'], 400 );
 		}
+
+		// replace the slug with the actual plugin id
+		$this->plugins[ $index ] = $plugin;
 
 		return true;
 	}
@@ -44,34 +49,35 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 		if ( empty( $this->plugins ) || ! is_array( $this->plugins ) ) {
 			return new WP_Error( 'missing_plugins', __( 'No plugins found.', 'jetpack' ) );
 		}
-		foreach( $this->plugins as $index => $plugin ) {
-			if ( ! preg_match( "/\.php$/", $plugin ) ) {
-				$plugin                  =  $plugin . '.php';
-				$this->plugins[ $index ] = $plugin;
-			}
+		foreach( $this->plugins as $index => $slug ) {
 
-			if ( $this::is_installed_plugin( $plugin ) ) {
+			// make sure it is not already installed
+			if ( $this::get_plugin_id_by_slug( $slug ) ) {
 				return new WP_Error( 'plugin_already_installed', __( 'The plugin is already installed', 'jetpack' ) );
 			}
 
-			if ( strpos( $plugin, '/' ) ) {
-				$slug = substr( $plugin, 0, strpos( $plugin, '/' ) );
-			} else {
-				$slug = $plugin;
-			}
 			$response    = wp_remote_get( "http://api.wordpress.org/plugins/info/1.0/$slug" );
 			$plugin_data = unserialize( $response['body'] );
 			if ( is_wp_error( $plugin_data ) ) {
 				return $plugin_data;
 			}
-			$this->download_links[ $plugin ] = $plugin_data->download_link;
+
+			$this->download_links[ $slug ] = $plugin_data->download_link;
 
 		}
 		return true;
 	}
 
-	protected static function is_installed_plugin( $plugin ) {
-		return in_array( $plugin, array_keys( get_plugins() ) );
+	protected static function get_plugin_id_by_slug( $slug ) {
+		$plugins = get_plugins();
+		if( ! is_array( $plugins ) ) {
+			return false;
+		}
+		foreach( $plugins as $id => $plugin_data ) {
+			if( strpos( $id, $slug ) !== false ) {
+				return $id;
+			}
+		}
+		return false;
 	}
-
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -279,7 +279,7 @@ new Jetpack_JSON_API_Plugins_Install_Endpoint( array(
 			'authorization' => 'Bearer YOUR_API_TOKEN'
 		),
 	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/plugins/akismet%2Fakismet/install'
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/plugins/akismet/install'
 ) );
 
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-delete-endpoint.php' );
@@ -313,7 +313,7 @@ new Jetpack_JSON_API_Plugins_Delete_Endpoint( array(
 	'path'            => '/sites/%s/plugins/%s/delete',
 	'path_labels' => array(
 		'$site'   => '(int|string) The site ID, The site domain',
-		'$plugin' => '(int|string) The plugin slug to install',
+		'$plugin' => '(int|string) The plugin slug to delete',
 	),
 	'response_format' => Jetpack_JSON_API_Plugins_Endpoint::$_response_format,
 	'example_request_data' => array(


### PR DESCRIPTION
the plugin slug could have been empty if the plugin was a single file,
and not stored in a directory
