### PR TITLE
Revert Facebook share count requests to use Facebook API

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -503,25 +503,10 @@ function sharing_add_footer() {
 		if ( apply_filters( 'jetpack_sharing_counts', true ) && is_array( $jetpack_sharing_counts ) && count( $jetpack_sharing_counts ) ) :
 			$sharing_post_urls = array_filter( $jetpack_sharing_counts );
 			if ( $sharing_post_urls ) :
-
-				/**
-				 * Defines whether a blog is a Jetpack site.
-				 *
-				 * @since 3.6.0
-				 *
-				 * @param bool false    Assumption on whether a blog is a Jetpack site.
-				 * @param int  $blog_id A blog ID to check.
-				 */
-				$is_jetpack = true === apply_filters( 'is_jetpack_site', false, get_current_blog_id() );
-				$site_id = $is_jetpack ? Jetpack_Options::get_option( 'id' ) : get_current_blog_id();
 ?>
 
 	<script type="text/javascript">
 		window.WPCOM_sharing_counts = <?php echo json_encode( array_flip( $sharing_post_urls ) ); ?>;
-		window.WPCOM_jetpack = <?php echo var_export( $is_jetpack, true ); ?>;
-		<?php if ( is_int( $site_id ) ): ?>
-		window.WPCOM_site_ID = <?php echo $site_id ?>;
-		<?php endif; ?>
 	</script>
 <?php
 			endif;

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -5,8 +5,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 		done_urls : [],
 		twitter_count : {},
 		get_counts : function() {
-			var facebookPostIds = [],
-				https_url, http_url, url, urls, id, service, service_url, path_ending;
+			var https_url, http_url, url, urls, id, service, service_url;
 
 			if ( 'undefined' === typeof WPCOM_sharing_counts ) {
 				return;
@@ -40,13 +39,14 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 						window.location.protocol +
 							'//api.pinterest.com/v1/urls/count.json?callback=WPCOMSharing.update_pinterest_count&url=' +
 							encodeURIComponent( url )
+					],
+					// Facebook protocol summing has been shown to falsely double counts, so we only request the current URL
+					facebook: [
+						window.location.protocol +
+							'//graph.facebook.com/?callback=WPCOMSharing.update_facebook_count&ids=' +
+							encodeURIComponent( url )
 					]
 				};
-
-				if ( jQuery( 'a[data-shared=sharing-facebook-' + id  + ']' ).length ) {
-					WPCOMSharing.bump_sharing_count_stat( 'facebook' );
-					facebookPostIds.push( id );
-				}
 
 				for ( service in urls ) {
 					if ( ! jQuery( 'a[data-shared=sharing-' + service + '-' + id  + ']' ).length ) {
@@ -61,17 +61,6 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				}
 
 				WPCOMSharing.done_urls[ id ] = true;
-			}
-
-			if ( facebookPostIds.length && ( 'WPCOM_site_ID' in window ) ) {
-				path_ending = window.WPCOM_jetpack ? 'jetpack-count' : 'count';
-				jQuery.ajax({
-					dataType: 'jsonp',
-					url: 'https://public-api.wordpress.com/rest/v1.1/sites/' + window.WPCOM_site_ID + '/sharing-buttons/facebook/' + path_ending,
-					jsonpCallback: 'WPCOMSharing.update_facebook_count',
-					data: { post_ID: facebookPostIds },
-					cache: true
-				});
 			}
 		},
 
@@ -100,21 +89,25 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 
 			return url;
 		},
-		update_facebook_count : function( data ) {
-			var index, length, post;
+		update_facebook_count: function( data ) {
+			var url, permalink;
 
-			if ( ! data || ! data.counts ) {
+			if ( ! data ) {
 				return;
 			}
 
-			for ( index = 0, length = data.counts.length; index < length; index++ ) {
-				post = data.counts[ index ];
-
-				if ( ! post.post_ID || ! post.count ) {
+			for ( url in data ) {
+				if ( ! data.hasOwnProperty( url ) || ! data[ url ].shares ) {
 					continue;
 				}
 
-				WPCOMSharing.inject_share_count( 'sharing-facebook-' + post.post_ID, post.count );
+				permalink = WPCOMSharing.get_permalink( url );
+
+				if ( ! ( permalink in WPCOM_sharing_counts ) ) {
+					continue;
+				}
+
+				WPCOMSharing.inject_share_count( 'sharing-facebook-' + WPCOM_sharing_counts[ permalink ], data[ url ].shares );
 			}
 		},
 		update_twitter_count : function( data ) {


### PR DESCRIPTION
Related: #1946

Despite the Facebook Graph API v1 [being sunsetted on April 30th](https://href.li/?https://developers.facebook.com/docs/apps/changelog), it appears that Facebook has made an exception for the endpoint from which sharing counts are made available. This means that we should no longer make requests to the WordPress.com REST API, but instead perform them directly against the Facebook Graph API.

See related Facebook Developer bug report, with official response that "not requiring an access token is intended and expected behavior".

https://developers.facebook.com/bugs/1461118160858999