### PR TITLE
Open sharing in same window

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -3,17 +3,15 @@
 abstract class Sharing_Source {
 	public    $button_style;
 	public    $smart;
-	protected $open_links;
+	protected $open_link_in_new;
 	protected $id;
 
 	public function __construct( $id, array $settings ) {
 		$this->id = $id;
+		$this->open_link_in_new = apply_filters( 'open_sharing_in_new_window', true );
 
 		if ( isset( $settings['button_style'] ) )
 			$this->button_style = $settings['button_style'];
-
-		if ( isset( $settings['open_links'] ) )
-			$this->open_links = $settings['open_links'];
 
 		if ( isset( $settings['smart'] ) )
 			$this->smart = $settings['smart'];
@@ -56,7 +54,7 @@ abstract class Sharing_Source {
 			$text = $title;
 			$klasses[] = 'no-text';
 
-			if ( $this->open_links == 'new' )
+			if ( true == $this->open_link_in_new )
 				$text .= __( ' (Opens in new window)', 'jetpack' );
 		}
 
@@ -76,7 +74,7 @@ abstract class Sharing_Source {
 			( $id ? esc_attr( $id ) : '' ),
 			implode( ' ', $klasses ),
 			$url,
-			( $this->open_links == 'new' ) ? ' target="_blank"' : '',
+			( $this->open_link_in_new == true ) ? ' target="_blank"' : '',
 			$title,
 			( $this->button_style == 'icon' ) ? '></span><span class="sharing-screen-reader-text"' : '',
 
@@ -166,8 +164,7 @@ abstract class Sharing_Source {
 	}
 
 	public function js_dialog( $name, $params = array() ) {
-		$open_window_in_new = apply_filters( 'open_sharing_in_new_window', true );
-		if ( true !== $open_window_in_new )
+		if ( true !== $this->open_link_in_new )
 			return;
 
 		$defaults = array(
@@ -1113,7 +1110,7 @@ class Share_Tumblr extends Sharing_Source {
 	public function get_display( $post ) {
 		if ( $this->smart ) {
 			$target = '';
-			if ( 'new' == $this->open_links )
+			if ( true == $this->open_link_in_new )
 				$target = '_blank';
 
 			return '<a target="' . $target . '" href="http://www.tumblr.com/share/link/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&name=' . rawurlencode( $this->get_share_title( $post->ID ) ) . '" title="' . __( 'Share on Tumblr', 'jetpack' ) . '" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:62px; height:20px; background:url(\'//platform.tumblr.com/v1/share_2.png\') top left no-repeat transparent;">' . __( 'Share on Tumblr', 'jetpack' ) . '</a>';

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -166,7 +166,8 @@ abstract class Sharing_Source {
 	}
 
 	public function js_dialog( $name, $params = array() ) {
-		if ( 'new' !== $this->open_links )
+		$open_window_in_new = apply_filters( 'open_sharing_in_new_window', true );
+		if ( true !== $open_window_in_new )
 			return;
 
 		$defaults = array(

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -183,9 +183,13 @@ abstract class Sharing_Source {
 		$opts = implode( ',', $opts );
 		?>
 		<script type="text/javascript">
+			var windowOpen;
 		jQuery(document).on( 'ready post-load', function(){
 			jQuery( 'a.share-<?php echo $name; ?>' ).on( 'click', function() {
-				window.open( jQuery(this).attr( 'href' ), 'wpcom<?php echo $name; ?>', '<?php echo $opts; ?>' );
+				if ( 'undefined' !== typeof windowOpen ){ // If there's another sharing window open, close it.
+					windowOpen.close();
+				}
+				windowOpen = window.open( jQuery(this).attr( 'href' ), 'wpcom<?php echo $name; ?>', '<?php echo $opts; ?>' );
 				return false;
 			});
 		});

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -8,7 +8,7 @@ abstract class Sharing_Source {
 
 	public function __construct( $id, array $settings ) {
 		$this->id = $id;
-		$this->open_link_in_new = apply_filters( 'open_sharing_in_new_window', true );
+		$this->open_link_in_new = apply_filters( 'jetpack_open_sharing_in_new_window', true );
 
 		if ( isset( $settings['button_style'] ) )
 			$this->button_style = $settings['button_style'];
@@ -47,10 +47,10 @@ abstract class Sharing_Source {
 	public function get_link( $url, $text, $title, $query = '', $id = false ) {
 		$klasses = array( 'share-'.$this->get_class(), 'sd-button' );
 
-		if ( $this->button_style == 'icon' || $this->button_style == 'icon-text' )
+		if ( 'icon' == $this->button_style || 'icon-text' == $this->button_style )
 			$klasses[] = 'share-icon';
 
-		if ( $this->button_style == 'icon' ) {
+		if ( 'icon' == $this->button_style ) {
 			$text = $title;
 			$klasses[] = 'no-text';
 
@@ -60,13 +60,13 @@ abstract class Sharing_Source {
 
 		$url = apply_filters( 'sharing_display_link', $url );
 		if ( !empty( $query ) ) {
-			if ( stripos( $url, '?' ) === false )
+			if ( false === stripos( $url, '?' ) )
 				$url .= '?'.$query;
 			else
 				$url .= '&amp;'.$query;
 		}
 
-		if ( $this->button_style == 'text' )
+		if ( 'text' == $this->button_style )
 			$klasses[] = 'no-icon';
 
 		return sprintf(
@@ -74,9 +74,9 @@ abstract class Sharing_Source {
 			( $id ? esc_attr( $id ) : '' ),
 			implode( ' ', $klasses ),
 			$url,
-			( $this->open_link_in_new == true ) ? ' target="_blank"' : '',
+			( true == $this->open_link_in_new ) ? ' target="_blank"' : '',
 			$title,
-			( $this->button_style == 'icon' ) ? '></span><span class="sharing-screen-reader-text"' : '',
+			( 'icon' == $this->button_style ) ? '></span><span class="sharing-screen-reader-text"' : '',
 
 			$text
 		);

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -166,6 +166,9 @@ abstract class Sharing_Source {
 	}
 
 	public function js_dialog( $name, $params = array() ) {
+		if ( 'new' !== $this->open_links )
+			return;
+
 		$defaults = array(
 			'menubar'   => 1,
 			'resizable' => 1,

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -330,15 +330,6 @@ class Sharing_Admin {
 	  						<input type="text" name="sharing_label" value="<?php echo esc_attr( $global['sharing_label'] ); ?>" />
 	  					</td>
 	  				</tr>
-	  				<tr valign="top">
-	  					<th scope="row"><label><?php _e( 'Open links in', 'jetpack' ); ?></label></th>
-	  					<td>
-	  						<select name="open_links">
-	  							<option<?php if ( $global['open_links'] == 'new' ) echo ' selected="selected"';?> value="new"><?php _e( 'New window', 'jetpack' ); ?></option>
-	  							<option<?php if ( $global['open_links'] == 'same' ) echo ' selected="selected"';?> value="same"><?php _e( 'Same window', 'jetpack' ); ?></option>
-	  						</select>
-	  					</td>
-	  				</tr>
 	  				<?php echo apply_filters( 'sharing_show_buttons_on_row_start', '<tr valign="top">' ); ?>
 	  					<th scope="row"><label><?php _e( 'Show buttons on', 'jetpack' ); ?></label></th>
 	  					<td>


### PR DESCRIPTION
fixes #1288 

We were always opening the sharing window in a new window.  This puts a stop to it if "same window" is selected.  