### PR TITLE
JSON API: fix notice when VideoPress is not configured.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -198,8 +198,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				} else {
 					if ( class_exists( 'Jetpack_Options' ) ) {
 						$videopress = Jetpack_Options::get_option( 'videopress', array() );
-						if ( $videopress['blog_id'] > 0 )
+						if ( isset( $videopress['blog_id'] ) && $videopress['blog_id'] > 0 ) {
 							$has_videopress = true;
+						}
 					}
 				}
 


### PR DESCRIPTION
Avoids notices like this one:
```
PHP Notice: Undefined index: blog_id in /wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php on line 201
```