### PR TITLE
Subscriptions: Update form submission action

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -527,6 +527,7 @@ class Jetpack_Subscriptions {
 		}
 
 		if ( $error ) {
+			$result = $error;
 			switch ( $error ) {
 				case 'invalid_email':
 					$redirect = add_query_arg( 'subscribe', 'invalid_email' );
@@ -539,6 +540,7 @@ class Jetpack_Subscriptions {
 					break;
 			}
 		} else {
+			$result = 'success';
 			$redirect = add_query_arg( 'subscribe', 'success' );
 		}
 
@@ -547,9 +549,9 @@ class Jetpack_Subscriptions {
 		 *
 		 * @since 3.7.0
 		 *
-		 * @param string $redirect Subscription form submission status.
+		 * @param string $result Result of form submission: success, invalid_email, already, error.
 		 */
-		do_action( 'jetpack_subscriptions_form_submission', $redirect );
+		do_action( 'jetpack_subscriptions_form_submission', $result );
 
 		wp_safe_redirect( "$redirect#$redirect_fragment" );
 		exit;

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -526,23 +526,23 @@ class Jetpack_Subscriptions {
 			}
 		}
 
-		if ( $error ) {
-			$result = $error;
-			switch ( $error ) {
-				case 'invalid_email':
-					$redirect = add_query_arg( 'subscribe', 'invalid_email' );
-					break;
-				case 'active': case 'pending':
-					$redirect = add_query_arg( 'subscribe', 'already' );
-					break;
-				default:
-					$redirect = add_query_arg( 'subscribe', 'error' );
-					break;
-			}
-		} else {
-			$result = 'success';
-			$redirect = add_query_arg( 'subscribe', 'success' );
+		switch ( $error ) {
+			case false:
+				$result = 'success';
+				break;
+			case 'invalid_email':
+				$result = $error;
+				break;
+			case 'active':
+			case 'pending':
+				$result = 'already';
+				break;
+			default:
+				$result = 'error';
+				break;
 		}
+
+		$redirect = add_query_arg( 'subscribe', $result );
 
 		/**
 		 * Fires on each subscription form submission.


### PR DESCRIPTION
Instead of using the full redirect URL, which requires more work to determine the result within the URL, add a $result variable that is set to either the error code or 'success'.

See #184, #2519