### PR TITLE
Publicize: remove help link

### DIFF
--- a/modules/publicize/assets/publicize-rtl.css
+++ b/modules/publicize/assets/publicize-rtl.css
@@ -94,21 +94,6 @@ div.publicize-service-right li {
 	font-size: 14px;
 }
 
-.publicize-info {
-	display: inline-block;
-	width: 16px;
-	height: 16px;
-	background-image: url( info-2x.png );
-	background-size: 16px 16px;
-	text-indent: -99999px;
-	float: right;
-	cursor: help;
-	text-decoration: none;
-	margin-left: 10px;
-	margin-top:3px;
-	font-size: 10%;
-}
-
 .pub-disconnect-button {
 	-webkit-border-image: none;
 	border-bottom-color: #CCC;

--- a/modules/publicize/assets/publicize.css
+++ b/modules/publicize/assets/publicize.css
@@ -94,21 +94,6 @@ div.publicize-service-right li {
 	font-size: 14px;
 }
 
-.publicize-info {
-	display: inline-block;
-	width: 16px;
-	height: 16px;
-	background-image: url( info-2x.png );
-	background-size: 16px 16px;
-	text-indent: -99999px;
-	float: left;
-	cursor: help;
-	text-decoration: none;
-	margin-right: 10px;
-	margin-top:3px;
-	font-size: 10%;
-}
-
 .pub-disconnect-button {
 	-webkit-border-image: none;
 	border-bottom-color: #CCC;

--- a/modules/publicize/assets/rtl/publicize-rtl.css
+++ b/modules/publicize/assets/rtl/publicize-rtl.css
@@ -96,21 +96,6 @@ div.publicize-service-right li {
 	font-size: 14px;
 }
 
-.publicize-info {
-	display: inline-block;
-	width: 16px;
-	height: 16px;
-	background-image: url( ../info-2x.png );
-	background-size: 16px 16px;
-	text-indent: -99999px;
-	float: right;
-	cursor: help;
-	text-decoration: none;
-	margin-left: 10px;
-	margin-top:3px;
-	font-size: 10%;
-}
-
 .pub-disconnect-button {
 	-webkit-border-image: none;
 	border-bottom-color: #CCC;

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -219,17 +219,9 @@ class Publicize_UI {
 									<a id="<?php echo esc_attr( $name ); ?>" class="publicize-add-connection button" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Connect', 'jetpack' ) ); ?></a>
 								<?php } else { ?>
 									<a id="<?php echo esc_attr( $name ); ?>" class="publicize-add-connection button add-new" href="<?php echo esc_url( $connect_url ); ?>" target="_top"><?php echo esc_html( __( 'Add New', 'jetpack' ) ); ?></a>
-								<?php } ?>
-
-
-							<?php
-							$help = apply_filters( 'publicize_help_text_' . $name, false );
-							if ( $help ) {
-								echo ' <a href="javascript:void(0);" title="' . esc_attr( $help ) . '" class="publicize-info">?</a>';
-							}
-							?>
-						</div>
-					</div>
+			  					<?php } ?>
+			  			</div>
+			  		</div>
 				<?php endforeach; ?>
 				</div>
 				<script>


### PR DESCRIPTION
That link never displayed any text.
It also used a non-existing image, so the link itself never appeared.