### PR TITLE
Autoupdates: log error code

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -200,8 +200,10 @@ class Jetpack_Autoupdate {
 				$this->log[ $items ][ $item ] = true;
 			} else {
 				$num_items_failed++;
-				$this->log[ $items ][ $item ] = new WP_Error( "$items-fail", $this->get_error_message( $item, $type = $items ) );
-				$items_failed[] = $item;
+				$error = $this->get_error( $item, $items );
+				$error_code = ( is_wp_error( $error ) ) ? $error->get_error_code() : false;
+				$this->log[ $items ][ $item ] = $error;
+				$items_failed[] = array( 'item' => $item, 'error' => $error_code );
 			}
 		}
 
@@ -260,9 +262,9 @@ class Jetpack_Autoupdate {
 	 * @param $item Example: 'jetpack/jetpack.php' for type 'plugin' or 'twentyfifteen' for type 'theme'
 	 * @param string $type 'plugin' or 'theme'
 	 *
-	 * @return bool|string
+	 * @return bool|WP_Error
 	 */
-	private function get_error_message( $item, $type = 'plugin' ) {
+	private function get_error( $item, $type = 'plugin' ) {
 		if ( ! isset( $this->autoupdate_results[ $type ] ) ) {
 			return false;
 		}
@@ -274,8 +276,8 @@ class Jetpack_Autoupdate {
 				default:
 					$id = $result->item->plugin;
 			}
-			if ( $id == $item && isset( $result->messages ) ) {
-				return implode( ', ', $result->messages );
+			if ( $id == $item && isset( $result->result ) ) {
+				return $result->result;
 			}
 		}
 		return false;


### PR DESCRIPTION
Base on a conversation with @dd32 , we determined it would be useful to include an error code in
our debugging script when we log failed plugin autoupdates.

@dd32 can you check that i'm handling the `$update_results` schema correctly?