### PR TITLE
Embeds: update the facebook embed handler

### DIFF
--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -26,13 +26,6 @@ wp_embed_register_handler( 'facebook-alternate-photo', JETPACK_FACEBOOK_PHOTO_AL
 wp_embed_register_handler( 'facebook-video', JETPACK_FACEBOOK_VIDEO_EMBED_REGEX, 'jetpack_facebook_embed_handler' );
 
 function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
-	static $did_script;
-
-	if ( ! $did_script ) {
-		$did_script = true;
-		add_action( 'wp_footer', 'jetpack_facebook_add_script' );
-	}
-
 	if ( false !== strpos( $url, 'video.php' ) ) {
 		$embed = sprintf( '<div class="fb-video" data-allowfullscreen="true" data-href="%s"></div>', esc_url( $url ) );
 	} else {
@@ -43,14 +36,9 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && ! empty( $_POST['action'] ) && 'parse-embed' == $_POST['action'] ) {
 		return $embed . '<script src="//connect.facebook.net/en_US/all.js#xfbml=1"></script>';
 	} else {
+		wp_enqueue_script( 'jetpack-facebook-embed', plugins_url( 'js/facebook.js', __FILE__ ), array( 'jquery' ) );
 		return $embed;
 	}
-}
-
-function jetpack_facebook_add_script() {
-	?>
-	<div id="fb-root"></div> <script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = "//connect.facebook.net/en_US/all.js#xfbml=1"; fjs.parentNode.insertBefore(js, fjs); }(document, "script", "facebook-jssdk"));</script>
-	<?php
 }
 
 add_shortcode( 'facebook', 'jetpack_facebook_shortcode_handler' );

--- a/modules/shortcodes/js/facebook.js
+++ b/modules/shortcodes/js/facebook.js
@@ -1,0 +1,25 @@
+(function() {
+	var facebookEmbed = function() {
+		if ( 'undefined' !== typeof FB && FB.XFBML ) {
+			FB.XFBML.parse();
+		} else {
+			var fbroot = document.createElement( 'div' );
+			fbroot.id = 'fb-root';
+			document.getElementsByTagName( 'body' )[0].appendChild( fbroot );
+
+			jQuery.getScript( '//connect.facebook.net/en_US/sdk.js', function() {
+				FB.init( {
+					appId  : '249643311490',
+					version: 'v2.3'
+				} );
+				FB.XFBML.parse();
+			} );
+		}
+	};
+
+	if ( 'undefined' !== typeof infiniteScroll ) {
+		jQuery( document.body ).on( 'post-load', facebookEmbed );
+	}
+
+	facebookEmbed();
+})();


### PR DESCRIPTION
Adjust the way the facebook script is loaded/fired so that it works with infinite scroll -- this adds a new js file that is enqueued properly (and thus compatible with infinite scroll) and detects IS loads and fires the appropriate facebook function to reprocess any embeds on the page that were loaded via IS.

Note that this last bit adds a new file shortcodes/js/instagram.js which has a corresponding file on WordPress.com and will need to be added to the build script as per @dereksmart's instructions :)
Similar approach to #2003 for instagram. 