### PR TITLE
Social Media Icons Widget: add Google+

### DIFF
--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -14,7 +14,6 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 	public function __construct() {
 		parent::__construct(
 			'wpcom_social_media_icons_widget',
-			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', esc_html__( 'Social Media Icons', 'jetpack' ) ),
 			array( 'description' => __( 'A simple widget that displays social media icons.', 'jetpack' ), )
 		);
@@ -75,15 +74,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		$html .= '<ul>';
 
 		$alt_text = esc_attr__( 'View %1$s&#8217;s profile on %2$s', 'jetpack' );
-
-		/**
-		 * Fires in the beginning of the list of Social Media accounts, inside the unordered list.
-		 *
-		 * Can be used to add a new Social Media Site to the Social Media Icons Widget.
-		 *
-		 * @since 3.7.0
-		 */
-		do_action( 'jetpack_social_media_icons_widget_list_before' );
+		$alt_text_numeric = esc_attr__( 'View this profile on %2$s', 'jetpack' );
 
 		if ( ! empty( $instance['facebook_username'] ) ) {
 			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['facebook_username'] ), 'Facebook' ) . '" href="' . esc_url( 'https://www.facebook.com/' . $instance['facebook_username'] . '/' ) . '" class="genericon genericon-facebook" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['facebook_username'] ), 'Facebook' ) . '</span></a></li>';
@@ -118,17 +109,9 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		}
 		
 		if ( ! empty( $instance['google_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( '' . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
+			$title_text = (is_numeric( $instance['google_username'] ) ? $alt_text_numeric : $alt_text);
+			$html .= '<li><a title="' . sprintf( $title_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( 'https://plus.google.com/u/1/' . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
 		}
-
-		/**
-		 * Fires at the end of the list of Social Media accounts, inside the unordered list.
-		 *
-		 * Can be used to add a new Social Media Site to the Social Media Icons Widget.
-		 *
-		 * @since 3.7.0
-		 */
-		do_action( 'jetpack_social_media_icons_widget_list_after' );
 
 		$html .= '</ul>';
 
@@ -182,12 +165,12 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'youtube_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'youtube_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['youtube_username'] ); ?>" />
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>"><?php _e( 'Vimeo username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'vimeo_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['vimeo_username'] ); ?>" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>"><?php _e( 'Google+ username:', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'google_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['google_username'] ); ?>" />
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>"><?php _e( 'Google+ Page:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'google_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['google_username'] ); ?>" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>"><?php _e( 'Vimeo username:', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'vimeo_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['vimeo_username'] ); ?>" />
 		</p>
 	<?php
 	}

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -29,6 +29,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'github_username'    => '',
 			'youtube_username'   => '',
 			'vimeo_username'     => '',
+			'google_username'    => '',
 		);
 
 		if ( is_active_widget( false, false, $this->id_base ) ) {
@@ -115,6 +116,10 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		if ( ! empty( $instance['vimeo_username'] ) ) {
 			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['vimeo_username'] ), 'Vimeo' ) . '" href="' . esc_url( 'https://vimeo.com/' . $instance['vimeo_username'] . '/' ) . '" class="genericon genericon-vimeo" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['vimeo_username'] ), 'Vimeo' ) . '</span></a></li>';
 		}
