### PR TITLE
allow related Twitter usernames and optional description without via

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -411,12 +411,13 @@ class Share_Twitter extends Sharing_Source {
 
 		if ( $via ) {
 			$via = '&via=' . rawurlencode( $via );
-
-			$related = $this->get_related_accounts( $post );
-			if ( ! empty( $related ) && $related !== $via )
-				$via .= '&related=' . rawurlencode( $related );
 		} else {
 			$via = '';
+		}
+
+		$related = $this->get_related_accounts( $post );
+		if ( ! empty( $related ) && $related !== $via ) {
+			$via .= '&related=' . rawurlencode( $related );
 		}
 
 		$share_url = $this->get_share_url( $post->ID );
@@ -445,20 +446,18 @@ class Share_Twitter extends Sharing_Source {
 		}
 
 		$via = $this->sharing_twitter_via( $post );
+		$related = $this->get_related_accounts( $post );
 		if ( $via ) {
-			$related = $this->get_related_accounts( $post );
-			if ( $related === $via )
+			$sig = " via @$via";
+			if ( $related === $via ) {
 				$related = false;
-
-			$sig     = " via @$via";
+			}
 		} else {
-			$via     = false;
-			$related = false;
-			$sig     = '';
+			$via = false;
+			$sig = '';
 		}
 
-
-		$suffix_length = $this->short_url_length + $strlen( " {$sig}" );
+		$suffix_length = $this->short_url_length + $strlen( $sig );
 		// $sig is handled by twitter in their 'via' argument.
 		// $post_link is handled by twitter in their 'url' argument.
 		if ( 140 < $strlen( $post_title ) + $suffix_length ) {


### PR DESCRIPTION
Allow a website to define `related` Twitter usernames without defining a `via` username.

A [Tweet Web Intent](https://dev.twitter.com/web/tweet-button/web-intent) supports `via` or `related` query parameters to describe Twitter accounts associated with a Tweet.

The `via` parameter adds a Tweet template component for the pre-composed Tweet. A logged-out Twitter viewer may be encouraged to log in / sign up to discover more content.

The `related` parameter suggests accounts related to the story and an optional description of the context of the related account. Related account values may be displayed after the Tweet to encourage a viewer to follow the Twitter account (if he does not already follow). The usernames might also inform future suggestions of accounts to follow.

Example:
An article appears on NBA.com summarizing the recent three-point shootout during the NBA All-Star weekend. The site may choose to add the winner or finalists as related Twitter accounts to the story, with optional descriptions describing the relationship to the story (winner, finalist, etc.). The site may separately choose to set a via such as NBA.

![tweet-intent-example](https://cloud.githubusercontent.com/assets/1100/6204756/327cb158-b50b-11e4-86b8-58f7fa6e7849.png)