### PR TITLE
Issue 1169 - Implement Picture-element and srcset support into Photon

### DIFF
--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -344,7 +344,7 @@ var wpcom_img_zoomer = {
         }
     },
     /**
-     * clearing the interbal for zoomImages: srcset fallback.
+     * clearing the interval for zoomImages: srcset fallback.
      */
 
     stop: function() {

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -331,15 +331,15 @@
          * Constructor
          */
         init: function() {
-            var t = this;
+            var _this = this;
             //Detecting srcset support. if  srcset support is true, add the srcset attribute for zoom support
-            if( t.getSrcSetSupport() === true ) {
-                t.addSrcSetToImages();
+            if( _this.getSrcSetSupport() === true ) {
+                _this.addSrcSetToImages();
             } else {
                 //If no srcset - fallback to detect zoom by calling zoomimages every second
                 try{
-                    t.zoomImages();
-                    t.timer = setInterval( function() { t.zoomImages(); }, t.interval );
+                    _this.zoomImages();
+                    _this.timer = setInterval( function() { _this.zoomImages(); }, _this.interval );
                 }
                 catch(e){
                     // print the error to the console with more information on failing
@@ -408,13 +408,13 @@
          */
 
         shouldZoom: function( scale ) {
-            var t = this;
+            var _this = this;
             // Do not operate on hidden frames.
             if ( 'innerWidth' in window && !window.innerWidth ) {
                 return false;
             }
             // Don't do anything until scale > 1
-            return !(scale === 1.0 && t.zoomed === false);
+            return !(scale === 1.0 && _this.zoomed === false);
 
         },
         /**
@@ -432,13 +432,13 @@
          * Run through all images and change the src according to the zoom being detected at detectZoom
          */
         zoomImages: function() {
-            var t,scale,imgs,i,imgScale, scaleFail;
-            t = this;
-            scale = t.getScale();
-            if ( ! t.shouldZoom( scale ) ){
+            var _this,scale,imgs,i,imgScale, scaleFail;
+            _this = this;
+            scale = _this.getScale();
+            if ( ! _this.shouldZoom( scale ) ){
                 return;
             }
-            t.zoomed = true;
+            _this.zoomed = true;
             // Loop through all the <img> elements on the page.
             imgs = document.getElementsByTagName('img');
             for ( i = 0; i < imgs.length; i++ ) {
@@ -446,7 +446,7 @@
                 if ( 'complete' in imgs[i] && ! imgs[i].complete ) {
                     continue;
                 }
-                // Skip images that don't need processing.
+                // Skip images that don'_this need processing.
                 imgScale = imgs[i].getAttribute('scale');
                 if ( imgScale === scale || imgScale === '0' ) {
                     continue;
@@ -465,7 +465,7 @@
                 if ( ! imgScale && imgs[i].getAttribute('data-lazy-src') && (imgs[i].getAttribute('data-lazy-src') !== imgs[i].getAttribute('src'))) {
                     continue;
                 }
-                if ( t.setScaledImageSrc( imgs[i], scale ) ) {
+                if ( _this.setScaledImageSrc( imgs[i], scale ) ) {
                     // Mark the img as having been processed at this scale.
 
                     imgs[i].setAttribute('scale', scale.toString());
@@ -484,10 +484,10 @@
          * @returns {boolean}
          */
         setScaledImageSrc: function ( img, scale ) {
-            var t, newSrc,prevSrc,origSrc;
-            t = this;
-            newSrc = t.scaleImage(img, scale);
-            // Don't set img.src unless it has changed. This avoids unnecessary reloads.
+            var _this, newSrc,prevSrc,origSrc;
+            _this = this;
+            newSrc = _this.getScaledImageSrc(img, scale);
+            // Don'_this set img.src unless it has changed. This avoids unnecessary reloads.
             if ( newSrc !== img.src ) {
                 // Store the original img.src
                 origSrc = img.getAttribute('src-orig');
@@ -518,11 +518,11 @@
          * @returns {boolean}
          */
         setScaledImageSrcSet: function ( img ) {
-            var t, srcSetArray,scale,newSrc;
-            t = this;
+            var _this, srcSetArray,scale,newSrc;
+            _this = this;
             srcSetArray = new Array([]);
             for( scale = 1; scale <= 5; scale++ ) {
-                newSrc = t.scaleImage(img, scale);
+                newSrc = _this.getScaledImageSrc(img, scale);
                 if( newSrc && typeof newSrc !== 'undefined' ) {
                     srcSetArray.push(newSrc+' '+scale+'x');
                 }
@@ -535,14 +535,14 @@
             return false;
         },
         /**
-         * Handles the scaling of the images that are being
+         * Returns new src URLs of images based on scale.
          *
          * @param img
          * @param scale
          * @returns string || false
          */
-        scaleImage: function( img, scale ) {
-            var t = this;
+        getScaledImageSrc: function( img, scale ) {
+            var _this = this;
 
             // Skip slideshow images
             if ( img.parentNode.className.match(/slideshow-slide/) ) {
@@ -550,22 +550,22 @@
             }
             // Scale gravatars that have ?s= or ?size=
             if ( img.src.match( /^https?:\/\/([^\/]*\.)?gravatar\.com\/.+[?&](s|size)=/ ) ) {
-                return t.getGravatarScale(img, scale);
+                return _this.getGravatarScale(img, scale);
             }
 
             // Scale resize queries (*.files.wordpress.com) that have ?w= or ?h=
             else if ( img.src.match( /^https?:\/\/([^\/]+)\.files\.wordpress\.com\/.+[?&][wh]=/ ) ) {
-                return t.getFilesWordpressComScale(img, scale);
+                return _this.getFilesWordpressComScale(img, scale);
             }
 
             // Scale mshots that have width
             else if ( img.src.match(/^https?:\/\/([^\/]+\.)*(wordpress|wp)\.com\/mshots\/.+[?&]w=\d+/) ) {
-                return t.getMshotsWithWidthScale(img, scale);
+                return _this.getMshotsWithWidthScale(img, scale);
             }
 
             // Scale simple imgpress queries (s0.wp.com) that only specify w/h/fit
             else if ( img.src.match(/^https?:\/\/([^\/.]+\.)*(wp|wordpress)\.com\/imgpress\?(.+)/) ) {
-                return t.getImgpressQueriesScale(img, scale);
+                return _this.getImgpressQueriesScale(img, scale);
             }
 
             // Scale LaTeX images or Photon queries (i#.wp.com)
@@ -573,12 +573,12 @@
                 img.src.match(/^https?:\/\/([^\/.]+\.)*(wp|wordpress)\.com\/latex\.php\?(latex|zoom)=(.+)/) ||
                 img.src.match(/^https?:\/\/i[\d]{1}\.wp\.com\/(.+)/)
             ) {
-                return t.getLatexPhotonScale(img, scale);
+                return _this.getLatexPhotonScale(img, scale);
             }
 
             // Scale static assets that have a name matching *-1x.png or *@1x.png
             else if ( img.src.match(/^https?:\/\/[^\/]+\/.*[-@]([12])x\.(gif|jpeg|jpg|png)(\?|$)/) ) {
-                return t.getStaticAssetsScale(img, scale);
+                return _this.getStaticAssetsScale(img, scale);
             }
 
             else {
@@ -595,8 +595,8 @@
          * @returns {*|XML|string|void}
          */
         getGravatarScale: function(img, scale) {
-            var t, newSrc,size,targetSize;
-            t = this;
+            var _this, newSrc,size,targetSize;
+            _this = this;
             newSrc = img.src.replace( /([?&](s|size)=)(\d+)/, function( $0, $1, $2, $3 ) {
                 // Stash the original size
                 var originalAtt = 'originals',
@@ -604,7 +604,7 @@
                 if ( originalSize === null ) {
                     originalSize = $3;
                     img.setAttribute(originalAtt, originalSize);
-                    if ( t.imgNeedsSizeAtts( img ) ) {
+                    if ( _this.imgNeedsSizeAtts( img ) ) {
                         // Fix width and height attributes to rendered dimensions.
                         img.width !== 0 ? img.width = img.width : '';
                         img.height !== 0 ? img.height =  img.height : '';
@@ -614,9 +614,9 @@
                 size = img.clientWidth;
                 // Convert CSS pixels to device pixels
                 targetSize = Math.ceil(img.clientWidth * scale);
-                // Don't go smaller than the original size
+                // Don'_this go smaller than the original size
                 targetSize = Math.max( targetSize, originalSize );
-                // Don't go larger than the service supports
+                // Don'_this go larger than the service supports
                 targetSize = Math.min( targetSize, 512 );
                 return $1 + targetSize;
             });
@@ -631,8 +631,8 @@
          */
         getFilesWordpressComScale: function (img, scale) {
             var newSrc, changedAttrs, matches,lr, thisAttr, thisVal, originalAtt,size,naturalSize,targetSize,
-                w, h, i, t,originalSize;
-            t = this;
+                w, h, i, _this,originalSize;
+            _this = this;
             newSrc = img.src;
             if ( img.src.match( /[?&]crop/ ) ) {
                 return false;
@@ -649,7 +649,7 @@
                 if ( originalSize === null ) {
                     originalSize = thisVal;
                     img.setAttribute(originalAtt, originalSize);
-                    if ( t.imgNeedsSizeAtts( img ) ) {
+                    if ( _this.imgNeedsSizeAtts( img ) ) {
                         // Fix width and height attributes to rendered dimensions.
                         img.width !== 0 ? img.width = img.width : '';
                         img.height !== 0 ? img.height =  img.height : '';
@@ -660,13 +660,13 @@
                 naturalSize = ( thisAttr === 'w' ? img.naturalWidth : img.naturalHeight );
                 // Convert CSS pixels to device pixels
                 targetSize = Math.ceil(size * scale);
-                // Don't go smaller than the original size
+                // Don'_this go smaller than the original size
                 targetSize = Math.max( targetSize, originalSize );
-                // Don't go bigger unless the current one is actually lacking
+                // Don'_this go bigger unless the current one is actually lacking
                 if ( scale > img.getAttribute('scale') && targetSize <= naturalSize ) {
                     targetSize = thisVal;
                 }
-                // Don't try to go bigger if the image is already smaller than was requested
+                // Don'_this try to go bigger if the image is already smaller than was requested
                 if ( naturalSize < thisVal ) {
                     targetSize = thisVal;
                 }
@@ -697,15 +697,15 @@
          * @returns {*|XML|string|void}
          */
         getMshotsWithWidthScale: function( img, scale ) {
-            var newSrc,originalAtt,size,targetSize, t,originalSize;
-            t = this;
+            var newSrc,originalAtt,size,targetSize, _this,originalSize;
+            _this = this;
             newSrc = img.src.replace( /([?&]w=)(\d+)/, function($0, $1, $2) {
                 // Stash the original size
                 originalAtt = 'originalw', originalSize = img.getAttribute(originalAtt);
                 if ( originalSize === null ) {
                     originalSize = $2;
                     img.setAttribute(originalAtt, originalSize);
-                    if ( t.imgNeedsSizeAtts( img ) ) {
+                    if ( _this.imgNeedsSizeAtts( img ) ) {
                         // Fix width and height attributes to rendered dimensions.
                         img.width !== 0 ? img.width = img.width : '';
                         img.height !== 0 ? img.height =  img.height : '';

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -447,17 +447,10 @@
                 return;
             }
             _this.zoomed = true;
-            // Loop through all the <img> elements on the page.
+            // Loop through all the <img> elements on the page and scale those images
             imgs = document.getElementsByTagName('img');
             for ( i = 0; i < imgs.length; i++ ) {
-                //check first if the image should be scaled
-                if( true === _this.isImageIsScalable( imgs[i], scale )) {
-                    // Adding scaled src attribute to image
-                    scaleSuccess = _this.setScaledImageSrc( imgs[i], scale );
-                } else {
-                    // This image cannot be scaled. continue to next image
-                    continue;
-                }
+                _this.setScaledImageSrc( imgs[i], scale );
             }
         },
         /**
@@ -502,8 +495,13 @@
         setScaledImageSrc: function ( img, scale ) {
             var _this, newSrc,prevSrc,origSrc;
             _this = this;
+            //first check if this image should be scaled. if not, return false.
+            if( false === _this.isImageIsScalable( img, scale ) ) {
+                return false;
+            }
+
             newSrc = _this.getScaledImageSrc(img, scale);
-            // Don'_this set img.src unless it has changed. This avoids unnecessary reloads.
+            // Don't  set img.src unless it has changed. This avoids unnecessary reloads.
             if ( newSrc !== img.src ) {
                 // Store the original img.src
                 origSrc = img.getAttribute('src-orig');
@@ -532,7 +530,6 @@
             img.setAttribute('scale', '0');
 
             return false;
-
         },
         /**
          * Adding srcset attributes to 1-5 zoom levels

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -320,11 +320,9 @@ var wpcom_img_zoomer = {
             return false;
         }
         // Do not apply the attributes if the image is already constrained by a parent element.
-        if ( img.width < img.naturalWidth || img.height < img.naturalHeight ) {
-            return false;
-        }
+        return !(img.width < img.naturalWidth || img.height < img.naturalHeight);
 
-        return true;
+
     },
 
     /**
@@ -410,10 +408,8 @@ var wpcom_img_zoomer = {
             return false;
         }
         // Don't do anything until scale > 1
-        if ( scale === 1.0 && t.zoomed === false ) {
-            return false;
-        }
-        return true;
+        return !(scale === 1.0 && t.zoomed === false);
+
     },
     /**
      * Run through all images and add to those image the srcset according to the same rules as zoomImages.

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -521,10 +521,12 @@
          * @returns {boolean}
          */
         setScaledImageSrcSet: function ( img ) {
-            var _this, srcSetArray,scale,newSrc;
+            var _this, srcSetArray,scale,newSrc,availableScales,i;
             _this = this;
             srcSetArray = new Array([]);
-            for( scale = 1; scale <= 5; scale++ ) {
+            availableScales = new Array( 1, 1.5, 2, 3, 4, 5); //The scales that we support
+            for( i = 0; i < availableScales.length; i++ ) {
+                scale = availableScales[i];
                 newSrc = _this.getScaledImageSrc(img, scale);
                 if( newSrc && typeof newSrc !== 'undefined' ) {
                     srcSetArray.push(newSrc+' '+scale+'x');

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -327,6 +327,9 @@ var wpcom_img_zoomer = {
         return true;
     },
 
+    /**
+     * Constructor
+     */
     init: function() {
         var t = this;
         //Detecting srcset support. if  srcset support is true, add the srcset attribute for zoom support
@@ -342,6 +345,9 @@ var wpcom_img_zoomer = {
             }
         }
     },
+    /**
+     * clearing the interbal for zoomImages: srcset fallback.
+     */
 
     stop: function() {
         if ( this.timer ) {
@@ -360,6 +366,11 @@ var wpcom_img_zoomer = {
         return typeof img.srcset !== 'undefined';
     },
 
+    /**
+     * converts floating scaling to real numbers
+     *
+     * @returns {Number}
+     */
 
     getScale: function() {
         var scale = detectZoom.device();
@@ -384,6 +395,13 @@ var wpcom_img_zoomer = {
         }
         return scale;
     },
+
+    /**
+     * Returns false if no Retina image is needed.
+     *
+     * @param scale
+     * @returns {boolean}
+     */
 
     shouldZoom: function( scale ) {
         var t = this;
@@ -567,6 +585,13 @@ var wpcom_img_zoomer = {
 
 
     },
+    /**
+     * Returns Enlarged Gravatar images based on scaling
+     *
+     * @param img
+     * @param scale
+     * @returns {*|XML|string|void}
+     */
     getGravatarScale: function(img, scale) {
         var t, newSrc,size,targetSize;
         t = this;
@@ -595,6 +620,13 @@ var wpcom_img_zoomer = {
         });
         return newSrc;
     },
+    /**
+     * Return enlarged WordPress.com URL hosted files based on scale
+     *
+     * @param img
+     * @param scale
+     * @returns {*}
+     */
     getFilesWordpressComScale: function (img, scale) {
         var newSrc, changedAttrs, matches,lr, thisAttr, thisVal, originalAtt,size,naturalSize,targetSize,
             w, h, i, t,originalSize;
@@ -655,6 +687,13 @@ var wpcom_img_zoomer = {
         }
         return newSrc;
     },
+    /**
+     * Return enlarged mshots images according to scale
+     *
+     * @param img
+     * @param scale
+     * @returns {*|XML|string|void}
+     */
     getMshotsWithWidthScale: function( img, scale ) {
         var newSrc,originalAtt,size,targetSize, t,originalSize;
         t = this;
@@ -688,6 +727,13 @@ var wpcom_img_zoomer = {
         });
         return newSrc;
     },
+    /**
+     * Return WordPress images URLS with Zoom parameters according to scale
+     *
+     * @param img
+     * @param scale
+     * @returns {*}
+     */
     getImgpressQueriesScale: function( img, scale ) {
         var newSrc, imgpressSafeFunctions, qs, q;
         newSrc = img.src;
@@ -713,6 +759,13 @@ var wpcom_img_zoomer = {
 
         return newSrc;
     },
+    /**
+     * Returning Photon or Latex URLS with Zoom parameters according to scale
+     *
+     * @param img
+     * @param scale
+     * @returns {*}
+     */
     getLatexPhotonScale: function( img, scale ) {
         var newSrc = img.src;
         // Fix width and height attributes to rendered dimensions.
@@ -727,6 +780,13 @@ var wpcom_img_zoomer = {
 
         return newSrc;
     },
+    /**
+     * Return static assets images dimensions based on scale
+     *
+     * @param img
+     * @param scale
+     * @returns {*}
+     */
     getStaticAssetsScale: function( img, scale ) {
         var newSrc, currentSize, newSize;
         newSrc = img.src;

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -377,23 +377,25 @@
         getScale: function() {
             var scale = detectZoom.device();
             // Round up to 1.5 or the next integer below the cap.
-            if      ( scale <= 1.0 ) {
-                scale = 1.0;
-            }
-            else if ( scale <= 1.5 ) {
-                scale = 1.5;
-            }
-            else if ( scale <= 2.0 ) {
-                scale = 2.0;
-            }
-            else if ( scale <= 3.0 ) {
-                scale = 3.0;
-            }
-            else if ( scale <= 4.0 ) {
-                scale = 4.0;
-            }
-            else                     {
-                scale = 5.0;
+            // To avoid long list of ifs, we are using  conditional logic.
+            switch (true) {
+                case scale <= 1.0 :
+                    scale = 1.0;
+                    break;
+                case scale <= 1.5 :
+                    scale = 1.5;
+                    break;
+                case scale <= 2.0 :
+                    scale = 2.0;
+                    break;
+                case scale <= 3.0 :
+                    scale = 3.0;
+                    break;
+                case scale <= 4.0 :
+                    scale = 4.0;
+                    break;
+                default:
+                    scale = 5.0;
             }
             return scale;
         },

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -333,7 +333,7 @@
         init: function() {
             var t = this;
             //Detecting srcset support. if  srcset support is true, add the srcset attribute for zoom support
-            if( t.srcSetSupport() === true ) {
+            if( t.getSrcSetSupport() === true ) {
                 t.addSrcSetToImages();
             } else {
                 //If no srcset - fallback to detect zoom by calling zoomimages every second
@@ -363,7 +363,7 @@
          * @returns {boolean}
          */
 
-        srcSetSupport: function() {
+        getSrcSetSupport: function() {
             var img = document.createElement('img');
             return typeof img.srcset !== 'undefined';
         },

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -440,7 +440,7 @@
          * Run through all images and change the src according to the zoom being detected at detectZoom
          */
         zoomImages: function() {
-            var _this,scale,imgs,i,imgScale, scaleFail;
+            var _this,scale,imgs,i,imgScale, scaleFail, scaleSuccess;
             _this = this;
             scale = _this.getScale();
             if ( ! _this.shouldZoom( scale ) ){
@@ -473,9 +473,11 @@
                 if ( ! imgScale && imgs[i].getAttribute('data-lazy-src') && (imgs[i].getAttribute('data-lazy-src') !== imgs[i].getAttribute('src'))) {
                     continue;
                 }
-                if ( _this.setScaledImageSrc( imgs[i], scale ) ) {
-                    // Mark the img as having been processed at this scale.
 
+                scaleSuccess = _this.setScaledImageSrc( imgs[i], scale );
+
+                if ( scaleSuccess === true ) {
+                    // Mark the img as having been processed at this scale.
                     imgs[i].setAttribute('scale', scale.toString());
                 }
                 else {

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -422,7 +422,7 @@
             }
             // Do not apply the attributes if the image is already constrained by a parent element.
             return !(img.width < img.naturalWidth || img.height < img.naturalHeight);
-            
+
         },
 
         /**
@@ -584,7 +584,6 @@
             }
 
             //Scale Photon queries (i#.wp.com)
-
             else if( img.src.match(/^https?:\/\/i[\d]{1}\.wp\.com\/(.+)/) ) {
                 return _this.getPhotonScale(img, scale);
             }
@@ -750,8 +749,7 @@
          * @returns {*}
          */
         getImgpressQueriesScale: function( img, scale ) {
-            var newSrc, imgpressSafeFunctions, qs, q;
-            newSrc = img.src;
+            var imgpressSafeFunctions, qs, q;
             imgpressSafeFunctions = ['zoom', 'url', 'h', 'w', 'fit', 'filter', 'brightness', 'contrast', 'colorize', 'smooth', 'unsharpmask'];
             // Search the query string for unsupported functions.
             qs = RegExp.$3.split('&');
@@ -761,18 +759,7 @@
                     return false;
                 }
             }
-            // Fix width and height attributes to rendered dimensions.
-            img.width !== 0 ? img.width = img.width : '';
-            img.height !== 0 ? img.height =  img.height : '';
-            // Compute new src
-            if ( scale === 1 ) {
-                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
-            }
-            else {
-                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
-            }
-
-            return newSrc;
+            return this.getImgSrcWithZoom( img, scale );
         },
         /**
          * Returning Latex URLS with Zoom parameters according to scale
@@ -782,18 +769,7 @@
          * @returns {*}
          */
         getLatexScale: function( img, scale ) {
-            var newSrc = img.src;
-            // Fix width and height attributes to rendered dimensions.
-            img.width !== 0 ? img.width = img.width : '';
-            img.height !== 0 ? img.height =  img.height : '';
-            // Compute new src
-            if ( scale === 1 ) {
-                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
-            } else {
-                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
-            }
-
-            return newSrc;
+            return this.getImgSrcWithZoom( img, scale );
         },
         /**
          * Returning Photon URLS with Zoom parameters according to scale
@@ -803,18 +779,7 @@
          * @returns {*}
          */
         getPhotonScale: function( img, scale ) {
-            var newSrc = img.src;
-            // Fix width and height attributes to rendered dimensions.
-            img.width !== 0 ? img.width = img.width : '';
-            img.height !== 0 ? img.height =  img.height : '';
-            // Compute new src
-            if ( scale === 1 ) {
-                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
-            } else {
-                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
-            }
-
-            return newSrc;
+            return this.getImgSrcWithZoom( img, scale );
         },
         /**
          * Return static assets images dimensions based on scale
@@ -841,7 +806,29 @@
             }
 
             return newSrc;
+        },
+        /**
+         * Return image src with zoom parameter according to scale
+         *
+         * @param img
+         * @param scale
+         * @returns {*}
+         */
+        getImgSrcWithZoom: function( img, scale ) {
+            var newSrc = img.src;
+            // Fix width and height attributes to rendered dimensions.
+            img.width !== 0 ? img.width = img.width : '';
+            img.height !== 0 ? img.height =  img.height : '';
+            // Compute new src
+            if ( scale === 1 ) {
+                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
+            } else {
+                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
+            }
+
+            return newSrc;
         }
+
     };
 
     wpcom_img_zoomer.init();

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -13,12 +13,13 @@
 
 //AMD and CommonJS initialization copied from https://github.com/zohararad/audio5js
 (function (root, ns, factory) {
-    "use strict";
+    /*global module, define, detectZoom  */
+    'use strict';
 
     if (typeof (module) !== 'undefined' && module.exports) { // CommonJS
         module.exports = factory(ns, root);
     } else if (typeof (define) === 'function' && define.amd) { // AMD
-        define("factory", function () {
+        define('factory', function () {
             return factory(ns, root);
         });
     } else {
@@ -26,13 +27,14 @@
     }
 
 }(window, 'detectZoom', function () {
-
+    var fallback, devicePixelRatio, ie8, ie10,webkitMobile,webkit,firefox4,firefox18,opera11,
+        mediaQueryBinarySearch,detectFunction;
     /**
      * Use devicePixelRatio if supported by the browser
      * @return {Number}
      * @private
      */
-    var devicePixelRatio = function () {
+    devicePixelRatio = function () {
         return window.devicePixelRatio || 1;
     };
 
@@ -41,7 +43,7 @@
      * @return {Object}
      * @private
      */
-    var fallback = function () {
+    fallback = function () {
         return {
             zoom: 1,
             devicePxPerCssPx: 1
@@ -53,7 +55,7 @@
      * @return {Object}
      * @private
      **/
-    var ie8 = function () {
+    ie8 = function () {
         var zoom = Math.round((screen.deviceXDPI / screen.logicalXDPI) * 100) / 100;
         return {
             zoom: zoom,
@@ -67,7 +69,7 @@
      * @return {Object}
      * @private
      */
-    var ie10 = function () {
+    ie10 = function () {
         var zoom = Math.round((document.documentElement.offsetHeight / window.innerHeight) * 100) / 100;
         return {
             zoom: zoom,
@@ -83,9 +85,10 @@
      * @return {Object}
      * @private
      */
-    var webkitMobile = function () {
-        var deviceWidth = (Math.abs(window.orientation) == 90) ? screen.height : screen.width;
-        var zoom = deviceWidth / window.innerWidth;
+    webkitMobile = function () {
+        var deviceWidth, zoom;
+        deviceWidth = (Math.abs(window.orientation) === 90) ? screen.height : screen.width;
+        zoom = deviceWidth / window.innerWidth;
         return {
             zoom: zoom,
             devicePxPerCssPx: zoom * devicePixelRatio()
@@ -108,13 +111,14 @@
      * @return {Object}
      * @private
      */
-    var webkit = function () {
-        var important = function (str) {
-            return str.replace(/;/g, " !important;");
+    webkit = function () {
+        var important, div, container ,zoom;
+        important = function (str) {
+            return str.replace(/;/g, ' !important;');
         };
 
-        var div = document.createElement('div');
-        div.innerHTML = "1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>0";
+        div = document.createElement('div');
+        div.innerHTML = '1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>0';
         div.setAttribute('style', important('font: 100px/1em sans-serif; -webkit-text-size-adjust: none; text-size-adjust: none; height: auto; width: 1em; padding: 0; overflow: visible;'));
 
         // The container exists so that the div will be laid out in its own flow
@@ -122,12 +126,12 @@
         // webpage as a whole.
         // Add !important and relevant CSS rule resets
         // so that other rules cannot affect the results.
-        var container = document.createElement('div');
+        container = document.createElement('div');
         container.setAttribute('style', important('width:0; height:0; overflow:hidden; visibility:hidden; position: absolute;'));
         container.appendChild(div);
 
         document.body.appendChild(container);
-        var zoom = 1000 / div.clientHeight;
+        zoom = 1000 / div.clientHeight;
         zoom = Math.round(zoom * 100) / 100;
         document.body.removeChild(container);
 
@@ -147,7 +151,7 @@
      * @return {Object}
      * @private
      */
-    var firefox4 = function () {
+    firefox4 = function () {
         var zoom = mediaQueryBinarySearch('min--moz-device-pixel-ratio', '', 0, 10, 20, 0.0001);
         zoom = Math.round(zoom * 100) / 100;
         return {
@@ -165,7 +169,7 @@
      * @return {Object}
      * @private
      */
-    var firefox18 = function () {
+    firefox18 = function () {
         return {
             zoom: firefox4().zoom,
             devicePxPerCssPx: devicePixelRatio()
@@ -180,7 +184,7 @@
      * @return {Object}
      * @private
      */
-    var opera11 = function () {
+    opera11 = function () {
         var zoom = window.top.outerWidth / window.top.innerWidth;
         zoom = Math.round(zoom * 100) / 100;
         return {
@@ -199,9 +203,8 @@
      * @param epsilon
      * @return {Number}
      */
-    var mediaQueryBinarySearch = function (property, unit, a, b, maxIter, epsilon) {
-        var matchMedia;
-        var head, style, div;
+    mediaQueryBinarySearch = function (property, unit, a, b, maxIter, epsilon) {
+        var matchMedia, head, style, div, ratio;
         if (window.matchMedia) {
             matchMedia = window.matchMedia;
         } else {
@@ -215,13 +218,14 @@
             document.body.appendChild(div);
 
             matchMedia = function (query) {
+                var matched;
                 style.sheet.insertRule('@media ' + query + '{.mediaQueryBinarySearch ' + '{text-decoration: underline} }', 0);
-                var matched = getComputedStyle(div, null).textDecoration == 'underline';
+                matched = getComputedStyle(div, null).textDecoration === 'underline';
                 style.sheet.deleteRule(0);
                 return {matches: matched};
             };
         }
-        var ratio = binarySearch(a, b, maxIter);
+        ratio = binarySearch(a, b, maxIter);
         if (div) {
             head.removeChild(style);
             document.body.removeChild(div);
@@ -229,11 +233,12 @@
         return ratio;
 
         function binarySearch(a, b, maxIter) {
-            var mid = (a + b) / 2;
+            var mid, query;
+            mid = (a + b) / 2;
             if (maxIter <= 0 || b - a < epsilon) {
                 return mid;
             }
-            var query = "(" + property + ":" + mid + unit + ")";
+            query = '(' + property + ':' + mid + unit + ')';
             if (matchMedia(query).matches) {
                 return binarySearch(mid, b, maxIter - 1);
             } else {
@@ -246,7 +251,7 @@
      * Generate detection function
      * @private
      */
-    var detectFunction = (function () {
+    detectFunction = (function () {
         var func = fallback;
         //IE8+
         if (!isNaN(screen.logicalXDPI) && !isNaN(screen.systemXDPI)) {
@@ -311,11 +316,14 @@ var wpcom_img_zoomer = {
     // Should we apply width/height attributes to control the image size?
     imgNeedsSizeAtts: function( img ) {
         // Do not overwrite existing width/height attributes.
-        if ( img.getAttribute('width') !== null || img.getAttribute('height') !== null )
+        if ( img.getAttribute('width') !== null || img.getAttribute('height') !== null ) {
             return false;
+        }
         // Do not apply the attributes if the image is already constrained by a parent element.
-        if ( img.width < img.naturalWidth || img.height < img.naturalHeight )
+        if ( img.width < img.naturalWidth || img.height < img.naturalHeight ) {
             return false;
+        }
+
         return true;
     },
 
@@ -336,8 +344,10 @@ var wpcom_img_zoomer = {
     },
 
     stop: function() {
-        if ( this.timer )
+        if ( this.timer ) {
             clearInterval( this.timer );
+        }
+
     },
 
     /**
@@ -354,32 +364,47 @@ var wpcom_img_zoomer = {
     getScale: function() {
         var scale = detectZoom.device();
         // Round up to 1.5 or the next integer below the cap.
-        if      ( scale <= 1.0 ) scale = 1.0;
-        else if ( scale <= 1.5 ) scale = 1.5;
-        else if ( scale <= 2.0 ) scale = 2.0;
-        else if ( scale <= 3.0 ) scale = 3.0;
-        else if ( scale <= 4.0 ) scale = 4.0;
-        else                     scale = 5.0;
+        if      ( scale <= 1.0 ) {
+            scale = 1.0;
+        }
+        else if ( scale <= 1.5 ) {
+            scale = 1.5;
+        }
+        else if ( scale <= 2.0 ) {
+            scale = 2.0;
+        }
+        else if ( scale <= 3.0 ) {
+            scale = 3.0;
+        }
+        else if ( scale <= 4.0 ) {
+            scale = 4.0;
+        }
+        else                     {
+            scale = 5.0;
+        }
         return scale;
     },
 
     shouldZoom: function( scale ) {
         var t = this;
         // Do not operate on hidden frames.
-        if ( "innerWidth" in window && !window.innerWidth )
+        if ( 'innerWidth' in window && !window.innerWidth ) {
             return false;
+        }
         // Don't do anything until scale > 1
-        if ( scale == 1.0 && t.zoomed == false )
+        if ( scale === 1.0 && t.zoomed === false ) {
             return false;
+        }
         return true;
     },
     /**
      * Run through all images and add to those image the srcset according to the same rules as zoomImages.
      */
     addSrcSetToImages: function() {
-        var imgs = document.getElementsByTagName("img");
+        var imgs, i;
+        imgs = document.getElementsByTagName('img');
 
-        for ( var i = 0; i < imgs.length; i++ ) {
+        for ( i = 0; i < imgs.length; i++ ) {
             this.setScaledImageSrcSet(imgs[i]);
         }
     },
@@ -387,45 +412,47 @@ var wpcom_img_zoomer = {
      * Run through all images and change the src according to the zoom being detected at detectZoom
      */
     zoomImages: function() {
-        var t = this;
-        var scale = t.getScale();
+        var t,scale,imgs,i,imgScale, scaleFail;
+        t = this;
+        scale = t.getScale();
         if ( ! t.shouldZoom( scale ) ){
             return;
         }
         t.zoomed = true;
         // Loop through all the <img> elements on the page.
-        var imgs = document.getElementsByTagName("img");
-
-        for ( var i = 0; i < imgs.length; i++ ) {
+        imgs = document.getElementsByTagName('img');
+        for ( i = 0; i < imgs.length; i++ ) {
             // Wait for original images to load
-            if ( "complete" in imgs[i] && ! imgs[i].complete )
+            if ( 'complete' in imgs[i] && ! imgs[i].complete ) {
                 continue;
-
+            }
             // Skip images that don't need processing.
-            var imgScale = imgs[i].getAttribute("scale");
-            if ( imgScale == scale || imgScale == "0" )
+            imgScale = imgs[i].getAttribute('scale');
+            if ( imgScale === scale || imgScale === '0' ) {
                 continue;
+            }
 
             // Skip images that have already failed at this scale
-            var scaleFail = imgs[i].getAttribute("scale-fail");
-            if ( scaleFail && scaleFail <= scale )
+            scaleFail = imgs[i].getAttribute('scale-fail');
+            if ( scaleFail && scaleFail <= scale ) {
                 continue;
-
+            }
             // Skip images that have no dimensions yet.
-            if ( ! ( imgs[i].width && imgs[i].height ) )
+            if ( ! ( imgs[i].width && imgs[i].height ) ) {
                 continue;
-
+            }
             // Skip images from Lazy Load plugins
-            if ( ! imgScale && imgs[i].getAttribute("data-lazy-src") && (imgs[i].getAttribute("data-lazy-src") !== imgs[i].getAttribute("src")))
+            if ( ! imgScale && imgs[i].getAttribute('data-lazy-src') && (imgs[i].getAttribute('data-lazy-src') !== imgs[i].getAttribute('src'))) {
                 continue;
-
+            }
             if ( t.setScaledImageSrc( imgs[i], scale ) ) {
                 // Mark the img as having been processed at this scale.
-                imgs[i].setAttribute("scale", scale);
+
+                imgs[i].setAttribute('scale', scale);
             }
             else {
                 // Set the flag to skip this image.
-                imgs[i].setAttribute("scale", "0");
+                imgs[i].setAttribute('scale', '0');
             }
         }
     },
@@ -437,22 +464,24 @@ var wpcom_img_zoomer = {
      * @returns {boolean}
      */
     setScaledImageSrc: function ( img, scale ) {
-        var t = this;
-        var newSrc = t.scaleImage(img, scale);
+        var t, newSrc,prevSrc,origSrc;
+        t = this;
+        newSrc = t.scaleImage(img, scale);
         // Don't set img.src unless it has changed. This avoids unnecessary reloads.
-        if ( newSrc != img.src ) {
+        if ( newSrc !== img.src ) {
             // Store the original img.src
-            var prevSrc, origSrc = img.getAttribute("src-orig");
+            origSrc = img.getAttribute('src-orig');
             if ( !origSrc ) {
                 origSrc = img.src;
-                img.setAttribute("src-orig", origSrc);
+                img.setAttribute('src-orig', origSrc);
             }
             // In case of error, revert img.src
             prevSrc = img.src;
             img.onerror = function(){
                 img.src = prevSrc;
-                if ( img.getAttribute("scale-fail") < scale )
-                    img.setAttribute("scale-fail", scale);
+                if ( img.getAttribute('scale-fail') < scale ) {
+                    img.setAttribute('scale-fail', scale);
+                }
                 img.onerror = null;
             };
             // Finally load the new image
@@ -469,11 +498,12 @@ var wpcom_img_zoomer = {
      * @returns {boolean}
      */
     setScaledImageSrcSet: function ( img ) {
-        var t = this;
-        var srcSetArray = Array();
-        for( var scale = 1; scale <= 5; scale++ ) {
-            var newSrc = t.scaleImage(img, scale);
-            if(newSrc && typeof newSrc !== 'undefined') {
+        var t, srcSetArray,scale,newSrc;
+        t = this;
+        srcSetArray = new Array([]);
+        for( scale = 1; scale <= 5; scale++ ) {
+            newSrc = t.scaleImage(img, scale);
+            if( newSrc && typeof newSrc !== 'undefined' ) {
                 srcSetArray.push(newSrc+' '+scale+'x');
             }
         }
@@ -495,9 +525,9 @@ var wpcom_img_zoomer = {
         var t = this;
 
         // Skip slideshow images
-        if ( img.parentNode.className.match(/slideshow-slide/) )
+        if ( img.parentNode.className.match(/slideshow-slide/) ) {
             return false;
-
+        }
         // Scale gravatars that have ?s= or ?size=
         if ( img.src.match( /^https?:\/\/([^\/]*\.)?gravatar\.com\/.+[?&](s|size)=/ ) ) {
             return t.getGravatarScale(img, scale);
@@ -538,10 +568,11 @@ var wpcom_img_zoomer = {
 
     },
     getGravatarScale: function(img, scale) {
-        var t = this;
-        var newSrc = img.src.replace( /([?&](s|size)=)(\d+)/, function( $0, $1, $2, $3 ) {
+        var t, newSrc,size,targetSize;
+        t = this;
+        newSrc = img.src.replace( /([?&](s|size)=)(\d+)/, function( $0, $1, $2, $3 ) {
             // Stash the original size
-            var originalAtt = "originals",
+            var originalAtt = 'originals',
                 originalSize = img.getAttribute(originalAtt);
             if ( originalSize === null ) {
                 originalSize = $3;
@@ -553,9 +584,9 @@ var wpcom_img_zoomer = {
                 }
             }
             // Get the width/height of the image in CSS pixels
-            var size = img.clientWidth;
+            size = img.clientWidth;
             // Convert CSS pixels to device pixels
-            var targetSize = Math.ceil(img.clientWidth * scale);
+            targetSize = Math.ceil(img.clientWidth * scale);
             // Don't go smaller than the original size
             targetSize = Math.max( targetSize, originalSize );
             // Don't go larger than the service supports
@@ -565,18 +596,22 @@ var wpcom_img_zoomer = {
         return newSrc;
     },
     getFilesWordpressComScale: function (img, scale) {
-        var newSrc = img.src;
-        if ( img.src.match( /[?&]crop/ ) )
+        var newSrc, changedAttrs, matches,lr, thisAttr, thisVal, originalAtt,size,naturalSize,targetSize,
+            w, h, i, t,originalSize;
+        t = this;
+        newSrc = img.src;
+        if ( img.src.match( /[?&]crop/ ) ) {
             return false;
-        var changedAttrs = {};
-        var matches = img.src.match( /([?&]([wh])=)(\d+)/g );
-        for ( var i = 0; i < matches.length; i++ ) {
-            var lr = matches[i].split( '=' );
-            var thisAttr = lr[0].replace(/[?&]/g, '' );
-            var thisVal = lr[1];
+        }
+        changedAttrs = {};
+        matches = img.src.match( /([?&]([wh])=)(\d+)/g );
+        for ( i = 0; i < matches.length; i++ ) {
+            lr = matches[i].split( '=' );
+            thisAttr = lr[0].replace(/[?&]/g, '' );
+            thisVal = lr[1];
 
             // Stash the original size
-            var originalAtt = 'original' + thisAttr, originalSize = img.getAttribute( originalAtt );
+            originalAtt = 'original' + thisAttr, originalSize = img.getAttribute( originalAtt );
             if ( originalSize === null ) {
                 originalSize = thisVal;
                 img.setAttribute(originalAtt, originalSize);
@@ -587,23 +622,26 @@ var wpcom_img_zoomer = {
                 }
             }
             // Get the width/height of the image in CSS pixels
-            var size = thisAttr == 'w' ? img.clientWidth : img.clientHeight;
-            var naturalSize = ( thisAttr == 'w' ? img.naturalWidth : img.naturalHeight );
+            size = thisAttr === 'w' ? img.clientWidth : img.clientHeight;
+            naturalSize = ( thisAttr === 'w' ? img.naturalWidth : img.naturalHeight );
             // Convert CSS pixels to device pixels
-            var targetSize = Math.ceil(size * scale);
+            targetSize = Math.ceil(size * scale);
             // Don't go smaller than the original size
             targetSize = Math.max( targetSize, originalSize );
             // Don't go bigger unless the current one is actually lacking
-            if ( scale > img.getAttribute("scale") && targetSize <= naturalSize )
+            if ( scale > img.getAttribute('scale') && targetSize <= naturalSize ) {
                 targetSize = thisVal;
+            }
             // Don't try to go bigger if the image is already smaller than was requested
-            if ( naturalSize < thisVal )
+            if ( naturalSize < thisVal ) {
                 targetSize = thisVal;
-            if ( targetSize != thisVal )
+            }
+            if ( targetSize !== thisVal ) {
                 changedAttrs[ thisAttr ] = targetSize;
+            }
         }
-        var w = changedAttrs.w || false;
-        var h = changedAttrs.h || false;
+        w = changedAttrs.w || false;
+        h = changedAttrs.h || false;
 
         if ( w ) {
             newSrc = img.src.replace(/([?&])w=\d+/g, function( $0, $1 ) {
@@ -618,9 +656,11 @@ var wpcom_img_zoomer = {
         return newSrc;
     },
     getMshotsWithWidthScale: function( img, scale ) {
-        var newSrc = img.src.replace( /([?&]w=)(\d+)/, function($0, $1, $2) {
+        var newSrc,originalAtt,size,targetSize, t,originalSize;
+        t = this;
+        newSrc = img.src.replace( /([?&]w=)(\d+)/, function($0, $1, $2) {
             // Stash the original size
-            var originalAtt = 'originalw', originalSize = img.getAttribute(originalAtt);
+            originalAtt = 'originalw', originalSize = img.getAttribute(originalAtt);
             if ( originalSize === null ) {
                 originalSize = $2;
                 img.setAttribute(originalAtt, originalSize);
@@ -631,28 +671,32 @@ var wpcom_img_zoomer = {
                 }
             }
             // Get the width of the image in CSS pixels
-            var size = img.clientWidth;
+            size = img.clientWidth;
             // Convert CSS pixels to device pixels
-            var targetSize = Math.ceil(size * scale);
+            targetSize = Math.ceil(size * scale);
             // Don't go smaller than the original size
             targetSize = Math.max( targetSize, originalSize );
             // Don't go bigger unless the current one is actually lacking
-            if ( scale > img.getAttribute("scale") && targetSize <= img.naturalWidth )
+            if ( scale > img.getAttribute('scale') && targetSize <= img.naturalWidth ) {
                 targetSize = $2;
-            if ( $2 != targetSize )
+            }
+            if ( $2 !== targetSize ) {
                 return $1 + targetSize;
+            }
+
             return $0;
         });
         return newSrc;
     },
     getImgpressQueriesScale: function( img, scale ) {
-        var newSrc = img.src;
-        var imgpressSafeFunctions = ["zoom", "url", "h", "w", "fit", "filter", "brightness", "contrast", "colorize", "smooth", "unsharpmask"];
+        var newSrc, imgpressSafeFunctions, qs, q;
+        newSrc = img.src;
+        imgpressSafeFunctions = ['zoom', 'url', 'h', 'w', 'fit', 'filter', 'brightness', 'contrast', 'colorize', 'smooth', 'unsharpmask'];
         // Search the query string for unsupported functions.
-        var qs = RegExp.$3.split('&');
-        for ( var q in qs ) {
+        qs = RegExp.$3.split('&');
+        for ( q in qs ) {
             q = qs[q].split('=')[0];
-            if ( imgpressSafeFunctions.indexOf(q) == -1 ) {
+            if ( imgpressSafeFunctions.indexOf(q) === -1 ) {
                 return false;
             }
         }
@@ -660,10 +704,12 @@ var wpcom_img_zoomer = {
         img.width !== 0 ? img.width = img.width : '';
         img.height !== 0 ? img.height =  img.height : '';
         // Compute new src
-        if ( scale == 1 )
+        if ( scale === 1 ) {
             newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
-        else
+        }
+        else {
             newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
+        }
 
         return newSrc;
     },
@@ -673,25 +719,30 @@ var wpcom_img_zoomer = {
         img.width !== 0 ? img.width = img.width : '';
         img.height !== 0 ? img.height =  img.height : '';
         // Compute new src
-        if ( scale == 1 )
+        if ( scale === 1 ) {
             newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
-        else
+        } else {
             newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
+        }
 
         return newSrc;
     },
     getStaticAssetsScale: function( img, scale ) {
-        var newSrc = img.src;
+        var newSrc, currentSize, newSize;
+        newSrc = img.src;
         // Fix width and height attributes to rendered dimensions.
         img.width !== 0 ? img.width = img.width : '';
         img.height !== 0 ? img.height =  img.height : '';
-        var currentSize = RegExp.$1, newSize = currentSize;
-        if ( scale <= 1 )
+        currentSize = RegExp.$1, newSize = currentSize;
+        if ( scale <= 1 ) {
             newSize = 1;
-        else
+        } else {
             newSize = 2;
-        if ( currentSize != newSize )
+        }
+
+        if ( currentSize !== newSize ) {
             newSrc = img.src.replace(/([-@])[12]x\.(gif|jpeg|jpg|png)(\?|$)/, '$1'+newSize+'x.$2$3');
+        }
 
         return newSrc;
     }

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -458,15 +458,6 @@
                     // This image cannot be scaled. continue to next image
                     continue;
                 }
-
-                if ( scaleSuccess === true ) {
-                    // Mark the img as having been processed at this scale.
-                    imgs[i].setAttribute('scale', scale.toString());
-                }
-                else {
-                    // Set the flag to skip this image.
-                    imgs[i].setAttribute('scale', '0');
-                }
             }
         },
         /**
@@ -522,6 +513,11 @@
                 }
                 // In case of error, revert img.src
                 prevSrc = img.src;
+
+                // Finally load the new image
+                img.src = newSrc;
+                img.setAttribute('scale', scale.toString());
+
                 img.onerror = function(){
                     img.src = prevSrc;
                     if ( img.getAttribute('scale-fail') < scale ) {
@@ -529,12 +525,14 @@
                     }
                     img.onerror = null;
                 };
-                // Finally load the new image
-                img.src = newSrc;
+
                 return true;
             }
+            //if the change is failing, mark the scale as zero so no more scaling attempts will be made
+            img.setAttribute('scale', '0');
 
             return false;
+
         },
         /**
          * Adding srcset attributes to 1-5 zoom levels

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -13,7 +13,7 @@
 
 //AMD and CommonJS initialization copied from https://github.com/zohararad/audio5js
 (function (root, ns, factory) {
-    /*global module, define, detectZoom  */
+    /*global module, define, detectZoom, window, console  */
     'use strict';
 
     if (typeof (module) !== 'undefined' && module.exports) { // CommonJS
@@ -343,7 +343,10 @@
                 }
                 catch(e){
                     // print the error to the console with more information on failing
-                    console.log(e);
+                    if(!window.console) {
+                        console.log(e);
+                    }
+
                 }
             }
         },

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -315,18 +315,6 @@
         timer: null,
         interval: 1000, // zoom polling interval in millisecond
 
-        // Should we apply width/height attributes to control the image size?
-        imgNeedsSizeAtts: function( img ) {
-            // Do not overwrite existing width/height attributes.
-            if ( img.getAttribute('width') !== null || img.getAttribute('height') !== null ) {
-                return false;
-            }
-            // Do not apply the attributes if the image is already constrained by a parent element.
-            return !(img.width < img.naturalWidth || img.height < img.naturalHeight);
-
-
-        },
-
         /**
          * Constructor
          */
@@ -420,6 +408,23 @@
             return !(scale === 1.0 && _this.zoomed === false);
 
         },
+
+        /**
+         * Test if img height and width should be set up again. depends on the images attributes.
+         *
+         * @param img
+         * @returns {boolean}
+         */
+        imgNeedsSizeAtts: function( img ) {
+            // Do not overwrite existing width/height attributes.
+            if ( img.getAttribute('width') !== null || img.getAttribute('height') !== null ) {
+                return false;
+            }
+            // Do not apply the attributes if the image is already constrained by a parent element.
+            return !(img.width < img.naturalWidth || img.height < img.naturalHeight);
+            
+        },
+
         /**
          * Run through all images and add to those image the srcset according to the same rules as zoomImages.
          */

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -87,7 +87,7 @@
      */
     webkitMobile = function () {
         var deviceWidth, zoom;
-        deviceWidth = (Math.abs(window.orientation) === 90) ? screen.height : screen.width;
+        deviceWidth = ( 90 === Math.abs(window.orientation) ) ? screen.height : screen.width;
         zoom = deviceWidth / window.innerWidth;
         return {
             zoom: zoom,
@@ -220,7 +220,7 @@
             matchMedia = function (query) {
                 var matched;
                 style.sheet.insertRule('@media ' + query + '{.mediaQueryBinarySearch ' + '{text-decoration: underline} }', 0);
-                matched = getComputedStyle(div, null).textDecoration === 'underline';
+                matched = 'underline' === getComputedStyle(div, null).textDecoration;
                 style.sheet.deleteRule(0);
                 return {matches: matched};
             };
@@ -321,7 +321,7 @@
         init: function() {
             var _this = this;
             //Detecting srcset support. if  srcset support is true, add the srcset attribute for zoom support
-            if( _this.getSrcSetSupport() === true ) {
+            if( true === _this.getSrcSetSupport() ) {
                 _this.addSrcSetToImages();
             } else {
                 //If no srcset - fallback to detect zoom by calling zoomimages every second
@@ -405,7 +405,7 @@
                 return false;
             }
             // Don't do anything until scale > 1
-            return !(scale === 1.0 && _this.zoomed === false);
+            return !( 1.0 === scale && false === _this.zoomed);
 
         },
 
@@ -468,7 +468,7 @@
                 return false;
             }
             // Skip images that don'_this need processing.
-            if ( imgScale === scale || imgScale === '0' ) {
+            if ( imgScale === scale || '0' === imgScale ) {
                 return false;
             }
             // Skip images that have already failed at this scale
@@ -597,12 +597,12 @@
 
             //Scale Photon queries (i#.wp.com)
             else if( img.src.match(/^https?:\/\/i[\d]{1}\.wp\.com\/(.+)/) ) {
-                return _this.getPhotonScale(img, scale);
+                return _this.getPhotonScale( img, scale );
             }
 
             // Scale static assets that have a name matching *-1x.png or *@1x.png
             else if ( img.src.match(/^https?:\/\/[^\/]+\/.*[-@]([12])x\.(gif|jpeg|jpg|png)(\?|$)/) ) {
-                return _this.getStaticAssetsScale(img, scale);
+                return _this.getStaticAssetsScale( img, scale );
             }
 
             else {
@@ -618,16 +618,16 @@
          * @param scale
          * @returns {*|XML|string|void}
          */
-        getGravatarScale: function(img, scale) {
+        getGravatarScale: function( img, scale ) {
             var _this, newSrc,size,targetSize;
             _this = this;
             newSrc = img.src.replace( /([?&](s|size)=)(\d+)/, function( $0, $1, $2, $3 ) {
                 // Stash the original size
                 var originalAtt = 'originals',
-                    originalSize = img.getAttribute(originalAtt);
-                if ( originalSize === null ) {
+                    originalSize = img.getAttribute( originalAtt );
+                if ( null === originalSize ) {
                     originalSize = $3;
-                    img.setAttribute(originalAtt, originalSize);
+                    img.setAttribute( originalAtt, originalSize );
                     if ( _this.imgNeedsSizeAtts( img ) ) {
                         // Fix width and height attributes to rendered dimensions.
                         img.width !== 0 ? img.width = img.width : '';
@@ -637,7 +637,7 @@
                 // Get the width/height of the image in CSS pixels
                 size = img.clientWidth;
                 // Convert CSS pixels to device pixels
-                targetSize = Math.ceil(img.clientWidth * scale);
+                targetSize = Math.ceil( img.clientWidth * scale );
                 // Don'_this go smaller than the original size
                 targetSize = Math.max( targetSize, originalSize );
                 // Don'_this go larger than the service supports
@@ -653,7 +653,7 @@
          * @param scale
          * @returns {*}
          */
-        getFilesWordpressComScale: function (img, scale) {
+        getFilesWordpressComScale: function ( img, scale ) {
             var newSrc, changedAttrs, matches,lr, thisAttr, thisVal, originalAtt,size,naturalSize,targetSize,
                 w, h, i, _this,originalSize;
             _this = this;
@@ -670,7 +670,7 @@
 
                 // Stash the original size
                 originalAtt = 'original' + thisAttr, originalSize = img.getAttribute( originalAtt );
-                if ( originalSize === null ) {
+                if ( null === originalSize ) {
                     originalSize = thisVal;
                     img.setAttribute(originalAtt, originalSize);
                     if ( _this.imgNeedsSizeAtts( img ) ) {
@@ -680,10 +680,10 @@
                     }
                 }
                 // Get the width/height of the image in CSS pixels
-                size = thisAttr === 'w' ? img.clientWidth : img.clientHeight;
-                naturalSize = ( thisAttr === 'w' ? img.naturalWidth : img.naturalHeight );
+                size = 'w' === thisAttr ? img.clientWidth : img.clientHeight;
+                naturalSize = ( 'w' === thisAttr ? img.naturalWidth : img.naturalHeight );
                 // Convert CSS pixels to device pixels
-                targetSize = Math.ceil(size * scale);
+                targetSize = Math.ceil( size * scale );
                 // Don'_this go smaller than the original size
                 targetSize = Math.max( targetSize, originalSize );
                 // Don'_this go bigger unless the current one is actually lacking
@@ -702,12 +702,12 @@
             h = changedAttrs.h || false;
 
             if ( w ) {
-                newSrc = img.src.replace(/([?&])w=\d+/g, function( $0, $1 ) {
+                newSrc = img.src.replace( /([?&])w=\d+/g, function( $0, $1 ) {
                     return $1 + 'w=' + w;
                 });
             }
             if ( h ) {
-                newSrc = newSrc.replace(/([?&])h=\d+/g, function( $0, $1 ) {
+                newSrc = newSrc.replace( /([?&])h=\d+/g, function( $0, $1 ) {
                     return $1 + 'h=' + h;
                 });
             }
@@ -726,7 +726,7 @@
             newSrc = img.src.replace( /([?&]w=)(\d+)/, function($0, $1, $2) {
                 // Stash the original size
                 originalAtt = 'originalw', originalSize = img.getAttribute(originalAtt);
-                if ( originalSize === null ) {
+                if ( null === originalSize ) {
                     originalSize = $2;
                     img.setAttribute(originalAtt, originalSize);
                     if ( _this.imgNeedsSizeAtts( img ) ) {
@@ -738,7 +738,7 @@
                 // Get the width of the image in CSS pixels
                 size = img.clientWidth;
                 // Convert CSS pixels to device pixels
-                targetSize = Math.ceil(size * scale);
+                targetSize = Math.ceil( size * scale );
                 // Don't go smaller than the original size
                 targetSize = Math.max( targetSize, originalSize );
                 // Don't go bigger unless the current one is actually lacking
@@ -767,7 +767,7 @@
             qs = RegExp.$3.split('&');
             for ( q in qs ) {
                 q = qs[q].split('=')[0];
-                if ( imgpressSafeFunctions.indexOf(q) === -1 ) {
+                if ( -1 === imgpressSafeFunctions.indexOf( q ) ) {
                     return false;
                 }
             }
@@ -814,7 +814,7 @@
             }
 
             if ( currentSize !== newSize ) {
-                newSrc = img.src.replace(/([-@])[12]x\.(gif|jpeg|jpg|png)(\?|$)/, '$1'+newSize+'x.$2$3');
+                newSrc = img.src.replace( /([-@])[12]x\.(gif|jpeg|jpg|png)(\?|$)/, '$1'+newSize+'x.$2$3' );
             }
 
             return newSrc;
@@ -832,10 +832,10 @@
             img.width !== 0 ? img.width = img.width : '';
             img.height !== 0 ? img.height =  img.height : '';
             // Compute new src
-            if ( scale === 1 ) {
-                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
+            if ( 1 === scale ) {
+                newSrc = img.src.replace( /\?(zoom=[^&]+&)?/, '?' );
             } else {
-                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
+                newSrc = img.src.replace( /\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&' );
             }
 
             return newSrc;

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -572,7 +572,7 @@ var wpcom_img_zoomer = {
 
         // Scale static assets that have a name matching *-1x.png or *@1x.png
         else if ( img.src.match(/^https?:\/\/[^\/]+\/.*[-@]([12])x\.(gif|jpeg|jpg|png)(\?|$)/) ) {
-            return t.getSaticAssetsScale(img, scale);
+            return t.getStaticAssetsScale(img, scale);
         }
 
         else {

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -342,6 +342,8 @@
                     t.timer = setInterval( function() { t.zoomImages(); }, t.interval );
                 }
                 catch(e){
+                    // print the error to the console with more information on failing
+                    console.log(e);
                 }
             }
         },

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -462,7 +462,7 @@ var wpcom_img_zoomer = {
             if ( t.setScaledImageSrc( imgs[i], scale ) ) {
                 // Mark the img as having been processed at this scale.
 
-                imgs[i].setAttribute('scale', scale);
+                imgs[i].setAttribute('scale', scale.toString());
             }
             else {
                 // Set the flag to skip this image.

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -1,0 +1,700 @@
+/* Jetpack retina support - adding srcest attribute with retina support
+ * Fallback for non-srcset browsers is done by Detect-Zoom Script
+ */
+
+/* Detect-zoom
+ * -----------
+ * Cross Browser Zoom and Pixel Ratio Detector
+ * Version 1.0.4 | Apr 1 2013
+ * dual-licensed under the WTFPL and MIT license
+ * Maintained by https://github.com/tombigel
+ * Original developer https://github.com/yonran
+ */
+
+//AMD and CommonJS initialization copied from https://github.com/zohararad/audio5js
+(function (root, ns, factory) {
+    "use strict";
+
+    if (typeof (module) !== 'undefined' && module.exports) { // CommonJS
+        module.exports = factory(ns, root);
+    } else if (typeof (define) === 'function' && define.amd) { // AMD
+        define("factory", function () {
+            return factory(ns, root);
+        });
+    } else {
+        root[ns] = factory(ns, root);
+    }
+
+}(window, 'detectZoom', function () {
+
+    /**
+     * Use devicePixelRatio if supported by the browser
+     * @return {Number}
+     * @private
+     */
+    var devicePixelRatio = function () {
+        return window.devicePixelRatio || 1;
+    };
+
+    /**
+     * Fallback function to set default values
+     * @return {Object}
+     * @private
+     */
+    var fallback = function () {
+        return {
+            zoom: 1,
+            devicePxPerCssPx: 1
+        };
+    };
+    /**
+     * IE 8 and 9: no trick needed!
+     * TODO: Test on IE10 and Windows 8 RT
+     * @return {Object}
+     * @private
+     **/
+    var ie8 = function () {
+        var zoom = Math.round((screen.deviceXDPI / screen.logicalXDPI) * 100) / 100;
+        return {
+            zoom: zoom,
+            devicePxPerCssPx: zoom * devicePixelRatio()
+        };
+    };
+
+    /**
+     * For IE10 we need to change our technique again...
+     * thanks https://github.com/stefanvanburen
+     * @return {Object}
+     * @private
+     */
+    var ie10 = function () {
+        var zoom = Math.round((document.documentElement.offsetHeight / window.innerHeight) * 100) / 100;
+        return {
+            zoom: zoom,
+            devicePxPerCssPx: zoom * devicePixelRatio()
+        };
+    };
+
+    /**
+     * Mobile WebKit
+     * the trick: window.innerWIdth is in CSS pixels, while
+     * screen.width and screen.height are in system pixels.
+     * And there are no scrollbars to mess up the measurement.
+     * @return {Object}
+     * @private
+     */
+    var webkitMobile = function () {
+        var deviceWidth = (Math.abs(window.orientation) == 90) ? screen.height : screen.width;
+        var zoom = deviceWidth / window.innerWidth;
+        return {
+            zoom: zoom,
+            devicePxPerCssPx: zoom * devicePixelRatio()
+        };
+    };
+
+    /**
+     * Desktop Webkit
+     * the trick: an element's clientHeight is in CSS pixels, while you can
+     * set its line-height in system pixels using font-size and
+     * -webkit-text-size-adjust:none.
+     * device-pixel-ratio: http://www.webkit.org/blog/55/high-dpi-web-sites/
+     *
+     * Previous trick (used before http://trac.webkit.org/changeset/100847):
+     * documentElement.scrollWidth is in CSS pixels, while
+     * document.width was in system pixels. Note that this is the
+     * layout width of the document, which is slightly different from viewport
+     * because document width does not include scrollbars and might be wider
+     * due to big elements.
+     * @return {Object}
+     * @private
+     */
+    var webkit = function () {
+        var important = function (str) {
+            return str.replace(/;/g, " !important;");
+        };
+
+        var div = document.createElement('div');
+        div.innerHTML = "1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>0";
+        div.setAttribute('style', important('font: 100px/1em sans-serif; -webkit-text-size-adjust: none; text-size-adjust: none; height: auto; width: 1em; padding: 0; overflow: visible;'));
+
+        // The container exists so that the div will be laid out in its own flow
+        // while not impacting the layout, viewport size, or display of the
+        // webpage as a whole.
+        // Add !important and relevant CSS rule resets
+        // so that other rules cannot affect the results.
+        var container = document.createElement('div');
+        container.setAttribute('style', important('width:0; height:0; overflow:hidden; visibility:hidden; position: absolute;'));
+        container.appendChild(div);
+
+        document.body.appendChild(container);
+        var zoom = 1000 / div.clientHeight;
+        zoom = Math.round(zoom * 100) / 100;
+        document.body.removeChild(container);
+
+        return{
+            zoom: zoom,
+            devicePxPerCssPx: zoom * devicePixelRatio()
+        };
+    };
+
+    /**
+     * no real trick; device-pixel-ratio is the ratio of device dpi / css dpi.
+     * (Note that this is a different interpretation than Webkit's device
+     * pixel ratio, which is the ratio device dpi / system dpi).
+     *
+     * Also, for Mozilla, there is no difference between the zoom factor and the device ratio.
+     *
+     * @return {Object}
+     * @private
+     */
+    var firefox4 = function () {
+        var zoom = mediaQueryBinarySearch('min--moz-device-pixel-ratio', '', 0, 10, 20, 0.0001);
+        zoom = Math.round(zoom * 100) / 100;
+        return {
+            zoom: zoom,
+            devicePxPerCssPx: zoom
+        };
+    };
+
+    /**
+     * Firefox 18.x
+     * Mozilla added support for devicePixelRatio to Firefox 18,
+     * but it is affected by the zoom level, so, like in older
+     * Firefox we can't tell if we are in zoom mode or in a device
+     * with a different pixel ratio
+     * @return {Object}
+     * @private
+     */
+    var firefox18 = function () {
+        return {
+            zoom: firefox4().zoom,
+            devicePxPerCssPx: devicePixelRatio()
+        };
+    };
+
+    /**
+     * works starting Opera 11.11
+     * the trick: outerWidth is the viewport width including scrollbars in
+     * system px, while innerWidth is the viewport width including scrollbars
+     * in CSS px
+     * @return {Object}
+     * @private
+     */
+    var opera11 = function () {
+        var zoom = window.top.outerWidth / window.top.innerWidth;
+        zoom = Math.round(zoom * 100) / 100;
+        return {
+            zoom: zoom,
+            devicePxPerCssPx: zoom * devicePixelRatio()
+        };
+    };
+
+    /**
+     * Use a binary search through media queries to find zoom level in Firefox
+     * @param property
+     * @param unit
+     * @param a
+     * @param b
+     * @param maxIter
+     * @param epsilon
+     * @return {Number}
+     */
+    var mediaQueryBinarySearch = function (property, unit, a, b, maxIter, epsilon) {
+        var matchMedia;
+        var head, style, div;
+        if (window.matchMedia) {
+            matchMedia = window.matchMedia;
+        } else {
+            head = document.getElementsByTagName('head')[0];
+            style = document.createElement('style');
+            head.appendChild(style);
+
+            div = document.createElement('div');
+            div.className = 'mediaQueryBinarySearch';
+            div.style.display = 'none';
+            document.body.appendChild(div);
+
+            matchMedia = function (query) {
+                style.sheet.insertRule('@media ' + query + '{.mediaQueryBinarySearch ' + '{text-decoration: underline} }', 0);
+                var matched = getComputedStyle(div, null).textDecoration == 'underline';
+                style.sheet.deleteRule(0);
+                return {matches: matched};
+            };
+        }
+        var ratio = binarySearch(a, b, maxIter);
+        if (div) {
+            head.removeChild(style);
+            document.body.removeChild(div);
+        }
+        return ratio;
+
+        function binarySearch(a, b, maxIter) {
+            var mid = (a + b) / 2;
+            if (maxIter <= 0 || b - a < epsilon) {
+                return mid;
+            }
+            var query = "(" + property + ":" + mid + unit + ")";
+            if (matchMedia(query).matches) {
+                return binarySearch(mid, b, maxIter - 1);
+            } else {
+                return binarySearch(a, mid, maxIter - 1);
+            }
+        }
+    };
+
+    /**
+     * Generate detection function
+     * @private
+     */
+    var detectFunction = (function () {
+        var func = fallback;
+        //IE8+
+        if (!isNaN(screen.logicalXDPI) && !isNaN(screen.systemXDPI)) {
+            func = ie8;
+        }
+        // IE10+ / Touch
+        else if (window.navigator.msMaxTouchPoints) {
+            func = ie10;
+        }
+        //Mobile Webkit
+        else if ('orientation' in window && typeof document.body.style.webkitMarquee === 'string') {
+            func = webkitMobile;
+        }
+        //WebKit
+        else if (typeof document.body.style.webkitMarquee === 'string') {
+            func = webkit;
+        }
+        //Opera
+        else if (navigator.userAgent.indexOf('Opera') >= 0) {
+            func = opera11;
+        }
+        //Last one is Firefox
+        //FF 18.x
+        else if (window.devicePixelRatio) {
+            func = firefox18;
+        }
+        //FF 4.0 - 17.x
+        else if (firefox4().zoom > 0.001) {
+            func = firefox4;
+        }
+
+        return func;
+    }());
+
+
+    return ({
+
+        /**
+         * Ratios.zoom shorthand
+         * @return {Number} Zoom level
+         */
+        zoom: function () {
+            return detectFunction().zoom;
+        },
+
+        /**
+         * Ratios.devicePxPerCssPx shorthand
+         * @return {Number} devicePxPerCssPx level
+         */
+        device: function () {
+            return detectFunction().devicePxPerCssPx;
+        }
+    });
+}));
+
+
+var wpcom_img_zoomer = {
+    zoomed: false,
+    timer: null,
+    interval: 1000, // zoom polling interval in millisecond
+
+    // Should we apply width/height attributes to control the image size?
+    imgNeedsSizeAtts: function( img ) {
+        // Do not overwrite existing width/height attributes.
+        if ( img.getAttribute('width') !== null || img.getAttribute('height') !== null )
+            return false;
+        // Do not apply the attributes if the image is already constrained by a parent element.
+        if ( img.width < img.naturalWidth || img.height < img.naturalHeight )
+            return false;
+        return true;
+    },
+
+    init: function() {
+        var t = this;
+        //Detecting srcset support. if  srcset support is true, add the srcset attribute for zoom support
+        if( t.srcSetSupport() === true ) {
+            t.addSrcSetToImages();
+        } else {
+            //If no srcset - fallback to detect zoom by calling zoomimages every second
+            try{
+                t.zoomImages();
+                t.timer = setInterval( function() { t.zoomImages(); }, t.interval );
+            }
+            catch(e){
+            }
+        }
+    },
+
+    stop: function() {
+        if ( this.timer )
+            clearInterval( this.timer );
+    },
+
+    /**
+     * testing srcset support in elements
+     * @returns {boolean}
+     */
+
+    srcSetSupport: function() {
+        var img = document.createElement('img');
+        return typeof img.srcset !== 'undefined';
+    },
+
+
+    getScale: function() {
+        var scale = detectZoom.device();
+        // Round up to 1.5 or the next integer below the cap.
+        if      ( scale <= 1.0 ) scale = 1.0;
+        else if ( scale <= 1.5 ) scale = 1.5;
+        else if ( scale <= 2.0 ) scale = 2.0;
+        else if ( scale <= 3.0 ) scale = 3.0;
+        else if ( scale <= 4.0 ) scale = 4.0;
+        else                     scale = 5.0;
+        return scale;
+    },
+
+    shouldZoom: function( scale ) {
+        var t = this;
+        // Do not operate on hidden frames.
+        if ( "innerWidth" in window && !window.innerWidth )
+            return false;
+        // Don't do anything until scale > 1
+        if ( scale == 1.0 && t.zoomed == false )
+            return false;
+        return true;
+    },
+    /**
+     * Run through all images and add to those image the srcset according to the same rules as zoomImages.
+     */
+    addSrcSetToImages: function() {
+        var imgs = document.getElementsByTagName("img");
+
+        for ( var i = 0; i < imgs.length; i++ ) {
+            this.setScaledImageSrcSet(imgs[i]);
+        }
+    },
+    /**
+     * Run through all images and change the src according to the zoom being detected at detectZoom
+     */
+    zoomImages: function() {
+        var t = this;
+        var scale = t.getScale();
+        if ( ! t.shouldZoom( scale ) ){
+            return;
+        }
+        t.zoomed = true;
+        // Loop through all the <img> elements on the page.
+        var imgs = document.getElementsByTagName("img");
+
+        for ( var i = 0; i < imgs.length; i++ ) {
+            // Wait for original images to load
+            if ( "complete" in imgs[i] && ! imgs[i].complete )
+                continue;
+
+            // Skip images that don't need processing.
+            var imgScale = imgs[i].getAttribute("scale");
+            if ( imgScale == scale || imgScale == "0" )
+                continue;
+
+            // Skip images that have already failed at this scale
+            var scaleFail = imgs[i].getAttribute("scale-fail");
+            if ( scaleFail && scaleFail <= scale )
+                continue;
+
+            // Skip images that have no dimensions yet.
+            if ( ! ( imgs[i].width && imgs[i].height ) )
+                continue;
+
+            // Skip images from Lazy Load plugins
+            if ( ! imgScale && imgs[i].getAttribute("data-lazy-src") && (imgs[i].getAttribute("data-lazy-src") !== imgs[i].getAttribute("src")))
+                continue;
+
+            if ( t.setScaledImageSrc( imgs[i], scale ) ) {
+                // Mark the img as having been processed at this scale.
+                imgs[i].setAttribute("scale", scale);
+            }
+            else {
+                // Set the flag to skip this image.
+                imgs[i].setAttribute("scale", "0");
+            }
+        }
+    },
+    /**
+     * Adding src attribute according to zoom state
+     *
+     * @param img
+     * @param scale
+     * @returns {boolean}
+     */
+    setScaledImageSrc: function ( img, scale ) {
+        var t = this;
+        var newSrc = t.scaleImage(img, scale);
+        // Don't set img.src unless it has changed. This avoids unnecessary reloads.
+        if ( newSrc != img.src ) {
+            // Store the original img.src
+            var prevSrc, origSrc = img.getAttribute("src-orig");
+            if ( !origSrc ) {
+                origSrc = img.src;
+                img.setAttribute("src-orig", origSrc);
+            }
+            // In case of error, revert img.src
+            prevSrc = img.src;
+            img.onerror = function(){
+                img.src = prevSrc;
+                if ( img.getAttribute("scale-fail") < scale )
+                    img.setAttribute("scale-fail", scale);
+                img.onerror = null;
+            };
+            // Finally load the new image
+            img.src = newSrc;
+            return true;
+        }
+
+        return false;
+    },
+    /**
+     * Adding srcset attributes to 1-5 zoom levels
+     *
+     * @param img
+     * @returns {boolean}
+     */
+    setScaledImageSrcSet: function ( img ) {
+        var t = this;
+        var srcSetArray = Array();
+        for( var scale = 1; scale <= 5; scale++ ) {
+            var newSrc = t.scaleImage(img, scale);
+            if(newSrc && typeof newSrc !== 'undefined') {
+                srcSetArray.push(newSrc+' '+scale+'x');
+            }
+        }
+        if(srcSetArray.length > 0) {
+            img.srcset = srcSetArray.join();
+            return true;
+        }
+
+        return false;
+    },
+    /**
+     * Handles the scaling of the images that are being
+     *
+     * @param img
+     * @param scale
+     * @returns string || false
+     */
+    scaleImage: function( img, scale ) {
+        var t = this;
+
+        // Skip slideshow images
+        if ( img.parentNode.className.match(/slideshow-slide/) )
+            return false;
+
+        // Scale gravatars that have ?s= or ?size=
+        if ( img.src.match( /^https?:\/\/([^\/]*\.)?gravatar\.com\/.+[?&](s|size)=/ ) ) {
+            return t.getGravatarScale(img, scale);
+        }
+
+        // Scale resize queries (*.files.wordpress.com) that have ?w= or ?h=
+        else if ( img.src.match( /^https?:\/\/([^\/]+)\.files\.wordpress\.com\/.+[?&][wh]=/ ) ) {
+            return t.getFilesWordpressComScale(img, scale);
+        }
+
+        // Scale mshots that have width
+        else if ( img.src.match(/^https?:\/\/([^\/]+\.)*(wordpress|wp)\.com\/mshots\/.+[?&]w=\d+/) ) {
+            return t.getMshotsWithWidthScale(img, scale);
+        }
+
+        // Scale simple imgpress queries (s0.wp.com) that only specify w/h/fit
+        else if ( img.src.match(/^https?:\/\/([^\/.]+\.)*(wp|wordpress)\.com\/imgpress\?(.+)/) ) {
+            return t.getImgpressQueriesScale(img, scale);
+        }
+
+        // Scale LaTeX images or Photon queries (i#.wp.com)
+        else if (
+            img.src.match(/^https?:\/\/([^\/.]+\.)*(wp|wordpress)\.com\/latex\.php\?(latex|zoom)=(.+)/) ||
+            img.src.match(/^https?:\/\/i[\d]{1}\.wp\.com\/(.+)/)
+        ) {
+            return t.getLatexPhotonScale(img, scale);
+        }
+
+        // Scale static assets that have a name matching *-1x.png or *@1x.png
+        else if ( img.src.match(/^https?:\/\/[^\/]+\/.*[-@]([12])x\.(gif|jpeg|jpg|png)(\?|$)/) ) {
+            return t.getSaticAssetsScale(img, scale);
+        }
+
+        else {
+            return false;
+        }
+
+
+    },
+    getGravatarScale: function(img, scale) {
+        var t = this;
+        var newSrc = img.src.replace( /([?&](s|size)=)(\d+)/, function( $0, $1, $2, $3 ) {
+            // Stash the original size
+            var originalAtt = "originals",
+                originalSize = img.getAttribute(originalAtt);
+            if ( originalSize === null ) {
+                originalSize = $3;
+                img.setAttribute(originalAtt, originalSize);
+                if ( t.imgNeedsSizeAtts( img ) ) {
+                    // Fix width and height attributes to rendered dimensions.
+                    img.width !== 0 ? img.width = img.width : '';
+                    img.height !== 0 ? img.height =  img.height : '';
+                }
+            }
+            // Get the width/height of the image in CSS pixels
+            var size = img.clientWidth;
+            // Convert CSS pixels to device pixels
+            var targetSize = Math.ceil(img.clientWidth * scale);
+            // Don't go smaller than the original size
+            targetSize = Math.max( targetSize, originalSize );
+            // Don't go larger than the service supports
+            targetSize = Math.min( targetSize, 512 );
+            return $1 + targetSize;
+        });
+        return newSrc;
+    },
+    getFilesWordpressComScale: function (img, scale) {
+        var newSrc = img.src;
+        if ( img.src.match( /[?&]crop/ ) )
+            return false;
+        var changedAttrs = {};
+        var matches = img.src.match( /([?&]([wh])=)(\d+)/g );
+        for ( var i = 0; i < matches.length; i++ ) {
+            var lr = matches[i].split( '=' );
+            var thisAttr = lr[0].replace(/[?&]/g, '' );
+            var thisVal = lr[1];
+
+            // Stash the original size
+            var originalAtt = 'original' + thisAttr, originalSize = img.getAttribute( originalAtt );
+            if ( originalSize === null ) {
+                originalSize = thisVal;
+                img.setAttribute(originalAtt, originalSize);
+                if ( t.imgNeedsSizeAtts( img ) ) {
+                    // Fix width and height attributes to rendered dimensions.
+                    img.width !== 0 ? img.width = img.width : '';
+                    img.height !== 0 ? img.height =  img.height : '';
+                }
+            }
+            // Get the width/height of the image in CSS pixels
+            var size = thisAttr == 'w' ? img.clientWidth : img.clientHeight;
+            var naturalSize = ( thisAttr == 'w' ? img.naturalWidth : img.naturalHeight );
+            // Convert CSS pixels to device pixels
+            var targetSize = Math.ceil(size * scale);
+            // Don't go smaller than the original size
+            targetSize = Math.max( targetSize, originalSize );
+            // Don't go bigger unless the current one is actually lacking
+            if ( scale > img.getAttribute("scale") && targetSize <= naturalSize )
+                targetSize = thisVal;
+            // Don't try to go bigger if the image is already smaller than was requested
+            if ( naturalSize < thisVal )
+                targetSize = thisVal;
+            if ( targetSize != thisVal )
+                changedAttrs[ thisAttr ] = targetSize;
+        }
+        var w = changedAttrs.w || false;
+        var h = changedAttrs.h || false;
+
+        if ( w ) {
+            newSrc = img.src.replace(/([?&])w=\d+/g, function( $0, $1 ) {
+                return $1 + 'w=' + w;
+            });
+        }
+        if ( h ) {
+            newSrc = newSrc.replace(/([?&])h=\d+/g, function( $0, $1 ) {
+                return $1 + 'h=' + h;
+            });
+        }
+        return newSrc;
+    },
+    getMshotsWithWidthScale: function( img, scale ) {
+        var newSrc = img.src.replace( /([?&]w=)(\d+)/, function($0, $1, $2) {
+            // Stash the original size
+            var originalAtt = 'originalw', originalSize = img.getAttribute(originalAtt);
+            if ( originalSize === null ) {
+                originalSize = $2;
+                img.setAttribute(originalAtt, originalSize);
+                if ( t.imgNeedsSizeAtts( img ) ) {
+                    // Fix width and height attributes to rendered dimensions.
+                    img.width !== 0 ? img.width = img.width : '';
+                    img.height !== 0 ? img.height =  img.height : '';
+                }
+            }
+            // Get the width of the image in CSS pixels
+            var size = img.clientWidth;
+            // Convert CSS pixels to device pixels
+            var targetSize = Math.ceil(size * scale);
+            // Don't go smaller than the original size
+            targetSize = Math.max( targetSize, originalSize );
+            // Don't go bigger unless the current one is actually lacking
+            if ( scale > img.getAttribute("scale") && targetSize <= img.naturalWidth )
+                targetSize = $2;
+            if ( $2 != targetSize )
+                return $1 + targetSize;
+            return $0;
+        });
+        return newSrc;
+    },
+    getImgpressQueriesScale: function( img, scale ) {
+        var newSrc = img.src;
+        var imgpressSafeFunctions = ["zoom", "url", "h", "w", "fit", "filter", "brightness", "contrast", "colorize", "smooth", "unsharpmask"];
+        // Search the query string for unsupported functions.
+        var qs = RegExp.$3.split('&');
+        for ( var q in qs ) {
+            q = qs[q].split('=')[0];
+            if ( imgpressSafeFunctions.indexOf(q) == -1 ) {
+                return false;
+            }
+        }
+        // Fix width and height attributes to rendered dimensions.
+        img.width !== 0 ? img.width = img.width : '';
+        img.height !== 0 ? img.height =  img.height : '';
+        // Compute new src
+        if ( scale == 1 )
+            newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
+        else
+            newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
+
+        return newSrc;
+    },
+    getLatexPhotonScale: function( img, scale ) {
+        var newSrc = img.src;
+        // Fix width and height attributes to rendered dimensions.
+        img.width !== 0 ? img.width = img.width : '';
+        img.height !== 0 ? img.height =  img.height : '';
+        // Compute new src
+        if ( scale == 1 )
+            newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
+        else
+            newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
+
+        return newSrc;
+    },
+    getStaticAssetsScale: function( img, scale ) {
+        var newSrc = img.src;
+        // Fix width and height attributes to rendered dimensions.
+        img.width !== 0 ? img.width = img.width : '';
+        img.height !== 0 ? img.height =  img.height : '';
+        var currentSize = RegExp.$1, newSize = currentSize;
+        if ( scale <= 1 )
+            newSize = 1;
+        else
+            newSize = 2;
+        if ( currentSize != newSize )
+            newSrc = img.src.replace(/([-@])[12]x\.(gif|jpeg|jpg|png)(\?|$)/, '$1'+newSize+'x.$2$3');
+
+        return newSrc;
+    }
+};
+
+wpcom_img_zoomer.init();

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -440,7 +440,7 @@
          * Run through all images and change the src according to the zoom being detected at detectZoom
          */
         zoomImages: function() {
-            var _this,scale,imgs,i,imgScale, scaleFail, scaleSuccess;
+            var _this,scale, imgs, i, scaleSuccess;
             _this = this;
             scale = _this.getScale();
             if ( ! _this.shouldZoom( scale ) ){
@@ -450,31 +450,14 @@
             // Loop through all the <img> elements on the page.
             imgs = document.getElementsByTagName('img');
             for ( i = 0; i < imgs.length; i++ ) {
-                // Wait for original images to load
-                if ( 'complete' in imgs[i] && ! imgs[i].complete ) {
+                //check first if the image should be scaled
+                if( true === _this.isImageIsScalable( imgs[i], scale )) {
+                    // Adding scaled src attribute to image
+                    scaleSuccess = _this.setScaledImageSrc( imgs[i], scale );
+                } else {
+                    // This image cannot be scaled. continue to next image
                     continue;
                 }
-                // Skip images that don'_this need processing.
-                imgScale = imgs[i].getAttribute('scale');
-                if ( imgScale === scale || imgScale === '0' ) {
-                    continue;
-                }
-
-                // Skip images that have already failed at this scale
-                scaleFail = imgs[i].getAttribute('scale-fail');
-                if ( scaleFail && scaleFail <= scale ) {
-                    continue;
-                }
-                // Skip images that have no dimensions yet.
-                if ( ! ( imgs[i].width && imgs[i].height ) ) {
-                    continue;
-                }
-                // Skip images from Lazy Load plugins
-                if ( ! imgScale && imgs[i].getAttribute('data-lazy-src') && (imgs[i].getAttribute('data-lazy-src') !== imgs[i].getAttribute('src'))) {
-                    continue;
-                }
-
-                scaleSuccess = _this.setScaledImageSrc( imgs[i], scale );
 
                 if ( scaleSuccess === true ) {
                     // Mark the img as having been processed at this scale.
@@ -485,6 +468,38 @@
                     imgs[i].setAttribute('scale', '0');
                 }
             }
+        },
+        /**
+         * Check if image should be scaled
+         * @param img
+         * @returns {boolean}
+         */
+        isImageIsScalable: function ( img, scale ) {
+            var imgScale, scaleFail;
+            imgScale = img.getAttribute('scale');
+            scaleFail = img.getAttribute('scale-fail');
+
+            // Wait for original images to load
+            if ( 'complete' in img && ! img.complete ) {
+                return false;
+            }
+            // Skip images that don'_this need processing.
+            if ( imgScale === scale || imgScale === '0' ) {
+                return false;
+            }
+            // Skip images that have already failed at this scale
+            if ( scaleFail && scaleFail <= scale ) {
+                return false;
+            }
+            // Skip images that have no dimensions yet.
+            if ( ! ( img.width && img.height ) ) {
+                return false;
+            }
+            // Skip images from Lazy Load plugins
+            if ( ! imgScale && img.getAttribute('data-lazy-src') && (img.getAttribute('data-lazy-src') !== img.getAttribute('src'))) {
+                return false;
+            }
+            return true;
         },
         /**
          * Adding src attribute according to zoom state

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -540,7 +540,7 @@ var wpcom_img_zoomer = {
 
         // Skip slideshow images
         if ( img.parentNode.className.match(/slideshow-slide/) ) {
-            return false;
+            return '';
         }
         // Scale gravatars that have ?s= or ?size=
         if ( img.src.match( /^https?:\/\/([^\/]*\.)?gravatar\.com\/.+[?&](s|size)=/ ) ) {
@@ -576,7 +576,7 @@ var wpcom_img_zoomer = {
         }
 
         else {
-            return false;
+            return '';
         }
 
 

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -573,12 +573,15 @@
                 return _this.getImgpressQueriesScale(img, scale);
             }
 
-            // Scale LaTeX images or Photon queries (i#.wp.com)
-            else if (
-                img.src.match(/^https?:\/\/([^\/.]+\.)*(wp|wordpress)\.com\/latex\.php\?(latex|zoom)=(.+)/) ||
-                img.src.match(/^https?:\/\/i[\d]{1}\.wp\.com\/(.+)/)
-            ) {
-                return _this.getLatexPhotonScale(img, scale);
+            // Scale LaTeX images
+            else if ( img.src.match(/^https?:\/\/([^\/.]+\.)*(wp|wordpress)\.com\/latex\.php\?(latex|zoom)=(.+)/) ) {
+                return _this.getLatexScale(img, scale);
+            }
+
+            //Scale Photon queries (i#.wp.com)
+
+            else if( img.src.match(/^https?:\/\/i[\d]{1}\.wp\.com\/(.+)/) ) {
+                return _this.getPhotonScale(img, scale);
             }
 
             // Scale static assets that have a name matching *-1x.png or *@1x.png
@@ -767,13 +770,34 @@
             return newSrc;
         },
         /**
-         * Returning Photon or Latex URLS with Zoom parameters according to scale
+         * Returning Latex URLS with Zoom parameters according to scale
          *
          * @param img
          * @param scale
          * @returns {*}
          */
-        getLatexPhotonScale: function( img, scale ) {
+        getLatexScale: function( img, scale ) {
+            var newSrc = img.src;
+            // Fix width and height attributes to rendered dimensions.
+            img.width !== 0 ? img.width = img.width : '';
+            img.height !== 0 ? img.height =  img.height : '';
+            // Compute new src
+            if ( scale === 1 ) {
+                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?');
+            } else {
+                newSrc = img.src.replace(/\?(zoom=[^&]+&)?/, '?zoom=' + scale + '&');
+            }
+
+            return newSrc;
+        },
+        /**
+         * Returning Photon URLS with Zoom parameters according to scale
+         *
+         * @param img
+         * @param scale
+         * @returns {*}
+         */
+        getPhotonScale: function( img, scale ) {
             var newSrc = img.src;
             // Fix width and height attributes to rendered dimensions.
             img.width !== 0 ? img.width = img.width : '';

--- a/_inc/jetpack-retina-support.js
+++ b/_inc/jetpack-retina-support.js
@@ -440,7 +440,7 @@
          * Run through all images and change the src according to the zoom being detected at detectZoom
          */
         zoomImages: function() {
-            var _this,scale, imgs, i, scaleSuccess;
+            var _this,scale, imgs, i;
             _this = this;
             scale = _this.getScale();
             if ( ! _this.shouldZoom( scale ) ){

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -609,7 +609,7 @@ class Jetpack {
 	 */
 	function devicepx() {
 		if ( Jetpack::is_active() ) {
-            wp_enqueue_script( 'jetpack-retina-support', plugins_url( '_inc/jetpack-retina-support', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
+            wp_enqueue_script( 'jetpack-retina-support', plugins_url( '_inc/jetpack-retina-support.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
         }
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -608,7 +608,7 @@ class Jetpack {
 	 * This improves the resolution of Photon images, gravatars and wordpress.com uploads on hi-res and zoomed browsers.
 	 */
 	function devicepx() {
-		if ( Jetpack::is_active() ) {
+        if ( Jetpack::is_active() ) {
             wp_enqueue_script( 'jetpack-retina-support', plugins_url( '_inc/jetpack-retina-support.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
         }
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -437,9 +437,9 @@ class Jetpack {
 		add_action( 'wp_ajax_jetpack-sync-reindex-status', array( $this, 'sync_reindex_status' ) );
 
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'devicepx' ) );
-		add_action( 'customize_controls_enqueue_scripts', array( $this, 'devicepx' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'devicepx' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'retina_support' ) );
+		add_action( 'customize_controls_enqueue_scripts', array( $this, 'retina_support' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'retina_support' ) );
 
 		// add_action( 'jetpack_admin_menu', array( $this, 'admin_menu_modules' ) );
 
@@ -607,7 +607,7 @@ class Jetpack {
 	 * Jetpack-Retina-Support
 	 * This improves the resolution of Photon images, gravatars and wordpress.com uploads on hi-res and zoomed browsers.
 	 */
-	function devicepx() {
+	function retina_support() {
         if ( Jetpack::is_active() ) {
             wp_enqueue_script( 'jetpack-retina-support', plugins_url( '_inc/jetpack-retina-support.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
         }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -604,13 +604,13 @@ class Jetpack {
 	}
 
 	/**
-	 * Device Pixels support
-	 * This improves the resolution of gravatars and wordpress.com uploads on hi-res and zoomed browsers.
+	 * Jetpack-Retina-Support
+	 * This improves the resolution of Photon images, gravatars and wordpress.com uploads on hi-res and zoomed browsers.
 	 */
 	function devicepx() {
 		if ( Jetpack::is_active() ) {
-			wp_enqueue_script( 'devicepx', set_url_scheme( 'http://s0.wp.com/wp-content/js/devicepx-jetpack.js' ), array(), gmdate( 'oW' ), true );
-		}
+            wp_enqueue_script( 'jetpack-retina-support', plugins_url( '_inc/jetpack-retina-support', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
+        }
 	}
 
 	/*

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -606,7 +606,11 @@ class Jetpack {
 	/**
 	 * Jetpack-Retina-Support
 	 * This improves the resolution of Photon images, gravatars and wordpress.com uploads on hi-res and zoomed browsers.
-	 */
+     *
+     * @uses wp_enqueue_script
+     * @action wp_enqueue_scripts, customize_controls_enqueue_scripts, admin_enqueue_scripts
+     * @return null
+     */
 	function retina_support() {
         if ( Jetpack::is_active() ) {
             wp_enqueue_script( 'jetpack-retina-support', plugins_url( '_inc/jetpack-retina-support.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );


### PR DESCRIPTION
# Adding srcset elements to Photon images

## issue 1169
See: https://github.com/Automattic/jetpack/issues/1169

## Problem
Retina images are being implemented by using devicepx-jetpack.js – in the past it was the best way to determine the user zoom level on every browser. If the user zoom in\zoom out or has a retina, Jetpack will immediately go to Photon and fetch the correct version of the image for the user’s zoom. The downsize of using this script is a function that runs every second – lead to performance issues. Users complained about it and you can find online several posts of developers about it. Google devicepx-jetpack.js for a lot of examples.

## General fix details
Original WordPress "devicepx" hosted file removed and new jetpack-retina-support added. The new file include srcset addition to supported browsers, Fallback is using the original devicepx methods.

## How to test
* Go with Chrome browser (supports srcset) to a page that use images (in the post itself or in the widgets) see that srcest attributes for zoom 1x,2x,3x,4x are being implemented by JavaScript for Photon, Wordpress.com & Gravatar.
* Go with Firefox browser (not supporting srcset), See that it is loading the appropriate image according to zoom level.

## Warning
We are losing functionality here. srcset does not reload the image dynamicly if the user is zooming in or out. 