### PR TITLE
Add recipe print binding to post-load on infinity

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -70,7 +70,7 @@ Scroller = function( settings ) {
 				self.thefooter();
 				// Fire the refresh
 				self.refresh();
-                self.determineURL(); // determine the url 
+                self.determineURL(); // determine the url
 			}
 		}, 250 );
 
@@ -95,6 +95,9 @@ Scroller = function( settings ) {
 
 	// Initialize any Core audio or video players loaded via IS
 	this.body.bind( 'post-load', { self: self }, self.initializeMejs );
+
+	// Bind any newly loaded recipe print buttons
+	this.body.bind( 'post-load', { self: self }, self.bindRecipePrint );
 };
 
 /**
@@ -422,6 +425,20 @@ Scroller.prototype.initializeMejs = function( ev, response ) {
 		};
 
 		$('.wp-audio-shortcode, .wp-video-shortcode').not( '.mejs-container' ).mediaelementplayer( settings );
+	});
+}
+
+/**
+ * Bind any newly loaded recipe print buttons
+ */
+Scroller.prototype.bindRecipePrint = function( ev, response ) {
+	$(function () {
+		$( '.jetpack-recipe-print a' ).click( function( event ) {
+      event.preventDefault();
+
+      // Print the DIV.
+      $( this ).closest( '.jetpack-recipe' ).printThis( { pageTitle: jetpack_recipes_vars.pageTitle, loadCSS: jetpack_recipes_vars.loadCSS } );
+    } );
 	});
 }
 

--- a/modules/shortcodes/js/recipes.js
+++ b/modules/shortcodes/js/recipes.js
@@ -1,11 +1,11 @@
 /* global jetpack_recipes_vars */
 ( function( $ ) {
-	$( window ).load( function() {
-		$( '.jetpack-recipe-print' ).on( 'click', 'a', function( event ) {
-			event.preventDefault();
+  $( window ).load( function() {
+    $( '.jetpack-recipe-print a' ).click( function( event ) {
+      event.preventDefault();
 
-			// Print the DIV.
-			$( this ).closest( '.jetpack-recipe' ).printThis( { pageTitle: jetpack_recipes_vars.pageTitle, loadCSS: jetpack_recipes_vars.loadCSS } );
-		} );
-	} );
+      // Print the DIV.
+      $( this ).closest( '.jetpack-recipe' ).printThis( { pageTitle: jetpack_recipes_vars.pageTitle, loadCSS: jetpack_recipes_vars.loadCSS } );
+    } );
+  } );
 } )( jQuery );

--- a/modules/shortcodes/js/recipes.js
+++ b/modules/shortcodes/js/recipes.js
@@ -1,7 +1,7 @@
 /* global jetpack_recipes_vars */
 ( function( $ ) {
 	$( window ).load( function() {
-		$( '.jetpack-recipe-print a' ).click( function( event ) {
+		$( '.jetpack-recipe-print' ).on( 'click', 'a', function( event ) {
 			event.preventDefault();
 
 			// Print the DIV.

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -6,8 +6,6 @@
 
 class Jetpack_Recipes {
 
-	private $scripts_and_style_included = false;
-
 	function __construct() {
 		add_action( 'init', array( $this, 'action_init' ) );
 	}
@@ -28,23 +26,11 @@ class Jetpack_Recipes {
 			return;
 		}
 
-		foreach ( $GLOBALS['posts'] as $p ) {
-			if ( has_shortcode( $p->post_content, 'recipe' ) ) {
-				$this->scripts_and_style_included = true;
-				break;
-			}
-		}
-
-		if ( ! $this->scripts_and_style_included ) {
-			return;
-		}
-
 		if( is_rtl() ) {
 			wp_enqueue_style( 'jetpack-recipes-style',  plugins_url( '/css/rtl/recipes-rtl.css',  __FILE__ ), array(), '20130919' );
 		} else {
 			wp_enqueue_style( 'jetpack-recipes-style',  plugins_url( '/css/recipes.css',  __FILE__ ), array(), '20130919' );
 		}
-
 
 		wp_enqueue_script( 'jetpack-recipes-printthis', plugins_url( '/js/recipes-printthis.js', __FILE__ ), array( 'jquery' ), '20131230' );
 		wp_enqueue_script( 'jetpack-recipes-js',        plugins_url( '/js/recipes.js', __FILE__ ),   array( 'jquery', 'jetpack-recipes-printthis' ), '20131230' );


### PR DESCRIPTION
Using things like infinite scroll, once more posts are loaded onto a page the recipe print functionality no longer works. This change will apply the click even to existing *and* future print buttons.