### PR TITLE
Widget Visibility: Fixed several issues...

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -252,6 +252,7 @@ class Jetpack_Widget_Conditions {
 					<?php
 
 					foreach ( $conditions['rules'] as $rule ) {
+						$rule = wp_parse_args( $rule, array( 'major' => '', 'minor' => '', 'has_children' => '' ) );
 						?>
 						<div class="condition">
 							<div class="selection alignleft">

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -547,30 +547,50 @@ class Jetpack_Widget_Conditions {
 						}
 					break;
 					case 'tag':
-						if ( ! $rule['minor'] && is_tag() ) {
-							$condition_result = true;
-						} else {
-							$rule['minor'] = self::maybe_get_split_term( $rule['minor'], $rule['major'] );
-							if ( is_singular() && $rule['minor'] && has_tag( $rule['minor'] ) ) {
+						// All tag pages.
+						if( ! $rule['minor'] ) {
+							if ( is_tag() ) {
 								$condition_result = true;
-							} else {
-								$tag = get_tag( $rule['minor'] );
-								if ( $tag && is_tag( $tag->slug ) ) {
+							}
+							else if ( is_singular() ) {
+								if( in_array( 'post_tag', get_post_taxonomies() ) ) {
 									$condition_result = true;
 								}
 							}
+							break;
+						}
+						
+						// All pages with the specified tag term.
+						if ( is_tag( $rule['minor'] ) ) {
+							$condition_result = true;
+						}
+						else if ( is_singular() && has_term( $rule['minor'], 'post_tag' ) ) {
+							$condition_result = true;
 						}
 					break;
 					case 'category':
-						if ( ! $rule['minor'] && is_category() ) {
-							$condition_result = true;
-						} else {
-							$rule['minor'] = self::maybe_get_split_term( $rule['minor'], $rule['major'] );
-							if ( is_category( $rule['minor'] ) ) {
+						// All category pages.
+						if( ! $rule['minor'] ) {
+							if ( is_category() ) {
 								$condition_result = true;
-							} else if ( is_singular() && $rule['minor'] && in_array( 'category', get_post_taxonomies() ) &&  has_category( $rule['minor'] ) )
-								$condition_result = true;
+							}
+							else if ( is_singular() ) {
+								if( in_array( 'category', get_post_taxonomies() ) ) {
+									$condition_result = true;
+								}
+							}
+							break;
 						}
+						
+						// All pages with the specified category term.
+						if ( is_category( $rule['minor'] ) ) {
+							$condition_result = true;
+						}
+						else if ( is_singular() && has_term( $rule['minor'], 'category' ) ) {
+							$condition_result = true;
+						}
+					break;
+
 					break;
 					case 'loggedin':
 						$condition_result = is_user_logged_in();
@@ -605,19 +625,45 @@ class Jetpack_Widget_Conditions {
 						}
 					break;
 					case 'taxonomy':
+						// All taxonomy pages.
+						if( ! $rule['minor'] ) {
+							if ( is_archive() ) {
+								if ( is_tag() || is_category() || is_tax() ) {
+									$condition_result = true;
+								}
+							}
+							else if ( is_singular() ) {
+								$post_taxonomies = get_post_taxonomies();
+								$condition_result = ! empty( $post_taxonomies );
+							}
+							break;
+						}
+
+						// Specified taxonomy page.
 						$term = explode( '_tax_', $rule['minor'] ); // $term[0] = taxonomy name; $term[1] = term id
 						if ( isset( $term[0] ) && isset( $term[1] ) ) {
 							$term[1] = self::maybe_get_split_term( $term[1], $term[0] );
 						}
-						if ( isset( $term[1] ) && is_tax( $term[0], $term[1] ) )
-							$condition_result = true;
-						else if ( isset( $term[1] ) && is_singular() && $term[1] && has_term( $term[1], $term[0] ) )
-							$condition_result = true;
-						else if ( is_singular() && $post_id = get_the_ID() ){
-							$terms = get_the_terms( $post_id, $rule['minor'] ); // Does post have terms in taxonomy?
-							if( $terms && ! is_wp_error( $terms ) ) {
+
+						// All pages of the specified taxonomy.
+						if ( ! isset( $term[1] ) || ! $term[1] ) {
+							if ( is_tax( $term[0] ) ) {
 								$condition_result = true;
 							}
+							else if ( is_singular() ) {
+								if( in_array( $term[0], get_post_taxonomies() ) ) {
+									$condition_result = true;
+								}
+							}
+							break;
+						}
+
+						// All pages with the specified taxonomy term.
+						if ( is_tax( $term[0], $term[1] ) ) {
+							$condition_result = true;
+						}
+						else if ( is_singular() && has_term( $term[1], $term[0] ) ) {
+							$condition_result = true;
 						}
 					break;
 				}

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -110,6 +110,15 @@ class Jetpack_Widget_Conditions {
 				else if ( 'post' == $minor )
 					$minor = 'post_type-post';
 
+				$post_types = get_post_types( array( 'public' => true ), 'objects' );
+
+				$support_archive_page = array();
+				foreach ( $post_types as $post_type ) {
+					if( $post_type->has_archive ) {
+						$support_archive_page[] = $post_type;
+					}
+				}
+
 				?>
 				<option value="front" <?php selected( 'front', $minor ); ?>><?php _e( 'Front page', 'jetpack' ); ?></option>
 				<option value="posts" <?php selected( 'posts', $minor ); ?>><?php _e( 'Posts page', 'jetpack' ); ?></option>
@@ -118,17 +127,26 @@ class Jetpack_Widget_Conditions {
 				<option value="search" <?php selected( 'search', $minor ); ?>><?php _e( 'Search results', 'jetpack' ); ?></option>
 				<optgroup label="<?php esc_attr_e( 'Post type:', 'jetpack' ); ?>">
 					<?php
-
-					$post_types = get_post_types( array( 'public' => true ), 'objects' );
-
 					foreach ( $post_types as $post_type ) {
 						?>
 						<option value="<?php echo esc_attr( 'post_type-' . $post_type->name ); ?>" <?php selected( 'post_type-' . $post_type->name, $minor ); ?>><?php echo esc_html( $post_type->labels->singular_name ); ?></option>
 						<?php
 					}
-
 					?>
 				</optgroup>
+				<?php if( ! empty( $support_archive_page ) ) {
+					?>
+				<optgroup label="<?php esc_attr_e( 'Archive page:', 'jetpack' ); ?>">
+					<?php
+					foreach ( $support_archive_page as $post_type ) {
+						?>
+						<option value="<?php echo esc_attr( 'archives-' . $post_type->name ); ?>" <?php selected( 'archives-' . $post_type->name, $minor ); ?>><?php echo esc_html( $post_type->labels->singular_name ); ?></option>
+						<?php
+					}
+					?>
+				</optgroup>
+					<?php
+				} ?>
 				<optgroup label="<?php esc_attr_e( 'Static page:', 'jetpack' ); ?>">
 					<?php
 
@@ -483,7 +501,8 @@ class Jetpack_Widget_Conditions {
 						else if ( ! $rule['minor'] )
 							$rule['minor'] = 'post_type-page';
 
-						switch ( $rule['minor'] ) {
+						$type = array_shift( explode( '-', $rule['minor'] ) );
+						switch ( $type ) {
 							case '404':
 								$condition_result = is_404();
 							break;
@@ -506,10 +525,15 @@ class Jetpack_Widget_Conditions {
 									$condition_result = is_front_page() && !is_paged();
 								}
 							break;
+							case 'post_type':
+								$condition_result = is_singular( substr( $rule['minor'], 10 ) );
+							break;
+							case 'archives':
+								$condition_result = is_post_type_archive( substr( $rule['minor'], 9 ) );
+							break;
 							default:
-								if ( substr( $rule['minor'], 0, 10 ) == 'post_type-' ) {
-									$condition_result = is_singular( substr( $rule['minor'], 10 ) );
-								} elseif ( $rule['minor'] == get_option( 'page_for_posts' ) ) {
+								// $rule['minor'] is the post ID for a page.
+								if ( $rule['minor'] == get_option( 'page_for_posts' ) ) {
 									// If $rule['minor'] is a page ID which is also the posts page
 									$condition_result = $wp_query->is_posts_page;
 								} else {


### PR DESCRIPTION
I had some downtime during my trial and it was suggested I work on a few simple issues.  I found the following five issues related Widget Visibility in the GitHub issues.

[Undefined index has_children in widget-conditions.php](https://github.com/Automattic/jetpack/issues/3070)
[Widget Visibility for “All taxonomy pages” and “All [custom tax] pages” not working](https://github.com/Automattic/jetpack/issues/3020)
[Widget Visibility: support custom post type archive pages](https://github.com/Automattic/jetpack/issues/3020)
[Widget Visibility for Custom Post Type for Pages and Custom Taxonomies Concurrently](https://github.com/Automattic/jetpack/issues/2170)
[Widget Visibility: add an AND condition](https://github.com/Automattic/jetpack/issues/852)

I found solutions to all of the issues and have tested them on my test site several times.