### PR TITLE
Make sure oEmbeds are videos before adding responsive videos filter

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -11,9 +11,13 @@ function jetpack_responsive_videos_init() {
 
 	/* If the theme does support 'jetpack-responsive-videos', wrap the videos */
 	add_filter( 'wp_video_shortcode', 'jetpack_responsive_videos_embed_html' );
-	add_filter( 'embed_oembed_html',  'jetpack_responsive_videos_embed_html' );
 	add_filter( 'video_embed_html',   'jetpack_responsive_videos_embed_html' );
-
+	
+	/* Check to make sure the content is a video before applying to oEmbeds */
+	if ( ! empty( get_media_embedded_in_content( 'video' ) ) ) {
+		add_filter( 'embed_oembed_html',  'jetpack_responsive_videos_embed_html' );
+	}
+	
 	/* Wrap videos in Buddypress */
 	add_filter( 'bp_embed_oembed_html', 'jetpack_responsive_videos_embed_html' );
 


### PR DESCRIPTION
Check oEmbeds for the presence of a video before adding the responsive videos filter. This prevents a bug where jetpack-video-wrapper was applied to non-video oEmbeds, like tweets from Twitter.