### PR TITLE
Adds support of displaying sharing count for multiple instances

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -71,6 +71,9 @@ abstract class Sharing_Source {
 		if ( $this->button_style == 'text' )
 			$klasses[] = 'no-icon';
 
+		if ( $id )
+			$klasses[] = esc_attr( $id );
+
 		return sprintf(
 			'<a rel="nofollow" class="%s" href="%s"%s title="%s"%s><span%s>%s</span></a>',
 			implode( ' ', $klasses ),

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -31,7 +31,7 @@ var WPCOMSharing = {
 		}
 	},
 	inject_share_count : function( dom_id, count ) {
-		jQuery( '#' + dom_id + ' span:first').append( '<span class="share-count">' + WPCOMSharing.format_count( count ) + '</span>' );
+		jQuery( '.' + dom_id ).each( function() { jQuery(this).find( 'span:first' ).append( '<span class="share-count">' + WPCOMSharing.format_count( count ) + '</span>' ); } );
 	},
 	format_count : function( count ) {
 		if ( count < 1000 )


### PR DESCRIPTION
per @kraftbj :
> By default, sharing_display() should only appear once per post, though users may want to insert multiple instances (before and after content, for example).

> Since the sharing counts are inserted based on the element's ID, jQuery will only insert the count to the first instance of the sharing buttons.

> Instead of using ID, we could use a class instead and insert it into all instances of a particular post's sharing buttons.

In order to support multiple instances I had to add a class (same as id attribute) and tweak the JavaScript the way it supports not id, but class.

JavaScript now uses $.each() method as simple class selector alone is not working as it is supposed to append the sharing count to first child span element.

work towards: https://github.com/Automattic/jetpack/issues/1234