### PR TITLE
Likes: to never double show on search results

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -896,8 +896,9 @@ class Jetpack_Likes {
 			if ( post_password_required() )
 				$enabled = false;
 
-      if ( in_array( 'get_the_excerpt', (array) $wp_current_filter ) )
-        $enabled = false;
+			if ( in_array( 'get_the_excerpt', (array) $wp_current_filter ) ) {
+				$enabled = false;
+			}
 
 			// Sharing Setting Overrides ****************************************
 

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -876,7 +876,7 @@ class Jetpack_Likes {
 	 */
 	function is_likes_visible() {
 
-		global $post;              // Used to apply 'sharing_show' filter
+		global $post, $wp_current_filter;              // Used to apply 'sharing_show' filter
 
 		// Never show on feeds or previews
 		if ( is_feed() || is_preview() || is_comments_popup() ) {
@@ -895,6 +895,9 @@ class Jetpack_Likes {
 
 			if ( post_password_required() )
 				$enabled = false;
+
+      if ( in_array( 'get_the_excerpt', (array) $wp_current_filter ) )
+        $enabled = false;
 
 			// Sharing Setting Overrides ****************************************
 


### PR DESCRIPTION
Likes button isno hide on excerpt from #484,
but... it makes dobul likes button (one is no wortk!) when enable on archives&search results.

Example
![screenshot_2014-12-21-03-06-26](https://cloud.githubusercontent.com/assets/5253290/5515870/ec08f886-88c2-11e4-9be6-63b4d8a77a93.png)

Fixed
![screenshot_2014-12-21-03-13-22](https://cloud.githubusercontent.com/assets/5253290/5515872/fc739fa0-88c2-11e4-8f4d-fb5e42517b2b.png)
