### PR TITLE
Tighten up user privs

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -256,9 +256,9 @@ class Jetpack_Network {
 	 * @since 2.9
 	 */
 	public function add_network_admin_menu() {
-		add_menu_page( __('Jetpack', 'jetpack'), __('Jetpack', 'jetpack'), 'read', 'jetpack', array($this, 'network_admin_page'), 'div', 3);
-		add_submenu_page('jetpack', __('Jetpack Sites', 'jetpack'), __('Sites', 'jetpack'), 'manage_options', 'jetpack', array($this, 'network_admin_page'));
-		add_submenu_page('jetpack', __('Settings', 'jetpack'), __('Settings', 'jetpack'), 'read', 'jetpack-settings', array($this, 'render_network_admin_settings_page'));
+		add_menu_page( __('Jetpack', 'jetpack'), __('Jetpack', 'jetpack'), 'manage_network_plugins', 'jetpack', array($this, 'network_admin_page'), 'div', 3);
+		add_submenu_page('jetpack', __('Jetpack Sites', 'jetpack'), __('Sites', 'jetpack'), 'manage_sites', 'jetpack', array($this, 'network_admin_page'));
+		add_submenu_page('jetpack', __('Settings', 'jetpack'), __('Settings', 'jetpack'), 'manage_network_plugins', 'jetpack-settings', array($this, 'render_network_admin_settings_page'));
 
 		/**
 		 * As jetpack_register_genericons is by default fired off a hook,
@@ -357,6 +357,9 @@ class Jetpack_Network {
 	 * @see Jetpack_Network::jetpack_sites_list()
 	 */
 	public function do_subsitedisconnect( $site_id = null ) {
+		if ( ! current_user_can( 'jetpack_disconnect' ) ) {
+			return;
+		}
 		$site_id = ( is_null( $site_id ) ) ? $_GET['site_id']: $site_id;
 		switch_to_blog( $site_id );
 		Jetpack::disconnect();
@@ -371,6 +374,10 @@ class Jetpack_Network {
 	 * @see Jetpack_Network::jetpack_sites_list();
 	 */
 	public function do_subsiteregister( $site_id = null ) {
+		if ( ! current_user_can( 'jetpack_disconnect' ) ) {
+			return;
+		}
+
 		$jp = Jetpack::init();
 
 		// Figure out what site we are working on

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -256,9 +256,9 @@ class Jetpack_Network {
 	 * @since 2.9
 	 */
 	public function add_network_admin_menu() {
-		add_menu_page( __('Jetpack', 'jetpack'), __('Jetpack', 'jetpack'), 'manage_network_plugins', 'jetpack', array($this, 'network_admin_page'), 'div', 3);
-		add_submenu_page('jetpack', __('Jetpack Sites', 'jetpack'), __('Sites', 'jetpack'), 'manage_sites', 'jetpack', array($this, 'network_admin_page'));
-		add_submenu_page('jetpack', __('Settings', 'jetpack'), __('Settings', 'jetpack'), 'manage_network_plugins', 'jetpack-settings', array($this, 'render_network_admin_settings_page'));
+		add_menu_page( __( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_network_plugins', 'jetpack', array( $this, 'network_admin_page' ), 'div', 3 );
+		add_submenu_page( 'jetpack', __( 'Jetpack Sites', 'jetpack' ), __( 'Sites', 'jetpack' ), 'manage_sites', 'jetpack', array( $this, 'network_admin_page' ) );
+		add_submenu_page( 'jetpack', __( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'manage_network_plugins', 'jetpack-settings', array( $this, 'render_network_admin_settings_page' ) );
 
 		/**
 		 * As jetpack_register_genericons is by default fired off a hook,

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -766,6 +766,11 @@ class Jetpack {
 					$caps = array( 'manage_options' );
 					break;
 				}
+
+				if ( ! self::is_active() && ! current_user_can( 'jetpack_connect' ) ) {
+					$caps = array( 'do_not_allow' );
+					break;
+				}
 				/**
 				 * Pass through. If it's not development mode, these should match the admin page.
 				 * Let users disconnect if it's development mode, just in case things glitch.
@@ -3103,6 +3108,10 @@ p {
 				$client_server->authorize();
 				exit;
 			case 'register' :
+				if ( ! current_user_can( 'jetpack_connect' ) ) {
+					$error = 'cheatin';
+					break;
+				}
 				check_admin_referer( 'jetpack-register' );
 				Jetpack::log( 'register' );
 				Jetpack::maybe_set_version_option();
@@ -5947,7 +5956,7 @@ p {
 	public function wp_dashboard_setup() {
 		if ( self::is_active() ) {
 			add_action( 'jetpack_dashboard_widget', array( __CLASS__, 'dashboard_widget_footer' ), 999 );
-		} elseif ( ! self::is_development_mode() ) {
+		} elseif ( ! self::is_development_mode() && current_user_can( 'jetpack_connect' ) ) {
 			add_action( 'jetpack_dashboard_widget', array( $this, 'dashboard_widget_connect_to_wpcom' ) );
 		}
 
@@ -6040,6 +6049,9 @@ p {
 	}
 
 	public function dashboard_widget_connect_to_wpcom() {
+		if ( Jetpack::is_active() || Jetpack::is_development_mode() || ! current_user_can( 'jetpack_connect' ) ) {
+			return;
+		}
 		?>
 		<div class="wpcom-connect">
 			<div class="jp-emblem">


### PR DESCRIPTION
Don't show admin pages to those who shouldn't see it, don't let roles connect that shouldn't be able to, and don't show the dashboard widget to users who shouldn't see it.

props @georgestephanis 