### PR TITLE
Fix to allow the Protect math form to work with wp_login_form()

### DIFF
--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -122,7 +122,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			          '<input type="input" name="jetpack_protect_num" value="" size="2" />' .
 			          '<input type="hidden" name="jetpack_protect_answer" value="' . $ans . '" />';
 
-			if ( $echo !== false ) {
+			if ( false !== $echo ) {
 				echo '<div style="margin: 5px 0 20px;">' . $output . '</div>';
 			} else {
 				return '<p class="jetpack-prove-humanity">' . $output . '</p>';

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -17,6 +17,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			self::$loaded = 1;
 
 			add_action( 'login_form', array( $this, 'math_form' ) );
+			add_filter( 'login_form_middle', array( $this, 'math_form_middle' ) );
 
 			if( isset( $_POST[ 'jetpack_protect_process_math_form' ] ) ) {
 				add_action( 'init', array( $this, 'process_generate_math_page' ) );
@@ -105,22 +106,37 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 		/**
 		 * Requires a user to solve a simple equation. Added to any WordPress login form.
 		 *
-		 * @return VOID outputs html
+		 * @param boolean $echo Default to echo and not return the equation fields.
+		 *
+		 * @return VOID|String outputs or returns html
 		 */
-		static function math_form() {
+		static function math_form( $echo = true ) {
 			$salt = get_site_option( 'jetpack_protect_key' ) . get_site_option( 'admin_email' );
 			$num1 = rand( 0, 10 );
 			$num2 = rand( 1, 10 );
 			$sum  = $num1 + $num2;
 			$ans  = sha1( $salt . $sum );
-			?>
-			<div style="margin: 5px 0 20px;">
-				<strong><?php esc_html_e( 'Prove your humanity:', 'jetpack' ); ?> </strong>
-				<?php echo $num1 ?> &nbsp; + &nbsp; <?php echo $num2 ?> &nbsp; = &nbsp;
-				<input type="input" name="jetpack_protect_num" value="" size="2" />
-				<input type="hidden" name="jetpack_protect_answer" value="<?php echo $ans; ?>" />
-			</div>
-		<?php
+
+			$output = '<strong>' . esc_html( 'Prove your humanity:', 'jetpack' ) . ' </strong>' .
+			          $num1 . ' &nbsp; + &nbsp; ' . $num2 . ' &nbsp; = &nbsp;' .
+			          '<input type="input" name="jetpack_protect_num" value="" size="2" />' .
+			          '<input type="hidden" name="jetpack_protect_answer" value="' . $ans . '" />';
+
+			if ( $echo !== false ) {
+				echo '<div style="margin: 5px 0 20px;">' . $output . '</div>';
+			} else {
+				return '<p class="jetpack_prove_humanity">' . $output . '</p>';
+			}
+		}
+
+
+		/**
+		 * Retrieves the non-echo version of the math form for use within custom login forms using wp_login_form()
+		 *
+		 * @return String returns html
+		 */
+		static function math_form_middle() {
+			return Jetpack_Protect_Math_Authenticate::math_form( false );
 		}
 
 	}

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -125,7 +125,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			if ( $echo !== false ) {
 				echo '<div style="margin: 5px 0 20px;">' . $output . '</div>';
 			} else {
-				return '<p class="jetpack_prove_humanity">' . $output . '</p>';
+				return '<p class="jetpack-prove-humanity">' . $output . '</p>';
 			}
 		}
 

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -117,7 +117,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			$sum  = $num1 + $num2;
 			$ans  = sha1( $salt . $sum );
 
-			$output = '<strong>' . esc_html( 'Prove your humanity:', 'jetpack' ) . ' </strong>' .
+			$output = '<strong>' . esc_html__( 'Prove your humanity:', 'jetpack' ) . ' </strong>' .
 			          $num1 . ' &nbsp; + &nbsp; ' . $num2 . ' &nbsp; = &nbsp;' .
 			          '<input type="input" name="jetpack_protect_num" value="" size="2" />' .
 			          '<input type="hidden" name="jetpack_protect_answer" value="' . $ans . '" />';

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -133,10 +133,12 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 		/**
 		 * Retrieves the non-echo version of the math form for use within custom login forms using wp_login_form()
 		 *
+		 * @param string $content Content to display. Default empty.
+		 *
 		 * @return String returns html
 		 */
-		static function math_form_middle() {
-			return Jetpack_Protect_Math_Authenticate::math_form( false );
+		static function math_form_middle( $content ) {
+			return $content . Jetpack_Protect_Math_Authenticate::math_form( false );
 		}
 
 	}


### PR DESCRIPTION
When generating a custom login form using wp_login_form() the Protect feature does not work properly due to the 'login_form' action not being called. The end result is that after you fill out the custom login form you're redirected to an intermediary page that has the "Prove your humanity" form on it.  Then, once you successfully answer the match question, you're redirected again to the main login form, which defeats the purpose of creating a custom login form in the first place. The attached screenshots demonstrate the flow experienced when using a custom login form and having Protect enabled.

![custom-login-step-1](https://cloud.githubusercontent.com/assets/1394549/9020227/788b87c2-37c5-11e5-8914-d372914d9ad2.png)

After successfully entering a username/password, the user is then directed to the math question:
![custom-login-step-2](https://cloud.githubusercontent.com/assets/1394549/9020229/788e9688-37c5-11e5-9900-f77b129c867d.png)

And then back to the default site login screen:
![custom-login-step-3](https://cloud.githubusercontent.com/assets/1394549/9020228/788e3fb2-37c5-11e5-9f87-545155d6cc00.png)




This patch modifies the Jetpack_Protect_Math_Authenticate::math_form() method to allow it to both directly echo or return an HTML string. Then, using the 'login_form_middle' filter that runs within the wp_login_form() function, the math problem can be successfully inserted into custom login forms without breaking the login flow. When it is inserted via the 'login_form_middle' filter I also have it use a container tag and class more fitting with the other elements output from wp_login_form().