### PR TITLE
My Jetpack: Fire request to change blog owner when master switched

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
@@ -46,8 +46,31 @@ class Jetpack_My_Jetpack_Page extends Jetpack_Admin_Page {
 				Jetpack::init()->stat( 'admin', 'change-primary-successful' );
 				Jetpack::init()->do_stats( 'server_side' );
 
+				// Change the blog owner dotcom side
+				$this->wpcom_switch_blog_owner( $new_master_user );
 			}
 		}
+	}
+
+	/*
+	 * Tell wpcom that the master user has switched
+	 * so we can update the 'wpcom_blog_owner'
+	 */
+	function wpcom_switch_blog_owner( $new_master ) {
+		$id = Jetpack::get_option( 'id', false );
+		$wpcom_user = Jetpack::get_connected_user_data( $new_master );
+
+		$request = array(
+			'blog_id'        => $id,
+			'new_blog_owner' => $wpcom_user['ID']
+		);
+
+		// Tell wpcom about the change
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client( array(
+			'user_id' => get_current_user_id()
+		) );
+		$xml->query( 'jetpack.switchMasterUser', $request );
 	}
 
 	/*

--- a/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
@@ -57,19 +57,16 @@ class Jetpack_My_Jetpack_Page extends Jetpack_Admin_Page {
 	 * so we can update the 'wpcom_blog_owner'
 	 */
 	function wpcom_switch_blog_owner( $new_master ) {
-		$id = Jetpack::get_option( 'id', false );
-		$wpcom_user = Jetpack::get_connected_user_data( $new_master );
-
 		$request = array(
-			'blog_id'        => $id,
-			'new_blog_owner' => $wpcom_user['ID']
+			'new_blog_owner' => $new_master
 		);
 
 		// Tell wpcom about the change
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => get_current_user_id()
+			'user_id' => get_current_user_id(),
 		) );
+
 		$xml->query( 'jetpack.switchMasterUser', $request );
 	}
 

--- a/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
@@ -67,7 +67,7 @@ class Jetpack_My_Jetpack_Page extends Jetpack_Admin_Page {
 			'user_id' => get_current_user_id(),
 		) );
 
-		$xml->query( 'jetpack.switchMasterUser', $request );
+		$xml->query( 'jetpack.switchBlogOwner', $request );
 	}
 
 	/*


### PR DESCRIPTION
This will fire off a request to dotcom to change the `wpcom_blog_owner` when the master user has changed hands.  

Relevant wpcom changes in r119940-wpcom