### PR TITLE
Galleries: remove unecessary script enqueue

### DIFF
--- a/functions.gallery.php
+++ b/functions.gallery.php
@@ -30,19 +30,7 @@ class Jetpack_Gallery_Settings {
 			wp_register_script( 'jetpack-gallery-settings', plugins_url( 'gallery-settings/gallery-settings.js', __FILE__ ), array( 'media-views' ), '20121225' );
 		}
 
-		/*
-		 * Register Gallery's admin.js here so we can upload images in the customizer
-		 */
-		if ( ! wp_script_is( 'gallery-widget-admin', 'registered' ) ) {
-			wp_register_script( 'gallery-widget-admin', plugins_url( 'modules/widgets/gallery/js/admin.js', __FILE__ ), array(
-				'media-models',
-				'media-views'
-			) );
-		}
-
 		wp_enqueue_script( 'jetpack-gallery-settings' );
-
-		wp_enqueue_script( 'gallery-widget-admin' );
 	}
 
 	/**


### PR DESCRIPTION
The script to enqueue gallery-widget-admin was added in eb848a7, rendering what was committed in dbabd4a (#1460) useless.

This also brings the file in sync with wpcom