### PR TITLE
Add a pre-connection check to the home and siteurl

### DIFF
--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -52,7 +52,7 @@ class Jetpack_Data {
 
 		// If it's empty, just fail out.
 		if ( ! $domain ) {
-			return new WP_Error( 'fail_domain_empty', sprintf( 'Domain `%1$s` just failed is_usable_domain check as it is empty.', $domain ) );
+			return new WP_Error( 'fail_domain_empty', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is empty.', 'jetpack' ), $domain ) );
 		}
 
 		// None of the explicit localhosts.
@@ -67,17 +67,17 @@ class Jetpack_Data {
 			'build.wordpress-develop.dev',
 		);
 		if ( in_array( $domain, $forbidden_domains ) ) {
-			return new WP_Error( 'fail_domain_forbidden', sprintf( 'Domain `%1$s` just failed is_usable_domain check as it is in the forbidden array.', $domain ) );
+			return new WP_Error( 'fail_domain_forbidden', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is in the forbidden array.', 'jetpack' ), $domain ) );
 		}
 
 		// No .dev or .local domains
 		if ( preg_match( '#\.(dev|local)$#i', $domain ) ) {
-			return new WP_Error( 'fail_domain_tld', sprintf( 'Domain `%1$s` just failed is_usable_domain check as it uses an invalid top level domain.', $domain ) );
+			return new WP_Error( 'fail_domain_tld', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it uses an invalid top level domain.', 'jetpack' ), $domain ) );
 		}
 
 		// No WPCOM subdomains
 		if ( preg_match( '#\.wordpress\.com$#i', $domain ) ) {
-			return new WP_Error( 'fail_subdomain_wpcom', sprintf( 'Domain `%1$s` just failed is_usable_domain check as it is a subdomain of wpcom.', $domain ) );
+			return new WP_Error( 'fail_subdomain_wpcom', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is a subdomain of WordPress.com.', 'jetpack' ), $domain ) );
 		}
 
 		// If PHP was compiled without support for the Filter module (very edge case)
@@ -93,7 +93,7 @@ class Jetpack_Data {
 		$ip = filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ? $ip : gethostbyname( $ip );
 
 		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_IPV4 ) && ! self::php_bug_66229_check( $ip ) ) {
-			return new WP_Error( 'fail_domain_bad_ip_range', sprintf( 'Domain `%1$s` just failed is_usable_domain check as its IP `%2$s` is either invalid, or in a reserved or private range.', $domain, $ip ) );
+			return new WP_Error( 'fail_domain_bad_ip_range', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as its IP `%2$s` is either invalid, or in a reserved or private range.', 'jetpack' ), $domain, $ip ) );
 		}
 
 		return true;

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -39,4 +39,87 @@ class Jetpack_Data {
 			'external_user_id' => (int) $user_id,
 		);
 	}
+
+	/**
+	 * This function mirrors Jetpack_Data::is_usable_domain() in the WPCOM codebase.
+	 *
+	 * @param $domain
+	 * @param array $extra
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function is_usable_domain( $domain, $extra = array() ) {
+
+		// If it's empty, just fail out.
+		if ( ! $domain ) {
+			return new WP_Error( 'fail_domain_empty', sprintf( 'Domain `%1$s` just failed is_usable_domain check as it is empty.', $domain ) );
+		}
+
+		// None of the explicit localhosts.
+		$forbidden_domains = array(
+			'wordpress.com',
+			'localhost',
+			'localhost.localdomain',
+			'127.0.0.1',
+			'local.wordpress.dev',
+			'local.wordpress-trunk.dev',
+			'src.wordpress-develop.dev',
+			'build.wordpress-develop.dev',
+		);
+		if ( in_array( $domain, $forbidden_domains ) ) {
+			return new WP_Error( 'fail_domain_forbidden', sprintf( 'Domain `%1$s` just failed is_usable_domain check as it is in the forbidden array.', $domain ) );
+		}
+
+		// No .dev or .local domains
+		if ( preg_match( '#\.(dev|local)$#i', $domain ) ) {
+			return new WP_Error( 'fail_domain_tld', sprintf( 'Domain `%1$s` just failed is_usable_domain check as it uses an invalid top level domain.', $domain ) );
+		}
+
+		// No WPCOM subdomains
+		if ( preg_match( '#\.wordpress\.com$#i', $domain ) ) {
+			return new WP_Error( 'fail_subdomain_wpcom', sprintf( 'Domain `%1$s` just failed is_usable_domain check as it is a subdomain of wpcom.', $domain ) );
+		}
+
+		// If PHP was compiled without support for the Filter module (very edge case)
+		if ( ! function_exists( 'filter_var' ) ) {
+			// Just pass back true for now, and let wpcom sort it out.
+			return true;
+		}
+
+		// Check the IP to make sure it's pingable.
+		$ip = gethostbyname( $domain );
+
+		// Doing this again as I was getting some false positives when gethostbyname() flaked out and returned the domain.
+		$ip = filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ? $ip : gethostbyname( $ip );
+
+		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_IPV4 ) && ! self::php_bug_66229_check( $ip ) ) {
+			return new WP_Error( 'fail_domain_bad_ip_range', sprintf( 'Domain `%1$s` just failed is_usable_domain check as its IP `%2$s` is either invalid, or in a reserved or private range.', $domain, $ip ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns true if the IP address passed in should not be in a reserved range, even if PHP says that it is.
+	 * See: https://bugs.php.net/bug.php?id=66229 and https://github.com/php/php-src/commit/d1314893fd1325ca6aa0831101896e31135a2658
+	 *
+	 * This function mirrors Jetpack_Data::php_bug_66229_check() in the WPCOM codebase.
+	 */
+	public static function php_bug_66229_check( $ip ) {
+		if ( ! filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return false;
+		}
+
+		$ip_arr = array_map( 'intval', explode( '.', $ip ) );
+
+		if ( 128 == $ip_arr[0] && 0 == $ip_arr[1] ) {
+			return true;
+		}
+
+		if ( 191 == $ip_arr[0] && 255 == $ip_arr[1] ) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -61,10 +61,10 @@ class Jetpack_Data {
 			'localhost',
 			'localhost.localdomain',
 			'127.0.0.1',
-			'local.wordpress.dev',
-			'local.wordpress-trunk.dev',
-			'src.wordpress-develop.dev',
-			'build.wordpress-develop.dev',
+			'local.wordpress.dev',         // VVV
+			'local.wordpress-trunk.dev',   // VVV
+			'src.wordpress-develop.dev',   // VVV
+			'build.wordpress-develop.dev', // VVV
 		);
 		if ( in_array( $domain, $forbidden_domains ) ) {
 			return new WP_Error( 'fail_domain_forbidden', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is in the forbidden array.', 'jetpack' ), $domain ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2298,15 +2298,18 @@ p {
 	 * Attempts Jetpack registration.  If it fail, a state flag is set: @see ::admin_page_load()
 	 */
 	public static function try_registration() {
-		// Before attempting to connect, let's make sure that the domains are viable.
-		$domains_to_check = array_unique( array(
-			'siteurl' => parse_url( get_site_url(), 'host' ),
-			'homeurl' => parse_url( get_home_url(), 'host' ),
-		) );
-		foreach ( $domains_to_check as $domain ) {
-			$result = Jetpack_Data::is_usable_domain( $domain );
-			if ( is_wp_error( $result ) ) {
-				return $result;
+		// Let's get some testing in beta versions and such.
+		if ( self::is_development_version() ) {
+			// Before attempting to connect, let's make sure that the domains are viable.
+			$domains_to_check = array_unique( array(
+				'siteurl' => parse_url( get_site_url(), 'host' ),
+				'homeurl' => parse_url( get_home_url(), 'host' ),
+			) );
+			foreach ( $domains_to_check as $domain ) {
+				$result = Jetpack_Data::is_usable_domain( $domain );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
 			}
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2299,11 +2299,11 @@ p {
 	 */
 	public static function try_registration() {
 		// Let's get some testing in beta versions and such.
-		if ( self::is_development_version() ) {
+		if ( self::is_development_version() && defined( 'PHP_URL_HOST' ) ) {
 			// Before attempting to connect, let's make sure that the domains are viable.
 			$domains_to_check = array_unique( array(
-				'siteurl' => parse_url( get_site_url(), 'host' ),
-				'homeurl' => parse_url( get_home_url(), 'host' ),
+				'siteurl' => parse_url( get_site_url(), PHP_URL_HOST ),
+				'homeurl' => parse_url( get_home_url(), PHP_URL_HOST ),
 			) );
 			foreach ( $domains_to_check as $domain ) {
 				$result = Jetpack_Data::is_usable_domain( $domain );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2298,6 +2298,18 @@ p {
 	 * Attempts Jetpack registration.  If it fail, a state flag is set: @see ::admin_page_load()
 	 */
 	public static function try_registration() {
+		// Before attempting to connect, let's make sure that the domains are viable.
+		$domains_to_check = array_unique( array(
+			'siteurl' => parse_url( get_site_url(), 'host' ),
+			'homeurl' => parse_url( get_home_url(), 'host' ),
+		) );
+		foreach ( $domains_to_check as $domain ) {
+			$result = Jetpack_Data::is_usable_domain( $domain );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
 		$result = Jetpack::register();
 
 		// If there was an error with registration and the site was not registered, record this so we can show a message.


### PR DESCRIPTION
This should rule out ones that map to private or reserved ranges, and
provide better error messages.

We regularly get folks trying to connect and hitting errors against these rules on wpcom -- so may as well try the rules on the .org site.

My only concern is if gethostbyname() somehow points to a local ip address because of some /etc/hosts rule on the server, it may somehow shut it down.  I'm not sure how likely that is, though, so we may want to rewrite it a touch for a softer launch, or include some sort of override.