### PR TITLE
Stats language

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -335,6 +335,22 @@ if ( -1 == document.location.href.indexOf( 'noheader' ) ) {
 <?php
 }
 
+/*
+ * Convert the sites' get_locale() to something wpcom can filter so
+ * we can translate the stats page accordingly.
+ */
+function convert_get_locale_to_lang( $locale ) {
+	if ( strpos( $locale, '_' ) !== FALSE ) {
+		$locale = explode( "_", $locale );
+	} elseif ( strpos( $locale, '-' ) !== FALSE ) {
+		$locale = explode( "-", $locale );
+	} else {
+		return;
+	}
+
+	return $locale[0];
+}
+
 function stats_reports_page() {
 	if ( isset( $_GET['dashboard'] ) )
 		return stats_dashboard_widget_content();
@@ -372,8 +388,9 @@ function stats_reports_page() {
 		'ssl' => is_ssl(),
 		'j' => sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION ),
 	);
-	if ( get_locale() !== 'en' ) {
-		$q['lang'] = get_locale();
+	$locale = convert_get_locale_to_lang( get_locale() );
+	if ( $locale !== 'en' ) {
+		$q['lang'] = $locale;
 	}
 	$args = array(
 		'view' => array( 'referrers', 'postviews', 'searchterms', 'clicks', 'post', 'table' ),

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -372,6 +372,9 @@ function stats_reports_page() {
 		'ssl' => is_ssl(),
 		'j' => sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION ),
 	);
+	if ( get_locale() !== 'en' ) {
+		$q['lang'] = get_locale();
+	}
 	$args = array(
 		'view' => array( 'referrers', 'postviews', 'searchterms', 'clicks', 'post', 'table' ),
 		'numdays' => 'int',

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -339,7 +339,7 @@ if ( -1 == document.location.href.indexOf( 'noheader' ) ) {
  * Convert the sites' get_locale() to something wpcom can filter so
  * we can translate the stats page accordingly.
  */
-function convert_get_locale_to_lang( $locale ) {
+function jetpack_convert_get_locale_to_lang( $locale ) {
 	if ( strpos( $locale, '_' ) !== FALSE ) {
 		$locale = explode( "_", $locale );
 	} elseif ( strpos( $locale, '-' ) !== FALSE ) {
@@ -388,7 +388,7 @@ function stats_reports_page() {
 		'ssl' => is_ssl(),
 		'j' => sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION ),
 	);
-	$locale = convert_get_locale_to_lang( get_locale() );
+	$locale = jetpack_convert_get_locale_to_lang( get_locale() );
 	if ( $locale !== 'en' ) {
 		$q['lang'] = $locale;
 	}

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -345,7 +345,7 @@ function convert_get_locale_to_lang( $locale ) {
 	} elseif ( strpos( $locale, '-' ) !== FALSE ) {
 		$locale = explode( "-", $locale );
 	} else {
-		return;
+		return $locale;
 	}
 
 	return $locale[0];

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -335,22 +335,6 @@ if ( -1 == document.location.href.indexOf( 'noheader' ) ) {
 <?php
 }
 
-/*
- * Convert the sites' get_locale() to something wpcom can filter so
- * we can translate the stats page accordingly.
- */
-function jetpack_convert_get_locale_to_lang( $locale ) {
-	if ( strpos( $locale, '_' ) !== FALSE ) {
-		$locale = explode( "_", $locale );
-	} elseif ( strpos( $locale, '-' ) !== FALSE ) {
-		$locale = explode( "-", $locale );
-	} else {
-		return $locale;
-	}
-
-	return $locale[0];
-}
-
 function stats_reports_page() {
 	if ( isset( $_GET['dashboard'] ) )
 		return stats_dashboard_widget_content();
@@ -388,9 +372,8 @@ function stats_reports_page() {
 		'ssl' => is_ssl(),
 		'j' => sprintf( '%s:%s', JETPACK__API_VERSION, JETPACK__VERSION ),
 	);
-	$locale = jetpack_convert_get_locale_to_lang( get_locale() );
-	if ( $locale !== 'en' ) {
-		$q['lang'] = $locale;
+	if ( get_locale() !== 'en_US' ) {
+		$q['jp_lang'] = get_locale();
 	}
 	$args = array(
 		'view' => array( 'referrers', 'postviews', 'searchterms', 'clicks', 'post', 'table' ),


### PR DESCRIPTION
Fixes #698 

Since dotcom won't read the full `get_locale` string, I wrote a custom function to change the string to match the `lang` attr.  So it changes `es_ES` to just `es`.  Let me know if there's a better way to do this.