### PR TITLE
Add missing parameter to the_title filter call

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -95,7 +95,7 @@ function jetpack_og_tags() {
 			$tags['og:title'] = ' ';
 		} else {
 			/** This filter is documented in core/src/wp-includes/post-template.php */
-			$tags['og:title'] = wp_kses( apply_filters( 'the_title', $data->post_title ), array() );
+			$tags['og:title'] = wp_kses( apply_filters( 'the_title', $data->post_title, $data->ID ), array() );
 		}
 
 		$tags['og:url']         = get_permalink( $data->ID );


### PR DESCRIPTION
In core, the filter call for `the_title` provides two parameters: the post title and [the post ID](https://github.com/WordPress/WordPress/blob/master/wp-includes/post-template.php#L156). The filter call in this file was not providing the post ID.

Omitting the ID in this instance of the filter causes a **Warning: Missing argument 2** error for functions that use the second parameter.