### PR TITLE
Check for presence of `id` option when building WPCOM connection link

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3641,6 +3641,9 @@ p {
 					break;
 				}
 				check_admin_referer( 'jetpack-register' );
+				if ( Jetpack_Options::get_option( 'blog_token' ) ) {
+					Jetpack::disconnect();
+				}
 				Jetpack::log( 'register' );
 				Jetpack::maybe_set_version_option();
 				$registered = Jetpack::try_registration();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3641,9 +3641,6 @@ p {
 					break;
 				}
 				check_admin_referer( 'jetpack-register' );
-				if ( Jetpack_Options::get_option( 'blog_token' ) ) {
-					Jetpack::disconnect();
-				}
 				Jetpack::log( 'register' );
 				Jetpack::maybe_set_version_option();
 				$registered = Jetpack::try_registration();
@@ -4255,7 +4252,7 @@ p {
 	}
 
 	function build_connect_url( $raw = false, $redirect = false ) {
-		if ( ! Jetpack_Options::get_option( 'blog_token' ) ) {
+		if ( ! Jetpack_Options::get_option( 'blog_token' ) || ! Jetpack_Options::get_option( 'id' ) ) {
 			$url = Jetpack::nonce_url_no_esc( Jetpack::admin_url( 'action=register' ), 'jetpack-register' );
 			if( is_network_admin() ) {
 			    $url = add_query_arg( 'is_multisite', network_admin_url(


### PR DESCRIPTION
This is an attempt at #2218. This doesn't truly fix the issue—only hide it to reduce the support load.

Even with this, we should add logging of some type, namely for beta testers and try to lock this down more.

This requires extra testing. I'll update to Needs Review when ready! :)