### PR TITLE
Subscriptions: make filter `jetpack_allow_per_post_subscriptions` usable from theme

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -90,20 +90,7 @@ class Jetpack_Subscriptions {
 		add_action( 'comment_post', array( $this, 'comment_subscribe_submit' ), 50, 2 );
 
 		// Adds post meta checkbox in the post submit metabox
-		if (
-			/**
-			 * Filter whether or not to show the per-post subscription option.
-			 *
-			 * @module subscriptions
-			 *
-			 * @since 3.7.0
-			 *
-			 * @param bool true = show checkbox option on all new posts | false = hide the option.
-			 */
-			apply_filters( 'jetpack_allow_per_post_subscriptions', false ) )
-		{
-			add_action( 'post_submitbox_misc_actions', array( $this, 'subscription_post_page_metabox' ) );
-		}
+		add_action( 'post_submitbox_misc_actions', array( $this, 'subscription_post_page_metabox' ) );
 
 		add_action( 'transition_post_status', array( $this, 'maybe_send_subscription_email' ), 10, 3 );
 	}
@@ -147,6 +134,21 @@ class Jetpack_Subscriptions {
 	 * Register post meta
 	 */
 	function subscription_post_page_metabox() {
+		if (
+			/**
+			 * Filter whether or not to show the per-post subscription option.
+			 *
+			 * @module subscriptions
+			 *
+			 * @since 3.7.0
+			 *
+			 * @param bool true = show checkbox option on all new posts | false = hide the option.
+			 */
+			 ! apply_filters( 'jetpack_allow_per_post_subscriptions', false ) )
+		{
+			return;
+		}
+
 		if ( has_filter( 'jetpack_subscriptions_exclude_these_categories' ) || has_filter( 'jetpack_subscriptions_include_only_these_categories' ) ) {
 			return;
 		}


### PR DESCRIPTION
This allows the `jetpack_allow_per_post_subscriptions` filter to be used in a theme's functions.php file as well.

to-test: add `add_filter( 'jetpack_allow_per_post_subscriptions', '__return_true' );` to your theme's functions.php.  You should see this when writing up a new post: https://cloudup.com/czXrr6ni5GX

fixes #2946 