### PR TITLE
Genericons MU plugin: add IE8 support.

### DIFF
--- a/_inc/genericons/README.md
+++ b/_inc/genericons/README.md
@@ -94,6 +94,10 @@ Base64 encoding comes with a 25% filesize overhead compared to just loading the 
 
 ## Changelog
 
+**3.4.1**
+
+* IE8 support restored.
+
 **3.4**
 
 * Updated: Update Google Plus icon to new geometric version. This also *retires* the "alt" version, so *please be mindful if you choose to update, make sure you use the `f206` glyph, not the `f218` glyph, as it no longer exists!

--- a/_inc/genericons/genericons/genericons.css
+++ b/_inc/genericons/genericons/genericons.css
@@ -11,6 +11,7 @@
    When the font is base64 encoded, cross-site embedding works in Firefox */
 @font-face {
   font-family: "Genericons";
+  src: url("./Genericons.eot");
   src: url("./Genericons.eot?") format("embedded-opentype");
   font-weight: normal;
   font-style: normal;

--- a/_inc/genericons/genericons/rtl/genericons-rtl.css
+++ b/_inc/genericons/genericons/rtl/genericons-rtl.css
@@ -1,4 +1,4 @@
-/* This file was automatically generated on Sep 18 2015 08:27:44 */
+/* This file was automatically generated on Sep 30 2015 12:24:15 */
 
 /**
 
@@ -13,6 +13,7 @@
    When the font is base64 encoded, cross-site embedding works in Firefox */
 @font-face {
   font-family: "Genericons";
+  src: url(".././Genericons.eot");
   src: url(".././Genericons.eot?") format("embedded-opentype");
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
IE8 support broke due to a bug in fontcustom, the tool to generate icon fonts.

Merges r124842-wpcom.