### PR TITLE
RSS Widget: add filter to customize RSS icon

### DIFF
--- a/modules/widgets/rsslinks-widget.php
+++ b/modules/widgets/rsslinks-widget.php
@@ -168,7 +168,7 @@ class Jetpack_RSS_Links_Widget extends WP_Widget {
 			/**
 			 * Filters the image used as RSS icon in the RSS widget.
 			 *
-			 * @since 3.5.0
+			 * @since 3.6.0
 			 *
 			 * @param string $var URL of RSS Widget icon.
 			 */

--- a/modules/widgets/rsslinks-widget.php
+++ b/modules/widgets/rsslinks-widget.php
@@ -157,19 +157,30 @@ class Jetpack_RSS_Links_Widget extends WP_Widget {
 
 		$link_item = '';
 		$format = $args['format'];
-		
+
 		if ( apply_filters( 'jetpack_rsslinks_widget_target_blank', false ) ) {
 			$link_target = '_blank';
 		} else {
 			$link_target = '_self';
 		}
-		
-		if ( 'image' == $format || 'text-image' == $format )
-			$link_item = '<a target="' . $link_target . '" href="' . get_bloginfo( $rss_type ) . '" title="' . esc_attr( $subscribe_to ) . '"><img src="' . esc_url( plugins_url( 'images/rss/' . $args['imagecolor'] . '-' . $args['imagesize'] . '.png', dirname( dirname( __FILE__ ) ) ) ) . '" alt="RSS Feed" /></a>';
-		if ( 'text-image' == $format )
+
+		if ( 'image' == $format || 'text-image' == $format ) {
+			/**
+			 * Filters the image used as RSS icon in the RSS widget.
+			 *
+			 * @since 3.5.0
+			 *
+			 * @param string plugins_url( 'images/rss/' . $args['imagecolor'] . '-' . $args['imagesize'] . '.png', dirname( dirname( __FILE__ ) ) ) URL of the RSS icon image.
+			 */
+			$link_image = apply_filters( 'jetpack_rss_widget_icon', plugins_url( 'images/rss/' . $args['imagecolor'] . '-' . $args['imagesize'] . '.png', dirname( dirname( __FILE__ ) ) ) );
+			$link_item = '<a target="' . $link_target . '" href="' . get_bloginfo( $rss_type ) . '" title="' . esc_attr( $subscribe_to ) . '"><img src="' . esc_url( $link_image ) . '" alt="RSS Feed" /></a>';
+		}
+		if ( 'text-image' == $format ) {
 			$link_item .= '&nbsp;<a target="' . $link_target . '" href="' . get_bloginfo( $rss_type ) . '" title="' . esc_attr( $subscribe_to ) . '">' . esc_html__( 'RSS - ' . $type_text, 'jetpack' ). '</a>';
-		if ( 'text' == $format )
+		}
+		if ( 'text' == $format ) {
 			$link_item = '<a target="' . $link_target . '" href="' . get_bloginfo( $rss_type ) . '" title="' . esc_attr( $subscribe_to ) . '">' . esc_html__( 'RSS - ' . $type_text, 'jetpack' ). '</a>';
+		}
 
 		if ( 'text' == $format )
 			echo '<li>';
@@ -182,10 +193,9 @@ class Jetpack_RSS_Links_Widget extends WP_Widget {
 			echo '</p>';
 
 	}
-} //Class Jetpack_RSS_Links_Widget
+} // Class Jetpack_RSS_Links_Widget
 
 function jetpack_rss_links_widget_init() {
 	register_widget( 'Jetpack_RSS_Links_Widget' );
 }
 add_action( 'widgets_init', 'jetpack_rss_links_widget_init' );
-?>

--- a/modules/widgets/rsslinks-widget.php
+++ b/modules/widgets/rsslinks-widget.php
@@ -170,7 +170,7 @@ class Jetpack_RSS_Links_Widget extends WP_Widget {
 			 *
 			 * @since 3.5.0
 			 *
-			 * @param string plugins_url( 'images/rss/' . $args['imagecolor'] . '-' . $args['imagesize'] . '.png', dirname( dirname( __FILE__ ) ) ) URL of the RSS icon image.
+			 * @param string $var URL of RSS Widget icon.
 			 */
 			$link_image = apply_filters( 'jetpack_rss_widget_icon', plugins_url( 'images/rss/' . $args['imagecolor'] . '-' . $args['imagesize'] . '.png', dirname( dirname( __FILE__ ) ) ) );
 			$link_item = '<a target="' . $link_target . '" href="' . get_bloginfo( $rss_type ) . '" title="' . esc_attr( $subscribe_to ) . '"><img src="' . esc_url( $link_image ) . '" alt="RSS Feed" /></a>';


### PR DESCRIPTION
Once this is merged, site owners could use a custom RSS icon by adding this code to a functionality plugin:

```php
function jeherve_custom_rss_widget_icon() {
        return 'https://i.imgur.com/ii9zlki.png';
}
add_filter( 'jetpack_rss_widget_icon', 'jeherve_custom_rss_widget_icon' );
```

Suggested here:
https://twitter.com/MrKevinJoy/status/577516892757327872