### PR TITLE
Syncing WordPress updates

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -89,7 +89,7 @@ class Jetpack_Autoupdate {
 		// if we need to update WordPress core, let's find the latest version number
 		if ( ! empty( $updates['wordpress'] ) ) {
 			$cur = get_preferred_from_update_core();
-			if ( isset( $cur->response ) && $cur->response === 'upgrade' ) {
+			if ( isset( $cur->response ) && 'upgrade' === $cur->response ) {
 				$updates['wp_update_version'] = $cur->current;
 			}
 		}

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -1,7 +1,6 @@
 <?php
 
 // Update any plugins that have been flagged for automatic updates
-// TODO: update themes and core
 class Jetpack_Autoupdate {
 
 	private static $instance = null;
@@ -22,6 +21,14 @@ class Jetpack_Autoupdate {
 			add_filter( 'auto_update_theme',   array( $this, 'autoupdate_theme' ), 10, 2 );
 			add_filter( 'auto_update_core',    array( $this, 'autoupdate_core' ), 10, 2 );
 		}
+
+		/**
+		 * Anytime WordPress saves update data, we'll want to update our jetpack option as well
+		 */
+		if ( is_main_site() ) {
+			add_filter( 'wp_get_update_data', array( $this, 'save_update_data' ), 10, 1 );
+		}
+
 	}
 
 	function autoupdate_plugin( $update, $item ) {
@@ -47,6 +54,61 @@ class Jetpack_Autoupdate {
 			return $autoupdate_core;
 		}
 		return $update;
+	}
+
+	/**
+	 * Filter for wp_get_update_data that doesn't actually filter anything
+	 * Used to save a Jetpack_Option when ever new updates are detected
+	 *
+	 */
+	function save_update_data( $update_data ) {
+		global $wp_version;
+
+		// If we are not on the main site, no need to save.
+		if ( ! is_main_site() ) {
+			return $update_data;
+		}
+
+		if ( isset( $update_data['counts'] ) ) {
+			$updates = $update_data['counts'];
+		}
+
+		$updates['wp_version'] = isset( $wp_version ) ? $wp_version : null;
+
+		if ( ! empty( $updates['wordpress'] ) ) {
+			$cur = get_preferred_from_update_core();
+			if ( isset( $cur->response ) && $cur->response === 'upgrade' ) {
+				$updates['wp_update_version'] = $cur->current;
+			}
+		}
+
+		$updates['site_is_vcs'] = (bool) $this->is_vcs();
+		Jetpack_Options::update_option( 'updates', $updates );
+		return $update_data;
+	}
+
+	/**
+	 * Finds out if a site is using a version control system.
+	 * We'll store that information as a transient with a 24 expiration.
+	 * We only need to check once per day.
+	 *
+	 * @return string ( '1' | '0' )
+	 */
+	function is_vcs() {
+		$is_vcs = get_transient( 'jetpack_site_is_vcs' );
+
+		if ( false === $is_vcs ) {
+			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+			$updater = new WP_Automatic_Updater();
+			$is_vcs  = strval( $updater->is_vcs_checkout( $context = ABSPATH ) );
+			// transients should not be empty
+			if ( empty( $is_vcs ) ) {
+				$is_vcs = '0';
+			}
+			set_transient( 'jetpack_site_is_vcs', $is_vcs, DAY_IN_SECONDS );
+		}
+
+		return $is_vcs;
 	}
 }
 Jetpack_Autoupdate::init();

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -82,7 +82,7 @@ class Jetpack_Autoupdate {
 			}
 		}
 
-		$updates['site_is_vcs'] = (bool) $this->is_vcs();
+		$updates['site_is_version_controlled'] = (bool) $this->is_version_controlled();
 		Jetpack_Options::update_option( 'updates', $updates );
 		return $update_data;
 	}
@@ -94,21 +94,21 @@ class Jetpack_Autoupdate {
 	 *
 	 * @return string ( '1' | '0' )
 	 */
-	function is_vcs() {
-		$is_vcs = get_transient( 'jetpack_site_is_vcs' );
+	function is_version_controlled() {
+		$is_version_controlled = get_transient( 'jetpack_site_is_vcs' );
 
-		if ( false === $is_vcs ) {
+		if ( false === $is_version_controlled ) {
 			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 			$updater = new WP_Automatic_Updater();
-			$is_vcs  = strval( $updater->is_vcs_checkout( $context = ABSPATH ) );
+			$is_version_controlled  = strval( $updater->is_vcs_checkout( $context = ABSPATH ) );
 			// transients should not be empty
-			if ( empty( $is_vcs ) ) {
-				$is_vcs = '0';
+			if ( empty( $is_version_controlled ) ) {
+				$is_version_controlled = '0';
 			}
-			set_transient( 'jetpack_site_is_vcs', $is_vcs, DAY_IN_SECONDS );
+			set_transient( 'jetpack_site_is_vcs', $is_version_controlled, DAY_IN_SECONDS );
 		}
 
-		return $is_vcs;
+		return $is_version_controlled;
 	}
 }
 Jetpack_Autoupdate::init();

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -32,7 +32,8 @@ class Jetpack_Options {
 				'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
 				'site_icon_url',			   // (string) url to the full site icon
 				'site_icon_id',				   // (int)    Attachment id of the site icon file
-				'dismissed_manage_banner'      // (bool)   Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
+				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
+				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 			);
 		case 'private' :
 			return array(

--- a/jetpack.php
+++ b/jetpack.php
@@ -64,6 +64,7 @@ add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 1
 add_action( 'init', array( 'Jetpack', 'init' ) );
 add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 add_filter( 'jetpack_static_url', array( 'Jetpack', 'staticize_subdomain' ) );
+add_filter( 'is_jetpack_site', '__return_true' );
 
 /**
  * Add an easy way to photon-ize a URL that is safe to call even if Jetpack isn't active.

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -299,10 +299,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				if ( $is_jetpack ) {
 					$response['options']['jetpack_version'] = get_option( 'jetpack_version' );
 
-					// If we are not on WPCOM, force WordPress to recalculate available updates.
-					if ( ! IS_WPCOM ) {
-						wp_update_plugins();
-						wp_update_themes();
+					// If we are not on WPCOM, force WordPress to re-calculate available updates.
+					if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
 						wp_get_update_data();
 					}
 					$response['options']['updates'] = Jetpack_Options::get_option( 'updates', array() );

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -299,6 +299,14 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				if ( $is_jetpack ) {
 					$response['options']['jetpack_version'] = get_option( 'jetpack_version' );
 
+					// If we are not on WPCOM, force WordPress to recalculate available updates.
+					if ( ! IS_WPCOM ) {
+						wp_update_plugins();
+						wp_update_themes();
+						wp_get_update_data();
+					}
+					$response['options']['updates'] = Jetpack_Options::get_option( 'updates', array() );
+
                     if( get_option( 'jetpack_main_network_site' ) ) {
 	                    $response['options']['main_network_site'] = (string) rtrim( get_option( 'jetpack_main_network_site' ), '/' );
                     }


### PR DESCRIPTION
`json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php`
is currently how we make update information available on wordpress.com  

i aim to create a sync-able jetpack option as well as add the update information to 
`json-endpoints/class.wpcom-json-api-get-site-endpoint.php`

this will improve the experience of managing sites on wordpress.com and fix #1566