### PR TITLE
BandCamp Shortcode: Switch to esc_attr instead of int for IDs

### DIFF
--- a/modules/shortcodes/bandcamp.php
+++ b/modules/shortcodes/bandcamp.php
@@ -60,17 +60,17 @@ function shortcode_handler_bandcamp( $atts ) {
 		return "[bandcamp: shortcode must include 'track', 'album', or 'video' param]";
 	}
 
-	if ( isset( $attributes['track'] ) ) {
-		$track = (int) $attributes['track'];
+	if ( isset( $attributes['track'] ) && is_numeric( $attributes['track'] ) ) {
+		$track = esc_attr( $attributes['track'] );
 		array_push( $argparts, "track={$track}" );
-	} elseif ( isset( $attributes['video'] ) ) {
-		$track = (int) $attributes['video']; // videos are referenced by track id
+	} elseif ( isset( $attributes['video'] ) && is_numeric( $attributes['video'] ) ) {
+		$track = esc_attr( $attributes['video'] ); // videos are referenced by track id
 		$urlbase = "//bandcamp.com/EmbeddedPlayer/v=2";
 		$isVideo = true;
 		array_push( $argparts, "track={$track}" );
 	}
-	if ( isset( $attributes['album'] ) ) {
-		$album = (int) $attributes['album'];
+	if ( isset( $attributes['album'] ) && is_numeric( $attributes['album'] ) ) {
+		$album = esc_attr( $attributes['album'] );
 		array_push( $argparts, "album={$album}" );
 	}
 


### PR DESCRIPTION
This avoids errors when an album ID, video ID, or track ID is larger than PHP_INT_MAX

This issue was already fixed in #55, but the changes were overwritten during a wpcom merge, in 34843a4c9ca88e242a6430a5aaa61095e7f9dfab

Reported here:
https://wordpress.org/support/topic/bandcamp-issue