### PR TITLE
New parameters on the list users endpoint

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1854,6 +1854,9 @@ new WPCOM_JSON_API_List_Users_Endpoint( array(
 		),
 		'authors_only'      => "(bool) Set to true to fetch authors only",
 		'type'              => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+		'search'            => '(string) Find matching users.',
+		'search_columns'    => '(array) Specify which columns to check for matching users. Only works when combined with `search` parameter.',
+		'role'              => '(string) Specify a specific user role to fetch.'
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -51,6 +51,18 @@ gnoring limits and offsets).',
 		if ( $authors_only )
 			$query['who'] = 'authors';
 
+		if ( ! empty( $args['search'] ) ) {
+			$query['search'] = $args['search'];
+		}
+
+		if ( ! empty( $args['search_columns'] ) ) {
+			$query['search_columns'] = $args['search_columns'];
+		}
+
+		if ( ! empty( $args['role'] ) ) {
+			$query['role'] = $args['role'];
+		}
+
 		$user_query = new WP_User_Query( $query );
 
 		$return = array();
@@ -64,6 +76,8 @@ gnoring limits and offsets).',
 					foreach ( $user_query->get_results() as $u ) {
 						$the_user = $this->get_author( $u, true );
 						if ( $the_user && ! is_wp_error( $the_user ) ) {
+							$userdata = get_userdata( $u );
+							$the_user->roles = ! is_wp_error( $userdata ) ? $userdata->roles : array();
 							$users[] = $the_user;
 						}
 					}


### PR DESCRIPTION
This adds three new request parameters for /sites/$site/users:
'search', 'search_column', and 'role'

Also adds 'roles' to the response.

To test:
1. checkout sync-list-users-endpoint
2. make a request to /sites/$site/users
3. ensure that roles is part of each returned user object
4. Try using 'search' and ensure that the expected users are returned
    - example: /sites/$site/users?search=*username*
    - you can use stars at the beginning and ending of the string for wildcard chars
5. Try using 'search_columns' in combination with 'search' and ensure the expected users are returned
     - example: /sites/$site/users?search=rocco@gmail*&search_column=email
6. Try using 'role' and ensure the expected users are returned
    - example: /sites/$site/users?role=administrator
