### PR TITLE
Facebook Like Box: Fallback to WordPress locale or English for unknown locale

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -291,15 +291,33 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 			$locale = GP_Locales::by_field( 'facebook_locale', $lang );
 		}
 
-		if ( ! $locale || empty( $locale->facebook_locale ) ) {
-			return 'en_US'; // Facebook requires a locale when pulling their SDK.
+		if ( ! $locale ) {
+			return false;
+		}
+
+		if ( empty( $locale->facebook_locale ) ) {
+			if ( empty( $locale->wp_locale ) ) {
+				return false;
+			} else {
+				// Facebook SDK is smart enough to fall back to en_US if a
+				// locale isn't supported. Since supported Facebook locales
+				// can fall out of sync, we'll attempt to use the known
+				// wp_locale value and rely on said fallback.
+				return $locale->wp_locale;
+			}
 		}
 
 		return $locale->facebook_locale;
 	}
 
 	function get_locale() {
-		return $this->guess_locale_from_lang( get_locale() );
+		$locale = $this->guess_locale_from_lang( get_locale() );
+
+		if ( ! $locale ) {
+			$locale = 'en_US';
+		}
+
+		return $locale;
 	}
 }
 


### PR DESCRIPTION
Merges r120105-wpcom.

Improves on #2795 and #2834.

