### PR TITLE
consistent verbiage when referring to linking/unlinking user accounts

### DIFF
--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -45,9 +45,9 @@
 							<h3>&nbsp</h3>
 							<div class="action-btns">
 								<# if ( data.currentUser.isUserConnected ) { #>
-									<a class="button" title="<?php esc_attr_e( 'Disconnect your WordPress.com account from Jetpack', 'jetpack' ); ?>" href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=unlink' ), 'jetpack-unlink' ); ?>"><?php esc_html_e( 'Unlink my account ', 'jetpack' ); ?></a>
+									<a class="button" title="<?php esc_attr_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?>" href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=unlink' ), 'jetpack-unlink' ); ?>"><?php esc_html_e( 'Unlink my account ', 'jetpack' ); ?></a>
 								<# } else { #>
-									<a class="button button-primary" href="<?php echo Jetpack::init()->build_connect_url() ?>" ><?php esc_html_e( 'Link your account', 'jetpack' ); ?></a>
+									<a class="button button-primary" title="<?php esc_attr_e( 'Link your account to WordPress.com', 'jetpack' ); ?>" href="<?php echo Jetpack::init()->build_connect_url() ?>" ><?php esc_html_e( 'Link my account', 'jetpack' ); ?></a>
 								<# } #>
 							</div>
 						</div>


### PR DESCRIPTION
@jessefriedman what do you think of this verbiage? 

`link/unlink my/your account`

whichever we choose, it should be consistent.  