### PR TITLE
Subscription Form: fix the fallback to hide label in new browsers

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -654,7 +654,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 
 		<script type="text/javascript">
 			if (("placeholder" in document.createElement("input"))) {
-				document.getElementById("jetpack-subscribe-label").style.visibility = 'hidden';
+				document.getElementById("jetpack-subscribe-label").style.display = 'none';
 			}
 		</script>
 


### PR DESCRIPTION
In #932, we added a fallback to hide the placeholder label we created for old browsers. Unfortunately, the label was still displayed in all browsers. The attached patch fixes things by hiding the label in all new browsers.
