### PR TITLE
Protect Module: IP address conversion

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -311,7 +311,7 @@ class Jetpack_Protect_Module {
 	function ip_address_is_in_range( $ip, $range_low, $range_high ) {
 		// inet_pton will give us binary string of an ipv4 or ipv6
 		// we can then use strcmp to see if the address is in range
-		if ( function_exists('inet_pton' ) ) {
+		if ( function_exists( 'inet_pton' ) ) {
 			$ip_num  = inet_pton( $ip );
 			$ip_low  = inet_pton( $range_low );
 			$ip_high = inet_pton( $range_high );

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -271,12 +271,11 @@ class Jetpack_Protect_Module {
 	 */
 	function ip_is_whitelisted( $ip ) {
 		// If we found an exact match in wp-config
-				if ( defined( 'JETPACK_IP_ADDRESS_OK' ) && JETPACK_IP_ADDRESS_OK == $ip ) {
+		if ( defined( 'JETPACK_IP_ADDRESS_OK' ) && JETPACK_IP_ADDRESS_OK == $ip ) {
 			return true;
 		}
 
 		$whitelist  = get_site_option( 'jetpack_protect_whitelist', array() );
-		$ip_long    = inet_pton( $ip );
 
 		if ( ! empty( $whitelist ) ) :
 			foreach ( $whitelist as $item ) :
@@ -286,10 +285,7 @@ class Jetpack_Protect_Module {
 				}
 
 				if ( $item->range && isset( $item->range_low ) && isset( $item->range_high ) ) {
-					$ip_low  = inet_pton( $item->range_low );
-					$ip_high = inet_pton( $item->range_high );
-					// If the IP is within range
-					if ( strcmp( $ip_long, $ip_low ) >= 0 && strcmp( $ip_long, $ip_high ) <= 0 ) {
+					if ( $this->ip_address_is_in_range( $ip, $item->range_low, $item->range_high ) ) {
 						return true;
 					}
 				}
@@ -297,6 +293,41 @@ class Jetpack_Protect_Module {
 		endif;
 
 		return false;
+	}
+
+	/**
+	 * Checks that a given IP address is within a given low - high range.
+	 * Servers that support inet_pton will use that function to convert the ip to number,
+	 * while other servers will use ip2long.
+	 *
+	 * NOTE: servers that do not support inet_pton cannot support ipv6.
+	 *
+	 * @param $ip
+	 * @param $range_low
+	 * @param $range_high
+	 *
+	 * @return bool
+	 */
+	function ip_address_is_in_range( $ip, $range_low, $range_high ) {
+
+		if ( function_exists('inet_pton' ) ) {
+			$ip_num  = inet_pton( $ip );
+			$ip_low  = inet_pton( $range_low );
+			$ip_high = inet_pton( $range_high );
+			if ( $ip_num && $ip_low && $ip_high && strcmp( $ip_num, $ip_low ) >= 0 && strcmp( $ip_num, $ip_high ) <= 0 ) {
+				return true;
+			}
+		} else {
+			$ip_num  = ip2long( $ip );
+			$ip_low  = ip2long( $range_low );
+			$ip_high = ip2long( $range_high );
+			if ( $ip_num && $ip_low && $ip_high && $ip_num >= $ip_low && $ip_num <= $ip_high ) {
+				return true;
+			}
+		}
+
+		return false;
+
 	}
 
 	/**

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -309,7 +309,8 @@ class Jetpack_Protect_Module {
 	 * @return bool
 	 */
 	function ip_address_is_in_range( $ip, $range_low, $range_high ) {
-
+		// inet_pton will give us binary string of an ipv4 or ipv6
+		// we can then use strcmp to see if the address is in range
 		if ( function_exists('inet_pton' ) ) {
 			$ip_num  = inet_pton( $ip );
 			$ip_low  = inet_pton( $range_low );
@@ -317,6 +318,7 @@ class Jetpack_Protect_Module {
 			if ( $ip_num && $ip_low && $ip_high && strcmp( $ip_num, $ip_low ) >= 0 && strcmp( $ip_num, $ip_high ) <= 0 ) {
 				return true;
 			}
+		// ip2long will give us an integer of an ipv4 address only. it will produce FALSE for ipv6
 		} else {
 			$ip_num  = ip2long( $ip );
 			$ip_low  = ip2long( $range_low );

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -59,7 +59,7 @@ function jetpack_protect_save_whitelist( $whitelist ) {
 				break;
 			}
 
-			if ( ! inet_pton( $low ) || ! inet_pton( $high ) ) {
+			if ( ! jetpack_convert_ip_address( $low ) || ! jetpack_convert_ip_address( $high ) ) {
 				$whitelist_error = true;
 				break;
 			}
@@ -74,7 +74,7 @@ function jetpack_protect_save_whitelist( $whitelist ) {
 				break;
 			}
 
-			if ( ! inet_pton( $item ) ) {
+			if ( ! jetpack_convert_ip_address( $item ) ) {
 				$whitelist_error = true;
 				break;
 			}
@@ -161,4 +161,23 @@ function jetpack_protect_ip_is_private( $ip ) {
 		}
 	}
 	return false;
+}
+
+/**
+ * Uses inet_pton if available to convert an IP address to a binary string.
+ * If inet_pton is not available, ip2long will convert the address to an integer.
+ * Returns false if an invalid IP address is given.
+ *
+ * NOTE: ip2long will return false for any ipv6 address. servers that do not support
+ * inet_pton will not support ipv6
+ *
+ * @param $ip
+ *
+ * @return int|string|bool
+ */
+function jetpack_convert_ip_address( $ip ) {
+	if ( function_exists( 'inet_pton' ) ) {
+		return inet_pton( $ip );
+	}
+	return ip2long( $ip );
 }


### PR DESCRIPTION
Only use `inet_pton` for conversions if the function exists.
Otherwise, use `ip2long`.

This addresses issue #1824

It should address the fatal errors on sites that do not support `inet_pton`. Those sites may still have issues if they are using ipv6 addresses.