### PR TITLE
Notes: Stop depending on `jquery.spin` so that `wp-admin/network` loads ...

### DIFF
--- a/modules/notes.php
+++ b/modules/notes.php
@@ -141,7 +141,7 @@ class Jetpack_Notifications {
 			wp_register_script( 'backbone', $this->wpcom_static_url( '/wp-includes/js/backbone.min.js' ), array( 'underscore' ), JETPACK_NOTES__CACHE_BUSTER );
 		}
 
-		wp_register_script( 'wpcom-notes-common', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/notes-common-v2.js' ), array( 'jquery', 'underscore', 'backbone', 'mustache', 'jquery.spin' ), JETPACK_NOTES__CACHE_BUSTER );
+		wp_register_script( 'wpcom-notes-common', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/notes-common-v2.js' ), array( 'jquery', 'underscore', 'backbone', 'mustache' ), JETPACK_NOTES__CACHE_BUSTER );
 		wp_enqueue_script( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.js' ), array( 'wpcom-notes-common' ), JETPACK_NOTES__CACHE_BUSTER );
 	}
 


### PR DESCRIPTION
...the notes properly

Issue #718

The notifications panel wasn't loading on `wp-admin/network` pages. This was apparently
due to a conflict between `jquery.spin` and some other library. Removing this library
from the list of dependencies for `notes-common-v2.js` allowed it to load.

Strangely enough, the spinner functionality didn't stop when I removed the dependency.
The library still appears to be loading from another request.

Were this to cause any bad side effects, it could be limited to only impacting the
network admin with a simple conditional `is_network_admin()`