### PR TITLE
Nova Menu CPT: fix notice when we have no taxonomies

### DIFF
--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -962,9 +962,12 @@ class Nova_Restaurant {
 			}
 		}
 
-		if ( isset( $term_id ) ) {
-			return get_term( $term_id, self::MENU_TAX );
+		if ( ! isset( $term_id ) ) {
+			return false;
 		}
+
+		return get_term( $term_id, self::MENU_TAX );
+
 	}
 
 	function list_labels( $post_id = 0 ) {


### PR DESCRIPTION
`Notice: Undefined variable: term_id in ...wp-content\plugins\jetpack\modules\custom-post-types\nova.php on line 965`
