### PR TITLE
The Search for Modules: New filter to add module search terms

### DIFF
--- a/_inc/jetpack-modules.models.js
+++ b/_inc/jetpack-modules.models.js
@@ -36,7 +36,7 @@ window.jetpackModules.models = (function( window, $, _, Backbone ) {
 
 				if ( m_search.length ) {
 					items = _.filter( items, function( item ) {
-						var search_text = item.name + ' ' + item.description;
+						var search_text = item.name + ' ' + item.description + ' ' + item.long_description + ' ' + item.search_terms + ' ' + item.jumpstart_desc + ' ' + item.module_tags;
 						return ( -1 !== search_text.toLowerCase().indexOf( m_search ) );
 					} );
 				}

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -96,7 +96,7 @@ class Jetpack_Admin {
 				$module_array['long_description']  = ob_get_clean();
 
 				ob_start();
-				do_action( 'jetpack_search_terms_' . $module );
+				echo apply_filters( 'jetpack_search_terms_' . $module, '' );
 				$module_array['search_terms'] = ob_get_clean();
 
 				$module_array['configurable'] = false;

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -95,6 +95,10 @@ class Jetpack_Admin {
 				}
 				$module_array['long_description']  = ob_get_clean();
 
+				ob_start();
+				do_action( 'jetpack_search_terms_' . $module );
+				$module_array['search_terms'] = ob_get_clean();
+
 				$module_array['configurable'] = false;
 				if ( current_user_can( 'manage_options' ) && apply_filters( 'jetpack_module_configurable_' . $module, false ) ) {
 					$module_array['configurable'] = sprintf( '<a href="%1$s">%2$s</a>', esc_url( Jetpack::module_configuration_url( $module ) ), __( 'Configure', 'jetpack' ) );

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -5,6 +5,8 @@
  * jetpack_module_more_info_<module-slug> hooks are for pre-connection information
  * jetpack_module_more_info_connected_<module-slug> hooks are used once the user
  * 		is connected to show them links to admin panels, usage info etc.
+ * jetpack_search_terms_<module-slug> hooks are searchable from the settings page.
+ *      Separate your search terms by comma.
  */
 
 // VaultPress (stub)
@@ -209,6 +211,11 @@ function stats_load_more_link( $description ) {
 	echo '<a class="button-secondary more-info-link" href="http://en.support.wordpress.com/stats/">' . esc_html__( 'Learn More', 'jetpack' ) . '</a>';
 }
 add_filter( 'jetpack_learn_more_button_stats', 'stats_load_more_link' );
+
+function jetpack_protect_search_terms() {
+	echo __( 'statistics, tracking, analytics, views, traffic', 'jetpack' );
+}
+add_action( 'jetpack_search_terms_stats', 'jetpack_stats_search_terms' );
 
 // Publicize
 function publicize_more_info() { ?>

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -212,8 +212,8 @@ function stats_load_more_link( $description ) {
 }
 add_filter( 'jetpack_learn_more_button_stats', 'stats_load_more_link' );
 
-function jetpack_protect_search_terms() {
-	echo __( 'statistics, tracking, analytics, views, traffic', 'jetpack' );
+function jetpack_stats_search_terms() {
+	echo _x( 'statistics, tracking, analytics, views, traffic', 'search terms', 'jetpack' );
 }
 add_action( 'jetpack_search_terms_stats', 'jetpack_stats_search_terms' );
 
@@ -476,7 +476,7 @@ function jetpack_protect_more_link() {
 add_action( 'jetpack_learn_more_button_protect', 'jetpack_protect_more_link' );
 
 function jetpack_protect_search_terms() {
-	echo __( 'security, secure, protection, botnet, brute force', 'jetpack' );
+	echo _x( 'security, secure, protection, botnet, brute force', 'search terms', 'jetpack' );
 }
 add_action( 'jetpack_search_terms_protect', 'jetpack_protect_search_terms' );
 

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -5,8 +5,8 @@
  * jetpack_module_more_info_<module-slug> hooks are for pre-connection information
  * jetpack_module_more_info_connected_<module-slug> hooks are used once the user
  * 		is connected to show them links to admin panels, usage info etc.
- * jetpack_search_terms_<module-slug> hooks are searchable from the settings page.
- *      Separate your search terms by comma.
+ * jetpack_search_terms_<module-slug> filters are searchable from the settings page.
+ *      Separate your search terms by comma, and please send translation context with _x()
  */
 
 // VaultPress (stub)
@@ -212,10 +212,11 @@ function stats_load_more_link( $description ) {
 }
 add_filter( 'jetpack_learn_more_button_stats', 'stats_load_more_link' );
 
-function jetpack_stats_search_terms() {
-	echo _x( 'statistics, tracking, analytics, views, traffic', 'search terms', 'jetpack' );
+function jetpack_stats_search_terms( $terms ) {
+	$terms = _x( 'statistics, tracking, analytics, views, traffic', 'search terms', 'jetpack' );
+	return $terms;
 }
-add_action( 'jetpack_search_terms_stats', 'jetpack_stats_search_terms' );
+add_filter( 'jetpack_search_terms_stats', 'jetpack_stats_search_terms' );
 
 // Publicize
 function publicize_more_info() { ?>
@@ -475,10 +476,11 @@ function jetpack_protect_more_link() {
 }
 add_action( 'jetpack_learn_more_button_protect', 'jetpack_protect_more_link' );
 
-function jetpack_protect_search_terms() {
-	echo _x( 'security, secure, protection, botnet, brute force', 'search terms', 'jetpack' );
+function jetpack_protect_search_terms( $terms ) {
+	$terms = _x( 'security, secure, protection, botnet, brute force', 'search terms', 'jetpack' );
+	return $terms;
 }
-add_action( 'jetpack_search_terms_protect', 'jetpack_protect_search_terms' );
+add_filter( 'jetpack_search_terms_protect', 'jetpack_protect_search_terms' );
 
 // JSON API
 function jetpack_json_api_more_info() { ?>

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -468,6 +468,11 @@ function jetpack_protect_more_link() {
 }
 add_action( 'jetpack_learn_more_button_protect', 'jetpack_protect_more_link' );
 
+function jetpack_protect_search_terms() {
+	echo __( 'security, secure, protection, botnet, brute force', 'jetpack' );
+}
+add_action( 'jetpack_search_terms_protect', 'jetpack_protect_search_terms' );
+
 // JSON API
 function jetpack_json_api_more_info() { ?>
 	<p><?php esc_html_e( 'Jetpack will allow you to authorize applications and services to securely connect to your blog and allow them to use your content in new ways and offer you new functionality.', 'jetpack' ); ?>


### PR DESCRIPTION
Fixes: #1837 & #614

Adds a new filter for adding search terms to modules and increases current search range.  

Example usage: adding search terms for Stats, done in `module-info.php` like so: 
```
function jetpack_stats_search_terms( $terms ) {
	$terms = _x( 'statistics, tracking, analytics, views, traffic', 'search terms', 'jetpack' );
	return $terms;
}
add_filter( 'jetpack_search_terms_stats', 'jetpack_stats_search_terms' );
```

Search terms should be comma-separated and for best results, please translate with context using `_x()` to make it easier for our fellow GlotPressers down the road.  
