### PR TITLE
Display Posts Widget: add filter to control post query parameters

### DIFF
--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -87,7 +87,22 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		$site_hash = $this->get_site_hash( $instance['url'] );
 		$data_from_cache = get_transient( 'display_posts_post_info_' . $site_hash );
 		if ( false === $data_from_cache ) {
-			$response = wp_remote_get( sprintf( 'https://public-api.wordpress.com/rest/v1/sites/%d/posts/', $site_info->ID ) );
+			$response = wp_remote_get(
+				sprintf(
+					'https://public-api.wordpress.com/rest/v1/sites/%1$d/posts/%2$s',
+					$site_info->ID,
+					/**
+					 * Filters the parameters used to fetch for posts in the Display Posts Widget.
+					 *
+					 * @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/
+					 *
+					 * @since 3.6.0
+					 *
+					 * @param string $args Extra parameters to filter posts returned from the WordPress.com REST API.
+					 */
+					apply_filters( 'jetpack_display_posts_widget_posts_params', '' )
+				)
+			 );
 			set_transient( 'display_posts_post_info_' . $site_hash, $response, 10 * MINUTE_IN_SECONDS );
 		} else {
 			$response = $data_from_cache;


### PR DESCRIPTION
Once that filter is added, site owners would be able to control what posts are returned by the Display Posts widget. here is an example where we only get posts using the "dogs" tag:

```php
function jeherve_test_display_posts_params() {
        return '?tag=dogs';
}
add_filter( 'jetpack_display_posts_widget_posts_params', 'jeherve_test_display_posts_params' );
```

See https://wordpress.org/support/topic/display-wordpress-posts-widget-order-by-option?replies=1&view=all
and
https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/