### PR TITLE
Add/empty trash days option to sync

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -358,6 +358,8 @@ class Jetpack {
 		add_action( 'update_option_siteurl', 			array( $this, 'update_jetpack_main_network_site_option' ) );
 		// Update jetpack_is_main_network on .com
 		add_filter( 'pre_option_jetpack_is_main_network', array( $this, 'is_main_network_option' ) );
+		// Update trash_folder_disabled on .com
+		add_filter( 'pre_option_trash_folder_disabled', array( $this, 'is_trash_folder_disabled' ) );
 		/*
 		 * Load things that should only be in Network Admin.
 		 *
@@ -386,7 +388,8 @@ class Jetpack {
 			'gmt_offset',
 			'timezone_string',
 			'jetpack_main_network_site',
-			'jetpack_is_main_network'
+			'jetpack_is_main_network',
+			'trash_folder_disabled'
 		);
 
 		add_action( 'update_option', array( $this, 'log_settings_change' ), 10, 3 );
@@ -661,6 +664,17 @@ class Jetpack {
 	public static function is_main_network_option( $option ) {
 		// return '1' or ''
 		return (string) (bool) Jetpack::is_multi_network();
+	}
+	
+	/**
+	 * Return whether trash folder is disabled, which happens if the site has a config with
+	 *
+	 *     define( 'EMPTY_TRASH_DAYS', 0 );
+	 *
+	 * @return boolean
+	 */
+	public static function is_trash_folder_disabled( $option ) {
+		return (bool) ( 0 === EMPTY_TRASH_DAYS );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -667,17 +667,6 @@ class Jetpack {
 		// return '1' or ''
 		return (string) (bool) Jetpack::is_multi_network();
 	}
-	
-	/**
-	 * Return whether trash folder is disabled, which happens if the site has a config with
-	 *
-	 *     define( 'EMPTY_TRASH_DAYS', 0 );
-	 *
-	 * @return boolean
-	 */
-	public static function is_trash_folder_disabled( $option ) {
-		return (bool) ( 0 === EMPTY_TRASH_DAYS );
-	}
 
 	/**
 	 * Implemented since there is no core is multi network function

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -358,8 +358,6 @@ class Jetpack {
 		add_action( 'update_option_siteurl', 			array( $this, 'update_jetpack_main_network_site_option' ) );
 		// Update jetpack_is_main_network on .com
 		add_filter( 'pre_option_jetpack_is_main_network', array( $this, 'is_main_network_option' ) );
-		// Update trash_folder_disabled on .com
-		add_filter( 'pre_option_trash_folder_disabled', array( $this, 'is_trash_folder_disabled' ) );
 		/*
 		 * Load things that should only be in Network Admin.
 		 *
@@ -385,12 +383,16 @@ class Jetpack {
 			'home',
 			'siteurl',
 			'blogname',
+			'blogdescription',
 			'gmt_offset',
 			'timezone_string',
 			'jetpack_main_network_site',
 			'jetpack_is_main_network',
-			'trash_folder_disabled'
+			'jetpack_empty_trash_days'
 		);
+
+		// Update to sync jetpack_empty_trash_days on .com
+		update_option( 'jetpack_empty_trash_days', EMPTY_TRASH_DAYS );
 
 		add_action( 'update_option', array( $this, 'log_settings_change' ), 10, 3 );
 

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -280,7 +280,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'default_ping_status'     => ( 'closed' == get_option( 'default_ping_status' ) ? false : true ),
 					'software_version'        => $wp_version,
 					'created_at'              => ! empty( $registered_date ) ? $this->format_date( $registered_date ) : '0000-00-00T00:00:00+00:00',
-					'trash_folder_disabled'   => (bool) get_option( 'trash_folder_disabled' ),
+					'empty_trash_days'        => (int) $this->get_empty_trash_days(),
 				);
 
 				if ( 'page' === get_option( 'show_on_front' ) ) {
@@ -332,6 +332,11 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 	function force_http( $url, $scheme, $orig_scheme ) {
 		return preg_replace('/^https:\/\//', 'http://', $url, 1 );
+	}
+	
+	function get_empty_trash_days() {
+		$empty_trash_days = get_option( 'jetpack_empty_trash_days' );
+		return ( false !== $empty_trash_days ) ? $empty_trash_days : EMPTY_TRASH_DAYS;
 	}
 
 }

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -279,7 +279,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'default_comment_status'  => ( 'closed' == get_option( 'default_comment_status' ) ? false : true ),
 					'default_ping_status'     => ( 'closed' == get_option( 'default_ping_status' ) ? false : true ),
 					'software_version'        => $wp_version,
-					'created_at'            => ! empty( $registered_date ) ? $this->format_date( $registered_date ) : '0000-00-00T00:00:00+00:00',
+					'created_at'              => ! empty( $registered_date ) ? $this->format_date( $registered_date ) : '0000-00-00T00:00:00+00:00',
+					'trash_folder_disabled'   => (bool) get_option( 'trash_folder_disabled' ),
 				);
 
 				if ( 'page' === get_option( 'show_on_front' ) ) {


### PR DESCRIPTION
This syncs the `EMPTY_TRASH_DAYS` config setting back to the shadow blog as a `jetpack_empty_trash_days` option. This is necessary for clients of the .com REST API to determine whether a given jetpack blog supports a trash folder (which allows the user to _untrash_ something) or whether the trash action is immediate and permanent.

I had initially tried to create this as a faux `pre_option` filter, but found that changes are not synced back to .com unless using `update_option()` directly on a real option.

/cc @enejb 