### PR TITLE
Bring back the connection prompt on the plugins page

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2754,8 +2754,9 @@ p {
 	}
 
 	function admin_connect_notice() {
-		// Don't show the connect notice on the jetpack settings page.
-		if ( empty( $_GET['page'] ) || 'jetpack' !== $_GET['page'] )
+		// Don't show the connect notice anywhere but the plugins.php or main jetpack page.
+		$current = get_current_screen();
+		if ( isset( $_GET['page'] ) && 'jetpack' !== $_GET['page'] || 'plugins' !== $current->parent_base )
 			return;
 
 		if ( ! current_user_can( 'jetpack_connect' ) )

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2754,9 +2754,9 @@ p {
 	}
 
 	function admin_connect_notice() {
-		// Don't show the connect notice anywhere but the plugins.php or main jetpack page.
+		// Don't show the connect notice anywhere but the plugins.php after activating
 		$current = get_current_screen();
-		if ( isset( $_GET['page'] ) && 'jetpack' !== $_GET['page'] || 'plugins' !== $current->parent_base )
+		if ( 'plugins' !== $current->parent_base )
 			return;
 
 		if ( ! current_user_can( 'jetpack_connect' ) )


### PR DESCRIPTION
fixes #1847 

Prompt to connect Jetpack was removed in <a href="https://github.com/Automattic/jetpack/commit/8209591cc39479a0898017733a94218941ff0221">8209591</a> as to not show anywhere but the main jetpack page.

bring it it back to the plugins page only. 