### PR TITLE
Display Posts Widget: speed and stability improvements.

### DIFF
--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -11,7 +11,7 @@
 /**
  * Disable direct access/execution to/of the widget code.
  */
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -52,8 +52,8 @@ function jetpack_display_posts_widget_cron_intervals( $current_schedules ) {
 /**
  * Execute the cron task
  */
-add_action( 'display_posts_widget_cron_update', 'display_posts_update_cron_action' );
-function display_posts_update_cron_action() {
+add_action( 'jetpack_display_posts_widget_cron_update', 'jetpack_display_posts_update_cron_action' );
+function jetpack_display_posts_update_cron_action() {
 	$widget = new Jetpack_Display_Posts_Widget();
 	$widget->cron_task();
 }
@@ -506,8 +506,8 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 * Checks if the cron task is enabled or not. If it is not - enable it.
 	 */
 	public static function check_for_cron() {
-		if ( ! wp_next_scheduled( 'display_posts_widget_cron_update' ) ) {
-			wp_schedule_event( time(), 'minutes_10', 'display_posts_widget_cron_update' );
+		if ( ! wp_next_scheduled( 'jetpack_display_posts_widget_cron_update' ) ) {
+			wp_schedule_event( time(), 'minutes_10', 'jetpack_display_posts_widget_cron_update' );
 		}
 	}
 

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -84,6 +84,12 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 */
 	public $widget_options_key_prefix = 'display_posts_site_data_';
 
+	/**
+	 * @var string The name of the cron that will update widget data.
+	 */
+	public static $cron_name = 'jetpack_display_posts_widget_cron_update';
+
+
 	public function __construct() {
 		parent::__construct(
 		// internal id
@@ -508,8 +514,8 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 * Checks if the cron task is enabled or not. If it is not - enable it.
 	 */
 	public static function check_for_cron() {
-		if ( ! wp_next_scheduled( 'jetpack_display_posts_widget_cron_update' ) ) {
-			wp_schedule_event( time(), 'minutes_10', 'jetpack_display_posts_widget_cron_update' );
+		if ( ! wp_next_scheduled( self::$cron_name ) ) {
+			wp_schedule_event( time(), 'minutes_10', self::$cron_name );
 		}
 	}
 

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -379,7 +379,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	/**
 	 * Parse external API response from the posts list request and handle errors if any occur.
 	 *
-	 * @param array|WP_Error $service_response The raw response to be parsed.
+	 * @param object|WP_Error $service_response The raw response to be parsed.
 	 *
 	 * @return array|WP_Error
 	 */
@@ -395,7 +395,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		/**
 		 * Check if the service returned proper posts array.
 		 */
-		if ( ! is_array( $service_response->posts ) ) {
+		if ( ! isset( $service_response->posts ) || ! is_array( $service_response->posts ) ) {
 			return new WP_Error(
 				'no_posts',
 				__( 'No posts data returned by remote.', 'jetpack' ),
@@ -444,7 +444,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	/**
 	 * Format the posts for better storage. Drop all the data that is not used.
 	 *
-	 * @param array $parsed_data Array of posts returned by the APIs.
+	 * @param object $parsed_data Array of posts returned by the APIs.
 	 *
 	 * @return array Formatted posts or an empty array if no posts were found.
 	 */

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -191,7 +191,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			return new WP_Error(
 				'remote_error',
 				__( 'We cannot display information for this blog.', 'jetpack' ),
-				$parsed_data['error']
+				$parsed_data->error
 			);
 		}
 

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -191,10 +191,18 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			);
 		}
 
+
+		/**
+		 * Extract service response body from the request.
+		 */
+
+		$service_response_body = wp_remote_retrieve_body( $service_response );
+
+
 		/**
 		 * No body has been set in the response. This should be pretty bad.
 		 */
-		if ( ! isset( $service_response['body'] ) ) {
+		if ( ! $service_response_body ) {
 			return new WP_Error(
 				'no_body',
 				__( 'Invalid remote response.', 'jetpack' ),
@@ -205,7 +213,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		/**
 		 * Parse the JSON response from the API. Convert to associative array.
 		 */
-		$parsed_data = json_decode( $service_response['body'] );
+		$parsed_data = json_decode( $service_response_body );
 
 		/**
 		 * If there is a problem with parsing the posts return an empty array.

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -718,7 +718,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 					$extra_data = $blog_data[ $info_key ]['error']->get_error_data();
 					if ( is_array( $extra_data ) ) {
-						$errors['debug'] = implode( ';', $extra_data );
+						$errors['debug'] = implode( '; ', $extra_data );
 					}
 					else {
 						$errors['debug'] = $extra_data;

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -20,9 +20,10 @@ function jetpack_display_posts_widget() {
 /**
  * Add a 10 minute interval to cron intervals.
  */
-add_filter('cron_schedules', 'jetpack_display_posts_widget_cron_intervals');
+add_filter( 'cron_schedules', 'jetpack_display_posts_widget_cron_intervals' );
 function jetpack_display_posts_widget_cron_intervals() {
-	$interval['minutes_10'] = array('interval' => 10 * MINUTE_IN_SECONDS, 'display' => 'Every 10 minutes');
+	$interval['minutes_10'] = array( 'interval' => 10 * MINUTE_IN_SECONDS, 'display' => 'Every 10 minutes' );
+
 	return $interval;
 }
 
@@ -34,12 +35,10 @@ function display_posts_update_cron_action() {
 	$widget->cron_task();
 }
 
-add_action('display_posts_widget_cron_update', 'display_posts_update_cron_action');
+add_action( 'display_posts_widget_cron_update', 'display_posts_update_cron_action' );
 /**
  * End of Cron tasks
  */
-
-
 /*
  * Display a list of recent posts from a WordPress.com or Jetpack-enabled blog.
  */
@@ -130,7 +129,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 *
 	 * @param array $service_response Response from the service.
 	 *
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	public function parse_service_response( $service_response ) {
 		/**

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -22,7 +22,7 @@ function jetpack_display_posts_widget() {
  */
 add_filter('cron_schedules', 'jetpack_display_posts_widget_cron_intervals');
 function jetpack_display_posts_widget_cron_intervals() {
-	$interval['minutes_10'] = array('interval' => 10*60, 'display' => 'Every 10 minutes');
+	$interval['minutes_10'] = array('interval' => 10 * MINUTE_IN_SECONDS, 'display' => 'Every 10 minutes');
 	return $interval;
 }
 

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -25,14 +25,28 @@ function jetpack_display_posts_widget() {
  * Cron tasks
  */
 
-/**
- * Add a 10 minute interval to cron intervals.
- */
 add_filter( 'cron_schedules', 'jetpack_display_posts_widget_cron_intervals' );
-function jetpack_display_posts_widget_cron_intervals() {
-	$interval['minutes_10'] = array( 'interval' => 10 * MINUTE_IN_SECONDS, 'display' => 'Every 10 minutes' );
 
-	return $interval;
+/**
+ * Adds 10 minute running interval to the cron schedules.
+ *
+ * @param array $current_schedules Currently defined schedules list.
+ *
+ * @return array
+ */
+function jetpack_display_posts_widget_cron_intervals( $current_schedules ) {
+
+	/**
+	 * Only add the 10 minute interval if it wasn't already set.
+	 */
+	if ( ! isset( $current_schedules['minutes_10'] ) ) {
+		$current_schedules['minutes_10'] = array(
+			'interval' => 10 * MINUTE_IN_SECONDS,
+			'display'  => 'Every 10 minutes'
+		);
+	}
+
+	return $current_schedules;
 }
 
 /**

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -76,6 +76,10 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 * Expiring transients have a name length maximum of 45 characters,
 	 * so this function returns an abbreviated MD5 hash to use instead of
 	 * the full URI.
+	 *
+	 * @param string $site Site to get the hash for.
+	 *
+	 * @return string
 	 */
 	public function get_site_hash( $site ) {
 		return substr( md5( $site ), 0, 21 );
@@ -499,6 +503,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			$this->update_instance( $site_url );
 		}
 
+		return true;
 	}
 
 	/**
@@ -773,12 +778,12 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		?>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>"/>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
 		</p>
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'url' ); ?>"><?php _e( 'Blog URL:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'url' ); ?>" name="<?php echo $this->get_field_name( 'url' ); ?>" type="text" value="<?php echo esc_attr( $url ); ?>"/>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'url' ); ?>" name="<?php echo $this->get_field_name( 'url' ); ?>" type="text" value="<?php echo esc_attr( $url ); ?>" />
 			<i>
 				<?php _e( "Enter a WordPress.com or Jetpack WordPress site URL.", 'jetpack' ); ?>
 			</i>
@@ -830,7 +835,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			?>
 			<p class="error-message">
 				<?php echo $where_message; ?>:
-				<br/>
+				<br />
 				<i>
 					<?php echo esc_html( $update_errors['message'] ); ?>
 					<?php
@@ -839,10 +844,10 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 					 */
 					if ( ! empty( $update_errors['debug'] ) ) {
 						?>
-						<br/>
-						<br/>
+						<br />
+						<br />
 						<?php echo __( 'Detailed information', 'jetpack' ); ?>:
-						<br/>
+						<br />
 						<?php echo esc_html( $update_errors['debug'] ); ?>
 						<?php
 					}
@@ -888,7 +893,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 *
 	 * @codeCoverageIgnore
 	 */
-	public function wp_get_option($param) {
-		return get_option($param);
+	public function wp_get_option( $param ) {
+		return get_option( $param );
 	}
 }

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -823,6 +823,14 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			<i>
 				<?php _e( "Enter a WordPress.com or Jetpack WordPress site URL.", 'jetpack' ); ?>
 			</i>
+			<?php
+			if ( empty( $url ) ) {
+				?>
+				<br />
+				<i class="error-message"><?php echo __( 'You must specify a valid blog URL!', 'jetpack' ); ?></i>
+				<?php
+			}
+			?>
 		</p>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'number_of_posts' ); ?>"><?php _e( 'Number of Posts to Display:', 'jetpack' ); ?></label>

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -669,7 +669,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	/**
 	 * Scan and extract first error from blog data array.
 	 *
-	 * @param array $blog_data Blog data to scan for errors.
+	 * @param array|WP_Error $blog_data Blog data to scan for errors.
 	 *
 	 * @return string First error message found
 	 */
@@ -732,7 +732,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 					 * we have no way to know the format. The widget works with
 					 * WP_Error objects only.
 					 */
-					$errors['message'] = reset( $error_messages );
+					$errors['message'] = reset( $blog_data[ $info_key ]['error'] );
 					break;
 				}
 

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -313,6 +313,9 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 		$cached_data = get_option( $this->widget_options_key_prefix . $site_hash );
 
+		/**
+		 * If the cache is empty, return an empty_cache error.
+		 */
 		if ( false === $cached_data ) {
 			return new WP_Error(
 				'empty_cache',
@@ -671,6 +674,15 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			'where'   => '',
 		);
 
+
+		/**
+		 * When the cache result is an error. Usually when the cache is empty.
+		 * This is not an error case for now.
+		 */
+		if ( is_wp_error( $blog_data ) ) {
+			return $errors;
+		}
+
 		/**
 		 * Loop through `site_info` and `posts` keys of $blog_data.
 		 */
@@ -846,7 +858,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		$instance          = array();
 		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
 		$instance['url']   = ( ! empty( $new_instance['url'] ) ) ? strip_tags( $new_instance['url'] ) : '';
-		$instance['url']   = str_replace( "http://", "", $instance['url'] );
+		$instance['url']   = preg_replace( "!^https?://!is", "", $instance['url'] );
 		$instance['url']   = untrailingslashit( $instance['url'] );
 
 		// Normalize www.

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -46,8 +46,14 @@ add_action('display_posts_widget_cron_update', 'display_posts_update_cron_action
 
 class Jetpack_Display_Posts_Widget extends WP_Widget {
 
+	/**
+	 * @var string Remote service API URL prefix.
+	 */
 	public $service_url = 'https://public-api.wordpress.com/rest/v1.1/';
 
+	/**
+	 * @var string Widget options key prefix.
+	 */
 	public $widget_options_key_prefix = 'display_posts_site_data_';
 
 	public function __construct() {
@@ -82,6 +88,8 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 * @param string $site Site to fetch the information for.
 	 *
 	 * @return mixed|WP_Error
+	 *
+	 * @deprecated
 	 */
 	public function get_site_info( $site ) {
 		$site_hash       = $this->get_site_hash( $site );

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -70,8 +70,6 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		 * Check the status of the cron task.
 		 */
 		self::check_for_cron();
-
-		$this->cron_task();
 	}
 
 	/**

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -9,7 +9,7 @@
  */
 add_action( 'widgets_init', 'jetpack_display_posts_widget' );
 function jetpack_display_posts_widget() {
-	 register_widget( 'Jetpack_Display_Posts_Widget' );
+	register_widget( 'Jetpack_Display_Posts_Widget' );
 }
 
 /*
@@ -21,7 +21,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 	public function __construct() {
 		parent::__construct(
-			// internal id
+		// internal id
 			'jetpack_display_posts_widget',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', __( 'Display WordPress Posts', 'jetpack' ) ),
@@ -41,7 +41,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	}
 
 	public function get_site_info( $site ) {
-		$site_hash = $this->get_site_hash( $site );
+		$site_hash       = $this->get_site_hash( $site );
 		$data_from_cache = get_transient( 'display_posts_site_info_' . $site_hash );
 		if ( false === $data_from_cache ) {
 			$raw_data = $this->fetch_site_info( $site );
@@ -57,12 +57,12 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 
 	/**
-     * Fetch a remote service endpoint and parse it.
-     *
+	 * Fetch a remote service endpoint and parse it.
+	 *
 	 * @param string $endpoint Parametrized endpoint to call.
 	 *
 	 * @return array|WP_Error
- 	 */
+	 */
 	public function fetch_service_endpoint( $endpoint ) {
 		$raw_data = wp_remote_get( $this->service_url . ltrim( $endpoint, '/' ) );
 
@@ -73,23 +73,23 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 
 	/**
-     * Parse data from service response.
-     * Do basic error handling for general service and data errors
-     *
+	 * Parse data from service response.
+	 * Do basic error handling for general service and data errors
+	 *
 	 * @param array $service_response Response from the service.
 	 *
 	 * @return array
-     */
+	 */
 	public function parse_service_response( $service_response ) {
 		/**
 		 * If there is an error, we add the error message to the parsed response
-         */
-        if ( is_wp_error( $service_response ) ) {
+		 */
+		if ( is_wp_error( $service_response ) ) {
 			return new WP_Error(
-							'general_error',
-							__( 'An error occurred while fetching data from remote.', 'jetpack' ),
-							$service_response->get_error_messages()
-						);
+				'general_error',
+				__( 'An error occurred while fetching data from remote.', 'jetpack' ),
+				$service_response->get_error_messages()
+			);
 		}
 
 		/**
@@ -97,10 +97,10 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		 */
 		if ( 200 !== wp_remote_retrieve_response_code( $service_response ) ) {
 			return new WP_Error(
-							'http_error',
-							__( 'An error occurred while fetching data from remote.', 'jetpack' ),
-							wp_remote_retrieve_response_message( $service_response )
-						);
+				'http_error',
+				__( 'An error occurred while fetching data from remote.', 'jetpack' ),
+				wp_remote_retrieve_response_message( $service_response )
+			);
 		}
 
 		/**
@@ -108,120 +108,117 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		 */
 		if ( ! isset( $service_response['body'] ) ) {
 			return new WP_Error(
-							'no_body',
-							__( 'Invalid data returned by remote.', 'jetpack' ),
-							'No body in response.'
-						);
+				'no_body',
+				__( 'Invalid data returned by remote.', 'jetpack' ),
+				'No body in response.'
+			);
 		}
 
 		/**
 		 * Parse the JSON response from the API. Convert to associative array.
-         */
+		 */
 		$parsed_data = json_decode( $service_response['body'] );
 
 		/**
-         * If there is a problem with parsing the posts return an empty array.
-         */
+		 * If there is a problem with parsing the posts return an empty array.
+		 */
 		if ( is_null( $parsed_data ) ) {
 			return new WP_Error(
-							'no_body',
-							__( 'Invalid data returned by remote.', 'jetpack' ),
-							'Invalid JSON from remote.'
-						);
+				'no_body',
+				__( 'Invalid data returned by remote.', 'jetpack' ),
+				'Invalid JSON from remote.'
+			);
 		}
 
 		/**
-         * Check for errors in the parsed body.
+		 * Check for errors in the parsed body.
 		 */
 		if ( isset( $parsed_data->error ) ) {
 			return new WP_Error(
-							'remote_error',
-							__( 'We cannot display information for this blog.', 'jetpack' ),
-							$parsed_data['error']
-						);
+				'remote_error',
+				__( 'We cannot display information for this blog.', 'jetpack' ),
+				$parsed_data['error']
+			);
 		}
 
 
 		/**
 		 * No errors found, return parsed data.
- 		 */
+		 */
 		return $parsed_data;
 	}
 
 	public function fetch_blog_data( $site, $original_data = array() ) {
 
-		if (!empty($original_data)) {
+		if ( ! empty( $original_data ) ) {
 			$widget_data = $original_data;
-		}
-		else {
+		} else {
 			$widget_data = array(
 				'site_info' => array(
-					'last_check' => null,
+					'last_check'  => null,
 					'last_update' => null,
-					'error' => array(),
-
+					'error'       => array(),
 					'data' => array(),
 				),
 				'posts' => array(
-					'last_check' => null,
+					'last_check'  => null,
 					'last_update' => null,
-					'error' => array(),
-
+					'error'       => array(),
 					'data' => array(),
 				)
 			);
 		}
 
 
-
 		$widget_data['site_info']['last_check'] = time();
 
-		$site_info_raw_data = $this->fetch_site_info( $site );
+		$site_info_raw_data    = $this->fetch_site_info( $site );
 		$site_info_parsed_data = $this->parse_site_info_response( $site_info_raw_data );
 
 
 		/**
-         * If there is an error with the fetched site info, save the error and update the checked time.
-         */
-		if ( is_wp_error($site_info_parsed_data)) {
+		 * If there is an error with the fetched site info, save the error and update the checked time.
+		 */
+		if ( is_wp_error( $site_info_parsed_data ) ) {
 			$widget_data['site_info']['error'] = $site_info_parsed_data;
 		}
 		/**
-         * If data is fetched successfully, update the data and set the proper time.
+		 * If data is fetched successfully, update the data and set the proper time.
 		 *
 		 * Data is only updated if we have valid results. This is done this way so we can show
 		 * something if external service is down.
- 		 *
-         */
+		 *
+		 */
 		else {
 			$widget_data['site_info']['last_update'] = time();
-			$widget_data['site_info']['data'] = $site_info_parsed_data;
-			$widget_data['site_info']['error'] = null;
+			$widget_data['site_info']['data']        = $site_info_parsed_data;
+			$widget_data['site_info']['error']       = null;
 		}
 
 		$widget_data['posts']['last_check'] = time();
 
-		$site_posts_raw_data = $this->fetch_posts_for_site( $site_info_parsed_data->ID );
+		$site_posts_raw_data    = $this->fetch_posts_for_site( $site_info_parsed_data->ID );
 		$site_posts_parsed_data = $this->parse_posts_response( $site_posts_raw_data );
 
 
 		/**
-         * If there is an error with the fetched posts, save the error and update the checked time.
-         */
-		if ( is_wp_error($site_info_parsed_data)) {
+		 * If there is an error with the fetched posts, save the error and update the checked time.
+		 */
+		if ( is_wp_error( $site_info_parsed_data ) ) {
 			$widget_data['posts']['error'] = $site_posts_parsed_data;
 		}
+
 		/**
-         * If data is fetched successfully, update the data and set the proper time.
-         *
+		 * If data is fetched successfully, update the data and set the proper time.
+		 *
 		 * Data is only updated if we have valid results. This is done this way so we can show
 		 * something if external service is down.
- 		 *
-         */
+		 *
+		 */
 		else {
 			$widget_data['posts']['last_update'] = time();
-			$widget_data['posts']['data'] = $site_posts_parsed_data;
-			$widget_data['posts']['error'] = null;
+			$widget_data['posts']['data']        = $site_posts_parsed_data;
+			$widget_data['posts']['error']       = null;
 		}
 
 		return $widget_data;
@@ -230,28 +227,27 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 	public function get_blog_data( $site ) {
 		// load from cache, if nothing return an error
-        $site_hash = $this->get_site_hash( $site );
+		$site_hash = $this->get_site_hash( $site );
 
-        //$cached_data = get_option('display_posts_site_data_' . $site_hash);
+		//$cached_data = get_option('display_posts_site_data_' . $site_hash);
 
-        $cached_data = get_transient( 'display_posts_site_data_' . $site_hash );
+		$cached_data = get_transient( 'display_posts_site_data_' . $site_hash );
 
 
+		if ( false === $cached_data ) {
 
-        if ( false === $cached_data ) {
-
-            $cached_data = $this->fetch_blog_data( $site );
-            set_transient( 'display_posts_site_data_' . $site_hash, $cached_data, 10 * MINUTE_IN_SECONDS );
-            /* TODO restore this later
-            return new WP_Error(
+			$cached_data = $this->fetch_blog_data( $site );
+			set_transient( 'display_posts_site_data_' . $site_hash, $cached_data, 10 * MINUTE_IN_SECONDS );
+			/* TODO restore this later
+			return new WP_Error(
 							'no_data_yet',
 							__( 'Data has not been updated yet.', 'jetpack' ),
 							'No data in cache yet.'
 						);
-            */
-        }
+			*/
+		}
 
-        return $cached_data;
+		return $cached_data;
 
 	}
 
@@ -260,10 +256,10 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	}
 
 	/**
-     * Fetch site information from the WordPress public API
-     *
-     * @param string $site URL of the site to fetch the information for.
-     *
+	 * Fetch site information from the WordPress public API
+	 *
+	 * @param string $site URL of the site to fetch the information for.
+	 *
 	 * @return array|WP_Error
 	 */
 	public function fetch_site_info( $site ) {
@@ -279,7 +275,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 * @param int $site_id The site to fetch the posts for.
 	 *
 	 * @return array|WP_Error
-     */
+	 */
 	public function fetch_posts_for_site( $site_id ) {
 
 		$response = $this->fetch_service_endpoint(
@@ -289,11 +285,11 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 				/**
 				 * Filters the parameters used to fetch for posts in the Display Posts Widget.
 				 *
-				 * @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/
+				 * @see    https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/
 				 *
 				 * @module widgets
 				 *
-				 * @since 3.6.0
+				 * @since  3.6.0
 				 *
 				 * @param string $args Extra parameters to filter posts returned from the WordPress.com REST API.
 				 */
@@ -305,12 +301,12 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	}
 
 	/**
-     * Parse external API response and handle errors if any occur.
-     *
-     * @param array|WP_Error $service_response The raw response to be parsed.
-     *
-     * @return array
-	*/
+	 * Parse external API response and handle errors if any occur.
+	 *
+	 * @param array|WP_Error $service_response The raw response to be parsed.
+	 *
+	 * @return array
+	 */
 	public function parse_posts_response( $service_response ) {
 
 		/**
@@ -325,15 +321,15 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		 */
 		if ( ! is_array( $service_response->posts ) ) {
 			return new WP_Error(
-							'no_posts',
-							__( 'No posts data returned by remote.', 'jetpack' ),
-							'No posts information set in the returned data.'
-						);
+				'no_posts',
+				__( 'No posts data returned by remote.', 'jetpack' ),
+				'No posts information set in the returned data.'
+			);
 		}
 
 		/**
-         * Format the posts to preserve storage space.
-         */
+		 * Format the posts to preserve storage space.
+		 */
 		return $this->format_posts_for_storage( $service_response );
 	}
 
@@ -352,17 +348,18 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		 */
 		if ( ! isset( $service_response->ID ) ) {
 			return new WP_Error(
-							'no_site_info',
-							__( 'Invalid site information returned from remote.', 'jetpack' ),
-							'No site ID present in the response.'
-						);
+				'no_site_info',
+				__( 'Invalid site information returned from remote.', 'jetpack' ),
+				'No site ID present in the response.'
+			);
 		}
 
 		return $service_response;
 	}
+
 	/**
-     * Format the posts for better storage. Drop all the data that is not used.
-     *
+	 * Format the posts for better storage. Drop all the data that is not used.
+	 *
 	 * @param array $parsed_data Array of posts returned by the APIs
 	 *
 	 * @return array Formatted posts or
@@ -377,9 +374,9 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		foreach ( $parsed_data->posts as $single_post ) {
 
 			$prepared_post = array(
-				'title'          => $single_post->title          ? $single_post->title           : '',
-				'excerpt'        => $single_post->excerpt        ? $single_post->excerpt         : '',
-				'featured_image' => $single_post->featured_image ? $single_post->featured_image  : '',
+				'title'          => $single_post->title ? $single_post->title : '',
+				'excerpt'        => $single_post->excerpt ? $single_post->excerpt : '',
+				'featured_image' => $single_post->featured_image ? $single_post->featured_image : '',
 				'url'            => $single_post->URL,
 			);
 
@@ -404,17 +401,18 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 		echo $args['before_widget'];
 
-        $data = $this->get_blog_data( $instance['url'] );
+		$data = $this->get_blog_data( $instance['url'] );
 
-        // check for errors
-        // TODO extract method
-        if ( is_wp_error( $data ) || empty( $data['site_info']['data'] ) ) {
-            echo '<p>' . __( 'Cannot load blog information at this time.', 'jetpack' ) . '</p>';
+		// check for errors
+		// TODO extract method
+		if ( is_wp_error( $data ) || empty( $data['site_info']['data'] ) ) {
+			echo '<p>' . __( 'Cannot load blog information at this time.', 'jetpack' ) . '</p>';
 			echo $args['after_widget'];
-			return;
-        }
 
-        $site_info = $data['site_info']['data'];
+			return;
+		}
+
+		$site_info = $data['site_info']['data'];
 
 		if ( ! empty( $title ) ) {
 			echo $args['before_title'] . esc_html( $title . ': ' . $site_info->name ) . $args['after_title'];
@@ -428,24 +426,25 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			echo '<p>' . __( 'Cannot load blog posts at this time.', 'jetpack' ) . '</p>';
 			echo '</div><!-- .jetpack-display-remote-posts -->';
 			echo $args['after_widget'];
+
 			return;
 		}
 
-        $posts_list = $data['posts']['data'];
+		$posts_list = $data['posts']['data'];
 
 		/**
 		 * Show only as much posts as we need. If we have less than configured amount,
-         * we must show only that much posts.
-         */
+		 * we must show only that much posts.
+		 */
 		$number_of_posts = min( $instance['number_of_posts'], count( $posts_list ) );
 
-		for ( $i = 0; $i < $number_of_posts; $i++ ) {
-			$single_post = $posts_list[$i];
-			$post_title = ( $single_post['title'] ) ? $single_post['title']: '( No Title )';
+		for ( $i = 0; $i < $number_of_posts; $i ++ ) {
+			$single_post = $posts_list[ $i ];
+			$post_title  = ( $single_post['title'] ) ? $single_post['title'] : '( No Title )';
 
 			$target = '';
 			if ( isset( $instance['open_in_new_window'] ) && $instance['open_in_new_window'] == true ) {
- 				 $target = ' target="_blank"';
+				$target = ' target="_blank"';
 			}
 			echo '<h4><a href="' . esc_url( $single_post['url'] ) . '"' . $target . '>' . esc_html( $post_title ) . '</a></h4>' . "\n";
 			if ( ( $instance['featured_image'] == true ) && ( ! empty ( $single_post['featured_image'] ) ) ) {
@@ -453,11 +452,11 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 				/**
 				 * Allows setting up custom Photon parameters to manipulate the image output in the Display Posts widget.
 				 *
-				 * @see https://developer.wordpress.com/docs/photon/
+				 * @see    https://developer.wordpress.com/docs/photon/
 				 *
 				 * @module widgets
 				 *
-				 * @since 3.6.0
+				 * @since  3.6.0
 				 *
 				 * @param array $args Array of Photon Parameters.
 				 */
@@ -495,7 +494,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 		$open_in_new_window = false;
 		if ( isset( $instance['open_in_new_window'] ) ) {
-		    $open_in_new_window = $instance['open_in_new_window'];
+			$open_in_new_window = $instance['open_in_new_window'];
 		}
 
 		if ( isset( $instance['featured_image'] ) ) {
@@ -513,23 +512,23 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		?>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>"/>
 		</p>
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'url' ); ?>"><?php _e( 'Blog URL:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'url' ); ?>" name="<?php echo $this->get_field_name( 'url' ); ?>" type="text" value="<?php echo esc_attr( $url ); ?>" />
+			<input class="widefat" id="<?php echo $this->get_field_id( 'url' ); ?>" name="<?php echo $this->get_field_name( 'url' ); ?>" type="text" value="<?php echo esc_attr( $url ); ?>"/>
 			<i>
-			<?php _e( "Enter a WordPress.com or Jetpack WordPress site URL.", 'jetpack' ); ?>
+				<?php _e( "Enter a WordPress.com or Jetpack WordPress site URL.", 'jetpack' ); ?>
 			</i>
 		</p>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'number_of_posts' ); ?>"><?php _e( 'Number of Posts to Display:', 'jetpack' ); ?></label>
 			<select name="<?php echo $this->get_field_name( 'number_of_posts' ); ?>">
 				<?php
-					for ($i = 1; $i <= 10; $i++) {
-					echo '<option value="' . $i . '" '.selected( $number_of_posts, $i ).'>' . $i . '</option>';
-					}
+				for ( $i = 1; $i <= 10; $i ++ ) {
+					echo '<option value="' . $i . '" ' . selected( $number_of_posts, $i ) . '>' . $i . '</option>';
+				}
 				?>
 			</select>
 		</p>
@@ -550,11 +549,11 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	}
 
 	public function update( $new_instance, $old_instance ) {
-		$instance = array();
+		$instance          = array();
 		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
-		$instance['url'] = ( ! empty( $new_instance['url'] ) ) ? strip_tags( $new_instance['url'] ) : '';
-		$instance['url'] = str_replace( "http://", "", $instance['url'] );
-		$instance['url'] = untrailingslashit( $instance['url'] );
+		$instance['url']   = ( ! empty( $new_instance['url'] ) ) ? strip_tags( $new_instance['url'] ) : '';
+		$instance['url']   = str_replace( "http://", "", $instance['url'] );
+		$instance['url']   = untrailingslashit( $instance['url'] );
 
 		// Normalize www.
 		$site_info = $this->get_site_info( $instance['url'] );
@@ -565,10 +564,11 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			}
 		}
 
-		$instance['number_of_posts'] = ( ! empty( $new_instance['number_of_posts'] ) ) ? intval( $new_instance['number_of_posts'] ) : '';
+		$instance['number_of_posts']    = ( ! empty( $new_instance['number_of_posts'] ) ) ? intval( $new_instance['number_of_posts'] ) : '';
 		$instance['open_in_new_window'] = ( ! empty( $new_instance['open_in_new_window'] ) ) ? true : '';
-		$instance['featured_image'] = ( ! empty( $new_instance['featured_image'] ) ) ? true : '';
-		$instance['show_excerpts'] = ( ! empty( $new_instance['show_excerpts'] ) ) ? true : '';
+		$instance['featured_image']     = ( ! empty( $new_instance['featured_image'] ) ) ? true : '';
+		$instance['show_excerpts']      = ( ! empty( $new_instance['show_excerpts'] ) ) ? true : '';
+
 		return $instance;
 	}
 }

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -7,6 +7,14 @@
  * Author URI: http://automattic.com
  * License: GPL2
  */
+
+/**
+ * Disable direct access/execution to/of the widget code.
+ */
+if (!defined('ABSPATH')) {
+	exit;
+}
+
 add_action( 'widgets_init', 'jetpack_display_posts_widget' );
 function jetpack_display_posts_widget() {
 	register_widget( 'Jetpack_Display_Posts_Widget' );

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -223,13 +223,13 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 				'site_info' => array(
 					'last_check'  => null,
 					'last_update' => null,
-					'error'       => array(),
+					'error'       => null,
 					'data'        => array(),
 				),
 				'posts'     => array(
 					'last_check'  => null,
 					'last_update' => null,
-					'error'       => array(),
+					'error'       => null,
 					'data'        => array(),
 				)
 			);
@@ -311,7 +311,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		// load from cache, if nothing return an error
 		$site_hash = $this->get_site_hash( $site );
 
-		$cached_data = get_option( $this->widget_options_key_prefix . $site_hash );
+		$cached_data = $this->wp_get_option( $this->widget_options_key_prefix . $site_hash );
 
 		/**
 		 * If the cache is empty, return an empty_cache error.
@@ -876,5 +876,19 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		$instance['show_excerpts']      = ( ! empty( $new_instance['show_excerpts'] ) ) ? true : '';
 
 		return $instance;
+	}
+
+
+	/**
+	 * This is just to make method mocks in the unit tests easier.
+	 *
+	 * @param string $param Option key to get
+	 *
+	 * @return mixed
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function wp_get_option($param) {
+		return get_option($param);
 	}
 }

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -519,14 +519,14 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 */
 	public function get_instances_sites() {
 
-		$widget_settings = get_option( 'widget_jetpack_display_posts_widget' );
+		$widget_settings = $this->wp_get_option( 'widget_jetpack_display_posts_widget' );
 
 		/**
 		 * If the widget still hasn't been added anywhere, the config will not be present.
 		 *
 		 * In such case we don't want to continue execution.
 		 */
-		if ( false === $widget_settings ) {
+		if ( false === $widget_settings || ! is_array( $widget_settings ) ) {
 			return false;
 		}
 
@@ -561,11 +561,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 		$option_key = $this->widget_options_key_prefix . $site_hash;
 
-		$instance_data = get_option( $option_key );
-
-		if ( empty( $instance_data ) ) {
-			$instance_data = array();
-		}
+		$instance_data = $this->wp_get_option( $option_key );
 
 		/**
 		 * Fetch blog data and save it in $instance_data.
@@ -576,10 +572,10 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		 * If the option doesn't exist yet - create a new option
 		 */
 		if ( false === $instance_data ) {
-			add_option( $option_key, $new_data );
+			$this->wp_add_option( $option_key, $new_data );
 		}
 		else {
-			update_option( $option_key, $new_data );
+			$this->wp_update_option( $option_key, $new_data );
 		}
 	}
 
@@ -901,5 +897,33 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 */
 	public function wp_get_option( $param ) {
 		return get_option( $param );
+	}
+
+	/**
+	 * This is just to make method mocks in the unit tests easier.
+	 *
+	 * @param string $option_name  Option name to be added
+	 * @param mixed  $option_value Option value
+	 *
+	 * @return mixed
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function wp_add_option( $option_name, $option_value ) {
+		return add_option( $option_name, $option_value );
+	}
+
+	/**
+	 * This is just to make method mocks in the unit tests easier.
+	 *
+	 * @param string $option_name  Option name to be updated
+	 * @param mixed  $option_value Option value
+	 *
+	 * @return mixed
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function wp_update_option( $option_name, $option_value ) {
+		return update_option( $option_name, $option_value );
 	}
 }

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -175,7 +175,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		if ( is_wp_error( $service_response ) ) {
 			return new WP_Error(
 				'general_error',
-				__( 'An error occurred while fetching data from remote.', 'jetpack' ),
+				__( 'An error occurred fetching the remote data.', 'jetpack' ),
 				$service_response->get_error_messages()
 			);
 		}
@@ -186,7 +186,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		if ( 200 !== wp_remote_retrieve_response_code( $service_response ) ) {
 			return new WP_Error(
 				'http_error',
-				__( 'An error occurred while fetching data from remote.', 'jetpack' ),
+				__( 'An error occurred fetching the remote data.', 'jetpack' ),
 				wp_remote_retrieve_response_message( $service_response )
 			);
 		}
@@ -197,7 +197,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		if ( ! isset( $service_response['body'] ) ) {
 			return new WP_Error(
 				'no_body',
-				__( 'Invalid data returned by remote.', 'jetpack' ),
+				__( 'Invalid remote response.', 'jetpack' ),
 				'No body in response.'
 			);
 		}
@@ -213,7 +213,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		if ( is_null( $parsed_data ) ) {
 			return new WP_Error(
 				'no_body',
-				__( 'Invalid data returned by remote.', 'jetpack' ),
+				__( 'Invalid remote response.', 'jetpack' ),
 				'Invalid JSON from remote.'
 			);
 		}
@@ -353,7 +353,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		if ( false === $cached_data ) {
 			return new WP_Error(
 				'empty_cache',
-				__( 'Information about this blog is being currently retrieved.', 'jetpack' )
+				__( 'Information about this blog is currently being retrieved.', 'jetpack' )
 			);
 		}
 
@@ -854,15 +854,28 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			 * Prepare the error messages.
 			 */
 
-			$where_message = __( 'An error occurred while downloading ', 'jetpack' );
+			$what_broke_down = '';
 			switch ( $update_errors['where'] ) {
-				case 'site_info':
-					$where_message .= __( 'blog information', 'jetpack' );
-					break;
 				case 'posts':
-					$where_message .= __( 'blog posts list', 'jetpack' );
+					$what_broke_down .= __( 'posts list', 'jetpack' );
+					break;
+
+				/**
+				 * If something else, beside `posts` and `site_info` broke,
+				 * don't handle it and default to blog `information`,
+				 * as it is generic enough.
+				 */
+				case 'site_info':
+				default:
+					$what_broke_down .= __( 'information', 'jetpack' );
 					break;
 			}
+
+			$where_message = sprintf(
+				__( 'An error occurred while downloading blog %s', 'jetpack' ),
+				$what_broke_down
+			);
+
 
 			?>
 			<p class="error-message">

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -453,21 +453,27 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		$formatted_posts = array();
 
 		/**
-		 * Loop through all the posts and format them appropriately.
+		 * Only go through the posts list if we have valid posts array.
 		 */
-		foreach ( $parsed_data->posts as $single_post ) {
-
-			$prepared_post = array(
-				'title'          => $single_post->title ? $single_post->title : '',
-				'excerpt'        => $single_post->excerpt ? $single_post->excerpt : '',
-				'featured_image' => $single_post->featured_image ? $single_post->featured_image : '',
-				'url'            => $single_post->URL,
-			);
+		if ( isset( $parsed_data->posts ) && is_array( $parsed_data->posts ) ) {
 
 			/**
-			 * Append the formatted post to the results.
+			 * Loop through all the posts and format them appropriately.
 			 */
-			$formatted_posts[] = $prepared_post;
+			foreach ( $parsed_data->posts as $single_post ) {
+
+				$prepared_post = array(
+					'title'          => $single_post->title ? $single_post->title : '',
+					'excerpt'        => $single_post->excerpt ? $single_post->excerpt : '',
+					'featured_image' => $single_post->featured_image ? $single_post->featured_image : '',
+					'url'            => $single_post->URL,
+				);
+
+				/**
+				 * Append the formatted post to the results.
+				 */
+				$formatted_posts[] = $prepared_post;
+			}
 		}
 
 		return $formatted_posts;

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -58,16 +58,22 @@ function jetpack_display_posts_update_cron_action() {
 	$widget->cron_task();
 }
 
-
 /**
  * Handle deactivation procedures where they are needed.
  *
  * If Extra Sidebar Widgets module is deactivated, the cron is not needed.
+ *
+ * If Jetpack is deactivated, the cron is not needed.
  */
 add_action( 'jetpack_deactivate_module_widgets', 'Jetpack_Display_Posts_Widget::deactivate_cron_static' );
+register_deactivation_hook( 'jetpack/jetpack.php', 'Jetpack_Display_Posts_Widget::deactivate_cron_static' );
 
 /**
- * Handle activation procedures where they are needed.
+ * Check if the cron should be running on WP shutdown.
+ *
+ * It is hooked on shutdown, so it doesn't slow down initial page load time.
+ *
+ * This handles cases outside plugin/module deactivation.
  */
 add_action( 'shutdown', 'jetpack_display_posts_conditionally_set_cron_run_status' );
 
@@ -610,6 +616,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		 */
 		if ( false === $this->should_cron_be_running() ) {
 			$this->deactivate_cron();
+
 			return true;
 		}
 

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -59,6 +59,13 @@ function jetpack_display_posts_update_cron_action() {
 }
 
 /**
+ * Check the status of the cron task when all plugins are loaded.
+ *
+ * @see Jetpack_Display_Posts_Widget::check_for_cron
+ */
+add_action( 'wp_loaded', 'Jetpack_Display_Posts_Widget::check_for_cron' );
+
+/**
  * End of Cron tasks
  */
 /*
@@ -87,11 +94,6 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 				'description' => __( 'Displays a list of recent posts from another WordPress.com or Jetpack-enabled blog.', 'jetpack' ),
 			)
 		);
-
-		/**
-		 * Check the status of the cron task.
-		 */
-		self::check_for_cron();
 	}
 
 	/**

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -1118,6 +1118,8 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	 * @param array  $args Optional. Request arguments.
 	 *
 	 * @return array|WP_Error
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function wp_wp_remote_get( $url, $args = array() ) {
 		return wp_remote_get( $url, $args );

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -224,9 +224,6 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			$widget_data['posts']['error'] = null;
 		}
 
-
-
-
 		return $widget_data;
 	}
 
@@ -522,9 +519,9 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'url' ); ?>"><?php _e( 'Blog URL:', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo $this->get_field_id( 'url' ); ?>" name="<?php echo $this->get_field_name( 'url' ); ?>" type="text" value="<?php echo esc_attr( $url ); ?>" />
-			<p>
+			<i>
 			<?php _e( "Enter a WordPress.com or Jetpack WordPress site URL.", 'jetpack' ); ?>
-			</p>
+			</i>
 		</p>
 		<p>
 			<label for="<?php echo $this->get_field_id( 'number_of_posts' ); ?>"><?php _e( 'Number of Posts to Display:', 'jetpack' ); ?></label>
@@ -536,6 +533,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 				?>
 			</select>
 		</p>
+		<p>
 			<label for="<?php echo $this->get_field_id( 'open_in_new_window' ); ?>"><?php _e( 'Open links in new window/tab:', 'jetpack' ); ?></label>
 			<input type="checkbox" name="<?php echo $this->get_field_name( 'open_in_new_window' ); ?>" <?php checked( $open_in_new_window, 1 ); ?> />
 		</p>

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -177,16 +177,16 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->getMock();
 
 		$mock->expects( $this->any() )
-			 ->method( 'fetch_site_info' )
+		     ->method( 'fetch_site_info' )
 		     ->with( 'http://test.com' )
-		     ->willReturn( 'test_param_1' );
+		     ->will( $this->returnValue( ( 'test_param_1' ) ) );
 
 		$test_error = new WP_Error( 'broke', 'the', 'test' );
 
 		$mock->expects( $this->any() )
-			 ->method( 'parse_site_info_response' )
+		     ->method( 'parse_site_info_response' )
 		     ->with( 'test_param_1' )
-		     ->willReturn( $test_error );
+		     ->will( $this->returnValue( $test_error ) );
 
 
 		$mock->expects( $this->never() )
@@ -241,28 +241,28 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->getMock();
 
 		$mock->expects( $this->any() )
-			 ->method( 'fetch_site_info' )
+		     ->method( 'fetch_site_info' )
 		     ->with( 'http://test.com' )
-		     ->willReturn( 'test_param_1' );
+		     ->will( $this->returnValue( 'test_param_1' ) );
 
 		$mock->expects( $this->any() )
-			 ->method( 'parse_site_info_response' )
+		     ->method( 'parse_site_info_response' )
 		     ->with( 'test_param_1' )
-		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
+		     ->will( $this->returnValue( ( (object) ( array( 'ID' => 'test_id' ) ) ) ) );
 
 		$mock->expects( $this->any() )
-			 ->method( 'fetch_posts_for_site' )
+		     ->method( 'fetch_posts_for_site' )
 		     ->with( 'test_id' )
-		     ->willReturn( 'test_param_2' );
+		     ->will( $this->returnValue( 'test_param_2' ) );
 
 
 		$test_error = new WP_Error( 'broke', 'the', 'test' );
 
 
 		$mock->expects( $this->any() )
-			 ->method( 'parse_posts_response' )
+		     ->method( 'parse_posts_response' )
 		     ->with( 'test_param_2' )
-		     ->willReturn( $test_error );
+		     ->will( $this->returnValue( $test_error ) );
 
 		$result = $mock->fetch_blog_data( 'http://test.com' );
 
@@ -312,28 +312,28 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->getMock();
 
 		$mock->expects( $this->any() )
-			 ->method( 'fetch_site_info' )
+		     ->method( 'fetch_site_info' )
 		     ->with( 'http://test.com' )
-		     ->willReturn( 'test_param_1' );
+		     ->will( $this->returnValue( 'test_param_1' ) );
 
 		$mock->expects( $this->any() )
-			 ->method( 'parse_site_info_response' )
+		     ->method( 'parse_site_info_response' )
 		     ->with( 'test_param_1' )
-		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
+		     ->will( $this->returnValue( ( (object) ( array( 'ID' => 'test_id' ) ) ) ) );
 
 		$mock->expects( $this->any() )
-			 ->method( 'fetch_posts_for_site' )
+		     ->method( 'fetch_posts_for_site' )
 		     ->with( 'test_id' )
-		     ->willReturn( 'test_param_2' );
+		     ->will( $this->returnValue( 'test_param_2' ) );
 
 
 		$test_error = new WP_Error( 'broke', 'the', 'test' );
 
 
 		$mock->expects( $this->any() )
-			 ->method( 'parse_posts_response' )
+		     ->method( 'parse_posts_response' )
 		     ->with( 'test_param_2' )
-		     ->willReturn( $test_error );
+		     ->will( $this->returnValue( $test_error ) );
 
 		$predefined_data = array(
 			'site_info' => array(
@@ -395,25 +395,25 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->getMock();
 
 		$mock->expects( $this->any() )
-			 ->method( 'fetch_site_info' )
+		     ->method( 'fetch_site_info' )
 		     ->with( 'http://test.com' )
-		     ->willReturn( 'test_param_1' );
+		     ->will( $this->returnValue( 'test_param_1' ) );
 
 		$mock->expects( $this->any() )
-			 ->method( 'parse_site_info_response' )
+		     ->method( 'parse_site_info_response' )
 		     ->with( 'test_param_1' )
-		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
+		     ->will( $this->returnValue( ( (object) ( array( 'ID' => 'test_id' ) ) ) ) );
 
 		$mock->expects( $this->any() )
-			 ->method( 'fetch_posts_for_site' )
+		     ->method( 'fetch_posts_for_site' )
 		     ->with( 'test_id' )
-		     ->willReturn( 'test_param_2' );
+		     ->will( $this->returnValue( 'test_param_2' ) );
 
 
 		$mock->expects( $this->any() )
-			 ->method( 'parse_posts_response' )
+		     ->method( 'parse_posts_response' )
 		     ->with( 'test_param_2' )
-		     ->willReturn( 'test_result_final' );
+		     ->will( $this->returnValue( 'test_result_final' ) );
 
 		$result = $mock->fetch_blog_data( 'http://test.com' );
 
@@ -458,14 +458,14 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->getMock();
 
 		$mock->expects( $this->any() )
-			 ->method( 'get_site_hash' )
+		     ->method( 'get_site_hash' )
 		     ->with( 'http://test.com' )
-		     ->willReturn( 'test_option_hash' );
+		     ->will( $this->returnValue( 'test_option_hash' ) );
 
 		$mock->expects( $this->any() )
-			 ->method( 'wp_get_option' )
+		     ->method( 'wp_get_option' )
 		     ->with( $mock->widget_options_key_prefix . 'test_option_hash' )
-		     ->willReturn( false );
+		     ->will( $this->returnValue( false ) );
 
 		$result = $mock->get_blog_data( 'http://test.com' );
 
@@ -492,14 +492,14 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->getMock();
 
 		$mock->expects( $this->any() )
-			 ->method( 'get_site_hash' )
+		     ->method( 'get_site_hash' )
 		     ->with( 'http://test.com' )
-		     ->willReturn( 'test_option_hash' );
+		     ->will( $this->returnValue( 'test_option_hash' ) );
 
 		$mock->expects( $this->any() )
-			 ->method( 'wp_get_option' )
+		     ->method( 'wp_get_option' )
 		     ->with( $mock->widget_options_key_prefix . 'test_option_hash' )
-		     ->willReturn( 'real value' );
+		     ->will( $this->returnValue( 'real value' ) );
 
 		$result = $mock->get_blog_data( 'http://test.com' );
 

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -1,0 +1,31 @@
+<?php
+
+require dirname( __FILE__ ) . '/../../../../modules/widgets/wordpress-post-widget.php';
+class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
+
+	/**
+	 * WP_Test_Jetpack_Display_Posts_Widget constructor.
+	 */
+	function __construct() {
+		parent::__construct();
+		$this->inst = new Jetpack_Display_Posts_Widget;
+	}
+
+	/**
+	 * Test parse_service_response when called with a WP_Error
+	 */
+	function test_parse_service_response_wp_error() {
+
+		$input_data = new WP_Error( 'test_case', 'TEST CASE', 'mydata' );
+
+		$result = $this->inst->parse_service_response( $input_data );
+
+		$this->assertTrue(is_wp_error($result));
+
+		$this->assertEquals(array('general_error'), $result->get_error_codes());
+		$this->assertEquals(array('An error occurred while fetching data from remote.'), $result->get_error_messages());
+		$this->assertEquals(array('TEST CASE'), $result->get_error_data());
+
+	}
+
+}

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -1213,4 +1213,106 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$this->assertEquals( $expected_result, $result );
 	}
 
+	/**
+	 * Test if jetpack_display_posts_widget_cron_intervals is working correctly with
+	 * predefined list of cron schedule.
+	 */
+	function test_jetpack_display_posts_widget_cron_intervals_predefined_schedule() {
+
+		$predefine_schedules = array(
+			'minutes_5'  => array(
+				'interval' => 300,
+				'display'  => 'Every five minutes'
+			),
+			'minutes_15' => array(
+				'interval' => 900,
+				'display'  => 'Every fifteen minutes'
+			)
+		);
+
+		$result = jetpack_display_posts_widget_cron_intervals( $predefine_schedules );
+
+		$expected_result = array(
+			'minutes_5'  => array(
+				'interval' => 300,
+				'display'  => 'Every five minutes'
+			),
+			'minutes_15' => array(
+				'interval' => 900,
+				'display'  => 'Every fifteen minutes'
+			),
+			'minutes_10' => array(
+				'interval' => 600,
+				'display'  => 'Every 10 minutes'
+			)
+		);
+
+		$this->assertEquals( $expected_result, $result );
+
+	}
+
+	/**
+	 * Test if jetpack_display_posts_widget_cron_intervals is working correctly with
+	 * no predefined cron schedules.
+	 */
+	function test_jetpack_display_posts_widget_cron_intervals_no_predefined_schedule() {
+
+		$predefine_schedules = array();
+
+		$result = jetpack_display_posts_widget_cron_intervals( $predefine_schedules );
+
+		$expected_result = array(
+			'minutes_10' => array(
+				'interval' => 600,
+				'display'  => 'Every 10 minutes'
+			)
+		);
+
+		$this->assertEquals( $expected_result, $result );
+
+	}
+
+
+	/**
+	 * Test if jetpack_display_posts_widget_cron_intervals is working correctly with
+	 * minutes_10 interval already defined.
+	 */
+	function test_jetpack_display_posts_widget_cron_intervals_predefined_schedule_no_overwrite() {
+
+		$predefine_schedules = array(
+			'minutes_5'  => array(
+				'interval' => 300,
+				'display'  => 'Every five minutes'
+			),
+			'minutes_10' => array(
+				'interval' => 12345,
+				'display'  => 'Bogus predefined interval'
+			),
+			'minutes_15' => array(
+				'interval' => 900,
+				'display'  => 'Every fifteen minutes'
+			)
+		);
+
+		$result = jetpack_display_posts_widget_cron_intervals( $predefine_schedules );
+
+		$expected_result = array(
+			'minutes_5'  => array(
+				'interval' => 300,
+				'display'  => 'Every five minutes'
+			),
+			'minutes_10' => array(
+				'interval' => 12345,
+				'display'  => 'Bogus predefined interval'
+			),
+			'minutes_15' => array(
+				'interval' => 900,
+				'display'  => 'Every fifteen minutes'
+			)
+		);
+
+		$this->assertEquals( $expected_result, $result );
+
+	}
+
 }

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -176,13 +176,15 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
-		$mock->method( 'fetch_site_info' )
+		$mock->expects( $this->any() )
+			 ->method( 'fetch_site_info' )
 		     ->with( 'http://test.com' )
 		     ->willReturn( 'test_param_1' );
 
 		$test_error = new WP_Error( 'broke', 'the', 'test' );
 
-		$mock->method( 'parse_site_info_response' )
+		$mock->expects( $this->any() )
+			 ->method( 'parse_site_info_response' )
 		     ->with( 'test_param_1' )
 		     ->willReturn( $test_error );
 
@@ -238,15 +240,18 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
-		$mock->method( 'fetch_site_info' )
+		$mock->expects( $this->any() )
+			 ->method( 'fetch_site_info' )
 		     ->with( 'http://test.com' )
 		     ->willReturn( 'test_param_1' );
 
-		$mock->method( 'parse_site_info_response' )
+		$mock->expects( $this->any() )
+			 ->method( 'parse_site_info_response' )
 		     ->with( 'test_param_1' )
 		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
 
-		$mock->method( 'fetch_posts_for_site' )
+		$mock->expects( $this->any() )
+			 ->method( 'fetch_posts_for_site' )
 		     ->with( 'test_id' )
 		     ->willReturn( 'test_param_2' );
 
@@ -254,7 +259,8 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$test_error = new WP_Error( 'broke', 'the', 'test' );
 
 
-		$mock->method( 'parse_posts_response' )
+		$mock->expects( $this->any() )
+			 ->method( 'parse_posts_response' )
 		     ->with( 'test_param_2' )
 		     ->willReturn( $test_error );
 
@@ -305,15 +311,18 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
-		$mock->method( 'fetch_site_info' )
+		$mock->expects( $this->any() )
+			 ->method( 'fetch_site_info' )
 		     ->with( 'http://test.com' )
 		     ->willReturn( 'test_param_1' );
 
-		$mock->method( 'parse_site_info_response' )
+		$mock->expects( $this->any() )
+			 ->method( 'parse_site_info_response' )
 		     ->with( 'test_param_1' )
 		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
 
-		$mock->method( 'fetch_posts_for_site' )
+		$mock->expects( $this->any() )
+			 ->method( 'fetch_posts_for_site' )
 		     ->with( 'test_id' )
 		     ->willReturn( 'test_param_2' );
 
@@ -321,7 +330,8 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$test_error = new WP_Error( 'broke', 'the', 'test' );
 
 
-		$mock->method( 'parse_posts_response' )
+		$mock->expects( $this->any() )
+			 ->method( 'parse_posts_response' )
 		     ->with( 'test_param_2' )
 		     ->willReturn( $test_error );
 
@@ -384,20 +394,24 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
-		$mock->method( 'fetch_site_info' )
+		$mock->expects( $this->any() )
+			 ->method( 'fetch_site_info' )
 		     ->with( 'http://test.com' )
 		     ->willReturn( 'test_param_1' );
 
-		$mock->method( 'parse_site_info_response' )
+		$mock->expects( $this->any() )
+			 ->method( 'parse_site_info_response' )
 		     ->with( 'test_param_1' )
 		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
 
-		$mock->method( 'fetch_posts_for_site' )
+		$mock->expects( $this->any() )
+			 ->method( 'fetch_posts_for_site' )
 		     ->with( 'test_id' )
 		     ->willReturn( 'test_param_2' );
 
 
-		$mock->method( 'parse_posts_response' )
+		$mock->expects( $this->any() )
+			 ->method( 'parse_posts_response' )
 		     ->with( 'test_param_2' )
 		     ->willReturn( 'test_result_final' );
 
@@ -443,11 +457,13 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
-		$mock->method( 'get_site_hash' )
+		$mock->expects( $this->any() )
+			 ->method( 'get_site_hash' )
 		     ->with( 'http://test.com' )
 		     ->willReturn( 'test_option_hash' );
 
-		$mock->method( 'wp_get_option' )
+		$mock->expects( $this->any() )
+			 ->method( 'wp_get_option' )
 		     ->with( $mock->widget_options_key_prefix . 'test_option_hash' )
 		     ->willReturn( false );
 
@@ -475,11 +491,13 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
-		$mock->method( 'get_site_hash' )
+		$mock->expects( $this->any() )
+			 ->method( 'get_site_hash' )
 		     ->with( 'http://test.com' )
 		     ->willReturn( 'test_option_hash' );
 
-		$mock->method( 'wp_get_option' )
+		$mock->expects( $this->any() )
+			 ->method( 'wp_get_option' )
 		     ->with( $mock->widget_options_key_prefix . 'test_option_hash' )
 		     ->willReturn( 'real value' );
 

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -24,7 +24,7 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$this->assertTrue( is_wp_error( $result ) );
 
 		$this->assertEquals( array( 'general_error' ), $result->get_error_codes() );
-		$this->assertEquals( array( 'An error occurred while fetching data from remote.' ), $result->get_error_messages() );
+		$this->assertEquals( array( 'An error occurred fetching the remote data.' ), $result->get_error_messages() );
 		$this->assertEquals( array( 'TEST CASE' ), $result->get_error_data() );
 
 	}
@@ -47,7 +47,7 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$this->assertTrue( is_wp_error( $result ) );
 
 		$this->assertEquals( array( 'http_error' ), $result->get_error_codes() );
-		$this->assertEquals( array( 'An error occurred while fetching data from remote.' ), $result->get_error_messages() );
+		$this->assertEquals( array( 'An error occurred fetching the remote data.' ), $result->get_error_messages() );
 		$this->assertEquals( 'TESTING, ATTENTION', $result->get_error_data() );
 
 	}
@@ -72,7 +72,7 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$this->assertTrue( is_wp_error( $result ) );
 
 		$this->assertEquals( array( 'no_body' ), $result->get_error_codes() );
-		$this->assertEquals( array( 'Invalid data returned by remote.' ), $result->get_error_messages() );
+		$this->assertEquals( array( 'Invalid remote response.' ), $result->get_error_messages() );
 		$this->assertEquals( 'No body in response.', $result->get_error_data() );
 
 	}
@@ -95,7 +95,7 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$this->assertTrue( is_wp_error( $result ) );
 
 		$this->assertEquals( array( 'no_body' ), $result->get_error_codes() );
-		$this->assertEquals( array( 'Invalid data returned by remote.' ), $result->get_error_messages() );
+		$this->assertEquals( array( 'Invalid remote response.' ), $result->get_error_messages() );
 		$this->assertEquals( 'Invalid JSON from remote.', $result->get_error_data() );
 
 	}
@@ -473,7 +473,7 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$message = $result->get_error_messages();
 
-		$this->assertEquals( array( 'Information about this blog is being currently retrieved.' ), $message );
+		$this->assertEquals( array( 'Information about this blog is currently being retrieved.' ), $message );
 
 		$codes = $result->get_error_codes();
 

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -655,4 +655,97 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 	}
 
 
+	/**
+	 * Test format_posts_for_storage with valid data
+	 */
+	function tests_format_posts_for_storage_valid() {
+
+		$posts_list_test = (object) ( array(
+			'posts' => array(
+				(object) ( array(
+					'title'          => 'test title 1',
+					'excerpt'        => 'This is my test excerpt 1',
+					'featured_image' => 'test image 1.png',
+					'URL'            => 'http://test.com/1',
+					'full_text'      => 'Full post text contained here'
+				) ),
+
+				(object) ( array(
+					'title'          => '',
+					'excerpt'        => 'This is my test excerpt 2',
+					'featured_image' => 'test image 2.png',
+					'URL'            => 'http://test.com/2',
+					'full_text'      => 'Full post text contained here'
+				) ),
+
+				(object) ( array(
+					'title'          => 'Test title 3',
+					'excerpt'        => '',
+					'featured_image' => 'test image 3.png',
+					'URL'            => 'http://test.com/3',
+					'full_text'      => 'Full post text contained here'
+				) ),
+
+				(object) ( array(
+					'title'          => '',
+					'excerpt'        => '',
+					'featured_image' => '',
+					'URL'            => '',
+					'full_text'      => ''
+				) ),
+			)
+		) );
+
+
+		$result = $this->inst->format_posts_for_storage( $posts_list_test );
+
+		$expected_posts_list = array(
+			array(
+				'title'          => 'test title 1',
+				'excerpt'        => 'This is my test excerpt 1',
+				'featured_image' => 'test image 1.png',
+				'url'            => 'http://test.com/1',
+			),
+			array(
+				'title'          => '',
+				'excerpt'        => 'This is my test excerpt 2',
+				'featured_image' => 'test image 2.png',
+				'url'            => 'http://test.com/2',
+			),
+			array(
+				'title'          => 'Test title 3',
+				'excerpt'        => '',
+				'featured_image' => 'test image 3.png',
+				'url'            => 'http://test.com/3',
+			),
+			array(
+				'title'          => '',
+				'excerpt'        => '',
+				'featured_image' => '',
+				'url'            => '',
+			)
+		);
+
+		$this->assertEquals( $expected_posts_list, $result );
+	}
+
+
+	/**
+	 * Test format_posts_for_storage with invalid data
+	 */
+	function tests_format_posts_for_storage_invalid() {
+
+		$posts_list_test = (object) ( array(
+			'posts' => 'invalid posts'
+		) );
+
+
+		$result = $this->inst->format_posts_for_storage( $posts_list_test );
+
+		$expected_posts_list = array();
+
+		$this->assertEquals( $expected_posts_list, $result );
+	}
+
+
 }

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -748,4 +748,292 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 	}
 
 
+	/**
+	 * Test cron_task with valid data
+	 */
+	function test_cron_task_valid_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'get_instances_sites', 'update_instance' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->expects( $this->any() )
+		     ->method( 'get_instances_sites' )
+		     ->will( $this->returnValue( array( 'test_url_1', 'test_url_2', 'test_url_3' ) ) );
+
+		$mock->expects( $this->at( 1 ) )
+		     ->method( 'update_instance' )
+		     ->with( 'test_url_1' );
+
+		$mock->expects( $this->at( 2 ) )
+		     ->method( 'update_instance' )
+		     ->with( 'test_url_2' );
+
+		$mock->expects( $this->at( 3 ) )
+		     ->method( 'update_instance' )
+		     ->with( 'test_url_3' );
+
+
+		$result = $mock->cron_task();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test cron_task with invalid data
+	 */
+	function test_cron_task_no_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'get_instances_sites', 'update_instance' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->expects( $this->any() )
+		     ->method( 'get_instances_sites' )
+		     ->will( $this->returnValue( array() ) );
+
+		$mock->expects( $this->never() )
+		     ->method( 'update_instance' );
+
+
+		$result = $mock->cron_task();
+
+		$this->assertTrue( $result );
+	}
+
+
+	/**
+	 * Test cron_task with no data
+	 */
+	function test_cron_task_invalid_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'get_instances_sites', 'update_instance' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->expects( $this->any() )
+		     ->method( 'get_instances_sites' )
+		     ->will( $this->returnValue( '' ) );
+
+		$mock->expects( $this->never() )
+		     ->method( 'update_instance' );
+
+
+		$result = $mock->cron_task();
+
+		$this->assertTrue( $result );
+	}
+
+
+	/**
+	 * Test get_instances_sites with valid data
+	 */
+	function test_get_instances_sites_valid_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'wp_get_option' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$url_list_test = array(
+			array( 'url' => 'test_url_1' ),
+			array( 'url' => 'test_url_2' ),
+			array( 'url' => 'test_url_3' ),
+			array( 'url' => 'test_url_3' ), // uniqueness test
+			array( 'url' => 'test_url_3' ), // uniqueness test
+		);
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_get_option' )
+		     ->with( 'widget_jetpack_display_posts_widget' )
+		     ->will( $this->returnValue( $url_list_test ) );
+
+		$result = $mock->get_instances_sites();
+
+		$expected_result = array(
+			'test_url_1',
+			'test_url_2',
+			'test_url_3',
+		);
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
+	/**
+	 * Test get_instances_sites with invalid data
+	 */
+	function test_get_instances_sites_invalid_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'wp_get_option' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_get_option' )
+		     ->with( 'widget_jetpack_display_posts_widget' )
+		     ->will( $this->returnValue( false ) );
+
+		$result = $mock->get_instances_sites();
+
+		$this->assertFalse( $result );
+	}
+
+
+	/**
+	 * Test get_instances_sites with invalid data, part 2
+	 */
+	function test_get_instances_sites_invalid_data_2() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'wp_get_option' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_get_option' )
+		     ->with( 'widget_jetpack_display_posts_widget' )
+		     ->will( $this->returnValue( 'my value' ) );
+
+		$result = $mock->get_instances_sites();
+
+		$this->assertFalse( $result );
+	}
+
+
+	/**
+	 * Test get_instances_sites with invalid data, part 2
+	 */
+	function test_get_instances_sites_empty_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'wp_get_option' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_get_option' )
+		     ->with( 'widget_jetpack_display_posts_widget' )
+		     ->will( $this->returnValue( array() ) );
+
+		$result = $mock->get_instances_sites();
+
+		$this->assertEquals( array(), $result );
+	}
+
+
+	/**
+	 * Test get_instances_sites with invalid data, part 2
+	 */
+	function test_get_instances_sites_broken_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'wp_get_option' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$broken_data = array(
+			array( 'my' => 'test', 'value' => 'contains', 'no' => 'url' ),
+			array( 'my2' => 'test', 'value2' => 'contains', 'no2' => 'url' ),
+			array( 'my3' => 'test', 'value3' => 'contains', 'no3' => 'url' ),
+		);
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_get_option' )
+		     ->with( 'widget_jetpack_display_posts_widget' )
+		     ->will( $this->returnValue( $broken_data ) );
+
+		$result = $mock->get_instances_sites();
+
+		$this->assertEquals( array(), $result );
+	}
+
+
+	/**
+	 * Test update_instance with valid data, new option
+	 */
+	function test_update_instance_valid_data_new_option() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array(
+                           'get_site_hash', 'wp_get_option',
+                           'fetch_blog_data', 'wp_add_option',
+                           'wp_update_option'
+                       ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->expects( $this->any() )
+		     ->method( 'get_site_hash' )
+		     ->with( 'http://test.com' )
+		     ->will( $this->returnValue( 'my_hash' ) );
+
+
+		$widget_data_original = false;
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_get_option' )
+		     ->with( $mock->widget_options_key_prefix.'my_hash' )
+		     ->will( $this->returnValue( $widget_data_original ) );
+
+		$mock->expects( $this->any() )
+		     ->method( 'fetch_blog_data' )
+		     ->with( 'http://test.com', false )
+		     ->will( $this->returnValue( 'new data' ) );
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_add_option' )
+		     ->with( $mock->widget_options_key_prefix.'my_hash', 'new data' );
+
+		$mock->expects( $this->never() )
+		     ->method( 'wp_update_option' );
+
+		$mock->update_instance('http://test.com');
+	}
+
+
+	/**
+	 * Test update_instance with valid data, update option
+	 */
+	function test_update_instance_valid_data_update_option() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array(
+			                           'get_site_hash', 'wp_get_option',
+			                           'fetch_blog_data', 'wp_add_option',
+			                           'wp_update_option'
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->expects( $this->any() )
+		     ->method( 'get_site_hash' )
+		     ->with( 'http://test.com' )
+		     ->will( $this->returnValue( 'my_hash' ) );
+
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_get_option' )
+		     ->with( $mock->widget_options_key_prefix.'my_hash' )
+		     ->will( $this->returnValue( array(123) ) );
+
+		$mock->expects( $this->any() )
+		     ->method( 'fetch_blog_data' )
+		     ->with( 'http://test.com', array(123) )
+		     ->will( $this->returnValue( 'new data' ) );
+
+		$mock->expects( $this->never() )
+		     ->method( 'wp_add_option' );
+
+		$mock->expects( $this->any() )
+		     ->method( 'wp_update_option' )
+			 ->with( $mock->widget_options_key_prefix.'my_hash', 'new data' );
+
+		$mock->update_instance('http://test.com');
+	}
+
+
 }

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -506,4 +506,153 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$this->assertEquals( 'real value', $result );
 	}
 
