### PR TITLE
Prevent a debug notice in Jetpack_RelatedPosts::_get_related_post_ids()

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -860,8 +860,8 @@ EOT;
 		// Build cache key
 		$cache_key = md5( serialize( $body ) );
 
-		// Cache is valid! Return cacheed value.
-		if ( is_array( $cache[ $cache_key ] ) && $cache[ $cache_key ][ 'expires' ] > $now_ts ) {
+		// Cache is valid! Return cached value.
+		if ( isset( $cache[ $cache_key ] ) && is_array( $cache[ $cache_key ] ) && $cache[ $cache_key ][ 'expires' ] > $now_ts ) {
 			return $cache[ $cache_key ][ 'payload' ];
 		}
 


### PR DESCRIPTION
Prevent a debug notice in `Jetpack_RelatedPosts::_get_related_post_ids()` when trying to access an array index that doesn't exist.