### PR TITLE
Shortcode: change double to single quote in slideshow gallery to avoid Grunt warning

### DIFF
--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -72,7 +72,7 @@ JetpackSlideshow.prototype.makeZeroWidthSpan = function() {
 	emptySpan.className = 'slideshow-line-height-hack';
 	// Having a NBSP makes IE act weird during transitions, but other
 	// browsers ignore a text node with a space in it as whitespace.
-	if ( -1 !== window.navigator.userAgent.indexOf( "MSIE " ) ) {
+	if ( -1 !== window.navigator.userAgent.indexOf( 'MSIE ' ) ) {
 		emptySpan.appendChild( document.createTextNode(' ') );
 	} else {
 		emptySpan.innerHTML = '&nbsp;';


### PR DESCRIPTION
If string is enclosed in double quotes, Grunt throws the warning: Strings must use singlequote. This patch fixes it.