+	/**
+	 * Test parse_posts_response with valid data
+	 */
+	function test_parse_posts_response_valid() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'format_posts_for_storage' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$service_response_test = (object) ( array(
+			'posts' => array( '1,2,3' ),
+		) );
+
+		$mock->expects( $this->any() )
+		     ->method( 'format_posts_for_storage' )
+		     ->with( $service_response_test )
+		     ->will( $this->returnValue( 'other test value' ) );
+
+		$result = $mock->parse_posts_response( $service_response_test );
+
+		$this->assertEquals( 'other test value', $result );
+	}
+
+	/**
+	 * Test parse_posts_response with WP_Error
+	 */
+	function test_parse_posts_response_wp_error() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'format_posts_for_storage' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$service_response_test_wp_err = new WP_Error( 'test code', 'test message', 'test_data' );
+
+		$mock->expects( $this->never() )
+		     ->method( 'format_posts_for_storage' );
+
+		$result = $mock->parse_posts_response( $service_response_test_wp_err );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$message = $result->get_error_messages();
+
+		$this->assertEquals( array( 'test message' ), $message );
+
+		$codes = $result->get_error_codes();
+
+		$this->assertEquals( array( 'test code' ), $codes );
+	}
+
+	/**
+	 * Test parse_posts_response with invalid data
+	 */
+	function test_parse_posts_response_invalid_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'format_posts_for_storage' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$service_response_test_invalid_data = (object) ( array(
+			'posts' => 'invalid data',
+		) );
+
+		$mock->expects( $this->never() )
+		     ->method( 'format_posts_for_storage' );
+
+		$result = $mock->parse_posts_response( $service_response_test_invalid_data );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$message = $result->get_error_messages();
+
+		$this->assertEquals( array( 'No posts data returned by remote.' ), $message );
+
+		$codes = $result->get_error_codes();
+
+		$this->assertEquals( array( 'no_posts' ), $codes );
+
+		$data = $result->get_error_data();
+
+		$this->assertEquals( 'No posts information set in the returned data.', $data );
+	}
+
+	/**
+	 * Test parse_site_info_response with valid data
+	 */
+	function test_parse_site_info_response_valid() {
+
+		$service_response_test_valid_data = (object) ( array(
+			'ID' => 55
+		) );
+
+		$result = $this->inst->parse_site_info_response( $service_response_test_valid_data );
+
+		$this->assertEquals( $service_response_test_valid_data, $result );
+
+	}
+
+	/**
+	 * Test parse_site_info_response with WP_Error
+	 */
+	function test_parse_site_info_response_wp_error() {
+
+		$service_response_test_wp_err = new WP_Error( 'test code', 'test message', 'test_data' );
+
+		$result = $this->inst->parse_site_info_response( $service_response_test_wp_err );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$message = $result->get_error_messages();
+
+		$this->assertEquals( array( 'test message' ), $message );
+
+		$codes = $result->get_error_codes();
+
+		$this->assertEquals( array( 'test code' ), $codes );
+	}
+
+
+	/**
+	 * Test parse_site_info_response with WP_Error
+	 */
+	function test_parse_site_info_response_invalid_data() {
+
+		$service_response_test_invalid_data = (object) ( array(
+			'not_valid' => 55
+		) );
+
+		$result = $this->inst->parse_site_info_response( $service_response_test_invalid_data );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$message = $result->get_error_messages();
+
+		$this->assertEquals( array( 'Invalid site information returned from remote.' ), $message );
+
+		$codes = $result->get_error_codes();
+
+		$this->assertEquals( array( 'no_site_info' ), $codes );
+
+		$data = $result->get_error_data();
+
+		$this->assertEquals( 'No site ID present in the response.', $data );
+	}
+
+
 }

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -959,10 +959,12 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		/** @var Jetpack_Display_Posts_Widget $mock */
 		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
 		             ->setMethods( array(
-                           'get_site_hash', 'wp_get_option',
-                           'fetch_blog_data', 'wp_add_option',
-                           'wp_update_option'
-                       ) )
+			                           'get_site_hash',
+			                           'wp_get_option',
+			                           'fetch_blog_data',
+			                           'wp_add_option',
+			                           'wp_update_option'
+		                           ) )
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
@@ -976,7 +978,7 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$mock->expects( $this->any() )
 		     ->method( 'wp_get_option' )
