### PR TITLE
JSON API: fix fatal in list embeds

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-embeds-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-embeds-endpoint.php
@@ -14,7 +14,11 @@ class WPCOM_JSON_API_List_Embeds_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		// list em
 		$output = array( 'embeds' => array() );
-
+	
+		if ( ! function_exists( '_wp_oembed_get_object' ) ) {
+			require_once( ABSPATH . WPINC . '/class-oembed.php' );
+		}
+				
 		global $wp_embed;
 		$oembed = _wp_oembed_get_object();
 


### PR DESCRIPTION
The `/embeds` endpoint (which lists available embeds) was returning a fatal error for Jetpack sites, when the wp_oembed class was not yet defined...

Fixes the following fatal:

> PHP Fatal error:  Call to undefined function _wp_oembed_get_object() in
> .../wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-embeds-endpoint.php on line 19