### PR TITLE
Add DNS Prefetching

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4930,4 +4930,27 @@ p {
 
 		return $tag;
 	}
+
+	/**
+	 * Stores and prints out domains to prefetch for page speed optimization.
+	 *
+	 * @param mixed $new_urls
+	 */
+	public static function dns_prefetch( $new_urls = null ) {
+		static $prefetch_urls = array();
+		if ( empty( $new_urls ) && ! empty( $prefetch_urls ) ) {
+			echo "\r\n";
+			foreach ( $prefetch_urls as $this_prefetch_url ) {
+				printf( "<link rel='dns-prefetch' href='%s'>\r\n", esc_attr( $this_prefetch_url ) );
+			}
+		} elseif ( ! empty( $new_urls ) ) {
+			if ( ! has_action( 'wp_head', array( __CLASS__, __FUNCTION__ ) ) ) {
+				add_action( 'wp_head', array( __CLASS__, __FUNCTION__ ) );
+			}
+			foreach ( (array) $new_urls as $this_new_url ) {
+				$prefetch_urls[] = strtolower( untrailingslashit( preg_replace( '#^https?://#i', '//', $this_new_url ) ) );
+			}
+			$prefetch_urls = array_unique( $prefetch_urls );
+		}
+	}
 }

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -36,3 +36,14 @@ function jetpack_comments_configuration_load() {
 }
 
 add_action( 'jetpack_modules_loaded', 'jetpack_comments_load' );
+
+Jetpack::dns_prefetch( array(
+	'//jetpack.wordpress.com',
+	'//s0.wp.com',
+	'//s1.wp.com',
+	'//s2.wp.com',
+	'//public-api.wordpress.com',
+	'//0.gravatar.com',
+	'//1.gravatar.com',
+	'//2.gravatar.com',
+) );

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -9,6 +9,14 @@
  * Module Tags: Social
  */
 
+Jetpack::dns_prefetch( array(
+	'//widgets.wp.com',
+	'//s0.wp.com',
+	'//0.gravatar.com',
+	'//1.gravatar.com',
+	'//2.gravatar.com',
+) );
+
 class Jetpack_Likes {
 	var $version = '20141028';
 

--- a/modules/photon.php
+++ b/modules/photon.php
@@ -9,4 +9,10 @@
  * Module Tags: Photos and Videos, Appearance
  */
 
+Jetpack::dns_prefetch( array(
+	'//i0.wp.com',
+	'//i1.wp.com',
+	'//i2.wp.com',
+) );
+
 Jetpack_Photon::instance();

--- a/tests/test_class.jetpack.php
+++ b/tests/test_class.jetpack.php
@@ -280,4 +280,30 @@ EXPECTED;
 
 		$this->assertTrue( $seen_orig );
 	}
+
+	/**
+	 * @author georgestephanis
+	 * @covers Jetpack::dns_prefetch
+	 * @since 3.3.0
+	 */
+	public function test_dns_prefetch() {
+		// Purge it for a clean start.
+		ob_start();
+		Jetpack::dns_prefetch();
+		ob_clean();
+
+		Jetpack::dns_prefetch( 'http://example1.com/' );
+		Jetpack::dns_prefetch( array(
+			'http://example2.com/',
+			'https://example3.com',
+		) );
+		Jetpack::dns_prefetch( 'https://example2.com' );
+
+		$expected = "\r\n" .
+		            "<link rel='dns-prefetch' href='//example1.com'>\r\n" .
+		            "<link rel='dns-prefetch' href='//example2.com'>\r\n" .
+		            "<link rel='dns-prefetch' href='//example3.com'>\r\n";
+
+		$this->assertEquals( $expected, get_echo( array( 'Jetpack', 'dns_prefetch' ) ) );
+	}
 } // end class


### PR DESCRIPTION
Fixes #1387

Some other modules may also benefit from this prefetching.

Possible enhancement: Strip any path part of the urls passed into `Jetpack::dns_prefetch()` so we can do automated prefetching for footer scripts and the like?