### PR TITLE
Updated the Plugin URL for Jetpack

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -2,7 +2,7 @@
 
 /*
  * Plugin Name: Jetpack by WordPress.com
- * Plugin URI: http://wordpress.org/plugins/jetpack/
+ * Plugin URI: http://jetpack.me
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
  * Version: 3.7.0-dev


### PR DESCRIPTION
Currently the Jetpack plugin url is set to .org I think it would be better to set it to point to Jetpack.me so that we send users to that site. This will also make it make more sense in the new plugin browser. 

The Plugin Handbook 
https://developer.wordpress.org/plugins/the-basics/header-requirements/

Says that 
`Plugin URI: The home page of the plugin, which might be on WordPress.org or on your own website. This must be unique to your plugin.` 



