### PR TITLE
Use WPCOM API for retrieving Facebook sharing button count

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -504,11 +504,14 @@ function sharing_add_footer() {
 		if ( apply_filters( 'jetpack_sharing_counts', true ) && is_array( $jetpack_sharing_counts ) && count( $jetpack_sharing_counts ) ) :
 			$sharing_post_urls = array_filter( $jetpack_sharing_counts );
 			if ( $sharing_post_urls ) :
+				$site_id = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
 ?>
 
 	<script type="text/javascript">
 		window.WPCOM_sharing_counts = <?php echo json_encode( array_flip( $sharing_post_urls ) ); ?>;
-		window.WPCOM_site_ID = <?php echo defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : Jetpack_Options::get_option( 'id', 0 ); ?>;
+		<?php if ( is_int( $site_id ) ): ?>
+		window.WPCOM_site_ID = <?php echo $site_id ?>;
+		<?php endif; ?>
 	</script>
 <?php
 			endif;

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -504,11 +504,13 @@ function sharing_add_footer() {
 		if ( apply_filters( 'jetpack_sharing_counts', true ) && is_array( $jetpack_sharing_counts ) && count( $jetpack_sharing_counts ) ) :
 			$sharing_post_urls = array_filter( $jetpack_sharing_counts );
 			if ( $sharing_post_urls ) :
-				$site_id = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+				$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
+				$site_id = $is_jetpack ? Jetpack_Options::get_option( 'id' ) : get_current_blog_id();
 ?>
 
 	<script type="text/javascript">
 		window.WPCOM_sharing_counts = <?php echo json_encode( array_flip( $sharing_post_urls ) ); ?>;
+		window.WPCOM_jetpack = <?php echo var_export( $is_jetpack, true ); ?>;
 		<?php if ( is_int( $site_id ) ): ?>
 		window.WPCOM_site_ID = <?php echo $site_id ?>;
 		<?php endif; ?>

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -75,6 +75,8 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 
 		// get the version of the url that was stored in the dom (sharing-$service-URL)
 		get_permalink: function( url ) {
+			var rxTrailingSlash, formattedSlashUrl;
+
 			if ( 'https:' === window.location.protocol ) {
 				url = url.replace( /^http:\/\//i, 'https://' );
 			} else {
@@ -85,8 +87,9 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 			// slash. We can account for this by checking whether either format
 			// exists as a known URL
 			if ( ! ( url in WPCOM_sharing_counts ) ) {
-				var rxTrailingSlash = /\/$/,
-					formattedSlashUrl = rxTrailingSlash.test( url ) ? url.replace( rxTrailingSlash, '' ) : url + '/';
+				rxTrailingSlash = /\/$/,
+				formattedSlashUrl = rxTrailingSlash.test( url ) ?
+					url.replace( rxTrailingSlash, '' ) : url + '/';
 
 				if ( formattedSlashUrl in WPCOM_sharing_counts ) {
 					url = formattedSlashUrl;
@@ -96,12 +99,14 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 			return url;
 		},
 		update_facebook_count : function( data ) {
+			var index, length, post;
+
 			if ( ! data || ! data.counts ) {
 				return;
 			}
 
-			for ( var d = 0, dl = data.counts.length; d < dl; d++ ) {
-				var post = data.counts[ d ];
+			for ( index = 0, length = data.counts.length; index < length; index++ ) {
+				post = data.counts[ index ];
 
 				if ( ! post.URL || ! post.count ) {
 					continue;

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -6,13 +6,14 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 		twitter_count : {},
 		get_counts : function() {
 			var facebookPostIds = [],
-				https_url, http_url, urls, id, service, service_url;
+				query = [],
+				https_url, http_url, url, urls, id, service, service_url, post_index, posts_length;
 
 			if ( 'undefined' === typeof WPCOM_sharing_counts ) {
 				return;
 			}
 
-			for ( var url in WPCOM_sharing_counts ) {
+			for ( url in WPCOM_sharing_counts ) {
 				id = WPCOM_sharing_counts[ url ];
 
 				if ( 'undefined' !== typeof WPCOMSharing.done_urls[ id ] ) {
@@ -62,11 +63,11 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 			}
 
 			if ( facebookPostIds.length ) {
-				var query = '';
-				for ( var p = 0, pl = facebookPostIds.length; p < pl; p++ ) {
-					query += 'post_ID[]=' + facebookPostIds[ p ] + '&';
+				posts_length = facebookPostIds.length;
+				for ( post_index = 0 ; post_index < posts_length; post_index++ ) {
+					query.push( 'post_ID[]=' + facebookPostIds[ post_index ] );
 				}
-				query = query.substring( 0, query.length - 1 );
+				query = query.join( '&' );
 
 				jQuery.getScript( 'https://public-api.wordpress.com/rest/v1.1/sites/' + WPCOM_site_ID + '/sharing-buttons/facebook/count/?' + query + '&callback=WPCOMSharing.update_facebook_count' );
 			}

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -69,7 +69,13 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				}
 				query = query.join( '&' );
 
-				jQuery.getScript( 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/count/?' + query + '&callback=WPCOMSharing.update_facebook_count' );
+				jQuery.ajax( {
+					url: 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/count/?' + query,
+					beforeSend: function( xhr ) {
+						xhr.setRequestHeader( 'X-Jetpack', '1' );
+					},
+					success: WPCOMSharing.update_facebook_count
+				} );
 			}
 		},
 

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -114,11 +114,11 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 			for ( index = 0, length = data.counts.length; index < length; index++ ) {
 				post = data.counts[ index ];
 
-				if ( ! post.URL || ! post.count ) {
+				if ( ! post.post_ID || ! post.count ) {
 					continue;
 				}
 
-				WPCOMSharing.inject_share_count( 'sharing-facebook-' + WPCOM_sharing_counts[ WPCOMSharing.get_permalink( post.URL ) ], post.count );
+				WPCOMSharing.inject_share_count( 'sharing-facebook-' + post.post_ID, post.count );
 			}
 		},
 		update_twitter_count : function( data ) {

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -72,7 +72,9 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				jQuery.ajax( {
 					url: 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/count/?' + query,
 					beforeSend: function( xhr ) {
-						xhr.setRequestHeader( 'X-Jetpack', '1' );
+						if ( window.WPCOM_jetpack ) {
+							xhr.setRequestHeader( 'X-Jetpack', '1' );							
+						}
 					},
 					success: WPCOMSharing.update_facebook_count
 				} );

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -62,14 +62,14 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				WPCOMSharing.done_urls[ id ] = true;
 			}
 
-			if ( facebookPostIds.length ) {
+			if ( facebookPostIds.length && ( 'WPCOM_site_ID' in window ) ) {
 				posts_length = facebookPostIds.length;
 				for ( post_index = 0 ; post_index < posts_length; post_index++ ) {
 					query.push( 'post_ID[]=' + facebookPostIds[ post_index ] );
 				}
 				query = query.join( '&' );
 
-				jQuery.getScript( 'https://public-api.wordpress.com/rest/v1.1/sites/' + WPCOM_site_ID + '/sharing-buttons/facebook/count/?' + query + '&callback=WPCOMSharing.update_facebook_count' );
+				jQuery.getScript( 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/count/?' + query + '&callback=WPCOMSharing.update_facebook_count' );
 			}
 		},
 

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -7,7 +7,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 		get_counts : function() {
 			var facebookPostIds = [],
 				query = [],
-				https_url, http_url, url, urls, id, service, service_url, post_index, posts_length;
+				https_url, http_url, url, urls, id, service, service_url, post_index, posts_length, path_ending;
 
 			if ( 'undefined' === typeof WPCOM_sharing_counts ) {
 				return;
@@ -69,15 +69,8 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				}
 				query = query.join( '&' );
 
-				jQuery.ajax( {
-					url: 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/count/?' + query,
-					beforeSend: function( xhr ) {
-						if ( window.WPCOM_jetpack ) {
-							xhr.setRequestHeader( 'X-Jetpack', '1' );							
-						}
-					},
-					success: WPCOMSharing.update_facebook_count
-				} );
+				path_ending = window.WPCOM_jetpack ? 'jetpack-count' : 'count';
+				jQuery.getScript( 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/' + path_ending + '/?' + query + '&callback=WPCOMSharing.update_facebook_count' );
 			}
 		},
 


### PR DESCRIPTION
Facebook is planning to sunset v1 of their API at the end of this month (April 2015). Since v2 requires all requests to be authenticated, it is no longer possible to call directly to Facebook to request the share count to be displayed upon Jetpack custom sharing button styles. This pull request seeks to call to a new WordPress.com REST API endpoint which effectively acts as a proxy layer, making an authenticated request to Facebook on behalf of the anonymous browser user.

For more information about the internal behavior of this endpoint, see r115558-wpcom and links referenced therein.

While the changes here appear to be substantial, there are three primary effects:

1) `get_counts` is no longer called with a single URL and is instead responsible for iterating over `WPCOM_sharing_counts`. We do this to enable a single request to be made to the WordPress.com sharing count endpoint for all desired post IDs.
2) The Facebook count retrieval no longer calls to the Facebook API and instead sends a single request with the current site ID and array of posts for which the sharing count is desired
3) The Facebook 04/30/2015 count deactivation has been removed

/cc @zinigor (since you've made recent changes to these files)