### PR TITLE
Tiled Gallery: Update

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -10,7 +10,7 @@ include_once dirname( __FILE__ ) . '/tiled-gallery/tiled-gallery-square.php';
 include_once dirname( __FILE__ ) . '/tiled-gallery/tiled-gallery-circle.php';
 
 class Jetpack_Tiled_Gallery {
-	private static $talaveras = array( 'rectangular', 'square', 'circle', 'rectangle' );
+	private static $talaveras = array( 'rectangular', 'square', 'circle', 'rectangle', 'columns' );
 
 	public function __construct() {
 		add_action( 'admin_init', array( $this, 'settings_api_init' ) );
@@ -172,6 +172,7 @@ class Jetpack_Tiled_Gallery {
 		$types['rectangular'] = __( 'Tiled Mosaic', 'jetpack' );
 		$types['square'] = __( 'Square Tiles', 'jetpack' );
 		$types['circle'] = __( 'Circles', 'jetpack' );
+		$types['coulmns'] = __( 'Tiled Columns', 'jetpack' );
 
 		return $types;
 	}

--- a/modules/tiled-gallery/tiled-gallery/templates/carousel-container.php
+++ b/modules/tiled-gallery/tiled-gallery/templates/carousel-container.php
@@ -1,11 +1,11 @@
-<?php 
-if ( defined( 'JSON_HEX_AMP' ) ) { 
-	// see shortcodes/slideshow.php 
-	// This is nice to have, but not strictly necessary since we use _wp_specialchars() below 
-	$extra = json_encode( $this->get_container_extra_data(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT ); 
-} else { 
-	$extra = json_encode( $this->get_container_extra_data() ); 
-} 
+<?php
+if ( defined( 'JSON_HEX_AMP' ) ) {
+	// see shortcodes/slideshow.php
+	// This is nice to have, but not strictly necessary since we use _wp_specialchars() below
+	$extra = json_encode( $this->get_container_extra_data(), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+} else {
+	$extra = json_encode( $this->get_container_extra_data() );
+}
 ?>
 <div
 	class="tiled-gallery type-<?php echo $this->type; ?> tiled-gallery-unresized"

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -13,7 +13,7 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
 
 		$this->img_src = add_query_arg( array( 'w' => $this->image->width, 'h' => $this->image->height, 'crop' => true ), $this->orig_file );
-      
+
    	}
 
 	public function fuzzy_image_meta() {
@@ -67,10 +67,9 @@ class Jetpack_Tiled_Gallery_Rectangular_Item extends Jetpack_Tiled_Gallery_Item 
 class Jetpack_Tiled_Gallery_Square_Item extends Jetpack_Tiled_Gallery_Item {
 	public function __construct( $attachment_image, $needs_attachment_link, $grayscale ) {
 		parent::__construct( $attachment_image, $needs_attachment_link, $grayscale );
-		$this->img_src_grayscale = jetpack_photon_url( $this->img_src, array( 'filter' => 'grayscale', 'resize' => array( $this->image->width, $this->image->height ) ) ); 
+		$this->img_src_grayscale = jetpack_photon_url( $this->img_src, array( 'filter' => 'grayscale', 'resize' => array( $this->image->width, $this->image->height ) ) );
 	}
 }
 
 class Jetpack_Tiled_Gallery_Circle_Item extends Jetpack_Tiled_Gallery_Square_Item {
 }
-?>

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -35,7 +35,7 @@ class Jetpack_Tiled_Gallery_Grouper {
 		if ( $images_left < 3 )
 			return array_fill( 0, $images_left, 1 );
 
-		foreach ( array( 'One_Three', 'Three_One', 'One_Two', 'Five', 'Four', 'Three', 'Two_One', 'Symmetric_Row', 'Panoramic' ) as $shape_name ) {
+		foreach ( array( 'Reverse_Symmetric_Row', 'Long_Symmetric_Row', 'One_Three', 'Three_One', 'One_Two', 'Five', 'Four', 'Three', 'Two_One', 'Symmetric_Row', 'Panoramic' ) as $shape_name ) {
 			$class_name = "Jetpack_Tiled_Gallery_$shape_name";
 			$shape = new $class_name( $this->images );
 			if ( $shape->is_possible() ) {

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -35,7 +35,7 @@ class Jetpack_Tiled_Gallery_Grouper {
 		if ( $images_left < 3 )
 			return array_fill( 0, $images_left, 1 );
 
-		foreach ( array( 'One_Three', 'One_Two', 'Five', 'Four', 'Three', 'Two_One', 'Symmetric_Row', 'Panoramic' ) as $shape_name ) {
+		foreach ( array( 'One_Three', 'Three_One', 'One_Two', 'Five', 'Four', 'Three', 'Two_One', 'Symmetric_Row', 'Panoramic' ) as $shape_name ) {
 			$class_name = "Jetpack_Tiled_Gallery_$shape_name";
 			$shape = new $class_name( $this->images );
 			if ( $shape->is_possible() ) {

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -35,7 +35,7 @@ class Jetpack_Tiled_Gallery_Grouper {
 		if ( $images_left < 3 )
 			return array_fill( 0, $images_left, 1 );
 
-		foreach ( array( 'Reverse_Symmetric_Row', 'Long_Symmetric_Row', 'One_Three', 'Three_One', 'One_Two', 'Five', 'Four', 'Three', 'Two_One', 'Symmetric_Row', 'Panoramic' ) as $shape_name ) {
+		foreach ( array( 'Reverse_Symmetric_Row', 'Long_Symmetric_Row', 'Symmetric_Row', 'One_Three', 'Three_One', 'One_Two', 'Five', 'Four', 'Three', 'Two_One', 'Panoramic' ) as $shape_name ) {
 			$class_name = "Jetpack_Tiled_Gallery_$shape_name";
 			$shape = new $class_name( $this->images );
 			if ( $shape->is_possible() ) {

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -14,6 +14,16 @@ class Jetpack_Tiled_Gallery_Layout_Rectangular extends Jetpack_Tiled_Gallery_Lay
 	}
 }
 
+class Jetpack_Tiled_Gallery_Layout_Columns extends Jetpack_Tiled_Gallery_Layout {
+	protected $type = 'rectangular'; // It doesn't need separate template for now
+
+	public function HTML( $context = array() ) {
+		$grouper = new Jetpack_Tiled_Gallery_Grouper( $this->attachments, array( 'Three_Columns', 'Two' ) );
+
+		return parent::HTML( array( 'rows'  => $grouper->grouped_images ) );
+	}
+}
+
 // Alias
 class Jetpack_Tiled_Gallery_Layout_Rectangle extends Jetpack_Tiled_Gallery_Layout_Rectangular {}
 
@@ -36,14 +46,21 @@ class Jetpack_Tiled_Gallery_Grouper {
 		'Panoramic'
 	);
 
-	public function __construct( $attachments ) {
+	public function __construct( $attachments, $shapes = array() ) {
 		$content_width = Jetpack_Tiled_Gallery::get_content_width();
 		$ua_info = new Jetpack_User_Agent_Info();
 
+		$this->overwrite_shapes( $shapes );
 		$this->last_shape = '';
 		$this->images = $this->get_images_with_sizes( $attachments );
 		$this->grouped_images = $this->get_grouped_images();
 		$this->apply_content_width( $content_width );
+	}
+
+	public function overwrite_shapes( $shapes ) {
+		if ( ! empty( $shapes ) ) {
+			$this->shapes = $shapes;
+		}
 	}
 
 	public function get_current_row_size() {

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -20,6 +20,22 @@ class Jetpack_Tiled_Gallery_Layout_Rectangle extends Jetpack_Tiled_Gallery_Layou
 // Image grouping and HTML generation logic
 class Jetpack_Tiled_Gallery_Grouper {
 	public $margin = 4;
+
+	// This list is ordered. If you put a shape that's likely to occur on top, it will happen all the time.
+	public $shapes = array(
+		'Reverse_Symmetric_Row',
+		'Long_Symmetric_Row',
+		'Symmetric_Row',
+		'One_Three',
+		'Three_One',
+		'One_Two',
+		'Five',
+		'Four',
+		'Three',
+		'Two_One',
+		'Panoramic'
+	);
+
 	public function __construct( $attachments ) {
 		$content_width = Jetpack_Tiled_Gallery::get_content_width();
 		$ua_info = new Jetpack_User_Agent_Info();
@@ -35,7 +51,7 @@ class Jetpack_Tiled_Gallery_Grouper {
 		if ( $images_left < 3 )
 			return array_fill( 0, $images_left, 1 );
 
-		foreach ( array( 'Reverse_Symmetric_Row', 'Long_Symmetric_Row', 'Symmetric_Row', 'One_Three', 'Three_One', 'One_Two', 'Five', 'Four', 'Three', 'Two_One', 'Panoramic' ) as $shape_name ) {
+		foreach ( $this->shapes as $shape_name ) {
 			$class_name = "Jetpack_Tiled_Gallery_$shape_name";
 			$shape = new $class_name( $this->images );
 			if ( $shape->is_possible() ) {

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -95,7 +95,10 @@ class Jetpack_Tiled_Gallery_One_Three extends Jetpack_Tiled_Gallery_Shape {
 
 	public function is_possible() {
 		return $this->is_not_as_previous() && $this->images_left > 3 &&
-			$this->images[0]->ratio < 0.8 && $this->images[1]->ratio >= 0.9 && $this->images[1]->ratio < 2.0 && $this->images[2]->ratio >= 0.9 && $this->images[2]->ratio < 2.0 && $this->images[3]->ratio >= 0.9 && $this->images[3]->ratio < 2.0;
+			$this->image_is_portrait( $this->images[0] ) &&
+			$this->image_is_landscape( $this->images[1] ) &&
+			$this->image_is_landscape( $this->images[2] ) &&
+			$this->image_is_landscape( $this->images[3] );
 	}
 }
 

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -87,6 +87,22 @@ class Jetpack_Tiled_Gallery_One_Three extends Jetpack_Tiled_Gallery_Shape {
 	}
 }
 
+class Jetpack_Tiled_Gallery_Three_One extends Jetpack_Tiled_Gallery_Shape {
+	public $shape = array( 3, 1 );
+
+	public function is_possible() {
+		// @todo $this->is_vertical( $image ), $this->is_horizontal( $image );
+		return $this->is_not_as_previous() && $this->images_left > 3 &&
+			$this->images[3]->ratio < 0.8 &&
+			$this->images[0]->ratio >= 0.9 &&
+			$this->images[0]->ratio < 2.0 &&
+			$this->images[1]->ratio >= 0.9 &&
+			$this->images[1]->ratio < 2.0 &&
+			$this->images[2]->ratio >= 0.9 &&
+			$this->images[2]->ratio < 2.0;
+	}
+}
+
 class Jetpack_Tiled_Gallery_Panoramic extends Jetpack_Tiled_Gallery_Shape {
 	public $shape = array( 1 );
 

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -126,8 +126,13 @@ class Jetpack_Tiled_Gallery_Symmetric_Row extends Jetpack_Tiled_Gallery_Shape {
 	public $shape = array( 1, 2, 1 );
 
 	public function is_possible() {
-		return $this->is_not_as_previous( 5 ) && $this->images_left >= 3 && $this->images_left != 5 &&
-			$this->images[0]->ratio < 0.8 && isset( $this->images[3] ) && $this->images[0]->ratio == $this->images[3]->ratio;
+		return $this->is_not_as_previous( 5 ) &&
+			$this->images_left > 3 &&
+			$this->images_left != 5 &&
+			$this->image_is_portrait( $this->images[0] ) &&
+			$this->image_is_landscape( $this->images[1] ) &&
+			$this->image_is_landscape( $this->images[2] ) &&
+			$this->image_is_portrait( $this->images[3] );
 	}
 }
 class Jetpack_Tiled_Gallery_Reverse_Symmetric_Row extends Jetpack_Tiled_Gallery_Shape {

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -166,4 +166,45 @@ class Jetpack_Tiled_Gallery_Long_Symmetric_Row extends Jetpack_Tiled_Gallery_Sha
 			$this->image_is_landscape( $this->images[6] );
 	}
 }
+
+class Jetpack_Tiled_Gallery_Three_Columns extends Jetpack_Tiled_Gallery_Shape {
+	public $shape = array();
+
+	public function __construct( $images ) {
+		parent::__construct( $images );
+
+		$total_ratio = $this->sum_ratios( $this->images_left );
+		$approximate_column_ratio = $total_ratio / 3;
+		$column_one_images = $column_two_images = $column_three_images = $sum = 0;
+
+		foreach ( $this->images as $image ) {
+			if ( $sum <= $approximate_column_ratio ) {
+				$column_one_images++;
+			}
+
+			if ( $sum > $approximate_column_ratio && $sum <= 2 * $approximate_column_ratio ) {
+				$column_two_images++;
+			}
+			$sum += $image->ratio;
+		}
+
+		$column_three_images = $this->images_left - $column_two_images - $column_one_images;
+
+		if ( $column_one_images ) {
+			$this->shape[] = $column_one_images;
+		}
+
+		if ( $column_two_images ) {
+			$this->shape[] = $column_two_images;
+		}
+
+		if ( $column_three_images ) {
+			$this->shape[] = $column_three_images;
+		}
+	}
+
+	public function is_possible() {
+		return ! empty( $this->shape );
+	}
+}
 ?>

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -118,7 +118,7 @@ class Jetpack_Tiled_Gallery_Panoramic extends Jetpack_Tiled_Gallery_Shape {
 	public $shape = array( 1 );
 
 	public function is_possible() {
-		return $this->images[0]->ratio >= 2.0;
+		return $this->image_is_panoramic( $this->images[0] );
 	}
 }
 

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -49,7 +49,7 @@ class Jetpack_Tiled_Gallery_Three extends Jetpack_Tiled_Gallery_Shape {
 
 	public function is_possible() {
 		$ratio = $this->sum_ratios( 3 );
-		return $this->images_left > 2 && $this->is_not_as_previous() &&
+		return $this->images_left > 2 && $this->is_not_as_previous( 3 ) &&
 			( ( $ratio < 2.5 ) || ( $ratio < 5 && $this->next_images_are_symmetric() ) || $this->is_wide_theme() );
 	}
 }
@@ -94,7 +94,7 @@ class Jetpack_Tiled_Gallery_One_Three extends Jetpack_Tiled_Gallery_Shape {
 	public $shape = array( 1, 3 );
 
 	public function is_possible() {
-		return $this->is_not_as_previous() && $this->images_left > 3 &&
+		return $this->is_not_as_previous( 3 ) && $this->images_left > 3 &&
 			$this->image_is_portrait( $this->images[0] ) &&
 			$this->image_is_landscape( $this->images[1] ) &&
 			$this->image_is_landscape( $this->images[2] ) &&
@@ -106,7 +106,7 @@ class Jetpack_Tiled_Gallery_Three_One extends Jetpack_Tiled_Gallery_Shape {
 	public $shape = array( 3, 1 );
 
 	public function is_possible() {
-		return $this->is_not_as_previous() && $this->images_left > 3 &&
+		return $this->is_not_as_previous( 3 ) && $this->images_left > 3 &&
 			$this->image_is_portrait( $this->images[3] ) &&
 			$this->image_is_landscape( $this->images[0] ) &&
 			$this->image_is_landscape( $this->images[1] ) &&
@@ -126,7 +126,7 @@ class Jetpack_Tiled_Gallery_Symmetric_Row extends Jetpack_Tiled_Gallery_Shape {
 	public $shape = array( 1, 2, 1 );
 
 	public function is_possible() {
-		return $this->is_not_as_previous() && $this->images_left >= 3 && $this->images_left != 5 &&
+		return $this->is_not_as_previous( 5 ) && $this->images_left >= 3 && $this->images_left != 5 &&
 			$this->images[0]->ratio < 0.8 && isset( $this->images[3] ) && $this->images[0]->ratio == $this->images[3]->ratio;
 	}
 }
@@ -134,7 +134,7 @@ class Jetpack_Tiled_Gallery_Reverse_Symmetric_Row extends Jetpack_Tiled_Gallery_
 	public $shape = array( 2, 1, 2 );
 
 	public function is_possible() {
-		return $this->is_not_as_previous() && $this->images_left > 15 &&
+		return $this->is_not_as_previous( 5 ) && $this->images_left > 15 &&
 			$this->image_is_landscape( $this->images[0] ) &&
 			$this->image_is_landscape( $this->images[1] ) &&
 			$this->image_is_portrait( $this->images[2] ) &&
@@ -147,7 +147,7 @@ class Jetpack_Tiled_Gallery_Long_Symmetric_Row extends Jetpack_Tiled_Gallery_Sha
 	public $shape = array( 3, 1, 3 );
 
 	public function is_possible() {
-		return $this->is_not_as_previous() && $this->images_left > 15 &&
+		return $this->is_not_as_previous( 5 ) && $this->images_left > 15 &&
 			$this->image_is_landscape( $this->images[0] ) &&
 			$this->image_is_landscape( $this->images[1] ) &&
 			$this->image_is_landscape( $this->images[2] ) &&

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -130,4 +130,31 @@ class Jetpack_Tiled_Gallery_Symmetric_Row extends Jetpack_Tiled_Gallery_Shape {
 			$this->images[0]->ratio < 0.8 && isset( $this->images[3] ) && $this->images[0]->ratio == $this->images[3]->ratio;
 	}
 }
+class Jetpack_Tiled_Gallery_Reverse_Symmetric_Row extends Jetpack_Tiled_Gallery_Shape {
+	public $shape = array( 2, 1, 2 );
+
+	public function is_possible() {
+		return $this->is_not_as_previous() && $this->images_left > 15 &&
+			$this->image_is_landscape( $this->images[0] ) &&
+			$this->image_is_landscape( $this->images[1] ) &&
+			$this->image_is_portrait( $this->images[2] ) &&
+			$this->image_is_landscape( $this->images[3] ) &&
+			$this->image_is_landscape( $this->images[4] );
+	}
+}
+
+class Jetpack_Tiled_Gallery_Long_Symmetric_Row extends Jetpack_Tiled_Gallery_Shape {
+	public $shape = array( 3, 1, 3 );
+
+	public function is_possible() {
+		return $this->is_not_as_previous() && $this->images_left > 15 &&
+			$this->image_is_landscape( $this->images[0] ) &&
+			$this->image_is_landscape( $this->images[1] ) &&
+			$this->image_is_landscape( $this->images[2] ) &&
+			$this->image_is_portrait( $this->images[3] ) &&
+			$this->image_is_landscape( $this->images[4] ) &&
+			$this->image_is_landscape( $this->images[5] ) &&
+			$this->image_is_landscape( $this->images[6] );
+	}
+}
 ?>

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -23,6 +23,18 @@ class Jetpack_Tiled_Gallery_Shape {
 		return Jetpack::get_content_width() > 1000;
 	}
 
+	public function image_is_landscape( $image ) {
+		return $image->ratio >= 1 && $image->ratio < 2;
+	}
+
+	public function image_is_portrait( $image ) {
+		return $image->ratio < 1;
+	}
+
+	public function image_is_panoramic( $image ) {
+		return $image->ratio >= 2;
+	}
+
 	public static function set_last_shape( $last_shape ) {
 		self::$shapes_used[] = $last_shape;
 	}
@@ -91,15 +103,11 @@ class Jetpack_Tiled_Gallery_Three_One extends Jetpack_Tiled_Gallery_Shape {
 	public $shape = array( 3, 1 );
 
 	public function is_possible() {
-		// @todo $this->is_vertical( $image ), $this->is_horizontal( $image );
 		return $this->is_not_as_previous() && $this->images_left > 3 &&
-			$this->images[3]->ratio < 0.8 &&
-			$this->images[0]->ratio >= 0.9 &&
-			$this->images[0]->ratio < 2.0 &&
-			$this->images[1]->ratio >= 0.9 &&
-			$this->images[1]->ratio < 2.0 &&
-			$this->images[2]->ratio >= 0.9 &&
-			$this->images[2]->ratio < 2.0;
+			$this->image_is_portrait( $this->images[3] ) &&
+			$this->image_is_landscape( $this->images[0] ) &&
+			$this->image_is_landscape( $this->images[1] ) &&
+			$this->image_is_landscape( $this->images[2] );
 	}
 }
 

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -49,7 +49,8 @@ class Jetpack_Tiled_Gallery_Three extends Jetpack_Tiled_Gallery_Shape {
 
 	public function is_possible() {
 		$ratio = $this->sum_ratios( 3 );
-		return $this->images_left > 2 && $this->is_not_as_previous( 3 ) &&
+		$has_enough_images = $this->images_left >= 3 && ! in_array( $this->images_left, array( 4, 6 ) );
+		return $has_enough_images && $this->is_not_as_previous( 3 ) &&
 			( ( $ratio < 2.5 ) || ( $ratio < 5 && $this->next_images_are_symmetric() ) || $this->is_wide_theme() );
 	}
 }

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -58,8 +58,11 @@ class Jetpack_Tiled_Gallery_Four extends Jetpack_Tiled_Gallery_Shape {
 	public $shape = array( 1, 1, 1, 1 );
 
 	public function is_possible() {
-		return $this->is_not_as_previous() && $this->sum_ratios( 4 ) < 3.5 &&
-			( $this->images_left == 4 || ( $this->images_left != 8 && $this->images_left > 5 ) );
+		return $this->is_not_as_previous() &&
+			(
+				( $this->sum_ratios( 4 ) < 3.5 && $this->images_left > 5 ) ||
+				( $this->sum_ratios( 4 ) < 7 && $this->images_left == 4 )
+			);
 	}
 }
 


### PR DESCRIPTION
Improve the shapes and distributions of shapes in the Tiled Gallery, based on observations for its usage.

1. Add 3-1 shape
2. Add 3-1-3 shape
3. Add 2-1-2 shape
4. Make the 1-2-1 shape not so symmetrical, so that it can be used from time to time
5. Add helpers for portrait, landscape, and panoramic images
6. Make some shapes less common, so that repetitions are slightly less obvious. Three can't happen on every other line now.
7. If a gallery is ending with exactly 4 landscape images, make the shape Four possible, so that [2,1] [1] is less common.
8. Add Tiled Columns gallery type, which is cool :-)