### PR TITLE
Pop up modals on settings page with URL parameter

### DIFF
--- a/_inc/jetpack-modules.js
+++ b/_inc/jetpack-modules.js
@@ -1,5 +1,5 @@
 
-( function( window, $, items, models, views, i18n, nonces ) {
+( function( window, $, items, models, views, i18n, modalinfo, nonces ) {
 	'use strict';
 
 	var modules, list_table, handle_module_tag_click, $the_table, $the_filters, $the_search, $jp_frame, $bulk_button, show_modal, hide_modal, set_modal_tab, originPoint;
@@ -58,6 +58,12 @@
 		$( '.modal' )[0].setAttribute( 'tabindex', '0' );
 		$( '.modal' ).focus();
 	};
+
+	$( window ).load(function() {
+		if( modalinfo ) {
+			show_modal( modalinfo, 'learn-more' );
+		}
+	});
 
 	hide_modal = function() {
 		$jp_frame.children( '.modal, .shade' ).hide();
@@ -138,4 +144,4 @@
 		event.preventDefault();
 	} );
 
-} ) ( this, jQuery, window.jetpackModulesData.modules, this.jetpackModules.models, this.jetpackModules.views, window.jetpackModulesData.i18n, window.jetpackModulesData.nonces );
+} ) ( this, jQuery, window.jetpackModulesData.modules, this.jetpackModules.models, this.jetpackModules.views, window.jetpackModulesData.i18n, window.jetpackModulesData.modalinfo, window.jetpackModulesData.nonces );

--- a/_inc/jetpack-modules.js
+++ b/_inc/jetpack-modules.js
@@ -59,6 +59,9 @@
 		$( '.modal' ).focus();
 	};
 
+	/**
+	 * If modalinfo is defined, auto popup the modal
+	 */
 	$( window ).load(function() {
 		if( modalinfo ) {
 			show_modal( modalinfo );

--- a/_inc/jetpack-modules.js
+++ b/_inc/jetpack-modules.js
@@ -61,7 +61,7 @@
 
 	$( window ).load(function() {
 		if( modalinfo ) {
-			show_modal( modalinfo, 'learn-more' );
+			show_modal( modalinfo );
 		}
 	});
 

--- a/_inc/jetpack-modules.js
+++ b/_inc/jetpack-modules.js
@@ -62,7 +62,7 @@
 	/**
 	 * If modalinfo is defined, auto popup the modal
 	 */
-	$( window ).load(function() {
+	$( document ).ready(function() {
 		if( modalinfo ) {
 			show_modal( modalinfo );
 		}

--- a/_inc/jetpack-modules.js
+++ b/_inc/jetpack-modules.js
@@ -63,7 +63,7 @@
 	 * If modalinfo is defined, auto popup the modal
 	 */
 	$( document ).ready(function() {
-		if( modalinfo ) {
+		if ( modalinfo ) {
 			show_modal( modalinfo );
 		}
 	});

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -50,6 +50,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			'i18n'    => array(
 				'search_placeholder' => __( 'Search Modules…', 'jetpack' ),
 			),
+			'modalinfo' =>  isset( $_GET['info'] ) ? $_GET['info'] : false,
 			'nonces'  => array(
 				'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
 			),

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -19,7 +19,8 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		$this->items = $this->all_items = Jetpack_Admin::init()->get_modules();
 		$this->items = $this->filter_displayed_table_items( $this->items );
 		$this->items = apply_filters( 'jetpack_modules_list_table_items', $this->items );
-		$this->_column_headers = array( $this->get_columns(), array(), array(), 'name' );
+		$this->_column_headers = array( $this->get_columns(), array(), array() );
+		$modal_info = isset( $_GET['info'] ) ? $_GET['info'] : false;
 
 		wp_register_script(
 			'models.jetpack-modules',
@@ -50,7 +51,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			'i18n'    => array(
 				'search_placeholder' => __( 'Search Modules…', 'jetpack' ),
 			),
-			'modalinfo' =>  isset( $_GET['info'] ) ? $_GET['info'] : false,
+			'modalinfo' => $this->module_info_check( $modal_info, $this->all_items ),
 			'nonces'  => array(
 				'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
 			),
@@ -307,6 +308,16 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 				break;
 			default:
 				return print_r( $item, true );
+		}
+	}
+
+	//Check if the info parameter provided in the URL corresponds to an actual module
+	function module_info_check( $info = false, $modules ){
+		if( false == $info ) {
+			return false;
+		}
+		else if( array_key_exists( $info, $modules ) ) {
+			return $info;
 		}
 	}
 

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -19,7 +19,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		$this->items = $this->all_items = Jetpack_Admin::init()->get_modules();
 		$this->items = $this->filter_displayed_table_items( $this->items );
 		$this->items = apply_filters( 'jetpack_modules_list_table_items', $this->items );
-		$this->_column_headers = array( $this->get_columns(), array(), array() );
+		$this->_column_headers = array( $this->get_columns(), array(), array(), 'name' );
 		$modal_info = isset( $_GET['info'] ) ? $_GET['info'] : false;
 
 		wp_register_script(

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -315,8 +315,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	function module_info_check( $info = false, $modules ) {
 		if ( false == $info ) {
 			return false;
-		}
-		else if ( array_key_exists( $info, $modules ) ) {
+		} else if ( array_key_exists( $info, $modules ) ) {
 			return $info;
 		}
 	}

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -125,7 +125,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			'all' => sprintf( $format, $title, $count, $url, $current ),
 		);
 		foreach ( $module_tags_unique as $title => $count ) {
-			if( 'Jumpstart' == $title ) {
+			if ( 'Jumpstart' == $title ) {
 				continue;
 			}
 			$key           = sanitize_title( $title );
@@ -312,11 +312,11 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	}
 
 	//Check if the info parameter provided in the URL corresponds to an actual module
-	function module_info_check( $info = false, $modules ){
-		if( false == $info ) {
+	function module_info_check( $info = false, $modules ) {
+		if ( false == $info ) {
 			return false;
 		}
-		else if( array_key_exists( $info, $modules ) ) {
+		else if ( array_key_exists( $info, $modules ) ) {
 			return $info;
 		}
 	}


### PR DESCRIPTION
a requirement for Just In Time Messaging will be to send the user to a
place to learn about a module and have a call-to-action.

This will allow you to add “&info=module-slug” to the end of the
settings page URL and auto pop a modal.

replaces #2212 