### PR TITLE
Sharing: return sharing buttons even when loaded via admin-ajax.php

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -571,7 +571,7 @@ function sharing_display( $text = '', $echo = false ) {
 	if ( empty( $post ) )
 		return $text;
 
-	if ( is_preview() || is_admin() ) {
+	if ( ( is_preview() || is_admin() ) && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 		return $text;
 	}
 


### PR DESCRIPTION
@see https://wordpress.org/support/topic/jetpack_likes-not-loaded-in-ajax-function