### PR TITLE
3rd Party: Be exact on file location.

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -5,7 +5,7 @@
  * is architected
  */
 
-require_once( 'buddypress.php' );
-require_once( 'wpml.php' );
-require_once( 'bitly.php' );
-require_once( 'bbpress.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/buddypress.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/wpml.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );


### PR DESCRIPTION
In odd cases, if a specific file calls wp-load.php directly, WP will call wp-settings.php, which loads active plugins. jetpack.php calls the 3rd-party.php which attempt to loads these files. If there is a file in the same directory that matches the names of our files, it will attempt to load that instead of Jetpack's causing gnashing and general sadness.

Example: The Nanotheme (theme forest) has a custom-style.php that outputs that theme's version of a custom CSS module. That file loads wp-load.php and with the above pattern loads the theme's bbpress.php. Stack trace:

<img width="1035" alt="screen shot 2015-09-11 at 20 53 51" src="https://cloud.githubusercontent.com/assets/88897/9829403/22c2c444-58c8-11e5-88e7-dc198ed55701.png">
