### PR TITLE
Add filter for choosing mobile theme menu

### DIFF
--- a/modules/minileven/theme/pub/minileven/functions.php
+++ b/modules/minileven/theme/pub/minileven/functions.php
@@ -155,6 +155,10 @@ function minileven_get_menu_location() {
 	$theme_slug = minileven_actual_current_theme();
 	$mods = get_option( "theme_mods_{$theme_slug}" );
 
+	if ( has_filter( 'jetpack_mobile_theme_menu' ) ) {
+		return array( 'primary' => apply_filters( 'jetpack_mobile_theme_menu', $menu_id ) );
+	}
+
 	if ( isset( $mods['nav_menu_locations'] ) && ! empty( $mods['nav_menu_locations'] ) )
 		return $mods['nav_menu_locations'];
 


### PR DESCRIPTION
Allows the user to specify a menu ID to be used for the Mobile Theme module. Example:

```php
function my_mobile_menu() {
    $menu_id = 17;
    return $menu_id;
}
add_filter( 'jetpack_mobile_theme_menu', 'my_mobile_menu' );
```

Fixes #1256