### PR TITLE
Amend comments with wp.org to w.org. The former isn't what you think…

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -181,7 +181,7 @@ function jetpack_og_tags() {
 		require_once JETPACK__GLOTPRESS_LOCALES_PATH;
 		$_locale = get_locale();
 
-		// We have to account for WP.org vs WP.com locale divergence
+		// We have to account for w.org vs WP.com locale divergence
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$gp_locale = GP_Locales::by_field( 'slug', $_locale );
 		} else {

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -939,7 +939,7 @@ class Jetpack_Likes {
 
 		$_locale = get_locale();
 
-		// We have to account for WP.org vs WP.com locale divergence
+		// We have to account for w.org vs WP.com locale divergence
 		if ( $this->in_jetpack ) {
 			if ( ! defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) || ! file_exists( JETPACK__GLOTPRESS_LOCALES_PATH ) ) {
 				return false;


### PR DESCRIPTION
…and the latter is pretty darn cool.

Fixes #3053 