### PR TITLE
Sharedaddy: Return early when adding the meta box if there's no post.

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -64,6 +64,9 @@ function sharing_email_send_post_content( $data ) {
 
 function sharing_add_meta_box() {
 	global $post;
+	if ( empty( $post ) ) { // If a current post is not defined, such as when editing a comment.
+		return;
+	}
 	$post_types = get_post_types( array( 'public' => true ) );
 	/**
 	 * Filter the Sharing Meta Box title.


### PR DESCRIPTION
Resolves the following PHP notice:
```​*E_NOTICE: /wp-content/plugins/jetpack/modules/sharedaddy/sharedaddy.php:76 - Trying to get property of non-object*​``` thrown when editing a comment.

Both the post editor and comment editor fires the `add_meta_box` action and we're not taking into account that there could be a time when a current post is not defined.