### PR TITLE
minor typo in Dutch translation

### DIFF
--- a/languages/jetpack-nl_NL.po
+++ b/languages/jetpack-nl_NL.po
@@ -2753,7 +2753,7 @@ msgstr "Zoek eenmaal, krijg resultaten voor alles! Op dit moment wordt het zoeke
 
 #: modules/module-info.php:753
 msgid "Omnisearch plays nice with other plugins by letting other providers offer results as well."
-msgstr "Omnisearc past goed bij andere plugins door andere providers ook resultaten aan te laten bieden."
+msgstr "Omnisearch past goed bij andere plugins door andere providers ook resultaten aan te laten bieden."
 
 #: modules/module-info.php:772
 msgid "Control which pages your widgets appear on with Widget Visibility."


### PR DESCRIPTION
the "h" of Omnisearch is missing

(and github apparently adds a line break at the end...)