### PR TITLE
[contact-form $attributes] now ok in do_shortcode

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -280,12 +280,20 @@ class Grunion_Contact_Form_Plugin {
 
 			// Get shortcode from post meta
 			$shortcode = get_post_meta( $_POST['contact-form-id'], '_g_feedback_shortcode', true );
-			// Get the attributes from post meta. $attributes not available here
-			$atts = get_post_meta( $_POST['contact-form-id'], '_g_feedback_shortcode_atts', true );
 
 			// Format it
 			if ( $shortcode != '' ) {
-				$shortcode = '[contact-form'.$atts.']' . $shortcode . '[/contact-form]';
+
+				// Get attributes from post meta.
+				$parameters = '';
+				$attributes = get_post_meta( $_POST['contact-form-id'], '_g_feedback_shortcode_atts', true );
+				if ( ! empty( $attributes ) && is_array( $attributes ) ) {
+					foreach( array_filter( $attributes ) as $param => $value  ) {
+						$parameters .= " $param=\"$value\"";
+					}
+				}
+
+				$shortcode = '[contact-form' . $parameters . ']' . $shortcode . '[/contact-form]';
 				do_shortcode( $shortcode );
 
 				// Recreate form
@@ -1343,19 +1351,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 			$shortcode_meta = get_post_meta( $attributes['id'], '_g_feedback_shortcode', true );
 
-			// Iterate through $attributes and concatenate as a string.
-			$atts = ' ';
-			foreach ($attributes as $key => $value) {
-				if ( '' != $value ) {
-			    	$atts .= $key.'="'.$value.'" ';
-			    } else {
-			    	$atts .= $key.' ';
-			    }
-			}
-
 			if ( $shortcode_meta != '' or $shortcode_meta != $content ) {
 				update_post_meta( $attributes['id'], '_g_feedback_shortcode', $content );
-				update_post_meta( $attributes['id'], '_g_feedback_shortcode_atts', $atts ); // Save the atts string to post_meta for later use. $sttributes is not available later in do_shortcode situations.
+
+				// Save attributes to post_meta for later use. They're not available later in do_shortcode situations.
+				update_post_meta( $attributes['id'], '_g_feedback_shortcode_atts', $attributes );
 			}
 
 		}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -280,10 +280,12 @@ class Grunion_Contact_Form_Plugin {
 
 			// Get shortcode from post meta
 			$shortcode = get_post_meta( $_POST['contact-form-id'], '_g_feedback_shortcode', true );
+			// Get the attributes from post meta. $attributes not available here
+			$atts = get_post_meta( $_POST['contact-form-id'], '_g_feedback_shortcode_atts', true );
 
 			// Format it
 			if ( $shortcode != '' ) {
-				$shortcode = '[contact-form]' . $shortcode . '[/contact-form]';
+				$shortcode = '[contact-form'.$atts.']' . $shortcode . '[/contact-form]';
 				do_shortcode( $shortcode );
 
 				// Recreate form
@@ -1341,8 +1343,19 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 			$shortcode_meta = get_post_meta( $attributes['id'], '_g_feedback_shortcode', true );
 
+			// Iterate through $attributes and concatenate as a string.
+			$atts = ' ';
+			foreach ($attributes as $key => $value) {
+				if ( '' != $value ) {
+			    	$atts .= $key.'="'.$value.'" ';
+			    } else {
+			    	$atts .= $key.' ';
+			    }
+			}
+
 			if ( $shortcode_meta != '' or $shortcode_meta != $content ) {
 				update_post_meta( $attributes['id'], '_g_feedback_shortcode', $content );
+				update_post_meta( $attributes['id'], '_g_feedback_shortcode_atts', $atts ); // Save the atts string to post_meta for later use. $sttributes is not available later in do_shortcode situations.
 			}
 
 		}


### PR DESCRIPTION
Previously, when using the [contact-form] shortcode in do_shortcode situations like a page template, the attributes like 'to' and 'subject' were being dropped. $attributes and all its variations aren't available by the time we get to processing the submission, so I had to rewrite it as a string earlier in the process, in store_shortcode(), when we still have access to $attributes. If someone knows how to get access to the shortcode attributes in process_form_submission() then we could save a few lines of code and keep attributes as an array.

Fixes #3187
