### PR TITLE
REST API: adjust permissions needed for adding a taxonomy term to a post

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -177,7 +177,11 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 					}
 					// only add a new tag/cat if the user has access to
 					$tax = get_taxonomy( $taxonomy );
-					if ( !current_user_can( $tax->cap->edit_terms ) ) {
+
+					// see https://core.trac.wordpress.org/ticket/26409
+					if ( 'category' === $taxonomy && ! current_user_can( $tax->cap->edit_terms ) ) {
+						continue;
+					} else if ( ! current_user_can( $tax->cap->assign_terms ) ) {
 						continue;
 					}
 

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -182,7 +182,11 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 					}
 					// only add a new tag/cat if the user has access to
 					$tax = get_taxonomy( $taxonomy );
-					if ( !current_user_can( $tax->cap->edit_terms ) ) {
+
+					// see https://core.trac.wordpress.org/ticket/26409
+					if ( 'category' === $taxonomy && ! current_user_can( $tax->cap->edit_terms ) ) {
+						continue;
+					} else if ( ! current_user_can( $tax->cap->assign_terms ) ) {
 						continue;
 					}
 

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -147,7 +147,11 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				if ( ! $term_info ) {
 					// only add a new tag/cat if the user has access to
 					$tax = get_taxonomy( $taxonomy );
-					if ( ! current_user_can( $tax->cap->edit_terms ) ) {
+
+					// see https://core.trac.wordpress.org/ticket/26409
+					if ( 'category' === $taxonomy && ! current_user_can( $tax->cap->edit_terms ) ) {
+						continue;
+					} else if ( ! current_user_can( $tax->cap->assign_terms ) ) {
 						continue;
 					}
 


### PR DESCRIPTION
This patch seeks to adjust the permission required for adding a tag to a post in the `/sites/post/new` and `/sites/post/$post` endpoints of all versions (1, 1.1, 1.2) of the REST API. The permission was previously set to `edit_terms` but it should be assign_terms in order to be consistent with wp-admin which uses `assign_terms`.

This patch is a merge from WP.com -- see r126453-wpcom