### PR TITLE
Fix/2189 make static add action

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-landing-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-landing-page.php
@@ -38,7 +38,7 @@ class Jetpack_Landing_Page extends Jetpack_Admin_Page {
 
 	function add_page_actions( $hook ) {
 		// Add landing page specific underscore templates
-		add_action( "admin_footer-$hook",        array( $this, 'js_templates' ) );
+		add_action( "admin_footer-$hook", array( 'Jetpack_Landing_Page', 'js_templates' ) );
 		/** This action is documented in class.jetpack.php */
 		do_action( 'jetpack_admin_menu', $hook );
 
@@ -134,7 +134,7 @@ class Jetpack_Landing_Page extends Jetpack_Admin_Page {
 		return $jp_menu_order;
 	}
 
-	function js_templates() {
+	public static function js_templates() {
 		Jetpack::init()->load_view( 'admin/landing-page-templates.php' );
 	}
 

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -57,6 +57,11 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 
 		wp_enqueue_script( 'jetpack-modules-list-table' );
 		add_action( 'admin_footer', array( 'Jetpack_Modules_List_Table', 'js_templates' ), 9 );
+
+		/**
+		 * @TODO: Hook documentation
+		 */
+		do_action( 'jetpack_modules_list_table_setup' );
 	}
 
 	public static function js_templates() {

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -59,7 +59,11 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		add_action( 'admin_footer', array( 'Jetpack_Modules_List_Table', 'js_templates' ), 9 );
 
 		/**
-		 * @TODO: Hook documentation
+		 * Fires after the Javascript templates are added to the module list.
+		 *
+		 * Allows removing the default Javascript templates to replace them with your own.
+		 *
+		 * @since 3.6.0
 		 */
 		do_action( 'jetpack_modules_list_table_setup' );
 	}

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -56,10 +56,10 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		) );
 
 		wp_enqueue_script( 'jetpack-modules-list-table' );
-		add_action( 'admin_footer', array( $this, 'js_templates' ), 9 );
+		add_action( 'admin_footer', array( 'Jetpack_Modules_List_Table', 'js_templates' ), 9 );
 	}
 
-	function js_templates() {
+	public static function js_templates() {
 		?>
 		<script type="text/html" id="tmpl-Jetpack_Modules_List_Table_Template">
 			<# var i = 0;


### PR DESCRIPTION
Possible fix for #2189 

This makes the `js_templates` methods static, changes the `add_action` calls accordingly, and adds a `jetpack_modules_list_table_setup` where timing a `remove_action` would otherwise be tricky.