### PR TITLE
Renaming some module names to remove redundant prefixes

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -326,7 +326,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	}
 
 	/**
-	 * Manage Jetpack Protect Settings
+	 * Manage Protect Settings
 	 *
 	 * ## OPTIONS
 	 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -52,8 +52,8 @@ class Jetpack {
 	);
 
 	public $plugins_to_deactivate = array(
-		'stats'               => array( 'stats/stats.php', 'WordPress.com Stats' ),
-		'shortlinks'          => array( 'stats/stats.php', 'WordPress.com Stats' ),
+		'stats'               => array( 'stats/stats.php', 'Site Stats' ),
+		'shortlinks'          => array( 'stats/stats.php', 'Site Stats' ),
 		'sharedaddy'          => array( 'sharedaddy/sharedaddy.php', 'Sharedaddy' ),
 		'twitter-widget'      => array( 'wickett-twitter-widget/wickett-twitter-widget.php', 'Wickett Twitter Widget' ),
 		'after-the-deadline'  => array( 'after-the-deadline/after-the-deadline.php', 'After The Deadline' ),
@@ -3058,7 +3058,7 @@ p {
 			}
 
 			if ( $throw ) {
-				trigger_error( sprintf( __( 'Jetpack contains the most recent version of the old &#8220;%1$s&#8221; plugin.', 'jetpack' ), 'WordPress.com Stats' ), E_USER_ERROR );
+				trigger_error( sprintf( __( 'Jetpack contains the most recent version of the old &#8220;%1$s&#8221; plugin.', 'jetpack' ), 'Site Stats' ), E_USER_ERROR );
 			}
 		}
 	}
@@ -3481,7 +3481,7 @@ p {
 		}
 
 		return '<br /><br />' . sprintf(
-			__( 'Jetpack now includes Jetpack Comments, which enables your visitors to use their WordPress.com, Twitter, or Facebook accounts when commenting on your site. To activate Jetpack Comments, <a href="%s">%s</a>.', 'jetpack' ),
+			__( 'Jetpack now includes Comments, which enables your visitors to use their WordPress.com, Twitter, or Facebook accounts when commenting on your site. To activate Comments, <a href="%s">%s</a>.', 'jetpack' ),
 			wp_nonce_url(
 				Jetpack::admin_url(
 					array(
@@ -6481,11 +6481,11 @@ p {
 				<h3><?php echo number_format_i18n( get_site_option( 'jetpack_protect_blocked_attempts', 0 ) ); ?></h3>
 				<p><?php echo esc_html_x( 'Blocked malicious login attempts', '{#} Blocked malicious login attempts -- number is on a prior line, text is a caption.', 'jetpack' ); ?></p>
 			<?php elseif ( current_user_can( 'jetpack_activate_modules' ) && ! self::is_development_mode() ) : ?>
-				<a href="<?php echo esc_url( wp_nonce_url( Jetpack::admin_url( array( 'action' => 'activate', 'module' => 'protect' ) ), 'jetpack_activate-protect' ) ); ?>" class="button button-jetpack" title="<?php esc_attr_e( 'Jetpack Protect helps to keep you secure from brute-force login attacks.', 'jetpack' ); ?>">
-					<?php esc_html_e( 'Activate Jetpack Protect', 'jetpack' ); ?>
+				<a href="<?php echo esc_url( wp_nonce_url( Jetpack::admin_url( array( 'action' => 'activate', 'module' => 'protect' ) ), 'jetpack_activate-protect' ) ); ?>" class="button button-jetpack" title="<?php esc_attr_e( 'Protect helps to keep you secure from brute-force login attacks.', 'jetpack' ); ?>">
+					<?php esc_html_e( 'Activate Protect', 'jetpack' ); ?>
 				</a>
 			<?php else : ?>
-				<?php esc_html_e( 'Jetpack Protect is inactive.', 'jetpack' ); ?>
+				<?php esc_html_e( 'Protect is inactive.', 'jetpack' ); ?>
 			<?php endif; ?>
 		</div>
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -52,8 +52,8 @@ class Jetpack {
 	);
 
 	public $plugins_to_deactivate = array(
-		'stats'               => array( 'stats/stats.php', 'Site Stats' ),
-		'shortlinks'          => array( 'stats/stats.php', 'Site Stats' ),
+		'stats'               => array( 'stats/stats.php', 'WordPress.com Stats' ),
+		'shortlinks'          => array( 'stats/stats.php', 'WordPress.com Stats' ),
 		'sharedaddy'          => array( 'sharedaddy/sharedaddy.php', 'Sharedaddy' ),
 		'twitter-widget'      => array( 'wickett-twitter-widget/wickett-twitter-widget.php', 'Wickett Twitter Widget' ),
 		'after-the-deadline'  => array( 'after-the-deadline/after-the-deadline.php', 'After The Deadline' ),
@@ -3058,7 +3058,7 @@ p {
 			}
 
 			if ( $throw ) {
-				trigger_error( sprintf( __( 'Jetpack contains the most recent version of the old &#8220;%1$s&#8221; plugin.', 'jetpack' ), 'Site Stats' ), E_USER_ERROR );
+				trigger_error( sprintf( __( 'Jetpack contains the most recent version of the old &#8220;%1$s&#8221; plugin.', 'jetpack' ), 'WordPress.com Stats' ), E_USER_ERROR );
 			}
 		}
 	}

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -106,7 +106,7 @@ jQuery(document).ready(function($) {
 			var commentFormMarkup = '<div id="jp-carousel-comment-form-container">';
 
 			if ( jetpackCarouselStrings.local_comments_commenting_as && jetpackCarouselStrings.local_comments_commenting_as.length ) {
-				// Jetpack comments not enabled, fallback to local comments
+				// Comments not enabled, fallback to local comments
 
 				if ( 1 !== Number( jetpackCarouselStrings.is_logged_in ) && 1 === Number( jetpackCarouselStrings.comment_registration ) ) {
 					commentFormMarkup += '<div id="jp-carousel-comment-form-commenting-as">' + jetpackCarouselStrings.local_comments_commenting_as + '</div>';

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -147,7 +147,7 @@ class Jetpack_Carousel {
 			);
 
 			if ( ! isset( $localize_strings['jetpack_comments_iframe_src'] ) || empty( $localize_strings['jetpack_comments_iframe_src'] ) ) {
-				// We're not using Jetpack comments after all, so fallback to standard local comments.
+				// We're not using Comments after all, so fallback to standard local comments.
 
 				if ( $is_logged_in ) {
 					$localize_strings['local_comments_commenting_as'] = '<p id="jp-carousel-commenting-as">' . sprintf( __( 'Commenting as %s', 'jetpack' ), $current_user->data->display_name ) . '</p>';

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Module Name: Jetpack Comments
+ * Module Name: Comments
  * Module Description: Let readers comment with WordPress.com, Twitter, Facebook, or Google+ accounts.
  * First Introduced: 1.4
  * Sort Order: 20

--- a/modules/comments/admin.php
+++ b/modules/comments/admin.php
@@ -69,7 +69,7 @@ class Jetpack_Comments_Settings {
 		// Create the section
 		add_settings_section(
 			'jetpack_comment_form',
-			__( 'Jetpack Comments', 'jetpack' ),
+			__( 'Comments', 'jetpack' ),
 			array( $this, 'comment_form_settings_section' ),
 			'discussion'
 		);
@@ -115,7 +115,7 @@ class Jetpack_Comments_Settings {
 	public function comment_form_settings_section() {
 	?>
 
-		<p id="jetpack-comments-settings"><?php _e( 'Adjust your Jetpack Comments form with a clever greeting and color-scheme.', 'jetpack' ); ?></p>
+		<p id="jetpack-comments-settings"><?php _e( 'Adjust your Comments form with a clever greeting and color-scheme.', 'jetpack' ); ?></p>
 
 	<?php
 	}

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -3,7 +3,7 @@
 require dirname( __FILE__ ) . '/base.php';
 
 /**
- * Main Jetpack Comments class
+ * Main Comments class
  *
  * @package JetpackComments
  * @version 1.4
@@ -45,14 +45,14 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	}
 
 	/**
-	 * Main constructor for Jetpack Comments
+	 * Main constructor for Comments
 	 *
 	 * @since JetpackComments (1.4)
 	 */
 	public function __construct() {
 		parent::__construct();
 
-		// Jetpack Comments is loaded
+		// Comments is loaded
 
 		/**
 		 * Fires after the Jetpack_Comments object has been instantiated

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -18,7 +18,7 @@ _x( 'Transform standard image galleries into full-screen slideshows.', 'Module D
 _x( 'Brings your photos and images to life as full-size, easily navigable galleries.', 'Jumpstart Description', 'jetpack' );
 
 // modules/comments.php
-_x( 'Jetpack Comments', 'Module Name', 'jetpack' );
+_x( 'Comments', 'Module Name', 'jetpack' );
 _x( 'Let readers comment with WordPress.com, Twitter, Facebook, or Google+ accounts.', 'Module Description', 'jetpack' );
 
 // modules/contact-form.php
@@ -124,13 +124,13 @@ _x( 'Site Icon', 'Module Name', 'jetpack' );
 _x( 'Add a site icon to your site.', 'Module Description', 'jetpack' );
 
 // modules/sso.php
-_x( 'Jetpack Single Sign On', 'Module Name', 'jetpack' );
-_x( 'Secure user authentication.', 'Module Description', 'jetpack' );
-_x( 'Lets you login to all your Jetpack-enabled sites with one click using your WordPress.com account.', 'Jumpstart Description', 'jetpack' );
+_x( 'Single Sign On', 'Module Name', 'jetpack' );
+_x( 'Allow your users to log in using their WordPress.com accounts.', 'Module Description', 'jetpack' );
+_x( 'lets you login to all your Jetpack-enabled sites with one click using your WordPress.com account.', 'Jumpstart Description', 'jetpack' );
 
 // modules/stats.php
-_x( 'WordPress.com Stats', 'Module Name', 'jetpack' );
-_x( 'Collect traffic stats and insights.', 'Module Description', 'jetpack' );
+_x( 'Site Stats', 'Module Name', 'jetpack' );
+_x( 'Monitor your stats with clear, concise reports and no additional load on your server.', 'Module Description', 'jetpack' );
 
 // modules/subscriptions.php
 _x( 'Subscriptions', 'Module Name', 'jetpack' );
@@ -235,6 +235,6 @@ _x( 'Recommended', 'Module Tag', 'jetpack' );
 //  - modules/minileven.php
 _x( 'Mobile', 'Module Tag', 'jetpack' );
 
-// Modules with `WordPress.com Stats` tag:
+// Modules with `Site Stats` tag:
 //  - modules/stats.php
-_x( 'WordPress.com Stats', 'Module Tag', 'jetpack' );
+_x( 'Site Stats', 'Module Tag', 'jetpack' );

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -181,15 +181,15 @@ function wpme_load_more_link( $description ) {
 add_filter( 'jetpack_learn_more_button_shortlinks', 'wpme_load_more_link' );
 
 
-// WordPress.com Stats
+// Site Stats
 function stats_more_info() { ?>
 	<div class="jp-info-img">
 		<a href="http://en.support.wordpress.com/stats/">
-			<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/stats.png' ) ?>" alt="<?php esc_attr_e( 'WordPress.com Stats', 'jetpack' ) ?>" width="300" height="150" />
+			<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/stats.png' ) ?>" alt="<?php esc_attr_e( 'Site Stats', 'jetpack' ) ?>" width="300" height="150" />
 		</a>
 	</div>
 
-	<p><?php esc_html_e( 'There are many plugins and services that provide statistics, but data can be overwhelming. WordPress.com Stats makes the most popular metrics easy to understand through a clear and attractive interface.', 'jetpack' ) ?></p>
+	<p><?php esc_html_e( 'There are many plugins and services that provide statistics, but data can be overwhelming. Site Stats makes the most popular metrics easy to understand through a clear and attractive interface.', 'jetpack' ) ?></p>
 <?php
 }
 add_action( 'jetpack_module_more_info_stats', 'stats_more_info' );
@@ -197,11 +197,11 @@ add_action( 'jetpack_module_more_info_stats', 'stats_more_info' );
 function stats_more_info_connected() { ?>
 	<div class="jp-info-img">
 		<a href="http://en.support.wordpress.com/stats/">
-			<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/stats.png' ) ?>" alt="<?php esc_attr_e( 'WordPress.com Stats', 'jetpack' ) ?>" width="300" height="150" />
+			<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/stats.png' ) ?>" alt="<?php esc_attr_e( 'Site Stats', 'jetpack' ) ?>" width="300" height="150" />
 		</a>
 	</div>
 
-	<p><?php esc_html_e( 'There are many plugins and services that provide statistics, but data can be overwhelming. WordPress.com Stats makes the most popular metrics easy to understand through a clear and attractive interface.', 'jetpack' ) ?></p>
+	<p><?php esc_html_e( 'There are many plugins and services that provide statistics, but data can be overwhelming. Site Stats makes the most popular metrics easy to understand through a clear and attractive interface.', 'jetpack' ) ?></p>
 	<p><?php printf( __( 'You can <a href="%s">view your stats dashboard here</a>.', 'jetpack' ), admin_url( 'admin.php?page=stats' ) ); ?></p>
 <?php
 }
@@ -461,11 +461,11 @@ add_action( 'jetpack_learn_more_button_enhanced-distribution', 'jetpack_enhanced
 
 // Protect
 function jetpack_protect_more_info() { ?>
-	<p><?php esc_html_e( 'Jetpack Protect is a cloud-powered brute force attack prevention tool. We leverage the millions of WordPress sites to identify and block malicious IPs.
+	<p><?php esc_html_e( 'Protect is a cloud-powered brute force attack prevention tool. We leverage the millions of WordPress sites to identify and block malicious IPs.
 
-Jetpack Protect tracks failed login attempts across all Jetpack-connected sites using the Protect module.  If any single IP has too many failed attempts in a short period of time, they are blocked from logging in to any site with this plugin installed.
+Protect tracks failed login attempts across all Jetpack-connected sites using the Protect module.  If any single IP has too many failed attempts in a short period of time, they are blocked from logging in to any site with this plugin installed.
 
-Jetpack Protect is derived from BruteProtect, and will disable BruteProtect on your site if it is currently enabled.', 'jetpack' ); ?></p><?php
+Protect is derived from BruteProtect, and will disable BruteProtect on your site if it is currently enabled.', 'jetpack' ); ?></p><?php
 }
 
 add_action( 'jetpack_module_more_info_protect', 'jetpack_protect_more_info' );
@@ -525,7 +525,7 @@ add_action( 'jetpack_module_more_info_contact-form', 'jetpack_contact_form_more_
 add_action( 'jetpack_module_more_info_connected_contact-form', 'jetpack_contact_form_more_info' );
 // Contact Form: STOP
 
-// Jetpack Comments: START
+// Comments: START
 function jetpack_comments_learn_more_button() {
     echo '<a class="button-secondary more-info-link" href="#">' . __( 'Learn More', 'jetpack' ) . '</a>';
 }
@@ -533,10 +533,10 @@ function jetpack_comments_learn_more_button() {
 function jetpack_comments_more_info() {
 ?>
 	<div class="jp-info-img">
-		<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/comments.png' ) ?>" alt="<?php esc_attr_e( 'Jetpack Comments Screenshot', 'jetpack' ) ?>" width="300" height="150" />
+		<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/comments.png' ) ?>" alt="<?php esc_attr_e( 'Comments Screenshot', 'jetpack' ) ?>" width="300" height="150" />
 	</div>
 
-	<p><?php esc_html_e( 'Jetpack Comments enables your visitors to use their WordPress.com, Twitter, or Facebook accounts when commenting on your site.', 'jetpack' ); ?></p>
+	<p><?php esc_html_e( 'Comments enables your visitors to use their WordPress.com, Twitter, or Facebook accounts when commenting on your site.', 'jetpack' ); ?></p>
 
 <?php	if ( 'jetpack_module_more_info_connected_comments' == current_filter() ) : ?>
 
@@ -552,7 +552,7 @@ function jetpack_comments_more_info() {
 add_action( 'jetpack_learn_more_button_comments', 'jetpack_comments_learn_more_button' );
 add_action( 'jetpack_module_more_info_comments', 'jetpack_comments_more_info' );
 add_action( 'jetpack_module_more_info_connected_comments', 'jetpack_comments_more_info' );
-// Jetpack Comments: STOP
+// Comments: STOP
 
 // Gallery Carousel: START
 function jetpack_carousel_learn_more_button() {
@@ -826,7 +826,7 @@ add_action( 'jetpack_learn_more_button_videopress', 'jetpack_videopress_more_lin
 // SSO: START
 function jetpack_sso_more_info() { ?>
 
-	<p><?php esc_html_e( 'With WordPress.com Single Sign On, your users will be able to log in to or register for your WordPress site with the same credentials they use on WordPress.com.  It\'s safe and secure.' , 'jetpack' ); ?></p>
+	<p><?php esc_html_e( 'With Single Sign On, your users will be able to log in to or register for your WordPress site with the same credentials they use on WordPress.com.  It\'s safe and secure.' , 'jetpack' ); ?></p>
 	<p><?php esc_html_e( 'Once enabled, a "Log in with WordPress.com" option will be added to your existing log in form.' , 'jetpack' ); ?></p>
 
 <?php

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -186,8 +186,8 @@ class Jetpack_Protect_Module {
 		<div id="message" class="updated jetpack-message jp-banner is-opt-in protect-error" style="display:block !important;">
 			<a class="jp-banner__dismiss" href="<?php echo esc_url( $opt_out_url ); ?>" title="<?php esc_attr_e( 'Dismiss this notice.', 'jetpack' ); ?>"></a>
 			<div class="jp-banner__content">
-				<h4><?php esc_html_e( 'Jetpack Protect cannot keep your site secure.', 'jetpack' ); ?></h4>
-				<p><?php printf( __( 'Thanks for activating Jetpack Protect! To start protecting your site, please network activate Jetpack on your Multisite installation and activate Protect on your primary site. Due to the way logins are handled on WordPress Multisite, Jetpack must be network-enabled in order for Protect to work properly. <a href="%s" target="_blank">Learn More</a>', 'jetpack' ), 'http://jetpack.me/support/multisite-protect' ); ?></p>
+				<h4><?php esc_html_e( 'Protect cannot keep your site secure.', 'jetpack' ); ?></h4>
+				<p><?php printf( __( 'Thanks for activating Protect! To start protecting your site, please network activate Jetpack on your Multisite installation and activate Protect on your primary site. Due to the way logins are handled on WordPress Multisite, Jetpack must be network-enabled in order for Protect to work properly. <a href="%s" target="_blank">Learn More</a>', 'jetpack' ), 'http://jetpack.me/support/multisite-protect' ); ?></p>
 			</div>
 			<div class="jp-banner__action-container is-opt-in">
 				<a href="<?php echo network_admin_url('plugins.php'); ?>" class="jp-banner__button" id="wpcom-connect"><?php _e( 'View Network Admin', 'jetpack' ); ?></a>
@@ -282,7 +282,7 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 3.4.0
 		 *
-		 * @param string jetpack_protect_get_ip IP stored by Jetpack Protect.
+		 * @param string jetpack_protect_get_ip IP stored by Protect.
 		 */
 		do_action( 'jpp_log_failed_attempt', jetpack_protect_get_ip() );
 
@@ -480,7 +480,7 @@ class Jetpack_Protect_Module {
 	
 	function block_with_math() {
 		/**
-		 * By default, Jetpack Protect will allow a user who has been blocked for too
+		 * By default, Protect will allow a user who has been blocked for too
 		 * many failed logins to start answering math questions to continue logging in
 		 *
 		 * For added security, you can disable this 
@@ -508,7 +508,7 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 3.4.0
 		 *
-		 * @param string $ip IP flagged by Jetpack Protect.
+		 * @param string $ip IP flagged by Protect.
 		 */
 		do_action( 'jpp_kill_login', $ip );
 		$help_url = 'http://jetpack.me/support/security/';

--- a/modules/protect/config-ui.php
+++ b/modules/protect/config-ui.php
@@ -12,7 +12,7 @@
 			<?php wp_nonce_field( 'jetpack-protect' ); ?>
 			<input type='hidden' name='action' value='get_protect_key' />
 			<p class="submit">
-				<?php _e( 'An API key is needed for Jetpack Protect.', 'jetpack' ); ?>
+				<?php _e( 'An API key is needed for Protect.', 'jetpack' ); ?>
 				<br /><br /><input type='submit' class='button-primary' value='<?php echo esc_attr( __( 'Get an API Key', 'jetpack' ) ); ?>' />
 			</p>
 		</form>

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				Jetpack_Protect_Math_Authenticate::generate_math_page();
 			} elseif ( $salted_ans != $correct_ans ) {
 				wp_die(
-				__( '<strong>You failed to correctly answer the math problem.</strong>  This is used to combat spam when the Jetpack Protect API is unavailable.  Please use your browser\'s back button to return to the login form, press the "refresh" button to generate a new math problem, and try to log in again.', 'jetpack' ),
+				__( '<strong>You failed to correctly answer the math problem.</strong>  This is used to combat spam when the Protect API is unavailable.  Please use your browser\'s back button to return to the login form, press the "refresh" button to generate a new math problem, and try to log in again.', 'jetpack' ),
 				'',
 				401
 				);

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Module Name: Jetpack Single Sign On
+ * Module Name: Single Sign On
  * Module Description: Secure user authentication.
- * Jumpstart Description: Lets you login to all your Jetpack-enabled sites with one click using your WordPress.com account.
+ * Jumpstart Description: Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.
  * Sort Order: 30
  * Recommendation Order: 5
  * First Introduced: 2.6
@@ -147,13 +147,13 @@ class Jetpack_SSO {
 
 		add_settings_section(
 			'jetpack_sso_settings',
-			__( 'Jetpack Single Sign On' , 'jetpack' ),
+			__( 'Single Sign On' , 'jetpack' ),
 			'__return_false',
 			'jetpack-sso'
 		);
 
 		/*
-		 * Settings > General > Jetpack Single Sign On
+		 * Settings > General > Single Sign On
 		 * Checkbox for Remove default login form
 		 */
 		 /* Hide in 2.9
@@ -173,7 +173,7 @@ class Jetpack_SSO {
 		*/
 
 		/*
-		 * Settings > General > Jetpack Single Sign On
+		 * Settings > General > Single Sign On
 		 * Require two step authentication
 		 */
 		register_setting(
@@ -192,7 +192,7 @@ class Jetpack_SSO {
 
 
 		/*
-		 * Settings > General > Jetpack Single Sign On
+		 * Settings > General > Single Sign On
 		 */
 		register_setting(
 			'jetpack-sso',
@@ -981,8 +981,8 @@ class Jetpack_SSO {
 		wp_enqueue_style( 'genericons' );
 		?>
 
-		<h3><?php _e( 'WordPress.com Single Sign On', 'jetpack' ); ?></h3>
-		<p><?php _e( 'Connecting with WordPress.com SSO enables you to log in via your WordPress.com account.', 'jetpack' ); ?></p>
+		<h3><?php _e( 'Single Sign On', 'jetpack' ); ?></h3>
+		<p><?php _e( 'Connecting with Single Sign On enables you to log in via your WordPress.com account.', 'jetpack' ); ?></p>
 
 		<?php if ( $this->is_user_connected( $user->ID ) ) : /* If the user is currently connected... */ ?>
 			<?php $user_data = $this->get_user_data( $user->ID ); ?>

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Module Name: WordPress.com Stats
+ * Module Name: Site Stats
  * Module Description: Collect traffic stats and insights.
  * Sort Order: 1
  * Recommendation Order: 2
  * First Introduced: 1.1
  * Requires Connection: Yes
  * Auto Activate: Yes
- * Module Tags: WordPress.com Stats, Recommended
+ * Module Tags: Site Stats, Recommended
  * Feature: Recommended, Traffic
  */
 

--- a/views/admin/landing-page-templates.php
+++ b/views/admin/landing-page-templates.php
@@ -11,7 +11,7 @@
 		$vp_link = 'https://vaultpress.com/jetpack?from=jpnux';
 		$target = '_blank';
 	}
-	$modules = 	array('Appearance', 'Developers', 'Mobile', 'Other', 'Photos and Videos', 'Social', 'WordPress.com Stats', 'Writing' );
+	$modules = 	array('Appearance', 'Developers', 'Mobile', 'Other', 'Photos and Videos', 'Social', 'Site Stats', 'Writing' );
 ?>
 <script id="tmpl-category" type="text/html">
 	<?php foreach( $modules as $module ){


### PR DESCRIPTION
Change module names so that we remove redundant "Jetpacks" and
"WordPress.coms". Specifically:

- “WordPress.com Stats" becomes "Site Stats"
- “Jetpack Single Sign On" becomes "Single Sign On"
- “WordPress.com Single Sign On" becomes "Single Sign On"
- “Jetpack Comments" becomes "Comments"
- “Jetpack Protect” becomes “Protect”