### PR TITLE
Fix unnecessary calls to functions using filters in sources. 

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1134,11 +1134,10 @@ class Share_Pinterest extends Sharing_Source {
 	}
 
 	public function get_display( $post ) {
-		$share_url = 'http://pinterest.com/pin/create/button/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&description=' . rawurlencode( $post->post_title );
 		$display = '';
 
 		if ( $this->smart )
-			$display .= sprintf( '<div class="pinterest_button"><a href="%s" data-pin-do="buttonBookmark" data-pin-config="beside"><img src="//assets.pinterest.com/images/pidgets/pinit_fg_en_rect_gray_20.png" /></a></div>', esc_url( $share_url ) );
+			$display .= sprintf( '<div class="pinterest_button"><a href="%s" data-pin-do="buttonBookmark" data-pin-config="beside"><img src="//assets.pinterest.com/images/pidgets/pinit_fg_en_rect_gray_20.png" /></a></div>', esc_url( 'http://pinterest.com/pin/create/button/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&description=' . rawurlencode( $post->post_title ) ) );
 		else
 			$display = $this->get_link( get_permalink( $post->ID ), _x( 'Pinterest', 'share to', 'jetpack' ), __( 'Click to share on Pinterest', 'jetpack' ), 'share=pinterest', 'sharing-pinterest-' . $post->ID );
 

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -428,11 +428,8 @@ class Share_Twitter extends Sharing_Source {
 			$via .= '&related=' . rawurlencode( $related );
 		}
 
-		$share_url = $this->get_share_url( $post->ID );
-		$post_title = $this->get_share_title( $post->ID );
-
 		if ( $this->smart ) {
-			return '<div class="twitter_button"><iframe allowtransparency="true" frameborder="0" scrolling="no" src="' . esc_url( $this->http() . '://platform.twitter.com/widgets/tweet_button.html?url=' . rawurlencode( $share_url ) . '&counturl=' . rawurlencode( get_permalink( $post->ID ) ) . '&count=horizontal&text=' . rawurlencode( $post_title . ':' ) . $via ) . '" style="width:101px; height:20px;"></iframe></div>';
+			return '<div class="twitter_button"><iframe allowtransparency="true" frameborder="0" scrolling="no" src="' . esc_url( $this->http() . '://platform.twitter.com/widgets/tweet_button.html?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&counturl=' . rawurlencode( get_permalink( $post->ID ) ) . '&count=horizontal&text=' . rawurlencode( $this->get_share_title( $post->ID ) . ':' ) . $via ) . '" style="width:101px; height:20px;"></iframe></div>';
 		} else {
 			if ( apply_filters( 'jetpack_register_post_for_share_counts', true, $post->ID, 'twitter' ) ) {
 				sharing_register_post_for_share_counts( $post->ID );
@@ -593,11 +590,10 @@ class Share_LinkedIn extends Sharing_Source {
 	}
 
 	public function get_display( $post ) {
-		$share_url = $this->get_share_url( $post->ID );
 		$display = '';
 
 		if ( $this->smart )
-			$display .= sprintf( '<div class="linkedin_button"><script type="in/share" data-url="%s" data-counter="right"></script></div>', esc_url( $share_url ) );
+			$display .= sprintf( '<div class="linkedin_button"><script type="in/share" data-url="%s" data-counter="right"></script></div>', esc_url( $this->get_share_url( $post->ID ) ) );
 		else
 			$display = $this->get_link( get_permalink( $post->ID ), _x( 'LinkedIn', 'share to', 'jetpack' ), __( 'Click to share on LinkedIn', 'jetpack' ), 'share=linkedin', 'sharing-linkedin-' . $post->ID );
 
@@ -699,9 +695,8 @@ class Share_Facebook extends Sharing_Source {
 	}
 
 	public function get_display( $post ) {
-		$share_url = $this->get_share_url( $post->ID );
 		if ( $this->smart ) {
-			return '<div class="fb-share-button" data-href="' . esc_attr( $share_url ) . '" data-layout="button_count"></div>';
+			return '<div class="fb-share-button" data-href="' . esc_attr( $this->get_share_url( $post->ID ) ) . '" data-layout="button_count"></div>';
 		}
 
 		if ( apply_filters( 'jetpack_register_post_for_share_counts', true, $post->ID, 'facebook' ) ) {
@@ -836,10 +831,8 @@ class Share_GooglePlus1 extends Sharing_Source {
 	}
 
 	public function get_display( $post ) {
-		$share_url = $this->get_share_url( $post->ID );
-
 		if ( $this->smart ) {
-			return '<div class="googleplus1_button"><div class="g-plus" data-action="share" data-annotation="bubble" data-href="' . esc_url( $share_url ) . '"></div></div>';
+			return '<div class="googleplus1_button"><div class="g-plus" data-action="share" data-annotation="bubble" data-href="' . esc_url( $this->get_share_url( $post->ID ) ) . '"></div></div>';
 		} else {
 			return $this->get_link( get_permalink( $post->ID ), _x( 'Google', 'share to', 'jetpack' ), __( 'Click to share on Google+', 'jetpack' ), 'share=google-plus-1', 'sharing-google-' . $post->ID );
 		}


### PR DESCRIPTION
Reference additional comments on #2046 

Because the $share_url and $share_title are only used in the "smart" version of the source, the calls to the get_share_url() and get_share_title() functions has been moved into the if statement. This prevents the functions from being called unnecessarily.

The reason for has become apparent in a use case where the sharing_permlink filter is used to alter the link, but requires a call to an external api to do so. Having the get_share_url() outside the if statement means that the function is called every time the button is rendered. Whereas, moving it inside the conditional ensures it is only called where necessary.

Because the use case is not using "smart" buttons, the function doesn't get called until the process_request() function is called after clicking the share button. This ensures that the api call is only made when an action is taken on the button.

Having filters in these two functions, get_share_url() and get_share_title(), means that we should avoid calling them unnecessarily, preventing extraneous processing and potential pitfalls such as that encountered in this use case.