### PR TITLE
Sharing: removed the tweet count from offical Twitter buttons

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -636,7 +636,7 @@ class Share_Twitter extends Sharing_Source {
 		if ( $this->smart ) {
 			$share_url = $this->get_share_url( $post->ID );
 			$post_title = $this->get_share_title( $post->ID );
-			return '<div class="twitter_button"><iframe allowtransparency="true" frameborder="0" scrolling="no" src="' . esc_url( $this->http() . '://platform.twitter.com/widgets/tweet_button.html?url=' . rawurlencode( $share_url ) . '&counturl=' . rawurlencode( get_permalink( $post->ID ) ) . '&count=horizontal&text=' . rawurlencode( $post_title . ':' ) . $via ) . '" style="width:101px; height:20px;"></iframe></div>';
+			return '<div class="twitter_button"><iframe allowtransparency="true" frameborder="0" scrolling="no" src="' . esc_url( $this->http() . '://platform.twitter.com/widgets/tweet_button.html?url=' . rawurlencode( $share_url ) . '&count=none&text=' . rawurlencode( $post_title . ':' ) . $via ) . '" style="width:55px; height:20px;"></iframe></div>';
 		} else {
 			if (
 				/**


### PR DESCRIPTION
due to share count API deprcation. This PR removes the `counturl` parameter, adjusts the `count` parameter to be `none` and tweaks the width of the button to be 50 pixels wide. See #2747 for more details.

About the Twitter button: https://dev.twitter.com/web/tweet-button/faq