### PR TITLE
Minor fixes to Facebook widget plugin for SSL

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -54,7 +54,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 
 
 		$title    = apply_filters( 'widget_title', $instance['title'] );
-		$page_url = str_replace( 'http://', 'https://', $like_args['href'] );
+		$page_url = set_url_scheme( $like_args['href'], 'https' );
 
 		$like_args['show_faces'] = (bool) $like_args['show_faces']         ? 'true' : 'false';
 		$like_args['stream']     = (bool) $like_args['stream']             ? 'true' : 'false';

--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -54,7 +54,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 
 
 		$title    = apply_filters( 'widget_title', $instance['title'] );
-		$page_url = ( is_ssl() ) ? str_replace( 'http://', 'https://', $like_args['href'] ) : $like_args['href'];
+		$page_url = str_replace( 'http://', 'https://', $like_args['href'] );
 
 		$like_args['show_faces'] = (bool) $like_args['show_faces']         ? 'true' : 'false';
 		$like_args['stream']     = (bool) $like_args['stream']             ? 'true' : 'false';
@@ -70,7 +70,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		$like_args = urlencode_deep( $like_args );
 		$like_url  = add_query_arg(
 			$like_args,
-			set_url_scheme( 'http://www.facebook.com/plugins/likebox.php' )
+			'https://www.facebook.com/plugins/likebox.php'
 		);
 
 		echo $before_widget;


### PR DESCRIPTION
Facebook forces SSL so linking the iframe to http:// causes an unnecessary redirect to https://