### PR TITLE
Nova Menus: use current instance to maintain object context

### DIFF
--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -65,7 +65,7 @@ class Nova_Restaurant {
 		}
 
 		if ( $menu_item_loop_markup ) {
-			$instance->menu_item_loop_markup = wp_parse_args( $menu_item_loop_markup, $this->default_menu_item_loop_markup );
+			$instance->menu_item_loop_markup = wp_parse_args( $menu_item_loop_markup, $instance->default_menu_item_loop_markup );
 		}
 
 		return $instance;


### PR DESCRIPTION
Use the current instance instead of `$this` in case `init` is called outside of the `Nova_Restaurant` class. Fixes #1309.
