### PR TITLE
Sharing: fix missing sharing counts when mutliple buttons on page

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -31,7 +31,7 @@ var WPCOMSharing = {
 		}
 	},
 	inject_share_count : function( dom_id, count ) {
-		jQuery( '#' + dom_id + ' span:first').append( '<span class="share-count">' + WPCOMSharing.format_count( count ) + '</span>' );
+		jQuery( '#' + dom_id + ' span').append( '<span class="share-count">' + WPCOMSharing.format_count( count ) + '</span>' );
 	},
 	format_count : function( count ) {
 		if ( count < 1000 )


### PR DESCRIPTION
In edd5ed4099d8706e08ec921e4ea768e0f10ac48c, we limited the sharing counts to the first instance of sharing buttons displayed on the page. Sharing counts should be displayed everywhere.