### PR TITLE
Infinite Scroll: Fatal error when calling protected method from WP_Query

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -441,7 +441,7 @@ class The_Neverending_Home_Page {
 
 		//code inspired by WP_Query class
 		if ( preg_match_all( '/".*?("|$)|((?<=[\t ",+])|^)[^\t ",+]+/', self::wp_query()->get( 's' ), $matches ) ) {
-			$search_terms = self::wp_query()->parse_search_terms( $matches[0] );
+			$search_terms = self::wp_query()->query_vars['search_terms'];
 			// if the search string has only short terms or stopwords, or is 10+ terms long, match it as sentence
 			if ( empty( $search_terms ) || count( $search_terms ) > 9 ) {
 				$search_terms = array( self::wp_query()->get( 's' ) );


### PR DESCRIPTION
Since we already have `wp_query()` we can use its `query_vars['search_terms']` property instead of calling `parse_search_terms()`. It gets populated on https://github.com/WordPress/WordPress/blob/4.3.1/wp-includes/query.php#L2075 with the same data.

Fixes #2255.