### PR TITLE
Adds members from Mercury to Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,3 +60,6 @@ notifications:
        - tony.kovanen@automattic.com
        - rocco@automattic.com
        - smart@automattic.com
+       - eric.binnion@automattic.com
+       - allendav@automattic.com
+       - beau@automattic.com


### PR DESCRIPTION
Per a chat that Mercury had last week, we would like to add the following three people to the Travis CI reports that are emailed.

Adds @beaulebens, @allendav, and myself.