### PR TITLE
Reduce pagination of Network Admin page to 25 sites

### DIFF
--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -29,7 +29,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		$sites = $jpms->wp_get_sites( array( 'exclude_blogs' => array( 1 ) ) );
 
 		// Setup pagination
-		$per_page = 40;
+		$per_page = 25;
 		$current_page = $this->get_pagenum();
 		$total_items = count( $sites );
 		$sites = array_slice( $sites, ( ( $current_page-1 ) * $per_page ), $per_page );

--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -6,7 +6,7 @@ if( ! class_exists( 'WP_List_Table' ) ) {
 
 class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
-	
+
 	public function get_columns() {
 		// site name, status, username connected under
 		$columns = array(
@@ -27,7 +27,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 		// Get sites
 		$sites = $jpms->wp_get_sites( array( 'exclude_blogs' => array( 1 ) ) );
-		
+
 		// Setup pagination
 		$per_page = 40;
 		$current_page = $this->get_pagenum();
@@ -55,15 +55,15 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
             		'edit'      	=> '<a href="' . network_admin_url( 'site-info.php?id=' . $item->blog_id )  .  '">' . __( 'Edit', 'jetpack' ) . '</a>',
         		'dashboard'	=> '<a href="' . get_admin_url( $item->blog_id, '', 'admin' ) . '">Dashboard</a>',
 			'view'		=> '<a href="' . get_site_url( $item->blog_id, '', 'admin' ) . '">View</a>',
-			'jetpack-' . $item->blog_id	=> '<a href="' . $jp_url . '">Jetpack</a>', 
+			'jetpack-' . $item->blog_id	=> '<a href="' . $jp_url . '">Jetpack</a>',
 		);
 
   		return sprintf('%1$s %2$s', '<strong>' . get_blog_option( $item->blog_id, 'blogname' ) . '</strong>', $this->row_actions($actions) );
 	}
 
 	public function column_blog_path( $item ) {
-		return 
-                         '<a href="' . 
+		return
+                         '<a href="' .
                          get_site_url( $item->blog_id, '', 'admin' ) .
                          '">' .
                          str_replace( array( 'http://', 'https://' ), '', get_site_url( $item->blog_id, '', 'admin' ) ) .
@@ -76,7 +76,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 		switch_to_blog( $item->blog_id );
 		if( $jp->is_active() ) {
-		   // Build url for disconnecting 
+		   // Build url for disconnecting
 		    $url = $jpms->get_url( array(
 			'name'	    => 'subsitedisconnect',
 			'site_id'   => $item->blog_id,
@@ -86,7 +86,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		    return '<a href="' . $url . '">Disconnect</a>';
 		}
 		restore_current_blog();
-		
+
 		// Build URL for connecting
 		$url = $jpms->get_url( array(
 		    'name'	=> 'subsiteregister',
@@ -107,7 +107,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 	function column_cb($item) {
         	return sprintf(
             		'<input type="checkbox" name="bulk[]" value="%s" />', $item->blog_id
-        	);    
+        	);
     	}
 
 	public function process_bulk_action() {
@@ -123,7 +123,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
             		case 'connect':
                 		foreach( $_POST['bulk'] as $k => $site ) {
 							$jpms->do_subsiteregister( $site );
-						} 
+						}
 				break;
             		case 'disconnect':
                 		foreach( $_POST['bulk'] as $k => $site ) {


### PR DESCRIPTION
There needs to be a lot of work done to the NA page for performance—need to convert it to using core functions, etc.

In the meantime, knocking down the sites per page will help Network Admin from crashing on certain providers (WP Engine being the case that inspired the change).

cc @jessefriedman as we discussed this some today in Slack.