### PR TITLE
Plugin Modify Endpoint: clear cache before updating

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -120,6 +120,11 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 
 	protected function update() {
 
+		wp_clean_plugins_cache();
+		ob_start();
+		wp_update_plugins(); // Check for Plugin updates
+		ob_end_clean();
+
 		$update_plugins = get_site_transient( 'update_plugins' );
 
 		if ( isset( $update_plugins->response ) ) {
@@ -146,11 +151,6 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 
 			$update_attempted = true;
 
-			wp_clean_plugins_cache();
-			ob_start();
-			wp_update_plugins(); // Check for Plugin updates
-			ob_end_clean();
-
 			// Object created inside the for loop to clean the messages for each plugin
 			$skin = new Automatic_Upgrader_Skin();
 			// The Automatic_Upgrader_Skin skin shouldn't output anything.
@@ -159,6 +159,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			// This avoids the plugin to be deactivated.
 			defined( 'DOING_CRON' ) or define( 'DOING_CRON', true );
 			$result = $upgrader->upgrade( $plugin );
+
 			$this->log[ $plugin ][]  = $upgrader->skin->get_upgrade_messages();
 		}
 


### PR DESCRIPTION
We were clearing the plugin cache within the foreach loop, which was optimal
for updating multiple plugins at once. But we've decided on calypso that it
is better to update one plugin per api call - it gives us better error reporting
and progress reporting. Thus we should clear the plugin cache before
starting the update process.
