### PR TITLE
Fixing Facebook embeds by including script in footer so it can append div to body tag.

### DIFF
--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -39,7 +39,7 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && ! empty( $_POST['action'] ) && 'parse-embed' == $_POST['action'] ) {
 		return $embed . '<script src="//connect.facebook.net/en_US/all.js#xfbml=1"></script>';
 	} else {
-		wp_enqueue_script( 'jetpack-facebook-embed', plugins_url( 'js/facebook.js', __FILE__ ), array( 'jquery' ) );
+		wp_enqueue_script( 'jetpack-facebook-embed', plugins_url( 'js/facebook.js', __FILE__ ), array( 'jquery' ), null, true );
 		return $embed;
 	}
 }


### PR DESCRIPTION
This script is currently being included in the document `<head>` and fails to append the necessary `div` to the `body` tag because it doesn't exist yet.

See: https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/js/facebook.js#L9

This issue prevents the proper js from being loaded and causes FB embeds not to render.  Moving the script to the footer solves this problem.