### PR TITLE
Carousel: avoid multiple handler calls.

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1425,6 +1425,10 @@ jQuery(document).ready(function($) {
 			return;
 		}
 		e.preventDefault();
+
+		// Stopping propagation in case there are parent elements
+		// with .gallery or .tiled-gallery class
+		e.stopPropagation();
 		$(this).jp_carousel('open', {start_index: $(this).find('.gallery-item, .tiled-gallery-item').index($(e.target).parents('.gallery-item, .tiled-gallery-item'))});
 	});
 


### PR DESCRIPTION
In cases when a page has multiple nested elements with `.tiled-gallery` or `.gallery` classes, the carousel click handler can fire several times. This results in losing the page's original overflow settings, so that when the carousel is closed, the page becomes unscrollable. This PR fixes the problem.
cc @richardmtl 