### PR TITLE
Protect Module: global and local whitelist

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -581,6 +581,15 @@ class Jetpack_Network {
 	 */
 	public function save_network_settings_page() {
 
+		// try to save the Protect whitelist before anything else, since that action can result in errors
+		$whitelist              = str_replace( ' ', '', $_POST['global-whitelist'] );
+		$whitelist              = explode( PHP_EOL, $whitelist);
+		$result                 = jetpack_protect_save_whitelist( $whitelist, $global = true );
+		if ( is_wp_error( $result ) ) {
+			wp_safe_redirect(add_query_arg(array('page' => 'jetpack-settings', 'error' => 'jetpack_protect_whitelist'), network_admin_url('admin.php')));
+			exit();
+		}
+
 		/*
 		 * Fields
 		 *

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -581,6 +581,12 @@ class Jetpack_Network {
 	 */
 	public function save_network_settings_page() {
 
+		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'jetpack-network-settings' ) ) {
+			// no nonce, push back to settings page
+			wp_safe_redirect(add_query_arg(array('page' => 'jetpack-settings'), network_admin_url('admin.php')));
+			exit();
+		}
+
 		// try to save the Protect whitelist before anything else, since that action can result in errors
 		$whitelist              = str_replace( ' ', '', $_POST['global-whitelist'] );
 		$whitelist              = explode( PHP_EOL, $whitelist);

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -583,7 +583,12 @@ class Jetpack_Network {
 
 		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'jetpack-network-settings' ) ) {
 			// no nonce, push back to settings page
-			wp_safe_redirect( add_query_arg( array('page' => 'jetpack-settings' ), network_admin_url( 'admin.php' ) ) );
+			wp_safe_redirect(
+				add_query_arg(
+					array( 'page' => 'jetpack-settings' ),
+					network_admin_url( 'admin.php' )
+				)
+			);
 			exit();
 		}
 
@@ -592,7 +597,12 @@ class Jetpack_Network {
 		$whitelist              = explode( PHP_EOL, $whitelist);
 		$result                 = jetpack_protect_save_whitelist( $whitelist, $global = true );
 		if ( is_wp_error( $result ) ) {
-			wp_safe_redirect(add_query_arg(array('page' => 'jetpack-settings', 'error' => 'jetpack_protect_whitelist'), network_admin_url('admin.php')));
+			wp_safe_redirect(
+				add_query_arg(
+					array( 'page' => 'jetpack-settings', 'error' => 'jetpack_protect_whitelist'),
+					network_admin_url('admin.php')
+				)
+			);
 			exit();
 		}
 
@@ -627,7 +637,12 @@ class Jetpack_Network {
 		);
 
 		update_site_option( $this->settings_name, $data );
-		wp_safe_redirect( add_query_arg( array( 'page' => 'jetpack-settings', 'updated' => 'true' ), network_admin_url( 'admin.php' ) ) );
+		wp_safe_redirect(
+			add_query_arg(
+				array( 'page' => 'jetpack-settings', 'updated' => 'true' ),
+				network_admin_url( 'admin.php' )
+			)
+		);
 		exit();
 	}
 

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -593,14 +593,14 @@ class Jetpack_Network {
 		}
 
 		// try to save the Protect whitelist before anything else, since that action can result in errors
-		$whitelist              = str_replace( ' ', '', $_POST['global-whitelist'] );
-		$whitelist              = explode( PHP_EOL, $whitelist);
-		$result                 = jetpack_protect_save_whitelist( $whitelist, $global = true );
+		$whitelist = str_replace( ' ', '', $_POST['global-whitelist'] );
+		$whitelist = explode( PHP_EOL, $whitelist );
+		$result    = jetpack_protect_save_whitelist( $whitelist, $global = true );
 		if ( is_wp_error( $result ) ) {
 			wp_safe_redirect(
 				add_query_arg(
-					array( 'page' => 'jetpack-settings', 'error' => 'jetpack_protect_whitelist'),
-					network_admin_url('admin.php')
+					array( 'page' => 'jetpack-settings', 'error' => 'jetpack_protect_whitelist' ),
+					network_admin_url( 'admin.php' )
 				)
 			);
 			exit();

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -583,7 +583,7 @@ class Jetpack_Network {
 
 		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'jetpack-network-settings' ) ) {
 			// no nonce, push back to settings page
-			wp_safe_redirect(add_query_arg(array('page' => 'jetpack-settings'), network_admin_url('admin.php')));
+			wp_safe_redirect( add_query_arg( array('page' => 'jetpack-settings' ), network_admin_url( 'admin.php' ) ) );
 			exit();
 		}
 
