### PR TITLE
Facebook Likebox: Return a language when none found.

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -260,8 +260,8 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 			$locale = GP_Locales::by_field( 'wp_locale', $lang );
 		}
 
-		if ( !$locale || empty( $locale->facebook_locale ) ) {
-			return false;
+		if ( ! $locale || empty( $locale->facebook_locale ) ) {
+			return 'en_US'; // Facebook requires a locale when pulling their SDK.
 		}
 
 		return $locale->facebook_locale;


### PR DESCRIPTION
If no language is used in the URL to grab the SDK, it fails. We fallback to en_US when we don't know of a language to try, so let's do the same when a known language as no facebook_locale.