### PR TITLE
Shortcodes: Medium: Improve URL path type matching

### DIFF
--- a/modules/shortcodes/medium.php
+++ b/modules/shortcodes/medium.php
@@ -48,12 +48,13 @@ function jetpack_embed_medium_shortcode( $atts ) {
 
 function jetpack_embed_medium_get_embed_type( $url ) {
 	$url_path = parse_url( $url, PHP_URL_PATH );
-	if ( 0 === strpos( $url_path, '/@' ) ) {
+	if ( preg_match( '/^\/@[\.\w]+$/', $url_path ) ) {
 		return 'profile';
-	} elseif ( preg_match( '#^/[^/]+/[^/]+$#', $url_path ) ) {
-		return 'story';
+	} else if ( preg_match( '/^\/[\da-zA-Z-]+$/', $url_path ) ) {
+		return 'collection';
 	}
-	return 'collection';
+
+	return 'story';
 }
 
 function jetpack_embed_medium_args( $atts ) {


### PR DESCRIPTION
Currently, user stories are interpreted as profiles, as they begin with an "@"-prefixed path. The patterns introduced in this pull request improve matching against profiles and collections, including more accurate supported characters.

Example URLs to test against:

- Profile: https://medium.com/@ev
- Collection: https://medium.com/the-story
- User Story: https://medium.com/@ev/why-i-m-glad-jack-is-back-at-twitter-9bbda2ae5dca#.wccthwtfl
- Collection Story: https://medium.com/the-story/taking-medium-to-the-next-level-cb7f223fad86#.3c3u7xrgk

Supported characters are not widely published, but were inferred as follows:

- For user names, numbers, letters, dots, and underscores are permitted. You can verify this by attempting to change your username from the [Medium settings page](https://medium.com/me/settings) to include any character not in this set, and observe the error message.
- For collections/publications, supported characters were inferred by attempting to include a variety of special characters and letters in the [Medium New Publication](https://medium.com/new-publication) form. After creating the Publication, all non-letters/numbers are converted to dashes.