### PR TITLE
JSON API: rename to jetpack-log

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-log-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-log-endpoint.php
@@ -1,7 +1,7 @@
 <?php
 
-class Jetpack_JSON_API_Log_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// GET /sites/%s/log
+class Jetpack_JSON_API_Jetpack_Log_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// GET /sites/%s/jetpack-log
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -582,10 +582,10 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-log-endpoint.php' );
 
-new Jetpack_JSON_API_Log_Endpoint( array(
+new Jetpack_JSON_API_Jetpack_Log_Endpoint( array(
 	'description'     => 'Get the Jetpack log',
 	'method'          => 'GET',
-	'path'            => '/sites/%s/log',
+	'path'            => '/sites/%s/jetpack-log',
 	'stat'            => 'log',
 	'path_labels' => array(
 		'$site' => '(int|string) The site ID, The site domain'

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -597,7 +597,7 @@ new Jetpack_JSON_API_Jetpack_Log_Endpoint( array(
 	'response_format' => array(
 		'log' => '(array) An array of jetpack log entries'
 	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/log'
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/jetpack-log'
 ) );
 
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-maybe-auto-update-endpoint.php' );


### PR DESCRIPTION
As per discussion prefixing the api endpoint with jetpack since the log is only returning Jetpack related data. 
