### PR TITLE
Protect: Include math-fallback.php before calling the class

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -218,6 +218,7 @@ class Jetpack_Protect_Module {
 		$use_math = $this->get_transient( 'brute_use_math' );
 
 		if ( 1 == $use_math && isset( $_POST['log'] ) ) {
+			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
 			Jetpack_Protect_Math_Authenticate::math_authenticate();
 		}
 


### PR DESCRIPTION
A quick and dirty way to ensure `PHP Fatal error: Class 'Jetpack_Protect_Math_Authenticate' not found in /var/www/wp-content/plugins/jetpack/modules/protect.php` errors won't incur by including the math-fallback.php file before calling that class.

I'm not pleased with this since I haven't been able to duplicate the error, but this check, I would think, should prevent it from occurring.

Fixes #1841