### PR TITLE
Contact Form: Fix multiple emails not parsing commas

### DIFF
--- a/modules/contact-form/js/grunion.js
+++ b/modules/contact-form/js/grunion.js
@@ -395,7 +395,7 @@ FB.ContactForm = (function() {
 				// Remove new lines that cause BR tags to show up
 				response = response.replace(/\n/g,' ');
 				// Convert characters to comma
-				response = response.replace( '%26#x002c;' , ',' );
+				response = response.replace( /%26#x002c;/g , ',' );
 
 				// Add new shortcode
 				if (currentCode.match(regexp)) {


### PR DESCRIPTION
Fixes #1136 better. 

We need to do a global replace for instances where there are more than one commas.  