### PR TITLE
Subscriptions: add action at the end of the form submission process

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -442,6 +442,15 @@ class Jetpack_Subscriptions {
 			$redirect = add_query_arg( 'subscribe', 'success' );
 		}
 
+		/**
+		 * Fires on each subscription form submission.
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param string $redirect Subscription form submission status.
+		 */
+		do_action( 'jetpack_subscriptions_form_submission', $redirect );
+
 		wp_safe_redirect( "$redirect#$redirect_fragment" );
 		exit;
 	}


### PR DESCRIPTION
Fixes #184

Allows third-party plugin developers to hook into the form process
and trigger actions depending on the submission status.

For example, one could trigger a counter every time the subscription process is successful, to count the number of successful subscription attempts:

```php
function jeherve_record_subs( $redirect ) {
        if ( strpos( $redirect, 'success' ) ) {
                jeherve_bump_my_stat( $redirect);
        }
}
add_action( 'jetpack_subscriptions_form_submission', 'jeherve_record_subs' );
```