### PR TITLE
Don't finish API calls early if using XML-RPC

### DIFF
--- a/class.json-api.php
+++ b/class.json-api.php
@@ -329,7 +329,9 @@ class WPCOM_JSON_API {
 		else
 			$this->output( $status_code, $response, $content_type );
 		$this->exit = $exit;
-		$this->finish_request();
+		if ( ! defined( 'XMLRPC_REQUEST' ) || ! XMLRPC_REQUEST ) {
+			$this->finish_request();
+		}
 	}
 
 	function set_output_status_code( $code = 200 ) {


### PR DESCRIPTION
When WordPress.com calls Jetpack's API, it does so encapsulating the
request inside XML-RPC. If the API terminates the request, Jetpack
returns JSON instead of an XML-RPC response, and WordPress.com fails
with a parser error.

Fixes #2792