### PR TITLE
Post Images: always use real image dimensions in OG Tags

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -209,7 +209,10 @@ class Jetpack_PostImages {
 
 			$too_big = ( ( ! empty( $meta['width'] ) && $meta['width'] > 1200 ) || ( ! empty( $meta['height'] ) && $meta['height'] > 1200 ) );
 
-			if ( $too_big ) {
+			if (
+				$too_big &&
+				( Jetpack::is_module_active( 'photon' ) || ( defined( 'WPCOM' ) && IS_WPCOM ) )
+			) {
 				$img_src = wp_get_attachment_image_src( $thumb, array( 1200, 1200 ) );
 			} else {
 				$img_src = wp_get_attachment_image_src( $thumb, 'full' );


### PR DESCRIPTION
When Photon is active, it resizes very large (`$too_big`) images to be 1200x1200px. It also adjusts `og:image:width` and `og:image:height` to use these new values.
When Photon isn't active on the other hand, wp_get_attachment_image_src returns the original image. `og:image:width` and `og:image:height` shouldn't be updated to 1200x1200.

Reported here:
https://wordpress.org/support/topic/publicize-featured-image-problem-on-facebook