### PR TITLE
Solves the problem of multiple share counters on the page

### DIFF
--- a/modules/theme-tools/site-logo/inc/compat.php
+++ b/modules/theme-tools/site-logo/inc/compat.php
@@ -39,6 +39,6 @@ if ( ! function_exists( 'get_site_logo' ) ) :
  * @return string Site logo ID or URL (the default).
  */
 function get_site_logo( $show = 'url' ) {
-	return jetpack_get_site_logo( $show = 'url' );
+	return jetpack_get_site_logo( $show );
 }
 endif;


### PR DESCRIPTION
This pull adds `input` markers to share counters to avoid having multiple IDs and allow updating several share counters at once (#1234). I have decided not to use classes here because the string that has been used for the ID is not really a class. Also, I have prettied the code up a bit.

This is close to a suggestion from #1237, but goes a little further.
