### PR TITLE
VideoPress: added a new embed player for video shortcodes.

### DIFF
--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -605,6 +605,7 @@ class VideoPress_Player {
 			}
 
 			$js_url = 'https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress-iframe.js';
+			$js_url = add_query_arg( 'jetpack_version', JETPACK__VERSION, $js_url );
 
 			return "<iframe width='" . esc_attr( $videopress_options['width'] )
 				. "' height='" . esc_attr( $videopress_options['height'] )
@@ -615,6 +616,7 @@ class VideoPress_Player {
 		} else {
 			$videopress_options = json_encode( $videopress_options );
 			$js_url = 'https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress.js';
+			$js_url = add_query_arg( 'jetpack_version', JETPACK__VERSION, $js_url );
 
 			return "<div id='{$video_container_id}'></div>
 				<script src='{$js_url}'></script>

--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -296,6 +296,7 @@ class VideoPress_Player {
 	 * @return string HTML5 video element and children
 	 */
 	private function html5_static() {
+		wp_enqueue_script( 'videopress' );
 		$thumbnail = esc_url( $this->video->poster_frame_uri );
 		$html = "<video id=\"{$this->video_id}\" width=\"{$this->video->calculated_width}\" height=\"{$this->video->calculated_height}\" poster=\"$thumbnail\" controls=\"true\"";
 		if ( isset( $this->options['autoplay'] ) && $this->options['autoplay'] === true )
@@ -332,13 +333,35 @@ class VideoPress_Player {
 
 	/**
 	 * Click to play dynamic HTML5-capable player.
-	 * The player displays a video preview section including poster frame, video title, play button and watermark on the original page load and calculates the playback capabilities of the browser. The video player is loaded when the visitor clicks on the video preview area.
-	 * If Flash Player 10 or above is available the browser will display the Flash version of the video. If HTML5 video appears to be supported and the browser may be capable of MP4 (H.264, AAC) or OGV (Theora, Vorbis) playback the browser will display its native HTML5 player.
+	 * The player displays a video preview section including poster frame,
+	 * video title, play button and watermark on the original page load
+	 * and calculates the playback capabilities of the browser. The video player
+	 * is loaded when the visitor clicks on the video preview area.
+	 * If Flash Player 10 or above is available the browser will display
+	 * the Flash version of the video. If HTML5 video appears to be supported
+	 * and the browser may be capable of MP4 (H.264, AAC) or OGV (Theora, Vorbis)
+	 * playback the browser will display its native HTML5 player.
 	 *
 	 * @since 1.5
 	 * @return string HTML markup
 	 */
 	private function html5_dynamic() {
+
+		/**
+		 * Filter the VideoPress legacy player feature
+		 *
+		 * This filter allows you to control whether the legacy VideoPress player should be used
+		 * instead of the improved one.
+		 *
+		 * @since 3.7
+		 *
+		 * @param boolean $use_videopress_legacy
+		 */
+		if ( ! apply_filters( 'jetpack_use_videopress_legacy_player', false ) ) {
+			return $this->html5_dynamic_next();
+		}
+
+		wp_enqueue_script( 'videopress' );
 		$video_placeholder_id = $this->video_container_id . '-placeholder';
 		$age_gate_required = $this->age_gate_required();
 		$width = absint( $this->video->calculated_width );
@@ -509,6 +532,51 @@ class VideoPress_Player {
 		return $html;
 	}
 
+	function html5_dynamic_next() {
+		$video_container_id = 'v-' . $this->video->guid;
+
+		if ( ! array_key_exists( 'hd', $this->options ) ) {
+			$this->options['hd'] = (bool) get_option( 'video_player_high_quality', false );
+		}
+
+		$videopress_options = array(
+			'width' => absint( $this->video->calculated_width ),
+			'height' => absint( $this->video->calculated_height ),
+		);
+		foreach ( $this->options as $option => $value ) {
+			switch ( $option ) {
+				case 'at':
+					if ( intval( $value ) ) {
+						$videopress_options[ $option ] = intval( $value );
+					}
+					break;
+				case 'autoplay':
+					$option = 'autoPlay';
+				case 'hd':
+				case 'loop':
+				case 'permalink':
+					if ( in_array( $value, array( 1, 'true', true ) ) ) {
+						$videopress_options[ $option ] = true;
+					} elseif ( in_array( $value, array( 0, 'false', false ) ) ) {
+						$videopress_options[ $option ] = false;
+					}
+					break;
+				case 'defaultlangcode':
+					if ( $value ) {
+						$iframe_url = add_query_arg( 'defaultLangCode', $value, $iframe_url );
+					}
+					break;
+			}
+		}
+		$videopress_options = json_encode( $videopress_options );
+
+		return "<div id='{$video_container_id}'></div>
+			<script src='https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress.js'></script>
+			<script>
+				videopress('{$this->video->guid}', document.querySelector('#{$video_container_id}'), {$videopress_options});
+			</script>";
+	}
+
 	/**
 	 * Only allow legitimate Flash parameters and their values
 	 *
@@ -618,6 +686,7 @@ class VideoPress_Player {
 	 * @return string HTML markup. Embed element with no children
 	 */
 	private function flash_embed() {
+		wp_enqueue_script( 'videopress' );
 		if ( ! isset( $this->video->players->swf ) || ! isset( $this->video->players->swf->url ) )
 			return '';
 
@@ -648,6 +717,7 @@ class VideoPress_Player {
 	 * @return HTML markup. Object and children.
 	 */
 	private function flash_object() {
+		wp_enqueue_script( 'videopress' );
 		if ( ! isset( $this->video->players->swf ) || ! isset( $this->video->players->swf->url ) )
 			return '';
 

--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -593,7 +593,9 @@ class VideoPress_Player {
 
 			foreach ( $videopress_options as $option => $value ) {
 				if ( ! in_array( $option, array( 'width', 'height' ) ) ) {
-					$iframe_url = add_query_arg( $option, $value, $iframe_url );
+
+					// add_query_arg ignores false as a value, so replacing it with 0
+					$iframe_url = add_query_arg( $option, ( false === $value ) ? 0 : $value, $iframe_url );
 				}
 			}
 

--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -573,9 +573,9 @@ class VideoPress_Player {
 				case 'hd':
 				case 'loop':
 				case 'permalink':
-					if ( in_array( $value, array( 1, 'true', true ) ) ) {
+					if ( in_array( $value, array( 1, 'true' ) ) ) {
 						$videopress_options[ $option ] = true;
-					} elseif ( in_array( $value, array( 0, 'false', false ) ) ) {
+					} elseif ( in_array( $value, array( 0, 'false' ) ) ) {
 						$videopress_options[ $option ] = false;
 					}
 					break;

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -115,7 +115,7 @@ class Jetpack_VideoPress_Shortcode {
 	 */
 	public static function enqueue_scripts() {
 		$js_url = ( is_ssl() ) ? 'https://v0.wordpress.com/js/videopress.js' : 'http://s0.videopress.com/js/videopress.js';
-		wp_enqueue_script( 'videopress', $js_url, array( 'jquery', 'swfobject' ), '1.09' );
+		wp_register_script( 'videopress', $js_url, array( 'jquery', 'swfobject' ), '1.09' );
 	}
 }
 

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -78,11 +78,11 @@ class Jetpack_VideoPress_Shortcode {
 		$options = apply_filters( 'videopress_shortcode_options', array(
 			'freedom' => $attr['freedom'],
 			'force_flash' => (bool) $attr['flashonly'],
-			'autoplay' => (bool) $attr['autoplay'],
+			'autoplay' => $attr['autoplay'],
 			'forcestatic' => $attr['forcestatic'],
-			'hd' => (bool) $attr['hd'],
-			'permalink' => (bool) $attr['permalink'],
-			'loop' => (bool) $attr['autoplay'],
+			'hd' => $attr['hd'],
+			'permalink' => $attr['permalink'],
+			'loop' => $attr['autoplay'],
 			'at' => (int) $attr['at'],
 			'defaultlangcode' => $attr['defaultlangcode']
 		) );

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -135,6 +135,6 @@ class Jetpack_VideoPress_Shortcode {
 // Initialize the shortcode handler.
 Jetpack_VideoPress_Shortcode::init();
 
-wp_oembed_add_provider( 'https://videopress.com/v/*', 'http://public-api.wordpress.com/oembed/1.0/' );
+wp_oembed_add_provider( '#^https?://videopress.com/v/.*#', 'http://public-api.wordpress.com/oembed/1.0/', true );
 
 add_filter( 'oembed_fetch_url', 'Jetpack_VideoPress_Shortcode::add_oembed_parameter' );

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -117,7 +117,23 @@ class Jetpack_VideoPress_Shortcode {
 		$js_url = ( is_ssl() ) ? 'https://v0.wordpress.com/js/videopress.js' : 'http://s0.videopress.com/js/videopress.js';
 		wp_register_script( 'videopress', $js_url, array( 'jquery', 'swfobject' ), '1.09' );
 	}
+
+	/**
+	 * Adds a `for` query parameter to the oembed provider request URL.
+	 * @param String $oembed_provider
+	 * @return String $ehnanced_oembed_provider
+	 */
+	public static function add_oembed_parameter( $oembed_provider ) {
+		if ( false === stripos( $oembed_provider, 'videopress.com' ) ) {
+			return $oembed_provider;
+		}
+		return add_query_arg( 'for', parse_url( home_url(), PHP_URL_HOST ), $oembed_provider );
+	}
 }
 
 // Initialize the shortcode handler.
 Jetpack_VideoPress_Shortcode::init();
+
+wp_oembed_add_provider( 'https://videopress.com/v/*', 'http://public-api.wordpress.com/oembed/1.0/' );
+
+add_filter( 'oembed_fetch_url', 'Jetpack_VideoPress_Shortcode::add_oembed_parameter' );

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -79,7 +79,7 @@ class Jetpack_VideoPress_Shortcode {
 		) );
 
 		// Enqueue VideoPress scripts
-		self::enqueue_scripts();
+		self::register_scripts();
 
 		require_once( dirname( __FILE__ ) . '/class.videopress-video.php' );
 		require_once( dirname( __FILE__ ) . '/class.videopress-player.php' );
@@ -107,13 +107,14 @@ class Jetpack_VideoPress_Shortcode {
 	}
 
 	/**
-	 * Enqueue scripts needed to play VideoPress videos
+	 * Register scripts needed to play VideoPress videos. One of the player methods will
+	 * enqueue thoe script if needed.
 	 *
 	 * @uses is_ssl()
-	 * @uses wp_enqueue_script()
+	 * @uses wp_register_script()
 	 * @return null
 	 */
-	public static function enqueue_scripts() {
+	public static function register_scripts() {
 		$js_url = ( is_ssl() ) ? 'https://v0.wordpress.com/js/videopress.js' : 'http://s0.videopress.com/js/videopress.js';
 		wp_register_script( 'videopress', $js_url, array( 'jquery', 'swfobject' ), '1.09' );
 	}

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -40,10 +40,15 @@ class Jetpack_VideoPress_Shortcode {
 
 		$attr = shortcode_atts( array(
 			'w' => 0,
+			'h' => 0,
 			'freedom' => false,
 			'flashonly' => false,
 			'autoplay' => false,
-			'hd' => false
+			'hd' => false,
+			'permalink' => true,
+			'loop' => false,
+			'at' => 0,
+			'defaultlangcode' => false,
 		), $attr );
 
 		$attr['forcestatic'] = false;
@@ -75,7 +80,11 @@ class Jetpack_VideoPress_Shortcode {
 			'force_flash' => (bool) $attr['flashonly'],
 			'autoplay' => (bool) $attr['autoplay'],
 			'forcestatic' => $attr['forcestatic'],
-			'hd' => (bool) $attr['hd']
+			'hd' => (bool) $attr['hd'],
+			'permalink' => (bool) $attr['permalink'],
+			'loop' => (bool) $attr['autoplay'],
+			'at' => (int) $attr['at'],
+			'defaultlangcode' => $attr['defaultlangcode']
 		) );
 
 		// Enqueue VideoPress scripts


### PR DESCRIPTION
This change adds a new wpvideo shortcode player embed for HTML5 dynamic case.
Here's what to test:
- [ ] using `wpvideo` shortcodes works properly with and without parameters
- [ ] using VideoPress links works properly with and without parameters
- [ ] using IE 11 the embed switches to inline mechanism as opposed to iframe embeds for all other cases
- [ ] added filters work properly.

Here are some examples:
https://videopress.com/v/v0WArS7c?hd=1&autoplay=1&loop=1&at=3 (parameters can vary)
[wpvideo v0WArS7c hd=1 autoplay=1 loop=1 at=3]