### PR TITLE
API: Adds endpoint for deleting users

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -38,6 +38,7 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-users-endpoint.ph
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-comment-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-post-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-user-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-taxonomy-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-upload-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-settings-endpoint.php' );
@@ -1860,6 +1861,34 @@ new WPCOM_JSON_API_List_Users_Endpoint( array(
 	),
 
 	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/users',
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	)
+) );
+
+new WPCOM_JSON_API_Update_User_Endpoint( array(
+	'description' => 'Delete a user of a site.',
+	'group'       => '__do_not_document',
+	'stat'        => 'users:delete',
+
+	'method'      => 'POST',
+	'path'        => '/sites/%s/users/%d/delete',
+	'path_labels' => array(
+		'$site'       => '(int|string) Site ID or domain',
+		'$user_ID'    => '(int) User ID'
+	),
+
+	'request_format' => array(
+		'reassign' => '(int) An optional id of a user to reassign posts to.',
+	),
+
+	'response_format' => array(
+		'success' => '(bool) Was the deletion of user successful?',
+	),
+
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/users/1/delete',
 	'example_request_data' => array(
 		'headers' => array(
 			'authorization' => 'Bearer YOUR_API_TOKEN'

--- a/json-endpoints/class.wpcom-json-api-update-user-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-user-endpoint.php
@@ -1,0 +1,101 @@
+<?php
+
+class WPCOM_JSON_API_Update_User_Endpoint extends WPCOM_JSON_API_Endpoint {
+
+	function callback( $path = '', $blog_id = 0, $user_id = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			if ( wpcom_get_blog_owner( $blog_id ) == $user_id ) {
+				return new WP_Error( 'forbidden', 'A site owner can not be removed through this endpoint.', 403 );
+			}
+		}
+
+		if ( $this->api->ends_with( $path, '/delete' ) ) {
+			return $this->delete_or_remove_user( $user_id );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if a user exists by checking to see if a WP_User object exists for a user ID.
+	 * @param  int $user_id
+	 * @return bool
+	 */
+	function user_exists( $user_id ) {
+		$user = get_user_by( 'id', $user_id );
+
+		return false != $user && is_a( $user, 'WP_User' );
+	}
+
+	/**
+	 * Validates user input and then decides whether to remove or delete a user.
+	 * @param  int $user_id
+	 * @return array|WP_Error
+	 */
+	function delete_or_remove_user( $user_id ) {
+		if ( 0 == $user_id ) {
+			return new WP_Error( 'invalid_input', 'A valid user ID must be specified.', 400 );
+		}
+
+		if ( get_current_user_id() == $user_id ) {
+			return new WP_Error( 'invalid_input', 'User can not remove or delete self through this endpoint.', 400 );
+		}
+
+		if ( ! $this->user_exists( $user_id ) ) {
+			return new WP_Error( 'invalid_input', 'A user does not exist with that ID.', 400 );
+		}
+
+		return is_multisite() ? $this->remove_user( $user_id ) : $this->delete_user( $user_id );
+	}
+
+	/**
+	 * Removes a user from the current site.
+	 * @param  int $user_id
+	 * @return array|WP_Error
+	 */
+	function remove_user( $user_id ) {
+		if ( ! current_user_can( 'remove_users' ) ) {
+			return new WP_Error( 'unauthorized', 'User cannot remove users for specified site.', 403 );
+		}
+
+		if ( ! is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
+			return new WP_Error( 'invalid_input', 'User is not a member of the specified site.', 400 );
+		}
+
+		return array(
+			'success' => remove_user_from_blog( $user_id, get_current_blog_id() )
+		);
+	}
+
+	/**
+	 * Deletes a user and optionally reassigns posts to another user.
+	 * @param  int $user_id
+	 * @return array|WP_Error
+	 */
+	function delete_user( $user_id ) {
+		if ( ! current_user_can( 'delete_users' ) ) {
+			return new WP_Error( 'unauthorized', 'User cannot delete users for specified site.', 403 );
+		}
+
+		$input = (array) $this->input();
+
+		if ( isset( $input['reassign'] ) ) {
+			if ( $user_id == $input['reassign'] ) {
+				return new WP_Error( 'invalid_input', 'Can not reassign posts to user being deleted.', 400 );
+			}
+
+			if ( ! $this->user_exists( $input['reassign'] ) ) {
+				return new WP_Error( 'invalid_input', 'User specified in reassign argument is not a member of the specified site.', 400 );
+			}
+		}
+
+		return array(
+			'success' => wp_delete_user( $user_id, intval( $input['reassign'] ) ),
+		);
+	}
+}


### PR DESCRIPTION
This endpoint allows removal of users on multisite and deletion of users from single WP installations.

This endpoint will be used for user management work.