### PR TITLE
Dynamically embed gists on posts using jsonp calls.

### DIFF
--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -36,5 +36,17 @@ function github_gist_shortcode( $atts, $content = '' ) {
 		$embed_url .= '?file=' . urlencode( $atts['file'] );
 
 	// inline style to prevent the bottom margin to the embed that themes like TwentyTen, et al., add to tables
-	return '<style>.gist table { margin-bottom: 0; }</style>' . '<div class="gist-oembed" data-gist="' . esc_attr( $embed_url ) . '"></div>';
+	$return = '<style>.gist table { margin-bottom: 0; }</style>' .
+			  '<div class="gist-oembed" data-gist="' . esc_attr( $embed_url ) . '"></div>';
+
+
+	if ( isset( $_POST[ 'type' ]) && 'embed' === $_POST[ 'type' ] &&
+			isset( $_POST[ 'action' ] ) && 'parse-embed' === $_POST['action'] ) {
+
+		ob_start();
+		wp_print_scripts( 'jetpack-gist-embed' );
+		$return .= ob_get_clean();
+	}
+
+	return  $return;
 }

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -30,23 +30,29 @@ function github_gist_shortcode( $atts, $content = '' ) {
 	if ( ! $id )
 		return '<!-- Invalid Gist ID -->';
 
-	$embed_url = "{$id}.json";
+	if ( ! empty( $atts['file'] ) ) {
+		$file = '?file=' . urlencode( $atts['file'] );
+	} else {
+		$file = '';
+	}
 
-	if ( ! empty( $atts['file'] ) )
-		$embed_url .= '?file=' . urlencode( $atts['file'] );
+	$embed_url = "{$id}.json" . $file;
 
 	// inline style to prevent the bottom margin to the embed that themes like TwentyTen, et al., add to tables
 	$return = '<style>.gist table { margin-bottom: 0; }</style>' .
 			  '<div class="gist-oembed" data-gist="' . esc_attr( $embed_url ) . '"></div>';
 
-
 	if ( isset( $_POST[ 'type' ]) && 'embed' === $_POST[ 'type' ] &&
 			isset( $_POST[ 'action' ] ) && 'parse-embed' === $_POST['action'] ) {
 
-		ob_start();
-		wp_print_scripts( 'jetpack-gist-embed' );
-		$return .= ob_get_clean();
+		return github_gist_simple_embed( $id, $file );
 	}
 
 	return  $return;
+}
+
+function github_gist_simple_embed( $id, $file ) {
+	$embed_url = $id . '.js' . $file;
+
+	return '<script type="text/javascript" src="//gist.github.com/' . $embed_url . '"></script>';
 }

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -10,6 +10,8 @@ wp_embed_register_handler( 'github-gist', '#https?://gist\.github\.com/([a-zA-Z0
 add_shortcode( 'gist', 'github_gist_shortcode' );
 
 function github_gist_embed_handler( $matches, $attr, $url, $rawattr ) {
+	wp_enqueue_script( 'jetpack-gist-embed', plugins_url( 'js/gist.js', __FILE__ ), array( 'jquery' ), false, true );
+
 	// Let the shortcode callback do all the work
 	return github_gist_shortcode( $attr, $url );
 }
@@ -28,10 +30,11 @@ function github_gist_shortcode( $atts, $content = '' ) {
 	if ( ! $id )
 		return '<!-- Invalid Gist ID -->';
 
-	$embed_url = "https://gist.github.com/{$id}.js";
+	$embed_url = "{$id}.json";
 
 	if ( ! empty( $atts['file'] ) )
-		$embed_url = add_query_arg( 'file', urlencode( $atts['file'] ), $embed_url );
+		$embed_url .= '?file=' . urlencode( $atts['file'] );
+
 	// inline style to prevent the bottom margin to the embed that themes like TwentyTen, et al., add to tables
-	return '<style>.gist table { margin-bottom: 0; }</style>' . '<script src="' . esc_url( $embed_url ) . '"></script>';
+	return '<style>.gist table { margin-bottom: 0; }</style>' . '<div class="gist-oembed" data-gist="' . esc_attr( $embed_url ) . '"></div>';
 }

--- a/modules/shortcodes/js/gist.js
+++ b/modules/shortcodes/js/gist.js
@@ -1,26 +1,28 @@
-;(function($, undefined) {
-    gistStylesheetLoaded = false;
+;(function( $, undefined ) {
+	var gistStylesheetLoaded = false,
+		gistEmbed = function() {
+			$( '.gist-oembed' ).each( function( i, el ) {
+				var url = 'https://gist.github.com/' + $( el ).data( 'gist' );
 
-    var gistEmbed = function( data ) {
-        $('.gist-oembed').each(function(i, el) {
-            var url = 'https://gist.github.com/' + $(el).data('gist');
-            $.ajax({
-                url: url,
-                dataType: 'jsonp'
-            }).done(function( response ) {
-                $(el).replaceWith( response.div );
+				$.ajax( {
+					url: url,
+					dataType: 'jsonp'
+				} ).done( function( response ) {
+					$( el ).replaceWith( response.div );
 
-                if ( ! gistStylesheetLoaded ) {
-                    $('head').append(
-                        "<link rel='stylesheet' href='" + response.stylesheet + "' type='text/css' />"
-                    );
+					if ( ! gistStylesheetLoaded ) {
+						var stylesheet = '<link rel="stylesheet" href="' +
+										response.stylesheet +
+										'" type="text/css" />';
 
-                    gistStylesheetLoaded = true;
-                }
-            });
-        });
-    };
+						$( 'head' ).append( stylesheet );
 
-    $(document).ready(gistEmbed);
-    $('body').on('post-load', gistEmbed);
-})(jQuery);
+						gistStylesheetLoaded = true;
+					}
+				} );
+			} );
+		};
+
+	$( document ).ready( gistEmbed );
+	$( 'body' ).on( 'post-load', gistEmbed );
+})( jQuery );

--- a/modules/shortcodes/js/gist.js
+++ b/modules/shortcodes/js/gist.js
@@ -3,7 +3,7 @@
 
     var gistEmbed = function( data ) {
         $('.gist-oembed').each(function(i, el) {
-            var url = 'https://gist.github.com/' + $(this).data('gist');
+            var url = 'https://gist.github.com/' + $(el).data('gist');
             $.ajax({
                 url: url,
                 dataType: 'jsonp'

--- a/modules/shortcodes/js/gist.js
+++ b/modules/shortcodes/js/gist.js
@@ -1,0 +1,26 @@
+;(function($, undefined) {
+    gistStylesheetLoaded = false;
+
+    var gistEmbed = function( data ) {
+        $('.gist-oembed').each(function(i, el) {
+            var url = 'https://gist.github.com/' + $(this).data('gist');
+            $.ajax({
+                url: url,
+                dataType: 'jsonp'
+            }).done(function( response ) {
+                $(el).replaceWith( response.div );
+
+                if ( ! gistStylesheetLoaded ) {
+                    $('head').append(
+                        "<link rel='stylesheet' href='" + response.stylesheet + "' type='text/css' />"
+                    );
+
+                    gistStylesheetLoaded = true;
+                }
+            });
+        });
+    };
+
+    $(document).ready(gistEmbed);
+    $('body').on('post-load', gistEmbed);
+})(jQuery);


### PR DESCRIPTION
What this does:

 * Loads stylesheet only once
 * Still works with `file` attribute on shortcode
 * Replaces the entire div generated by jetpack with the gist html (or maybe should put the code inside the div?)

Fixes #2839 