### PR TITLE
Add rest_api_update_site_settings filter docblock

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -196,6 +196,13 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		// $this->input() retrieves posted arguments whitelisted and casted to the $request_format
 		// specs that get passed in when this class is instantiated
+		/**
+		 * Filters the settings to be updated on the site.
+		 * 
+		 * @since 3.6
+		 * 
+		 * @param array $input Associative array of site settings to be updated.
+		 */
 		$input = apply_filters( 'rest_api_update_site_settings', $this->input() );
 
 		$jetpack_relatedposts_options = array();


### PR DESCRIPTION
Per @jeherve's comment at https://github.com/Automattic/jetpack/pull/2114/files#r30107157, we should include a DocBlock explaining the `rest_api_update_site_settings` filter. This pull request adds said DocBlock.

/cc @dereksmart 