### PR TITLE
Sharing: allow site owners to specify a custom Facebook app ID.

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -743,7 +743,7 @@ class Share_Facebook extends Sharing_Source {
 			 *
 			 * @since 3.8.0
 			 *
-			 * @param int $fb_app_id Facebook App ID. Default to empty.
+			 * @param int $fb_app_id Facebook App ID. Default to 249643311490 (WordPress.com's App ID).
 			 */
 			$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );
 			if ( is_numeric( $fb_app_id ) ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -745,7 +745,7 @@ class Share_Facebook extends Sharing_Source {
 			 *
 			 * @param int $fb_app_id Facebook App ID. Default to empty.
 			 */
-			$fb_app_id = absint( apply_filters( 'jetpack_sharing_facebook_app_id', '' ) );
+			$fb_app_id = absint( apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' ) );
 			if ( ! empty( $fb_app_id ) ) {
 				$fb_app_id = '&appId=' . $fb_app_id;
 			}

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -738,9 +738,19 @@ class Share_Facebook extends Sharing_Source {
 			if ( ! $locale ) {
 				$locale = 'en_US';
 			}
-			?>
-			<div id="fb-root"></div>
-			<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = '//connect.facebook.net/<?php echo $locale; ?>/sdk.js#xfbml=1&appId=249643311490&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
+			/**
+			 * Filter the App ID used in the official Facebook Share button.
+			 *
+			 * @since 3.8.0
+			 *
+			 * @param int $fb_app_id Facebook App ID. Default to empty.
+			 */
+			$fb_app_id = absint( apply_filters( 'jetpack_sharing_facebook_app_id', '' ) );
+			if ( ! empty( $fb_app_id ) ) {
+				$fb_app_id = '&appId=' . $fb_app_id;
+			}
+			?><div id="fb-root"></div>
+			<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = '//connect.facebook.net/<?php echo $locale; ?>/sdk.js#xfbml=1<?php echo $fb_app_id; ?>&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
 			<script>
 			jQuery( document.body ).on( 'post-load', function() {
 				if ( 'undefined' !== typeof FB ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -745,9 +745,11 @@ class Share_Facebook extends Sharing_Source {
 			 *
 			 * @param int $fb_app_id Facebook App ID. Default to empty.
 			 */
-			$fb_app_id = absint( apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' ) );
-			if ( ! empty( $fb_app_id ) ) {
+			$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );
+			if ( is_numeric( $fb_app_id ) ) {
 				$fb_app_id = '&appId=' . $fb_app_id;
+			} else {
+				$fb_app_id = '';
 			}
 			?><div id="fb-root"></div>
 			<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = '//connect.facebook.net/<?php echo $locale; ?>/sdk.js#xfbml=1<?php echo $fb_app_id; ?>&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>

--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -41,13 +41,16 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 	} else {
 		wp_enqueue_script( 'jetpack-facebook-embed', plugins_url( 'js/facebook.js', __FILE__ ), array( 'jquery' ), null, true );
 		/** This filter is documented in modules/sharedaddy/sharing-sources.php */
-		$fb_app_id = absint( apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' ) );
+		$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );
+		if ( ! is_numeric( $fb_app_id ) ) {
+			$fb_app_id = '';
+		}
 		wp_localize_script(
 			'jetpack-facebook-embed',
 			'jpfbembed',
 			array(
 				'appid' => $fb_app_id
-				)
+			)
 		);
 		return $embed;
 	}

--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -40,6 +40,15 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 		return $embed . '<script src="//connect.facebook.net/en_US/all.js#xfbml=1"></script>';
 	} else {
 		wp_enqueue_script( 'jetpack-facebook-embed', plugins_url( 'js/facebook.js', __FILE__ ), array( 'jquery' ), null, true );
+		/** This filter is documented in modules/sharedaddy/sharing-sources.php */
+		$fb_app_id = absint( apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' ) );
+		wp_localize_script(
+			'jetpack-facebook-embed',
+			'jpfbembed',
+			array(
+				'appid' => $fb_app_id
+				)
+		);
 		return $embed;
 	}
 }

--- a/modules/shortcodes/js/facebook.js
+++ b/modules/shortcodes/js/facebook.js
@@ -1,4 +1,4 @@
-/* global FB */
+/* global FB, jpfbembed */
 (function( window ) {
 	var facebookEmbed = function() {
 		if ( 'undefined' !== typeof FB && FB.XFBML ) {
@@ -14,7 +14,7 @@
 
 	window.fbAsyncInit = function() {
 		FB.init( {
-			appId  : '249643311490',
+			appId  : jpfbembed.appid,
 			version: 'v2.3'
 		} );
 

--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -68,9 +68,11 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		$locale = $this->get_locale();
 
 		/** This filter is documented in modules/sharedaddy/sharing-sources.php */
-		$fb_app_id = absint( apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' ) );
-		if ( ! empty( $fb_app_id ) ) {
+		$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );
+		if ( is_numeric( $fb_app_id ) ) {
 			$fb_app_id = '&appId=' . $fb_app_id;
+		} else {
+			$fb_app_id = '';
 		}
 
 		echo $before_widget;

--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -67,6 +67,12 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 
 		$locale = $this->get_locale();
 
+		/** This filter is documented in modules/sharedaddy/sharing-sources.php */
+		$fb_app_id = absint( apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' ) );
+		if ( ! empty( $fb_app_id ) ) {
+			$fb_app_id = '&appId=' . $fb_app_id;
+		}
+
 		echo $before_widget;
 
 		if ( ! empty( $title ) ) :
@@ -84,7 +90,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		<div class="fb-page" data-href="<?php echo esc_url( $page_url ); ?>" data-height="<?php echo intval( $like_args['height'] ); ?>" data-hide-cover="<?php echo esc_attr( $like_args['cover'] ); ?>" data-show-facepile="<?php echo esc_attr( $like_args['show_faces'] ); ?>" data-show-posts="<?php echo esc_attr( $like_args['stream'] ); ?>">
 		<div class="fb-xfbml-parse-ignore"><blockquote cite="<?php echo esc_url( $page_url ); ?>"><a href="<?php echo esc_url( $page_url ); ?>"><?php echo esc_html( $title ); ?></a></blockquote></div>
 		</div>
-		<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = '//connect.facebook.net/<?php echo esc_html( $locale ); ?>/sdk.js#xfbml=1&appId=249643311490&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
+		<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = '//connect.facebook.net/<?php echo esc_html( $locale ); ?>/sdk.js#xfbml=1<?php echo $fb_app_id; ?>&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
 		<?php
 		echo $after_widget;
 


### PR DESCRIPTION
This custom App ID will be used with the official Facebook Share button,
with the Facebook Like Box, and with the Facebook shortcode.

It also avoids having the Facebook Share button display a link to WordPress.com by default. This behaviour was introduced in 82cbc63e5bddeb0a9a261d769e3c579180f591b5, but an App ID isn't required for that button:
https://developers.facebook.com/docs/plugins/share-button

Site owners can then specify a custom App ID with a code snippet like this one:

```php
function jeherve_custom_fb_app_id() {
	return '190102077773016';
}
add_filter( 'jetpack_sharing_facebook_app_id', 'jeherve_custom_fb_app_id' );
```

Originally reported here:
https://wordpress.org/support/topic/how-to-remove-link-to-wordpresscom-on-facebook-shares?replies=3&view=all#post-7332376