### PR TITLE
Jetpack CLI: direct users to vaultpress site to configure

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -276,6 +276,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 				if ( 'all' == $args[1] ) {
 					$action = ( 'deactivate' == $action ) ? 'deactivate_all' : 'activate_all';
 				}
+				// VaultPress needs to be handled on their site.
+				if ( ( 'activate' == $action || 'deactivate' == $action || 'toggle' == $action ) && 'vaultpress' == $args[1] ) {
+					WP_CLI::error( sprintf( _x( 'Please visit %s to configure your VaultPress subscription.', '%s is a website', 'jetpack' ), esc_url( 'https://vaultpress.com/jetpack/' ) ) );
+				}
 			} else {
 				WP_CLI::line( __( 'Please specify a valid module.', 'jetpack' ) );
 				$action = 'list';
@@ -287,6 +291,9 @@ class Jetpack_CLI extends WP_CLI_Command {
 				$modules = Jetpack::get_available_modules();
 				sort( $modules );
 				foreach( $modules as $module_slug ) {
+					if ( 'vaultpress' == $module_slug ) {
+						continue;
+					}
 					$active = Jetpack::is_module_active( $module_slug ) ? __( 'Active', 'jetpack' ) : __( 'Inactive', 'jetpack' );
 					WP_CLI::line( "\t" . str_pad( $module_slug, 24 ) . $active );
 				}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -276,8 +276,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 				if ( 'all' == $args[1] ) {
 					$action = ( 'deactivate' == $action ) ? 'deactivate_all' : 'activate_all';
 				}
-				// VaultPress needs to be handled on their site.
-				if ( ( 'activate' == $action || 'deactivate' == $action || 'toggle' == $action ) && 'vaultpress' == $args[1] ) {
+				// VaultPress needs to be handled elsewhere.
+				if ( in_array( $action, array( 'activate', 'deactivate', 'toggle' ) ) && 'vaultpress' == $args[1] ) {
 					WP_CLI::error( sprintf( _x( 'Please visit %s to configure your VaultPress subscription.', '%s is a website', 'jetpack' ), esc_url( 'https://vaultpress.com/jetpack/' ) ) );
 				}
 			} else {


### PR DESCRIPTION
Fixes #2348

Don't let users activate, deactivate, or toggle VaultPress with the CLI.  Instead direct them to vautpress.com/jetpack to configure.  

Remove it from the module list as well.