### PR TITLE
Tiled Galleries: Use "inherit" to reset color property, part 2

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/rtl/tiled-gallery-rtl.css
+++ b/modules/tiled-gallery/tiled-gallery/rtl/tiled-gallery-rtl.css
@@ -1,4 +1,4 @@
-/* This file was automatically generated on May 26 2014 22:30:22 */
+/* This file was automatically generated on Oct 01 2015 20:17:19 */
 
 /* =Tiled Gallery Default Styles
 -------------------------------------------------------------- */
@@ -27,7 +27,7 @@
 .tiled-gallery .tiled-gallery-item a { /* Needs to reset some properties for theme compatibility */
 	background: transparent;
 	border: none;
-	color: none;
+	color: inherit;
 	margin: 0;
 	padding: 0;
 	text-decoration: none;


### PR DESCRIPTION
Merges r124960-wpcom.

Completes #2302 by applying the same change to the RTL stylesheet as well.