### PR TITLE
Stats: Verify $stats_roles is an array before using it as the haystack.

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -120,7 +120,7 @@ function stats_map_meta_caps( $caps, $cap, $user_id, $args ) {
 		$stats_roles = stats_get_option( 'roles' );
 
 		// Is the users role in the available stats roles?
-		if ( in_array( $user_role, $stats_roles ) ) {
+		if ( is_array( $stats_roles ) && in_array( $user_role, $stats_roles ) ) {
 			$caps = array( 'read' );
 		}
 	}


### PR DESCRIPTION
We're using `$stats_roles` as the haystack for `in_array` without confirming we're getting an array.

Error notice thrown in 2236272-t; still investigating root cause.