### PR TITLE
Facebook Like Box Widget: add filter to title

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -77,7 +77,11 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 
 		if ( ! empty( $title ) ) :
 			echo $before_title;
-			?><a href="<?php echo esc_url( $page_url ); ?>"><?php echo esc_html( $title ); ?></a><?php
+
+			$likebox_widget_title = '<a href="' . esc_url( $page_url ) . '">' . esc_html( $title ) . '</a>';
+
+			echo apply_filters( 'jetpack_facebook_likebox_title', $likebox_widget_title, $title, $page_url );
+
 			echo $after_title;
 		endif;
 


### PR DESCRIPTION
The `jetpack_facebook_likebox_title` filter will allow site owners to remove the link in the widget title, or have it open in a new window.

Fixes #892

Suggested here:
https://wordpress.org/support/topic/filter-on-facebook-widget-title?replies=1
