### PR TITLE
REST API: Add `wp_update_version` string to `/sites/$site/updates/` endpoint.

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
@@ -18,6 +18,14 @@ class Jetpack_JSON_API_Updates_Status extends Jetpack_JSON_API_Endpoint {
 
 		include( ABSPATH . WPINC . '/version.php' ); // $wp_version;
 		$result['wp_version'] = isset( $wp_version ) ? $wp_version : null;
+
+		if ( ! empty( $result['wordpress'] ) ) {
+			$cur = get_preferred_from_update_core();
+			if ( isset( $cur->response ) && $cur->response === 'upgrade' ) {
+				$result['wp_update_version'] = $cur->current;
+			}
+		}
+
 		$result['jp_version'] = JETPACK__VERSION;
 
 		return $result;

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -453,6 +453,7 @@ new Jetpack_JSON_API_Updates_Status( array(
 		'translations' => '(int) The total number of translation updates.',
 		'total'        => '(int) The total number of updates.',
 		'wp_version'   => '(safehtml) The wp_version string.',
+		'wp_update_version' => '(safehtml) The wp_version to update string.',
 		'jp_version'   => '(safehtml) The site Jetpack version.',
 	),
 	'example_request_data' => array(


### PR DESCRIPTION
`wp_update_version` should have the version of the core update available, if there is one.

cc @roccotripaldi 