### PR TITLE
Open Graph: Adds a filter to modify the fallback og:description tag.

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -108,7 +108,17 @@ function jetpack_og_tags() {
 			}
 		}
 		if ( empty( $tags['og:description'] ) ) {
-			$tags['og:description'] = __('Visit the post for more.', 'jetpack');
+				/**
+				 * Filter the fallback `og:description` used when no excerpt information is provided.
+				 *
+				 * @module sharedaddy, publicize
+				 *
+				 * @since 3.9.0
+				 *
+				 * @param string $var  Fallback og:description. Default is translated `Visit the post for more'.
+				 * @param object $data Post object for the current post.
+				 */
+			$tags['og:description'] = apply_filters( 'jetpack_open_graph_fallback_description', __( 'Visit the post for more.', 'jetpack' ), $data );
 		} else {
 			// Intentionally not using a filter to prevent pollution. @see https://github.com/Automattic/jetpack/pull/2899#issuecomment-151957382
 			$tags['og:description'] = wp_kses( trim( convert_chars( wptexturize( $tags['og:description'] ) ) ), array() );


### PR DESCRIPTION
When there is no excerpt (either no text in the post content to generate an auto-excerpt, no explicit excerpt, or is a password-protected post), Jetpack provides "Visit the post for more" description to keep Facebook and others happy.

This adds a filter to modify it, as well as passes the `$data` object (which is a copy of the global `$post`.

Example use case: A mixed-content site that includes some image-only photoblog posts. This would add an ability to directly add a filtering function that modifies the default only when the post format is an image post.

Suggesting a separate filter since there is no chance to modify the description prior (both existing generic OG filters fire after this and would require checking specifically for the fallback description, then modifying it).

Yay or nay?