### PR TITLE
Contact Form: now able to set admin email as recipient from the form builder

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -884,18 +884,18 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		global $post;
 
 		// Set up the default subject and recipient for this form
-		$default_to = get_option( 'admin_email' );
+		$default_to = '';
 		$default_subject = "[" . get_option( 'blogname' ) . "]";
 
 		if ( !empty( $attributes['widget'] ) && $attributes['widget'] ) {
+			$default_to .= get_option( 'admin_email' );
 			$attributes['id'] = 'widget-' . $attributes['widget'];
-
 			$default_subject = sprintf( _x( '%1$s Sidebar', '%1$s = blog name', 'jetpack' ), $default_subject );
 		} else if ( $post ) {
 			$attributes['id'] = $post->ID;
 			$default_subject = sprintf( _x( '%1$s %2$s', '%1$s = blog name, %2$s = post title', 'jetpack' ), $default_subject, Grunion_Contact_Form_Plugin::strip_tags( $post->post_title ) );
 			$post_author = get_userdata( $post->post_author );
-			$default_to = $post_author->user_email;
+			$default_to .= $post_author->user_email;
 		}
 
 		// Keep reference to $this for parsing form fields

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1303,6 +1303,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		$to = $valid_emails;
 
+		// Last ditch effort to set a recipient if somehow none have been set.
+		if ( empty( $to ) ) {
+			$to = get_option( 'admin_email' );
+		}
+
 		// Make sure we're processing the form we think we're processing... probably a redundant check.
 		if ( $widget ) {
 			if ( 'widget-' . $widget != $_POST['contact-form-id'] ) {


### PR DESCRIPTION
Fixes #1873 

Fall back to the post author's email first for forms within a post/page. Fall back to admin_email for forms in widgets.  

If by some change no email has been set by the time the form is processed on the front end, fall back to admin_email as well.  