### PR TITLE
Fix proposed for issue #2026

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1594,14 +1594,14 @@ class Jetpack {
 			}
 		}
 
-		$modules = apply_filters( 'jetpack_get_available_modules', $modules, $min_version, $max_version );
+		$mods = apply_filters( 'jetpack_get_available_modules', $modules, $min_version, $max_version );
 
 		if ( ! $min_version && ! $max_version ) {
-			return array_keys( $modules );
+			return array_keys( $mods );
 		}
 
 		$r = array();
-		foreach ( $modules as $slug => $introduced ) {
+		foreach ( $mods as $slug => $introduced ) {
 			if ( $min_version && version_compare( $min_version, $introduced, '>=' ) ) {
 				continue;
 			}


### PR DESCRIPTION
Avoid altering the local static $modules variable in Jetpack::get_available_modules() by any filter hooks. Only filter returned array. See https://github.com/Automattic/jetpack/issues/2026