### PR TITLE
Fix: Don't redirect twice on activation or update 

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -36,7 +36,7 @@ class Jetpack_Admin {
 		add_action( 'jetpack_admin_menu',            array( $this->settings_page, 'add_actions' ) );
 
 		// Add redirect to current page for activation/deactivation of modules
-		add_action( 'jetpack_pre_activate_module',   array( $this, 'fix_redirect' ) );
+		add_action( 'jetpack_pre_activate_module',   array( $this, 'fix_redirect' ), 10, 2 );
 		add_action( 'jetpack_pre_deactivate_module', array( $this, 'fix_redirect' ) );
 
 		// Add module bulk actions handler
@@ -197,7 +197,10 @@ class Jetpack_Admin {
 		}
 	}
 
-	function fix_redirect() {
+	function fix_redirect( $module, $redirect = true ) {
+		if ( ! $redirect ) {
+			return;
+		}
 		if ( wp_get_referer() ) {
 			add_filter( 'wp_redirect', 'wp_get_referer' );
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2003,7 +2003,7 @@ class Jetpack {
 	}
 
 	public static function activate_module( $module, $exit = true, $redirect = true ) {
-		do_action( 'jetpack_pre_activate_module', $module, $exit );
+		do_action( 'jetpack_pre_activate_module', $module, $exit, $redirect );
 
 		$jetpack = Jetpack::init();
 


### PR DESCRIPTION
Might just fix all of these issues: 
#1868, #1846, #1840

But will definitely fix: #1846

- Adds a param to `jetpack_pre_activate_module` that allows us to control a redirect after module activation.

In 3.4, we started calling a new method `do_version_bump()` <a href="https://github.com/Automattic/jetpack/blob/master/jetpack.php#L63">#</a> on every update or activation.  
This then triggered `activate_manage`, 
then `activate_module` (916064c), 
then the `jetpack_pre_activate_module` hook, 
then the `fix_redirect()` method <a href="https://github.com/Automattic/jetpack/blob/f9d70c1d0aa9a1f6befee5aa1506bb5b706acd81/class.jetpack-admin.php#L200">#</a> , 
which had already been called, resulting in multiple redirects. 

Since we're already sending over a false $redirect param from `activate_manage()` <a href="https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L391">#</a> , this PR will stop that method from triggering the redirect in `fix_redirect()`.  

TL;DR - we were redirecting twice on plugin activation and updates, and this puts a stop to it.