### PR TITLE
Sync: Include content_width mock option in sync

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -511,6 +511,7 @@ class Jetpack {
 		$this->sync->mock_option( 'has_file_system_write_access', array( 'Jetpack', 'file_system_write_access' ) );
 		$this->sync->mock_option( 'is_version_controlled', array( 'Jetpack', 'is_version_controlled' ) );
 		$this->sync->mock_option( 'max_upload_size', 'wp_max_upload_size' );
+		$this->sync->mock_option( 'content_width', array( 'Jetpack', 'get_content_width' ) );
 
 		/**
 		 * Trigger an update to the main_network_site when we update the blogname of a site.


### PR DESCRIPTION
This pull request seeks to sync the result of [`Jetpack::get_content_width`](https://github.com/Automattic/jetpack/blob/aa0a15ea6a474a09d524ccc39070ff9877632db5/class.jetpack.php#L5546-L5559) to WordPress.com.