### PR TITLE
Add XMLRPC endpoint to refresh publicize conns.

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -99,23 +99,14 @@ class Publicize extends Publicize_Base {
 		}
 	}
 
-	function fetch_connections() {
-		Jetpack::load_xml_rpc_client();
-		$xml = new Jetpack_IXR_Client();
-		$xml->query( 'jetpack.fetchPublicizeConnections' );
-
-		if ( !$xml->isError() ) {
-			$response = $xml->getResponse();
-			Jetpack_Options::update_option( 'publicize_connections', $response );
-			return $response;
-		}
-
-		return false;
+	function receive_updated_publicize_connections( $publicize_connections ) {
+		Jetpack_Options::update_option( 'publicize_connections', $publicize_connections );
+		return true;
 	}
 
 	function register_update_publicize_connections_xmlrpc_method( $methods ) {
 		return array_merge( $methods, array(
-			'jetpack.updatePublicizeConnections' => array( $this, 'fetch_connections' ),
+			'jetpack.updatePublicizeConnections' => array( $this, 'receive_updated_publicize_connections' ),
 		) );
 	}
 
@@ -181,7 +172,15 @@ class Publicize extends Publicize_Base {
 				break;
 
 			case 'completed':
-				$this->fetch_connections();
+				Jetpack::load_xml_rpc_client();
+				$xml = new Jetpack_IXR_Client();
+				$xml->query( 'jetpack.fetchPublicizeConnections' );
+
+				if ( ! $xml->isError() ) {
+					$response = $xml->getResponse();
+					Jetpack_Options::update_option( 'publicize_connections', $response );
+				}
+
 				break;
 
 			case 'delete':


### PR DESCRIPTION
We are introducting v1.1 of publicize connection endpoints in the WP.com/Jetpack REST API.

Because all information about keyring tokens and publicize connections is stored on WordPress.com and not on the remote Jetpack side, we are not going to duplicate these endpoints in Jetpack proper. Instead, we're adding Jetpack support by keeping the code for the endpoints on WordPress.com only.

These new endpoints allow both the creation and deletion of publicize connections on the remote Jetpack site. In order for the sharing options page to be up to date on the Jetpack site, we need to update the `publicize_connections` Jetpack option whenever a connection is added or removed on the WP.com side.

To do so requires remotely forcing the refresh of the `publicize_connections` option. Previously, this option was only refreshed when a connection was completed from the Jetpack site via the sharing page UI. Now we also allow refreshing this option via a remote XMLRPC call, which will be triggered from the WP.com JSON API endpoint.
