### PR TITLE
Adds resonsive video support to BuddyPress

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -14,6 +14,9 @@ function jetpack_responsive_videos_init() {
 	add_filter( 'embed_oembed_html',  'jetpack_responsive_videos_embed_html' );
 	add_filter( 'video_embed_html',   'jetpack_responsive_videos_embed_html' );
 
+	/* Wrap videos in Buddypress */
+	add_filter( 'bp_embed_oembed_html', 'jetpack_responsive_videos_embed_html' );
+
 }
 add_action( 'after_setup_theme', 'jetpack_responsive_videos_init', 99 );
 


### PR DESCRIPTION
Buddypress uses it's own filter on oembeds, https://buddypress.trac.wordpress.org/browser/trunk/src/bp-core/bp-core-classes.php#L2059, this adds jetpacks responsive video support to BuddyPress
