### PR TITLE
Jetpack : was causing an infinite loop in save_update_data

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -180,30 +180,13 @@ class Jetpack_Autoupdate {
 			}
 		}
 
-		// Only show them if the user has the ability to update them.
-		// Check for permission.
-		if (  ! current_user_can( 'update_plugins' ) ) {
-			$updates['plugins'] = 0;
-		}
-		if ( ! current_user_can( 'update_themes' ) ) {
-			$updates['themes'] = 0;
-		}
-
-		if ( ! current_user_can( 'update_core' ) ) {
-			$updates['wordpress'] = 0;
-		}
-
-		if ( ( current_user_can( 'update_plugins' )
-			|| current_user_can( 'update_themes' )
-			|| current_user_can( 'update_core' ) )
-			&& wp_get_translation_updates() ) {
+		if ( wp_get_translation_updates() ) {
 			$updates['translations'] = 1;
 		}
 
 		$updates['total'] = $updates['plugins'] + $updates['themes'] + $updates['wordpress'] + $updates['translations'];
 
 		$updates['site_is_version_controlled'] = (bool) $this->is_version_controlled();
-		error_log( 'before saving: ' . json_encode( $updates ) );
 		Jetpack_Options::update_option( 'updates', $updates );
 	}
 

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -156,7 +156,7 @@ class Jetpack_Autoupdate {
 		$updates_data = Jetpack_Options::get_option( 'updates' );
 		// just overwrite the defaults.
 		$updates = wp_parse_args( $updates_data, $defaults );
-		// just over write the exitsing options
+		// just over write the existing options
 		$updates = wp_parse_args( $new_updates, $updates );
 
 		// Stores the current version of WordPress.


### PR DESCRIPTION
WP 4.1 This PR tries to fix that. By making sure that we don't call another one.
And only overwriting the new values instead of parsing for the existing once.

**DON'T MERGE STILL NEEDS TESTING...**
