### PR TITLE
Strict Standards: Don't call non-static method statically

### DIFF
--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -21,7 +21,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 		);
 		$control_ops 	= array( 'width' => 250 );
 
-		add_action( 'admin_enqueue_scripts', array( 'Jetpack_Gallery_Widget', 'enqueue_admin_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 
 		$this->WP_Widget( 'gallery', apply_filters( 'jetpack_widget_name', __( 'Gallery', 'jetpack' ) ), $widget_ops, $control_ops );
 	}


### PR DESCRIPTION
FIx: #1960

New non-static method introduced in eb848a7 was being called statically which was throwing errors.  