### PR TITLE
Theme Tools: Include existing breadcrumb code.

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -13,6 +13,7 @@ $tools = array(
 	'theme-tools/infinite-scroll.php',
 	'theme-tools/responsive-videos.php',
 	'theme-tools/site-logo.php',
+	'theme-tools/site-breadcrumbs.php',
 	'custom-post-types/comics.php',
 	'custom-post-types/testimonial.php',
 	'custom-post-types/nova.php',


### PR DESCRIPTION
The code for the site breadcrumbs theme tool has been included for Jetpack for a bit of time now, but wasn't actually being loaded.

Fixes a problem for a handful of Automattic themes expecting JP to have this code. :)