### PR TITLE
 Merge wpcom 11may2015/retire stumbleupon

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -49,7 +49,6 @@ class Sharing_Service {
 			'facebook'      => 'Share_Facebook',
 			'linkedin'      => 'Share_LinkedIn',
 			'reddit'        => 'Share_Reddit',
-			'stumbleupon'   => 'Share_Stumbleupon',
 			'twitter'       => 'Share_Twitter',
 			'press-this'    => 'Share_PressThis',
 			'google-plus-1' => 'Share_GooglePlus1',

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -498,45 +498,6 @@ class Share_Twitter extends Sharing_Source {
 	}
 }
 
-class Share_Stumbleupon extends Sharing_Source {
-	var $shortname = 'stumbleupon';
-	var $genericon = '\f223';
-	public function __construct( $id, array $settings ) {
-		parent::__construct( $id, $settings );
-
-		if ( 'official' == $this->button_style )
-			$this->smart = true;
-		else
-			$this->smart = false;
-	}
-
-	public function get_name() {
-		return __( 'StumbleUpon', 'jetpack' );
-	}
-
-	public function has_custom_button_style() {
-		return $this->smart;
-	}
-
-	public function get_display( $post ) {
-		if ( $this->smart )
-			return '<div class="stumbleupon_button"><iframe src="http://www.stumbleupon.com/badge/embed/1/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&amp;title=' . rawurlencode( $this->get_share_title( $post->ID ) ) . '" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:74px; height: 18px;" allowTransparency="true"></iframe></div>';
-		else
-			return $this->get_link( get_permalink( $post->ID ), _x( 'StumbleUpon', 'share to', 'jetpack' ), __( 'Click to share on StumbleUpon', 'jetpack' ), 'share=stumbleupon' );
-	}
-
-	public function process_request( $post, array $post_data ) {
-		$stumbleupon_url = $this->http() . '://www.stumbleupon.com/submit?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&title=' . rawurlencode( $this->get_share_title( $post->ID ) );
-
-		// Record stats
-		parent::process_request( $post, $post_data );
-
-		// Redirect to Stumbleupon
-		wp_redirect( $stumbleupon_url );
-		die();
-	}
-}
-
 class Share_Reddit extends Sharing_Source {
 	var $shortname = 'reddit';
 	var $genericon = '\f222';


### PR DESCRIPTION
Retiring Stumbleupon as a sharing button

@jkudish said it best: 
Despite supporting https for their script tag, Stumble Upon's sharing badge loads a bunch of http only resources, thus producing mixed-content warnings and not working properly for https sites. Stumble Upon has no plans to update this as per their public documentation. So we've decided to remove support for their service.

Brings code in sync with dotcom