### PR TITLE
Images: Allow a filter to disable image resizing via WPCOM

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -475,6 +475,11 @@ class Jetpack_PostImages {
 			return $src;
 		}
 
+		// See if we should bypass WordPress.com SaaS resizing
+		if ( has_filter( 'jetpack_images_fit_image_url_override' ) ) {
+			return apply_filters( 'jetpack_images_fit_image_url_override', $src, $width, $height );
+		}
+
 		// If WPCOM hosted image use native transformations
 		$img_host = parse_url( $src, PHP_URL_HOST );
 		if ( '.files.wordpress.com' == substr( $img_host, -20 ) ) {


### PR DESCRIPTION
Allow users to set a `jetpack_images_fit_image_url_override` filter which if
set will be used to determin the url to a resized image. This allows users to
bypass Photon / WordPress.com.

Resolves #1083
