### PR TITLE
Fix/youtube shortcodes

### DIFF
--- a/functions.compat.php
+++ b/functions.compat.php
@@ -17,8 +17,9 @@ function jetpack_shortcode_get_youtube_id( $url ) {
 */
 function jetpack_get_youtube_id( $url ) {
 	// Do we have an $atts array?  Get first att
-	if ( is_array( $url ) )
-		$url = $url[0];
+	if ( is_array( $url ) ) {
+		$url = reset( $url );
+	}
 
 	$url = youtube_sanitize_url( $url );
 	$url = parse_url( $url );

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -360,3 +360,20 @@ if ( apply_filters( 'jetpack_comments_allow_oembed', get_option('embed_autourls'
 		add_filter( 'comment_text', 'youtube_link', 1 );
 	}
 }
+
+/**
+ * Core changes to do_shortcode (https://core.trac.wordpress.org/changeset/34747) broke "improper" shortcodes
+ * with the format [shortcode=http://url.com].  
+ *
+ * This removes the "=" from the shortcode so it can be parsed.
+ *
+ * @see https://github.com/Automattic/jetpack/issues/3121
+ */
+function jetpack_fix_youtube_shortcode_display_filter( $content ) {
+	if ( strpos( $content, '[youtube=' ) !== false ) {
+		$content = preg_replace( '@\[youtube=(.*?)\]@', '[youtube $1]', $content );
+	}
+
+	return $content;
+}
+add_filter( 'the_content', 'jetpack_fix_youtube_shortcode_display_filter', 7 );


### PR DESCRIPTION
fixes #3121

2nd commit fixes all `undefined` notices that were thrown when using the new shortcode format `[youtube url=http://url.com]`.