### PR TITLE
Add a "Support" link to the Plugin action links

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2728,7 +2728,7 @@ p {
 			return array_merge(
 				$jetpack_home,
 				array( 'settings' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack_modules' ), __( 'Settings', 'jetpack' ) ) ),
-				array( 'settings' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack-debugger '), __( 'Support', 'jetpack' ) ) ),
+				array( 'support' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack-debugger '), __( 'Support', 'jetpack' ) ) ),
 				$actions
 				);
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2728,6 +2728,7 @@ p {
 			return array_merge(
 				$jetpack_home,
 				array( 'settings' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack_modules' ), __( 'Settings', 'jetpack' ) ) ),
+				array( 'settings' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack-debugger '), __( 'Support', 'jetpack' ) ) ),
 				$actions
 				);
 			}


### PR DESCRIPTION
Add a new link called "Support" to the /plugins page which will link to the in-dashboard Debugger and allow users to troubleshoot their site and contact Jetpack Support.