### PR TITLE
The WordPress.com button on NUX page wasn't expanding to fit translations

### DIFF
--- a/scss/templates/_nux-landing-2015.scss
+++ b/scss/templates/_nux-landing-2015.scss
@@ -420,13 +420,13 @@
 			} 
 
 			.button {
-                height: auto;
-                min-height: 28px;
-                line-height: 18px;
-                white-space: normal;
+				height: auto;
+				min-height: 28px;
+				line-height: 18px;
+				white-space: normal;
 				max-width: 200px;
 				margin-bottom: 0;
-                padding-top: 2px;
+				padding-top: 2px;
 			}
 			.feat {
 				@include vertalign;

--- a/scss/templates/_nux-landing-2015.scss
+++ b/scss/templates/_nux-landing-2015.scss
@@ -420,8 +420,13 @@
 			} 
 
 			.button {
+                height: auto;
+                min-height: 28px;
+                line-height: 18px;
+                white-space: normal;
 				max-width: 200px;
 				margin-bottom: 0;
+                padding-top: 2px;
 			}
 			.feat {
 				@include vertalign;


### PR DESCRIPTION
I've made the button multi-line if needed to expand for longer translated content 

fixes #2701