### PR TITLE
Backport fixes from SoundCloud 2.3.1 through 3.0.2

### DIFF
--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -102,11 +102,7 @@ function soundcloud_shortcode($atts, $content = null) {
 
 	// The "iframe" option must be true to load the iframe widget
 	if ( isset( $options[ 'iframe' ] ) ) {
-		$iframe = soundcloud_booleanize($options['iframe'])
-		// Default to flash widget for permalink urls (e.g. http://soundcloud.com/{username})
-		// because HTML5 widget doesn’t support those yet
-		? preg_match('/api.soundcloud.com/i', $options['url'])
-		: false;
+		$iframe = soundcloud_booleanize($options['iframe']);
 
 		if ( $iframe ) {
 			return soundcloud_iframe_widget( $options );

--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -65,7 +65,6 @@ function soundcloud_shortcode($atts, $content = null) {
 			'auto_play'     => soundcloud_get_option('auto_play'),
 			'show_comments' => soundcloud_get_option('show_comments'),
 			'color'         => soundcloud_get_option('color'),
-			'theme_color'   => soundcloud_get_option('theme_color'),
 		)),
 	));
 

--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -181,7 +181,7 @@ function soundcloud_oembed_params_callback($match) {
 function soundcloud_iframe_widget($options) {
 
 	// Build URL
-	$url = set_url_scheme( 'http://w.soundcloud.com/player/?' . http_build_query($options['params']) );
+	$url = set_url_scheme( 'https://w.soundcloud.com/player/?' . http_build_query($options['params']) );
 	// Set default width if not defined
 	$width = isset($options['width']) && $options['width'] !== 0 ? $options['width'] : '100%';
 	// Set default height if not defined
@@ -200,7 +200,7 @@ function soundcloud_iframe_widget($options) {
 function soundcloud_flash_widget($options) {
 
 	// Build URL
-	$url = set_url_scheme( 'http://player.soundcloud.com/player.swf?' . http_build_query($options['params']) );
+	$url = set_url_scheme( 'https://player.soundcloud.com/player.swf?' . http_build_query($options['params']) );
 	// Set default width if not defined
 	$width = isset($options['width']) && $options['width'] !== 0 ? $options['width'] : '100%';
 	// Set default height if not defined

--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -56,15 +56,20 @@ function soundcloud_shortcode($atts, $content = null) {
 	}
 	$shortcode_options['params'] = $shortcode_params;
 
+	$player_type = soundcloud_get_option('player_type', 'visual');
+	$isIframe    = $player_type !== 'flash';
+	$isVisual    = !$player_type || $player_type === 'visual';
+
 	// User preference options
 	$plugin_options = array_filter(array(
-		'iframe' => soundcloud_get_option('player_iframe', true),
+		'iframe' => $isIframe,
 		'width'  => soundcloud_get_option('player_width'),
-		'height' =>  soundcloud_url_has_tracklist($shortcode_options['url']) ? soundcloud_get_option('player_height_multi') : soundcloud_get_option('player_height'),
+		'height' => soundcloud_url_has_tracklist($shortcode_options['url']) ? soundcloud_get_option('player_height_multi') : soundcloud_get_option('player_height'),
 		'params' => array_filter(array(
 			'auto_play'     => soundcloud_get_option('auto_play'),
 			'show_comments' => soundcloud_get_option('show_comments'),
 			'color'         => soundcloud_get_option('color'),
+			'visual'        => ($isVisual ? 'true' : 'false')
 		)),
 	));
 
@@ -100,15 +105,25 @@ function soundcloud_shortcode($atts, $content = null) {
 	if (isset($options['height']) && !preg_match('/^\d+$/', $options['height'])) { unset($options['height']); }
 
 	// The "iframe" option must be true to load the iframe widget
-	if ( isset( $options[ 'iframe' ] ) ) {
-		$iframe = soundcloud_booleanize($options['iframe']);
+	$iframe = soundcloud_booleanize($options['iframe']);
 
-		if ( $iframe ) {
-			return soundcloud_iframe_widget( $options );
-		}
-	}
+  // Remove visual parameter from Flash widget or when it's false because that's the default
+  if ($options['params']['visual'] && (!$iframe || !soundcloud_booleanize($options['params']['visual']))) {
+    unset($options['params']['visual']);
+  }
 
-	return soundcloud_flash_widget( $options );
+  // Merge in "url" value
+  $options['params'] = array_merge(array(
+    'url' => $options['url']
+  ), $options['params']);
+
+  // Return html embed code
+  if ($iframe) {
+    return soundcloud_iframe_widget($options);
+  } else {
+    return soundcloud_flash_widget($options);
+  }
+
 }
 
 /**
@@ -165,17 +180,14 @@ function soundcloud_oembed_params_callback($match) {
  */
 function soundcloud_iframe_widget($options) {
 
-	// Merge in "url" value
-	$options['params'] = array_merge(array(
-		'url' => $options['url']
-	), $options['params']);
-
 	// Build URL
 	$url = set_url_scheme( 'http://w.soundcloud.com/player/?' . http_build_query($options['params']) );
 	// Set default width if not defined
 	$width = isset($options['width']) && $options['width'] !== 0 ? $options['width'] : '100%';
 	// Set default height if not defined
-	$height = isset($options['height']) && $options['height'] !== 0 ? $options['height'] : (soundcloud_url_has_tracklist($options['url']) ? '450' : '166');
+  $height = isset($options['height']) && $options['height'] !== 0
+              ? $options['height']
+              : (soundcloud_url_has_tracklist($options['url']) || (isset($options['params']['visual']) && soundcloud_booleanize($options['params']['visual'])) ? '450' : '166');
 
 	return sprintf('<iframe width="%s" height="%s" scrolling="no" frameborder="no" src="%s"></iframe>', $width, $height, $url);
 }
@@ -186,11 +198,6 @@ function soundcloud_iframe_widget($options) {
  * @return {string}            Flash embed code
  */
 function soundcloud_flash_widget($options) {
-
-	// Merge in "url" value
-	$options['params'] = array_merge(array(
-		'url' => $options['url']
-	), $options['params']);
 
 	// Build URL
 	$url = set_url_scheme( 'http://player.soundcloud.com/player.swf?' . http_build_query($options['params']) );


### PR DESCRIPTION
SoundClould has many fixes. Of primary interest are defaulting to the iframe embed (which works across devices) and https support. Fixes #1418.