### PR TITLE
Contact Form: admin make_it ham should report ham to akismet instead of spam

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -213,7 +213,7 @@ function grunion_handle_bulk_spam() {
 		 *
 		 * @since 2.2.0
 		 *
-		 * @param string $comment_status Usually 'spam'
+		 * @param string $comment_status Usually is 'spam', otherwise 'ham'.
 		 * @param array $akismet_values From '_feedback_akismet_values' in comment meta
 		 */
 		do_action( 'contact_form_akismet', 'spam', $akismet_values );
@@ -646,7 +646,7 @@ function grunion_ajax_spam() {
 		wp_transition_post_status( 'publish', 'spam', $post );
 
 		/** This action is already documented in modules/contact-form/admin.php */
-		do_action( 'contact_form_akismet', 'spam', $akismet_values );
+		do_action( 'contact_form_akismet', 'ham', $akismet_values );
 
 		$comment_author_email = $reply_to_addr = $message = $to = $headers = false;
 		$blog_url = parse_url( site_url() );


### PR DESCRIPTION
props @kitchin for the original patch in #2733

Original comment from @kitchin:
The "Not spam" action in Contact Form admin calls Akismet::http_post( $query_string, "submit-{$as}" ) with $as='spam'.

Compare wp-content/plugins/akismet/class.akismet.php, Line 561, in function submit_nonspam_comment():
self::http_post( Akismet::build_query( $comment ), 'submit-ham' )

I looked at the svn repo and it's been this way since Grunion came into Jetpack, 2012/04/24.

--

This has indeed been broken for a long time.  The original bug was introduced in https://plugins.trac.wordpress.org/changeset/346594.  h/t @cfinke for finding where it was introduced.