### PR TITLE
Expose connected user data in wp.getOptions

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3945,7 +3945,7 @@ p {
 		return $methods;
 	}
 
-    function jetpack_getOptions( $args ) {
+	function jetpack_getOptions( $args ) {
 		global $wp_xmlrpc_server;
 		$options = $wp_xmlrpc_server->wp_getOptions( $args );
 		$user_data = $this->get_connected_user_data();


### PR DESCRIPTION
To help the mobile apps help the user figure out which wp.com account
they're connected to, include user ID, username, and email in
wp.getOptions.

Also includes number of sites so the app can decide if it should suggest
Jetpack Manage.
