### PR TITLE
API: Allows searching by display_name in list users endpoint

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1928,10 +1928,10 @@ new WPCOM_JSON_API_List_Users_Endpoint( array(
 			'display_name'  => 'Order by display name.',
 			'post_count'    => 'Order by number of posts published.',
 		),
-		'authors_only'      => "(bool) Set to true to fetch authors only",
+		'authors_only'      => '(bool) Set to true to fetch authors only',
 		'type'              => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
 		'search'            => '(string) Find matching users.',
-		'search_columns'    => '(array) Specify which columns to check for matching users. Only works when combined with `search` parameter.',
+		'search_columns'    => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
 		'role'              => '(string) Specify a specific user role to fetch.'
 	),
 


### PR DESCRIPTION
@rralian added the ability to search by `display_name` on WPCOM. Syncing those changes over.