### PR TITLE
Fix Auto activation of modules.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -356,8 +356,11 @@ class Jetpack {
 			update_option( 'jetpack_options', $jetpack_options );
 		}
 
-		if ( Jetpack::is_active() && Jetpack::maybe_set_version_option() ) {
-			do_action( 'jetpack_sync_all_registered_options' );
+		if ( Jetpack::is_active() ) {
+			list( $version ) = explode( ':', Jetpack_Options::get_option( 'version' ) );
+			if ( JETPACK__VERSION != $version ) {
+				do_action( 'jetpack_sync_all_registered_options' );
+			}
 		}
 
 		if ( get_option( 'jetpack_json_api_full_management' ) ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -359,6 +359,7 @@ class Jetpack {
 		if ( Jetpack::is_active() ) {
 			list( $version ) = explode( ':', Jetpack_Options::get_option( 'version' ) );
 			if ( JETPACK__VERSION != $version ) {
+				add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
 				do_action( 'jetpack_sync_all_registered_options' );
 			}
 		}
@@ -1485,7 +1486,7 @@ class Jetpack {
 		return $files;
 	}
 
-	public function activate_new_modules() {
+	public function activate_new_modules( $redirect = false ) {
 		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
 			return;
 		}
@@ -1535,13 +1536,15 @@ class Jetpack {
 		Jetpack::state( 'message', 'modules_activated' );
 		Jetpack::activate_default_modules( $jetpack_version, JETPACK__VERSION, $reactivate_modules );
 
-		$page = 'jetpack'; // make sure we redirect to either settings or the jetpack page
-		if( isset( $_GET['page'] ) && in_array( $_GET['page'] , array( 'jetpack', 'jetpack_modules' ) ) ) {
-			$page = $_GET['page'];
-		}
+		if ( $redirect ) {
+			$page = 'jetpack'; // make sure we redirect to either settings or the jetpack page
+			if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'jetpack', 'jetpack_modules' ) ) ) {
+				$page = $_GET['page'];
+			}
 
-		wp_safe_redirect( Jetpack::admin_url( 'page='.$page ) );
-		exit;
+			wp_safe_redirect( Jetpack::admin_url( 'page=' . $page ) );
+			exit;
+		}
 	}
 
 	/**
@@ -3067,7 +3070,7 @@ p {
 		}
 
 		if ( ! $error = $error ? $error : Jetpack::state( 'error' ) ) {
-			$this->activate_new_modules();
+			$this->activate_new_modules( true );
 		}
 
 		switch ( $error ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1486,7 +1486,7 @@ class Jetpack {
 		return $files;
 	}
 
-	public function activate_new_modules( $redirect = false ) {
+	public static function activate_new_modules( $redirect = false ) {
 		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
 			return;
 		}
@@ -3070,7 +3070,7 @@ p {
 		}
 
 		if ( ! $error = $error ? $error : Jetpack::state( 'error' ) ) {
-			$this->activate_new_modules( true );
+			self::activate_new_modules( true );
 		}
 
 		switch ( $error ) {


### PR DESCRIPTION
`maybe_set_version_option` is used on admin page load to auto activate
modules. This is not a good fix because this will sync all the options while not loading an admin page. 