### PR TITLE
Update Twitter URLs. Use HTTPS

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -6,7 +6,7 @@
  * we need for twitter cards.
  *
  * @see /wp-content/blog-plugins/open-graph.php
- * @see https://dev.twitter.com/docs/cards
+ * @see https://dev.twitter.com/cards/overview
  */
 class Jetpack_Twitter_Cards {
 
@@ -164,7 +164,7 @@ class Jetpack_Twitter_Cards {
 	static function twitter_cards_gallery( $extract, $og_tags ) {
 		foreach( $extract['images'] as $key => $value ) {
 			if ( $key > 3 ) {
-				break; // Can only send a max of 4 picts (https://dev.twitter.com/docs/cards/types/gallery-card)
+				break; // only the first 4 appear in card template (https://dev.twitter.com/cards/types/gallery)
 			}
 			$og_tags[ 'twitter:image' . $key ] = add_query_arg( 'w', 640, $value['url'] );
 		}

--- a/class.media-extractor.php
+++ b/class.media-extractor.php
@@ -113,7 +113,7 @@ class Jetpack_Media_Meta_Extractor {
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) && ( self::HASHTAGS & $what_to_extract ) ) {
 			//This regex does not exactly match Twitter's
 			// if there are problems/complaints we should implement this:
-			//   https://github.com/twitter/twitter-text-java/blob/master/src/com/twitter/Regex.java
+			//   https://github.com/twitter/twitter-text/blob/master/java/src/com/twitter/Regex.java
 			if ( preg_match_all( '/(?:^|\s)#(\w*\p{L}+\w*)/u', $stripped_content, $matches ) ) {
 				$hashtags = array_values( array_unique( $matches[1] ) ); //array_unique() retains the keys!
 				$hashtags = array_map( 'strtolower', $hashtags );

--- a/modules/protect/dashboard-widget.php
+++ b/modules/protect/dashboard-widget.php
@@ -23,10 +23,10 @@
 
 		<?php if ( ! wp_is_mobile() ) : // sharing url strings don't work for mobile due to twitter / facebook settings ?>
 			<div class="jetpack-security-sharing">
-				<?php $twitter_plug = sprintf( __( 'My WordPress site has been protected from %d malicious log in attempts. Thanks @jetpack! http://jetpack.me', 'jetpack' ), $blocked_attacks );
+				<?php $twitter_plug = sprintf( __( 'My WordPress site has been protected from %d malicious log in attempts. Thanks @jetpack!', 'jetpack' ), $blocked_attacks );
 				$facebook_plug_title = sprintf( __( 'My WordPress site has been protected from %d malicious log in attempts.', 'jetpack' ), $blocked_attacks );
 				$facebook_plug_summary = __( 'Protect your WordPress site with Jetpack.', 'jetpack' ) ?>
-				<a class="dashicons dashicons-twitter" target="_blank" href="http://twitter.com/home?status=<?php echo urlencode( $twitter_plug ) ?>"></a>
+				<a class="dashicons dashicons-twitter" target="_blank" href="https://twitter.com/intent/tweet?text=<?php echo rawurlencode( $twitter_plug ); ?>&url=<?php echo urlencode('https://jetpack.me/'); ?>&related=jetpack"></a>
 				<a class="dashicons dashicons-facebook-alt" target="_blank" href="https://www.facebook.com/sharer/sharer.php?s=100&p[url]=http%3A%2F%2Fjetpack.me&amp;p[title]=<?php echo urlencode( $facebook_plug_title ) ?>&amp;p[summary]=<?php echo $facebook_plug_summary ?>"></a>
 			</div>
 		<?php endif; ?>

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -99,13 +99,13 @@ abstract class Publicize_Base {
 		if ( isset( $cmeta['connection_data']['meta']['link'] ) ) {
 			return $cmeta['connection_data']['meta']['link'];
 		} elseif ( 'facebook' == $service_name && isset( $cmeta['connection_data']['meta']['facebook_page'] ) ) {
-			return 'http://facebook.com/' . $cmeta['connection_data']['meta']['facebook_page'];
+			return 'https://www.facebook.com/' . $cmeta['connection_data']['meta']['facebook_page'];
 		} elseif ( 'facebook' == $service_name ) {
-			return 'http://www.facebook.com/' . $cmeta['external_id'];
+			return 'https://www.facebook.com/' . $cmeta['external_id'];
 		} elseif ( 'tumblr' == $service_name && isset( $cmeta['connection_data']['meta']['tumblr_base_hostname'] ) ) {
 			 return 'http://' . $cmeta['connection_data']['meta']['tumblr_base_hostname'];
 		} elseif ( 'twitter' == $service_name ) {
-			return 'http://twitter.com/' . substr( $cmeta['external_display'], 1 ); // Has a leading '@'
+			return 'https://twitter.com/' . substr( $cmeta['external_display'], 1 ); // Has a leading '@'
 		} elseif ( 'google_plus' == $service_name && isset( $cmeta['connection_data']['meta']['google_plus_page'] ) ) {
 			return 'https://plus.google.com/' . $cmeta['connection_data']['meta']['google_plus_page'];
 		} elseif ( 'google_plus' == $service_name ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -350,7 +350,7 @@ class Share_Email extends Sharing_Source {
 class Share_Twitter extends Sharing_Source {
 	var $shortname = 'twitter';
 	var $genericon = '\f202';
-	// 'https://dev.twitter.com/docs/api/1.1/get/help/configuration' ( 2013/06/24 ) short_url_length is 22
+	// 'https://dev.twitter.com/rest/reference/get/help/configuration' ( 2015/02/06 ) short_url_length is 22, short_url_length_https is 23
 	var $short_url_length = 24;
 
 	public function __construct( $id, array $settings ) {
@@ -474,7 +474,7 @@ class Share_Twitter extends Sharing_Source {
 		$url = $post_link;
 		$twitter_url = add_query_arg(
 			urlencode_deep( array_filter( compact( 'via', 'related', 'text', 'url' ) ) ),
-			sprintf( '%s://twitter.com/intent/tweet', $this->http() )
+			'https://twitter.com/intent/tweet'
 		);
 
 		// Redirect to Twitter


### PR DESCRIPTION
Update Twitter URLs in the WordPress plugin, including URLs appearing in comments.

Twitter.com is HTTPS. User and Tweet URLs should always use HTTPS scheme.

The Tweet compose URL used by the Protect module's dashboard widget is no longer correct. Use Tweet Intent instead. I moved the Jetpack.me URL into a separate URL parameter, placing it outside the pre-selected text in the intent. Passing a related Twitter account of jetpack provides a post-Tweet follow hint.