### PR TITLE
Readd sync non public posts to wp.com

### DIFF
--- a/modules/manage.php
+++ b/modules/manage.php
@@ -13,4 +13,14 @@
  */
 
 add_action( 'jetpack_activate_module_manage', array( Jetpack::init(), 'toggle_module_on_wpcom' ) );
-add_action( 'jetpack_deactivate_module_manage', array( Jetpack::init(), 'toggle_module_on_wpcom' )  );
+add_action( 'jetpack_deactivate_module_manage', array( Jetpack::init(), 'toggle_module_on_wpcom' ) );
+
+// Re add sync for non public posts when the optin is selected in Calypso.
+// This will only work if you have manage enabled as well.
+if ( Jetpack_Options::get_option( 'sync_non_public_post_stati' ) ) {
+	$sync_options = array(
+		'post_types' => get_post_types( array( 'public' => true ) ),
+		'post_stati' => get_post_stati(),
+	);
+	Jetpack_Sync::sync_posts( __FILE__, $sync_options );
+}


### PR DESCRIPTION
This used to be part of the JSON API but was removed in Jetpack 3.4
in https://github.com/Automattic/jetpack/commit/5810dcc41261de8afb2cfb57e13b2d7936df9b1e#diff-0c6e974dad0b4fa49b54a0b15d96fecd

By adding it to the manage modules it will only work if the manage module is enabled as well. 
Suggestion and thoughts? 

cc @georgestephanis, @rralian 