### PR TITLE
Landing Page: Add link to WordPress button for other admins

### DIFF
--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -41,6 +41,12 @@
 
 			<?php endif; ?>
 
+			<?php if ( $data['is_connected'] && ! $data['is_user_connected'] && current_user_can( 'jetpack_connect_user' ) ) : ?>
+				<div class="link-button" style="width: 100%; text-align: center; margin-top: 15px;">
+					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to WordPress.com', 'jetpack' ); ?></a>
+				</div>
+			<?php endif; ?>
+
 			<?php // Recommended modules on the landing page ?>
 			<div class="module-grid">
 				<h2 title="Get the most out of Jetpack with these features"><?php _e( 'Get the most out of Jetpack with...', 'jetpack' ); ?></h2>


### PR DESCRIPTION
Button was stripped during development of the new landing page.  This brings it back so other admins can connect to their wpcom account.

Note:  Button text link needs Glotpress love