### PR TITLE
Related Posts: add post classes to post's container class

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -776,7 +776,19 @@ EOT;
 				$post->ID
 			),
 			'img' => $this->_generate_related_post_image_params( $post->ID ),
-			'classes' => get_post_class( null, $post->ID ),
+			/**
+			 * Filter the post css classes added on HTML markup.
+			 *
+			 * @since  3.7.2
+			 *
+			 * @param array get_post_class( '', $post->ID ) CSS classes added on post HTML markup.
+			 * @param string $post_id Post ID.
+			 */
+			'classes' => apply_filters(
+				'jetpack_relatedposts_filter_post_css_classes',
+				get_post_class( '', $post->ID ),
+				$post->ID
+			),
 		);
 	}
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -781,12 +781,12 @@ EOT;
 			 *
 			 * @since  3.7.2
 			 *
-			 * @param array get_post_class( '', $post->ID ) CSS classes added on post HTML markup.
+			 * @param array array() CSS classes added on post HTML markup.
 			 * @param string $post_id Post ID.
 			 */
 			'classes' => apply_filters(
 				'jetpack_relatedposts_filter_post_css_classes',
-				get_post_class( '', $post->ID ),
+				array(),
 				$post->ID
 			),
 		);

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -779,7 +779,7 @@ EOT;
 			/**
 			 * Filter the post css classes added on HTML markup.
 			 *
-			 * @since  3.7.2
+			 * @since  3.8.0
 			 *
 			 * @param array array() CSS classes added on post HTML markup.
 			 * @param string $post_id Post ID.

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -776,6 +776,7 @@ EOT;
 				$post->ID
 			),
 			'img' => $this->_generate_related_post_image_params( $post->ID ),
+			'classes' => get_post_class( null, $post->ID ),
 		);
 	}
 

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -68,7 +68,11 @@
 
 			$.each( posts, function( index, post ) {
 				var anchor = self.getAnchor( post, 'jp-relatedposts-post-a' );
-				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index + ' ' + post.classes.join( ' ' );
+				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index;
+
+				if ( post.classes.length > 0 ) {
+					classes += ' ' + post.classes.join( ' ' );
+				}
 
 				html += '<p class="' + classes + '" data-post-id="' + post.id + '" data-post-format="' + post.format + '">';
 				html += '<span class="jp-relatedposts-post-title">' + anchor[0] + post.title + anchor[1] + '</span>';
@@ -85,7 +89,12 @@
 
 			$.each( posts, function( index, post ) {
 				var anchor = self.getAnchor( post, 'jp-relatedposts-post-a' );
-				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index + ' ' + post.classes.join( ' ' );
+				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index;
+
+				if ( post.classes.length > 0 ) {
+					classes += ' ' + post.classes.join( ' ' );
+				}
+
 				if ( ! post.img.src ) {
 					classes += ' jp-relatedposts-post-nothumbs';
 				} else {

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -68,7 +68,7 @@
 
 			$.each( posts, function( index, post ) {
 				var anchor = self.getAnchor( post, 'jp-relatedposts-post-a' );
-				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index;
+				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index + ' ' + post.classes.join( ' ' );
 
 				html += '<p class="' + classes + '" data-post-id="' + post.id + '" data-post-format="' + post.format + '">';
 				html += '<span class="jp-relatedposts-post-title">' + anchor[0] + post.title + anchor[1] + '</span>';
@@ -85,7 +85,7 @@
 
 			$.each( posts, function( index, post ) {
 				var anchor = self.getAnchor( post, 'jp-relatedposts-post-a' );
-				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index;
+				var classes = 'jp-relatedposts-post jp-relatedposts-post' + index + ' ' + post.classes.join( ' ' );
 				if ( ! post.img.src ) {
 					classes += ' jp-relatedposts-post-nothumbs';
 				} else {


### PR DESCRIPTION
Initially I was thinking on adding a new method to return only category classes, but I think it's better to use `get_post_class` since it also adds custom taxonomies and so on.

Also a new filter is there to allow users to customize the outputed css classes.

Fixes #2809