### PR TITLE
Updated the site api endpoint

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -1058,7 +1058,8 @@ EOT;
 		if ( substr( $filter, 0, 28 ) === 'pre_option_jetpack_constant_' ) {
 			$constant = substr( $filter, 28 );
 			if ( defined( $constant ) ) {
-				return constant( $constant );
+				// We if constant is set to false we will not shortcut the get_option function and will return the default value.
+				return constant( $constant ) === false ? null : constant( $constant );
 			}
 			return $this->default_constant( $constant );
 		}

--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -1026,7 +1026,15 @@ EOT;
 	 *
 	 */
 	function register_constant( $constant ) {
+		add_filter( 'default_option_jetpack_constant_'. $constant, array( $this, 'get_default_constant' ), 10, 2 );
 		$this->register( 'constant', $constant );
+	}
+
+	function get_default_constant( $default, $constant ) {
+		if ( defined( $constant ) ) {
+			return constant( $constant );
+		}
+		return $default;
 	}
 	/**
 	 * Simular to $this->options() function.

--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -837,7 +837,7 @@ class Jetpack_Sync {
 	function sync_all_constants() {
 		// add the constant to sync.
 		foreach( $this->get_all_constants() as $constant ) {
-			$this->register_constant( $contsant );
+			$this->register_constant( $constant );
 		}
 		add_action( 'shutdown', array( $this, 'register_all_module_constants' ), 8 );
 	}
@@ -1058,8 +1058,9 @@ EOT;
 		if ( substr( $filter, 0, 28 ) === 'pre_option_jetpack_constant_' ) {
 			$constant = substr( $filter, 28 );
 			if ( defined( $constant ) ) {
-				// We if constant is set to false we will not shortcut the get_option function and will return the default value.
-				return constant( $constant ) === false ? null : constant( $constant );
+				// If constant is set to false we will not shortcut the get_option function and will return the default value.
+				// Hance we set it to null. Which in most cases would produce the same result.
+				return false === constant( $constant ) ? null : constant( $constant );
 			}
 			return $this->default_constant( $constant );
 		}

--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -26,6 +26,7 @@ class Jetpack_Sync {
 		add_action( 'jetpack_heartbeat',  array( $this, 'sync_all_registered_options' ) );
 
 		// Sync constants on heartbeat and plugin upgrade and connects
+		add_action( 'init', array( $this, 'register_constants_as_options' ) );
 		add_action( 'jetpack_sync_all_registered_options', array( $this, 'sync_all_constants' ) );
 		add_action( 'jetpack_heartbeat',  array( $this, 'sync_all_constants' ) );
 
@@ -808,9 +809,8 @@ class Jetpack_Sync {
 
 /* Constants Sync */
 
