### PR TITLE
Comments: added a filter to allow disabling comments per post type.

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -175,6 +175,18 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * @since JetpackComments (1.4)
 	 */
 	public function comment_form_before() {
+		/**
+		 * Filters the setting that determines if Jetpagk comments should be enabled for
+		 * the current post type.
+		 *
+		 * @since 3.8.1
+		 *
+		 * @param boolean $return Should comments be enabled?
+		 */
+		if ( ! apply_filters( 'jetpack_comment_form_enabled_for_' . get_post_type(), true ) ) {
+			return;
+		}
+
 		// Add some JS to the footer
 		add_action( 'wp_footer', array( $this, 'watch_comment_parent' ), 100 );
 
@@ -188,6 +200,10 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * @since JetpackComments (1.4)
 	 */
 	public function comment_form_after() {
+		/** This filter is documented in modules/comments/comments.php */
+		if ( ! apply_filters( 'jetpack_comment_form_enabled_for_' . get_post_type(), true ) ) {
+			return;
+		}
 
 		// Throw it all out and drop in our replacement
 		ob_end_clean();
@@ -413,6 +429,14 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		// Bail if token is expired or not valid
 		if ( $check !== $post_array['sig'] )
 			wp_die( __( 'Invalid security token.', 'jetpack' ) );
+
+		/** This filter is documented in modules/comments/comments.php */
+		if ( ! apply_filters( 'jetpack_comment_form_enabled_for_' . get_post_type( $post_array['comment_post_ID'] ), true ) ) {
+			// In case the comment POST is legit, but the comments are
+			// now disabled, we don't allow the comment
+
+			wp_die( __( 'Comments are not allowed.', 'jetpack' ) );
+		}
 	}
 
 	/** Capabilities **********************************************************/

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -179,6 +179,8 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		 * Filters the setting that determines if Jetpagk comments should be enabled for
 		 * the current post type.
 		 *
+		 * @module comments
+		 *
 		 * @since 3.8.1
 		 *
 		 * @param boolean $return Should comments be enabled?


### PR DESCRIPTION
This would fix #2882 by allowing to disable Jetpack comments for certain post types, for example:
```
// disabling comments for pages
add_filter( 'jetpack_comment_form_enabled_for_page', '__return_false');
```

Disabling will revert WordPress to its comment behaviour as it would have been without Jetpack.