### PR TITLE
Remove Tiled Mosaic UI and default override

### DIFF
--- a/functions.gallery.php
+++ b/functions.gallery.php
@@ -49,15 +49,13 @@ class Jetpack_Gallery_Settings {
 	 * Outputs a view template which can be used with wp.media.template
 	 */
 	function print_media_templates() {
-		$default_gallery_type = apply_filters( 'jetpack_default_gallery_type', 'default' );
-
 		?>
 		<script type="text/html" id="tmpl-jetpack-gallery-settings">
 			<label class="setting">
 				<span><?php _e( 'Type', 'jetpack' ); ?></span>
 				<select class="type" name="type" data-setting="type">
 					<?php foreach ( $this->gallery_types as $value => $caption ) : ?>
-						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $default_gallery_type ); ?>><?php echo esc_html( $caption ); ?></option>
+						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value ); ?>><?php echo esc_html( $caption ); ?></option>
 					<?php endforeach; ?>
 				</select>
 			</label>

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -15,12 +15,6 @@ class Jetpack_Tiled_Gallery {
 	public function __construct() {
 		add_action( 'admin_init', array( $this, 'settings_api_init' ) );
 		add_filter( 'jetpack_gallery_types', array( $this, 'jetpack_gallery_types' ), 9 );
-		add_filter( 'jetpack_default_gallery_type', array( $this, 'jetpack_default_gallery_type' ) );
-	}
-
-	public function tiles_enabled() {
-		// Check the setting status
-		return '' != get_option( 'tiled_galleries' );
 	}
 
 	public function set_atts( $atts ) {
@@ -40,10 +34,6 @@ class Jetpack_Tiled_Gallery {
 
 		$this->atts['id'] = (int) $this->atts['id'];
 		$this->float = is_rtl() ? 'right' : 'left';
-
-		// Default to rectangular is tiled galleries are checked
-		if ( $this->tiles_enabled() && ( ! $this->atts['type'] || 'default' == $this->atts['type'] ) )
-			$this->atts['type'] = 'rectangular';
 
 		if ( !$this->atts['orderby'] ) {
 			$this->atts['orderby'] = sanitize_sql_orderby( $this->atts['orderby'] );
@@ -162,12 +152,6 @@ class Jetpack_Tiled_Gallery {
 	 * Media UI integration
 	 */
 	function jetpack_gallery_types( $types ) {
-		if ( get_option( 'tiled_galleries' ) && isset( $types['default'] ) ) {
-			// Tiled is set as the default, meaning that type='default'
-			// will still display the mosaic.
-			$types['thumbnails'] = $types['default'];
-			unset( $types['default'] );
-		}
 
 		$types['rectangular'] = __( 'Tiled Mosaic', 'jetpack' );
 		$types['square'] = __( 'Square Tiles', 'jetpack' );
@@ -176,36 +160,10 @@ class Jetpack_Tiled_Gallery {
 		return $types;
 	}
 
-	function jetpack_default_gallery_type( $default ) {
-		return ( get_option( 'tiled_galleries' ) ? 'rectangular' : 'default' );
-	}
-
 	static function get_talaveras() {
 		return self::$talaveras;
 	}
 
-	/**
-	 * Add a checkbox field to the Carousel section in Settings > Media
-	 * for setting tiled galleries as the default.
-	 */
-	function settings_api_init() {
-		global $wp_settings_sections;
-
-		// Add the setting field [tiled_galleries] and place it in Settings > Media
-		if ( isset( $wp_settings_sections['media']['carousel_section'] ) )
-			$section = 'carousel_section';
-		else
-			$section = 'default';
-
-		add_settings_field( 'tiled_galleries', __( 'Tiled Galleries', 'jetpack' ), array( $this, 'setting_html' ), 'media', $section );
-		register_setting( 'media', 'tiled_galleries', 'esc_attr' );
-	}
-
-	function setting_html() {
-		echo '<label><input name="tiled_galleries" type="checkbox" value="1" ' .
-			checked( 1, '' != get_option( 'tiled_galleries' ), false ) . ' /> ' .
-			__( 'Display all your gallery pictures in a cool mosaic.', 'jetpack' ) . '</br></label>';
-	}
 }
 
 add_action( 'init', array( 'Jetpack_Tiled_Gallery', 'init' ) );


### PR DESCRIPTION
Removes the Tiled Mosaic checkbox from Settings > Media and stops Jetpack from overriding the default gallery type with Tiled Mosaic. IMHO, this PR simplifies gallery behavior with Jetpack given that:

- Previously, users had to check an obscure box in Settings > Media before TM's would work. With this PR, the checkbox isn't needed. TM's can always be selected as a gallery type if the module is active.
- Previously, Jetpack was overriding the default gallery type (Thumbnail Grid) with TM when the above checkbox was enabled, potentially confusing gallery shortcode users. This PR stops that behavior.

In short, by merging this PR, things are much more intuitive: with the TM module active, Jetpack's three new gallery types become available in the gallery shortcode and Add Media modal. No more, no less.

Fixes #1287.