### PR TITLE
Jetpack Manage: Track FORCE_SSL_ADMIN constant

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -822,6 +822,7 @@ class Jetpack_Sync {
 			'WP_AUTO_UPDATE_CORE',
 			'WP_HTTP_BLOCK_EXTERNAL',
 			'WP_ACCESSIBLE_HOSTS',
+			'FORCE_SSL_ADMIN',
 			);
 	}
 	/**


### PR DESCRIPTION
Start tracking FORCE_SSL_ADMIN value so that we have a better idea when a site is under ssl and when not. 

Help with https://github.com/Automattic/jetpack/issues/1435
