### PR TITLE
Use site domain instead of blog_id ton wp.com stats link.

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -381,8 +381,6 @@ function stats_reports_page() {
 		$domain = $url_parts['host'];
 	}
 
-	$blog_id = stats_get_option( 'blog_id' );
-
 	if ( !isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) {
 		$nojs_url = add_query_arg( 'nojs', '1' );
 		$http = is_ssl() ? 'https' : 'http';

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -370,16 +370,8 @@ function stats_reports_page() {
 	if ( isset( $_GET['dashboard'] ) )
 		return stats_dashboard_widget_content();
 
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$blog_id = get_current_blog_id();
-		$bloginfo = get_blog_details( (int) $blog_id );
-		$domain = $bloginfo->domain;
-	} else {
-		$blog_id = Jetpack_Options::get_option( 'id' );
-		$url = home_url();
-		$url_parts = parse_url( $url );
-		$domain = $url_parts['host'];
-	}
+	$blog_id = stats_get_option( 'blog_id' );
+	$domain = Jetpack::build_raw_urls( get_home_url() );
 
 	if ( !isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) {
 		$nojs_url = add_query_arg( 'nojs', '1' );

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -370,6 +370,17 @@ function stats_reports_page() {
 	if ( isset( $_GET['dashboard'] ) )
 		return stats_dashboard_widget_content();
 
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$blog_id = get_current_blog_id();
+		$bloginfo = get_blog_details( (int) $blog_id );
+		$domain = $bloginfo->domain;
+	} else {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		$url = home_url();
+		$url_parts = parse_url( $url );
+		$domain = $url_parts['host'];
+	}
+
 	$blog_id = stats_get_option( 'blog_id' );
 
 	if ( !isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) {
@@ -385,7 +396,7 @@ function stats_reports_page() {
 <p class="hide-if-no-js"><img width="32" height="32" alt="<?php esc_attr_e( 'Loading&hellip;', 'jetpack' ); ?>" src="<?php
 /** This filter is documented in modules/shortcodes/audio.php */
 echo esc_url( apply_filters( 'jetpack_static_url', "{$http}://en.wordpress.com/i/loading/loading-64.gif" ) ); ?>" /></p>
-<p style="font-size: 11pt; margin: 0;"><a href="https://wordpress.com/stats/<?php echo $blog_id; ?>"><?php esc_html_e( 'View stats on WordPress.com right now', 'jetpack' ); ?></a></p>
+<p style="font-size: 11pt; margin: 0;"><a href="https://wordpress.com/stats/<?php echo $domain; ?>"><?php esc_html_e( 'View stats on WordPress.com right now', 'jetpack' ); ?></a></p>
 <p class="hide-if-js"><?php esc_html_e( 'Your Site Stats work better with Javascript enabled.', 'jetpack' ); ?><br />
 <a href="<?php echo esc_url( $nojs_url ); ?>"><?php esc_html_e( 'View Site Stats without Javascript', 'jetpack' ); ?></a>.</p>
 </div>


### PR DESCRIPTION
Fixes #2222 

I used something similar to where we [get $domain on another module](https://github.com/Automattic/jetpack/blob/e92880156b40ff407d887a694f2eae59087c356e/modules/likes.php#L865-L874).