### PR TITLE
i18n: add translation comments to module tags 

### DIFF
--- a/tools/build-module-headings-translations.php
+++ b/tools/build-module-headings-translations.php
@@ -62,6 +62,7 @@ foreach ( $tags as $tag => $files ) {
 	foreach ( $files as $file ) {
 		$file_contents .= "//  - {$file}\r\n";
 	}
+	$file_contents .= "/* translators: This is a search term that relates to a module. We want this to be searchable in multiple languages. */\r\n";
 	$file_contents .= "_x( '{$tag}', 'Module Tag', 'jetpack' );\r\n";
 }
 


### PR DESCRIPTION
automatically add explanations to the translators what they are translating.  

example after running grunt: 
https://cloudup.com/iP83QkM5kFh