### PR TITLE
API: Adds holiday snow to /sites/$site/settings endpoint

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -2425,6 +2425,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'twitter_via'                  => '(string) Twitter username to include in tweets when people share using the Twitter button',
 		'jetpack-twitter-cards-site-tag' => '(string) The Twitter username of the owner of the site\'s domain.',
 		'eventbrite_api_token'         => '(int) The Keyring token ID for an Eventbrite token to associate with the site',
+		'holidaysnow'                  => '(bool) Enable snowfall on frontend of site?'
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -126,6 +126,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$eventbrite_api_token = null;
 				}
 
+				$holiday_snow = false;
+				if ( function_exists( 'jetpack_holiday_snow_option_name' ) ) {
+					$holiday_snow = (bool) get_option( jetpack_holiday_snow_option_name() );
+				}
+
 				$response[$key] = array(
 
 					// also exists as "options"
@@ -172,6 +177,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'twitter_via'             => (string) get_option( 'twitter_via' ),
 					'jetpack-twitter-cards-site-tag' => (string) get_option( 'jetpack-twitter-cards-site-tag' ),
 					'eventbrite_api_token'    => $eventbrite_api_token,
+					'holidaysnow'             => $holiday_snow
 				);
 
 				if ( class_exists( 'Sharing_Service' ) ) {
@@ -331,6 +337,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						}
 					}
 					break;
+
+				case 'holidaysnow':
+					if ( empty( $value ) || WPCOM_JSON_API::is_falsy( $value ) ) {
+						if ( function_exists( 'jetpack_holiday_snow_option_name' ) && delete_option( jetpack_holiday_snow_option_name() ) ) {
+							$updated[ $key ] = false;
+						}
+ 					} else if ( function_exists( 'jetpack_holiday_snow_option_name' ) && update_option( jetpack_holiday_snow_option_name(), 'letitsnow' ) ) {
+						$updated[ $key ] = true;
+ 					}
+ 					break;
 
 				// no worries, we've already whitelisted and casted arguments above
 				default:


### PR DESCRIPTION
Holiday snow if an option that is available at `/wp-admin/options-general.php` during the holiday season. This PR allows a user to toggle the holiday snow setting through the API.

To test:
- Checkout `add/site-settings-holiday-snow` branch
- Go to [https://developer.wordpress.com/docs/api/console/](https://developer.wordpress.com/docs/api/console/)
- Enter `/sites/$site/settings`
- Ensure that `holidaysnow` is returned
- `POST` to the same endpoint with `holidaysnow=(true|false)`
- Can you change the setting?
- Each time, test that snow appears/disappears on the frontend of the site.