### PR TITLE
Subscriptions Widget: Better subscribe failure UX

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -635,15 +635,14 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		} else { ?>
 			<form action="#" method="post" accept-charset="utf-8" id="subscribe-blog-<?php echo $widget_id; ?>">
 				<?php
-				if ( ! isset ( $_GET['subscribe'] ) OR $_GET['subscribe'] != 'success' ) {
+				if ( ! isset ( $_GET['subscribe'] ) || 'success' != $_GET['subscribe'] ) {
 					?><div id="subscribe-text"><?php echo wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total['value'] ), $subscribe_text ) ); ?></div><?php
 				}
 
 				if ( $show_subscribers_total && 0 < $subscribers_total['value'] ) {
 					echo wpautop( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $subscribers_total['value'], 'jetpack' ), number_format_i18n( $subscribers_total['value'] ) ) );
 				}
-
-				if ( ! isset ( $_GET['subscribe'] ) OR $_GET['subscribe'] != 'success' ) { ?>
+				if ( ! isset ( $_GET['subscribe'] ) || 'success' != $_GET['subscribe'] ) { ?>
 					<p id="subscribe-email">
 						<label id="jetpack-subscribe-label" for="<?php echo esc_attr( $subscribe_field_id ); ?>">
 							<?php echo !empty( $subscribe_placeholder ) ? esc_html( $subscribe_placeholder ) : esc_html__( 'Email Address:', 'jetpack' ); ?>

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -635,7 +635,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		} else { ?>
 			<form action="#" method="post" accept-charset="utf-8" id="subscribe-blog-<?php echo $widget_id; ?>">
 				<?php
-				if ( ! isset ( $_GET['subscribe'] ) ) {
+				if ( ! isset ( $_GET['subscribe'] ) OR $_GET['subscribe'] != 'success' ) {
 					?><div id="subscribe-text"><?php echo wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total['value'] ), $subscribe_text ) ); ?></div><?php
 				}
 
@@ -643,7 +643,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 					echo wpautop( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $subscribers_total['value'], 'jetpack' ), number_format_i18n( $subscribers_total['value'] ) ) );
 				}
 
-				if ( ! isset ( $_GET['subscribe'] ) ) { ?>
+				if ( ! isset ( $_GET['subscribe'] ) OR $_GET['subscribe'] != 'success' ) { ?>
 					<p id="subscribe-email">
 						<label id="jetpack-subscribe-label" for="<?php echo esc_attr( $subscribe_field_id ); ?>">
 							<?php echo !empty( $subscribe_placeholder ) ? esc_html( $subscribe_placeholder ) : esc_html__( 'Email Address:', 'jetpack' ); ?>


### PR DESCRIPTION
Improved user experience of subscribe widget when the form submission fails. Full details here: https://wordpress.org/support/topic/fix-proposal-subscription-widget-form-disappears-after-error?replies=2