### PR TITLE
fixed #3093 . wp_embed_register_handler for vimeo url.

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -202,6 +202,23 @@ function vimeo_link_callback( $matches ) {
 	return "\n" . vimeo_shortcode( $atts ) . "\n";
 }
 
+/**
+ * For bare URLs on their own line of the form
+ * https://vimeo.com/141358
+ */
+function wpcom_vimeo_embed_crazy_url( $matches, $attr, $url ) {
+	$id = jetpack_shortcode_get_vimeo_id( array( $url ) );
+	$param = array_merge( $attr, array( 'id' => $id ) );
+	return vimeo_shortcode( $param );
+}
+
+function wpcom_vimeo_embed_crazy_url_init() {
+	wp_embed_register_handler( 'wpcom_vimeo_embed_crazy_url', '#^https?://(.+\.)?vimeo\.com/.*#', 'wpcom_vimeo_embed_crazy_url' );
+}
+
+add_action( 'init', 'wpcom_vimeo_embed_crazy_url_init' );
+
+
 /** This filter is documented in modules/shortcodes/youtube.php */
 if ( apply_filters( 'jetpack_comments_allow_oembed', get_option('embed_autourls') ) ) {
 	// We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway, so the iframe gets filtered out.

--- a/tests/php/modules/shortcodes/test_class.vimeo.php
+++ b/tests/php/modules/shortcodes/test_class.vimeo.php
@@ -89,4 +89,26 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 		$this->assertContains( 'height="' . $height . '"', $shortcode_content );
 	}
 
+	/**
+	 * @author Toro_Unit
+	 * @covers ::vimeo_shortcode
+	 * @since 3.9
+	 */
+	public function test_replace_url_with_iframe_in_the_content() {
+		global $post;
+
+		$video_id = '141358';
+		$url = 'http://vimeo.com/' . $video_id;
+		$post = $this->factory->post->create_and_get( array( 'post_content' => $url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		wp_reset_postdata();
+		$this->assertContains( '<div class="embed-vimeo"', $actual );
+		$this->assertContains( '<iframe src="https://player.vimeo.com/video/'.$video_id.'"', $actual );
+	}
+
 }

--- a/tests/php/modules/shortcodes/test_class.youtube.php
+++ b/tests/php/modules/shortcodes/test_class.youtube.php
@@ -39,4 +39,28 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 		$this->assertContains( $youtube_id, $shortcode_content );
 	}
 
+	/**
+	 * @author Toro_Unit
+	 * @covers ::youtube_shortcode
+	 * @since 3.9
+	 */
+	public function test_replace_url_with_iframe_in_the_content() {
+		global $post;
+
+		$youtube_id = 'JaNH56Vpg-A';
+		$url = 'http://www.youtube.com/watch?v=' . $youtube_id;
+		$post = $this->factory->post->create_and_get( array( 'post_content' => $url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		wp_reset_postdata();
+		$this->assertContains( "<span class='embed-youtube'", $actual );
+		$this->assertContains( "<iframe class='youtube-player'", $actual );
+		$this->assertContains( "http://www.youtube.com/embed/$youtube_id", $actual );
+
+	}
+
 }


### PR DESCRIPTION
Fixed #3093 .
Add wp_embed_register_handler for vimeo url.

And add unit test for `wpcom_youtube_embed_crazy_url_init` and `wpcom_vimeo_embed_crazy_url_init`.



