### PR TITLE
Admin Page: adds a notice with some text and a link to the survey page after disconnection.

### DIFF
--- a/_inc/jp.js
+++ b/_inc/jp.js
@@ -65,7 +65,7 @@
 
 		// Hide the successful connection message after a little bit
 		setTimeout( function(){
-			jQuery( '.jetpack-message' ).hide( 600 );
+			jQuery( '.jetpack-message:not(.stay-visible)' ).hide( 600 );
 		}, 6000);
 
 		// Modal events

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2887,7 +2887,7 @@ p {
 				<div class="squeezer">
 					<h4>
 						<?php echo sprintf(
-							__( 'You have successfully terminated the connection between Jetpack and WordPress.com. Please help us make Jetpack better by <a href="%s">answering several questions</a>.', 'jetpack' ),
+							__( 'You have successfully disconnected Jetpack.<br><br>Would you tell us why? Just <a href="%s">answering two simple questions</a> would help us improve Jetpack.', 'jetpack' ),
 							'https://jetpack.me/survey-disconnected/'
 						); ?>
 					</h4>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2886,8 +2886,10 @@ p {
 			<div id="message" class="jetpack-message stay-visible">
 				<div class="squeezer">
 					<h4>
+						<?php _e( 'You have successfully disconnected Jetpack.', 'jetpack' ); ?>
+						<br />
 						<?php echo sprintf(
-							__( 'You have successfully disconnected Jetpack.<br />Would you tell us why? Just <a href="%s">answering two simple questions</a> would help us improve Jetpack.', 'jetpack' ),
+							__( 'Would you tell us why? Just <a href="%s">answering two simple questions</a> would help us improve Jetpack.', 'jetpack' ),
 							'https://jetpack.me/survey-disconnected/'
 						); ?>
 					</h4>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2993,7 +2993,7 @@ p {
 				check_admin_referer( 'jetpack-disconnect' );
 				Jetpack::log( 'disconnect' );
 				Jetpack::disconnect();
-				wp_safe_redirect( Jetpack::admin_url() );
+				wp_safe_redirect( Jetpack::admin_url( 'disconnected=true' ) );
 				exit;
 			case 'reconnect' :
 				if ( ! current_user_can( 'jetpack_reconnect' ) ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2366,6 +2366,11 @@ p {
 			add_action( 'load-index.php', array( $this, 'prepare_manage_jetpack_notice' ) );
 		}
 
+		// If the plugin has just been disconnected from WP.com, show the survey notice
+		if ( isset( $_GET['disconnected'] ) && 'true' === $_GET['disconnected'] ) {
+			add_action( 'admin_notices', array( $this, 'disconnect_survey_notice' ) );
+		}
+
 		add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
 
 		if ( current_user_can( 'manage_options' ) && 'ALWAYS' == JETPACK_CLIENT__HTTPS && ! self::permit_ssl() ) {
@@ -2870,6 +2875,26 @@ p {
 			),
 			__( 'click here', 'jetpack' )
 		);
+	}
+
+	/**
+	 * Show the survey link when the user has just disconnected Jetpack.
+	 */
+	function disconnect_survey_notice() {
+		?>
+		<div class="wrap">
+			<div id="message" class="jetpack-message stay-visible">
+				<div class="squeezer">
+					<h4>
+						<?php echo sprintf(
+							__( 'You have successfully terminated the connection between Jetpack and WordPress.com. Please help us make Jetpack better by <a href="%s">answering several questions</a>.', 'jetpack' ),
+							'https://jetpack.me/survey-disconnected/'
+						); ?>
+					</h4>
+				</div>
+			</div>
+		</div>
+		<?php
 	}
 
 	/*

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2368,7 +2368,7 @@ p {
 
 		// If the plugin has just been disconnected from WP.com, show the survey notice
 		if ( isset( $_GET['disconnected'] ) && 'true' === $_GET['disconnected'] ) {
-			add_action( 'admin_notices', array( $this, 'disconnect_survey_notice' ) );
+			add_action( 'jetpack_notices', array( $this, 'disconnect_survey_notice' ) );
 		}
 
 		add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
@@ -2887,7 +2887,7 @@ p {
 				<div class="squeezer">
 					<h4>
 						<?php echo sprintf(
-							__( 'You have successfully disconnected Jetpack.<br><br>Would you tell us why? Just <a href="%s">answering two simple questions</a> would help us improve Jetpack.', 'jetpack' ),
+							__( 'You have successfully disconnected Jetpack.<br />Would you tell us why? Just <a href="%s">answering two simple questions</a> would help us improve Jetpack.', 'jetpack' ),
 							'https://jetpack.me/survey-disconnected/'
 						); ?>
 					</h4>


### PR DESCRIPTION
This is a work in progress which in the end will allow us to ask users to fill out a survey to tell us about the reason why they have disconnected. You are welcome to review and test, some things to consider when you do:
* the notice placement is yet to be determined, if you have a better idea, please leave a comment;
* we may want to display the notice until the user decides to dismiss it rather than just on the redirection page after disconnection.
cc @richardmuscat 