### PR TITLE
Update/videopress data fetch

### DIFF
--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -599,13 +599,6 @@ class VideoPress_Player {
 				}
 			}
 
-			if ( ! isset( $videopress_options['width'] ) ) {
-				$videopress_options['width'] = '100%';
-			}
-			if ( ! isset( $videopress_options['height'] ) ) {
-				$videopress_options['height'] = '100%';
-			}
-
 			$js_url = 'https://s0.wp.com/wp-content/plugins/video/assets/js/next/videopress-iframe.js';
 			$js_url = add_query_arg( 'jetpack_version', JETPACK__VERSION, $js_url );
 

--- a/modules/videopress/class.videopress-video.php
+++ b/modules/videopress/class.videopress-video.php
@@ -166,7 +166,7 @@ class VideoPress_Video {
 	 * @var string $guid VideoPress unique identifier
 	 * @var int $maxwidth maximum requested video width. final width and height are calculated on VideoPress servers based on the aspect ratio of the original video upload.
 	 */
-	public function __construct( $guid, $maxwidth = 0 ) {
+	public function __construct( $guid, $maxwidth = 640 ) {
 		$this->guid = $guid;
 
 		$maxwidth = absint( $maxwidth );
@@ -175,8 +175,12 @@ class VideoPress_Video {
 
 		$data = $this->get_data();
 		if ( is_wp_error( $data ) || empty( $data ) ) {
-			$this->error = $data;
-			return;
+			if ( ! apply_filters( 'jetpack_videopress_use_legacy_player', false ) ) {
+				$data = (object) array( 'guid' => $guid, 'width' => $maxwidth, 'height' => $maxwidth / 16 * 9 );
+			} else {
+				$this->error = $data;
+				return;
+			}
 		}
 
 		if ( isset( $data->blog_id ) )

--- a/modules/videopress/class.videopress-video.php
+++ b/modules/videopress/class.videopress-video.php
@@ -175,7 +175,9 @@ class VideoPress_Video {
 
 		$data = $this->get_data();
 		if ( is_wp_error( $data ) || empty( $data ) ) {
+			/** This filter is documented in modules/videopress/class.videopress-player.php */
 			if ( ! apply_filters( 'jetpack_videopress_use_legacy_player', false ) ) {
+				// Unlike the Flash player, the new player does it's own error checking, age gate, etc.
 				$data = (object) array( 'guid' => $guid, 'width' => $maxwidth, 'height' => $maxwidth / 16 * 9 );
 			} else {
 				$this->error = $data;


### PR DESCRIPTION
Grabbing data from WordPress.com isn't necessary for the new VideoPress player. It does it's own error checking and age gating.