### PR TITLE
Contact form: Makes the fields get sent and displayed in correct order

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -295,27 +295,24 @@ function grunion_manage_post_columns( $col, $post_id ) {
 				if ( !empty( $author_email ) )
 					$author_name_line = get_avatar( $author_email, 32 );
 
-				$author_name_line .= "<strong>{$author_name}</strong><br />";
+				$author_name_line .= sprintf( "<strong>%s</strong><br />", esc_html( $author_name ) );
 			}
 
 			$author_email_line = '';
 			if ( !empty( $author_email ) ) {
-				$author_email_line = "<a href='mailto:{$author_email}'>";
-				$author_email_line .= "{$author_email}</a><br />";
+				$author_email_line = sprintf( "<a href='%1\$s'>%2\$s</a><br />", esc_url( "mailto:" . $author_email ) , esc_html( $author_email ) );
 			}
 
 			$author_url_line = '';
 			if ( !empty( $author_url ) ) {
-				$author_url_line = "<a href='{$author_url}'>";
-				$author_url_line .= "{$author_url}</a><br />";
-
+				$author_url_line = sprintf( "<a href='%1\$s'>%1\$s</a><br />", esc_url( $author_url ) );
 			}
 
 			echo $author_name_line;
 			echo $author_email_line;
 			echo $author_url_line;
-			echo "<a href='edit.php?post_type=feedback&s={$author_ip}";
-			echo "&mode=detail'>{$author_ip}</a><br />";
+			echo "<a href='edit.php?post_type=feedback&s=" . urlencode( $author_ip );
+			echo "&mode=detail'>" . esc_html( $author_ip ) . "</a><br />";
 			if ( $form_url ) {
 				echo '<a href="' . esc_url( $form_url ) . '">' . esc_html( $form_url ) . '</a>';
 			}

--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -6,6 +6,7 @@
 .contact-form label { margin-bottom: 3px; float: none; font-weight: bold; display: block; }
 .contact-form label.checkbox, .contact-form label.radio { margin-bottom: 3px; float: none; font-weight: bold; display: inline-block; }
 .contact-form label span { color: #AAA; margin-left: 4px; font-weight: normal; }
+.contact-form-submission { margin-bottom: 4em; }
 .form-errors .form-error-message { color: red; }
 .textwidget .contact-form input[type='text'], .textwidget .contact-form input[type='email'], .textwidget .contact-form textarea { width: 250px; max-width: 100%; box-sizing: border-box; }
 #jetpack-check-feedback-spam { margin: 1px 8px 0px 0px; }

--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -6,7 +6,8 @@
 .contact-form label { margin-bottom: 3px; float: none; font-weight: bold; display: block; }
 .contact-form label.checkbox, .contact-form label.radio { margin-bottom: 3px; float: none; font-weight: bold; display: inline-block; }
 .contact-form label span { color: #AAA; margin-left: 4px; font-weight: normal; }
-.contact-form-submission { margin-bottom: 4em; }
+.contact-form-submission { margin-bottom: 4em; padding: 1.5em 1em; }
+.contact-form-submission p { margin: 0 auto; }
 .form-errors .form-error-message { color: red; }
 .textwidget .contact-form input[type='text'], .textwidget .contact-form input[type='email'], .textwidget .contact-form textarea { width: 250px; max-width: 100%; box-sizing: border-box; }
 #jetpack-check-feedback-spam { margin: 1px 8px 0px 0px; }

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1103,9 +1103,32 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		return $r;
 	}
 
+	/**
+	 * Returns a success message to be returned if the form is sent via AJAX.
+	 *
+	 * @param Integer $feedback_id
+	 * @param Grunion_Contact_Form $form
+	 *
+	 * @return String $message
+	 */
 	static function success_message( $feedback_id, $form ) {
-		$r_success_message = '';
+		return wp_kses(
+			"<blockquote>\n"
+			. join( self::get_compiled_form( $feedback_id, $form ), '<br />' )
+			. "</blockquote><br /><br />",
+			array( 'br' => array(), 'blockquote' => array() )
+		);
+	}
 
+	/**
+	 * Returns a compiled form with labels and values in a form of  an array
+	 * of lines.
+	 * @param Integer $feedback_id
+	 * @param Grunion_Contact_Form $form
+	 *
+	 * @return Array $lines
+	 */
+	static function get_compiled_form( $feedback_id, $form) {
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
 		$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $feedback_id );
@@ -1119,7 +1142,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			'textarea' => false, // not a post_meta key.  This is stored in post_content
 		);
 
