### PR TITLE
Sharing / Twenty Sixteen: make sure Sharing appears on search page

### DIFF
--- a/modules/theme-tools/compat/twentysixteen.php
+++ b/modules/theme-tools/compat/twentysixteen.php
@@ -36,10 +36,10 @@ function twentysixteen_gallery_widget_content_width( $width ) {
 add_filter( 'gallery_widget_content_width', 'twentysixteen_gallery_widget_content_width' );
 
 /**
- * Remove sharing and likes from custom excerpt.
+ * Remove ratings from excerpts that are used as intro on blog index, single, and archive pages.
  */
 function twentysixteen_remove_share() {
-	if ( has_excerpt() ) {
+	if ( is_single() || is_archive() || is_home() ) {
 	    remove_filter( 'the_excerpt', 'sharing_display', 19 );
 	    if ( class_exists( 'Jetpack_Likes' ) ) {
 	        remove_filter( 'the_excerpt', array( Jetpack_Likes::init(), 'post_likes' ), 30, 1 );


### PR DESCRIPTION
Currently, if one of a post in search page has a custom excerpt, sharing won't appear on all other posts. 

With this change, sharing will only be removed from blog index, single, and archive page where excerpts are used as intro in the theme.