### PR TITLE
Three new filters for sending post emails to subscribers 

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -176,6 +176,14 @@ class Jetpack_Subscriptions {
 			return;
 		}
 
+		/*
+		 * Array of categories that will never trigger subscription emails.
+		 * Will not send subscription emails from any post from within these categories.
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param array - Array of category slugs or ID's
+		 */
 		$excluded_categories = apply_filters( 'jetpack_subscriptions_exclude_these_categories', array() );
 
 		// Never email posts from these categories
@@ -183,7 +191,15 @@ class Jetpack_Subscriptions {
 			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 		}
 
-		$only_these_categories = apply_filters( 'jetpack_subscriptions_include_only_these_categories', array() );
+		/*
+		 * ONLY send subscription emails for these categories
+		 * Will ONLY send subscription emails to these categories.
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param array - Array of category slugs or ID's
+		 */
+		$only_these_categories = apply_filters( 'jetpack_subscriptions_exclude_all_categories_except', array() );
 
 		// Only emails posts from these categories
 		if ( ! empty( $only_these_categories ) && ! in_category( $only_these_categories, $post->ID ) ) {

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -89,8 +89,19 @@ class Jetpack_Subscriptions {
 		add_action( 'comment_post', array( $this, 'comment_subscribe_submit' ), 50, 2 );
 
 		// Adds post meta checkbox in the post submit metabox
-		add_action( 'post_submitbox_misc_actions', array( $this, 'subscription_post_page_metabox' ) );
-		add_action( 'save_post', array( $this, 'save_subscribe_meta' ) );
+		if (
+			/**
+			 * Filter whether or not to show the per-post subscription option.
+			 *
+			 * @since 3.7.0
+			 *
+			 * @param bool true = show checkbox option on all new posts | false = hide the option.
+			 */
+			apply_filters( 'jetpack_allow_per_post_subscriptions', false ) )
+		{
+			add_action( 'post_submitbox_misc_actions', array( $this, 'subscription_post_page_metabox' ) );
+			add_action( 'save_post', array( $this, 'save_subscribe_meta' ) );
+		}
 	}
 
 	function post_is_public( $the_post ) {

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -153,7 +153,7 @@ class Jetpack_Subscriptions {
 		<?php endif;
 	}
 
-	/*
+	/**
 	 * Checks whether or not the post should be emailed to subscribers
 	 *
 	 * It checks for the following things in order:
@@ -176,13 +176,13 @@ class Jetpack_Subscriptions {
 			return;
 		}
 
-		/*
+		/**
 		 * Array of categories that will never trigger subscription emails.
 		 * Will not send subscription emails from any post from within these categories.
 		 *
 		 * @since 3.7.0
 		 *
-		 * @param array - Array of category slugs or ID's
+		 * @param array $args Array of category slugs or ID's.
 		 */
 		$excluded_categories = apply_filters( 'jetpack_subscriptions_exclude_these_categories', array() );
 
@@ -191,13 +191,13 @@ class Jetpack_Subscriptions {
 			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 		}
 
-		/*
+		/**
 		 * ONLY send subscription emails for these categories
 		 * Will ONLY send subscription emails to these categories.
 		 *
 		 * @since 3.7.0
 		 *
-		 * @param array - Array of category slugs or ID's
+		 * @param array $args Array of category slugs or ID's.
 		 */
 		$only_these_categories = apply_filters( 'jetpack_subscriptions_exclude_all_categories_except', array() );
 


### PR DESCRIPTION
This PR does a couple things:
- The per-post subscription email option is OFF by default. 
- Renames and refactors the method that adds the meta to skip email.  It now is hooked onto `transition_post_status` instead of `save_post` so we can reliably only do things when the post is being published.
- Adds 3 new filters (explained below)

<strong>Filter `jetpack_allow_per_post_subscriptions`:</strong>
- Example usage: `add_filter( 'jetpack_allow_per_post_subscriptions', '__return_true' );`
- Will add a checkbox option to every new post of whether or not to email the post to subs

<strong>Filter `jetpack_subscriptions_exclude_these_categories`:</strong>
- Example usage: 
```php
add_filter( 'jetpack_subscriptions_exclude_these_categories', 'exclude_these' );
function exclude_these( $categories ) {
    $categories = array( 'category-slug', 'category-slug-2');
    return $categories;
}
```
- Will never send subscriptions emails to whatever categories are in that array

<strong>Filter `jetpack_subscriptions_exclude_all_categories_except`:</strong>
- Example usage: 
```php
add_filter( 'jetpack_subscriptions_exclude_all_categories_except', 'exclude_all_except' );
function exclude_all_except( $categories ) {
    $categories = array( 'category-slug', 'category-slug-2');
    return $categories;
}
```
- Will never send subscription email for posts, UNLESS the post in in one of these categories.  

NOTE: 
- These filters are not meant to be used together.  Only one should be used at a time.  They will override each other and it will be awkward. 
- If either of the category filters are set, then the per-post checkbox will not display no matter what.  