### PR TITLE
WCAG: Add alt if not set, but there is a title attribute.  

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/templates/partials/item.php
+++ b/modules/tiled-gallery/tiled-gallery/templates/partials/item.php
@@ -1,6 +1,10 @@
 <?php
-$add_link = 'none' !== $this->link; 
-$hide_title = ( empty( $item->image_alt ) ) ? true : false;
+$add_link = 'none' !== $this->link;
+
+// We do this for accessibility.  Titles without alt's break screen readers.
+if ( empty( $item->image_alt ) && ! empty( $item->image_title ) ) {
+	$item->image_alt = $item->image_title;
+}
 ?>
 <div class="tiled-gallery-item<?php if ( isset( $item->size ) ) echo " tiled-gallery-item-$item->size"; ?>">
 	<?php if ( $add_link ): ?>
@@ -13,11 +17,7 @@ $hide_title = ( empty( $item->image_alt ) ) ? true : false;
 			height="<?php echo esc_attr( $item->image->height ); ?>"
 			data-original-width="<?php echo esc_attr( $item->image->width ); ?>"
 			data-original-height="<?php echo esc_attr( $item->image->height ); ?>"
-			<?php
-				if ( ! $hide_title ) {
-					echo 'title="' . esc_attr( $item->image_title ) . '"';
-				}
-			?>
+			title="<?php echo esc_attr( $item->image_title ); ?>"
 			alt="<?php echo esc_attr( $item->image_alt ); ?>"
 			style="width: <?php echo esc_attr( $item->image->width ); ?>px; height: <?php echo esc_attr( $item->image->height ); ?>px;"
 		/>
@@ -36,11 +36,7 @@ $hide_title = ( empty( $item->image_alt ) ) ? true : false;
 				height="<?php echo esc_attr( $item->image->height ); ?>"
 				data-original-width="<?php echo esc_attr( $item->image->width ); ?>"
 				data-original-height="<?php echo esc_attr( $item->image->height ); ?>"
-				<?php
-					if ( ! $hide_title ) {
-						echo 'title="' . esc_attr( $item->image_title ) . '"';
-					}
-				?>
+				title="<?php echo esc_attr( $item->image_title ); ?>"
 				align="left"
 				alt="<?php echo esc_attr( $item->image_alt ); ?>"
 				style="width: <?php echo esc_attr( $item->image->width ); ?>px; height: <?php echo esc_attr( $item->image->height ); ?>px;"

--- a/modules/tiled-gallery/tiled-gallery/templates/partials/item.php
+++ b/modules/tiled-gallery/tiled-gallery/templates/partials/item.php
@@ -1,5 +1,7 @@
 <?php
-$add_link = 'none' !== $this->link; ?>
+$add_link = 'none' !== $this->link; 
+$hide_title = ( empty( $item->image_alt ) ) ? true : false;
+?>
 <div class="tiled-gallery-item<?php if ( isset( $item->size ) ) echo " tiled-gallery-item-$item->size"; ?>">
 	<?php if ( $add_link ): ?>
 	<a href="<?php echo $item->link; ?>" border="0">
@@ -11,7 +13,11 @@ $add_link = 'none' !== $this->link; ?>
 			height="<?php echo esc_attr( $item->image->height ); ?>"
 			data-original-width="<?php echo esc_attr( $item->image->width ); ?>"
 			data-original-height="<?php echo esc_attr( $item->image->height ); ?>"
-			title="<?php echo esc_attr( $item->image_title ); ?>"
+			<?php
+				if ( ! $hide_title ) {
+					echo 'title="' . esc_attr( $item->image_title ) . '"';
+				}
+			?>
 			alt="<?php echo esc_attr( $item->image_alt ); ?>"
 			style="width: <?php echo esc_attr( $item->image->width ); ?>px; height: <?php echo esc_attr( $item->image->height ); ?>px;"
 		/>
@@ -30,7 +36,11 @@ $add_link = 'none' !== $this->link; ?>
 				height="<?php echo esc_attr( $item->image->height ); ?>"
 				data-original-width="<?php echo esc_attr( $item->image->width ); ?>"
 				data-original-height="<?php echo esc_attr( $item->image->height ); ?>"
-				title="<?php echo esc_attr( $item->image_title ); ?>"
+				<?php
+					if ( ! $hide_title ) {
+						echo 'title="' . esc_attr( $item->image_title ) . '"';
+					}
+				?>
 				align="left"
 				alt="<?php echo esc_attr( $item->image_alt ); ?>"
 				style="width: <?php echo esc_attr( $item->image->width ); ?>px; height: <?php echo esc_attr( $item->image->height ); ?>px;"


### PR DESCRIPTION
replaces #2680 with a solution that will add an `alt` to the element if there is a title, but not an alt.  This is preferred to the prior fix that would delete the title if no alt found.  

fixes #2679