### PR TITLE
Adds QUnit tests to Jetpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ matrix:
      env: WP_VERSION=4.2.0 WP_TRAVISCI=travis:phpunit
    - php: "5.6"
      env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+   - php: "5.6"
+     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:js
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,6 +116,11 @@ module.exports = function(grunt) {
 				}
 			}
 		},
+		qunit: {
+			files: [
+				'tests/qunit/**/*.html'
+			]
+		},
 		phplint: {
 			files: [
 				'*.php',
@@ -447,6 +452,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-shell');
 	grunt.loadNpmTasks('grunt-phplint');
 	grunt.loadNpmTasks('grunt-contrib-jshint');
+	grunt.loadNpmTasks('grunt-contrib-qunit');
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-wp-i18n');
 	grunt.loadNpmTasks('grunt-contrib-sass');
@@ -500,6 +506,6 @@ module.exports = function(grunt) {
 	grunt.registerTask('test', 'Runs all unit tasks.', ['phpunit']);
 
 	// Travis CI tasks.
-	// @todo grunt.registerTask('travis:js', 'Runs Javascript Travis CI tasks.', [ 'jshint:corejs', 'qunit' ]);
+	grunt.registerTask('travis:js', 'Runs Javascript Travis CI tasks.', [ 'jshint:src', 'qunit' ]);
 	grunt.registerTask('travis:phpunit', 'Runs PHPUnit Travis CI tasks.', 'phpunit');
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-jshint": "^0.9.2",
+    "grunt-contrib-qunit": "~0.7.0",
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-cssjanus": "~0.2.2",
@@ -25,6 +26,9 @@
     "grunt-phplint": "0.0.5",
     "grunt-search": "^0.1.6",
     "grunt-shell": "^0.6.4",
-    "grunt-wp-i18n": "~0.4.6"
+    "grunt-wp-i18n": "~0.4.6",
+    "qunitjs": "~1.20.0",
+    "sinon": "~1.17.0",
+    "sinon-qunit": "~2.0.0"
   }
 }

--- a/tests/qunit/gallery-settings.js
+++ b/tests/qunit/gallery-settings.js
@@ -1,0 +1,27 @@
+/* global wp, jQuery */
+jQuery( function() {
+	module( 'gallery-settings' );
+
+	wp.media.gallery = wp.media.gallery || {};
+	wp.media.gallery.defaults = wp.media.gallery.defaults || {};
+
+	test( 'should wrap the render method', function( assert ) {
+		var settings = new wp.media.view.Settings.Gallery(),
+			parentMock = this.mock( wp.media.view.Settings.prototype ),
+			templateMock = this.mock( wp.media );
+
+		assert.expect( 4 );
+
+		parentMock.expects( 'render' );
+		templateMock
+			.expects( 'template' )
+			.withArgs( 'jetpack-gallery-settings' )
+			.returns( jQuery( '<span />' ) );
+
+		settings.render();
+
+		parentMock.verify();
+		templateMock.verify();
+	});
+
+});

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Jetpack QUnit Test Suite</title>
+
+		<!-- Dependencies -->
+		<script src="../../../../../../src/wp-includes/js/jquery/jquery.js"></script>
+		<script src="../../../../../../src/wp-includes/js/jquery/ui/core.js"></script>
+		<script src="../../../../../../src/wp-includes/js/underscore.min.js"></script>
+		<script src="../../../../../../src/wp-includes/js/backbone.min.js"></script>
+		<script src="../../../../../../src/wp-includes/js/wp-backbone.js"></script>
+		<script src="../../../../../../src/wp-includes/js/zxcvbn.min.js"></script>
+		<script src="../../../../../../src/wp-includes/js/wp-util.js"></script>
+
+		<script src="../../../../../../src/wp-includes/js/media-models.js"></script>
+		<script src="../../../../../../src/wp-includes/js/media-views.js"></script>
+		
+		<!-- QUnit -->
+		<link rel="stylesheet" href="../../node_modules/qunitjs/qunit/qunit.css" type="text/css" media="screen" />
+		<script src="../../node_modules/qunitjs/qunit/qunit.js"></script>
+		<script src="../../node_modules/sinon/pkg/sinon.js"></script>
+		<script src="../../node_modules/sinon-qunit/lib/sinon-qunit.js"></script>
+		<script>QUnit.config.hidepassed = false;</script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+		<div id="qunit-fixture"></div>
+
+		<!-- Tested files -->
+		<script src="../../_inc/gallery-settings.js"></script>
+
+		<!-- Unit tests -->
+		<script src="gallery-settings.js"></script>
+	</body>
+</html>

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -9,7 +9,6 @@
 		<script src="../../../../../../src/wp-includes/js/underscore.min.js"></script>
 		<script src="../../../../../../src/wp-includes/js/backbone.min.js"></script>
 		<script src="../../../../../../src/wp-includes/js/wp-backbone.js"></script>
-		<script src="../../../../../../src/wp-includes/js/zxcvbn.min.js"></script>
 		<script src="../../../../../../src/wp-includes/js/wp-util.js"></script>
 
 		<script src="../../../../../../src/wp-includes/js/media-models.js"></script>


### PR DESCRIPTION
This PR mostly copies what WP Core does to test JavaScript with some simplifications. There is one new unit tests that is only there to show how (and if) JS tests would work in Jetpack.