### PR TITLE
Minileven: Add hooks before and after header

### DIFF
--- a/modules/minileven/theme/pub/minileven/header.php
+++ b/modules/minileven/theme/pub/minileven/header.php
@@ -43,8 +43,23 @@
 			</div><!-- .search-form-->
 		</div><!-- .menu-search-->
 
-	<?php if ( function_exists( 'minileven_header' ) )
-		minileven_header();
+	<?php
+		/**
+		 * Fires before Minileven header.
+		 *
+		 * @since 3.4.0
+		 */
+		 do_action( 'jetpack_mobile_header_before' );
+
+		 if ( function_exists( 'minileven_header' ) )
+			minileven_header();
+
+		/**
+		 * Fires after Minileven header.
+		 *
+		 * @since 3.4.0
+		 */
+		do_action( 'jetpack_mobile_header_after' );
 	?>
 
 	<div id="page" class="hfeed">


### PR DESCRIPTION
Create and document `jetpack_mobile_header_before` and `jetpack_mobile_header_after` hooks for Minileven header. Closes #1555 for real this time.