### PR TITLE
Add Twenty Sixteen Compat Files

### DIFF
--- a/modules/infinite-scroll/themes/twentysixteen-rtl.css
+++ b/modules/infinite-scroll/themes/twentysixteen-rtl.css
@@ -1,0 +1,161 @@
+.infinite-scroll .pagination {
+	display: none;
+}
+
+.infinite-wrap > article:before,
+.infinite-wrap > article:after {
+	content: "";
+	display: table;
+}
+
+.infinite-wrap > article:after {
+	clear: both;
+}
+
+.infinite-wrap > article {
+	margin-bottom: 3.5em;
+}
+
+/* Spinner */
+.site-main .infinite-loader {
+	clear: both;
+	color: currentColor;
+	height: 42px;
+	margin-bottom: 3.5em;
+}
+
+.infinite-loader .spinner {
+	right: 50% !important;
+	top: 50% !important;
+}
+
+/* Click-to-load */
+#infinite-handle {
+	clear: both;
+	margin-right: 7.6923%;
+	margin-left: 7.6923%;
+	text-align: center;
+}
+
+.site-main #infinite-handle span {
+	background: #1a1a1a;
+	border-radius: 2px;
+	color: #fff;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	font-size: inherit;
+	font-weight: 700;
+	letter-spacing: 0.046875em;
+	line-height: 1;
+	padding: 0.84375em 0.875em 0.78125em;
+	text-transform: uppercase;
+}
+
+#infinite-handle span:hover,
+#infinite-handle span:focus {
+	background: #007acc;
+}
+
+#infinite-handle button:focus {
+	outline-offset: 0.375em;
+}
+
+/* Footer */
+body #infinite-footer {
+	display: none;
+	z-index: 999;
+}
+
+body #infinite-footer .container {
+	background-color: #fff;
+	background-color: rgba(255, 255, 255, 0.8);
+	border-color: #d1d1d1;
+	padding: 0 7.6923%;
+	width: 100% !important;
+}
+
+body #infinite-footer .blog-info {
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	height: 2.1875em;
+	line-height: 2.1875em;
+}
+
+body #infinite-footer .blog-info a {
+	color: #1a1a1a;
+	font-size: inherit
+}
+
+body #infinite-footer .blog-credits {
+	font-size: 13px;
+	font-size: 0.8125rem;
+	height: 2.692307692em;
+	line-height: 2.692307692em;
+}
+
+body #infinite-footer .blog-credits,
+body #infinite-footer .blog-credits a {
+	color: #686868;
+}
+
+body #infinite-footer .blog-info a:hover,
+body #infinite-footer .blog-info a:focus,
+body #infinite-footer .blog-credits a:hover,
+body #infinite-footer .blog-credits a:focus {
+	color: #007acc;
+	text-decoration: none;
+}
+
+@media screen and (min-width: 44.375em) {
+	.infinite-wrap > article,
+	.site-main .infinite-loader {
+		margin-bottom: 5.25em;
+	}
+
+	.infinite-loader .spinner {
+		right: 7.6923% !important;
+		margin-right: 12px;
+	}
+
+	#infinite-handle {
+		text-align: right;
+	}
+
+	.site-main #infinite-handle span {
+		display: inline-block;
+	}
+
+	body #infinite-footer .container {
+		padding: 0 0.761904762em;
+		width: -webkit-calc(100% - 42px) !important;
+		width: calc(100% - 42px) !important;
+	}
+
+	body:not(.custom-background-image) #infinite-footer {
+		bottom: 21px !important;
+	}
+}
+
+@media screen and (min-width: 56.875em) {
+	.infinite-loader .spinner {
+		right: 0 !important;
+	}
+
+	#infinite-handle {
+		margin: 0;
+	}
+
+	.no-sidebar .infinite-loader .spinner {
+		right: 50% !important;
+		margin: 0;
+	}
+
+	.no-sidebar #infinite-handle {
+		text-align: center;
+	}
+}
+
+@media screen and (min-width: 61.5625em) {
+	.infinite-wrap > article,
+	.site-main .infinite-loader {
+		margin-bottom: 7.0em;
+	}
+}

--- a/modules/infinite-scroll/themes/twentysixteen.css
+++ b/modules/infinite-scroll/themes/twentysixteen.css
@@ -1,0 +1,161 @@
+.infinite-scroll .pagination {
+	display: none;
+}
+
+.infinite-wrap > article:before,
+.infinite-wrap > article:after {
+	content: "";
+	display: table;
+}
+
+.infinite-wrap > article:after {
+	clear: both;
+}
+
+.infinite-wrap > article {
+	margin-bottom: 3.5em;
+}
+
+/* Spinner */
+.site-main .infinite-loader {
+	clear: both;
+	color: currentColor;
+	height: 42px;
+	margin-bottom: 3.5em;
+}
+
+.infinite-loader .spinner {
+	left: 50% !important;
+	top: 50% !important;
+}
+
+/* Click-to-load */
+#infinite-handle {
+	clear: both;
+	margin-right: 7.6923%;
+	margin-left: 7.6923%;
+	text-align: center;
+}
+
+.site-main #infinite-handle span {
+	background: #1a1a1a;
+	border-radius: 2px;
+	color: #fff;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	font-size: inherit;
+	font-weight: 700;
+	letter-spacing: 0.046875em;
+	line-height: 1;
+	padding: 0.84375em 0.875em 0.78125em;
+	text-transform: uppercase;
+}
+
+#infinite-handle span:hover,
+#infinite-handle span:focus {
+	background: #007acc;
+}
+
+#infinite-handle button:focus {
+	outline-offset: 0.375em;
+}
+
+/* Footer */
+body #infinite-footer {
+	display: none;
+	z-index: 999;
+}
+
+body #infinite-footer .container {
+	background-color: #fff;
+	background-color: rgba(255, 255, 255, 0.8);
+	border-color: #d1d1d1;
+	padding: 0 7.6923%;
+	width: 100% !important;
+}
+
+body #infinite-footer .blog-info {
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	height: 2.1875em;
+	line-height: 2.1875em;
+}
+
+body #infinite-footer .blog-info a {
+	color: #1a1a1a;
+	font-size: inherit
+}
+
+body #infinite-footer .blog-credits {
+	font-size: 13px;
+	font-size: 0.8125rem;
+	height: 2.692307692em;
+	line-height: 2.692307692em;
+}
+
+body #infinite-footer .blog-credits,
+body #infinite-footer .blog-credits a {
+	color: #686868;
+}
+
+body #infinite-footer .blog-info a:hover,
+body #infinite-footer .blog-info a:focus,
+body #infinite-footer .blog-credits a:hover,
+body #infinite-footer .blog-credits a:focus {
+	color: #007acc;
+	text-decoration: none;
+}
+
+@media screen and (min-width: 44.375em) {
+	.infinite-wrap > article,
+	.site-main .infinite-loader {
+		margin-bottom: 5.25em;
+	}
+
+	.infinite-loader .spinner {
+		left: 7.6923% !important;
+		margin-left: 12px;
+	}
+
+	#infinite-handle {
+		text-align: left;
+	}
+
+	.site-main #infinite-handle span {
+		display: inline-block;
+	}
+
+	body #infinite-footer .container {
+		padding: 0 0.761904762em;
+		width: -webkit-calc(100% - 42px) !important;
+		width: calc(100% - 42px) !important;
+	}
+
+	body:not(.custom-background-image) #infinite-footer {
+		bottom: 21px !important;
+	}
+}
+
+@media screen and (min-width: 56.875em) {
+	.infinite-loader .spinner {
+		left: 0 !important;
+	}
+
+	#infinite-handle {
+		margin: 0;
+	}
+
+	.no-sidebar .infinite-loader .spinner {
+		left: 50% !important;
+		margin: 0;
+	}
+
+	.no-sidebar #infinite-handle {
+		text-align: center;
+	}
+}
+
+@media screen and (min-width: 61.5625em) {
+	.infinite-wrap > article,
+	.site-main .infinite-loader {
+		margin-bottom: 7.0em;
+	}
+}

