### PR TITLE
Add heading_level option to portfolio shortcode

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -400,6 +400,7 @@ class Jetpack_Portfolio {
 			'showposts'       => -1,
 			'order'           => 'asc',
 			'orderby'         => 'date',
+			'heading_level'   => 2,
 		), $atts, 'portfolio' );
 
 		// A little sanitization
@@ -455,6 +456,10 @@ class Jetpack_Portfolio {
 				$atts['orderby'] = implode( ' ', $parsed );
 			}
 		}
+		
+		$atts['heading_level'] = absint( $atts['heading_level'] );
+		$atts['heading_level'] = $atts['heading_level'] == 0 ? 1 : ( $atts['heading_level'] > 6 ? 6 : $atts['heading_level'] );
+		
 
 		// enqueue shortcode styles when shortcode is used
 		wp_enqueue_style( 'jetpack-portfolio-style', plugins_url( 'css/portfolio-shortcode.css', __FILE__ ), array(), '20140326' );
@@ -545,7 +550,7 @@ class Jetpack_Portfolio {
 					echo self::get_portfolio_thumbnail_link( $post_id );
 					?>
 
-					<h2 class="portfolio-entry-title"><a href="<?php echo esc_url( get_permalink() ); ?>" title="<?php echo esc_attr( the_title_attribute( ) ); ?>"><?php the_title(); ?></a></h2>
+					<h<?php echo esc_attr( $atts['heading_level'] ); ?> class="portfolio-entry-title"><a href="<?php echo esc_url( get_permalink() ); ?>" title="<?php echo esc_attr( the_title_attribute( ) ); ?>"><?php the_title(); ?></a></h<?php echo esc_attr( $atts['heading_level'] ); ?>>
 
 						<div class="portfolio-entry-meta">
 						<?php


### PR DESCRIPTION
The portfolio shortcode currently produces HTML with a 2nd rank heading. For many themes this is not ideal as often the site title is an h1, the page title is an h2, so the logical heading is a h3. However, as this is very theme and use dependant, a change to h3 is not ideal either. To me, it makes sense to add an option to allow the user to control the heading rank should they wish (values restricted to 1--6), but it defaults to 2 so there is minimal impact to existing users.
Can be seen working at http://www.nicholsonweb.co.uk/projects/ to change the heading level to 3.