### PR TITLE
Move the Link To WPCOM button back to the top of admin page

### DIFF
--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -37,6 +37,12 @@
 
 		<?php endif; ?>
 
+		<?php if ( $data['is_connected'] && ! $data['is_user_connected'] && current_user_can( 'jetpack_connect_user' ) ) : ?>
+			<div class="link-button" style="width: 100%; text-align: center; margin-top: 15px;">
+				<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to WordPress.com', 'jetpack' ); ?></a>
+			</div>
+		<?php endif; ?>
+
 		<div class="nux-intro jp-content" style="display: none;">
 
 		<h1 title="<?php esc_attr_e( 'Improve your site with Jetpack', 'jetpack' ); ?>"><?php _e( 'Improve your site with Jetpack', 'jetpack' ); ?></h1>
@@ -245,12 +251,6 @@
 		</div><?php // nux-foot ?>
 
 		</div><?php // nux-intro ?>
-
-			<?php if ( $data['is_connected'] && ! $data['is_user_connected'] && current_user_can( 'jetpack_connect_user' ) ) : ?>
-				<div class="link-button" style="width: 100%; text-align: center; margin-top: 15px;">
-					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Link your account to WordPress.com', 'jetpack' ); ?></a>
-				</div>
-			<?php endif; ?>
 
 </div><!-- .landing -->
 


### PR DESCRIPTION
It got left down below during the admin page rework.  Move it back to the top to show to unlinked users.  

before: https://cloudup.com/cChciA62R-M
after: https://cloudup.com/cVD8llZcgyJ