### PR TITLE
Contact Form: Add the option to send contact form feedback to bcc recipients.

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -513,7 +513,7 @@ function grunion_ajax_shortcode() {
 
 	$attributes = array();
 
-	foreach ( array( 'subject', 'to' ) as $attribute ) {
+	foreach ( array( 'subject', 'bcc', 'to' ) as $attribute ) {
 		if ( isset( $_POST[$attribute] ) && strlen( $_POST[$attribute] ) ) {
 			$attributes[$attribute] = stripslashes( $_POST[$attribute] );
 		}
@@ -573,6 +573,7 @@ function grunion_ajax_shortcode_to_json() {
 
 	$out = array(
 		'to'      => '',
+		'bcc'     => '',
 		'subject' => '',
 		'fields'  => array(),
 	);
@@ -582,8 +583,9 @@ function grunion_ajax_shortcode_to_json() {
 	}
 
 	$to = $grunion->get_attribute( 'to' );
+	$bcc = $grunion->get_attribute( 'bcc' );
 	$subject = $grunion->get_attribute( 'subject' );
-	foreach ( array( 'to', 'subject' ) as $attribute ) {
+	foreach ( array( 'to', 'bcc', 'subject' ) as $attribute ) {
 		$value = $grunion->get_attribute( $attribute );
 		if ( isset( $grunion->defaults[$attribute] ) && $value == $grunion->defaults[$attribute] ) {
 			$value = '';

--- a/modules/contact-form/grunion-form-view.php
+++ b/modules/contact-form/grunion-form-view.php
@@ -230,6 +230,9 @@ wp_localize_script( 'grunion', 'GrunionFB_i18n', array(
 				<label for="fb-fieldname"><?php esc_html_e( 'Enter your email address', 'jetpack' ); ?></label>
 				<input type="text" id="fb-field-my-email" style="background: #FFF !important;" />
 
+				<label for="fb-fieldname" style="margin-top: 14px;"><?php esc_html_e( 'Do you want to add BCC email addresses?', 'jetpack' ); ?></label>
+				<input type="text" id="fb-field-bcc" style="background: #FFF !important;" />
+
 				<label for="fb-fieldemail" style="margin-top: 14px;"><?php esc_html_e( 'What should the subject line be?', 'jetpack' ); ?></label>
 				<input type="text" id="fb-field-subject" style="background: #FFF !important;" />
 			</div>

--- a/modules/contact-form/js/grunion.js
+++ b/modules/contact-form/js/grunion.js
@@ -42,6 +42,7 @@ FB.ContactForm = (function() {
 	'action' : 'grunion_shortcode',
 	'_ajax_nonce' : ajax_nonce_shortcode,
 	'to' : '',
+	'bcc': '',
 	'subject' : '',
 	'fields' : {}
 	};
@@ -151,6 +152,7 @@ FB.ContactForm = (function() {
 	function buildPreview () {
 		try {
 			if (fbForm.to) { jQuery('#fb-field-my-email').val(fbForm.to); }
+			if (fbForm.bcc) { jQuery('#fb-field-bcc').val(fbForm.bcc); }
 			if (fbForm.subject) { jQuery('#fb-field-subject').val(fbForm.subject); }
 			// Loop over and add fields
 			jQuery.each(fbForm.fields, function(index, value) {
@@ -329,6 +331,7 @@ FB.ContactForm = (function() {
 					fbForm.fields[index] = value;
 				});
 				fbForm.to = data.to;
+				fbForm.bcc = data.bcc;
 				fbForm.subject = data.subject;
 			}
 		} catch(e) {
@@ -522,6 +525,16 @@ FB.ContactForm = (function() {
 		} catch(e) {
 			if (debug) {
 				console.log('updateMyEmail(): ' + e);
+			}
+		}
+	}
+	function updateFormBcc () {
+		try {
+			var thisBcc = jQuery('#fb-field-bcc').val();
+			fbForm.bcc = thisBcc;
+		} catch (e) {
+			if (debug) {
+				console.log('updateFormBcc(): ' + e);
 			}
 		}
 	}
@@ -762,6 +775,9 @@ FB.ContactForm = (function() {
 			});
 			jQuery('#fb-field-my-email').blur(function () {
 				updateMyEmail();
+			});
+			jQuery('#fb-field-bcc').blur(function () {
+				updateFormBcc();
 			});
 			jQuery('#fb-field-subject').blur(function () {
 				updateSubject();


### PR DESCRIPTION
Fixes #631 

I tested it and seems to work fine, but more testing is needed.

Adds a new `contact_form_bcc` filter.
