### PR TITLE
API: Add keys to author whitelist to match WPCOM

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -502,11 +502,16 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$docs = array(
 				'ID'          => '(int)',
 				'user_login'  => '(string)',
+				'login'       => '(string)',
 				'email'       => '(string|false)',
 				'name'        => '(string)',
+				'first_name'  => '(string)',
+				'last_name'   => '(string)',
+				'nice_name'   => '(string)',
 				'URL'         => '(URL)',
 				'avatar_URL'  => '(URL)',
 				'profile_URL' => '(URL)',
+				'roles'       => '(array:string)'
 			);
 			$return[$key] = (object) $this->cast_and_filter( $value, $docs, false, $for_output );
 			break;


### PR DESCRIPTION
This PR updates the keys that are filtered for `authors` to match WPCOM.

To test:
- Checkout `update/author-whitelist`
- Make a request to `/sites/$site/users`
- Ensure that `login', 'first_name', etc. are returned in the REST console

Note: You may need to checkout #2552 as well to get the new `roles` information.