### PR TITLE
JSON API: fix date format issue

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1256,7 +1256,7 @@ EOPHP;
 		} else {
 			$date_time = date_create( "$date+0000" );
 			if ( $date_time ) {
-				$timestamp = strtotime( "$date+0000" );
+				$timestamp = date_format( $date_time, 'u' );
 			} else {
 				$timestamp = 0;
 			}


### PR DESCRIPTION
we cannot use the getTimestamp() method because it is not supported in
PHP < 5.3.  Instead we'll use strtotime()

Fix issue #1326 
