### PR TITLE
Contact Form: Use default email address instead of silently failing

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1231,9 +1231,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$valid_emails[] = $email;
 		}
 
-		// No one to send it to :(
+		// No one to send it to, which means none of the "to" attributes are valid emails.
+		// Use default email instead.
 		if ( !$valid_emails ) {
-			return false;
+			$valid_emails = $this->defaults['to'];
 		}
 
 		$to = $valid_emails;


### PR DESCRIPTION
Before, if there were no valid email addresses as recipients, the form would not process at all with no error.  This will defualt to the post_author, or admin_email if it's not in a post.

fixes #1610 