### PR TITLE
Twitter Cards: Remove deprecated card types

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -47,11 +47,7 @@ class Jetpack_Twitter_Cards {
 			$featured = Jetpack_PostImages::from_thumbnail( $post->ID, 240, 240 );
 			if ( !empty( $featured ) && count( $featured ) > 0 ) {
 				if ( (int) $featured[0]['src_width'] >= 280 && (int) $featured[0]['src_height'] >= 150 ) {
-					if ( 'image' === get_post_format( $post->ID ) ) {
-						$card_type = 'photo';
-					} else {
-						$card_type = 'summary_large_image';
-					}
+					$card_type = 'summary_large_image';
 					$og_tags['twitter:image:src'] = add_query_arg( 'w', 640, $featured[0]['src'] );
 				} else {
 					$og_tags['twitter:image'] = add_query_arg( 'w', 240, $featured[0]['src'] );
@@ -95,12 +91,8 @@ class Jetpack_Twitter_Cards {
 		// Make sure we have a description for Twitter, their validator isn't happy without some content (single space not valid).
 		if ( ! isset( $og_tags['og:description'] ) || '' == trim( $og_tags['og:description'] ) || __('Visit the post for more.', 'jetpack') == $og_tags['og:description'] ) { // empty( trim( $og_tags['og:description'] ) ) isn't valid php
 			$has_creator = ( ! empty($og_tags['twitter:creator']) && '@wordpressdotcom' != $og_tags['twitter:creator'] ) ? true : false;
-			if ( 'photo' == $card_type ) {
-				$og_tags['twitter:description'] = ( $has_creator ) ? sprintf( __('Photo post by %s.', 'jetpack'), $og_tags['twitter:creator'] ) : __('Photo post.', 'jetpack');
-			} elseif ( ! empty( $extract ) && 'video' == $extract['type'] ) { // use $extract['type'] since $card_type is 'summary' for video posts
+			if ( ! empty( $extract ) && 'video' == $extract['type'] ) { // use $extract['type'] since $card_type is 'summary' for video posts
 				$og_tags['twitter:description'] = ( $has_creator ) ? sprintf( __('Video post by %s.', 'jetpack'), $og_tags['twitter:creator'] ) : __('Video post.', 'jetpack');
-			} elseif ( 'gallery' == $card_type ) {
-				$og_tags['twitter:description'] = ( $has_creator ) ? sprintf( __('Gallery post by %s.', 'jetpack'), $og_tags['twitter:creator'] ) : __('Gallery post.', 'jetpack');
 			} else {
 				$og_tags['twitter:description'] = ( $has_creator ) ? sprintf( __('Post by %s.', 'jetpack'), $og_tags['twitter:creator'] ) : __('Visit the post for more.', 'jetpack');
 			}
@@ -146,18 +138,10 @@ class Jetpack_Twitter_Cards {
 
 			// Not falling back on Gravatar, because there's no way to know if we end up with an auto-generated one.
 
-		} elseif ( 1 == $img_count && ( 'image' == $extract['type'] || 'gallery' == $extract['type'] ) ) {
-			// 1 image = photo
+		} elseif ( $img_count && ( 'image' == $extract['type'] || 'gallery' == $extract['type'] ) ) {
 			// Test for $extract['type'] to limit to image and gallery, so we don't send a potential fallback image like a Gravatar as a photo post.
-			$card_type = 'photo';
+			$card_type = 'summary_large_image';
 			$og_tags['twitter:image'] = add_query_arg( 'w', 1400, ( empty( $extract['images'] ) ) ? $extract['image'] : $extract['images'][0]['url'] );
-		} elseif ( $img_count <= 3 ) {
-			// 2-3 images = summary with small thumbnail
-			$og_tags['twitter:image'] = add_query_arg( 'w', 240, ( empty( $extract['images'] ) ) ? $extract['image'] : $extract['images'][0]['url'] );
-		} elseif ( $img_count >= 4 ) {
-			// >= 4 images = gallery
-			$card_type = 'gallery';
-			$og_tags = self::twitter_cards_gallery( $extract, $og_tags );
 		}
 
 		return array( $og_tags, $card_type );

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -147,16 +147,6 @@ class Jetpack_Twitter_Cards {
 		return array( $og_tags, $card_type );
 	}
 
-	static function twitter_cards_gallery( $extract, $og_tags ) {
-		foreach( $extract['images'] as $key => $value ) {
-			if ( $key > 3 ) {
-				break; // only the first 4 appear in card template (https://dev.twitter.com/cards/types/gallery)
-			}
-			$og_tags[ 'twitter:image' . $key ] = add_query_arg( 'w', 640, $value['url'] );
-		}
-		return $og_tags;
-	}
-
 	static function twitter_cards_output( $og_tag ) {
 		return ( false !== strpos( $og_tag, 'twitter:' ) ) ? preg_replace( '/property="([^"]+)"/', 'name="\1"', $og_tag ) : $og_tag;
 	}

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -68,7 +68,7 @@ class Jetpack_Twitter_Cards {
 
 				if ( 'gallery' == $extract['type'] ) {
 					list( $og_tags, $card_type ) = self::twitter_cards_define_type_based_on_image_count( $og_tags, $extract );
-				} else if ( 'video' == $extract['type'] ) {
+				} elseif ( 'video' == $extract['type'] ) {
 					// Leave as summary, but with large pict of poster frame (we know those comply to Twitter's size requirements)
 					$card_type = 'summary_large_image';
 					$og_tags['twitter:image:src'] = add_query_arg( 'w', 640, $extract['image'] );


### PR DESCRIPTION
Twitter is [retiring the Photo, Gallery, and Product card types](https://twittercommunity.com/t/deprecating-the-photo-gallery-and-product-cards/38961).
* Product cards are not used in Jetpack, so no change.
* Photo and Gallery will fallback to `summary_large_image` by Twitter, so making matching change in JP.
* Removing now unused `twitter_cards_gallery` function.

Fixes #2224