### PR TITLE
JSON: add fallback to original slug approach

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -178,16 +178,20 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 				$slug = $update_plugins->no_update[ $plugin_file ]->slug;
 			}
 		}
+
 		if ( empty( $slug ) && isset( $update_plugins->response ) ) {
 			if ( isset( $update_plugins->response[ $plugin_file ] ) ) {
 				$slug = $update_plugins->response[ $plugin_file ]->slug;
 			}
 		}
-		if ( empty ( $slug) ) {
-			$slug = $plugin_file;
-		}
 
+		// Try to infer from the plugin file if not cached
+		if ( empty( $slug) ) {
+			$slug = dirname( $plugin_file );
+			if ( '.' === $slug ) {
+				$slug = preg_replace("/(.+)\.php$/", "$1", $plugin_file );
+			}
+		}
 		return $slug;
 	}
-
 }


### PR DESCRIPTION
If we can't get the cached plugin slug, let's try to infer that from the path to the plugin file. This should ease the issue of showing plugins twice, where uncached plugins have the plugin file path instead of the slug.

cc: @lezama 
