### PR TITLE
Related Posts: Bring UI in line with WordPress.com version

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1,6 +1,6 @@
 <?php
 class Jetpack_RelatedPosts {
-	const VERSION = '20140611';
+	const VERSION = '20141201';
 	const SHORTCODE = 'jetpack-related-posts';
 
 	/**
@@ -684,7 +684,7 @@ EOT;
 			return wp_strip_all_tags( $post_title );
 		}
 
-		$post_title = wp_trim_words( wp_strip_all_tags( strip_shortcodes( $post_content ) ), 5 );
+		$post_title = wp_trim_words( wp_strip_all_tags( strip_shortcodes( $post_content ) ), 5, '…' );
 		if ( ! empty( $post_title ) ) {
 			return $post_title;
 		}
@@ -706,7 +706,7 @@ EOT;
 		else
 			$excerpt = $post_excerpt;
 
-		return wp_trim_words( wp_strip_all_tags( strip_shortcodes( $excerpt ) ), 30 );
+		return wp_trim_words( wp_strip_all_tags( strip_shortcodes( $excerpt ) ), 50, '…' );
 	}
 
 	/**

--- a/modules/related-posts/related-posts.css
+++ b/modules/related-posts/related-posts.css
@@ -90,6 +90,17 @@ div#jp-relatedposts div.jp-relatedposts-items p {
 	line-height: 20px;
 	margin: 0;
 }
+div#jp-relatedposts div.jp-relatedposts-items-visual div.jp-relatedposts-post-nothumbs {
+	position:relative;
+}
+div#jp-relatedposts div.jp-relatedposts-items-visual div.jp-relatedposts-post-nothumbs a.jp-relatedposts-post-aoverlay {
+	position:absolute;
+	top:0;
+	bottom:0;
+	left:0;
+	right:0;
+	display:block;
+}
 
 div#jp-relatedposts div.jp-relatedposts-items p {
 	margin-bottom: 0;

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -33,7 +33,9 @@
 			}
 		},
 
-		getAnchor: function( post ) {
+		getAnchor: function( post, classNames ) {
+			var self = this;
+
 			var anchor_title = post.title;
 			if ( '' !== ( '' + post.excerpt ) ) {
 				anchor_title += '\n\n' + post.excerpt;
@@ -42,7 +44,7 @@
 			var anchor = $( '<a>' );
 
 			anchor.attr({
-				'class': 'jp-relatedposts-post-a',
+				'class': classNames,
 				'href': post.url,
 				'title': anchor_title,
 				'rel': 'nofollow',
@@ -62,7 +64,7 @@
 			var html = '';
 
 			$.each( posts, function( index, post ) {
-				var anchor = self.getAnchor( post );
+				var anchor = self.getAnchor( post, 'jp-relatedposts-post-a' );
 				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index;
 
 				html += '<p class="' + classes + '" data-post-id="' + post.id + '" data-post-format="' + post.format + '">';
@@ -79,7 +81,7 @@
 			var html = '';
 
 			$.each( posts, function( index, post ) {
-				var anchor = self.getAnchor( post );
+				var anchor = self.getAnchor( post, 'jp-relatedposts-post-a' );
 				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index;
 				if ( ! post.img.src ) {
 					classes += ' jp-relatedposts-post-nothumbs';
@@ -90,6 +92,9 @@
 				html += '<div class="' + classes + '" data-post-id="' + post.id + '" data-post-format="' + post.format + '">';
 				if ( post.img.src ) {
 					html += anchor[0] + '<img class="jp-relatedposts-post-img" src="' + post.img.src + '" width="' + post.img.width + '" alt="' + post.title + '" />' + anchor[1];
+				} else {
+					var anchor_overlay = self.getAnchor( post, 'jp-relatedposts-post-a jp-relatedposts-post-aoverlay' );
+					html += anchor_overlay[0] + anchor_overlay[1];
 				}
 				html += '<h4 class="jp-relatedposts-post-title">' + anchor[0] + post.title + anchor[1] + '</h4>';
 				html += '<p class="jp-relatedposts-post-excerpt">' + post.excerpt + '</p>';
@@ -98,6 +103,28 @@
 				html += '</div>';
 			} );
 			return '<div class="jp-relatedposts-items jp-relatedposts-items-visual">' + html + '</div>';
+		},
+
+		/**
+		 * We want to set a max height on the excerpt however we want to set
+		 * this according to the natual pacing of the page as we never want to
+		 * cut off a line of text in the middle so we need to do some detective
+		 * work.
+		 */
+		setVisualExcerptHeights: function() {
+			var elements = $( '#jp-relatedposts .jp-relatedposts-post-nothumbs .jp-relatedposts-post-excerpt' );
+
+			if ( 0 >= elements.length )
+				return;
+
+			var fontSize = parseInt( elements.first().css( 'font-size' ) ),
+				lineHeight = parseInt( elements.first().css( 'line-height' ) );
+
+			// Show 5 lines of text
+			elements.css(
+				'max-height',
+				( 5 * lineHeight / fontSize ) + 'em'
+			);
 		},
 
 		getTrackedUrl: function( anchor ) {
@@ -144,7 +171,9 @@
 				html = jprp.generateVisualHtml( response.items );
 			}
 
-			$( '#jp-relatedposts' ).append( html ).show();
+			$( '#jp-relatedposts' ).append( html );
+			jprp.setVisualExcerptHeights();
+			$( '#jp-relatedposts' ).show();
 
 			$( '#jp-relatedposts a.jp-relatedposts-post-a' ).click(function() {
 				this.href = jprp.getTrackedUrl( this );

--- a/modules/related-posts/rtl/related-posts-rtl.css
+++ b/modules/related-posts/rtl/related-posts-rtl.css
@@ -1,4 +1,4 @@
-/* This file was automatically generated on Mar 07 2014 15:56:55 */
+/* This file was automatically generated on Dec 01 2014 22:02:36 */
 
 /**
  * Styles for Jetpack related posts
@@ -92,6 +92,17 @@ div#jp-relatedposts div.jp-relatedposts-items p {
 	line-height: 20px;
 	margin: 0;
 }
+div#jp-relatedposts div.jp-relatedposts-items-visual div.jp-relatedposts-post-nothumbs {
+	position:relative;
+}
+div#jp-relatedposts div.jp-relatedposts-items-visual div.jp-relatedposts-post-nothumbs a.jp-relatedposts-post-aoverlay {
+	position:absolute;
+	top:0;
+	bottom:0;
+	right:0;
+	left:0;
+	display:block;
+}
 
 div#jp-relatedposts div.jp-relatedposts-items p {
 	margin-bottom: 0;
@@ -106,6 +117,7 @@ div#jp-relatedposts div.jp-relatedposts-items-visual h4.jp-relatedposts-post-tit
 }
 
 div#jp-relatedposts div.jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-title a {
+	font-size: inherit;
 	font-weight: normal;
 	text-decoration: none;
 	filter: alpha(opacity=100);


### PR DESCRIPTION
Some niceties / UI tweaks for related posts:
- Limit excerpts to 5 lines max (resolves #1249)
- Use UTF-8 ellipsis to prevent double encoding issue (#1282)
- Make entire excerpt clickable
