### PR TITLE
Get Users Endpoint: new parameters

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1853,6 +1853,9 @@ new WPCOM_JSON_API_List_Users_Endpoint( array(
 		),
 		'authors_only'      => "(bool) Set to true to fetch authors only",
 		'type'              => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+		'search'            => '(search) Find matching users.',
+		'search_columns'    => '(array) Specify which columns to check for matching users. Only works when combined with `search` parameter.',
+		'role'              => '(string) Specify a specific user role to fetch.'
 	),
 
 	'response_format' => array(

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1853,7 +1853,7 @@ new WPCOM_JSON_API_List_Users_Endpoint( array(
 		),
 		'authors_only'      => "(bool) Set to true to fetch authors only",
 		'type'              => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
-		'search'            => '(search) Find matching users.',
+		'search'            => '(string) Find matching users.',
 		'search_columns'    => '(array) Specify which columns to check for matching users. Only works when combined with `search` parameter.',
 		'role'              => '(string) Specify a specific user role to fetch.'
 	),

--- a/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -51,6 +51,18 @@ gnoring limits and offsets).',
 		if ( $authors_only )
 			$query['who'] = 'authors';
 
+		if ( ! empty( $args['search'] ) ) {
+			$query['search'] = $args['search'];
+		}
+
+		if ( ! empty( $args['search_columns'] ) ) {
+			$query['search_columns'] = $args['search_columns'];
+		}
+
+		if ( ! empty( $args['role'] ) ) {
+			$query['role'] = $args['role'];
+		}
+
 		$user_query = new WP_User_Query( $query );
 
 		$return = array();


### PR DESCRIPTION
To better mirror the WP_User_Query class, we should offer more robust
parameters in the JSON API. `role` will allow you to specify a specific role
to fetch, `search` and `search_columns` will allow you to search for
matching users.