### PR TITLE
Custom CSS: Add jetpack_custom_css_pre_post_id filter.

### DIFF
--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -341,6 +341,21 @@ class Jetpack_Custom_CSS {
 	 * @return int|bool The post ID if it exists; false otherwise.
 	 */
 	static function post_id() {
+		/**
+		 * Filter the ID of the post where Custom CSS is stored, before the ID is retrieved.
+		 *
+		 * If the callback function returns a non-null value, then post_id() will immediately
+		 * return that value, instead of retrieving the normal post ID.
+		 *
+		 * @since 3.8.1
+		 *
+		 * @param null null The ID to return instead of the normal ID.
+		 */
+		$custom_css_post_id = apply_filters( 'jetpack_custom_css_pre_post_id', null );
+		if ( ! is_null( $custom_css_post_id ) ) {
+			return $custom_css_post_id;
+		}
+
 		$custom_css_post_id = wp_cache_get( 'custom_css_post_id' );
 
 		if ( false === $custom_css_post_id ) {

--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -347,6 +347,8 @@ class Jetpack_Custom_CSS {
 		 * If the callback function returns a non-null value, then post_id() will immediately
 		 * return that value, instead of retrieving the normal post ID.
 		 *
+		 * @module custom-css
+		 *
 		 * @since 3.8.1
 		 *
 		 * @param null null The ID to return instead of the normal ID.


### PR DESCRIPTION
This allows other plugins to override the post where Custom CSS is saved.

My use case for this is [the Remote CSS plugin for WordCamp.org](https://make.wordpress.org/community/2015/06/16/editing-wordcamp-css-locally-with-git/), which needs a way to sanitize untrusted CSS. 

With this filter, I can create a second `safecss` post and call `Jetpack_Custom_CSS::save()` to sanitize and save my untrusted CSS to that second post, while still allowing Jetpack's regular Custom CSS post to function simultaneously.