### PR TITLE
Shortcodes: update slideshow gallery shortcode

### DIFF
--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -72,7 +72,7 @@ JetpackSlideshow.prototype.makeZeroWidthSpan = function() {
 	emptySpan.className = 'slideshow-line-height-hack';
 	// Having a NBSP makes IE act weird during transitions, but other
 	// browsers ignore a text node with a space in it as whitespace.
-	if (jQuery.browser.msie) {
+	if ( -1 !== window.navigator.userAgent.indexOf( "MSIE " ) ) {
 		emptySpan.appendChild( document.createTextNode(' ') );
 	} else {
 		emptySpan.innerHTML = '&nbsp;';


### PR DESCRIPTION
jQuery.browser was deprecated in jQuery 1.9. We've continued to be able to use it via the jQuery migrate plugin, but this is not a viable option longterm. Additionally this broke instances where we need to load the script without loading the migrate plugin, as was the case in the Calypso Editor.

This implements a simpler approach to detecting older version of IE

Merges r123630-wpcom.