@@ -627,7 +627,7 @@ class Jetpack_Network {
 		);
 
 		update_site_option( $this->settings_name, $data );
-		wp_safe_redirect(add_query_arg(array('page' => 'jetpack-settings', 'updated' => 'true'), network_admin_url('admin.php')));
+		wp_safe_redirect( add_query_arg( array( 'page' => 'jetpack-settings', 'updated' => 'true' ), network_admin_url( 'admin.php' ) ) );
 		exit();
 	}
 

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -45,7 +45,8 @@ class Jetpack_Network {
 	 * @since 2.9
 	 */
 	private function __construct() {
-		 require_once( ABSPATH . '/wp-admin/includes/plugin.php' ); // For the is_plugin... check
+		require_once( ABSPATH . '/wp-admin/includes/plugin.php' ); // For the is_plugin... check
+		require_once( JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php' ); // For managing the global whitelist
 		/*
 		 * Sanity check to ensure the install is Multisite and we
 		 * are in Network Admin
@@ -635,7 +636,8 @@ class Jetpack_Network {
 
 		$data = array(
 			'modules' => $modules,
-			'options' => $options
+			'options' => $options,
+			'jetpack_protect_whitelist' => jetpack_protect_format_whitelist(),
 		);
 
 		Jetpack::init()->load_view( 'admin/network-settings.php', $data );

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -35,6 +35,7 @@ class Jetpack_Options {
 				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
+				'protect_whitelist'            // (array) IP Address for the Protect module to ignore
 			);
 
 		case 'private' :

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -325,7 +325,11 @@ class Jetpack_Protect_Module {
 			return true;
 		}
 
-		$whitelist  = get_site_option( 'jetpack_protect_whitelist', array() );
+		$whitelist  = jetpack_protect_get_local_whitelist();
+
+		if ( is_multisite() ) {
+			$whitelist = array_merge( $whitelist, get_site_option( 'jetpack_protect_network_whitelist', array() ) );
+		}
 
 		if ( ! empty( $whitelist ) ) :
 			foreach ( $whitelist as $item ) :
@@ -448,7 +452,6 @@ class Jetpack_Protect_Module {
 		}
 
 		$this->api_key   = get_site_option( 'jetpack_protect_key', false );
-		$this->whitelist = get_site_option( 'jetpack_protect_whitelist', array() );
 		$this->user_ip   = jetpack_protect_get_ip();
 	}
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -328,7 +328,7 @@ class Jetpack_Protect_Module {
 		$whitelist  = jetpack_protect_get_local_whitelist();
 
 		if ( is_multisite() ) {
-			$whitelist = array_merge( $whitelist, get_site_option( 'jetpack_protect_network_whitelist', array() ) );
+			$whitelist = array_merge( $whitelist, get_site_option( 'jetpack_protect_global_whitelist', array() ) );
 		}
 
 		if ( ! empty( $whitelist ) ) :

--- a/modules/protect/config-ui.php
+++ b/modules/protect/config-ui.php
@@ -22,7 +22,7 @@
 
 	<?php
 	global $current_user;
-	$whitelist = jetpack_protect_format_whitelist( $this->whitelist ); // todo remove 'local' from schema when we merge next iteration on calypso
+	$whitelist = jetpack_protect_format_whitelist();
 	?>
 	<div class="protect-whitelist">
 

--- a/modules/protect/config-ui.php
+++ b/modules/protect/config-ui.php
@@ -30,14 +30,29 @@
 			<h3><?php _e( 'Whitelist Management', 'jetpack' ); ?></h3>
 
 			<?php if( ! empty( $this->whitelist_error ) ) : ?>
-				<p class="error"><?php  _e('One of your IP addresses was not valid.', 'jetpack'); ?></p>
+				<p class="error"><?php  _e( 'One of your IP addresses was not valid.', 'jetpack' ); ?></p>
 			<?php endif; ?>
 
 			<?php if( $this->whitelist_saved === true ) : ?>
-				<p class="success"><?php  _e('Whitelist saved.', 'jetpack'); ?></p>
+				<p class="success"><?php  _e( 'Whitelist saved.', 'jetpack' ); ?></p>
 			<?php endif; ?>
 
-			<p><?php _e( 'Whitelisting an IP address prevents it from ever being blocked by Jetpack. ', 'jetpack' ); ?><br><small><?php _e( 'Make sure to add your most frequently used IP addresses as they can change between your home, office or other locations. Removing an IP address from the list below will remove it from your whitelist.', 'jetpack' ); ?></small></p>
+			<p>
+				<?php _e( 'Whitelisting an IP address prevents it from ever being blocked by Jetpack. ', 'jetpack' ); ?><br />
+
+				<?php if ( is_multisite() && current_user_can( 'manage_network' ) ) : ?>
+					<a href="<?php echo network_admin_url( 'admin.php?page=jetpack-settings' ); ?>">
+						<?php _e( 'You can manage your network-wide whitelist via the network admin.', 'jetpack' ); ?>
+					</a><br />
+				<?php endif; ?>
+
+				<small>
+					<?php _e( 'Make sure to add your most frequently used IP addresses as they can change between your home, office or other locations. Removing an IP address from the list below will remove it from your whitelist.', 'jetpack' ); ?>
+				</small>
+			</p>
+
+
+
 			<p><strong><?php printf( __( 'Your current IP: %s', 'jetpack' ), $this->user_ip ); ?></strong></p>
 			<?php wp_nonce_field( 'jetpack-protect' ); ?>
 			<input type='hidden' name='action' value='jetpack_protect_save_whitelist' />

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -24,6 +24,33 @@ function jetpack_protect_format_whitelist( $whitelist = null ) {
 	return $formatted;
 }
 
+/**
+ * Gets the local Protect whitelist
+ *
+ * The 'local' part of the whitelist only really applies to multisite installs,
+ * which can have a network wide whitelist, as well as a local list that applies
+ * only to the current site. On single site installs, there will only be a local
+ * whitelist.
+ *
+ * @return array A list of IP Address objects or an empty array
+ */
+function jetpack_protect_get_local_whitelist() {
+	$whitelist = Jetpack_Options::get_option( 'protect_whitelist' );
+
+	if ( false === $whitelist ) {
+		// The local whitelist has never been set
+		if ( is_multisite() ) {
+			// On a multisite, we can check for a legacy site_option, and default to an empty array
+			$whitelist = get_site_option( 'jetpack_protect_whitelist', array() );
+		} else {
+			// On a single site, we can just use an empty array
+			$whitelist = array();
+		}
+	}
+
+	return $whitelist;
+}
+
 function jetpack_protect_save_whitelist( $whitelist ) {
 	$whitelist_error    = false;
 	$new_items          = array();

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -147,7 +147,7 @@ function jetpack_protect_save_whitelist( $whitelist, $global = false ) {
 		// once a user has saved their network wide whitelist, we can permanently remove the legacy option
 		delete_site_option( 'jetpack_protect_whitelist' );
 	} else {
-		Jetpack_Options::update_option()
+		Jetpack_Options::update_option( 'protect_whitelist', $new_items );
 	}
 
 	return true;

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -32,9 +32,9 @@ function jetpack_protect_format_whitelist() {
 		$global_whitelist = get_site_option( 'jetpack_protect_network_whitelist', array() );
 		foreach( $global_whitelist as $item ) {
 			if ( $item->range ) {
-				$formatted['local'][] = $item->range_low . ' - ' . $item->range_high;
+				$formatted['global'][] = $item->range_low . ' - ' . $item->range_high;
 			} else {
-				$formatted['local'][] = $item->ip_address;
+				$formatted['global'][] = $item->ip_address;
 			}
 		}
 	}

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -29,7 +29,13 @@ function jetpack_protect_format_whitelist() {
 
 	if ( is_multisite() && current_user_can( 'manage_network' ) ) {
 		$formatted['global'] = array();
-		$global_whitelist = get_site_option( 'jetpack_protect_network_whitelist', array() );
+		$global_whitelist = get_site_option( 'jetpack_protect_global_whitelist' );
+
+		if ( false === $global_whitelist ) {
+			// if the global whitelist has never been set, check for a legacy option set prior to 3.6
+			$global_whitelist = get_site_option( 'jetpack_protect_whitelist', array() );
+		}
+
 		foreach( $global_whitelist as $item ) {
 			if ( $item->range ) {
 				$formatted['global'][] = $item->range_low . ' - ' . $item->range_high;
@@ -143,8 +149,8 @@ function jetpack_protect_save_whitelist( $whitelist, $global = false ) {
 	}
 
 	if ( $global ) {
-		update_site_option( 'jetpack_protect_network_whitelist', $new_items );
-		// once a user has saved their network wide whitelist, we can permanently remove the legacy option
+		update_site_option( 'jetpack_protect_global_whitelist', $new_items );
+		// once a user has saved their global whitelist, we can permanently remove the legacy option
 		delete_site_option( 'jetpack_protect_whitelist' );
 	} else {
 		Jetpack_Options::update_option( 'protect_whitelist', $new_items );

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -29,7 +29,7 @@ function jetpack_protect_format_whitelist() {
 
 	if ( is_multisite() && current_user_can( 'manage_network' ) ) {
 		$formatted['global'] = array();
-		$global_whitelist = get_site_option( 'jetpack_protect_global_whitelist' );
+		$global_whitelist = jetpack_protect_get_global_whitelist();
 
 		if ( false === $global_whitelist ) {
 			// if the global whitelist has never been set, check for a legacy option set prior to 3.6
@@ -64,7 +64,7 @@ function jetpack_protect_get_local_whitelist() {
 	if ( false === $whitelist ) {
 		// The local whitelist has never been set
 		if ( is_multisite() ) {
-			// On a multisite, we can check for a legacy site_option that existed prior to v 3.6, and default to an empty array
+			// On a multisite, we can check for a legacy site_option that existed prior to v 3.6, or default to an empty array
 			$whitelist = get_site_option( 'jetpack_protect_whitelist', array() );
 		} else {
 			// On a single site, we can just use an empty array
@@ -72,6 +72,23 @@ function jetpack_protect_get_local_whitelist() {
 		}
 	}
 
+	return $whitelist;
+}
+
+/**
+ * Get the global, network-wide whitelist
+ *
+ * It will revert to the legacy site_option if jetpack_protect_global_whitelist has never been set
+ *
+ * @return array
+ */
+function jetpack_protect_get_global_whitelist() {
+	$whitelist = get_site_option( 'jetpack_protect_global_whitelist' );
+
+	if ( false === $whitelist ) {
+		// The global whitelist has never been set. Check for legacy site_option, or default to an empty array
+		$whitelist = get_site_option( 'jetpack_protect_whitelist', array() );
+	}
 	return $whitelist;
 }
 

--- a/views/admin/network-settings.php
+++ b/views/admin/network-settings.php
@@ -13,6 +13,7 @@
 	<form action="edit.php?action=jetpack-network-settings" method="POST">
 		<h3><?php _e( 'Global', 'jetpack' ); ?></h3>
 		<p><?php _e( 'These settings affect all sites on the network.', 'jetpack' ); ?></p>
+		<?php wp_nonce_field( 'jetpack-network-settings' ); ?>
 		<table class="form-table">
 <?php /*
 			<tr valign="top">

--- a/views/admin/network-settings.php
+++ b/views/admin/network-settings.php
@@ -35,6 +35,7 @@
 			<tr valign="top">
 				<th scope="row"><label for="sub-site-override"><?php _e( 'Protect whitelist', 'jetpack' ); ?></label></th>
 				<td>
+					<p><strong><?php printf( __( 'Your current IP: %s', 'jetpack' ), jetpack_protect_get_ip() ); ?></strong></p>
 					<textarea name="global-whitelist" style="width: 100%;" rows="8"><?php echo implode( PHP_EOL, $jetpack_protect_whitelist['global'] ); ?></textarea> <br />
 					<label for="global-whitelist"><?php _e('IPv4 and IPv6 are acceptable. <br />To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', 'jetpack' ); ?></label>
 				</td>

--- a/views/admin/network-settings.php
+++ b/views/admin/network-settings.php
@@ -33,6 +33,14 @@ if( isset( $_GET['updated'] ) && 'true' == $_GET['updated'] ) {
 					<label for="sub-site-override"><?php _e( 'Allow individual site administrators to manage their own connections (connect and disconnect) to <a href="//wordpress.com">WordPress.com</a>', 'jetpack' ); ?></label>
 				</td>
 			</tr>
+
+			<tr valign="top">
+				<th scope="row"><label for="sub-site-override"><?php _e( 'Protect whitelist', 'jetpack' ); ?></label></th>
+				<td>
+					<textarea name="global-whitelist" style="width: 100%;" rows="8"><?php echo implode( PHP_EOL, $jetpack_protect_whitelist['global'] ); ?></textarea> <br />
+					<label for="global-whitelist"><?php _e('IPv4 and IPv6 are acceptable. <br />To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', 'jetpack' ); ?></label>
+				</td>
+			</tr>
 <?php /* Remove the toggles for 2.9, re-evaluate how they're done and added for a 3.0 release. They don't feel quite right yet.
 			<tr>
 				<th scope="row"><label for="manage_auto_activated_modules">Manage modules</label></th>

--- a/views/admin/network-settings.php
+++ b/views/admin/network-settings.php
@@ -1,15 +1,12 @@
-<?php
-	extract( $data );
+<?php extract( $data ); ?>
 
+<?php if ( isset( $_GET['updated'] ) && 'true' == $_GET['updated'] ) : ?>
+	<div class="updated"><?php esc_html_e( 'Jetpack Network Settings Updated!', 'jetpack' ); ?></div>
+<?php endif; ?>
 
-if( isset( $_GET['updated'] ) && 'true' == $_GET['updated'] ) {
-?>
-
-<div class="updated"><?php esc_html_e( 'Jetpack Network Settings Updated!', 'jetpack' ); ?></div>
-
-<?php
-}
-?>
+<?php if ( isset( $_GET['error'] ) && 'jetpack_protect_whitelist' == $_GET['error'] ) : ?>
+	<div class="error"><?php esc_html_e( 'One of your IP addresses was not valid.', 'jetpack' ); ?></div>
+<?php endif; ?>
 
 <div class="wrap">
 	<h2><?php _e( 'Network Settings', 'jetpack' ); ?></h2>


### PR DESCRIPTION
On a multisite install, whitelists apply to the entire network. This is not ideal because sometimes we only want to whitelist an IP address for the current site.

This PR will differentiate between local whitelist and global whitelist.

To test, you will need a multi-site sandbox. 

1. Before you apply this PR, activate Protect on a few of the sub-sites, and configure the whitelist. Note how the whitelist is always the same for every site.

2. Now apply this PR to your sandbox.

3. Ensure that the whitelist you saved in step 1 is still applying to all sub-sites.

4. Save a new whitelist on a sub-site #1. Ensure that it is not applied to any other sub-site.

5. As a super admin, go to the jepack network settings page. Ensure that the whitelist from step 1 is showing up.

6. Save a new global whitelist. Ensure that the whitelist on sub-site #1 remains unchanged. And that the whitelist on any other sub-site is now blank.

7. Ensure that you cannot get locked out by using faulty credentials if your IP is on the global whitelist, or a local site's whitelist.

See? That was easy!