### PR TITLE
Jetpack Sync: Sync all options and constants on Jetpack Connection

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -90,6 +90,8 @@ class Jetpack_Client_Server {
 			} else {
 				Jetpack::activate_default_modules();
 			}
+			// Sync all registers options and constants
+			do_action( 'jetpack_sync_all_registered_options' );
 
 			$jetpack->sync->register( 'noop' ); // Spawn a sync to make sure the Jetpack Servers know what modules are active.
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -90,10 +90,9 @@ class Jetpack_Client_Server {
 			} else {
 				Jetpack::activate_default_modules();
 			}
+
 			// Sync all registers options and constants
 			do_action( 'jetpack_sync_all_registered_options' );
-
-			$jetpack->sync->register( 'noop' ); // Spawn a sync to make sure the Jetpack Servers know what modules are active.
 
 			// Start nonce cleaner
 			wp_clear_scheduled_hook( 'jetpack_clean_nonces' );


### PR DESCRIPTION
Curretly we only sync options that are in different modules and because they are activated. 
We don't sync all options and constants. This PR tries to address this issue. 