### PR TITLE
Landing Page/Jump Start: Add sharing buttons to pages on jump start

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -584,17 +584,7 @@ class Jetpack {
 				$hidden = array();
 
 				// Set where to show sharing buttons
-				if ( !is_array( $sharing_options ) )
-					$sharing_options = array();
-
-				// Restore sharing options defaults
-				$sharing_options['global'] = array(
-					'button_style'  => 'icon',
-					'sharing_label' => 'Share This:',
-					'open_links'    => 'same',
-					'show'          => array( 'post' ),
-					'custom'        => isset( $sharing_options['global']['custom'] ) ? $sharing_options['global']['custom'] : array()
-				);
+				$sharing_options['global']['show'] = array( 'post' );
 				update_option( 'sharing-options', $sharing_options );
 
 				// Send a success response so that we can display an error message.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -571,8 +571,9 @@ class Jetpack {
 				Jetpack::state( 'message', 'no_message' );
 			}
 
-			// Set the default sharing buttons if none have been set.
+			// Set the default sharing buttons and set to display on posts if none have been set.
 			$sharing_services = get_option( 'sharing-services' );
+			$sharing_options  = get_option( 'sharing-options' );
 			if ( empty( $sharing_services['visible'] ) ) {
 				// Default buttons to set
 				$visible = array(
@@ -581,6 +582,20 @@ class Jetpack {
 					'google-plus-1',
 				);
 				$hidden = array();
+
+				// Set where to show sharing buttons
+				if ( !is_array( $sharing_options ) )
+					$sharing_options = array();
+
+				// Restore sharing options defaults
+				$sharing_options['global'] = array(
+					'button_style'  => 'icon',
+					'sharing_label' => 'Share This:',
+					'open_links'    => 'same',
+					'show'          => array( 'post' ),
+					'custom'        => isset( $sharing_options['global']['custom'] ) ? $sharing_options['global']['custom'] : array()
+				);
+				update_option( 'sharing-options', $sharing_options );
 
 				// Send a success response so that we can display an error message.
 				$success = update_option( 'sharing-services', array( 'visible' => $visible, 'hidden' => $hidden ) );


### PR DESCRIPTION
Before we were only adding buttons to the sharing settings on Jump Start.  Now we are also adding them to all posts by default (only if jump started)