### PR TITLE
Fix “Unknown Client ID” Error when disconnect/connect in Jetpack 3.4.1

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -345,7 +345,7 @@ class Jetpack {
 			delete_metadata( 'post', 0, 'gplus_authorship_disabled', null, true );
 		}
 
-		if ( ! get_option( 'jetpack_private_options' ) ) {
+		if ( ! is_array( get_option( 'jetpack_private_options' ) ) ) {
 			$jetpack_options = get_option( 'jetpack_options', array() );
 			foreach( Jetpack_Options::get_option_names( 'private' ) as $option_name ) {
 				if ( isset( $jetpack_options[ $option_name ] ) ) {


### PR DESCRIPTION
In 3.4 I added an upgrade routine that does `if ( ! get_option( 'jetpack_private_options' ) )` in order to check if we had already defined this option. This check isn't effective when `get_option( 'jetpack_private_options' )` returns an empty array :disappointed: 