### PR TITLE
Autoupdates: add more data to the jetpack_updates option

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -110,11 +110,14 @@ class Jetpack_Autoupdate {
 
 		// Stores the individual update counts as well as the total count.
 		if ( isset( $update_data['counts'] ) ) {
-			$updates = $update_data['counts'];
+			$updates['counts'] = $update_data['counts'];
 		}
 
 		// Stores the current version of WordPress.
 		$updates['wp_version'] = $wp_version;
+		$updates['update_core'] = get_site_transient( 'update_core' );
+		$updates['update_plugins'] = get_site_transient( 'update_core' );
+		$updates['update_themes'] = get_site_transient( 'update_themes' );
 
 		// If we need to update WordPress core, let's find the latest version number.
 		if ( ! empty( $updates['wordpress'] ) ) {

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -97,22 +97,26 @@ class Jetpack_Autoupdate {
 
 	/**
 	 * Calculates available updates and saves them to a Jetpack Option
-	 * Update data is saved in the following schema:
+	 *
+	 * jetpack_updates is saved in the following schema:
 	 *
 	 * array (
-	 *      'plugins'                       => (int) number of plugin updates available
-	 *      'themes'                        => (int) number of theme updates available
-	 *      'wordpress'                     => (int) number of wordpress core updates available
-	 *      'translations'                  => (int) number of translation updates available
-	 *      'total'                         => (int) total of all available updates
-	 *      'wp_version'                    => (string) the current version of WordPress that is running
-	 *      'wp_update_version'             => (string) the latest available version of WordPress, only present if a WordPress update is needed
-	 *      'transients' => array(
-	 *          'update_core'               => (array) The contents of update_core transient
-	 *          'update_plugins'            => (array) The contents of update_plugins transient
-	 *          'update_themes'             => (array) The contents of update_themes transient
-	 *      )
+	 *      'plugins'                       => (int) Number of plugin updates available.
+	 *      'themes'                        => (int) Number of theme updates available.
+	 *      'wordpress'                     => (int) Number of WordPress core updates available.
+	 *      'translations'                  => (int) Number of translation updates available.
+	 *      'total'                         => (int) Total of all available updates.
+	 *      'wp_update_version'             => (string) The latest available version of WordPress, only present if a WordPress update is needed.
 	 * )
+	 *
+	 * jetpack_update_details is saved in the following schema:
+	 *
+	 * array (
+	 *      'update_core'       => (array) The contents of the update_core transient.
+	 *      'update_themes'     => (array) The contents of the update_themes transient.
+	 *      'update_plugins'    => (array) The contents of the update_plugins transient.
+	 * )
+	 *
 	 */
 	function save_update_data() {
 		global $wp_version;
@@ -123,12 +127,6 @@ class Jetpack_Autoupdate {
 		if ( isset( $update_data['counts'] ) ) {
 			$updates = $update_data['counts'];
 		}
-		
-		$updates['transients'] = array(
-			'update_core' => get_site_transient( 'update_core' ),
-			'update_plugins' => get_site_transient( 'update_plugins' ),
-			'update_themes' => get_site_transient( 'update_themes' ),
-		);
 
 		// If we need to update WordPress core, let's find the latest version number.
 		if ( ! empty( $updates['wordpress'] ) ) {
@@ -139,6 +137,14 @@ class Jetpack_Autoupdate {
 		}
 
 		Jetpack_Options::update_option( 'updates', $updates );
+
+		// Let's also store and sync more details about what updates are needed.
+		$update_details = array(
+			'update_core' => get_site_transient( 'update_core' ),
+			'update_plugins' => get_site_transient( 'update_plugins' ),
+			'update_themes' => get_site_transient( 'update_themes' ),
+		);
+		Jetpack_Options::update_option( 'update_details', $update_details );
 	}
 
 	/**

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -98,13 +98,18 @@ class Jetpack_Autoupdate {
 	 * Update data is saved in the following schema:
 	 *
 	 * array (
-	 *      'plugins'                       => (int) number of plugin updates available
-	 *      'themes'                        => (int) number of theme updates available
-	 *      'wordpress'                     => (int) number of wordpress core updates available
-	 *      'translations'                  => (int) number of translation updates available
-	 *      'total'                         => (int) total of all available updates
+	 *      'counts' => array(
+	 *          'plugins'                   => (int) number of plugin updates available
+	 *          'themes'                    => (int) number of theme updates available
+	 *          'wordpress'                 => (int) number of wordpress core updates available
+	 *          'translations'              => (int) number of translation updates available
+	 *          'total'                     => (int) total of all available updates
+	 *      )
 	 *      'wp_version'                    => (string) the current version of WordPress that is running
 	 *      'wp_update_version'             => (string) the latest available version of WordPress, only present if a WordPress update is needed
+	 *      'update_core'                   => (array) The contents of update_core transient
+	 *      'update_plugins'                => (array) The contents of update_plugins transient
+	 *      'update_themes'                 => (array) The contents of update_themes transient
 	 * )
 	 */
 	function save_update_data() {

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -130,6 +130,9 @@ class Jetpack_Autoupdate {
 
 		$update_data = wp_get_update_data();
 
+		// Stores the current version of WordPress.
+		$updates['wp_version'] = $wp_version;
+
 		// Stores the individual update counts as well as the total count.
 		if ( isset( $update_data['counts'] ) ) {
 			$updates = $update_data['counts'];

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -47,8 +47,10 @@ class Jetpack_Autoupdate {
 			add_action( 'set_site_transient_update_plugins', array( $this, 'save_update_data' ) );
 			add_action( 'set_site_transient_update_themes', array( $this, 'save_update_data' ) );
 			add_action( 'set_site_transient_update_core', array( $this, 'save_update_data' ) );
+
 			// Anytime a connection to jetpack is made, sync the update data
-			add_action( 'update_option_jetpack_blog_token', array( $this, 'save_update_data' ) );
+			add_action( 'jetpack_site_registered', array( $this, 'save_update_data' ) );
+
 			// Anytime the Jetpack Version changes, sync the the update data
 			add_action( 'updating_jetpack_version', array( $this, 'save_update_data' ) );
 		}

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -126,12 +126,7 @@ class Jetpack_Autoupdate {
 			return;
 		}
 
-		global $wp_version;
-
 		$update_data = wp_get_update_data();
-
-		// Stores the current version of WordPress.
-		$updates['wp_version'] = $wp_version;
 
 		// Stores the individual update counts as well as the total count.
 		if ( isset( $update_data['counts'] ) ) {

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -42,11 +42,15 @@ class Jetpack_Autoupdate {
 			add_action( 'shutdown', array( $this, 'log_results' ) );
 		}
 
-		// Anytime WordPress saves update data, we'll want to update our Jetpack option as well.
 		if ( is_main_site() ) {
+			// Anytime WordPress saves update data, we'll want to update our Jetpack option as well.
 			add_action( 'set_site_transient_update_plugins', array( $this, 'save_update_data' ) );
 			add_action( 'set_site_transient_update_themes', array( $this, 'save_update_data' ) );
 			add_action( 'set_site_transient_update_core', array( $this, 'save_update_data' ) );
+			// Anytime a connection to jetpack is made, sync the update data
+			add_action( 'update_option_jetpack_blog_token', array( $this, 'save_update_data' ) );
+			// Anytime the Jetpack Version changes, sync the the update data
+			add_action( 'updating_jetpack_version', array( $this, 'save_update_data' ) );
 		}
 
 	}
@@ -116,7 +120,7 @@ class Jetpack_Autoupdate {
 		// Stores the current version of WordPress.
 		$updates['wp_version'] = $wp_version;
 		$updates['update_core'] = get_site_transient( 'update_core' );
-		$updates['update_plugins'] = get_site_transient( 'update_core' );
+		$updates['update_plugins'] = get_site_transient( 'update_plugins' );
 		$updates['update_themes'] = get_site_transient( 'update_themes' );
 
 		// If we need to update WordPress core, let's find the latest version number.

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -120,9 +120,9 @@ class Jetpack_Autoupdate {
 	 */
 	function save_update_data() {
 
-		if ( ! current_user_can( 'update_plugins' ) ) {
-			// `wp_get_updated_data` will not return useful information if a user cannot manage plugins.
-			// We should should therefore bail to avoid saving incomplete data
+		if ( ! current_user_can( 'update_plugins' ) || ! current_user_can( 'update_core') || ! current_user_can( 'update_themes') ) {
+			// `wp_get_updated_data` will not return useful information if a user does not have the capabilities.
+			// We should should therefore bail to avoid saving incomplete data.
 			return;
 		}
 

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -98,18 +98,18 @@ class Jetpack_Autoupdate {
 	 * Update data is saved in the following schema:
 	 *
 	 * array (
-	 *      'counts' => array(
-	 *          'plugins'                   => (int) number of plugin updates available
-	 *          'themes'                    => (int) number of theme updates available
-	 *          'wordpress'                 => (int) number of wordpress core updates available
-	 *          'translations'              => (int) number of translation updates available
-	 *          'total'                     => (int) total of all available updates
-	 *      )
+	 *      'plugins'                       => (int) number of plugin updates available
+	 *      'themes'                        => (int) number of theme updates available
+	 *      'wordpress'                     => (int) number of wordpress core updates available
+	 *      'translations'                  => (int) number of translation updates available
+	 *      'total'                         => (int) total of all available updates
 	 *      'wp_version'                    => (string) the current version of WordPress that is running
 	 *      'wp_update_version'             => (string) the latest available version of WordPress, only present if a WordPress update is needed
-	 *      'update_core'                   => (array) The contents of update_core transient
-	 *      'update_plugins'                => (array) The contents of update_plugins transient
-	 *      'update_themes'                 => (array) The contents of update_themes transient
+	 *      'transients' => array(
+	 *          'update_core'               => (array) The contents of update_core transient
+	 *          'update_plugins'            => (array) The contents of update_plugins transient
+	 *          'update_themes'             => (array) The contents of update_themes transient
+	 *      )
 	 * )
 	 */
 	function save_update_data() {
@@ -119,14 +119,16 @@ class Jetpack_Autoupdate {
 
 		// Stores the individual update counts as well as the total count.
 		if ( isset( $update_data['counts'] ) ) {
-			$updates['counts'] = $update_data['counts'];
+			$updates = $update_data['counts'];
 		}
 
 		// Stores the current version of WordPress.
 		$updates['wp_version'] = $wp_version;
-		$updates['update_core'] = get_site_transient( 'update_core' );
-		$updates['update_plugins'] = get_site_transient( 'update_plugins' );
-		$updates['update_themes'] = get_site_transient( 'update_themes' );
+		$updates['transients'] = array(
+			'update_core' => get_site_transient( 'update_core' ),
+			'update_plugins' => get_site_transient( 'update_plugins' ),
+			'update_themes' => get_site_transient( 'update_themes' ),
+		);
 
 		// If we need to update WordPress core, let's find the latest version number.
 		if ( ! empty( $updates['wordpress'] ) ) {

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -123,9 +123,7 @@ class Jetpack_Autoupdate {
 		if ( isset( $update_data['counts'] ) ) {
 			$updates = $update_data['counts'];
 		}
-
-		// Stores the current version of WordPress.
-		$updates['wp_version'] = $wp_version;
+		
 		$updates['transients'] = array(
 			'update_core' => get_site_transient( 'update_core' ),
 			'update_plugins' => get_site_transient( 'update_plugins' ),

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -119,6 +119,13 @@ class Jetpack_Autoupdate {
 	 *
 	 */
 	function save_update_data() {
+
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			// `wp_get_updated_data` will not return useful information if a user cannot manage plugins.
+			// We should should therefore bail to avoid saving incomplete data
+			return;
+		}
+
 		global $wp_version;
 
 		$update_data = wp_get_update_data();

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -32,7 +32,8 @@ class Jetpack_Options {
 				'site_icon_url',               // (string) url to the full site icon
 				'site_icon_id',                // (int)    Attachment id of the site icon file
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
-				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
+				'updates',                     // (array) Information about available updates to plugins, theme, WordPress core, and if site is under version control.
+				'update_details',              // (array) Details from updated related transients: update_core, update_plugins, and update_themes.
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 				'protect_whitelist'            // (array) IP Address for the Protect module to ignore

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4594,6 +4594,8 @@ p {
 			)
 		);
 
+		do_action( 'jetpack_site_registered', $json->jetpack_id, $json->jetpack_secret, $jetpack_public );
+
 		// Initialize Jump Start for the first and only time.
 		if ( ! Jetpack_Options::get_option( 'jumpstart' ) ) {
 			Jetpack_Options::update_option( 'jumpstart', 'new_connection' );

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -329,7 +329,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					// If the sync happends right then we should be able to see that we are not dealing with a network site
 					$response['options']['is_multi_network'] = (bool) get_option( 'jetpack_is_main_network', true  );
 					$response['options']['is_multi_site'] = (bool) get_option( 'jetpack_is_multi_site', true );
-
+					// Show available updates
+					$response['options']['updates'] = get_option( 'jetpack_updates' );
 				}
 
 				if ( ! current_user_can( 'edit_posts' ) )

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -329,8 +329,14 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					// If the sync happends right then we should be able to see that we are not dealing with a network site
 					$response['options']['is_multi_network'] = (bool) get_option( 'jetpack_is_main_network', true  );
 					$response['options']['is_multi_site'] = (bool) get_option( 'jetpack_is_multi_site', true );
+
 					// Show available updates
-					$response['options']['updates'] = get_option( 'jetpack_updates' );
+					$updates = Jetpack_Options::get_option( 'jetpack_updates' );
+					if ( isset( $updates['transients'] ) ) {
+						// Transients can be quite large, and they are not needed on this endpoint.
+						unset( $updates['transients'] );
+					}
+					$response['options']['updates'] = $updates;
 				}
 
 				if ( ! current_user_can( 'edit_posts' ) )

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -329,7 +329,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					// If the sync happends right then we should be able to see that we are not dealing with a network site
 					$response['options']['is_multi_network'] = (bool) get_option( 'jetpack_is_main_network', true  );
 					$response['options']['is_multi_site'] = (bool) get_option( 'jetpack_is_multi_site', true );
-					
+
 				}
 
 				if ( ! current_user_can( 'edit_posts' ) )

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -330,13 +330,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$response['options']['is_multi_network'] = (bool) get_option( 'jetpack_is_main_network', true  );
 					$response['options']['is_multi_site'] = (bool) get_option( 'jetpack_is_multi_site', true );
 
-					// Show available updates
-					$updates = Jetpack_Options::get_option( 'updates' );
-					if ( isset( $updates['transients'] ) ) {
-						// Transients can be quite large, and they are not needed on this endpoint.
-						unset( $updates['transients'] );
-					}
-					$response['options']['updates'] = $updates;
+					// Show available updates.
+					$response['options']['updates'] = Jetpack_Options::get_option( 'updates' );
 				}
 
 				if ( ! current_user_can( 'edit_posts' ) )

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -331,7 +331,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$response['options']['is_multi_site'] = (bool) get_option( 'jetpack_is_multi_site', true );
 
 					// Show available updates
-					$updates = Jetpack_Options::get_option( 'jetpack_updates' );
+					$updates = Jetpack_Options::get_option( 'updates' );
 					if ( isset( $updates['transients'] ) ) {
 						// Transients can be quite large, and they are not needed on this endpoint.
 						unset( $updates['transients'] );

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -329,9 +329,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					// If the sync happends right then we should be able to see that we are not dealing with a network site
 					$response['options']['is_multi_network'] = (bool) get_option( 'jetpack_is_main_network', true  );
 					$response['options']['is_multi_site'] = (bool) get_option( 'jetpack_is_multi_site', true );
-
-					// Show available updates.
-					$response['options']['updates'] = Jetpack_Options::get_option( 'updates' );
+					
 				}
 
 				if ( ! current_user_can( 'edit_posts' ) )


### PR DESCRIPTION
The jetpack_updates options should also contain the contents of
the following core transients: update_core, update_plugins, update_themes.

jetpack_updates should be synced more regularly, not just when a transient is updated.

and jetpack_updates should be exposed on the /sites/$site, and /sites/me endpoints.