### PR TITLE
JSON APi: Remove DISALLOW_FILE_EDIT data from the endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -357,7 +357,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					// By default we assume that site does have system write access if the value is not set yet.
 					$file_mod_denied_reason['has_no_file_system_write_access'] = ! (bool)( get_option( 'jetpack_has_file_system_write_access', true ) );
 
-					$file_mod_denied_reason['disallow_file_edit'] = (bool) get_option( 'jetpack_constant_DISALLOW_FILE_EDIT' );
 					$file_mod_denied_reason['disallow_file_mods'] = (bool) get_option( 'jetpack_constant_DISALLOW_FILE_MODS' );
 
 					$file_mod_disabled_reasons = array();


### PR DESCRIPTION
DISALLOW_FILE_EDIT constant boolean doesn't relate to if the site has file permission enabled or not just if the admin wants files to be edited via the wp-admin ui. 

Would fix https://github.com/Automattic/wp-calypso/issues/669