### PR TITLE
Sharing: do not use WPCOMSharing if it is disabled via filter

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -181,7 +181,9 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 
 	function WPCOMSharing_do() {
 		var $more_sharing_buttons;
-		WPCOMSharing.get_counts();
+		if ( 'undefined' !== typeof WPCOMSharing ) {
+			WPCOMSharing.get_counts();
+		}
 		$more_sharing_buttons = $( '.sharedaddy a.sharing-anchor' );
 
 		$more_sharing_buttons.click( function() {


### PR DESCRIPTION
To reproduce the error:
1. add `add_filter( 'jetpack_sharing_counts', '__return_false' );` in a functionality plugin
2. Try to use the email sharing button

cc @rudzki 

@aduth Seems like the problem began with ad2130a863b9f17ad98692aa455977dfed4eab2b. Does my change seem okay to you?

Thanks!