### PR TITLE
Subscriptions: remove label from widget title

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -599,7 +599,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 
 		// Display the subscription form
 		echo $args['before_widget'];
-		echo $args['before_title'] . '<label for="' . esc_attr( $subscribe_field_id ) . '">' . esc_attr( $instance['title'] ) . '</label>' . $args['after_title'] . "\n";
+		echo $args['before_title'] . esc_attr( $instance['title'] ) . $args['after_title'] . "\n";
 
 		$referer = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 


### PR DESCRIPTION
It often causes layout issues in themes
And doesn't seem to bring additional information since we already have another label in the form itself

Suggested here:
https://wordpress.org/support/topic/blog-subscriptions-widget-multiple-form-labels-error?replies=5#post-6405820