### PR TITLE
Module Info: add Instagram to the list of available shortcodes.

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -111,6 +111,7 @@ function jetpack_shortcodes_more_info_connected() { ?>
 		'flickr' => 'http://support.wordpress.com/videos/flickr-video/',
 		'gist' => 'http://en.support.wordpress.com/gist/',
 		'googlemaps' => 'http://support.wordpress.com/google-maps/',
+		'instagram' => 'https://en.support.wordpress.com/instagram/instagram-images/', 
 		'jetpack_subscription_form' => 'http://jetpack.me/support/subscriptions/#display',
 		'polldaddy' => 'http://support.polldaddy.com/wordpress-shortcodes/',
 		'presentation' => 'http://en.support.wordpress.com/presentations/',


### PR DESCRIPTION
Reported here:
https://wordpress.org/support/topic/instagram-embedshortcode?replies=3&view=all#post-7735625