### PR TITLE
Revert "Changes to load the new notifications client."

### DIFF
--- a/modules/notes.php
+++ b/modules/notes.php
@@ -125,11 +125,7 @@ class Jetpack_Notifications {
 	}
 
 	function styles_and_scripts() {
-		if ( !is_rtl() ) {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
-		} else {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
-		}
+		wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 
 		$this->print_js();
@@ -162,7 +158,7 @@ class Jetpack_Notifications {
 					<span class="noticon noticon-notification"></span>
 					</span>',
 			'meta'   => array(
-				'html'  => '<div id="wpnt-notes-panel2" style="display:none" lang="'. esc_attr( get_locale() ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>',
+				'html'  => '<div id="wpnt-notes-panel" style="display:none" lang="'. esc_attr( get_locale() ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>',
 				'class' => 'menupop',
 			),
 			'parent' => 'top-secondary',
@@ -175,7 +171,6 @@ class Jetpack_Notifications {
 <script type="text/javascript">
 /* <![CDATA[ */
 	var wpNotesIsJetpackClient = true;
-	var wpNotesIsJetpackClientV2 = true;
 <?php if ( $link_accounts_url ) : ?>
 	var wpNotesLinkAccountsURL = '<?php print $link_accounts_url; ?>';
 <?php endif; ?>


### PR DESCRIPTION
This reverts the changes to load the new notifications client and restores loading the original.
After discussion internally, we'll wait until we resolve some issues with the new one before releasing to Jetpack.
cc: @apeatling 