### PR TITLE
Add trailing slash to share URL (for counting purposes only)

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -401,7 +401,7 @@ function sharing_register_post_for_share_counts( $post_id ) {
 	if ( ! isset( $jetpack_sharing_counts ) || ! is_array( $jetpack_sharing_counts ) )
 		$jetpack_sharing_counts = array();
 
-	$jetpack_sharing_counts[ (int) $post_id ] = get_permalink( $post_id );
+	$jetpack_sharing_counts[ (int) $post_id ] = trailingslashit( get_permalink( $post_id ) );
 }
 
 function sharing_maybe_enqueue_scripts() {


### PR DESCRIPTION
Twitter normalizes the URL when getting the count with a trailing slash, which is great. Unfortunately, they return this normalized URL instead of the URL you asked for. This causes inaccurate share counts for Twitter if you don't have trailing slashes. Adding a trailing slash to the URL in the `WPCOM_sharing_counts` array fixes the issue.

I verified that this doesn't break Facebook share counts. I couldn't test with LinkedIn.