### PR TITLE
Update force_ssl_login to force_ssl_admin.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6262,9 +6262,10 @@ p {
 	 * @return boolean
 	 **/
 	private function is_ssl_required_to_visit_site() {
+		global $wp_version;
 		$ssl = is_ssl();
 
-		if ( force_ssl_login() ) {
+		if ( version_compare( $wp_version, '4.4-alpha', '<=' ) && force_ssl_login() ) { // force_ssl_login deprecated WP 4.4.
 			$ssl = true;
 		} else if ( force_ssl_admin() ) {
 			$ssl = true;

--- a/tests/test_class.jetpack.php
+++ b/tests/test_class.jetpack.php
@@ -219,7 +219,7 @@ EXPECTED;
 	 */
 	public function test_check_identity_crisis_will_not_report_crisis_if_a_siteurl_mismatch_when_forcing_ssl() {
 		// Kick in with force ssl and store master user data
-		force_ssl_login( true );
+		force_ssl_admin( true );
 		Jetpack_Options::update_option( 'master_user', 'test' );
 		Jetpack_Options::update_option( 'user_tokens', array( 'test' => 'herp.derp.test' ) );
 		add_filter( 'jetpack_development_mode', '__return_false', 1, 1 );


### PR DESCRIPTION
WordPress 4.4 will deprecate `force_ssl_login` in favor of more usage of `force_ssl_admin`. Updating the one usage in JP proper and one unit test.