### PR TITLE
Site Icon: add inline docs

### DIFF
--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -101,7 +101,7 @@ class Jetpack_Site_Icon {
 		 *
 		 * @since 3.2.0
 		 *
-		 * @param bool false Default is false, keep at false if you want to never load this option.
+		 * @param bool Output Site Icon Meta Elements.
 		 */
 		if ( apply_filters( 'site_icon_has_favicon', false ) ) {
 			return;
@@ -742,7 +742,7 @@ class Jetpack_Site_Icon {
 		 *
 		 * @since 3.2.0
 		 *
-		 * @param array $site_icon_sizes An array of sizes for site icons to be saved in.
+		 * @param array $site_icon_sizes Sizes available for the Site Icon.  Default is array(256, 128, 80, 64, 32, 16).
 		 */
 		self::$site_icon_sizes = apply_filters( 'site_icon_image_sizes', self::$site_icon_sizes );
 		// use a natural sort of numbers

--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -96,7 +96,13 @@ class Jetpack_Site_Icon {
 	 *
 	 */
 	public function site_icon_add_meta() {
-
+		/**
+		 * Toggles the Favicon meta elements from being loaded.
+		 *
+		 * @since 3.2.0
+		 *
+		 * @param bool false Default is false, keep at false if you want to never load this option.
+		 */
 		if ( apply_filters( 'site_icon_has_favicon', false ) ) {
 			return;
 		}
@@ -116,6 +122,7 @@ class Jetpack_Site_Icon {
 	 * Display icons in RSS2.
 	 */
 	public function rss2_icon() {
+		/** This filter is documented in modules/site-icon/jetpack-site-icon.php */
 		if ( apply_filters( 'site_icon_has_favicon', false ) ) {
 			return;
 		}
@@ -143,6 +150,7 @@ class Jetpack_Site_Icon {
 	 *
 	 */
 	public function atom_icon() {
+		/** This filter is documented in modules/site-icon/jetpack-site-icon.php */
 		if ( apply_filters( 'site_icon_has_favicon', false ) ) {
 			return;
 		}
@@ -730,8 +738,11 @@ class Jetpack_Site_Icon {
 	 */
 	public static function additional_sizes( $sizes ) {
 		/**
-		 * site_icon_image_sizes
-		 * filter the different dimentions that the image should be saved in
+		 * Filter the different dimensions that a site icon is saved in.
+		 *
+		 * @since 3.2.0
+		 *
+		 * @param array $site_icon_sizes An array of sizes for site icons to be saved in.
 		 */
 		self::$site_icon_sizes = apply_filters( 'site_icon_image_sizes', self::$site_icon_sizes );
 		// use a natural sort of numbers
@@ -767,7 +778,7 @@ class Jetpack_Site_Icon {
 	 * @return array
 	 */
 	public static function intermediate_image_sizes( $sizes ) {
-
+		/** This filter is documented in modules/site-icon/jetpack-site-icon.php */
 		self::$site_icon_sizes = apply_filters( 'site_icon_image_sizes', self::$site_icon_sizes );
 		foreach( self::$site_icon_sizes as $size ) {
 			$sizes[] = 'site_icon-'.$size;

--- a/modules/site-icon/site-icon-functions.php
+++ b/modules/site-icon/site-icon-functions.php
@@ -26,7 +26,17 @@ function jetpack_get_site_icon( $blog_id = null, $size = '512', $default = '', $
 	$alt = ( $alt ? esc_attr( $alt ) : __( 'Site Icon', 'jetpack' ) );
 	$src = esc_url( jetpack_site_icon_url( $blog_id, $size, $default ) );
 	$avatar = "<img alt='{$alt}' src='{$src}' class='$class' height='{$size}' width='{$size}' />";
-
+	/**
+	 * Filters the display options for the Site Icon.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @param string $avatar The Site Icon in an html image tag.
+	 * @param int $blog_id The Blog ID.
+	 * @param string $size The size of the Site Icon, default is 512.
+	 * @param string $default The default URL for the Site Icon.
+	 * @param string $alt The alt tag for the avatar.
+	 */
 	return apply_filters( 'jetpack-get_site_icon', $avatar, $blog_id, $size, $default, $alt );
 }
 endif;

--- a/modules/site-icon/site-icon-functions.php
+++ b/modules/site-icon/site-icon-functions.php
@@ -32,7 +32,7 @@ function jetpack_get_site_icon( $blog_id = null, $size = '512', $default = '', $
 	 * @since 3.2.0
 	 *
 	 * @param string $avatar The Site Icon in an html image tag.
-	 * @param int $blog_id The Blog ID.
+	 * @param int    $blog_id The local site Blog ID.
 	 * @param string $size The size of the Site Icon, default is 512.
 	 * @param string $default The default URL for the Site Icon.
 	 * @param string $alt The alt tag for the avatar.


### PR DESCRIPTION
Document `jetpack-get_site_icon` filter in `site-icon-functions.php`.
Document `site_icon_has_favicon` in `jetpack-site-icon.php`.
Document `site_icon_image_sizes` in `jetpack-site-icon.php`.