### PR TITLE
Site Icon: link to customizer's Site Icon section

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -93,7 +93,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 						<span class='info'>{{{ item.name }}}</span>
 						<div class="row-actions">
 							<span class="dep-msg"><?php _ex( 'WordPress now has Site Icon built in!', '"Site Icon" is the feature name.', 'jetpack' ); ?></span>
-							<span class='configure'><a href="<?php esc_html_e( admin_url( 'options-general.php' ), 'jetpack' ); ?>"><?php _e( 'configure' , 'jetpack' ); ?></a></span>
+							<span class='configure'><a href="<?php esc_html_e( admin_url( 'customize.php?autofocus[control]=site_icon' ), 'jetpack' ); ?>"><?php _e( 'Configure' , 'jetpack' ); ?></a></span>
 						</div>
 					</td>
 				</tr>


### PR DESCRIPTION
Core's Site Icon lives in the customizer, not in Settings > General.
I also capitalized the C of Configure, for consistency with other Jetpack modules' controls.