### PR TITLE
Fixed get_file_data hash bug

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1819,10 +1819,10 @@ class Jetpack {
 	 * Like core's get_file_data implementation, but caches the result.
 	 */
 	public static function get_file_data( $file, $headers ) {
-                //Get just the filename from $file (i.e. exclude full path) so that a consistent hash is generated
-                $fileName = basename($file);
+		//Get just the filename from $file (i.e. exclude full path) so that a consistent hash is generated
+		$file_name = basename( $file );
 		$file_data_option = Jetpack_Options::get_option( 'file_data', array() );
-		$key              = md5( $fileName . serialize( $headers ) );
+		$key              = md5( $file_name . serialize( $headers ) );
 		$refresh_cache    = is_admin() && isset( $_GET['page'] ) && 'jetpack' === substr( $_GET['page'], 0, 7 );
 
 		// If we don't need to refresh the cache, and already have the value, short-circuit!

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1819,8 +1819,10 @@ class Jetpack {
 	 * Like core's get_file_data implementation, but caches the result.
 	 */
 	public static function get_file_data( $file, $headers ) {
+                //Get just the filename from $file (i.e. exclude full path) so that a consistent hash is generated
+                $fileName = basename($file);
 		$file_data_option = Jetpack_Options::get_option( 'file_data', array() );
-		$key              = md5( $file . serialize( $headers ) );
+		$key              = md5( $fileName . serialize( $headers ) );
 		$refresh_cache    = is_admin() && isset( $_GET['page'] ) && 'jetpack' === substr( $_GET['page'], 0, 7 );
 
 		// If we don't need to refresh the cache, and already have the value, short-circuit!


### PR DESCRIPTION
$key in get_file_data is generated using full system path of module.
This causes a new entry to be added to the file_data field in the
database every time the folder path changes (it's a problem when deploying site to
new folders with version tags via Ansible). Overtime this field gets huge and causes site meltdown right after deployment when the field attempts to update for each module.