### PR TITLE
Publicize: Prevent shortlink suffix from being appended to custom message

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -32,7 +32,7 @@ abstract class Publicize_Base {
 	*/
 	var $default_prefix  = '';
 	var $default_message = '%title%';
-	var $default_suffix  = ' %url%';
+	var $default_suffix  = '';
 
 	/**
 	 * What WP capability is require to create/delete global connections?


### PR DESCRIPTION
Publicize Next does not use the wp.me shortlinks, so we shouldn't append the shortlink to the custom message. Without this changeset, both the wp.me links and full URL (from Publicize Next) would be included in the message if a user had saved a draft prior to publishing.

Duplicate of r119157 to sneak in before 3.6