### PR TITLE
Minileven: Start after DOM ready

### DIFF
--- a/modules/minileven/theme/pub/minileven/js/small-menu.js
+++ b/modules/minileven/theme/pub/minileven/js/small-menu.js
@@ -3,7 +3,7 @@
  *
  * Handles toggling the navigation menu for small screens.
  */
-( function() {
+jQuery( document ).ready( function() {
 	var nav = document.getElementById( 'access' ), button, menu;
 	if ( ! nav ) {
 		return;
@@ -33,4 +33,4 @@
 			menu.className += ' toggled-on';
 		}
 	};
-} )();
+} );


### PR DESCRIPTION
Normally, this script (small-menu.js) is loaded at the bottom of the page, so all the DOM elements it modifies are present. However, when used in combination with plugin WP Minify Fix, all minified javascript is loaded together in the head of the page, before the DOM is ready. As a result, the button.onclick function is not set and nothing happens when the user presses the Menu-button.
This patch solves that by wrapping the function inside jQuery( document ).ready. Note that this wrapper was present earlier and removed by @cfinke's 57fcd65da92824986e90b2c6f7ccf1f32eb7e8b6. Please let me know if there was a reason for removing it.
