### PR TITLE
Move `ob_start` outside of shortcode query tests

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -529,6 +529,8 @@ class Jetpack_Portfolio {
 		$query = self::portfolio_query( $atts );
 		$portfolio_index_number = 0;
 
+		ob_start();
+
 		// If we have posts, create the html
 		// with hportfolio markup
 		if ( $query->have_posts() ) {
@@ -536,7 +538,7 @@ class Jetpack_Portfolio {
 			// Render styles
 			//self::themecolor_styles();
 
-			ob_start(); ?>
+		?>
 			<div class="jetpack-portfolio-shortcode column-<?php echo esc_attr( $atts['columns'] ); ?>">
 			<?php  // open .jetpack-portfolio
 

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -497,10 +497,12 @@ class Jetpack_Testimonial {
 
 		$testimonial_index_number = 0;
 
+		ob_start();
+
 		// If we have testimonials, create the html
 		if ( $query->have_posts() ) {
 
-			ob_start(); ?>
+		?>
 			<div class="jetpack-testimonial-shortcode column-<?php echo esc_attr( $atts['columns'] ); ?>">
 				<?php  // open .jetpack-testimonial-shortcode
 


### PR DESCRIPTION
Fixes #1871 for portfolio and testimonial shortcodes.