### PR TITLE
Check for response.html before using indexOf on it.

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -394,7 +394,7 @@ Scroller.prototype.maybeLoadMejs = function() {
  */
 Scroller.prototype.initializeMejs = function( ev, response ) {
 	// Are there media players in the incoming set of posts?
-	if ( -1 === response.html.indexOf( 'wp-audio-shortcode' ) && -1 === response.html.indexOf( 'wp-video-shortcode' ) ) {
+	if ( ! response.html || -1 === response.html.indexOf( 'wp-audio-shortcode' ) && -1 === response.html.indexOf( 'wp-video-shortcode' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
This is a sanity check and should be there in the off-chance that `response.html` is `null` (yes I have seen it happen). Bottom line, if there is no `response.html`, then it's obvious that media player JS will not be needed.
