### PR TITLE
Add jetpack_disable_no_verify_ssl_certs filter

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -135,7 +135,11 @@ class Jetpack_Client {
 	 */
 	public static function _wp_remote_request( $url, $args, $set_fallback = false ) {
 		/**
-		 * Force `sslverify`.
+		 * SSL verification (`sslverify`) for the JetpackClient remote request 
+		 * defaults to off, use this filter to force it on.
+		 * 
+		 * Return `true` to ENABLE SSL verification, return `false`
+		 * to DISABLE SSL verification.
 		 * 
 		 * @since 3.6
 		 * 

--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -134,6 +134,10 @@ class Jetpack_Client {
 	 * @return array|WP_Error WP HTTP response on success
 	 */
 	public static function _wp_remote_request( $url, $args, $set_fallback = false ) {
+		if ( apply_filters( 'jetpack_disable_no_verify_ssl_certs', false ) ) {
+			return wp_remote_request( $url, $args );
+		}
+		
 		$fallback = Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' );
 		if ( false === $fallback ) {
 			Jetpack_Options::update_option( 'fallback_no_verify_ssl_certs', 0 );

--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -134,6 +134,13 @@ class Jetpack_Client {
 	 * @return array|WP_Error WP HTTP response on success
 	 */
 	public static function _wp_remote_request( $url, $args, $set_fallback = false ) {
+		/**
+		 * Force `sslverify`.
+		 * 
+		 * @since 3.6
+		 * 
+		 * @param bool Whether to force `sslverify` or not.
+		 */
 		if ( apply_filters( 'jetpack_disable_no_verify_ssl_certs', false ) ) {
 			return wp_remote_request( $url, $args );
 		}

--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -145,7 +145,7 @@ class Jetpack_Client {
 		 * 
 		 * @param bool Whether to force `sslverify` or not.
 		 */
-		if ( apply_filters( 'jetpack_disable_no_verify_ssl_certs', false ) ) {
+		if ( apply_filters( 'jetpack_client_verify_ssl_certs', false ) ) {
 			return wp_remote_request( $url, $args );
 		}
 		


### PR DESCRIPTION
Provides a filter for anyone that wants to force `sslverify`.

Fixes #2145