### PR TITLE
Carousel: added a polyfill for browsers that do not support Date.now

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -18,6 +18,13 @@ jQuery(document).ready(function($) {
 		}
 	}
 
+	// Adding a polyfill for browsers that do not have Date.now
+	if ( 'undefined' === typeof Date.now ) {
+		Date.now = function now() {
+			return new Date().getTime();
+		};
+	}
+
 	var keyListener = function(e){
 		switch(e.which){
 			case 38: // up


### PR DESCRIPTION
This should fix #1631, thanks to @jeherve for bringing it up and to @osiux for suggesting a solution!