### PR TITLE
IDC: Remove Jetpack IDC notice from all admin pages.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -19,7 +19,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 		$list_table = new Jetpack_Modules_List_Table;
 		?>
 		<div class="clouds-sm"></div>
-		<?php /** This action is documented in class.jetpack.php */
+		<?php /** This action is already documented in views/admin/admin-page.php */
 		do_action( 'jetpack_notices' ) ?>
 		<div class="page-content configure">
 			<div class="frame top hide-if-no-js">

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3112,7 +3112,6 @@ p {
 
 			// Identity crisis notices
 			add_action( 'jetpack_notices', array( $this, 'alert_identity_crisis' ) );
-			add_action( 'admin_notices',   array( $this, 'alert_identity_crisis' ) );
 		}
 
 		// If the plugin has just been disconnected from WP.com, show the survey notice

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5945,6 +5945,11 @@ p {
 	 * Displays an admin_notice, alerting the user to an identity crisis.
 	 */
 	public function alert_identity_crisis() {
+		// @todo temporary killing of feature in 3.8.1 as it revealed a number of scenarios not foreseen.
+		if ( ! Jetpack::is_development_version() ) {
+			return;
+		}
+
 		// @todo temporary copout for dealing with domain mapping
 		// @see https://github.com/Automattic/jetpack/issues/2702
 		if ( is_multisite() && defined( 'SUNRISE' ) && ! Jetpack::is_development_version() ) {


### PR DESCRIPTION
Remains on Jetpack-specific admin pages via `jetpack_notices` hook already present in the code.

Additionally, updates outdated reference on an usage of `do_action( 'jetpack_notices' )` referring to an old previous location of the inline documentation.

Per previous conversation with @dereksmart, this is targeted for 3.8.1 as a stopgap solution to the high support load being caused by the IDC prompt. For vNext and vFuture, more improvements ( #2997 , etc ) will be investigated/developed.