### PR TITLE
Don't add sharing buttons to sidebars, only to the main content block

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -587,6 +587,11 @@ function sharing_display( $text = '', $echo = false ) {
 		return $text;
 	}
 
+	// Don't add to sidebar or other widgets, only to the central content block of the page.
+	if ( !in_the_loop() || !is_main_query() ) {
+		return $text;
+	}
+
 	// Don't output flair on excerpts
 	if ( in_array( 'get_the_excerpt', (array) $wp_current_filter ) ) {
 		return $text;


### PR DESCRIPTION
We had a problem that we used `register_sidebar()` twice to create a couple more blocks on our page.

Each block was firing the `the_content` filter. And so we ended up with three sets of sharing buttons on our page, instead of just the one we wanted in the main content area. (The theme we are using is layerswp.)

This patch fixes the issue, by checking whether we are in the main content block or not. I saw the technique recommended in the links below.

In fact `! in_the_loop()` was enough in our case, but the `! is_main_query()` check is recommended here: http://wordpress.stackexchange.com/questions/67716/how-to-determine-if-a-filter-is-called-in-a-sidebar-widget-context

Some more tips here: https://pippinsplugins.com/playing-nice-with-the-content-filter/

I have already submitted a similar patch to a different plugin: https://wordpress.org/support/topic/avoid-adding-to-secondary-blocks-created-on-the-page-eg-with-register_sidebar

Cheers!