### PR TITLE
Heartbeat: Improved json api full managment stat.

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -113,18 +113,18 @@ class Jetpack_Heartbeat {
 
 		$json_api_full_management = Jetpack_Options::get_option( 'json_api_full_management', null );
 		if ( $json_api_full_management === null ) {
-			$return["{$prefix}full_manage"] = 'unset';
+			$return["{$prefix}manage-enabled"] = 'unset';
 		} elseif ( $json_api_full_management === false ) {
-			$return["{$prefix}full_manage"] = 'false';
+			$return["{$prefix}manage-enabled"] = 'false';
 		} elseif ( $json_api_full_management === true ) {
-			$return["{$prefix}full_manage"] = 'true';
+			$return["{$prefix}manage-enabled"] = 'true';
 		} else {
-			$return["{$prefix}full_manage"] = Jetpack_Options::get_option( 'json_api_full_management', null );
+			$return["{$prefix}manage-enabled"] = $json_api_full_management;
 		}
 
 		if ( ! Jetpack_Options::get_option( 'public' ) ) {
 			// Also flag things as private since we don't provide the user with option to easy opt into if the site is private
-			$return["{$prefix}full_manage"] = 'private-' . $return["{$prefix}full_manage"];
+			$return["{$prefix}full_manage"] = 'private-' . $return["{$prefix}manage-enabled"];
 		}
 
 		// is-multi-network can have three values, `single-site`, `single-network`, and `multi-network`

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -111,18 +111,15 @@ class Jetpack_Heartbeat {
 		$return["{$prefix}identitycrisis"] = Jetpack::check_identity_crisis( 1 ) ? 'yes' : 'no';
 		$return["{$prefix}plugins"]        = implode( ',', Jetpack::get_active_plugins() );
 
-		switch ( Jetpack_Options::get_option( 'json_api_full_management', null ) ) {
-			case null:
-				$return["{$prefix}full_manage"] = 'unset';
-				break;
-			case false:
-				$return["{$prefix}full_manage"] = 'false';
-				break;
-			case true:
-				$return["{$prefix}full_manage"] = 'true';
-				break;
-			default:
-				$return["{$prefix}full_manage"] = Jetpack_Options::get_option( 'json_api_full_management', null );
+		$json_api_full_management = Jetpack_Options::get_option( 'json_api_full_management', null );
+		if ( $json_api_full_management === null ) {
+			$return["{$prefix}full_manage"] = 'unset';
+		} elseif ( $json_api_full_management === false ) {
+			$return["{$prefix}full_manage"] = 'false';
+		} elseif ( $json_api_full_management === true ) {
+			$return["{$prefix}full_manage"] = 'true';
+		} else {
+			$return["{$prefix}full_manage"] = Jetpack_Options::get_option( 'json_api_full_management', null );
 		}
 
 		if ( ! Jetpack_Options::get_option( 'public' ) ) {


### PR DESCRIPTION
Currently because the php switch statement uses loose comparison unset and false produce the same result in the heartbeat stat. Which doesn't provide us with info about how many people explicitly turn off json api management after enabling  it. 

This PR tries to fix that by replacing the switch statement with a if else.