### PR TITLE
IS: only disable in the Customizer when previewing a non-active theme.

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1357,8 +1357,9 @@ class The_Neverending_Home_Page {
 	 */
 	public static function archive_supports_infinity() {
 		$supported = current_theme_supports( 'infinite-scroll' ) && ( is_home() || is_archive() || is_search() );
-		// Disable infinite scroll in customizer previews
-		if ( isset( $_REQUEST[ 'wp_customize' ] ) && 'on' === $_REQUEST[ 'wp_customize' ] ) {
+
+		// Disable when previewing a non-active theme in the customizer
+		if ( is_customize_preview() && ! $GLOBALS['wp_customize']->is_theme_active() ) {
 			return false;
 		}
 


### PR DESCRIPTION
Merges r122634-wpcom.