### PR TITLE
New Feature: Filter Module Info Long Description

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -93,6 +93,15 @@ class Jetpack_Admin {
 				} else {
 					do_action( 'jetpack_module_more_info_' . $module );
 				}
+				
+				/**
+				* Get the long description.
+	 			*
+	 			* @since 3.5
+	 			*
+	 			* @param ob_get_clean() The long description
+	 			* @param $module The module name
+	 			*/
 				$module_array['long_description'] = apply_filters( 'jetpack_long_module_description', ob_get_clean(), $module );
 
 				$module_array['configurable'] = false;

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -99,8 +99,8 @@ class Jetpack_Admin {
 	 			*
 	 			* @since 3.5.0
 	 			*
-	 			* @param ob_get_clean() $string $required The long description.
-	 			* @param $module $string The module name.
+	 			* @param string ob_get_clean() The module long description.
+				* @param string $module The module name.
 	 			*/
 				$module_array['long_description'] = apply_filters( 'jetpack_long_module_description', ob_get_clean(), $module );
 

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -95,12 +95,12 @@ class Jetpack_Admin {
 				}
 				
 				/**
-				* Get the long description.
+				* Filter the long description of a module.
 	 			*
-	 			* @since 3.5
+	 			* @since 3.5.0
 	 			*
-	 			* @param ob_get_clean() The long description
-	 			* @param $module The module name
+	 			* @param ob_get_clean() $string $required The long description.
+	 			* @param $module $string The module name.
 	 			*/
 				$module_array['long_description'] = apply_filters( 'jetpack_long_module_description', ob_get_clean(), $module );
 


### PR DESCRIPTION
As per https://wordpress.org/support/topic/hook-after-module-infophp-is-loaded?replies=9#post-6772580...

Some of the modules stop other plugins from working, for example; photon doesn't work with fancybox. I'd like to update the long description to let my clients know about conflicts in each of the modules.

This would allow developers to add a filter such as:

function custom_jetpack_more_info($module_description, $module_name) {
if($module_name == 'photon') $module_description .= "Photon doesn't play nice with Fancybox";
return $module_description;
}
add_filter( 'jetpack_long_module_description', 'custom_jetpack_more_info', 10, 2 );