### PR TITLE
Vimeo shortcode: wrap embed output of link

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -131,6 +131,36 @@ function vimeo_shortcode( $atts ) {
 
 add_shortcode( 'vimeo', 'vimeo_shortcode' );
 
+/**
+ * Callback to modify output of embedded Vimeo video using Jetpack's shortcode.
+ *
+ * @since 3.9
+ *
+ * @param array $matches Regex partial matches against the URL passed.
+ * @param array $attr Attributes received in embed response
+ * @param array $url Requested URL to be embedded
+ *
+ * @return string Return output of Vimeo shortcode with the proper markup.
+ */
+function wpcom_vimeo_embed_url( $matches, $attr, $url ) {
+	return vimeo_shortcode( array( $url ) );
+}
+
+/**
+ * For bare URLs on their own line of the form
+ * http://vimeo.com/12345
+ *
+ * @since 3.9
+ *
+ * @uses wpcom_vimeo_embed_url
+ */
+function wpcom_vimeo_embed_url_init() {
+	wp_embed_register_handler( 'wpcom_vimeo_embed_url', '#https?://(.+\.)?vimeo\.com/#i', 'wpcom_vimeo_embed_url' );
+}
+
+// Register handler to modify Vimeo embeds using Jetpack's shortcode output.
+add_action( 'init', 'wpcom_vimeo_embed_url_init' );
+
 function vimeo_embed_to_shortcode( $content ) {
 	if ( false === stripos( $content, 'player.vimeo.com/video/' ) )
 		return $content;

--- a/tests/php/modules/shortcodes/test_class.vimeo.php
+++ b/tests/php/modules/shortcodes/test_class.vimeo.php
@@ -89,4 +89,26 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 		$this->assertContains( 'height="' . $height . '"', $shortcode_content );
 	}
 
+	/**
+	 * @author Toro_Unit
+	 * @covers ::vimeo_shortcode
+	 * @since 3.9
+	 */
+	public function test_replace_url_with_iframe_in_the_content() {
+		global $post;
+
+		$video_id = '141358';
+		$url = 'http://vimeo.com/' . $video_id;
+		$post = $this->factory->post->create_and_get( array( 'post_content' => $url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		wp_reset_postdata();
+		$this->assertContains( '<div class="embed-vimeo"', $actual );
+		$this->assertContains( '<iframe src="https://player.vimeo.com/video/'.$video_id.'"', $actual );
+	}
+
 }

--- a/tests/php/modules/shortcodes/test_class.youtube.php
+++ b/tests/php/modules/shortcodes/test_class.youtube.php
@@ -39,4 +39,28 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 		$this->assertContains( $youtube_id, $shortcode_content );
 	}
 
+	/**
+	 * @author Toro_Unit
+	 * @covers ::youtube_shortcode
+	 * @since 3.9
+	 */
+	public function test_replace_url_with_iframe_in_the_content() {
+		global $post;
+
+		$youtube_id = 'JaNH56Vpg-A';
+		$url = 'http://www.youtube.com/watch?v=' . $youtube_id;
+		$post = $this->factory->post->create_and_get( array( 'post_content' => $url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		wp_reset_postdata();
+		$this->assertContains( "<span class='embed-youtube'", $actual );
+		$this->assertContains( "<iframe class='youtube-player'", $actual );
+		$this->assertContains( "http://www.youtube.com/embed/$youtube_id", $actual );
+
+	}
+
 }


### PR DESCRIPTION
By @eliorivero:

> The approach is similar to what is done for YouTube: the output of the embed result is modified using the Vimeo shortcode output, wrapping it in the proper markup.
> On a side note, I found odd that the markup for Vimeo is wrapped in a div while the one for YouTube is wrapped in a span with display: block.

As well as some tests by @torounit, thanks for that!

This is a "best of" compilation of two PRs that aim to fix #3093.