### PR TITLE
Remove filter which converts https home_url to http

### DIFF
--- a/class.json-api.php
+++ b/class.json-api.php
@@ -141,8 +141,6 @@ class WPCOM_JSON_API {
 
 		$this->exit = (bool) $exit;
 
-		add_filter( 'home_url', array( $this, 'ensure_http_scheme_of_home_url' ), 10, 3 );
-
 		add_filter( 'user_can_richedit', '__return_true' );
 
 		add_filter( 'comment_edit_pre', array( $this, 'comment_edit_pre' ) );
@@ -483,14 +481,6 @@ class WPCOM_JSON_API {
 		}
 
 		return $response;
-	}
-
-	function ensure_http_scheme_of_home_url( $url, $path, $original_scheme ) {
-		if ( $original_scheme ) {
-			return $url;
-		}
-
-		return preg_replace( '#^https:#', 'http:', $url );
 	}
 
 	function comment_edit_pre( $comment_content ) {

--- a/modules/shortcodes/mesh.php
+++ b/modules/shortcodes/mesh.php
@@ -1,0 +1,15 @@
+<?php
+
+// Nicer Mesh email subscription output
+function subscription_email_mesh( $existing ) {
+	$existing[] = array(
+		'regex' => '@<div style=".*?" class="mesh-embed">\s*<div style="padding-top: 100%"></div>\s*(?:<p>)<iframe src="(https://me\.sh.*?)".*?</iframe>\s*</div>@',
+		'endpoint' => 'https://me.sh/oembed'
+	);
+
+	return $existing;
+}
+
+add_filter( 'subscription_email_oembeds', 'subscription_email_mesh' );
+
+wp_oembed_add_provider( '#https?://me.sh/.*#i', 'https://me.sh/oembed?format=json', true );


### PR DESCRIPTION
A filter is added to the `home_url` which is forcing a https connection to http 
For more info see internal P2 post on operationapi

I made this change to my sites local Jetpack plugin and you can see the URL parameter is correct 
https://public-api.wordpress.com/rest/v1/sites/43850591/?pretty=true

