### PR TITLE
Social Links: check if the class doesn't already exist

### DIFF
--- a/modules/theme-tools/social-links.php
+++ b/modules/theme-tools/social-links.php
@@ -18,6 +18,8 @@ function jetpack_theme_supports_social_links() {
 }
 add_action( 'init', 'jetpack_theme_supports_social_links', 30 );
 
+if ( ! class_exists( 'Social_Links' ) {
+
 class Social_Links {
 
 	/**
@@ -224,8 +226,10 @@ class Social_Links {
 	/**
 	 * Back-compat function for versions prior to 4.0.
 	 */
-	private function is_customize_preview() { 
-		global $wp_customize; 
-		return is_a( $wp_customize, 'WP_Customize_Manager' ) && $wp_customize->is_preview(); 
-	} 
+	private function is_customize_preview() {
+		global $wp_customize;
+		return is_a( $wp_customize, 'WP_Customize_Manager' ) && $wp_customize->is_preview();
+	}
 }
+
+} // end if ( ! class_exists( 'Social_Links' )


### PR DESCRIPTION
Solves problems like the one reported here:
https://wordpress.org/support/topic/fatal-error-cannot-redeclare-class-social_links?replies=1&view=all