### PR TITLE
Related Posts: Update related-posts.js

### DIFF
--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -22,7 +22,7 @@
 			}
 
 			var args = 'relatedposts=1';
-			if ( ! $( '#jp-relatedposts' ).data( 'exclude' ) ) {
+			if ( $( '#jp-relatedposts' ).data( 'exclude' ) ) {
 				args += '&relatedposts_exclude=' + $( '#jp-relatedposts' ).data( 'exclude' );
 			}
 


### PR DESCRIPTION
The logic at line 25 is inverted.

Using the original code, when "#jp-relatedposts" doesn't have an "exclude" data (set at modules/related-posts/jetpack-related-posts.php line 201), the request contains "&relatedposts_exclude=undefined"; when it does, the argument is missing.

This inverts the buggy logic above.

This bug can be observed at <http://t.du9l.com/2015/09/prevent-a-package-from-being-installed-on-ubuntu/>.