### PR TITLE
Connect Notice: don't deactivate Jetpack on dismiss

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -32,6 +32,7 @@ class Jetpack_Options {
 				'site_icon_url',               // (string) url to the full site icon
 				'site_icon_id',                // (int)    Attachment id of the site icon file
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
+				'dismissed_connect_notice',    // (bool) Dismiss Jetpack connect notice allows the user to dismiss the notice permanently
 				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 			);
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2754,8 +2754,9 @@ p {
 	}
 
 	function admin_connect_notice() {
-		// Don't show the connect notice on the jetpack settings page.
-		if ( empty( $_GET['page'] ) || 'jetpack' !== $_GET['page'] )
+		// Don't show the connect notice anywhere but the plugins.php or main jetpack page.
+		$current = get_current_screen();
+		if ( isset( $_GET['page'] ) && 'jetpack' !== $_GET['page'] || 'plugins' !== $current->parent_base )
 			return;
 
 		if ( ! current_user_can( 'jetpack_connect' ) )

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2156,6 +2156,11 @@ p {
 	public static function plugin_activation( $network_wide ) {
 		Jetpack_Options::update_option( 'activated', 1 );
 
+		// Re-enable the connect notice banner on activation if it was dismissed on same site before
+		if ( Jetpack_Options::get_option( 'dismissed_connect_notice' ) ) {
+			Jetpack_Options::update_option( 'dismissed_connect_notice', false );
+		}
+
 		if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' ) ) {
 			Jetpack::bail_on_activation( sprintf( __( 'Jetpack requires WordPress version %s or later.', 'jetpack' ), JETPACK__MINIMUM_WP_VERSION ) );
 		}


### PR DESCRIPTION
Dismissing this notice actually dismisses the connect notice instead of deactivating Jetpack.  

https://cloudup.com/c_lyajP5rPh

From the beginning of this git repo's history, clicking the "X", or "dismiss" button on the connect banner resulted in Jetpack deactivating all-together.  Since it's been here since the beginning of time, I'm not sure why this is designed like that, but it does not seem like expected behavior so I've written a patch.  

@georgestephanis, maybe you can shed some light on this? 

Kind of related: #1853 