### PR TITLE
Photon just in time message on the media upload page

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -52,15 +52,15 @@
 
 			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
 			$.post( jitmL10n.ajaxurl, data, function (response) {
-				console.log(response);
 				// If there's no response, something bad happened
-				if ( ! response ) {
-					console.log( 'Option "jetpack_dismiss_jitm" not updated.' );
+				if ( true == response['success'] ) {
+					$('.jp-jitm').html('<p><span class="icon"></span>Success! Photon is now active.</p>');
+					hide_msg = setTimeout(function () {
+						$('.jp-jitm').hide('slow');
+					}, 5000);
+				} else {
+					$('.jp-jitm').html('<p><span class="icon"></span>We are sorry but unfortunately Photon did not activate.</p>');
 				}
-				$('.jp-jitm').html('<p><span class="icon"></span>Success! Photon is now active.</p>');
-				hide_msg = setTimeout(function () {
-					$('.jp-jitm').hide('slow');
-				}, 5000);
 			});
 
 		});

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -1,0 +1,67 @@
+/* global jitmL10n, jQuery */
+
+(function($, jitmL10n) {
+
+	///////////////////////////////////////
+	// INIT
+	///////////////////////////////////////
+
+	var data;
+
+	$(document).ready(function () {
+
+		data = {
+			'action'                :   'jitm_ajax',
+			'jitmNonce'             :   jitmL10n.jitm_nonce
+		};
+
+		initEvents();
+
+	});
+
+	///////////////////////////////////////
+	// FUNCTIONS
+	///////////////////////////////////////
+
+	function initEvents() {
+		// On dismiss of JITM admin notice
+		$('.jetpack-jitm .dismiss').click(function() {
+			// hide the notice
+			$('.jetpack-jitm').hide();
+
+			// track in mc stats
+			new Image().src = data.jitmStatsURLS.dismiss;
+			new Image().src = data.jitmSERPStatsURLS.dismiss;
+
+			// ajax request to save dismiss and never show again
+			data.jitmActionToTake = 'dismiss';
+
+			$.post( jitmL10n.ajaxurl, data, function (response) {
+				// If there's no response, something bad happened
+				if ( ! response ) {
+					//console.log( 'Option "jetpack_dismiss_jitm" not updated.' );
+				}
+
+			});
+		});
+
+		$('.jp-jitm .activate').click(function() {
+
+			data.jitmActionToTake = 'activate';
+			data.jitmModuleToActivate = 'photon';
+
+			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
+			$.post( jitmL10n.ajaxurl, data, function (response) {
+				// If there's no response, something bad happened
+				if ( ! response ) {
+					console.log( 'Option "jetpack_dismiss_jitm" not updated.' );
+				} else{
+					console.log( response );
+				}
+
+			});
+
+		});
+	}
+
+})(jQuery, jitmL10n);

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -25,6 +25,9 @@
 	///////////////////////////////////////
 
 	function initEvents() {
+
+		var module_slug, success_msg, fail_msg, hide_msg;
+
 		// On dismiss of JITM admin notice
 		$('.jp-jitm .dismiss').click(function() {
 			// hide the notice
@@ -36,7 +39,7 @@
 			data.jitmModule = module_slug;
 
 			$.post( jitmL10n.ajaxurl, data, function (response) {
-				if ( true == response['success'] ) {
+				if ( true === response.success ) {
 					//console.log('successfully dismissed for ever')
 				}
 			});
@@ -48,15 +51,15 @@
 
 			// get the module we're working with using the data-module attribute
 			module_slug = $(this).data('module');
-			success_msg = data[module_slug]['success'];
-			fail_msg = data[module_slug]['fail'];
+			success_msg = data[module_slug].success;
+			fail_msg = data[module_slug].fail;
 
 			data.jitmModule = module_slug;
 
 			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
 			$.post( jitmL10n.ajaxurl, data, function (response) {
 				// If there's no response, something bad happened
-				if ( true == response['success'] ) {
+				if ( true === response.success ) {
 					$('.jp-jitm').html('<p><span class="icon"></span>'+success_msg+'</p>');
 					hide_msg = setTimeout(function () {
 						$('.jp-jitm').hide('slow');

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -12,7 +12,8 @@
 
 		data = {
 			'action'        :   'jitm_ajax',
-			'jitmNonce'     :   jitmL10n.jitm_nonce
+			'jitmNonce'     :   jitmL10n.jitm_nonce,
+			'photon'        :   jitmL10n.photon_msgs
 		};
 
 		initEvents();
@@ -25,41 +26,43 @@
 
 	function initEvents() {
 		// On dismiss of JITM admin notice
-		$('.jetpack-jitm .dismiss').click(function() {
+		$('.jp-jitm .dismiss').click(function() {
 			// hide the notice
-			$('.jetpack-jitm').hide();
-
-			// track in mc stats
-			new Image().src = data.jitmStatsURLS.dismiss;
-			new Image().src = data.jitmSERPStatsURLS.dismiss;
+			$('.jp-jitm').hide();
 
 			// ajax request to save dismiss and never show again
 			data.jitmActionToTake = 'dismiss';
+			module_slug = $(this).data('module');
+			data.jitmModule = module_slug;
 
 			$.post( jitmL10n.ajaxurl, data, function (response) {
-				// If there's no response, something bad happened
-				if ( ! response ) {
-					//console.log( 'Option "jetpack_dismiss_jitm" not updated.' );
+				if ( true == response['success'] ) {
+					//console.log('successfully dismissed for ever')
 				}
-
 			});
 		});
 
 		$('.jp-jitm .activate').click(function() {
 
 			data.jitmActionToTake = 'activate';
-			data.jitmModuleToActivate = 'photon';
+
+			// get the module we're working with using the data-module attribute
+			module_slug = $(this).data('module');
+			success_msg = data[module_slug]['success'];
+			fail_msg = data[module_slug]['fail'];
+
+			data.jitmModule = module_slug;
 
 			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
 			$.post( jitmL10n.ajaxurl, data, function (response) {
 				// If there's no response, something bad happened
 				if ( true == response['success'] ) {
-					$('.jp-jitm').html('<p><span class="icon"></span>Success! Photon is now active.</p>');
+					$('.jp-jitm').html('<p><span class="icon"></span>'+success_msg+'</p>');
 					hide_msg = setTimeout(function () {
 						$('.jp-jitm').hide('slow');
 					}, 5000);
 				} else {
-					$('.jp-jitm').html('<p><span class="icon"></span>We are sorry but unfortunately Photon did not activate.</p>');
+					$('.jp-jitm').html('<p><span class="icon"></span>'+fail_msg+'</p>');
 				}
 			});
 

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -11,8 +11,8 @@
 	$(document).ready(function () {
 
 		data = {
-			'action'                :   'jitm_ajax',
-			'jitmNonce'             :   jitmL10n.jitm_nonce
+			'action'        :   'jitm_ajax',
+			'jitmNonce'     :   jitmL10n.jitm_nonce
 		};
 
 		initEvents();
@@ -52,13 +52,15 @@
 
 			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
 			$.post( jitmL10n.ajaxurl, data, function (response) {
+				console.log(response);
 				// If there's no response, something bad happened
 				if ( ! response ) {
 					console.log( 'Option "jetpack_dismiss_jitm" not updated.' );
-				} else{
-					console.log( response );
 				}
-
+				$('.jp-jitm').html('<p><span class="icon"></span>Success! Photon is now active.</p>');
+				hide_msg = setTimeout(function () {
+					$('.jp-jitm').hide('slow');
+				}, 5000);
 			});
 
 		});

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -20,6 +20,7 @@ class Jetpack_JITM {
 	}
 
 	private function __construct() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_css_header' ) );
 		add_action( 'post-upload-ui', array( $this, 'photon_msg' ) );
 	}
 
@@ -34,6 +35,18 @@ class Jetpack_JITM {
 
 	}
 
+	/*
+	* Function to enqueue jitm css specifically in the header
+	*/
+	function enqueue_css_header( $hook ) {
+	
+		$wp_styles = new WP_Styles();
+
+		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+		wp_enqueue_style( 'jetpack-jitm-css', plugins_url( "css/jetpack-admin-jitm{$min}.css", JETPACK__PLUGIN_FILE ), false, JETPACK__VERSION . '-20121016' );
+		$wp_styles->add_data( 'jetpack-jitm-css', 'rtl', true );
+	}
 }
 
 if ( apply_filters( 'Jetpack_JITM_msgs', false ) ) {

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -42,7 +42,12 @@ class Jetpack_JITM {
 					</a>
 				</p>
 			</div>
-		<?php }
+		<?php
+			//jitm is being dismissed forever, tr8ack it
+			$jetpack = Jetpack::init();
+			$jetpack->stat( 'jitm', 'photon-viewed' );
+			$jetpack->do_stats( 'server_side' );
+		}
 	}
 	
 	/*

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -52,7 +52,7 @@ class Jetpack_JITM {
 				</p>
 			</div>
 		<?php
-			//jitm is being dismissed forever, tr8ack it
+			//jitm is being viewed, track it
 			$jetpack = Jetpack::init();
 			$jetpack->stat( 'jitm', 'photon-viewed' );
 			$jetpack->do_stats( 'server_side' );

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -28,8 +28,10 @@ class Jetpack_JITM {
 	 *
 	 */
 	function photon_msg() {
-		echo 'YOUR PHOTON';
-		_e( 'Activate Photon', 'jetpack' );
+		echo '<div class="jp-jitm"><a href="#" class="dismiss"><span class="genericon genericon-close"></span></a><p><span class="icon"></span>';
+		_e( 'Activate Photon and Jetpack will mirror your images to our free CDN servers, delivering them to your visitors optimized and faster than ever, learn more ', 'jetpack' );
+		echo '</div>';
+
 	}
 
 }

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -3,7 +3,7 @@
 /**
  * Jetpack just in time messaging through out the admin
  *
- * @since 3.7
+ * @since 3.7.0
  */
 class Jetpack_JITM {
 
@@ -81,7 +81,9 @@ class Jetpack_JITM {
 /**
  * Filter to turn off all just in time messages
  *
- * @since 3.7
+ * @since 3.7.0
+ *
+ * @param bool true Whether to show just in time messages.
  */
 if ( apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
 	Jetpack_JITM::init();

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -35,9 +35,17 @@ class Jetpack_JITM {
 	 */
 	function photon_msg() {
 		if ( current_user_can( 'jetpack_manage_modules' ) ) { ?>
-			<div class="jp-jitm"><a href="#"  data-module="photon" class="dismiss"><span class="genericon genericon-close"></span></a>
-				<p><span class="icon"></span>
+			<div class="jp-jitm">
+				<a href="#"  data-module="photon" class="dismiss"><span class="genericon genericon-close"></span></a>
+				<div class="jp-emblem">
+					<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 172.9 172.9" enable-background="new 0 0 172.9 172.9" xml:space="preserve">
+						<path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z"/>
+					</svg>
+				</div>
+				<p>
 					<?php _e( 'Mirror your images to our free Jetpack CDN to deliver them to your visitors optimized and faster than ever.', 'jetpack' ); ?>
+				</p>
+				<p>
 					<a href="#" data-module="photon" class="activate button button-jetpack">
 						<?php esc_html_e( 'Activate Photon', 'jetpack' ); ?>
 					</a>

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -78,6 +78,6 @@ class Jetpack_JITM {
 	}
 }
 
-if ( apply_filters( 'Jetpack_JITM_msgs', false ) ) {
+if ( apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
 	Jetpack_JITM::init();
 }

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -20,16 +20,18 @@ class Jetpack_JITM {
 	}
 
 	private function __construct() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_css_header' ) );
-		add_action( 'post-upload-ui', array( $this, 'photon_msg' ) );
+		if ( ! Jetpack::is_module_active( 'photon' ) ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_css_header' ) );
+			add_action( 'post-upload-ui', array( $this, 'photon_msg' ) );
+		}
 	}
 
 	/*
-	 * Present Photon JITM activation msg
+	 * Present Photon just in time activation msg
 	 *
 	 */
 	function photon_msg() {
-		if ( current_user_can( 'activate_plugins' ) && ! Jetpack::is_module_active( 'photon' ) ) { ?>
+		if ( current_user_can( 'activate_plugins' ) ) { ?>
 			<div class="jp-jitm"><a href="#" class="dismiss"><span class="genericon genericon-close"></span></a>
 				<p><span class="icon"></span>
 					<?php _e( 'Mirror your images to our free Jetpack CDN to deliver them to your visitors optimized and faster than ever.', 'jetpack' ); ?>
@@ -41,7 +43,7 @@ class Jetpack_JITM {
 			</div>
 		<?php }
 	}
-
+	
 	/*
 	* Function to enqueue jitm css specifically in the header
 	*/

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -43,7 +43,7 @@ class Jetpack_JITM {
 					</svg>
 				</div>
 				<p>
-					<?php _e( 'Automatically deliver super-fast images to your visitors, optimized for any device.', 'jetpack' ); ?>
+					<?php _e( 'Deliver super-fast images to your visitors that are automatically optimized for any device.', 'jetpack' ); ?>
 				</p>
 				<p>
 					<a href="#" data-module="photon" class="activate button button-jetpack">

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -43,7 +43,7 @@ class Jetpack_JITM {
 					</svg>
 				</div>
 				<p>
-					<?php _e( 'Mirror your images to our free Jetpack CDN to deliver them to your visitors optimized and faster than ever.', 'jetpack' ); ?>
+					<?php _e( 'Automatically deliver super-fast images to your visitors, optimized for any device.', 'jetpack' ); ?>
 				</p>
 				<p>
 					<a href="#" data-module="photon" class="activate button button-jetpack">

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -20,7 +20,9 @@ class Jetpack_JITM {
 	}
 
 	private function __construct() {
-		if ( ! Jetpack::is_module_active( 'photon' ) ) {
+		$jetpack_hide_jitm = Jetpack_Options::get_option( 'hide_jitm' );
+
+		if ( ! Jetpack::is_module_active( 'photon' ) && 'hide' != $jetpack_hide_jitm['photon'] ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'post-upload-ui', array( $this, 'photon_msg' ) );
 		}
@@ -32,10 +34,10 @@ class Jetpack_JITM {
 	 */
 	function photon_msg() {
 		if ( current_user_can( 'activate_plugins' ) ) { ?>
-			<div class="jp-jitm"><a href="#" class="dismiss"><span class="genericon genericon-close"></span></a>
+			<div class="jp-jitm"><a href="#"  data-module="photon" class="dismiss"><span class="genericon genericon-close"></span></a>
 				<p><span class="icon"></span>
 					<?php _e( 'Mirror your images to our free Jetpack CDN to deliver them to your visitors optimized and faster than ever.', 'jetpack' ); ?>
-					<a href="#" class="activate button button-jetpack">
+					<a href="#" data-module="photon" class="activate button button-jetpack">
 						<?php esc_html_e( 'Activate Photon', 'jetpack' ); ?>
 					</a>
 				</p>
@@ -62,6 +64,10 @@ class Jetpack_JITM {
 			array(
 				'ajaxurl'       => admin_url( 'admin-ajax.php' ),
 				'jitm_nonce'    => wp_create_nonce( 'jetpack-jitm-nonce' ),
+				'photon_msgs'   => array(
+					'success' => __( 'Success! Photon is now actively optimizing and serving your images for free.' ),
+					'fail' => __( 'We are sorry but unfortunately Photon did not activate.' )
+				)
 			)
 		);
 	}

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -70,8 +70,8 @@ class Jetpack_JITM {
 				'ajaxurl'       => admin_url( 'admin-ajax.php' ),
 				'jitm_nonce'    => wp_create_nonce( 'jetpack-jitm-nonce' ),
 				'photon_msgs'   => array(
-					'success' => __( 'Success! Photon is now actively optimizing and serving your images for free.' ),
-					'fail' => __( 'We are sorry but unfortunately Photon did not activate.' )
+					'success' => __( 'Success! Photon is now actively optimizing and serving your images for free.', 'jetpack' ),
+					'fail' => __( 'We are sorry but unfortunately Photon did not activate.', 'jetpack' )
 				)
 			)
 		);

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Jetpack just in time messaging through out the admin
+ *
+ */
+class Jetpack_JITM {
+
+	/**
+	 * @var Jetpack_JITM
+	 **/
+	private static $instance = null;
+
+	static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new Jetpack_JITM;
+		}
+
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_action( 'post-html-upload-ui', array( $this, 'photon_msg' ) );
+	}
+
+	/*
+	 * Present Photon JITM activation msg
+	 *
+	 */
+	function photon_msg() {
+		_e( 'Activate Photon', 'jetpack' );
+	}
+
+}
+
+if ( apply_filters( 'Jetpack_JITM_msgs', false ) ) {
+	Jetpack_JITM::init();
+}

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -21,11 +21,11 @@ class Jetpack_JITM {
 	}
 
 	private function __construct() {
+		global $pagenow;
 		$jetpack_hide_jitm = Jetpack_Options::get_option( 'hide_jitm' );
-
-		if ( ! Jetpack::is_module_active( 'photon' ) && 'hide' != $jetpack_hide_jitm['photon'] ) {
+		if ( 'media-new.php' == $pagenow && ! Jetpack::is_module_active( 'photon' ) && 'hide' != $jetpack_hide_jitm['photon'] ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
-			add_action( 'post-upload-ui', array( $this, 'photon_msg' ) );
+			add_action( 'post-plupload-upload-ui', array( $this, 'photon_msg' ) );
 		}
 	}
 
@@ -63,7 +63,7 @@ class Jetpack_JITM {
 	* Function to enqueue jitm css and js
 	*/
 	function jitm_enqueue_files( $hook ) {
-	
+
 		$wp_styles = new WP_Styles();
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		wp_enqueue_style( 'jetpack-jitm-css', plugins_url( "css/jetpack-admin-jitm{$min}.css", JETPACK__PLUGIN_FILE ), false, JETPACK__VERSION . '-20121016' );
@@ -76,11 +76,11 @@ class Jetpack_JITM {
 			'jetpack-jitm-js',
 			'jitmL10n',
 			array(
-				'ajaxurl'       => admin_url( 'admin-ajax.php' ),
-				'jitm_nonce'    => wp_create_nonce( 'jetpack-jitm-nonce' ),
-				'photon_msgs'   => array(
+				'ajaxurl'     => admin_url( 'admin-ajax.php' ),
+				'jitm_nonce'  => wp_create_nonce( 'jetpack-jitm-nonce' ),
+				'photon_msgs' => array(
 					'success' => __( 'Success! Photon is now actively optimizing and serving your images for free.', 'jetpack' ),
-					'fail' => __( 'We are sorry but unfortunately Photon did not activate.', 'jetpack' )
+					'fail'    => __( 'We are sorry but unfortunately Photon did not activate.', 'jetpack' )
 				)
 			)
 		);

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -21,7 +21,7 @@ class Jetpack_JITM {
 
 	private function __construct() {
 		if ( ! Jetpack::is_module_active( 'photon' ) ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_css_header' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'post-upload-ui', array( $this, 'photon_msg' ) );
 		}
 	}
@@ -35,8 +35,7 @@ class Jetpack_JITM {
 			<div class="jp-jitm"><a href="#" class="dismiss"><span class="genericon genericon-close"></span></a>
 				<p><span class="icon"></span>
 					<?php _e( 'Mirror your images to our free Jetpack CDN to deliver them to your visitors optimized and faster than ever.', 'jetpack' ); ?>
-					<a href="<?php echo esc_url( wp_nonce_url( Jetpack::admin_url( array( 'action' => 'activate', 'module' => 'photon' ) ), 'jetpack_activate-photon' ) ); ?>"
-					   class="button button-jetpack">
+					<a href="#" class="activate button button-jetpack">
 						<?php esc_html_e( 'Activate Photon', 'jetpack' ); ?>
 					</a>
 				</p>
@@ -45,16 +44,26 @@ class Jetpack_JITM {
 	}
 	
 	/*
-	* Function to enqueue jitm css specifically in the header
+	* Function to enqueue jitm css and js
 	*/
-	function enqueue_css_header( $hook ) {
+	function jitm_enqueue_files( $hook ) {
 	
 		$wp_styles = new WP_Styles();
-
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-
 		wp_enqueue_style( 'jetpack-jitm-css', plugins_url( "css/jetpack-admin-jitm{$min}.css", JETPACK__PLUGIN_FILE ), false, JETPACK__VERSION . '-20121016' );
 		$wp_styles->add_data( 'jetpack-jitm-css', 'rtl', true );
+
+		// Enqueue javascript to handle jitm notice events
+		wp_enqueue_script( 'jetpack-jitm-js', plugins_url( '_inc/jetpack-jitm.js', JETPACK__PLUGIN_FILE ),
+			array( 'jquery' ), JETPACK__VERSION . '-20121111', true );
+		wp_localize_script(
+			'jetpack-jitm-js',
+			'jitmL10n',
+			array(
+				'ajaxurl'       => admin_url( 'admin-ajax.php' ),
+				'jitm_nonce'    => wp_create_nonce( 'jetpack-jitm-nonce' ),
+			)
+		);
 	}
 }
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -71,7 +71,7 @@ class Jetpack_JITM {
 
 		// Enqueue javascript to handle jitm notice events
 		wp_enqueue_script( 'jetpack-jitm-js', plugins_url( '_inc/jetpack-jitm.js', JETPACK__PLUGIN_FILE ),
-			array( 'jquery' ), JETPACK__VERSION . '-20121111', true );
+			array( 'jquery' ), JETPACK__VERSION, true );
 		wp_localize_script(
 			'jetpack-jitm-js',
 			'jitmL10n',

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -3,6 +3,7 @@
 /**
  * Jetpack just in time messaging through out the admin
  *
+ * @since 3.7
  */
 class Jetpack_JITM {
 
@@ -77,7 +78,11 @@ class Jetpack_JITM {
 		);
 	}
 }
-
+/**
+ * Filter to turn off all just in time messages
+ *
+ * @since 3.7
+ */
 if ( apply_filters( 'jetpack_just_in_time_msgs', false ) ) {
 	Jetpack_JITM::init();
 }

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -20,7 +20,7 @@ class Jetpack_JITM {
 	}
 
 	private function __construct() {
-		add_action( 'post-html-upload-ui', array( $this, 'photon_msg' ) );
+		add_action( 'post-upload-ui', array( $this, 'photon_msg' ) );
 	}
 
 	/*
@@ -28,6 +28,7 @@ class Jetpack_JITM {
 	 *
 	 */
 	function photon_msg() {
+		echo 'YOUR PHOTON';
 		_e( 'Activate Photon', 'jetpack' );
 	}
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -29,10 +29,17 @@ class Jetpack_JITM {
 	 *
 	 */
 	function photon_msg() {
-		echo '<div class="jp-jitm"><a href="#" class="dismiss"><span class="genericon genericon-close"></span></a><p><span class="icon"></span>';
-		_e( 'Activate Photon and Jetpack will mirror your images to our free CDN servers, delivering them to your visitors optimized and faster than ever, learn more ', 'jetpack' );
-		echo '</div>';
-
+		if ( current_user_can( 'activate_plugins' ) && ! Jetpack::is_module_active( 'photon' ) ) { ?>
+			<div class="jp-jitm"><a href="#" class="dismiss"><span class="genericon genericon-close"></span></a>
+				<p><span class="icon"></span>
+					<?php _e( 'Mirror your images to our free Jetpack CDN to deliver them to your visitors optimized and faster than ever.', 'jetpack' ); ?>
+					<a href="<?php echo esc_url( wp_nonce_url( Jetpack::admin_url( array( 'action' => 'activate', 'module' => 'photon' ) ), 'jetpack_activate-photon' ) ); ?>"
+					   class="button button-jetpack">
+						<?php esc_html_e( 'Activate Photon', 'jetpack' ); ?>
+					</a>
+				</p>
+			</div>
+		<?php }
 	}
 
 	/*

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -33,7 +33,7 @@ class Jetpack_JITM {
 	 *
 	 */
 	function photon_msg() {
-		if ( current_user_can( 'activate_plugins' ) ) { ?>
+		if ( current_user_can( 'jetpack_manage_modules' ) ) { ?>
 			<div class="jp-jitm"><a href="#"  data-module="photon" class="dismiss"><span class="genericon genericon-close"></span></a>
 				<p><span class="icon"></span>
 					<?php _e( 'Mirror your images to our free Jetpack CDN to deliver them to your visitors optimized and faster than ever.', 'jetpack' ); ?>

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -63,7 +63,8 @@ class Jetpack_Options {
 			'last_heartbeat',               // (int)    The timestamp of the last heartbeat that fired.
 			'last_security_report',         // (int)    The timestamp of the last security report that was run.
 			'sync_bulk_reindexing',         // (bool)   If a bulk reindex is currently underway.
-			'jumpstart'                     // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
+			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
+			'hide_jitm'                     // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 		);
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -580,7 +580,7 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'filter_default_modules' ) );
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
-		// JITM for plugin search filter
+		// A filter to control all just in time messages
 		add_filter( 'Jetpack_JITM_msgs', '__return_true' );
 
 		/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -702,6 +702,11 @@ class Jetpack {
 			Jetpack::log( 'activate', $module_slug );
 			Jetpack::activate_module( $module_slug, false, false );
 			Jetpack::state( 'message', 'no_message' );
+
+			//jitm is being activated, track it
+			$this->stat( 'jitm', $module_slug.'-activated' );
+			$this->do_stats( 'server_side' );
+
 			wp_send_json_success();
 		}
 		if ( isset( $_REQUEST['jitmActionToTake'] ) && 'dismiss' == $_REQUEST['jitmActionToTake'] ) {
@@ -718,6 +723,11 @@ class Jetpack {
 			}
 
 			Jetpack_Options::update_option( 'hide_jitm', $jetpack_hide_jitm );
+
+			//jitm is being dismissed forever, track it
+			$this->stat( 'jitm', $module_slug.'-dismissed' );
+			$this->do_stats( 'server_side' );
+
 			wp_send_json_success();
 		}
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -577,6 +577,9 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'filter_default_modules' ) );
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
+		// JITM for plugin search filter
+		add_filter( 'Jetpack_JITM_msgs', '__return_true' );
+
 		/**
 		 * This is the hack to concatinate all css files into one.
 		 * For description and reasoning see the implode_frontend_css method

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -695,7 +695,7 @@ class Jetpack {
 	function jetpack_jitm_ajax_callback() {
 		// Check for nonce
 		if ( ! isset( $_REQUEST['jitmNonce'] ) || ! wp_verify_nonce( $_REQUEST['jitmNonce'], 'jetpack-jitm-nonce' ) ) {
-			wp_die( 'permissions check failed' );
+			wp_die( 'Module activation failed due to lack of appropriate permissions' );
 		}
 		if ( isset( $_REQUEST['jitmActionToTake'] ) && 'activate' == $_REQUEST['jitmActionToTake'] ) {
 			$module_slug = $_REQUEST['jitmModule'];
@@ -703,7 +703,7 @@ class Jetpack {
 			Jetpack::activate_module( $module_slug, false, false );
 			Jetpack::state( 'message', 'no_message' );
 
-			//jitm is being activated, track it
+			//A Jetpack module is being activated through a JITM, track it
 			$this->stat( 'jitm', $module_slug.'-activated' );
 			$this->do_stats( 'server_side' );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -704,6 +704,11 @@ class Jetpack {
 			Jetpack::state( 'message', 'no_message' );
 			wp_send_json_success();
 		}
+		if ( isset( $_REQUEST['jitmActionToTake'] ) && 'dismiss' == $_REQUEST['jitmActionToTake'] ) {
+			// Update the jitm_plugins option
+			Jetpack_Options::update_option( 'hide_jitm', true );
+			wp_send_json_success();
+		}
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6015,7 +6015,7 @@ p {
 		<div class="wpcom-connect">
 			<div class="jp-emblem">
 			<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 172.9 172.9" enable-background="new 0 0 172.9 172.9" xml:space="preserve">
-  				<path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z"/>
+				<path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z"/>
 			</svg>
 			</div>
 			<h3><?php esc_html_e( 'Boost traffic, enhance security, and improve performance.', 'jetpack' ); ?></h3>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -698,15 +698,26 @@ class Jetpack {
 			wp_die( 'permissions check failed' );
 		}
 		if ( isset( $_REQUEST['jitmActionToTake'] ) && 'activate' == $_REQUEST['jitmActionToTake'] ) {
-			$module_slug = $_REQUEST['jitmModuleToActivate'];
+			$module_slug = $_REQUEST['jitmModule'];
 			Jetpack::log( 'activate', $module_slug );
 			Jetpack::activate_module( $module_slug, false, false );
 			Jetpack::state( 'message', 'no_message' );
 			wp_send_json_success();
 		}
 		if ( isset( $_REQUEST['jitmActionToTake'] ) && 'dismiss' == $_REQUEST['jitmActionToTake'] ) {
-			// Update the jitm_plugins option
-			Jetpack_Options::update_option( 'hide_jitm', true );
+			// get the hide_jitm options array
+			$jetpack_hide_jitm = Jetpack_Options::get_option( 'hide_jitm' );
+			$module_slug = $_REQUEST['jitmModule'];
+
+			if( ! $jetpack_hide_jitm ) {
+				$jetpack_hide_jitm = array(
+					$module_slug => 'hide'
+				);
+			} else {
+				$jetpack_hide_jitm[$module_slug] = 'hide';
+			}
+
+			Jetpack_Options::update_option( 'hide_jitm', $jetpack_hide_jitm );
 			wp_send_json_success();
 		}
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -581,7 +581,7 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
 		// A filter to control all just in time messages
-		add_filter( 'Jetpack_JITM_msgs', '__return_true' );
+		add_filter( 'jetpack_just_in_time_msgs', '__return_true' );
 
 		/**
 		 * This is the hack to concatinate all css files into one.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -550,6 +550,9 @@ class Jetpack {
 		add_action( 'wp_ajax_jetpack_admin_ajax',  array( $this, 'jetpack_jumpstart_ajax_callback' ) );
 		add_action( 'update_option', array( $this, 'jumpstart_has_updated_module_option' ) );
 
+		// JITM AJAX callback function
+		add_action( 'wp_ajax_jitm_ajax',  array( $this, 'jetpack_jitm_ajax_callback' ) );
+
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'devicepx' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'devicepx' ) );
@@ -684,6 +687,22 @@ class Jetpack {
 		}
 
 		wp_die();
+	}
+
+	/**
+	 * The callback for the JITM ajax requests.
+	 */
+	function jetpack_jitm_ajax_callback() {
+		// Check for nonce
+		if ( ! isset( $_REQUEST['jitmNonce'] ) || ! wp_verify_nonce( $_REQUEST['jitmNonce'], 'jetpack-jitm-nonce' ) ) {
+			wp_die( 'permissions check failed' );
+		}
+		if ( isset( $_REQUEST['jitmActionToTake'] ) && 'activate' == $_REQUEST['jitmActionToTake'] ) {
+			$module_slug = $_REQUEST['jitmModuleToActivate'];
+			Jetpack::log( 'activate', $module_slug );
+			Jetpack::activate_module( $module_slug, false, false );
+			Jetpack::state( 'message', 'no_message' );
+		}
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -702,6 +702,7 @@ class Jetpack {
 			Jetpack::log( 'activate', $module_slug );
 			Jetpack::activate_module( $module_slug, false, false );
 			Jetpack::state( 'message', 'no_message' );
+			wp_send_json_success();
 		}
 	}
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -51,6 +51,7 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php'    );
 
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
+	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php'      );
 }
 
 // Play nice with http://wp-cli.org/

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -1,55 +1,93 @@
 // Just in Time Messaging – message prompts
 
+// PHOTON
 .jp-jitm {
-	background: #fff;
-	padding: 0 5px 0 15px;
-	margin: 25px 0 15px 0;
+	border-radius: 2px;
+	max-width: 95%;
+	margin: 2em auto 0 auto;
+	padding: .85em;
+	background: #fcfcfc;
 	border: 1px solid #dedede;
+	text-align: center;
 
-	p {
-		font-size: 1.2em;
-		ine-height: 1.6em;
-		vertical-align: middle;
+	@media (min-width: 1100px) { max-width: 650px; }
+
+	// clear hack
+	&:before, &:after {
+		content: "";
+		display: table;
+	}
+	&:after {
+		clear: both;
 	}
 
-	.icon {
-		float: left;
-		margin: 1px 5px 0 0;
-		&:before {
-			font-family: 'jetpack' !important;
-			content: '\f102';
-			color: #8cc258;
-			font-size: 2em;
-		}
+	.activate {
+		margin-top: .8em;
+	} 
+	.jp-emblem {
+		width: 25px;
+		height: 25px; // for ie svg
+		margin: .45em auto .65em auto;
 	}
-
+	svg {
+		width: 100%;
+		height: 100%;
+	}
+	path {
+		fill: #8cc258;
+	}
 	.dismiss {
+		margin: 0;
 		text-decoration: none;
 		float: right;
-		margin: 5px 0 0 0;
 		&:before {
-			color: #333;
+			color: #666;
 			font: 400 15px/1 dashicons;
 			content: '\f158';
 		}
 	}
-
-} // jp-jitm
-
-@media (max-width: 640px) {
-	.media-modal .jp-jitm {
-		padding: 10px;
+	p {
+		font-size: 1em;
+		line-height: 165%;
 	}
-}
 
-@media (max-width: 600px) {
-	.jp-jitm {
-		padding-right: 10px;
-	}
-	.jp-jitm .icon {
-		margin: 10px 5px 20px -5px;
-		&:before {
-			font-size: 2.5em;
+} // .jp-jitm
+
+.media-upload-form .jp-jitm {
+	max-width: 100%;
+
+	@media (min-width: 1100px) { 
+		.jp-emblem, p {
+			float: left;
+			margin: 0 1em 0 0;
+			padding-top: 4px;
 		}
+		.jp-emblem {
+			width: 20px;
+			height: 20px; // for ie svg
+		}
+		p + p {
+			margin: 0;
+			padding: 0;
+		}
+		.activate {
+			margin-top: 0;
+		}
+	} // > 1100px
+
+} // .media-upload-form (wp-admin/media-new.php)
+
+.media-modal-content .jp-jitm {
+
+	@media (max-width: 1100px) {
+		max-width: 90%;
 	}
+
+} // .media-modal-content (post / page > add media)
+
+// when jetpack is connected, we need to move up the upload prompt content so the photo JITM can fit properly.
+.jetpack-connected .media-modal-content .uploader-inline-content {
+	top: 20%;
 }
+
+// END PHOTON

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -1,49 +1,49 @@
 // Just in Time Messaging – message prompts
 
 .jp-jitm {
-  background: #fff;
-  padding: 0 5px 0 15px;
-  margin: 25px 0 15px 0;
-  border: 1px solid #dedede;
+    background: #fff;
+    padding: 0 5px 0 15px;
+    margin: 25px 0 15px 0;
+    border: 1px solid #dedede;
 
-  p {
-	font-size: 1.2em;
-	line-height: 1.6em;
-	vertical-align: middle;
-  }
+    p {
+        font-size: 1.2em;
+        line-height: 1.6em;
+        vertical-align: middle;
+    }
 
-  .icon {
-	float: left;
-	margin: 1px 5px 0 0;
-	&:before {
-	  font-family: 'jetpack' !important;
-	  content: '\f102';
-	  color: #8cc258;
-	  font-size: 2em
-	}
-  }
+    .icon {
+        float: left;
+        margin: 1px 5px 0 0;
+        &:before {
+            font-family: 'jetpack' !important;
+            content: '\f102';
+            color: #8cc258;
+            font-size: 2em
+        }
+    }
 
-  .dismiss {
-	text-decoration: none;
-	float: right;
-	margin: 5px 0 0 0;
-	&:before {
-	  color: #333;
-	  font: 400 15px/1 dashicons;
-	  content: '\f158';
-	}
-  }
+    .dismiss {
+        text-decoration: none;
+        float: right;
+        margin: 5px 0 0 0;
+        &:before {
+            color: #333;
+            font: 400 15px/1 dashicons;
+            content: '\f158';
+        }
+    }
 
 } // jp-jitm
 
 @media (max-width: 600px) {
-  .jp-jitm {
-	padding-right: 10px;
-  }
-  .jp-jitm .icon {
-	margin: 10px 5px 20px -5px;
-	&:before {
-	  font-size: 2.5em;
-	}
-  }
+    .jp-jitm {
+        padding-right: 10px;
+    }
+    .jp-jitm .icon {
+        margin: 10px 5px 20px -5px;
+        &:before {
+            font-size: 2.5em;
+        }
+    }
 }

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -1,49 +1,55 @@
 // Just in Time Messaging – message prompts
 
 .jp-jitm {
-    background: #fff;
-    padding: 0 5px 0 15px;
-    margin: 25px 0 15px 0;
-    border: 1px solid #dedede;
+	background: #fff;
+	padding: 0 5px 0 15px;
+	margin: 25px 0 15px 0;
+	border: 1px solid #dedede;
 
-    p {
-        font-size: 1.2em;
-        line-height: 1.6em;
-        vertical-align: middle;
-    }
+	p {
+		font-size: 1.2em;
+		ine-height: 1.6em;
+		vertical-align: middle;
+	}
 
-    .icon {
-        float: left;
-        margin: 1px 5px 0 0;
-        &:before {
-            font-family: 'jetpack' !important;
-            content: '\f102';
-            color: #8cc258;
-            font-size: 2em
-        }
-    }
+	.icon {
+		float: left;
+		margin: 1px 5px 0 0;
+		&:before {
+			font-family: 'jetpack' !important;
+			content: '\f102';
+			color: #8cc258;
+			font-size: 2em;
+		}
+	}
 
-    .dismiss {
-        text-decoration: none;
-        float: right;
-        margin: 5px 0 0 0;
-        &:before {
-            color: #333;
-            font: 400 15px/1 dashicons;
-            content: '\f158';
-        }
-    }
+	.dismiss {
+		text-decoration: none;
+		float: right;
+		margin: 5px 0 0 0;
+		&:before {
+			color: #333;
+			font: 400 15px/1 dashicons;
+			content: '\f158';
+		}
+	}
 
 } // jp-jitm
 
+@media (max-width: 640px) {
+	.media-modal .jp-jitm {
+		padding: 10px;
+	}
+}
+
 @media (max-width: 600px) {
-    .jp-jitm {
-        padding-right: 10px;
-    }
-    .jp-jitm .icon {
-        margin: 10px 5px 20px -5px;
-        &:before {
-            font-size: 2.5em;
-        }
-    }
+	.jp-jitm {
+		padding-right: 10px;
+	}
+	.jp-jitm .icon {
+		margin: 10px 5px 20px -5px;
+		&:before {
+			font-size: 2.5em;
+		}
+	}
 }

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -7,43 +7,43 @@
   border: 1px solid #dedede;
 
   p {
-    font-size: 1.2em;
-    line-height: 1.6em;
-    vertical-align: middle;
+	font-size: 1.2em;
+	line-height: 1.6em;
+	vertical-align: middle;
   }
 
   .icon {
-    float: left;
-    margin: 1px 5px 0 0;
-    &:before {
-      font-family: 'jetpack' !important;
-      content: '\f102';
-      color: #8cc258;
-      font-size: 2em
-    }
+	float: left;
+	margin: 1px 5px 0 0;
+	&:before {
+	  font-family: 'jetpack' !important;
+	  content: '\f102';
+	  color: #8cc258;
+	  font-size: 2em
+	}
   }
 
   .dismiss {
-    text-decoration: none;
-    float: right;
-    margin: 5px 0 0 0;
-    &:before {
-      color: #333;
-      font: 400 15px/1 dashicons;
-      content: '\f158';
-    }
+	text-decoration: none;
+	float: right;
+	margin: 5px 0 0 0;
+	&:before {
+	  color: #333;
+	  font: 400 15px/1 dashicons;
+	  content: '\f158';
+	}
   }
 
 } // jp-jitm
 
 @media (max-width: 600px) {
   .jp-jitm {
-    padding-right: 10px;
+	padding-right: 10px;
   }
   .jp-jitm .icon {
-    margin: 10px 5px 20px -5px;
-    &:before {
-      font-size: 2.5em;
-    }
+	margin: 10px 5px 20px -5px;
+	&:before {
+	  font-size: 2.5em;
+	}
   }
 }

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -1,0 +1,49 @@
+// Just in Time Messaging – message prompts
+
+.jp-jitm {
+  background: #fff;
+  padding: 0 5px 0 15px;
+  margin: 25px 0 15px 0;
+  border: 1px solid #dedede;
+
+  p {
+    font-size: 1.2em;
+    line-height: 1.6em;
+    vertical-align: middle;
+  }
+
+  .icon {
+    float: left;
+    margin: 1px 5px 0 0;
+    &:before {
+      font-family: 'jetpack' !important;
+      content: '\f102';
+      color: #8cc258;
+      font-size: 2em
+    }
+  }
+
+  .dismiss {
+    text-decoration: none;
+    float: right;
+    margin: 5px 0 0 0;
+    &:before {
+      color: #333;
+      font: 400 15px/1 dashicons;
+      content: '\f158';
+    }
+  }
+
+} // jp-jitm
+
+@media (max-width: 600px) {
+  .jp-jitm {
+    padding-right: 10px;
+  }
+  .jp-jitm .icon {
+    margin: 10px 5px 20px -5px;
+    &:before {
+      font-size: 2.5em;
+    }
+  }
+}


### PR DESCRIPTION
A new just in time message is created and added only if an admin is viewing the media upload page and Photon is not active. The admin is presented with a message with a call to action to activate Photon which they also dismiss forever. 

This message uses ajax to perform it's actions so users will not be removed from the page while uploading media.

When testing head to: /wp-admin/media-new.php and make sure Photon is not active. Click the activate button, you should see a success message and Photon will activate. If you deactivate Photon and head back the message will reappear and give you the opportunity to dismiss it. Once dismissed the only way to get it back is to delete the hide_jitm jetpack option (this can be done by deleting Jetpack) 