### PR TITLE
XML-RPC: Return $args to native state.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4469,6 +4469,7 @@ p {
 			);
 		}
 		$wp_xmlrpc_server->blog_options = array_merge( $wp_xmlrpc_server->blog_options, $options );
+		$args = stripslashes_deep( $args );
 		return $wp_xmlrpc_server->wp_getOptions( $args );
 	}
 


### PR DESCRIPTION
Fixes #1677.

Since we are escaping `$args` for an authentication check, un-escaping via `stripslashes_deep` will return `$args` to the native state expected by WordPress when we call `$wp_xmlrpc_server->wp_getOptions( $args );`.

Another alternative is `$newargs = $args` and then escape/authenticate '$newargs`.