### PR TITLE
Contact Form: Allow empty admin email field

### DIFF
--- a/modules/contact-form/js/grunion.js
+++ b/modules/contact-form/js/grunion.js
@@ -481,6 +481,11 @@ FB.ContactForm = (function() {
 		}
 	}
 	function validateEmails( emails ) {
+		// Field is allwed to be empty :)
+		if ( 0 === emails.length ) {
+			return true;
+		}
+
 		var $e, emailList = emails.split( ',' );
 
 		for ( $e = 0 ; $e < emailList.length ; $e++ ) {


### PR DESCRIPTION
fixes #2867

Might have to run grunt or change the grunion.js enqueue version string to bust the js cache