### PR TITLE
Heartbeat: Return only uniquely active plugins

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1694,7 +1694,7 @@ class Jetpack {
 
 		sort( $active_plugins );
 
-		return $active_plugins;
+		return array_unique( $active_plugins );
 	}
 
 	/**


### PR DESCRIPTION
Previously, when requesting the list of active plugins, we would pull the list of network activated plugins and the list of plugins active on a subsite—which includes network activated plugins. This PR runs the array through `array_unique` to reduce the noise a bit.