### PR TITLE
Contact Form: Upgrade/replace the contact_form_is_spam filter.

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -828,7 +828,7 @@ function grunion_recheck_queue() {
 	foreach ( $approved_feedbacks as $feedback ) {
 		$meta = get_post_meta( $feedback->ID, '_feedback_akismet_values', true );
 
-		$is_spam = apply_filters( 'contact_form_is_spam', $meta );
+		$is_spam = apply_filters( 'jetpack_contact_form_is_spam', false, $meta );
 
 		if ( $is_spam ) {
 			wp_update_post( array( 'ID' => $feedback->ID, 'post_status' => 'spam' ) );

--- a/tests/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/modules/contact-form/test_class.grunion-contact-form.php
@@ -9,7 +9,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Remove any relevant filters that might exist before running the tests
 		remove_all_filters( 'grunion_still_email_spam' );
-		remove_all_filters( 'contact_form_is_spam' );
+		remove_all_filters( 'jetpack_contact_form_is_spam' );
 		remove_all_filters( 'wp_mail' );
 	}
 
@@ -57,7 +57,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		// Remove filters after running tests
 		remove_all_filters( 'wp_mail' );
 		remove_all_filters( 'grunion_still_email_spam' );
-		remove_all_filters( 'contact_form_is_spam' );
+		remove_all_filters( 'jetpack_contact_form_is_spam' );
 	}
 
 	private function add_field_values( $values ) {
@@ -343,7 +343,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_fails_if_spam_marked_with_WP_Error() {
-		add_filter( 'contact_form_is_spam', function() {
+		add_filter( 'jetpack_contact_form_is_spam', function() {
 			return new WP_Error( 'spam', 'Message is spam' );
 		}, 11 ); // Run after akismet filter
 
@@ -359,7 +359,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_wont_send_spam_if_marked_as_spam_with_true() {
-		add_filter( 'contact_form_is_spam', function() {
+		add_filter( 'jetpack_contact_form_is_spam', function() {
 			return true;
 		}, 11 ); // Run after akismet filter
 
@@ -376,7 +376,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_labels_message_as_spam_in_subject_if_marked_as_spam_with_true_and_sending_spam() {
-		add_filter( 'contact_form_is_spam', function() {
+		add_filter( 'jetpack_contact_form_is_spam', function() {
 			return true;
 		}, 11 ); // Run after akismet filter
 


### PR DESCRIPTION
This issue surfaced here: https://wordpress.org/support/topic/possible-conflict-with-jetpack-contact-form

The contact_form_is_spam filter, when it was created, should have been designed to accept two arguments: $is_spam and $form. Only passing in $form means that the filter can only be processed by one function, since after the first function, the return value will be boolean and the form data will lost.

This commit drops the contact_form_is_spam filter and replaces it with a new filter, jetpack_contact_form_is_spam. This new filter takes two arguments ($is_spam and $form) so that it can be processed by multiple functions without losing data, and once $is_spam is set to true, all future functions should just pass that on.