### PR TITLE
Only print the dashboard head JS on the dashboard

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -68,7 +68,7 @@ function stats_load() {
 		add_action( 'wp_dashboard_setup', 'stats_register_dashboard_widget' );
 	} elseif ( current_user_can( 'view_stats' ) ) {
 		// New way.
-		add_action( 'admin_head', 'stats_dashboard_head' );
+		add_action( 'load-index.php', 'stats_enqueue_dashboard_head' );
 		add_action( 'wp_dashboard_setup', 'stats_register_widget_control_callback' ); // hacky but works
 		add_action( 'jetpack_dashboard_widget', 'stats_jetpack_dashboard_widget' );
 	}
@@ -77,6 +77,10 @@ function stats_load() {
 
 
 	add_filter( 'pre_option_db_version', 'stats_ignore_db_version' );
+}
+
+function stats_enqueue_dashboard_head() {
+	add_action( 'admin_head', 'stats_dashboard_head' );
 }
 
 /**


### PR DESCRIPTION
Fixes a JS error introduced in ab2ae39c0ece0e

---

This bug is causing JavaScript errors all over the dashboard, because it’s loading code that depends on Underscore but Underscore [is only enqueued](https://github.com/Automattic/jetpack/blob/fd19ca74a9894d04fe87f143ed4863afda3cb98a/modules/stats.php#L275) (by Jetpack) on the site stats screen.

![screen shot 2015-04-09 at 2 43 36 am](https://cloud.githubusercontent.com/assets/353790/7061600/52af6ada-de62-11e4-8baf-ee6627fb608b.png)

![screen shot 2015-04-09 at 2 44 49 am](https://cloud.githubusercontent.com/assets/353790/7061619/7032007c-de62-11e4-9ded-ff3170b84a93.png)