### PR TITLE
Core Themes Compat: Make Photon'd Full-size Image Full Width in Twenty Sixteen

### DIFF
--- a/modules/theme-tools/compat/twentysixteen-rtl.css
+++ b/modules/theme-tools/compat/twentysixteen-rtl.css
@@ -763,4 +763,8 @@ iframe[src^="http://api.mixcloud.com/"] {
 	body:not(.search-results) article:not(.type-page) .jp-relatedposts:last-child:after {
 		display: none;
 	}
+
+	body:not(.search-results) article:not(.type-page) img.below-entry-meta {
+		width: auto;
+	}
 }

--- a/modules/theme-tools/compat/twentysixteen.css
+++ b/modules/theme-tools/compat/twentysixteen.css
@@ -763,4 +763,8 @@ iframe[src^="http://api.mixcloud.com/"] {
 	body:not(.search-results) article:not(.type-page) .jp-relatedposts:last-child:after {
 		display: none;
 	}
+
+	body:not(.search-results) article:not(.type-page) img.below-entry-meta {
+		width: auto;
+	}
 }


### PR DESCRIPTION
Since Photon adds `width` attribute with the size of a parent container, full-size image in Twenty Sixteen isn't full width with Photon. This PR intends to fix the issue.

<strong>Before:</strong>
<img src="https://cldup.com/BMdH1HQue7.png" />

<strong>After:</strong>
<img src="https://cldup.com/YmAcvh8p1U.png" />

