### PR TITLE
Infinite Scroll: Disable IS in customizer previews

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1073,6 +1073,10 @@ class The_Neverending_Home_Page {
 	 */
 	public static function archive_supports_infinity() {
 		$supported = current_theme_supports( 'infinite-scroll' ) && ( is_home() || is_archive() || is_search() );
+		// Disable infinite scroll in customizer previews
+		if ( 'on' === $_REQUEST[ 'wp_customize' ] ) {
+			return false;
+		}
 
 		return (bool) apply_filters( 'infinite_scroll_archive_supported', $supported, self::get_settings() );
 	}


### PR DESCRIPTION
When previewing a theme other than the current theme, the infinite scroll
results include structure and styles for the current theme, causing the page to
become an amalgam of the two. Eventually it would be good for the Infinite
Scroll requests to include the previewed theme, but for now disabling IS in
Customizer previews is a better experience.