### PR TITLE
IDC: don't show notice for sites using domain mapping

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5893,6 +5893,12 @@ p {
 	 * Displays an admin_notice, alerting the user to an identity crisis.
 	 */
 	public function alert_identity_crisis() {
+		// @todo temporary copout for dealing with domain mapping
+		// @see https://github.com/Automattic/jetpack/issues/2702
+		if ( is_multisite() && defined( 'SUNRISE' ) && ! Jetpack::is_development_version() ) {
+			return;
+		}
+
 		if ( ! current_user_can( 'jetpack_disconnect' ) ) {
 			return;
 		}


### PR DESCRIPTION
This is a TEMP copout solution to the domain mapping/IDC problem outlined in #2702.    

Please leave that issue open, as we should work out an actual solution for 3.8.  

note: will still show the alert if using a development version.  

cc @kraftbj 