### PR TITLE
Post Images: avoid errors when is_module_active doesn't exist

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -211,7 +211,10 @@ class Jetpack_PostImages {
 
 			if (
 				$too_big &&
-				( Jetpack::is_module_active( 'photon' ) || ( defined( 'WPCOM' ) && IS_WPCOM ) )
+				(
+					( method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'photon' ) ) ||
+					( defined( 'WPCOM' ) && IS_WPCOM )
+				)
 			) {
 				$img_src = wp_get_attachment_image_src( $thumb, array( 1200, 1200 ) );
 			} else {


### PR DESCRIPTION
Like on WordPress.com.
Error introduced in #3114. Sorry, I didn't think about that use case earlier.