### PR TITLE
REST API: updates to the Menus endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
@@ -497,6 +497,7 @@ class WPCOM_JSON_API_Menus_Update_Menu_Endpoint extends WPCOM_JSON_API_Menus_Abs
 		}
 
 		$data = $this->input( true, false );
+		$data['id'] = $menu_id;
 		$data = $this->complexify( array( $data ) );
 		if ( is_wp_error( $data ) ) {
 			return $data;

--- a/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
@@ -652,7 +652,7 @@ class WPCOM_JSON_API_Menus_Get_Menu_Endpoint extends WPCOM_JSON_API_Menus_Abstra
 
 		$menu->items = $items;
 
-		return $this->simplify( $menu );
+		return array( 'menu' => $this->simplify( $menu ) );
 	}
 }
 


### PR DESCRIPTION
1. REST API: Menus: Properly key single-menu get response.
2. REST API: Menus: Remove requirement for redundant menu id.