### PR TITLE
Add option to testimonials shortcode to show full testimonial

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -400,7 +400,6 @@ class Jetpack_Portfolio {
 			'showposts'       => -1,
 			'order'           => 'asc',
 			'orderby'         => 'date',
-			'show_excerpt'    => true,
 		), $atts, 'portfolio' );
 
 		// A little sanitization
@@ -565,9 +564,9 @@ class Jetpack_Portfolio {
 				<?php
 				// The content
 				if ( false !== $atts['display_content'] ): 
-							if ( true == $atts['show_excerpt'] ) { ?>
+							if ( true == $atts['display_content'] ) { ?>
 								<div class="portfolio-entry-content"><?php the_excerpt(); ?></div><!-- close .portfolio-entry -->
-						<?php } else { ?>
+						<?php } elseif (0 == strcmp( 'full', $atts['display_content'] ) ) { ?>
 								<div class="portfolio-entry-content"><?php the_content(); ?></div><!-- close .portfolio-entry -->
 							<?php }
 				$portfolio_index_number++;

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -563,12 +563,13 @@ class Jetpack_Portfolio {
 
 				<?php
 				// The content
-				if ( false !== $atts['display_content'] ): 
-							if ( true == $atts['display_content'] ) { ?>
-								<div class="portfolio-entry-content"><?php the_excerpt(); ?></div><!-- close .portfolio-entry -->
-						<?php } elseif ( 'full' === $atts['display_content'] ) { ?>
-								<div class="portfolio-entry-content"><?php the_content(); ?></div><!-- close .portfolio-entry -->
-							<?php }
+				if ( false !== $atts['display_content'] ) {
+					if ( 'full' === $atts['display_content'] ) {
+						echo '<div class="portfolio-entry-content">' . the_content() . '</div>';
+					} else {
+						echo '<div class="portfolio-entry-content">' . the_excerpt() . '</div>';
+					}
+				}
 				$portfolio_index_number++;
 			} // end of while loop
 

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -569,8 +569,9 @@ class Jetpack_Portfolio {
 					} else {
 						echo '<div class="portfolio-entry-content">' . the_excerpt() . '</div>';
 					}
-				}
-				$portfolio_index_number++;
+				} ?>
+				</div><!-- close .portfolio-entry -->
+				<?php $portfolio_index_number++;
 			} // end of while loop
 
 			wp_reset_postdata();

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -400,6 +400,7 @@ class Jetpack_Portfolio {
 			'showposts'       => -1,
 			'order'           => 'asc',
 			'orderby'         => 'date',
+			'show_excerpt'    => true,
 		), $atts, 'portfolio' );
 
 		// A little sanitization
@@ -563,11 +564,13 @@ class Jetpack_Portfolio {
 
 				<?php
 				// The content
-				if ( false != $atts['display_content'] ): ?>
-					<div class="portfolio-entry-content"><?php the_excerpt(); ?></div>
-				<?php endif; ?>
-				</div><!-- close .portfolio-entry -->
-			<?php
+				if ( false !== $atts['display_content'] ): 
++							if ( true == $atts['show_excerpt'] ) { ?>
++								<div class="portfolio-entry-content"><?php the_excerpt(); ?></div><!-- close .portfolio-entry -->
++							<?php } else { ?>
++										<div class="portfolio-entry-content"><?php the_content(); ?></div><!-- close .portfolio-entry -->
++								<?php }
+				endif;
 				$portfolio_index_number++;
 			} // end of while loop
 

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -411,7 +411,7 @@ class Jetpack_Portfolio {
 			$atts['display_tags'] = false;
 		}
 
