### PR TITLE
Sharing Icon: revert default back to `icon-text`

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -239,7 +239,7 @@ class Sharing_Service {
 
 		// Defaults
 		$options['global'] = array(
-			'button_style'  => 'icon',
+			'button_style'  => 'icon-text',
 			'sharing_label' => $this->default_sharing_label,
 			'open_links'    => 'same',
 			'show'          => array(),


### PR DESCRIPTION
Was changed in d5399384ee748e2645b08413fa04e3fdb3de5a4b for jump start, but that doesn't fly for dotcom

cc @zinigor 