### PR TITLE
Jetpack CLI: allow modification of all options, require confirmation for some

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -459,10 +459,12 @@ class Jetpack_CLI extends WP_CLI_Command {
 	public function options( $args, $assoc_args ) {
 		$action = isset( $args[0] ) ? $args[0] : 'list';
 		$safe_to_modify = Jetpack::get_jetpack_options_for_reset();
-		$flagged = !in_array( $args[1], $safe_to_modify ) ? true : false;
 
 		// Jumpstart is special
 		array_push( $safe_to_modify, 'jumpstart' );
+
+		// Is the option flagged as unsafe?
+		$flagged = !in_array( $args[1], $safe_to_modify ) ? true : false;
 
 		if ( ! in_array( $action, array( 'list', 'get', 'delete', 'update' ) ) ) {
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -191,7 +191,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch ( $action ) {
 			case 'options':
-				$options_to_reset = Jetpack::get_jetapck_options_for_reset();
+				$options_to_reset = Jetpack::get_jetpack_options_for_reset();
 
 				// Reset the Jetpack options
 				_e( "Resetting Jetpack Options...\n", "jetpack" );
@@ -458,7 +458,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 */
 	public function options( $args, $assoc_args ) {
 		$action = isset( $args[0] ) ? $args[0] : 'list';
-		$safe_to_modify = Jetpack::get_jetapck_options_for_reset();
+		$safe_to_modify = Jetpack::get_jetpack_options_for_reset();
 		$flagged = !in_array( $args[1], $safe_to_modify ) ? true : false;
 
 		// Jumpstart is special
@@ -558,7 +558,7 @@ class Jetpack_CLI extends WP_CLI_Command {
  *
  * Written outside of the class so it's not listed as an executable command w/ 'wp jetpack'
  *
- * @param $flagged   bool   false = normal option | true = flagged by get_jetapck_options_for_reset()
+ * @param $flagged   bool   false = normal option | true = flagged by get_jetpack_options_for_reset()
  * @param $error_msg string (optional)
  */
 function jetpack_cli_are_you_sure( $flagged = false, $error_msg = false ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -566,9 +566,10 @@ class Jetpack_CLI extends WP_CLI_Command {
  *
  * Written outside of the class so it's not listed as an executable command w/ 'wp jetpack'
  *
+ * @param $flagged   bool   false = normal option | true = flagged by get_jetapck_options_for_reset()
  * @param $error_msg string (optional)
  */
-function jetpack_cli_are_you_sure( $error_msg = false ) {
+function jetpack_cli_are_you_sure( $flagged = false, $error_msg = false ) {
 	$cli = new Jetpack_CLI();
 
 	// Default cancellation message
@@ -576,7 +577,13 @@ function jetpack_cli_are_you_sure( $error_msg = false ) {
 		$error_msg = sprintf( __( 'Action cancelled. Have a question? %sjetpack.me/support%s', 'jetpack' ), $cli->green_open, $cli->color_close );
 	}
 
-	WP_CLI::line( _x( 'Are you sure? This cannot be undone. Type "yes" to continue:', '"yes" is a command.  Do not translate that.', 'jetpack' ) );
+	if ( ! $flagged ) {
+		$prompt_message = __( 'Are you sure? This cannot be undone. Type "yes" to continue:', '"yes" is a command.  Do not translate that.', 'jetpack' );
+	} else {
+		$prompt_message = __( 'Are you sure? Deleting this option may disconnect your site from jetpack.  Type "yes" to continue.', 'jetpack' );
+	}
+
+	WP_CLI::line( $prompt_message );
 	$handle = fopen( "php://stdin", "r" );
 	$line = fgets( $handle );
 	if ( 'yes' != trim( $line ) ){

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -464,7 +464,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		array_push( $safe_to_modify, 'jumpstart' );
 
 		// Is the option flagged as unsafe?
-		$flagged = !in_array( $args[1], $safe_to_modify ) ? true : false;
+		$flagged = ! in_array( $args[1], $safe_to_modify );
 
 		if ( ! in_array( $action, array( 'list', 'get', 'delete', 'update' ) ) ) {
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -572,7 +572,7 @@ function jetpack_cli_are_you_sure( $flagged = false, $error_msg = false ) {
 	if ( ! $flagged ) {
 		$prompt_message = __( 'Are you sure? This cannot be undone. Type "yes" to continue:', '"yes" is a command.  Do not translate that.', 'jetpack' );
 	} else {
-		$prompt_message = __( 'Are you sure? Deleting this option may disconnect your site from jetpack.  Type "yes" to continue.', 'jetpack' );
+		$prompt_message = __( 'Are you sure? Modifying this option may disrupt your Jetpack connection.  Type "yes" to continue.', 'jetpack' );
 	}
 
 	WP_CLI::line( $prompt_message );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -459,6 +459,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	public function options( $args, $assoc_args ) {
 		$action = isset( $args[0] ) ? $args[0] : 'list';
 		$safe_to_modify = Jetpack::get_jetapck_options_for_reset();
+		$flagged = !in_array( $args[1], $safe_to_modify ) ? true : false;
 
 		// Jumpstart is special
 		array_push( $safe_to_modify, 'jumpstart' );
@@ -494,22 +495,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 				WP_CLI::success( "\t" . $option );
 				break;
 			case 'delete':
-				// Check if it's safe to modify
-				if ( ! in_array( $args[1], $safe_to_modify ) ) {
-					WP_CLI::error( __( 'It is not recommended to delete this option.', 'jetpack' ) );
-				}
-
-				// Are you sure?
-				jetpack_cli_are_you_sure();
+				jetpack_cli_are_you_sure( $flagged );
 
 				Jetpack_Options::delete_option( $args[1] );
 				WP_CLI::success( sprintf( __( 'Deleted option: %s', 'jetpack' ), $args[1] ) );
 				break;
 			case 'update':
-				// Check if it's safe to modify
-				if ( ! in_array( $args[1], $safe_to_modify ) ) {
-					WP_CLI::error( __( 'It is not recommended to change this option.', 'jetpack' ) );
-				}
+				jetpack_cli_are_you_sure( $flagged );
 
 				// Updating arrays would get pretty tricky...
 				$value = Jetpack_Options::get_option( $args[1] );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5784,8 +5784,9 @@ p {
 	public static function get_jetapck_options_for_reset() {
 		$jetpack_options            = Jetpack_Options::get_option_names();
 		$jetpack_options_non_compat = Jetpack_Options::get_option_names( 'non_compact' );
+		$jetpack_options_private    = Jetpack_Options::get_option_names( 'private' );
 
-		$all_jp_options = array_merge( $jetpack_options, $jetpack_options_non_compat );
+		$all_jp_options = array_merge( $jetpack_options, $jetpack_options_non_compat, $jetpack_options_private );
 
 		// A manual build of the wp options
 		$wp_options = array(
@@ -5815,8 +5816,8 @@ p {
 			'site_logo',
 		);
 
-		// Whitelist some Jetpack options
-		$whitelist_terms = array(
+		// Flag some Jetpack options as unsafe
+		$unsafe_options = array(
 			'id',                           // (int)    The Client ID/WP.com Blog ID of this site.
 			'master_user',                  // (int)    The local User ID of the user who connected this site to jetpack.wordpress.com.
 			'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time
@@ -5824,11 +5825,17 @@ p {
 
 			// non_compact
 			'activated',
+
+			// private
+			'register',
+			'blog_token',                  // (string) The Client Secret/Blog Token of this site.
+			'user_token',                  // (string) The User Token of this site. (deprecated)
+			'user_tokens'
 		);
 
 		// Remove the whitelisted Jetpack options
-		foreach ( $whitelist_terms as $whitelist_term ) {
-			if ( false !== ( $key = array_search( $whitelist_term, $all_jp_options ) ) ) {
+		foreach ( $unsafe_options as $unsafe_option ) {
+			if ( false !== ( $key = array_search( $unsafe_option, $all_jp_options ) ) ) {
 				unset( $all_jp_options[ $key ] );
 			}
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5781,7 +5781,7 @@ p {
 	 *
 	 * @return array of options to delete.
 	 */
-	public static function get_jetapck_options_for_reset() {
+	public static function get_jetpack_options_for_reset() {
 		$jetpack_options            = Jetpack_Options::get_option_names();
 		$jetpack_options_non_compat = Jetpack_Options::get_option_names( 'non_compact' );
 		$jetpack_options_private    = Jetpack_Options::get_option_names( 'private' );
@@ -5864,7 +5864,7 @@ p {
 
 
 		// Manual build of module options
-		$option_names = self::get_jetapck_options_for_reset();
+		$option_names = self::get_jetpack_options_for_reset();
 
 		if ( in_array( $option_name, $option_names['wp_options'] ) ) {
 			Jetpack_Options::update_option( 'jumpstart', 'jetpack_action_taken' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5833,7 +5833,7 @@ p {
 			'user_tokens'
 		);
 
-		// Remove the whitelisted Jetpack options
+		// Remove the unsafe Jetpack options
 		foreach ( $unsafe_options as $unsafe_option ) {
 			if ( false !== ( $key = array_search( $unsafe_option, $all_jp_options ) ) ) {
 				unset( $all_jp_options[ $key ] );


### PR DESCRIPTION
Before, the CLI straight up prohibited modification of certain options.  This will allow the modification of any Jetpack option, but throws a confirmation prompt as a warning when modifying dangerous ones.  

`Are you sure? Modifying this option may disrupt your Jetpack connection.  Type "yes" to continue.`

To test, try to delete or update one of the "unsafe" options, like `version`.  