### PR TITLE
Staging Site Improvements

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -170,7 +170,7 @@ class Jetpack_Sync {
 		}
 
 		// Don't sync anything from a staging site.
-		if ( Jetpack::is_development_mode() || Jetpack::jetpack_is_staging_site() ) {
+		if ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) {
 			return false;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5783,7 +5783,7 @@ p {
 	 * @return array An array of options that do not match.  If everything is good, it will evaluate to false.
 	 */
 	public static function check_identity_crisis( $force_recheck = false ) {
-		if ( ! Jetpack::is_active() || Jetpack::is_development_mode() )
+		if ( ! Jetpack::is_active() || Jetpack::is_development_mode() || Jetpack::is_staging_site() )
 			return false;
 
 		if ( $force_recheck || false === ( $errors = get_transient( 'jetpack_has_identity_crisis' ) ) ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6016,7 +6016,7 @@ p {
 		/**
 		 * Filters the flags of known staging sites.
 		 *
-		 * @since 3.8.1
+		 * @since 3.9.0
 		 *
 		 * @param array $known_staging {
 		 *     An array of arrays that each are used to check if the current site is staging.
@@ -6046,7 +6046,7 @@ p {
 		/**
 		 * Filters is_staging_site check.
 		 *
-		 * @since 3.8.1
+		 * @since 3.9.0
 		 *
 		 * @param bool $is_staging If the current site is a staging site.
 		 */

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5990,7 +5990,9 @@ p {
 	 *
 	 * @return bool True = already whitelsisted False = not whitelisted
 	 */
-	public static function jetpack_is_staging_site() {
+	public static function is_staging_site() {
+		$is_staging = false;
+
 		$current_whitelist = Jetpack_Options::get_option( 'identity_crisis_whitelist' );
 		if ( ! $current_whitelist ) {
 			return false;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6018,9 +6018,11 @@ p {
 		 *
 		 * @since 3.8.1
 		 *
-		 * @param array $known_staging
-		 *        type array 'urls'      URLs of staging sites in regex to check against site_url.
-		 *        type array 'cosntants' PHP constants of known staging/developement environments.
+		 * @param array $known_staging {
+		 *     An array of arrays that each are used to check if the current site is staging.
+		 *     @type array $urls      URLs of staging sites in regex to check against site_url.
+		 *     @type array $cosntants PHP constants of known staging/developement environments.
+		 *  }
 		 */
 		$known_staging = apply_filters( 'jetpack_known_staging', $known_staging );
 
@@ -6044,7 +6046,7 @@ p {
 		/**
 		 * Filters is_staging_site check.
 		 *
-		 * @since 2.3.2
+		 * @since 3.8.1
 		 *
 		 * @param bool $is_staging If the current site is a staging site.
 		 */

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -143,6 +143,22 @@ EXPECTED;
 	public function pre_test_check_identity_crisis_will_report_crisis_if_an_http_site_and_siteurl_mismatch( $errors ){
 		$this->assertCount( 1, $errors );
 	}
+
+	/**
+	 * @author  kraftbj
+	 * @covers Jetpack::is_staging_site
+	 * @since  3.8.1
+	 */
+	public function test_is_staging_site_will_report_staging_for_wpengine_sites_by_url() {
+		add_filter( 'site_url', array( $this, 'pre_test_is_staging_site_will_report_staging_for_wpengine_sites_by_url' ) );
+		$this->assertTrue( MockJetpack::is_staging_site() );
+		remove_filter( 'site_url', array( $this, 'pre_test_is_staging_site_will_report_staging_for_wpengine_sites_by_url' ) );
+
+	}
+
+	public function pre_test_is_staging_site_will_report_staging_for_wpengine_sites_by_url(){
+		return 'http://bjk.staging.wpengine.com';
+	}
 	/*
 	 * @author tonykova
 	 * @covers Jetpack::implode_frontend_css

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -147,7 +147,7 @@ EXPECTED;
 	/**
 	 * @author  kraftbj
 	 * @covers Jetpack::is_staging_site
-	 * @since  3.8.1
+	 * @since  3.9.0
 	 */
 	public function test_is_staging_site_will_report_staging_for_wpengine_sites_by_url() {
 		add_filter( 'site_url', array( $this, 'pre_test_is_staging_site_will_report_staging_for_wpengine_sites_by_url' ) );


### PR DESCRIPTION
Refactors and enhances the `is_staging_site` check in a few ways.

This should reduce support load by:
* Not displaying the IDC prompt if a known staging site.
* In addition to the whitelisted option, known staging URLs/constants can auto-trigger yes (WP Engine initially, we can tack on others if the approach is sound).