### PR TITLE
Related Posts: add new filter to allow disabling nofollow

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -674,6 +674,14 @@ EOT;
 			'title' => $this->_to_utf8( $this->_get_title( $post->post_title, $post->post_content ) ),
 			'date' => get_the_date( '', $post->ID ),
 			'format' => get_post_format( $post->ID ),
+			/**
+			 * Filters the rel attribute for the Related Posts' links.
+			 *
+			 * @since 3.7.0
+			 *
+			 * @param bool true Should the link rel attribute for Related Posts' links be dislpayed? Default is yes (true).
+			 */
+			'rel' => apply_filters( 'jetpack_relatedposts_filter_post_link_rel_enabled', true ),
 			'excerpt' => html_entity_decode( $this->_to_utf8( $this->_get_excerpt( $post->post_excerpt, $post->post_content ) ), ENT_QUOTES, 'UTF-8' ),
 			'context' => apply_filters(
 				'jetpack_relatedposts_filter_post_context',

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -679,9 +679,10 @@ EOT;
 			 *
 			 * @since 3.7.0
 			 *
-			 * @param bool true Should the link rel attribute for Related Posts' links be dislpayed? Default is yes (true).
+			 * @param string nofollow Link rel attribute for Related Posts' link. Default is nofollow.
+			 * @param int $post->ID Post ID.
 			 */
-			'rel' => apply_filters( 'jetpack_relatedposts_filter_post_link_rel_enabled', true ),
+			'rel' => apply_filters( 'jetpack_relatedposts_filter_post_link_rel', 'nofollow', $post->ID ),
 			'excerpt' => html_entity_decode( $this->_to_utf8( $this->_get_excerpt( $post->post_excerpt, $post->post_content ) ), ENT_QUOTES, 'UTF-8' ),
 			'context' => apply_filters(
 				'jetpack_relatedposts_filter_post_context',

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -44,13 +44,19 @@
 				anchor_title += '\n\n' + post.excerpt;
 			}
 
+			if ( post.rel ) {
+				anchor_rel = 'nofollow';
+			} else {
+				anchor_rel = '';
+			}
+
 			var anchor = $( '<a>' );
 
 			anchor.attr({
 				'class': classNames,
 				'href': post.url,
 				'title': anchor_title,
-				'rel': 'nofollow',
+				'rel': anchor_rel,
 				'data-origin': post.url_meta.origin,
 				'data-position': post.url_meta.position
 			});

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -44,19 +44,13 @@
 				anchor_title += '\n\n' + post.excerpt;
 			}
 
-			if ( post.rel ) {
-				anchor_rel = 'nofollow';
-			} else {
-				anchor_rel = '';
-			}
-
 			var anchor = $( '<a>' );
 
 			anchor.attr({
 				'class': classNames,
 				'href': post.url,
 				'title': anchor_title,
-				'rel': anchor_rel,
+				'rel': post.rel,
 				'data-origin': post.url_meta.origin,
 				'data-position': post.url_meta.position
 			});


### PR DESCRIPTION
Fixes #2233 
cc @xyu 

If this filter is merged, it would then become possible to disable nofollow on Related Posts' links with the following snippet:

```php
function jeherve_custom_rp_rel( $post_id ) {
	return '';
}
add_filter( 'jetpack_relatedposts_filter_post_link_rel', 'jeherve_custom_rp_rel', 20, 2 );
```