### PR TITLE
Add static keyword to method to fix strict standards notice

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1094,7 +1094,7 @@ class Jetpack {
 	 *
 	 * @return null
 	 */
-	public function perform_security_reporting() {
+	public static function perform_security_reporting() {
 		$last_run = Jetpack_Options::get_option( 'last_security_report' );
 
 		$fifteen_minutes_ago = time() - ( 15 * MINUTE_IN_SECONDS );


### PR DESCRIPTION
The `Jetpack::perform_security_reporting` method needs to be declared `static`ally because it is used statically:

```php
add_action( 'init', array( __CLASS__, 'perform_security_reporting' ) );
```