### PR TITLE
re-add a "disconnect" footer link that takes them to My Jetpack

### DIFF
--- a/_inc/footer.php
+++ b/_inc/footer.php
@@ -19,6 +19,9 @@
 					<a href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack-debugger' ) ); ?>" title="<?php esc_attr_e( 'Test your site&#8217;s compatibility with Jetpack.', 'jetpack' ); ?>"><?php _e( 'Debug', 'jetpack' ); ?></a>
 					<a href="http://jetpack.me/contact-support/" title="<?php esc_attr_e( 'Contact the Jetpack Happiness Squad.', 'jetpack' ); ?>"><?php _e( 'Support', 'jetpack' ); ?></a>
 					<a href="http://jetpack.me/survey/?rel=<?php echo JETPACK__VERSION; ?>" title="<?php esc_attr_e( 'Take a survey.  Tell us how we&#8217;re doing.', 'jetpack' ); ?>"><?php _e( 'Give Us Feedback', 'jetpack' ); ?></a>
+					<?php if ( current_user_can( 'jetpack_disconnect' ) ) : ?>
+						<a href="<?php echo esc_url( Jetpack::admin_url( 'page=my_jetpack#disconnect' ) ); ?>"><?php esc_html_e( 'Disconnect Jetpack', 'jetpack' ); ?></a>
+					<?php endif; ?>
 				</div>
 			</nav><!-- .secondary -->
 		</div><!-- .footer -->

--- a/_inc/jp-my-jetpack.js
+++ b/_inc/jp-my-jetpack.js
@@ -46,6 +46,14 @@
 	The function used to display the disconnect confirmation and support buttons
 	 */
 	function confirmJetpackDisconnect() {
+		if ( window.location.hash.substr( '#disconnect' ) ) {
+			$( '#jetpack-disconnect-content' ).show();
+			$( '#my-jetpack-content, .my-jetpack-actions' ).hide();
+
+			//Log My Jetpack event "wants to disconnect Jetpack" in MC Stats
+			new Image().src = data.stats_urls.disconnect_site;
+		}
+
 		$( '#jetpack-disconnect' ).click( function() {
 			$( '#jetpack-disconnect-content' ).show();
 			$( '#my-jetpack-content, .my-jetpack-actions' ).hide();


### PR DESCRIPTION
Takes them directly to the My Jetpack disconnect confirmation.  

Meant for back-compatibility (users are used to it there), and to be removed eventually.

Re-uses strings, so no need for another .pot file.  