### PR TITLE
Landing page: change messaging

### DIFF
--- a/scss/templates/_nux-landing-2015.scss
+++ b/scss/templates/_nux-landing-2015.scss
@@ -76,6 +76,10 @@
 	padding-bottom: 20px;
 	text-align:center;
 
+	.connect-btn {
+		text-align:center;
+	}
+
 	#jumpstart-cta,
 	.jumpstart-desc {
 		padding: 0;

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -253,18 +253,15 @@
 </div><!-- .landing -->
 
 	<?php else : ?>
-		<div class="wpcom-connect">
-			<h1 title="<?php esc_attr_e( 'Boost traffic, enhance security, and improve performance.', 'jetpack' ); ?>"><?php esc_html_e( 'Boost traffic, enhance security, and improve performance.', 'jetpack' ); ?></h1>
+		<div id="jump-start-area" class="j-row">
+			<h1 title="Please Connect Jetpack."><?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?></h1>
 			<div class="j-row">
-				<div class="j-col j-sm-12 j-md-8 j-lrg-7 connect-desc">
-					<p><?php _e( 'Jetpack connects your site to WordPress.com to give you traffic and customization tools, enhanced security, speed boosts, and more.', 'jetpack' ); ?></p>
-					<p><?php _e( 'To start using Jetpack, connect to your WordPress.com account by clicking the button (if you don’t have an account you can create one quickly and for free).', 'jetpack' ); ?></p>
-				</div>
-				<div class="j-col j-sm-12 j-md-4 j-lrg-5 connect-btn">
+				<div class="j-col j-sm-12 j-md-8 connect-desc" style="float:none; margin:0 auto; text-align:center; padding-bottom:20px;">
+					<p><?php echo wp_kses( __( 'Connecting Jetpack will show you <strong>stats</strong> about your traffic, <strong>protect</strong> you from brute force attacks, <strong>speed up</strong> your images and photos, and enable other <strong>traffic and security</strong> features.' ), 'jetpack' ) ?></p>
 					<?php if ( ! $data['is_connected'] && current_user_can( 'jetpack_connect' ) ) : ?>
-						<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?></a>
+						<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect Jetpack', 'jetpack' ); ?></a>
 					<?php elseif ( $data['is_connected'] && ! $data['is_user_connected'] && current_user_can( 'jetpack_connect_user' ) ) : ?>
-						<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to WordPress.com', 'jetpack' ); ?></a>
+						<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to Jetpack', 'jetpack' ); ?></a>
 					<?php endif; ?>
 				</div>
 			</div>

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -260,7 +260,7 @@
 				<?php if ( ! $data['is_connected'] && current_user_can( 'jetpack_connect' ) ) : ?>
 					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect Jetpack', 'jetpack' ); ?></a>
 				<?php elseif ( $data['is_connected'] && ! $data['is_user_connected'] && current_user_can( 'jetpack_connect_user' ) ) : ?>
-					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to Jetpack', 'jetpack' ); ?></a>
+					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect your account', 'jetpack' ); ?></a>
 				<?php endif; ?>
 			</div>
 		</div>

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -254,7 +254,7 @@
 
 	<?php else : ?>
 		<div id="jump-start-area" class="j-row">
-			<h1 title="<?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?>"><?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?></h1>
+			<h1 title="<?php esc_attr_e( 'Please Connect Jetpack', 'jetpack' ); ?>"><?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?></h1>
 			<div class="j-row">
 				<div class="j-col j-sm-12 j-md-8 connect-desc" style="float:none; margin:0 auto; text-align:center; padding-bottom:20px;">
 					<p><?php echo wp_kses( __( 'Connecting Jetpack will show you <strong>stats</strong> about your traffic, <strong>protect</strong> you from brute force attacks, <strong>speed up</strong> your images and photos, and enable other <strong>traffic and security</strong> features.' ), 'jetpack' ) ?></p>

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -254,7 +254,7 @@
 
 	<?php else : ?>
 		<div id="jump-start-area" class="j-row">
-			<h1 title="Please Connect Jetpack."><?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?></h1>
+			<h1 title="<?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?>"><?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?></h1>
 			<div class="j-row">
 				<div class="j-col j-sm-12 j-md-8 connect-desc" style="float:none; margin:0 auto; text-align:center; padding-bottom:20px;">
 					<p><?php echo wp_kses( __( 'Connecting Jetpack will show you <strong>stats</strong> about your traffic, <strong>protect</strong> you from brute force attacks, <strong>speed up</strong> your images and photos, and enable other <strong>traffic and security</strong> features.' ), 'jetpack' ) ?></p>

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -255,15 +255,13 @@
 	<?php else : ?>
 		<div id="jump-start-area" class="j-row">
 			<h1 title="<?php esc_attr_e( 'Please Connect Jetpack', 'jetpack' ); ?>"><?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?></h1>
-			<div class="j-row">
-				<div class="j-col j-sm-12 j-md-8 connect-desc" style="float:none; margin:0 auto; text-align:center; padding-bottom:20px;">
-					<p><?php echo wp_kses( __( 'Connecting Jetpack will show you <strong>stats</strong> about your traffic, <strong>protect</strong> you from brute force attacks, <strong>speed up</strong> your images and photos, and enable other <strong>traffic and security</strong> features.' ), 'jetpack' ) ?></p>
-					<?php if ( ! $data['is_connected'] && current_user_can( 'jetpack_connect' ) ) : ?>
-						<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect Jetpack', 'jetpack' ); ?></a>
-					<?php elseif ( $data['is_connected'] && ! $data['is_user_connected'] && current_user_can( 'jetpack_connect_user' ) ) : ?>
-						<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to Jetpack', 'jetpack' ); ?></a>
-					<?php endif; ?>
-				</div>
+			<div class="connect-btn j-col j-sm-12 j-md-12">
+				<p><?php echo wp_kses( __( 'Connecting Jetpack will show you <strong>stats</strong> about your traffic, <strong>protect</strong> you from brute force attacks, <strong>speed up</strong> your images and photos, and enable other <strong>traffic and security</strong> features.' ), 'jetpack' ) ?></p>
+				<?php if ( ! $data['is_connected'] && current_user_can( 'jetpack_connect' ) ) : ?>
+					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect Jetpack', 'jetpack' ); ?></a>
+				<?php elseif ( $data['is_connected'] && ! $data['is_user_connected'] && current_user_can( 'jetpack_connect_user' ) ) : ?>
+					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to Jetpack', 'jetpack' ); ?></a>
+				<?php endif; ?>
 			</div>
 		</div>
 	<?php endif; ?>


### PR DESCRIPTION
Making messaging simpler and consistent as per P2 thread.

This change includes:
- A call to action that says “Connect Jetpack” to match with what we’re
asking the user to do
- A heading saying “Please Connect Jetpack”
- A simpler line of descriptive text highlighting the key features
- Centre aligned text and Jump Start style box