### PR TITLE
Carousel: make sure the page doesn't scroll back to the top when closing carousel view

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -8,7 +8,7 @@ jQuery(document).ready(function($) {
 	var overlay, comments, gallery, container, nextButton, previousButton, info, transitionBegin,
 	caption, resizeTimeout, photo_info, close_hint, commentInterval, lastSelectedSlide,
 	screenPadding = 110, originalOverflow = $('body').css('overflow'), originalHOverflow = $('html').css('overflow'), proportion = 85,
-	last_known_location_hash = '', imageMeta, titleAndDescription, commentForm, leftColWrapper;
+	last_known_location_hash = '', imageMeta, titleAndDescription, commentForm, leftColWrapper, scrollPos;
 
 	if ( window.innerWidth <= 760 ) {
 		screenPadding = Math.round( ( window.innerWidth / 760 ) * 110 );
@@ -481,6 +481,7 @@ jQuery(document).ready(function($) {
 			// prevent html from overflowing on some of the new themes.
 			originalHOverflow = $('html').css('overflow');
 			$('html').css('overflow', 'hidden');
+			scrollPos = $( window ).scrollTop();
 
 			// Re-apply inline-block style here and give an initial value for the width
 			// This value will get replaced with a more appropriate value once the slide is loaded
@@ -530,6 +531,7 @@ jQuery(document).ready(function($) {
 				.trigger('jp_carousel.beforeClose')
 				.fadeOut('fast', function(){
 					container.trigger('jp_carousel.afterClose');
+					$( window ).scrollTop( scrollPos );
 				});
 
 		},

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -389,11 +389,9 @@ jQuery(document).ready(function($) {
 					if ( history.pushState ) {
 						history.pushState('', document.title, window.location.pathname + window.location.search);
 					} else {
-						last_known_location_hash = '';
 						window.location.hash = '';
 					}
 					last_known_location_hash = '';
-					window.location.hash = '';
 					gallery.opened = false;
 				})
 				.on( 'transitionend.jp-carousel ', '.jp-carousel-slide', function ( e ) {

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -386,6 +386,12 @@ jQuery(document).ready(function($) {
 					$(window).scrollTop(scroll);
 				})
 				.bind('jp_carousel.afterClose', function(){
+					if ( history.pushState ) {
+						history.pushState('', document.title, window.location.pathname + window.location.search);
+					} else {
+						last_known_location_hash = '';
+						window.location.hash = '';
+					}
 					last_known_location_hash = '';
 					window.location.hash = '';
 					gallery.opened = false;


### PR DESCRIPTION
fixes #1125

Save the scroll position on open, and make sure it scrolls to same position for all browsers after close.  

read comments in #1125 for more info. 