### PR TITLE
Sync WP Version

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -435,8 +435,16 @@ class Jetpack {
 		 */
 		add_filter( 'jetpack_require_lib_dir', 		array( $this, 'require_lib_dir' ) );
 
-
+		/**
+		 * We need sync object even in Multisite mode
+		 */
 		$this->sync = new Jetpack_Sync;
+
+		/**
+		 * Trigger a wp_version sync when updating WP versions
+		 **/
+		add_action( 'upgrader_process_complete', array( 'Jetpack', 'update_get_wp_version' ), 10, 2 );
+		$this->sync->mock_option( 'wp_version', array( 'Jetpack', 'get_wp_version' ) );
 
 		/*
 		 * Load things that should only be in Network Admin.
@@ -1196,7 +1204,6 @@ class Jetpack {
 			return 1;
 		}
 		return 0;
-
 	}
 
 	/**
@@ -1215,6 +1222,26 @@ class Jetpack {
 			$is_version_controlled = '0';
 		}
 		return $is_version_controlled;
+	}
+	/*
+	 * Sync back wp_version
+	 */
+	public static function get_wp_version() {
+		global $wp_version;
+		return $wp_version;
+	}
+	/**
+	 * Keeps wp_version in sync with .com when WordPress core updates
+	 **/
+	public static function update_get_wp_version( $update, $meta_data ) {
+		if ( 'update' === $meta_data['action'] && 'core' === $meta_data['type'] ) {
+			/** This action is documented in wp-includes/option.php */
+			/**
+			 * This triggers the sync for the jetpack version
+			 * See Jetpack_Sync options method for more info.
+			 */
+			do_action( 'add_option_jetpack_wp_version', 'jetpack_wp_version', (string) Jetpack::get_wp_version() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Let us sync the WP version separately. 
This PR synced the WP version on every heartbeat as well as after the user updates WordPress Core.