### PR TITLE
Subscritpions: fix invalid field when no email address

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -566,13 +566,13 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM )
 		    && false === apply_filters( 'jetpack_auto_fill_logged_in_user', false )
 		) {
-			$subscribe_email = esc_html__( 'Email Address', 'jetpack' );
+			$subscribe_email = '';
 		} else {
 			global $current_user;
 			if ( ! empty( $current_user->user_email ) ) {
 				$subscribe_email = esc_attr( $current_user->user_email );
 			} else {
-				$subscribe_email = esc_html__( 'Email Address', 'jetpack' );
+				$subscribe_email = '';
 			}
 		}
 


### PR DESCRIPTION
Fixes #1428

Value was previously set to empty, but I set it to "Email Address" in https://github.com/Automattic/jetpack/commit/d8c135369a8514cb2932a214664655e19b01e111#diff-6e4337c8315c90dd70aea03475af1dc1L638