### PR TITLE
Sharing: use Jetpack version number when enqueing sharing.js

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -624,7 +624,12 @@ function sharing_display( $text = '', $echo = false ) {
 			$sharing_content .= '</div></div></div>';
 
 			// Register our JS
-			wp_register_script( 'sharing-js', plugin_dir_url( __FILE__ ).'sharing.js', array( 'jquery' ), JETPACK__VERSION );
+			if ( defined( 'JETPACK__VERSION' ) ) {
+				$ver = JETPACK__VERSION;
+			} else {
+				$ver = '20141212';
+			}
+			wp_register_script( 'sharing-js', plugin_dir_url( __FILE__ ).'sharing.js', array( 'jquery' ), $ver );
 			add_action( 'wp_footer', 'sharing_add_footer' );
 		}
 	}

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -624,7 +624,7 @@ function sharing_display( $text = '', $echo = false ) {
 			$sharing_content .= '</div></div></div>';
 
 			// Register our JS
-			wp_register_script( 'sharing-js', plugin_dir_url( __FILE__ ).'sharing.js', array( 'jquery' ), '20140920' );
+			wp_register_script( 'sharing-js', plugin_dir_url( __FILE__ ).'sharing.js', array( 'jquery' ), JETPACK__VERSION );
 			add_action( 'wp_footer', 'sharing_add_footer' );
 		}
 	}


### PR DESCRIPTION
This way we won't run into issues during plugin updates making changes to that file.