### PR TITLE
Notifications: Changes to load the new notifications client.

### DIFF
--- a/modules/notes.php
+++ b/modules/notes.php
@@ -125,7 +125,11 @@ class Jetpack_Notifications {
 	}
 
 	function styles_and_scripts() {
-		wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+		if ( !is_rtl() ) {
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+		} else {
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+		}
 		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 
 		$this->print_js();
@@ -158,7 +162,7 @@ class Jetpack_Notifications {
 					<span class="noticon noticon-notification"></span>
 					</span>',
 			'meta'   => array(
-				'html'  => '<div id="wpnt-notes-panel" style="display:none" lang="'. esc_attr( get_locale() ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>',
+				'html'  => '<div id="wpnt-notes-panel2" style="display:none" lang="'. esc_attr( get_locale() ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>',
 				'class' => 'menupop',
 			),
 			'parent' => 'top-secondary',
@@ -171,6 +175,7 @@ class Jetpack_Notifications {
 <script type="text/javascript">
 /* <![CDATA[ */
 	var wpNotesIsJetpackClient = true;
+	var wpNotesIsJetpackClientV2 = true;
 <?php if ( $link_accounts_url ) : ?>
 	var wpNotesLinkAccountsURL = '<?php print $link_accounts_url; ?>';
 <?php endif; ?>


### PR DESCRIPTION
Submitting mainly for discussion.

This sets a var `wpNotesIsJetpackV2 = true` to let the code loaded from wpcom in `admin-bar-v2.js` know to load the new notifications client. Also in the markup, the id of the panel needs to be `wpnt-notes-panel2` instead of `wpnt-notes-panel` to get the right css rules. Separate change to load the appropriate stylesheet if `is_rtl()`

I talked to @lezama and @rase- briefly about this. I'm not sure if you guys should ship to users in upcoming release, we have been testing the new client internally, but have not had a chance for larger scale testing yet - though because the code is loaded from wpcom it is possible for us to update later to fix any issues that come up.