### PR TITLE
Contact Form: admin make_it ham should report ham to akismet not spam

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -656,7 +656,7 @@ function grunion_ajax_spam() {
 		 * @param string $comment_status Usually 'spam'
 		 * @param array $akismet_values From '_feedback_akismet_values' in comment meta
 		 **/
-		do_action( 'contact_form_akismet', 'spam', $akismet_values );
+		do_action( 'contact_form_akismet', 'ham', $akismet_values );
 
 		$comment_author_email = $reply_to_addr = $message = $to = $headers = false;
 		$blog_url = parse_url( site_url() );


### PR DESCRIPTION
The "Not spam" action in Contact Form admin calls `Akismet::http_post( $query_string, "submit-{$as}" )` with $as='spam'.

Compare wp-content/plugins/akismet/class.akismet.php, Line 561, in function submit_nonspam_comment():
`self::http_post( Akismet::build_query( $comment ), 'submit-ham' )`

I looked at the svn repo and it's been this way since Grunion came into Jetpack, 2012/04/24.