### PR TITLE
JSON API: add check for `login` scheme

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5408,7 +5408,7 @@ p {
 
 	// Make sure the login form is POSTed to the signed URL so we can reverify the request
 	function post_login_form_to_signed_url( $url, $path, $scheme ) {
-		if ( 'wp-login.php' !== $path || 'login_post' !== $scheme ) {
+		if ( 'wp-login.php' !== $path || ( 'login_post' !== $scheme && 'login' !== $scheme ) ) {
 			return $url;
 		}
 


### PR DESCRIPTION
This adds a check for both the `login` and `login_post` scheme for back-compat.  

The issue as reported by @koke and @lezama:
<a href="https://href.li/?http://core.trac.wordpress.org/changeset/34213">r34213-core</a> changed the action attribute of the login form to `use wp_login_url()`, which uses the login scheme instead of `login_post`. This is stripping all the $_GET parameters from the action URL, and the login fails.

To reproduce: 
- Have a site running WordPress trunk and Jetpack (tried with master, but Miguel said 3.7 failed as well).
- Go to https://wps.koke.me/wpcom-oauth.php, Authorize (not global), and select that site from the OAuth2 screen
- OAuth2 flow takes you to the site’s wp-login.php
- Verify the action url in the login form

See the post on internal Jetpack p2 for more info.