### PR TITLE
Stats: Don't add tracking script/pixel for previewed views.

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -123,7 +123,7 @@ function stats_map_meta_caps( $caps, $cap, $user_id, $args ) {
 function stats_template_redirect() {
 	global $wp_the_query, $current_user, $stats_footer;
 
-	if ( is_feed() || is_robots() || is_trackback() )
+	if ( is_feed() || is_robots() || is_trackback() || is_preview() )
 		return;
 
 	$options = stats_get_options();


### PR DESCRIPTION
We're including tracking pixels/script when Previewing a post if the settings are set to count views from the visitor role previewing the post. It doesn't make sense to count a preview :)