### PR TITLE
Photon: Filter Responsive Images srcset array

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -58,6 +58,9 @@ class Jetpack_Photon {
 		// Core image retrieval
 		add_filter( 'image_downsize', array( $this, 'filter_image_downsize' ), 10, 3 );
 
+		// Responsive image srcset substitution
+		add_filter( 'wp_get_attachment_image_srcset_array', array( $this, 'filter_srcset_array' ) );
+
 		// Helpers for maniuplated images
 		add_action( 'wp_enqueue_scripts', array( $this, 'action_wp_enqueue_scripts' ), 9 );
 	}
@@ -560,6 +563,26 @@ class Jetpack_Photon {
 		}
 
 		return $image;
+	}
+
+	/**
+	 * Filters an array of image `srcset` values, replacing each URL with its Photon equivalent.
+	 *
+	 * @since 3.8.0
+	 * @param array $sources An array of image urls and widths.
+	 * @uses self::validate_image_url, jetpack_photon_url
+	 * @return array An array of Photon image urls and widths.
+	 */
+	public function filter_srcset_array( $sources ) {
+		foreach ( $sources as $i => $source ) {
+			if ( ! self::validate_image_url( $source['url'] ) ) {
+				continue;
+			}
+
+			$sources[ $i ]['url'] = jetpack_photon_url( $source['url'] );
+		}
+
+		return $sources;
 	}
 
 	/**

--- a/class.photon.php
+++ b/class.photon.php
@@ -579,7 +579,18 @@ class Jetpack_Photon {
 				continue;
 			}
 
-			$sources[ $i ]['url'] = jetpack_photon_url( $source['url'] );
+			$url = $source['url'];
+
+			list( $width, $height ) = Jetpack_Photon::parse_dimensions_from_filename( $url );
+			$url = Jetpack_Photon::strip_image_dimensions_maybe( $url );
+
+			$args = array();
+			if ( $width && $height ) {
+				$args['w'] = $width;
+				$args['h'] = $height;
+			}
+
+			$sources[ $i ]['url'] = jetpack_photon_url( $url, $args );
 		}
 
 		return $sources;

--- a/class.photon.php
+++ b/class.photon.php
@@ -579,15 +579,12 @@ class Jetpack_Photon {
 				continue;
 			}
 
-			$url = $source['url'];
-
-			list( $width, $height ) = Jetpack_Photon::parse_dimensions_from_filename( $url );
-			$url = Jetpack_Photon::strip_image_dimensions_maybe( $url );
+			$url = Jetpack_Photon::strip_image_dimensions_maybe( $source['url'] );
 
 			$args = array();
-			if ( $width && $height ) {
-				$args['w'] = $width;
-				$args['h'] = $height;
+			$descriptor = $source['descriptor'];
+			if ( $descriptor === 'w' ) {
+				$args[ $descriptor ] = $source['value'];
 			}
 
 			$sources[ $i ]['url'] = jetpack_photon_url( $url, $args );

--- a/class.photon.php
+++ b/class.photon.php
@@ -582,9 +582,8 @@ class Jetpack_Photon {
 			$url = Jetpack_Photon::strip_image_dimensions_maybe( $source['url'] );
 
 			$args = array();
-			$descriptor = $source['descriptor'];
-			if ( $descriptor === 'w' ) {
-				$args[ $descriptor ] = $source['value'];
+			if ( 'w' === $source['descriptor'] ) {
+				$args['w'] = $source['value'];
 			}
 
 			$sources[ $i ]['url'] = jetpack_photon_url( $url, $args );


### PR DESCRIPTION
Related (Resolves?): #2804

This pull request seeks to update Photon to adjust image URLs included in the `srcset` attribute introduced as part of the [WordPress 4.4](https://wordpress.org/news/2015/10/wordpress-4-4-beta-1/) "Responsive Images" feature.

This is a relatively naive approach. It simply filters the `wp_get_attachment_image_srcset_array` array applied by the core `wp_get_attachment_image_srcset_array` function. It may be preferable to hook in to and override the `sizes` returned by `wp_get_attachment_metadata`, as this is the mechanism used by the `srcset` behavior to determine viable responsive image candidates.