### PR TITLE
Subscribe Widget: Set the placeholder ID based on widget ID.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -882,7 +882,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			(function( d ) {
 				// Creates placeholders for IE
 				if ( ( 'placeholder' in d.createElement( 'input' ) ) ) {
-					var label = d.getElementById( 'jetpack-subscribe-label' );
+					var label = d.querySelector( 'label[for=subscribe-field-<?php echo $widget_id; ?>]' );
 						label.style.clip 	 = 'rect(1px, 1px, 1px, 1px)';
 						label.style.position = 'absolute';
 						label.style.height   = '1px';

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -880,7 +880,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			Custom functionality for safari and IE
 			 */
 			(function( d ) {
-				// Creates placeholders for IE
+				// In case the placeholder functionality is available we remove labels
 				if ( ( 'placeholder' in d.createElement( 'input' ) ) ) {
 					var label = d.querySelector( 'label[for=subscribe-field-<?php echo $widget_id; ?>]' );
 						label.style.clip 	 = 'rect(1px, 1px, 1px, 1px)';


### PR DESCRIPTION
Fixes #3166

There are some other elements that are IDs, which make the HTML with multiple subscribe widgets invalid which should be investigated too, but not needed for 3166.