### PR TITLE
Allow subscribe_text to contain block-level elements, fixes #1298

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -623,7 +623,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		<form action="#" method="post" accept-charset="utf-8" id="subscribe-blog-<?php echo $widget_id; ?>">
 			<?php
 			if ( ! isset ( $_GET['subscribe'] ) ) {
-				?><p id="subscribe-text"><?php echo $subscribe_text ?></p><?php
+				?><div id="subscribe-text"><?php echo wpautop( $subscribe_text ); ?></div><?php
 			}
 
 			if ( $show_subscribers_total && 0 < $subscribers_total['value'] ) {


### PR DESCRIPTION
This commit addresses #1298.

The modification will allow the `subscribe_text` field to contain block-level elements, as having it wrapped with a `p` tag was allowing only inline-level elements. In addition to that, use `wpautop()` on the `$subscribe_text` variable for consistency - `wpautop()` is already being used on `$subscribe_text` when displayed on success.