-		if ( $atts['display_content'] && 'true' != $atts['display_content'] ) {
+		if ( $atts['display_content'] && 'true' != $atts['display_content'] && 'full' != $atts['display_content'] ) {
 			$atts['display_content'] = false;
 		}
 

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -566,7 +566,7 @@ class Jetpack_Portfolio {
 				if ( false !== $atts['display_content'] ): 
 							if ( true == $atts['display_content'] ) { ?>
 								<div class="portfolio-entry-content"><?php the_excerpt(); ?></div><!-- close .portfolio-entry -->
-						<?php } elseif (0 == strcmp( 'full', $atts['display_content'] ) ) { ?>
+						<?php } elseif ( 'full' === $atts['display_content'] ) { ?>
 								<div class="portfolio-entry-content"><?php the_content(); ?></div><!-- close .portfolio-entry -->
 							<?php }
 				$portfolio_index_number++;

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -565,12 +565,11 @@ class Jetpack_Portfolio {
 				<?php
 				// The content
 				if ( false !== $atts['display_content'] ): 
-+							if ( true == $atts['show_excerpt'] ) { ?>
-+								<div class="portfolio-entry-content"><?php the_excerpt(); ?></div><!-- close .portfolio-entry -->
-+							<?php } else { ?>
-+										<div class="portfolio-entry-content"><?php the_content(); ?></div><!-- close .portfolio-entry -->
-+								<?php }
-				endif;
+							if ( true == $atts['show_excerpt'] ) { ?>
+								<div class="portfolio-entry-content"><?php the_excerpt(); ?></div><!-- close .portfolio-entry -->
+						<?php } else { ?>
+								<div class="portfolio-entry-content"><?php the_content(); ?></div><!-- close .portfolio-entry -->
+							<?php }
 				$portfolio_index_number++;
 			} // end of while loop
 

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -521,7 +521,6 @@ class Jetpack_Testimonial {
 
 		$atts['showposts'] = intval( $atts['showposts'] );
 
-
 		if ( $atts['order'] ) {
 			$atts['order'] = urldecode( $atts['order'] );
 			$atts['order'] = strtoupper( $atts['order'] );
@@ -592,13 +591,14 @@ class Jetpack_Testimonial {
 					<div class="testimonial-entry <?php echo esc_attr( self::get_testimonial_class( $testimonial_index_number, $atts['columns'] ) ); ?>">
 						<?php
 						// The content
-						if ( false !== $atts['display_content'] ): 
-							if ( true == $atts['display_content'] ) { ?>
-								<div class="testimonial-entry-content"><?php the_excerpt(); ?></div>
-							<?php } elseif ( 'full' === $atts['display_content'] ) { ?>
-										<div class="testimonial-entry-content"><?php the_content(); ?></div>
-							<?php } ?>
-
+						if ( false !== $atts['display_content'] ) {
+							if ( 'full' === $atts['display_content'] ) {
+								echo '<div class="testimonial-entry-content">' . the_content() . '</div>';
+							} else {
+								echo '<div class="testimonial-entry-content">' . the_excerpt() . '</div>';
+							}
+						}
+						?>
 						<span class="testimonial-entry-title">&#8213; <a href="<?php echo esc_url( get_permalink() ); ?>" title="<?php echo esc_attr( the_title_attribute( ) ); ?>"><?php the_title(); ?></a></span>
 						<?php
 						// Featured image

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -595,7 +595,7 @@ class Jetpack_Testimonial {
 						if ( false !== $atts['display_content'] ): 
 							if ( true == $atts['display_content'] ) { ?>
 								<div class="testimonial-entry-content"><?php the_excerpt(); ?></div>
-							<?php } elseif (0 == strcmp( 'full', $atts['display_content'] ) ) { ?>
+							<?php } elseif ( 'full' === $atts['display_content'] ) { ?>
 										<div class="testimonial-entry-content"><?php the_content(); ?></div>
 							<?php } ?>
 

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -509,7 +509,7 @@ class Jetpack_Testimonial {
 		), $atts, 'testimonial' );
 
 		// A little sanitization
-		if ( $atts['display_content'] && 'true' != $atts['display_content'] ) {
+		if ( $atts['display_content'] && 'true' != $atts['display_content'] && 'full' != $atts['display_content'] ) {
 			$atts['display_content'] = false;
 		}
 

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -506,6 +506,7 @@ class Jetpack_Testimonial {
 			'showposts'       => -1,
 			'order'           => 'asc',
 			'orderby'         => 'date',
+			'show_excerpt'	  => true,
 		), $atts, 'testimonial' );
 
 		// A little sanitization
@@ -592,8 +593,12 @@ class Jetpack_Testimonial {
 					<div class="testimonial-entry <?php echo esc_attr( self::get_testimonial_class( $testimonial_index_number, $atts['columns'] ) ); ?>">
 						<?php
 						// The content
-						if ( false !== $atts['display_content'] ): ?>
-							<div class="testimonial-entry-content"><?php the_excerpt(); ?></div>
+						if ( false !== $atts['display_content'] ): 
+							if ( true == $atts['show_excerpt'] ) { ?>
+								<div class="testimonial-entry-content"><?php the_excerpt(); ?></div>
+							<?php } else { ?>
+										<div class="testimonial-entry-content"><?php the_content(); ?></div>
+								<?php }
 						<?php endif; ?>
 
 						<span class="testimonial-entry-title">&#8213; <a href="<?php echo esc_url( get_permalink() ); ?>" title="<?php echo esc_attr( the_title_attribute( ) ); ?>"><?php the_title(); ?></a></span>

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -506,7 +506,6 @@ class Jetpack_Testimonial {
 			'showposts'       => -1,
 			'order'           => 'asc',
 			'orderby'         => 'date',
-			'show_excerpt'	  => true,
 		), $atts, 'testimonial' );
 
 		// A little sanitization
@@ -594,12 +593,11 @@ class Jetpack_Testimonial {
 						<?php
 						// The content
 						if ( false !== $atts['display_content'] ): 
-							if ( true == $atts['show_excerpt'] ) { ?>
+							if ( true == $atts['display_content'] ) { ?>
 								<div class="testimonial-entry-content"><?php the_excerpt(); ?></div>
-							<?php } else { ?>
+							<?php } elseif (0 == strcmp( 'full', $atts['display_content'] ) ) { ?>
 										<div class="testimonial-entry-content"><?php the_content(); ?></div>
-								<?php }
-						 endif; ?>
+							<?php } ?>
 
 						<span class="testimonial-entry-title">&#8213; <a href="<?php echo esc_url( get_permalink() ); ?>" title="<?php echo esc_attr( the_title_attribute( ) ); ?>"><?php the_title(); ?></a></span>
 						<?php

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -599,7 +599,7 @@ class Jetpack_Testimonial {
 							<?php } else { ?>
 										<div class="testimonial-entry-content"><?php the_content(); ?></div>
 								<?php }
-						<?php endif; ?>
+						 endif; ?>
 
 						<span class="testimonial-entry-title">&#8213; <a href="<?php echo esc_url( get_permalink() ); ?>" title="<?php echo esc_attr( the_title_attribute( ) ); ?>"><?php the_title(); ?></a></span>
 						<?php


### PR DESCRIPTION
Add the `show_excerpt` attribute to the `testimonials` shortcode to give users the option to show the full testimonial. Set to `true` by default.

Fixes #2814 