### PR TITLE
Update Sync: move to class.jetpack.php

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -446,6 +446,8 @@ class Jetpack {
 		add_action( 'upgrader_process_complete', array( 'Jetpack', 'update_get_wp_version' ), 10, 2 );
 		$this->sync->mock_option( 'wp_version', array( 'Jetpack', 'get_wp_version' ) );
 
+		add_action( 'init', array( $this, 'sync_update_data') );
+
 		/*
 		 * Load things that should only be in Network Admin.
 		 *
@@ -1256,6 +1258,70 @@ class Jetpack {
 		}
 	}
 
+	function sync_update_data() {
+		// Anytime WordPress saves update data, we'll want to sync update data
+		add_action( 'set_site_transient_update_plugins', array( 'Jetpack', 'refresh_update_data' ) );
+		add_action( 'set_site_transient_update_themes', array( 'Jetpack', 'refresh_update_data' ) );
+		add_action( 'set_site_transient_update_core', array( 'Jetpack', 'refresh_update_data' ) );
+		// Anytime a connection to jetpack is made, sync the update data
+		add_action( 'jetpack_site_registered', array( 'Jetpack', 'refresh_update_data' ) );
+		// Anytime the Jetpack Version changes, sync the the update data
+		add_action( 'updating_jetpack_version', array( 'Jetpack', 'refresh_update_data' ) );
+
+		if ( current_user_can( 'update_core' ) && current_user_can( 'update_plugins' ) && current_user_can( 'update_themes' ) ) {
+			$this->sync->mock_option( 'updates', array( 'Jetpack', 'get_updates' ) );
+		}
+
+		$this->sync->mock_option( 'update_details', array( 'Jetpack', 'get_update_details' ) );
+	}
+
+	/**
+	 * jetpack_updates is saved in the following schema:
+	 *
+	 * array (
+	 *      'plugins'                       => (int) Number of plugin updates available.
+	 *      'themes'                        => (int) Number of theme updates available.
+	 *      'wordpress'                     => (int) Number of WordPress core updates available.
+	 *      'translations'                  => (int) Number of translation updates available.
+	 *      'total'                         => (int) Total of all available updates.
+	 *      'wp_update_version'             => (string) The latest available version of WordPress, only present if a WordPress update is needed.
+	 * )
+	 * @return array
+	 */
+	public static function get_updates() {
+		$update_data = wp_get_update_data();
+
+		// Stores the individual update counts as well as the total count.
+		if ( isset( $update_data['counts'] ) ) {
+			$updates = $update_data['counts'];
+		}
+
+		// If we need to update WordPress core, let's find the latest version number.
+		if ( ! empty( $updates['wordpress'] ) ) {
+			$cur = get_preferred_from_update_core();
+			if ( isset( $cur->response ) && 'upgrade' === $cur->response ) {
+				$updates['wp_update_version'] = $cur->current;
+			}
+		}
+		return isset( $updates ) ? $updates : array();
+	}
+
+	public static function get_update_details() {
+		$update_details = array(
+			'update_core' => get_site_transient( 'update_core' ),
+			'update_plugins' => get_site_transient( 'update_plugins' ),
+			'update_themes' => get_site_transient( 'update_themes' ),
+		);
+		return $update_details;
+	}
+
+	public static function refresh_update_data() {
+		if ( current_user_can( 'update_core' ) && current_user_can( 'update_plugins' ) && current_user_can( 'update_themes' ) ) {
+			do_action( 'add_option_jetpack_updates', 'jetpack_updates', Jetpack::get_updates() );
+		}
+		do_action( 'add_option_jetpack_update_details', 'jetpack_update_details', Jetpack::get_update_details() );
+	}
+
 	/**
 	 * Invalides the transient as well as triggers the update of the mock option.
 	 *
@@ -1273,8 +1339,6 @@ class Jetpack {
 		 */
 		do_action( 'update_option_jetpack_single_user_site', 'jetpack_single_user_site', (bool) Jetpack::is_single_user_site() );
 	}
-
-
 
 	/**
 	 * Is Jetpack active?

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1258,6 +1258,9 @@ class Jetpack {
 		}
 	}
 
+	/**
+	 * Triggers a sync of update counts and update details
+	 */
 	function sync_update_data() {
 		// Anytime WordPress saves update data, we'll want to sync update data
 		add_action( 'set_site_transient_update_plugins', array( 'Jetpack', 'refresh_update_data' ) );
@@ -1317,8 +1320,16 @@ class Jetpack {
 
 	public static function refresh_update_data() {
 		if ( current_user_can( 'update_core' ) && current_user_can( 'update_plugins' ) && current_user_can( 'update_themes' ) ) {
+			/** This action is documented in wp-includes/option.php */
+			/**
+			 * This triggers the sync for refreshing the count of available updates for the site.
+			 */
 			do_action( 'add_option_jetpack_updates', 'jetpack_updates', Jetpack::get_updates() );
 		}
+		/** This action is documented in wp-includes/option.php */
+		/**
+		 * This triggers the sync for refreshing update details for the site.
+		 */
 		do_action( 'add_option_jetpack_update_details', 'jetpack_update_details', Jetpack::get_update_details() );
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1320,15 +1320,25 @@ class Jetpack {
 
 	public static function refresh_update_data() {
 		if ( current_user_can( 'update_core' ) && current_user_can( 'update_plugins' ) && current_user_can( 'update_themes' ) ) {
-			/** This action is documented in wp-includes/option.php */
 			/**
-			 * This triggers the sync for refreshing the count of available updates for the site.
+			 * Fires whenever the amount of updates needed for a site changes.
+			 * Syncs an array that includes the number of theme, plugin, and core updates available, as well as the latest core version available.
+			 *
+			 * @since 3.7.0
+			 *
+			 * @param string jetpack_updates
+			 * @param array Update counts calculated by Jetpack::get_updates
 			 */
 			do_action( 'add_option_jetpack_updates', 'jetpack_updates', Jetpack::get_updates() );
 		}
-		/** This action is documented in wp-includes/option.php */
 		/**
-		 * This triggers the sync for refreshing update details for the site.
+		 * Fires whenever the amount of updates needed for a site changes.
+		 * Syncs an array of core, theme, and plugin data, and which of each is out of date
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param string jetpack_update_details
+		 * @param array Update details calculated by Jetpack::get_update_details
 		 */
 		do_action( 'add_option_jetpack_update_details', 'jetpack_update_details', Jetpack::get_update_details() );
 	}


### PR DESCRIPTION
We are moving the sync logic from class.jetpack.autoupdate.php to
class.jetpack.php so that we can initiate the sync when we have the current user data.

The current user data wasn't available in class.jetpack.autoupdate.php
and it was needed to do permission checks.

Closes #2640