### PR TITLE
Subs Widget: better error for when emails has blocked subscriptions

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -534,6 +534,9 @@ class Jetpack_Subscriptions {
 				$result = $error;
 				break;
 			case 'active':
+			case 'blocked_email':
+				$result = 'opted_out';
+				break;
 			case 'pending':
 				$result = 'already';
 				break;
@@ -733,6 +736,9 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			switch ( $_GET['subscribe'] ) :
 				case 'invalid_email' : ?>
 					<p class="error"><?php esc_html_e( 'The email you entered was invalid. Please check and try again.', 'jetpack' ); ?></p>
+				<?php break;
+				case 'opted_out' : ?>
+					<p class="error"><?php esc_html_e( 'The email address has opted out of subscription emails.', 'jetpack' ); ?></p>
 				<?php break;
 				case 'already' : ?>
 					<p class="error"><?php esc_html_e( 'You have already subscribed to this site. Please check your inbox.', 'jetpack' ); ?></p>

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -738,7 +738,10 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 					<p class="error"><?php esc_html_e( 'The email you entered was invalid. Please check and try again.', 'jetpack' ); ?></p>
 				<?php break;
 				case 'opted_out' : ?>
-					<p class="error"><?php esc_html_e( 'The email address has opted out of subscription emails.', 'jetpack' ); ?></p>
+					<p class="error"><?php printf( _x( "The email address has opted out of subscription emails. %1s You can manage your preferences at %2s", '%1s is a line break, %2s is a website', 'jetpack' ),
+							'<br />',
+							'<a href="https://subscribe.wordpress.com/" target="_blank">subscribe.wordpress.com</a>'
+						); ?>
 				<?php break;
 				case 'already' : ?>
 					<p class="error"><?php esc_html_e( 'You have already subscribed to this site. Please check your inbox.', 'jetpack' ); ?></p>

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -740,7 +740,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				case 'opted_out' : ?>
 					<p class="error"><?php printf( __( 'The email address has opted out of subscription emails. <br /> You can manage your preferences at <a href="%1$s" title="%2$s" target="_blank">subscribe.wordpress.com</a>', 'jetpack' ),
 							'https://subscribe.wordpress.com/',
-							__( 'Mange your email preferences.', 'jetpack' )
+							__( 'Manage your email preferences.', 'jetpack' )
 						); ?>
 				<?php break;
 				case 'already' : ?>

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -738,9 +738,9 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 					<p class="error"><?php esc_html_e( 'The email you entered was invalid. Please check and try again.', 'jetpack' ); ?></p>
 				<?php break;
 				case 'opted_out' : ?>
-					<p class="error"><?php printf( _x( "The email address has opted out of subscription emails. %1s You can manage your preferences at %2s", '%1s is a line break, %2s is a website', 'jetpack' ),
-							'<br />',
-							'<a href="https://subscribe.wordpress.com/" target="_blank">subscribe.wordpress.com</a>'
+					<p class="error"><?php printf( __( 'The email address has opted out of subscription emails. <br /> You can manage your preferences at <a href="%1$s" title="%2$s" target="_blank">subscribe.wordpress.com</a>', 'jetpack' ),
+							'https://subscribe.wordpress.com/',
+							__( 'Mange your email preferences.', 'jetpack' )
 						); ?>
 				<?php break;
 				case 'already' : ?>


### PR DESCRIPTION
Fixes #2007

To test: 
append this to a url that has the subscription widget `?subscribe=opted_out`