### PR TITLE
Identity crisis resolution

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -168,8 +168,8 @@ class Jetpack_Sync {
 			return false;
 		}
 
-		// Don't sync anything while in development mode
-		if ( Jetpack::is_development_mode() ) {
+		// Don't sync anything from a staging site.
+		if ( Jetpack::is_development_mode() || Jetpack::jetpack_is_staging_site() ) {
 			return false;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5345,8 +5345,8 @@ p {
 		return apply_filters( 'jetpack_has_identity_crisis', $errors, $force_recheck );
 	}
 	
-	public static function resolve_identity_crisis( $key = null ) {
-		
+	public static function resolve_identity_crisis( $key = null )
+	{
 		if( $key ) {
 			$identity_options = array( $key );
 		} else {
@@ -5356,7 +5356,6 @@ p {
 		if( is_array( $identity_options ) ) :  foreach( $identity_options as $identity_option ) :
 			Jetpack_Sync::sync_options( __FILE__, $identity_option );
 		endforeach; endif;
-		
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5514,7 +5514,7 @@ p {
 ?>
 <script>
 (function( $ ) {
-	var SECOND_IN_MS = 500;
+	var SECOND_IN_MS = 1000;
 
 	function contactSupport( e ) {
 		e.preventDefault();
@@ -5539,7 +5539,7 @@ p {
 				$( '.jp-id-crisis-question' ).hide();
 				$( '.banner-title' ).hide();
 				$( '#jp-id-crisis-success' ).show();
-				setTimeout( autodismissSuccessBanner, 8 * SECOND_IN_MS );
+				setTimeout( autodismissSuccessBanner, 4 * SECOND_IN_MS );
 			});
 
 		});
@@ -5569,7 +5569,7 @@ p {
 				$( '.jp-id-crisis-question' ).hide();
 				$( '.banner-title' ).hide();
 				$( '#jp-id-crisis-success' ).show();
-				setTimeout( autodismissSuccessBanner, 8 * SECOND_IN_MS );
+				setTimeout( autodismissSuccessBanner, 4 * SECOND_IN_MS );
 			});
 		});
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5454,17 +5454,17 @@ p {
 
 		<div id="message" class="error jetpack-message jp-identity-crisis">
 			<div class="jp-id-banner__content">
-				<h4><?php _e( 'Something has gotten mixed up and needs your attention for Jetpack to function properly.', 'jetpack' ); ?></h4>
+				<h4><?php _e( 'Your Jetpack connection isn’t working as it should be.', 'jetpack' ); ?></h4>
 
 				<p class="jp-id-crisis-question"
-				   id="jp-id-crisis-question-1"><?php printf( __( 'We noticed that your site used to be at <strong>%1$s</strong> and now it\'s at <strong> %2$s </strong>.  Did you permanently move this site?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+				   id="jp-id-crisis-question-1"><?php printf( __( 'Jetpack is looking for your site be at <strong>%1$s</strong><small>(previous)</small> did you permanently move it here <strong> %2$s </strong><small>(current)</small>.', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					<br/>
 					<a href="#" onclick="alert('fixing...'); return false;" class="button button-primary regular">Yes</a>
 					<a href="#" class="button" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-2').show(); return false">No</a>
 				</p>
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-2"
-				   style="display: none;"><?php printf( __( 'Is this a completely separate site than the one that was at <strong> %1$s </strong>?', 'jetpack' ), $errors[ $key ] ); ?>
+				   style="display: none;"><?php printf( __( 'Is this website a distinctly separate website from <strong> %1$s </strong>?', 'jetpack' ), $errors[ $key ] ); ?>
 					<br/>
 					<a href="#"
 					   onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3a').show(); return false">Yes</a>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5563,7 +5563,7 @@ p {
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-2"
 				   style="display: none;"><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					<div class="btn-group">
-						<a href="#" class="button button-primary is-distinct-site">Reset the connection</a>
+						<a href="#" class="button is-distinct-site">Reset the connection</a>
 						<a href="#" class="button not-distinct-site">This is a dev environment</a>
 						<a href="#" class="button not-distinct-site">Submit a support ticket</a>
 					</div>
@@ -5571,16 +5571,18 @@ p {
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3a"
 				   style="display: none;"><?php printf( __( 'Would you like us to reset your options?  This will remove your followers and linked services from <strong>%1$s</strong>.', 'jetpack' ), (string) get_option( $key ) ); ?>
-					<br/>
-					<a href="<?php echo $this->build_reconnect_url() ?>">Yes</a>
-					<a href="#" class="not-reconnecting">No</a>
+					<div class="btn-group">
+						<a href="<?php echo $this->build_reconnect_url() ?>" class="button">Yes</a>
+						<a href="#" class="button not-reconnecting">No</a>
+					</div>
 				</p>
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3b"
 				   style="display: none;"><?php printf( __( 'Is <strong>%1$s</strong> a staging or development site?.', 'jetpack' ), (string) get_option( $key ) ); ?>
-					<br/>
-					<a href="#dismiss-forever" class="is-staging-or-dev">Yes</a>
-					<a href="#" class="not-staging-or-dev">No (or not sure)</a>
+					<div class="btn-group">
+						<a href="#dismiss-forever" class="button is-staging-or-dev">Yes</a>
+						<a href="#" class="button not-staging-or-dev">No (or not sure)</a>
+					</div>
 				</p>
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-contact-support" style="display: none;">It's probably

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -562,7 +562,7 @@ class Jetpack {
 		// Jump Start AJAX callback function
 		add_action( 'wp_ajax_jetpack_admin_ajax',  array( $this, 'jetpack_jumpstart_ajax_callback' ) );
 		add_action( 'update_option', array( $this, 'jumpstart_has_updated_module_option' ) );
-		
+
 		// Identity Crisis AJAX callback function
 		add_action( 'wp_ajax_jetpack_resolve_identity_crisis', array( $this, 'resolve_identity_crisis_ajax_callback' ) );
 
@@ -5300,7 +5300,7 @@ p {
 
 				// If it's not the same as the local value...
 				if ( $cloud_value !== get_option( $cloud_key ) ) {
-					
+
 					$parsed_cloud_value = parse_url( $cloud_value );
 					// If the current options is an IP address
 					if ( filter_var( $parsed_cloud_value[ 'host' ], FILTER_VALIDATE_IP ) ) {
@@ -5347,7 +5347,7 @@ p {
 		 */
 		return apply_filters( 'jetpack_has_identity_crisis', $errors, $force_recheck );
 	}
-	
+
 	public static function resolve_identity_crisis( $key = null )
 	{
 		if( $key ) {
@@ -5355,47 +5355,48 @@ p {
 		} else {
 			$identity_options = self::identity_crisis_options_to_check();
 		}
-		
+
 		if( is_array( $identity_options ) ) {  foreach( $identity_options as $identity_option ) {
 			Jetpack_Sync::sync_options( __FILE__, $identity_option );
 		} }
 	}
-	
+
 	public static function whitelist_current_url()
 	{
 		$options_to_check = self::identity_crisis_options_to_check();
 		$cloud_options = Jetpack::init()->get_cloud_site_options( $options_to_check );
-		
+
 		foreach ( $cloud_options as $cloud_key => $cloud_value ) {
 			Jetpack::whitelist_identity_crisis_value ( $cloud_key, $cloud_value )
 		}
-		
+
 		return;
 	}
-	
+
 	public static function resolve_identity_crisis_ajax_callback()
 	{
 		/*
 			FIXME turn on nonce
 		*/
 		//check_ajax_referer( 'resolve-identity-crisis', 'ajax-nonce' );
-		
-		switch ( $_POST[ 'action' ] ) {
+
+		switch ( $_POST[ 'crisis_resolution_action' ] ) {
 			case 'site_migrated':
 				Jetpack::resolve_identity_crisis();
-				return 'ok';
+				echo 'ok';
 				break;
-				
+
 			case 'whitelist':
-				Jetpack::whitelist_current_url( )
-				return 'ok';
+				Jetpack::whitelist_current_url();
+				echo 'ok';
 				break;
-			
+
 			default:
-				return 'missing action';
+				echo 'missing action';
 				break;
 		}
-		
+
+		wp_die();
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5467,7 +5467,7 @@ p {
 	}
 
 	function autodismissSuccessBanner() {
-		$( '.jp-identity-crisis' ).addClass( 'dismiss' );
+		$( '.jp-identity-crisis' ).fadeOut(600); //.addClass( 'dismiss' );
 	}
 
 	var data = { action: 'jetpack_resolve_identity_crisis', 'ajax-nonce': '<?php echo $nonce; ?>' };

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5297,10 +5297,12 @@ p {
 
 				// If it's not the same as the local value...
 				if ( $cloud_value !== get_option( $cloud_key ) ) {
+					
+					$parsed_cloud_value = parse_url( $cloud_value );
 					// If the current options is an IP address
-					if ( filter_var( preg_replace( '#^http(s)?://', '', $cloud_value ), FILTER_VALIDATE_IP ) ) {
+					if ( filter_var( $parsed_cloud_value[ 'host' ], FILTER_VALIDATE_IP ) ) {
 						// Give the new value a Jetpack to fly in to the clouds
-						Jetpack_Sync::sync_options( __FILE__, $cloud_key );
+						Jetpack::resolve_identity_crisis( $cloud_key );
 						continue;
 					}
 
@@ -5341,6 +5343,20 @@ p {
 		 * @param bool $force_recheck Ignore any cached transient and manually re-check. Default to false.
 		 */
 		return apply_filters( 'jetpack_has_identity_crisis', $errors, $force_recheck );
+	}
+	
+	public static function resolve_identity_crisis( $key = null ) {
+		
+		if( $key ) {
+			$identity_options = array( $key );
+		} else {
+			$identity_options = self::identity_crisis_options_to_check();
+		}
+		
+		if( is_array( $identity_options ) ) :  foreach( $identity_options as $identity_option ) :
+			Jetpack_Sync::sync_options( __FILE__, $identity_option );
+		endforeach; endif;
+		
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1757,10 +1757,6 @@ class Jetpack {
 			Jetpack::deactivate_module( $active_module );
 		}
 
-		if ( version_compare( $jetpack_version, '1.9.2', '<' ) && version_compare( '1.9-something', JETPACK__VERSION, '<' ) ) {
-			add_action( 'jetpack_activate_default_modules', array( $this->sync, 'sync_all_registered_options' ), 1000 );
-		}
-
 		$new_version = JETPACK__VERSION . ':' . time();
 		/** This action is documented in class.jetpack.php */
 		do_action( 'updating_jetpack_version', $new_version, $jetpack_old_version );
@@ -2796,8 +2792,7 @@ p {
 			// Show the notice on the Dashboard only for now
 
 			add_action( 'load-index.php', array( $this, 'prepare_manage_jetpack_notice' ) );
-		add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
-		add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
+			add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
 		}
 
 		// If the plugin has just been disconnected from WP.com, show the survey notice
@@ -5010,13 +5005,6 @@ p {
 		// Explode hostname on '.'
 		$exploded_host = explode( '.', $host );
 
-		// Retreive the name and TLD
-		$name = $exploded_host[ count( $exploded_host ) - 2 ];
-		$tld = $exploded_host[ count( $exploded_host ) - 1 ];
-
-		// Rebuild domain excluding subdomains
-		$domain = $name . '.' . $tld;
-
 		// Retrieve the name and TLD
 		if ( count( $exploded_host ) > 1 ) {
 			$name = $exploded_host[ count( $exploded_host ) - 2 ];
@@ -5318,7 +5306,7 @@ p {
 
 					$parsed_cloud_value = parse_url( $cloud_value );
 					// If the current options is an IP address
-					if ( filter_var( $parsed_cloud_value[ 'host' ], FILTER_VALIDATE_IP ) ) {
+					if ( filter_var( $parsed_cloud_value['host'], FILTER_VALIDATE_IP ) ) {
 						// Give the new value a Jetpack to fly in to the clouds
 						Jetpack::resolve_identity_crisis( $cloud_key );
 						continue;
@@ -5337,7 +5325,7 @@ p {
 						 *
 						 * @see https://github.com/Automattic/jetpack/issues/1006
 						 */
-						if( ( 'home' == $cloud_key || 'siteurl' == $cloud_key )
+						if ( ( 'home' == $cloud_key || 'siteurl' == $cloud_key )
 							&& ( substr( $cloud_value, 0, 8 ) == "https://" )
 							&& Jetpack::init()->is_ssl_required_to_visit_site() ) {
 							// Ok, we found a mismatch of http and https because of wp-config, not an invalid url
@@ -5363,21 +5351,21 @@ p {
 		return apply_filters( 'jetpack_has_identity_crisis', $errors, $force_recheck );
 	}
 
-	public static function resolve_identity_crisis( $key = null )
-	{
-		if( $key ) {
+	public static function resolve_identity_crisis( $key = null ) {
+		if ( $key ) {
 			$identity_options = array( $key );
 		} else {
 			$identity_options = self::identity_crisis_options_to_check();
 		}
 
-		if( is_array( $identity_options ) ) {  foreach( $identity_options as $identity_option ) {
-			Jetpack_Sync::sync_options( __FILE__, $identity_option );
-		} }
+		if ( is_array( $identity_options ) ) {
+			foreach( $identity_options as $identity_option ) {
+				Jetpack_Sync::sync_options( __FILE__, $identity_option );
+			}
+		}
 	}
 
-	public static function whitelist_current_url()
-	{
+	public static function whitelist_current_url() {
 		$options_to_check = Jetpack::identity_crisis_options_to_check();
 		$cloud_options = Jetpack::init()->get_cloud_site_options( $options_to_check );
 
@@ -5388,8 +5376,7 @@ p {
 		return;
 	}
 	
-	public static function resolve_identity_crisis_ajax_callback()
-	{
+	public static function resolve_identity_crisis_ajax_callback() {
 		/*
 			FIXME turn on nonce
 		*/
@@ -5422,8 +5409,7 @@ p {
 	 *
 	 * @return bool Whether the value was added to the whitelist, or false if it was already there.
 	 */
-	public static function whitelist_identity_crisis_value ( $key, $value )
-	{
+	public static function whitelist_identity_crisis_value( $key, $value ) {
 		if ( Jetpack::is_identity_crisis_value_whitelisted( $key, $value ) ) {
 			return false;
 		}
@@ -5518,19 +5504,22 @@ p {
 	/**
 	 * Displays an admin_notice, alerting the user to an identity crisis.
 	 */
-	public function alert_identity_crisis ()
-	{
+	public function alert_identity_crisis() {
 		//JESSE: this needs to get included in your POST as "ajax-nonce"
-		$ajax_nonce = wp_create_nonce( "resolve-identity-crisis" );
+		$ajax_nonce = wp_create_nonce( 'resolve-identity-crisis' );
 
 		$this->identity_crisis_js( $ajax_nonce );
 
-		if ( ! current_user_can( 'manage_options' ) ) return;
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-		if ( ! $errors = self::check_identity_crisis() ) return;
+		if ( ! $errors = self::check_identity_crisis() ) {
+			return;
+		}
 
 		$key = 'siteurl';
-		if( ! $errors[ $key ] ) {
+		if ( ! $errors[ $key ] ) {
 			$key = 'home';
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1757,10 +1757,6 @@ class Jetpack {
 			Jetpack::deactivate_module( $active_module );
 		}
 
-		if ( version_compare( $jetpack_version, '1.9.2', '<' ) && version_compare( '1.9-something', JETPACK__VERSION, '<' ) ) {
-			add_action( 'jetpack_activate_default_modules', array( $this->sync, 'sync_all_registered_options' ), 1000 );
-		}
-
 		$new_version = JETPACK__VERSION . ':' . time();
 		/** This action is documented in class.jetpack.php */
 		do_action( 'updating_jetpack_version', $new_version, $jetpack_old_version );
@@ -2796,8 +2792,7 @@ p {
 			// Show the notice on the Dashboard only for now
 
 			add_action( 'load-index.php', array( $this, 'prepare_manage_jetpack_notice' ) );
-		add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
-		add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
+			add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
 		}
 
 		// If the plugin has just been disconnected from WP.com, show the survey notice
@@ -5010,13 +5005,6 @@ p {
 		// Explode hostname on '.'
 		$exploded_host = explode( '.', $host );
 
-		// Retreive the name and TLD
-		$name = $exploded_host[ count( $exploded_host ) - 2 ];
-		$tld = $exploded_host[ count( $exploded_host ) - 1 ];
-
-		// Rebuild domain excluding subdomains
-		$domain = $name . '.' . $tld;
-
 		// Retrieve the name and TLD
 		if ( count( $exploded_host ) > 1 ) {
 			$name = $exploded_host[ count( $exploded_host ) - 2 ];
@@ -5317,9 +5305,8 @@ p {
 				if ( $cloud_value !== get_option( $cloud_key ) ) {
 
 					$parsed_cloud_value = parse_url( $cloud_value );
-					
-					// If the current option is an IP address
-					if ( filter_var( $parsed_cloud_value[ 'host' ], FILTER_VALIDATE_IP ) ) {
+					// If the current options is an IP address
+					if ( filter_var( $parsed_cloud_value['host'], FILTER_VALIDATE_IP ) ) {
 						// Give the new value a Jetpack to fly in to the clouds
 						Jetpack::resolve_identity_crisis( $cloud_key );
 						continue;
@@ -5338,7 +5325,7 @@ p {
 						 *
 						 * @see https://github.com/Automattic/jetpack/issues/1006
 						 */
-						if( ( 'home' == $cloud_key || 'siteurl' == $cloud_key )
+						if ( ( 'home' == $cloud_key || 'siteurl' == $cloud_key )
 							&& ( substr( $cloud_value, 0, 8 ) == "https://" )
 							&& Jetpack::init()->is_ssl_required_to_visit_site() ) {
 							// Ok, we found a mismatch of http and https because of wp-config, not an invalid url
@@ -5364,21 +5351,21 @@ p {
 		return apply_filters( 'jetpack_has_identity_crisis', $errors, $force_recheck );
 	}
 
-	public static function resolve_identity_crisis( $key = null )
-	{
-		if( $key ) {
+	public static function resolve_identity_crisis( $key = null ) {
+		if ( $key ) {
 			$identity_options = array( $key );
 		} else {
 			$identity_options = self::identity_crisis_options_to_check();
 		}
 
-		if( is_array( $identity_options ) ) {  foreach( $identity_options as $identity_option ) {
-			Jetpack_Sync::sync_options( __FILE__, $identity_option );
-		} }
+		if ( is_array( $identity_options ) ) {
+			foreach( $identity_options as $identity_option ) {
+				Jetpack_Sync::sync_options( __FILE__, $identity_option );
+			}
+		}
 	}
 
-	public static function whitelist_current_url()
-	{
+	public static function whitelist_current_url() {
 		$options_to_check = Jetpack::identity_crisis_options_to_check();
 		$cloud_options = Jetpack::init()->get_cloud_site_options( $options_to_check );
 
@@ -5389,8 +5376,10 @@ p {
 		return;
 	}
 	
-	public static function resolve_identity_crisis_ajax_callback()
-	{
+	public static function resolve_identity_crisis_ajax_callback() {
+		/*
+			FIXME turn on nonce
+		*/
 		check_ajax_referer( 'resolve-identity-crisis', 'ajax-nonce' );
 
 		switch ( $_POST[ 'crisis_resolution_action' ] ) {
@@ -5420,8 +5409,7 @@ p {
 	 *
 	 * @return bool Whether the value was added to the whitelist, or false if it was already there.
 	 */
-	public static function whitelist_identity_crisis_value ( $key, $value )
-	{
+	public static function whitelist_identity_crisis_value( $key, $value ) {
 		if ( Jetpack::is_identity_crisis_value_whitelisted( $key, $value ) ) {
 			return false;
 		}
@@ -5516,19 +5504,22 @@ p {
 	/**
 	 * Displays an admin_notice, alerting the user to an identity crisis.
 	 */
-	public function alert_identity_crisis ()
-	{
+	public function alert_identity_crisis() {
 		//JESSE: this needs to get included in your POST as "ajax-nonce"
-		$ajax_nonce = wp_create_nonce( "resolve-identity-crisis" );
+		$ajax_nonce = wp_create_nonce( 'resolve-identity-crisis' );
 
 		$this->identity_crisis_js( $ajax_nonce );
 
-		if ( ! current_user_can( 'manage_options' ) ) return;
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-		if ( ! $errors = self::check_identity_crisis() ) return;
+		if ( ! $errors = self::check_identity_crisis() ) {
+			return;
+		}
 
 		$key = 'siteurl';
-		if( ! $errors[ $key ] ) {
+		if ( ! $errors[ $key ] ) {
 			$key = 'home';
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5384,17 +5384,45 @@ p {
 
 		if ( ! $errors = self::check_identity_crisis() )
 			return;
+
+		$key = 'siteurl';
+		if( ! $errors[ $key ] ) {
+			$key = 'home';
+		}
+
 		?>
 
 		<div id="message" class="updated jetpack-message jp-identity-crisis">
-			<div class="jp-banner__content">
-				<h4><?php _e( 'Something has gotten mixed up!', 'jetpack' ); ?></h4>
-				<?php foreach ( $errors as $key => $value ) : ?>
-					<p><?php printf( __( 'Your <code>%1$s</code> option is set up as <strong>%2$s</strong>, but your WordPress.com connection lists it as <strong>%3$s</strong>!', 'jetpack' ), $key, (string) get_option( $key ), $value ); ?></p>
-				<?php endforeach; ?>
-				<p><a href="<?php echo $this->build_reconnect_url() ?>"><?php _e( 'The data listed above is not for my current site. Please disconnect, and then form a new connection to WordPress.com for this site using my current settings.', 'jetpack' ); ?></a></p>
-				<p><a href="#"><?php _e( 'Ignore the difference. This is just a staging site for the real site referenced above.', 'jetpack' ); ?></a></p>
-				<p><a href="#"><?php _e( 'That used to be my URL for this site before I changed it. Update the WordPress.com Cloud\'s data to match my current settings.', 'jetpack' ); ?></a></p>
+			<div class="jp-id-banner__content">
+				<h4><?php _e( 'Something has gotten mixed up with your Jetpack!', 'jetpack' ); ?></h4>
+				
+				<p class="jp-id-crisis-question" id="jp-id-crisis-question-1"><?php printf( __( 'We noticed that site used to be at <strong>%1$s</strong>, and now it\'s at <strong> %2$s </strong>.  Did you permanently move this site between those URLs?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+					<br />
+					<a href="#" onclick="alert('fixing...'); return false;">Yes</a>
+					<a href="#" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-2').show(); return false">No</a>
+				</p>
+				
+				<p class="jp-id-crisis-question" id="jp-id-crisis-question-2" style="display: none;"><?php printf( __( 'Is this a completely separate site than the one that was at <strong> %1$s </strong>?', 'jetpack' ), $errors[ $key ] ); ?>
+					<br />
+					<a href="#" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3a').show(); return false">Yes</a>
+					<a href="#" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3b').show(); return false">No</a>
+				</p>
+				
+				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3a" style="display: none;"><?php printf( __( 'Would you like us to reset your options?  This will remove your followers and linked services from <strong>%1$s</strong>.', 'jetpack' ), (string) get_option( $key ) ); ?>
+					<br />
+					<a href="<?php echo $this->build_reconnect_url() ?>" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3a').show(); return false">Yes</a>
+					<a href="#" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-contact-support').show(); return false">No</a>
+				</p>
+				
+				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3b" style="display: none;"><?php printf( __( 'Is <strong>%1$s</strong> a staging or development site?.', 'jetpack' ), (string) get_option( $key ) ); ?>
+					<br />
+					<a href="#dismiss-forever" onclick="alert('ok, going away forevah'); return false">Yes</a>
+					<a href="#" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery
+					('#jp-id-crisis-contact-support').show(); return false">No (or not sure)</a>
+				</p>
+				
+				<p class="jp-id-crisis-question" id="jp-id-crisis-contact-support" style="display: none;">It's probably best that you get in touch with support at this point...</p>
+
 			</div>
 		</div>
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5353,9 +5353,9 @@ p {
 			$identity_options = self::identity_crisis_options_to_check();
 		}
 		
-		if( is_array( $identity_options ) ) :  foreach( $identity_options as $identity_option ) :
+		if( is_array( $identity_options ) ) {  foreach( $identity_options as $identity_option ) {
 			Jetpack_Sync::sync_options( __FILE__, $identity_option );
-		endforeach; endif;
+		} }
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5458,10 +5458,16 @@ p {
 ?>
 <script>
 (function( $ ) {
+	var SECOND_IN_MS = 1000;
+
 	function contactSupport( e ) {
 		e.preventDefault();
 		$( '.jp-id-crisis-question' ).hide();
 		$( '#jp-id-crisis-contact-support' ).show();
+	}
+
+	function autodismissSuccessBanner() {
+		$( '#jp-id-crisis-success' ).addClass( 'dismiss' );
 	}
 
 	var data = { action: 'jetpack_resolve_identity_crisis', 'ajax-nonce': '<?php echo $nonce; ?>' };
@@ -5475,6 +5481,7 @@ p {
 				$( '.jp-id-crisis-question' ).hide();
 				$( '.banner-title' ).hide();
 				$( '#jp-id-crisis-success' ).show();
+				setTimeout( autodismissSuccessBanner, 8 * SECOND_IN_MS );
 			});
 
 		});
@@ -5496,6 +5503,7 @@ p {
 				$( '.jp-id-crisis-question' ).hide();
 				$( '.banner-title' ).hide();
 				$( '#jp-id-crisis-success' ).show();
+				setTimeout( autodismissSuccessBanner, 8 * SECOND_IN_MS );
 			});
 		});
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5351,6 +5351,15 @@ p {
 		return apply_filters( 'jetpack_has_identity_crisis', $errors, $force_recheck );
 	}
 
+	/*
+	 * Resolve ID crisis
+	 *
+	 * If the URL has changed, but the rest of the options are the same (i.e. blog/user tokens)
+	 * The user has the option to update the shadow site with the new URL before a new
+	 * token is created.
+	 *
+	 * @param $key : Which option to sync.  null defautlts to home and siteurl
+	 */
 	public static function resolve_identity_crisis( $key = null ) {
 		if ( $key ) {
 			$identity_options = array( $key );
@@ -5368,6 +5377,11 @@ p {
 		}
 	}
 
+	/*
+	 * Whitelist URL
+	 *
+	 * Ignore the URL differences between the blog and the shadow site.
+	 */
 	public static function whitelist_current_url() {
 		$options_to_check = Jetpack::identity_crisis_options_to_check();
 		$cloud_options = Jetpack::init()->get_cloud_site_options( $options_to_check );
@@ -5378,7 +5392,15 @@ p {
 
 		return;
 	}
-	
+
+	/*
+	 * Ajax callbacks for ID crisis resolutions
+	 *
+	 * Things that could happen here:
+	 *  - site_migrated : Update the URL on the shadow blog to match new domain
+	 *  - whitelist     : Ignore the URL difference
+	 *  - default       : Error message
+	 */
 	public static function resolve_identity_crisis_ajax_callback() {
 		check_ajax_referer( 'resolve-identity-crisis', 'ajax-nonce' );
 
@@ -5459,6 +5481,8 @@ p {
 	var data = { action: 'jetpack_resolve_identity_crisis', 'ajax-nonce': '<?php echo $nonce; ?>' };
 
 	$( document ).ready(function() {
+
+		// Site moved: Update the URL on the shadow blog
 		$( '.site-moved' ).click(function( e ) {
 			e.preventDefault();
 			data.crisis_resolution_action = 'site_migrated';
@@ -5472,16 +5496,19 @@ p {
 
 		});
 
+		// URL hasn't changed, next question please.
 		$( '.site-not-moved' ).click(function( e ) {
 			e.preventDefault();
 			$( '.jp-id-crisis-question' ).hide();
 			$( '#jp-id-crisis-question-2' ).show();
 		});
 
+		// Reset connection: two separate sites.
 		$( '.reset-connection' ).click(function( e ) {
 			$( '#jp-id-crisis-question-2 .spinner' ).show();
 		});
 
+		// It's a dev environment.  Ignore.
 		$( '.is-dev-env' ).click(function( e ) {
 			data.crisis_resolution_action = 'whitelist';
 			$( '#jp-id-crisis-question-2 .spinner' ).show();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5551,14 +5551,15 @@ p {
 			<div class="jp-id-banner__content">
 				<h3><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h3>
 
-				<p class="jp-id-crisis-question"
-				   id="jp-id-crisis-question-1"><?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
-				</p>
-				<div class="btn-group">
-					<a href="#" class="button button-primary regular site-moved"><?php _e( 'I\'ve updated it.' ); ?></a>
-					<a href="#" class="button site-not-moved" ><?php _e( 'That\'s still my domain.' ); ?></a>
+				<div class="jp-id-crisis-question" id="jp-id-crisis-question-1">
+					<p>
+					<?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+					</p>
+					<div class="btn-group">
+						<a href="#" class="button button-primary regular site-moved"><?php _e( 'I\'ve updated it.' ); ?></a>
+						<a href="#" class="button site-not-moved" ><?php _e( 'That\'s still my domain.' ); ?></a>
+					</div>
 				</div>
-				
 
 				<div class="jp-id-crisis-question" id="jp-id-crisis-question-2">
 					<p style="display: none;"><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5559,8 +5559,7 @@ p {
 				</div>
 
 				<div class="jp-id-crisis-success" id="jp-id-crisis-success" style="display: none;">
-					<h3 class="success-notice"><?php printf( __( 'Thank you for taking the time. We have updated our records accordingly.', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
-					</p>
+					<h3 class="success-notice"><?php printf( __( 'Thank you for taking the time. We have updated our records accordingly.', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?></h3>
 				</div>
 			</div>
 		</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5553,37 +5553,40 @@ p {
 
 				<p class="jp-id-crisis-question"
 				   id="jp-id-crisis-question-1"><?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
-				
-					<div class="btn-group">
+				</p>
+				<div class="btn-group">
 					<a href="#" class="button button-primary regular site-moved"><?php _e( 'I\'ve updated it.' ); ?></a>
 					<a href="#" class="button site-not-moved" ><?php _e( 'That\'s still my domain.' ); ?></a>
-					</div>
-				</p>
+				</div>
+				
 
-				<p class="jp-id-crisis-question" id="jp-id-crisis-question-2"
-				   style="display: none;"><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+				<div class="jp-id-crisis-question" id="jp-id-crisis-question-2">
+					<p style="display: none;"><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+					</p>	
 					<div class="btn-group">
 						<a href="#" class="button is-distinct-site">Reset the connection</a>
 						<a href="#" class="button not-distinct-site">This is a dev environment</a>
 						<a href="#" class="button not-distinct-site">Submit a support ticket</a>
 					</div>
-				</p>
+				</div>
 
-				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3a"
-				   style="display: none;"><?php printf( __( 'Would you like us to reset your options?  This will remove your followers and linked services from <strong>%1$s</strong>.', 'jetpack' ), (string) get_option( $key ) ); ?>
+				<div class="jp-id-crisis-question" id="jp-id-crisis-question-3a">
+					<p style="display: none;"><?php printf( __( 'Would you like us to reset your options?  This will remove your followers and linked services from <strong>%1$s</strong>.', 'jetpack' ), (string) get_option( $key ) ); ?>
+					</p>
 					<div class="btn-group">
 						<a href="<?php echo $this->build_reconnect_url() ?>" class="button">Yes</a>
 						<a href="#" class="button not-reconnecting">No</a>
 					</div>
-				</p>
-
+				</div>
+				
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3b"
 				   style="display: none;"><?php printf( __( 'Is <strong>%1$s</strong> a staging or development site?.', 'jetpack' ), (string) get_option( $key ) ); ?>
-					<div class="btn-group">
-						<a href="#dismiss-forever" class="button is-staging-or-dev">Yes</a>
-						<a href="#" class="button not-staging-or-dev">No (or not sure)</a>
-					</div>
 				</p>
+				<div class="btn-group">
+					<a href="#dismiss-forever" class="button is-staging-or-dev">Yes</a>
+					<a href="#" class="button not-staging-or-dev">No (or not sure)</a>
+				</div>
+				
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-contact-support" style="display: none;">It's probably
 					best that you get in touch with support at this point...</p>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5463,6 +5463,11 @@ p {
 	 * @return bool True = already whitelsisted False = not whitelisted
 	 */
 	public static function jetpack_is_staging_site() {
+		$current_whitelist = Jetpack_Options::get_option( 'identity_crisis_whitelist' );
+		if ( ! $current_whitelist ) {
+			return false;
+		}
+
 		$options_to_check  = Jetpack::identity_crisis_options_to_check();
 		$cloud_options     = Jetpack::init()->get_cloud_site_options( $options_to_check );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5393,7 +5393,7 @@ p {
 		/*
 			FIXME turn on nonce
 		*/
-		//check_ajax_referer( 'resolve-identity-crisis', 'ajax-nonce' );
+		check_ajax_referer( 'resolve-identity-crisis', 'ajax-nonce' );
 
 		switch ( $_POST[ 'crisis_resolution_action' ] ) {
 			case 'site_migrated':
@@ -5454,7 +5454,7 @@ p {
 		return false;
 	}
 
-	public function identity_crisis_js() {
+	public function identity_crisis_js( $nonce ) {
 ?>
 <script>
 (function( $ ) {
@@ -5464,7 +5464,7 @@ p {
 		$( '#jp-id-crisis-contact-support' ).show();
 	}
 
-	var data = { action: 'jetpack_resolve_identity_crisis' };
+	var data = { action: 'jetpack_resolve_identity_crisis', 'ajax-nonce': '<?php echo $nonce; ?>' };
 
 	$( document ).ready(function() {
 		$( '.site-moved' ).click(function( e ) {
@@ -5519,7 +5519,10 @@ p {
 	 */
 	public function alert_identity_crisis ()
 	{
-		$this->identity_crisis_js();
+		//JESSE: this needs to get included in your POST as "ajax-nonce"
+		$ajax_nonce = wp_create_nonce( "resolve-identity-crisis" );
+
+		$this->identity_crisis_js( $ajax_nonce );
 
 		if ( ! current_user_can( 'manage_options' ) ) return;
 
@@ -5529,9 +5532,6 @@ p {
 		if( ! $errors[ $key ] ) {
 			$key = 'home';
 		}
-
-		//JESSE: this needs to get included in your POST as "ajax-nonce"
-		$ajax_nonce = wp_create_nonce( "resolve-identity-crisis" );
 
 		?>
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5299,7 +5299,7 @@ p {
 			foreach ( $cloud_options as $cloud_key => $cloud_value ) {
 
 				// FIXME: FOR TESTING ONLY.  DO NOT COMMIT TO MASTER
-				$cloud_value = str_replace( 'wpsandbox.me', 'com', $cloud_value );
+//				$cloud_value = str_replace( 'wpsandbox.me', 'com', $cloud_value );
 
 				// If it's not the same as the local value...
 				if ( $cloud_value !== get_option( $cloud_key ) ) {
@@ -5361,6 +5361,9 @@ p {
 		if ( is_array( $identity_options ) ) {
 			foreach( $identity_options as $identity_option ) {
 				Jetpack_Sync::sync_options( __FILE__, $identity_option );
+
+				// Fire off the sync manually
+				do_action( "update_option_{$identity_option}" );
 			}
 		}
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5470,11 +5470,12 @@ p {
 		$( '.site-moved' ).click(function( e ) {
 			e.preventDefault();
 			data.crisis_resolution_action = 'site_migrated';
-			$.post( ajaxurl, data, function( res ) {
-				alert( res );
+			$.post( ajaxurl, data, function() {
+				$( '.jp-id-crisis-question' ).hide();
+				$( '.banner-title' ).hide();
+				$( '#jp-id-crisis-success' ).show();
 			});
 
-			alert( 'fixing...' );
 		});
 
 		$( '.site-not-moved' ).click(function( e ) {
@@ -5486,10 +5487,11 @@ p {
 		$( '.is-dev-env' ).click(function( e ) {
 			$( '.jp-id-crisis-question' ).hide();
 			data.crisis_resolution_action = 'whitelist';
-			$.post( ajaxurl, data, function( res ) {
-				alert( res );
+			$.post( ajaxurl, data, function() {
+				$( '.jp-id-crisis-question' ).hide();
+				$( '.banner-title' ).hide();
+				$( '#jp-id-crisis-success' ).show();
 			});
-			alert( 'whitelisting site...' );
 		});
 
 		$( '.not-reconnecting' ).click(contactSupport);
@@ -5512,7 +5514,7 @@ p {
 
 		if ( ! current_user_can( 'manage_options' ) ) return;
 
-		//if ( ! $errors = self::check_identity_crisis() ) return;
+		if ( ! $errors = self::check_identity_crisis() ) return;
 
 		$key = 'siteurl';
 		if( ! $errors[ $key ] ) {
@@ -5535,7 +5537,7 @@ p {
 
 		<div id="message" class="error jetpack-message jp-identity-crisis">
 			<div class="jp-id-banner__content">
-				<h3><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h3>
+				<h3 class="banner-title"><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h3>
 
 				<div class="jp-id-crisis-question" id="jp-id-crisis-question-1">
 					<p><?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
@@ -5556,6 +5558,10 @@ p {
 					</div>
 				</div>
 
+				<div class="jp-id-crisis-success" id="jp-id-crisis-success" style="display: none;">
+					<h3 class="success-notice"><?php printf( __( 'Thank you for taking the time. We have updated our records accordingly.', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+					</p>
+				</div>
 			</div>
 		</div>
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5467,7 +5467,7 @@ p {
 	}
 
 	function autodismissSuccessBanner() {
-		$( '#jp-id-crisis-success' ).addClass( 'dismiss' );
+		$( '.jp-identity-crisis' ).addClass( 'dismiss' );
 	}
 
 	var data = { action: 'jetpack_resolve_identity_crisis', 'ajax-nonce': '<?php echo $nonce; ?>' };

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5572,17 +5572,17 @@ p {
 		?>
 
 		<style>
-			.jp-identity-crisis {
-			}
-
 			.jp-identity-crisis .btn-group {
-					margin-top: 15px;
+					margin: 15px 0;
 				}
 			.jp-identity-crisis strong {
 					color: #518d2a;
 				}
 			.jp-identity-crisis.dismiss {
 				display: none;
+			}
+			.jp-identity-crisis .button {
+				margin-right: 4px;
 			}
 		</style>
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5458,7 +5458,7 @@ p {
 ?>
 <script>
 (function( $ ) {
-	var SECOND_IN_MS = 1000;
+	var SECOND_IN_MS = 500;
 
 	function contactSupport( e ) {
 		e.preventDefault();
@@ -5546,7 +5546,7 @@ p {
 			.jp-identity-crisis strong {
 					color: #518d2a;
 				}
-			.jp-id-crisis-success.dismiss {
+			.jp-identity-crisis.dismiss {
 				display: none;
 			}
 		</style>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5289,6 +5289,9 @@ p {
 			$options_to_check = self::identity_crisis_options_to_check();
 			$cloud_options = Jetpack::init()->get_cloud_site_options( $options_to_check );
 			$errors        = array();
+
+			
+
 			foreach ( $cloud_options as $cloud_key => $cloud_value ) {
 				// If it's not the same as the local value...
 				if ( $cloud_value !== get_option( $cloud_key ) ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5530,6 +5530,23 @@ p {
 			$key = 'home';
 		}
 
+		//JESSE: this needs to get included in your POST as "ajax-nonce"
+		$ajax_nonce = wp_create_nonce( "resolve-identity-crisis" );
+
+		?>
+
+		<style>
+			.jp-identity-crisis {
+			}
+
+			.jp-identity-crisis .btn-group {
+					margin-top: 15px;
+				}
+			.jp-identity-crisis strong {
+					color: $green;
+				}
+		</style>
+
 		<div id="message" class="error jetpack-message jp-identity-crisis">
 			<div class="jp-id-banner__content">
 				<h3><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h3>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5455,6 +5455,25 @@ p {
 		return false;
 	}
 
+	/**
+	 * Checks whether the home and siteurl specifically are whitelisted
+	 * Written so that we don't have re-check $key and $value params every time
+	 * we want to check if this site is whitelisted, for example in footer.php
+	 *
+	 * @return bool True = already whitelsisted False = not whitelisted
+	 */
+	public static function jetpack_is_staging_site() {
+		$options_to_check  = Jetpack::identity_crisis_options_to_check();
+		$cloud_options     = Jetpack::init()->get_cloud_site_options( $options_to_check );
+
+		foreach ( $cloud_options as $cloud_key => $cloud_value ) {
+			if ( ! self::is_identity_crisis_value_whitelisted( $cloud_key, $cloud_value ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	public function identity_crisis_js( $nonce ) {
 ?>
 <script>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5411,6 +5411,25 @@ p {
 				echo 'whitelisted';
 				break;
 
+			case 'reset_connection':
+				// Delete the options first so it doesn't get confused which site to disconnect dotcom-side
+				Jetpack_Options::delete_option(
+					array(
+						'register',
+						'blog_token',
+						'user_token',
+						'user_tokens',
+						'master_user',
+						'time_diff',
+						'fallback_no_verify_ssl_certs',
+						'id',
+					)
+				);
+				delete_transient( 'jetpack_has_identity_crisis' );
+
+				echo 'reset-connection-success';
+				break;
+
 			default:
 				echo 'missing action';
 				break;
@@ -5525,7 +5544,12 @@ p {
 
 		// Reset connection: two separate sites.
 		$( '.reset-connection' ).click(function( e ) {
-			$( '#jp-id-crisis-question-2 .spinner' ).show();
+			data.crisis_resolution_action = 'reset_connection';
+			$.post( ajaxurl, data, function( response ) {
+				if ( 'reset-connection-success' === response ) {
+					window.location.replace( '<?php echo Jetpack::admin_url(); ?>' );
+				}
+			});
 		});
 
 		// It's a dev environment.  Ignore.
@@ -5604,7 +5628,7 @@ p {
 					<p><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services. <a href="#" title="What does resetting the connection mean?"><em>What does this mean?</em></a>', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					</p>
 					<div class="btn-group">
-						<a href="<?php echo $this->build_reconnect_url() ?>" class="button reset-connection">Reset the connection</a>
+						<a href="#" class="button reset-connection">Reset the connection</a>
 						<a href="#" class="button is-dev-env">This is a development environment</a>
 						<a href="https://jetpack.me/support" class="button contact-support">Submit a support ticket</a>
 						<span class="spinner"></span>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5300,7 +5300,7 @@ p {
 					// If the current options is an IP address
 					if ( filter_var( preg_replace( '#^http(s)?://', '', $cloud_value ), FILTER_VALIDATE_IP ) ) {
 						// Give the new value a Jetpack to fly in to the clouds
-						Jetpack_Sync::sync_options( __FILE__, $cloud_value );
+						Jetpack_Sync::sync_options( __FILE__, $cloud_key );
 						continue;
 					}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5562,8 +5562,8 @@ p {
 					</div>
 				</div>
 
-				<div class="jp-id-crisis-question" id="jp-id-crisis-question-2">
-					<p><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+				<div class="jp-id-crisis-question" id="jp-id-crisis-question-2" style="display: none;">
+					<p><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services. <a href="#" title="What does resetting the connection mean?"><em>What does this mean?</em></a>', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					</p>
 					<div class="btn-group">
 						<a href="<?php echo $this->build_reconnect_url() ?>" class="button reset-connection">Reset the connection</a>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2790,7 +2790,11 @@ p {
 			// Show the notice on the Dashboard only for now
 
 			add_action( 'load-index.php', array( $this, 'prepare_manage_jetpack_notice' ) );
-			add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
+
+			// @todo remove the conditional when it's ready for prime time
+			if ( Jetpack::is_development_version() ) {
+				add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
+			}
 		}
 
 		// If the plugin has just been disconnected from WP.com, show the survey notice
@@ -5295,7 +5299,6 @@ p {
 			$errors        = array();
 
 			foreach ( $cloud_options as $cloud_key => $cloud_value ) {
-
 				// If it's not the same as the local value...
 				if ( $cloud_value !== get_option( $cloud_key ) ) {
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -574,6 +574,8 @@ class Jetpack {
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'devicepx' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'devicepx' ) );
 
+		// add_action( 'jetpack_admin_menu', array( $this, 'admin_menu_modules' ) );
+
 		add_action( 'jetpack_activate_module', array( $this, 'activate_module_actions' ) );
 
 		add_action( 'plugins_loaded', array( $this, 'extra_oembed_providers' ), 100 );
@@ -1753,6 +1755,10 @@ class Jetpack {
 
 			$reactivate_modules[] = $active_module;
 			Jetpack::deactivate_module( $active_module );
+		}
+
+		if ( version_compare( $jetpack_version, '1.9.2', '<' ) && version_compare( '1.9-something', JETPACK__VERSION, '<' ) ) {
+			add_action( 'jetpack_activate_default_modules', array( $this->sync, 'sync_all_registered_options' ), 1000 );
 		}
 
 		$new_version = JETPACK__VERSION . ':' . time();
@@ -5367,12 +5373,12 @@ p {
 		$cloud_options = Jetpack::init()->get_cloud_site_options( $options_to_check );
 
 		foreach ( $cloud_options as $cloud_key => $cloud_value ) {
-			Jetpack::whitelist_identity_crisis_value ( $cloud_key, $cloud_value )
+			Jetpack::whitelist_identity_crisis_value ( $cloud_key, $cloud_value );
 		}
 
 		return;
 	}
-
+	
 	public static function resolve_identity_crisis_ajax_callback()
 	{
 		/*
@@ -5387,8 +5393,8 @@ p {
 				break;
 
 			case 'whitelist':
-				Jetpack::whitelist_current_url();
-				echo 'ok';
+				Jetpack::whitelist_current_url( );
+				return 'ok';
 				break;
 
 			default:
@@ -5455,22 +5461,24 @@ p {
 
 		<div id="message" class="error jetpack-message jp-identity-crisis">
 			<div class="jp-id-banner__content">
-				<h4><?php _e( 'Your Jetpack connection isn’t working as it should be.', 'jetpack' ); ?></h4>
+				<h4><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h4>
 
 				<p class="jp-id-crisis-question"
-				   id="jp-id-crisis-question-1"><?php printf( __( 'Jetpack is looking for your site be at <strong>%1$s</strong><small>(previous)</small> did you permanently move it here <strong> %2$s </strong><small>(current)</small>.', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+				   id="jp-id-crisis-question-1"><?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					<br/>
-					<a href="#" onclick="alert('fixing...'); return false;" class="button button-primary regular">Yes</a>
-					<a href="#" class="button" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-2').show(); return false">No</a>
+					<a href="#" onclick="alert('fixing...'); return false;" class="button button-primary regular"><?php _e( 'I\'ve updated it.' ); ?> </a>
+					<a href="#" class="button" onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-2').show(); return false"><?php _e( 'That\'s still my domain.' ); ?> </a>
 				</p>
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-2"
-				   style="display: none;"><?php printf( __( 'Is this website a distinctly separate website from <strong> %1$s </strong>?', 'jetpack' ), $errors[ $key ] ); ?>
+				   style="display: none;"><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					<br/>
-					<a href="#"
-					   onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3a').show(); return false">Yes</a>
-					<a href="#"
-					   onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3b').show(); return false">No</a>
+					<a href="#" class="button button-primary regular"
+					   onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3a').show(); return false">Reset the connection</a>
+					<a href="#" class="button"
+					   onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3b').show(); return false">This is a dev environment</a>
+					<a href="#" class="button"
+					   onclick="jQuery('.jp-id-crisis-question').hide(); jQuery('#jp-id-crisis-question-3b').show(); return false">Submit a support ticket</a>
 				</p>
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3a"

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5546,6 +5546,9 @@ p {
 			.jp-identity-crisis strong {
 					color: #518d2a;
 				}
+			.jp-id-crisis-success.dismiss {
+				display: none;
+			}
 		</style>
 
 		<div id="message" class="error jetpack-message jp-identity-crisis">
@@ -5574,7 +5577,7 @@ p {
 				</div>
 
 				<div class="jp-id-crisis-success" id="jp-id-crisis-success" style="display: none;">
-					<h3 class="success-notice"><?php printf( __( 'Thanks for taking the time to sort things out. We have updated our records accordingly!', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?></h3>
+					<h3 class="success-notice"><?php printf( __( 'Thanks for taking the time to sort things out. We&#039;ve updated our records accordingly!', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?></h3>
 				</div>
 			</div>
 		</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5543,7 +5543,7 @@ p {
 					margin-top: 15px;
 				}
 			.jp-identity-crisis strong {
-					color: $green;
+					color: #518d2a;
 				}
 		</style>
 
@@ -5562,10 +5562,11 @@ p {
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-2"
 				   style="display: none;"><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
-					<br/>
-					<a href="#" class="is-distinct-site">Reset the connection</a>
-					<a href="#" class="not-distinct-site">This is a dev environment</a>
-					<a href="#" class="not-distinct-site">Submit a support ticket</a>
+					<div class="btn-group">
+						<a href="#" class="button button-primary is-distinct-site">Reset the connection</a>
+						<a href="#" class="button not-distinct-site">This is a dev environment</a>
+						<a href="#" class="button not-distinct-site">Submit a support ticket</a>
+					</div>
 				</p>
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3a"

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5522,7 +5522,7 @@ p {
 
 		if ( ! current_user_can( 'manage_options' ) ) return;
 
-		//if ( ! $errors = self::check_identity_crisis() ) return;
+		if ( ! $errors = self::check_identity_crisis() ) return;
 
 		$key = 'siteurl';
 		if( ! $errors[ $key ] ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2797,6 +2797,7 @@ p {
 
 			add_action( 'load-index.php', array( $this, 'prepare_manage_jetpack_notice' ) );
 		add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
+		add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
 		}
 
 		// If the plugin has just been disconnected from WP.com, show the survey notice
@@ -5009,6 +5010,13 @@ p {
 		// Explode hostname on '.'
 		$exploded_host = explode( '.', $host );
 
+		// Retreive the name and TLD
+		$name = $exploded_host[ count( $exploded_host ) - 2 ];
+		$tld = $exploded_host[ count( $exploded_host ) - 1 ];
+
+		// Rebuild domain excluding subdomains
+		$domain = $name . '.' . $tld;
+
 		// Retrieve the name and TLD
 		if ( count( $exploded_host ) > 1 ) {
 			$name = $exploded_host[ count( $exploded_host ) - 2 ];
@@ -5523,13 +5531,15 @@ p {
 
 		<div id="message" class="error jetpack-message jp-identity-crisis">
 			<div class="jp-id-banner__content">
-				<h4><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h4>
+				<h3><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h3>
 
 				<p class="jp-id-crisis-question"
 				   id="jp-id-crisis-question-1"><?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
-					<br/>
+				
+					<div class="btn-group">
 					<a href="#" class="button button-primary regular site-moved"><?php _e( 'I\'ve updated it.' ); ?></a>
 					<a href="#" class="button site-not-moved" ><?php _e( 'That\'s still my domain.' ); ?></a>
+					</div>
 				</p>
 
 				<p class="jp-id-crisis-question" id="jp-id-crisis-question-2"

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -574,8 +574,6 @@ class Jetpack {
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'devicepx' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'devicepx' ) );
 
-		// add_action( 'jetpack_admin_menu', array( $this, 'admin_menu_modules' ) );
-
 		add_action( 'jetpack_activate_module', array( $this, 'activate_module_actions' ) );
 
 		add_action( 'plugins_loaded', array( $this, 'extra_oembed_providers' ), 100 );
@@ -5298,9 +5296,6 @@ p {
 
 			foreach ( $cloud_options as $cloud_key => $cloud_value ) {
 
-				// FIXME: FOR TESTING ONLY.  DO NOT COMMIT TO MASTER
-//				$cloud_value = str_replace( 'wpsandbox.me', 'com', $cloud_value );
-
 				// If it's not the same as the local value...
 				if ( $cloud_value !== get_option( $cloud_key ) ) {
 
@@ -5389,8 +5384,6 @@ p {
 		foreach ( $cloud_options as $cloud_key => $cloud_value ) {
 			Jetpack::whitelist_identity_crisis_value( $cloud_key, $cloud_value );
 		}
-
-		return;
 	}
 
 	/*
@@ -5532,11 +5525,6 @@ p {
 	 * Displays an admin_notice, alerting the user to an identity crisis.
 	 */
 	public function alert_identity_crisis() {
-		//JESSE: this needs to get included in your POST as "ajax-nonce"
-		$ajax_nonce = wp_create_nonce( 'resolve-identity-crisis' );
-
-		$this->identity_crisis_js( $ajax_nonce );
-
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
@@ -5544,6 +5532,10 @@ p {
 		if ( ! $errors = self::check_identity_crisis() ) {
 			return;
 		}
+
+		// Include the js!
+		$ajax_nonce = wp_create_nonce( 'resolve-identity-crisis' );
+		$this->identity_crisis_js( $ajax_nonce );
 
 		$key = 'siteurl';
 		if ( ! $errors[ $key ] ) {
@@ -5587,7 +5579,7 @@ p {
 					<div class="btn-group">
 						<a href="<?php echo $this->build_reconnect_url() ?>" class="button reset-connection">Reset the connection</a>
 						<a href="#" class="button is-dev-env">This is a development environment</a>
-						<a href="#" class="button contact-support">Submit a support ticket</a>
+						<a href="https://jetpack.me/support" class="button contact-support">Submit a support ticket</a>
 						<span class="spinner"></span>
 					</div>
 				</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5297,6 +5297,13 @@ p {
 
 				// If it's not the same as the local value...
 				if ( $cloud_value !== get_option( $cloud_key ) ) {
+					// If the current options is an IP address
+					if ( filter_var( preg_replace( '#^http(s)?://', '', $cloud_value ), FILTER_VALIDATE_IP ) ) {
+						// Give the new value a Jetpack to fly in to the clouds
+						Jetpack_Sync::sync_options( __FILE__, $cloud_value );
+						continue;
+					}
+
 					// And it's not been added to the whitelist...
 					if ( ! self::is_identity_crisis_value_whitelisted( $cloud_key, $cloud_value ) ) {
 						/*

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5377,9 +5377,6 @@ p {
 	}
 	
 	public static function resolve_identity_crisis_ajax_callback() {
-		/*
-			FIXME turn on nonce
-		*/
 		check_ajax_referer( 'resolve-identity-crisis', 'ajax-nonce' );
 
 		switch ( $_POST[ 'crisis_resolution_action' ] ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5566,7 +5566,7 @@ p {
 				</div>
 
 				<div class="jp-id-crisis-success" id="jp-id-crisis-success" style="display: none;">
-					<h3 class="success-notice"><?php printf( __( 'Thank you for taking the time. We have updated our records accordingly.', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?></h3>
+					<h3 class="success-notice"><?php printf( __( 'Thanks for taking the time to sort things out. We have updated our records accordingly!', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?></h3>
 				</div>
 			</div>
 		</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5552,8 +5552,7 @@ p {
 				<h3><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h3>
 
 				<div class="jp-id-crisis-question" id="jp-id-crisis-question-1">
-					<p>
-					<?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+					<p><?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					</p>
 					<div class="btn-group">
 						<a href="#" class="button button-primary regular site-moved"><?php _e( 'I\'ve updated it.' ); ?></a>
@@ -5562,7 +5561,7 @@ p {
 				</div>
 
 				<div class="jp-id-crisis-question" id="jp-id-crisis-question-2">
-					<p style="display: none;"><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
+					<p><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					</p>	
 					<div class="btn-group">
 						<a href="#" class="button is-distinct-site">Reset the connection</a>
@@ -5570,27 +5569,6 @@ p {
 						<a href="#" class="button not-distinct-site">Submit a support ticket</a>
 					</div>
 				</div>
-
-				<div class="jp-id-crisis-question" id="jp-id-crisis-question-3a">
-					<p style="display: none;"><?php printf( __( 'Would you like us to reset your options?  This will remove your followers and linked services from <strong>%1$s</strong>.', 'jetpack' ), (string) get_option( $key ) ); ?>
-					</p>
-					<div class="btn-group">
-						<a href="<?php echo $this->build_reconnect_url() ?>" class="button">Yes</a>
-						<a href="#" class="button not-reconnecting">No</a>
-					</div>
-				</div>
-				
-				<p class="jp-id-crisis-question" id="jp-id-crisis-question-3b"
-				   style="display: none;"><?php printf( __( 'Is <strong>%1$s</strong> a staging or development site?.', 'jetpack' ), (string) get_option( $key ) ); ?>
-				</p>
-				<div class="btn-group">
-					<a href="#dismiss-forever" class="button is-staging-or-dev">Yes</a>
-					<a href="#" class="button not-staging-or-dev">No (or not sure)</a>
-				</div>
-				
-
-				<p class="jp-id-crisis-question" id="jp-id-crisis-contact-support" style="display: none;">It's probably
-					best that you get in touch with support at this point...</p>
 
 			</div>
 		</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5493,17 +5493,6 @@ p {
 		});
 
 		$( '.not-reconnecting' ).click(contactSupport);
-
-		$( '.is-staging-or-dev' ).click(function( e ) {
-			e.preventDefault();
-			$( '.jp-id-crisis-question' ).hide();
-			data.crisis_resolution_action = 'whitelist';
-			$.post( ajaxurl, data, function( res ) {
-				alert( res );
-			});
-			alert( 'whitelisting site...' );
-		});
-
 		$( '.not-staging-or-dev' ).click(contactSupport);
 	});
 })( jQuery );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5483,16 +5483,13 @@ p {
 			$( '#jp-id-crisis-question-2' ).show();
 		});
 
-		$( '.is-distinct-site' ).click(function( e ) {
-			e.preventDefault();
+		$( '.is-dev-env' ).click(function( e ) {
 			$( '.jp-id-crisis-question' ).hide();
-			$( '#jp-id-crisis-question-3a' ).show();
-		});
-
-		$( '.not-distinct-site' ).click(function( e ) {
-			e.preventDefault();
-			$( '.jp-id-crisis-question' ).hide();
-			$( '#jp-id-crisis-question-3b' ).show();
+			data.crisis_resolution_action = 'whitelist';
+			$.post( ajaxurl, data, function( res ) {
+				alert( res );
+			});
+			alert( 'whitelisting site...' );
 		});
 
 		$( '.not-reconnecting' ).click(contactSupport);
@@ -5526,7 +5523,7 @@ p {
 
 		if ( ! current_user_can( 'manage_options' ) ) return;
 
-		if ( ! $errors = self::check_identity_crisis() ) return;
+		//if ( ! $errors = self::check_identity_crisis() ) return;
 
 		$key = 'siteurl';
 		if( ! $errors[ $key ] ) {
@@ -5562,11 +5559,11 @@ p {
 
 				<div class="jp-id-crisis-question" id="jp-id-crisis-question-2">
 					<p><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
-					</p>	
+					</p>
 					<div class="btn-group">
-						<a href="#" class="button is-distinct-site">Reset the connection</a>
-						<a href="#" class="button not-distinct-site">This is a dev environment</a>
-						<a href="#" class="button not-distinct-site">Submit a support ticket</a>
+					<a href="<?php echo $this->build_reconnect_url() ?>" class="button reset-connection">Reset the connection</a>
+						<a href="#" class="button is-dev-env">This is a development environment</a>
+						<a href="#" class="button contact-support">Submit a support ticket</a>
 					</div>
 				</div>
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5290,9 +5290,11 @@ p {
 			$cloud_options = Jetpack::init()->get_cloud_site_options( $options_to_check );
 			$errors        = array();
 
-			
-
 			foreach ( $cloud_options as $cloud_key => $cloud_value ) {
+
+				// FIXME: FOR TESTING ONLY.  DO NOT COMMIT TO MASTER
+				$cloud_value = str_replace( 'wpsandbox.me', 'com', $cloud_value );
+
 				// If it's not the same as the local value...
 				if ( $cloud_value !== get_option( $cloud_key ) ) {
 					// And it's not been added to the whitelist...

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5378,11 +5378,11 @@ p {
 
 	public static function whitelist_current_url()
 	{
-		$options_to_check = self::identity_crisis_options_to_check();
+		$options_to_check = Jetpack::identity_crisis_options_to_check();
 		$cloud_options = Jetpack::init()->get_cloud_site_options( $options_to_check );
 
 		foreach ( $cloud_options as $cloud_key => $cloud_value ) {
-			Jetpack::whitelist_identity_crisis_value ( $cloud_key, $cloud_value );
+			Jetpack::whitelist_identity_crisis_value( $cloud_key, $cloud_value );
 		}
 
 		return;
@@ -5422,8 +5422,9 @@ p {
 	 *
 	 * @return bool Whether the value was added to the whitelist, or false if it was already there.
 	 */
-	public static function whitelist_identity_crisis_value( $key, $value ) {
-		if ( self::is_identity_crisis_url_whitelisted( $key, $value ) ) {
+	public static function whitelist_identity_crisis_value ( $key, $value )
+	{
+		if ( Jetpack::is_identity_crisis_value_whitelisted( $key, $value ) ) {
 			return false;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5470,6 +5470,7 @@ p {
 		$( '.site-moved' ).click(function( e ) {
 			e.preventDefault();
 			data.crisis_resolution_action = 'site_migrated';
+			$( '#jp-id-crisis-question-1 .spinner' ).show();
 			$.post( ajaxurl, data, function() {
 				$( '.jp-id-crisis-question' ).hide();
 				$( '.banner-title' ).hide();
@@ -5484,9 +5485,13 @@ p {
 			$( '#jp-id-crisis-question-2' ).show();
 		});
 
+		$( '.reset-connection' ).click(function( e ) {
+			$( '#jp-id-crisis-question-2 .spinner' ).show();
+		});
+
 		$( '.is-dev-env' ).click(function( e ) {
-			$( '.jp-id-crisis-question' ).hide();
 			data.crisis_resolution_action = 'whitelist';
+			$( '#jp-id-crisis-question-2 .spinner' ).show();
 			$.post( ajaxurl, data, function() {
 				$( '.jp-id-crisis-question' ).hide();
 				$( '.banner-title' ).hide();
@@ -5545,6 +5550,7 @@ p {
 					<div class="btn-group">
 						<a href="#" class="button button-primary regular site-moved"><?php _e( 'I\'ve updated it.' ); ?></a>
 						<a href="#" class="button site-not-moved" ><?php _e( 'That\'s still my domain.' ); ?></a>
+						<span class="spinner"></span>
 					</div>
 				</div>
 
@@ -5552,9 +5558,10 @@ p {
 					<p><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?>
 					</p>
 					<div class="btn-group">
-					<a href="<?php echo $this->build_reconnect_url() ?>" class="button reset-connection">Reset the connection</a>
+						<a href="<?php echo $this->build_reconnect_url() ?>" class="button reset-connection">Reset the connection</a>
 						<a href="#" class="button is-dev-env">This is a development environment</a>
 						<a href="#" class="button contact-support">Submit a support ticket</a>
+						<span class="spinner"></span>
 					</div>
 				</div>
 

--- a/scss/templates/_id-crisis.scss
+++ b/scss/templates/_id-crisis.scss
@@ -1,3 +1,4 @@
+// styles are inline for now - line 5073 - class.jetpack.php, move here.
 .jp-identity-crisis {
 	.btn-group {
 		margin-top: 15px;

--- a/scss/templates/_id-crisis.scss
+++ b/scss/templates/_id-crisis.scss
@@ -1,0 +1,8 @@
+.jp-identity-crisis {
+	.btn-group {
+		margin-top: 15px;
+	}
+	strong {
+		color: $green;
+	}
+}


### PR DESCRIPTION
<strong>Important details: </strong>
- Please, no comments about the UI.  The goal here is to merge the functionality in and work out the UI/verbiage in another PR.  
- Currently will only display if `is_development_version()`.  I plan on leaving it like this until it's 100% good to go. 

<strong>Testing instructions: </strong>
- Trigger an ID crisis in one of the ways outlined on the jetpackfuel p2.  
- Play out the following scenarios: 

<strong>Scenario 1 - I've a new domain name:</strong>
- By clicking "I've Updated It", it should sync your home/siteurl over to wpcom.  You should see this reflected by the NA, and in calypso.  If you don't see the change immediately, give it a minute.  
- Note that it doesn't change the blog's domain yet (wpcom side), however the domain will change upon disconnect with George's new script.  

<strong>Scenario 2 - this is a completely different site: </strong>
- By clicking "That is still my domain" -> "Reset connection", this should spool up a brand new shadow blog along with a new blog ID with the new URL. 
- The old site should not be affected. 

<strong>Scenario 3 - This is a development/staging site: </strong>
- By clicking "That is still my domain" -> "This is a dev environment", it should have saved a `identity_crisis_whitelist` option locally with the site url and path.  
- It will make it so `Jetpack::is_staging_environment()` is `true`.  This will be helpful <a href="https://github.com/Automattic/jetpack/issues/2153">in the future</a> as well.  
- You should not see any CTA's to disconnect the site, nor should anything sync to dotcom from this site.  
- NOTE: this is the area that can use the most improvement.  Before this goes live, we will add a notice similar to our `dev_mode`, but about staging.  

There is a lot at play with ID Crises, so I very well may have missed something.  For more conversation about this, see the conversation below