### PR TITLE
Merge wpcom/26may2015

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -104,6 +104,11 @@ abstract class WPCOM_JSON_API_Endpoint {
 	 */
 	var $allow_unauthorized_request = false;
 
+	/**
+	 * @var bool Set to true if the endpoint should accept site based (not user based) authentication.
+	 */
+	var $allow_jetpack_site_auth = false;
+
 	function __construct( $args ) {
 		$defaults = array(
 			'in_testing'           => false,
@@ -132,6 +137,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			'custom_fields_filtering' => false,
 			'allow_cross_origin_request' => false,
 			'allow_unauthorized_request' => false,
+			'allow_jetpack_site_auth'    => false,
 		);
 
 		$args = wp_parse_args( $args, $defaults );
@@ -159,8 +165,8 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$this->can_use_user_details_instead_of_blog_membership = $args['can_use_user_details_instead_of_blog_membership'];
 
 		$this->allow_cross_origin_request = (bool) $args['allow_cross_origin_request'];
-
 		$this->allow_unauthorized_request = (bool) $args['allow_unauthorized_request'];
+		$this->allow_jetpack_site_auth    = (bool) $args['allow_jetpack_site_auth'];
 
 		$this->version     = $args['version'];
 

--- a/class.media-summary.php
+++ b/class.media-summary.php
@@ -249,6 +249,7 @@ class Jetpack_Media_Summary {
 				'show_read_more' => false,
 				'max_words'      => $max_words,
 				'max_chars'      => $max_chars,
+				'read_more_threshold' => 25,
 			) ) );
 		} else {
 			$post_excerpt = apply_filters( 'get_the_excerpt', $post_excerpt );

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -75,8 +75,6 @@ function jetpack_og_tags() {
 			$publicize_facebook_user = get_post_meta( $data->ID, '_publicize_facebook_user', true );
 			if ( ! empty( $publicize_facebook_user ) ) {
 				$tags['article:author'] = esc_url( $publicize_facebook_user );
-			} else {
-				$tags['article:author'] = get_author_posts_url( $data->post_author );
 			}
 		}
 	}

--- a/modules/widgets/goodreads.php
+++ b/modules/widgets/goodreads.php
@@ -120,16 +120,11 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 		<input class="widefat" id="' . esc_attr( $this->get_field_id( 'title' ) ) . '" name="' . esc_attr( $this->get_field_name( 'title' ) ) . '" type="text" value="' . esc_attr( $instance['title'] ) . '" />
 		</label></p>
 		<p><label for="' . esc_attr( $this->get_field_id( 'user_id' ) ) . '">';
+		printf( __( 'Goodreads numeric user ID <a href="%s" target="_blank">(instructions)</a>:', 'jetpack' ), 'https://en.support.wordpress.com/widgets/goodreads-widget/#goodreads-user-id' );
 		if ( 'invalid' === $instance['user_id'] ) {
-			$invalid_notice = _x( 'Invalid User ID, please verify and re-enter your', 'Goodreads numeric user id', 'jetpack' );
-			echo '<span class="error">' . $invalid_notice . '</span>&nbsp;';
+			printf( '<br /><small class="error">%s</small>&nbsp;', __( 'Invalid User ID, please verify and re-enter your Goodreads numeric user ID.', 'jetpack' ) );
 			$instance['user_id'] = '';
 		}
-		$goodreads_id = sprintf (
-			__( 'Goodreads numeric user id <a href="%s" target="_blank">(instructions)</a>:', 'jetpack' ),
-			'http://support.wordpress.com/widgets/goodreads-widget/#goodreads-user-id'
-		);
-		echo $goodreads_id;
 		echo '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'user_id' ) ) . '" name="' . esc_attr( $this->get_field_name( 'user_id' ) ) . '" type="text" value="' . esc_attr( $instance['user_id'] ) . '" />
 		</label></p>
 		<p><label for="' . esc_attr( $this->get_field_id( 'shelf' ) ) . '">' . esc_html__( 'Shelf:', 'jetpack' ) . '


### PR DESCRIPTION
REST API: rename the endpoint property checked for Jetpack authentication (to `allow_jetpack_site_auth`)
Open Graph: Omit the url if no facebook url is found
Publicize: Increase "read more" to 25 words 
Goodreads Widget: Update error messages for translations 