### PR TITLE
Add various dev filters to Sharing_Source::get_link()

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -47,6 +47,7 @@ abstract class Sharing_Source {
 	}
 
 	public function get_link( $url, $text, $title, $query = '', $id = false ) {
+		$args = func_get_args();
 		$klasses = array( 'share-'.$this->get_class(), 'sd-button' );
 
 		if ( $this->button_style == 'icon' || $this->button_style == 'icon-text' )
@@ -59,8 +60,11 @@ abstract class Sharing_Source {
 			if ( $this->open_links == 'new' )
 				$text .= __( ' (Opens in new window)', 'jetpack' );
 		}
-
-		$url = apply_filters( 'sharing_display_link', $url );
+		
+		$id = apply_filters( 'sharing_display_id', $id, $this, $args );
+		$url = apply_filters( 'sharing_display_link', $url, $this, $id, $args );
+		$query = apply_filters( 'sharing_display_query', $query, $this, $id, $args );
+		
 		if ( !empty( $query ) ) {
 			if ( stripos( $url, '?' ) === false )
 				$url .= '?'.$query;
@@ -70,7 +74,11 @@ abstract class Sharing_Source {
 
 		if ( $this->button_style == 'text' )
 			$klasses[] = 'no-icon';
-
+		
+		$klasses = apply_filters( 'sharing_display_classes', $klasses, $this, $id, $args );
+		$title = apply_filters( 'sharing_display_title', $title, $this, $id, $args );
+		$text = apply_filters( 'sharing_display_text', $text, $this, $id, $args );
+		
 		return sprintf(
 			'<a rel="nofollow" data-shared="%s" class="%s" href="%s"%s title="%s"><span%s>%s</span></a>',
 			( $id ? esc_attr( $id ) : '' ),

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -61,9 +61,10 @@ abstract class Sharing_Source {
 				$text .= __( ' (Opens in new window)', 'jetpack' );
 		}
 		
-		$id = apply_filters( 'sharing_display_id', $id, $this, $args );
-		$url = apply_filters( 'sharing_display_link', $url, $this, $id, $args );
-		$query = apply_filters( 'sharing_display_query', $query, $this, $id, $args );
+		$id = apply_filters( 'jetpack_sharing_display_id', $id, $this, $args );
+		$url = apply_filters( 'sharing_display_link', $url, $this, $id, $args ); // backwards compatibility
+		$url = apply_filters( 'jetpack_sharing_display_link', $url, $this, $id, $args );
+		$query = apply_filters( 'jetpack_sharing_display_query', $query, $this, $id, $args );
 		
 		if ( !empty( $query ) ) {
 			if ( stripos( $url, '?' ) === false )
@@ -75,9 +76,9 @@ abstract class Sharing_Source {
 		if ( $this->button_style == 'text' )
 			$klasses[] = 'no-icon';
 		
-		$klasses = apply_filters( 'sharing_display_classes', $klasses, $this, $id, $args );
-		$title = apply_filters( 'sharing_display_title', $title, $this, $id, $args );
-		$text = apply_filters( 'sharing_display_text', $text, $this, $id, $args );
+		$klasses = apply_filters( 'jetpack_sharing_display_classes', $klasses, $this, $id, $args );
+		$title = apply_filters( 'jetpack_sharing_display_title', $title, $this, $id, $args );
+		$text = apply_filters( 'jetpack_sharing_display_text', $text, $this, $id, $args );
 		
 		return sprintf(
 			'<a rel="nofollow" data-shared="%s" class="%s" href="%s"%s title="%s"><span%s>%s</span></a>',


### PR DESCRIPTION
Howdy,

Recently had to make some modifications to output of the sharing buttons for a client, and found that the provided filters were a bit weak. 

I've added a few that I feel provide as much versatility as possible without doing anything obnoxious. 

The only unorthodox thing I'm doing here is passing all of the original arguments to each filter using `func_get_args()`.  This is so that developers always have the full context.  (I've verified this function is safe with PHP 5.2+)

However, a more complete implementation might need to include full and immediate filtering of all arguments, pre-output or manipulation. Something like:
`extract ( apply_filters('sharing_display_args', compact('url', 'text', 'title', 'query', 'id') ) );`

Which, I didn't include because I'm fairly certain `extract()` is not kosher even in this application :)

Please let me know if you'd prefer any adjustments, or if you have any thoughts on the above.  I can add via a second pull request if desired. 

Clif
