### PR TITLE
Likes: Add conditional for is_comments_popup as 4.5 deprecates it.

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -1022,9 +1022,16 @@ class Jetpack_Likes {
 	function is_likes_visible() {
 
 		global $post, $wp_current_filter;              // Used to apply 'sharing_show' filter
+		// @todo: Remove this block when 4.5 is the minimum
+		global $wp_version;
+		$comment_popup = false;
+		if ( version_compare( $wp_version, '4.5-alpha', '<=' ) ) {
+			$comment_popup = is_comments_popup();
+		}
+		// End 4.5 conditional block.
 
 		// Never show on feeds or previews
-		if ( is_feed() || is_preview() || is_comments_popup() ) {
+		if ( is_feed() || is_preview() || $comment_popup ) { // @todo: Remove $comment_popup when 4.5 is minimum.
 			$enabled = false;
 
 		// Not a feed or preview, so what is it?


### PR DESCRIPTION
4.5 (and trunk currently) deprecates `is_comments_popup` and will throw deprecation notices on anyone running JP on trunk.

Marking as 3.8.2 but as long as it gets merged to master, all good.