### PR TITLE
Responsive Videos: only wrap video oEmbeds

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -53,8 +53,7 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 	if ( empty( $html ) || ! is_string( $html ) || ! $url ) {
 		return $html;
 	}
-
-	$is_video = false;
+	
 	/**
 	 * oEmbed Video Providers.
 	 *
@@ -85,7 +84,7 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 	$is_video = preg_match( $video_patterns, $url );
 
 	// If the oEmbed is a video, wrap it in the responsive wrapper.
-	if ( $is_video ) {
+	if ( false !== $is_video ) {
 		return jetpack_responsive_videos_embed_html( $html );
 	}
 

--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -13,8 +13,9 @@ function jetpack_responsive_videos_init() {
 	add_filter( 'wp_video_shortcode', 'jetpack_responsive_videos_embed_html' );
 	add_filter( 'video_embed_html',   'jetpack_responsive_videos_embed_html' );
 
-	/* Only wrap oEmbeds if YouTube or Vimeo */
+	/* Only wrap oEmbeds if video */
 	add_filter( 'embed_oembed_html',  'jetpack_responsive_videos_maybe_wrap_oembed', 10, 2 );
+	add_filter( 'embed_handler_html', 'jetpack_responsive_videos_maybe_wrap_oembed', 10, 2 );
 
 	/* Wrap videos in Buddypress */
 	add_filter( 'bp_embed_oembed_html', 'jetpack_responsive_videos_embed_html' );
@@ -53,7 +54,11 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 	if ( empty( $html ) || ! is_string( $html ) || ! $url ) {
 		return $html;
 	}
-	
+
+	$jetpack_video_wrapper = '<div class="jetpack-video-wrapper">';
+
+	$already_wrapped = preg_match( $jetpack_video_wrapper, $html );
+
 	/**
 	 * oEmbed Video Providers.
 	 *
@@ -84,7 +89,7 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 	$is_video = preg_match( $video_patterns, $url );
 
 	// If the oEmbed is a video, wrap it in the responsive wrapper.
-	if ( false !== $is_video ) {
+	if ( 1 !== $already_wrapped && 0 !== $is_video ) {
 		return jetpack_responsive_videos_embed_html( $html );
 	}
 

--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -89,7 +89,7 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 	$is_video = preg_match( $video_patterns, $url );
 
 	// If the oEmbed is a video, wrap it in the responsive wrapper.
-	if ( 1 !== $already_wrapped && 0 !== $is_video ) {
+	if ( 1 !== $already_wrapped && 1 === $is_video ) {
 		return jetpack_responsive_videos_embed_html( $html );
 	}
 

--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -11,12 +11,14 @@ function jetpack_responsive_videos_init() {
 
 	/* If the theme does support 'jetpack-responsive-videos', wrap the videos */
 	add_filter( 'wp_video_shortcode', 'jetpack_responsive_videos_embed_html' );
-	add_filter( 'embed_oembed_html',  'jetpack_responsive_videos_embed_html' );
 	add_filter( 'video_embed_html',   'jetpack_responsive_videos_embed_html' );
+	add_filter( 'wp_embed_handler_youtube', 'jetpack_responsive_videos_embed_html' );
+
+	/* Only wrap oEmbeds if YouTube or Vimeo */
+	add_filter( 'embed_oembed_html',  'jetpack_responsive_videos_maybe_wrap_oembed', 10, 2 );
 
 	/* Wrap videos in Buddypress */
 	add_filter( 'bp_embed_oembed_html', 'jetpack_responsive_videos_embed_html' );
-
 }
 add_action( 'after_setup_theme', 'jetpack_responsive_videos_init', 99 );
 
@@ -41,4 +43,28 @@ function jetpack_responsive_videos_embed_html( $html ) {
 	wp_enqueue_style( 'jetpack-responsive-videos-style' );
 
 	return '<div class="jetpack-video-wrapper">' . $html . '</div>';
+}
+
+/**
+ * Check if oEmbed is YouTube or Vimeo before wrapping.
+ *
+ * @return string
+ */
+function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
+	if ( empty( $html ) || ! is_string( $html ) || ! $url ) {
+		return $html;
+	}
+
+	$is_vimeo = $is_youtube = false;
+	$yt_pattern = '#^https?://(?:www\.)?(?:youtube\.com/watch|youtu\.be/)#';
+	$vimeo_pattern = '#^https?://(.+\.)?vimeo\.com/.*#';
+
+	$is_vimeo = ( preg_match( $vimeo_pattern, $url ) );
+	$is_youtube = ( preg_match( $yt_pattern, $url ) );
+
+	if ( $is_vimeo || $is_youtube ) {
+		return jetpack_responsive_videos_embed_html( $html );
+	}
+
+	return $html;
 }