+		
+		if ( ! empty( $instance['google_username'] ) ) {
+			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( '' . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
+		}
 
 		/**
 		 * Fires at the end of the list of Social Media accounts, inside the unordered list.
@@ -179,6 +184,10 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>"><?php _e( 'Vimeo username:', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'vimeo_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['vimeo_username'] ); ?>" />
+		</p>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>"><?php _e( 'Google+ Page:', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'google_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['google_username'] ); ?>" />
 		</p>
 	<?php
 	}

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -119,8 +119,8 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		}
 
 		if ( ! empty( $instance['google_username'] ) ) {
-			$title_text = (is_numeric( $instance['google_username'] ) ? $alt_text_numeric : $alt_text);
-			$plus = ( (!is_numeric( $instance['google_username']) && substr($instance['google_username'], 0,1 ) != "+" ) ? "+" : "" );
+			$title_text = ( is_numeric( $instance['google_username'] ) ? $alt_text_numeric : $alt_text );
+			$plus = ( ( !is_numeric( $instance['google_username'] ) && substr( $instance['google_username'], 0, 1 ) != "+" ) ? "+" : "" );
 			$html .= '<li><a title="' . sprintf( $title_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( 'https://plus.google.com/u/0/' . $plus . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
 		}
 		

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -120,7 +120,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 
 		if ( ! empty( $instance['google_username'] ) ) {
 			$title_text = (is_numeric( $instance['google_username'] ) ? $alt_text_numeric : $alt_text);
-			$html .= '<li><a title="' . sprintf( $title_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( 'https://plus.google.com/u/1/' . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
+			$html .= '<li><a title="' . sprintf( $title_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( 'https://plus.google.com/u/0/' . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
 		}
 		
 		/**

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -120,7 +120,8 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 
 		if ( ! empty( $instance['google_username'] ) ) {
 			$title_text = (is_numeric( $instance['google_username'] ) ? $alt_text_numeric : $alt_text);
-			$html .= '<li><a title="' . sprintf( $title_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( 'https://plus.google.com/u/0/' . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
+			$plus = ( (!is_numeric( $instance['google_username']) && substr($instance['google_username'], 0,1 ) != "+" ) ? "+" : "" );
+			$html .= '<li><a title="' . sprintf( $title_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( 'https://plus.google.com/u/0/' . $plus . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
 		}
 		
 		/**

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -14,6 +14,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 	public function __construct() {
 		parent::__construct(
 			'wpcom_social_media_icons_widget',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', esc_html__( 'Social Media Icons', 'jetpack' ) ),
 			array( 'description' => __( 'A simple widget that displays social media icons.', 'jetpack' ), )
 		);
@@ -75,6 +76,15 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 
 		$alt_text = esc_attr__( 'View %1$s&#8217;s profile on %2$s', 'jetpack' );
 		$alt_text_numeric = esc_attr__( 'View this profile on %2$s', 'jetpack' );
+		
+		/**
+		 * Fires in the beginning of the list of Social Media accounts, inside the unordered list.
+		 *
+		 * Can be used to add a new Social Media Site to the Social Media Icons Widget.
+		 *
+		 * @since 3.7.0
+		 */
+		do_action( 'jetpack_social_media_icons_widget_list_before' );
 
 		if ( ! empty( $instance['facebook_username'] ) ) {
 			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['facebook_username'] ), 'Facebook' ) . '" href="' . esc_url( 'https://www.facebook.com/' . $instance['facebook_username'] . '/' ) . '" class="genericon genericon-facebook" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['facebook_username'] ), 'Facebook' ) . '</span></a></li>';
@@ -107,11 +117,20 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		if ( ! empty( $instance['vimeo_username'] ) ) {
 			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['vimeo_username'] ), 'Vimeo' ) . '" href="' . esc_url( 'https://vimeo.com/' . $instance['vimeo_username'] . '/' ) . '" class="genericon genericon-vimeo" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['vimeo_username'] ), 'Vimeo' ) . '</span></a></li>';
 		}
-		
+
 		if ( ! empty( $instance['google_username'] ) ) {
 			$title_text = (is_numeric( $instance['google_username'] ) ? $alt_text_numeric : $alt_text);
 			$html .= '<li><a title="' . sprintf( $title_text, esc_attr( $instance['google_username'] ), 'Google+' ) . '" href="' . esc_url( 'https://plus.google.com/u/1/' . $instance['google_username'] . '/' ) . '" class="genericon genericon-googleplus" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['google_username'] ), 'Google+' ) . '</span></a></li>';
 		}
+		
+		/**
+		 * Fires at the end of the list of Social Media accounts, inside the unordered list.
+		 *
+		 * Can be used to add a new Social Media Site to the Social Media Icons Widget.
+		 *
+		 * @since 3.7.0
+		 */
+		do_action( 'jetpack_social_media_icons_widget_list_after' );
 
 		$html .= '</ul>';
 
@@ -165,12 +184,12 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'youtube_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'youtube_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['youtube_username'] ); ?>" />
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>"><?php _e( 'Google+ username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'google_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['google_username'] ); ?>" />
-		</p>
-		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>"><?php _e( 'Vimeo username:', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'vimeo_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['vimeo_username'] ); ?>" />
+		</p>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>"><?php _e( 'Google+ username:', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'google_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'google_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['google_username'] ); ?>" />
 		</p>
 	<?php
 	}


### PR DESCRIPTION
Add a Google+ link to the normal social icons - technically not a username, but kept the variable naming convention. Uses the correct genericon to go along with it.