### PR TITLE
Photon: made the downsize filter return resulting image dimensions.

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -516,8 +516,8 @@ class Jetpack_Photon {
 				// Generate Photon URL
 				$image = array(
 					jetpack_photon_url( $image_url, $photon_args ),
-					false,
-					false
+					$image_args['width'],
+					$image_args['height']
 				);
 			} elseif ( is_array( $size ) ) {
 				// Pull width and height values from the provided array, if possible
@@ -556,8 +556,8 @@ class Jetpack_Photon {
 				// Generate Photon URL
 				$image = array(
 					jetpack_photon_url( $image_url, $photon_args ),
-					false,
-					false
+					$width,
+					$height
 				);
 			}
 		}


### PR DESCRIPTION
In order to fix #2919 we needed to return image dimensions from the `filter_image_downsize` function. This PR does this by returning the resulting dimensions that are sent to Photon for processing.