### PR TITLE
Add a filter so that user can add thier own bots 

### DIFF
--- a/class.jetpack-user-agent.php
+++ b/class.jetpack-user-agent.php
@@ -1391,6 +1391,12 @@ class Jetpack_User_Agent_Info {
 			'teoma', 'twiceler', 'yahooseeker', 'yahooysmcm', 'yammybot',
 		);
 
+		/**
+		 * Allows user to add thier own bot agents.
+		 *
+		 */
+		$bot_agents = apply_filters( 'jetpack_bot_agents', $bot_agents );
+
 		foreach ( $bot_agents as $bot_agent ) {
 			if ( false !== stripos( $ua, $bot_agent ) ) {
 				return true;


### PR DESCRIPTION
This PR tries to address this issue. 
https://github.com/Automattic/jetpack/issues/1402

Adding the filter 'jetpack_bot_agents' would allow users to add their own bots that they want to ignore in the stats. 

Need to see if this will have any significant performance issues before merging. 
