### PR TITLE
ATD: Fix a fatal error in the text post editor view.

### DIFF
--- a/modules/after-the-deadline/atd.core.js
+++ b/modules/after-the-deadline/atd.core.js
@@ -359,7 +359,8 @@ AtDCore.prototype.markMyWords = function(container_nodes, errors) {
 		ecount = 0, /* track number of highlighted errors */
 		parent = this,
 		bogus = this._isTinyMCE ? ' data-mce-bogus="1"' : '',
-		emptySpan = '<span class="mceItemHidden"' + bogus + '>&nbsp;</span>';
+		emptySpan = '<span class="mceItemHidden"' + bogus + '>&nbsp;</span>',
+		textOnlyMode;
 
 	/**
 	 * Split a text node into an ordered list of siblings:
@@ -489,9 +490,22 @@ AtDCore.prototype.markMyWords = function(container_nodes, errors) {
 							if ( parent.isIE() && node.nodeValue.length > 0 && node.nodeValue.substr(0, 1) === ' ' ) {
 								return parent.create( emptySpan + node.nodeValue.substr( 1, node.nodeValue.length - 1 ).replace( regexp, result ), false );
 							} else {
-								splitNodes = splitTextNode( node, regexp, result );
-								span = parent.create( '<span />' );
+								if ( textOnlyMode ) {
+									return parent.create( node.nodeValue.replace( regexp, result ), false );
+								}
 
+								span = parent.create( '<span />' );
+								if ( typeof textOnlyMode === 'undefined' ) {
+									// cache this to avoid adding / removing nodes unnecessarily
+									textOnlyMode = typeof span.appendChild !== 'function';
+									if ( textOnlyMode ) {
+										parent.remove( span );
+										return parent.create( node.nodeValue.replace( regexp, result ), false );
+									}
+								}
+
+								// "Visual" mode
+								splitNodes = splitTextNode( node, regexp, result );
 								for ( var i = 0; i < splitNodes.length; i++ ) {
 									span.appendChild( splitNodes[i] );
 								}


### PR DESCRIPTION
This applies the previous behavior (see #2382) when working in an environment that does not support calling appendChild on a node (aka, the wp-admin "text" editor -- as opposed to the "visual" editor)
Said environment is not vulnerable to XSS because the post contents are not parsed by the browser's rendering engine.

Upstream: https://github.com/Automattic/atd-core/pull/2

To reproduce the fatal js error ('undefined is not a function'), enable the module, create a new post or edit an existing one, switch to `Text`, click `proofread`. An error appears in the console & the page has to be reloaded in order to continue editing.