### PR TITLE
Add 'author' field to the 'Themes Active' endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
@@ -3,6 +3,24 @@
 class Jetpack_JSON_API_Themes_Active_Endpoint extends Jetpack_JSON_API_Themes_Endpoint {
 	// GET  /sites/%s/themes/mine => current theme
 	// POST /sites/%s/themes/mine => switch theme
+
+	// The following is copy-pasted from Jetpack_JSON_API_Themes_Endpoint,
+	// with an additional line for 'author'. Unfortunately, due to the
+	// current architecture (using a static variable for $_response_format
+	// instead of e.g. a function), we cannot dynamically add 'author'
+	// to parent::$_response_format here but need to keep this in sync with
+	// Jetpack_JSON_API_Themes_Endpoint manually.
+	static $_response_format = array(
+		'id'           => '(string) The theme\'s ID.',
+		'screenshot'   => '(string) A theme screenshot URL',
+		'name'         => '(string) The name of the theme.',
+		'description'  => '(string) A description of the theme.',
+		'author'       => '(string) The author of the theme.',
+		'tags'         => '(array) Tags indicating styles and features of the theme.',
+		'log'          => '(array) An array of log strings',
+		'autoupdate'   => '(bool) Whether the theme is automatically updated',
+	);
+
 	public function callback( $path = '', $blog_id = 0  ) {
 
 		if ( is_wp_error( $error = $this->validate_call( $blog_id, 'switch_themes', true ) ) ) {
@@ -44,6 +62,9 @@ class Jetpack_JSON_API_Themes_Active_Endpoint extends Jetpack_JSON_API_Themes_En
 	}
 
 	protected function get_current_theme() {
-		return $this->format_theme( wp_get_theme() );
+		$theme = wp_get_theme();
+		$result = $this->format_theme( $theme );
+		$result['author'] = $theme->get( 'Author' );
+		return $result;
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
@@ -13,6 +13,8 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 	protected $bulk = true;
 	protected $log;
 
+	// TODO: When modifiying the following, don't forget to keep $_response_format
+	// in class.jetpack-json-api-check-capabilities-endpoint.php sync'ed (see note there).
 	static $_response_format = array(
 		'id'           => '(string) The theme\'s ID.',
 		'screenshot'   => '(string) A theme screenshot URL',


### PR DESCRIPTION
This is required for the Calypso theme showcase;
specifically for theme activation, when we display a
'Thanks for choosing "Theme" by "Author" message'.

(Not adding to the generic Themes endpoint to keep that one
lean, e.g. when used for listing themes.)

(Alternative approach to #2499, which extends the generic Themes endpoint.)