### PR TITLE
Carousel: make sure gallery var is defined before to use it.

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -958,17 +958,17 @@ jQuery(document).ready(function($) {
 			if ( 'undefined' === typeof args.medium_file || 'undefined' === typeof args.large_file ) {
 				return args.orig_file;
 			}
-			
+
 			// Check if the image is being served by Photon (using a regular expression on the hostname).
-			
+
 			var imageLinkParser = document.createElement( 'a' );
 			imageLinkParser.href = args.large_file;
 
 			var isPhotonUrl = ( imageLinkParser.hostname.match(/^i[\d]{1}.wp.com$/i) != null );
-									
+
 			var medium_size_parts	= gallery.jp_carousel( 'getImageSizeParts', args.medium_file, args.orig_width, isPhotonUrl );
 			var large_size_parts	= gallery.jp_carousel( 'getImageSizeParts', args.large_file, args.orig_width, isPhotonUrl );
-									
+
 			var large_width       = parseInt( large_size_parts[0], 10 ),
 				large_height      = parseInt( large_size_parts[1], 10 ),
 				medium_width      = parseInt( medium_size_parts[0], 10 ),
@@ -990,12 +990,12 @@ jQuery(document).ready(function($) {
 
 			return args.orig_file;
 		},
-		
+
 		getImageSizeParts: function( file, orig_width, isPhotonUrl ) {
 			var size		= isPhotonUrl ?
 							file.replace( /.*=([\d]+%2C[\d]+).*$/, '$1' ) :
 							file.replace( /.*-([\d]+x[\d]+)\..+$/, '$1' );
-						
+
 			var size_parts  = ( size !== file ) ?
 							( isPhotonUrl ? size.split( '%2C' ) : size.split( 'x' ) ) :
 							[ orig_width, 0 ];
@@ -1005,7 +1005,7 @@ jQuery(document).ready(function($) {
 			if ( size_parts[0] === '9999' ) {
 				size_parts[0] = '0';
 			}
-			
+
 			if ( size_parts[1] === '9999' ) {
 				size_parts[1] = '0';
 			}
@@ -1466,6 +1466,10 @@ jQuery(document).ready(function($) {
 
 	// Makes carousel work on page load and when back button leads to same URL with carousel hash (ie: no actual document.ready trigger)
 	$( window ).on( 'hashchange', function () {
+		if ( 'undefined' === typeof gallery ) {
+			return;
+		}
+
 		var hashRegExp = /jp-carousel-(\d+)/,
 			matches, attachmentId, galleries, selectedThumbnail;
 


### PR DESCRIPTION
Reported here:
https://wordpress.org/support/topic/jetpack-carouseljs-hashtag-issues