### PR TITLE
Enhance/jetpack cli

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -78,6 +78,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				usleep( 4000 ); // For dramatic effect lolz
 			}
 		} else {
+			// Just the basics
 			WP_CLI::success( __( 'Jetpack is currently connected to WordPress.com', 'jetpack' ) );
 			WP_CLI::line( sprintf( __( 'The Jetpack Version is %s', 'jetpack' ), JETPACK__VERSION ) );
 			WP_CLI::line( sprintf( __( 'The WordPress.com blog_id is %d', 'jetpack' ), Jetpack_Options::get_option( 'id' ) ) );
@@ -177,20 +178,12 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * wp jetpack reset options
 	 * wp jetpack reset modules
 	 *
-	 * @synopsis <modules>
+	 * @synopsis <modules|options>
 	 */
 	public function reset( $args, $assoc_args ) {
 		$action = isset( $args[0] ) ? $args[0] : 'prompt';
 		if ( ! in_array( $action, array( 'options', 'modules' ) ) ) {
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
-		}
-
-		if ( in_array( $action, array( 'user' ) ) ) {
-			if ( isset( $args[1] ) ) {
-				$action = $args[1];
-			} else {
-				$action = 'prompt';
-			}
 		}
 
 		switch ( $action ) {
@@ -202,22 +195,22 @@ class Jetpack_CLI extends WP_CLI_Command {
 				sleep(1); // Take a breath
 				foreach ( $options_to_reset['jp_options'] as $option_to_reset ) {
 					Jetpack_Options::delete_option( $option_to_reset );
-					usleep( 300000 );
+					usleep( 100000 );
 					WP_CLI::success( sprintf( __( '%s option reset', 'jetpack' ), $option_to_reset ) );
 				}
 
 				// Reset the WP options
 				_e( "Resetting the jetpack options stored in wp_options...\n", "jetpack" );
-				sleep(1); // Take a breath
+				usleep( 500000 ); // Take a breath
 				foreach ( $options_to_reset['wp_options'] as $option_to_reset ) {
 					delete_option( $option_to_reset );
-					usleep( 300000 );
+					usleep( 100000 );
 					WP_CLI::success( sprintf( __( '%s option reset', 'jetpack' ), $option_to_reset ) );
 				}
 
 				// Reset to default modules
 				_e( "Resetting default modules...\n", "jetpack" );
-				sleep(1); // Take a breath
+				usleep( 500000 ); // Take a breath
 				$default_modules = Jetpack::get_default_modules();
 				Jetpack_Options::update_option( 'active_modules', $default_modules );
 				WP_CLI::success( __( 'Modules reset to default.', 'jetpack' ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -50,7 +50,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * wp jetpack disconnect user username
 	 * wp jetpack disconnect user email@domain.com
 	 *
-	 * @synopsis blog|[user <user_id>]
+	 * @synopsis <blog|user> [<user_identifier>]
 	 */
 	public function disconnect( $args, $assoc_args ) {
 		if ( ! Jetpack::is_active() ) {
@@ -79,7 +79,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 					WP_CLI::error( __( 'Please specify a valid user.', 'jetpack' ) );
 				}
 			} else {
-				WP_CLI::error( __( 'Please specify a user.', 'jetpack' ) );
+				WP_CLI::error( __( 'Please specify a user by either ID, username, or email.', 'jetpack' ) );
 			}
 		}
 
@@ -123,14 +123,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * wp jetpack module deactivate stats
 	 * wp jetpack module toggle stats
 	 *
-	 * @synopsis [list|activate|deactivate|toggle [<module_name>]]
+	 * @synopsis <list|activate|deactivate|toggle> [<module_name>]
 	 */
 	public function module( $args, $assoc_args ) {
 		$action = isset( $args[0] ) ? $args[0] : 'list';
 		if ( ! in_array( $action, array( 'list', 'activate', 'deactivate', 'toggle' ) ) ) {
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
 		}
-
 		if ( in_array( $action, array( 'activate', 'deactivate', 'toggle' ) ) ) {
 			if ( isset( $args[1] ) ) {
 				$module_slug = $args[1];
@@ -145,7 +144,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 				$action = 'list';
 			}
 		}
-
 		switch ( $action ) {
 			case 'list':
 				WP_CLI::line( __( 'Available Modules:', 'jetpack' ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -206,11 +206,14 @@ class Jetpack_CLI extends WP_CLI_Command {
 		if ( in_array( $action, array( 'activate', 'deactivate', 'toggle' ) ) ) {
 			if ( isset( $args[1] ) ) {
 				$module_slug = $args[1];
-				if ( ! Jetpack::is_module( $module_slug ) ) {
+				if ( 'all' !== $module_slug && ! Jetpack::is_module( $module_slug ) ) {
 					WP_CLI::error( sprintf( __( '%s is not a valid module.', 'jetpack' ), $module_slug ) );
 				}
 				if ( 'toggle' == $action ) {
 					$action = Jetpack::is_module_active( $module_slug ) ? 'deactivate' : 'activate';
+				}
+				if ( 'all' == $args[1] ) {
+					$action = ( 'deactivate' == $action ) ? 'deactivate_all' : 'activate_all';
 				}
 			} else {
 				WP_CLI::line( __( 'Please specify a valid module.', 'jetpack' ) );
@@ -233,11 +236,20 @@ class Jetpack_CLI extends WP_CLI_Command {
 				Jetpack::activate_module( $module_slug, false, false );
 				WP_CLI::success( sprintf( __( '%s has been activated.', 'jetpack' ), $module['name'] ) );
 				break;
+			case 'activate_all':
+				$modules = Jetpack::get_available_modules();
+				Jetpack_Options::update_option( 'active_modules', $modules );
+				WP_CLI::success( __( 'All modules activated!', 'jetpack' ) );
+				break;
 			case 'deactivate':
 				$module = Jetpack::get_module( $module_slug );
 				Jetpack::log( 'deactivate', $module_slug );
 				Jetpack::deactivate_module( $module_slug );
 				WP_CLI::success( sprintf( __( '%s has been deactivated.', 'jetpack' ), $module['name'] ) );
+				break;
+			case 'deactivate_all':
+				Jetpack_Options::update_option( 'active_modules', '' );
+				WP_CLI::success( __( 'All modules deactivated!', 'jetpack' ) );
 				break;
 			case 'toggle':
 				// Will never happen, should have been handled above and changed to activate or deactivate.

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -108,12 +108,18 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * options (coming soon?): Resets all DB options to Jetpack default
+	 * modules: Resets modules to default state ( get_default_modules() )
 	 *
-	 * modules: Resets active modules to default
+	 * options: Resets all Jetpack options except:
+	 *  - All private options (Blog token, user token, etc...)
+	 *  - id (The Client ID/WP.com Blog ID of this site)
+	 *  - master_user
+	 *  - version
+	 *  - activated
 	 *
 	 * ## EXAMPLES
 	 *
+	 * wp jetpack reset options
 	 * wp jetpack reset modules
 	 *
 	 * @synopsis <modules>
@@ -181,13 +187,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * list: View all available modules, and their status.
+	 * list          : View all available modules, and their status.
+	 * activate all  : Activate all modules
+	 * deactivate all: Deactivate all modules
 	 *
-	 * activate <module_slug>: Activate a module.
-	 *
-	 * deactivate <module_slug>: Deactivate a module.
-	 *
-	 * toggle <module_slug>: Toggle a module on or off.
+	 * activate   <module_slug> : Activate a module.
+	 * deactivate <module_slug> : Deactivate a module.
+	 * toggle     <module_slug> : Toggle a module on or off.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -195,6 +201,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * wp jetpack module activate stats
 	 * wp jetpack module deactivate stats
 	 * wp jetpack module toggle stats
+	 *
+	 * wp jetpack module activate all
+	 * wp jetpack module deactivate all
 	 *
 	 * @synopsis <list|activate|deactivate|toggle> [<module_name>]
 	 */
@@ -212,6 +221,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				if ( 'toggle' == $action ) {
 					$action = Jetpack::is_module_active( $module_slug ) ? 'deactivate' : 'activate';
 				}
+				// Bulk actions
 				if ( 'all' == $args[1] ) {
 					$action = ( 'deactivate' == $action ) ? 'deactivate_all' : 'activate_all';
 				}
@@ -262,7 +272,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * whitelist: Whitelist your current IP
+	 * whitelist: Whitelist an IP address
 	 *
 	 * ## EXAMPLES
 	 *
@@ -292,8 +302,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 				$new_ip      = $args[1];
 				$current_ips = get_site_option( 'jetpack_protect_whitelist' );
 
-				// Loop through IP's that have already been whitelisted,
-				// We'll need to re-save them manually because jetpack_protect_save_whitelist() doesn't handle it.
+				// Build array of IPs that are already whitelisted.
+				// We'll need to re-save them manually otherwise jetpack_protect_save_whitelist() will overwrite the option
 				foreach( $current_ips as $k => $range_or_ip ) {
 					foreach( $range_or_ip as $key => $ip ) {
 						if ( ! empty( $ip ) ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -201,7 +201,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			case 'activate':
 				$module = Jetpack::get_module( $module_slug );
 				Jetpack::log( 'activate', $module_slug );
-				Jetpack::activate_module( $module_slug, false );
+				Jetpack::activate_module( $module_slug, false, false );
 				WP_CLI::success( sprintf( __( '%s has been activated.', 'jetpack' ), $module['name'] ) );
 				break;
 			case 'deactivate':

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -134,12 +134,41 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch ( $action ) {
 			case 'options':
-				WP_CLI::success( __( 'This doesn\'t work yet.', 'jetpack' ) );
+				$options_to_reset = Jetpack::get_jetapck_options_for_reset();
+
+				// Reset the Jetpack options
+				_e( "Resetting Jetpack Options...\n", "jetpack" );
+				sleep(1); // Take a breath
+				foreach ( $options_to_reset['jp_options'] as $option_to_reset ) {
+					Jetpack_Options::delete_option( $option_to_reset );
+					usleep( 300000 );
+					WP_CLI::success( sprintf( __( '%s option reset', 'jetpack' ), $option_to_reset ) );
+				}
+
+				// Reset the WP options
+				_e( "Resetting the jetpack options stored in wp_options...\n", "jetpack" );
+				sleep(1); // Take a breath
+				foreach ( $options_to_reset['wp_options'] as $option_to_reset ) {
+					delete_option( $option_to_reset );
+					usleep( 300000 );
+					WP_CLI::success( sprintf( __( '%s option reset', 'jetpack' ), $option_to_reset ) );
+				}
+
+				// Reset to default modules
+				_e( "Resetting default modules...\n", "jetpack" );
+				sleep(1); // Take a breath
+				$default_modules = Jetpack::get_default_modules();
+				Jetpack_Options::update_option( 'active_modules', $default_modules );
+				WP_CLI::success( __( 'Modules reset to default.', 'jetpack' ) );
+
+				// Jumpstart option is special
+				Jetpack_Options::update_option( 'jumpstart', 'new_connection' );
+				WP_CLI::success( __( 'jumpstart option reset', 'jetpack' ) );
 				break;
 			case 'modules':
 				$default_modules = Jetpack::get_default_modules();
 				Jetpack_Options::update_option( 'active_modules', $default_modules );
-				WP_CLI::success( __( 'wooo modules!', 'jetpack' ) );
+				WP_CLI::success( __( 'Modules reset to default.', 'jetpack' ) );
 				break;
 			case 'prompt':
 				WP_CLI::error( __( 'Please specify if you would like to reset your options, or modules', 'jetpack' ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -104,6 +104,50 @@ class Jetpack_CLI extends WP_CLI_Command {
 	}
 
 	/**
+	 * Reset Jetpack options and settings
+	 *
+	 * ## OPTIONS
+	 *
+	 * options: Resets all DB options to Jetpack default (coming soon?)
+	 *
+	 * modules: Resets active modules to default
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp jetpack reset modules
+	 *
+	 * @synopsis <modules>
+	 */
+	public function reset( $args, $assoc_args ) {
+		$action = isset( $args[0] ) ? $args[0] : 'prompt';
+		if ( ! in_array( $action, array( 'options', 'modules' ) ) ) {
+			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
+		}
+
+		if ( in_array( $action, array( 'user' ) ) ) {
+			if ( isset( $args[1] ) ) {
+				$action = $args[1];
+			} else {
+				$action = 'prompt';
+			}
+		}
+
+		switch ( $action ) {
+			case 'options':
+				WP_CLI::success( __( 'This doesn\'t work yet.', 'jetpack' ) );
+				break;
+			case 'modules':
+				$default_modules = Jetpack::get_default_modules();
+				Jetpack_Options::update_option( 'active_modules', $default_modules );
+				WP_CLI::success( __( 'wooo modules!', 'jetpack' ) );
+				break;
+			case 'prompt':
+				WP_CLI::error( __( 'Please specify if you would like to reset your options, or active modules', 'jetpack' ) );
+				break;
+		}
+	}
+
+	/**
 	 * Manage Jetpack Modules
 	 *
 	 * ## OPTIONS

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -234,6 +234,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 		if ( ! in_array( $action, array( 'whitelist' ) ) ) {
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
 		}
+		// Check if module is active
+		if ( ! Jetpack::is_module_active( __FUNCTION__ ) ) {
+			WP_CLI::error( sprintf( __( '%s is not active. You can activate it with "wp jetpack module activate %s"', 'jetpack' ), __FUNCTION__, __FUNCTION__ ) );
+		}
 		if ( in_array( $action, array( 'whitelist' ) ) ) {
 			if ( isset( $args[1] ) ) {
 				$action = 'whitelist';

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -492,17 +492,16 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch ( $action ) {
 			case 'get':
-				WP_CLI::line( "\t" . str_pad( __( 'Option', 'jetpack' ), 20 ) . __( 'Value', 'jetpack' ) );
-				WP_CLI::line( "\t" . str_pad( $args[1], 20 ) . $option );
+				WP_CLI::success( "\t" . $option );
 				break;
 			case 'delete':
-				// Are you sure?
-				jetpack_cli_are_you_sure();
-
 				// Check if it's safe to modify
 				if ( ! in_array( $args[1], $safe_to_modify ) ) {
 					WP_CLI::error( __( 'It is not recommended to delete this option.', 'jetpack' ) );
 				}
+
+				// Are you sure?
+				jetpack_cli_are_you_sure();
 
 				Jetpack_Options::delete_option( $args[1] );
 				WP_CLI::success( sprintf( __( 'Deleted option: %s', 'jetpack' ), $args[1] ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -352,12 +352,18 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 				// Build array of IPs that are already whitelisted.
 				// We'll need to re-save them manually otherwise jetpack_protect_save_whitelist() will overwrite the option
-				foreach( $current_ips as $k => $range_or_ip ) {
-					foreach( $range_or_ip as $key => $ip ) {
-						if ( ! empty( $ip ) ) {
-							$whitelist[] = $ip;
-						}
+				foreach( $current_ips as $current_ip ) {
+					// Save IP ranges
+					if ( $current_ip->range ) {
+						$whitelist[] = $current_ip->range_low . " - " . $current_ip->range_high;
+					} else { // Save individual IPs
+						$whitelist[] = $current_ip->ip_address;
 					}
+				}
+
+				// Check to see if the IP is already there (single IP only)
+				if ( in_array( $new_ip, $whitelist ) ) {
+					WP_CLI::error( __( "$new_ip has already been whitelisted", 'jetpack' ) );
 				}
 
 				// Append new IP to whitelist array
@@ -372,7 +378,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				WP_CLI::success( sprintf( __( '%s has been whitelisted.', 'jetpack' ), $new_ip ) );
 				break;
 			case 'prompt':
-				WP_CLI::error( __( 'Please enter the IP address you want to whitelist.', 'jetpack' ) );
+				WP_CLI::error( __( "Please enter the IP address you want to whitelist.\nYou can save a range of IPs {low_range}-{high_range}. No spaces allowed.\nExample: 1.1.1.1-2.2.2.2", 'jetpack' ) );
 				break;
 		}
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5607,6 +5607,74 @@ p {
 	}
 
 	/*
+	 * Check the heartbeat data
+	 *
+	 * Organizes the heartbeat data by severity.  For example, if the site
+	 * is in an ID crisis, it will be in the $filtered_data['bad'] array.
+	 *
+	 * Data will be added to "caution" array, if it either:
+	 *  - Out of date Jetpack version
+	 *  - Out of date WP version
+	 *  - Out of date PHP version
+	 *
+	 * $return array $filtered_data
+	 */
+	public static function jetpack_check_heartbeat_data() {
+		$raw_data = Jetpack_Heartbeat::generate_stats_array();
+
+		$good    = array();
+		$caution = array();
+		$bad     = array();
+
+		foreach ( $raw_data as $stat => $value ) {
+
+			// Check jetpack version
+			if ( 'version' == $stat ) {
+				if ( version_compare( $value, JETPACK__VERSION, '<' ) ) {
+					$caution[ $stat ] = $value . " - min supported is " . JETPACK__VERSION;
+					continue;
+				}
+			}
+
+			// Check WP version
+			if ( 'wp-version' == $stat ) {
+				if ( version_compare( $value, JETPACK__MINIMUM_WP_VERSION, '<' ) ) {
+					$caution[ $stat ] = $value . " - min supported is " . JETPACK__MINIMUM_WP_VERSION;
+					continue;
+				}
+			}
+
+			// Check PHP version
+			if ( 'php-version' == $stat ) {
+				if ( version_compare( PHP_VERSION, '5.2.4', '<' ) ) {
+					$caution[ $stat ] = $value . " - min supported is 5.2.4";
+					continue;
+				}
+			}
+
+			// Check ID crisis
+			if ( 'identitycrisis' == $stat ) {
+				if ( 'yes' == $value ) {
+					$bad[ $stat ] = $value;
+					continue;
+				}
+			}
+
+			// The rest are good :)
+			$good[ $stat ] = $value;
+		}
+
+		$filtered_data = array(
+			'good'    => $good,
+			'caution' => $caution,
+			'bad'     => $bad
+		);
+
+		return $filtered_data;
+	}
+
+
+	/*
 	 * This method is used to organize all options that can be reset
 	 * without disconnecting Jetpack.
 	 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5607,22 +5607,21 @@ p {
 	}
 
 	/*
-	 * Check if an option of a Jetpack module has been updated.
+	 * This method is used to organize all options that can be reset
+	 * without disconnecting Jetpack.
 	 *
-	 * If any module option has been updated before Jump Start has been dismissed,
-	 * update the 'jumpstart' option so we can hide Jump Start.
+	 * It is used in class.jetpack-cli.php to reset options
+	 *
+	 * @return array of options to delete.
 	 */
-	public static function jumpstart_has_updated_module_option( $option_name = '' ) {
-		// Bail if Jump Start has already been dismissed
-		if ( 'new_connection' !== Jetpack::get_option( 'jumpstart' ) ) {
-			return false;
-		}
+	public static function get_jetapck_options_for_reset() {
+		$jetpack_options            = Jetpack_Options::get_option_names();
+		$jetpack_options_non_compat = Jetpack_Options::get_option_names( 'non_compact' );
 
-		$jetpack = Jetpack::init();
+		$all_jp_options = array_merge( $jetpack_options, $jetpack_options_non_compat );
 
-
-		// Manual build of module options
-		$option_names = array(
+		// A manual build of the wp options
+		$wp_options = array(
 			'sharing-options',
 			'disabled_likes',
 			'disabled_reblogs',
@@ -5649,7 +5648,84 @@ p {
 			'site_logo',
 		);
 
-		if ( in_array( $option_name, $option_names ) ) {
+		// Whitelist some Jetpack options
+		// @todo remove the commented out options
+		$whitelist_terms = array(
+			'id',                           // (int)    The Client ID/WP.com Blog ID of this site.
+//			'publicize_connections',        // (array)  An array of Publicize connections from WordPress.com
+			'master_user',                  // (int)    The local User ID of the user who connected this site to jetpack.wordpress.com.
+			'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time
+//			'old_version',                  // (string) Used to determine which modules are the most recently added. previous_version:time
+//			'fallback_no_verify_ssl_certs', // (int)    Flag for determining if this host must skip SSL Certificate verification due to misconfigured SSL.
+//			'time_diff',                    // (int)    Offset between Jetpack server's clocks and this server's clocks. Jetpack Server Time = time() + (int) Jetpack_Options::get_option( 'time_diff' )
+//			'public',                       // (int|bool) If we think this site is public or not (1, 0), false if we haven't yet tried to figure it out.
+//			'videopress',                   // (array)  VideoPress options array.
+//			'is_network_site',              // (int|bool) If we think this site is a network or a single blog (1, 0), false if we haven't yet tried to figue it out.
+//			'social_links',                 // (array)  The specified links for each social networking site.
+//			'identity_crisis_whitelist',    // (array)  An array of options, each having an array of the values whitelisted for it.
+//			'gplus_authors',                // (array)  The Google+ authorship information for connected users.
+//			'last_heartbeat',               // (int)    The timestamp of the last heartbeat that fired.
+//			'last_security_report',         // (int)    The timestamp of the last security report that was run.
+//			'sync_bulk_reindexing',         // (bool)   If a bulk reindex is currently underway.
+			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
+
+			// non_compact
+			'activated',
+//			'available_modules',
+//			'do_activate',
+//			'log',
+//			'publicize',
+//			'slideshow_background_color',
+//			'widget_twitter',
+//			'wpcc_options',
+//			'relatedposts',
+//			'file_data',
+//			'security_report',
+//			'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
+//			'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
+//			'autoupdate_core',             // (bool)   Whether or not to autoupdate core
+//			'json_api_full_management',    // (bool)   Allow full management (eg. Activate, Upgrade plugins) of the site via the JSON API.
+//			'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
+//			'site_icon_url',               // (string) url to the full site icon
+//			'site_icon_id',                // (int)    Attachment id of the site icon file
+//			'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
+//			'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
+		);
+
+		// Remove the whitelisted Jetpack options
+		foreach ( $whitelist_terms as $whitelist_term ) {
+			if ( ( $key = array_search( $whitelist_term, $all_jp_options ) ) !== false ) {
+				unset( $all_jp_options[ $key ] );
+			}
+		}
+
+		$options = array(
+			'jp_options' => $all_jp_options,
+			'wp_options' => $wp_options
+		);
+
+		return $options;
+	}
+
+	/*
+	 * Check if an option of a Jetpack module has been updated.
+	 *
+	 * If any module option has been updated before Jump Start has been dismissed,
+	 * update the 'jumpstart' option so we can hide Jump Start.
+	 */
+	public static function jumpstart_has_updated_module_option( $option_name = '' ) {
+		// Bail if Jump Start has already been dismissed
+		if ( 'new_connection' !== Jetpack::get_option( 'jumpstart' ) ) {
+			return false;
+		}
+
+		$jetpack = Jetpack::init();
+
+
+		// Manual build of module options
+		$option_names = self::get_jetapck_options_for_reset();
+
+		if ( in_array( $option_name, $option_names['wp_options'] ) ) {
 			Jetpack_Options::update_option( 'jumpstart', 'jetpack_action_taken' );
 
 			//Jump start is being dismissed send data to MC Stats

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5717,52 +5717,19 @@ p {
 		);
 
 		// Whitelist some Jetpack options
-		// @todo remove the commented out options
 		$whitelist_terms = array(
 			'id',                           // (int)    The Client ID/WP.com Blog ID of this site.
-//			'publicize_connections',        // (array)  An array of Publicize connections from WordPress.com
 			'master_user',                  // (int)    The local User ID of the user who connected this site to jetpack.wordpress.com.
 			'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time
-//			'old_version',                  // (string) Used to determine which modules are the most recently added. previous_version:time
-//			'fallback_no_verify_ssl_certs', // (int)    Flag for determining if this host must skip SSL Certificate verification due to misconfigured SSL.
-//			'time_diff',                    // (int)    Offset between Jetpack server's clocks and this server's clocks. Jetpack Server Time = time() + (int) Jetpack_Options::get_option( 'time_diff' )
-//			'public',                       // (int|bool) If we think this site is public or not (1, 0), false if we haven't yet tried to figure it out.
-//			'videopress',                   // (array)  VideoPress options array.
-//			'is_network_site',              // (int|bool) If we think this site is a network or a single blog (1, 0), false if we haven't yet tried to figue it out.
-//			'social_links',                 // (array)  The specified links for each social networking site.
-//			'identity_crisis_whitelist',    // (array)  An array of options, each having an array of the values whitelisted for it.
-//			'gplus_authors',                // (array)  The Google+ authorship information for connected users.
-//			'last_heartbeat',               // (int)    The timestamp of the last heartbeat that fired.
-//			'last_security_report',         // (int)    The timestamp of the last security report that was run.
-//			'sync_bulk_reindexing',         // (bool)   If a bulk reindex is currently underway.
 			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
 
 			// non_compact
 			'activated',
-//			'available_modules',
-//			'do_activate',
-//			'log',
-//			'publicize',
-//			'slideshow_background_color',
-//			'widget_twitter',
-//			'wpcc_options',
-//			'relatedposts',
-//			'file_data',
-//			'security_report',
-//			'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
-//			'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
-//			'autoupdate_core',             // (bool)   Whether or not to autoupdate core
-//			'json_api_full_management',    // (bool)   Allow full management (eg. Activate, Upgrade plugins) of the site via the JSON API.
-//			'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
-//			'site_icon_url',               // (string) url to the full site icon
-//			'site_icon_id',                // (int)    Attachment id of the site icon file
-//			'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
-//			'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 		);
 
 		// Remove the whitelisted Jetpack options
 		foreach ( $whitelist_terms as $whitelist_term ) {
-			if ( ( $key = array_search( $whitelist_term, $all_jp_options ) ) !== false ) {
+			if ( false !== ( $key = array_search( $whitelist_term, $all_jp_options ) ) ) {
 				unset( $all_jp_options[ $key ] );
 			}
 		}


### PR DESCRIPTION
Some serious Jetpack CLI love.  

Fixed/enhanced: `module`
Useage: `wp jetpack module <action>`
`list`: View all available modules, and their status.
`activate all`: Bulk activate all modules
`deactivate all`: Bulk deactivate all modules
`activate  <module_slug>`: Activate a module.
`deactivate <module_slug>`: Deactivate a module.
`toggle <module_slug>`: Toggle a module on or off.

Fixed: `disconnect`
Useage: `wp jetpack disconnect <action>`
`blog`: Disconnect the entire blog.
`user <user_identifier>`: Disconnect a specific user from WordPress.com.

New: `status full`
Useage: `wp jetpack status full`
- Displays all data that we get from the heartbeat.  some options will show red/yellow if there's a problem with the setup (i.e. out of date wp version, php version, etc...)
- New method `jetpack_check_heartbeat_data()` written to handle that organization. 

New: `reset`
Useage: `wp jetpack reset <action>`
`modules`: Resets modules to default state ( get_default_modules() )
`options`: Resets all Jetpack options except:
- All private options (Blog token, user token, etc...)
- id (The Client ID/WP.com Blog ID of this site)
- master_user
- version
- activated

New method introduced `get_jetapck_options_for_reset()` to handle which options to reset.


New: `protect`
- Whitelist an IP address
Useage: `wp jetpack protect whitelist <ip address>`
`whitelist list` : List your whitelist 
`whitelist clear` : clear your whitelist

New: `options`
- List, Get, Update (some), Delete (some) Jetpack_Options

(some) == all except those whitelisted in the "reset" function
(Also, can't update option arrays, only strings)
Useage:  `wp jetpack options <list|get|delete|update> [<option_name>] [<option_value>]`

Also fixes #1175