### PR TITLE
Testimonial shortcode

### DIFF
--- a/modules/custom-post-types/css/testimonial-shortcode.css
+++ b/modules/custom-post-types/css/testimonial-shortcode.css
@@ -1,0 +1,101 @@
+.jetpack-testimonial-shortcode {
+	clear: both;
+	margin: 0;
+	overflow: hidden;
+	padding: 0;
+}
+
+.testimonial-entry {
+	float: left;
+	margin: 0 0 3em;
+	padding: 0;
+	width: 100%;
+}
+
+/* Column setting */
+.testimonial-entry-column-1 {
+	width: 100%;
+}
+
+.testimonial-entry-column-2 {
+	margin-right: 4%;
+	width: 48%;
+}
+
+.testimonial-entry-column-3 {
+	margin-right: 3.5%;
+	width: 31%;
+}
+
+.testimonial-entry-column-4 {
+	margin-right: 3%;
+	width: 22%;
+}
+
+.testimonial-entry-column-5 {
+	margin-right: 2.5%;
+	width: 18%;
+}
+
+.testimonial-entry-column-6 {
+	margin-right: 2%;
+	width: 15%;
+}
+.testimonial-entry-first-item-row {
+	clear: both;
+}
+.testimonial-entry-last-item-row {
+	margin-right: 0;
+}
+
+@media screen and (max-width:768px) {
+	.testimonial-entry-mobile-first-item-row{
+		margin-right: 4%;
+		width: 48%;
+		clear:both;
+	}
+	.testimonial-entry-first-item-row {
+		clear:none;
+	}
+	.testimonial-entry-mobile-last-item-row{
+		width: 48%;
+		margin-right: 0;
+	}
+}
+
+.testimonial-featured-image {
+	padding: 0;
+	margin: 0;
+}
+
+.testimonial-featured-image img {
+	border: 0;
+	height: auto;
+	max-width: 100%;
+	vertical-align: middle;
+}
+
+.testimonial-entry-title {
+	font-weight: 700;
+	margin: 0;
+	padding: 0;
+}
+
+.testimonial-featured-image + .testimonial-entry-title {
+	margin-top: 1.0em;
+}
+
+.testimonial-entry-title a {
+	border: 0;
+	text-decoration: none;
+}
+
+/* Entry Content */
+.testimonial-entry-content {
+	margin: 0.75em 0;
+	padding: 0;
+}
+
+.testimonial-entry-content > :last-child {
+	margin: 0;
+}

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -357,7 +357,7 @@ class Jetpack_Testimonial {
 					$query->the_post();
 					$post_id = get_the_ID();
 					?>
-					<div class="testimonial-entry <?php echo esc_attr( self::get_project_class( $i, $atts['columns'] ) ); ?>">
+					<div class="testimonial-entry <?php echo esc_attr( self::get_testimonial_class( $i, $atts['columns'] ) ); ?>">
 						<?php
 						// The content
 						if ( false != $atts['display_content'] ): ?>
@@ -391,11 +391,11 @@ class Jetpack_Testimonial {
 	}
 
 	/**
-	 * Individual project class
+	 * Individual testimonial class
 	 *
 	 * @return string
 	 */
-	static function get_project_class( $i, $columns ) {
+	static function get_testimonial_class( $i, $columns ) {
 		$class = array();
 
 		$class[] = 'testimonial-entry-column-'.$columns;
@@ -424,7 +424,7 @@ class Jetpack_Testimonial {
 		 * @param int $columns number of columns to display the content in.
 		 *
 		 */
-		return apply_filters( 'testimonial-project-post-class', implode( " ", $class) , $i, $columns );
+		return apply_filters( 'testimonial-entry-post-class', implode( " ", $class) , $i, $columns );
 	}
 
 	/**

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -43,7 +43,10 @@ class Jetpack_Testimonial {
 
 		$this->maybe_register_cpt();
 
+		// Register [jetpack_testimonials] always and
 		// register [testimonials] if [testimonials] isn't already set
+		add_shortcode( 'jetpack_testimonials', array( $this, 'jetpack_testimonial_shortcode' ) );
+
 		if ( ! array_key_exists( 'testimonials', $shortcode_tags ) ) {
 			add_shortcode( 'testimonials', array( $this, 'jetpack_testimonial_shortcode' ) );
 		}
@@ -462,7 +465,7 @@ function jetpack_testimonial_custom_control_classes() {
 			<textarea rows="5" style="width:100%;" <?php $this->link(); ?>><?php echo esc_textarea( $this->value() ); ?></textarea>
 			</label>
 			<?php
- 		}
+		}
 
 		public static function sanitize_content( $value ) {
 			if ( ! empty( $value ) )

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -41,8 +41,9 @@ class Jetpack_Testimonial {
 
 		$this->maybe_register_cpt();
 
-		// Testimonial Shortcode
-		add_shortcode( 'testimonial', array( $this, 'jetpack_testimonial_shortcode' ) );
+		// [testimonials] for wpcom, [jetpack_testimonials] for dotorg
+		add_shortcode( 'testimonials', array( $this, 'jetpack_testimonial_shortcode' ) );
+		add_shortcode( 'jetpack_testimonials', array( $this, 'jetpack_testimonial_shortcode' ) );
 
 	}
 

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -33,6 +33,8 @@ class Jetpack_Testimonial {
 	 * WordPress. We'll just return early instead.
 	 */
 	function __construct() {
+		global $shortcode_tags;
+
 		// Make sure the post types are loaded for imports
 		add_action( 'import_start', array( $this, 'register_post_types' ) );
 
@@ -41,8 +43,10 @@ class Jetpack_Testimonial {
 
 		$this->maybe_register_cpt();
 
-		// register [jetpack_testimonials]
-		add_shortcode( 'jetpack_testimonials', array( $this, 'jetpack_testimonial_shortcode' ) );
+		// register [testimonials] if [testimonials] isn't already set
+		if ( ! array_key_exists( 'testimonials', $shortcode_tags ) ) {
+			add_shortcode( 'testimonials', array( $this, 'jetpack_testimonial_shortcode' ) );
+		}
 	}
 
 

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -41,10 +41,8 @@ class Jetpack_Testimonial {
 
 		$this->maybe_register_cpt();
 
-		// [testimonials] for wpcom, [jetpack_testimonials] for dotorg
-		add_shortcode( 'testimonials', array( $this, 'jetpack_testimonial_shortcode' ) );
+		// register [jetpack_testimonials]
 		add_shortcode( 'jetpack_testimonials', array( $this, 'jetpack_testimonial_shortcode' ) );
-
 	}
 
 


### PR DESCRIPTION
addresses #1345 
This adds a [testimonial] shortcode that will display your testimonials.  

Some questions/thoughts: 
- Since this will be included in wpcom as well (through the build script), is it still best to prefix the functions with `jetpack`?
- There is (intentionally) very minimal styling here.  It's basically the same as [portfolio], where most of the styling is for the columns, with the thought being that the user can style it to their liking. Thoughts? (cc @MichaelArestad)