### PR TITLE
JSON API: Increase limit of attachments returned with a post from 5 to 100

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -415,7 +415,7 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'attachments':
 				$response[$key] = array();
-				$_attachments = get_posts( array( 'post_parent' => $post->ID, 'post_status' => 'inherit', 'post_type' => 'attachment' ) );
+				$_attachments = get_posts( array( 'post_parent' => $post->ID, 'post_status' => 'inherit', 'post_type' => 'attachment', 'posts_per_page' => 100 ) );
 				foreach ( $_attachments as $attachment ) {
 					$response[$key][$attachment->ID] = $this->get_attachment( $attachment );
 				}


### PR DESCRIPTION
Right now no `posts_per_page` is specified so it defaults to 5.

Including up to 100 will save our mobile app a subsequent call to retrieve all attachments.