### PR TITLE
Use ob_end_clean instead of ob_clean to stop buffering and fix risky test

### DIFF
--- a/tests/test_class.jetpack.php
+++ b/tests/test_class.jetpack.php
@@ -290,7 +290,7 @@ EXPECTED;
 		// Purge it for a clean start.
 		ob_start();
 		Jetpack::dns_prefetch();
-		ob_clean();
+		ob_end_clean();
 
 		Jetpack::dns_prefetch( 'http://example1.com/' );
 		Jetpack::dns_prefetch( array(


### PR DESCRIPTION
One of the tests was calling ob_start followed by ob_clean without stopping the buffering, and the test was showing up as risky through phpunit. This commit calls ob_end_clean instead and swaps the large phpunit 'R' for a more relaxing '.'.