### PR TITLE
Sharing / Likes: make sure you can disable them on front page.

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -932,7 +932,7 @@ class Jetpack_Likes {
 				}
 
 			// Single page
-			} elseif ( is_page() ) {
+			} elseif ( is_page() && ! is_front_page() ) {
 				if ( ! $this->is_single_page_enabled() ) {
 					$enabled = false;
 				}

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -620,7 +620,7 @@ function sharing_display( $text = '', $echo = false ) {
 	if ( !is_feed() ) {
 		if ( is_singular() && in_array( get_post_type(), $global['show'] ) ) {
 			$show = true;
-		} elseif ( in_array( 'index', $global['show'] ) && ( is_home() || is_archive() || is_search() || in_array( get_post_type(), $global['show'] ) ) ) {
+		} elseif ( in_array( 'index', $global['show'] ) && ( is_home() || is_front_page() || is_archive() || is_search() || in_array( get_post_type(), $global['show'] ) ) ) {
 			$show = true;
 		}
 	}


### PR DESCRIPTION
This commit fixes the following issue:
1. In Settings > Reading, set a custom front page.
2. In Settings > Sharing, enable shares and likes on front page, but not on pages.
3. Go to your front page: shares and likes don't appear. You have to select Pages in Settings > Sharing for them to appear.

You can now enable Likes and Shares on your front page without enabling theme on all other pages of your site.

Reported here:
https://wordpress.org/support/topic/jetpack-not-showing-social-buttons-on-customizr-front-page

I've tested multiple scenarios, and all seem to work as expected now:
- Shares enabled only on front page.
- Shares enabled on front page and pages.
- Shares enabled only on front page but disabled just for that front page.
- Shares enabled on front page and pages, and disabled just for that front page.

I'd be happy if someone else could test this, though.