### PR TITLE
Update is_jetpack checks to also check if code is executing on WordPress.com

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1045,7 +1045,7 @@ EOPHP;
 					return null;
 				$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
 				$post_id = $author->ID;
-				if ( $is_jetpack ) {
+				if ( $is_jetpack && ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) { 
 					$ID    = get_post_meta( $post_id, '_jetpack_post_author_external_id', true );
 					$email = get_post_meta( $post_id, '_jetpack_author_email', true );
 					$login = '';

--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -309,7 +309,7 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[$key] = (string) $this->api->add_global_ID( $blog_id, $post->ID );
 				break;
 			case 'featured_image' :
-				if ( $is_jetpack ) {
+				if ( $is_jetpack && ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 					$response[ $key ] = get_post_meta( $post->ID, '_jetpack_featured_image', true );
 				} else {
 					$image_attributes = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );

--- a/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -306,7 +306,7 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 				$response[$key] = (string) $this->api->add_global_ID( $blog_id, $post->ID );
 				break;
 			case 'featured_image' :
-				if ( $is_jetpack ) {
+				if ( $is_jetpack && ( defined( 'IS_WPCOM' ) && IS_WPCOM )  ) { 
 					$response[ $key ] = get_post_meta( $post->ID, '_jetpack_featured_image', true );
 				} else {
 					$image_attributes = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );


### PR DESCRIPTION
Previously, we would rely on the is_jetpack_site filter (while executing code on WordPress.com) to see if a certain blog is a Jetpack blog.

We only expected this code to execute on WordPress.com run code (aka /me/posts) rather then by the target Jetpack blog.

However, now Jetpack uses a filter with the same name in some of the syncing code, so the author and featured image code using the filter are incorrect.

This change updates the check to only execute the block if the code is also being executed by .com (and not by the jp blog itsself). That way /me/posts and others are happy, and the Jetpack blog returns the correct info for /sites/$site/posts/* as well.

The bug that this caused was all Jetpack posts (on the jptest site) were returning an author of 0. Since the wrong author code in get_author was running.