### PR TITLE
Jump Start: Don't re-initialize after connection cycle

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4442,9 +4442,13 @@ p {
 				'id'         => (int)    $json->jetpack_id,
 				'blog_token' => (string) $json->jetpack_secret,
 				'public'     => $jetpack_public,
-				'jumpstart'  => 'new_connection'
 			)
 		);
+
+		// Initialize Jump Start for the first and only time.
+		if ( ! Jetpack_Options::get_option( 'jumpstart' ) ) {
+			Jetpack_Options::update_option( 'jumpstart', 'new_connection' );
+		};
 
 		return true;
 	}


### PR DESCRIPTION
Fixes #1782

Before, it was updating the jumpstart option on every connection cycle.  This adds a check to make sure it has never been set before.