### PR TITLE
Shortcodes: Add inline docs for hooks in audio.php

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -326,7 +326,9 @@ class Share_Email extends Sharing_Source {
 
 			<?php do_action( 'sharing_email_dialog', 'jetpack' ); ?>
 
-			<img style="float: right; display: none" class="loading" src="<?php echo apply_filters( 'jetpack_static_url', plugin_dir_url( __FILE__ ) . 'images/loading.gif' ); ?>" alt="loading" width="16" height="16" />
+			<img style="float: right; display: none" class="loading" src="<?php 
+			/** This filter is documented in modules/shortcodes/audio.php */
+			echo apply_filters( 'jetpack_static_url', plugin_dir_url( __FILE__ ) . 'images/loading.gif' ); ?>" alt="loading" width="16" height="16" />
 			<input type="submit" value="<?php esc_attr_e( 'Send Email', 'jetpack' ); ?>" class="sharing_send" />
 			<a href="#cancel" class="sharing_cancel"><?php _e( 'Cancel', 'jetpack' ); ?></a>
 

--- a/modules/shortcodes/audio.php
+++ b/modules/shortcodes/audio.php
@@ -67,6 +67,28 @@ class AudioShortcode {
 		self::$add_script = true;
 		$atts[0] = strip_tags( join( ' ', $atts ) );
 		$src = ltrim( $atts[0], '=' );
+		
+        /**
+         * Set the audio player default colors.
+         *
+         * @since 1.4.0
+         *
+         * @param array $ap_options {
+         *      The default colors for the audio player in hexidecimal format (e.g. 0x#F8F8F8). 
+         *      
+         *      @type string $bg              Background color.
+         *      @type string $leftbg          Left background color.
+         *      @type string $lefticon        Left icon color.
+         *      @type string $rightbg         Right background color.
+         *      @type string $rightbghover    Right background hover color.
+         *      @type string $righticon       Right icon color.
+         *      @type string $righticonhover  Right icon hover color.
+         *      @type string $text            Text color.
+         *      @type string $slider          Slider color.
+         *      @type string $track           Track color.
+         *      @type string $border          Border color.
+         *      @type string $loader          Loader color. 
+         */
 		$ap_options = apply_filters(
 			'audio_player_default_colors',
 			array(
@@ -260,6 +282,14 @@ CONTROLS;
 		}
 		$html5_audio .= "<span id='wp-as-{$post_id}_{$ap_playerID}-playing'></span>";
 
+        /**
+         * Sets external resource URL.
+         *
+         * @since 1.4.0
+         *
+         * @param string $args URL of external resource. 
+         *
+         */
 		$swfurl = apply_filters(
 			'jetpack_static_url',
 			set_url_scheme( "http://en.wordpress.com/wp-content/plugins/audio-player/player.swf" )

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -357,7 +357,9 @@ function stats_reports_page() {
 	<h2><?php esc_html_e( 'Site Stats', 'jetpack'); ?> <a style="font-size:13px;" href="<?php echo esc_url( admin_url('admin.php?page=jetpack&configure=stats') ); ?>"><?php esc_html_e( 'Configure', 'jetpack'); ?></a></h2>
 </div>
 <div id="stats-loading-wrap" class="wrap">
-<p class="hide-if-no-js"><img width="32" height="32" alt="<?php esc_attr_e( 'Loading&hellip;', 'jetpack' ); ?>" src="<?php echo esc_url( apply_filters( 'jetpack_static_url', "{$http}://en.wordpress.com/i/loading/loading-64.gif" ) ); ?>" /></p>
+<p class="hide-if-no-js"><img width="32" height="32" alt="<?php esc_attr_e( 'Loading&hellip;', 'jetpack' ); ?>" src="<?php 
+/** This filter is documented in modules/shortcodes/audio.php */
+echo esc_url( apply_filters( 'jetpack_static_url', "{$http}://en.wordpress.com/i/loading/loading-64.gif" ) ); ?>" /></p>
 <p style="font-size: 11pt; margin: 0;"><a href="https://wordpress.com/stats/<?php echo $blog_id; ?>"><?php esc_html_e( 'View stats on WordPress.com right now', 'jetpack' ); ?></a></p>
 <p class="hide-if-js"><?php esc_html_e( 'Your Site Stats work better with Javascript enabled.', 'jetpack' ); ?><br />
 <a href="<?php echo esc_url( $nojs_url ); ?>"><?php esc_html_e( 'View Site Stats without Javascript', 'jetpack' ); ?></a>.</p>

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -135,6 +135,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		if ( 'text' != $display ) {
 			$get_image_options = array(
 				'fallback_to_avatars' => true,
+				/** This filter is documented in modules/shortcodes/audio.php */
 				'gravatar_default' => apply_filters( 'jetpack_static_url', set_url_scheme( 'http://en.wordpress.com/i/logo/white-gray-80.png' ) ),
 			);
 			if ( 'grid' == $display ) {


### PR DESCRIPTION
Added inline documentation for audio player default colors and primary inline documentation reference for 'jetpack_static_url'