### PR TITLE
Confirm args['status'] is set.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -42,8 +42,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		}
 
 		// determine statuses
-		$status = $args['status'];
-		$status = ( $status ) ? explode( ',', $status ) : array( 'publish' );
+		$status = ( ! empty( $args['status'] ) ) ? explode( ',', $args['status'] ) : array( 'publish' );
 		if ( is_user_logged_in() ) {
 			$statuses_whitelist = array(
 				'publish',


### PR DESCRIPTION
Resolves
```
​*E_NOTICE: /home//public_html/wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php:45 - Undefined index: status*​
```

Seen when bulk indexing posts via site sync.