### PR TITLE
Theme Tools: use underscore in filter name to include tools.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6225,6 +6225,7 @@ p {
 		$deprecated_list = array(
 			'jetpack_bail_on_shortcode' => 'jetpack_shortcodes_to_include',
 			'wpl_sharing_2014_1'        => null,
+			'jetpack-tools-to-include'  => 'jetpack_tools_to_include',
 		);
 
 		// This is a silly loop depth. Better way?

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -27,7 +27,7 @@ $tools = array(
  *
  * @param array $tools Array of extra tools to include.
  */
-$jetpack_tools_to_include = apply_filters( 'jetpack-tools-to-include', $tools );
+$jetpack_tools_to_include = apply_filters( 'jetpack_tools_to_include', $tools );
 
 if ( ! empty( $jetpack_tools_to_include ) ) {
 	foreach ( $jetpack_tools_to_include as $tool ) {


### PR DESCRIPTION
dashes don't play well with the inline doc parser.

@see #148 for some earlier discussions where we had agreed to change the filter name.