### PR TITLE
Tiled Galleries: Use "inherit" to reset color property

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery.css
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery.css
@@ -25,7 +25,7 @@
 .tiled-gallery .tiled-gallery-item a { /* Needs to reset some properties for theme compatibility */
 	background: transparent;
 	border: none;
-	color: none;
+	color: inherit;
 	margin: 0;
 	padding: 0;
 	text-decoration: none;


### PR DESCRIPTION
Replaces "none", which is invalid. Run Grunt locally to test concatenation. Fixes #1579. 