### PR TITLE
Protect: Use Google Recaptcha instead of the math fallback

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -25,10 +25,10 @@ class Jetpack_Protect_Module {
 	private $user_ip;
 	private $local_host;
 	private $api_endpoint;
-	public $last_request;
-	public $last_response_raw;
-	public $last_response;
-	private $block_login_with_math;
+	public  $last_request;
+	public  $last_response_raw;
+	public  $last_response;
+	private $block_login_with_fallback;
 
 	/**
 	 * Singleton implementation
@@ -336,15 +336,15 @@ class Jetpack_Protect_Module {
 			$this->block_with_fallback();
 		}
 
-		if ( ( 1 == $use_fallback || 1 == $this->block_login_with_math ) && isset( $_POST['log'] ) ) {
+		if ( ( 1 == $use_fallback || 1 == $this->block_login_with_fallback ) && isset( $_POST['log'] ) ) {
 			// If recaptcha keys are defined, use it as fallback instead of math captcha.
 			if ( defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' ) ) {
 				include_once dirname( __FILE__ ) . '/protect/recaptcha-fallback.php';
 				Jetpack_Protect_Recaptcha_Fallback::recaptcha_authenticate();
+			}else{
+				include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
+				Jetpack_Protect_Math_Authenticate::math_authenticate();
 			}
-
-			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
-			Jetpack_Protect_Math_Authenticate::math_authenticate();
 		}
 
 		return $user;
@@ -499,16 +499,16 @@ class Jetpack_Protect_Module {
 		 *
 		 * @param bool Whether to allow fallback captcha for blocked users or not.
 		 */
-		$this->block_login_with_math = 1;
+		$this->block_login_with_fallback = 1;
 
 		/**
-		 * Allow Math fallback for blocked IPs.
+		 * Allow fallback for blocked IPs.
 		 *
 		 * @module protect
 		 *
 		 * @since 3.6.0
 		 *
-		 * @param bool true Should we fallback to the Math questions when an IP is blocked. Default to true.
+		 * @param bool true Should we fallback to the fallback when an IP is blocked. Default to true.
 		 */
 		$allow_fallback_on_fail = apply_filters( 'jpp_use_captcha_when_blocked', true );
 		if( ! $allow_fallback_on_fail ) {

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -51,7 +51,7 @@ class Jetpack_Protect_Module {
 		add_action( 'jetpack_deactivate_module_protect', array ( $this, 'on_deactivation' ) );
 		add_action( 'init', array ( $this, 'maybe_get_protect_key' ) );
 		add_action( 'jetpack_modules_loaded', array ( $this, 'modules_loaded' ) );
-		add_action( 'login_head', array ( $this, 'check_use_math' ) );
+		add_action( 'login_head', array ( $this, 'check_use_fallback' ) );
 		add_filter( 'authenticate', array ( $this, 'check_preauth' ), 10, 3 );
 		add_action( 'wp_login', array ( $this, 'log_successful_login' ), 10, 2 );
 		add_action( 'wp_login_failed', array ( $this, 'log_failed_attempt' ) );
@@ -281,16 +281,16 @@ class Jetpack_Protect_Module {
 		 */
 		do_action( 'jpp_log_failed_attempt', jetpack_protect_get_ip() );
 
-		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
+		if ( isset( $_COOKIE['jpp_fallback_pass'] ) ) {
 
-			$transient = $this->get_transient( 'jpp_math_pass_' . $_COOKIE['jpp_math_pass'] );
+			$transient = $this->get_transient( 'jpp_fallback_pass_' . $_COOKIE['jpp_fallback_pass'] );
 			$transient--;
 
 			if ( ! $transient || $transient < 1 ) {
-				$this->delete_transient( 'jpp_math_pass_' . $_COOKIE['jpp_math_pass'] );
-				setcookie( 'jpp_math_pass', 0, time() - DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false );
+				$this->delete_transient( 'jpp_fallback_pass_' . $_COOKIE['jpp_fallback_pass'] );
+				setcookie( 'jpp_fallback_pass', 0, time() - DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false );
 			} else {
-				$this->set_transient( 'jpp_math_pass_' . $_COOKIE['jpp_math_pass'], $transient, DAY_IN_SECONDS );
+				$this->set_transient( 'jpp_fallback_pass_' . $_COOKIE['jpp_fallback_pass'], $transient, DAY_IN_SECONDS );
 			}
 
 		}
@@ -320,7 +320,7 @@ class Jetpack_Protect_Module {
 	/**
 	 * Checks for loginability BEFORE authentication so that bots don't get to go around the log in form.
 	 *
-	 * If we are using our math fallback, authenticate via math-fallback.php
+	 * If we are using our fallback, authenticate via recaptcha-fallback.php or math-fallback.php
 	 *
 	 * @param string $user
 	 * @param string $username
@@ -329,14 +329,20 @@ class Jetpack_Protect_Module {
 	 * @return string $user
 	 */
 	function check_preauth( $user = 'Not Used By Protect', $username = 'Not Used By Protect', $password = 'Not Used By Protect' ) {
-		$allow_login = $this->check_login_ability( true );
-		$use_math    = $this->get_transient( 'brute_use_math' );
+		$allow_login  = $this->check_login_ability( true );
+		$use_fallback = $this->get_transient( 'brute_use_fallback' );
 
 		if ( ! $allow_login ) {
-			$this->block_with_math();
+			$this->block_with_fallback();
 		}
 
-		if ( ( 1 == $use_math || 1 == $this->block_login_with_math ) && isset( $_POST['log'] ) ) {
+		if ( ( 1 == $use_fallback || 1 == $this->block_login_with_math ) && isset( $_POST['log'] ) ) {
+			// If recaptcha keys are defined, use it as fallback instead of math captcha.
+			if ( defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' ) ) {
+				include_once dirname( __FILE__ ) . '/protect/recaptcha-fallback.php';
+				Jetpack_Protect_Recaptcha_Fallback::recaptcha_authenticate();
+			}
+
 			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
 			Jetpack_Protect_Math_Authenticate::math_authenticate();
 		}
@@ -421,7 +427,7 @@ class Jetpack_Protect_Module {
 	 *
 	 * @param bool $preauth Whether or not we are checking prior to authorization
 	 *
-	 * @return bool Either returns true, fires $this->kill_login, or includes a math fallback and returns false
+	 * @return bool Either returns true, fires $this->kill_login, or includes a math or recaptcha fallback and returns false
 	 */
 	function check_login_ability( $preauth = false ) {
 		$headers         = $this->get_headers();
@@ -444,7 +450,7 @@ class Jetpack_Protect_Module {
 		}
 
 		if ( isset( $transient_value ) && 'blocked' == $transient_value['status'] ) {
-			$this->block_with_math();
+			$this->block_with_fallback();
 		}
 
 		if ( isset( $transient_value ) && 'blocked-hard' == $transient_value['status'] ) {
@@ -455,7 +461,13 @@ class Jetpack_Protect_Module {
 		// Now we check with the Protect API to see if we should allow login
 		$response = $this->protect_call( $action = 'check_ip' );
 
-		if ( isset( $response['math'] ) && ! function_exists( 'brute_math_authenticate' ) ) {
+		if ( isset( $response['fallback'] ) && ! function_exists( 'brute_math_authenticate' ) ) {
+			if ( defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' ) ) {
+				include_once dirname( __FILE__ ) . '/protect/recaptcha-fallback.php';
+				new Jetpack_Protect_Recaptcha_Fallback;
+				return false;
+			}
+
 			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
 			new Jetpack_Protect_Math_Authenticate;
 
@@ -463,7 +475,7 @@ class Jetpack_Protect_Module {
 		}
 
 		if ( 'blocked' == $response['status'] ) {
-			$this->block_with_math();
+			$this->block_with_fallback();
 		}
 
 		if ( 'blocked-hard' == $response['status'] ) {
@@ -473,10 +485,11 @@ class Jetpack_Protect_Module {
 		return true;
 	}
 
-	function block_with_math() {
+	function block_with_fallback() {
 		/**
 		 * By default, Protect will allow a user who has been blocked for too
-		 * many failed logins to start answering math questions to continue logging in
+		 * many failed logins to start answering math questions or succesfully responses
+		 * to recaptcha challenge to continue logging in
 		 *
 		 * For added security, you can disable this.
 		 *
@@ -484,10 +497,10 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 3.6.0
 		 *
-		 * @param bool Whether to allow math for blocked users or not.
+		 * @param bool Whether to allow fallback captcha for blocked users or not.
 		 */
-
 		$this->block_login_with_math = 1;
+
 		/**
 		 * Allow Math fallback for blocked IPs.
 		 *
@@ -497,10 +510,17 @@ class Jetpack_Protect_Module {
 		 *
 		 * @param bool true Should we fallback to the Math questions when an IP is blocked. Default to true.
 		 */
-		$allow_math_fallback_on_fail = apply_filters( 'jpp_use_captcha_when_blocked', true );
-		if ( ! $allow_math_fallback_on_fail ) {
+		$allow_fallback_on_fail = apply_filters( 'jpp_use_captcha_when_blocked', true );
+		if( ! $allow_fallback_on_fail ) {
 			$this->kill_login();
 		}
+
+		if ( defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' ) ) {
+			include_once dirname( __FILE__ ) . '/protect/recaptcha-fallback.php';
+			new Jetpack_Protect_Recaptcha_Fallback;
+			return false;
+		}
+
 		include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
 		new Jetpack_Protect_Math_Authenticate;
 
@@ -532,13 +552,18 @@ class Jetpack_Protect_Module {
 	}
 
 	/*
-	 * Checks if the protect API call has failed, and if so initiates the math captcha fallback.
+	 * Checks if the protect API call has failed, and if so initiates the math captcha or recaptcha fallback.
 	 */
-	public function check_use_math() {
-		$use_math = $this->get_transient( 'brute_use_math' );
-		if ( $use_math ) {
-			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
-			new Jetpack_Protect_Math_Authenticate;
+	public function check_use_fallback() {
+		$use_fallback = $this->get_transient( 'brute_use_fallback' );
+		if ( $use_fallback ) {
+			if ( defined( 'RECAPTCHA_PUBLIC_KEY' ) && defined( 'RECAPTCHA_PRIVATE_KEY' ) ) {
+				include_once dirname( __FILE__ ) . '/protect/recaptcha-fallback.php';
+				new Jetpack_Protect_Recaptcha_Fallback;
+			}else{
+				include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
+				new Jetpack_Protect_Math_Authenticate;
+			}
 		}
 	}
 
@@ -688,11 +713,11 @@ class Jetpack_Protect_Module {
 		if ( isset( $response['status'] ) && ! isset( $response['error'] ) ) {
 			$response['expire'] = time() + $response['seconds_remaining'];
 			$this->set_transient( $transient_name, $response, $response['seconds_remaining'] );
-			$this->delete_transient( 'brute_use_math' );
+			$this->delete_transient( 'brute_use_fallback' );
 		} else { // Fallback to Math Captcha if no response from API host
-			$this->set_transient( 'brute_use_math', 1, 600 );
-			$response['status'] = 'ok';
-			$response['math']   = true;
+			$this->set_transient( 'brute_use_fallback', 1, 600 );
+			$response['status'] 	= 'ok';
+			$response['fallback']   = true;
 		}
 
 		if ( isset( $response['error'] ) ) {

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -36,8 +36,8 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			$salted_ans  = sha1( $salt . $ans );
 			$correct_ans = isset( $_POST[ 'jetpack_protect_answer' ] ) ? $_POST[ 'jetpack_protect_answer' ] : '' ;
 
-			if( isset( $_COOKIE[ 'jpp_math_pass' ] ) ) {
-				$transient = Jetpack_Protect_Module::get_transient( 'jpp_math_pass_' . $_COOKIE[ 'jpp_math_pass' ] );
+			if( isset( $_COOKIE[ 'jpp_fallback_pass' ] ) ) {
+				$transient = Jetpack_Protect_Module::get_transient( 'jpp_fallback_pass_' . $_COOKIE[ 'jpp_fallback_pass' ] );
 				if( !$transient || $transient < 1 ) {
 					Jetpack_Protect_Math_Authenticate::generate_math_page();
 				}
@@ -63,11 +63,6 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 		 * @return none, execution stopped
 		 */
 		static function generate_math_page( $error = false ) {
-			$salt = get_site_option( 'jetpack_protect_key' ) . get_site_option( 'admin_email' );
-			$num1 = rand( 0, 10 );
-			$num2 = rand( 1, 10 );
-			$sum  = $num1 + $num2;
-			$ans  = sha1( $salt . $sum );
 			ob_start();
 			?>
 			<h2><?php _e( 'Please solve this math problem to prove that you are not a bot.  Once you solve it, you will need to log in again.', 'jetpack' ); ?></h2>
@@ -96,8 +91,8 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				Jetpack_Protect_Math_Authenticate::generate_math_page(true);
 			} else {
 				$temp_pass = substr( sha1( rand( 1, 100000000 ) . get_site_option( 'jetpack_protect_key' ) ), 5, 25 );
-				Jetpack_Protect_Module::set_transient( 'jpp_math_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
-				setcookie('jpp_math_pass', $temp_pass, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false);
+				Jetpack_Protect_Module::set_transient( 'jpp_fallback_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
+				setcookie('jpp_fallback_pass', $temp_pass, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false);
 				return true;
 			}
 		}

--- a/modules/protect/recaptcha-fallback.php
+++ b/modules/protect/recaptcha-fallback.php
@@ -93,7 +93,7 @@ if ( ! class_exists( 'Jetpack_Protect_Recaptcha_Fallback' ) ) {
 			if ( true === $result ) {
 				$temp_pass = substr( sha1( rand( 1, 100000000 ) . get_site_option( 'jetpack_protect_key' ) ), 5, 25 );
 				Jetpack_Protect_Module::set_transient( 'jpp_fallback_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
-				setcookie('jpp_fallback_pass_', $temp_pass, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false);
+				setcookie('jpp_fallback_pass', $temp_pass, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false);
 				return true;
 			} else {
 				Jetpack_Protect_Recaptcha_Fallback::generate_recaptcha_page(true);

--- a/modules/protect/recaptcha-fallback.php
+++ b/modules/protect/recaptcha-fallback.php
@@ -1,0 +1,131 @@
+<?php
+
+if ( ! class_exists( 'Jetpack_Protect_Recaptcha_Fallback' ) ) {
+	/*
+	 * The recaptcha fallback if we can't talk to the Protect API and recapcha
+	 * keys are defined
+	 */
+	class Jetpack_Protect_Recaptcha_Fallback {
+
+		static $loaded;
+
+		function __construct() {
+
+			if ( self::$loaded ) {
+				return;
+			}
+
+			self::$loaded = 1;
+
+			add_action( 'login_form', array( $this, 'recaptcha_form' ) );
+
+			if( isset( $_POST[ 'jetpack_protect_process_recaptcha_form' ] ) ) {
+				add_action( 'init', array( $this, 'process_generate_recaptcha_page' ) );
+			}
+
+			require_once plugin_dir_path( __FILE__ ) . '../sharedaddy/recaptcha.php';
+		}
+
+		/**
+		 * Verifies that a user answered correctly the recaptcha challenge while logging in.
+		 *
+		 * @return bool Returns true if the math is correct
+		 * @throws Error if insuffient $_POST variables are present.
+		 * @throws Error message if the math is wrong
+		 */
+		static function recaptcha_authenticate() {
+			$recaptcha_response = isset( $_POST['g-recaptcha-response'] ) ? $_POST['g-recaptcha-response'] : '' ;
+
+			if( isset( $_COOKIE[ 'jpp_fallback_pass' ] ) ) {
+				$transient = Jetpack_Protect_Module::get_transient( 'jpp_fallback_pass_' . $_COOKIE[ 'jpp_fallback_pass' ] );
+				if( !$transient || $transient < 1 ) {
+					Jetpack_Protect_Recaptcha_Fallback::generate_recaptcha_page();
+				}
+				return true;
+			}
+
+			$recaptcha = new Jetpack_ReCaptcha( RECAPTCHA_PUBLIC_KEY, RECAPTCHA_PRIVATE_KEY );
+			$result    = $recaptcha->verify( $recaptcha_response, $_SERVER['REMOTE_ADDR'] );
+
+			if ( empty( $recaptcha_response ) ) {
+				Jetpack_Protect_Recaptcha_Fallback::generate_recaptcha_page();
+			} elseif ( $result !== true ) {
+				wp_die(
+				__( '<strong>You failed to correctly answer the recaptcha challenge.</strong>  This is used to combat spam when the Protect API is unavailable.  Please use your browser\'s back button to return to the login form, press the "refresh" button to generate a new challenge, and try to log in again.', 'jetpack' ),
+				'',
+				401
+				);
+			} else {
+				return true;
+			}
+		}
+
+		/**
+		 * Creates an interim page to show a recaptcha challenge
+		 *
+		 * @return none, execution stopped
+		 */
+		static function generate_recaptcha_page( $error = false ) {
+			ob_start();
+			?>
+			<h2><?php _e( 'Please solve this captcha to prove that you are not a bot.  Once you solve it, you will need to log in again.', 'jetpack' ); ?></h2>
+			<?php if ($error): ?>
+				<h3><?php _e( 'Your answer was incorrect, please try again.', 'jetpack' ); ?></h3>
+			<?php endif ?>
+
+			<form action="<?php echo wp_login_url(); ?>" method="post" accept-charset="utf-8">
+				<?php Jetpack_Protect_Recaptcha_Fallback::recaptcha_form(true); ?>
+				</div>
+				<input type="hidden" name="jetpack_protect_process_recaptcha_form" value="1" id="jetpack_protect_process_recaptcha_form" />
+				<p><input type="submit" value="<?php esc_html_e( 'Continue &rarr;', 'jetpack' ); ?>"></p>
+			</form>
+			<?php
+			$recaptchapage = ob_get_contents();
+			ob_end_clean();
+			wp_die( $recaptchapage );
+		}
+
+		public function process_generate_recaptcha_page() {
+			$recaptcha = new Jetpack_ReCaptcha( RECAPTCHA_PUBLIC_KEY, RECAPTCHA_PRIVATE_KEY );
+			$response  = ! empty( $_POST['g-recaptcha-response'] ) ? $_POST['g-recaptcha-response'] : '';
+			$result    = $recaptcha->verify( $response, $_SERVER['REMOTE_ADDR'] );
+
+			if ( true === $result ) {
+				$temp_pass = substr( sha1( rand( 1, 100000000 ) . get_site_option( 'jetpack_protect_key' ) ), 5, 25 );
+				Jetpack_Protect_Module::set_transient( 'jpp_fallback_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
+				setcookie('jpp_fallback_pass_', $temp_pass, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false);
+				return true;
+			} else {
+				Jetpack_Protect_Recaptcha_Fallback::generate_recaptcha_page(true);
+			}
+		}
+
+		/**
+		 * Requires a user to solve recaptcha challenge. Added to any WordPress login form.
+		 *
+		 * @param boolean $is_form_page
+		 *
+		 * @return VOID outputs html
+		 */
+		static function recaptcha_form( $is_form_page = false ) {
+			$options = array(
+				'tag_attributes' => array(
+					'size'     => ! $is_form_page ? 'compact' : 'normal',
+				),
+			);
+
+			$recaptcha = new Jetpack_ReCaptcha( RECAPTCHA_PUBLIC_KEY, RECAPTCHA_PRIVATE_KEY, $options );
+			if ( ! $is_form_page) :
+			?>
+			<div style="    margin: 0 auto; width: 164px;">
+			<?php
+			endif;
+			echo $recaptcha->get_recaptcha_html(); // xss ok
+			if ( ! $is_form_page ) :
+			?>
+			</div>
+			<?php
+			endif;
+		}
+	}
+}

--- a/modules/sharedaddy/recaptcha.php
+++ b/modules/sharedaddy/recaptcha.php
@@ -77,6 +77,7 @@ class Jetpack_ReCaptcha {
 			'tag_attributes' => array(
 				'theme'    => 'light',
 				'type'     => 'image',
+				'size'     => 'normal',
 				'tabindex' => 0,
 			),
 		);
@@ -164,6 +165,7 @@ class Jetpack_ReCaptcha {
 				data-sitekey="%s"
 				data-theme="%s"
 				data-type="%s"
+				data-size="%s"
 				data-tabindex="%s"></div>
 			<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=%s"%s></script>
 			',
@@ -171,6 +173,7 @@ class Jetpack_ReCaptcha {
 			esc_attr( $this->site_key ),
 			esc_attr( $this->config['tag_attributes']['theme'] ),
 			esc_attr( $this->config['tag_attributes']['type'] ),
+			esc_attr( $this->config['tag_attributes']['size'] ),
 			esc_attr( $this->config['tag_attributes']['tabindex'] ),
 			rawurlencode( $this->config['language'] ),
 			$this->config['script_async'] ? ' async' : ''


### PR DESCRIPTION
If RECAPTCHA_PUBLIC_KEY and RECAPTCHA_PRIVATE_KEY are defined, use recaptcha as fallback instead of math problem captcha.

Looks like this:
![selection_004](https://cloud.githubusercontent.com/assets/204463/10183294/ac9c3a2c-66f3-11e5-82eb-94bbf5b871c0.png)
![selection_003](https://cloud.githubusercontent.com/assets/204463/10183296/af26738e-66f3-11e5-90e1-b243120cfef2.png)

Fixes #2762 