### PR TITLE
JSON API: avoid notices when updating a post in the WordPress.com post editor

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1087,8 +1087,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		if ( in_array( $ext, array( 'ogv', 'mp4', 'mov', 'wmv', 'avi', 'mpg', '3gp', '3g2', 'm4v' ) ) ) {
 			$metadata = wp_get_attachment_metadata( $media_item->ID );
-			$response['height'] = $metadata['height'];
-			$response['width']  = $metadata['width'];
+			if ( isset( $metadata['height'], $metadata['width'] ) ) {
+				$response['height'] = $metadata['height'];
+				$response['width']  = $metadata['width'];
+			}
 
 			// add VideoPress info
 			if ( function_exists( 'video_get_info_by_blogpostid' ) ) {
@@ -1314,7 +1316,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				require_once(  get_template_directory() . $function_file );
 			}
 		}
-		
+
 		// add inc/wpcom.php and/or includes/wpcom.php
 		wpcom_load_theme_compat_file();
 

--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -254,7 +254,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			unset( $input['likes_enabled'] );
 		}
 
-		if ( isset( $input['likes_enabled'] ) ) {
+		if ( isset( $input['sharing_enabled'] ) ) {
 			$sharing = $input['sharing_enabled'];
 			unset( $input['sharing_enabled'] );
 		}

--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -565,7 +565,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			return $return;
 		}
 
