### PR TITLE
NUX: Capability checks to toggle modules

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -647,7 +647,7 @@ class Jetpack {
 
 	function jetpack_admin_ajax_callback() {
 		// Check for nonce
-		if ( ! isset( $_REQUEST['adminNonce'] ) || ! wp_verify_nonce( $_REQUEST['adminNonce'], 'jetpack-admin-nonce' ) ) {
+		if ( ! isset( $_REQUEST['adminNonce'] ) || ! wp_verify_nonce( $_REQUEST['adminNonce'], 'jetpack-admin-nonce' ) || ! current_user_can( 'jetpack_manage_modules' ) ) {
 			wp_die( 'permissions check failed' );
 		}
 

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -126,6 +126,7 @@
 						$normalized_site_url = Jetpack::build_raw_urls( get_home_url() );
 						$manage_active = Jetpack::is_module_active( 'manage' );
 					?>
+					<?php if ( current_user_can( 'jetpack_manage_modules' ) ) : ?>
 					<div id="manage-row" class="j-row goto <?php echo ( $manage_active ) ? 'activated' : ''; ?>">
 						<div class="feat j-col j-lrg-7 j-md-8 j-sm-7">
 							<a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jpnux' ); ?>" class="button button-primary manage-cta-active" target="_blank" style="display: <?php echo ( $manage_active ) ? 'inline-block' : 'none'; ?>;" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>"><?php _e( 'Go to WordPress.com', 'jetpack' ); ?></a>
@@ -147,6 +148,7 @@
 							</div>
 						</div>
 					</div><?php // j-row ?>
+					<?php endif; ?>
 
 				</div> <?php // nux-in ?>
 			</div><?php // j-col ?>

--- a/views/admin/landing-page-templates.php
+++ b/views/admin/landing-page-templates.php
@@ -57,6 +57,7 @@
 			<# } #>
 			<p title="{{ data.short_description }}">{{{ data.short_description }}}</p>
 		</div>
+		<?php if ( current_user_can( 'jetpack_manage_modules' ) ) : ?>
 		<div class="act j-col j-lrg-4 j-md-12 j-sm-5">
 			<div class="module-action">
 				<span>
@@ -90,5 +91,6 @@
 				</span>
 			</div>
 		</div>
+		<?php endif; ?>
 	</div><?php // j-row ?>
 </script>


### PR DESCRIPTION
Don't show module toggles to anyone but those that can do so.  

Add the capability check to the ajax permissions check as well.  