### PR TITLE
Subscriptions: Toggle subscription on a per-post basis

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -494,6 +494,7 @@ class Jetpack_Sync {
 		$post['extra'] = array(
 			'author' => get_the_author_meta( 'display_name', $post_obj->post_author ),
 			'author_email' => get_the_author_meta( 'email', $post_obj->post_author ),
+			'dont_email_post_to_subs' => get_post_meta( $post_obj->ID, '_jetpack_dont_email_post_to_subs', true ),
 		);
 
 		if ( $fid = get_post_thumbnail_id( $id ) ) {

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -130,7 +130,7 @@ class Jetpack_Subscriptions {
 		// only show checkbox if post hasn't been published
 		if ( get_post_status( $post->ID ) !== 'publish' ) : ?>
 			<div class="misc-pub-section">
-				<label for="_jetpack_dont_email_post_to_subs">Jetpack Subscriptions: </label><br>
+				<label for="_jetpack_dont_email_post_to_subs"><?php _e( 'Jetpack Subscriptions:', 'jetpack' ); ?></label><br>
 				<input type="checkbox" name="_jetpack_dont_email_post_to_subs" id="jetpack-per-post-subscribe" value="1" <?php checked( $disable_subscribe_value, 1, true ); ?> />
 				<?php _e( 'Don&#8217;t send this to subscribers', 'jetpack' ); ?>
 			</div>

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -129,10 +129,11 @@ class Jetpack_Subscriptions {
 		wp_nonce_field( 'disable_subscribe', 'disable_subscribe_nonce' );
 		// only show checkbox if post hasn't been published
 		if ( get_post_status( $post->ID ) !== 'publish' ) : ?>
-			<p class="misc-pub-section">
+			<div class="misc-pub-section">
+				<label for="_jetpack_dont_email_post_to_subs">Jetpack Subscriptions: </label><br>
 				<input type="checkbox" name="_jetpack_dont_email_post_to_subs" id="jetpack-per-post-subscribe" value="1" <?php checked( $disable_subscribe_value, 1, true ); ?> />
-				<?php _e( 'Don&#8217;t email this post to subscribers', 'jetpack' ); ?>
-			</p>
+				<?php _e( 'Don&#8217;t send this to subscribers', 'jetpack' ); ?>
+			</div>
 		<?php endif;
 	}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -68,6 +68,9 @@ class Jetpack_Subscriptions {
 		// @see: https://twitter.com/nacin/status/378246957451333632
 		self::$hash = md5( get_option( 'siteurl' ) );
 
+		// Will we send emails to subscribers?
+		add_filter( 'jetpack_sync_post_module_custom_data', array( $this, 'jetpack_toggle_subscription' ), 10, 2 );
+
 		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'xmlrpc_methods' ) );
 
 		// @todo remove sync from subscriptions and move elsewhere...
@@ -87,6 +90,10 @@ class Jetpack_Subscriptions {
 
 		// Catch comment posts and check for subscriptions.
 		add_action( 'comment_post', array( $this, 'comment_subscribe_submit' ), 50, 2 );
+
+		// Adds post meta checkbox in the post submit metabox
+		add_action( 'post_submitbox_misc_actions', array( $this, 'subscription_post_page_metabox' ) );
+		add_action( 'save_post', array( $this, 'save_subscribe_meta' ) );
 	}
 
 	function post_is_public( $the_post ) {
@@ -112,6 +119,61 @@ class Jetpack_Subscriptions {
 				'jetpack.subscriptions.subscribe' => array( $this, 'subscribe' ),
 			)
 		);
+	}
+
+	/*
+	 * Disable Subscribe on Single Post
+	 * Register post meta
+	 */
+	function subscription_post_page_metabox() {
+		global $post;
+		$disable_subscribe_value = get_post_meta( $post->ID, '_jetpack_disable_subscribe_this_post', true );
+		// Nonce it
+		wp_nonce_field( 'disable_subscribe', 'disable_subscribe_nonce' );
+		// only show checkbox if post hasn't been published
+		if ( get_post_status( $post->ID ) !== 'publish' ) : ?>
+			<p class="misc-pub-section">
+				<input type="checkbox" name="_jetpack_disable_subscribe_this_post" id="jetpack-per-post-subscribe" value="1" <?php checked( $disable_subscribe_value, 1, true ); ?> />
+				<?php _e( 'Don&#8217;t email this post to subscribers', 'jetpack' ); ?>
+			</p>
+		<?php endif;
+	}
+	/*
+	 * Disable Subscribe on Single Post
+	 * Save the meta
+	 */
+	function save_subscribe_meta(){
+		global $post;
+		if ( ! is_object( $post ) ) {
+			return;
+		}
+		// Check nonce
+		if ( empty( $_POST['disable_subscribe_nonce'] ) || ! wp_verify_nonce( $_POST['disable_subscribe_nonce'], 'disable_subscribe' ) ) {
+			return;
+		}
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return $post->ID;
+		}
+		if ( isset( $_POST['_jetpack_disable_subscribe_this_post'] ) ) {
+			update_post_meta( $post->ID, '_jetpack_disable_subscribe_this_post', $_POST['_jetpack_disable_subscribe_this_post'] );
+		} else {
+			delete_post_meta( $post->ID, '_jetpack_disable_subscribe_this_post' );
+		}
+		return $post;
+	}
+	/*
+	 * Send some [module_custom_data] to HQ to tell them if we want to
+	 * send email to subscribers for this post
+	 *
+	 * @return bool
+	 */
+	function jetpack_toggle_subscription( $data , $post ) {
+		if ( "1" === get_post_meta( $post->ID, '_jetpack_disable_subscribe_this_post', true ) ) {
+			$data['subscriptions_send_email'] = false;
+		} else {
+			$data['subscriptions_send_email'] = true;
+		}
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
fixes #757

This adds a new checkbox to the post submitbox area that allows the poster to bypass email subscriptions for this post.  It adds some custom post meta and passes it to dotcom where we'll check for it and stop the email if it's set.  

<strong>To Test: </strong>
Publish a new post with and without the checkbox checked.  Should email to subscribers if not checked, and vice-a-versa.  

![screen shot 2015-08-19 at 1 22 53 pm](https://cloud.githubusercontent.com/assets/7129409/9363592/6e7b78e6-4675-11e5-9456-8c51d035d308.png)
