### PR TITLE
REST API: Site Settings: Add Jetpack Twitter site username option

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -3010,6 +3010,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'sharing_show'                 => '(string|array:string) Post type or array of types where sharing buttons are to be displayed',
 		'sharing_open_links'           => '(string) Link target for sharing buttons (same or new)',
 		'twitter_via'                  => '(string) Twitter username to include in tweets when people share using the Twitter button',
+		'jetpack-twitter-cards-site-tag' => '(string) The Twitter username of the owner of the site\'s domain.',
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -155,6 +155,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'disabled_reblogs'        => (bool) get_option( 'disabled_reblogs' ),
 					'jetpack_comment_likes_enabled' => (bool) get_option( 'jetpack_comment_likes_enabled', false ),
 					'twitter_via'             => (string) get_option( 'twitter_via' ),
+					'jetpack-twitter-cards-site-tag' => (string) get_option( 'jetpack-twitter-cards-site-tag' ),
 				);
 
 				if ( class_exists( 'Sharing_Service' ) ) {


### PR DESCRIPTION
This pull request seeks to add the `jetpack-twitter-cards-site-tag` option to be manageable via the site settings REST API endpoint. Jetpack sites don't use the `twitter_via` option as used on WPCOM, so we should include its variant.

See internal changeset r112806-wpcom.