### PR TITLE
Minileven: Add inline documentation to hooks in footer.

### DIFF
--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -22,21 +22,25 @@
 	$current_url =  trailingslashit( home_url( add_query_arg( array(), $wp->request ) ) );
 ?>
 		<a href="<?php echo $current_url . '?ak_action=reject_mobile'; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
+
 		<?php
 			/**
-			 * Fires after View Full Site link.
-			 *
-			 * @since 1.8.0
-			 */
+			* Fires after the View Full Site link in the Mobile Theme's footer.
+			*
+			* By default, a promo to download the native apps is added to this action.
+			*
+			* @since 1.8.0
+			*/
 			do_action( 'wp_mobile_theme_footer' );
 
 			/**
-			 * Fires before footer credits.
-			 *
-			 * @since 1.8.0
-			 */
+			* Fires before the credit links in the Mobile Theme's footer.
+			*
+			* @since 1.8.0
+			*/
 			do_action( 'minileven_credits' );
 		?>
+
 		<a href="<?php echo esc_url( __( 'http://wordpress.org/', 'jetpack' ) ); ?>" title="<?php esc_attr_e( 'Semantic Personal Publishing Platform', 'jetpack' ); ?>" rel="generator"><?php printf( __( 'Proudly powered by %s', 'jetpack' ), 'WordPress' ); ?></a>
 	</div>
 </footer><!-- #colophon -->

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -25,19 +25,19 @@
 
 		<?php
 			/**
-			* Fires after the View Full Site link in the Mobile Theme's footer.
-			*
-			* By default, a promo to download the native apps is added to this action.
-			*
-			* @since 1.8.0
-			*/
+			 * Fires after the View Full Site link in the Mobile Theme's footer.
+			 *
+			 * By default, a promo to download the native apps is added to this action.
+			 *
+			 * @since 1.8.0
+			 */
 			do_action( 'wp_mobile_theme_footer' );
 
 			/**
-			* Fires before the credit links in the Mobile Theme's footer.
-			*
-			* @since 1.8.0
-			*/
+			 * Fires before the credit links in the Mobile Theme's footer.
+			 *
+			 * @since 1.8.0
+			 */
 			do_action( 'minileven_credits' );
 		?>
 

--- a/modules/minileven/theme/pub/minileven/footer.php
+++ b/modules/minileven/theme/pub/minileven/footer.php
@@ -22,8 +22,21 @@
 	$current_url =  trailingslashit( home_url( add_query_arg( array(), $wp->request ) ) );
 ?>
 		<a href="<?php echo $current_url . '?ak_action=reject_mobile'; ?>"><?php _e( 'View Full Site', 'jetpack' ); ?></a><br />
-		<?php do_action( 'wp_mobile_theme_footer' ); ?>
-		<?php do_action( 'minileven_credits' ); ?>
+		<?php
+			/**
+			 * Fires after View Full Site link.
+			 *
+			 * @since 1.8.0
+			 */
+			do_action( 'wp_mobile_theme_footer' );
+
+			/**
+			 * Fires before footer credits.
+			 *
+			 * @since 1.8.0
+			 */
+			do_action( 'minileven_credits' );
+		?>
 		<a href="<?php echo esc_url( __( 'http://wordpress.org/', 'jetpack' ) ); ?>" title="<?php esc_attr_e( 'Semantic Personal Publishing Platform', 'jetpack' ); ?>" rel="generator"><?php printf( __( 'Proudly powered by %s', 'jetpack' ), 'WordPress' ); ?></a>
 	</div>
 </footer><!-- #colophon -->


### PR DESCRIPTION
Document `wp_mobile_theme_footer` and `minileven_credits` in modules/minileven/theme/pub/minileven/footer.php