### PR TITLE
Redirect back to My Jetpack page after link/unlink user account

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3120,11 +3120,12 @@ p {
 				wp_safe_redirect( Jetpack::admin_url( 'page=jetpack' ) );
 				exit;
 			case 'unlink' :
+				$redirect = isset( $_GET['redirect'] ) ? array( 'page' => $_GET['redirect'] ) : '';
 				check_admin_referer( 'jetpack-unlink' );
 				Jetpack::log( 'unlink' );
 				$this->unlink_user();
 				Jetpack::state( 'message', 'unlinked' );
-				wp_safe_redirect( Jetpack::admin_url() );
+				wp_safe_redirect( Jetpack::admin_url( $redirect ) );
 				exit;
 			default:
 				do_action( 'jetpack_unrecognized_action', sanitize_key( $_GET['action'] ) );

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -45,7 +45,7 @@
 							<h3>&nbsp</h3>
 							<div class="action-btns">
 								<# if ( data.currentUser.isUserConnected ) { #>
-									<a class="button" title="<?php esc_attr_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?>" href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=unlink' ), 'jetpack-unlink' ); ?>"><?php esc_html_e( 'Unlink my account ', 'jetpack' ); ?></a>
+									<a class="button" title="<?php esc_attr_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?>" href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=unlink&redirect=my_jetpack' ), 'jetpack-unlink' ); ?>"><?php esc_html_e( 'Unlink my account ', 'jetpack' ); ?></a>
 								<# } else { #>
 									<a class="button button-primary" title="<?php esc_attr_e( 'Link your account to WordPress.com', 'jetpack' ); ?>" href="<?php echo Jetpack::init()->build_connect_url() ?>" ><?php esc_html_e( 'Link my account', 'jetpack' ); ?></a>
 								<# } #>

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -47,7 +47,7 @@
 								<# if ( data.currentUser.isUserConnected ) { #>
 									<a class="button" title="<?php esc_attr_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?>" href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=unlink&redirect=my_jetpack' ), 'jetpack-unlink' ); ?>"><?php esc_html_e( 'Unlink my account ', 'jetpack' ); ?></a>
 								<# } else { #>
-									<a class="button button-primary" title="<?php esc_attr_e( 'Link your account to WordPress.com', 'jetpack' ); ?>" href="<?php echo Jetpack::init()->build_connect_url() ?>" ><?php esc_html_e( 'Link my account', 'jetpack' ); ?></a>
+									<a class="button button-primary" title="<?php esc_attr_e( 'Link your account to WordPress.com', 'jetpack' ); ?>" href="<?php echo Jetpack::init()->build_connect_url( false, Jetpack::admin_url( array( 'page' => 'my_jetpack' ) ) ); ?>" ><?php esc_html_e( 'Link your account', 'jetpack' ); ?></a>
 								<# } #>
 							</div>
 						</div>


### PR DESCRIPTION
This will make sure we redirect back to My Jetpack after linking/unlinking a user account