### PR TITLE
Ensure IXR_Client is loaded before extending.

### DIFF
--- a/class.jetpack-ixr-client.php
+++ b/class.jetpack-ixr-client.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once( ABSPATH . WPINC . '/class-IXR.php' );
+
 /**
  * IXR_Client
  *


### PR DESCRIPTION
Under unknown circumstances, multiple users have reported this error message:
`[Fri Sep 04 04:07:55 2015] [warn] mod_fcgid: stderr: PHP Fatal error:  Class 'IXR_Client' not found in /wp-content/plugins/jetpack/class.jetpack-ixr-client.php on line 10`

I've previously attempted to debug the root cause, but have been unable to. In either case, ensuring IXR_Client is loaded should resolve.