### PR TITLE
Image Widget: use figure and figcaption instead of [caption]

### DIFF
--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -87,10 +87,13 @@ class Jetpack_Image_Widget extends WP_Widget {
 				$output = '<a href="' . esc_attr( $instance['link'] ) . '">' . $output . '</a>';
 			if ( '' != $instance['caption'] ) {
 				/** This filter is documented in core/src/wp-includes/default-widgets.php */
-				$caption = apply_filters( 'widget_text', $instance['caption'] );
-				$output = '[caption align="align' .  esc_attr( $instance['align'] ) . '" width="' . esc_attr( $instance['img_width'] ) .'"]' . $output . ' ' . $caption . '[/caption]'; // wp_kses_post caption on update
+				$caption   = apply_filters( 'widget_text', $instance['caption'] );
+				$img_width = ( ! empty( $instance['img_width'] ) ? 'style="width: ' . esc_attr( $instance['img_width'] ) .'px"' : '' );
+				$output    = '<figure ' . $img_width .' class="wp-caption align' .  esc_attr( $instance['align'] ) . '">
+					' . $output . '
+					<figcaption class="wp-caption-text">' . $caption . '</figcaption>
+				</figure>'; // wp_kses_post caption on update
 			}
-
 			echo '<div class="jetpack-image-container">' . do_shortcode( $output ) . '</div>';
 		}
 


### PR DESCRIPTION
`[caption]` never displayed any caption in the Image widget. Let's switch and use the standard HTML `figure` and `figcaption` instead.
Also check if image width exists before to add that value to the HTML. In some cases, image width is set to 0 until you save widget settings again.

Reported in 2435477-t