### PR TITLE
Fix issue #1918

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4905,7 +4905,7 @@ p {
 			$name = $exploded_host[count($exploded_host) - 2];
 			$tld = $exploded_host[count($exploded_host) - 1];
 			// Rebuild domain excluding subdomains
-			    $domain = $name . '.' . $tld;
+			$domain = $name . '.' . $tld;
 		} else {
 			$domain = $host;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4900,16 +4900,15 @@ p {
 		// Explode hostname on '.'
 		$exploded_host = explode( '.', $host );
 
-        // Retrieve the name and TLD
-        if ( count( $exploded_host) > 1 ) {
-            $name = $exploded_host[count($exploded_host) - 2];
-            $tld = $exploded_host[count($exploded_host) - 1];
-            // Rebuild domain excluding subdomains
-            $domain = $name . '.' . $tld;
-        } else {
-            $domain = $host;
-        }
-
+		// Retrieve the name and TLD
+		if ( count( $exploded_host) > 1 ) {
+			$name = $exploded_host[count($exploded_host) - 2];
+			$tld = $exploded_host[count($exploded_host) - 1];
+			// Rebuild domain excluding subdomains
+			    $domain = $name . '.' . $tld;
+		} else {
+			$domain = $host;
+		}
 		// Array of Automattic domains
 		$domain_whitelist = array( 'wordpress.com', 'wp.com' );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4900,12 +4900,15 @@ p {
 		// Explode hostname on '.'
 		$exploded_host = explode( '.', $host );
 
-		// Retreive the name and TLD
-		$name = $exploded_host[ count( $exploded_host ) - 2 ];
-		$tld = $exploded_host[ count( $exploded_host ) - 1 ];
-
-		// Rebuild domain excluding subdomains
-		$domain = $name . '.' . $tld;
+        // Retrieve the name and TLD
+        if ( count( $exploded_host) > 1 ) {
+            $name = $exploded_host[count($exploded_host) - 2];
+            $tld = $exploded_host[count($exploded_host) - 1];
+            // Rebuild domain excluding subdomains
+            $domain = $name . '.' . $tld;
+        } else {
+            $domain = $host;
+        }
 
 		// Array of Automattic domains
 		$domain_whitelist = array( 'wordpress.com', 'wp.com' );


### PR DESCRIPTION
Fix for issue: #1918

Fix to remove the Notice when the local host domain does not include a period.
Also correct spelling of retrieve.