-		if ( 'revision' === $input['type'] ) {
+		if ( isset( $input['type'] ) && 'revision' === $input['type'] ) {
 			$return['preview_nonce'] = wp_create_nonce( 'post_preview_' . $input['parent'] );
 		}
 

--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -222,12 +222,20 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 
 		unset( $input['comments_open'], $input['pings_open'] );
 
-		$insert['menu_order'] = $input['menu_order'];
-		unset( $input['menu_order'] );
+		if ( isset( $input['menu_order'] ) ) {
+			$insert['menu_order'] = $input['menu_order'];
+			unset( $input['menu_order'] );
+		}
 
-		$publicize = $input['publicize'];
-		$publicize_custom_message = $input['publicize_message'];
-		unset( $input['publicize'], $input['publicize_message'] );
+		if ( isset( $input['publicize'] ) ) {
+			$publicize = $input['publicize'];
+			unset( $input['publicize'] );
+		}
+
+		if ( isset( $input['publicize_message'] ) ) {
+			$publicize_custom_message = $input['publicize_message'];
+			unset( $input['publicize_message'] );
+		}
 
 		if ( isset( $input['featured_image'] ) ) {
 			$featured_image = trim( $input['featured_image'] );
@@ -236,17 +244,25 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			unset( $input['featured_image'] );
 		}
 
-		$metadata = $input['metadata'];
-		unset( $input['metadata'] );
+		if ( isset( $input['metadata'] ) ) {
+			$metadata = $input['metadata'];
+			unset( $input['metadata'] );
+		}
 
-		$likes = $input['likes_enabled'];
-		$sharing = $input['sharing_enabled'];
+		if ( isset( $input['likes_enabled'] ) ) {
+			$likes = $input['likes_enabled'];
+			unset( $input['likes_enabled'] );
+		}
 
-		unset( $input['likes_enabled'] );
-		unset( $input['sharing_enabled'] );
+		if ( isset( $input['likes_enabled'] ) ) {
+			$sharing = $input['sharing_enabled'];
+			unset( $input['sharing_enabled'] );
+		}
 
-		$sticky = $input['sticky'];
-		unset( $input['sticky'] );
+		if ( isset( $input['sticky'] ) ) {
+			$sticky = $input['sticky'];
+			unset( $input['sticky'] );
+		}
 
 		foreach ( $input as $key => $value ) {
 			$insert["post_$key"] = $value;

--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -409,7 +409,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 		// We ask the user/dev to pass Publicize services he/she wants activated for the post, but Publicize expects us
 		// to instead flag the ones we don't want to be skipped. proceed with said logic.
 		// any posts coming from Path (client ID 25952) should also not publicize
-		if ( $publicize === false || 25952 == $this->api->token_details['client_id'] ) {
+		if ( $publicize === false || ( isset( $this->api->token_details['client_id'] ) && 25952 == $this->api->token_details['client_id'] ) ) {
 			// No publicize at all, skip all by ID
 			foreach ( $GLOBALS['publicize_ui']->publicize->get_services( 'all' ) as $name => $service ) {
 				delete_post_meta( $post_id, $GLOBALS['publicize_ui']->publicize->POST_SKIP . $name );

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -571,7 +571,7 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			return $return;
 		}
 
-		if ( 'revision' === $input['type'] ) {
+		if ( isset( $input['type'] ) && 'revision' === $input['type'] ) {
 			$return['preview_nonce'] = wp_create_nonce( 'post_preview_' . $input['parent'] );
 		}
 

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -414,7 +414,7 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 		// We ask the user/dev to pass Publicize services he/she wants activated for the post, but Publicize expects us
 		// to instead flag the ones we don't want to be skipped. proceed with said logic.
 		// any posts coming from Path (client ID 25952) should also not publicize
-		if ( $publicize === false || 25952 == $this->api->token_details['client_id'] ) {
+		if ( $publicize === false || ( isset( $this->api->token_details['client_id'] ) && 25952 == $this->api->token_details['client_id'] ) ) {
 			// No publicize at all, skip all by ID
 			foreach ( $GLOBALS['publicize_ui']->publicize->get_services( 'all' ) as $name => $service ) {
 				delete_post_meta( $post_id, $GLOBALS['publicize_ui']->publicize->POST_SKIP . $name );

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -229,12 +229,20 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 
 		unset( $input['discussion'] );
 
-		$insert['menu_order'] = $input['menu_order'];
-		unset( $input['menu_order'] );
+		if ( isset( $input['menu_order'] ) ) {
+			$insert['menu_order'] = $input['menu_order'];
+			unset( $input['menu_order'] );
+		}
 
-		$publicize = $input['publicize'];
-		$publicize_custom_message = $input['publicize_message'];
-		unset( $input['publicize'], $input['publicize_message'] );
+		if ( isset( $input['publicize'] ) ) {
+			$publicize = $input['publicize'];
+			unset( $input['publicize'] );
+		}
+
+		if ( isset( $input['publicize_message'] ) ) {
+			$publicize_custom_message = $input['publicize_message'];
+			unset( $input['publicize_message'] );
+		}
 
 		if ( isset( $input['featured_image'] ) ) {
 			$featured_image = trim( $input['featured_image'] );
@@ -242,17 +250,25 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			unset( $input['featured_image'] );
 		}
 
-		$metadata = $input['metadata'];
-		unset( $input['metadata'] );
+		if ( isset( $input['metadata'] ) ) {
+			$metadata = $input['metadata'];
+			unset( $input['metadata'] );
+		}
 
-		$likes = $input['likes_enabled'];
-		$sharing = $input['sharing_enabled'];
+		if ( isset( $input['likes_enabled'] ) ) {
+			$likes = $input['likes_enabled'];
+			unset( $input['likes_enabled'] );
+		}
 
-		unset( $input['likes_enabled'] );
-		unset( $input['sharing_enabled'] );
+		if ( isset( $input['sharing_enabled'] ) ) {
+			$sharing = $input['sharing_enabled'];
+			unset( $input['sharing_enabled'] );
+		}
 
-		$sticky = $input['sticky'];
-		unset( $input['sticky'] );
+		if ( isset( $input['sticky'] ) ) {
+			$sticky = $input['sticky'];
+			unset( $input['sticky'] );
+		}
 
 		foreach ( $input as $key => $value ) {
 			$insert["post_$key"] = $value;

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -229,12 +229,20 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 		unset( $input['discussion'] );
 
-		$insert['menu_order'] = $input['menu_order'];
-		unset( $input['menu_order'] );
+		if ( isset( $input['menu_order'] ) ) {
+			$insert['menu_order'] = $input['menu_order'];
+			unset( $input['menu_order'] );
+		}
 
-		$publicize = $input['publicize'];
-		$publicize_custom_message = $input['publicize_message'];
-		unset( $input['publicize'], $input['publicize_message'] );
+		if ( isset( $input['publicize'] ) ) {
+			$publicize = $input['publicize'];
+			unset( $input['publicize'] );
+		}
+
+		if ( isset( $input['publicize_message'] ) ) {
+			$publicize_custom_message = $input['publicize_message'];
+			unset( $input['publicize_message'] );
+		}
 
 		if ( isset( $input['featured_image'] ) ) {
 			$featured_image = trim( $input['featured_image'] );
@@ -242,17 +250,25 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			unset( $input['featured_image'] );
 		}
 
-		$metadata = $input['metadata'];
-		unset( $input['metadata'] );
+		if ( isset( $input['metadata'] ) ) {
+			$metadata = $input['metadata'];
+			unset( $input['metadata'] );
+		}
 
-		$likes = $input['likes_enabled'];
-		$sharing = $input['sharing_enabled'];
+		if ( isset( $input['likes_enabled'] ) ) {
+			$likes = $input['likes_enabled'];
+			unset( $input['likes_enabled'] );
+		}
 
-		unset( $input['likes_enabled'] );
-		unset( $input['sharing_enabled'] );
+		if ( isset( $input['sharing_enabled'] ) ) {
+			$sharing = $input['sharing_enabled'];
+			unset( $input['sharing_enabled'] );
+		}
 
-		$sticky = $input['sticky'];
-		unset( $input['sticky'] );
+		if ( isset( $input['sticky'] ) ) {
+			$sticky = $input['sticky'];
+			unset( $input['sticky'] );
+		}
 
 		foreach ( $input as $key => $value ) {
 			$insert["post_$key"] = $value;

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -414,7 +414,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		// We ask the user/dev to pass Publicize services he/she wants activated for the post, but Publicize expects us
 		// to instead flag the ones we don't want to be skipped. proceed with said logic.
 		// any posts coming from Path (client ID 25952) should also not publicize
-		if ( $publicize === false || 25952 == $this->api->token_details['client_id'] ) {
+		if ( $publicize === false || ( isset( $this->api->token_details['client_id'] ) && 25952 == $this->api->token_details['client_id'] ) ) {
 			// No publicize at all, skip all by ID
 			foreach ( $GLOBALS['publicize_ui']->publicize->get_services( 'all' ) as $name => $service ) {
 				delete_post_meta( $post_id, $GLOBALS['publicize_ui']->publicize->POST_SKIP . $name );

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -571,7 +571,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			return $return;
 		}
 
-		if ( 'revision' === $input['type'] ) {
+		if ( isset( $input['type'] ) && 'revision' === $input['type'] ) {
 			$return['preview_nonce'] = wp_create_nonce( 'post_preview_' . $input['parent'] );
 		}
 


### PR DESCRIPTION
Here were the notices I got:

`[11-Jul-2015 15:43:32] PHP Notice:  Undefined index:  menu_order in /wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php on line 232
[11-Jul-2015 15:43:32] PHP Notice:  Undefined index:  metadata in /wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php on line 245
[11-Jul-2015 15:43:32] PHP Notice:  Undefined index:  client_id in /wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php on line 401
[11-Jul-2015 15:43:32] PHP Notice:  Undefined index:  type in /wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php on line 558
`