### PR TITLE
adds sticky=require option to posts-list endpoint and updates accepted p...

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -716,8 +716,9 @@ new WPCOM_JSON_API_Update_Post_v1_1_Endpoint( array(
 			'auto-draft' => 'Save a placeholder for a newly created post, with no content.',
 		),
 		'sticky'    => array(
-			'false'   => 'Post is not marked as sticky.',
-			'true'    => 'Stick the post to the front page.',
+			'include' => 'Sticky posts are not excluded from the list.',
+			'exclude' => 'Sticky posts are excluded from the list.',
+			'require' => 'Only include sticky posts',
 		),
 		'password'  => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
 		'parent'    => "(int) The post ID of the new post's parent.",

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -436,6 +436,7 @@ new WPCOM_JSON_API_List_Posts_v1_1_Endpoint( array(
 		'sticky'    => array(
 			'include'   => 'Sticky posts are not excluded from the list.',
 			'exclude'   => 'Sticky posts are excluded from the list.',
+			'require'   => 'Only include sticky posts',
 		),
 		'author'   => "(int) Author's user ID",
 		'search'   => '(string) Search query',
@@ -716,9 +717,8 @@ new WPCOM_JSON_API_Update_Post_v1_1_Endpoint( array(
 			'auto-draft' => 'Save a placeholder for a newly created post, with no content.',
 		),
 		'sticky'    => array(
-			'include' => 'Sticky posts are not excluded from the list.',
-			'exclude' => 'Sticky posts are excluded from the list.',
-			'require' => 'Only include sticky posts',
+			'false'   => 'Post is not marked as sticky.',
+			'true'    => 'Stick the post to the front page.',
 		),
 		'password'  => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
 		'parent'    => "(int) The post ID of the new post's parent.",

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -102,6 +102,11 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			if ( is_array( $sticky ) ) {
 				$query['post__not_in'] = $sticky;
 			}
+		} else if ( $args['sticky'] === 'require' ) {
+			$sticky = get_option( 'sticky_posts' );
+			if ( is_array( $sticky ) ) {
+				$query['post__in'] = $sticky;
+			}
 		}
 
 		if ( isset( $args['exclude'] ) ) {


### PR DESCRIPTION
This PR adds some filtering options for the posts-list in the jetpack API, which matches functionality already existing in wpcom.

* sticky=include (sticky posts are treated the same as all other posts)
* sticky=exclude (sticky posts are excluded from the results)
* sticky=require (only sticky posts are included in the response)

/cc @samhotchkiss 