### PR TITLE
Testimonials: Better compatibility with Infinite Scroll and Revisions

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -255,7 +255,7 @@ class The_Neverending_Home_Page {
 			self::$settings = apply_filters( 'infinite_scroll_settings', $settings );
 		}
 
-		/** This filter is documented in modules/infinite-scroll/infinity.php */
+		/** This filter is already documented in modules/infinite-scroll/infinity.php */
 		return (object) apply_filters( 'infinite_scroll_settings', self::$settings );
 	}
 


### PR DESCRIPTION
1. Add revision support
2. Better compatibility with Infinite Scroll: if Infinite Scroll is set to 'click', use our custom reading setting instead of core's `posts_per_page`.

@michaeldcain 2) doesn't seem to work for me. Infinite Scroll doesn't work for me as soon as I change this setting, with or without the patch (using Twenty Fifteen). Am I missing something?

![screen shot 2015-12-14 at 3 43 37 pm](https://cloud.githubusercontent.com/assets/426388/11783962/2304575a-a27a-11e5-98f8-5bdd38c15b3a.png)
