### PR TITLE
Merge wpcom 11may2015/gallery widget

### DIFF
--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -366,9 +366,11 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 			wp_enqueue_media();
 
 			wp_enqueue_script( 'gallery-widget-admin', plugins_url( '/gallery/js/admin.js', __FILE__ ), array(
-				'media-models',
-				'media-views'
-			) );
+					'media-models',
+					'media-views'
+				),
+				'20150501'
+			);
 
 			$js_settings = array(
 				'thumbSize' => self::THUMB_SIZE

--- a/modules/widgets/gallery/js/admin.js
+++ b/modules/widgets/gallery/js/admin.js
@@ -6,10 +6,10 @@
 	var $thumbs;
 
 	$(function(){
-		$( document.body ) .on( 'click', '.widget-content .gallery-widget-choose-images', function( event ) {
+		$( document.body ) .on( 'click', '.gallery-widget-choose-images', function( event ) {
 			event.preventDefault();
 
-			var widget_form = $( this ).closest( 'form' );
+			var widget_form = $( this ).closest( 'form, .form' );
 
 			$ids    = widget_form.find( '.gallery-widget-ids' );
 			$thumbs	= widget_form.find( '.gallery-widget-thumbs' );


### PR DESCRIPTION
Fixes some gallery widget issues
 * Allow adding multiple widget instances via the Customizer, fixes #7370. Props designsimply.
 * Make sure the Choose Images button works in accessibility mode in wp-admin. Fixes #7268, props designsimply.

Brings code in sync with dotcom 