### PR TITLE
Photon: Serve https images by default.

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -627,10 +627,11 @@ class Jetpack_Photon {
 			 * @module photon
 			 *
 			 * @since 2.4.0
+			 * @since 3.9.0 Default to false.
 			 *
-			 * @param bool true Should Photon ignore images using the HTTPS scheme. Default to true.
+			 * @param bool $reject_https Should Photon ignore images using the HTTPS scheme. Default to false.
 			 */
-			apply_filters( 'jetpack_photon_reject_https', true )
+			apply_filters( 'jetpack_photon_reject_https', false )
 		) {
 			return false;
 		}


### PR DESCRIPTION
As https becomes more and more the norm, let's default to Photonizing https images.

Marking as 3.8.1. If punted to 3.9/vFuture, inline docs need to be updated.

Fixes #2015