### PR TITLE
Stats Dashboard: removed additional requests on resize in favor of redraws.

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -891,39 +891,31 @@ function stats_register_widget_control_callback() {
 function stats_dashboard_head() { ?>
 <script type="text/javascript">
 /* <![CDATA[ */
-jQuery(window).load( function() {
-	jQuery( function($) {
-		var dashStats = jQuery( '#dashboard_stats div.inside' );
+jQuery( function($) {
+	var dashStats = jQuery( '#dashboard_stats div.inside' );
 
-		if ( dashStats.find( '.dashboard-widget-control-form' ).length ) {
-			return;
-		}
+	if ( dashStats.find( '.dashboard-widget-control-form' ).length ) {
+		return;
+	}
 
-		if ( ! dashStats.length ) {
-			dashStats = jQuery( '#dashboard_stats div.dashboard-widget-content' );
-			var h = parseInt( dashStats.parent().height() ) - parseInt( dashStats.prev().height() );
-			var args = 'width=' + dashStats.width() + '&height=' + h.toString();
+	if ( ! dashStats.length ) {
+		dashStats = jQuery( '#dashboard_stats div.dashboard-widget-content' );
+		var h = parseInt( dashStats.parent().height() ) - parseInt( dashStats.prev().height() );
+		var args = 'width=' + dashStats.width() + '&height=' + h.toString();
+	} else {
+		if ( jQuery('#dashboard_stats' ).hasClass('postbox') ) {
+			var args = 'width=' + ( dashStats.prev().width() * 2 ).toString();
 		} else {
-			if ( jQuery('#dashboard_stats' ).hasClass('postbox') ) {
-				var args = 'width=' + ( dashStats.prev().width() * 2 ).toString();
-			} else {
-				var args = 'width=' + ( dashStats.width() * 2 ).toString();
-			}
+			var args = 'width=' + ( dashStats.width() * 2 ).toString();
 		}
+	}
 
-		dashStats
-			.not( '.dashboard-widget-control' )
-			.load( 'admin.php?page=stats&noheader&dashboard&' + args );
+	dashStats
+		.not( '.dashboard-widget-control' )
+		.load( 'admin.php?page=stats&noheader&dashboard&' + args );
 
-		jQuery( window ).one( 'resize', function() {
-			jQuery( '#stat-chart' ).css( 'width', 'auto' );
-		} );
-		jQuery( window ).on( 'resize', function() {
-
-			// Wrapping this call in an anonymous function because drawChart
-			// is not available on first run
-			drawChart();
-		} );
+	jQuery( window ).one( 'resize', function() {
+		jQuery( '#stat-chart' ).css( 'width', 'auto' );
 	} );
 } );
 /* ]]> */

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -893,13 +893,6 @@ function stats_dashboard_head() { ?>
 /* <![CDATA[ */
 jQuery(window).load( function() {
 	jQuery( function($) {
-		resizeChart();
-		jQuery(window).resize( _.debounce( function(){
-			resizeChart();
-		}, 100) );
-	} );
-
-	function resizeChart() {
 		var dashStats = jQuery( '#dashboard_stats div.inside' );
 
 		if ( dashStats.find( '.dashboard-widget-control-form' ).length ) {
@@ -918,8 +911,20 @@ jQuery(window).load( function() {
 			}
 		}
 
-		dashStats.not( '.dashboard-widget-control' ).load( 'admin.php?page=stats&noheader&dashboard&' + args );
-	}
+		dashStats
+			.not( '.dashboard-widget-control' )
+			.load( 'admin.php?page=stats&noheader&dashboard&' + args );
+
+		jQuery( window ).one( 'resize', function() {
+			jQuery( '#stat-chart' ).css( 'width', 'auto' );
+		} );
+		jQuery( window ).on( 'resize', function() {
+
+			// Wrapping this call in an anonymous function because drawChart
+			// is not available on first run
+			drawChart();
+		} );
+	} );
 } );
 /* ]]> */
 </script>


### PR DESCRIPTION
Previously the stats widget was broken because on every resize it would re-request new HTML from .com, and it wouldn't work properly when added to the DOM dynamically. This PR removes additional requests entirely, replacing them with redraws.

There are several points of concern here:
* This needs testing in different browsers, I only tried FF on Mac and Win 10 so far.
* Redraws happen on each resize event callback, perhaps we need to keep `debounce` if it hurts performance too much. I have removed `debounce` to keep resizing more fluid.