### PR TITLE
Replaces a4d926f with something that's more readable

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2915,8 +2915,9 @@ p {
 						<?php _e( 'You have successfully disconnected Jetpack.', 'jetpack' ); ?>
 						<br />
 						<?php echo sprintf(
-							__( 'Would you tell us why? Just <a href="%s">answering two simple questions</a> would help us improve Jetpack.', 'jetpack' ),
-							'https://jetpack.me/survey-disconnected/" target="_blank'
+							__( 'Would you tell us why? Just <a href="%s" target="%s">answering two simple questions</a> would help us improve Jetpack.', 'jetpack' ),
+							'https://jetpack.me/survey-disconnected/',
+							'_blank'
 						); ?>
 					</h4>
 				</div>


### PR DESCRIPTION
This is meant to serve as a reminder to clean up a4d926f - as that was a temporary workaround to not break strings for 3.5