### PR TITLE
Instagram: ensure that Embeds Render correctly in Feeds

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -69,7 +69,7 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 	$min_width = 320;
 
 	if ( is_feed() ) {
-		$media_url = sprintf( 'http://instagr.am/p/%s/media/?size=l', $matches[2] );
+		$media_url = sprintf( 'http://instagr.am/p/%s/media/?size=l', $matches[3] );
 		return sprintf( '<a href="%s" title="%s"><img src="%s" alt="Instagram Photo" /></a>', esc_url( $url ), esc_attr__( 'View on Instagram', 'jetpack' ), esc_url( $media_url ) );
 	}
 


### PR DESCRIPTION
Steps to reproduce the issue:

1. Create a new post and inserted https://instagram.com/p/7F9H34sxS2/ in the post body.
2. Publish the post.
3. in the RSS feed, here is the output:

```html
<p><a href="https://instagram.com/p/7F9H34sxS2/" title="View on Instagram"><img src="http://instagr.am/p/am.com/media/?size=l" alt="Instagram Photo" /></a></p>
```

Make note of the `src` being:

`http://instagr.am/p/am.com/media/?size=l`

For the image to show up, it should be:

`http://instagr.am/p/7F9H34sxS2/media/?size=l`


Props @druesome 
