### PR TITLE
SSO: Retain redirect_to for bypass to wp.com logins

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -361,6 +361,7 @@ class Jetpack_SSO {
 			&& $this->bypass_login_forward_wpcom()
 		) {
 			add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+			$this->maybe_save_cookie_redirect();
 			wp_safe_redirect( $this->build_sso_url() );
 		}
 


### PR DESCRIPTION
When using the `jetpack_sso_bypass_login_forward_wpcom` filter to bypass the local login straight to SSO, we are jumping straight to WP.com before checking if there is a `redirect_to` arg and setting the cookie SSO uses to retain that.

How to test:
0. Add `add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true');` to a core functionality plugin and verify that visiting your wp-admin skips the local login form.
1. Logged out of both your local site and WP.com, try to visit your site's tools.php directly (e.g. example.com/wp-admin/tools.php )

Before patch: Login successful, dumped to the generic endpoint (/wp-admin/ for most users, /wp-admin/profile.php for subscriber users)

After patch: Login successful, dumped to /wp-admin/tools.php

Hat tip to Prof Jim Proctor and his team in the Environment Studies program at Lewis and Clark University whose pretty darn sweet https://ds.lclark.edu Jetpack-powered multisite who assisted in revealing the bug and confirming the patch.