### PR TITLE
Add locale support to the API.

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -324,6 +324,7 @@ class Jetpack_XMLRPC_Server {
 		$post_body    = is_null( $json_api_args[2] ) ? null : (string) $json_api_args[2];
 		$my_id        = (int) $json_api_args[3];
 		$user_details = (array) $json_api_args[4];
+		$locale       = (string) $json_api_args[5];
 
 		if ( !$verify_api_user_args ) {
 			$user_id = 0;
@@ -352,6 +353,25 @@ class Jetpack_XMLRPC_Server {
 		error_log( "VERIFIED USER_ID: " . (int) $user_id );
 		error_log( "-- end json api via jetpack debugging -- " );
 		*/
+
+
+		if ( 'en' !== $locale ) {
+			// .org mo files are named slightly different from .com, and all we have is this the locale -- try to guess them.
+			if ( strpos( $locale, '-' ) !== false ) {
+				$pieces = explode( '-', $locale );
+				$new_locale = $locale_pieces[0];
+				$new_locale .= ( ! empty( $locale_pieces[1] ) ) ? '_' . strtoupper( $locale_pieces[1] ) : '';
+			} else {
+				// .com might pass 'fr' because thats what our language files are named as, where core seems
+				// to do fr_FR - so try that if we don't think we can load the file.
+				if ( ! file_exists( WP_LANG_DIR . '/' . $locale . '.mo' ) ) {
+					$new_locale =  $locale . '_' . strtoupper( $locale );
+				}
+			}
+
+			unload_textdomain( 'default' );
+			load_textdomain( 'default', WP_LANG_DIR . '/' . $new_locale . '.mo' );
+		}
 
 		$old_user = wp_get_current_user();
 		wp_set_current_user( $user_id );

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -354,9 +354,9 @@ class Jetpack_XMLRPC_Server {
 		error_log( "-- end json api via jetpack debugging -- " );
 		*/
 
-
 		if ( 'en' !== $locale ) {
 			// .org mo files are named slightly different from .com, and all we have is this the locale -- try to guess them.
+			$new_locale = $locale;
 			if ( strpos( $locale, '-' ) !== false ) {
 				$pieces = explode( '-', $locale );
 				$new_locale = $locale_pieces[0];
@@ -369,8 +369,10 @@ class Jetpack_XMLRPC_Server {
 				}
 			}
 
-			unload_textdomain( 'default' );
-			load_textdomain( 'default', WP_LANG_DIR . '/' . $new_locale . '.mo' );
+			if ( file_exists( WP_LANG_DIR . '/' . $new_locale . '.mo' ) ) {
+				unload_textdomain( 'default' );
+				load_textdomain( 'default', WP_LANG_DIR . '/' . $new_locale . '.mo' );
+			}
 		}
 
 		$old_user = wp_get_current_user();


### PR DESCRIPTION
D43 is also needed from Phabricator. Once both of these patches are applied, and you have a language pack, you can test by making a request to:

https://public-api.wordpress.com/rest/v1/sites/$blog/post-formats/?pretty=true&locale=$locale

If you have the WPCom patch applied, you can load https://public-api.wordpress.com/rest/v1/sites/justin.wpsandbox.me/post-formats/?pretty=true&locale=de specifically to test in German.

and you should see the post formats translated.

