### PR TITLE
Add custom site url filter for Publicize module and 3 uses of site_url function

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -71,7 +71,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$blog_id = (int) $this->api->get_blog_id_for_output();
 
 		$is_jetpack = true === apply_filters( 'is_jetpack_site', false, $blog_id );
-		$site_url = get_option( 'siteurl' );
+		$site_url = site_url();
 
 		if ( $is_jetpack ) {
 			remove_filter( 'option_stylesheet', 'fix_theme_location' );

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -156,6 +156,11 @@ class Publicize extends Publicize_Base {
 				$wpcom_blog_id = !empty( $wpcom_blog_id ) ? $wpcom_blog_id : $stats_options['blog_id'];
 
 				$user = wp_get_current_user();
+				/**
+				 * Replace URL passed to API
+				 *
+				 * @param string $custom_site_url The value returned by site_url function.
+				 */
 				$custom_site_url = apply_filters( 'publicize_custom_site_url', site_url() );
 				$redirect = $this->api_url( $service_name, urlencode_deep( array(
 					'action'       => 'request',

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -156,11 +156,12 @@ class Publicize extends Publicize_Base {
 				$wpcom_blog_id = !empty( $wpcom_blog_id ) ? $wpcom_blog_id : $stats_options['blog_id'];
 
 				$user = wp_get_current_user();
+				$custom_site_url = apply_filters( 'publicize_custom_site_url', site_url() );
 				$redirect = $this->api_url( $service_name, urlencode_deep( array(
 					'action'       => 'request',
 					'redirect_uri' => add_query_arg( array( 'action' => 'done' ), menu_page_url( 'sharing', false ) ),
 					'for'          => 'publicize', // required flag that says this connection is intended for publicize
-					'siteurl'      => site_url(),
+					'siteurl'      => $custom_site_url,
 					'state'        => $user->ID,
 					'blog_id'      => $wpcom_blog_id,
 					'secret_1'	   => $verification['secret_1'],

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -654,7 +654,7 @@ function stats_get_blog() {
 		'path'                => $home['path'],
 		'blogname'            => get_option( 'blogname' ),
 		'blogdescription'     => get_option( 'blogdescription' ),
-		'siteurl'             => get_option( 'siteurl' ),
+		'siteurl'             => site_url(),
 		'gmt_offset'          => get_option( 'gmt_offset' ),
 		'timezone_string'     => get_option( 'timezone_string' ),
 		'stats_version'       => STATS_VERSION,

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -63,7 +63,7 @@ class Jetpack_Subscriptions {
 
 		// Don't use COOKIEHASH as it could be shared across installs && is non-unique in multisite.
 		// @see: https://twitter.com/nacin/status/378246957451333632
-		self::$hash = md5( get_option( 'siteurl' ) );
+		self::$hash = md5( site_url() );
 
 		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'xmlrpc_methods' ) );
 


### PR DESCRIPTION
Add a new filter 'publicize_custom_site_url' in publicize module to make it possible for platforms that have different domains on backend versus frontend, to have a valid request in order to be able to connect to social media networks from the Jetpack Settings in wp-admin. 

On a side note, replace get_option( 'siteurl' ) with site_url() function in 3 modules: json-endpoints, subscriptions and stats. This is necessary for sites that have filters on site_url() applied to get_option( 'siteurl' ).