### PR TITLE
Sanitize IP address in Protect Error

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -391,7 +391,7 @@ class Jetpack_Protect_Module {
 		$help_url = 'http://jetpack.me/support/security/';
 
 		wp_die(
-			sprintf( __( 'Your IP (%1$s) has been flagged for potential security violations.  <a href="%2$s">Find out more...</a>', 'jetpack' ), $ip, esc_url($help_url) ),
+			sprintf( __( 'Your IP (%1$s) has been flagged for potential security violations.  <a href="%2$s">Find out more...</a>', 'jetpack' ), str_replace( 'http://', '', esc_url( 'http://' . $ip ) ), esc_url( $help_url ) ),
 			__( 'Login Blocked by Jetpack', 'jetpack' ),
 			array( 'response' => 403 )
 		);


### PR DESCRIPTION
Fixes #1934

Note that, in order to use esc_url, we have to add http:// (so that it has a valid protocol), then we can remove it once we get the validated string back.