### PR TITLE
More accurate staticize_subdomain() URL matching

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4666,11 +4666,15 @@ p {
 		// Explode hostname on '.'
 		$exploded_host = explode( '.', $host);
 		
-		// Retreive the domain name
-		$domain = $exploded_host[ count( $exploded_host ) - 2 ];
+		// Retreive the name and TLD
+		$name = $exploded_host[ count( $exploded_host ) - 2 ];
+		$tld = $exploded_host[ count( $exploded_host ) - 1 ];
+		
+		// Rebuild domain excluding subdomains
+		$domain = $name . '.' . $tld;
 		
 		// Array of Automattic domains
-		$domain_whitelist = array( 'wordpress', 'wp' );
+		$domain_whitelist = array( 'wordpress.com', 'wp.com' );
 		
 		// Return $url if not an Automattic domain
 		if ( ! in_array( $domain, $domain_whitelist) ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4664,7 +4664,7 @@ p {
 		$host = parse_url( $url, PHP_URL_HOST );
 		
 		// Explode hostname on '.'
-		$exploded_host = explode( '.', $host);
+		$exploded_host = explode( '.', $host );
 		
 		// Retreive the name and TLD
 		$name = $exploded_host[ count( $exploded_host ) - 2 ];
@@ -4677,7 +4677,7 @@ p {
 		$domain_whitelist = array( 'wordpress.com', 'wp.com' );
 		
 		// Return $url if not an Automattic domain
-		if ( ! in_array( $domain, $domain_whitelist) ) {
+		if ( ! in_array( $domain, $domain_whitelist ) ) {
 			return $url;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4659,8 +4659,21 @@ p {
 	}
 
 	public static function staticize_subdomain( $url ) {
+		
+		// Extract hostname from URL
 		$host = parse_url( $url, PHP_URL_HOST );
-		if ( ! preg_match( '/.?(?:wordpress|wp)\.com$/', $host ) ) {
+		
+		// Explode hostname on '.'
+		$exploded_host = explode( '.', $host);
+		
+		// Retreive the domain name
+		$domain = $exploded_host[ count( $exploded_host ) - 2 ];
+		
+		// Array of Automattic domains
+		$domain_whitelist = array( 'wordpress', 'wp' );
+		
+		// Return $url if not an Automattic domain
+		if ( ! in_array( $domain, $domain_whitelist) ) {
 			return $url;
 		}
 


### PR DESCRIPTION
Previously, `staticize_subdomain()` was not correctly handling SSL domains ending in `wp.com`. See this comment for details:

https://github.com/Automattic/jetpack/issues/1663#issuecomment-75966403

Fixes #1663.