### PR TITLE
Sharing: Add bbpress support

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -8,3 +8,4 @@
 require_once( 'buddypress.php' );
 require_once( 'wpml.php' );
 require_once( 'bitly.php' );
+require_once( 'bbpress.php' );

--- a/3rd-party/bbpress.php
+++ b/3rd-party/bbpress.php
@@ -1,0 +1,21 @@
+<?php
+
+add_action( 'bbp_get_topic_content',           'jetpack_sharing_bbpress' );
+add_action( 'bbp_template_after_single_forum', 'jetpack_sharing_bbpress' );
+add_action( 'bbp_template_after_single_topic', 'jetpack_sharing_bbpress' );
+add_action( 'bbp_template_after_lead_topic',   'jetpack_sharing_bbpress' );
+
+/**
+ * Display Jetpack "Sharing" buttons on bbPress 2.x forums/ topics/ lead topics/ replies.
+ *
+ * Determination if the sharing buttons should display on the post type is handled within sharing_display().
+ *
+ * @author David Decker
+ * @since  3.6.0
+ */
+function jetpack_sharing_bbpress() {
+
+	if ( function_exists( 'sharing_display' ) ) {
+		echo sharing_display();
+	}
+}


### PR DESCRIPTION
Hooks into various bbPress hooks to add sharing buttons when the CPTs are enabled via Settings->Sharing including:
* bbp_get_topic_content
* bbp_template_after_single_forum
* bbp_template_after_single_topic
* bbp_template_after_lead_topic

Fixes #426