### PR TITLE
Notes Module: Avoid a PHP Notice when the request doesn't contain a User-Agent header

### DIFF
--- a/modules/notes.php
+++ b/modules/notes.php
@@ -60,7 +60,9 @@ class Jetpack_Notifications {
 			return $version;
 		}
 
-		preg_match( '/MSIE (\d+)/', $_SERVER['HTTP_USER_AGENT'], $matches );
+		$user_agent = isset( $_SERVER['HTTP_USER_AGENT']  ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+
+		preg_match( '/MSIE (\d+)/', $user_agent, $matches );
 		$version = empty( $matches[1] ) ? null : $matches[1];
 		if ( empty( $version ) || !$version ) {
 			return false;


### PR DESCRIPTION
Not all requests include a User-Agent, although all requests which Notes are displayed on should.
This small change simply checks that a user-agent exists before the IE checks are run, avoiding the notice all together.
