### PR TITLE
Slideshare Shortcode: Brings shortcode in sync with dotcom 

### DIFF
--- a/modules/shortcodes/slideshare.php
+++ b/modules/shortcodes/slideshare.php
@@ -1,8 +1,25 @@
 <?php
+
+// guarantee use of https
+wp_oembed_remove_provider( '#https?://(www\.)?slideshare\.net/.*#i' );
+wp_oembed_add_provider( '#https?://(www\.)?slideshare\.net/.*#i', 'https://www.slideshare.net/api/oembed/2', true );
+
 /*
  * Slideshare shortcode format:
- * [slideshare id=5342235&doc=camprock-101002163655-phpapp01&w=300&h=200]
+ * Old style (still compatible): [slideshare id=5342235&doc=camprock-101002163655-phpapp01&w=300&h=200]
+ * New style: [slideshare id=5342235&w=300&h=200&fb=0&mw=0&mh=0&sc=no]
+ *
+ * Legend:
+ *	id 	= 	Document ID provided by Slideshare
+ *	w	=	Width of iFrame 	(int)
+ *	h	=	Height of iFrame 	(int)
+ *	fb	=	iFrame frameborder 	(int)
+ *	mw	=	iFrame marginwidth 	(int)
+ *	mh	=	iFrame marginheight	(int)
+ *	sc	=	iFrame Scrollbar	(yes/no)
  **/
+
+add_shortcode( 'slideshare', 'slideshare_shortcode' );
 
 function slideshare_shortcode( $atts ) {
 	global $content_width;
@@ -10,38 +27,62 @@ function slideshare_shortcode( $atts ) {
 	$params = shortcode_new_to_old_params( $atts );
 	parse_str( $params, $arguments );
 
-	if ( empty( $arguments ) ) {
+	if ( empty( $arguments ) )
 		return '<!-- SlideShare error: no arguments -->';
-	}
 
-	extract( $arguments, EXTR_SKIP );
+	extract( $arguments );
 
-	$pattern = '/[^-_a-zA-Z0-9]/';
-	if ( empty( $id ) || preg_match( $pattern, $id ) ) {
+	// check that the Slideshare ID contains letters, numbers and query strings
+	$pattern = '/[^-_a-zA-Z0-9?=&]/';
+	if ( empty( $id ) || preg_match( $pattern, $id ) )
 		return '<!-- SlideShare error: id is missing or has illegal characters -->';
-	}
 
-	if ( empty( $doc ) || preg_match( $pattern, $doc ) ) {
-		return '<!-- SlideShare error: doc is missing or has illegal characters -->';
-	}
-
-	if ( empty( $w ) && !empty( $content_width ) ) {
+	// check the width/height
+	if ( empty( $w ) && ! empty( $content_width ) )
 		$w = intval( $content_width );
-	} elseif ( ! ( $w = intval( $w ) ) || $w < 300 || $w > 1600 ) {
+	elseif ( ! ( $w = intval( $w ) ) || $w < 300 || $w > 1600 )
 		$w = 425;
-	} else {
+	else
 		$w = intval( $w );
-	}
 
 	$h = ceil( $w * 348 / 425 );
 
-	$player = "<object type='application/x-shockwave-flash' wmode='opaque' data='http://static.slideshare.net/swf/ssplayer2.swf?id=$id&doc=$doc' width='$w' height='$h'><param name='movie' value='http://static.slideshare.net/swf/ssplayer2.swf?id=$id&doc=$doc' /><param name='allowFullScreen' value='true' /></object>";
-
-	if ( !empty( $type ) && $type == 'd' ) {
-		$player = "<object style='margin: 0px;' width='$w' height='$h'><param name='movie' value='http://static.slidesharecdn.com/swf/ssplayerd.swf?doc=$doc' /><param name='allowFullScreen' value='true' /><param name='wmode' value='opaque' /><embed src='http://static.slidesharecdn.com/swf/ssplayerd.swf?doc=$doc' type='application/x-shockwave-flash' allowfullscreen='true' wmode='opaque' width='$w' height='$h'></embed></object>";
+	if ( isset( $pro ) ) {
+		$source = "https://www.slideshare.net/slidesharepro/$id";
+	} else {
+		$source = "https://www.slideshare.net/slideshow/embed_code/$id";
 	}
+
+	if ( isset( $rel ) )
+		$source = add_query_arg( 'rel', intval( $rel ), $source );
+
+	if ( isset( $startSlide ) )
+		$source = add_query_arg( 'startSlide', intval( $startSlide ), $source );
+
+	$player = sprintf( "<iframe src='%s' width='%d' height='%d'", esc_url( $source ), $w, $h );
+
+	// check the frameborder
+	if ( isset( $fb ) )
+		$player .= " frameborder='" . intval( $fb ) . "'";
+
+	// check the margin width; if not empty, cast as int
+	if ( isset( $mw ) )
+		$player .= " marginwidth='" . intval( $mw ) . "'";
+
+	// check the margin height, if not empty, cast as int
+	if ( isset( $mh ) )
+		$player .= " marginheight='" . intval( $mh ) . "'";
+
+	if ( ! empty( $style ) )
+		$player .= " style='" . $style . "'";
+
+	// check the scrollbar; cast as a lowercase string for comparison
+	$sc = isset( $sc ) ? strtolower( $sc ) : '';
+
+	if ( in_array( $sc, array( 'yes', 'no' ) ) )
+		$player .= " scrolling='" . $sc . "'";
+
+	$player .= ' allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>';
 
 	return $player;
 }
-
-add_shortcode( 'slideshare', 'slideshare_shortcode' );


### PR DESCRIPTION
And fixes #2048 

Slideshare hasn't been working at all for a while.  This will bring the shortcode completely in sync with dotcom, and will stay in sync as it has been added to the build script.  

Here's a shortcode you can use to test:

`[slideshare id=49189584&doc=060915t3wwdcfinal-150609193147-lva1-app6892]`

Will replace PR #2121