### PR TITLE
Sharing: add a filter to change the output of the Facebook button.

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -702,7 +702,16 @@ class Share_Facebook extends Sharing_Source {
 	public function get_display( $post ) {
 		if ( $this->smart ) {
 			$share_url = $this->get_share_url( $post->ID );
-			return '<div class="fb-share-button" data-href="' . esc_attr( $share_url ) . '" data-layout="button_count"></div>';
+			$fb_share_html = '<div class="fb-share-button" data-href="' . esc_attr( $share_url ) . '" data-layout="button_count"></div>';
+			/**
+			 * Filter the output of the Facebook Sharing button.
+			 *
+			 * @since 3.6.0
+			 *
+			 * @param string $fb_share_html Facebook Sharing button HTML.
+			 * @param string $share_url URL of the post to share.
+			 */
+			return apply_filters( 'jetpack_sharing_facebook_button', $fb_share_html, $share_url );
 		}
 
 		if ( apply_filters( 'jetpack_register_post_for_share_counts', true, $post->ID, 'facebook' ) ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -711,7 +711,7 @@ class Share_Facebook extends Sharing_Source {
 			 * @param string $fb_share_html Facebook Sharing button HTML.
 			 * @param string $share_url URL of the post to share.
 			 */
-			return apply_filters( 'jetpack_sharing_facebook_button', $fb_share_html, $share_url );
+			return apply_filters( 'jetpack_sharing_facebook_official_button_output', $fb_share_html, $share_url );
 		}
 
 		if ( apply_filters( 'jetpack_register_post_for_share_counts', true, $post->ID, 'facebook' ) ) {


### PR DESCRIPTION
Fixes #1570 
Once this filter makes it in Jetpack, site owners could use something like this to define a custom sharing button (the Like button in this example):

```php
function jeherve_custom_fb_button( $fb_share_html, $share_url ) {
        $custom_fb_button = '<div class="fb-like" data-href="' . $share_url . '" data-layout="standard" data-action="like" data-show-faces="true" data-share="true"></div>';
        return $custom_fb_button;
}
add_filter( 'jetpack_sharing_facebook_official_button_output', 'jeherve_custom_fb_button', 2 );
```

cc @aduth Since the Like button includes a few other arguments that could be customized, I chose to filter the whole button output. What do you think?