-		     ->with( $mock->widget_options_key_prefix.'my_hash' )
+		     ->with( $mock->widget_options_key_prefix . 'my_hash' )
 		     ->will( $this->returnValue( $widget_data_original ) );
 
 		$mock->expects( $this->any() )
@@ -986,12 +988,12 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$mock->expects( $this->any() )
 		     ->method( 'wp_add_option' )
-		     ->with( $mock->widget_options_key_prefix.'my_hash', 'new data' );
+		     ->with( $mock->widget_options_key_prefix . 'my_hash', 'new data' );
 
 		$mock->expects( $this->never() )
 		     ->method( 'wp_update_option' );
 
-		$mock->update_instance('http://test.com');
+		$mock->update_instance( 'http://test.com' );
 	}
 
 
@@ -1002,8 +1004,10 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		/** @var Jetpack_Display_Posts_Widget $mock */
 		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
 		             ->setMethods( array(
-			                           'get_site_hash', 'wp_get_option',
-			                           'fetch_blog_data', 'wp_add_option',
+			                           'get_site_hash',
+			                           'wp_get_option',
+			                           'fetch_blog_data',
+			                           'wp_add_option',
 			                           'wp_update_option'
 		                           ) )
 		             ->disableOriginalConstructor()
@@ -1017,12 +1021,12 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$mock->expects( $this->any() )
 		     ->method( 'wp_get_option' )
