### PR TITLE
Fix: correct multibyte strings truncate (multiple bugs fixed)

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -66,10 +66,14 @@ class Jetpack_Admin {
 		foreach ( $available_modules as $module ) {
 			if ( $module_array = $this->jetpack->get_module( $module ) ) {
 				$short_desc = apply_filters( 'jetpack_short_module_description', $module_array['description'], $module );
-				// Fix: correct multibyte strings truncate
-				$short_desc_trunc = ( mb_strlen( $short_desc ) > 143 )
-							? mb_substr( $short_desc, 0, 140 ) . '...'
-							: $short_desc;
+				// Fix: correct multibyte strings truncate with checking for mbstring extension
+				$short_desc_trunc = ( function_exists( 'mb_strlen' ) )
+							? ( ( mb_strlen( $short_desc ) > 143 )
+								? mb_substr( $short_desc, 0, 140 ) . '...'
+								: $short_desc )
+							: ( ( strlen( $short_desc ) > 143 )
+								? substr( $short_desc, 0, 140 ) . '...'
+								: $short_desc );
 
 				$module_array['module']            = $module;
 				$module_array['activated']         = ( $jetpack_active ? in_array( $module, $active_modules ) : false );

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -66,7 +66,10 @@ class Jetpack_Admin {
 		foreach ( $available_modules as $module ) {
 			if ( $module_array = $this->jetpack->get_module( $module ) ) {
 				$short_desc = apply_filters( 'jetpack_short_module_description', $module_array['description'], $module );
-				$short_desc_trunc = ( strlen( $short_desc ) > 143 ) ? substr( $short_desc, 0, 140 ) . '...' : $short_desc;
+				// Fix: correct multibyte strings truncate
+				$short_desc_trunc = ( mb_strlen( $short_desc ) > 143 )
+							? mb_substr( $short_desc, 0, 140 ) . '...'
+							: $short_desc;
 
 				$module_array['module']            = $module;
 				$module_array['activated']         = ( $jetpack_active ? in_array( $module, $active_modules ) : false );


### PR DESCRIPTION
Hello!

This patch fixes multiple issues:

* Admin: JS Error while using RTL locale #767 
* Settings js error #1096 
* Switching WP lang to ru_RU breaks JP admin CSS #1275

P.S. Thanks for help http://devtiplog.com/posts/error-json_encode-in-jetpack-for-wordpress/
