### PR TITLE
Fix/idc enqueue alert styles correctly

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5885,7 +5885,7 @@ p {
 							<p><?php printf( __( 'It looks like you may have changed your domain. Is <strong>%1$s</strong> still your site\'s domain, or have you updated it to <strong> %2$s </strong>?', 'jetpack' ), $errors[ $key ], (string) get_option( $key ) ); ?></p>
 							</div>
 						<div class="btn-group">
-							<a href="#" class="regular site-moved"><?php _e( 'I\'ve updated it.', 'jetpack' ); ?></a> or <a href="#" class="site-not-moved" ><?php _e( 'That\'s still my domain.', 'jetpack' ); ?></a>
+							<a href="#" class="regular site-moved"><?php _e( 'I\'ve updated it.', 'jetpack' ); ?></a> <span class="idc-separator">|</span> <a href="#" class="site-not-moved" ><?php _e( 'That\'s still my domain.', 'jetpack' ); ?></a>
 							<span class="spinner"></span>
 						</div>
 					<?php endif ; ?>
@@ -5896,9 +5896,9 @@ p {
 						<p><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services. %3s What does this mean? %4s', 'jetpack' ), $errors[ $key ], (string) get_option( $key ), "<a href='https://jetpack.me/support/what-does-resetting-the-connection-mean/' target='_blank' title='" . esc_attr__( 'What does resetting the connection mean?', 'jetpack' ) . "'><em>", "</em></a>" ); ?></p>
 					</div>
 					<div class="btn-group">
-						<a href="#" class="button reset-connection"><?php _e( 'Reset the connection', 'jetpack' ); ?></a>
-						<a href="#" class="button is-dev-env"><?php _e( 'This is a development environment', 'jetpack' ); ?></a>
-						<a href="https://jetpack.me/contact-support/" class="button contact-support"><?php _e( 'Submit a support ticket', 'jetpack' ); ?></a>
+						<a href="#" class="reset-connection"><?php _e( 'Reset the connection', 'jetpack' ); ?></a> <span class="idc-separator">|</span>
+						<a href="#" class="is-dev-env"><?php _e( 'This is a development environment', 'jetpack' ); ?></a> <span class="idc-separator">|</span>
+						<a href="https://jetpack.me/contact-support/" class="contact-support"><?php _e( 'Submit a support ticket', 'jetpack' ); ?></a>
 						<span class="spinner"></span>
 					</div>
 				</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3011,7 +3011,8 @@ p {
 
 			// @todo remove the conditional when it's ready for prime time
 			if ( Jetpack::is_development_version() ) {
-				add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
+				add_action( 'jetpack_notices', array( $this, 'alert_identity_crisis' ) );
+				add_action( 'load-index.php', array( $this, 'alert_identity_crisis' ) );
 			}
 		}
 
@@ -5821,6 +5822,11 @@ p {
 		// Include the js!
 		$ajax_nonce = wp_create_nonce( 'resolve-identity-crisis' );
 		$this->identity_crisis_js( $ajax_nonce );
+
+		// Include the CSS!
+		if ( ! wp_script_is( 'jetpack', 'done' ) ) {
+			$this->admin_banner_styles();
+		}
 
 		if ( ! array_key_exists( 'error_code', $errors ) ) {
 			$key = 'siteurl';

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5858,7 +5858,7 @@ p {
 			}
 		</style>
 
-		<div id="message" class="error jetpack-message jp-identity-crisis">
+		<div id="message" class="error jetpack-message jp-identity-crisis stay-visible">
 			<div class="service-mark"></div>
 			<div class="jp-id-banner__content">
 				<!-- <h3 class="banner-title"><?php _e( 'Something\'s not quite right with your Jetpack connection! Let\'s fix that.', 'jetpack' ); ?></h3> -->

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3012,7 +3012,7 @@ p {
 			// @todo remove the conditional when it's ready for prime time
 			if ( Jetpack::is_development_version() ) {
 				add_action( 'jetpack_notices', array( $this, 'alert_identity_crisis' ) );
-				add_action( 'load-index.php', array( $this, 'alert_identity_crisis' ) );
+				add_action( 'admin_notices', array( $this, 'alert_identity_crisis' ) );
 			}
 		}
 
@@ -5816,6 +5816,12 @@ p {
 		}
 
 		if ( ! $errors = self::check_identity_crisis() ) {
+			return;
+		}
+
+		// Only show on dashboard and jetpack pages
+		$screen = get_current_screen();
+		if ( 'dashboard' !== $screen->base && ! did_action( 'jetpack_notices' ) ) {
 			return;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5893,7 +5893,13 @@ p {
 
 				<div class="jp-id-crisis-question" id="jp-id-crisis-question-2" style="display: none;">
 					<div class="banner-content">
-						<p><?php printf( __( 'Are  <strong> %2$s </strong> and <strong> %1$s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services. %3s What does this mean? %4s', 'jetpack' ), $errors[ $key ], (string) get_option( $key ), "<a href='https://jetpack.me/support/what-does-resetting-the-connection-mean/' target='_blank' title='" . esc_attr__( 'What does resetting the connection mean?', 'jetpack' ) . "'><em>", "</em></a>" ); ?></p>
+						<p><?php printf( __( 'Are <strong> %2s </strong> and <strong> %1s </strong> two completely separate websites? If so we should create a new connection, which will reset your followers and linked services. %3sWhat does this mean?%4s', 'jetpack' ),
+								$errors[ $key ],
+								(string) get_option( $key ),
+								'<a href="https://jetpack.me/support/what-does-resetting-the-connection-mean/" target="_blank" title="' . esc_attr__( 'What does resetting the connection mean?', 'jetpack' ) . '"><em>',
+								'</em></a>'
+							); ?>
+						</p>
 					</div>
 					<div class="btn-group">
 						<a href="#" class="reset-connection"><?php _e( 'Reset the connection', 'jetpack' ); ?></a> <span class="idc-separator">|</span>

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -55,6 +55,10 @@
 					border-bottom: 1px solid rgba(255, 255, 255, 0.80);
 				}
 			}
+
+			.idc-separator {
+				margin: 0 6px;
+			}
 		}
 	}
 }

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -28,11 +28,13 @@
 				margin: 0;
 				font-size: 13px;
 				color: #fff;
+				opacity: 100;
 
 				strong {
 					text-decoration: none;
 					font-weight: 600;
 					color: #fff;
+					opacity: 100;
 				}
 			}
 		}

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -28,13 +28,13 @@
 				margin: 0;
 				font-size: 13px;
 				color: #fff;
-				opacity: 100;
+				opacity: 1.0;
 
 				strong {
 					text-decoration: none;
 					font-weight: 600;
 					color: #fff;
-					opacity: 100;
+					opacity: 1.0;
 				}
 			}
 		}

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -37,6 +37,14 @@
 					opacity: 1.0;
 				}
 			}
+
+			a {
+				display: inline-block;
+				color: rgba(255, 255, 255, 0.80);
+				border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+				text-decoration: none;
+				-webkit-transform: all 1s ease;
+			}
 		}
 		.btn-group {
 			display: table-row;


### PR DESCRIPTION
Fixes #2595

Will only show the alert on the dashboard page and jetpack pages now, instead of all admin pages.  

Seems as though some of the styles are still being overridden in the jetpack pages.  @justinkropp mind taking a look?

(run grunt to see the opacity change)