--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -57,7 +57,12 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 
 	$jetpack_video_wrapper = '<div class="jetpack-video-wrapper">';
 
-	$already_wrapped = preg_match( $jetpack_video_wrapper, $html );
+	$already_wrapped = strpos( $html, $jetpack_video_wrapper );
+
+	// If the oEmbed has already been wrapped, return the html.
+	if ( false !== $already_wrapped ) {
+		return $html;
+	}
 
 	/**
 	 * oEmbed Video Providers.
@@ -89,7 +94,7 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 	$is_video = preg_match( $video_patterns, $url );
 
 	// If the oEmbed is a video, wrap it in the responsive wrapper.
-	if ( 1 !== $already_wrapped && 1 === $is_video ) {
+	if ( false === $already_wrapped && 1 === $is_video ) {
 		return jetpack_responsive_videos_embed_html( $html );
 	}
 

--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -56,13 +56,19 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 	}
 
 	$is_video = false;
+	/**
+	 * oEmbed Video Providers.
+	 *
+	 * A whitelist of oEmbed video provider Regex patterns to check against before wrapping the output.
+	 *
+	 * @since 3.7
+	 *
+	 * @param array $video_patterns oEmbed video provider Regex patterns.
+	 */
 	$video_patterns = apply_filters( 'jetpack_responsive_videos_oembed_videos', array(
-		'http://((m|www)\.)?youtube\.com/watch',
-		'https://((m|www)\.)?youtube\.com/watch',
-		'http://((m|www)\.)?youtube\.com/playlist',
-		'https://((m|www)\.)?youtube\.com/playlist',
-		'http://youtu\.be/',
-		'https://youtu\.be/',
+		'https?://((m|www)\.)?youtube\.com/watch',
+		'https?://((m|www)\.)?youtube\.com/playlist',
+		'https?://youtu\.be/',
 		'https?://(.+\.)?vimeo\.com/',
 		'https?://(www\.)?dailymotion\.com/',
 		'https?://dai.ly/',
@@ -73,10 +79,13 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 		'https?://(www\.)?collegehumor\.com/video/',
 		'https?://(www\.|embed\.)?ted\.com/talks/'
 	) );
+
+	// Merge patterns to run in a single preg_match call.
 	$video_patterns = '(' . implode( '|', $video_patterns ) . ')';
 
 	$is_video = preg_match( $video_patterns, $url );
 
+	// If the oEmbed is a video, wrap it in the responsive wrapper.
 	if ( $is_video ) {
 		return jetpack_responsive_videos_embed_html( $html );
 	}

--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -55,15 +55,31 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 		return $html;
 	}
 
-	$is_vimeo = $is_youtube = false;
-	$yt_pattern = '#^https?://(?:www\.)?(?:youtube\.com/watch|youtu\.be/)#';
-	$vimeo_pattern = '#^https?://(.+\.)?vimeo\.com/.*#';
+	$is_video = false;
+	$video_patterns = apply_filters( 'jetpack_responsive_videos_oembed_videos', array(
+		'#http://((m|www)\.)?youtube\.com/watch.*#i',
+		'#https://((m|www)\.)?youtube\.com/watch.*#i',
+		'#http://((m|www)\.)?youtube\.com/playlist.*#i',
+		'#https://((m|www)\.)?youtube\.com/playlist.*#i',
+		'#http://youtu\.be/.*#i',
+		'#https://youtu\.be/.*#i',
+		'#https?://(.+\.)?vimeo\.com/.*#i',
+		'#https?://(www\.)?dailymotion\.com/.*#i',
+		'#https?://dai.ly/*#i',
+		'#https?://(www\.)?hulu\.com/watch/.*#i',
+		'#https?://wordpress.tv/.*#i',
+		'#https?://(www\.)?funnyordie\.com/videos/.*#i',
+		'#https?://vine.co/v/.*#i',
+		'#https?://(www\.)?collegehumor\.com/video/.*#i',
+		'#https?://(www\.|embed\.)?ted\.com/talks/.*#i'
+	) );
 
