### PR TITLE
Refactor the bbPress Sharing Options.

### DIFF
--- a/3rd-party/bbpress.php
+++ b/3rd-party/bbpress.php
@@ -1,5 +1,5 @@
 <?php
-add_action( 'bbp_init', 'jetpack_bbpress_compat' );
+add_action( 'init', 'jetpack_bbpress_compat', 11 ); // Priority 11 needed to ensure sharing_display is loaded.
 
 /**
  * Adds Jetpack + bbPress Compatability filters.

--- a/3rd-party/bbpress.php
+++ b/3rd-party/bbpress.php
@@ -1,9 +1,21 @@
 <?php
+add_action( 'bbp_init', 'jetpack_bbpress_compat' );
 
-add_action( 'bbp_get_topic_content',           'jetpack_sharing_bbpress' );
-add_action( 'bbp_template_after_single_forum', 'jetpack_sharing_bbpress' );
-add_action( 'bbp_template_after_single_topic', 'jetpack_sharing_bbpress' );
-add_action( 'bbp_template_after_lead_topic',   'jetpack_sharing_bbpress' );
+/**
+ * Adds Jetpack + bbPress Compatability filters.
+ *
+ * Runs on the `bbp_init` hook as an easy way to determine if bbPress is active.
+ *
+ * @author Brandon Kraft
+ * @since  3.7.1
+ */
+function jetpack_bbpress_compat() {
+	if ( function_exists( 'sharing_display' ) ) {
+		add_filter( 'bbp_get_topic_content',           'sharing_display', 19 );
+		add_action( 'bbp_template_after_single_forum', 'jetpack_sharing_bbpress' );
+		add_action( 'bbp_template_after_single_topic', 'jetpack_sharing_bbpress' );
+	}
+}
 
 /**
  * Display Jetpack "Sharing" buttons on bbPress 2.x forums/ topics/ lead topics/ replies.
@@ -11,11 +23,8 @@ add_action( 'bbp_template_after_lead_topic',   'jetpack_sharing_bbpress' );
  * Determination if the sharing buttons should display on the post type is handled within sharing_display().
  *
  * @author David Decker
- * @since  3.6.0
+ * @since  3.7.0
  */
 function jetpack_sharing_bbpress() {
-
-	if ( function_exists( 'sharing_display' ) ) {
-		echo sharing_display();
-	}
+	sharing_display( null, true );
 }

--- a/3rd-party/bbpress.php
+++ b/3rd-party/bbpress.php
@@ -2,7 +2,7 @@
 add_action( 'init', 'jetpack_bbpress_compat', 11 ); // Priority 11 needed to ensure sharing_display is loaded.
 
 /**
- * Adds Jetpack + bbPress Compatability filters.
+ * Adds Jetpack + bbPress Compatibility filters.
  *
  * @author Brandon Kraft
  * @since  3.7.1

--- a/3rd-party/bbpress.php
+++ b/3rd-party/bbpress.php
@@ -4,8 +4,6 @@ add_action( 'init', 'jetpack_bbpress_compat', 11 ); // Priority 11 needed to ens
 /**
  * Adds Jetpack + bbPress Compatability filters.
  *
- * Runs on the `bbp_init` hook as an easy way to determine if bbPress is active.
- *
  * @author Brandon Kraft
  * @since  3.7.1
  */


### PR DESCRIPTION
* `bbp_get_topic_content` is actually a filter. Fixes #2708
* `bbp_get_topic_content` can natively use sharing_display since it assumes a filter is calling it.
* Hook everything onto `bbp_init` as an easy way to confirm bbPress is active, after all plugins have been loaded.
* Condition all actions within a check for `sharing_display()`.
* Change `jetpack_sharing_bbpress` to use `sharing_display`'s second argument to echo to simplify future changes on Sharing's output when known to be echoed.
* Removes the `bbp_template_after_lead_topic` as it would duplicate sharing buttons on lead topic posts after consultation with @johnjamesjacoby

Slack chat in w.org slack #bbpress: https://wordpress.slack.com/archives/bbpress/p1442419246000088