### PR TITLE
Stats: Make loading of stats async

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -145,13 +145,11 @@ function stats_template_redirect() {
 		$post = '0';
 	}
 
-	$http = is_ssl() ? 'https' : 'http';
-	$week = gmdate( 'YW' );
-
+	$script = set_url_scheme( '//stats.wp.com/e-' . gmdate( 'YW' ) . '.js' );
 	$data = stats_array( compact( 'v', 'j', 'blog', 'post', 'tz' ) );
 
 	$stats_footer = <<<END
-<script type='text/javascript' src='$http://stats.wp.com/e-$week.js' async defer></script>
+<script type='text/javascript' src='{$script}' async defer></script>
 <script type='text/javascript'>
 	_stq = window._stq || [];
 	_stq.push([ 'view', {{$data}} ]);

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -151,14 +151,13 @@ function stats_template_redirect() {
 	$data = stats_array( compact( 'v', 'j', 'blog', 'post', 'tz' ) );
 
 	$stats_footer = <<<END
+<script type='text/javascript' src='$http://stats.wp.com/e-$week.js' async defer></script>
+<script type='text/javascript'>
+	_stq = window._stq || [];
+	_stq.push([ 'view', {{$data}} ]);
+	_stq.push([ 'clickTrackerInit', '{$blog}', '{$post}' ]);
+</script>
 
-	<script src="$http://stats.wp.com/e-$week.js" type="text/javascript"></script>
-	<script type="text/javascript">
-	st_go({{$data}});
-	var load_cmc = function(){linktracker_init($blog,$post,2);};
-	if ( typeof addLoadEvent != 'undefined' ) addLoadEvent(load_cmc);
-	else load_cmc();
-	</script>
 END;
 }
 


### PR DESCRIPTION
Make sure we don't hold up the page with stats tracking code by making them
async. This requires a new stats tracking JS file which will be distributed
starting next week (Jan 18th):
http://stats.wp.com/e-201504.js

NOTE: If this change is applied before Jan 18th stats will stop working!

Resolves #566