### PR TITLE
Set capabilities to prevent Feedback creation in admin, fixes #3117

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -106,7 +106,20 @@ class Grunion_Contact_Form_Plugin {
 			'public'            => FALSE,
 			'rewrite'           => FALSE,
 			'query_var'         => FALSE,
-			'capability_type'   => 'page'
+			'capability_type'   => 'page',
+			'capabilities'		=> array(
+				'create_posts'        => false,
+				'publish_posts'       => 'publish_pages',
+				'edit_posts'          => 'edit_pages',
+				'edit_others_posts'   => 'edit_others_pages',
+				'delete_posts'        => 'delete_pages',
+				'delete_others_posts' => 'delete_others_pages',
+				'read_private_posts'  => 'read_private_pages',
+				'edit_post'           => 'edit_page',
+				'delete_post'         => 'delete_page',
+				'read_post'           => 'read_page',
+			),
+			'map_meta_cap'		=> true,
 		) );
 
 		// Add to REST API post type whitelist


### PR DESCRIPTION
These capabilities will allow to read, edit, delete and perform other tasks in admin but will not allow Feedback creation addressing the concern raised in #3117, since as reported in #3115, it's a source of conflicts (IMHO it's also confusing for user).