### PR TITLE
API: Fixes issue where user could not update any information about self

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
@@ -35,9 +35,6 @@ class WPCOM_JSON_API_Site_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 			if ( ! current_user_can_for_blog( $blog_id, 'promote_users' ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot promote users for specified site', 403 );
 			}
-			if ( get_current_user_id() == $user_id ) {
-				return new WP_Error( 'unauthorized', 'You cannot change your own role', 403 );
-			}
 			return $this->update_user( $user_id );
 		} else {
 			return new WP_Error( 'bad_request', 'An unsupported request method was used.' );
@@ -62,6 +59,11 @@ class WPCOM_JSON_API_Site_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 	public function update_user( $user_id ) {
 		$input = $this->input();
 		$user['ID'] = $user_id;
+
+		if ( get_current_user_id() == $user_id && isset( $input['roles'] ) ) {
+			return new WP_Error( 'unauthorized', 'You cannot change your own role', 403 );
+		}
+
 		if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 			foreach ( $input as $key => $value ) {
 				if ( ! is_array( $value ) ) {


### PR DESCRIPTION
While attempting to update a user through the `POST /sites/$sites/users/$user` I found an unexpected bug.

To test existence of bug:
- Go to [WordPress.com REST API console](https://developer.wordpress.com/docs/api/console/)
- Make a `POST` request to `/sites/$site/users/$user` where `$site` is a self-hosted site that you are an admin on and `$user` is your user ID.
- For the body of the request, enter `name=testdisplayname`.
- You should notice an unauthorized error.
  - If you open the `Network` Chrome developers panel, you'll see that the error says `You cannot change your own role`

This happens because the conditional only checks if the user is attempting to update oneself. We should also be checking if `roles` is even in the input array. This PR does that.

To test:
- Checkout `fix/update-user-endpoint-roles`
- Make the same request as above.
- Does request succeed?