### PR TITLE
Add REST API Blog Auth & Stats function using it.

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -222,6 +222,12 @@ class Jetpack_Client {
 
 	/**
 	 * Query the WordPress.com REST API using the blog token
+	 *
+	 * @param string  $path
+	 * @param string  $version
+	 * @param array   $args
+	 * @param string  $body
+	 * @return array|WP_Error $response Data.
 	 */
 	static function wpcom_json_api_request_as_blog( $path, $version = self::WPCOM_JSON_API_VERSION, $args = array(), $body = null ) {
 		$filtered_args = array_intersect_key( $args, array(
@@ -230,6 +236,13 @@ class Jetpack_Client {
 			'redirection' => 'int',
 		) );
 
+		/**
+		 * Determines whether Jetpack can send outbound https requests to the WPCOM api.
+		 *
+		 * @since 3.6.0
+		 *
+		 * @param bool $proto Defaults to true.
+		 */
 		$proto = apply_filters( 'jetpack_can_make_outbound_https', true ) ? 'https' : 'http';
 
 		// unprecedingslashit

--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -1,6 +1,9 @@
 <?php
 
 class Jetpack_Client {
+	const WPCOM_JSON_API_HOST    = 'public-api.wordpress.com';
+	const WPCOM_JSON_API_VERSION = '1.1';
+
 	/**
 	 * Makes an authorized remote request using Jetpack_Signature
 	 *
@@ -216,4 +219,36 @@ class Jetpack_Client {
 			}
 		}
 	}
+
+	/**
+	 * Query the WordPress.com REST API using the blog token
+	 */
+	static function wpcom_json_api_request_as_blog( $path, $version = self::WPCOM_JSON_API_VERSION, $args = array(), $body = null ) {
+		$filtered_args = array_intersect_key( $args, array(
+			'method'      => 'string',
+			'timeout'     => 'int',
+			'redirection' => 'int',
+		) );
+
+		$proto = apply_filters( 'jetpack_can_make_outbound_https', true ) ? 'https' : 'http';
+
+		// unprecedingslashit
+		$_path = preg_replace( '/^\//', '', $path );
+
+		// Use GET by default whereas `remote_request` uses POST
+		if ( isset( $filtered_args['method'] ) && strtoupper( $filtered_args['method'] === 'POST' ) ) {
+			$request_method = 'POST';
+		} else {
+			$request_method = 'GET';
+		}
+
+		$validated_args = array_merge( $filtered_args, array(
+			'url'     => sprintf( '%s://%s/rest/v%s/%s', $proto, self::WPCOM_JSON_API_HOST, $version, $_path ),
+			'blog_id' => (int) Jetpack_Options::get_option( 'id' ),
+			'method'  => $request_method,
+		) );
+
+		return Jetpack_Client::remote_request( $validated_args, $body );
+	}
+
 }

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -33,7 +33,9 @@ class Jetpack_Options {
 				'site_icon_id',                // (int)    Attachment id of the site icon file
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
 				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
+				'restapi_stats_cache',         // (array) Stats Cache data.
 			);
+
 		case 'private' :
 			return array(
 				'register',

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -130,10 +130,18 @@ class Jetpack_Options {
 	 *
 	 * @param string $name Option name
 	 * @param mixed $value Option value
+	 * @param string $autoload If not compact option, allows specifying whether to autoload or not.
 	 */
-	public static function update_option( $name, $value ) {
+	public static function update_option( $name, $value, $autoload = null ) {
 		do_action( 'pre_update_jetpack_option_' . $name, $name, $value );
 		if ( self::is_valid( $name, 'non_compact' ) ) {
+			/**
+			 * Allowing update_option to change autoload status only shipped in WordPress v4.2
+			 * @link https://github.com/WordPress/WordPress/commit/305cf8b95
+			 */
+			if ( version_compare( $GLOBALS['wp_version'], '4.2', '>=' ) ) {
+				return update_option( "jetpack_$name", $value, $autoload );
+			}
 			return update_option( "jetpack_$name", $value );
 		}
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1234,7 +1234,8 @@ function stats_str_getcsv( $csv ) {
  * @return string
  */
 function jetpack_stats_api_path( $resource = '' ) {
-	return sprintf( '/sites/%d/stats%s', stats_get_option( 'blog_id' ), $resource );
+	$resource = ltrim( $resource, '/' );
+	return sprintf( '/sites/%d/stats/%s', stats_get_option( 'blog_id' ), $resource );
 }
 
 /**

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1253,7 +1253,7 @@ function stats_get_from_restapi( $args = array(), $resource = '' ) {
 		$time = key( $stats_cache[ $cache_key ] );
 		if ( time() - $time < ( 5 * MINUTE_IN_SECONDS ) ) {
 			$cached_stats = $stats_cache[ $cache_key ][ $time ];
-			$cached_stats = array_merge( array( 'cached_at' => $time ), $cached_stats );
+			$cached_stats = (object) array_merge( array( 'cached_at' => $time ), (array) $cached_stats );
 			return $cached_stats;
 		}
 		unset( $stats_cache[ $cache_key ] );

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1227,6 +1227,12 @@ function stats_str_getcsv( $csv ) {
 	return $data;
 }
 
+/**
+ * Abstract out building the rest api stats path.
+ *
+ * @param  string $resource
+ * @return string
+ */
 function jetpack_stats_api_path( $resource = '' ) {
 	return sprintf( '/sites/%d/stats%s', stats_get_option( 'blog_id' ), $resource );
 }
@@ -1234,6 +1240,10 @@ function jetpack_stats_api_path( $resource = '' ) {
 /**
  * Fetches stats data from the REST API.  Caches locally for 5 minutes.
  *
+ * @link: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/
+ *
+ * @param  array|string   $args     The args that are passed to the endpoint
+ * @param  string         $resource Optional sub-endpoint following /stats/
  * @return array|WP_Error
  */
 function stats_get_from_restapi( $args = array(), $resource = '' ) {

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1252,7 +1252,9 @@ function stats_get_from_restapi( $args = array(), $resource = '' ) {
 	if ( isset( $stats_cache[ $cache_key ] ) ) {
 		$time = key( $stats_cache[ $cache_key ] );
 		if ( time() - $time < ( 5 * MINUTE_IN_SECONDS ) ) {
-			return $stats_cache[ $cache_key ][ $time ];
+			$cached_stats = $stats_cache[ $cache_key ][ $time ];
+			$cached_stats = array_merge( array( 'cached_at' => $time ), $cached_stats );
+			return $cached_stats;
 		}
 		unset( $stats_cache[ $cache_key ] );
 	}

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1236,7 +1236,7 @@ function jetpack_stats_api_path( $resource = '' ) {
  *
  * @return array|WP_Error
  */
-function stats_get_from_restapi( $args, $resource = '' ) {
+function stats_get_from_restapi( $args = array(), $resource = '' ) {
 	$endpoint    = jetpack_stats_api_path( $resource );
 	$api_version = '1.1';
 	$args        = wp_parse_args( $args, array() );


### PR DESCRIPTION
Major props to @jblz who had done the grunt of this lifting.

To Test:

On WPCOM push through a commit to the `$this->jetpack_auth_allowed_sites` on or about line 87 of `public.api/rest/class.wpcom-json-api.php` adding the site id that you will be testing with.

Then, from the Jetpack site whose id was whitelisted for testing, run this from the command line:

```
wp eval "print_r( stats_get_from_restapi() );"
```

through wp-cli.  It should give you good data back.

This pull request does NOT in any way account for a gui, it is merely providing utility functions.