### PR TITLE
Sharing: fix plus signs appearing in tweets shared from iOS.

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -697,7 +697,7 @@ class Share_Twitter extends Sharing_Source {
 
 		$url = $post_link;
 		$twitter_url = add_query_arg(
-			urlencode_deep( array_filter( compact( 'via', 'related', 'text', 'url' ) ) ),
+			rawurlencode_deep( array_filter( compact( 'via', 'related', 'text', 'url' ) ) ),
 			'https://twitter.com/intent/tweet'
 		);
 


### PR DESCRIPTION
`rawurlencode_deep` converts spaces into `%20`, which works on iOS and everywhere else.
`urlencode_deep` on the other hand, converts spaces into `+`, which works on Andoid and desktop browsers, but not on iOS.

Fixes #2853