### PR TITLE
Shortcodes: add auto embed option inside comments

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -77,7 +77,7 @@ function vimeo_shortcode( $atts ) {
 	if ( ! $height ) {
 		$height = round( ( $width / 640 ) * 360 );
 	}
-	
+
 	/**
 	 * Filter the Vimeo player width.
 	 *
@@ -86,7 +86,7 @@ function vimeo_shortcode( $atts ) {
 	 * @param int $width Width of the Vimeo player in pixels.
 	 */
 	$width = (int) apply_filters( 'vimeo_width', $width );
-	
+
 	/**
 	 * Filter the Vimeo player height.
 	 *
@@ -110,7 +110,7 @@ function vimeo_shortcode( $atts ) {
 	}
 
 	$html = sprintf( '<div class="embed-vimeo" style="text-align:center;"><iframe src="%1$s" width="%2$u" height="%3$u" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>', esc_url( $url ), $width, $height );
-	
+
 	/**
 	 * Filter the Vimeo player HTML.
 	 *
@@ -119,7 +119,7 @@ function vimeo_shortcode( $atts ) {
 	 * @param string $html Embedded Vimeo player HTML.
 	 */
 	$html = apply_filters( 'video_embed_html', $html );
-	
+
 	return $html;
 }
 
@@ -162,3 +162,45 @@ function vimeo_embed_to_shortcode( $content ) {
 }
 
 add_filter( 'pre_kses', 'vimeo_embed_to_shortcode' );
+
+/**
+ * Replaces plain-text links to Vimeo videos with Vimeo embeds.
+ *
+ * @since 3.7.0
+ *
+ * @param string $content HTML content
+ * @return string The content with embeds instead of URLs
+ */
+function vimeo_link( $content ) {
+	return preg_replace_callback( '#https://vimeo.com/\d*#', 'vimeo_link_callback', $content );
+}
+
+/**
+ * Callback function for the regex that replaces Vimeo URLs with Vimeo embeds.
+ *
+ * @since 3.7.0
+ *
+ * @param array $matches An array containing a Vimeo URL.
+ * @return string THe Vimeo HTML embed code.
+ */
+function vimeo_link_callback( $matches ) {
+	// Grab the Vimeo ID from the URL
+	if ( preg_match( '|vimeo\.com/(\d+)/?$|i', $matches[0], $match ) ) {
+		$id = (int) $match[1];
+	}
+
+	// Pass that ID to the Vimeo shortcode function.
+	if ( $id ) {
+		$atts = array( 'id' => $id );
+	}
+	return "\n" . vimeo_shortcode( $atts ) . "\n";
+}
+
+/** This filter is documented in modules/shortcodes/youtube.php */
+if ( apply_filters( 'jetpack_comments_allow_oembed', get_option('embed_autourls') ) ) {
+	// We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway, so the iframe gets filtered out.
+	if ( ! is_admin() ) {
+		// Higher priority because we need it before auto-link and autop get to it
+		add_filter( 'comment_text', 'vimeo_link', 1 );
+	}
+}


### PR DESCRIPTION
Controlled by the same filter as for YouTube and PollDaddy, `jetpack_comments_allow_oembed`

To auto-embed a video, we grab the Vimeo URL from the comment content, and replace it
with an iFrame code.

Suggested here:
https://wordpress.org/support/topic/jetpack-shotcodes-in-comments-videos