### PR TITLE
Site Icon: Play nicely with Core's feature

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -245,7 +245,12 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		$image['src'] = jetpack_site_icon_url( null, '512' );
 	}
 
-	// Fourth fall back, blank image
+	// Fourth fall back, Core Site Icon. Added in WP 4.3.
+	if ( empty( $image ) && ( function_exists( 'has_site_icon') && has_site_icon() ) ) {
+		$image['src'] = get_site_icon_url( null, '512' );
+	}
+
+	// Finally fall back, blank image
 	if ( empty( $image ) ) {
 		$image['src'] = apply_filters( 'jetpack_open_graph_image_default', 'https://s0.wp.com/i/blank.jpg' );
 	}

--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -68,14 +68,21 @@ class Jetpack_Site_Icon {
 		add_filter( 'display_media_states',   array( $this, 'add_media_state' ) );
 		add_action( 'admin_init',             array( $this, 'admin_init' ) );
 		add_action( 'admin_init',             array( $this, 'delete_site_icon_hook' ) );
-		add_action( 'atom_head', array( $this, 'atom_icon' ) );
-		add_action( 'rss2_head', array( $this, 'rss2_icon' ) );
 
 		add_action( 'admin_print_styles-options-general.php', array( $this, 'add_general_options_styles' ) );
 
-		// Add the favicon to the front end and backend
-		add_action( 'wp_head',           array( $this, 'site_icon_add_meta' ) );
-		add_action( 'admin_head',        array( $this, 'site_icon_add_meta' ) );
+		// Add the favicon to the front end and backend if Core's site icon not used.
+		/**
+		 * As of WP 4.3 and JP 3.6, both are outputting the same icons so no need to fire these.
+		 * This is a temporary solution until Jetpack's module primary function is deprecated.
+		 * In the future, Jetpack's can output other sizes using Core's icon.
+		 */
+		if ( function_exists( 'has_site_icon' ) && ! has_site_icon() ) {
+			add_action( 'wp_head',           array( $this, 'site_icon_add_meta' ) );
+			add_action( 'admin_head',        array( $this, 'site_icon_add_meta' ) );
+			add_action( 'atom_head',         array( $this, 'atom_icon' ) );
+			add_action( 'rss2_head',         array( $this, 'rss2_icon' ) );
+		}
 
 		add_action( 'delete_option',     array( 'Jetpack_Site_Icon', 'delete_temp_data' ), 10, 1); // used to clean up after itself.
 		add_action( 'delete_attachment', array( 'Jetpack_Site_Icon', 'delete_attachment_data' ), 10, 1); // in case user deletes the attachment via

--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -77,7 +77,7 @@ class Jetpack_Site_Icon {
 		 * This is a temporary solution until Jetpack's module primary function is deprecated.
 		 * In the future, Jetpack's can output other sizes using Core's icon.
 		 */
-		if ( function_exists( 'has_site_icon' ) && ! has_site_icon() ) {
+		if ( ! function_exists('has_site_icon') || ! has_site_icon() ) {
 			add_action( 'wp_head',           array( $this, 'site_icon_add_meta' ) );
 			add_action( 'admin_head',        array( $this, 'site_icon_add_meta' ) );
 			add_action( 'atom_head',         array( $this, 'atom_icon' ) );


### PR DESCRIPTION
See #2326

1. Adds a fallback for og:image tags.
2. Kills output of Jetpack Site Icon when Core's icon is being used.

These methods should be considered temporary until a full-scale deprecation is possible when 4.3 is the minimum version of WordPress. The aim is something we can ship before 4.3 launches so we play nicely together while determining the long-term plan.

Idea: `if ( function_exists( 'has_site_icon' ) &&  ! jetpack_has_site_icon() )`. Serving as a 4.3 version check and if the user has already set our icon. If true, then hide our uploader and maybe filter `jetpack_site_icon_url` to Core's in the event someone is using us after a function_exists check?