### PR TITLE
Jump Start: remove test code

### DIFF
--- a/_inc/jp.js
+++ b/_inc/jp.js
@@ -275,25 +275,6 @@
 
 			return false;
 		});
-
-		/*
-			RESET EVERYTHING (for testing only)
-			@todo remove
-		 */
-
-		$( '#jump-start-deactivate' ).click(function () {
-			$( '.spinner' ).show();
-
-			data.jumpStartDeactivate = 'jump-start-deactivate';
-
-			$.post( jetpackL10n.ajaxurl, data, function ( response ) {
-				//$('#jumpstart-cta').html(response);
-				$( '#deactivate-success' ).html( response );
-				$( '.spinner' ).hide();
-			});
-
-			return false;
-		});
 	}
 
 })( jQuery, jetpackL10n.modules, jetpackL10n.currentVersion, jetpackL10n );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -659,25 +659,6 @@ class Jetpack {
 				exit;
 			}
 
-		} elseif ( isset( $_REQUEST['jumpStartDeactivate'] ) && 'jump-start-deactivate' == $_REQUEST['jumpStartDeactivate'] ) {
-
-			// FOR TESTING ONLY
-			// @todo remove
-			$modules = (array) $_REQUEST['jumpstartModSlug'];
-			foreach( $modules as $module => $value ) {
-				if ( !in_array( $value['module_slug'], Jetpack::get_default_modules() ) ) {
-					Jetpack::log( 'deactivate', $value['module_slug'] );
-					Jetpack::deactivate_module( $value['module_slug'] );
-					Jetpack::state( 'message', 'no_message' );
-				} else {
-					Jetpack::log( 'activate', $value['module_slug'] );
-					Jetpack::activate_module( $value['module_slug'], false, false );
-					Jetpack::state( 'message', 'no_message' );
-				}
-			}
-
-			Jetpack_Options::update_option( 'jumpstart', 'new_connection' );
-			echo "reload the page";
 		}
 
 		wp_die();

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -87,7 +87,3 @@
 			<path class="body" fill="#518d2a" d="M38.032,47.3l4.973-5.157l7.597,1.996l0.878-0.91l0.761-0.789l-0.688-2.838l-0.972-0.926l-1.858,1.926 l-2.206-2.1l3.803-3.944l0.09-3.872L80,0L61.201,10.382L60.2,15.976l-5.674,1.145l-8.09-7.702L34.282,22.024l8.828-1.109 l2.068,2.929l-4.996,0.655l-3.467,3.595l0.166-4.469l-4.486,0.355L21.248,35.539l-0.441,4.206l-2.282,2.366l-2.04,6.961 L27.69,37.453l4.693,1.442l-2.223,2.306l-4.912,0.095l-7.39,22.292l-8.06,3.848l-2.408,9.811l-3.343-0.739L0,86.739l30.601-31.733 l8.867,2.507l-7.782,8.07l-1.496-0.616l-0.317-2.623l-7.197,7.463l11.445-2.604l16.413-7.999L38.032,47.3z M42.774,16.143 l3.774-3.914l2.85,2.713L42.774,16.143z"/>
 		</svg>
 	</div>
-<div id="deactivate-success"></div>
-<?php if ( Jetpack::is_development_version() ) { ?>
-	<a id="jump-start-deactivate" style="cursor:pointer; display: block; text-align: center; margin-top: 25px;"><?php esc_html_e( 'RESET EVERYTHING (during testing only) - will reset modules to default as well', 'jetpack' ); ?></a>
-<?php } // is_development_version ?>


### PR DESCRIPTION
This removes the "reset everything" link that was shown in dev versions.  No longer needed, as Jump Start has been pretty well tested by now and this can now be done via Jetpack CLI.