### PR TITLE
Change "sharing_add_footer" priority to temporarily fix jQuery undefined console errors when using ShareDaddy with jQuery enqueued in the footer. See https://github.com/Automattic/jetpack/pull/1666.

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -635,7 +635,7 @@ function sharing_display( $text = '', $echo = false ) {
 				$ver = '20141212';
 			}
 			wp_register_script( 'sharing-js', plugin_dir_url( __FILE__ ).'sharing.js', array( 'jquery' ), $ver );
-			add_action( 'wp_footer', 'sharing_add_footer' );
+			add_action( 'wp_footer', 'sharing_add_footer', 20 );
 		}
 	}
 


### PR DESCRIPTION
Change "sharing_add_footer" priority to temporarily fix jQuery undefined console errors when using ShareDaddy with jQuery enqueued in the footer. See https://github.com/Automattic/jetpack/pull/1666.