### PR TITLE
Add author support to portfolio CPT closes #3018

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -401,7 +401,7 @@ class Jetpack_Portfolio {
 			'display_types'   => true,
 			'display_tags'    => true,
 			'display_content' => true,
-			'display_author' => true,
+			'display_author'  => false,
 			'show_filter'     => false,
 			'include_type'    => false,
 			'include_tag'     => false,

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -728,8 +728,12 @@ class Jetpack_Portfolio {
 	 * @return html
 	 */
 	static function get_project_author() {
-		$html = '<div class="project-author"><span>' . esc_html__( 'Author:', 'jetpack' ) . '</span> ';
-		$html .= '<a href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a>';
+		$html = '<div class="project-author">';
+		/* translators: %1$s is link to author posts, %2$s is author display name */
+		$html .= sprintf( __( '<span>Author:</span> <a href="%1$s">%2$s</a>', 'jetpack' ),
+			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+			esc_html( get_the_author() )
+		);
 		$html .= '</div>';
 
 		return $html;

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -235,6 +235,7 @@ class Jetpack_Portfolio {
 				'title',
 				'editor',
 				'thumbnail',
+				'author',
 				'comments',
 				'publicize',
 				'wpcom-markdown',
@@ -400,6 +401,7 @@ class Jetpack_Portfolio {
 			'display_types'   => true,
 			'display_tags'    => true,
 			'display_content' => true,
+			'display_author' => true,
 			'show_filter'     => false,
 			'include_type'    => false,
 			'include_tag'     => false,
@@ -416,6 +418,10 @@ class Jetpack_Portfolio {
 
 		if ( $atts['display_tags'] && 'true' != $atts['display_tags'] ) {
 			$atts['display_tags'] = false;
+		}
+
+		if ( $atts['display_author'] && 'true' != $atts['display_author'] ) {
+			$atts['display_author'] = false;
 		}
 
 		if ( $atts['display_content'] && 'true' != $atts['display_content'] && 'full' != $atts['display_content'] ) {
@@ -563,6 +569,10 @@ class Jetpack_Portfolio {
 						if ( false != $atts['display_tags'] ) {
 							echo self::get_project_tags( $post_id );
 						}
+
+						if ( false != $atts['display_author'] ) {
+							echo self::get_project_author( $post_id );
+						}
 						?>
 						</div>
 
@@ -707,6 +717,19 @@ class Jetpack_Portfolio {
 			$tags[] = '<a href="' . esc_url( $project_tag_link ) . '" rel="tag">' . esc_html( $project_tag->name ) . '</a>';
 		}
 		$html .= ' '. implode( ', ', $tags );
+		$html .= '</div>';
+
+		return $html;
+	}
+
+	/**
+	 * Displays the author of the current portfolio project.
+	 *
+	 * @return html
+	 */
+	static function get_project_author() {
+		$html = '<div class="project-author"><span>' . esc_html__( 'Author:', 'jetpack' ) . '</span> ';
+		$html .= '<a href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a>';
 		$html .= '</div>';
 
 		return $html;


### PR DESCRIPTION
Adds:
- support in CPT registration
- parameter for portfolio shortcode
- markup for front end display, which includes the label Author: followed by the author display name linked to the author's posts page.

<img width="408" alt="portfolio-author" src="https://cloud.githubusercontent.com/assets/1041600/11643594/b630cd80-9d23-11e5-87bb-a51bf0be9445.png">

If this is merged, the documentation at
https://en.support.wordpress.com/portfolios/portfolio-shortcode/#attributes
must be update to add the new parameter:
> display_author: display Project author linked to its posts page. (true/false)