### PR TITLE
Social Media Icons: update actions to filters.

### DIFF
--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -11,6 +11,8 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 
 	private $defaults;
 
+	private $services;
+
 	public function __construct() {
 		parent::__construct(
 			'wpcom_social_media_icons_widget',
@@ -29,6 +31,17 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'github_username'    => '',
 			'youtube_username'   => '',
 			'vimeo_username'     => '',
+		);
+
+		$this->services = array(
+			'facebook' => array( 'Facebook', 'https://www.facebook.com/%s/' ),
+			'twitter' => array( 'Twitter', 'https://twitter.com/%s/' ),
+			'instagram' => array( 'Instagram', 'https://instagram.com/%s/' ),
+			'pinterest' => array( 'Pinterest', 'https://www.pinterest.com/%s/' ),
+			'linkedin' => array( 'LinkedIn', 'https://www.linkedin.com/in/%s/' ),
+			'github' => array( 'GitHub', 'https://github.com/%s/' ),
+			'youtube' => array( 'YouTube', 'https://www.youtube.com/%s/' ),
+			'vimeo' => array( 'Vimeo', 'https://vimeo.com/%s/' ),
 		);
 
 		if ( is_active_widget( false, false, $this->id_base ) ) {
@@ -63,78 +76,63 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			wp_enqueue_style( 'genericons' );
 		}
 
-		// before widget arguments
-		$html = $args['before_widget'];
-
-		if ( ! empty( $instance['title'] ) ) {
-			$html .= $args['before_title'] . esc_html( $instance['title'] ) . $args['after_title'];
-		}
-
-		// display output
-		$html .= '<ul>';
+		$index = 10;
+		$html = array();
 
 		$alt_text = esc_attr__( 'View %1$s&#8217;s profile on %2$s', 'jetpack' );
 
-		/**
-		 * Fires in the beginning of the list of Social Media accounts, inside the unordered list.
-		 * Can be used to add a new Social Media Site to the Social Media Icons Widget.
-		 *
-		 * @module widgets
-		 *
-		 * @since 3.7.0
-		 *
-		 * @param string $html Widget HTML structure.
-		 */
-		$html = apply_filters( 'jetpack_social_media_icons_widget_list_before', $html );
+		foreach ( $this->services as $service => $data ) {
+			list( $service_name, $url ) = $data;
 
-		if ( ! empty( $instance['facebook_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['facebook_username'] ), 'Facebook' ) . '" href="' . esc_url( 'https://www.facebook.com/' . $instance['facebook_username'] . '/' ) . '" class="genericon genericon-facebook" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['facebook_username'] ), 'Facebook' ) . '</span></a></li>';
-		}
+			if ( ! isset( $instance[ $service . '_username' ] ) ) {
+				continue;
+			}
+			$index += 10;
+			$username = $instance[ $service . '_username' ];
 
-		if ( ! empty( $instance['twitter_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['twitter_username'] ), 'Twitter' ) . '" href="' . esc_url( 'https://twitter.com/' . $instance['twitter_username'] . '/' ) . '" class="genericon genericon-twitter" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['twitter_username'] ), 'Twitter' ) . '</span></a></li>';
-		}
+			/**
+			 * Fires for each profile link in the social icons widget. Can be used
+			 * to change the links for certain social networks if needed.
+			 *
+			 * @module widgets
+			 *
+			 * @since 3.8.0
+			 *
+			 * @param string $url the currently processed URL
+			 * @param string $service the lowercase service slug, e.g. 'facebook', 'youtube', etc.
+			 */
+			$link = apply_filters( 'jetpack_social_media_icons_widget_profile_link', esc_url( sprintf( $url, $username ) ), $service );
 
-		if ( ! empty( $instance['instagram_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['instagram_username'] ), 'Instagram' ) . '" href="' . esc_url( 'https://instagram.com/' . $instance['instagram_username'] . '/' ) . '" class="genericon genericon-instagram" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['instagram_username'] ), 'Instagram' ) . '</span></a></li>';
-		}
-
-		if ( ! empty( $instance['pinterest_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['pinterest_username'] ), 'Pinterest' ) . '" href="' . esc_url( 'https://www.pinterest.com/' . $instance['pinterest_username'] . '/' ) . '" class="genericon genericon-pinterest-alt" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['pinterest_username'] ), 'Pinterest' ) . '</span></a></li>';
-		}
-
-		if ( ! empty( $instance['linkedin_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['linkedin_username'] ), 'LinkedIn' ) . '" href="' . esc_url( 'https://www.linkedin.com/in/' . $instance['linkedin_username'] . '/' ) . '" class="genericon genericon-linkedin-alt" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['linkedin_username'] ), 'LinkedIn' ) . '</span></a></li>';
-		}
-
-		if ( ! empty( $instance['github_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['github_username'] ), 'GitHub' ) . '" href="' . esc_url( 'https://github.com/' . $instance['github_username'] . '/' ) . '" class="genericon genericon-github" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['github_username'] ), 'GitHub' ) . '</span></a></li>';
-		}
-
-		if ( ! empty( $instance['youtube_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['youtube_username'] ), 'YouTube' ) . '" href="' . esc_url( 'https://www.youtube.com/channel/' . $instance['youtube_username'] ) . '" class="genericon genericon-youtube" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['youtube_username'] ), 'YouTube' ) . '</span></a></li>';
-		}
-
-		if ( ! empty( $instance['vimeo_username'] ) ) {
-			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['vimeo_username'] ), 'Vimeo' ) . '" href="' . esc_url( 'https://vimeo.com/' . $instance['vimeo_username'] . '/' ) . '" class="genericon genericon-vimeo" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['vimeo_username'] ), 'Vimeo' ) . '</span></a></li>';
+			$html[ $index ] =
+				'<a title="' . sprintf( $alt_text, esc_attr( $username ), $service_name )
+				. '" href="' . $link
+				. '" class="genericon genericon-' . $service . '" target="_blank"><span class="screen-reader-text">'
+				. sprintf( $alt_text, esc_html( $username ), $service_name )
+				. '</span></a>';
 		}
 
 		/**
-		 * Fires at the end of the list of Social Media accounts, inside the unordered list.
+		 * Fires at the end of the list of Social Media accounts.
 		 * Can be used to add a new Social Media Site to the Social Media Icons Widget.
+		 * The filter function passed the array of HTML entries that will be sorted
+		 * by key, each wrapped in a list item element and output as an unsorted list.
 		 *
 		 * @module widgets
 		 *
-		 * @since 3.7.0
+		 * @since 3.8.0
 		 *
-		 * @param string $html Widget HTML structure.
+		 * @param array $html Associative array of HTML snippets per each icon.
 		 */
-		$html = apply_filters( 'jetpack_social_media_icons_widget_list_after', $html );
+		$html = apply_filters( 'jetpack_social_media_icons_widget_array', $html );
 
-		$html .= '</ul>';
+		ksort( $html );
+		$html = '<ul><li>' . join( '</li><li>', $html ) . '</li></ul>';
 
-		// after widget arguments
-		$html .= $args['after_widget'];
+		if ( ! empty( $instance['title'] ) ) {
+			$html = $args['before_title'] . esc_html( $instance['title'] ) . $args['after_title'] . $html;
+		}
+
+		$html = $args['before_widget'] . $html . $args['after_widget'];
 
 		/**
 		 * Filters the Social Media Icons widget output.
@@ -151,44 +149,39 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 	// backend
 	public function form( $instance ) {
 		$instance = wp_parse_args( (array) $instance, $this->defaults );
-	?>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php _e( 'Title:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'facebook_username' ) ); ?>"><?php _e( 'Facebook username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'facebook_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'facebook_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['facebook_username'] ); ?>" />
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'twitter_username' ) ); ?>"><?php _e( 'Twitter username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'twitter_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'twitter_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['twitter_username'] ); ?>" />
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'instagram_username' ) ); ?>"><?php _e( 'Instagram username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'instagram_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'instagram_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['instagram_username'] ); ?>" />
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'pinterest_username' ) ); ?>"><?php _e( 'Pinterest username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'pinterest_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'pinterest_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['pinterest_username'] ); ?>" />
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'linkedin_username' ) ); ?>"><?php _e( 'LinkedIn username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'linkedin_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'linkedin_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['linkedin_username'] ); ?>" />
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'github_username' ) ); ?>"><?php _e( 'GitHub username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'github_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'github_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['github_username'] ); ?>" />
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'youtube_username' ) ); ?>"><?php _e( 'YouTube channel ID:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'youtube_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'youtube_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['youtube_username'] ); ?>" />
-		</p>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>"><?php _e( 'Vimeo username:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'vimeo_username' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'vimeo_username' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['vimeo_username'] ); ?>" />
-		</p>
-	<?php
+		?>
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php _e( 'Title:', 'jetpack' ); ?></label>
+				<input
+						class="widefat"
+						id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+						name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+						type="text"
+						value="<?php echo esc_attr( $instance['title'] ); ?>"
+					/>
+			</p>
+		<?php
+
+		foreach ( $this->services as $service => $data ) {
+			list( $service_name, $url ) = $data;
+			?>
+				<p>
+					<label for="<?php echo esc_attr( $this->get_field_id( $service . '_username' ) ); ?>">
+					<?php
+						/* translators: %s is a social network name, e.g. Facebook */
+						printf( __( '%s username:', 'jetpack' ), $service_name );
+					?>
+				</label>
+				<input
+						class="widefat"
+						id="<?php echo esc_attr( $this->get_field_id( $service . '_username' ) ); ?>"
+						name="<?php echo esc_attr( $this->get_field_name( $service . '_username' ) ); ?>"
+						type="text"
+						value="<?php echo esc_attr( $instance[ $service . '_username'] ); ?>"
+					/>
+				</p>
+			<?php
+		}
 	}
 
 	// updating widget settings

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -89,8 +89,13 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			if ( ! isset( $instance[ $service . '_username' ] ) ) {
 				continue;
 			}
-			$index += 10;
 			$username = $link_username = $instance[ $service . '_username' ];
+
+			if ( empty( $username ) ) {
+				continue;
+			}
+
+			$index += 10;
 
 			if (
 				$service === 'googleplus'
@@ -98,6 +103,12 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 				&& substr( $username, 0, 1 ) !== "+"
 			) {
 				$link_username = "+" . $username;
+			}
+
+			if ( $service === 'youtube' && substr( $username, 0, 2 ) == 'UC' ) {
+				$link_username = "channel/" . $username;
+			} else if ( $service === 'youtube' ) {
+				$link_username = "user/" . $username;
 			}
 
 			/**

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -77,14 +77,15 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 
 		/**
 		 * Fires in the beginning of the list of Social Media accounts, inside the unordered list.
-		 *
 		 * Can be used to add a new Social Media Site to the Social Media Icons Widget.
 		 *
 		 * @module widgets
 		 *
 		 * @since 3.7.0
+		 *
+		 * @param string $html Widget HTML structure.
 		 */
-		do_action( 'jetpack_social_media_icons_widget_list_before' );
+		$html = apply_filters( 'jetpack_social_media_icons_widget_list_before', $html );
 
 		if ( ! empty( $instance['facebook_username'] ) ) {
 			$html .= '<li><a title="' . sprintf( $alt_text, esc_attr( $instance['facebook_username'] ), 'Facebook' ) . '" href="' . esc_url( 'https://www.facebook.com/' . $instance['facebook_username'] . '/' ) . '" class="genericon genericon-facebook" target="_blank"><span class="screen-reader-text">' . sprintf( $alt_text, esc_html( $instance['facebook_username'] ), 'Facebook' ) . '</span></a></li>';
@@ -120,14 +121,15 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 
 		/**
 		 * Fires at the end of the list of Social Media accounts, inside the unordered list.
-		 *
 		 * Can be used to add a new Social Media Site to the Social Media Icons Widget.
 		 *
 		 * @module widgets
 		 *
 		 * @since 3.7.0
+		 *
+		 * @param string $html Widget HTML structure.
 		 */
-		do_action( 'jetpack_social_media_icons_widget_list_after' );
+		$html = apply_filters( 'jetpack_social_media_icons_widget_list_after', $html );
 
 		$html .= '</ul>';
 

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -31,6 +31,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'github_username'    => '',
 			'youtube_username'   => '',
 			'vimeo_username'     => '',
+			'googleplus_username' => '',
 		);
 
 		$this->services = array(
@@ -42,6 +43,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'github' => array( 'GitHub', 'https://github.com/%s/' ),
 			'youtube' => array( 'YouTube', 'https://www.youtube.com/%s/' ),
 			'vimeo' => array( 'Vimeo', 'https://vimeo.com/%s/' ),
+			'googleplus' => array( 'Google+', 'https://plus.google.com/u/0/%s/' ),
 		);
 
 		if ( is_active_widget( false, false, $this->id_base ) ) {
@@ -88,7 +90,15 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 				continue;
 			}
 			$index += 10;
-			$username = $instance[ $service . '_username' ];
+			$username = $link_username = $instance[ $service . '_username' ];
+
+			if (
+				$service === 'googleplus'
+				&& ! is_numeric( $username )
+				&& substr( $username, 0, 1 ) !== "+"
+			) {
+				$link_username = "+" . $username;
+			}
 
 			/**
 			 * Fires for each profile link in the social icons widget. Can be used
@@ -101,7 +111,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			 * @param string $url the currently processed URL
 			 * @param string $service the lowercase service slug, e.g. 'facebook', 'youtube', etc.
 			 */
-			$link = apply_filters( 'jetpack_social_media_icons_widget_profile_link', esc_url( sprintf( $url, $username ) ), $service );
+			$link = apply_filters( 'jetpack_social_media_icons_widget_profile_link', esc_url( sprintf( $url, $link_username ) ), $service );
 
 			$html[ $index ] =
 				'<a title="' . sprintf( $alt_text, esc_attr( $username ), $service_name )

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -35,14 +35,14 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		);
 
 		$this->services = array(
-			'facebook' => array( 'Facebook', 'https://www.facebook.com/%s/' ),
-			'twitter' => array( 'Twitter', 'https://twitter.com/%s/' ),
-			'instagram' => array( 'Instagram', 'https://instagram.com/%s/' ),
-			'pinterest' => array( 'Pinterest', 'https://www.pinterest.com/%s/' ),
-			'linkedin' => array( 'LinkedIn', 'https://www.linkedin.com/in/%s/' ),
-			'github' => array( 'GitHub', 'https://github.com/%s/' ),
-			'youtube' => array( 'YouTube', 'https://www.youtube.com/%s/' ),
-			'vimeo' => array( 'Vimeo', 'https://vimeo.com/%s/' ),
+			'facebook'   => array( 'Facebook', 'https://www.facebook.com/%s/' ),
+			'twitter'    => array( 'Twitter', 'https://twitter.com/%s/' ),
+			'instagram'  => array( 'Instagram', 'https://instagram.com/%s/' ),
+			'pinterest'  => array( 'Pinterest', 'https://www.pinterest.com/%s/' ),
+			'linkedin'   => array( 'LinkedIn', 'https://www.linkedin.com/in/%s/' ),
+			'github'     => array( 'GitHub', 'https://github.com/%s/' ),
+			'youtube'    => array( 'YouTube', 'https://www.youtube.com/%s/' ),
+			'vimeo'      => array( 'Vimeo', 'https://vimeo.com/%s/' ),
 			'googleplus' => array( 'Google+', 'https://plus.google.com/u/0/%s/' ),
 		);
 


### PR DESCRIPTION
As actions, it could only echo an additional icon before or after the whole widget.

Once this is fixed, site owners will be able to use the filters like in this example:

```php
/**
 * Add a link to a LinkedIn Company Page at the end of the Social Icons widget.
 *
 * @return string $html Social Icons widget HTML structure.
 */
function jeherve_linkedin_company_page_widget( $html ) {

	// LinkedIn Company information.
	$linkedin_company_name = 'Automattic';
	$linkedin_company_url  = 'https://www.linkedin.com/company/58194';

	// Build the icon.
	$linkedin_icon = '<li>
		<a
			title="' . esc_attr( $linkedin_company_name ) . '"
			href="' . esc_url( $linkedin_company_url ) . '"
			class="genericon genericon-linkedin"
			target="_blank"
		>
			<span class="screen-reader-text">
				' . esc_html( $linkedin_company_name ) . '
			</span>
		</a>
	</li>';

	// return the existing Widget HTML, and add the LinkedIn Icon.
	return $html . $linkedin_icon;

}
add_filter( 'jetpack_social_media_icons_widget_list_after', 'jeherve_linkedin_company_page_widget' );
```