### PR TITLE
Add/heartbeat data

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -115,6 +115,7 @@ class Jetpack_Heartbeat {
 		$return["{$prefix}is-multisite"]   = is_multisite() ? 'multisite' : 'singlesite';
 		$return["{$prefix}identitycrisis"] = Jetpack::check_identity_crisis( 1 ) ? 'yes' : 'no';
 		$return["{$prefix}plugins"]        = implode( ',', Jetpack::get_active_plugins() );
+		$return["{$prefix}themes"]         = Jetpack::get_parsed_theme_data();
 
 		$return["{$prefix}single-user-site"]= Jetpack::is_single_user_site();
 

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -116,6 +116,7 @@ class Jetpack_Heartbeat {
 		$return["{$prefix}identitycrisis"] = Jetpack::check_identity_crisis( 1 ) ? 'yes' : 'no';
 		$return["{$prefix}plugins"]        = implode( ',', Jetpack::get_active_plugins() );
 		$return["{$prefix}themes"]         = Jetpack::get_parsed_theme_data();
+		$return["{$prefix}plugins-extra"]  = Jetpack::get_parsed_plugin_data();
 		$return["{$prefix}users"]          = count_users();
 
 		$return["{$prefix}single-user-site"]= Jetpack::is_single_user_site();

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -116,6 +116,7 @@ class Jetpack_Heartbeat {
 		$return["{$prefix}identitycrisis"] = Jetpack::check_identity_crisis( 1 ) ? 'yes' : 'no';
 		$return["{$prefix}plugins"]        = implode( ',', Jetpack::get_active_plugins() );
 		$return["{$prefix}themes"]         = Jetpack::get_parsed_theme_data();
+		$return["{$prefix}users"]          = count_users();
 
 		$return["{$prefix}single-user-site"]= Jetpack::is_single_user_site();
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1700,6 +1700,31 @@ class Jetpack {
 	}
 
 	/**
+	 * Gets and parses additional plugin data to send with the heartbeat data
+	 *
+	 * @since 3.8.1
+	 *
+	 * @return array Array of plugin data
+	 */
+	public static function get_parsed_plugin_data() {
+		$all_plugins    = get_plugins();
+		$active_plugins = Jetpack::get_active_plugins();
+
+		$plugins = array();
+		foreach ( $all_plugins as $path => $plugin_data ) {
+			$plugins[ $path ] = array(
+					'is_active' => in_array( $path, $active_plugins ),
+					'file'      => $path,
+					'name'      => $plugin_data['Name'],
+					'version'   => $plugin_data['Version'],
+					'author'    => $plugin_data['Author'],
+			);
+		}
+
+		return $plugins;
+	}
+
+	/**
 	 * Gets and parses theme data to send with the heartbeat data
 	 *
 	 * @since 3.8.1

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1739,10 +1739,10 @@ class Jetpack {
 		foreach ( $all_themes as $slug => $theme_data ) {
 			$theme_headers = array();
 			foreach ( $header_keys as $header_key ) {
-				$theme_headers[$header_key] = $theme_data->get( $header_key );
+				$theme_headers[ $header_key ] = $theme_data->get( $header_key );
 			}
 
-			$themes[$slug] = array(
+			$themes[ $slug ] = array(
 					'is_active_theme' => $slug == wp_get_theme()->get_template(),
 					'slug' => $slug,
 					'theme_root' => $theme_data->get_theme_root_uri(),

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1700,6 +1700,36 @@ class Jetpack {
 	}
 
 	/**
+	 * Gets and parses theme data to send with the heartbeat data
+	 *
+	 * @since 3.8.1
+	 *
+	 * @return array Array of theme data
+	 */
+	public static function get_parsed_theme_data() {
+		$all_themes = wp_get_themes( array( 'allowed' => true ) );
+		$header_keys = array( 'Name', 'Description', 'Author', 'Version', 'ThemeURI', 'AuthorURI', 'Status', 'Tags' );
+
+		$themes = array();
+		foreach ( $all_themes as $slug => $theme_data ) {
+			$theme_headers = array();
+			foreach ( $header_keys as $header_key ) {
+				$theme_headers[$header_key] = $theme_data->get( $header_key );
+			}
+
+			$themes[$slug] = array(
+					'is_active_theme' => $slug == wp_get_theme()->get_template(),
+					'slug' => $slug,
+					'theme_root' => $theme_data->get_theme_root_uri(),
+					'parent' => $theme_data->parent(),
+					'headers' => $theme_headers
+			);
+		}
+
+		return $themes;
+	}
+
+	/**
 	 * Checks whether a specific plugin is active.
 	 *
 	 * We don't want to store these in a static variable, in case


### PR DESCRIPTION
This adds the following data to the heartbeat: 

**Theme data**
- is_active
- slug
- theme root
- parent (if it's a child theme)
- theme headers 

**plugin data**
- is_active
- plugin file
- name
- author
- version 

**User count data**
Gives us the count of users by role for the site. 

To Test: 
- connect jetpack to your sandbox, and run from wpcom: `wp jetpack get-heartbeat --blog_id=YOUR_ID`