### PR TITLE
Sharing Buttons: Remove cache busting of Facebook count request

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -6,8 +6,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 		twitter_count : {},
 		get_counts : function() {
 			var facebookPostIds = [],
-				query = [],
-				https_url, http_url, url, urls, id, service, service_url, post_index, posts_length, path_ending;
+				https_url, http_url, url, urls, id, service, service_url, path_ending;
 
 			if ( 'undefined' === typeof WPCOM_sharing_counts ) {
 				return;
@@ -63,16 +62,11 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 			}
 
 			if ( facebookPostIds.length && ( 'WPCOM_site_ID' in window ) ) {
-				posts_length = facebookPostIds.length;
-				for ( post_index = 0 ; post_index < posts_length; post_index++ ) {
-					query.push( 'post_ID[]=' + facebookPostIds[ post_index ] );
-				}
-				query = query.join( '&' );
-
 				path_ending = window.WPCOM_jetpack ? 'jetpack-count' : 'count';
 				jQuery.ajax({
 					dataType: 'jsonp',
-					url: 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/' + path_ending + '/?' + query,
+					url: 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/' + path_ending,
+					data: { post_ID: facebookPostIds },
 					success: WPCOMSharing.update_facebook_count,
 					cache: true
 				});

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -70,7 +70,12 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				query = query.join( '&' );
 
 				path_ending = window.WPCOM_jetpack ? 'jetpack-count' : 'count';
-				jQuery.getScript( 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/' + path_ending + '/?' + query + '&callback=WPCOMSharing.update_facebook_count' );
+				jQuery.ajax({
+					dataType: 'jsonp',
+					url: 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/' + path_ending + '/?' + query,
+					success: WPCOMSharing.update_facebook_count,
+					cache: true
+				});
 			}
 		},
 


### PR DESCRIPTION
This pull request seeks to replace the existing `$.getScript` call with the equivalent JSONP `$.ajax` call, so as we can pass an additional option to prevent the `_=` cache-busting query argument from being sent with the request.

/cc @georgestephanis 