### PR TITLE
Added a new module header tag to prevent translations interrupting the rendering of modules

### DIFF
--- a/_inc/jp.js
+++ b/_inc/jp.js
@@ -140,7 +140,7 @@
 
 		// create the map
 		for ( i = 0, length = modules.length; i < length; i++ ) {
-			if( modules[i].module_tags.indexOf(prop) !== -1 ) {
+			if( modules[i].feature.indexOf(prop) !== -1 ) {
 				val = modules[i].name.toLowerCase();
 				result.push( {
 					index: i,

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1733,6 +1733,7 @@ class Jetpack {
 			'requires_connection'   => 'Requires Connection',
 			'auto_activate'         => 'Auto Activate',
 			'module_tags'           => 'Module Tags',
+			'feature'               => 'Feature',
 		);
 
 		$file = Jetpack::get_module_path( Jetpack::get_module_slug( $module ) );

--- a/modules/carousel.php
+++ b/modules/carousel.php
@@ -9,7 +9,8 @@
  * First Introduced: 1.5
  * Requires Connection: No
  * Auto Activate: No
- * Module Tags: Photos and Videos, Jumpstart
+ * Module Tags: Photos and Videos
+ * Feature: Jumpstart
  */
 
 include dirname( __FILE__ ) . '/carousel/jetpack-carousel.php';

--- a/modules/contact-form.php
+++ b/modules/contact-form.php
@@ -8,7 +8,8 @@
  * First Introduced: 1.3
  * Requires Connection: No
  * Auto Activate: Yes
- * Module Tags: Other, Jumpstart
+ * Module Tags: Other
+ * Feature: Jumpstart
  */
 
 include dirname( __FILE__ ) . '/contact-form/grunion-contact-form.php';

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -8,7 +8,8 @@
  * First Introduced: 1.1
  * Requires Connection: No
  * Auto Activate: Yes
- * Module Tags: Social, Appearance, Jumpstart
+ * Module Tags: Social, Appearance
+ * Feature: Jumpstart
  */
 
 define( 'GROFILES__CACHE_BUSTER', gmdate( 'YM' ) . 'aa' ); // Break CDN cache, increment when gravatar.com/js/gprofiles.js changes

--- a/modules/manage.php
+++ b/modules/manage.php
@@ -7,7 +7,8 @@
  * Recommendation Order: 3
  * First Introduced: 3.4
  * Requires Connection: Yes
- * Module Tags: Centralized Management, Recommended, Jumpstart
+ * Module Tags: Centralized Management, Recommended
+ * Feature: Recommended, Jumpstart
  */
 
 add_action( 'jetpack_activate_module_manage', array( Jetpack::init(), 'toggle_module_on_wpcom' ) );

--- a/modules/minileven.php
+++ b/modules/minileven.php
@@ -9,6 +9,7 @@
  * Requires Connection: No
  * Auto Activate: No
  * Module Tags: Appearance, Mobile, Recommended
+ * Feature: Recommended
  */
 
 function jetpack_load_minileven() {

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -8,6 +8,7 @@
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Recommended
+ * Feature: Recommended
  */
 
 add_action( 'jetpack_activate_module_monitor', array( Jetpack::init(), 'toggle_module_on_wpcom' ) );

--- a/modules/photon.php
+++ b/modules/photon.php
@@ -8,7 +8,8 @@
  * First Introduced: 2.0
  * Requires Connection: Yes
  * Auto Activate: No
- * Module Tags: Photos and Videos, Appearance, Recommended, Jumpstart
+ * Module Tags: Photos and Videos, Appearance, Recommended
+ * Feature: Recommended, Jumpstart
  */
 
 Jetpack::dns_prefetch( array(

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -8,6 +8,7 @@
  * Requires Connection: Yes
  * Auto Activate: Yes
  * Module Tags: Recommended
+ * Feature: Recommended
  */
 
 include_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';

--- a/modules/publicize.php
+++ b/modules/publicize.php
@@ -8,6 +8,7 @@
  * Requires Connection: Yes
  * Auto Activate: Yes
  * Module Tags: Social, Recommended
+ * Feature: Recommended
  */
 
 class Jetpack_Publicize {

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -8,7 +8,8 @@
  * Recommendation Order: 9
  * Requires Connection: Yes
  * Auto Activate: No
- * Module Tags: Recommended, Jumpstart
+ * Module Tags: Recommended
+ * Feature: Recommended, Jumpstart
  */
 class Jetpack_RelatedPosts_Module {
 	/**

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -9,7 +9,8 @@
  * Major Changes In: 1.2
  * Requires Connection: No
  * Auto Activate: Yes
- * Module Tags: Social, Recommended, Jumpstart
+ * Module Tags: Social, Recommended
+ * Feature: Recommended, Jumpstart
  */
 
 if ( !function_exists( 'sharing_init' ) )

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -9,7 +9,8 @@
  * First Introduced: 2.6
  * Requires Connection: Yes
  * Auto Activate: No
- * Module Tags: Developers, Jumpstart
+ * Module Tags: Developers
+ * Feature: Jumpstart
  */
 
 class Jetpack_SSO {

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -8,6 +8,7 @@
  * Requires Connection: Yes
  * Auto Activate: Yes
  * Module Tags: WordPress.com Stats, Recommended
+ * Feature: Recommended
  */
 
 if ( defined( 'STATS_VERSION' ) ) {

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -8,7 +8,8 @@
  * First Introduced: 1.2
  * Requires Connection: Yes
  * Auto Activate: Yes
- * Module Tags: Social, Jumpstart
+ * Module Tags: Social
+ * Feature: Jumpstart
  */
 
 add_action( 'jetpack_modules_loaded', 'jetpack_subscriptions_load' );


### PR DESCRIPTION
Removed the term Jumpstart from the "Module Tags" because it was being translated and interrupting the rendering of modules on the admin page