### PR TITLE
Protect Module: fix syntax error

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -260,7 +260,7 @@ class Jetpack_Protect_Module {
 	 */
 	function ip_is_whitelisted( $ip ) {
 		// If we found an exact match in wp-config
-		if ( defined( 'JETPACK_IP_ADDRESS_OK' ) && 'JETPACK_IP_ADDRESS_OK' == $ip ) {
+		if ( defined( 'JETPACK_IP_ADDRESS_OK' ) && JETPACK_IP_ADDRESS_OK == $ip ) {
 			return true;
 		}
 


### PR DESCRIPTION
When checking for the contant `JETPACK_IP_ADDRESS_OK` we are using
`'JETPACK_IP_ADDRESS_OK'` instead of the expected unquoted string.