### PR TITLE
Bring modules back

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -10,6 +10,9 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 
 		Jetpack::init();
 
+		// Core is now sanitizing which values are __set(), so we must add all_items to compatible fields.
+		array_push( $this->compat_fields, 'all_items' );
+
 		$this->items = $this->all_items = Jetpack_Admin::init()->get_modules();
 		$this->items = $this->filter_displayed_table_items( $this->items );
 		$this->items = apply_filters( 'jetpack_modules_list_table_items', $this->items );

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -10,7 +10,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 
 		Jetpack::init();
 
-		// Core is now sanitizing which values are __set(), so we must add all_items to compatible fields.
+		// WP_List_Table is now sanitizing which values are __set(), so we must add all_items to compatible fields.
 		array_push( $this->compat_fields, 'all_items' );
 
 		$this->items = $this->all_items = Jetpack_Admin::init()->get_modules();


### PR DESCRIPTION
fixes #1489 

WP_List_Table is now sanitizing which values are __set(), we must add all_items to compatible fields so we can list our modules in a table.  