### PR TITLE
Enhancement to track Unique Activations and Deactivations

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -10,16 +10,27 @@ class Jetpack_Client_Server {
 		$args = array();
 		$redirect = isset( $data['redirect'] ) ? esc_url_raw( (string) $data['redirect'] ) : '';
 
+		$jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' );
 		// Checking if site has been active/connected previously before recording unique connection
-		if ( ! Jetpack_Options::get_option( 'unique_connection' ) ) {
-			// Save connection status to options table to prevent tracking on connection cycle
-			Jetpack_Options::update_option( 'unique_connection', 'connected' );
+		if ( ! $jetpack_unique_connection ) {
+			// jetpack_unique_connection option has never been set
+			$jetpack_unique_connection = array(
+				'connected' => 0,
+				'disconnected' => 0,
+			);
 
+			update_option( 'jetpack_unique_connection', $jetpack_unique_connection );
+
+			//track unique connection
 			$jetpack = Jetpack::init();
 
 			$jetpack->stat( 'connections', 'unique-connection' );
 			$jetpack->do_stats( 'server_side' );
 		}
+
+		// increment number of times connected
+		$jetpack_unique_connection['connected'] += 1;
+		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
 
 		do {
 			$jetpack = Jetpack::init();

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -10,6 +10,17 @@ class Jetpack_Client_Server {
 		$args = array();
 		$redirect = isset( $data['redirect'] ) ? esc_url_raw( (string) $data['redirect'] ) : '';
 
+		// Checking if site has been active/connected previously before recording unique connection
+		if ( ! Jetpack_Options::get_option( 'unique_connection' ) ) {
+			// Save connection status to options table to prevent tracking on connection cycle
+			Jetpack_Options::update_option( 'unique_connection', 1 );
+
+			$jetpack = Jetpack::init();
+
+			$jetpack->stat( 'connections', 'unique-connection' );
+			$jetpack->do_stats( 'server_side' );
+		}
+
 		do {
 			$jetpack = Jetpack::init();
 			$role = $jetpack->translate_current_user_to_role();

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -13,7 +13,7 @@ class Jetpack_Client_Server {
 		// Checking if site has been active/connected previously before recording unique connection
 		if ( ! Jetpack_Options::get_option( 'unique_connection' ) ) {
 			// Save connection status to options table to prevent tracking on connection cycle
-			Jetpack_Options::update_option( 'unique_connection', 1 );
+			Jetpack_Options::update_option( 'unique_connection', 'connected' );
 
 			$jetpack = Jetpack::init();
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -34,7 +34,7 @@ class Jetpack_Options {
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
 				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 				'restapi_stats_cache',         // (array) Stats Cache data.
-				'unique_connection',           // (string)  A flag to determine a unique connection to wordpress.com - connected = connection made at one time, disconnected = has been disconnected at one time
+				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -34,7 +34,7 @@ class Jetpack_Options {
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
 				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 				'restapi_stats_cache',         // (array) Stats Cache data.
-				'unique_connection',           // (int)  A flag to determine a unique connection to wordpress.com - 1 = connection made at one time, 2 = has been disconnected at one time
+				'unique_connection',           // (string)  A flag to determine a unique connection to wordpress.com - connected = connection made at one time, disconnected = has been disconnected at one time
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -34,6 +34,7 @@ class Jetpack_Options {
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
 				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 				'restapi_stats_cache',         // (array) Stats Cache data.
+				'unique_connection',           // (int)  A flag to determine a unique connection to wordpress.com - 1 = connection made at one time, 2 = has been disconnected at one time
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -376,15 +376,16 @@ class Jetpack {
 				add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
 				do_action( 'jetpack_sync_all_registered_options' );
 			}
+
+			//if Jetpack is connected check if jetpack_unique_connection and if not then set it
+			if ( ! get_option( 'jetpack_unique_connection' ) ) {
+				update_option( 'jetpack_unique_connection', 'connected' );
+			}
 		}
 
 		if ( get_option( 'jetpack_json_api_full_management' ) ) {
 			delete_option( 'jetpack_json_api_full_management' );
 			self::activate_manage();
-		}
-
-		if ( ! get_option( 'jetpack_unique_connection' ) ) {
-			update_option( 'jetpack_unique_connection', 'connected' );
 		}
 
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -384,8 +384,9 @@ class Jetpack {
 		}
 
 		if ( ! get_option( 'jetpack_unique_connection' ) ) {
-			update_option( 'jetpack_unique_connection', 1 );
+			update_option( 'jetpack_unique_connection', 'connected' );
 		}
+
 	}
 
 	static function activate_manage( ) {
@@ -2269,9 +2270,9 @@ p {
 		}
 
 		// Check then record unique disconnection if site has never been disconnected previously
-		if ( 2 != Jetpack_Options::get_option( 'unique_connection' ) ) {
+		if ( 'disconnected' != Jetpack_Options::get_option( 'unique_connection' ) ) {
 			// Save connection status to options table to prevent tracking on connection cycle
-			Jetpack_Options::update_option( 'unique_connection', 2 );
+			Jetpack_Options::update_option( 'unique_connection', 'disconnected' );
 
 			$jetpack = Jetpack::init();
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -382,6 +382,10 @@ class Jetpack {
 			delete_option( 'jetpack_json_api_full_management' );
 			self::activate_manage();
 		}
+
+		if ( ! get_option( 'jetpack_unique_connection' ) ) {
+			update_option( 'jetpack_unique_connection', 1 );
+		}
 	}
 
 	static function activate_manage( ) {
@@ -2262,6 +2266,17 @@ p {
 
 		if ( $update_activated_state ) {
 			Jetpack_Options::update_option( 'activated', 4 );
+		}
+
+		// Check then record unique disconnection if site has never been disconnected previously
+		if ( 2 != Jetpack_Options::get_option( 'unique_connection' ) ) {
+			// Save connection status to options table to prevent tracking on connection cycle
+			Jetpack_Options::update_option( 'unique_connection', 2 );
+
+			$jetpack = Jetpack::init();
+
+			$jetpack->stat( 'connections', 'unique-disconnect' );
+			$jetpack->do_stats( 'server_side' );
 		}
 
 		// Disable the Heartbeat cron
@@ -4453,6 +4468,11 @@ p {
 		// Initialize Jump Start for the first and only time.
 		if ( ! Jetpack_Options::get_option( 'jumpstart' ) ) {
 			Jetpack_Options::update_option( 'jumpstart', 'new_connection' );
+
+			$jetpack = Jetpack::init();
+
+			$jetpack->stat( 'jumpstart', 'unique-views' );
+			$jetpack->do_stats( 'server_side' );
 		};
 
 		return true;


### PR DESCRIPTION
Added option jetpack_unique_connection which has two states. "connected" = site is connected, "disconnected" = site has been deactivated

Stats are fired only if jetpack_unique_connection doesn't exist which will track only unique activations or in the case of a deactivation stats will only fire if jetpack_unique_connection is set to "connected".

Deactivating or deleting Jetpack will not remove jetpack_unique_connection, preventing tracking of cycled connections.

Also added stat tracking for Jump Start to differentiate between a unique Jump Start view and repeated views

replaces #2095 