-		$contact_form_message = "<blockquote>\n";
+		$compiled_form = array();
 
 		// "Standard" field whitelist
 		foreach ( $field_value_map as $type => $meta_key ) {
@@ -1136,11 +1159,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 					$value = trim( $value );
 				}
 
-				$contact_form_message .= sprintf(
+				$field_index = array_search( $field_ids[ $type ], $field_ids['all'] );
+				$compiled_form[ $field_index ] = sprintf(
 					_x( '%1$s: %2$s', '%1$s = form field label, %2$s = form field value', 'jetpack' ),
 					wp_kses( $field->get_attribute( 'label' ), array() ),
 					wp_kses( $value, array() )
-				) . '<br />';
+				);
 			}
 		}
 
@@ -1153,24 +1177,24 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$i = 0;
 			foreach ( $field_ids['extra'] as $field_id ) {
 				$field = $form->fields[$field_id];
+				$field_index = array_search( $field_id, $field_ids['all'] );
 
 				$label = $field->get_attribute( 'label' );
 
-				$contact_form_message .= sprintf(
+				$compiled_form[ $field_index ] = sprintf(
 					_x( '%1$s: %2$s', '%1$s = form field label, %2$s = form field value', 'jetpack' ),
 					wp_kses( $label, array() ),
 					wp_kses( $extra_fields[$extra_field_keys[$i]], array() )
-				) . '<br />';
+				);
 
 				$i++;
 			}
 		}
 
-		$contact_form_message .= "</blockquote><br /><br />";
+		// Sorting lines by the field index
+		ksort( $compiled_form );
 
-		$r_success_message .= wp_kses( $contact_form_message, array( 'br' => array(), 'blockquote' => array() ) );
-
-		return $r_success_message;
+		return $compiled_form;
 	}
 
 	/**
@@ -1471,39 +1495,6 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		$date_time_format = sprintf( $date_time_format, get_option( 'date_format' ), get_option( 'time_format' ) );
 		$time = date_i18n( $date_time_format, current_time( 'timestamp' ) );
 
-		$message = "$comment_author_label: $comment_author\n";
-		if ( !empty( $comment_author_email ) ) {
-			$message .= "$comment_author_email_label: $comment_author_email\n";
-		}
-		if ( !empty( $comment_author_url ) ) {
-			$message .= "$comment_author_url_label: $comment_author_url\n";
-		}
-		if ( !empty( $comment_content_label ) ) {
-			$message .= "$comment_content_label: $comment_content\n";
-		}
-		if ( !empty( $extra_values ) ) {
-			foreach ( $extra_values as $label => $value ) {
-				$message .= preg_replace( '#^\d+_#i', '', $label ) . ': ' . trim( $value ) . "\n";
-			}
-		}
-		$message .= "\n";
-		$message .= __( 'Time:', 'jetpack' ) . ' ' . $time . "\n";
-		$message .= __( 'IP Address:', 'jetpack' ) . ' ' . $comment_author_IP . "\n";
-		$message .= __( 'Contact Form URL:', 'jetpack' ) . " $url\n";
-
-		if ( is_user_logged_in() ) {
-			$message .= "\n";
-			$message .= sprintf(
-				__( 'Sent by a verified %s user.', 'jetpack' ),
-				isset( $GLOBALS['current_site']->site_name ) && $GLOBALS['current_site']->site_name ? $GLOBALS['current_site']->site_name : '"' . get_option( 'blogname' ) . '"'
-			);
-		} else {
-			$message .= __( 'Sent by an unverified visitor to your site.', 'jetpack' );
-		}
-
-		$message = apply_filters( 'contact_form_message', $message );
-		$message = Grunion_Contact_Form_Plugin::strip_tags( $message );
-
 		// keep a copy of the feedback as a custom post type
 		$feedback_time   = current_time( 'mysql' );
 		$feedback_title  = "{$comment_author} - {$feedback_time}";
@@ -1559,6 +1550,34 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 * @param array $extra_values Contact form fields not included in $all_values
 		 **/
 		do_action( 'grunion_pre_message_sent', $post_id, $all_values, $extra_values );
