### PR TITLE
Subscribe Widget: Rewrote JS to remove jQuery dependency

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -679,9 +679,12 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			
 				var form = d.getElementById('subscribe-blog-<?php echo $widget_id; ?>'), 
 					input = d.getElementById('<?php echo esc_attr( $subscribe_field_id ); ?>'),
-					handler = function(event) {
+					handler = function(e) {
 						if (input.value === '') {
 							input.focus();
+							
+							if (e.preventDefault)
+								e.preventDefault();
 							return false; 
 						}
 					}; 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -667,7 +667,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			</form>
 
 			<script>
-			( function( d ) {
+			(function( d ) {
 				if ( ( 'placeholder' in d.createElement( 'input' ) ) ) {
 					var label = d.getElementById( 'jetpack-subscribe-label' );
 						label.style.clip 	 = 'rect(1px, 1px, 1px, 1px)';
@@ -679,22 +679,24 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			
 				var form = d.getElementById('subscribe-blog-<?php echo $widget_id; ?>'), 
 					input = d.getElementById('<?php echo esc_attr( $subscribe_field_id ); ?>'),
-					handler = function(e) {
-						if (input.value === '') {
+					handler = function( event ) {
+						if ( '' === input.value ) {
 							input.focus();
 							
-							if (e.preventDefault)
-								e.preventDefault();
+							if ( event.preventDefault ){
+								event.preventDefault();
+							}
+							
 							return false; 
 						}
 					}; 
 			
-				if (window.addEventListener) {
-					form.addEventListener('submit', handler, false);
+				if ( window.addEventListener ) {
+					form.addEventListener( 'submit', handler, false );
 				} else {
-					form.attachEvent('onsubmit', handler);
+					form.attachEvent( 'onsubmit', handler );
 				}
-			} ) ( document );
+			})( document );
 			</script>
 		<?php } ?>
 		<?php

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -667,25 +667,31 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			</form>
 
 			<script>
-				( function( d ) {
-					if ( ( 'placeholder' in d.createElement( 'input' ) ) ) {
-						var label = d.getElementById( 'jetpack-subscribe-label' );
-	 					label.style.clip 	 = 'rect(1px, 1px, 1px, 1px)';
-	 					label.style.position = 'absolute';
-	 					label.style.height   = '1px';
-	 					label.style.width    = '1px';
-	 					label.style.overflow = 'hidden';
-					}
-				} ) ( document );
-
-				// Special check for required email input because Safari doesn't support HTML5 "required"
-				jQuery( '#subscribe-blog-<?php echo $widget_id; ?>' ).submit( function( event ) {
-					var requiredInput = jQuery( this ).find( '.required' );
-					if ( requiredInput.val() == '' ) {
-						event.preventDefault();
-						requiredInput.focus();
-					}
-				});
+			( function( d ) {
+				if ( ( 'placeholder' in d.createElement( 'input' ) ) ) {
+					var label = d.getElementById( 'jetpack-subscribe-label' );
+						label.style.clip 	 = 'rect(1px, 1px, 1px, 1px)';
+						label.style.position = 'absolute';
+						label.style.height   = '1px';
+						label.style.width    = '1px';
+						label.style.overflow = 'hidden';
+				}
+			
+				var form = d.getElementById('subscribe-blog-<?php echo $widget_id; ?>'), 
+					input = d.getElementById('<?php echo esc_attr( $subscribe_field_id ); ?>'),
+					handler = function(event) {
+						if (input.value === '') {
+							input.focus();
+							return false; 
+						}
+					}; 
+			
+				if (window.addEventListener) {
+					form.addEventListener('submit', handler, false);
+				} else {
+					form.attachEvent('onsubmit', handler);
+				}
+			} ) ( document );
 			</script>
 		<?php } ?>
 		<?php


### PR DESCRIPTION
This fixes #2032 

I've tested the code in IE11 under IE8 emulation mode from inside the developer console, by first removing the original jQuery handler and running this code instead. I don't have the other browsers to test against, but if it works in IE8 it should work everywhere else. 

(I've also tested it against Firefox beta channel to check if the `addEventHandler` works, but since it supports rejecting form submits with `require` I'm not sure if it worked, but I think it did) 