### PR TITLE
Add front view notification for admin if carousel bails

### DIFF
--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -22,6 +22,21 @@ div.jp-carousel-fadeaway {
 	background-size: 200px 126px;
 }
 
+.jp-carousel-msg {
+	font-family: "Open Sans", sans-serif;
+	font-style: normal;
+	display: inline-block;
+	line-height: 19px;
+	padding: 11px 15px;
+	font-size: 14px;
+	text-align: center;
+	margin: 25px 20px 0 2px;
+	background-color: #fff;
+	border-left: 4px solid #ffba00;
+	-webkit-box-shadow: 0 1px 1px 0 rgba(0,0,0,0.1);
+	box-shadow: 0 1px 1px 0 rgba(0,0,0,0.1);
+}
+
 @media
 only screen and (-webkit-min-device-pixel-ratio: 1.5),
 only screen and (-o-min-device-pixel-ratio: 3/2),

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -81,7 +81,7 @@ class Jetpack_Carousel {
 	function display_bail_message( $output= '' ) {
 		// Displays a message on top of gallery if carousel has bailed
 		$message = '<div class="jp-carousel-msg"><p>';
-		$message .= __( 'The carousel plugin has been disabled, because someone is overriding the [gallery] shortcode.', 'jetpack' );
+		$message .= __( 'The carousel plugin has been disabled, because another plugin or a theme is overriding the [gallery] shortcode.', 'jetpack' );
 		$message .= '</p></div>';
 		// put before gallery output
 		$output = $message . $output;

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -77,12 +77,26 @@ class Jetpack_Carousel {
 	function asset_version( $version ) {
 		return apply_filters( 'jp_carousel_asset_version', $version );
 	}
-
+	
+	function display_bail_message( $output= '' ) {
+		// Displays a message on top of gallery if carousel has bailed
+		$message = '<div class="jp-carousel-msg"><p>';
+		$message .= __( 'The carousel plugin has been disabled, because someone is overriding the [gallery] shortcode.', 'jetpack' );
+		$message .= '</p></div>';
+		// put before gallery output
+		$output = $message . $output;
+		return $output;
+	}
+	
 	function enqueue_assets( $output ) {
 		if ( ! empty( $output ) && ! apply_filters( 'jp_carousel_force_enable', false ) ) {
 			// Bail because someone is overriding the [gallery] shortcode.
 			remove_filter( 'gallery_style', array( $this, 'add_data_to_container' ) );
 			remove_filter( 'wp_get_attachment_image_attributes', array( $this, 'add_data_to_images' ) );
+			// Display message that carousel has bailed, if user is super_admin
+			if ( is_super_admin() ) {
+				add_filter( 'post_gallery', array( $this, 'display_bail_message' ) );
+			}
 			return $output;
 		}
 


### PR DESCRIPTION
As proposed in https://github.com/Automattic/jetpack/issues/1023, this adds a front end notification for the admin if the carousel module bails.
The style is identical to the `.update-nag` class in the admin back end.

Potential problems: Priorities from custom [gallery] shortcode override functions. This implementation uses the default '10' priority.