### PR TITLE
A fix to correct unique disconnect tracking

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -16,8 +16,9 @@ class Jetpack_Client_Server {
 		if ( ! $jetpack_unique_connection ) {
 			// jetpack_unique_connection option has never been set
 			$jetpack_unique_connection = array(
-				'connected' => 0,
-				'disconnected' => 0,
+				'connected'     => 0,
+				'disconnected'  => 0,
+				'version'       => '3.6.1'
 			);
 
 			update_option( 'jetpack_unique_connection', $jetpack_unique_connection );

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -25,7 +25,7 @@ class Jetpack_Client_Server {
 			//track unique connection
 			$jetpack = Jetpack::init();
 
-			$jetpack->stat( 'connectionstest', 'unique-connection' );
+			$jetpack->stat( 'connections', 'unique-connection' );
 			$jetpack->do_stats( 'server_side' );
 		}
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -25,7 +25,7 @@ class Jetpack_Client_Server {
 			//track unique connection
 			$jetpack = Jetpack::init();
 
-			$jetpack->stat( 'connections', 'unique-connection' );
+			$jetpack->stat( 'connectionstest', 'unique-connection' );
 			$jetpack->do_stats( 'server_side' );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2336,12 +2336,12 @@ p {
 
 		$jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' );
 		// Check then record unique disconnection if site has never been disconnected previously
-		if ( $jetpack_unique_connection['disconnected'] < 1 ) {
+		if ( $jetpack_unique_connection['disconnected'] == 1 ) {
 
 			//track unique disconnect
 			$jetpack = Jetpack::init();
 
-			$jetpack->stat( 'connections', 'unique-disconnect' );
+			$jetpack->stat( 'connectionstest', 'unique-disconnect' );
 			$jetpack->do_stats( 'server_side' );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -381,7 +381,7 @@ class Jetpack {
 			if ( ! get_option( 'jetpack_unique_connection' ) ) {
 				$jetpack_unique_connection = array(
 					'connected' => 1,
-					'disconnected' => 0,
+					'disconnected' => -1,
 				);
 				update_option( 'jetpack_unique_connection', $jetpack_unique_connection );
 			}
@@ -2336,17 +2336,21 @@ p {
 
 		$jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' );
 		// Check then record unique disconnection if site has never been disconnected previously
-		if ( $jetpack_unique_connection['disconnected'] == 1 ) {
+		if ( $jetpack_unique_connection['disconnected'] == -1 ) {
+			$jetpack_unique_connection['disconnected'] = 1;
+		}
+		else {
+			if ( $jetpack_unique_connection['disconnected'] == 0 ) {
+				//track unique disconnect
+				$jetpack = Jetpack::init();
 
-			//track unique disconnect
-			$jetpack = Jetpack::init();
-
-			$jetpack->stat( 'connectionstest', 'unique-disconnect' );
-			$jetpack->do_stats( 'server_side' );
+				$jetpack->stat( 'connections', 'unique-disconnect' );
+				$jetpack->do_stats( 'server_side' );
+			}
+			// increment number of times disconnected
+			$jetpack_unique_connection['disconnected'] += 1;
 		}
 
-		// increment number of times disconnected
-		$jetpack_unique_connection['disconnected'] += 1;
 		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
 
 		// Disable the Heartbeat cron

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2336,11 +2336,11 @@ p {
 
 		$jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' );
 		// Check then record unique disconnection if site has never been disconnected previously
-		if ( $jetpack_unique_connection['disconnected'] == -1 ) {
+		if ( -1 == $jetpack_unique_connection['disconnected'] ) {
 			$jetpack_unique_connection['disconnected'] = 1;
 		}
 		else {
-			if ( $jetpack_unique_connection['disconnected'] == 0 ) {
+			if ( 0 == $jetpack_unique_connection['disconnected'] ) {
 				//track unique disconnect
 				$jetpack = Jetpack::init();
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -378,10 +378,14 @@ class Jetpack {
 			}
 
 			//if Jetpack is connected check if jetpack_unique_connection exists and if not then set it
-			if ( ! get_option( 'jetpack_unique_connection' ) ) {
+			$jetpack_unique_connection = get_option( 'jetpack_unique_connection' );
+			if ( $jetpack_unique_connection && array_key_exists( 'version', $jetpack_unique_connection ) ) {
+				return;
+			} else {
 				$jetpack_unique_connection = array(
-					'connected' => 1,
-					'disconnected' => -1,
+					'connected'     => 1,
+					'disconnected'  => -1,
+					'version'       => '3.6.1'
 				);
 				update_option( 'jetpack_unique_connection', $jetpack_unique_connection );
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -379,9 +379,8 @@ class Jetpack {
 
 			//if Jetpack is connected check if jetpack_unique_connection exists and if not then set it
 			$jetpack_unique_connection = get_option( 'jetpack_unique_connection' );
-			if ( $jetpack_unique_connection && array_key_exists( 'version', $jetpack_unique_connection ) ) {
-				return;
-			} else {
+			$is_unique_connection = $jetpack_unique_connection && array_key_exists( 'version', $jetpack_unique_connection );
+			if ( ! $is_unique_connection ) {
 				$jetpack_unique_connection = array(
 					'connected'     => 1,
 					'disconnected'  => -1,


### PR DESCRIPTION
Previously connected sites (updated sites) will start with a value of -1 for `jetpack_unique_connection[disconnect]`.  This way we can differentiate between previously connected sites and newly connected sites while keeping the disconnect count accurate

Unique disconnects will only be tracked if the site was connected for the first time after 3.6