### PR TITLE
Likes: Sync all public post types.

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -564,8 +564,11 @@ class Jetpack_Likes {
 		add_action( "admin_print_scripts-edit.php", array( $this, 'enqueue_admin_scripts' ) );
 
 		if ( $this->in_jetpack ) {
+			$post_stati = get_post_stati( array( 'public' => true ) ); // All public post stati
+			$post_stati[] = 'private';                                 // Content from private stati will be redacted
 			Jetpack_Sync::sync_posts( __FILE__, array(
 				'post_types' => get_post_types( array( 'public' => true ) ),
+				'post_stati' => $post_stati,
 				) );
 		}
 	}

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -564,7 +564,9 @@ class Jetpack_Likes {
 		add_action( "admin_print_scripts-edit.php", array( $this, 'enqueue_admin_scripts' ) );
 
 		if ( $this->in_jetpack ) {
-			Jetpack_Sync::sync_posts( __FILE__ );
+			Jetpack_Sync::sync_posts( __FILE__, array(
+				'post_types' => get_post_types( array( 'public' => true ) ),
+				) );
 		}
 	}
 


### PR DESCRIPTION
When Likes are enabled, Custom Post Types will display the chrome for Likes, but will never load the like button since they aren't synced up to wpcom. Most users won't notice this since the Stats module takes care of syncing public CPTs.

This PR modifies Likes to sync public CPTs as well for those without Stats enabled.

cc: @xyu since it extends on the fix of #697