### PR TITLE
add check on ob_end_clean for cases where output_buffering is disabled

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -914,7 +914,9 @@ class The_Neverending_Home_Page {
 			// Fire wp_head to ensure that all necessary scripts are enqueued. Output isn't used, but scripts are extracted in self::action_wp_footer.
 			ob_start();
 			wp_head();
-			ob_end_clean();
+			while ( ob_get_length() ) {
+				ob_end_clean();
+			}
 
 			$results['type'] = 'success';
 
@@ -949,7 +951,9 @@ class The_Neverending_Home_Page {
 			// Fire wp_footer to ensure that all necessary scripts are enqueued. Output isn't used, but scripts are extracted in self::action_wp_footer.
 			ob_start();
 			wp_footer();
-			ob_end_clean();
+			while ( ob_get_length() ) {
+				ob_end_clean();
+			}
 
 			if ( 'success' == $results['type'] ) {
 				global $currentday;


### PR DESCRIPTION
By adding a conditional check this fixes cases where wp_head and wp_footer are accidentally output on add_action( 'custom_ajax_infinite_scroll',    array( $this, 'query' ) ) on some older systems where output_buffering is Off or insufficient (below the recommended default of 4096).