### PR TITLE
Unit Tests: Update Matrix to add 7.0, hhvm, etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ matrix:
    - php: "7.0"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    # Disabling PHP 7.0 / 4.2.0 as it throws same name class constructor notices fixed in 4.3.
-   - php: "7.0"
-     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
+   #- php: "7.0"
+   #  env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,6 @@ env:
 
 matrix:
   include:
-   - php: "nightly"
-     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   # Disabling PHP nightly / 4.2.0 as it throws same name class constructor notices fixed in 4.3.
-   #- php: "nightly"
-   #  env: WP_VERSION=4.2.0
-   - php: "nightly"
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.2"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.2"
@@ -40,8 +33,31 @@ matrix:
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.6"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "7.0"
+     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
+   # Disabling PHP 7.0 / 4.2.0 as it throws same name class constructor notices fixed in 4.3.
+   - php: "7.0"
+     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
+   - php: "7.0"
+     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: hhvm
+     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
+   - php: hhvm
+     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
+   - php: hhvm
+     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "nightly"
+     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
+   # Disabling PHP nightly / 4.2.0 as it throws same name class constructor notices fixed in 4.3.
+   #- php: "nightly"
+   #  env: WP_VERSION=4.2.0
+   - php: "nightly"
+     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.6"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:js
+  allow_failures:
+   - php: hhvm
+   - php: "nightly"
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ php:
 env:
     - WP_VERSION=master WP_TRAVISCI=travis:phpunit
 
-
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,
 # so it doesn't need to be re-defined below.
+
+# Test WP trunk/master and two latest versions on minimum (5.2).
+# Test WP latest two versions (4.4, 4.4) on most popular (5.5, 5.6).
+# Test WP latest stable (4.4) on other supported PHP (5.3, 5.4).
+# Test WP trunk/master on edge platforms (7.0, hhvm, PHP nightly).
 
 # WP_VERSION specifies the tag to use. The way these tests are configured to run
 # requires at least WordPress 3.8. Specify "master" to test against SVN trunk.
@@ -28,15 +32,7 @@ matrix:
    - php: "5.2"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "5.3"
-     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   - php: "5.3"
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
-   - php: "5.3"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
-   - php: "5.4"
-     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   - php: "5.4"
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.4"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
@@ -52,25 +48,14 @@ matrix:
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   - php: "7.0"
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
-   - php: "7.0"
-     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   - php: hhvm
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
-   - php: hhvm
-     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "nightly"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   - php: "nightly"
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.6"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:js
   allow_failures:
-   - php: hhvm
-   - php: "nightly"
+   # - php: "nightly"
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,29 +27,39 @@ matrix:
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.2"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.2"
+     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "5.3"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.3"
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.3"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.3"
+     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "5.4"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.4"
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.4"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.4"
+     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.5"
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.5"
+     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
      # 5.6 / master already included above as first build.
    - php: "5.6"
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.6"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.6"
+     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    # Disabling PHP 7.0 / 4.2.0 as it throws same name class constructor notices fixed in 4.3.
@@ -57,12 +67,16 @@ matrix:
    #  env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "7.0"
+     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: hhvm
+     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "nightly"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    # Disabling PHP nightly / 4.2.0 as it throws same name class constructor notices fixed in 4.3.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # Travis CI Configuration File
 
-# Explicitly set container-based infrastructure. See http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
+# Tell Travis CI we're using PHP
 language: php
 
 # PHP version used in first build configuration.

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,24 @@ matrix:
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.2"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.3"
+     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
+   - php: "5.3"
+     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.3"
+     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.4"
+     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
+   - php: "5.4"
+     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.4"
+     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.5"
+     env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
+   - php: "5.5"
+     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.5"
+     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
      # 5.6 / master already included above as first build.
    - php: "5.6"
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Travis CI Configuration File
 
-# Tell Travis CI we're using PHP
+# Explicitly set container-based infrastructure. See http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
 language: php
 
 # PHP version used in first build configuration.

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,64 +24,46 @@ matrix:
    - php: "5.2"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.2"
-     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
-   - php: "5.2"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.2"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "5.3"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.3"
-     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
-   - php: "5.3"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.3"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "5.4"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.4"
-     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
-   - php: "5.4"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.4"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   - php: "5.5"
-     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
      # 5.6 / master already included above as first build.
    - php: "5.6"
-     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
-   - php: "5.6"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.6"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   # Disabling PHP 7.0 / 4.2.0 as it throws same name class constructor notices fixed in 4.3.
-   #- php: "7.0"
-   #  env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   - php: hhvm
-     env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
    - php: "nightly"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   # Disabling PHP nightly / 4.2.0 as it throws same name class constructor notices fixed in 4.3.
-   #- php: "nightly"
-   #  env: WP_VERSION=4.2.0
    - php: "nightly"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
    - php: "5.6"

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6451,9 +6451,7 @@ p {
 		global $wp_version;
 		$ssl = is_ssl();
 
-		if ( version_compare( $wp_version, '4.4-alpha', '<=' ) && force_ssl_login() ) { // force_ssl_login deprecated WP 4.4.
-			$ssl = true;
-		} else if ( force_ssl_admin() ) {
+		if ( force_ssl_admin() ) {
 			$ssl = true;
 		}
 		return $ssl;

--- a/tests/php/test_class.jetpack-media-extractor.php
+++ b/tests/php/test_class.jetpack-media-extractor.php
@@ -397,9 +397,9 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 
 		$result = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id, Jetpack_Media_Meta_Extractor::MENTIONS );
 
-		if ( version_compare( PHP_VERSION, '5.3.0' ) == -1 ) {
+		if ( version_compare( PHP_VERSION, '5.4.0' ) == -1 ) {
 			$this->markTestSkipped(
-				'This test is failing in PHP 5.2 for unknown reasons. Skipping pending further verification.'
+				'This test is failing in PHP 5.2 and PHP 5.3 for unknown reasons. Skipping pending further verification.'
 				);
 			return;
 		}


### PR DESCRIPTION
* Added PHP 5.3-5.6, 7.0, hhvm support.
* Set hhvm and nightly to allow failures.
* Expand a skipped test to include 5.3 since it fails there too for unknown reasons.

Question: Do we need to test every PHP ver against every ver of WP supported? Perhaps latest stable of WP for intermediate versions—5.3, 5.5. Leaving 5.2 as the lowest possible, 5.4 as the current suggested WP version, 5.6 as the latest in the 5.x branch.

I'm fine leaving it like it is in the PR, but can understand if folks don't want Travis taking so long.