### PR TITLE
Add skip_version_control_check setting that lets us overwrite the autoupdate check.

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -35,7 +35,15 @@ class Jetpack_Autoupdate {
 			add_filter( 'auto_update_theme',   array( $this, 'autoupdate_theme' ), 10, 2 );
 			add_filter( 'auto_update_core',    array( $this, 'autoupdate_core' ), 10, 2 );
 			add_action( 'automatic_updates_complete', array( $this, 'automatic_updates_complete' ), 999, 1 );
+
+			if ( Jetpack_Options::get_option( 'skip_version_control_check', false ) ) {
+				add_filter( 'automatic_updates_is_vcs_checkout', array( $this, '__return_false'), 99 );
+			}
 		}
+	}
+
+	public function __return_false( $result ) {
+		return false;
 	}
 
 	public function autoupdate_plugin( $update, $item ) {

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -35,7 +35,7 @@ class Jetpack_Options {
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
-				'protect_whitelist'           // (array) IP Address for the Protect module to ignore
+				'protect_whitelist'            // (array) IP Address for the Protect module to ignore
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -27,6 +27,7 @@ class Jetpack_Options {
 				'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
 				'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
 				'autoupdate_core',             // (bool)   Whether or not to autoupdate core
+				'skip_version_control_check',  // (bool) Whether or not to ignore the version control check that happends in the during the auto updates
 				'json_api_full_management',    // (bool)   Allow full management (eg. Activate, Upgrade plugins) of the site via the JSON API.
 				'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
 				'site_icon_url',               // (string) url to the full site icon
@@ -34,7 +35,7 @@ class Jetpack_Options {
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
-				'protect_whitelist'            // (array) IP Address for the Protect module to ignore
+				'protect_whitelist'           // (array) IP Address for the Protect module to ignore
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -493,6 +493,7 @@ class Jetpack {
 			'stylesheet',
 			"theme_mods_{$theme_slug}",
 			'jetpack_sync_non_public_post_stati',
+			'skip_version_control_check',
 			'jetpack_options',
 			'site_icon', // (int) - ID of core's Site Icon attachment ID
 			'default_post_format',
@@ -1263,6 +1264,10 @@ class Jetpack {
 		if ( !class_exists( 'WP_Automatic_Updater' ) ) {
 			require_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 		}
+
+		$jetpack_autoupdate = Jetpack_Autoupdate::init();
+		remove_filter( 'automatic_updates_is_vcs_checkout', array( $jetpack_autoupdate, '__return_false' ), 99 );
+
 		$updater = new WP_Automatic_Updater();
 		$is_version_controlled = strval( $updater->is_vcs_checkout( $context = ABSPATH ) );
 		// transients should not be empty
@@ -3183,6 +3188,10 @@ p {
 	public static function log_settings_change( $option, $old_value, $value ) {
 		switch( $option ) {
 			case 'jetpack_sync_non_public_post_stati':
+				self::log( $option, $value );
+				break;
+
+			case 'skip_version_control_check':
 				self::log( $option, $value );
 				break;
 		}

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -141,6 +141,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					// new stuff starts here
 					'blog_public'             => (int) get_option( 'blog_public' ),
 					'jetpack_sync_non_public_post_stati' => (bool) Jetpack_Options::get_option( 'sync_non_public_post_stati' ),
+					'jetpack_skip_version_control_check' => (bool) Jetpack_Options::get_option( 'skip_version_control_check' ),
 					'jetpack_relatedposts_allowed' => (bool) $this->jetpack_relatedposts_supported(),
 					'jetpack_relatedposts_enabled' => (bool) $jetpack_relatedposts_options[ 'enabled' ],
 					'jetpack_relatedposts_show_headline' => (bool) $jetpack_relatedposts_options[ 'show_headline' ],
@@ -252,6 +253,9 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						}
 						$updated[ $key ] = jetpack_protect_format_whitelist();
 					}
+					break;
+				case 'skip_version_control_check':
+					Jetpack_Options::update_option( 'skip_version_control_check', $value );
 					break;
 				case 'jetpack_sync_non_public_post_stati':
 					Jetpack_Options::update_option( 'sync_non_public_post_stati', $value );

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -261,5 +261,13 @@
 	<?php endif; ?>
 <div id="deactivate-success"></div>
 <?php if ( Jetpack::is_development_version() ) { ?>
+	<?php
+	if( isset( $_GET['skip_version_true'] ) ) {
+		Jetpack_Options::update_option( 'skip_version_control_check', true );
+	}
+	if( isset( $_GET['skip_version_false'] ) ) {
+		Jetpack_Options::update_option( 'skip_version_control_check', false );
+	}
+	var_dump( Jetpack_Options::get_option( 'skip_version_control_check', false ) ); ?>
 	<a id="jump-start-deactivate" style="cursor:pointer; display: block; text-align: center; margin-top: 25px;"><?php esc_html_e( 'RESET EVERYTHING (during testing only) - will reset modules to default as well', 'jetpack' ); ?></a>
 <?php } // is_development_version ?>


### PR DESCRIPTION
Core does a check when performing autoupdates to see if a site is under version control. This check causes false positives sometimes and prevents users from performing the autoupdate.

This PR adds an option that lets the user control if they want to slip the version control check. This lets us perform autoupdates even though the site might be under version control, it is an option that the user has to opt into.

**THIS PR STILL NEEDS MORE TESTING**

**To test**:
We need to make sure that the check works as expected. 
If the option in set to true. Autoupdated should happened as expected. Both with the scheduled `maybe_auto_update` action and the `maybe_auto_update` endpoint.

We need to make sure that the data from for when we check weather a site is under version control or not is still valid and not influenced by the new filter that we added.

