### PR TITLE
Enhance/reimplement latex using mathjax

### DIFF
--- a/modules/latex.php
+++ b/modules/latex.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Beautiful Math
- * Module Description: Use LaTeX markup language in posts and pages for complex equations and other geekery.
+ * Module Description: Use MathJax in posts and pages for complex equations and other geekery.
  * Sort Order: 12
  * First Introduced: 1.1
  * Requires Connection: No
@@ -20,87 +20,470 @@
  * $latex [a, b]$              ->  [latex][a, b][/latex]
  */
 
-function latex_markup( $content ) {
-	$regex = '%
-		\$latex(?:=\s*|\s+)
-		((?:
-			[^$]+ # Not a dollar
-		|
-			(?<=(?<!\\\\)\\\\)\$ # Dollar preceded by exactly one slash
-		)+)
-		(?<!\\\\)\$ # Dollar preceded by zero slashes
-	%ix';
-	return preg_replace_callback( $regex, 'latex_src', $content );
-}
+class Jetpack_Latex {
+	/**
+	 * Singleton.
+	 *
+	 * @since 3.8.0
+	 * @access private
+	 * @var Jetpack_Latex
+	 */
+	private static $__instance = null;
 
-function latex_src( $matches ) {
-	$latex = $matches[1];
+	/**
+	 * Whether or not MathJax.js has been output on the current page.
+	 *
+	 * @since 3.8.0
+	 * @access private
+	 * @var boolean
+	 */
+	private $has_output_scripts = false;
 
-	$bg = latex_get_default_color( 'bg' );
-	$fg = latex_get_default_color( 'text', '000' );
-	$s = 0;
+	/**
+	 * Get singleton.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return Jetpack_Latex
+	 */
+	public static function instance() {
+		if ( ! self::$__instance ) {
+			self::$__instance = new self();
+		}
 
-
-	$latex = latex_entity_decode( $latex );
-	if ( preg_match( '/.+(&fg=[0-9a-f]{6}).*/i', $latex, $fg_matches ) ) {
-		$fg = substr( $fg_matches[1], 4 );
-		$latex = str_replace( $fg_matches[1], '', $latex );
+		return self::$__instance;
 	}
-	if ( preg_match( '/.+(&bg=[0-9a-f]{6}).*/i', $latex, $bg_matches ) ) {
-		$bg = substr( $bg_matches[1], 4 );
-		$latex = str_replace( $bg_matches[1], '', $latex );
+
+	/**
+	 * Add actions, filters, and the shortcode for Latex.
+	 *
+	 * @since 3.8.0
+	 */
+	public function __construct() {
+		add_action( 'wp_head', array( $this, 'latex_mathjax_config_output' ), 2 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'latex_enqueue_scripts' ) );
+
+		add_filter( 'no_texturize_shortcodes', array( $this, 'latex_no_texturize' ) );
+
+		add_filter( 'the_content', array( $this, 'latex_markup' ), 9 ); // before wptexturize
+		add_filter( 'comment_text', array( $this, 'latex_markup' ), 9 ); // before wptexturize
+		add_shortcode( 'latex', array( $this, 'latex_shortcode' ) );
 	}
-	if ( preg_match( '/.+(&s=[0-9-]{1,2}).*/i', $latex, $s_matches ) ) {
-		$s = (int) substr( $s_matches[1], 3 );
-		$latex = str_replace( $s_matches[1], '', $latex );
+
+	/**
+	 * MathJax configuration.
+	 *
+	 * In-line MathJax configuration options give us more granularity than simply
+	 * picking one of the built-in configurations. It also makes it filterable.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @link http://docs.mathjax.org/en/latest/configuration.html#using-in-line-configuration-options
+	 *
+	 * @return array
+	 */
+	public function latex_mathjax_config() {
+		$config = array(
+			// TeX-AMS_HTML.js allows math to be specified in TeX or LaTeX notation, with the AMSmath and AMSsymbols packages included, and produces output using the HTML-CSS output processor.
+			'config' => array( 'TeX-AMS_HTML.js' ),
+			'jax'    => array(
+				'input/TeX',
+				'output/HTML-CSS',
+				'output/CommonHTML',
+			),
+			'extensions' => array(
+				'tex2jax.js',
+				'CHTML-preview.js',
+				'Safe.js'
+			),
+			'TeX' => array(
+				'extensions' => array(
+					'AMSmath.js',
+					'AMSsymbols.js',
+				),
+				'Macros' => array(
+					// \i command sequence is supported by WP Latex but not MathJax.
+					'i' => "{\\imath}",
+					// \j command sequence is supported by WP Latex but not MathJax.
+					'j' => "{\\jmath}",
+				),
+			),
+			'tex2jax' => array(
+				'inlineMath' => array(
+					array( '$latex ', '$' ),
+				),
+				// Disable display math.
+				'displayMath' => array(),
+				// Do not process \ref{...} commands outside of math mode.
+				'processRefs' => false,
+				// Do not process LaTeX environments outside of math mode.
+				'processEnvironments' => false,
+				// Elements with this class will not be processed by MathJax.
+				'ignoreClass' => 'math_ignore',
+				// Elements with this class inside of ignored elements will be processed.
+				'processClass' => 'math_process',
+			),
+			// Specify a z-index for MathMenu so it appears properly when used inside modals.
+			'MathMenu' => array(
+				'styles' => array(
+					'.MathJax_Menu' => array('z-index' => 2001),
+				),
+			),
+			// 'showMathMenu' => false,
+		);
+
+		// Users who can edit posts or pages should see math parse error details.
+		if ( current_user_can( 'edit_posts' ) || current_user_can( 'edit_pages' ) ) {
+			$config['TeX']['noErrors']    = array( 'disabled' => true );
+			$config['TeX']['noUndefined'] = array( 'disabled' => true );
+		}
+
+		return $config;
 	}
 
-	return latex_render( $latex, $fg, $bg, $s );
+	/**
+	 * Output in-line MathJax configuration.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @link http://docs.mathjax.org/en/latest/configuration.html#using-in-line-configuration-options
+	 * @link https://github.com/mathjax/MathJax-website/commit/df7f655623b1a6fc0bc637d9f4b47cb3461aa118
+	 */
+	public function latex_mathjax_config_output() {
+		/**
+		 * Allow MathJax configuration to be overridden.
+		 *
+		 * There are many more configuration options available than are outlined
+		 * here. Please see the MathJax documentation for a full list.
+		 *
+		 * @link http://docs.mathjax.org/en/latest/index.html
+		 *
+		 * @since 3.8.0
+		 *
+		 * @param array $config {
+		 *     In-line MathJax configuration options.
+		 *
+		 *     @type array $config     Use a pre-defined configuration file.
+		 *     @type array $jax        Specify input and output methods for MathJax.
+		 *     @type array $extensions Specify which MathJax extensions to load.
+		 *     @type array $TeX        Define Macros, specify which TeX extensions to load, and more.
+		 *     @type array $tex2jax    Define math delimiters and other options.
+		 *     @type array $MathMenu   Control the contextual menu that is available on mathematics that are typeset by MathJax.
+		 * }
+		 */
+		$config = apply_filters( 'latex_mathjax_config', $this->latex_mathjax_config() );
+
+		?>
+		<script type="text/x-mathjax-config">
+			MathJax.Hub.Register.StartupHook( 'MathMenu Ready', function() {
+				MathJax.Menu.BGSTYLE['z-index'] = 2000;
+			} );
+			MathJax.Hub.Config( <?php echo wp_json_encode( $config ); ?> );
+		</script>
+	<?php }
+
+	/**
+	 * Output MathJax.js script tag on the page if it hasn't already been done.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @link http://docs.mathjax.org/en/latest/configuration.html#using-in-line-configuration-options
+	 * @link https://github.com/mathjax/MathJax-website/commit/df7f655623b1a6fc0bc637d9f4b47cb3461aa118
+	 *
+	 * @return boolean
+	 */
+	public function output_mathjax_script() {
+		if ( true === $this->has_output_scripts ) {
+			return false;
+		}
+
+		$this->has_output_scripts = true;
+
+		$mathjax_url = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js';
+
+		if ( $locale = get_locale() ) {
+			$_locale = explode('_', $locale);
+			$mathjax_url .= '?locale=' . $_locale[0];
+		}
+
+		/**
+		 * Allow MathJax URL to be overridden.
+		 *
+		 * @since 3.8.0
+		 *
+		 * @param string $mathjax_url MathJax.js URL.
+		 */
+		$mathjax_url = apply_filters( 'latex_mathjax_url', $mathjax_url );
+
+		wp_enqueue_script( 'latex_mathjax', $mathjax_url, array(), null, true );
+
+		return true;
+	}
+
+	/**
+	 * Find and process LaTeX markup.
+	 *
+	 * @since 1.1
+	 *
+	 * @param  string $content
+	 * @return string
+	 */
+	public function latex_markup( $content ) {
+		$regex = '%
+			\$latex(?:=\s*|\s+)
+			((?:
+				[^$]+ # Not a dollar
+			|
+				(?<=(?<!\\\\)\\\\)\$ # Dollar preceded by exactly one slash
+			)+)
+			(?<!\\\\)\$ # Dollar preceded by zero slashes
+		%ix';
+		return preg_replace_callback( $regex, array( $this, 'latex_src' ), $content );
+	}
+
+	/**
+	 * Render LaTeX markup with colors and size.
+	 *
+	 * @since 1.1
+	 *
+	 * @param  array $matches RegEx matches from preg_replace_callback in latex_markup.
+	 * @return string         LaTeX expression.
+	 */
+	public function latex_src( $matches ) {
+		$latex = $matches[1];
+
+		$bg = $this->get_default_color( 'bg' );
+		$fg = $this->get_default_color( 'text', '000' );
+		$s = 0;
+
+		$latex = $this->entity_decode( $latex );
+		if ( preg_match( '/.+(&fg=[0-9a-f]{6}).*/i', $latex, $fg_matches ) ) {
+			$fg = substr( $fg_matches[1], 4 );
+			$latex = str_replace( $fg_matches[1], '', $latex );
+		}
+		if ( preg_match( '/.+(&bg=[0-9a-f]{6}).*/i', $latex, $bg_matches ) ) {
+			$bg = substr( $bg_matches[1], 4 );
+			$latex = str_replace( $bg_matches[1], '', $latex );
+		}
+		if ( preg_match( '/.+(&s=[0-9-]{1,2}).*/i', $latex, $s_matches ) ) {
+			$s = (int) substr( $s_matches[1], 3 );
+			$latex = str_replace( $s_matches[1], '', $latex );
+		}
+
+		return $this->render( $latex, $fg, $bg, $s );
+	}
+
+	/**
+	 * Get colors for LaTeX expressions.
+	 *
+	 * @since 1.1
+	 *
+	 * @global array $themecolors
+	 *
+	 * @param  string $color
+	 * @param  string $default_color Default 'ffffff'.
+	 * @return string
+	 */
+	public function get_default_color( $color, $default_color = 'ffffff' ) {
+		global $themecolors;
+		return isset($themecolors[$color]) ? $themecolors[$color] : $default_color;
+	}
+
+	/**
+	 * Decode HTML entities in LaTeX expressions.
+	 *
+	 * @since 1.1
+	 *
+	 * @param  string $latex LaTeX expression.
+	 * @return string        LaTeX expression.
+	 */
+	public function entity_decode( $latex ) {
+		return str_replace( array( '&lt;', '&gt;', '&quot;', '&#039;', '&#038;', '&amp;', "\n", "\r" ), array( '<', '>', '"', "'", '&', '&', ' ', ' ' ), $latex );
+	}
+
+	/**
+	 * Convert latex shortcode size into points (pt in CSS).
+	 *
+	 * This is truer to WP Latex size than converting to LaTeX size commands.
+	 * LaTeX size commands can still be used directly if desired, of course.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param  int $s
+	 * @return mixed  Font size in points if successful, otherwise false.
+	 */
+	public function latex_size_pt( $s ) {
+		switch ( (int) $s ) {
+			case 1 :
+				return '12pt';
+			case 2 :
+				return '14.4pt';
+			case 3 :
+				return '17.28pt';
+			case 4 :
+				return '20.74pt';
+			case 5 :
+				return '24.88pt';
+			case -1 :
+				return '11pt'; // 9 in LaTeX
+			case -2 :
+				return '10pt'; // 7 in LaTeX
+			case -3 :
+				return '8pt'; // 6 in LaTeX
+			case -4 :
+				return '7pt'; // 5 in LaTeX
+			default :
+				return false;
+		}
+	}
+
+	/**
+	 * Workarounds for shortcomings in MathJax's rendering.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param  strign $latex LaTeX expression.
+	 * @param  string  $fg   Foreground color.
+	 * @param  string  $bg   Background color.
+	 * @param  integer $s    Font size.
+	 * @return mixed         String if successful, otherwise false.
+	 */
+	public function mathjax_text_mode_workarounds( $latex, $fg, $bg, $s ) {
+		switch ( $latex ) {
+			case '\LaTeX' :
+			case '\TeX' :
+				return '$latex \mathrm{' . $latex . '}$';
+			case '\AmS' :
+			case '\AmS-\TeX' :
+			case '\AmS-\LaTeX' :
+				return $this->render_img( $latex, $fg, $bg, $s );
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * Print a valid MathJax expression.
+	 *
+	 * Wraps LaTeX expression with LaTeX font size command sequence when necessary.
+	 * Wraps expression in a span to control colors when necessary.
+	 *
+	 * @since 1.1
+	 *
+	 * @param  string  $latex LaTeX expression.
+	 * @param  string  $fg    Foreground color.
+	 * @param  string  $bg    Background color.
+	 * @param  integer $s     Font size. Default '0'.
+	 * @return string         LaTeX expression.
+	 */
+	public function render( $latex, $fg, $bg, $s = 0 ) {
+		// Output MathJax if it's not already on the page.
+		$this->output_mathjax_script();
+
+		$latex_size_pt   = $this->latex_size_pt( $s );
+		$styles          = array();
+		$text_mode_value = $this->mathjax_text_mode_workarounds( trim( $latex ), $fg, $bg, $s );
+
+		if ( $fg ) {
+			$styles[] = 'color: #' . $fg . ';';
+		}
+		if ( $bg ) {
+			$styles[] = 'background-color: #' . $bg . ';';
+		}
+		if ( $latex_size_pt ) {
+			$styles[] = 'font-size: ' . $latex_size_pt . ';';
+		}
+
+		if ( $text_mode_value ) {
+			$output   = $text_mode_value;
+			$styles[] = 'line-height: 0;';
+		} else {
+			$output = sprintf('$latex %s$', $latex);
+		}
+
+		if ( $styles ) {
+			$output = sprintf('<span style="display: inline-block;%s">%s</span>',
+				implode('', $styles),
+				$output
+			);
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Render a LaTeX expression using WP Latex.
+	 *
+	 * To use for edge cases where MathJax can't render something.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param  string  $latex LaTeX expression.
+	 * @param  string  $fg    Foreground color.
+	 * @param  string  $bg    Background color.
+	 * @param  integer $s     Font size.
+	 * @return string
+	 */
+	public function render_img( $latex, $fg, $bg, $s = 0 ) {
+		$url = "//s0.wp.com/latex.php?latex=" . urlencode( $latex ) . "&bg=" . $bg . "&fg=" . $fg . "&s=" . $s;
+
+		$scale = '';
+		if ( @ $img_info = getimagesize( 'http:' . $url ) ) {
+			list($width, $height) = $img_info;
+			$url .= '&zoom=2';
+			$scale = ' width="' . $width . '"  height="' . $height . '" srcset="' . $url . ' 2x" scale="2"';
+		}
+
+		$url = esc_url( $url );
+		$alt = str_replace( '\\', '&#92;', esc_attr( $latex ) );
+		return '<img src="' . $url . '" alt="' . $alt . '" title="' . $alt . '" class="latex"' . $scale . ' />';
+	}
+
+	/**
+	 * The shortcode way. The attributes are the same as the old ones - 'fg' and 'bg', instead of foreground
+	 * and background, and 's' is for the font size.
+	 *
+	 * @since 1.1
+	 *
+	 * Example: [latex s=4 bg=00f fg=ff0]\LaTeX[/latex]
+	 *
+	 * @param array   $atts
+	 * @param string  $content Default ''.
+	 * @return string LaTeX expression.
+	 */
+	public function latex_shortcode( $atts, $content = '' ) {
+		$atts = shortcode_atts( array(
+			's'  => 0,
+			'bg' => $this->get_default_color( 'bg' ),
+			'fg' => $this->get_default_color( 'text', '000' )
+		), $atts, 'latex' );
+
+		return $this->render( $this->entity_decode( $content ), $atts['fg'], $atts['bg'], $atts['s'] );
+	}
+
+	/**
+	 * LaTeX needs to be untexturized.
+	 *
+	 * @since 1.1
+	 *
+	 * @param  array $shortcodes
+	 * @return array
+	 */
+	public function latex_no_texturize( $shortcodes ) {
+		$shortcodes[] = 'latex';
+		return $shortcodes;
+	}
+
+	/**
+	 * Enqueue Latex helper script.
+	 *
+	 * @uses wp_enqueue_script, plugins_url
+	 * @action wp_enqueue_script
+	 * @return null
+	 */
+	public function latex_enqueue_scripts() {
+		wp_enqueue_script( 'latex', plugins_url( 'modules/latex/latex.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), null, true );
+	}
 }
 
-function latex_get_default_color( $color, $default_color = 'ffffff' ) {
-	global $themecolors;
-	return isset($themecolors[$color]) ? $themecolors[$color] : $default_color;
-}
-
-function latex_entity_decode( $latex ) {
-	return str_replace( array( '&lt;', '&gt;', '&quot;', '&#039;', '&#038;', '&amp;', "\n", "\r" ), array( '<', '>', '"', "'", '&', '&', ' ', ' ' ), $latex );
-}
-
-function latex_render( $latex, $fg, $bg, $s = 0 ) {
-	$url = "//s0.wp.com/latex.php?latex=" . urlencode( $latex ) . "&bg=" . $bg . "&fg=" . $fg . "&s=" . $s;
-	$url = esc_url( $url );
-	$alt = str_replace( '\\', '&#92;', esc_attr( $latex ) );
-
-	return '<img src="' . $url . '" alt="' . $alt . '" title="' . $alt . '" class="latex" />';
-}
-
-/**
- * The shortcode way. The attributes are the same as the old ones - 'fg' and 'bg', instead of foreground
- * and background, and 's' is for the font size.
- *
- * Example: [latex s=4 bg=00f fg=ff0]\LaTeX[/latex]
- */
-function latex_shortcode( $atts, $content = '' ) {
-	extract( shortcode_atts( array(
-		's' => 0,
-		'bg' => latex_get_default_color( 'bg' ),
-		'fg' => latex_get_default_color( 'text', '000' )
-	), $atts, 'latex' ) );
-
-	return latex_render( latex_entity_decode( $content ), $fg, $bg, $s );
-}
-
-/**
- * LaTeX needs to be untexturized
- */
-function latex_no_texturize( $shortcodes ) {
-	$shortcodes[] = 'latex';
-	return $shortcodes;
-}
-
-add_filter( 'no_texturize_shortcodes', 'latex_no_texturize' );
-
-add_filter( 'the_content', 'latex_markup', 9 ); // before wptexturize
-add_filter( 'comment_text', 'latex_markup', 9 ); // before wptexturize
-add_shortcode( 'latex', 'latex_shortcode' );
+Jetpack_Latex::instance();

--- a/modules/latex.php
+++ b/modules/latex.php
@@ -354,9 +354,14 @@ class Jetpack_Latex {
 			case '\TeX' :
 				return '$latex \mathrm{' . $latex . '}$';
 			case '\AmS' :
+				$img_tag = '<img src="//s0.wp.com/latex.php?latex=%%5CAmS&amp;bg=%s&amp;fg=%s&amp;s=%s&amp;zoom=2" alt="\AmS" title="\AmS" class="latex" width="40" height="17" srcset="//s0.wp.com/latex.php?latex=%%5CAmS&amp;bg=%s&amp;fg=%s&amp;s=%s&amp;zoom=2 2x" scale="2">';
+				return sprintf( $img_tag, $bg, $fg, $s, $bg, $fg, $s );
 			case '\AmS-\TeX' :
+				$img_tag = '<img src="//s0.wp.com/latex.php?latex=%%5CAmS-%%5CTeX&amp;bg=%s&amp;fg=%s&amp;s=%s&amp;zoom=2" alt="\AmS-\TeX" title="\AmS-\TeX" class="latex" width="74" height="18" srcset="//s0.wp.com/latex.php?latex=%%5CAmS-%%5CTeX&amp;bg=%s&amp;fg=%s&amp;s=%s&amp;zoom=2 2x" scale="2">';
+				return sprintf( $img_tag, $bg, $fg, $s, $bg, $fg, $s );
 			case '\AmS-\LaTeX' :
-				return $this->render_img( $latex, $fg, $bg, $s );
+				$img_tag = '<img src="//s0.wp.com/latex.php?latex=%%5CAmS-%%5CLaTeX&amp;bg=%s&amp;fg=%s&amp;s=%s&amp;zoom=2" alt="\AmS-\LaTeX" title="\AmS-\LaTeX" class="latex" width="85" height="18" srcset="//s0.wp.com/latex.php?latex=%%5CAmS-%%5CLaTeX&amp;bg=%s&amp;fg=%s&amp;s=%s&amp;zoom=2 2x" scale="2">';
+				return sprintf( $img_tag, $bg, $fg, $s, $bg, $fg, $s );
 			default:
 				return false;
 		}
@@ -409,34 +414,6 @@ class Jetpack_Latex {
 		}
 
 		return $output;
-	}
-
-	/**
-	 * Render a LaTeX expression using WP Latex.
-	 *
-	 * To use for edge cases where MathJax can't render something.
-	 *
-	 * @since 3.8.0
-	 *
-	 * @param  string  $latex LaTeX expression.
-	 * @param  string  $fg    Foreground color.
-	 * @param  string  $bg    Background color.
-	 * @param  integer $s     Font size.
-	 * @return string
-	 */
-	public function render_img( $latex, $fg, $bg, $s = 0 ) {
-		$url = "//s0.wp.com/latex.php?latex=" . urlencode( $latex ) . "&bg=" . $bg . "&fg=" . $fg . "&s=" . $s;
-
-		$scale = '';
-		if ( @ $img_info = getimagesize( 'http:' . $url ) ) {
-			list($width, $height) = $img_info;
-			$url .= '&zoom=2';
-			$scale = ' width="' . $width . '"  height="' . $height . '" srcset="' . $url . ' 2x" scale="2"';
-		}
-
-		$url = esc_url( $url );
-		$alt = str_replace( '\\', '&#92;', esc_attr( $latex ) );
-		return '<img src="' . $url . '" alt="' . $alt . '" title="' . $alt . '" class="latex"' . $scale . ' />';
 	}
 
 	/**

--- a/modules/latex/latex.js
+++ b/modules/latex/latex.js
@@ -1,12 +1,19 @@
 ( function( $ ) {
-	$( document.body ).on( 'post-load', function( response ) {
+	'use strict';
+	$( document.body ).on( 'post-load', function() {
 		// New posts have been added to the page. Re-typeset MathJax if necessary.
 		if ( typeof MathJax !== 'undefined' ) {
-			MathJax.Hub.Queue( [
-				'Typeset',
-				MathJax.Hub,
-				jQuery('.infinite-wrap').get().pop() // Only typeset in the newest infinite-wrap element.
-			] );
+			$( '.infinite-wrap' ).not( '.mathjax-typeset' ).each( function() {
+				var wrap = this;
+
+				MathJax.Hub.Queue( [
+					'Typeset',
+					MathJax.Hub,
+					wrap
+				] );
+
+				$( wrap ).addClass( 'mathjax-typeset' );
+			} );
 		}
 	} );
 } )( jQuery );

--- a/modules/latex/latex.js
+++ b/modules/latex/latex.js
@@ -1,0 +1,8 @@
+( function( $ ) {
+	$( document.body ).on( 'post-load', function() {
+		// New posts have been added to the page. Re-typeset MathJax if necessary.
+		if ( typeof MathJax !== 'undefined' ) {
+			MathJax.Hub.Queue( [ 'Typeset', MathJax.Hub ] );
+		}
+	} );
+} )( jQuery );

--- a/modules/latex/latex.js
+++ b/modules/latex/latex.js
@@ -1,8 +1,12 @@
 ( function( $ ) {
-	$( document.body ).on( 'post-load', function() {
+	$( document.body ).on( 'post-load', function( response ) {
 		// New posts have been added to the page. Re-typeset MathJax if necessary.
 		if ( typeof MathJax !== 'undefined' ) {
-			MathJax.Hub.Queue( [ 'Typeset', MathJax.Hub ] );
+			MathJax.Hub.Queue( [
+				'Typeset',
+				MathJax.Hub,
+				jQuery('.infinite-wrap').get().pop() // Only typeset in the newest infinite-wrap element.
+			] );
 		}
 	} );
 } )( jQuery );

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -280,8 +280,8 @@ function latex_more_info() { ?>
 		</a>
 	</div>
 
-	<p><?php printf( esc_html__( '%s is a powerful markup language for writing complex mathematical equations, formulas, etc.', 'jetpack' ), '<a href="http://www.latex-project.org/" target="_blank"><img src="//s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1" alt="LaTeX logo" title="LaTeX" style="vertical-align: -25%" /></a>' ); ?></p>
-	<p><?php printf( esc_html__( 'Jetpack combines the power of %s and the simplicity of WordPress to give you the ultimate in math blogging platforms.', 'jetpack' ), '<img src="//s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1" alt="LaTeX logo" title="LaTeX" style="vertical-align: -25%" />' ); ?></p>
+	<p><?php printf( esc_html__( '%s is a powerful markup language for writing complex mathematical equations, formulas, etc.', 'jetpack' ), '<a href="http://www.latex-project.org/" target="_blank"><img src="https://s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1" alt="LaTeX" title="LaTeX" width="39" height="16" srcset="https://s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1&amp;zoom=2 2x" scale="2" style="vertical-align: -25%"></a>' ); ?></p>
+	<p><?php printf( esc_html__( 'Jetpack combines the power of %s and the simplicity of WordPress to give you the ultimate in math blogging platforms.', 'jetpack' ), '<img src="https://s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1" alt="LaTeX" title="LaTeX" width="39" height="16" srcset="https://s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1&amp;zoom=2 2x" scale="2" style="vertical-align: -25%">' ); ?></p>
 	<p><?php esc_html_e( 'Wow, that sounds nerdy.', 'jetpack' ) ?></p>
 <?php
 }
@@ -294,8 +294,8 @@ function latex_more_info_connected() { ?>
 		</a>
 	</div>
 
-	<p><?php printf( esc_html__( '%s is a powerful markup language for writing complex mathematical equations, formulas, etc.', 'jetpack' ), '<a href="http://www.latex-project.org/" target="_blank"><img src="//s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1" alt="LaTeX logo" title="LaTeX" style="vertical-align: -25%" /></a>' ); ?></p>
-	<p><?php printf( __( 'Use <code>$latex your latex code here$</code> or <code>[latex]your latex code here[/latex]</code> to include %s in your posts and comments. There are <a href="%s" target="_blank">all sorts of options</a> available.', 'jetpack' ), '<img src="//s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1" alt="LaTeX logo" title="LaTeX" style="vertical-align: -25%" />', 'http://support.wordpress.com/latex/' ); ?></p>
+	<p><?php printf( esc_html__( '%s is a powerful markup language for writing complex mathematical equations, formulas, etc.', 'jetpack' ), '<a href="http://www.latex-project.org/" target="_blank"><img src="https://s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1" alt="LaTeX" title="LaTeX" width="39" height="16" srcset="https://s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1&amp;zoom=2 2x" scale="2" style="vertical-align: -25%"></a>' ); ?></p>
+	<p><?php printf( __( 'Use <code>$latex your latex code here$</code> or <code>[latex]your latex code here[/latex]</code> to include %s in your posts and comments. There are <a href="%s" target="_blank">all sorts of options</a> available.', 'jetpack' ), '<img src="https://s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1" alt="LaTeX" title="LaTeX" width="39" height="16" srcset="https://s0.wp.com/latex.php?latex=%5CLaTeX&amp;bg=transparent&amp;fg=000&amp;s=-1&amp;zoom=2 2x" scale="2" style="vertical-align: -25%">', 'http://support.wordpress.com/latex/' ); ?></p>
 <?php
 }
 add_action( 'jetpack_module_more_info_connected_latex', 'latex_more_info_connected' );

--- a/tests/modules/latex/test_class.latex.php
+++ b/tests/modules/latex/test_class.latex.php
@@ -1,0 +1,246 @@
+<?php
+
+class WP_Test_Latex extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->setGlobals();
+
+		require_once dirname( __FILE__ ) . '/../../../modules/latex.php';
+	}
+
+	/**
+	 * @author popthestack
+	 * @global array $themecolors
+	 * @since 3.8.0
+	 */
+	private function setGlobals() {
+		global $themecolors;
+
+		if ( ! isset( $themecolors ) ) {
+			$themecolors = array();
+		}
+
+		$themecolors['text'] = '';
+		$themecolors['bg']   = '';
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::instance
+	 * @since 3.8.0
+	 */
+	public function test_latex_instance() {
+		$this->assertInstanceOf( 'Jetpack_Latex', Jetpack_Latex::instance() );
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::instance
+	 * @since 3.8.0
+	 */
+	public function test_latex_instance_singleton() {
+		$latex = Jetpack_Latex::instance();
+
+		$this->assertEquals( $latex, Jetpack_Latex::instance() );
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::latex_shortcode
+	 * @since 3.8.0
+	 */
+	public function test_latex_shortocde_exists() {
+		$this->assertEquals( true, shortcode_exists( 'latex' ) );
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::latex_no_texturize
+	 * @since 3.8.0
+	 */
+	public function test_latex_no_texturize() {
+		$this->assertEquals( array( 'latex' ), Jetpack_Latex::instance()->latex_no_texturize( array() ) );
+	}
+
+	public function test_latex_output_mathjax_script() {
+		$latex = Jetpack_Latex::instance();
+
+		ob_start();
+		$result = $latex->output_mathjax_script();
+		$script_tag = ob_get_clean();
+
+		$this->assertContains( 'MathJax.js', $script_tag );
+		$this->assertTrue( $result );
+
+		// It should not output anything a second time.
+		$this->assertFalse( $latex->output_mathjax_script() );
+	}
+
+	public function test_latex_mathjax_config_output() {
+		$latex = Jetpack_Latex::instance();
+
+		ob_start();
+		$latex->latex_mathjax_config_output();
+		$script_tag = ob_get_clean();
+
+		$this->assertContains( 'MathJax.Hub.Config', $script_tag );
+		$this->assertContains( 'text/x-mathjax-config', $script_tag );
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::render
+	 * @since 3.8.0
+	 */
+	public function test_latex_render() {
+		$latex = Jetpack_Latex::instance();
+		$math = '1 + 2';
+		$this->assertEquals( '$latex ' . $math . '$', $latex->render( $math, '', '', 0 ) );
+		$this->assertEquals( '<span style="display: inline-block;font-size: 12pt;">$latex 1 + 2$</span>', $latex->render( $math, '', '', 1 ) );
+		$this->assertEquals( '<span style="display: inline-block;color: #000;background-color: #fff;">$latex ' . $math . '$</span>', $latex->render( $math, '000', 'fff', 0 ) );
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::latex_mathjax_config
+	 * @since 3.8.0
+	 */
+	public function test_latex_mathjax_config() {
+		$admin_id = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+		wp_set_current_user( $admin_id );
+
+		$config = Jetpack_Latex::instance()->latex_mathjax_config();
+		$this->assertInternalType( 'array', $config );
+		$this->assertArrayHasKey( 'config', $config );
+		$this->assertArrayHasKey( 'jax', $config );
+		$this->assertArrayHasKey( 'extensions', $config );
+		$this->assertArrayHasKey( 'TeX', $config );
+		$this->assertArrayHasKey( 'tex2jax', $config );
+
+		$this->assertEquals( true, $config['TeX']['noErrors']['disabled'] );
+		$this->assertEquals( true, $config['TeX']['noUndefined']['disabled'] );
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::latex_mathjax_config
+	 * @since 3.8.0
+	 */
+	public function test_latex_mathjax_config_error_reporting() {
+		$user_id = $this->factory->user->create( array(
+			'role' => 'subscriber',
+		) );
+		wp_set_current_user( $user_id );
+
+		$config = Jetpack_Latex::instance()->latex_mathjax_config();
+		$this->assertArrayNotHasKey( 'noErrors', $config['TeX'] );
+		$this->assertArrayNotHasKey( 'noUndefined', $config['TeX']);
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::latex_size_pt
+	 * @since 3.8.0
+	 */
+	public function test_latex_size_pt() {
+		$latex = Jetpack_Latex::instance();
+		$this->assertEquals( false, $latex->latex_size_pt( 0 ) );
+		$this->assertEquals( false, $latex->latex_size_pt( -5 ) );
+		$this->assertEquals( false, $latex->latex_size_pt( 6 ) );
+		$this->assertEquals( '12pt', $latex->latex_size_pt( 1 ) );
+		$this->assertEquals( '14.4pt', $latex->latex_size_pt( 2 ) );
+		$this->assertEquals( '17.28pt', $latex->latex_size_pt( 3 ) );
+		$this->assertEquals( '20.74pt', $latex->latex_size_pt( 4 ) );
+		$this->assertEquals( '24.88pt', $latex->latex_size_pt( 5 ) );
+		$this->assertEquals( '11pt', $latex->latex_size_pt( -1 ) );
+		$this->assertEquals( '10pt', $latex->latex_size_pt( -2 ) );
+		$this->assertEquals( '8pt', $latex->latex_size_pt( -3 ) );
+		$this->assertEquals( '7pt', $latex->latex_size_pt( -4 ) );
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::mathjax_text_mode_workarounds
+	 * @since 3.8.0
+	 */
+	public function test_latex_mathjax_text_mode_workarounds() {
+		$fg = '';
+		$bg = '';
+		$s  = 0;
+		$latex = Jetpack_Latex::instance();
+		$this->assertEquals( false, $latex->mathjax_text_mode_workarounds( '1 + 2', $fg, $bg, $s ) );
+		$this->assertEquals( false, $latex->mathjax_text_mode_workarounds( '4', $fg, $bg, $s ) );
+		$this->assertEquals( '$latex \mathrm{\LaTeX}$', $latex->mathjax_text_mode_workarounds( '\LaTeX', $fg, $bg, $s ) );
+		$this->assertEquals( '$latex \mathrm{\TeX}$', $latex->mathjax_text_mode_workarounds( '\TeX', $fg, $bg, $s ) );
+		// Purposefully not testing \AmS, \AmS-\TeX, and \AmS-\LaTeX because $latex->render_img makes an HTTP request.
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::entity_decode
+	 * @since 3.8.0
+	 */
+	public function test_latex_entity_decode() {
+		$entities = '$latex 1 &lt; 2 &#038; 23&amp;fg=ccc$';
+		$decoded  = '$latex 1 < 2 & 23&fg=ccc$';
+		$latex    = Jetpack_Latex::instance();
+		$this->assertEquals( $decoded, $latex->entity_decode( $entities ) );
+	}
+
+	/**
+	 * @author popthestack
+	 * @global array $themecolors
+	 * @covers Jetpack_Latex::get_default_color
+	 * @since 3.8.0
+	 */
+	public function test_latex_get_default_color() {
+		global $themecolors;
+
+		$latex = Jetpack_Latex::instance();
+
+		$themecolors['testcolor1'] = 'ccc';
+		$this->assertEquals( 'ccc', $latex->get_default_color( 'testcolor1' ) );
+		$this->assertEquals( 'f00', $latex->get_default_color( 'testcolor2', 'f00' ) );
+
+		$this->assertEquals( '', $latex->get_default_color( 'text' ) );
+		$this->assertEquals( '', $latex->get_default_color( 'bg' ) );
+		$this->assertEquals( '', $latex->get_default_color( 'text', '000' ) );
+		$this->assertEquals( '', $latex->get_default_color( 'bg', 'fff' ) );
+	}
+
+	/**
+	 * @author popthestack
+	 * @global array $themecolors
+	 * @covers Jetpack_Latex::latex_src
+	 * @since 3.8.0
+	 */
+	public function test_latex_src() {
+		global $themecolors;
+
+		$latex = Jetpack_Latex::instance();
+
+		$matches  = array( '', 'e^{\i \pi} + 1 = 0' );
+		$rendered = '$latex e^{\i \pi} + 1 = 0$';
+		$this->assertEquals( $rendered, $latex->latex_src( $matches ) );
+
+		$themecolors['text'] = 'f00';
+		$themecolors['bg']   = '000';
+		$this->assertEquals( '<span style="display: inline-block;color: #f00;background-color: #000;">' . $rendered . '</span>', $latex->latex_src( $matches ) );
+	}
+
+	/**
+	 * @author popthestack
+	 * @covers Jetpack_Latex::latex_markup
+	 * @since 3.8.0
+	 */
+	public function test_latex_markup() {
+		$markup   = '<p>Some math: $latex e^{\i \pi} + 1 = 0$.</p><p>Some more math:<br />$latex f(x) & = Sin(\pi)x - Sin(\pi^2)x + Cos(-\pi^3)*x$</p>';
+		$rendered = '<p>Some math: $latex e^{\i \pi} + 1 = 0$.</p><p>Some more math:<br />$latex f(x) & = Sin(\pi)x - Sin(\pi^2)x + Cos(-\pi^3)*x$</p>';
+		$this->assertEquals( $rendered, Jetpack_Latex::instance()->latex_markup( $markup ) );
+	}
+
+} // end class

--- a/tests/modules/latex/test_class.latex.php
+++ b/tests/modules/latex/test_class.latex.php
@@ -67,14 +67,9 @@ class WP_Test_Latex extends WP_UnitTestCase {
 	public function test_latex_output_mathjax_script() {
 		$latex = Jetpack_Latex::instance();
 
-		ob_start();
-		$result = $latex->output_mathjax_script();
-		$script_tag = ob_get_clean();
+		$this->assertTrue( $latex->output_mathjax_script() );
 
-		$this->assertContains( 'MathJax.js', $script_tag );
-		$this->assertTrue( $result );
-
-		// It should not output anything a second time.
+		// It shouldn't do anything if called a second time.
 		$this->assertFalse( $latex->output_mathjax_script() );
 	}
 

--- a/tests/modules/latex/test_class.latex.php
+++ b/tests/modules/latex/test_class.latex.php
@@ -171,7 +171,9 @@ class WP_Test_Latex extends WP_UnitTestCase {
 		$this->assertEquals( false, $latex->mathjax_text_mode_workarounds( '4', $fg, $bg, $s ) );
 		$this->assertEquals( '$latex \mathrm{\LaTeX}$', $latex->mathjax_text_mode_workarounds( '\LaTeX', $fg, $bg, $s ) );
 		$this->assertEquals( '$latex \mathrm{\TeX}$', $latex->mathjax_text_mode_workarounds( '\TeX', $fg, $bg, $s ) );
-		// Purposefully not testing \AmS, \AmS-\TeX, and \AmS-\LaTeX because $latex->render_img makes an HTTP request.
+		$this->assertContains( '%5CAmS', $latex->mathjax_text_mode_workarounds( '\AmS', $fg, $bg, $s ) );
+		$this->assertContains( '%5CAmS-%5CTeX', $latex->mathjax_text_mode_workarounds( '\AmS-\TeX', $fg, $bg, $s ) );
+		$this->assertContains( '%5CAmS-%5CLaTeX', $latex->mathjax_text_mode_workarounds( '\AmS-\LaTeX', $fg, $bg, $s ) );
 	}
 
 	/**


### PR DESCRIPTION
This pull request re-implements the Jetpack Latex module using [MathJax](https://www.mathjax.org/).

Rendering math equations as PNGs doesn't work well with shifting page layouts, it removes some typesetting information, and isn't very high resolution. Using MathJax allows the browser itself to handle fonts and typesetting in order to keep the output pretty.

This shouldn't cause any backwards compatibility breaks.

Some points for discussion:

 * I'm purposefully serving MathJax files from the MathJax CDN. Given the size of the MathJax assets (~40 MB) I wanted to see what others thought before including them in the repo.
 * The change to `jetpack-modules.js` to run MathJax for the Beautiful Math modal description in the admin is not my favorite. It feels hacky.
 * `wp_encode_json` for the options might not safe enough; however, the options need to be filterable.
 * Please let me know where this could benefit from more inline documentation. It's not always easy to spot places it's lacking when you've got all the code in your head. :)