### PR TITLE
Minileven: Add class to div wrapping the View Mobile Site link

### DIFF
--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -90,7 +90,7 @@ function jetpack_mobile_template( $theme ) {
 }
 
 function jetpack_mobile_available() {
-	echo '<div class="jetpack_mobile_link" style="text-align:center;margin:10px 0;"><a href="'. home_url( '?ak_action=accept_mobile' ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
+	echo '<div class="jetpack-mobile-link" style="text-align:center;margin:10px 0;"><a href="'. home_url( '?ak_action=accept_mobile' ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
 }
 
 function jetpack_mobile_request_handler() {

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -90,7 +90,7 @@ function jetpack_mobile_template( $theme ) {
 }
 
 function jetpack_mobile_available() {
-	echo '<div style="text-align:center;margin:10px 0;"><a href="'. home_url( '?ak_action=accept_mobile' ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
+	echo '<div class="jetpack_mobile_link" style="text-align:center;margin:10px 0;"><a href="'. home_url( '?ak_action=accept_mobile' ) . '">' . __( 'View Mobile Site', 'jetpack' ) . '</a></div>';
 }
 
 function jetpack_mobile_request_handler() {


### PR DESCRIPTION
If the user's theme clashes with the View Mobile Site link that is added (after the user uses the "View Full Site" link from the mobile theme), adding a class to the wrapping div helps with custom CSS to correct.