### PR TITLE
Prevent generating Facebook profile links for app-scoped user IDs

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -723,7 +723,11 @@ class Publicize extends Publicize_Base {
 		if ( 'facebook' == $service_name && isset( $connection_meta['connection_data']['meta']['facebook_profile'] ) && $submit_post ) {
 			$publicize_facebook_user = get_post_meta( $post_id, '_publicize_facebook_user' );
 			if ( empty( $publicize_facebook_user ) || 0 != $connection_meta['connection_data']['user_id'] ) {
-				update_post_meta( $post_id, '_publicize_facebook_user', $this->get_profile_link( 'facebook', $connection ) );
+				$profile_link = $this->get_profile_link( 'facebook', $connection );
+
+				if ( false !== $profile_link ) {
+					update_post_meta( $post_id, '_publicize_facebook_user', $profile_link );
+				}
 			}
 		}
 	}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -97,11 +97,14 @@ abstract class Publicize_Base {
 		$cmeta = $this->get_connection_meta( $c );
 
 		if ( isset( $cmeta['connection_data']['meta']['link'] ) ) {
+			if ( 'facebook' == $service_name && 0 === strpos( parse_url( $cmeta['connection_data']['meta']['link'], PHP_URL_PATH ), '/app_scoped_user_id/' ) ) {
+				// App-scoped Facebook user IDs are not usable profile links
+				return false;
+			}
+
 			return $cmeta['connection_data']['meta']['link'];
 		} elseif ( 'facebook' == $service_name && isset( $cmeta['connection_data']['meta']['facebook_page'] ) ) {
 			return 'https://www.facebook.com/' . $cmeta['connection_data']['meta']['facebook_page'];
-		} elseif ( 'facebook' == $service_name ) {
-			return 'https://www.facebook.com/' . $cmeta['external_id'];
 		} elseif ( 'tumblr' == $service_name && isset( $cmeta['connection_data']['meta']['tumblr_base_hostname'] ) ) {
 			 return 'http://' . $cmeta['connection_data']['meta']['tumblr_base_hostname'];
 		} elseif ( 'twitter' == $service_name ) {

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -173,11 +173,9 @@ class Publicize_UI {
 										<?php endif; ?>
 
 										<li class="publicize-connection" data-connection-id="<?php echo esc_attr( $id ); ?>">
+											<?php esc_html_e( 'Connected as:', 'jetpack' ); ?>
 											<?php
 											if ( !empty( $profile_link ) ) : ?>
-
-											</style>
-												<?php esc_html_e( 'Connected as:', 'jetpack' ); ?>
 												<a class="publicize-profile-link" href="<?php echo esc_url( $profile_link ); ?>" target="_top">
 													<?php echo esc_html( $connection_display ); ?>
 												</a><?php

--- a/modules/theme-tools/social-links.php
+++ b/modules/theme-tools/social-links.php
@@ -121,6 +121,12 @@ class Social_Links {
 		) );
 
 		foreach ( $this->services as $service ) {
+			$choices = $this->get_customize_select( $service );
+
+			if ( empty( $choices ) ) {
+				continue;
+			}
+
 			$wp_customize->add_setting( "jetpack_options[social_links][$service]", array(
 				'type'    => 'option',
 				'default' => '',
@@ -131,7 +137,7 @@ class Social_Links {
 				'section'  => 'jetpack_social_links',
 				'settings' => "jetpack_options[social_links][$service]",
 				'type'     => 'select',
-				'choices'  => $this->get_customize_select( $service ),
+				'choices'  => $choices,
 			) );
 		}
 	}
@@ -196,9 +202,21 @@ class Social_Links {
 		);
 
 		$connected_services = $this->publicize->get_services( 'connected' );
-		if ( isset( $connected_services[ $service ] ) )
-			foreach ( $connected_services[ $service ] as $c )
-				$choices[ $this->publicize->get_profile_link( $service, $c ) ] = $this->publicize->get_display_name( $service, $c );
+		if ( isset( $connected_services[ $service ] ) ) {
+			foreach ( $connected_services[ $service ] as $c ) {
+				$profile_link = $this->publicize->get_profile_link( $service, $c );
+
+				if ( false === $profile_link ) {
+					continue;
+				}
+
+				$choices[ $profile_link ] = $this->publicize->get_display_name( $service, $c );
+			}
+		}
+
+		if ( 1 === count( $choices ) ) {
+			return array();
+		}
 
 		return $choices;
 	}


### PR DESCRIPTION
WordPress.com now uses the latest Facebook API when establishing a Publicize connection. As of Facebook API v2, new Facebook authorizations no longer provide a username or user ID that can be used to generate a profile URL ([reference](https://developers.facebook.com/docs/apps/upgrading#upgrading_v2_0_user_ids)). Existing authorizations will continue to provide a user ID from which a profile URL can be generated. To account for these newer unusable "app-scoped" user IDs, we should detect whether a Facebook connection meta contains a link, and if so, only use the link if it is not intended for an app-scoped user profile (which is prefixed with "/app_scoped_user_id/").

Because the existing Publicize UI and Social Links theme tool were designed with the expectation that connections would always provide a usable profile link, these have been adjusted to account for the possibility that a `false` value is returned by `Publicize_Base::get_profile_link`.

By only assigning the `_publicize_facebook_user` post meta for non-app-scoped user IDs, we can prevent the possibility that a app-scoped user profile link is set as the `article:author` Open Graph meta attribute. This has been the cause of some Publicize failures, as Facebook encounters a parse error when following the profile link.