### PR TITLE
Stats: removed the extra header to avoid having many nested headers.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6623,7 +6623,7 @@ p {
 	public function wp_dashboard_setup() {
 		if ( self::is_active() ) {
 			add_action( 'jetpack_dashboard_widget', array( __CLASS__, 'dashboard_widget_footer' ), 999 );
-			$widget_title = __( 'Jetpack', 'jetpack' );
+			$widget_title = __( 'Site Stats', 'jetpack' );
 		} elseif ( ! self::is_development_mode() && current_user_can( 'jetpack_connect' ) ) {
 			add_action( 'jetpack_dashboard_widget', array( $this, 'dashboard_widget_connect_to_wpcom' ) );
 			$widget_title = __( 'Please Connect Jetpack', 'jetpack' );

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -829,18 +829,15 @@ function stats_dashboard_widget_control() {
 
 function stats_jetpack_dashboard_widget() {
 	?>
-	<h3>
-		<span class="js-toggle-stats_dashboard_widget_control">
-			<?php esc_html_e( 'Configure', 'jetpack' ); ?>
-		</span>
-		<?php esc_html_e( 'Site Stats', 'jetpack' ); ?>
-	</h3>
 	<form id="stats_dashboard_widget_control" action="<?php esc_url( admin_url() ); ?>" method="post">
 		<?php stats_dashboard_widget_control(); ?>
 		<?php wp_nonce_field( 'edit-dashboard-widget_dashboard_stats', 'dashboard-widget-nonce' ); ?>
 		<input type="hidden" name="widget_id" value="dashboard_stats" />
 		<?php submit_button( __( 'Submit', 'jetpack' ) ); ?>
 	</form>
+	<span id="js-toggle-stats_dashboard_widget_control">
+		<?php esc_html_e( 'Configure', 'jetpack' ); ?>
+	</span>
 	<div id="dashboard_stats">
 		<div class="inside">
 			<div style="height: 250px;"></div>
@@ -848,16 +845,22 @@ function stats_jetpack_dashboard_widget() {
 	</div>
 	<script>
 		jQuery(document).ready(function($){
-			$('.js-toggle-stats_dashboard_widget_control').click(function(e){
+			var $toggle = $('#js-toggle-stats_dashboard_widget_control');
+
+			$toggle.parent().prev().append( $toggle );
+			$toggle.show().click(function(e){
 				e.preventDefault();
+				e.stopImmediatePropagation();
 				$(this).parent().toggleClass('controlVisible');
 				$('#stats_dashboard_widget_control').slideToggle();
 			});
 		});
 	</script>
 	<style>
-		.js-toggle-stats_dashboard_widget_control {
+		#js-toggle-stats_dashboard_widget_control {
+			display: none;
 			float: right;
+			margin-top: 0.2em;
 			font-weight: 400;
 			color: #444;
 			font-size: .8em;
@@ -969,7 +972,7 @@ jQuery(window).load( function() {
 #top-search p {
 	color: #999;
 }
-#stats-info h4 {
+#stats-info h3 {
 	font-size: 1em;
 	margin: 0 0 .5em 0 !important;
 }
@@ -1066,7 +1069,7 @@ function stats_dashboard_widget_content() {
 <div id="stats-info">
 	<div id="top-posts" class='stats-section'>
 		<div class="stats-section-inner">
-		<h4 class="heading"><?php _e( 'Top Posts' , 'jetpack' ); ?></h4>
+		<h3 class="heading"><?php _e( 'Top Posts' , 'jetpack' ); ?></h3>
 		<?php
 		if ( empty( $top_posts ) ) {
 			?>
@@ -1090,7 +1093,7 @@ function stats_dashboard_widget_content() {
 	</div>
 	<div id="top-search" class='stats-section'>
 		<div class="stats-section-inner">
-		<h4 class="heading"><?php _e( 'Top Searches' , 'jetpack' ); ?></h4>
+		<h3 class="heading"><?php _e( 'Top Searches' , 'jetpack' ); ?></h3>
 		<?php
 		if ( empty( $searches ) ) {
 			?>


### PR DESCRIPTION
This also solves the style compatibility problem that came up after core changed the way dashboard widget headers behave. This fixes #2916 by making the widget look like this:
<img width="534" alt="screen shot 2015-11-18 at 20 49 33" src="https://cloud.githubusercontent.com/assets/374293/11247562/ff513a42-8e35-11e5-844b-b3f64370c770.png">
cc @jeffgolenski and @justinkropp who we've had a conversation about this yesterday.