### PR TITLE
Twitter Cards: remove default @jetpack twitter:site meta tag

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -199,7 +199,7 @@ class Jetpack_Twitter_Cards {
 		$site_tag = get_option( 'jetpack-twitter-cards-site-tag' );
 		if ( empty( $site_tag ) ) {
 			return;
-		} else if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		} elseif ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			return 'wordpressdotcom';
 		} else {
 			return $site_tag;

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -201,9 +201,9 @@ class Jetpack_Twitter_Cards {
 			return;
 		} else if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			return 'wordpressdotcom';
+		} else {
+			return $site_tag;
 		}
-
-		return $site_tag;
 	}
 
 	static function settings_field() {

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -203,9 +203,8 @@ class Jetpack_Twitter_Cards {
 			} else {
 				return;
 			}
-		} else {
-			return $site_tag;
 		}
+		return $site_tag;
 	}
 
 	static function settings_field() {

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -28,7 +28,9 @@ class Jetpack_Twitter_Cards {
 		$site_tag = self::site_tag();
 		$site_tag = apply_filters( 'jetpack_sharing_twitter_via', $site_tag, ( is_singular() ? $post->ID : null ) );
 		$site_tag = apply_filters( 'jetpack_twitter_cards_site_tag', $site_tag, $og_tags );
-		$og_tags['twitter:site'] = self::sanitize_twitter_user( $site_tag );
+		if ( ! empty( $site_tag ) ) {
+			$og_tags['twitter:site'] = self::sanitize_twitter_user( $site_tag );
+		}
 
 		if ( ! is_singular() || ! empty( $og_tags['twitter:card'] ) ) {
 			return $og_tags;
@@ -196,8 +198,11 @@ class Jetpack_Twitter_Cards {
 	static function site_tag() {
 		$site_tag = get_option( 'jetpack-twitter-cards-site-tag' );
 		if ( empty( $site_tag ) ) {
-			$site_tag = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'wordpressdotcom' : 'jetpack';
+			return;
+		} else if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return 'wordpressdotcom';
 		}
+
 		return $site_tag;
 	}
 

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -198,9 +198,11 @@ class Jetpack_Twitter_Cards {
 	static function site_tag() {
 		$site_tag = get_option( 'jetpack-twitter-cards-site-tag' );
 		if ( empty( $site_tag ) ) {
-			return;
-		} elseif ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			return 'wordpressdotcom';
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				return 'wordpressdotcom';
+			} else {
+				return;
+			}
 		} else {
 			return $site_tag;
 		}


### PR DESCRIPTION
Fixes #1908

That meta tag is added by default when you don't set a username under Settings > Sharing
It causes confusion.