### PR TITLE
Related Posts: Allow filter by `post_format`

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -489,6 +489,7 @@ EOT;
 		$defaults = array(
 			'size' => (int)$options['size'],
 			'post_type' => get_post_type( $post_id ),
+			'post_formats' => array(),
 			'has_terms' => array(),
 			'date_range' => array(),
 			'exclude_post_ids' => array(),
@@ -514,7 +515,7 @@ EOT;
 	 *
 	 * @param int $post_id
 	 * @param array $args
-	 * @uses apply_filters, get_post_types
+	 * @uses apply_filters, get_post_types, get_post_format_strings
 	 * @return array
 	 */
 	protected function _get_es_filters_from_args( $post_id, array $args ) {
@@ -552,6 +553,18 @@ EOT;
 				$filters[] = array( 'terms' => array( 'post_type' => $sanitized_post_types ) );
 		} else if ( in_array( $args['post_type'], $valid_post_types ) && 'all' != $args['post_type'] ) {
 			$filters[] = array( 'term' => array( 'post_type' => $args['post_type'] ) );
+		}
+
+		$args['post_formats'] = apply_filters( 'jetpack_relatedposts_filter_post_formats', $args['post_formats'], $post_id );
+		$valid_post_formats = get_post_format_strings();
+		$sanitized_post_formats = array();
+		foreach ( $args['post_formats'] as $pf ) {
+			if ( array_key_exists( $pf, $valid_post_formats ) ) {
+				$sanitized_post_formats[] = $pf;
+			}
+		}
+		if ( ! empty( $sanitized_post_formats ) ) {
+			$filters[] = array( 'terms' => array( 'post_format' => $sanitized_post_formats ) );
 		}
 
 		$args['date_range'] = apply_filters( 'jetpack_relatedposts_filter_date_range', $args['date_range'], $post_id );


### PR DESCRIPTION
We have added `post_format` into the Elasticsearch index so we can how filter
by that for related posts. By default all post formats are returned however
there is now a `jetpack_relatedposts_filter_post_formats` that can be used like
so:

``` php
// Only return image and gallery post formats
function jetpackme_related_post_only_images( $post_formats, $post_id ) {
    $post_formats[] = 'image';
    $post_formats[] = 'gallery';
    return $post_formats;
}
add_filter(
    'jetpack_relatedposts_filter_post_formats',
    'jetpackme_related_post_only_images'
);
```

Resolves #287