-		     ->with( $mock->widget_options_key_prefix.'my_hash' )
-		     ->will( $this->returnValue( array(123) ) );
+		     ->with( $mock->widget_options_key_prefix . 'my_hash' )
+		     ->will( $this->returnValue( array( 123 ) ) );
 
 		$mock->expects( $this->any() )
 		     ->method( 'fetch_blog_data' )
-		     ->with( 'http://test.com', array(123) )
+		     ->with( 'http://test.com', array( 123 ) )
 		     ->will( $this->returnValue( 'new data' ) );
 
 		$mock->expects( $this->never() )
@@ -1030,10 +1034,75 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$mock->expects( $this->any() )
 		     ->method( 'wp_update_option' )
-			 ->with( $mock->widget_options_key_prefix.'my_hash', 'new data' );
+		     ->with( $mock->widget_options_key_prefix . 'my_hash', 'new data' );
 
-		$mock->update_instance('http://test.com');
+		$mock->update_instance( 'http://test.com' );
 	}
 
+
+	/**
+	 * Test extract_errors_from_blog_data with WP_Error input
+	 */
+	function test_extract_errors_from_blog_data_wp_error() {
+		$input_data = new WP_Error( 'test_case', 'TEST CASE', 'mydata' );
+
+		$result = $this->inst->extract_errors_from_blog_data( $input_data );
+
+		$this->assertEquals( array( 'message' => '', 'debug' => '', 'where' => '' ), $result );
+	}
+
+
+	/**
+	 * Test extract_errors_from_blog_data with array error in site_info
+	 */
+	function test_extract_errors_from_blog_data_array_error_site_info() {
+
+
+		$input_data = array(
+			'site_info' => array(
+				'error' => array(1,2,4,5)
+			),
+			'posts' => array(
+				'error' => array('a','b','c','d')
+			),
+		);
+
+
+		$result = $this->inst->extract_errors_from_blog_data( $input_data );
+
+		$expected_result = array(
+			'message' => 1,
+			'debug' => '',
+			'where' => 'site_info'
+		);
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
+	/**
+	 * Test extract_errors_from_blog_data with array error in posts
+	 */
+	function test_extract_errors_from_blog_data_array_error_posts() {
+
+
+		$input_data = array(
+			'site_info' => array(
+				'error' => null
+			),
+			'posts' => array(
+				'error' => array('a','b','c','d')
+			),
+		);
+
+
+		$result = $this->inst->extract_errors_from_blog_data( $input_data );
+
+		$expected_result = array(
+			'message' => 'a',
+			'debug' => '',
+			'where' => 'posts'
+		);
+		$this->assertEquals( $expected_result, $result );
+	}
 
 }

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -63,7 +63,7 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 			'array'    => 123,
 			'data'     => array( 1, 2, 3 ),
 			'response' => array(
-				'code'    => 200,
+				'code' => 200,
 			)
 		);
 
