### PR TITLE
Tiled Galleries: set fallbacks for each image's alt attribute.

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -7,7 +7,17 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		$this->grayscale = $grayscale;
 
 		$this->image_title = $this->image->post_title;
+
 		$this->image_alt = get_post_meta( $this->image->ID, '_wp_attachment_image_alt', true );
+		// If no Alt value, use the caption
+		if ( empty( $this->image_alt ) && ! empty( $this->image->post_excerpt ) ) {
+			$this->image_alt = trim( strip_tags( $this->image->post_excerpt ) );
+		}
+		// If still no Alt value, use the title
+		if ( empty( $this->image_alt ) && ! empty( $this->image->post_title ) ) {
+			$this->image_alt = trim( strip_tags( $this->image->post_title ) );
+		}
+
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
 		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
 


### PR DESCRIPTION
If an image doesn't have an alt value set, fallback and display a caption first. If no caption was defined, use the attachment title.

@see https://core.trac.wordpress.org/browser/tags/4.2.2/src/wp-includes/media.php#L744

Suggested here:
https://wordpress.org/support/topic/feature-request-image-alt-for-tiled-galleries?replies=3&view=all#post-7350583