### PR TITLE
Publicize: Add filter to modify global connections hidden checkbox

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -595,7 +595,17 @@ jQuery( function($) {
 							$hidden_checkbox = false;
 							if ( !$done && ( 0 == $cmeta['connection_data']['user_id'] && !current_user_can( $this->publicize->GLOBAL_CAP ) ) ) {
 								$disabled = ' disabled="disabled"';
-								$hidden_checkbox = true;
+								/**
+								 * Filters the checkboxes for global connections with non-prilvedges users.
+ 								 *
+ 								 * @since 3.7.0
+ 								 *
+ 								 * @param bool  $checked Indicates if this connection should be enabled. Default true.
+ 								 * @param int   $post->ID ID of the current post
+ 								 * @param string $name Name of the connection (Facebook, Twitter, etc)
+ 								 * @param array $connection Array of data about the connection.
+ 								 */
+								$hidden_checkbox = apply_filters( 'publicize_checkbox_global_default', true, $post->ID, $name, $connection );
 							}
 
 							// Determine the state of the checkbox (on/off) and allow filtering


### PR DESCRIPTION
This adds a `publicize_checkbox_global_default` to allow site administrators to change the default behavior of global social media accounts set as a "hidden checkbox" that would be submitted when a non-admin submits a post.

cc: @codebykat @jkudish - This approach okay or would future Publicize work render it null?

Fixes #2258 