### PR TITLE
Wufoo shortcode: Use the proper escaping method to avoid XSS issues.

### DIFF
--- a/modules/shortcodes/wufoo.php
+++ b/modules/shortcodes/wufoo.php
@@ -48,7 +48,7 @@ function wufoo_shortcode( $atts ) {
 	$js_embed .= "'formHash':'$formhash', ";
 	$js_embed .= "'autoResize':".(bool)( $autoresize ).",";
 	$js_embed .= "'height':'". (int) $height ."',";
-	$js_embed .= "'header':'".esc_attr( $header )."' ";
+	$js_embed .= "'header':'".esc_js( $header )."' ";
 
 	/**
 	* Only output SSL value if passes as param


### PR DESCRIPTION
Merges r121391-wpcom.