### PR TITLE
Sharing Buttons: Remove Twitter share count requests from custom buttons

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -3,9 +3,8 @@ var sharing_js_options;
 if ( sharing_js_options && sharing_js_options.counts ) {
 	var WPCOMSharing = {
 		done_urls : [],
-		twitter_count : {},
 		get_counts : function() {
-			var https_url, http_url, url, urls, id, service, service_url;
+			var url, urls, id, service, service_url;
 
 			if ( 'undefined' === typeof WPCOM_sharing_counts ) {
 				return;
@@ -18,17 +17,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 					continue;
 				}
 
-				// get both the http and https version of these URLs
-				https_url = url.replace( /^http:\/\//i, 'https://' );
-				http_url  = url.replace( /^https:\/\//i, 'http://' );
-
 				urls = {
-					twitter: [
-						'https://cdn.api.twitter.com/1/urls/count.json?callback=WPCOMSharing.update_twitter_count&url=' +
-							encodeURIComponent( http_url ),
-						'https://cdn.api.twitter.com/1/urls/count.json?callback=WPCOMSharing.update_twitter_count&url=' +
-							encodeURIComponent( https_url )
-					],
 					// LinkedIn actually gets the share count for both the http and https version automatically -- so we don't need to do extra magic
 					linkedin: [
 							'https://www.linkedin.com/countserv/count/share?format=jsonp&callback=WPCOMSharing.update_linkedin_count&url=' +
@@ -74,9 +63,8 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				url = url.replace( /^https:\/\//i, 'http://' );
 			}
 
-			// Some services (e.g. Twitter) canonicalize the URL with a trailing
-			// slash. We can account for this by checking whether either format
-			// exists as a known URL
+			// Some services canonicalize the URL with a trailing slash. We can
+			// account for this by checking whether either format is known
 			if ( ! ( url in WPCOM_sharing_counts ) ) {
 				rxTrailingSlash = /\/$/,
 				formattedSlashUrl = rxTrailingSlash.test( url ) ?
@@ -108,21 +96,6 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				}
 
 				WPCOMSharing.inject_share_count( 'sharing-facebook-' + WPCOM_sharing_counts[ permalink ], data[ url ].shares );
-			}
-		},
-		update_twitter_count : function( data ) {
-			if ( 'number' === typeof data.count ) {
-				var permalink = WPCOMSharing.get_permalink( data.url );
-
-				if ( ! WPCOMSharing.twitter_count[ permalink ] ) {
-					WPCOMSharing.twitter_count[ permalink ] = 0;
-				}
-
-				WPCOMSharing.twitter_count[ permalink ] += data.count;
-
-				if ( WPCOMSharing.twitter_count[ permalink ] > 0 ) {
-					WPCOMSharing.inject_share_count( 'sharing-twitter-' + WPCOM_sharing_counts[ permalink ], WPCOMSharing.twitter_count[ permalink ] );
-				}
 			}
 		},
 		update_linkedin_count : function( data ) {


### PR DESCRIPTION
Related: #2747

This pull request seeks to remove share count requests from custom button styles, as the undocumented endpoint used to retrieve these counts is slated to be removed altogether, as described at #2747.

The changes here __do not__ remove the count parameters from the official button output, which is a separate task related to #2747. These parameters will continue to affect the display of official buttons until the new Twitter button styles have been made available and will simply have no effect once this occurs. We should remove the count parameters only once the new styles have been published.

__Testing instructions:__

- Verify that Twitter sharing counts no longer appear on custom button styles (i.e. any style aside from "Official")
- Verify that counts for other services (Facebook, Pinterest, LinkedIn) remain unaffected
- Verify that no errors occur in the developer tools console