### PR TITLE
Infinite Scroll: Switch from old enqueue method to wp_enqueue.

### DIFF
--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -198,7 +198,7 @@ class Jetpack_Infinite_Scroll_Extras {
 
 		// VideoPress Jetpack module
 		if ( Jetpack::is_module_active( 'videopress' ) ) {
-			Jetpack_VideoPress_Shortcode::enqueue_scripts();
+			wp_enqueue_script( 'videopress' );
 		}
 
 		// Fire the post_gallery action early so Carousel scripts are present.


### PR DESCRIPTION
Fixes #2584 
Tested it by having both IS and VP active (previously fataled), then publishing a VP shortcode in a post under the fold so it would have to be triggered by IS. The first set of posts did not have VP to ensure that it wouldn't have been normally loaded by WP sans IS.

@zinigor 