### PR TITLE
Implement themes search in the themes list endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-list-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-list-endpoint.php
@@ -7,6 +7,53 @@ class Jetpack_JSON_API_Themes_List_Endpoint extends Jetpack_JSON_API_Themes_Endp
 
 	public function validate_input( $theme ) {
 		$this->themes = wp_get_themes( array( 'allowed' => true ) );
+
+		// Shamelessly lifted from WP_Themes_List_Table::prepare_items()
+		// in wp-admin/includes/class-wp-themes-list-table.php
+		$args = $this->query_args();
+
+		if ( ! empty( $args['search'] ) )
+			$this->search_terms = array_unique( array_filter( array_map( 'trim', explode( ',', strtolower( wp_unslash( $args['search'] ) ) ) ) ) );
+		if ( ! empty( $args['features'] ) )
+			$this->features = $args['features'];
+		if ( $this->search_terms || $this->features ) {
+			foreach ( $this->themes as $key => $theme ) {
+				if ( ! $this->search_theme( $theme ) )
+					unset( $this->themes[ $key ] );
+			}
+		}
+
+		return true;
+	}
+
+	// Shamelessly lifted from WP_Themes_List_Table::search_theme()
+	// in wp-admin/includes/class-wp-themes-list-table.php
+	/**
+	 * @param WP_Theme $theme
+	 * @return bool
+	 */
+	public function search_theme( $theme ) {
+		// Search the features
+		foreach ( $this->features as $word ) {
+			if ( ! in_array( $word, $theme->get('Tags') ) )
+				return false;
+		}
+		// Match all phrases
+		foreach ( $this->search_terms as $word ) {
+			if ( in_array( $word, $theme->get('Tags') ) )
+				continue;
+			foreach ( array( 'Name', 'Description', 'Author', 'AuthorURI' ) as $header ) {
+				// Don't mark up; Do translate.
+				if ( false !== stripos( strip_tags( $theme->display( $header, false, true ) ), $word ) ) {
+					continue 2;
+				}
+			}
+			if ( false !== stripos( $theme->get_stylesheet(), $word ) )
+				continue;
+			if ( false !== stripos( $theme->get_template(), $word ) )
+				continue;
+			return false;
+		}
 		return true;
 	}
 

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -62,6 +62,10 @@ new Jetpack_JSON_API_Themes_List_Endpoint( array(
 	'path_labels' => array(
 		'$site' => '(int|string) The site ID, The site domain'
 	),
+	'query_parameters' => array(
+		'search'   => '(string) Query string to look for in a theme.',
+		'features' => '(array) Features to look for in a theme.'
+	),
 	'response_format' => array(
 		'found'  => '(int) The total number of themes found.',
 		'themes' => '(array) An array of theme objects.',


### PR DESCRIPTION
This adds `search` and a `features` query strings to the `themes` endpoint, allowing us (e.g. from within Calypso) to query for a theme and have the results already filtered on the server side (i.e. on whatever self-hosted site that Jetpack is installed), thus reducing network response size (compared to doing the search within Calypso, after receiving the entire list of installed themes -- especially in cases like a multisite installation with many network activated themes).

Code is mostly copied from `wp-admin/includes/class-wp-themes-list-table.php` where it's used for the search field in `wp-admin/themes.php`, with slight modifications.

To test:
- Check out this PR's branch on a Jetpack site of yours (which should be already connected to WPCOM)
- Go to https://developer.wordpress.com/docs/api/console/
- Enter `/v1/sites/<yourjetpacksite>/themes?search=twentyfifteen`.
- Check that _only_ relevant themes installed on that Jetpack site are returned -- in this example, it should be only Twenty Fifteen (if it's installed). (On `master`, you'd get the entire list of themes installed on that site regardless.)
- Now, try `/v1/sites/<yourjetpacksite>/themes?features[]=blue&features[]=left-sidebar
  ` -- this should also return Twenty Fifteen, possibly among others
