### PR TITLE
Contact Form: Make render() aware of incoming array values.

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1913,7 +1913,11 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		$field_placeholder = ( ! empty( $placeholder ) ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
 
 		if ( isset( $_POST[ $field_id ] ) ) {
-			$this->value = stripslashes( (string) $_POST[ $field_id ] );
+			if ( is_array( $_POST[ $field_id ] ) ) {
+				$this->value = array_map( 'stripslashes', $_POST[ $field_id ] );
+			} else {
+				$this->value = stripslashes( (string) $_POST[ $field_id ] );
+			}
 		} elseif ( isset( $_GET[ $field_id ] ) ) {
 			$this->value = stripslashes( (string) $_GET[ $field_id ] );
 		} elseif (


### PR DESCRIPTION
The checkbox-multiple field type was added in #2806, but render() wasn't updated to handle incoming array values. Because of that, it would attempt to convert the array to a string, which would fail, causing a PHP warning and a "headers already sent" error.