### PR TITLE
API: Add to the plugins api endpoint whether the plugin is unistallable.

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -27,6 +27,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		'autoupdate'      => '(boolean) Whether the plugin is automatically updated',
 		'next_autoupdate' => '(string) Y-m-d H:i:s for next scheduled update event',
 		'log'             => '(array:safehtml) An array of update log strings.',
+		'uninstallable'   => '(boolean) Whether the plugin is unistallable.',
 	);
 
 	protected function result() {
@@ -110,6 +111,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		$plugin['update']          = $this->get_plugin_updates( $plugin_file );
 		$plugin['next_autoupdate'] = date( 'Y-m-d H:i:s', wp_next_scheduled( 'wp_maybe_auto_update' ) );
 		$plugin['autoupdate']      = in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins', array() ) );
+		$plugin['uninstallable']   = is_uninstallable_plugin( $plugin_file );
 		if ( ! empty ( $this->log[ $plugin_file ] ) ) {
 			$plugin['log'] = $this->log[ $plugin_file ];
 		}


### PR DESCRIPTION
It would be great to know if the plugin has data that it want to delete as well. 

Reference to function in WP `is_uninstallable_plugin`
https://developer.wordpress.org/reference/functions/is_uninstallable_plugin/#source-code


it gives us an idea if the plugin has a unistall hook which the plugin uses to clean after itself. 

