### PR TITLE
Add filter to Widget Conditions to allow empty categories and tags as a dropdown option

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -39,7 +39,7 @@ class Jetpack_Widget_Conditions {
 				<option value=""><?php _e( 'All category pages', 'jetpack' ); ?></option>
 				<?php
 
-				$categories = get_categories( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => apply_filters( 'jetpack_widget_conditions_show_empty_terms' , false , $major , $minor ) ) );
+				$categories = get_categories( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => false ) );
 				usort( $categories, array( __CLASS__, 'strcasecmp_name' ) );
 
 				foreach ( $categories as $category ) {
@@ -79,7 +79,7 @@ class Jetpack_Widget_Conditions {
 				<option value=""><?php _e( 'All tag pages', 'jetpack' ); ?></option>
 				<?php
 
-				$tags = get_tags( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => apply_filters( 'jetpack_widget_conditions_show_empty_terms' , false , $major , $minor ) ) );
+				$tags = get_tags( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => false ) );
 				usort( $tags, array( __CLASS__, 'strcasecmp_name' ) );
 
 				foreach ( $tags as $tag ) {

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -39,7 +39,7 @@ class Jetpack_Widget_Conditions {
 				<option value=""><?php _e( 'All category pages', 'jetpack' ); ?></option>
 				<?php
 
-				$categories = get_categories( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC' ) );
+				$categories = get_categories( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => apply_filters( 'jetpack_widget_conditions_show_empty_terms' , false , $major , $minor ) ) );
 				usort( $categories, array( __CLASS__, 'strcasecmp_name' ) );
 
 				foreach ( $categories as $category ) {
@@ -79,7 +79,7 @@ class Jetpack_Widget_Conditions {
 				<option value=""><?php _e( 'All tag pages', 'jetpack' ); ?></option>
 				<?php
 
-				$tags = get_tags( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC' ) );
+				$tags = get_tags( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => apply_filters( 'jetpack_widget_conditions_show_empty_terms' , false , $major , $minor ) ) );
 				usort( $tags, array( __CLASS__, 'strcasecmp_name' ) );
 
 				foreach ( $tags as $tag ) {


### PR DESCRIPTION
By default Widget Conditions does not display empty categories and tags. We get people setting up their sites with widgets and who want to setup their widget conditions prior to publishing posts on the site/category/tag.  This type of filter would make it quite easier enable. 

Without this type of filter, one need to add a filter to get_terms_args on all the requests which generate the dropdown ( like the following https://github.com/jwenerd/jetpack/compare/Automattic:master...jwenerd:master ) 
