### PR TITLE
Fix/dev mode behavior when Jetpack is connected 

### DIFF
--- a/_inc/footer.php
+++ b/_inc/footer.php
@@ -1,6 +1,6 @@
 <?php
 global $current_user;
-$is_active         = Jetpack::is_active();
+$is_active         = Jetpack::is_active() && ! Jetpack::is_development_mode();
 $user_token        = Jetpack_Data::get_access_token( $current_user->ID );
 $is_user_connected = $user_token && ! is_wp_error( $user_token );
 $is_master_user    = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
@@ -28,7 +28,7 @@ $is_master_user    = $current_user->ID == Jetpack_Options::get_option( 'master_u
 					<a href="http://jetpack.me/contact-support/" title="<?php esc_attr_e( 'Contact the Jetpack Happiness Squad.', 'jetpack' ); ?>"><?php _e( 'Support', 'jetpack' ); ?></a>
 					<a href="http://jetpack.me/survey/?rel=<?php echo JETPACK__VERSION; ?>" title="<?php esc_attr_e( 'Take a survey.  Tell us how we&#8217;re doing.', 'jetpack' ); ?>"><?php _e( 'Give Us Feedback', 'jetpack' ); ?></a>
 
-					<?php if ( $is_active && current_user_can( 'jetpack_disconnect' ) && ! Jetpack::is_development_mode() ) : ?>
+					<?php if ( $is_active && current_user_can( 'jetpack_disconnect' ) ) : ?>
 						<a href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=disconnect' ), 'jetpack-disconnect' ); ?>" onclick="return confirm('<?php echo htmlspecialchars( __('Are you sure you want to disconnect from WordPress.com?', 'jetpack'), ENT_QUOTES ); ?>');"><?php esc_html_e( 'Disconnect from WordPress.com', 'jetpack' ); ?></a>
 					<?php endif; ?>
 					<?php if ( $is_active && $is_user_connected && ! $is_master_user ) : ?>

--- a/_inc/footer.php
+++ b/_inc/footer.php
@@ -28,7 +28,7 @@ $is_master_user    = $current_user->ID == Jetpack_Options::get_option( 'master_u
 					<a href="http://jetpack.me/contact-support/" title="<?php esc_attr_e( 'Contact the Jetpack Happiness Squad.', 'jetpack' ); ?>"><?php _e( 'Support', 'jetpack' ); ?></a>
 					<a href="http://jetpack.me/survey/?rel=<?php echo JETPACK__VERSION; ?>" title="<?php esc_attr_e( 'Take a survey.  Tell us how we&#8217;re doing.', 'jetpack' ); ?>"><?php _e( 'Give Us Feedback', 'jetpack' ); ?></a>
 
-					<?php if ( $is_active && current_user_can( 'jetpack_disconnect' ) ) : ?>
+					<?php if ( $is_active && current_user_can( 'jetpack_disconnect' ) && ! Jetpack::is_development_mode() ) : ?>
 						<a href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=disconnect' ), 'jetpack-disconnect' ); ?>" onclick="return confirm('<?php echo htmlspecialchars( __('Are you sure you want to disconnect from WordPress.com?', 'jetpack'), ENT_QUOTES ); ?>');"><?php esc_html_e( 'Disconnect from WordPress.com', 'jetpack' ); ?></a>
 					<?php endif; ?>
 					<?php if ( $is_active && $is_user_connected && ! $is_master_user ) : ?>

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -153,7 +153,7 @@ class Jetpack_Admin {
 		}
 
 		if ( Jetpack::is_development_mode() ) {
-			return ! ( $module['requires_connection'] && ! Jetpack::is_active() );
+			return ! ( $module['requires_connection'] );
 		} else {
 			return Jetpack::is_active();
 		}

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -77,7 +77,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 						<# if ( item.configurable ) { #>
 							<span class='configure'>{{{ item.configurable }}}</span>
 						<# } #>
-						<# if ( item.activated && 'vaultpress' !== item.module ) { #>
+						<# if ( item.activated && 'vaultpress' !== item.module && item.available ) { #>
 							<span class='delete'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=deactivate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.deactivate_nonce }}}"><?php _e( 'Deactivate', 'jetpack' ); ?></a></span>
 						<# } else if ( item.available ) { #>
 							<span class='activate'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=activate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.activate_nonce }}}"><?php _e( 'Activate', 'jetpack' ); ?></a></span>
@@ -148,7 +148,11 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		if ( ! is_array( $module ) || empty( $module ) )
 			return false;
 
-		return ! ( $module['requires_connection'] && ! Jetpack::is_active() );
+		if ( Jetpack::is_development_mode() ) {
+			return ! ( $module['requires_connection'] );
+		} else {
+			return Jetpack::is_active();
+		}
 	}
 
 	static function is_module_displayed( $module ) {

--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -168,6 +168,11 @@ class Jetpack_Sync {
 			return false;
 		}
 
+		// Don't sync anything while in development mode
+		if ( Jetpack::is_development_mode() ) {
+			return false;
+		}
+
 		$sync_data = $this->get_common_sync_data();
 
 		$wp_importing = defined( 'WP_IMPORTING' ) && WP_IMPORTING;


### PR DESCRIPTION
Make dev mode act like dev mode even when it was turned on while Jetpack was connected.  

Here's a list of what will now happen when development mode is activated on a connected Jetpack site.  
- Hides "disconnect from WordPress" link
- Kills any sync communication to dotcom
- Greys out `requires_connection` modules on the settings page
- Can't edit settings for those modules either, nor activate/deactivate them

For more context, check out #2156 

Fixes #2156 

cc @kraftbj 