### PR TITLE
Fix removal of attachment page code from wpcom merge

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -244,7 +244,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		$image = '';
 
 		// Grab obvious image if $post is an attachment page for an image
-		if ( is_attachment( $post->ID ) && substr( $post->post_mime_type, 0, 5) == 'image' ) {
+		if ( is_attachment( $post->ID ) && 'image' == substr( $post->post_mime_type, 0, 5 ) ) {
 			$image = wp_get_attachment_url( $post->ID );
 		}
 

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -243,8 +243,13 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		global $post;
 		$image = '';
 
+		// Grab obvious image if $post is an attachment page for an image
+		if ( is_attachment( $post->ID ) && substr( $post->post_mime_type, 0, 5) == 'image' ) {
+			$image = wp_get_attachment_url( $post->ID );
+		}
+
 		// Attempt to find something good for this post using our generalized PostImages code
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
+		if ( ! $image && class_exists( 'Jetpack_PostImages' ) ) {
 			$post_images = Jetpack_PostImages::get_images( $post->ID, array( 'width' => $width, 'height' => $height ) );
 			if ( $post_images && ! is_wp_error( $post_images ) ) {
 				$image = array();


### PR DESCRIPTION
The code from https://github.com/Automattic/jetpack/pull/1265 was accidentally removed in a wpcom merge, this adds it back.