### PR TITLE
Fix undefined index for conditions POST var in Customizer

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -309,6 +309,10 @@ class Jetpack_Widget_Conditions {
 	 * @return array Modified settings.
 	 */
 	public static function widget_update( $instance, $new_instance, $old_instance ) {
+		if ( empty( $_POST['conditions'] ) ) {
+			return $instance;
+		}
+
 		$conditions = array();
 		$conditions['action'] = $_POST['conditions']['action'];
 		$conditions['rules'] = array();


### PR DESCRIPTION
I've noticed at times that a PHP notice is triggered in Widget Visibility when managing widgets in the Customizer.

This is more of a patch for a symptom, not fixing the underlying problem. It seems that Widget Visibility is doing the wrong thing by accessing the conditions data via `$_POST` in the first place. It should instead be adding this data to the widget's own inputs so that it would be available in `$instance` to begin with. 