### PR TITLE
Contributing guide: Update URL for inline documentation standard.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ When creating Pull Requests, remember:
 
 There are a few bonuses that can increase the chances that your Pull Request is accepted:
 
-- If you've created a new action or filter, [add inline documentation](https://make.wordpress.org/core/handbook/inline-documentation-standards/php-documentation-standards/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
+- If you've created a new action or filter, [add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
 - Create [unit tests](https://github.com/Automattic/jetpack/tree/master/tests) if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
 - If [Grunt](http://gruntjs.com/) is installed on your testing environmenent, run it after committing your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/), compile Sass to CSS, and [a few other things](https://github.com/Automattic/jetpack/blob/master/Gruntfile.js).
 


### PR DESCRIPTION
The previous URL was moved to this new one, and opening the old one resulted in a 404 error.