### PR TITLE
Sharing / CSS: update headings in admin pages

### DIFF
--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -896,14 +896,16 @@ class Jetpack_Custom_CSS {
 		?>
 		<div class="wrap">
 			<?php
+
 			/**
 			 * Fires right before the custom css page begins.
 			 *
 			 * @since 1.7.0
 			 */
 			do_action( 'custom_design_header' );
+
 			?>
-			<h2><?php _e( 'CSS Stylesheet Editor', 'jetpack' ); ?></h2>
+			<h1><?php _e( 'CSS Stylesheet Editor', 'jetpack' ); ?></h1>
 			<form id="safecssform" action="" method="post">
 				<?php wp_nonce_field( 'safecss' ) ?>
 				<?php wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce', false ); ?>
@@ -1129,12 +1131,14 @@ class Jetpack_Custom_CSS {
 					</div>
 				</div>
 				<?php
+
 				/**
 				 * Allows addition of elements to the submit box for custom css on the wp-admin side.
 				 *
 				 * @since 2.0.3
 				 */
 				do_action( 'custom_css_submitbox_misc_actions' );
+
 				?>
 			</div>
 		</div>

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -562,7 +562,7 @@ class Jetpack_Likes {
 		$this->updated_message(); ?>
 		<div class="wrap">
 			<div class="icon32" id="icon-options-general"><br /></div>
-			<h2><?php esc_html_e( 'Sharing Settings', 'jetpack' ); ?></h2>
+			<h1><?php esc_html_e( 'Sharing Settings', 'jetpack' ); ?></h1>
 			<?php
 				/** This action is documented in modules/sharedaddy/sharing.php */
 				do_action( 'pre_admin_screen_sharing' );
@@ -583,7 +583,7 @@ class Jetpack_Likes {
 	 * Returns just the "sharing buttons" w/ like option block, so it can be inserted into different sharing page contexts
 	 */
 	function sharing_block() { ?>
-		<h3><?php esc_html_e( 'Sharing Buttons', 'jetpack' ); ?></h3>
+		<h2><?php esc_html_e( 'Sharing Buttons', 'jetpack' ); ?></h2>
 		<form method="post" action="">
 		<table class="form-table">
 		<tbody>

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -42,7 +42,7 @@ class Publicize_UI {
 	function management_page() { ?>
 		<div class="wrap">
 			<div class="icon32" id="icon-options-general"><br /></div>
-			<h2><?php _e( 'Sharing Settings', 'jetpack' ); ?></h2>
+			<h1><?php _e( 'Sharing Settings', 'jetpack' ); ?></h1>
 
 				<?php
 				/** This action is documented in modules/sharedaddy/sharing.php */
@@ -106,7 +106,7 @@ class Publicize_UI {
 		?>
 
 		<form action="" id="publicize-form">
-			<h3 id="publicize"><?php _e( 'Publicize', 'jetpack' ) ?></h3>
+			<h2 id="publicize"><?php _e( 'Publicize', 'jetpack' ) ?></h2>
 
 			<?php
 				if ( ! empty( $_GET['action'] ) && 'deny' == $_GET['action'] ) {

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -170,7 +170,7 @@ class Sharing_Admin {
 
 	<div class="wrap">
 		<div class="icon32" id="icon-options-general"><br /></div>
-		<h2><?php _e( 'Sharing Settings', 'jetpack' ); ?></h2>
+		<h1><?php _e( 'Sharing Settings', 'jetpack' ); ?></h1>
 
 		<?php
 		/**
@@ -184,7 +184,7 @@ class Sharing_Admin {
 		<?php if ( current_user_can( 'manage_options' ) ) : ?>
 
 		<div class="share_manage_options">
-		<h3><?php _e( 'Sharing Buttons', 'jetpack' ) ?></h3>
+		<h2><?php _e( 'Sharing Buttons', 'jetpack' ) ?></h2>
 		<p><?php _e( 'Add sharing buttons to your blog and allow your visitors to share posts with their friends.', 'jetpack' ) ?></p>
 
 		<div id="services-config">


### PR DESCRIPTION
@see https://make.wordpress.org/core/2015/07/31/headings-in-admin-screens-change-in-wordpress-4-3/
In WP 4.3, Headings in Admin screens changed from h2 to h1. We must reflect those changes in admin pages created by Jetpack.

In the future, we'll need to update subheadings as well, as Core updates theirs.

This change is compatible with WP installs still running 4.2. Headings will be a big bigger for them, but I think that's still acceptable:

![screen shot 2015-08-23 at 11 28 32 am](https://cloud.githubusercontent.com/assets/426388/9427686/5e89428e-498a-11e5-9a15-26c426958d4d.png)
![screen shot 2015-08-23 at 11 28 46 am](https://cloud.githubusercontent.com/assets/426388/9427687/6b1b113a-498a-11e5-82ab-b4d8810352d9.png)