### PR TITLE
ATD: Split leading & trailing text into new nodes

### DIFF
--- a/modules/after-the-deadline.php
+++ b/modules/after-the-deadline.php
@@ -63,7 +63,7 @@ include( dirname( __FILE__ ) . '/after-the-deadline/config-options.php' );
 include( dirname( __FILE__ ) . '/after-the-deadline/config-unignore.php' );
 include( dirname( __FILE__ ) . '/after-the-deadline/proxy.php' );
 
-define( 'ATD_VERSION', '20140527' );
+define( 'ATD_VERSION', '20150708' );
 
 /*
  * Display the AtD configuration options


### PR DESCRIPTION
Prevent self-XSS by adding the text before or after an "underlined" word to their own sibling text nodes.

Previous behavior was to create a new HTML element with the whole line being processed thereby permitting script execution (XSS) in the surrounding text (in some browsers).

This change limits the vector to the matched text which _should_ be safe due to tokenization.

See upstream:
* https://github.com/Automattic/atd-core/pull/1/commits