### PR TITLE
Photon: Make sure to always get a size for an image in image_downsize

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -456,7 +456,7 @@ class Jetpack_Photon {
 
 				// `full` is a special case in WP
 				// To ensure filter receives consistent data regardless of requested size, `$image_args` is overridden with dimensions of original image.
-				if ( 'full' == $size || ! $image_meta = image_get_intermediate_size( $attachment_id, $size )) {
+				if ( 'full' == $size || ! $image_meta = image_get_intermediate_size( $attachment_id, $size ) ) {
 					$image_meta = wp_get_attachment_metadata( $attachment_id );
 				}
 

--- a/class.photon.php
+++ b/class.photon.php
@@ -454,21 +454,10 @@ class Jetpack_Photon {
 
 				$photon_args = array();
 
-				$image_meta = array();
 				// `full` is a special case in WP
 				// To ensure filter receives consistent data regardless of requested size, `$image_args` is overridden with dimensions of original image.
-				if ( 'full' == $size ) {
+				if ( 'full' == $size || ! $image_meta = image_get_intermediate_size( $attachment_id, $size )) {
 					$image_meta = wp_get_attachment_metadata( $attachment_id );
-				}
-				// When a size is set with only a height or width, e.g. (`set_post_thumbnail_size( 1200, 0, true );`), we need an image size for Photon to pass along later.
-				elseif ( 'post-thumbnail' == $size || ! $image_args['width'] || ! $image_args['height'] ) {
-					$image_meta = image_get_intermediate_size( $attachment_id, $size );
-
-					// The post thumbnail is unable to get the intermediate size, likely because it's smaller than the size of the post thumbnail.
-					// Let's get the full-size image so we're not distorting it later.
-					if ( 'post-thumbnail' == $size && ! $image_meta ) {
-						$image_meta = wp_get_attachment_metadata( $attachment_id );
-					}
 				}
 
 				if ( isset( $image_meta['width'], $image_meta['height'] ) ) {


### PR DESCRIPTION
fixes #3080

Mimic how core handles it, i.e. checking for intermediate size first.  https://github.com/WordPress/WordPress/blob/bc1e479fd03b95c5b977726878adcc19ffd38832/wp-includes/media.php#L194

When we're filtering the image through image_downsize, we first check to see if an `intermediate` size is present, and if not then fall back to the sizes from the attachment meta.  This makes checking for 0 values for width and height is moot, which is why the elseif has been removed here. 

to-test: 
- photon active
- upload photos to featured images, and jetpack's portfolios.  
- Each image should have srcset 
- all urls should be photonized w/ `resize` params
- make sure no image distortion takes place 
- test on pre-4.4 site (no srcset available)