--- a/modules/infinite-scroll/themes/twentysixteen.php
+++ b/modules/infinite-scroll/themes/twentysixteen.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Infinite Scroll Theme Assets
+ *
+ * Register support for Twenty Sixteen.
+ */
+
+/**
+ * Add theme support for infinite scroll
+ */
+function twentysixteen_infinite_scroll_init() {
+	add_theme_support( 'infinite-scroll', array(
+		'container' => 'main',
+		'render'    => 'twentysixteen_infinite_scroll_render',
+		'footer'    => 'content',
+	) );
+}
+add_action( 'after_setup_theme', 'twentysixteen_infinite_scroll_init' );
+
+/**
+ * Custom render function for Infinite Scroll.
+ */
+function twentysixteen_infinite_scroll_render() {
+	while ( have_posts() ) {
+		the_post();
+		if ( is_search() ) {
+			get_template_part( 'template-parts/content', 'search' );
+		} else {
+			get_template_part( 'template-parts/content', get_post_format() );
+		}
+	}
+}
+
+/**
+ * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
+ */
+function twentysixteen_infinite_scroll_enqueue_styles() {
+	wp_enqueue_style( 'infinity-twentysixteen', plugins_url( 'twentysixteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20151102' );
+	wp_style_add_data( 'infinity-twentysixteen', 'rtl', 'replace' );
+}
+add_action( 'wp_enqueue_scripts', 'twentysixteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/theme-tools.php
+++ b/modules/theme-tools.php
@@ -37,6 +37,7 @@ function jetpack_load_theme_compat() {
 	$compat_files = apply_filters( 'jetpack_theme_compat_files', array(
 		'twentyfourteen' => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfourteen.php',
 		'twentyfifteen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfifteen.php',
+		'twentysixteen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentysixteen.php',
 	) );
 
 	_jetpack_require_compat_file( get_stylesheet(), $compat_files );

--- a/modules/theme-tools/compat/twentysixteen-rtl.css
+++ b/modules/theme-tools/compat/twentysixteen-rtl.css
@@ -1,0 +1,723 @@
+/**
+ * Jetpack Comments
+ */
+
+.comment-form iframe {
+	margin: 0;
+}
+
+
+/**
+ * Extra Widgets
+ */
+
+ /* Blog Subscriptions Widget */
+.jetpack_subscription_widget #subscribe-email input {
+	padding: 0.625em 0.4375em;
+	width: 100%;
+}
+
+.jetpack_subscription_widget form > :last-child {
+	margin-bottom: 0;
+}
+
+ /* Contact Info Widget */
+.widget_contact_info .contact-map {
+	margin-bottom: 1.75em;
+}
+
+/* Display WordPress Posts Widget */
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts {
+	margin: 0;
+}
+
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts h4 {
+	font-size: inherit;
+	margin: 0 0 0.875em;
+}
+
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts img {
+	margin-bottom: 0.875em;
+}
+
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts p {
+	font-size: inherit;
+	line-height: 1.75 !important;
+	margin: 0 0 1.75em !important;
+}
+
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts > :last-child {
+	margin-bottom: 0 !important;
+}
+
+/* Gallery Widget */
+.widget-gallery .slideshow-window {
+	border-radius: 0;
+}
+
+/* Goodreads Widget */
+.widget_goodreads div[class^="gr_custom_container"] {
+	background-color: transparent;
+	border: 0;
+	border-radius: 0;
+	color: inherit;
+	padding: 0;
+}
+
+.widget_goodreads div[class^="gr_custom_container"] a {
+	color: inherit;
+}
+
+.widget_goodreads div[class^="gr_custom_each_container"] {
+	border: 0;
+	margin-bottom: 1.75em;
+	padding-bottom: 0;
+}
+
+.widget_goodreads h2[class^="gr_custom_header"],
+.widget_goodreads div[class^="gr_custom_author"] {
+	font-size: inherit;
+}
+
+/* Gravatar Profile Widget */
+.widget-grofile .grofile-thumbnail {
+	width: 300px;
+}
+
+.widget-area .widget-grofile h4 {
+	font-size: inherit;
+	font-weight: 900;
+	margin: 1.75em 0 0;
+}
+
+.widget-area .widget-grofile .grofile-accounts {
+	margin-top: 0.4375em;
+}
+
+/* Image Widget */
+.widget_image .wp-caption {
+	margin-bottom: 0;
+}
+
+/* RSS Links Widget */
+.widget_rss_links img {
+	position: relative;
+	top: -1px;
+}
+
+/* Social Media Icon Widget */
+.widget.widget_wpcom_social_media_icons_widget ul {
+	margin: 0 0 -0.4375em;
+}
+
+.widget.widget_wpcom_social_media_icons_widget ul:before,
+.widget.widget_wpcom_social_media_icons_widget ul:after {
+	content: "";
+	display: table;
+}
+
+.widget.widget_wpcom_social_media_icons_widget ul:after {
+	clear: both;
+}
+
+.widget.widget_wpcom_social_media_icons_widget li {
+	float: right;
+	margin: 0 0 0.4375em 0.4375em;
+}
+
+.widget.widget_wpcom_social_media_icons_widget li a {
+	border: 1px solid currentColor;
+	border-radius: 50%;
+	color: inherit;
+	display: block;
+	height: 35px;
+	position: relative;
+	width: 35px;
+}
+
+.widget.widget_wpcom_social_media_icons_widget li a:before {
+	height: 33px;
+	line-height: 33px;
+	text-align: center;
+	width: 33px;
+}
+
+.widget.widget_wpcom_social_media_icons_widget li a:hover:before,
+.widget.widget_wpcom_social_media_icons_widget li a:focus:before {
+	opacity: 0.8;
+}
+
+/* Top Posts & Pages Widget */
+.widget_top-posts .widgets-list-layout .widgets-list-layout-blavatar {
+	border-radius: 50%;
+	margin-left: 0.4375em;
+	max-width: 2.625em;
+}
+
+.widget_top-posts .widgets-list-layout-links {
+	width: auto;
+	float: right;
+	padding-top: 0.4375em;
+}
+
+.widget_top-posts .widgets-list-layout li {
+	margin-bottom: 0.4375em;
+}
+
+.widget_top-posts .widgets-list-layout li:last-child {
+	margin-bottom: 0;
+}
+
+.widget_top-posts .widgets-grid-layout img {
+	border-radius: 50%;
+}
+
+.widget-grid-view-image:nth-child(odd) {
+	clear: both;
+}
+
+/* Upcoming Events Widget */
+.widget_upcoming_events_widget .upcoming-events li {
+	margin-bottom: 0.875em
+}
+
+
+/**
+ * Shortcodes
+ */
+
+/* Contact Form */
+.entry-content .contact-form label {
+	color: inherit;
+	display: block;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	font-size: 0.8125rem;
+	font-weight: 400;
+	letter-spacing: 0.076923077em;
+	line-height: 1.6153846154;
+	margin-bottom: 0.5384615385em;
+	text-transform: uppercase;
+}
+
+.entry-content .contact-form label span {
+	color: inherit;
+	letter-spacing: 0;
+	opacity: 0.7;
+	text-transform: capitalize;
+}
+
+.entry-content .contact-form input[type="text"],
+.entry-content .contact-form input[type="email"],
+.entry-content .contact-form textarea {
+	margin-bottom: 1.75em;
+	max-width: 100%;
+	width: 100%;
+}
+
+.entry-content .contact-form label.checkbox,
+.entry-content .contact-form label.radio {
+	font-family: inherit;
+	font-size: inherit;
+	letter-spacing: 0;
+	margin-bottom: 0;
+	text-transform: none;
+}
+
+.entry-content .contact-form label.checkbox:nth-last-child(2),
+.entry-content .contact-form label.radio:nth-last-child(2) {
+	margin-bottom: 0.875em;
+}
+
+.entry-content .contact-form input[type="radio"],
+.entry-content .contact-form input[type="checkbox"] {
+	margin-bottom: 0.875em;
+}
+
+.entry-content .contact-form select {
+	margin-bottom: 1.75em;
+}
+
+/* Facebook */
+.fb_iframe_widget {
+	margin-bottom: 1.75em;
+	max-width: 100%;
+}
+
+.fb_iframe_widget span {
+	max-width: 100%;
+}
+
+/* Gist */
+.gist table {
+	table-layout: auto;
+}
+
+.entry-content .gist .gist-file {
+	margin-bottom: 1.75em;
+}
+
+/* Instagram */
+.instagram-media {
+	margin-bottom: 1.75em !important;
+}
+
+/* Mixclound */
+iframe[src^="http://api.mixcloud.com/"] {
+	margin-right: -8px;
+	max-width: -webkit-calc(100% + 8px);
+	max-width: calc(100% + 8px);
+}
+
+/* Polldaddy */
+.PDS_Poll {
+	display: block !important;
+	margin-bottom: 1.75em;
+}
+
+.PDS_Poll .pds-box {
+	max-width: 100%;
+	width: auto;
+}
+
+/* Portfolio */
+.entry-content .portfolio-entry {
+	margin-bottom: 1.75em;
+}
+
+.entry-content .portfolio-entry-title,
+.entry-content .portfolio-entry-meta {
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+}
+
+.entry-content .portfolio-entry-title a,
+.entry-content .portfolio-entry-meta a {
+	box-shadow: none;
+}
+
+.entry-content .portfolio-entry-title a:hover,
+.entry-content .portfolio-entry-meta a:hover {
+	box-shadow: 0 1px 0 0 currentColor;
+}
+
+.entry-content .portfolio-entry-meta span,
+.entry-content .portfolio-entry-meta a {
+	font-size: 1em;
+}
+
+.entry-content .portfolio-entry-title {
+	font-size: inherit;
+	line-height: 1.3125;
+}
+
+.entry-content .portfolio-featured-image + .portfolio-entry-title {
+	margin-top: 0.875em;
+	margin-bottom: 0.4375em;
+}
+
+.entry-content .portfolio-entry-meta,
+.entry-content .portfolio-entry-content p {
+	font-size: 13px;
+	font-size: 0.8125em;
+	line-height: 1.615384615;
+}
+
+.entry-content .portfolio-entry-content p:last-child {
+	margin-bottom: 0;
+}
+
+.entry-content .portfolio-entry-title + .portfolio-entry-meta {
+	margin-top: 0.538461538em;
+}
+
+.entry-content .portfolio-entry-content {
+	margin-top: 0.875em;
+}
+
+.entry-content .portfolio-entry-content p {
+	margin-bottom: 1.615384615em;
+}
+
+/* Presentation */
+.entry-content .presentation-wrapper {
+	margin: 0 0 1.75em;
+	max-width: 100%;
+}
+
+.presentation {
+	max-width: 100%;
+}
+
+/* Recipes */
+.entry-content .jetpack-recipe {
+	border: 0;
+	margin: 0 0 1.75em;
+	padding: 0;
+}
+
+.entry-content .jetpack-recipe-title {
+	border: 0;
+	margin-top: 0;
+	padding: 0;
+}
+
+.entry-content .jetpack-recipe .jetpack-recipe-meta {
+	font-size: inherit;
+	margin: 0;
+}
+
+/* Scribd */
+.scribd_iframe_embed + div {
+	margin-bottom: 28px;
+}
+
+/* Slideshow */
+.entry-content .slideshow-window {
+	border-radius: 0;
+	margin-bottom: 1.75em;
+}
+
+/* Subscription Form */
+.entry-content .jetpack_subscription_widget {
+	border-top: 0;
+	font-size: inherit;
+	margin-bottom: 1.75em;
+	padding: 0;
+}
+
+.entry-content #subscribe-email input {
+	font-size: inherit;
+	line-height: normal;
+	padding: 0.625em 0.4375em;
+	width: 100%;
+}
+
+.entry-content .jetpack_subscription_widget input[type="submit"] {
+	font-size: inherit;
+	padding: 0.84375em 0.875em 0.78125em;
+}
+
+/* Testimonial */
+.entry-content .testimonial-entry {
+	margin-bottom: 1.75em;
+}
+
+.entry-content .testimonial-entry-content {
+	margin: 0;
+}
+
+.entry-content .testimonial-entry-title,
+.entry-content .testimonial-entry-content p {
+	font-size: 13px;
+	font-size: 0.8125em;
+	line-height: 1.615384615;
+	margin: 0;
+}
+
+.entry-content .testimonial-entry-content p {
+	margin-bottom: 1.615384615em;
+}
+
+.entry-content .testimonial-entry-title {
+	float: right;
+}
+
+.entry-content .testimonial-entry-title a {
+	box-shadow: none;
+}
+
+.entry-content .testimonial-entry-title a:hover {
+	box-shadow: 0 1px 0 0 currentColor;
+}
+
+.entry-content .testimonial-featured-image img {
+	float: left;
+	max-width: 42px;
+}
+
+/* Twitter-timeline */
+.entry-content iframe[id*="twitter-widget-"] {
+	margin-bottom: 1.75em !important;
+}
+
+
+/**
+ * Responsive Videos
+ */
+.hentry .jetpack-video-wrapper {
+	margin-bottom: 1.75em;
+}
+
+
+/**
+ * Related Posts
+ */
+
+.entry-content #jp-relatedposts {
+	margin: 0;
+	padding-top: 0.875em;
+	position: relative;
+}
+
+.entry-content #jp-relatedposts:before {
+	background-color: currentColor;
+	content: "";
+	height: 1px;
+	opacity: 0.2;
+	position: absolute;
+	top: 0;
+	width: 100%;
+}
+
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline {
+	color: inherit;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	font-size: 0.8125rem;
+	font-weight: 400;
+	line-height: 1;
+	margin-bottom: 1.076923077em;
+}
+
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline em:before {
+	display: none;
+}
+
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline em {
+	font-weight: 400;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-headline em:after {
+	content: ":";
+}
+
+.entry-content .jp-relatedposts-post-aoverlay,
+.entry-content .jp-relatedposts-post-a {
+	box-shadow: none;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
+	margin-bottom: 1.75em;
+	width: 100%;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post span {
+	max-width: 100%;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items p,
+.entry-content #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
+	font-size: 13px;
+	font-size: 0.8125rem;
+	letter-spacing: 0;
+	line-height: 1.615384615;
+}
+
+.jp-relatedposts-post-date,
+.jp-relatedposts-post-context {
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+}
+
+.jp-relatedposts-post-title,
+#jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post-excerpt,
+.entry-content #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
+	margin-bottom: 1.076923077em;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-title a {
+	font-weight: 700;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-title a:hover,
+.entry-content .jp-relatedposts-post-aoverlay:hover + .jp-relatedposts-post-title .jp-relatedposts-post-a {
+	box-shadow: 0 1px 0 0 currentColor;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-title a:hover,
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post:hover .jp-relatedposts-post-title a {
+	text-decoration: none;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date,
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
+.entry-content #jp-relatedposts .jp-relatedposts-items-visual .jp-relatedposts-post {
+	opacity: 1;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items-visual .jp-relatedposts-post {
+	padding-left: 0;
+}
+
+.entry-content .jp-relatedposts-post-a:hover img.jp-relatedposts-post-img,
+.entry-content .jp-relatedposts-post-a:focus img.jp-relatedposts-post-img {
+	opacity: 0.85;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post img.jp-relatedposts-post-img {
+	margin-bottom: 0.875em;
+	max-width: 100%;
+}
+
+
+/**
+ * Sharing
+ */
+
+.sharedaddy {
+	padding: 0.875em 0;
+	position: relative;
+}
+
+.sharedaddy:before {
+	background-color: currentColor;
+	content: "";
+	height: 1px;
+	opacity: 0.2;
+	position: absolute;
+	top: 0;
+	width: 100%;
+}
+
+.sharedaddy:last-child {
+	padding-bottom: 0 !important;
+}
+
+.sd-block {
+	line-height: 1;
+}
+
+.sd-like {
+	padding-bottom: 0.25em;
+}
+
+.hentry div.sharedaddy h3.sd-title,
+.hentry h3.sd-title {
+	color: inherit;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	font-size: 0.8125rem;
+	font-weight: 400;
+	line-height: 1;
+	margin-bottom: 1.076923077em;
+}
+
+.hentry div.sharedaddy h3.sd-title:before {
+	display: none;
+}
+
+.sd-social-icon-text .sd-content ul,
+.sd-social-text .sd-content ul {
+	margin-bottom: -0.3125em !important;
+}
+
+.sd-social-icon .sd-content ul {
+	margin-bottom: 0 !important;
+}
+
+.sd-social-official .sd-content ul {
+	margin-bottom: -0.625em !important;
+}
+
+.hentry #sharing_email .sharing_send,
+.hentry .sd-content ul li .option a.share-ustom,
+.hentry .sd-content ul li a.sd-button,
+.hentry .sd-content ul li.advanced a.share-more,
+.hentry .sd-content ul li.preview-item div.option.option-smart-off a,
+.hentry .sd-social-icon .sd-content ul li a.sd-button,
+.hentry .sd-social-icon-text .sd-content ul li a.sd-button,
+.hentry .sd-social-official .sd-content > ul > li .digg_button > a,
+.hentry .sd-social-official .sd-content > ul > li > a.sd-button,
+.hentry .sd-social-text .sd-content ul li a.sd-button {
+	box-shadow: none;
+}
+
+
+/**
+ * Stats
+ */
+
+#wpstats {
+	display: none;
+}
+
+
+/**
+ * Tiled gallery
+ */
+
+.entry-content .tiled-gallery {
+	margin-bottom: 1.75em;
+}
+
+
+/**
+ * Media Queries
+ */
+
+@media screen and (min-width: 56.875em) {
+	.widget-area .jetpack_subscription_widget #subscribe-email input {
+		padding: 0.4615384615em 0.5384615385em;
+	}
+
+	.widget_contact_info .contact-map {
+		margin-bottom: 1.615384615em;
+	}
+
+	.widget_jetpack_display_posts_widget .jetpack-display-remote-posts h4,
+	.widget_jetpack_display_posts_widget .jetpack-display-remote-posts img {
+		margin-bottom: 1.076923077em;
+	}
+
+	.widget_jetpack_display_posts_widget .jetpack-display-remote-posts p {
+		line-height: 1.615384615em !important;
+		margin: 0 0 1.615384615em !important;
+	}
+
+	.widget_goodreads div[class^="gr_custom_each_container"] {
+		margin-bottom: 1.615384615em;
+	}
+
+	.widget-area .widget-grofile h4 {
+		margin: 1.615384615em 0 0;
+	}
+
+	.widget-area .widget-grofile .grofile-accounts {
+		margin-top: 0.538461538em;
+	}
+
+	.widget.widget_wpcom_social_media_icons_widget ul {
+		margin: 0 0 -0.538461538em;
+	}
+
+	.widget.widget_wpcom_social_media_icons_widget li {
+		margin: 0 0 0.538461538em 0.538461538em;
+	}
+
+	.widget_top-posts .widgets-list-layout .widgets-list-layout-blavatar {
+		margin-left: 0.538461538em;
+		max-width: 3.230769231em;
+	}
+
+	.widget_top-posts .widgets-list-layout-links {
+		padding-top: 0.807692308em;
+	}
+
+	.widget_top-posts .widgets-list-layout li {
+		margin-bottom: 0.538461538em;
+	}
+
+	.widget_upcoming_events_widget .upcoming-events li {
+		margin-bottom: 1.076923077em
+	}
+
+	.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
+		padding-left: 0.875em;
+		width: 33%;
+	}
+}
+
+@media screen and (min-width: 61.5625em) {
+	.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
+		margin-bottom: 0;
+	}
+}

--- a/modules/theme-tools/compat/twentysixteen-rtl.css
+++ b/modules/theme-tools/compat/twentysixteen-rtl.css
@@ -6,6 +6,21 @@
 	margin: 0;
 }
 
+.comment-form .subscribe-label {
+	font-family: Merriweather, Georgia, serif;
+	font-weight: 400;
+	letter-spacing: 0;
+	text-transform: none;
+}
+
+.comment-subscription-form {
+	margin: 1.75em 0 0;
+}
+
+.comment-subscription-form + .comment-subscription-form  {
+	margin-top: 0.875em;
+}
+
 
 /**
  * Extra Widgets

--- a/modules/theme-tools/compat/twentysixteen.css
+++ b/modules/theme-tools/compat/twentysixteen.css
@@ -1,0 +1,723 @@
+/**
+ * Jetpack Comments
+ */
+
+.comment-form iframe {
+	margin: 0;
+}
+
+
+/**
+ * Extra Widgets
+ */
+
+ /* Blog Subscriptions Widget */
+.jetpack_subscription_widget #subscribe-email input {
+	padding: 0.625em 0.4375em;
+	width: 100%;
+}
+
+.jetpack_subscription_widget form > :last-child {
+	margin-bottom: 0;
+}
+
+ /* Contact Info Widget */
+.widget_contact_info .contact-map {
+	margin-bottom: 1.75em;
+}
+
+/* Display WordPress Posts Widget */
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts {
+	margin: 0;
+}
+
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts h4 {
+	font-size: inherit;
+	margin: 0 0 0.875em;
+}
+
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts img {
+	margin-bottom: 0.875em;
+}
+
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts p {
+	font-size: inherit;
+	line-height: 1.75 !important;
+	margin: 0 0 1.75em !important;
+}
+
+.widget_jetpack_display_posts_widget .jetpack-display-remote-posts > :last-child {
+	margin-bottom: 0 !important;
+}
+
+/* Gallery Widget */
+.widget-gallery .slideshow-window {
+	border-radius: 0;
+}
+
+/* Goodreads Widget */
+.widget_goodreads div[class^="gr_custom_container"] {
+	background-color: transparent;
+	border: 0;
+	border-radius: 0;
+	color: inherit;
+	padding: 0;
+}
+
+.widget_goodreads div[class^="gr_custom_container"] a {
+	color: inherit;
+}
+
+.widget_goodreads div[class^="gr_custom_each_container"] {
+	border: 0;
+	margin-bottom: 1.75em;
+	padding-bottom: 0;
+}
+
+.widget_goodreads h2[class^="gr_custom_header"],
+.widget_goodreads div[class^="gr_custom_author"] {
+	font-size: inherit;
+}
+
+/* Gravatar Profile Widget */
+.widget-grofile .grofile-thumbnail {
+	width: 300px;
+}
+
+.widget-area .widget-grofile h4 {
+	font-size: inherit;
+	font-weight: 900;
+	margin: 1.75em 0 0;
+}
+
+.widget-area .widget-grofile .grofile-accounts {
+	margin-top: 0.4375em;
+}
+
+/* Image Widget */
+.widget_image .wp-caption {
+	margin-bottom: 0;
+}
+
+/* RSS Links Widget */
+.widget_rss_links img {
+	position: relative;
+	top: -1px;
+}
+
+/* Social Media Icon Widget */
+.widget.widget_wpcom_social_media_icons_widget ul {
+	margin: 0 0 -0.4375em;
+}
+
+.widget.widget_wpcom_social_media_icons_widget ul:before,
+.widget.widget_wpcom_social_media_icons_widget ul:after {
+	content: "";
+	display: table;
+}
+
+.widget.widget_wpcom_social_media_icons_widget ul:after {
+	clear: both;
+}
+
+.widget.widget_wpcom_social_media_icons_widget li {
+	float: left;
+	margin: 0 0.4375em 0.4375em 0;
+}
+
+.widget.widget_wpcom_social_media_icons_widget li a {
+	border: 1px solid currentColor;
+	border-radius: 50%;
+	color: inherit;
+	display: block;
+	height: 35px;
+	position: relative;
+	width: 35px;
+}
+
+.widget.widget_wpcom_social_media_icons_widget li a:before {
+	height: 33px;
+	line-height: 33px;
+	text-align: center;
+	width: 33px;
+}
+
+.widget.widget_wpcom_social_media_icons_widget li a:hover:before,
+.widget.widget_wpcom_social_media_icons_widget li a:focus:before {
+	opacity: 0.8;
+}
+
+/* Top Posts & Pages Widget */
+.widget_top-posts .widgets-list-layout .widgets-list-layout-blavatar {
+	border-radius: 50%;
+	margin-right: 0.4375em;
+	max-width: 2.625em;
+}
+
+.widget_top-posts .widgets-list-layout-links {
+	width: auto;
+	float: left;
+	padding-top: 0.4375em;
+}
+
+.widget_top-posts .widgets-list-layout li {
+	margin-bottom: 0.4375em;
+}
+
+.widget_top-posts .widgets-list-layout li:last-child {
+	margin-bottom: 0;
+}
+
+.widget_top-posts .widgets-grid-layout img {
+	border-radius: 50%;
+}
+
+.widget-grid-view-image:nth-child(odd) {
+	clear: both;
+}
+
+/* Upcoming Events Widget */
+.widget_upcoming_events_widget .upcoming-events li {
+	margin-bottom: 0.875em
+}
+
+
+/**
+ * Shortcodes
+ */
+
+/* Contact Form */
+.entry-content .contact-form label {
+	color: inherit;
+	display: block;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	font-size: 0.8125rem;
+	font-weight: 400;
+	letter-spacing: 0.076923077em;
+	line-height: 1.6153846154;
+	margin-bottom: 0.5384615385em;
+	text-transform: uppercase;
+}
+
+.entry-content .contact-form label span {
+	color: inherit;
+	letter-spacing: 0;
+	opacity: 0.7;
+	text-transform: capitalize;
+}
+
+.entry-content .contact-form input[type="text"],
+.entry-content .contact-form input[type="email"],
+.entry-content .contact-form textarea {
+	margin-bottom: 1.75em;
+	max-width: 100%;
+	width: 100%;
+}
+
+.entry-content .contact-form label.checkbox,
+.entry-content .contact-form label.radio {
+	font-family: inherit;
+	font-size: inherit;
+	letter-spacing: 0;
+	margin-bottom: 0;
+	text-transform: none;
+}
+
+.entry-content .contact-form label.checkbox:nth-last-child(2),
+.entry-content .contact-form label.radio:nth-last-child(2) {
+	margin-bottom: 0.875em;
+}
+
+.entry-content .contact-form input[type="radio"],
+.entry-content .contact-form input[type="checkbox"] {
+	margin-bottom: 0.875em;
+}
+
+.entry-content .contact-form select {
+	margin-bottom: 1.75em;
+}
+
+/* Facebook */
+.fb_iframe_widget {
+	margin-bottom: 1.75em;
+	max-width: 100%;
+}
+
+.fb_iframe_widget span {
+	max-width: 100%;
+}
+
+/* Gist */
+.gist table {
+	table-layout: auto;
+}
+
+.entry-content .gist .gist-file {
+	margin-bottom: 1.75em;
+}
+
+/* Instagram */
+.instagram-media {
+	margin-bottom: 1.75em !important;
+}
+
+/* Mixclound */
+iframe[src^="http://api.mixcloud.com/"] {
+	margin-left: -8px;
+	max-width: -webkit-calc(100% + 8px);
+	max-width: calc(100% + 8px);
+}
+
+/* Polldaddy */
+.PDS_Poll {
+	display: block !important;
+	margin-bottom: 1.75em;
+}
+
+.PDS_Poll .pds-box {
+	max-width: 100%;
+	width: auto;
+}
+
+/* Portfolio */
+.entry-content .portfolio-entry {
+	margin-bottom: 1.75em;
+}
+
+.entry-content .portfolio-entry-title,
+.entry-content .portfolio-entry-meta {
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+}
+
+.entry-content .portfolio-entry-title a,
+.entry-content .portfolio-entry-meta a {
+	box-shadow: none;
+}
+
+.entry-content .portfolio-entry-title a:hover,
+.entry-content .portfolio-entry-meta a:hover {
+	box-shadow: 0 1px 0 0 currentColor;
+}
+
+.entry-content .portfolio-entry-meta span,
+.entry-content .portfolio-entry-meta a {
+	font-size: 1em;
+}
+
+.entry-content .portfolio-entry-title {
+	font-size: inherit;
+	line-height: 1.3125;
+}
+
+.entry-content .portfolio-featured-image + .portfolio-entry-title {
+	margin-top: 0.875em;
+	margin-bottom: 0.4375em;
+}
+
+.entry-content .portfolio-entry-meta,
+.entry-content .portfolio-entry-content p {
+	font-size: 13px;
+	font-size: 0.8125em;
+	line-height: 1.615384615;
+}
+
+.entry-content .portfolio-entry-content p:last-child {
+	margin-bottom: 0;
+}
+
+.entry-content .portfolio-entry-title + .portfolio-entry-meta {
+	margin-top: 0.538461538em;
+}
+
+.entry-content .portfolio-entry-content {
+	margin-top: 0.875em;
+}
+
+.entry-content .portfolio-entry-content p {
+	margin-bottom: 1.615384615em;
+}
+
+/* Presentation */
+.entry-content .presentation-wrapper {
+	margin: 0 0 1.75em;
+	max-width: 100%;
+}
+
+.presentation {
+	max-width: 100%;
+}
+
+/* Recipes */
+.entry-content .jetpack-recipe {
+	border: 0;
+	margin: 0 0 1.75em;
+	padding: 0;
+}
+
+.entry-content .jetpack-recipe-title {
+	border: 0;
+	margin-top: 0;
+	padding: 0;
+}
+
+.entry-content .jetpack-recipe .jetpack-recipe-meta {
+	font-size: inherit;
+	margin: 0;
+}
+
+/* Scribd */
+.scribd_iframe_embed + div {
+	margin-bottom: 28px;
+}
+
+/* Slideshow */
+.entry-content .slideshow-window {
+	border-radius: 0;
+	margin-bottom: 1.75em;
+}
+
+/* Subscription Form */
+.entry-content .jetpack_subscription_widget {
+	border-top: 0;
+	font-size: inherit;
+	margin-bottom: 1.75em;
+	padding: 0;
+}
+
+.entry-content #subscribe-email input {
+	font-size: inherit;
+	line-height: normal;
+	padding: 0.625em 0.4375em;
+	width: 100%;
+}
+
+.entry-content .jetpack_subscription_widget input[type="submit"] {
+	font-size: inherit;
+	padding: 0.84375em 0.875em 0.78125em;
+}
+
+/* Testimonial */
+.entry-content .testimonial-entry {
+	margin-bottom: 1.75em;
+}
+
+.entry-content .testimonial-entry-content {
+	margin: 0;
+}
+
+.entry-content .testimonial-entry-title,
+.entry-content .testimonial-entry-content p {
+	font-size: 13px;
+	font-size: 0.8125em;
+	line-height: 1.615384615;
+	margin: 0;
+}
+
+.entry-content .testimonial-entry-content p {
+	margin-bottom: 1.615384615em;
+}
+
+.entry-content .testimonial-entry-title {
+	float: left;
+}
+
+.entry-content .testimonial-entry-title a {
+	box-shadow: none;
+}
+
+.entry-content .testimonial-entry-title a:hover {
+	box-shadow: 0 1px 0 0 currentColor;
+}
+
+.entry-content .testimonial-featured-image img {
+	float: right;
+	max-width: 42px;
+}
+
+/* Twitter-timeline */
+.entry-content iframe[id*="twitter-widget-"] {
+	margin-bottom: 1.75em !important;
+}
+
+
+/**
+ * Responsive Videos
+ */
+.hentry .jetpack-video-wrapper {
+	margin-bottom: 1.75em;
+}
+
+
+/**
+ * Related Posts
+ */
+
+.entry-content #jp-relatedposts {
+	margin: 0;
+	padding-top: 0.875em;
+	position: relative;
+}
+
+.entry-content #jp-relatedposts:before {
+	background-color: currentColor;
+	content: "";
+	height: 1px;
+	opacity: 0.2;
+	position: absolute;
+	top: 0;
+	width: 100%;
+}
+
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline {
+	color: inherit;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	font-size: 0.8125rem;
+	font-weight: 400;
+	line-height: 1;
+	margin-bottom: 1.076923077em;
+}
+
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline em:before {
+	display: none;
+}
+
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline em {
+	font-weight: 400;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-headline em:after {
+	content: ":";
+}
+
+.entry-content .jp-relatedposts-post-aoverlay,
+.entry-content .jp-relatedposts-post-a {
+	box-shadow: none;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
+	margin-bottom: 1.75em;
+	width: 100%;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post span {
+	max-width: 100%;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items p,
+.entry-content #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
+	font-size: 13px;
+	font-size: 0.8125rem;
+	letter-spacing: 0;
+	line-height: 1.615384615;
+}
+
+.jp-relatedposts-post-date,
+.jp-relatedposts-post-context {
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+}
+
+.jp-relatedposts-post-title,
+#jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post-excerpt,
+.entry-content #jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
+	margin-bottom: 1.076923077em;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-title a {
+	font-weight: 700;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-title a:hover,
+.entry-content .jp-relatedposts-post-aoverlay:hover + .jp-relatedposts-post-title .jp-relatedposts-post-a {
+	box-shadow: 0 1px 0 0 currentColor;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-title a:hover,
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post:hover .jp-relatedposts-post-title a {
+	text-decoration: none;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-date,
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post .jp-relatedposts-post-context,
+.entry-content #jp-relatedposts .jp-relatedposts-items-visual .jp-relatedposts-post {
+	opacity: 1;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items-visual .jp-relatedposts-post {
+	padding-right: 0;
+}
+
+.entry-content .jp-relatedposts-post-a:hover img.jp-relatedposts-post-img,
+.entry-content .jp-relatedposts-post-a:focus img.jp-relatedposts-post-img {
+	opacity: 0.85;
+}
+
+.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post img.jp-relatedposts-post-img {
+	margin-bottom: 0.875em;
+	max-width: 100%;
+}
+
+
+/**
+ * Sharing
+ */
+
+.sharedaddy {
+	padding: 0.875em 0;
+	position: relative;
+}
+
+.sharedaddy:before {
+	background-color: currentColor;
+	content: "";
+	height: 1px;
+	opacity: 0.2;
+	position: absolute;
+	top: 0;
+	width: 100%;
+}
+
+.sharedaddy:last-child {
+	padding-bottom: 0 !important;
+}
+
+.sd-block {
+	line-height: 1;
+}
+
+.sd-like {
+	padding-bottom: 0.25em;
+}
+
+.hentry div.sharedaddy h3.sd-title,
+.hentry h3.sd-title {
+	color: inherit;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
+	font-size: 13px;
+	font-size: 0.8125rem;
+	font-weight: 400;
+	line-height: 1;
+	margin-bottom: 1.076923077em;
+}
+
+.hentry div.sharedaddy h3.sd-title:before {
+	display: none;
+}
+
+.sd-social-icon-text .sd-content ul,
+.sd-social-text .sd-content ul {
+	margin-bottom: -0.3125em !important;
+}
+
+.sd-social-icon .sd-content ul {
+	margin-bottom: 0 !important;
+}
+
+.sd-social-official .sd-content ul {
+	margin-bottom: -0.625em !important;
+}
+
+.hentry #sharing_email .sharing_send,
+.hentry .sd-content ul li .option a.share-ustom,
+.hentry .sd-content ul li a.sd-button,
+.hentry .sd-content ul li.advanced a.share-more,
+.hentry .sd-content ul li.preview-item div.option.option-smart-off a,
+.hentry .sd-social-icon .sd-content ul li a.sd-button,
+.hentry .sd-social-icon-text .sd-content ul li a.sd-button,
+.hentry .sd-social-official .sd-content > ul > li .digg_button > a,
+.hentry .sd-social-official .sd-content > ul > li > a.sd-button,
+.hentry .sd-social-text .sd-content ul li a.sd-button {
+	box-shadow: none;
+}
+
+
+/**
+ * Stats
+ */
+
+#wpstats {
+	display: none;
+}
+
+
+/**
+ * Tiled gallery
+ */
+
+.entry-content .tiled-gallery {
+	margin-bottom: 1.75em;
+}
+
+
+/**
+ * Media Queries
+ */
+
+@media screen and (min-width: 56.875em) {
+	.widget-area .jetpack_subscription_widget #subscribe-email input {
+		padding: 0.4615384615em 0.5384615385em;
+	}
+
+	.widget_contact_info .contact-map {
+		margin-bottom: 1.615384615em;
+	}
+
+	.widget_jetpack_display_posts_widget .jetpack-display-remote-posts h4,
+	.widget_jetpack_display_posts_widget .jetpack-display-remote-posts img {
+		margin-bottom: 1.076923077em;
+	}
+
+	.widget_jetpack_display_posts_widget .jetpack-display-remote-posts p {
+		line-height: 1.615384615em !important;
+		margin: 0 0 1.615384615em !important;
+	}
+
+	.widget_goodreads div[class^="gr_custom_each_container"] {
+		margin-bottom: 1.615384615em;
+	}
+
+	.widget-area .widget-grofile h4 {
+		margin: 1.615384615em 0 0;
+	}
+
+	.widget-area .widget-grofile .grofile-accounts {
+		margin-top: 0.538461538em;
+	}
+
+	.widget.widget_wpcom_social_media_icons_widget ul {
+		margin: 0 0 -0.538461538em;
+	}
+
+	.widget.widget_wpcom_social_media_icons_widget li {
+		margin: 0 0.538461538em 0.538461538em 0;
+	}
+
+	.widget_top-posts .widgets-list-layout .widgets-list-layout-blavatar {
+		margin-right: 0.538461538em;
+		max-width: 3.230769231em;
+	}
+
+	.widget_top-posts .widgets-list-layout-links {
+		padding-top: 0.807692308em;
+	}
+
+	.widget_top-posts .widgets-list-layout li {
+		margin-bottom: 0.538461538em;
+	}
+
+	.widget_upcoming_events_widget .upcoming-events li {
+		margin-bottom: 1.076923077em
+	}
+
+	.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
+		padding-right: 0.875em;
+		width: 33%;
+	}
+}
+
+@media screen and (min-width: 61.5625em) {
+	.entry-content #jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post {
+		margin-bottom: 0;
+	}
+}

--- a/modules/theme-tools/compat/twentysixteen.css
+++ b/modules/theme-tools/compat/twentysixteen.css
@@ -6,6 +6,21 @@
 	margin: 0;
 }
 
