### PR TITLE
Open Graph: add WP Facebook Like Button to the conflicting plugins

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -217,6 +217,7 @@ class Jetpack {
 		'wp-facebook-open-graph-protocol/wp-facebook-ogp.php',   // WP Facebook Open Graph protocol
 		'wp-ogp/wp-ogp.php',                                     // WP-OGP
 		'zoltonorg-social-plugin/zosp.php',                      // Zolton.org Social Plugin
+		'wp-fb-share-like-button/wp_fb_share-like_widget.php'    // WP Facebook Like Button
 	);
 
 	/**


### PR DESCRIPTION
https://wordpress.org/plugins/wp-fb-share-like-button/

