### PR TITLE
Site Icon: Start using core's Site Icon

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -78,12 +78,12 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			_.each( data.items, function( item, key, list ) {
 				if ( item === undefined ) return;
 				if ( jetpackModulesData.coreIconAvailable && 'site-icon' == item.module ) { #>
-				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #>" id="site-icon">
+				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #>" id="site-icon-deprecated">
 					<th scope="row" class="check-column">&nbsp;</th>
 					<td class='name column-name'>
-						<span class='info'><a href="#">{{{ item.name }}}</a></span>
+						<span class='info'>{{{ item.name }}}</span>
 						<div class="row-actions">
-							<span><a style="color: #222;"><?php _e( 'WordPress now has Site Icons built in!', 'jetpack' ); ?></a></span>
+							<span style="color: #555;"><?php _e( 'WordPress now has Site Icons built in!', 'jetpack' ); ?></a></span>
 							<span class='configure'><a href="<?php esc_html_e( admin_url( 'options-general.php' ) ); ?>">configure</a></span>
 						</div>
 					</td>

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -86,7 +86,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 						<span class='info'>{{{ item.name }}}</span>
 						<div class="row-actions">
 							<span class="dep-msg"><?php _e( 'WordPress now has Site Icons built in!', 'jetpack' ); ?></span>
-							<span class='configure'><a href="<?php esc_html_e( admin_url( 'options-general.php' ) ); ?>">Configure</a></span>
+							<span class='configure'><a href="<?php esc_html_e( admin_url( 'options-general.php' ) ); ?>"><?php _e( 'configure' , 'jetpack' ); ?></a></span>
 						</div>
 					</td>
 				</tr>

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -78,13 +78,15 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			_.each( data.items, function( item, key, list ) {
 				if ( item === undefined ) return;
 				if ( jetpackModulesData.coreIconAvailable && 'site-icon' == item.module ) { #>
-				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #>" id="site-icon-deprecated">
-					<th scope="row" class="check-column">&nbsp;</th>
+				<tr class="jetpack-module deprecated <# if ( ++i % 2 ) { #> alternate<# } #>" id="site-icon-deprecated">
+					<th scope="row" class="check-column">
+					<input type="checkbox" name="modules[]" value="{{{ item.module }}}" disabled />
+					</th>
 					<td class='name column-name'>
 						<span class='info'>{{{ item.name }}}</span>
 						<div class="row-actions">
-							<span style="color: #555;"><?php _e( 'WordPress now has Site Icons built in!', 'jetpack' ); ?></a></span>
-							<span class='configure'><a href="<?php esc_html_e( admin_url( 'options-general.php' ) ); ?>">configure</a></span>
+							<span class="dep-msg"><?php _e( 'WordPress now has Site Icons built in!', 'jetpack' ); ?></span>
+							<span class='configure'><a href="<?php esc_html_e( admin_url( 'options-general.php' ) ); ?>">Configure</a></span>
 						</div>
 					</td>
 				</tr>

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -55,6 +55,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			'nonces'  => array(
 				'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
 			),
+			'coreIconAvailable' => Jetpack::jetpack_site_icon_available_in_core(),
 		) );
 
 		wp_enqueue_script( 'jetpack-modules-list-table' );
@@ -76,7 +77,18 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			if ( data.items.length ) {
 			_.each( data.items, function( item, key, list ) {
 				if ( item === undefined ) return;
-				#>
+				if ( jetpackModulesData.coreIconAvailable && 'site-icon' == item.module ) { #>
+				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #>" id="site-icon">
+					<th scope="row" class="check-column">&nbsp;</th>
+					<td class='name column-name'>
+						<span class='info'><a href="#">{{{ item.name }}}</a></span>
+						<div class="row-actions">
+							<span><a style="color: #222;"><?php _e( 'WordPress now has Site Icons built in!', 'jetpack' ); ?></a></span>
+							<span class='configure'><a href="<?php esc_html_e( admin_url( 'options-general.php' ) ); ?>">configure</a></span>
+						</div>
+					</td>
+				</tr>
+				<# return; } #>
 				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
 					<th scope="row" class="check-column">
 						<input type="checkbox" name="modules[]" value="{{{ item.module }}}" />

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -587,6 +587,9 @@ class Jetpack {
 			add_action( 'wp_print_styles', array( $this, 'implode_frontend_css' ), -1 ); // Run first
 			add_action( 'wp_print_footer_scripts', array( $this, 'implode_frontend_css' ), -1 ); // Run first to trigger before `print_late_styles`
 		}
+
+		// Check if site icon is available in core, and if so convert Jetpack's to use it.
+		add_action( 'admin_init', array( $this, 'jetpack_site_icon_available_in_core' ) );
 	}
 
 	/**
@@ -6034,6 +6037,55 @@ p {
 			</div>
 		</div>
 		<?php
+	}
+
+	/*
+	 * A graceful transition to using Core's site icon.
+	 *
+	 * All of the hard work has already been done with the image
+	 * in all_done_page(). All that needs to be done now is update
+	 * the option and display proper messaging.
+	 *
+	 * @todo remove when WP 4.3 is minimum
+	 *
+	 * @since 3.6.1
+	 *
+	 * @return bool false = Core's icon not available || true = Core's icon is available
+	 */
+	public function jetpack_site_icon_available_in_core() {
+		global $wp_version;
+		$core_icon_available = function_exists( 'has_site_icon' ) && version_compare( $wp_version, '4.3-beta' ) >= 0;
+
+		if ( ! $core_icon_available ) {
+			return false;
+		}
+
+		// No need for Jetpack's site icon anymore if core's is already set
+		if ( has_site_icon() ) {
+			if ( Jetpack::is_module_active( 'site-icon' ) ) {
+				Jetpack::log( 'deactivate', 'site-icon' );
+				Jetpack::deactivate_module( 'site-icon' );
+			}
+			return true;
+		}
+
+		// Transfer Jetpack's site icon to use core.
+		$site_icon_id = Jetpack::get_option( 'site_icon_id' );
+		if ( $site_icon_id ) {
+			// Update core's site icon
+			update_option( 'site_icon', $site_icon_id );
+
+			// Delete Jetpack's icon option. We still want the blavatar and attached data though.
+			delete_option( 'site_icon_id' );
+		}
+
+		// No need for Jetpack's site icon anymore
+		if ( Jetpack::is_module_active( 'site-icon' ) ) {
+			Jetpack::log( 'deactivate', 'site-icon' );
+			Jetpack::deactivate_module( 'site-icon' );
+		}
+
+		return true;
 	}
 
 }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -589,7 +589,7 @@ class Jetpack {
 		}
 
 		// Check if site icon is available in core, and if so convert Jetpack's to use it.
-		add_action( 'admin_init', array( $this, 'jetpack_site_icon_available_in_core' ) );
+		add_action( 'admin_init', array( 'Jetpack', 'jetpack_site_icon_available_in_core' ) );
 	}
 
 	/**
@@ -6052,7 +6052,7 @@ p {
 	 *
 	 * @return bool false = Core's icon not available || true = Core's icon is available
 	 */
-	public function jetpack_site_icon_available_in_core() {
+	public static function jetpack_site_icon_available_in_core() {
 		global $wp_version;
 		$core_icon_available = function_exists( 'has_site_icon' ) && version_compare( $wp_version, '4.3-beta' ) >= 0;
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -467,7 +467,6 @@ class Jetpack {
 		$this->sync->mock_option( 'main_network_site', array( $this, 'jetpack_main_network_site_option' ) );
 		$this->sync->mock_option( 'single_user_site', array( 'Jetpack', 'is_single_user_site' ) );
 
-
 		/**
 		 * Trigger an update to the main_network_site when we update the blogname of a site.
 		 *
@@ -590,6 +589,29 @@ class Jetpack {
 
 		// Check if site icon is available in core, and if so convert Jetpack's to use it.
 		add_action( 'admin_init', array( 'Jetpack', 'jetpack_site_icon_available_in_core' ) );
+
+		// If a Site Icon is uploaded to core, make it syncable
+		add_action( 'add_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
+		add_action( 'jetpack_heartbeat',    array( $this, 'jetpack_sync_core_icon' ) );
+	}
+
+	/*
+	 * Make sure any site icon added to core can get
+	 * synced back to dotcom, so we can display it there.
+	 */
+	function jetpack_sync_core_icon() {
+		if ( function_exists( 'get_site_icon_url' ) ) {
+			$url = get_site_icon_url();
+		} else {
+			return;
+		}
+
+		require_once( JETPACK__PLUGIN_DIR . 'modules/site-icon/site-icon-functions.php' );
+		// If there's a core icon, maybe update the option.  If not, fall back to Jetpack's.
+		if ( ! empty( $url ) && $url !== jetpack_site_icon_url() ) {
+			// This is the option that is synced with dotcom
+			Jetpack_Options::update_option( 'site_icon_url', $url );
+		}
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -588,9 +588,6 @@ class Jetpack {
 			add_action( 'wp_print_footer_scripts', array( $this, 'implode_frontend_css' ), -1 ); // Run first to trigger before `print_late_styles`
 		}
 
-		// Check if site icon is available in core, and if so convert Jetpack's to use it.
-		add_action( 'admin_init', array( 'Jetpack', 'jetpack_site_icon_available_in_core' ) );
-
 		// Sync Core Icon: Detect changes in Core's Site Icon and make it syncable.  
 		add_action( 'add_option_site_icon',    array( $this, 'jetpack_sync_core_icon' ) );
 		add_action( 'update_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -451,7 +451,8 @@ class Jetpack {
 			'stylesheet',
 			"theme_mods_{$theme_slug}",
 			'jetpack_sync_non_public_post_stati',
-			'jetpack_options'
+			'jetpack_options',
+			'site_icon' // (int) - ID of core's Site Icon attachment ID
 		);
 
 		foreach( Jetpack_Options::get_option_names( 'non-compact' ) as $option ) {
@@ -590,9 +591,12 @@ class Jetpack {
 		// Check if site icon is available in core, and if so convert Jetpack's to use it.
 		add_action( 'admin_init', array( 'Jetpack', 'jetpack_site_icon_available_in_core' ) );
 
-		// If a Site Icon is uploaded to core, make it syncable
-		add_action( 'add_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
-		add_action( 'jetpack_heartbeat',    array( $this, 'jetpack_sync_core_icon' ) );
+		// Sync Core Icon: Detect changes in Core's Site Icon and make it syncable.  
+		add_action( 'add_option_site_icon',    array( $this, 'jetpack_sync_core_icon' ) );
+		add_action( 'update_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
+		add_action( 'delete_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
+		add_action( 'jetpack_heartbeat',       array( $this, 'jetpack_sync_core_icon' ) );
+
 	}
 
 	/*
@@ -611,6 +615,8 @@ class Jetpack {
 		if ( ! empty( $url ) && $url !== jetpack_site_icon_url() ) {
 			// This is the option that is synced with dotcom
 			Jetpack_Options::update_option( 'site_icon_url', $url );
+		} else if ( empty( $url ) && did_action( 'delete_option_site_icon' ) ) {
+			Jetpack_Options::delete_option( 'site_icon_url' );
 		}
 	}
 

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -245,7 +245,12 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		$image['src'] = jetpack_site_icon_url( null, '512' );
 	}
 
-	// Fourth fall back, blank image
+	// Fourth fall back, Core Site Icon. Added in WP 4.3.
+	if ( empty( $image ) && ( function_exists( 'has_site_icon') && has_site_icon() ) ) {
+		$image['src'] = get_site_icon_url( null, '512' );
+	}
+
+	// Finally fall back, blank image
 	if ( empty( $image ) ) {
 		$image['src'] = apply_filters( 'jetpack_open_graph_image_default', 'https://s0.wp.com/i/blank.jpg' );
 	}

--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -68,14 +68,21 @@ class Jetpack_Site_Icon {
 		add_filter( 'display_media_states',   array( $this, 'add_media_state' ) );
 		add_action( 'admin_init',             array( $this, 'admin_init' ) );
 		add_action( 'admin_init',             array( $this, 'delete_site_icon_hook' ) );
-		add_action( 'atom_head', array( $this, 'atom_icon' ) );
-		add_action( 'rss2_head', array( $this, 'rss2_icon' ) );
 
 		add_action( 'admin_print_styles-options-general.php', array( $this, 'add_general_options_styles' ) );
 
-		// Add the favicon to the front end and backend
-		add_action( 'wp_head',           array( $this, 'site_icon_add_meta' ) );
-		add_action( 'admin_head',        array( $this, 'site_icon_add_meta' ) );
+		// Add the favicon to the front end and backend if Core's site icon not used.
+		/**
+		 * As of WP 4.3 and JP 3.6, both are outputting the same icons so no need to fire these.
+		 * This is a temporary solution until Jetpack's module primary function is deprecated.
+		 * In the future, Jetpack's can output other sizes using Core's icon.
+		 */
+		if ( function_exists( 'has_site_icon' ) && ! has_site_icon() ) {
+			add_action( 'wp_head',           array( $this, 'site_icon_add_meta' ) );
+			add_action( 'admin_head',        array( $this, 'site_icon_add_meta' ) );
+			add_action( 'atom_head',         array( $this, 'atom_icon' ) );
+			add_action( 'rss2_head',         array( $this, 'rss2_icon' ) );
+		}
 
 		add_action( 'delete_option',     array( 'Jetpack_Site_Icon', 'delete_temp_data' ), 10, 1); // used to clean up after itself.
 		add_action( 'delete_attachment', array( 'Jetpack_Site_Icon', 'delete_attachment_data' ), 10, 1); // in case user deletes the attachment via

--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -77,7 +77,7 @@ class Jetpack_Site_Icon {
 		 * This is a temporary solution until Jetpack's module primary function is deprecated.
 		 * In the future, Jetpack's can output other sizes using Core's icon.
 		 */
-		if ( function_exists( 'has_site_icon' ) && ! has_site_icon() ) {
+		if ( ! function_exists('has_site_icon') || ! has_site_icon() ) {
 			add_action( 'wp_head',           array( $this, 'site_icon_add_meta' ) );
 			add_action( 'admin_head',        array( $this, 'site_icon_add_meta' ) );
 			add_action( 'atom_head',         array( $this, 'atom_icon' ) );

--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -77,7 +77,7 @@ class Jetpack_Site_Icon {
 		 * This is a temporary solution until Jetpack's module primary function is deprecated.
 		 * In the future, Jetpack's can output other sizes using Core's icon.
 		 */
-		if ( ! function_exists('has_site_icon') || ! has_site_icon() ) {
+		if ( ( function_exists( 'has_site_icon' ) && ! has_site_icon() ) || ! function_exists( 'has_site_icon' ) ) {
 			add_action( 'wp_head',           array( $this, 'site_icon_add_meta' ) );
 			add_action( 'admin_head',        array( $this, 'site_icon_add_meta' ) );
 			add_action( 'atom_head',         array( $this, 'atom_icon' ) );

--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -198,9 +198,9 @@ class Jetpack_Site_Icon {
 	 */
 	public function upload_balavatar_head() {
 
-		wp_register_script( 'site-icon-crop',  plugin_dir_url( __FILE__ ). "js/site-icon-crop.js"  , array( 'jquery', 'jcrop' ) ,  self::$assets_version, false);
+		wp_register_script( 'jetpack-site-icon-crop',  plugin_dir_url( __FILE__ ). "js/site-icon-crop.js"  , array( 'jquery', 'jcrop' ) ,  self::$assets_version, false);
 		if ( isset( $_REQUEST['step'] )  && $_REQUEST['step'] == 2 ) {
-			wp_enqueue_script( 'site-icon-crop' );
+			wp_enqueue_script( 'jetpack-site-icon-crop' );
 			wp_enqueue_style( 'jcrop' );
 		}
 		wp_enqueue_style( 'site-icon-admin' );
@@ -371,7 +371,7 @@ class Jetpack_Site_Icon {
 		$crop_ration = $crop_data['large_image_data'][0] / $crop_data['resized_image_data'][0]; // always bigger then 1
 
 		// lets make sure that the Javascript ia also loaded
-		wp_localize_script( 'site-icon-crop', 'Site_Icon_Crop_Data', self::initial_crop_data( $crop_data['large_image_data'][0] , $crop_data['large_image_data'][1], $crop_data['resized_image_data'][0], $crop_data['resized_image_data'][1] ) );
+		wp_localize_script( 'jetpack-site-icon-crop', 'Site_Icon_Crop_Data', self::initial_crop_data( $crop_data['large_image_data'][0] , $crop_data['large_image_data'][1], $crop_data['resized_image_data'][0], $crop_data['resized_image_data'][1] ) );
 		?>
 
 		<h2 class="site-icon-title"><?php esc_html_e( 'Site Icon', 'jetpack' ); ?> <span class="small"><?php esc_html_e( 'crop the image', 'jetpack' ); ?></span></h2>

--- a/modules/site-icon/jetpack-site-icon.php
+++ b/modules/site-icon/jetpack-site-icon.php
@@ -84,6 +84,9 @@ class Jetpack_Site_Icon {
 			add_action( 'rss2_head',         array( $this, 'rss2_icon' ) );
 		}
 
+		// Check if site icon is available in core, and if so convert Jetpack's to use it.
+		add_action( 'admin_init',        array( 'Jetpack', 'jetpack_site_icon_available_in_core' ) );
+
 		add_action( 'delete_option',     array( 'Jetpack_Site_Icon', 'delete_temp_data' ), 10, 1); // used to clean up after itself.
 		add_action( 'delete_attachment', array( 'Jetpack_Site_Icon', 'delete_attachment_data' ), 10, 1); // in case user deletes the attachment via
 		add_filter( 'get_post_metadata', array( 'Jetpack_Site_Icon', 'delete_attachment_images' ), 10, 4 );

--- a/scss/templates/_main.scss
+++ b/scss/templates/_main.scss
@@ -1399,6 +1399,7 @@ body {
 // Icons
 // ==========================================================================
 
+.jetpack-modules #site-icon-deprecated .info,
 .modules h3.icon,
 .jetpack-modules .info a {
 	width: auto;
@@ -1577,6 +1578,9 @@ body {
 	content: '\f475';
 }
 
+.jetpack-modules #site-icon-deprecated .info:before {
+	content: '\f475';
+}
 
 
 // ==========================================================================

--- a/scss/templates/_settings.scss
+++ b/scss/templates/_settings.scss
@@ -131,6 +131,15 @@
 		&#vaultpress {
 			opacity: 1;
 		}
+		&.deprecated {
+			span {
+				color: #888;
+			}
+			.dep-msg {
+				margin-right: 10px;
+				color: #555;
+			}
+		}
 		th,
 		td {
 			background: #fff;
@@ -387,6 +396,14 @@
 
 } // < 782
 
+@media (max-width: 650px) {
+
+	.table-bordered.jetpack-modules tr.jetpack-module.deprecated td .row-actions {
+		float: none;
+		padding-left: 18px;
+	}
+}
+
 @media (max-width: 430px) {
 
 		// Hide activate / config links on really small screens. Users can still utlize these actions by tapping on the title of the module
@@ -394,4 +411,7 @@
 			display: none;
 		}
 
+		.table-bordered.jetpack-modules tr.jetpack-module.deprecated td .row-actions {
+			display: block;
+		}
 } // < 430


### PR DESCRIPTION
This is meant to be a seamless under-the-hood transition to deprecating Jetpack's site icon in favor of core.  

- If user already has Jetpack Site Icon set, this will take that icon, transfer it to core's version, and deactivate Jetpack's Site Icon.

- Modifies the Module list on the Jetpack Settings page so Site Icon cannot be activated.  Instead, we tell them about Core's new Site Icon and a link to configure it.  

- Makes sure that core's site icon also gets synced back to wpcom

My thinking is that we'll leave it like this until 4.3 is the minimum supported WP version.  Then we can remove the module completely.  

This includes @kraftbj's commits from #2328 as well, so that PR can be discarded.  

fixes #2326