### PR TITLE
Open Graph: remove All In One SEO from the conflicting plugins

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -178,7 +178,6 @@ class Jetpack {
 		                                                         // 2 Click Social Media Buttons
 		'add-link-to-facebook/add-link-to-facebook.php',         // Add Link to Facebook
 		'add-meta-tags/add-meta-tags.php',                       // Add Meta Tags
-		'all-in-one-seo-pack/all_in_one_seo_pack.php',           // All in One SEO Pack
 		'easy-facebook-share-thumbnails/esft.php',               // Easy Facebook Share Thumbnail
 		'facebook/facebook.php',                                 // Facebook (official plugin)
 		'facebook-awd/AWD_facebook.php',                         // Facebook AWD All in one


### PR DESCRIPTION
AIOSEO was updated in 2.2.4 to handle Jetpack's OG tags better.
See patch here: https://plugins.trac.wordpress.org/ticket/2304

Jetpack's OG tags are now automatically removed when you activate AIOSEO's Social Meta module.