### PR TITLE
Filter for opening RSS Links in new window/tab

### DIFF
--- a/modules/widgets/rsslinks-widget.php
+++ b/modules/widgets/rsslinks-widget.php
@@ -141,12 +141,19 @@ class Jetpack_RSS_Links_Widget extends WP_Widget {
 
 		$link_item = '';
 		$format = $args['format'];
+		
+		if ( has_filter( 'jetpack_rsslinks_widget_target_blank' ) && apply_filters( 'jetpack_rsslinks_widget_target_blank', false ) ) {
+			$link_target = '_blank';
+		} else {
+			$link_target = '_self';
+		}
+		
 		if ( 'image' == $format || 'text-image' == $format )
-			$link_item = '<a href="' . get_bloginfo($rss_type) . '" title="' . esc_attr( $subscribe_to ) . '"><img src="' . esc_url( plugins_url( 'images/rss/' . $args['imagecolor'] . '-' . $args['imagesize'] . '.png', dirname( dirname( __FILE__ ) ) ) ) . '" alt="RSS Feed" /></a>';
+			$link_item = '<a target="' . $link_target . '" href="' . get_bloginfo($rss_type) . '" title="' . esc_attr( $subscribe_to ) . '"><img src="' . esc_url( plugins_url( 'images/rss/' . $args['imagecolor'] . '-' . $args['imagesize'] . '.png', dirname( dirname( __FILE__ ) ) ) ) . '" alt="RSS Feed" /></a>';
 		if ( 'text-image' == $format )
-			$link_item .= '&nbsp;<a href="' . get_bloginfo($rss_type) . '" title="' . esc_attr( $subscribe_to ) . '">' . esc_html__('RSS - ' . $type_text, 'jetpack'). '</a>';
+			$link_item .= '&nbsp;<a target="' . $link_target . '" href="' . get_bloginfo($rss_type) . '" title="' . esc_attr( $subscribe_to ) . '">' . esc_html__('RSS - ' . $type_text, 'jetpack'). '</a>';
 		if ( 'text' == $format )
-			$link_item = '<a href="' . get_bloginfo($rss_type) . '" title="' . esc_attr( $subscribe_to ) . '">' . esc_html__('RSS - ' . $type_text, 'jetpack'). '</a>';
+			$link_item = '<a target="' . $link_target . '" href="' . get_bloginfo($rss_type) . '" title="' . esc_attr( $subscribe_to ) . '">' . esc_html__('RSS - ' . $type_text, 'jetpack'). '</a>';
 
 		if ( 'text' == $format )
 			echo '<li>';


### PR DESCRIPTION
Creates a filter for opening links in the RSS Links widget in a new window or tab. Uses the default behavior (`_self`) if the filter is not present or returns a non-true value.

Use filter like so:

`add_filter( 'jetpack_rsslinks_widget_target_blank', '__return_true' );`

Fixes #1628.