### PR TITLE
Shortlink: Short-circuit earlier

### DIFF
--- a/modules/shortlinks.php
+++ b/modules/shortlinks.php
@@ -9,7 +9,7 @@
  * Module Tags: Social
  */
 
-add_filter( 'get_shortlink', 'wpme_get_shortlink_handler', 1, 4 );
+add_filter( 'pre_get_shortlink', 'wpme_get_shortlink_handler', 1, 4 );
 
 if ( !function_exists( 'wpme_dec2sixtwo' ) ) {
 	function wpme_dec2sixtwo( $num ) {


### PR DESCRIPTION
Switches to using pre_get_shortlink, allows us to return the shortlink
earlier, before the core version of the generator runs.

Fixes #2587