### PR TITLE
REST API: add `supports` field to the post-types endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -517,7 +517,7 @@ class WPCOM_JSON_API_List_Post_Types_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$formatted_post_type_object[ $value ] = $post_type_object->{ $key };
 			}
 			$formatted_post_type_object['api_queryable'] = $is_queryable;
-
+			$formatted_post_type_object['supports'] = get_all_post_type_supports( $post_type );
 			$formatted_post_type_objects[] = $formatted_post_type_object;
 		}
 


### PR DESCRIPTION
Adds a `supports` field to the post type objects returned in the` sites/$site/post-types` endpoint which returns all of the "features" that the endpoint supports, as returned by the `get_all_post_type_supports` core function.