### PR TITLE
Themes endpoint: Add `active` flag to each theme

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
@@ -12,6 +12,7 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 
 	protected $bulk = true;
 	protected $log;
+	protected $current_theme_id;
 
 	static $_response_format = array(
 		'id'           => '(string) The theme\'s ID.',
@@ -100,7 +101,8 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 		$id = $theme->get_stylesheet();
 		$formatted_theme = array(
 			'id'          => $id,
-			'screenshot'  => jetpack_photon_url( $theme->get_screenshot(), array(), 'network_path' )
+			'screenshot'  => jetpack_photon_url( $theme->get_screenshot(), array(), 'network_path' ),
+			'active'      => $id === $this->current_theme_id,
 		);
 
 		foreach( $fields as $key => $field ) {
@@ -151,6 +153,8 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 			$themes = array_slice( $themes, (int) $args['offset'] );
 		if ( isset( $args['limit'] ) )
 			$themes = array_slice( $themes, 0, (int) $args['limit'] );
+
+		$this->current_theme_id = wp_get_theme()->get_stylesheet();
 
 		return array_map( array( $this, 'format_theme' ), $themes );
 	}


### PR DESCRIPTION
... where `active` denotes the currently active theme.