### PR TITLE
VideoPress overhaul: new upgrade handling and video management.

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -36,6 +36,7 @@ class Jetpack_Options {
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
+				'subscriptions',               // (array) An array of subscriptions that the site has.
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -36,7 +36,7 @@ class Jetpack_Options {
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
-				'subscriptions',               // (array) An array of subscriptions that the site has.
+				'upgrades',                    // (array) An array of upgrades that the site has.
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -35,7 +35,7 @@ class Jetpack_Options {
 				'updates',                     // (array) information about available updates to plugins, theme, WordPress core, and if site is under version control
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
-				'protect_whitelist'            // (array) IP Address for the Protect module to ignore
+				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5756,6 +5756,52 @@ p {
 		<?php
 	}
 
+	/**
+	 * Find out whether the current site has any subscriptions.
+	 *
+	 * Subscription could be anything from VideoPress to the Akismet+VaultPress Bundle.
+	 *
+	 * @param $force_refresh bool Whether to force a call to wpcom to verify subscriptions, or to trust the cached data.
+	 * @return mixed False for no subscriptions, otherwise an array of subscriptions.
+	 */
+	public static function get_site_subscriptions( $force_refresh = false ) {
+		$data = Jetpack_Options::get_option( 'subscriptions', array() );
+
+		// If we need to force a refresh, or our data is either not there, or more than a week out of date…
+		if ( $force_refresh || empty( $data['last-checked'] ) || ( $data['last-checked'] < strtotime( '-1 week' ) ) ) {
+
+			Jetpack::load_xml_rpc_client();
+			$ixr = new Jetpack_IXR_Client( array( 'user_id' => JETPACK_MASTER_USER, ) );
+			$ixr->query( 'jetpack.getSiteSubscriptions' );
+			if ( $ixr->isError() ) {
+				return new WP_Error( 'xmlrpc-error', __( 'XML-RPC Error.' ), $ixr );
+			}
+			$remote_subscriptions = $ixr->getResponse();
+
+			$parsed_subscriptions = array();
+			if ( is_array( $remote_subscriptions ) ) {
+				foreach ( $remote_subscriptions as $sub ) {
+					$parsed_subscriptions[] = array(
+						'wpcom_blog_id' => Jetpack_Options::get_option( 'id' ),
+						'expiration'    => $sub['expiration'],
+						'slug'          => $sub['slug'],
+						'name'          => $sub['name'], // Note that this will likely just be in english? Will need to support translations.
+						'details_url'   => $sub['details_url'],
+					);
+				}
+			}
+
+			$data = array(
+				'last-checked'  => time(),
+				'subscriptions' => $parsed_subscriptions,
+			);
+
+			Jetpack_Options::update_option( 'subscriptions', $data );
+		}
+
+		return $data['subscriptions'];
+	}
+
 	/*
 	 * A graceful transition to using Core's site icon.
 	 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -22,6 +22,10 @@ jetpack_do_activate (bool)
 	Flag for "activating" the plugin on sites where the activation hook never fired (auto-installs)
 */
 
+// Upgrade product IDs
+define( 'WPCOM_VIDEOPRESS', 15 );
+define( 'WPCOM_VIDEOPRESS_PRO', 47 );
+
 class Jetpack {
 	var $xmlrpc_server = null;
 
@@ -5757,49 +5761,51 @@ p {
 	}
 
 	/**
-	 * Find out whether the current site has any subscriptions.
+	 * Find out whether the current site has any upgrades.
 	 *
-	 * Subscription could be anything from VideoPress to the Akismet+VaultPress Bundle.
+	 * Upgrade could be anything from VideoPress to the Akismet+VaultPress Bundle.
 	 *
 	 * @param $force_refresh bool Whether to force a call to wpcom to verify subscriptions, or to trust the cached data.
-	 * @return mixed False for no subscriptions, otherwise an array of subscriptions.
+	 * @return mixed False for no upgrades, otherwise an array of upgrades.
 	 */
-	public static function get_site_subscriptions( $force_refresh = false ) {
-		$data = Jetpack_Options::get_option( 'subscriptions', array() );
+	public static function get_site_upgrades( $force_refresh = false ) {
+		$data = Jetpack_Options::get_option( 'upgrades', array() );
+		$blog_id = Jetpack_Options::get_option( 'id' );
 
 		// If we need to force a refresh, or our data is either not there, or more than a week out of date…
 		if ( $force_refresh || empty( $data['last-checked'] ) || ( $data['last-checked'] < strtotime( '-1 week' ) ) ) {
 
-			Jetpack::load_xml_rpc_client();
-			$ixr = new Jetpack_IXR_Client( array( 'user_id' => JETPACK_MASTER_USER, ) );
-			$ixr->query( 'jetpack.getSiteSubscriptions' );
-			if ( $ixr->isError() ) {
-				return new WP_Error( 'xmlrpc-error', __( 'XML-RPC Error.' ), $ixr );
+			$response = Jetpack_Client::wpcom_json_api_request_as_blog(
+				'/sites/' . $blog_id . '/upgrades',
+				'1.1'
+			);
+			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				return new WP_Error( 'rest_api_request_failed', 'Could not make a REST API request.' );
 			}
-			$remote_subscriptions = $ixr->getResponse();
 
-			$parsed_subscriptions = array();
-			if ( is_array( $remote_subscriptions ) ) {
-				foreach ( $remote_subscriptions as $sub ) {
-					$parsed_subscriptions[] = array(
-						'wpcom_blog_id' => Jetpack_Options::get_option( 'id' ),
-						'expiration'    => $sub['expiration'],
-						'slug'          => $sub['slug'],
-						'name'          => $sub['name'], // Note that this will likely just be in english? Will need to support translations.
-						'details_url'   => $sub['details_url'],
+			$result = json_decode( wp_remote_retrieve_body( $response ) );
+
+			$parsed_upgrades = array();
+			if ( is_array( $result ) ) {
+				foreach ( $result as $upgrade ) {
+					$parsed_upgrades[] = array(
+						'wpcom_blog_id' => $blog_id,
+						'product_id'    => $upgrade['product_id'],
+						'expiration'    => strtotime( $upgrade['expiry'] ),
 					);
 				}
 			}
 
-			$data = array(
-				'last-checked'  => time(),
-				'subscriptions' => $parsed_subscriptions,
+			Jetpack_Options::update_option(
+				'upgrades',
+				array(
+					'last-checked'  => time(),
+					'upgrades' => $parsed_upgrades,
+				)
 			);
-
-			Jetpack_Options::update_option( 'subscriptions', $data );
 		}
 
-		return $data['subscriptions'];
+		return $data['upgrades'];
 	}
 
 	/*

--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -296,6 +296,7 @@ class VideoPress_Player {
 	 * @return string HTML5 video element and children
 	 */
 	private function html5_static() {
+		wp_enqueue_script( 'videopress' );
 		$thumbnail = esc_url( $this->video->poster_frame_uri );
 		$html = "<video id=\"{$this->video_id}\" width=\"{$this->video->calculated_width}\" height=\"{$this->video->calculated_height}\" poster=\"$thumbnail\" controls=\"true\"";
 		if ( isset( $this->options['autoplay'] ) && $this->options['autoplay'] === true )
@@ -332,13 +333,35 @@ class VideoPress_Player {
 
 	/**
 	 * Click to play dynamic HTML5-capable player.
-	 * The player displays a video preview section including poster frame, video title, play button and watermark on the original page load and calculates the playback capabilities of the browser. The video player is loaded when the visitor clicks on the video preview area.
-	 * If Flash Player 10 or above is available the browser will display the Flash version of the video. If HTML5 video appears to be supported and the browser may be capable of MP4 (H.264, AAC) or OGV (Theora, Vorbis) playback the browser will display its native HTML5 player.
+	 * The player displays a video preview section including poster frame,
+	 * video title, play button and watermark on the original page load
+	 * and calculates the playback capabilities of the browser. The video player
+	 * is loaded when the visitor clicks on the video preview area.
+	 * If Flash Player 10 or above is available the browser will display
+	 * the Flash version of the video. If HTML5 video appears to be supported
+	 * and the browser may be capable of MP4 (H.264, AAC) or OGV (Theora, Vorbis)
+	 * playback the browser will display its native HTML5 player.
 	 *
 	 * @since 1.5
 	 * @return string HTML markup
 	 */
 	private function html5_dynamic() {
+
+		/**
+		 * Filter the VideoPress legacy player feature
+		 *
+		 * This filter allows you to control whether the legacy VideoPress player should be used
+		 * instead of the improved one.
+		 *
+		 * @since 3.7
+		 *
+		 * @param boolean $use_videopress_legacy
+		 */
+		if ( ! apply_filters( 'jetpack_use_videopress_legacy_player', false ) ) {
+			return $this->html5_dynamic_next();
+		}
+
+		wp_enqueue_script( 'videopress' );
 		$video_placeholder_id = $this->video_container_id . '-placeholder';
 		$age_gate_required = $this->age_gate_required();
 		$width = absint( $this->video->calculated_width );
@@ -509,6 +532,53 @@ class VideoPress_Player {
 		return $html;
 	}
 
+	function html5_dynamic_next() {
+		wp_enqueue_script( 'videopress-next' );
+
+		$video_container_id = 'v-' . $this->video->guid;
+
+		if ( ! array_key_exists( 'hd', $this->options ) ) {
+			$this->options['hd'] = (bool) get_option( 'video_player_high_quality', false );
+		}
+
+		$videopress_options = array(
+			'width' => absint( $this->video->calculated_width ),
+			'height' => absint( $this->video->calculated_height ),
+		);
+		foreach ( $this->options as $option => $value ) {
+			switch ( $option ) {
+				case 'at':
+					if ( intval( $value ) ) {
+						$videopress_options[ $option ] = intval( $value );
+					}
+					break;
+				case 'autoplay':
+					$option = 'autoPlay';
+				case 'hd':
+				case 'loop':
+				case 'permalink':
+					if ( in_array( $value, array( 1, 'true', true ) ) ) {
+						$videopress_options[ $option ] = true;
+					} elseif ( in_array( $value, array( 0, 'false', false ) ) ) {
+						$videopress_options[ $option ] = false;
+					}
+					break;
+				case 'defaultlangcode':
+					if ( $value ) {
+						$iframe_url = add_query_arg( 'defaultLangCode', $value, $iframe_url );
+					}
+					break;
+			}
+		}
+		$videopress_options = json_encode( $videopress_options );
+
+		return "<div id='{$video_container_id}'></div>
+			<script src='https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress.js'></script>
+			<script>
+				videopress('{$this->video->guid}', document.querySelector('#{$video_container_id}'), {$videopress_options});
+			</script>";
+	}
+
 	/**
 	 * Only allow legitimate Flash parameters and their values
 	 *
@@ -609,6 +679,7 @@ class VideoPress_Player {
 	 * @return string HTML markup. Embed element with no children
 	 */
 	private function flash_embed() {
+		wp_enqueue_script( 'videopress' );
 		if ( ! isset( $this->video->players->swf ) || ! isset( $this->video->players->swf->url ) )
 			return '';
 
@@ -639,6 +710,7 @@ class VideoPress_Player {
 	 * @return HTML markup. Object and children.
 	 */
 	private function flash_object() {
+		wp_enqueue_script( 'videopress' );
 		if ( ! isset( $this->video->players->swf ) || ! isset( $this->video->players->swf->url ) )
 			return '';
 

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -108,7 +108,7 @@ class Jetpack_VideoPress_Shortcode {
 	 */
 	public static function enqueue_scripts() {
 		$js_url = ( is_ssl() ) ? 'https://v0.wordpress.com/js/videopress.js' : 'http://s0.videopress.com/js/videopress.js';
-		wp_enqueue_script( 'videopress', $js_url, array( 'jquery', 'swfobject' ), '1.09' );
+		wp_register_script( 'videopress', $js_url, array( 'jquery', 'swfobject' ), '1.09' );
 	}
 }
 

--- a/modules/videopress/videopress.php
+++ b/modules/videopress/videopress.php
@@ -63,6 +63,27 @@ class Jetpack_VideoPress {
 		add_filter( 'videopress_shortcode_options', array( $this, 'videopress_shortcode_options' ) );
 	}
 
+	/**
+	 * Returns true if the current site has VideoPress upgrades active.
+	 *
+	 * @return Boolean
+	 */
+	static public function has_active_upgrade() {
+		$upgrades = Jetpack::get_site_upgrades();
+
+		foreach ( $upgrades as $upgrade ) {
+			if (
+				$upgrade['product_id'] === WPCOM_VIDEOPRESS
+				|| $upgrade['product_id'] === WPCOM_VIDEOPRESS
+				|| $upgrade['product_id'] === WPCOM_JETPACK_BUSINESS
+				|| $upgrade['product_id'] === WPCOM_JETPACK_PREMIUM
+			) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	function wp_ajax_videopress_get_upload_token() {
 		if ( ! $this->can( 'upload_videos' ) )
 			return wp_send_json_error();

--- a/modules/videopress/videopress.php
+++ b/modules/videopress/videopress.php
@@ -22,6 +22,7 @@ class Jetpack_VideoPress {
 
 	function __construct() {
 		$this->version = time(); // <s>ghost</s> cache busters!
+
 		add_action( 'jetpack_modules_loaded', array( $this, 'jetpack_modules_loaded' ) );
 		add_action( 'jetpack_activate_module_videopress', array( $this, 'jetpack_module_activated' ) );
 		add_action( 'jetpack_deactivate_module_videopress', array( $this, 'jetpack_module_deactivated' ) );
@@ -69,10 +70,10 @@ class Jetpack_VideoPress {
 
 		foreach ( $upgrades as $upgrade ) {
 			if (
-				$upgrade['product_id'] === WPCOM_VIDEOPRESS
-				|| $upgrade['product_id'] === WPCOM_VIDEOPRESS
-				|| $upgrade['product_id'] === WPCOM_JETPACK_BUSINESS
-				|| $upgrade['product_id'] === WPCOM_JETPACK_PREMIUM
+				$upgrade['product_id'] == WPCOM_VIDEOPRESS
+				|| $upgrade['product_id'] == WPCOM_VIDEOPRESS
+				|| $upgrade['product_id'] == WPCOM_JETPACK_BUSINESS
+				|| $upgrade['product_id'] == WPCOM_JETPACK_PREMIUM
 			) {
 				return true;
 			}
@@ -218,6 +219,9 @@ class Jetpack_VideoPress {
 	 */
 	function jetpack_configuration_screen() {
 		$options = $this->get_options();
+		if ( ! self::has_active_upgrade() ) {
+			$this->upgrade_notice();
+		}
 		?>
 		<div class="narrow">
 			<form method="post" id="videopress-settings">
@@ -225,21 +229,6 @@ class Jetpack_VideoPress {
 				<?php wp_nonce_field( 'videopress-settings' ); ?>
 
 				<table id="menu" class="form-table">
-					<tr>
-						<th scope="row" colspan="2">
-							<p><?php
-								_e(
-									sprintf(
-										'Please note that the VideoPress module requires an active '
-										. '<a href="http://wordpress.com/plans/%s" target="_blank">'
-										. 'upgrade plan'
-										. '</a>.',
-										Jetpack_Options::get_option( 'id' )
-									),
-									'jetpack'
-								); ?></p>
-						</th>
-					</tr>
 					<tr>
 						<th scope="row">
 							<label><?php _e( 'Video Library Access', 'jetpack' ); ?></label>
@@ -282,6 +271,28 @@ class Jetpack_VideoPress {
 
 				<?php submit_button(); ?>
 			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Shows the notice that tells the user that it is necessary to purchase an upgrade.
+	 */
+	function upgrade_notice() {
+		?>
+		<div class="notice notice-success">
+			<p>
+				<?php echo sprintf(
+					_e(
+						'Please note that the VideoPress module requires an active '
+						. '<a href="http://wordpress.com/plans/%s" target="_blank">'
+						. 'upgrade plan'
+						. '</a>.',
+						'jetpack'
+					),
+					Jetpack_Options::get_option( 'id' )
+				); ?>
+			</p>
 		</div>
 		<?php
 	}

--- a/modules/videopress/videopress.php
+++ b/modules/videopress/videopress.php
@@ -57,7 +57,26 @@ class Jetpack_VideoPress {
 			add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		}
 
+		if ( $this->can( 'upload_videos' ) && $options['blog_id'] ) {
+			add_action( 'wp_ajax_videopress-get-upload-token', array( $this, 'wp_ajax_videopress_get_upload_token' ) );
+		}
+
 		add_filter( 'videopress_shortcode_options', array( $this, 'videopress_shortcode_options' ) );
+	}
+
+	function wp_ajax_videopress_get_upload_token() {
+		if ( ! $this->can( 'upload_videos' ) )
+			return wp_send_json_error();
+
+		$result = $this->query( 'jetpack.vpGetUploadToken' );
+		if ( is_wp_error( $result ) )
+			return wp_send_json_error( array( 'message' => __( 'Could not obtain a VideoPress upload token. Please try again later.', 'jetpack' ) ) );
+
+		$response = $result;
+		if ( empty( $response['videopress_blog_id'] ) || empty( $response['videopress_token'] ) || empty( $response[ 'videopress_action_url' ] ) )
+			return wp_send_json_error( array( 'message' => __( 'Could not obtain a VideoPress upload token. Please try again later.', 'jetpack' ) ) );
+
+		return wp_send_json_success( $response );
 	}
 
 	/**

--- a/modules/videopress/videopress.php
+++ b/modules/videopress/videopress.php
@@ -90,7 +90,7 @@ class Jetpack_VideoPress {
 		foreach ( $upgrades as $upgrade ) {
 			if (
 				$upgrade['product_id'] == WPCOM_VIDEOPRESS
-				|| $upgrade['product_id'] == WPCOM_VIDEOPRESS
+				|| $upgrade['product_id'] == WPCOM_VIDEOPRESS_PRO
 				|| $upgrade['product_id'] == WPCOM_JETPACK_BUSINESS
 				|| $upgrade['product_id'] == WPCOM_JETPACK_PREMIUM
 			) {


### PR DESCRIPTION
This PR replaces and continues where #2438 left off. It will change how Jetpack works with WordPress.com in terms of VideoPress upgrades and video management. As a side effect it aims to fix the following issues: #2340, #2337, #1953, #1952, #1551.