### PR TITLE
Display Posts widget: switch to the current version of the API, 1.1

### DIFF
--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -42,7 +42,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		$site_hash = $this->get_site_hash( $site );
 		$data_from_cache = get_transient( 'display_posts_site_info_' . $site_hash );
 		if ( false === $data_from_cache ) {
-			$response = wp_remote_get( sprintf( 'https://public-api.wordpress.com/rest/v1/sites/%s', urlencode( $site ) ) );
+			$response = wp_remote_get( sprintf( 'https://public-api.wordpress.com/rest/v1.1/sites/%s', urlencode( $site ) ) );
 			set_transient( 'display_posts_site_info_' . $site_hash, $response, 10 * MINUTE_IN_SECONDS );
 		} else {
 			$response = $data_from_cache;
@@ -89,7 +89,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		if ( false === $data_from_cache ) {
 			$response = wp_remote_get(
 				sprintf(
-					'https://public-api.wordpress.com/rest/v1/sites/%1$d/posts/%2$s',
+					'https://public-api.wordpress.com/rest/v1.1/sites/%1$d/posts/%2$s',
 					$site_info->ID,
 					/**
 					 * Filters the parameters used to fetch for posts in the Display Posts Widget.


### PR DESCRIPTION
It will solve problems like the widget not returning Sticky posts (v1 excluded sticky posts from that query)

cc @dcoleonline, who originally reported the issue.