### PR TITLE
Contact Form: Validate "To" emails before allowing save

### DIFF
--- a/modules/contact-form/js/grunion.js
+++ b/modules/contact-form/js/grunion.js
@@ -21,7 +21,8 @@ GrunionFB_i18n = jQuery.extend( {
 	savedMessage: 'Saved successfully',
 	requiredLabel: '(required)',
 	exitConfirmMessage: 'Are you sure you want to exit the form editor without saving?  Any changes you have made will be lost.',
-	maxNewFields: 5
+	maxNewFields: 5,
+	invalidEmail: ' is an invalid email address.'
 }, GrunionFB_i18n );
 
 GrunionFB_i18n.moveInstructions = GrunionFB_i18n.moveInstructions.replace( '\n', '<br />' );
@@ -475,7 +476,7 @@ FB.ContactForm = (function() {
 
 		for ( $e = 0 ; $e < emailList.length ; $e++ ) {
 			if ( false === validateEmail( emailList[ $e ] ) ) {
-				alert( emailList[ $e ] + ' is invalid' );
+				alert( emailList[ $e ] + GrunionFB_i18n.invalidEmail );
 				return false;
 			}
 		}

--- a/modules/contact-form/js/grunion.js
+++ b/modules/contact-form/js/grunion.js
@@ -448,10 +448,15 @@ FB.ContactForm = (function() {
 	function switchTabs (whichType) {
 		try {
 			if (whichType === 'preview') {
+				if ( ! validateEmails( jQuery( '#fb-field-my-email' ).val() ) ) {
+					return;
+				}
 				jQuery('#tab-preview a').addClass('current');
 				jQuery('#tab-settings a').removeClass('current');
 				jQuery('#fb-preview-form, #fb-desc').show();
 				jQuery('#fb-email-settings, #fb-email-desc').hide();
+				showAndHideMessage( GrunionFB_i18n.savedMessage );
+
 			} else {
 				jQuery('#tab-preview a').removeClass('current');
 				jQuery('#tab-settings a').addClass('current');
@@ -464,6 +469,23 @@ FB.ContactForm = (function() {
 				console.log('switchTabs(): ' + e);
 			}
 		}
+	}
+	function validateEmails( emails ) {
+		var $e, emailList = emails.split( ',' );
+
+		for ( $e = 0 ; $e < emailList.length ; $e++ ) {
+			if ( false === validateEmail( emailList[ $e ] ) ) {
+				alert( emailList[ $e ] + ' is invalid' );
+				return false;
+			}
+		}
+
+		return true;
+	}
+	/* Uses The Official Standard: RFC 5322 -- http://www.regular-expressions.info/email.html */
+	function validateEmail( email ) {
+		var re = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/i;
+		return re.test( email );
 	}
 	function updateLabel () {
 		try {
@@ -705,7 +727,6 @@ FB.ContactForm = (function() {
 			});
 			jQuery('#fb-prev-form').click(function () {
 				switchTabs('preview');
-				showAndHideMessage( GrunionFB_i18n.savedMessage );
 				return false;
 			});
 			jQuery('#tab-settings a').click(function () {


### PR DESCRIPTION
Replaces #1756 with a .js solution which will alert the user at the earliest possible time.  

Enhances #1619 

When using the GUI to build the form, if an invalid email addres is used, we alert() them and stop the function until it's fixed.

Uses regex from The Official Standard: RFC 5322 (http://www.regular-expressions.info/email.html) to validate the email address, which will pick up 99.99% of valid emails.  