@@ -85,9 +85,9 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$input_data = array(
 			'response' => array(
-				'code'    => 200,
+				'code' => 200,
 			),
-			'body' => 'asd'
+			'body'     => 'asd'
 		);
 
 		$result = $this->inst->parse_service_response( $input_data );
@@ -108,10 +108,10 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$input_data = array(
 			'response' => array(
-				'code'    => 200,
+				'code' => 200,
 			),
-			'body' => json_encode(
-				array('error' => 'test error')
+			'body'     => json_encode(
+				array( 'error' => 'test error' )
 			),
 		);
 
@@ -133,20 +133,359 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$input_data = array(
 			'response' => array(
-				'code'    => 200,
+				'code' => 200,
 			),
-			'body' => json_encode(
-				array('mydata' => 'your data')
+			'body'     => json_encode(
+				array( 'mydata' => 'your data' )
 			),
 		);
 
 		$result = $this->inst->parse_service_response( $input_data );
 
-		$expectedValue = new stdClass;
+		$expectedValue         = new stdClass;
 		$expectedValue->mydata = 'your data';
 
-		$this->assertEquals($expectedValue, $result);
+		$this->assertEquals( $expectedValue, $result );
 
+	}
+
+
+	/**
+	 * Test what value returns get_site_hash
+	 */
+	function test_get_site_hash() {
+
+		$result = $this->inst->get_site_hash( 'http://test.com' );
+
+		$this->assertEquals( '1aa0d4413384d91bc0d45', $result );
+	}
+
+
+	/**
+	 * Test fetch_blog_data with invalid site info
+	 */
+	function test_fetch_blog_data_invalid_site_info() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array(
+			                           'fetch_site_info',
+			                           'parse_site_info_response',
+			                           'fetch_posts_for_site',
+			                           'parse_posts_response'
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->method( 'fetch_site_info' )
+		     ->with( 'http://test.com' )
+		     ->willReturn( 'test_param_1' );
+
+		$test_error = new WP_Error( 'broke', 'the', 'test' );
+
+		$mock->method( 'parse_site_info_response' )
+		     ->with( 'test_param_1' )
+		     ->willReturn( $test_error );
+
+
+		$mock->expects( $this->never() )
+		     ->method( 'fetch_posts_for_site' );
+
+		$mock->expects( $this->never() )
+		     ->method( 'parse_posts_response' );
+
+		$result = $mock->fetch_blog_data( 'http://test.com' );
+
+		/**
+		 * Verify last update, last check times as they are dynamic
+		 */
+
+		$current_time = time();
+
+		$this->assertTrue( abs( $current_time - $result['site_info']['last_check'] ) < 10 );
+		$this->assertTrue( empty( $result['site_info']['last_update'] ) );
+
+		unset( $result['site_info']['last_check'], $result['site_info']['last_update'] );
+
+		$check_value = array(
+			'site_info' => array(
+				'data'  => array(),
+				'error' => $test_error
+			),
+			'posts'     => array(
+				'data'        => array(),
+				'error'       => null,
+				'last_check'  => null,
+				'last_update' => null,
+			)
+		);
+
+		$this->assertEquals( $check_value, $result );
+	}
+
+
+	/**
+	 * Test fetch_blog_data with invalid posts info
+	 */
+	function test_fetch_blog_data_invalid_post_info() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array(
+			                           'fetch_site_info',
+			                           'parse_site_info_response',
+			                           'fetch_posts_for_site',
+			                           'parse_posts_response'
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->method( 'fetch_site_info' )
+		     ->with( 'http://test.com' )
+		     ->willReturn( 'test_param_1' );
+
+		$mock->method( 'parse_site_info_response' )
+		     ->with( 'test_param_1' )
+		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
+
+		$mock->method( 'fetch_posts_for_site' )
+		     ->with( 'test_id' )
+		     ->willReturn( 'test_param_2' );
+
+
+		$test_error = new WP_Error( 'broke', 'the', 'test' );
+
+
+		$mock->method( 'parse_posts_response' )
+		     ->with( 'test_param_2' )
+		     ->willReturn( $test_error );
+
+		$result = $mock->fetch_blog_data( 'http://test.com' );
+
+		/**
+		 * Verify last update, last check times as they are dynamic
+		 */
+
+		$current_time = time();
+
+		$this->assertTrue( abs( $current_time - $result['site_info']['last_check'] ) < 10 );
+		$this->assertTrue( abs( $current_time - $result['site_info']['last_update'] ) < 10 );
+
+		$this->assertTrue( abs( $current_time - $result['posts']['last_check'] ) < 10 );
+		$this->assertTrue( empty( $result['posts']['last_update'] ) );
+
+		unset( $result['site_info']['last_check'], $result['site_info']['last_update'] );
+		unset( $result['posts']['last_check'], $result['posts']['last_update'] );
+
+		$check_value = array(
+			'site_info' => array(
+				'data'  => ( (object) ( array( 'ID' => 'test_id' ) ) ),
+				'error' => null
+			),
+			'posts'     => array(
+				'data'  => array(),
+				'error' => $test_error
+			)
+		);
+
+		$this->assertEquals( $check_value, $result );
+	}
+
+
+	/**
+	 * Test fetch_blog_data with invalid posts info
+	 */
+	function test_fetch_blog_data_invalid_post_info_predefined_data() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array(
+			                           'fetch_site_info',
+			                           'parse_site_info_response',
+			                           'fetch_posts_for_site',
+			                           'parse_posts_response'
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->method( 'fetch_site_info' )
+		     ->with( 'http://test.com' )
+		     ->willReturn( 'test_param_1' );
+
+		$mock->method( 'parse_site_info_response' )
+		     ->with( 'test_param_1' )
+		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
+
+		$mock->method( 'fetch_posts_for_site' )
+		     ->with( 'test_id' )
+		     ->willReturn( 'test_param_2' );
+
+
+		$test_error = new WP_Error( 'broke', 'the', 'test' );
+
+
+		$mock->method( 'parse_posts_response' )
+		     ->with( 'test_param_2' )
+		     ->willReturn( $test_error );
+
+		$predefined_data = array(
+			'site_info' => array(
+				'data'  => ( (object) ( array( 'ID' => 'test_id' ) ) ),
+				'error' => null
+			),
+			'posts'     => array(
+				'data'  => array( 'my predefined array' ),
+				'error' => $test_error
+			)
+		);
+
+
+		$result = $mock->fetch_blog_data( 'http://test.com', $predefined_data );
+
+		/**
+		 * Verify last update, last check times as they are dynamic
+		 */
+
+		$current_time = time();
+
+		$this->assertTrue( abs( $current_time - $result['site_info']['last_check'] ) < 10 );
+		$this->assertTrue( abs( $current_time - $result['site_info']['last_update'] ) < 10 );
+
+		$this->assertTrue( abs( $current_time - $result['posts']['last_check'] ) < 10 );
+		$this->assertTrue( empty( $result['posts']['last_update'] ) );
+
+		unset( $result['site_info']['last_check'], $result['site_info']['last_update'] );
+		unset( $result['posts']['last_check'], $result['posts']['last_update'] );
+
+		$check_value = array(
+			'site_info' => array(
+				'data'  => ( (object) ( array( 'ID' => 'test_id' ) ) ),
+				'error' => null
+			),
+			'posts'     => array(
+				'data'  => array( 'my predefined array' ),
+				'error' => $test_error
+			)
+		);
+
+		$this->assertEquals( $check_value, $result );
+	}
+
+
+	/**
+	 * Test fetch_blog_data with fully valid values
+	 */
+	function test_fetch_blog_data_valid() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array(
+			                           'fetch_site_info',
+			                           'parse_site_info_response',
+			                           'fetch_posts_for_site',
+			                           'parse_posts_response'
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->method( 'fetch_site_info' )
+		     ->with( 'http://test.com' )
+		     ->willReturn( 'test_param_1' );
+
+		$mock->method( 'parse_site_info_response' )
+		     ->with( 'test_param_1' )
+		     ->willReturn( ( (object) ( array( 'ID' => 'test_id' ) ) ) );
+
+		$mock->method( 'fetch_posts_for_site' )
+		     ->with( 'test_id' )
+		     ->willReturn( 'test_param_2' );
+
+
+		$mock->method( 'parse_posts_response' )
+		     ->with( 'test_param_2' )
+		     ->willReturn( 'test_result_final' );
+
+		$result = $mock->fetch_blog_data( 'http://test.com' );
+
+		/**
+		 * Verify last update, last check times as they are dynamic
+		 */
+
+		$current_time = time();
+
+		$this->assertTrue( abs( $current_time - $result['site_info']['last_check'] ) < 10 );
+		$this->assertTrue( abs( $current_time - $result['site_info']['last_update'] ) < 10 );
+
+		$this->assertTrue( abs( $current_time - $result['posts']['last_check'] ) < 10 );
+		$this->assertTrue( abs( $current_time - $result['posts']['last_update'] ) < 10 );
+
+		unset( $result['site_info']['last_check'], $result['site_info']['last_update'] );
+		unset( $result['posts']['last_check'], $result['posts']['last_update'] );
+
+		$check_value = array(
+			'site_info' => array(
+				'data'  => ( (object) ( array( 'ID' => 'test_id' ) ) ),
+				'error' => null
+			),
+			'posts'     => array(
+				'data'  => 'test_result_final',
+				'error' => null
+			)
+		);
+
+		$this->assertEquals( $check_value, $result );
+	}
+
+
+	/**
+	 * Test fetch_blog_data with fully valid values
+	 */
+	function test_get_blog_data_invalid_cache() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'get_site_hash', 'wp_get_option' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->method( 'get_site_hash' )
+		     ->with( 'http://test.com' )
+		     ->willReturn( 'test_option_hash' );
+
+		$mock->method( 'wp_get_option' )
+		     ->with( $mock->widget_options_key_prefix . 'test_option_hash' )
+		     ->willReturn( false );
+
+		$result = $mock->get_blog_data( 'http://test.com' );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$message = $result->get_error_messages();
+
+		$this->assertEquals( array( 'Information about this blog is being currently retrieved.' ), $message );
+
+		$codes = $result->get_error_codes();
+
+		$this->assertEquals( array( 'empty_cache' ), $codes );
+	}
+
+
+	/**
+	 * Test fetch_blog_data with fully valid values
+	 */
+	function test_get_blog_data_valid_cache() {
+		/** @var Jetpack_Display_Posts_Widget $mock */
+		$mock = $this->getMockBuilder( 'Jetpack_Display_Posts_Widget' )
+		             ->setMethods( array( 'get_site_hash', 'wp_get_option' ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+		$mock->method( 'get_site_hash' )
+		     ->with( 'http://test.com' )
+		     ->willReturn( 'test_option_hash' );
+
+		$mock->method( 'wp_get_option' )
+		     ->with( $mock->widget_options_key_prefix . 'test_option_hash' )
+		     ->willReturn( 'real value' );
+
+		$result = $mock->get_blog_data( 'http://test.com' );
+
+		$this->assertEquals( 'real value', $result );
 	}
 
 }

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -1060,10 +1060,10 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$input_data = array(
 			'site_info' => array(
-				'error' => array(1,2,4,5)
+				'error' => array( 1, 2, 4, 5 )
 			),
-			'posts' => array(
-				'error' => array('a','b','c','d')
+			'posts'     => array(
+				'error' => array( 'a', 'b', 'c', 'd' )
 			),
 		);
 
@@ -1072,8 +1072,8 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$expected_result = array(
 			'message' => 1,
-			'debug' => '',
-			'where' => 'site_info'
+			'debug'   => '',
+			'where'   => 'site_info'
 		);
 		$this->assertEquals( $expected_result, $result );
 	}
@@ -1089,8 +1089,8 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 			'site_info' => array(
 				'error' => null
 			),
-			'posts' => array(
-				'error' => array('a','b','c','d')
+			'posts'     => array(
+				'error' => array( 'a', 'b', 'c', 'd' )
 			),
 		);
 
@@ -1099,8 +1099,116 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$expected_result = array(
 			'message' => 'a',
-			'debug' => '',
-			'where' => 'posts'
+			'debug'   => '',
+			'where'   => 'posts'
+		);
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
+	/**
+	 * Test extract_errors_from_blog_data with valid WP_Error in site_info
+	 */
+	function test_extract_errors_from_blog_data_valid_wp_error_site_info() {
+
+
+		$input_data = array(
+			'site_info' => array(
+				'error' => new WP_Error( 'site_info_code', 'SITE INFO MESSAGE', 'SITE INFO DEBUG' )
+			),
+			'posts'     => array(
+				'error' => new WP_Error( 'posts_code', 'POSTS MESSAGE', 'POSTS DEBUG' )
+			),
+		);
+
+
+		$result = $this->inst->extract_errors_from_blog_data( $input_data );
+
+		$expected_result = array(
+			'message' => 'SITE INFO MESSAGE',
+			'debug'   => 'SITE INFO DEBUG',
+			'where'   => 'site_info'
+		);
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
+	/**
+	 * Test extract_errors_from_blog_data with valid WP_Error in posts
+	 */
+	function test_extract_errors_from_blog_data_valid_wp_error_posts() {
+
+
+		$input_data = array(
+			'site_info' => array(
+				'error' => null
+			),
+			'posts'     => array(
+				'error' => new WP_Error( 'posts_code', 'POSTS MESSAGE', 'POSTS DEBUG' )
+			),
+		);
+
+
+		$result = $this->inst->extract_errors_from_blog_data( $input_data );
+
+		$expected_result = array(
+			'message' => 'POSTS MESSAGE',
+			'debug'   => 'POSTS DEBUG',
+			'where'   => 'posts'
+		);
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
+	/**
+	 * Test extract_errors_from_blog_data with valid WP_Error with array debug
+	 */
+	function test_extract_errors_from_blog_data_valid_wp_error_posts_array_debug() {
+
+
+		$input_data = array(
+			'site_info' => array(
+				'error' => null
+			),
+			'posts'     => array(
+				'error' => new WP_Error( 'posts_code', 'POSTS MESSAGE', array( 1, 2, 3, 4 ) )
+			),
+		);
+
+
+		$result = $this->inst->extract_errors_from_blog_data( $input_data );
+
+		$expected_result = array(
+			'message' => 'POSTS MESSAGE',
+			'debug'   => '1; 2; 3; 4',
+			'where'   => 'posts'
+		);
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
+	/**
+	 * Test extract_errors_from_blog_data with errors that are not WP_Error or array
+	 */
+	function test_extract_errors_from_blog_data_no_errors() {
+
+
+		$input_data = array(
+			'site_info' => array(
+				'error' => 'dsa'
+			),
+			'posts'     => array(
+				'error' => 'asd'
+			),
+		);
+
+
+		$result = $this->inst->extract_errors_from_blog_data( $input_data );
+
+		$expected_result = array(
+			'message' => '',
+			'debug'   => '',
+			'where'   => 'posts'
 		);
 		$this->assertEquals( $expected_result, $result );
 	}

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -1,6 +1,7 @@
 <?php
 
 require dirname( __FILE__ ) . '/../../../../modules/widgets/wordpress-post-widget.php';
+
 class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 	/**
@@ -20,11 +21,131 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 		$result = $this->inst->parse_service_response( $input_data );
 
-		$this->assertTrue(is_wp_error($result));
+		$this->assertTrue( is_wp_error( $result ) );
 
-		$this->assertEquals(array('general_error'), $result->get_error_codes());
-		$this->assertEquals(array('An error occurred while fetching data from remote.'), $result->get_error_messages());
-		$this->assertEquals(array('TEST CASE'), $result->get_error_data());
+		$this->assertEquals( array( 'general_error' ), $result->get_error_codes() );
+		$this->assertEquals( array( 'An error occurred while fetching data from remote.' ), $result->get_error_messages() );
+		$this->assertEquals( array( 'TEST CASE' ), $result->get_error_data() );
+
+	}
+
+
+	/**
+	 * Test parse_service_response when called with a WP_Error
+	 */
+	function test_parse_service_response_bad_request() {
+
+		$input_data = array(
+			'response' => array(
+				'code'    => 500,
+				'message' => 'TESTING, ATTENTION'
+			)
+		);
+
+		$result = $this->inst->parse_service_response( $input_data );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$this->assertEquals( array( 'http_error' ), $result->get_error_codes() );
+		$this->assertEquals( array( 'An error occurred while fetching data from remote.' ), $result->get_error_messages() );
+		$this->assertEquals( 'TESTING, ATTENTION', $result->get_error_data() );
+
+	}
+
+
+	/**
+	 * Test parse_service_response when called with missing body
+	 */
+	function test_parse_service_response_missing_body() {
+
+		$input_data = array(
+			'some'     => array(),
+			'array'    => 123,
+			'data'     => array( 1, 2, 3 ),
+			'response' => array(
+				'code'    => 200,
+			)
+		);
+
+		$result = $this->inst->parse_service_response( $input_data );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$this->assertEquals( array( 'no_body' ), $result->get_error_codes() );
+		$this->assertEquals( array( 'Invalid data returned by remote.' ), $result->get_error_messages() );
+		$this->assertEquals( 'No body in response.', $result->get_error_data() );
+
+	}
+
+
+	/**
+	 * Test parse_service_response when called with broken body
+	 */
+	function test_parse_service_response_invalid_body_json() {
+
+		$input_data = array(
+			'response' => array(
+				'code'    => 200,
+			),
+			'body' => 'asd'
+		);
+
+		$result = $this->inst->parse_service_response( $input_data );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$this->assertEquals( array( 'no_body' ), $result->get_error_codes() );
+		$this->assertEquals( array( 'Invalid data returned by remote.' ), $result->get_error_messages() );
+		$this->assertEquals( 'Invalid JSON from remote.', $result->get_error_data() );
+
+	}
+
+
+	/**
+	 * Test parse_service_response when called with body that has error
+	 */
+	function test_parse_service_response_body_has_error() {
+
+		$input_data = array(
+			'response' => array(
+				'code'    => 200,
+			),
+			'body' => json_encode(
+				array('error' => 'test error')
+			),
+		);
+
+		$result = $this->inst->parse_service_response( $input_data );
+
+		$this->assertTrue( is_wp_error( $result ) );
+
+		$this->assertEquals( array( 'remote_error' ), $result->get_error_codes() );
+		$this->assertEquals( array( 'We cannot display information for this blog.' ), $result->get_error_messages() );
+		$this->assertEquals( 'test error', $result->get_error_data() );
+
+	}
+
+
+	/**
+	 * Test parse_service_response when called with body that has error
+	 */
+	function test_parse_service_response_valid_body() {
+
+		$input_data = array(
+			'response' => array(
+				'code'    => 200,
+			),
+			'body' => json_encode(
+				array('mydata' => 'your data')
+			),
+		);
+
+		$result = $this->inst->parse_service_response( $input_data );
+
+		$expectedValue = new stdClass;
+		$expectedValue->mydata = 'your data';
+
+		$this->assertEquals($expectedValue, $result);
 
 	}
 

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -851,17 +851,12 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 			                           'get_instances_sites',
 			                           'update_instance',
 			                           'should_cron_be_running',
-			                           'deactivate_cron'
 		                           ) )
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
 		$mock->expects( $this->any() )
 		     ->method( 'should_cron_be_running' )
-		     ->will( $this->returnValue( false ) );
-
-		$mock->expects( $this->exactly(1) )
-		     ->method( 'deactivate_cron' )
 		     ->will( $this->returnValue( false ) );
 
 		$mock->expects( $this->never() )


### PR DESCRIPTION
This Pull Request contains speed and reliability improvements of the Display Posts Widget.

The following things have changed since the previous version:

* Blog information and posts are collected in the background through `wp_cron`, so there would be no page load blocks when the cache expires and new information is pulled.
* Widget instance information is now unified and stored permanently in an option and transients usage has been dropped from the main widget functionality. 
* Cache storage size has been greatly reduced.
* Widget load and render speed has been improved and made more consistent.
* Errors are now more informative and are shown in the widget configuration.
* Errors shown to visitors in the widget area have been reduced. If we have blog posts cached, we always show the last copy we have, not an error. 
* Some general code improvements and HTML fixes. 



