### PR TITLE
Manage: Add wordpress.com to safe redirect whitelist

### DIFF
--- a/modules/manage.php
+++ b/modules/manage.php
@@ -14,6 +14,24 @@
 
 add_action( 'jetpack_activate_module_manage', array( Jetpack::init(), 'toggle_module_on_wpcom' ) );
 add_action( 'jetpack_deactivate_module_manage', array( Jetpack::init(), 'toggle_module_on_wpcom' ) );
+add_action( 'customize_register', 'add_wpcom_to_allowed_redirect_hosts' );
+
+// Add wordpress.com to the safe redirect whitelist if the Manage module is enabled
+// so the customizer can `return` to wordpress.com if invoked from there.
+function add_wpcom_to_allowed_redirect_hosts( $domains ) {
+	if ( Jetpack::is_module_active( 'manage' ) ) {
+		add_filter( 'allowed_redirect_hosts', allow_wpcom_domain );
+	}
+}
+
+// Return $domains, with 'wordpress.com' appended.
+function allow_wpcom_domain( $domains ) {
+	if ( empty( $domains ) ) {
+		$domains = array();
+	}
+	$domains[] = 'wordpress.com';
+	return array_unique( $domains );
+}
 
 // Re add sync for non public posts when the optin is selected in Calypso.
 // This will only work if you have manage enabled as well.

--- a/modules/manage.php
+++ b/modules/manage.php
@@ -20,7 +20,7 @@ add_action( 'customize_register', 'add_wpcom_to_allowed_redirect_hosts' );
 // so the customizer can `return` to wordpress.com if invoked from there.
 function add_wpcom_to_allowed_redirect_hosts( $domains ) {
 	if ( Jetpack::is_module_active( 'manage' ) ) {
-		add_filter( 'allowed_redirect_hosts', allow_wpcom_domain );
+		add_filter( 'allowed_redirect_hosts', 'allow_wpcom_domain' );
 	}
 }
 


### PR DESCRIPTION
This way, the customizer can return to wordpress.com if invoked from there, i.e. using the `return` query arg.

To test:
1. Point your browser to
https://<jetpacksite>/wp-admin/customize.php?theme=twentyfifteen&return=%2F%2Fwordpress.com
2. Close the customizer using the top left 'X'
3. Check you're being redirected to wordpress.com

This is required to fix what testers found to be an issue with the Jetpack-integrated Calypso Theme Showcase, see https://teamhyperion.wordpress.com/2015/08/20/call-for-testing-theme-showcase-jetpack-integration/#comment-2532 -- so it'd be great if we could get this into 3.7, since it's practically a fix for an issue found during 3.7-beta testing.

/cc @ehg @folletto