### PR TITLE
added filters to customise tiled gallery item outputs based on db info

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -22,3 +22,4 @@ data-image-title="<?php echo esc_attr( wptexturize( $item->image->post_title ) )
 data-image-description="<?php echo esc_attr( wpautop( wptexturize( $item->image->post_content ) ) ); ?>"
 data-medium-file="<?php echo esc_url( $item->medium_file() ); ?>"
 data-large-file="<?php echo esc_url( $item->large_file() ); ?>"
+<?php echo apply_filters( 'jetpack_tiled_gallery_item_carousel_image_args', $item ); ?>

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -21,8 +21,7 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
 		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
 
-		$this->img_src = add_query_arg( array( 'w' => $this->image->width, 'h' => $this->image->height, 'crop' => true ), $this->orig_file );
-
+		$this->img_src = apply_filters( 'jetpack_tiled_gallery_item_src', add_query_arg( array( 'w' => $this->image->width, 'h' => $this->image->height, 'crop' => true ), $this->orig_file ), $this->image );
 	}
 
 	public function fuzzy_image_meta() {


### PR DESCRIPTION
I'm currently developing a self-hosted site that utilises the tiled gallery plugin (plus some other useful features of Jetpack).

One use case that Jetpack enforces that I don't use is the WordPress CDN (Proton) which utilises query vars for resizing images (e.g. `image_name.jpg?w=300&h=400&crop=1`). I have a custom WP/JavaScript solution which uses pre-generated thumbnails ("medium", "large" and "max" as an example of different sized generated thumbnails) and I wanted to remove the query vars inserted into the tiled gallery item `img src` and also add some extra attributes to the tiled gallery item template output.

Since there were no existing filters to hook into regarding the output of the tiled gallery template code (nor were there any hookable JS events that I could find), I inserted my own actions/filters at the necessary points that I needed in order to get my existing `img src` swapping script to apply to tiled gallery items.

Would be great if this pull request (or something like this) could be included or even extended to help support some further customisation to support non-WP CDNs and loading smaller sized images (maybe even via HTML5 spec). If there is such a way to utilise a modified template file within a custom theme's file structure (e.g. putting in a custom theme file at `wp-content/themes/example_theme/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php` to overwrite the equivalent within the `tiled-gallery` plugin's folder) then please let me know!

I realise my use case is very specific but I wonder if anyone else has needed this particular feature as well. I'm just not looking forward to my two extra lines being wiped in a casual update to Jetpack. This is probably the only related thread I found online which related to my issue: https://wordpress.org/support/topic/jetpack-tiled-mosaic-gallery-not-loading-all-images-1

The reason I've implemented my solution is that when a client posts a tiled gallery with 100 images all being loaded at full size (1200px+) but are being displayed at max ~300px within the design, it seems very wasteful and slow to load and scroll through such big images for small spaces. Jetpack supports showing big/small images for the zoomed image in the slideshow, yet doesn't for the thumbnail (in fact, if no WP CDN is used I think Jetpack shows the full size image for the thumbnail and then a sized image for the zoomed/lightboxed image).