### PR TITLE
Debugger: Add $_SERVER[SERVER_PORT]

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -56,6 +56,7 @@ class Jetpack_Debugger {
 		$debug_info .= "\r\n" . esc_html( "JETPACK__PLUGIN_DIR: " . JETPACK__PLUGIN_DIR );
 		$debug_info .= "\r\n" . esc_html( "SITE_URL: " . site_url() );
 		$debug_info .= "\r\n" . esc_html( "HOME_URL: " . home_url() );
+		$debug_info .= "\r\n" . esc_html( "SERVER_PORT:" . $_SERVER['SERVER_PORT'] );
 
 
 		foreach ( array (

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -56,7 +56,7 @@ class Jetpack_Debugger {
 		$debug_info .= "\r\n" . esc_html( "JETPACK__PLUGIN_DIR: " . JETPACK__PLUGIN_DIR );
 		$debug_info .= "\r\n" . esc_html( "SITE_URL: " . site_url() );
 		$debug_info .= "\r\n" . esc_html( "HOME_URL: " . home_url() );
-		$debug_info .= "\r\n" . esc_html( "SERVER_PORT:" . $_SERVER['SERVER_PORT'] );
+		$debug_info .= "\r\n" . esc_html( "SERVER_PORT: " . $_SERVER['SERVER_PORT'] );
 
 
 		foreach ( array (


### PR DESCRIPTION
The verification of the Jetpack signature assumes that a HTTP site will use `80` and a HTTPS site will use `443`, which is very much not always true. A site may be behind a loadbalancer, behind Varnish, nginx proxy in front of Apache, etc etc etc.

This can often end up with a difference of expectations between what Jetpack expects and what is provided by the local site.

Without prejudice to a future conversation about if that's still the best way to approach things, let's add the `$_SERVER['SERVER_PORT']` to the debug.

Our way around this now is asking the user to manually set this value in their wp-config.php, which is probably okay enough. BUT, we have a constant that we could use instead ( `JETPACK_SIGNATURE__HTTP_PORT` and `JETPACK_SIGNATURE__HTTPS_PORT` ). The process of trying to get info from the user on what that port should be, though, is much more painful.

If we include this in the debug report, we can faster provider users with a more specific way to hardcode what Jetpack should expect (rather than force their system to provide to us what to expect).