### PR TITLE
Post Updates: When a post is updated and is transitioning from a draf…

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -112,6 +112,11 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			}
 			$last_status = $post->post_status;
 			$new_status = isset( $input['status'] ) ? $input['status'] : $last_status;
+
+			// Make sure that drafts get the current date when transitioning to publish if not supplied in the post.
+			if ( 'publish' === $new_status && 'draft' === $last_status && ! isset( $input['date_gmt'] ) ) {
+				$input['date_gmt'] = gmdate( 'Y-m-d H:i:s' );
+			}
 		}
 
 		// Fix for https://iorequests.wordpress.com/2014/08/13/scheduled-posts-made-in-the/

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -112,6 +112,11 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			}
 			$last_status = $post->post_status;
 			$new_status = isset( $input['status'] ) ? $input['status'] : $last_status;
+
+			// Make sure that drafts get the current date when transitioning to publish if not supplied in the post.
+			if ( 'publish' === $new_status && 'draft' === $last_status && ! isset( $input['date_gmt'] ) ) {
+				$input['date_gmt'] = gmdate( 'Y-m-d H:i:s' );
+			}
 		}
 
 		// Fix for https://iorequests.wordpress.com/2014/08/13/scheduled-posts-made-in-the/

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -87,6 +87,11 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			}
 			$last_status = $post->post_status;
 			$new_status = $input['status'];
+
+			// Make sure that drafts get the current date when transitioning to publish if not supplied in the post.
+			if ( 'publish' === $new_status && 'draft' === $last_status && ! isset( $input['date_gmt'] ) ) {
+				$input['date_gmt'] = gmdate( 'Y-m-d H:i:s' );
+			}
 		}
 
 		// Fix for https://iorequests.wordpress.com/2014/08/13/scheduled-posts-made-in-the/


### PR DESCRIPTION
…t to publish, make sure that the date, if not specified in the posted data, is set to the current date.

The issue this fixes is the case in which a draft has been saved and set aside but then is much later updated with an API call that posts only the updated status. In this case, the date isn't updated, and posts published between the time that the draft was saved and published will appear in the post list as having been created more recently. The expectation is that when a draft is published, it will be given the publication date and not the draft date.