### PR TITLE
Don't require height/width values in the Twitter Timeline widget

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -115,8 +115,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		$instance['title']         = sanitize_text_field( $new_instance['title'] );
 		$instance['width']         = (int) $new_instance['width'];
 		$instance['height']        = (int) $new_instance['height'];
-		$instance['width']         = ( 0 !== (int) $new_instance['width'] )  ? (int) $new_instance['width']  : 225;
-		$instance['height']        = ( 0 !== (int) $new_instance['height'] ) ? (int) $new_instance['height'] : 400;
+		$instance['width']         = ( 0 !== (int) $new_instance['width'] )  ? (int) $new_instance['width']  : '';
+		$instance['height']        = ( 0 !== (int) $new_instance['height'] ) ? (int) $new_instance['height'] : '';
 		$instance['tweet-limit']   = ( 0 !== (int) $new_instance['tweet-limit'] ) ? (int) $new_instance['tweet-limit'] : null;
 
 		// If they entered something that might be a full URL, try to parse it out


### PR DESCRIPTION
Fix for https://github.com/Automattic/jetpack/issues/1405 and https://github.com/Automattic/jetpack/issues/210