### PR TITLE
Use full SSL pinterest url instead of protocol relative.

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1205,7 +1205,7 @@ class Share_Pinterest extends Sharing_Source {
 	}
 
 	public function get_external_url( $post ) {
-		$url = '//www.pinterest.com/pin/create/button/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&media=' . rawurlencode( $this->get_image( $post ) ) . '&description=' . rawurlencode( $post->post_title );
+		$url = 'https://www.pinterest.com/pin/create/button/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&media=' . rawurlencode( $this->get_image( $post ) ) . '&description=' . rawurlencode( $post->post_title );
 
 		/**
 		 * Filters the Pinterest share URL used in sharing button output.


### PR DESCRIPTION
Fixes #2838 

I think we were using a [protocol relative url](http://www.paulirish.com/2010/the-protocol-relative-url/) as of now, but like the note in the article says, better to use the SSL one.

> Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the https:// asset.