+
+		$message = self::get_compiled_form( $post_id, $this );
+
+		array_push(
+			$message,
+			"", // Empty line left intentionally
+			__( 'Time:', 'jetpack' ) . ' ' . $time,
+			__( 'IP Address:', 'jetpack' ) . ' ' . $comment_author_IP,
+			__( 'Contact Form URL:', 'jetpack' ) . " " . $url
+		);
+
+		if ( is_user_logged_in() ) {
+			array_push(
+				$message,
+				"",
+				sprintf(
+					__( 'Sent by a verified %s user.', 'jetpack' ),
+					isset( $GLOBALS['current_site']->site_name ) && $GLOBALS['current_site']->site_name ?
+						$GLOBALS['current_site']->site_name : '"' . get_option( 'blogname' ) . '"'
+				)
+			);
+		} else {
+			array_push( $message, __( 'Sent by an unverified visitor to your site.', 'jetpack' ) );
+		}
+
+		$message = join( $message, "\n" );
+		$message = apply_filters( 'contact_form_message', $message );
+		$message = Grunion_Contact_Form_Plugin::strip_tags( $message );
 
 		// schedule deletes of old spam feedbacks
 		if ( !wp_next_scheduled( 'grunion_scheduled_delete' ) ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1113,10 +1113,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 */
 	static function success_message( $feedback_id, $form ) {
 		return wp_kses(
-			"<blockquote>\n"
-			. join( self::get_compiled_form( $feedback_id, $form ), '<br />' )
-			. "</blockquote><br /><br />",
-			array( 'br' => array(), 'blockquote' => array() )
+			'<blockquote class="contact-form-submission">'
+			. '<p>' . join( self::get_compiled_form( $feedback_id, $form ), '</p><p>' ) . '</p>'
+			. '</blockquote>',
+			array( 'br' => array(), 'blockquote' => array( 'class' => array() ), 'p' => array() )
 		);
 	}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1537,19 +1537,6 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 		update_post_meta( $post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );
-		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
-
-		/**
-		 * Fires right before the contact form message is sent via email to
-		 * the recipient specified in the contact form.
-		 *
-		 * @since ?
-		 * @module Contact_Forms
-		 * @param integer $post_id Post contact form lives on
-		 * @param array $all_values Contact form fields
-		 * @param array $extra_values Contact form fields not included in $all_values
-		 **/
-		do_action( 'grunion_pre_message_sent', $post_id, $all_values, $extra_values );
 
 		$message = self::get_compiled_form( $post_id, $this );
 
@@ -1578,6 +1565,20 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		$message = join( $message, "\n" );
 		$message = apply_filters( 'contact_form_message', $message );
 		$message = Grunion_Contact_Form_Plugin::strip_tags( $message );
+
+		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
+
+		/**
+		 * Fires right before the contact form message is sent via email to
+		 * the recipient specified in the contact form.
+		 *
+		 * @since ?
+		 * @module Contact_Forms
+		 * @param integer $post_id Post contact form lives on
+		 * @param array $all_values Contact form fields
+		 * @param array $extra_values Contact form fields not included in $all_values
+		 **/
+		do_action( 'grunion_pre_message_sent', $post_id, $all_values, $extra_values );
 
 		// schedule deletes of old spam feedbacks
 		if ( !wp_next_scheduled( 'grunion_scheduled_delete' ) ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1106,10 +1106,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns a success message to be returned if the form is sent via AJAX.
 	 *
-	 * @param Integer $feedback_id
-	 * @param Grunion_Contact_Form $form
+	 * @param int $feedback_id
+	 * @param object Grunion_Contact_Form $form
 	 *
-	 * @return String $message
+	 * @return string $message
 	 */
 	static function success_message( $feedback_id, $form ) {
 		return wp_kses(
@@ -1123,12 +1123,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	/**
 	 * Returns a compiled form with labels and values in a form of  an array
 	 * of lines.
-	 * @param Integer $feedback_id
-	 * @param Grunion_Contact_Form $form
+	 * @param int $feedback_id
+	 * @param object Grunion_Contact_Form $form
 	 *
-	 * @return Array $lines
+	 * @return array $lines
 	 */
-	static function get_compiled_form( $feedback_id, $form) {
+	static function get_compiled_form( $feedback_id, $form ) {
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
 		$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $feedback_id );


### PR DESCRIPTION
This PR introduces a new method that compiles the form into an array of lines that is sorted by field indexes, so that no field is out of place. Also now both the success message that shows the completed form and the email body are generated by a single method. Fixes #49 

Replaces #1433 