### PR TITLE
Custom content types whitelist in the REST API

### DIFF
--- a/modules/custom-post-types/comics.php
+++ b/modules/custom-post-types/comics.php
@@ -72,6 +72,9 @@ class Jetpack_Comic {
 		add_action( 'admin_footer-edit.php', array( $this, 'admin_footer' ) );
 		add_action( 'load-edit.php', array( $this, 'bulk_edit' ) );
 		add_action( 'admin_notices', array( $this, 'bulk_edit_notices' ) );
+
+		// REST API whitelist
+		add_filter( 'rest_api_allowed_post_types', array( $this, 'rest_api_whitelist' ) );
 	}
 
 	public function admin_footer() {
@@ -478,6 +481,18 @@ class Jetpack_Comic {
 		}
 
 		return $query;
+	}
+
+	/**
+	 * whitelist the post type in the API
+	 */
+	function rest_api_whitelist( $allowed_post_types ) {
+		// only run for REST API requests
+		if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST )
+			return $allowed_post_types;
+
+		$allowed_post_types[] = self::POST_TYPE;
+		return $allowed_post_types;
 	}
 
 }

--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -95,6 +95,7 @@ class Nova_Restaurant {
 		add_filter( 'enter_title_here',       array( $this, 'change_default_title' ) );
 		add_filter( 'post_updated_messages',  array( $this, 'updated_messages'     ) );
 		add_filter( 'dashboard_glance_items', array( $this, 'add_to_dashboard'     ) );
+		add_filter( 'rest_api_allowed_post_types', array( $this, 'rest_api_whitelist' ) );
 	}
 
 	/**
@@ -1139,6 +1140,18 @@ class Nova_Restaurant {
 		}
 
 		return ' class="' . esc_attr( $class ) . '"';
+	}
+
+	/**
+	 * whitelist the post type in the API
+	 */
+	function rest_api_whitelist( $allowed_post_types ) {
+		// only run for REST API requests
+		if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST )
+			return $allowed_post_types;
+
+		$allowed_post_types[] = self::MENU_ITEM_POST_TYPE;
+		return $allowed_post_types;
 	}
 }
 

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -77,7 +77,7 @@ class Jetpack_Portfolio {
 		}
 
 		// REST API whitelist
-		add_filter( 'rest_api_allowed_post_types',              					   array( $this, 'rest_api_whitelist'      ) );
+		add_filter( 'rest_api_allowed_post_types',                                     array( $this, 'rest_api_whitelist'      ) );
 	}
 
 	/**

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -75,6 +75,9 @@ class Jetpack_Portfolio {
 		if ( $setting && $this->site_supports_portfolios() ) {
 			add_action( 'switch_theme',                                                array( $this, 'deactivation_post_type_support' ) );
 		}
+
+		// REST API whitelist
+		add_filter( 'rest_api_allowed_post_types',              					   array( $this, 'rest_api_whitelist'      ) );
 	}
 
 	/**
@@ -420,6 +423,18 @@ class Jetpack_Portfolio {
 		if( 'edit.php' == $hook && self::CUSTOM_POST_TYPE == $screen->post_type && current_theme_supports( 'post-thumbnails' ) ) {
 			wp_add_inline_style( 'wp-admin', '.manage-column.column-thumbnail { width: 50px; } @media screen and (max-width: 360px) { .column-thumbnail{ display:none; } }' );
 		}
+	}
+
+	/**
+	 * whitelist the post type in the API
+	 */
+	function rest_api_whitelist( $allowed_post_types ) {
+		// only run for REST API requests
+		if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST )
+			return $allowed_post_types;
+
+		$allowed_post_types[] = self::CUSTOM_POST_TYPE;
+		return $allowed_post_types;
 	}
 
 	/**

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -44,6 +44,7 @@ class Jetpack_Testimonial {
 		add_filter( 'enter_title_here',                         array( $this, 'change_default_title'    ) );
 		add_filter( 'manage_jetpack-testimonial_posts_columns', array( $this, 'edit_title_column_label' ) );
 		add_filter( 'post_updated_messages',                    array( $this, 'updated_messages'        ) );
+		add_filter( 'rest_api_allowed_post_types',              array( $this, 'rest_api_whitelist'      ) );
 		add_action( 'customize_register',                       array( $this, 'customize_register'      ) );
 
 		$num_testimonials = self::count_testimonials();
@@ -154,6 +155,17 @@ class Jetpack_Testimonial {
 		return $messages;
 	}
 
+	/**
+	 * whitelist the post type in the API
+	 */
+	function rest_api_whitelist( $allowed_post_types ) {
+		// only run for REST API requests
+		if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST )
+			return $allowed_post_types;
+
+		$allowed_post_types[] = self::TESTIMONIAL_POST_TYPE;
+		return $allowed_post_types;
+	}
 
 	function set_testimonial_option() {
 		$testimonials_option = get_option( 'jetpack_testimonial' );


### PR DESCRIPTION
If active, custom content types should be available via the REST API. The following patch adds them to the whitelist when each CPT is active.