### PR TITLE
My Jetpack: added a message about why it is impossible to disconnect.

### DIFF
--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -144,12 +144,20 @@
 				<div id="jetpack-disconnect-content">
 					<div class="j-row">
 						<div class="j-col j-lrg-12 j-md-12 j-sm-12">
-							<h2><?php _e( 'Disconnecting Jetpack', 'jetpack' ); ?></h2>
-							<p><?php _e( 'Before you completely disconnect Jetpack is there anything we can do to help?', 'jetpack' ); ?></p>
+
 							<?php if ( ! Jetpack::jetpack_is_staging_site() ) : ?>
+								<h2><?php _e( 'Disconnecting Jetpack', 'jetpack' ); ?></h2>
+								<p><?php _e( 'Before you completely disconnect Jetpack is there anything we can do to help?', 'jetpack' ); ?></p>
 								<a class="button" id="confirm-disconnect" title="<?php esc_attr_e( 'Disconnect Jetpack', 'jetpack' ); ?>" href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=disconnect' ), 'jetpack-disconnect' ); ?>"><?php _e( 'Confirm Disconnect', 'jetpack' ); ?></a>
 								<a class="button primary" id="support-no-disconnect" target="_blank" title="<?php esc_attr_e( 'Jetpack Support', 'jetpack' ); ?>" href="http://jetpack.me/contact-support/"><?php esc_html_e( 'I Need Support', 'jetpack' ); ?></a>
 							<?php else : ?>
+								<h2><?php _e( 'Can not disconnect Jetpack', 'jetpack' ); ?></h2>
+								<p><?php
+									printf(
+										__( 'Because this site is in staging mode, disconnecting it is not possible. You can learn more about how staging sites work in <a href="%s" target="_blank">the developer reference section</a>.', 'jetpack' ),
+										'https://jetpack.me/support/why-cant-i-disconnect-my-site/'
+									);
+								?></p>
 								<input type="button" class="button" disabled="disabled" id="confirm-disconnect" value="<?php _e( 'Confirm Disconnect', 'jetpack' ); ?>">
 								<a class="button primary" id="support-no-disconnect" target="_blank" title="<?php esc_attr_e( 'Jetpack Support', 'jetpack' ); ?>" href="https://jetpack.me/support/why-cant-i-disconnect-my-site/"><?php esc_html_e( 'I Need Support', 'jetpack' ); ?></a>
 							<?php endif; ?>

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -154,7 +154,7 @@
 								<h2><?php _e( 'Can not disconnect Jetpack', 'jetpack' ); ?></h2>
 								<p><?php
 									printf(
-										__( 'Because this site is in staging mode, disconnecting it is not possible. You can learn more about how staging sites work in <a href="%s" target="_blank">the developer reference section</a>.', 'jetpack' ),
+										__( 'Disconnecting is not possible while in staging mode.<br /><a href="%s" target="_blank">Learn more about how staging sites work</a>.', 'jetpack' ),
 										'https://jetpack.me/support/why-cant-i-disconnect-my-site/'
 									);
 								?></p>


### PR DESCRIPTION
This fixes #2627, cc @kraftbj.
@jeffgolenski can you please take a look at the notice and give some design advice?

The disconnect message when it is possible to disconnect remains unchanged:
![screen shot 2015-12-02 at 17 30 11](https://cloud.githubusercontent.com/assets/374293/11533417/a1dd1dfa-991a-11e5-9b44-9aade77b2e25.png)

The message when it is not possible to disconnect becomes this:
![screen shot 2015-12-02 at 17 30 05](https://cloud.githubusercontent.com/assets/374293/11533443/c8e47646-991a-11e5-8c5a-27e69923ef1d.png)
