### PR TITLE
Open Graph: Indicate deprecated filter as such.

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -14,7 +14,8 @@ function jetpack_og_tags() {
 	/**
 	 * Allow Jetpack to output Open Graph Meta Tags.
 	 *
-	 * @since 2.0.3
+	 * @since 2.0.0
+	 * @deprecated 2.0.3 Duplicative filter. Use `jetpack_enable_open_graph`.
 	 *
 	 * @param bool true Should Jetpack's Open Graph Meta Tags be enabled. Default to true.
 	 */


### PR DESCRIPTION
`jetpack_enable_opengraph` was added in 2.0, deprecated in 2.0.3 since we also had `jetpack_enable_open_graph`. Inline documentation should reflect the deprecation.