### PR TITLE
Stop hiding the WP admin footer in Jetpack admin pages

### DIFF
--- a/scss/templates/_main.scss
+++ b/scss/templates/_main.scss
@@ -1134,7 +1134,6 @@ body {
 	position: relative;
 	padding: em(140px) 0 em(60px);
 	text-align: center;
-	//@include gradient--vertical(lighten($green, 5%), $green);
 
 	&:before,
 	&:after {
@@ -1148,20 +1147,16 @@ body {
 		margin-top: -1px; // Removes subpixel gap on retina landscape
 		width: 100%;
 		height: 195px;
-		//background: url('../images/the-undercloud.svg') center top repeat-x;
 	}
 	&:after {
 		display: none;
-		/* bottom: 0;
-		width: 100%;
-		height: 50px;
-		background: url('../images/the-footcloud.svg') center bottom no-repeat;
-		background-size: auto 45px;
-		z-index: 1; */
 	}
 	.download-jetpack {
 		margin-bottom: 33px;
 	}
+	@include minbreakpoint(large-desktop){
+			padding-bottom: 35px;
+	};
 	@include breakpoint(large-desktop) {
 		padding-top: 165px;
 		padding-bottom: 0;
@@ -1244,6 +1239,9 @@ body {
 		margin-bottom: 30px;
 		border-bottom: 1px solid #eee;
 	};
+	@include minbreakpoint(large-desktop){
+			margin-bottom: 0;
+	};
 	@include breakpoint(tablet){
 		padding: 8px 15px 8px;
 		border-bottom: none;
@@ -1299,6 +1297,10 @@ body {
 		@include minbreakpoint(tablet){
 			padding: 0 15px 10px 15px;
 			border-bottom: 1px solid #eee;
+		}
+		@include minbreakpoint(large-desktop){
+			padding: 0 15px 10px 15px;
+			border-bottom: none;
 		}
 }
 

--- a/scss/templates/_main.scss
+++ b/scss/templates/_main.scss
@@ -31,9 +31,6 @@ ul#adminmenu a.toplevel_page_jetpack:after {
 .folded #wpcontent {
 	margin-left: 36px;
 }
-#wpfooter {
-	display: none;
-}
 
 .jp-content {
 	background: $clouds;

--- a/scss/templates/_main.scss
+++ b/scss/templates/_main.scss
@@ -1151,12 +1151,13 @@ body {
 		//background: url('../images/the-undercloud.svg') center top repeat-x;
 	}
 	&:after {
-		bottom: 0;
+		display: none;
+		/* bottom: 0;
 		width: 100%;
 		height: 50px;
 		background: url('../images/the-footcloud.svg') center bottom no-repeat;
 		background-size: auto 45px;
-		z-index: 1;
+		z-index: 1; */
 	}
 	.download-jetpack {
 		margin-bottom: 33px;
@@ -1168,9 +1169,9 @@ body {
 		&:before {
 			background-size: 160% auto;
 		}
-		&:after {
+		/*&:after {
 			display: none;
-		}
+		}*/
 		ul {
 			float: none;
 			overflow: hidden; // Clears the float
@@ -1192,7 +1193,6 @@ body {
 }
 .footer nav {
 	max-width: 100%;
-	// color: #c8e3a2;
 
 	a,
 	a:visited {
@@ -1206,14 +1206,12 @@ body {
 		}
 	}
 	@include breakpoint(large-desktop){
-		border: none;
-		padding: 0;
 
 		a,
 		a:visited {
 			&:hover,
 			&:focus {
-				color: #fff;
+				color: $green;
 			}
 		}
 	};
@@ -1241,9 +1239,14 @@ body {
 	li {
 		margin-right: 5px;
 	}
-	@include breakpoint(large-desktop){
-		margin: 0 30px;
-		padding: 8px 15px 30px;
+	@include minbreakpoint(tablet){
+		padding: 8px 15px 10px;
+		margin-bottom: 30px;
+		border-bottom: 1px solid #eee;
+	};
+	@include breakpoint(tablet){
+		padding: 8px 15px 8px;
+		border-bottom: none;
 	};
 	@include breakpoint(large-phone){
 		margin: 0;
@@ -1291,13 +1294,12 @@ body {
 			}
 		}
 	}
-	/*@include breakpoint(large-desktop){
-		display: none;
-	};*/
 }
 .secondary {
-	padding: 10px 15px 0 15px;
-	//border-top: 1px solid #8eb345;
+		@include minbreakpoint(tablet){
+			padding: 0 15px 10px 15px;
+			border-bottom: 1px solid #eee;
+		}
 }
 
 


### PR DESCRIPTION
Is there some reason we were hiding this in the first place?  I think we should include it.  

fixes #1863

(run grunt to see change)