### PR TITLE
Infinite Scroll: Don't clobber the posts_per_page option if provided

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -211,13 +211,15 @@ class The_Neverending_Home_Page {
 					$settings['type'] = 'click';
 			}
 
-			// Ignore posts_per_page theme setting for [click] type
-			if ( 'click' == $settings['type'] )
-				$settings['posts_per_page'] = (int) get_option( 'posts_per_page' );
-
-			// Backwards compatibility for posts_per_page setting
-			elseif ( false === $settings['posts_per_page'] )
-				$settings['posts_per_page'] = 7;
+			// posts_per_page defaults to 7 for scroll, posts_per_page option for click
+			if ( false === $settings['posts_per_page'] ) {
+				if ( 'scroll' === $settings['type'] ) {
+					$settings['posts_per_page'] = 7;
+				}
+				else {
+					$settings['posts_per_page'] = (int) get_option( 'posts_per_page' );
+				}
+			}
 
 			// Force display of the click handler and attendant bits when the type isn't `click`
 			if ( 'click' !== $settings['type'] ) {


### PR DESCRIPTION
Infinite Scroll currently <a href="https://github.com/Automattic/jetpack/blob/master/modules/infinite-scroll/infinity.php#L214">clobbers any passed-in value</a> for `posts_per_page` if the `type` is set to `click`. This PR changes the behavior to match <a href="https://jetpack.me/support/infinite-scroll/">the documentation</a>:

<blockquote><strong>posts_per_page</strong>
By default, the type argument controls how many posts are loaded each time Infinite Scroll acts. For the scroll type, seven (7) posts are loaded each time Infinite Scroll is activated. For the click type, a site’s “Blog pages show at most” value found under Settings → Reading is used.

If, however, a theme’s layout expects a certain number of posts, the posts_per_page argument will override the defaults discussed in the preceding paragraph. This control is beneficial, for example, in a theme with a three-column layout where greater or fewer than three posts would result in an uneven layout.</blockquote>

This fixes one of the issues I reported in #2807.