### PR TITLE
Portfolio CPT: set shortcode image size to 'large' and add...

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -479,8 +479,8 @@ class Jetpack_Portfolio {
 		$atts['columns'] = absint( $atts['columns'] );
 
 		$atts['showposts'] = intval( $atts['showposts'] );
-		
-		
+
+
 		if ( $atts['order'] ) {
 			$atts['order'] = urldecode( $atts['order'] );
 			$atts['order'] = strtoupper( $atts['order'] );
@@ -501,7 +501,7 @@ class Jetpack_Portfolio {
 				}
 				$parsed[] = $orderby;
 			}
-			
+
 			if ( empty( $parsed ) ) {
 				unset($atts['orderby']);
 			} else {
@@ -750,7 +750,7 @@ class Jetpack_Portfolio {
 	 */
 	static function get_thumbnail( $post_id ) {
 		if ( has_post_thumbnail( $post_id ) ) {
-			return '<a class="portfolio-featured-image" href="' . esc_url( get_permalink( $post_id ) ) . '">' . get_the_post_thumbnail( $post_id, 'full' ) . '</a>';
+			return '<a class="portfolio-featured-image" href="' . esc_url( get_permalink( $post_id ) ) . '">' . get_the_post_thumbnail( $post_id, apply_filters( 'jetpack_portfolio_thumbnail_size', 'large' ) ) . '</a>';
 		}
 	}
 }


### PR DESCRIPTION
...`jetpack_portfolio_thumbnail_size` filter to allow themes to set their own size. Fixes #1181.