### PR TITLE
Sharing / Publicize: API Updates

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -45,7 +45,6 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-taxonomy-endpoi
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-user-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-upload-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-settings-endpoint.php' );
-require_once( $json_endpoints_dir . 'class.wpcom-json-api-publicize-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-sharing-buttons-endpoint.php' );
 
 // **********
@@ -2433,74 +2432,6 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 	),
 
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/settings?pretty=1',
-) );
-
-/**
- * Publicize Endpoints
- */
-
-new WPCOM_JSON_API_Get_Connections_Endpoint( array(
-	'description' => 'Get a list of a site\'s current Publicize connections to third-party services for the current user (personal or shared).',
-	'group'       => 'Publicize',
-	'stat'        => 'connections',
-	'method'      => 'GET',
-	'path'        => '/sites/%s/connections/',
-	'path_labels' => array(
-		'$site' => '(int|string) Site ID or domain',
-	),
-	'query_parameters' => array(
-		'service'   => "(string) Get Publicize connections for a specific service only. Default is 'all' but you can enter 'facebook', 'twitter', etc."
-	),
-	'response_format' => array(
-		'connections'    => '(array:object) List of Publicize connections'
-	)
-) );
-
-new WPCOM_JSON_API_Get_Connection_Endpoint( array(
-	'description' => 'Get information about a specific Publicize connection.',
-	'group'       => 'Publicize',
-	'stat'        => 'connections:1',
-	'method'      => 'GET',
-	'path'        => '/sites/%s/connections/%d',
-	'path_labels' => array(
-		'$site'          => '(int|string) Site ID or domain',
-		'$connection_id' => '(int) The ID of the Publicize connection',
-	),
-	'response_format' => array(
-		'ID'               => '(int) Identifier for the Publicize connection',
-		'token_ID'         => '(int) Identifier for the Keyring token',
-		'conn_ID'          => '(int) Identifier for the Publicize connection',
-		'site_ID'          => '(int) Identifier for the Site',
-		'user_ID'          => '(int) Identifier for the Publicize connection user, or 0 if the connection is shared',
-		'shared'           => '(bool) Is this connection specific to the current user, or a shared one for the site?',
-		'service'          => '(string) An identifier for the type of service (facebook, linkedin, path, tumblr, etc)',
-		'label'            => '(string) Formatted nicename for the service.',
-		'issued'           => '(ISO 8601 datetime) When the conncetion was created',
-		'expires'          => '(ISO 8601 datetime) When the connection expires and needs to be refreshed',
-		'external_ID'      => '(string) An identifier for the user on the third-party service',
-		'external_name'    => '(string) Usually a username or login name.',
-		'external_display' => '(string) How the user prefers their name to be displayed on the third-party service.',
-		'URL'              => '(string|null) URL to the user\'s profile. NULL if there is no URL to link to.',
-		'status'           => '(string) The current status of the connection. "ok" for connections with no problems, and "broken" for connections that need fixed.',
-		'refresh_url'      => '(string) The URL to refresh a token if it is broken.',
-		'meta'             => '(object) Extra and optional metadata for the current Publicize connection',
-	)
-) );
-
-new WPCOM_JSON_API_Delete_Connection_Endpoint( array(
-	'description' => 'Delete a publicize connection.',
-	'group'		  => 'Publicize',
-	'stat'		  => 'connections:1:delete',
-	'method'	  => 'POST',
-	'path'		  => '/sites/%s/connections/%d/delete',
-	'path_labels' => array(
-		'$site'          => '(int|string) Site ID or domain',
-		'$connection_id' => 'The ID of the connection',
-	),
-	'response_format' => array(
-		'ID'      => '(int) Identifier for the connection',
-		'deleted' => '(bool) Confirmation that the connection has been removed'
-	)
 ) );
 
 /**

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -2440,7 +2440,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 
 new WPCOM_JSON_API_Get_Sharing_Buttons_Endpoint( array(
 	'description' => 'Get a list of a site\'s sharing buttons.',
-	'group'       => '__do_not_document',
+	'group'       => 'sharing',
 	'stat'        => 'sharing-buttons',
 	'method'      => 'GET',
 	'path'        => '/sites/%s/sharing-buttons/',
@@ -2513,7 +2513,7 @@ new WPCOM_JSON_API_Get_Sharing_Button_Endpoint( array(
 
 new WPCOM_JSON_API_Update_Sharing_Buttons_Endpoint( array(
 	'description' => 'Edit all sharing buttons for a site.',
-	'group'       => '__do_not_document',
+	'group'       => 'sharing',
 	'stat'        => 'sharing-buttons:X:POST',
 	'method'      => 'POST',
 	'path'        => '/sites/%s/sharing-buttons',

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -274,6 +274,11 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$wordads = has_any_blog_stickers( array( 'wordads-approved', 'wordads-approved-misfits' ), $blog_id );
 				}
 
+				$publicize_permanently_disabled = false;
+				if ( function_exists( 'is_publicize_permanently_disabled' ) ) {
+					$publicize_permanently_disabled = is_publicize_permanently_disabled( $blog_id );
+				}
+
 				$response[$key] = array(
 					'timezone'                => (string) get_option( 'timezone_string' ),
 					'gmt_offset'              => (float) get_option( 'gmt_offset' ),
@@ -310,6 +315,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'software_version'        => $wp_version,
 					'created_at'              => ! empty( $registered_date ) ? $this->format_date( $registered_date ) : '0000-00-00T00:00:00+00:00',
 					'wordads'                 => $wordads,
+					'publicize_permanently_disabled' => $publicize_permanently_disabled,
 				);
 
 				if ( 'page' === get_option( 'show_on_front' ) ) {


### PR DESCRIPTION
1. REST API: deprecate v1 of Publicize & Keyring endpoints
2. REST API: add `publicize_enabled` flag in site options
3. REST API: document sharing endpoints & fix broken/slow tests

I tested and it doesn't affect Sharing and Publicize management, whether in wp-admin or in Calypso.