### PR TITLE
Sharing: Add filter docblock for `is_jetpack_site`

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -508,7 +508,7 @@ function sharing_add_footer() {
 				/**
 				 * Defines whether a blog is a Jetpack site.
 				 *
-				 * @since 3.5.0
+				 * @since 3.6.0
 				 *
 				 * @param bool false    Assumption on whether a blog is a Jetpack site.
 				 * @param int  $blog_id A blog ID to check.

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -504,6 +504,15 @@ function sharing_add_footer() {
 		if ( apply_filters( 'jetpack_sharing_counts', true ) && is_array( $jetpack_sharing_counts ) && count( $jetpack_sharing_counts ) ) :
 			$sharing_post_urls = array_filter( $jetpack_sharing_counts );
 			if ( $sharing_post_urls ) :
+
+				/**
+				 * Defines whether a blog is a Jetpack site.
+				 *
+				 * @since 3.5.0
+				 *
+				 * @param bool false    Assumption on whether a blog is a Jetpack site.
+				 * @param int  $blog_id A blog ID to check.
+				 */
 				$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
 				$site_id = $is_jetpack ? Jetpack_Options::get_option( 'id' ) : get_current_blog_id();
 ?>


### PR DESCRIPTION
As mentioned by @jeherve at https://github.com/Automattic/jetpack/pull/1946#discussion_r29448698, new filter usage should include a DocBlock or DocBlock reference. This pull request adds a DocBlock definition for the `is_jetpack_site` filter usage in `sharing-service.php`. The filter is used elsewhere already, and other updates will need to be made.

General questions related to filter documenting:

- How do we reconcile WordPress.com file syncing for referenced DocBlocks?
- Should we prefer to document `add_filter` or `apply_filter` usage?
- Is there a guideline on which filter to prefer the DocBlock be fully described (not referenced)?