### PR TITLE
Jump Start: check for new header tags

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-landing-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-landing-page.php
@@ -64,7 +64,7 @@ class Jetpack_Landing_Page extends Jetpack_Admin_Page {
 
 		$module_info = array();
 		foreach ( $modules as $module => $value ) {
-			if ( in_array( $tag, $value['module_tags'] ) ) {
+			if ( in_array( $tag, $value['feature'] ) ) {
 				$module_info[] = array(
 					'module_slug'   => $value['module'],
 					'module_name'   => $value['name'],

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1766,6 +1766,13 @@ class Jetpack {
 			$mod['module_tags'] = array( self::translate_module_tag( 'Other' ) );
 		}
 
+		if ( $mod['feature'] ) {
+			$mod['feature'] = explode( ',', $mod['feature'] );
+			$mod['feature'] = array_map( 'trim', $mod['feature'] );
+		} else {
+			$mod['feature'] = array( self::translate_module_tag( 'Other' ) );
+		}
+
 		return $mod;
 	}
 


### PR DESCRIPTION
New module header tags were updated in #1815 which broke jump start's module activation.  We need to check for the new tag in order for it to work.  