### PR TITLE
Check image passed to `jetpack_photon_url` against custom Photon domain

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -47,8 +47,8 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
 	if (
-		$image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST )
-		|| in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
+		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
+		|| $image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST )
 	) {
 		$photon_url = add_query_arg( $args, $image_url );
 		return jetpack_photon_url_scheme( $photon_url, $scheme );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -41,11 +41,13 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		$args = rawurlencode_deep( $args );
 	}
 
+	/** This filter is documented below. */
+	$custom_photon_url = apply_filters( 'jetpack_photon_domain', '', $image_url );
+
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
 	if (
-		/** This filter is documented below. */
-		apply_filters( 'jetpack_photon_domain', '', $image_url ) === $image_url_parts['host']
+		$image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST )
 		|| in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
 	) {
 		$photon_url = add_query_arg( $args, $image_url );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -45,7 +45,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
 	if (
 		/** This filter is documented below. */
-		apply_filters( 'jetpack_photon_domain', '', $image_url ) === $image_url_parts['host'] )
+		apply_filters( 'jetpack_photon_domain', '', $image_url ) === $image_url_parts['host']
 		|| in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
 	) {
 		$photon_url = add_query_arg( $args, $image_url );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -43,10 +43,17 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
-    if ( in_array( 
-			$image_url_parts['host'], 
-			array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com', apply_filters( 'jetpack_photon_domain', '', $image_url ) ) 
-		) ) {
+
+	// Check if the image matches a custom Photon domain.
+	/** This filter is documented below. */
+	if ( apply_filters( 'jetpack_photon_domain', '', $image_url ) === $image_url_parts['host'] ) {
+		$photon_url = add_query_arg( $args, $image_url );
+
+		return jetpack_photon_url_scheme( $photon_url, $scheme );
+	}
+
+	// Check if the image url matches one of the default Photon domains.
+	if ( in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) ) {
 		$photon_url = add_query_arg( $args, $image_url );
 
 		return jetpack_photon_url_scheme( $photon_url, $scheme );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -43,19 +43,12 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
-
-	// Check if the image matches a custom Photon domain.
-	/** This filter is documented below. */
-	if ( apply_filters( 'jetpack_photon_domain', '', $image_url ) === $image_url_parts['host'] ) {
+	if (
+		/** This filter is documented below. */
+		apply_filters( 'jetpack_photon_domain', '', $image_url ) === $image_url_parts['host'] )
+		|| in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
+	) {
 		$photon_url = add_query_arg( $args, $image_url );
-
-		return jetpack_photon_url_scheme( $photon_url, $scheme );
-	}
-
-	// Check if the image url matches one of the default Photon domains.
-	if ( in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) ) {
-		$photon_url = add_query_arg( $args, $image_url );
-
 		return jetpack_photon_url_scheme( $photon_url, $scheme );
 	}
 

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -43,7 +43,10 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
-	if ( in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) ) ) {
+    if ( in_array( 
+			$image_url_parts['host'], 
+			array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com', apply_filters( 'jetpack_photon_domain', '', $image_url ) ) 
+		) ) {
 		$photon_url = add_query_arg( $args, $image_url );
 
 		return jetpack_photon_url_scheme( $photon_url, $scheme );


### PR DESCRIPTION
When checking to see if an image URL which is passed into
`jetpack_photon_url()` is already a Photon URL, recognize images from
custom Photon domains as well as the default hosted service.

Addresses #2522