### PR TITLE
Use `wp_add_inline_style` for inline wpstats css

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -54,7 +54,7 @@ function stats_load() {
 
 	add_action( 'wp_head', 'stats_admin_bar_head', 100 );
 
-	add_action( 'wp_head', 'stats_hide_smile_css' );
+	add_action( 'wp_enqueue_scripts', 'stats_hide_smile_css' );
 
 	add_action( 'jetpack_admin_menu', 'stats_admin_menu' );
 
@@ -579,8 +579,7 @@ function stats_configuration_screen() {
 function stats_hide_smile_css() {
 	$options = stats_get_options();
 	if ( isset( $options['hide_smile'] ) && $options['hide_smile'] ) {
-	?>
-<style type='text/css'>img#wpstats{display:none}</style><?php
+		wp_add_inline_style( 'jetpack_css', 'img#wpstats{display:none}' );
 	}
 }
 


### PR DESCRIPTION
[wp_add_inline_style](http://codex.wordpress.org/Function_Reference/wp_add_inline_style) Has been available since 3.3, and Jetpack already requires 3.9, so no problems there.

Is there some reason this wasn't being done already?