+.comment-form .subscribe-label {
+	font-family: Merriweather, Georgia, serif;
+	font-weight: 400;
+	letter-spacing: 0;
+	text-transform: none;
+}
+
+.comment-subscription-form {
+	margin: 1.75em 0 0;
+}
+
+.comment-subscription-form + .comment-subscription-form  {
+	margin-top: 0.875em;
+}
+
 
 /**
  * Extra Widgets

--- a/modules/theme-tools/compat/twentysixteen.php
+++ b/modules/theme-tools/compat/twentysixteen.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack Compatibility File
+ * See: http://jetpack.me/
+ */
+
+function twentysixteen_jetpack_setup() {
+	/**
+	 * Add theme support for Responsive Videos.
+	 */
+	add_theme_support( 'jetpack-responsive-videos' );
+}
+add_action( 'after_setup_theme', 'twentysixteen_jetpack_setup' );
+
+function twentysixteen_init_jetpack() {
+	/**
+	 * Add our compat CSS file for custom widget stylings and such.
+	 * Set the version equal to filemtime for development builds, and the JETPACK__VERSION for production
+	 * or skip it entirely for wpcom.
+	 */
+	$version = false;
+	if ( method_exists( 'Jetpack', 'is_development_version' ) ) {
+		$version = Jetpack::is_development_version() ? filemtime( plugin_dir_path( __FILE__ ) . 'twentysixteen.css' ) : JETPACK__VERSION;
+	}
+	wp_enqueue_style( 'twentysixteen-jetpack', plugins_url( 'twentysixteen.css', __FILE__ ), array(), $version );
+	wp_style_add_data( 'twentysixteen-jetpack', 'rtl', 'replace' );
+}
+add_action( 'init', 'twentysixteen_init_jetpack' );
+
+/**
+ * Alter gallery widget default width.
+ */
+function twentysixteen_gallery_widget_content_width( $width ) {
+	return 390;
+}
+add_filter( 'gallery_widget_content_width', 'twentysixteen_gallery_widget_content_width' );
+
+/**
+ * Remove sharing and likes from custom excerpt.
+ */
+function twentysixteen_remove_share() {
+	if ( has_excerpt() ) {
+	    remove_filter( 'the_excerpt', 'sharing_display',19 );
+	    if ( class_exists( 'Jetpack_Likes' ) ) {
+	        remove_filter( 'the_excerpt', array( Jetpack_Likes::init(), 'post_likes' ), 30, 1 );
+	    }
+	}
+}
+add_action( 'loop_start', 'twentysixteen_remove_share' );


### PR DESCRIPTION
Theme compat files for Twenty Sixteen. These include...

* Add support for Responsive Videos.
* Alter Gallery widget default width.
* Remove Sharing and Likes from custom excerpt because the excerpt is used as intro in the theme.
* Add support and style tweak for Infinite Scroll.
* Style front-end modules to match the style of the theme.