### PR TITLE
User Agent detection: make sure jetpack_is_mobile doesn't exist.

### DIFF
--- a/class.jetpack-user-agent.php
+++ b/class.jetpack-user-agent.php
@@ -1,65 +1,67 @@
 <?php
 
-function jetpack_is_mobile( $kind = 'any', $return_matched_agent = false ) {
-	static $kinds = array( 'smart' => false, 'dumb' => false, 'any' => false );
-	static $first_run = true;
-	static $matched_agent = '';
+if ( ! function_exists( 'jetpack_is_mobile' ) ) {
+	function jetpack_is_mobile( $kind = 'any', $return_matched_agent = false ) {
+		static $kinds = array( 'smart' => false, 'dumb' => false, 'any' => false );
+		static $first_run = true;
+		static $matched_agent = '';
 
-	$ua_info = new Jetpack_User_Agent_Info();
+		$ua_info = new Jetpack_User_Agent_Info();
 
-	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) || strpos( strtolower( $_SERVER['HTTP_USER_AGENT'] ), 'ipad' ) )
-		return false;
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) || strpos( strtolower( $_SERVER['HTTP_USER_AGENT'] ), 'ipad' ) )
+			return false;
 
-	// Remove Samsung Galaxy tablets (SCH-I800) from being mobile devices
-	if ( strpos( strtolower( $_SERVER['HTTP_USER_AGENT'] ) , 'sch-i800') )
-		return false;
+		// Remove Samsung Galaxy tablets (SCH-I800) from being mobile devices
+		if ( strpos( strtolower( $_SERVER['HTTP_USER_AGENT'] ) , 'sch-i800') )
+			return false;
 
-	if( $ua_info->is_android_tablet() &&  $ua_info->is_kindle_touch() === false )
-		return false;
+		if( $ua_info->is_android_tablet() &&  $ua_info->is_kindle_touch() === false )
+			return false;
 
-	if( $ua_info->is_blackberry_tablet() )
-		return false;
+		if( $ua_info->is_blackberry_tablet() )
+			return false;
 
-	if ( $first_run ) {
-		$first_run = false;
+		if ( $first_run ) {
+			$first_run = false;
 
-		//checks for iPhoneTier devices & RichCSS devices
-		if ( $ua_info->isTierIphone() || $ua_info->isTierRichCSS() ) {
-			 $kinds['smart'] = true;
-		     $matched_agent = $ua_info->matched_agent;
-		}
+			//checks for iPhoneTier devices & RichCSS devices
+			if ( $ua_info->isTierIphone() || $ua_info->isTierRichCSS() ) {
+				 $kinds['smart'] = true;
+			     $matched_agent = $ua_info->matched_agent;
+			}
 
-		if ( !$kinds['smart'] ) {
-			// if smart, we are not dumb so no need to check
-			$dumb_agents = $ua_info->dumb_agents;
-			$agent = strtolower( $_SERVER['HTTP_USER_AGENT'] );
-			foreach ( $dumb_agents as $dumb_agent ) {
-				if ( false !== strpos( $agent, $dumb_agent ) ) {
-					$kinds['dumb'] = true;
-					$matched_agent = $dumb_agent;
-					break;
+			if ( !$kinds['smart'] ) {
+				// if smart, we are not dumb so no need to check
+				$dumb_agents = $ua_info->dumb_agents;
+				$agent = strtolower( $_SERVER['HTTP_USER_AGENT'] );
+				foreach ( $dumb_agents as $dumb_agent ) {
+					if ( false !== strpos( $agent, $dumb_agent ) ) {
+						$kinds['dumb'] = true;
+						$matched_agent = $dumb_agent;
+						break;
+					}
+				}
+
+				if ( !$kinds['dumb'] ) {
+					if ( isset( $_SERVER['HTTP_X_WAP_PROFILE'] ) ) {
+						$kinds['dumb'] = true;
+						$matched_agent = 'http_x_wap_profile';
+					} elseif ( isset( $_SERVER['HTTP_ACCEPT']) && ( preg_match( '/wap\.|\.wap/i', $_SERVER['HTTP_ACCEPT'] ) || false !== strpos( strtolower( $_SERVER['HTTP_ACCEPT'] ), 'application/vnd.wap.xhtml+xml' ) ) ) {
+						$kinds['dumb'] = true;
+						$matched_agent = 'vnd.wap.xhtml+xml';
+					}
 				}
 			}
 
-			if ( !$kinds['dumb'] ) {
-				if ( isset( $_SERVER['HTTP_X_WAP_PROFILE'] ) ) {
-					$kinds['dumb'] = true;
-					$matched_agent = 'http_x_wap_profile';
-				} elseif ( isset( $_SERVER['HTTP_ACCEPT']) && ( preg_match( '/wap\.|\.wap/i', $_SERVER['HTTP_ACCEPT'] ) || false !== strpos( strtolower( $_SERVER['HTTP_ACCEPT'] ), 'application/vnd.wap.xhtml+xml' ) ) ) {
-					$kinds['dumb'] = true;
-					$matched_agent = 'vnd.wap.xhtml+xml';
-				}
-			}
+			if ( $kinds['dumb'] || $kinds['smart'] )
+				$kinds['any'] = true;
 		}
 
-		if ( $kinds['dumb'] || $kinds['smart'] )
-			$kinds['any'] = true;
+		if ( $return_matched_agent )
+			return $matched_agent;
+
+		return $kinds[$kind];
 	}
-
-	if ( $return_matched_agent )
-		return $matched_agent;
-
-	return $kinds[$kind];
 }
 
 class Jetpack_User_Agent_Info {


### PR DESCRIPTION
This should avoid issues like the one described here:
https://wordpress.org/support/topic/jetpack-fatal-error-cannot-redeclare-jetpack_is_mobile-1