### PR TITLE
JSON API: Allow updating (and inserting) a post by slug instead of post id (PUT requests)

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -95,7 +95,7 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 	 * @param string $field
 	 * @param string $field_value
 	 * @param string $context Post use context (e.g. 'display')
-	 * @return array Post
+	 * @return array|WP_Error Post or error.
 	 **/
 	function get_post_by( $field, $field_value, $context = 'display' ) {
 		global $blog_id;


### PR DESCRIPTION
We have an external system that is pushing content into WordPress. This external system has its own IDs comprised of hexadecimal hashes, e.g. `e4d909c290d0fb1ca068ffaddf22cbd0`. We are storing these posts in WordPress and supplying the external ID in the `post_name`.

We want to be able to allow the external system to push content into WordPress without having to figure out what its post ID is and whether it has been imported yet.

In other words, what we have to do right now to import a post is make a request to `/sites/$site/posts/slug:e4d909c290d0fb1ca068ffaddf22cbd0` to determine if the post has been inserted yet an to obtain the ID, and then we have to make an additional request to `/sites/$site/posts/new` if the post hadn't been inserted yet, or to `/sites/$site/posts/$post_ID` if it is already present. So we're required to make an extra API request if we don't keep track of the post IDs for content previously inserted, which I don't think we should have to do.

In yet other words, I'm keen for the API to be more RESTful by supporting `PUT`-like way of pushing content into WordPress via the API.

Please note that this PR represents an untested proof of concept as I couldn't quickly figure out how to make API requests locally (in VIP Quckstart).
