### PR TITLE
Jumpstart descriptions: add missing translation function

### DIFF
--- a/views/admin/landing-page-templates.php
+++ b/views/admin/landing-page-templates.php
@@ -41,7 +41,7 @@
 	<div class="j-col j-lrg-4 jp-jumpstart {{ ( data.activated ) ? 'active' : '' }}">
 		<strong>{{{ data.name }}}</strong>
 		<# if ( data.activated ) { #>
-			<span class="jp-config-status">Activated</span>
+			<span class="jp-config-status"><?php esc_html_e( 'Activated', 'jetpack' ); ?></span>
 		<# } #>
 		<small>{{{ data.jumpstart_desc }}}</small>
 	</div>


### PR DESCRIPTION
To fix this missing translation:

![screen shot 2015-06-19 at 4 55 28 pm](https://cloud.githubusercontent.com/assets/426388/8256043/91730054-16a4-11e5-8c6d-4c646a52d95b.png)
