### PR TITLE
The translate() function was not accurately and effectively translating

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1743,8 +1743,9 @@ class Jetpack {
 			return false;
 		}
 
-		$mod['name']                    = translate( $mod['name'], 'jetpack' );
-		$mod['description']             = translate( $mod['description'], 'jetpack' );
+		$mod['jumpstart_desc']          = _x( $mod['jumpstart_desc'], 'Jumpstart Description', 'jetpack' );
+		$mod['name']                    = _x( $mod['name'], 'Module Name', 'jetpack' );
+		$mod['description']             = _x( $mod['description'], 'Module Description', 'jetpack' );
 		$mod['sort']                    = empty( $mod['sort'] ) ? 10 : (int) $mod['sort'];
 		$mod['recommendation_order']    = empty( $mod['recommendation_order'] ) ? 20 : (int) $mod['recommendation_order'];
 		$mod['deactivate']              = empty( $mod['deactivate'] );


### PR DESCRIPTION
The translate() function was not accurately and effectively translating names or descriptions of modules. The call for this function has been replaced with _x()