### PR TITLE
Unset keywords array from image meta.

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -287,6 +287,11 @@ class Jetpack_Carousel {
 			}
 		}
 
+		// See https://github.com/Automattic/jetpack/issues/2765
+		if ( isset( $img_meta['keywords'] ) ) {
+			unset( $img_meta['keywords'] );
+		}
+
 		$img_meta = json_encode( array_map( 'strval', $img_meta ) );
 
 		$attr['data-attachment-id']     = $attachment_id;

--- a/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -1,10 +1,16 @@
 <?php
+// See https://github.com/Automattic/jetpack/issues/2765
+$fuzzy_image_meta = $item->fuzzy_image_meta();
+if ( isset( $fuzzy_image_meta['keywords'] ) ) {
+	unset( $fuzzy_image_meta['keywords'] );
+}
+
 if ( defined( 'JSON_HEX_AMP' ) ) {
 	// see shortcodes/slideshow.php
 	// This is nice to have, but not strictly necessary since we use _wp_specialchars() below
-	$fuzzy_image_meta = json_encode( array_map( 'strval', $item->fuzzy_image_meta() ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	$fuzzy_image_meta = json_encode( array_map( 'strval', $fuzzy_image_meta ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 } else {
-	$fuzzy_image_meta = json_encode( array_map( 'strval', $item->fuzzy_image_meta() ) );
+	$fuzzy_image_meta = json_encode( array_map( 'strval', $fuzzy_image_meta ) );
 }
 ?>
 data-attachment-id="<?php echo esc_attr( $item->image->ID ); ?>"


### PR DESCRIPTION
Core added a keywords array to image meta. Unset it until long-term solution is found. Meant to ensure we don't PHP notice ourselves forever.

See #2765