### PR TITLE
Subscriptions - Adds a "help" icon link to the per-post option text

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -133,6 +133,7 @@ class Jetpack_Subscriptions {
 				<label for="_jetpack_dont_email_post_to_subs"><?php _e( 'Jetpack Subscriptions:', 'jetpack' ); ?></label><br>
 				<input type="checkbox" name="_jetpack_dont_email_post_to_subs" id="jetpack-per-post-subscribe" value="1" <?php checked( $disable_subscribe_value, 1, true ); ?> />
 				<?php _e( 'Don&#8217;t send this to subscribers', 'jetpack' ); ?>
+				<a class="dashicons dashicons-editor-help" style="color: #B4B9BE;" href="http://jetpack.me/support/subscriptions/#subscriptions-off-per-post" target="_blank"></a>
 			</div>
 		<?php endif;
 	}


### PR DESCRIPTION
Adds a "help" icon link to the text, so that people can click to get more information about what is actually happening.  For more backstory on that, check out Jetpack's p2 post by @jeherve.  Note that if we include it, we'll need to create a new section in jetpack.me/support/subscriptions for this.  