### PR TITLE
Site Logo: Allow the site logo to be output in themes through the `jetpa...

### DIFF
--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -86,6 +86,7 @@ function jetpack_the_site_logo() {
 
 	echo apply_filters( 'jetpack_the_site_logo', $html, $logo, $size );
 }
+add_action( 'jetpack_the_site_logo', 'jetpack_the_site_logo' );
 
 /**
  * Whether the site is being previewed in the Customizer.


### PR DESCRIPTION
...ck_the_site_logo` action.

Considering having themes output the site logo through a hook, rather than using the `jetpack_the_site_logo()` template tag directly.

Community discussion on ThemeShaper: http://themeshaper.com/2014/10/25/making-features-available-to-themes/
