### PR TITLE
Stats: Explicitly specify date in CSV API requests

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1031,7 +1031,8 @@ function stats_dashboard_widget_content() {
 
 	$post_ids = array();
 
-	$csv_args = array( 'top' => '&limit=8', 'search' => '&limit=5' );
+	$csv_end_date = date( 'Y-m-d', current_time( 'timestamp' ) );
+	$csv_args = array( 'top' => "&limit=8&end=$csv_end_date", 'search' => "&limit=5&end=$csv_end_date" );
 	/* translators: Stats dashboard widget postviews list: "$post_title $views Views" */
 	$printf = __( '%1$s %2$s Views' , 'jetpack' );
 


### PR DESCRIPTION
The [stats csv api](https://stats.wordpress.com/csv.php) says that the `end` parameter (which is currently not specified in CSV requests) defaults to the UTC date. If it's not explicitly specified, then after UTC midnight, any site with a negative UTC offset will be requesting stats for the next day.

We can fix that by explicitly specifying date in the request.