### PR TITLE
Widgets: Call proper php5 constructor.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -564,7 +564,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$widget_ops  = array( 'classname' => 'jetpack_subscription_widget', 'description' => __( 'Add an email signup form to allow people to subscribe to your blog.', 'jetpack' ) );
 		$control_ops = array( 'width' => 300 );
 
-		$this->WP_Widget( 'blog_subscription', __( 'Blog Subscriptions (Jetpack)', 'jetpack' ), $widget_ops, $control_ops );
+		parent::__construct( 'blog_subscription', __( 'Blog Subscriptions (Jetpack)', 'jetpack' ), $widget_ops, $control_ops );
 	}
 
 	function widget( $args, $instance ) {

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -23,7 +23,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 
-		$this->WP_Widget( 'gallery', apply_filters( 'jetpack_widget_name', __( 'Gallery', 'jetpack' ) ), $widget_ops, $control_ops );
+		parent::__construct( 'gallery', apply_filters( 'jetpack_widget_name', __( 'Gallery', 'jetpack' ) ), $widget_ops, $control_ops );
 	}
 
 	/**

--- a/modules/widgets/rsslinks-widget.php
+++ b/modules/widgets/rsslinks-widget.php
@@ -10,7 +10,7 @@ class Jetpack_RSS_Links_Widget extends WP_Widget {
 
 	function Jetpack_RSS_Links_Widget() {
 		$widget_ops = array( 'classname' => 'widget_rss_links', 'description' => __( "Links to your blog's RSS feeds", 'jetpack' ) );
-		$this->WP_Widget( 'rss_links', __( 'RSS Links (Jetpack)', 'jetpack' ), $widget_ops );
+		parent::__construct( 'rss_links', __( 'RSS Links (Jetpack)', 'jetpack' ), $widget_ops );
 	}
 
 	function widget( $args, $instance ) {


### PR DESCRIPTION
Stop calling legacy constructor.

Partial fix of #2323, we should still also merge #2324 for a later release.