### PR TITLE
Open Graph: Use specific formatting functions instead of the excerpt

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -110,7 +110,7 @@ function jetpack_og_tags() {
 		if ( empty( $tags['og:description'] ) ) {
 			$tags['og:description'] = __('Visit the post for more.', 'jetpack');
 		} else {
-			/** This filter is documented in src/wp-includes/post-template.php */
+			// Intentionally not using a filter to prevent pollution. @see https://github.com/Automattic/jetpack/pull/2899#issuecomment-151957382
 			$tags['og:description'] = wp_kses( trim( convert_chars( wptexturize( $tags['og:description'] ) ) ), array() );
 		}
 

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -111,7 +111,7 @@ function jetpack_og_tags() {
 			$tags['og:description'] = __('Visit the post for more.', 'jetpack');
 		} else {
 			/** This filter is documented in src/wp-includes/post-template.php */
-			$tags['og:description'] = wp_kses( trim( apply_filters( 'the_excerpt', $tags['og:description'] ) ), array() );
+			$tags['og:description'] = wp_kses( trim( convert_chars( wptexturize( $tags['og:description'] ) ) ), array() );
 		}
 
 		$tags['article:published_time'] = date( 'c', strtotime( $data->post_date_gmt ) );


### PR DESCRIPTION
Avoid sharedaddy/likes code inserted into the og:description.

Fixes #2723 

I didn't go with `the_title` filter for fear someone adds extra code there expecting it to only fire on the title. Open to a specific `og:description` formatting filter, although, there are plenty that could be used.