### PR TITLE
Sync: Adds options to improve WordPress.com editor experience

### DIFF
--- a/modules/post-by-email.php
+++ b/modules/post-by-email.php
@@ -12,16 +12,6 @@
  */
 
 add_action( 'jetpack_modules_loaded', array( 'Jetpack_Post_By_Email', 'init' ) );
-
-Jetpack_Sync::sync_options( __FILE__,
-	'large_size_w',
-	'large_size_h',
-	'thumbnail_size_w',
-	'thumbnail_size_h',
-	'medium_size_w',
-	'medium_size_h'
-);
-
 add_action( 'jetpack_activate_module_post-by-email',   array( 'Jetpack_Post_By_Email', 'module_toggle' ) );
 add_action( 'jetpack_deactivate_module_post-by-email', array( 'Jetpack_Post_By_Email', 'module_toggle' ) );
 


### PR DESCRIPTION
Adds: 
- default_post_format
- default_category
- <strike>allowed_file_types</strike>
- thumbnail_crop
- image_default_link_type
- featured_images_enabled

Moves the following options, that used to only be synced when the post by email module was on, to `class.jetpack.php` so that they are regularly synced.
- large_size_w
- large_size_h
- thumbnail_size_w
- thumbnail_size_h
- medium_size_w
- medium_size_h

cc @lezama for review.