### PR TITLE
JSON endpoints for plugins

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-list-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-list-endpoint.php
@@ -6,6 +6,7 @@ class Jetpack_JSON_API_Plugins_List_Endpoint extends Jetpack_JSON_API_Plugins_En
 	protected $needed_capabilities = 'activate_plugins';
 
 	public function validate_input( $plugin ) {
+		wp_update_plugins();
 		$this->plugins = array_keys( get_plugins() );
 		return true;
 	}

--- a/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
@@ -6,8 +6,8 @@ class Jetpack_JSON_API_Updates_Status extends Jetpack_JSON_API_Endpoint {
 
 	protected function result() {
 
-		// pass an option to do it conditional;
 		wp_update_themes();
+		wp_update_plugins();
 
 		$update_data = wp_get_update_data();
 		if ( !  isset( $update_data['counts'] ) ) {


### PR DESCRIPTION
calling `wp_update_plugins()` will give us more percise data on the
 `/sites/%s/plugins` endpoint and on the `/sites/%s/updates` endpoint