### PR TITLE
Updates Endpoint: adding fields to the response

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -191,15 +191,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[$key] = (bool) $this->api->is_following( $blog_id );
 				break;
 			case 'options':
-				// Figure out if site can be managed via the JP JSON API module
-				$json_api_can_manage = false;
-				if ( class_exists( 'Jetpack_Options' ) ) {
-					$json_api_can_manage = Jetpack_Options::get_option( 'json_api_full_management', false );
-				}
-				// full management may be enabled, but the module may not be activated
-				if ( method_exists( 'Jetpack', 'is_module_active' ) && ! Jetpack::is_module_active( 'json-api' ) ) {
-					$json_api_can_manage = false;
-				}
 				// Figure out if the blog supports VideoPress, have to do some extra checking for JP blogs
 				$has_videopress = false;
 				if ( get_option( 'video_upgrade' ) == '1' ) {
@@ -265,7 +256,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'timezone'                => (string) get_option( 'timezone_string' ),
 					'gmt_offset'              => (float) get_option( 'gmt_offset' ),
 					'videopress_enabled'      => $has_videopress,
-					'json_api_can_manage'     => (bool) $json_api_can_manage,
 					'login_url'               => wp_login_url(),
 					'admin_url'               => get_admin_url(),
 					'is_mapped_domain'        => $is_mapped_domain,
@@ -303,6 +293,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
                     if( get_option( 'jetpack_main_network_site' ) ) {
 	                    $response['options']['main_network_site'] = (string) rtrim( get_option( 'jetpack_main_network_site' ), '/' );
                     }
+
+					$response['options']['json_api_full_management'] = Jetpack_Options::get_option( 'json_api_full_management', false );
 
 					// Sites have to prove that they are not main_network site.
 					// If the sync happends right then we should be able to see that we are not dealing with a network site

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -191,6 +191,15 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[$key] = (bool) $this->api->is_following( $blog_id );
 				break;
 			case 'options':
+				// Figure out if site can be managed via the JP JSON API module
+				$json_api_can_manage = false;
+				if ( class_exists( 'Jetpack_Options' ) ) {
+					$json_api_can_manage = Jetpack_Options::get_option( 'json_api_full_management', false );
+				}
+				// full management may be enabled, but the module may not be activated
+				if ( method_exists( 'Jetpack', 'is_module_active' ) && ! Jetpack::is_module_active( 'json-api' ) ) {
+					$json_api_can_manage = false;
+				}
 				// Figure out if the blog supports VideoPress, have to do some extra checking for JP blogs
 				$has_videopress = false;
 				if ( get_option( 'video_upgrade' ) == '1' ) {
@@ -256,6 +265,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'timezone'                => (string) get_option( 'timezone_string' ),
 					'gmt_offset'              => (float) get_option( 'gmt_offset' ),
 					'videopress_enabled'      => $has_videopress,
+					'json_api_can_manage'     => (bool) $json_api_can_manage,
 					'login_url'               => wp_login_url(),
 					'admin_url'               => get_admin_url(),
 					'is_mapped_domain'        => $is_mapped_domain,
@@ -318,6 +328,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				);
 				break;
 			}
+
 		}
 		if ( $is_jetpack ) {
 			add_filter( 'option_stylesheet', 'fix_theme_location' );

--- a/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
@@ -26,28 +26,16 @@ class Jetpack_JSON_API_Updates_Status extends Jetpack_JSON_API_Endpoint {
 			}
 		}
 
-		$result['jp_version']   = JETPACK__VERSION;
-		$result['is_vcs']       = $this->is_vcs();
-		$result['can_manage']   = $this->can_manage();
+		$result['jp_version'] = JETPACK__VERSION;
+		$result['is_vcs']     = $this->is_vcs();
 
 		return $result;
 
 	}
 
 	private function is_vcs() {
-		if ( ! function_exists( 'is_vcs_checkout' ) ) {
-			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-		}
+		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 		$context = 'WP_PLUGINS_DIR';
 		return WP_Automatic_Updater::is_vcs_checkout( $context );
-	}
-
-	private function can_manage() {
-		if ( ! Jetpack::is_module_active( 'json-api') ) {
-			return false;
-		}
-
-		return Jetpack_Options::get_option( 'json_api_full_management', false );
-
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
@@ -26,9 +26,28 @@ class Jetpack_JSON_API_Updates_Status extends Jetpack_JSON_API_Endpoint {
 			}
 		}
 
-		$result['jp_version'] = JETPACK__VERSION;
+		$result['jp_version']   = JETPACK__VERSION;
+		$result['is_vcs']       = $this->is_vcs();
+		$result['can_manage']   = $this->can_manage();
 
 		return $result;
+
+	}
+
+	private function is_vcs() {
+		if ( ! function_exists( 'is_vcs_checkout' ) ) {
+			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+		$context = 'WP_PLUGINS_DIR';
+		return WP_Automatic_Updater::is_vcs_checkout( $context );
+	}
+
+	private function can_manage() {
+		if ( ! Jetpack::is_module_active( 'json-api') ) {
+			return false;
+		}
+
+		return Jetpack_Options::get_option( 'json_api_full_management', false );
 
 	}
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -455,6 +455,8 @@ new Jetpack_JSON_API_Updates_Status( array(
 		'wp_version'   => '(safehtml) The wp_version string.',
 		'wp_update_version' => '(safehtml) The wp_version to update string.',
 		'jp_version'   => '(safehtml) The site Jetpack version.',
+		'is_vcs'            => '(bool) Is the site under version controll?',
+		'can_manage'        => '(bool) Can we manage updates via the JSON-API?',
 	),
 	'example_request_data' => array(
 		'headers' => array(

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -456,7 +456,6 @@ new Jetpack_JSON_API_Updates_Status( array(
 		'wp_update_version' => '(safehtml) The wp_version to update string.',
 		'jp_version'   => '(safehtml) The site Jetpack version.',
 		'is_vcs'            => '(bool) Is the site under version controll?',
-		'can_manage'        => '(bool) Can we manage updates via the JSON-API?',
 	),
 	'example_request_data' => array(
 		'headers' => array(


### PR DESCRIPTION
Adding is_vcs, which tells us if the site is under version control, and can_manage,
which tells us if the site can be managed via the json-api.

Will fix #1566 and help us in other areas of calypso.

I'm hoping to get this in the next minor release.

@lezama does this seem okay?