### PR TITLE
Added version tracking to all JITM messages

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -65,7 +65,7 @@ class Jetpack_JITM {
 		<?php
 			//jitm is being viewed, track it
 			$jetpack = Jetpack::init();
-			$jetpack->stat( 'jitm', 'manage-viewed' );
+			$jetpack->stat( 'jitm', 'manage-viewed-' . JETPACK__VERSION );
 			$jetpack->do_stats( 'server_side' );
 		}
 	}
@@ -95,7 +95,7 @@ class Jetpack_JITM {
 		<?php
 			//jitm is being viewed, track it
 			$jetpack = Jetpack::init();
-			$jetpack->stat( 'jitm', 'photon-viewed' );
+			$jetpack->stat( 'jitm', 'photon-viewed-' . JETPACK__VERSION );
 			$jetpack->do_stats( 'server_side' );
 		}
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -825,7 +825,7 @@ class Jetpack {
 			Jetpack::state( 'message', 'no_message' );
 
 			//A Jetpack module is being activated through a JITM, track it
-			$this->stat( 'jitm', $module_slug.'-activated' );
+			$this->stat( 'jitm', $module_slug.'-activated-' . JETPACK__VERSION );
 			$this->do_stats( 'server_side' );
 
 			wp_send_json_success();
@@ -846,7 +846,7 @@ class Jetpack {
 			Jetpack_Options::update_option( 'hide_jitm', $jetpack_hide_jitm );
 
 			//jitm is being dismissed forever, track it
-			$this->stat( 'jitm', $module_slug.'-dismissed' );
+			$this->stat( 'jitm', $module_slug.'-dismissed-' . JETPACK__VERSION );
 			$this->do_stats( 'server_side' );
 
 			wp_send_json_success();


### PR DESCRIPTION
With versions appended to tracked stats we’ll be able to effectively run tests between Jetpack versions

@jessefriedman is the original author, all props to him.

Depends on #2778. This PR should be merged before `add/jitm-manage` branch is deleted, so it's preferred to get this one in first, then #2778.
