### PR TITLE
Adjustments to user dropdown in My Jetpack

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
@@ -81,7 +81,7 @@ class Jetpack_My_Jetpack_Page extends Jetpack_Admin_Page {
 	function jetpack_are_other_users_linked_and_admin() {
 		// If only one admin
 		$all_users = count_users();
-		if ( 2 > $all_users['avail_roles']['administrator'] ) {
+		if ( 1 < $all_users['avail_roles']['administrator'] ) {
 			return false;
 		}
 

--- a/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-my-jetpack-page.php
@@ -81,7 +81,7 @@ class Jetpack_My_Jetpack_Page extends Jetpack_Admin_Page {
 	function jetpack_are_other_users_linked_and_admin() {
 		// If only one admin
 		$all_users = count_users();
-		if ( 1 < $all_users['avail_roles']['administrator'] ) {
+		if ( 2 > $all_users['avail_roles']['administrator'] ) {
 			return false;
 		}
 

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -93,32 +93,40 @@
 				<div class="j-row my-jetpack-actions">
 					<div class="j-col j-lrg-6 j-md-6 j-sm-12">
 						<h4><?php _e( 'Jetpack Primary User', 'jetpack' ); ?></h4>
-						<form action="" method="post">
-							<select name="jetpack-new-master" id="user-list">
-								<?php
-								$all_users = get_users();
-								$primary_text = __( '(primary)', 'jetpack' );
+						<?php
+						// Only show dropdown if there are other admins
+						$all_users = count_users();
+						if ( 1 < $all_users['avail_roles']['administrator'] ) : ?>
+							<form action="" method="post">
+								<select name="jetpack-new-master" id="user-list">
+									<?php
+									$all_users = get_users();
+									$primary_text = __( '(primary)', 'jetpack' );
 
-								foreach ( $all_users as $user ) {
-									if ( Jetpack::is_user_connected( $user->ID ) && $user->caps['administrator'] ) {
-										if ( $user->ID == Jetpack_Options::get_option( 'master_user' ) ) {
-											$master_user_option = "<option selected value='{$user->ID}'>$user->user_login $primary_text</option>";
-										} else {
-											$user_options .= "<option value='{$user->ID}'>$user->user_login</option>";
+									foreach ( $all_users as $user ) {
+										if ( Jetpack::is_user_connected( $user->ID ) && $user->caps['administrator'] ) {
+											if ( $user->ID == Jetpack_Options::get_option( 'master_user' ) ) {
+												$master_user_option = "<option selected value='{$user->ID}'>$user->user_login $primary_text</option>";
+											} else {
+												$user_options .= "<option value='{$user->ID}'>$user->user_login</option>";
+											}
 										}
 									}
-								}
-								// Show master first
-								echo $master_user_option;
+									// Show master first
+									echo $master_user_option;
 
-								// Show the rest of the linked admins
-								$user_options = ! empty( $user_options ) ? $user_options : printf( __( '%sConnect more admins%s', 'jetpack' ), "<option disabled='disabled'>", "</option>" );
-								echo $user_options;
-								?>
-							</select>
-							<?php wp_nonce_field( 'jetpack_change_primary_user', '_my_jetpack_nonce' ); ?>
-							<input type="submit" name="jetpack-set-master-user" id="save-primary-btn" class="button button-primary" value="Save" title="<?php esc_attr_e( 'Set the primary account holder', 'jetpack' ); ?>"/>
-						</form>
+									// Show the rest of the linked admins
+									$user_options = ! empty( $user_options ) ? $user_options : printf( __( '%sConnect more admins%s', 'jetpack' ), "<option disabled='disabled'>", "</option>" );
+									echo $user_options;
+									?>
+								</select>
+								<?php wp_nonce_field( 'jetpack_change_primary_user', '_my_jetpack_nonce' ); ?>
+								<input type="submit" name="jetpack-set-master-user" id="save-primary-btn" class="button button-primary" value="Save" title="<?php esc_attr_e( 'Set the primary account holder', 'jetpack' ); ?>"/>
+							</form>
+						<?php else : ?>
+							<p>{{{ data.masterUser.masterUser.data.user_login }}}</p>
+							<p><em><?php _e( 'Create additional admins to change primary user.', 'jetpack' ); ?></em></p>
+						<?php endif; ?>
 					</div>
 					<div class="j-col j-lrg-6 j-md-6 j-sm-12">
 						<h4><?php _e( 'Disconnect Jetpack', 'jetpack' ); ?></h4>

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -95,13 +95,13 @@
 						<h4><?php _e( 'Jetpack Primary User', 'jetpack' ); ?></h4>
 						<?php
 						// Only show dropdown if there are other admins
-						$all_users = count_users();
+						$all_users    = count_users();
+						$primary_text = __( '(primary)', 'jetpack' );
 						if ( 1 < $all_users['avail_roles']['administrator'] ) : ?>
 							<form action="" method="post">
 								<select name="jetpack-new-master" id="user-list">
 									<?php
 									$all_users = get_users();
-									$primary_text = __( '(primary)', 'jetpack' );
 
 									foreach ( $all_users as $user ) {
 										if ( Jetpack::is_user_connected( $user->ID ) && $user->caps['administrator'] ) {
@@ -121,10 +121,14 @@
 									?>
 								</select>
 								<?php wp_nonce_field( 'jetpack_change_primary_user', '_my_jetpack_nonce' ); ?>
-								<input type="submit" name="jetpack-set-master-user" id="save-primary-btn" class="button button-primary" value="Save" title="<?php esc_attr_e( 'Set the primary account holder', 'jetpack' ); ?>"/>
+								<# if ( data.otherAdminsLinked ) { #>
+									<input type="submit" name="jetpack-set-master-user" id="save-primary-btn" class="button button-primary" value="Save" title="<?php esc_attr_e( 'Set the primary account holder', 'jetpack' ); ?>"/>
+								<# } else { #>
+									<input type="submit" disabled="disabled" name="jetpack-set-master-user" id="save-primary-btn" class="button" value="Save" title="<?php esc_attr_e( 'Set the primary account holder', 'jetpack' ); ?>"/>
+								<# } #>
 							</form>
 						<?php else : ?>
-							<p>{{{ data.masterUser.masterUser.data.user_login }}}</p>
+							<p>{{{ data.masterUser.masterUser.data.user_login }}} <?php echo $primary_text; ?></p>
 							<p><em><?php _e( 'Create additional admins to change primary user.', 'jetpack' ); ?></em></p>
 						<?php endif; ?>
 					</div>


### PR DESCRIPTION
Fixes #2301 

"save" button should be not actionable when no other admins are connected.

The entire dropdown should be hidden and replaced with a message when there are no other admins at all. 