### PR TITLE
Fix for missing official Facebook btn

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -672,7 +672,7 @@ class Share_Facebook extends Sharing_Source {
 	}
 
 	function guess_locale_from_lang( $lang ) {
-		if ( 'en' == $lang || 'en_US' == $lang || !$lang ) {
+		if ( 'en' == $lang || 'en_US' == $lang || 'en_AU' == $lang || 'en_CA' == $lang || !$lang ) {
 			return 'en_US';
 		}
 


### PR DESCRIPTION
From what I can tell Facebook doesn’t support English Australian or
English Canadian as a separate language so we should default to English
US.

fixes #2089