### PR TITLE
Add custom service name as a class

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -918,7 +918,7 @@ class Share_Custom extends Sharing_Advanced_Source {
 	var $shortname;
 
 	public function get_class() {
-		return 'custom';
+		return 'custom share-' . sanitize_html_class( strtolower( $this->name ) );
 	}
 
 	public function __construct( $id, array $settings ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -918,7 +918,7 @@ class Share_Custom extends Sharing_Advanced_Source {
 	var $shortname;
 
 	public function get_class() {
-		return 'custom share-' . sanitize_html_class( strtolower( $this->name ) );
+		return 'custom share-custom-' . sanitize_html_class( strtolower( $this->name ) );
 	}
 
 	public function __construct( $id, array $settings ) {


### PR DESCRIPTION
If using multiple custom sharing services it's difficult to target these with the same class "share-custom". It'd be nice if each one could have a unique class, based from the name.