### PR TITLE
Add 'author' field to the themes endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
@@ -18,6 +18,7 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 		'screenshot'   => '(string) A theme screenshot URL',
 		'name'         => '(string) The name of the theme.',
 		'description'  => '(string) A description of the theme.',
+		'author'       => '(string) The author of the theme.',
 		'tags'         => '(array) Tags indicating styles and features of the theme.',
 		'log'          => '(array) An array of log strings',
 		'autoupdate'   => '(bool) Whether the theme is automatically updated',
@@ -93,6 +94,7 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 		$fields = array(
 			'name'        => 'Name',
 			'description' => 'Description',
+			'author'      => 'Author',
 			'tags'        => 'Tags',
 			'version'     => 'Version'
 		);


### PR DESCRIPTION
This is required for the Calypso theme showcase;
specifically for theme activation, when we display a
'Thanks for choosing "Theme" by "Author" message'.