### PR TITLE
Add/plans

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -36,6 +36,7 @@ class Jetpack_Options {
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
+				'subscriptions',               // (array) An array of subscriptions that the site has.
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -36,7 +36,7 @@ class Jetpack_Options {
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
-				'subscriptions',               // (array) An array of subscriptions that the site has.
+				'upgrades',                    // (array) An array of upgrades that the site has.
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -35,7 +35,7 @@ class Jetpack_Options {
 				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
-				'protect_whitelist'            // (array) IP Address for the Protect module to ignore
+				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -25,6 +25,8 @@ jetpack_do_activate (bool)
 // Upgrade product IDs
 define( 'WPCOM_VIDEOPRESS', 15 );
 define( 'WPCOM_VIDEOPRESS_PRO', 47 );
+define( 'WPCOM_JETPACK_PREMIUM', 2000 );
+define( 'WPCOM_JETPACK_BUSINESS', 2001 );
 
 class Jetpack {
 	var $xmlrpc_server = null;
@@ -6100,7 +6102,11 @@ p {
 		$blog_id = Jetpack_Options::get_option( 'id' );
 
 		// If we need to force a refresh, or our data is either not there, or more than a week out of date…
-		if ( $force_refresh || empty( $data['last-checked'] ) || ( $data['last-checked'] < strtotime( '-1 week' ) ) ) {
+		if (
+			$force_refresh
+			|| empty( $data['last-checked'] )
+			|| ( $data['last-checked'] < strtotime( '-1 week' ) )
+		) {
 
 			$response = Jetpack_Client::wpcom_json_api_request_as_blog(
 				'/sites/' . $blog_id . '/upgrades',
@@ -6113,23 +6119,22 @@ p {
 			$result = json_decode( wp_remote_retrieve_body( $response ) );
 
 			$parsed_upgrades = array();
-			if ( is_array( $result ) ) {
-				foreach ( $result as $upgrade ) {
+			if ( is_object( $result ) && is_array( $result->upgrades ) ) {
+				foreach ( $result->upgrades as $upgrade ) {
 					$parsed_upgrades[] = array(
 						'wpcom_blog_id' => $blog_id,
-						'product_id'    => $upgrade['product_id'],
-						'expiration'    => strtotime( $upgrade['expiry'] ),
+						'product_id'    => $upgrade->product_id,
+						'expiration'    => strtotime( $upgrade->expiry ),
 					);
 				}
 			}
 
-			Jetpack_Options::update_option(
-				'upgrades',
-				array(
-					'last-checked'  => time(),
-					'upgrades' => $parsed_upgrades,
-				)
+			$data = array(
+				'last-checked'  => time(),
+				'upgrades' => $parsed_upgrades,
 			);
+
+			Jetpack_Options::update_option( 'upgrades', $data );
 		}
 
 		return $data['upgrades'];

--- a/modules/videopress/videopress.php
+++ b/modules/videopress/videopress.php
@@ -63,6 +63,27 @@ class Jetpack_VideoPress {
 		add_filter( 'videopress_shortcode_options', array( $this, 'videopress_shortcode_options' ) );
 	}
 
+	/**
+	 * Returns true if the current site has VideoPress upgrades active.
+	 *
+	 * @return Boolean
+	 */
+	static public function has_active_upgrade() {
+		$upgrades = Jetpack::get_site_upgrades();
+
+		foreach ( $upgrades as $upgrade ) {
+			if (
+				$upgrade['product_id'] === WPCOM_VIDEOPRESS
+				|| $upgrade['product_id'] === WPCOM_VIDEOPRESS
+				|| $upgrade['product_id'] === WPCOM_JETPACK_BUSINESS
+				|| $upgrade['product_id'] === WPCOM_JETPACK_PREMIUM
+			) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	function wp_ajax_videopress_get_upload_token() {
 		if ( ! $this->can( 'upload_videos' ) )
 			return wp_send_json_error();


### PR DESCRIPTION
New Jetpack fn to let Jetpack side query wpcom to find out if there's any subscriptions attached to the current site.

Not used yet, but necessary for VideoPress migration to per-Jetpack-site.

I'm also unsure if we should change this to query a WPCOM REST API endpoint instead of via a custom xmlrpc one that gives subscription info instead.  cc: @beaulebens @zinigor ?  We have the ability to query wpcom rest api endpoints with a site token, if the endpoints are configured to accept it.