### PR TITLE
Tiled Galleries: Show columns setting for Thumbnail Grid when Tiled Mosaic galleries are the default

### DIFF
--- a/_inc/gallery-settings.js
+++ b/_inc/gallery-settings.js
@@ -20,7 +20,7 @@
 			$el.find( 'select[name=type]' ).on( 'change', function () {
 				var columnSetting = $el.find( 'select[name=columns]' ).closest( 'label.setting' );
 
-				if ( 'default' === $( this ).val() ) {
+				if ( 'default' === $( this ).val() || 'thumbnails' === $( this ).val() ) {
 					columnSetting.show();
 				} else {
 					columnSetting.hide();


### PR DESCRIPTION
Previously, the Columns setting was only being shown when the "default" gallery type was being displayed. But when Tiled Mosaic galleries were set as the default under Settings > Media, the "default" type (previously Thumbnail Grid) was renamed to "thumbnails" here:

https://github.com/Automattic/jetpack/blob/3.5.3/modules/tiled-gallery/tiled-gallery.php#L168-169

So adding a simple check to see if we want a "default" gallery *or* a "thumbnails" gallery fixes #1287.