### PR TITLE
make sure that math fallback is there

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -218,6 +218,7 @@ class Jetpack_Protect_Module {
 		$use_math = $this->get_transient( 'brute_use_math' );
 
 		if ( 1 == $use_math && isset( $_POST['log'] ) ) {
+			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
 			Jetpack_Protect_Math_Authenticate::math_authenticate();
 		}
 


### PR DESCRIPTION
Specific use cases can cause math fallback to be missing from protect, this PR fixes that, fixes #1841 