### PR TITLE
Open Graph: add image:width and image:height when available

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -237,7 +237,13 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 	// Second fall back, Site Logo
 	if ( empty( $image ) && ( function_exists( 'jetpack_has_site_logo' ) && jetpack_has_site_logo() ) ) {
-		$image['src'] = jetpack_get_site_logo( 'url' );
+		$image['src']        = jetpack_get_site_logo( 'url' );
+
+		$image_dimensions    = jetpack_get_site_logo_dimensions();
+		if ( ! empty( $image_dimensions ) ) {
+			$image['width']  = $image_dimensions['width'];
+			$image['height'] = $image_dimensions['height'];
+		}
 	}
 
 	// Third fall back, Site Icon

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -99,11 +99,11 @@ function jetpack_og_tags() {
 
 	// Get image info and build tags
 	if ( ! post_password_required() ) {
-		$image_info                  = jetpack_og_get_image( $image_width, $image_height );
+		$image_info       = jetpack_og_get_image( $image_width, $image_height );
 
-		$tags['og:image']            = $image_info['src'];
+		$tags['og:image'] = $image_info['src'];
 		if ( ! empty( $image_info['width'] ) ) {
-			$tags['og:image:width']  = $image_info['width'];
+			$tags['og:image:width'] = $image_info['width'];
 		}
 		if ( ! empty( $image_info['height'] ) ) {
 			$tags['og:image:height'] = $image_info['height'];

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -248,7 +248,9 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 	// Third fall back, Site Icon
 	if ( empty( $image ) && ( function_exists( 'jetpack_has_site_icon' ) && jetpack_has_site_icon() ) ) {
-		$image['src'] = jetpack_site_icon_url( null, '512' );
+		$image['src']     = jetpack_site_icon_url( null, '512' );
+		$image['width']   = '512';
+		$image['height']  = '512';
 	}
 
 	// Fourth fall back, blank image

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -97,8 +97,18 @@ function jetpack_og_tags() {
 
 	$tags['og:site_name'] = get_bloginfo( 'name' );
 
-	if ( !post_password_required() )
-		$tags['og:image']     = jetpack_og_get_image( $image_width, $image_height );
+	// Get image info and build tags
+	if ( ! post_password_required() ) {
+		$image_info                  = jetpack_og_get_image( $image_width, $image_height );
+
+		$tags['og:image']            = $image_info['src'];
+		if ( ! empty( $image_info['width'] ) ) {
+			$tags['og:image:width']  = $image_info['width'];
+		}
+		if ( ! empty( $image_info['height'] ) ) {
+			$tags['og:image:height'] = $image_info['height'];
+		}
+	}
 
 	// Facebook whines if you give it an empty title
 	if ( empty( $tags['og:title'] ) )
@@ -166,17 +176,21 @@ function jetpack_og_tags() {
 function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { // Facebook requires thumbnails to be a minimum of 200x200
 	$image = '';
 
-	if ( is_singular() && !is_home() ) {
+	if ( is_singular() && ! is_home() ) {
 		global $post;
 		$image = '';
 
 		// Attempt to find something good for this post using our generalized PostImages code
 		if ( class_exists( 'Jetpack_PostImages' ) ) {
 			$post_images = Jetpack_PostImages::get_images( $post->ID, array( 'width' => $width, 'height' => $height ) );
-			if ( $post_images && !is_wp_error( $post_images ) ) {
+			if ( $post_images && ! is_wp_error( $post_images ) ) {
 				$image = array();
 				foreach ( (array) $post_images as $post_image ) {
-					$image[] = $post_image['src'];
+					$image['src']    = $post_image['src'];
+					if ( isset( $post_image['src_width'], $post_image['src_height'] ) ) {
+						$image['width']  = $post_image['src_width'];
+						$image['height'] = $post_image['src_height'];
+					}
 				}
 			}
 		}
@@ -184,50 +198,56 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		$author = get_queried_object();
 		if ( function_exists( 'get_avatar_url' ) ) {
 			// Prefer the core function get_avatar_url() if available, WP 4.2+
-			$image = get_avatar_url( $author->user_email, array( 'size' => $width ) );
+			$image['src'] = get_avatar_url( $author->user_email, array( 'size' => $width ) );
 		}
 		else {
 			$has_filter = has_filter( 'pre_option_show_avatars', '__return_true' );
-			if ( !$has_filter ) {
+			if ( ! $has_filter ) {
 				add_filter( 'pre_option_show_avatars', '__return_true' );
 			}
 			$avatar = get_avatar( $author->user_email, $width );
-			if ( !$has_filter ) {
+			if ( ! $has_filter ) {
 				remove_filter( 'pre_option_show_avatars', '__return_true' );
 			}
 
-			if ( !empty( $avatar ) && !is_wp_error( $avatar ) ) {
+			if ( ! empty( $avatar ) && ! is_wp_error( $avatar ) ) {
 				if ( preg_match( '/src=["\']([^"\']+)["\']/', $avatar, $matches ) );
-					$image = wp_specialchars_decode( $matches[1], ENT_QUOTES );
+					$image['src'] = wp_specialchars_decode( $matches[1], ENT_QUOTES );
 			}
 		}
 	}
 
-	if ( empty( $image ) )
+	if ( empty( $image ) ) {
 		$image = array();
-	else if ( !is_array( $image ) )
-		$image = array( $image );
+	} else if ( ! is_array( $image ) ) {
+		$image = array(
+			'src' => $image
+		);
+	}
 
 	// First fall back, blavatar
 	if ( empty( $image ) && function_exists( 'blavatar_domain' ) ) {
 		$blavatar_domain = blavatar_domain( site_url() );
-		if ( blavatar_exists( $blavatar_domain ) )
-			$image[] = blavatar_url( $blavatar_domain, 'img', $width, false, true );
+		if ( blavatar_exists( $blavatar_domain ) ) {
+			$image['src']    = blavatar_url( $blavatar_domain, 'img', $width, false, true );
+			$image['width']  = $width;
+			$image['height'] = $height;
+		}
 	}
 
 	// Second fall back, Site Logo
 	if ( empty( $image ) && ( function_exists( 'jetpack_has_site_logo' ) && jetpack_has_site_logo() ) ) {
-		$image[] = jetpack_get_site_logo( 'url' );
+		$image['src'] = jetpack_get_site_logo( 'url' );
 	}
 
 	// Third fall back, Site Icon
 	if ( empty( $image ) && ( function_exists( 'jetpack_has_site_icon' ) && jetpack_has_site_icon() ) ) {
-		$image[] = jetpack_site_icon_url( null, '512' );
+		$image['src'] = jetpack_site_icon_url( null, '512' );
 	}
 
 	// Fourth fall back, blank image
 	if ( empty( $image ) ) {
-		$image[] = apply_filters( 'jetpack_open_graph_image_default', 'https://s0.wp.com/i/blank.jpg' );
+		$image['src'] = apply_filters( 'jetpack_open_graph_image_default', 'https://s0.wp.com/i/blank.jpg' );
 	}
 
 	return $image;
@@ -241,7 +261,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 function jetpack_og_get_image_gravatar( $email, $width ) {
 	$image = '';
 	if ( function_exists( 'get_avatar_url' ) ) {
-		$avatar = get_avatar_url($email, $width);
+		$avatar = get_avatar_url( $email, $width );
 		if ( ! empty( $avatar ) ) {
 			if ( is_array( $avatar ) )
 				$image = $avatar[0];

--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -46,7 +46,6 @@ function jetpack_get_site_logo( $show = 'url' ) {
  * 		@type string $width Width of the logo in pixels.
  * 		@type string $height Height of the logo in pixels.
  * }
-}
  */
 function jetpack_get_site_logo_dimensions() {
 	$dimensions = array();

--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -31,6 +31,50 @@ function jetpack_get_site_logo( $show = 'url' ) {
 }
 
 /**
+ * Retrieve an array of the dimensions of the Site Logo.
+ *
+ * @uses Site_Logo::theme_size()
+ * @uses get_option( 'thumbnail_size_w' )
+ * @uses get_option( 'thumbnail_size_h' )
+ * @uses global $_wp_additional_image_sizes;
+ *
+ * @since 3.6.0
+ *
+ * @return array $dimensions {
+ *		An array of dimensions of the Site Logo.
+ *
+ * 		@type string $width Width of the logo in pixels.
+ * 		@type string $height Height of the logo in pixels.
+ * }
+}
+ */
+function jetpack_get_site_logo_dimensions() {
+	$dimensions = array();
+
+	// Get the image size to use with the logo.
+	$size = site_logo()->theme_size();
+
+	// If the size is the default `thumbnail`, get its dimensions
+	if ( empty( $size ) ) {
+		return false;
+	} else if ( 'thumbnail' == $size ) {
+		$dimensions  = array(
+			'width'  => get_option( 'thumbnail_size_w' ),
+			'height' => get_option( 'thumbnail_size_h' ),
+		);
+	} else {
+		global $_wp_additional_image_sizes;
+
+		$dimensions  = array(
+			'width'  => $_wp_additional_image_sizes[$size]['width'],
+			'height' => $_wp_additional_image_sizes[$size]['height'],
+		);
+	}
+
+	return $dimensions;
+}
+
+/**
  * Determine if a site logo is assigned or not.
  *
  * @uses get_option

--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -54,7 +54,7 @@ function jetpack_get_site_logo_dimensions() {
 	// Get the image size to use with the logo.
 	$size = site_logo()->theme_size();
 
-	// If the size is the default `thumbnail`, get its dimensions
+	// If the size is the default `thumbnail`, get its dimensions. Otherwise, get them from $_wp_additional_image_sizes
 	if ( empty( $size ) ) {
 		return false;
 	} else if ( 'thumbnail' == $size ) {


### PR DESCRIPTION
Fixes #2104

- Grab the dimensions from `Jetpack_PostImages::get_images` when available
- Add dimensions to Site Logo and Site Icon fallbacks