-	$is_vimeo = ( preg_match( $vimeo_pattern, $url ) );
-	$is_youtube = ( preg_match( $yt_pattern, $url ) );
+	foreach ( $video_patterns as $video_pattern ) {
+		$is_video = preg_match( $video_pattern, $url );
 
-	if ( $is_vimeo || $is_youtube ) {
-		return jetpack_responsive_videos_embed_html( $html );
+		if ( $is_video ) {
+			return jetpack_responsive_videos_embed_html( $html );
+		}
 	}
 
 	return $html;

--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -12,7 +12,6 @@ function jetpack_responsive_videos_init() {
 	/* If the theme does support 'jetpack-responsive-videos', wrap the videos */
 	add_filter( 'wp_video_shortcode', 'jetpack_responsive_videos_embed_html' );
 	add_filter( 'video_embed_html',   'jetpack_responsive_videos_embed_html' );
-	add_filter( 'wp_embed_handler_youtube', 'jetpack_responsive_videos_embed_html' );
 
 	/* Only wrap oEmbeds if YouTube or Vimeo */
 	add_filter( 'embed_oembed_html',  'jetpack_responsive_videos_maybe_wrap_oembed', 10, 2 );

--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -57,29 +57,28 @@ function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
 
 	$is_video = false;
 	$video_patterns = apply_filters( 'jetpack_responsive_videos_oembed_videos', array(
-		'#http://((m|www)\.)?youtube\.com/watch.*#i',
-		'#https://((m|www)\.)?youtube\.com/watch.*#i',
-		'#http://((m|www)\.)?youtube\.com/playlist.*#i',
-		'#https://((m|www)\.)?youtube\.com/playlist.*#i',
-		'#http://youtu\.be/.*#i',
-		'#https://youtu\.be/.*#i',
-		'#https?://(.+\.)?vimeo\.com/.*#i',
-		'#https?://(www\.)?dailymotion\.com/.*#i',
-		'#https?://dai.ly/*#i',
-		'#https?://(www\.)?hulu\.com/watch/.*#i',
-		'#https?://wordpress.tv/.*#i',
-		'#https?://(www\.)?funnyordie\.com/videos/.*#i',
-		'#https?://vine.co/v/.*#i',
-		'#https?://(www\.)?collegehumor\.com/video/.*#i',
-		'#https?://(www\.|embed\.)?ted\.com/talks/.*#i'
+		'http://((m|www)\.)?youtube\.com/watch',
+		'https://((m|www)\.)?youtube\.com/watch',
+		'http://((m|www)\.)?youtube\.com/playlist',
+		'https://((m|www)\.)?youtube\.com/playlist',
+		'http://youtu\.be/',
+		'https://youtu\.be/',
+		'https?://(.+\.)?vimeo\.com/',
+		'https?://(www\.)?dailymotion\.com/',
+		'https?://dai.ly/',
+		'https?://(www\.)?hulu\.com/watch/',
+		'https?://wordpress.tv/',
+		'https?://(www\.)?funnyordie\.com/videos/',
+		'https?://vine.co/v/',
+		'https?://(www\.)?collegehumor\.com/video/',
+		'https?://(www\.|embed\.)?ted\.com/talks/'
 	) );
+	$video_patterns = '(' . implode( '|', $video_patterns ) . ')';
 
-	foreach ( $video_patterns as $video_pattern ) {
-		$is_video = preg_match( $video_pattern, $url );
+	$is_video = preg_match( $video_patterns, $url );
 
-		if ( $is_video ) {
-			return jetpack_responsive_videos_embed_html( $html );
-		}
+	if ( $is_video ) {
+		return jetpack_responsive_videos_embed_html( $html );
 	}
 
 	return $html;


### PR DESCRIPTION
When called on `embed_oembed_html`, checks against a whitelist of video oEmbed endpoints. Fixes #2440