### PR TITLE
Publicize: Add master kill switch filter for Publicize

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -325,6 +325,21 @@ abstract class Publicize_Base {
 			$submit_post = false;
 		}
 
+		/**
+		 * Filter if a post should be skipped during Publicize.
+		 *
+		 * @module publicize
+		 *
+		 * @since 3.9.0
+		 *
+		 * @param bool   $skip    Should the post be skipped? Default false.
+		 * @param int    $post_id The post ID being considered.
+		 * @param object $post    The post object being considered.
+		 */
+		if ( apply_filters( 'jetpack_skip_all_publicize', false, $post_id, $post ) ) {
+			$submit_post = false;
+		}
+
 		// Did this request happen via wp-admin?
 		$from_web = 'post' == strtolower( $_SERVER['REQUEST_METHOD'] ) && isset( $_POST[$this->ADMIN_PAGE] );
 


### PR DESCRIPTION
Fixes #7.

Yup, #7 

Previously, this approach was added, but was ruled null in light of `wpas_submit_post?`, however, various problems were found with using that filter within Jetpack. While those problems need to be fixed (and spun off of the original issue), we should still provide an easy-to-use filter to act as a killswitch for Publicize.

Use case: force disable Publicize by category. When a post is published, if it is has a certain taxonomy, ensure it never goes out.

Most recently requested in 2428358-t