### PR TITLE
Related Posts: Fix issue with links in IE <= 9

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1,6 +1,6 @@
 <?php
 class Jetpack_RelatedPosts {
-	const VERSION = '20141201';
+	const VERSION = '20150408';
 	const SHORTCODE = 'jetpack-related-posts';
 
 	/**

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -26,10 +26,15 @@
 				args += '&relatedposts_exclude=' + $( '#jp-relatedposts' ).data( 'exclude' );
 			}
 
+			var pathname = locationObject.pathname;
+			if ( '/' !== pathname[0] ) {
+				pathname = '/' + pathname;
+			}
+
 			if ( '' === locationObject.search ) {
-				return locationObject.pathname + '?' + args;
+				return pathname + '?' + args;
 			} else {
-				return locationObject.pathname + locationObject.search + '&' + args;
+				return pathname + locationObject.search + '&' + args;
 			}
 		},
 
@@ -131,10 +136,15 @@
 			args += '&relatedposts_origin=' + $( anchor ).data( 'origin' );
 			args += '&relatedposts_position=' + $( anchor ).data( 'position' );
 
+			var pathname = anchor.pathname;
+			if ( '/' !== pathname[0] ) {
+				pathname = '/' + pathname;
+			}
+
 			if ( '' === anchor.search ) {
-				return anchor.pathname + '?' + args;
+				return pathname + '?' + args;
 			} else {
-				return anchor.pathname + anchor.search + '&' + args;
+				return pathname + anchor.search + '&' + args;
 			}
 		},
 


### PR DESCRIPTION
In old IE `pathname` of anchors are returned without the initial / causing
relative mayhem. This patch prepends a slash if the first character of the
`pathname` returned is not a slash to fix this issue. Props hokkaidosm.

https://wordpress.org/support/topic/related-post-article-link-is-broken