### PR TITLE
Added a new JITM message for Manage on the update-core.php admin page

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -48,6 +48,8 @@
 
 		$( '.jp-jitm .activate' ).click(function() {
 
+			$( '.button').addClass( 'hide' );
+			$( '.jetpack-spinner' ).toggleClass( 'hide' );
 			data.jitmActionToTake = 'activate';
 
 			// get the module we're working with using the data-module attribute
@@ -62,7 +64,7 @@
 				// If there's no response, something bad happened
 				if ( true === response.success ) {
 					$( '.msg' ).html( success_msg );
-					$( '.button' ).toggleClass( 'hide' );
+					$( '#jetpack-wordpressdotcom, .jetpack-spinner' ).toggleClass( 'hide' );
 					if ( 'manage' !== data.jitmModule ){
 						hide_msg = setTimeout( function () {
 							$( '.jp-jitm' ).hide( 'slow' );

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -30,46 +30,46 @@
 		var module_slug, success_msg, fail_msg, hide_msg;
 
 		// On dismiss of JITM admin notice
-		$('.jp-jitm .dismiss').click(function() {
+		$( '.jp-jitm .dismiss' ).click( function() {
 			// hide the notice
-			$('.jp-jitm').hide();
+			$( '.jp-jitm' ).hide();
 
 			// ajax request to save dismiss and never show again
 			data.jitmActionToTake = 'dismiss';
-			module_slug = $(this).data('module');
+			module_slug = $(this).data( 'module' );
 			data.jitmModule = module_slug;
 
-			$.post( jitmL10n.ajaxurl, data, function (response) {
+			$.post( jitmL10n.ajaxurl, data, function ( response ) {
 				if ( true === response.success ) {
 					//console.log('successfully dismissed for ever')
 				}
 			});
 		});
 
-		$('.jp-jitm .activate').click(function() {
+		$( '.jp-jitm .activate' ).click(function() {
 
 			data.jitmActionToTake = 'activate';
 
 			// get the module we're working with using the data-module attribute
-			module_slug = $(this).data('module');
+			module_slug = $( this ).data( 'module' );
 			success_msg = data[module_slug].success;
 			fail_msg = data[module_slug].fail;
 
 			data.jitmModule = module_slug;
 
 			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
-			$.post( jitmL10n.ajaxurl, data, function (response) {
+			$.post( jitmL10n.ajaxurl, data, function ( response ) {
 				// If there's no response, something bad happened
 				if ( true === response.success ) {
-					$('.msg').html(success_msg);
-					$('.button').toggleClass('hide');
+					$( '.msg' ).html( success_msg );
+					$( '.button' ).toggleClass( 'hide' );
 					if ( 'manage' !== data.jitmModule ){
-						hide_msg = setTimeout(function () {
-							$('.jp-jitm').hide('slow');
-						}, 5000);
+						hide_msg = setTimeout( function () {
+							$( '.jp-jitm' ).hide( 'slow' );
+						}, 5000 );
 					}
 				} else {
-					$('.jp-jitm').html('<p><span class="icon"></span>'+fail_msg+'</p>');
+					$( '.jp-jitm' ).html( '<p><span class="icon"></span>'+fail_msg+'</p>' );
 				}
 			});
 

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -62,7 +62,7 @@
 				// If there's no response, something bad happened
 				if ( true === response.success ) {
 					$('.msg').html(success_msg);
-					$('.button').toggle();
+					$('.button').toggleClass('hide');
 					if ( 'manage' !== data.jitmModule ){
 						hide_msg = setTimeout(function () {
 							$('.jp-jitm').hide('slow');

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -13,7 +13,8 @@
 		data = {
 			'action'        :   'jitm_ajax',
 			'jitmNonce'     :   jitmL10n.jitm_nonce,
-			'photon'        :   jitmL10n.photon_msgs
+			'photon'        :   jitmL10n.photon_msgs,
+			'manage'        :   jitmL10n.manage_msgs
 		};
 
 		initEvents();
@@ -60,10 +61,13 @@
 			$.post( jitmL10n.ajaxurl, data, function (response) {
 				// If there's no response, something bad happened
 				if ( true === response.success ) {
-					$('.jp-jitm').html('<p><span class="icon"></span>'+success_msg+'</p>');
-					hide_msg = setTimeout(function () {
-						$('.jp-jitm').hide('slow');
-					}, 5000);
+					$('.msg').html(success_msg);
+					$('.button').toggle();
+					if ( 'manage' !== data.jitmModule ){
+						hide_msg = setTimeout(function () {
+							$('.jp-jitm').hide('slow');
+						}, 5000);
+					}
 				} else {
 					$('.jp-jitm').html('<p><span class="icon"></span>'+fail_msg+'</p>');
 				}

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -48,7 +48,7 @@
 
 		$( '.jp-jitm .activate' ).click(function() {
 
-			$( '.button').addClass( 'hide' );
+			$( '.button' ).addClass( 'hide' );
 			$( '.jetpack-spinner' ).toggleClass( 'hide' );
 			data.jitmActionToTake = 'activate';
 
@@ -65,13 +65,13 @@
 				if ( true === response.success ) {
 					$( '.msg' ).html( success_msg );
 					$( '#jetpack-wordpressdotcom, .jetpack-spinner' ).toggleClass( 'hide' );
-					if ( 'manage' !== data.jitmModule ){
+					if ( 'manage' !== data.jitmModule ) {
 						hide_msg = setTimeout( function () {
 							$( '.jp-jitm' ).hide( 'slow' );
 						}, 5000 );
 					}
 				} else {
-					$( '.jp-jitm' ).html( '<p><span class="icon"></span>'+fail_msg+'</p>' );
+					$( '.jp-jitm' ).html( '<p><span class="icon"></span>' + fail_msg + '</p>' );
 				}
 			});
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -65,7 +65,7 @@ class Jetpack_JITM {
 		<?php
 			//jitm is being viewed, track it
 			$jetpack = Jetpack::init();
-			$jetpack->stat( 'jitm', 'manage-viewed' );
+			$jetpack->stat( 'jitm', 'manage-viewed-' . JETPACK__VERSION );
 			$jetpack->do_stats( 'server_side' );
 		}
 	}
@@ -95,7 +95,7 @@ class Jetpack_JITM {
 		<?php
 			//jitm is being viewed, track it
 			$jetpack = Jetpack::init();
-			$jetpack->stat( 'jitm', 'photon-viewed' );
+			$jetpack->stat( 'jitm', 'photon-viewed-' . JETPACK__VERSION );
 			$jetpack->do_stats( 'server_side' );
 		}
 	}

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -23,8 +23,8 @@ class Jetpack_JITM {
 	private function __construct() {
 		global $pagenow;
 		$jetpack_hide_jitm = Jetpack_Options::get_option( 'hide_jitm' );
-		$showphoton = empty($jetpack_hide_jitm['photon']) ? 'show' : $jetpack_hide_jitm['photon'];
-		$showmanage = empty($jetpack_hide_jitm['manage']) ? 'show' : $jetpack_hide_jitm['manage'];
+		$showphoton = empty( $jetpack_hide_jitm['photon'] ) ? 'show' : $jetpack_hide_jitm['photon'];
+		$showmanage = empty( $jetpack_hide_jitm['manage'] ) ? 'show' : $jetpack_hide_jitm['manage'];
 		if ( 'media-new.php' == $pagenow && ! Jetpack::is_module_active( 'photon' ) && 'hide' != $showphoton ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'post-plupload-upload-ui', array( $this, 'photon_msg' ) );
@@ -53,7 +53,7 @@ class Jetpack_JITM {
 					</svg>
 				</div>
 				<p class="msg">
-					<?php _e( 'Reduce risk by automating your updates from one free and convenient place.', 'jetpack' ); ?>
+					<?php _e( 'Reduce security risks with automated plugin updates.', 'jetpack' ); ?>
 				</p>
 				<p>
 					<a href="#" data-module="manage" class="activate button button-jetpack <?php if( Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Activate WordPress.com Tools', 'jetpack' ); ?></a><a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jitm' ); ?>" target="_blank" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>" class="activate button button-jetpack <?php if( ! Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Go to WordPress.com', 'jetpack' ); ?></a>
@@ -121,7 +121,7 @@ class Jetpack_JITM {
 					'fail'    => __( 'We are sorry but unfortunately Photon did not activate.', 'jetpack' )
 				),
 				'manage_msgs' => array(
-					'success' => __( 'Success! Manage is now active!.', 'jetpack' ),
+					'success' => __( 'Success! WordPress.com tools are now active!.', 'jetpack' ),
 					'fail'    => __( 'We are sorry but unfortunately Manage did not activate.', 'jetpack' )
 				)
 			)

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -21,6 +21,9 @@ class Jetpack_JITM {
 	}
 
 	private function __construct() {
+		if ( ! Jetpack::is_active() ) {
+			return;
+		}
 		global $pagenow;
 		$jetpack_hide_jitm = Jetpack_Options::get_option( 'hide_jitm' );
 		$showphoton = empty( $jetpack_hide_jitm['photon'] ) ? 'show' : $jetpack_hide_jitm['photon'];

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -53,7 +53,7 @@ class Jetpack_JITM {
 					</svg>
 				</div>
 				<p class="msg">
-					<?php _e( 'Manage, update, and control all your updates from all your sites in one free and convenient place.', 'jetpack' ); ?>
+					<?php _e( 'Reduce risk by automating your updates from one free and convenient place.', 'jetpack' ); ?>
 				</p>
 				<p>
 					<a href="#" data-module="manage" class="activate button button-jetpack <?php if( Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Activate WordPress.com Tools', 'jetpack' ); ?></a><a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jitm' ); ?>" target="_blank" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>" class="activate button button-jetpack <?php if( ! Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Go to WordPress.com', 'jetpack' ); ?></a>

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -59,7 +59,7 @@ class Jetpack_JITM {
 					<?php _e( 'Reduce security risks with automated plugin updates.', 'jetpack' ); ?>
 				</p>
 				<p>
-					<a href="#" data-module="manage" class="activate button button-jetpack <?php if( Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Activate WordPress.com Tools', 'jetpack' ); ?></a><a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jitm' ); ?>" target="_blank" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>" class="activate button button-jetpack <?php if( ! Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Go to WordPress.com', 'jetpack' ); ?></a>
+					<a href="#" data-module="manage" class="activate button button-jetpack <?php if( Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Activate Now', 'jetpack' ); ?></a><a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jitm' ); ?>" target="_blank" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>" class="activate button button-jetpack <?php if( ! Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Go to WordPress.com', 'jetpack' ); ?></a>
 				</p>
 			</div>
 		<?php

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -121,7 +121,7 @@ class Jetpack_JITM {
 					'fail'    => __( 'We are sorry but unfortunately Photon did not activate.', 'jetpack' )
 				),
 				'manage_msgs' => array(
-					'success' => __( 'Success! WordPress.com tools are now active!.', 'jetpack' ),
+					'success' => __( 'Success! WordPress.com tools are now active.', 'jetpack' ),
 					'fail'    => __( 'We are sorry but unfortunately Manage did not activate.', 'jetpack' )
 				)
 			)

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -59,7 +59,7 @@ class Jetpack_JITM {
 					<?php _e( 'Reduce security risks with automated plugin updates.', 'jetpack' ); ?>
 				</p>
 				<p>
-					<a href="#" data-module="manage" class="activate button button-jetpack <?php if( Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Activate Now', 'jetpack' ); ?></a><a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jitm' ); ?>" target="_blank" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>" class="activate button button-jetpack <?php if( ! Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Go to WordPress.com', 'jetpack' ); ?></a>
+					<img class="jetpack-spinner hide" style="margin-top: 13px;" width="17" height="17" src="<?php echo esc_url( includes_url( 'images/spinner-2x.gif' ) ); ?>" alt="Loading ..." /><a href="#" data-module="manage" class="activate button button-jetpack <?php if( Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Activate Now', 'jetpack' ); ?></a><a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jitm' ); ?>" target="_blank" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>" id="jetpack-wordpressdotcom" class="activate button button-jetpack <?php if( ! Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Go to WordPress.com', 'jetpack' ); ?></a>
 				</p>
 			</div>
 		<?php
@@ -87,9 +87,7 @@ class Jetpack_JITM {
 					<?php _e( 'Speed up your photos and save bandwidth costs by using a free content delivery network.', 'jetpack' ); ?>
 				</p>
 				<p>
-					<a href="#" data-module="photon" class="activate button button-jetpack">
-						<?php esc_html_e( 'Activate Photon', 'jetpack' ); ?>
-					</a>
+					<img class="jetpack-spinner hide" style="margin-top: 13px;" width="17" height="17" src="<?php echo esc_url( includes_url( 'images/spinner-2x.gif' ) ); ?>" alt="Loading ..." /><a href="#" data-module="photon" class="activate button button-jetpack"><?php esc_html_e( 'Activate Photon', 'jetpack' ); ?></a>
 				</p>
 			</div>
 		<?php
@@ -107,7 +105,7 @@ class Jetpack_JITM {
 
 		$wp_styles = new WP_Styles();
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-		wp_enqueue_style( 'jetpack-jitm-css', plugins_url( "css/jetpack-admin-jitm{$min}.css", JETPACK__PLUGIN_FILE ), false, JETPACK__VERSION . '-20121016' );
+		wp_enqueue_style( 'jetpack-jitm-css', plugins_url( "css/jetpack-admin-jitm{$min}.css", JETPACK__PLUGIN_FILE ), false, JETPACK__VERSION . '-201243242' );
 		$wp_styles->add_data( 'jetpack-jitm-css', 'rtl', true );
 
 		// Enqueue javascript to handle jitm notice events

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -23,9 +23,47 @@ class Jetpack_JITM {
 	private function __construct() {
 		global $pagenow;
 		$jetpack_hide_jitm = Jetpack_Options::get_option( 'hide_jitm' );
-		if ( 'media-new.php' == $pagenow && ! Jetpack::is_module_active( 'photon' ) && 'hide' != $jetpack_hide_jitm['photon'] ) {
+		$showphoton = empty($jetpack_hide_jitm['photon']) ? 'show' : $jetpack_hide_jitm['photon'];
+		$showmanage = empty($jetpack_hide_jitm['manage']) ? 'show' : $jetpack_hide_jitm['manage'];
+		if ( 'media-new.php' == $pagenow && ! Jetpack::is_module_active( 'photon' ) && 'hide' != $showphoton ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'post-plupload-upload-ui', array( $this, 'photon_msg' ) );
+		}
+		else if ( 'update-core.php' == $pagenow && 'hide' != $showmanage ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
+			add_action( 'admin_notices', array( $this, 'manage_msg' ) );
+		}
+	}
+
+
+	/*
+	 * Present Manage just in time activation msg on update-core.php
+	 *
+	 */
+	function manage_msg() {
+		if ( current_user_can( 'jetpack_manage_modules' ) ) {
+			$normalized_site_url = Jetpack::build_raw_urls( get_home_url() );
+			$manage_active = Jetpack::is_module_active( 'manage' );
+			?>
+			<div class="jp-jitm">
+				<a href="#"  data-module="manage" class="dismiss"><span class="genericon genericon-close"></span></a>
+				<div class="jp-emblem">
+					<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 172.9 172.9" enable-background="new 0 0 172.9 172.9" xml:space="preserve">
+						<path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z"/>
+					</svg>
+				</div>
+				<p class="msg">
+					<?php _e( 'Manage, update, and control all your updates from all your sites in one free and convenient place.', 'jetpack' ); ?>
+				</p>
+				<p>
+					<a href="#" data-module="manage" class="activate button button-jetpack <?php if( Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Activate WordPress.com Tools', 'jetpack' ); ?></a><a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $normalized_site_url . '?from=jitm' ); ?>" target="_blank" title="<?php esc_attr_e( 'Go to WordPress.com to try these features', 'jetpack' ); ?>" class="activate button button-jetpack <?php if( ! Jetpack::is_module_active( 'manage' ) ) { echo 'hide'; } ?>"><?php esc_html_e( 'Go to WordPress.com', 'jetpack' ); ?></a>
+				</p>
+			</div>
+		<?php
+			//jitm is being viewed, track it
+			$jetpack = Jetpack::init();
+			$jetpack->stat( 'jitm', 'manage-viewed' );
+			$jetpack->do_stats( 'server_side' );
 		}
 	}
 
@@ -42,7 +80,7 @@ class Jetpack_JITM {
 						<path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z"/>
 					</svg>
 				</div>
-				<p>
+				<p class="msg">
 					<?php _e( 'Speed up your photos and save bandwidth costs by using a free content delivery network.', 'jetpack' ); ?>
 				</p>
 				<p>
@@ -58,7 +96,7 @@ class Jetpack_JITM {
 			$jetpack->do_stats( 'server_side' );
 		}
 	}
-	
+
 	/*
 	* Function to enqueue jitm css and js
 	*/
@@ -81,6 +119,10 @@ class Jetpack_JITM {
 				'photon_msgs' => array(
 					'success' => __( 'Success! Photon is now actively optimizing and serving your images for free.', 'jetpack' ),
 					'fail'    => __( 'We are sorry but unfortunately Photon did not activate.', 'jetpack' )
+				),
+				'manage_msgs' => array(
+					'success' => __( 'Success! Manage is now active!.', 'jetpack' ),
+					'fail'    => __( 'We are sorry but unfortunately Manage did not activate.', 'jetpack' )
 				)
 			)
 		);

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -826,7 +826,7 @@ class Jetpack {
 			Jetpack::state( 'message', 'no_message' );
 
 			//A Jetpack module is being activated through a JITM, track it
-			$this->stat( 'jitm', $module_slug.'-activated' );
+			$this->stat( 'jitm', $module_slug.'-activated-' . JETPACK__VERSION );
 			$this->do_stats( 'server_side' );
 
 			wp_send_json_success();
@@ -847,7 +847,7 @@ class Jetpack {
 			Jetpack_Options::update_option( 'hide_jitm', $jetpack_hide_jitm );
 
 			//jitm is being dismissed forever, track it
-			$this->stat( 'jitm', $module_slug.'-dismissed' );
+			$this->stat( 'jitm', $module_slug.'-dismissed-' . JETPACK__VERSION );
 			$this->do_stats( 'server_side' );
 
 			wp_send_json_success();

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -43,7 +43,7 @@
 	}
 
 	.activate {
-		margin-top: .8em;
+		margin-top: .5em;
 	} 
 	.jp-emblem {
 		width: 25px;

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -10,7 +10,28 @@
 	border: 1px solid #dedede;
 	text-align: center;
 
-	@media (min-width: 1100px) { max-width: 650px; }
+    @media (min-width: 1100px) {
+        .jp-emblem, p {
+            float: left;
+            margin: .5em 1em 0 .5em;
+            padding-top: 4px;
+        }
+        .jp-emblem {
+            width: 20px;
+            height: 20px; // for ie svg
+        }
+        p + p {
+            margin: 0;
+            padding: 0;
+        }
+        .activate {
+            margin-top: 0;
+        }
+    } // > 1100px
+
+    @media (max-width: 1100px) {
+        max-width: 90%;
+    }
 
 	// clear hack
 	&:before, &:after {
@@ -56,38 +77,6 @@
     }
 
 } // .jp-jitm
-
-.media-upload-form .jp-jitm {
-	max-width: 100%;
-
-	@media (min-width: 1100px) { 
-		.jp-emblem, p {
-			float: left;
-			margin: 0 1em 0 0;
-			padding-top: 4px;
-		}
-		.jp-emblem {
-			width: 20px;
-			height: 20px; // for ie svg
-		}
-		p + p {
-			margin: 0;
-			padding: 0;
-		}
-		.activate {
-			margin-top: 0;
-		}
-	} // > 1100px
-
-} // .media-upload-form (wp-admin/media-new.php)
-
-.media-modal-content .jp-jitm {
-
-	@media (max-width: 1100px) {
-		max-width: 90%;
-	}
-
-} // .media-modal-content (post / page > add media)
 
 // when jetpack is connected, we need to move up the upload prompt content so the photo JITM can fit properly.
 .jetpack-connected .media-modal-content .uploader-inline-content {

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -1,6 +1,6 @@
 // Just in Time Messaging - message prompts
 
-// PHOTON
+// NOTICE
 .jp-jitm {
 	border-radius: 2px;
 	max-width: 95%;
@@ -51,6 +51,10 @@
 		line-height: 165%;
 	}
 
+    .hide {
+        display: none;
+    }
+
 } // .jp-jitm
 
 .media-upload-form .jp-jitm {
@@ -90,4 +94,4 @@
 	top: 20%;
 }
 
-// END PHOTON
+// END NOTICE

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -1,33 +1,33 @@
 // Just in Time Messaging - message prompts
 
-// NOTICE
 .jp-jitm {
 	border-radius: 2px;
-	max-width: 95%;
+	max-width: 100%;
 	margin: 2em auto 0 auto;
 	padding: .85em;
 	background: #fcfcfc;
 	border: 1px solid #dedede;
 	text-align: center;
 
-    @media (min-width: 1100px) {
-        .jp-emblem, p {
-            float: left;
-            margin: .5em 1em 0 .5em;
-            padding-top: 4px;
-        }
-        .jp-emblem {
-            width: 20px;
-            height: 20px; // for ie svg
-        }
-        p + p {
-            margin: 0;
-            padding: 0;
-        }
-        .activate {
-            margin-top: 0;
-        }
-    } // > 1100px
+	@media (min-width: 1100px) {
+		.jp-emblem, p {
+			float: left;
+			margin: .5em 1em 0 .5em;
+			padding-top: 4px;
+		}
+		.jp-emblem {
+			width: 20px;
+			height: 20px; // for ie svg
+			margin-right: .5em;
+		}
+		p + p {
+			margin: 0;
+			padding: 0;
+		}
+		.activate {
+			margin-top: 0;
+		}
+	} // > 1100px
 
     @media (max-width: 1100px) {
         max-width: 90%;
@@ -78,9 +78,12 @@
 
 } // .jp-jitm
 
+// update core page
+.update-core-php .jp-jitm {
+	@media (min-width: 1100px) { margin: 3em 2em 0 auto; }
+}
+
 // when jetpack is connected, we need to move up the upload prompt content so the photo JITM can fit properly.
 .jetpack-connected .media-modal-content .uploader-inline-content {
 	top: 20%;
 }
-
-// END NOTICE


### PR DESCRIPTION
This JITM is designed to guide users to use WordPress.com tools. The message will appear (with variations to the call-to-action) whether Jetpack Manage is active or not. 

If Jetpack Manage is not active the user can activate it through an ajax call in the message. Once Manage is active the call-to-action becomes a dynamic link to that specific sites plugin management page on WordPress.com.

How to test:
- Checkout branch, run grunt!
- Start with both Photon and Mange not active/enabled
- Head over to the Updates page in the admin (wp-admin/update-core.php)
- View the message make sure it looks good, click the "Activate WordPress.com Tools" button
- You should receive a success message and a new button saying "Go to WordPress.com" which should take you to your plugins page for the site you're working in
- Go back to the admin and refresh the update-core.php page. The message should not disappear. 
- Dismissing the notice (x top right corner) should make the JITM disappear forever (only reset Jetpack options will bring it back)
Final Test
- Head over to Media -> Add New and make sure the Photon JITM works/looks good. That notice should be present if Photon is not enabled and it's never been dismissed. Dismissing one JITM doesn't dismiss all JITM's. 
 