### PR TITLE
Related Posts: Add filter for `_enabled_for_request()`

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -991,21 +991,22 @@ EOT;
 
 		// Must have feature enabled
 		$options = $this->get_options();
-		if ( ! $options['enabled'] )
+		if ( ! $options['enabled'] ) {
 			$enabled = false;
+		}
 
 		// Only run for frontend pages
-		if ( is_admin() )
+		if ( is_admin() ) {
 			$enabled = false;
+		}
 
 		// Only run for standalone posts
-		if ( ! is_single() )
+		if ( ! is_single() ) {
 			$enabled = false;
+		}
 
 		// Allow filters to override
-		$enabled = apply_filters( 'jetpack_relatedposts_filter_enabled_for_request', $enabled );
-
-		return $enabled;
+		return apply_filters( 'jetpack_relatedposts_filter_enabled_for_request', $enabled );
 	}
 
 	/**


### PR DESCRIPTION
Allow the return value of function to be filtered by
`jetpack_relatedposts_filter_enabled_for_request` this will allow related posts
to be shown on pages as well.

Example:

``` php
function jetpackme_enable_for_pages( $enabled ) {
    if ( is_page() )
        $enabled = true;

    return $enabled;
}
add_filter(
    'jetpack_relatedposts_filter_enabled_for_request',
    'jetpackme_enable_for_pages'
);
```

Please note by default related posts will only return related content of the
same `post_type` so doing the above will only return related pages not posts to
adjust this see the `jetpack_relatedposts_filter_post_type` filter.

Resolves #1307
