### PR TITLE
deploy-to-svn script: Update to allow deploy of HEAD

### DIFF
--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -11,19 +11,19 @@ TARGET=$1
 
 cd $JETPACK_GIT_DIR
 
+# Make sure we don't have uncommitted changes.
+if [[ -n $( git status -s --porcelain ) ]]; then
+	echo "Uncommitted changes found."
+	echo "Please deal with them and try again clean."
+	exit 1
+fi
+
 if [ "$1" != "HEAD" ]; then
 
 	# Make sure we're trying to deploy something that's been tagged. Don't deploy non-tagged.
 	if [ -z $( git tag | grep "^$TARGET$" ) ]; then
 		echo "Tag $TARGET not found in git repository."
 		echo "Please try again with a valid tag."
-		exit 1
-	fi
-
-	# Make sure we don't have uncommitted changes.
-	if [[ -n $( git status -s --porcelain ) ]]; then
-		echo "Uncommitted changes found."
-		echo "Please deal with them and try again clean."
 		exit 1
 	fi
 else

--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -1,31 +1,40 @@
 #!/bin/bash
 
 if [ $# -eq 0 ]; then
-	echo 'Usage: `./deploy-to-svn.sh <tag>`'
+	echo 'Usage: `./deploy-to-svn.sh <tag | HEAD>`'
 	exit 1
 fi
 
 JETPACK_GIT_DIR=$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" )
 JETPACK_SVN_DIR="/tmp/jetpack"
-TAG=$1
+TARGET=$1
 
 cd $JETPACK_GIT_DIR
 
-# Make sure we're trying to deploy something that's been tagged. Don't deploy non-tagged.
-if [ -z $( git tag | grep "^$TAG$" ) ]; then
-	echo "Tag $TAG not found in git repository."
-	echo "Please try again with a valid tag."
-	exit 1
+if [ "$1" != "HEAD" ]; then
+
+	# Make sure we're trying to deploy something that's been tagged. Don't deploy non-tagged.
+	if [ -z $( git tag | grep "^$TARGET$" ) ]; then
+		echo "Tag $TARGET not found in git repository."
+		echo "Please try again with a valid tag."
+		exit 1
+	fi
+
+	# Make sure we don't have uncommitted changes.
+	if [[ -n $( git status -s --porcelain ) ]]; then
+		echo "Uncommitted changes found."
+		echo "Please deal with them and try again clean."
+		exit 1
+	fi
+else
+	read -p "You are about to deploy a change from an unstable state 'HEAD'. This should only be done to update string typos for translators. Are you sure? [y/N]" -n 1 -r
+	if [[ $REPLY != "y" && $REPLY != "Y" ]]
+	then
+		exit 1
+	fi
 fi
 
-# Make sure we don't have uncommitted changes.
-if [[ -n $( git status -s --porcelain ) ]]; then
-	echo "Uncommitted changes found."
-	echo "Please deal with them and try again clean."
-	exit 1
-fi
-
-git checkout $TAG
+git checkout $TARGET
 
 # Prep a home to drop our new files in. Just make it in /tmp so we can start fresh each time.
 rm -rf $JETPACK_SVN_DIR
@@ -66,12 +75,12 @@ done
 echo "Done!"
 
 # Tag the release.
-# svn cp trunk tags/$TAG
+# svn cp trunk tags/$TARGET
 
 # Change stable tag in the tag itself, and commit (tags shouldn't be modified after comitted)
-# perl -pi -e "s/Stable tag: .*/Stable tag: $TAG/" tags/$TAG/readme.txt
+# perl -pi -e "s/Stable tag: .*/Stable tag: $TARGET/" tags/$TARGET/readme.txt
 # svn ci
 
 # Update trunk to point to the freshly tagged and shipped release.
-# perl -pi -e "s/Stable tag: .*/Stable tag: $TAG/" trunk/readme.txt
+# perl -pi -e "s/Stable tag: .*/Stable tag: $TARGET/" trunk/readme.txt
 # svn ci


### PR DESCRIPTION
With the new translations pulling directly from the svn trunk, sometimes (when typos are found right after a beta) it will be useful to update trunk with correct strings without having to create a new tag.  

<b>This should only be used to update strings.</b>