### PR TITLE
API: Adds a super admin flag to list users endpoint

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -500,18 +500,19 @@ abstract class WPCOM_JSON_API_Endpoint {
 			break;
 		case 'author' :
 			$docs = array(
-				'ID'          => '(int)',
-				'user_login'  => '(string)',
-				'login'       => '(string)',
-				'email'       => '(string|false)',
-				'name'        => '(string)',
-				'first_name'  => '(string)',
-				'last_name'   => '(string)',
-				'nice_name'   => '(string)',
-				'URL'         => '(URL)',
-				'avatar_URL'  => '(URL)',
-				'profile_URL' => '(URL)',
-				'roles'       => '(array:string)'
+				'ID'             => '(int)',
+				'user_login'     => '(string)',
+				'login'          => '(string)',
+				'email'          => '(string|false)',
+				'name'           => '(string)',
+				'first_name'     => '(string)',
+				'last_name'      => '(string)',
+				'nice_name'      => '(string)',
+				'URL'            => '(URL)',
+				'avatar_URL'     => '(URL)',
+				'profile_URL'    => '(URL)',
+				'is_super_admin' => '(bool)',
+				'roles'          => '(array:string)'
 			);
 			$return[$key] = (object) $this->cast_and_filter( $value, $docs, false, $for_output );
 			break;

--- a/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -1,9 +1,8 @@
 <?php
 class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
-	public $response_format = array(
-		'found'    => '(int) The total number of authors found that match the request (i
-gnoring limits and offsets).',
+	var $response_format = array(
+		'found'    => '(int) The total number of authors found that match the request (ignoring limits and offsets).',
 		'users'  => '(array:author) Array of user objects',
 	);
 
@@ -73,11 +72,15 @@ gnoring limits and offsets).',
 					break;
 				case 'users' :
 					$users = array();
+					$is_multisite = is_multisite();
 					foreach ( $user_query->get_results() as $u ) {
 						$the_user = $this->get_author( $u, true );
 						if ( $the_user && ! is_wp_error( $the_user ) ) {
 							$userdata = get_userdata( $u );
 							$the_user->roles = ! is_wp_error( $userdata ) ? $userdata->roles : array();
+							if ( $is_multisite ) {
+								$the_user->is_super_admin = user_can( $the_user->ID, 'manage_network' );
+							}
 							$users[] = $the_user;
 						}
 					}


### PR DESCRIPTION
Adds an `is_super_admin` flag to the list users endpoint.

To test:
- Using the REST API console, query `/sites/$site/users` where `$site` is on a multisite installation
- Each user should have an `is_super_admin` flag.
- On a single site installation, the `is_super_admin` flag should not be present