### PR TITLE
NUX: Don't allow module toggle in dev mode

### DIFF
--- a/scss/templates/_nux-landing-2015.scss
+++ b/scss/templates/_nux-landing-2015.scss
@@ -321,6 +321,14 @@
 			}
 		}
 
+		.unavailable {
+			opacity: 0.3;
+
+			.act {
+				display: none;
+			}
+		}
+
 		.paid {
 			top: 4px;
 			margin-left: 12px;

--- a/scss/templates/_nux-landing-2015.scss
+++ b/scss/templates/_nux-landing-2015.scss
@@ -322,7 +322,7 @@
 		}
 
 		.unavailable {
-			opacity: 0.3;
+			opacity: 0.5;
 
 			.act {
 				display: none;

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -132,7 +132,7 @@
 						$normalized_site_url = Jetpack::build_raw_urls( get_home_url() );
 						$manage_active = Jetpack::is_module_active( 'manage' );
 					?>
-					<?php if ( current_user_can( 'jetpack_manage_modules' ) && $data['is_user_connected'] ) : ?>
+					<?php if ( current_user_can( 'jetpack_manage_modules' ) && $data['is_user_connected'] && ! Jetpack::is_development_mode() ) : ?>
 					<div id="manage-row" class="j-row goto <?php echo ( $manage_active ) ? 'activated' : ''; ?>">
 						<div class="feat j-col j-lrg-7 j-md-8 j-sm-7">
 							<a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jpnux' ); ?>" class="button button-primary manage-cta-active" target="_blank" style="display: <?php echo ( $manage_active ) ? 'inline-block' : 'none'; ?>;" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>"><?php _e( 'Go to WordPress.com', 'jetpack' ); ?></a>

--- a/views/admin/landing-page-templates.php
+++ b/views/admin/landing-page-templates.php
@@ -47,7 +47,11 @@
 </script>
 <?php // NUX - Performance and security section ?>
 <script id="tmpl-mod-nux" type="text/html">
-	<div id="toggle-{{ data.module }}" data-index="{{ data.index }}" class="{{ data.activated ? 'activated' : '' }} j-row">
+	<?php if ( Jetpack::is_development_mode() ) : ?>
+		<div id="toggle-{{ data.module }}" data-index="{{ data.index }}" class="{{ data.activated ? 'activated' : '' }} {{ data.requires_connection && 'vaultpress' !== data.module ? 'unavailable' : '' }} j-row">
+	<?php else : ?>
+		<div id="toggle-{{ data.module }}" data-index="{{ data.index }}" class="{{ data.activated ? 'activated' : '' }} j-row">
+	<?php endif; ?>
 		<div href="{{ data.url }}" tabindex="0" data-index="{{ data.index }}" data-name="{{ data.name }}" class="feat j-col j-lrg-8 j-md-12 j-sm-7">
 			<h4 title="{{ data.name }}" style="cursor: pointer; display: inline;">{{{ data.name }}}</h4>
 			<# if ( 'vaultpress' == data.module ) { #>


### PR DESCRIPTION
Fixes #2672

Hides the toggles and greys out row for modules that requires connection while in dev mode.

- Completely hides any manage CTA. 
- Modals still work
- Run `grunt` to see changes

Looks like this: 
![screen shot 2015-09-17 at 9 31 40 am](https://cloud.githubusercontent.com/assets/7129409/9934388/ecd56ba6-5d1e-11e5-9b02-850efb9f73f9.png)