### PR TITLE
Add whitelist filter for phpunit tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,21 @@
 <phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
-    <testsuites>
-        <!-- Default test suite to run all tests -->
-        <testsuite>
-            <directory prefix="test_" suffix=".php">tests</directory>
-        </testsuite>
-    </testsuites>
-    <groups>
-        <exclude>
-            <group>external-http</group>
-        </exclude>
-    </groups>
+	<testsuites>
+		<!-- Default test suite to run all tests -->
+		<testsuite>
+			<directory prefix="test_" suffix=".php">tests</directory>
+		</testsuite>
+	</testsuites>
+	<groups>
+		<exclude>
+			<group>external-http</group>
+		</exclude>
+	</groups>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<directory suffix=".php">.</directory>
+			<exclude>
+				<directory suffix=".php">tests</directory>
+			</exclude>
+		</whitelist>
+	</filter>
 </phpunit>


### PR DESCRIPTION
Don't include the tests directory in code coverage output, and
only show the appropriate set of files. This makes the coverage
report a lot more readable, and should speed up phpunit.