### PR TITLE
Stats: make sure the Stats URL is always escaped properly.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3691,7 +3691,7 @@ p {
 	 * @return bool If it worked.
 	 */
 	static function do_server_side_stat( $args ) {
-		$response = wp_remote_get( self::build_stats_url( $args ) );
+		$response = wp_remote_get( esc_url_raw( self::build_stats_url( $args ) ) );
 		if ( is_wp_error( $response ) )
 			return false;
 


### PR DESCRIPTION
`build_stats_url()` includes a filter, `jetpack_stats_base_url`, and `add_query_arg`
Both could lead to a non-valid URL later used in `do_server_side_stat()`

`build_stats_url()` is also used in `do_stats()`, but it is escaped there.