-	function sync_all_constants() {
-		// list of contants to sync needed by Jetpack
-		$constants = array(
+	function get_all_constants() {
+		return array(
 			'EMPTY_TRASH_DAYS',
 			'WP_POST_REVISIONS',
 			'AUTOMATIC_UPDATER_DISABLED',
@@ -823,14 +823,38 @@ class Jetpack_Sync {
 			'WP_HTTP_BLOCK_EXTERNAL',
 			'WP_ACCESSIBLE_HOSTS',
 			);
-
-		// add the constant to sync.
-		foreach( $constants as $contant ) {
-			$this->register_constant( $contant );
+	}
+	/**
+	 * This lets us get the constant value like get_option( 'jetpack_constant_CONSTANT' );
+	 * Not the best way to get the constant value but necessery in some cases like in the API.
+	 */
+	function register_constants_as_options() {
+		foreach( $this->get_all_constants() as $constant ) {
+			add_filter( 'pre_option_jetpack_constant_'. $constant, array( $this, 'get_default_constant' ) );
 		}
+	}
 
+	function sync_all_constants() {
+		// add the constant to sync.
+		foreach( $this->get_all_constants() as $constant ) {
+			$this->register_constant( $contsant );
+		}
 		add_action( 'shutdown', array( $this, 'register_all_module_constants' ), 8 );
+	}
 
+	/**
+	 * Returns default values of Constants
+	 */
+	function default_constant( $constant ) {
+		switch( $constant ) {
+			case 'WP_AUTO_UPDATE_CORE':
+				return 'minor';
+				break;
+
+			default:
+				return null;
+				break;
+		}
 	}
 
 	function register_all_module_constants() {
@@ -1010,7 +1034,6 @@ EOT;
 	 * @param  string or array  $callback
 	 */
 	function mock_option( $option , $callback ) {
-
 		add_filter( 'pre_option_jetpack_'. $option, $callback );
 		// This shouldn't happen but if it does we return the same as before.
 		add_filter( 'option_jetpack_'. $option, $callback );
@@ -1026,15 +1049,19 @@ EOT;
 	 *
 	 */
 	function register_constant( $constant ) {
-		add_filter( 'default_option_jetpack_constant_'. $constant, array( $this, 'get_default_constant' ), 10, 2 );
 		$this->register( 'constant', $constant );
 	}
 
-	function get_default_constant( $default, $constant ) {
-		if ( defined( $constant ) ) {
-			return constant( $constant );
+	function get_default_constant() {
+		$filter = current_filter();
+		// We don't know what the constant is so we get it from the current filter.
+		if ( substr( $filter, 0, 28 ) === 'pre_option_jetpack_constant_' ) {
+			$constant = substr( $filter, 28 );
+			if ( defined( $constant ) ) {
+				return constant( $constant );
+			}
+			return $this->default_constant( $constant );
 		}
-		return $default;
 	}
 	/**
 	 * Simular to $this->options() function.

--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -1055,7 +1055,7 @@ EOT;
 	function get_default_constant() {
 		$filter = current_filter();
 		// We don't know what the constant is so we get it from the current filter.
-		if ( substr( $filter, 0, 28 ) === 'pre_option_jetpack_constant_' ) {
+		if ( 'pre_option_jetpack_constant_' === substr( $filter, 0, 28 ) ) {
 			$constant = substr( $filter, 28 );
 			if ( defined( $constant ) ) {
 				// If constant is set to false we will not shortcut the get_option function and will return the default value.

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -347,6 +347,26 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$response['options']['is_multi_network'] = (bool) get_option( 'jetpack_is_main_network', true  );
 					$response['options']['is_multi_site'] = (bool) get_option( 'jetpack_is_multi_site', true );
 
+					$file_mod_denied_reason = array();
+					$file_mod_denied_reason['automatic_updater_disabled'] = (bool) get_option( 'jetpack_constant_AUTOMATIC_UPDATER_DISABLED' );
+
+					// WP AUTO UPDATE CORE defaults to minor, '1' if true and '0' if set to false.
+					$file_mod_denied_reason['wp_auto_update_core_disabled'] =  ! ( (bool) get_option( 'jetpack_constant_WP_AUTO_UPDATE_CORE', 'minor' ) );
+					$file_mod_denied_reason['is_version_controlled'] = (bool) get_option( 'jetpack_is_version_controlled' );
+
+					// By default we assume that site does have system write access if the value is not set yet.
+					$file_mod_denied_reason['has_no_file_system_write_access'] = ! (bool)( get_option( 'jetpack_has_file_system_write_access', true ) );
+
+					$file_mod_denied_reason['disallow_file_edit'] = (bool) get_option( 'jetpack_constant_DISALLOW_FILE_EDIT' );
+					$file_mod_denied_reason['disallow_file_mods'] = (bool) get_option( 'jetpack_constant_DISALLOW_FILE_MODS' );
+
+					$file_mod_disabled_reasons = array();
+					foreach( $file_mod_denied_reason as $reason => $set ) {
+						if ( $set ) {
+							$file_mod_disabled_reasons[] = $reason;
+						}
+					}
+					$response['options']['file_mod_disabled'] = empty( $file_mod_disabled_reasons ) ? false : $file_mod_disabled_reasons;
 				}
 
 				if ( ! current_user_can( 'edit_posts' ) )


### PR DESCRIPTION
Update to be the same as the recent changes on .com to the setting api endpoint. 

To test
Go to https://developer.wordpress.com/docs/api/console/

and request the endpoint 
/sites/$siteID 

Notice that it returns the same data as /me/sites for a particular site. 

Change constants to something else. 
Retest. 

cc: @roccotripaldi and @lezama 

I think this doesn't quite work as expected yet. 