### PR TITLE
Removed the double headline in the jump start success message 

### DIFF
--- a/_inc/jp.js
+++ b/_inc/jp.js
@@ -265,8 +265,7 @@
 					});
 				});
 
-				$( '#jumpstart-success' ).html( response );
-				$( '.spinner' ).hide();
+				$( '.spinner, .jumpstart-desc, #jumpstart-cta' ).hide();
 				$( '.jumpstart-message, .miguel' ).toggle();
 
 				// Log Jump Start event in MC Stats

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -14,7 +14,7 @@
 
 				<div id="jump-start-success"></div>
 				<div id="jump-start-area" class="j-row">
-					<h1 class="jumpstart-desc" title="Jump start your site by activating these components"><?php _e( 'Jump Start your site', 'jetpack' ); ?></h1>
+					<h1 class="jumpstart-desc" title="Jump Start your site by activating these components"><?php _e( 'Jump Start your site', 'jetpack' ); ?></h1>
 					<div class="jumpstart-desc j-col j-sm-12 j-md-12 j-lrg-8">
 						<div class="jumpstart-message">
 							<p id="jumpstart-paragraph-before"><?php echo sprintf( __( 'To immediately boost performance, security, and engagement, we recommend activating <strong>%s</strong> and a few others. Click <strong>Jump Start</strong> to activate these modules.', 'jetpack' ), $data['jumpstart_list'] ); ?>

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -14,7 +14,7 @@
 
 				<div id="jump-start-success"></div>
 				<div id="jump-start-area" class="j-row">
-					<h1 title="Jump start your site by activating these components"><?php _e( 'Jump Start your site', 'jetpack' ); ?></h1>
+					<h1 class="jumpstart-desc" title="Jump start your site by activating these components"><?php _e( 'Jump Start your site', 'jetpack' ); ?></h1>
 					<div class="jumpstart-desc j-col j-sm-12 j-md-12 j-lrg-8">
 						<div class="jumpstart-message">
 							<p id="jumpstart-paragraph-before"><?php echo sprintf( __( 'To immediately boost performance, security, and engagement, we recommend activating <strong>%s</strong> and a few others. Click <strong>Jump Start</strong> to activate these modules.', 'jetpack' ), $data['jumpstart_list'] ); ?>


### PR DESCRIPTION
The original headline for jump start wasn't being removed when a user was presented with the success message this has been fixed

fix #1766 