### PR TITLE
Don't show the Jetpack admin page to subscribers

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -770,6 +770,12 @@ class Jetpack {
 					break;
 				}
 
+				// Don't ever show to subscribers
+				if ( ! current_user_can( 'edit_posts' ) ) {
+					$caps = array( 'do_not_allow' );
+					break;
+				}
+
 				if ( ! self::is_active() && ! current_user_can( 'jetpack_connect' ) ) {
 					$caps = array( 'do_not_allow' );
 					break;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6069,7 +6069,7 @@ p {
 
 
 		<?php if ( ! current_user_can( 'edit_posts' ) && self::is_user_connected() ) : ?>
-			<a class="button" title="<?php esc_attr_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?>" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'unlink', 'redirect' => 'sub-unlink' ), admin_url( 'index.php' ) ), 'jetpack-unlink' ) ); ?>"><?php esc_html_e( 'Unlink my account ', 'jetpack' ); ?></a>
+			<div style="width: 100%; text-align: center; padding-top: 20px; clear: both;"><a class="button" title="<?php esc_attr_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?>" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'unlink', 'redirect' => 'sub-unlink' ), admin_url( 'index.php' ) ), 'jetpack-unlink' ) ); ?>"><?php esc_html_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?></a></div>
 		<?php endif; ?>
 
 		</footer>


### PR DESCRIPTION
Related conversations: 
#2305
https://a8c.slack.com/archives/jetpack/p1437757796000257

The first commit simply removes all UI, thus not allowing any subs who are currently linked to be able to unlink.  

The second commit adds the ability for them to do so via the dashboard widget.  My fear with this is that it may be over-engineered for such a small edge-case.  

Thoughts? 