### PR TITLE
Document hook in icalendar-reader.php

### DIFF
--- a/_inc/lib/icalendar-reader.php
+++ b/_inc/lib/icalendar-reader.php
@@ -87,6 +87,13 @@ class iCalendarReader {
 	protected function filter_past_and_recurring_events( $events ) {
 		$upcoming = array();
 		$set_recurring_events = array();
+		/**
+		 * This filter allows any time to be passed in for testing or changing timezones, etc...
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param object time() A time object.
+		 */
 		$current = apply_filters( 'ical_get_current_time', time() );
 
 		foreach ( $events as $event ) {


### PR DESCRIPTION
Added documentation for ical_get_current_time hook that can be used to pass in any time as $current.