### PR TITLE
[Contact Form] Rewrite CSV export to properly handle multiple options questions in the form.

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -869,6 +869,8 @@ class Grunion_Contact_Form_Plugin {
 	 * @param  int    $post_id The id of the post
 	 * @param  array  $fields  An array containing the names of all the fields of the csv
 	 * @return String The csv row
+	 *
+	 * @deprecated This is no longer needed, as of the CSV export rewrite.
 	 */
 	protected static function make_csv_row_from_feedback( $post_id, $fields ) {
 		$content_fields = self::parse_fields_from_content( $post_id );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -527,6 +527,131 @@ class Grunion_Contact_Form_Plugin {
 		<?php
 	}
 
+
+	/**
+	 * Get `_feedback_extra_fields` field from post meta data.
+	 *
+	 * @param int $post_id Id of the post to fetch meta data for.
+	 *
+	 * @return mixed
+	 *
+	 * @codeCoverageIgnore - No need to be covered.
+	 */
+	public function get_post_meta_for_csv_export( $post_id ) {
+		return get_post_meta( $post_id, '_feedback_extra_fields', true );
+	}
+
+	/**
+	 * Get parsed feedback post fields.
+	 *
+	 * @param int $post_id Id of the post to fetch parsed contents for.
+	 *
+	 * @return array
+	 *
+	 * @codeCoverageIgnore - No need to be covered.
+	 */
+	public function get_parsed_field_contents_of_post( $post_id ) {
+		return self::parse_fields_from_content( $post_id );
+	}
+
+	/**
+	 * Prepares feedback post data for CSV export.
+	 *
+	 * @param array $post_ids Post IDs to fetch the data for. These need to be Feedback posts.
+	 *
+	 * @return array
+	 */
+	public function get_export_data_for_posts( $post_ids ) {
+
+		$posts_data  = array();
+		$field_names = array();
+		$result      = array();
+
+		/**
+		 * Fetch posts and get the possible field names for later use
+		 */
+		foreach ( $post_ids as $post_id ) {
+
+
+			/**
+			 * Fetch post meta data.
+			 */
+			$post_meta_data = $this->get_post_meta_for_csv_export( $post_id );
+
+			/**
+			 * If `$post_meta_data` is not an array or if it is empty, then there is no
+			 * feedback to work with. Skip it.
+			 */
+			if ( ! is_array( $post_meta_data ) || empty( $post_meta_data ) ) {
+				continue;
+			}
+
+			/**
+			 * Fetch post main data, because we need the subject line for the feedback form.
+			 */
+			$post_real_data = $this->get_parsed_field_contents_of_post( $post_id );
+
+			/**
+			 * If `$post_real_data` is not an array or there is no `_feedback_subject` set,
+			 * then something must be wrong with the feedback post. Skip it.
+			 */
+			if ( ! is_array( $post_real_data ) || ! isset( $post_real_data['_feedback_subject'] ) ) {
+				continue;
+			}
+
+			/**
+			 * Prepend the feedback subject to the list of fields.
+			 */
+			$post_meta_data = array_merge(
+				array( __( 'Contact Form', 'jetpack' ) => $post_real_data['_feedback_subject'] ),
+				$post_meta_data
+			);
+
+
+			/**
+			 * Save post metadata for later usage.
+			 */
+			$posts_data[ $post_id ] = $post_meta_data;
+
+			/**
+			 * Save field names, so we can use them as header fields later in the CSV.
+			 */
+			$field_names = array_merge( $field_names, array_keys( $post_meta_data ) );
+		}
+
+		/**
+		 * Make sure the field names are unique, because we don't want duplicate data.
+		 */
+		$field_names = array_unique( $field_names );
+
+		/**
+		 * Loop through every post, which is essentially CSV row.
+		 */
+		foreach ( $posts_data as $post_id => $single_post_data ) {
+
+			/**
+			 * Go through all the possible fields and check if the field is available
+			 * in the current post.
+			 *
+			 * If it is - add the data as a value.
+			 * If it is not - add an empty string, which is just a placeholder in the CSV.
+			 */
+			foreach ( $field_names as $single_field_name ) {
+				if (
+					isset( $single_post_data[ $single_field_name ] )
+					&& ! empty( $single_post_data[ $single_field_name ] )
+				) {
+					$result[ $single_field_name ][] = trim( $single_post_data[ $single_field_name ] );
+				}
+				else {
+					$result[ $single_field_name ][] = '';
+				}
+			}
+		}
+
+		return $result;
+	}
+
 	/**
 	 * download as a csv a contact form or all of them in a csv file
 	 */
@@ -558,13 +683,35 @@ class Grunion_Contact_Form_Plugin {
 		}
 
 		$feedbacks = get_posts( $args );
-		$filename  = sanitize_file_name( $filename );
-		$fields    = $this->get_field_names( $feedbacks );
 
-		array_unshift( $fields, __( 'Contact Form', 'jetpack' ) );
-
-		if ( empty( $feedbacks ) )
+		if ( empty( $feedbacks ) ) {
 			return;
+		}
+
+		$filename  = sanitize_file_name( $filename );
+
+		/**
+		 * Prepare data for export.
+		 */
+		$data = $this->get_export_data_for_posts( $feedbacks );
+
+		/**
+		 * If `$data` is empty, there's nothing we can do below.
+		 */
+		if ( ! is_array( $data ) || empty( $data ) ) {
+			return;
+		}
+
+		/**
+		 * Extract field names from `$data` for later use.
+		 */
+		$fields = array_keys( $data );
+
+		/**
+		 * Count how many rows will be exported.
+		 */
+		$row_count = count( reset( $data ) );
+
 
 		// Forces the download of the CSV instead of echoing
 		header( 'Content-Disposition: attachment; filename=' . $filename );
@@ -574,12 +721,30 @@ class Grunion_Contact_Form_Plugin {
 
 		$output = fopen( 'php://output', 'w' );
 
-		// Prints the header
+		/**
+		 * Print CSV headers
+		 */
 		fputcsv( $output, $fields );
 
-		// Create the csv string from the array of post ids
-		foreach ( $feedbacks as $feedback ) {
-			fputcsv( $output, self::make_csv_row_from_feedback( $feedback, $fields ) );
+
+		/**
+		 * Print rows to the output.
+		 */
+		for ( $i = 0; $i < $row_count; $i ++ ) {
+
+			$current_row = array();
+
+			/**
+			 * Put all the fields in `$current_row` array.
+			 */
+			foreach ( $fields as $single_field_name ) {
+				$current_row[] = $data[ $single_field_name ][ $i ];
+			}
+
+			/**
+			 * Output the complete CSV row
+			 */
+			fputcsv( $output, $current_row );
 		}
 
 		fclose( $output );
@@ -623,7 +788,10 @@ class Grunion_Contact_Form_Plugin {
 	 * Get the names of all the form's fields
 	 *
 	 * @param  array|int $posts the post we want the fields of
+	 *
 	 * @return array     the array of fields
+	 *
+	 * @deprecated As this is no longer necessary as of the CSV export rewrite. - 2015-12-29
 	 */
 	protected function get_field_names( $posts ) {
 		$posts = (array) $posts;

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -548,6 +548,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		             ->setMethods( array(
 			                           'get_post_meta_for_csv_export',
 			                           'get_parsed_field_contents_of_post',
+			                           'get_post_content_for_csv_export',
+			                           'map_parsed_field_contents_of_post_to_field_names'
 		                           ) )
 		             ->disableOriginalConstructor()
 		             ->getMock();
@@ -580,6 +582,28 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			array( 16, array( '_feedback_subject' => 'subj2' ) ),
 		);
 
+		$get_post_content_for_csv_export_map = array(
+			array( 15, 'This is my test 15' ),
+			array( 16, 'This is my test 16' ),
+		);
+
+		$mapped_fields_contents_map = array(
+			array(
+				array( '_feedback_subject' => 'subj1', '_feedback_main_comment' => 'This is my test 15' ),
+				array(
+					'Contact Form' => 'subj1',
+					'4_Comment'    => 'This is my test 15'
+				)
+			),
+			array(
+				array( '_feedback_subject' => 'subj2', '_feedback_main_comment' => 'This is my test 16' ),
+				array(
+					'Contact Form' => 'subj2',
+					'4_Comment'    => 'This is my test 16'
+				)
+			),
+		);
+
 		$mock->expects( $this->exactly( 2 ) )
 		     ->method( 'get_post_meta_for_csv_export' )
 		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
@@ -588,6 +612,14 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$mock->expects( $this->exactly( 2 ) )
 		     ->method( 'get_parsed_field_contents_of_post' )
 		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_post_content_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_content_for_csv_export_map ) );
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'map_parsed_field_contents_of_post_to_field_names' )
+		     ->will( $this->returnValueMap( $mapped_fields_contents_map ) );
 
 		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
 
@@ -599,6 +631,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'key4'         => array( 'value4', 'value4' ),
 			'key5'         => array( '', 'value5' ),
 			'key6'         => array( '', 'value6' ),
+			'4_Comment'    => array( 'This is my test 15', 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -616,6 +649,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		             ->setMethods( array(
 			                           'get_post_meta_for_csv_export',
 			                           'get_parsed_field_contents_of_post',
+			                           'get_post_content_for_csv_export',
+			                           'map_parsed_field_contents_of_post_to_field_names'
 		                           ) )
 		             ->disableOriginalConstructor()
 		             ->getMock();
@@ -639,6 +674,29 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			array( 16, array( '_feedback_subject' => 'subj2' ) ),
 		);
 
+
+		$get_post_content_for_csv_export_map = array(
+			array( 15, 'This is my test 15' ),
+			array( 16, 'This is my test 16' ),
+		);
+
+		$mapped_fields_contents_map = array(
+			array(
+				array( '_feedback_subject' => 'subj1', '_feedback_main_comment' => 'This is my test 15' ),
+				array(
+					'Contact Form' => 'subj1',
+					'4_Comment'    => 'This is my test 15'
+				)
+			),
+			array(
+				array( '_feedback_subject' => 'subj2', '_feedback_main_comment' => 'This is my test 16' ),
+				array(
+					'Contact Form' => 'subj2',
+					'4_Comment'    => 'This is my test 16'
+				)
+			),
+		);
+
 		$mock->expects( $this->exactly( 2 ) )
 		     ->method( 'get_post_meta_for_csv_export' )
 		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
@@ -648,6 +706,14 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		     ->method( 'get_parsed_field_contents_of_post' )
 		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
 
+		$mock->expects( $this->exactly( 1 ) )
+		     ->method( 'get_post_content_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_content_for_csv_export_map ) );
+
+		$mock->expects( $this->exactly( 1 ) )
+		     ->method( 'map_parsed_field_contents_of_post_to_field_names' )
+		     ->will( $this->returnValueMap( $mapped_fields_contents_map ) );
+
 		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
 
 		$expected_result = array(
@@ -656,6 +722,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'key4'         => array( 'value4' ),
 			'key5'         => array( 'value5' ),
 			'key6'         => array( 'value6' ),
+			'4_Comment'    => array( 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -672,6 +739,9 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		             ->setMethods( array(
 			                           'get_post_meta_for_csv_export',
 			                           'get_parsed_field_contents_of_post',
+			                           'get_post_content_for_csv_export',
+			                           'map_parsed_field_contents_of_post_to_field_names'
+
 		                           ) )
 		             ->disableOriginalConstructor()
 		             ->getMock();
@@ -689,6 +759,13 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		$mock->expects( $this->never() )
 		     ->method( 'get_parsed_field_contents_of_post' );
+
+		$mock->expects( $this->never() )
+		     ->method( 'get_post_content_for_csv_export' );
+
+		$mock->expects( $this->never() )
+		     ->method( 'map_parsed_field_contents_of_post_to_field_names' );
+
 
 		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
 
@@ -709,6 +786,9 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		             ->setMethods( array(
 			                           'get_post_meta_for_csv_export',
 			                           'get_parsed_field_contents_of_post',
+			                           'get_post_content_for_csv_export',
+			                           'map_parsed_field_contents_of_post_to_field_names'
+
 		                           ) )
 		             ->disableOriginalConstructor()
 		             ->getMock();
@@ -741,6 +821,28 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			array( 16, array( '_feedback_subject' => 'subj2' ) ),
 		);
 
+		$get_post_content_for_csv_export_map = array(
+			array( 15, 'This is my test 15' ),
+			array( 16, 'This is my test 16' ),
+		);
+
+		$mapped_fields_contents_map = array(
+			array(
+				array( '_feedback_subject' => 'subj1', '_feedback_main_comment' => 'This is my test 15' ),
+				array(
+					'Contact Form' => 'subj1',
+					'4_Comment'    => 'This is my test 15'
+				)
+			),
+			array(
+				array( '_feedback_subject' => 'subj2', '_feedback_main_comment' => 'This is my test 16' ),
+				array(
+					'Contact Form' => 'subj2',
+					'4_Comment'    => 'This is my test 16'
+				)
+			),
+		);
+
 		$mock->expects( $this->exactly( 2 ) )
 		     ->method( 'get_post_meta_for_csv_export' )
 		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
@@ -750,6 +852,14 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		     ->method( 'get_parsed_field_contents_of_post' )
 		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
 
+		$mock->expects( $this->exactly( 1 ) )
+		     ->method( 'get_post_content_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_content_for_csv_export_map ) );
+
+		$mock->expects( $this->exactly( 1 ) )
+		     ->method( 'map_parsed_field_contents_of_post_to_field_names' )
+		     ->will( $this->returnValueMap( $mapped_fields_contents_map ) );
+
 		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
 
 		$expected_result = array(
@@ -758,6 +868,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'key4'         => array( 'value4' ),
 			'key5'         => array( 'value5' ),
 			'key6'         => array( 'value6' ),
+			'4_Comment'    => array( 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -775,6 +886,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		             ->setMethods( array(
 			                           'get_post_meta_for_csv_export',
 			                           'get_parsed_field_contents_of_post',
+			                           'get_post_content_for_csv_export',
+			                           'map_parsed_field_contents_of_post_to_field_names'
 		                           ) )
 		             ->disableOriginalConstructor()
 		             ->getMock();
@@ -823,5 +936,36 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertEquals( $expected_result, $result );
 	}
 
+	/**
+	 * Test map_parsed_field_contents_of_post_to_field_names
+	 *
+	 * @group csvexport
+	 */
+	public function test_map_parsed_field_contents_of_post_to_field_names() {
+
+		$input_data = array(
+			'test_field'             => 'moonstruck',
+			'_feedback_subject'      => 'This is my form',
+			'_feedback_author_email' => '',
+			'_feedback_author'       => 'John Smith',
+			'_feedback_author_url'   => 'http://example.com',
+			'_feedback_main_comment' => 'This is my comment!',
+			'another_field'          => 'thunderstruck'
+		);
+
+		$plugin = new Grunion_Contact_Form_Plugin();
+
+		$result = $plugin->map_parsed_field_contents_of_post_to_field_names( $input_data );
+
+
+		$expected_result = array(
+			'Contact Form' => 'This is my form',
+			'1_Name'       => 'John Smith',
+			'3_Website'    => 'http://example.com',
+			'4_Comment'    => 'This is my comment!'
+		);
+
+		$this->assertEquals( $expected_result, $result );
+	}
 
 } // end class

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -535,4 +535,293 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		// sure we don't output anything harmful
 		$this->assertEquals( "[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type=&#039;&#039;email&#039;&#039; req&#039;uired=&#039;1&#039;/][contact-field label='asdasd' type='text'/][contact-field id='1' required &#039;derp&#039; herp asd lkj]adsasd[/contact-field]", $html );
 	}
+
+
+	/**
+	 * Test get_export_data_for_posts with fully vaid data input.
+	 *
+	 * @group csvexport
+	 */
+	public function test_get_export_data_for_posts_fully_valid_data() {
+		/** @var Grunion_Contact_Form_Plugin $mock */
+		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		             ->setMethods( array(
+			                           'get_post_meta_for_csv_export',
+			                           'get_parsed_field_contents_of_post',
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+
+		$get_post_meta_for_csv_export_map = array(
+			array(
+				15,
+				array(
+					'key1' => 'value1',
+					'key2' => 'value2',
+					'key3' => 'value3',
+					'key4' => 'value4',
+
+				)
+			),
+			array(
+				16,
+				array(
+					'key3' => 'value3',
+					'key4' => 'value4',
+					'key5' => 'value5',
+					'key6' => 'value6'
+				)
+			),
+		);
+
+		$get_parsed_field_contents_of_post_map = array(
+			array( 15, array( '_feedback_subject' => 'subj1' ) ),
+			array( 16, array( '_feedback_subject' => 'subj2' ) ),
+		);
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_post_meta_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
+
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_parsed_field_contents_of_post' )
+		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
+
+		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
+
+		$expected_result = array(
+			'Contact Form' => array( 'subj1', 'subj2' ),
+			'key1'         => array( 'value1', '' ),
+			'key2'         => array( 'value2', '' ),
+			'key3'         => array( 'value3', 'value3' ),
+			'key4'         => array( 'value4', 'value4' ),
+			'key5'         => array( '', 'value5' ),
+			'key6'         => array( '', 'value6' ),
+		);
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
+	/**
+	 * Test get_export_data_for_posts with single invalid entry for post meta
+	 *
+	 * @group csvexport
+	 */
+	public function test_get_export_data_for_posts_invalid_single_entry_meta() {
+		/** @var Grunion_Contact_Form_Plugin $mock */
+		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		             ->setMethods( array(
+			                           'get_post_meta_for_csv_export',
+			                           'get_parsed_field_contents_of_post',
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+
+		$get_post_meta_for_csv_export_map = array(
+			array( 15, null ),
+			array(
+				16,
+				array(
+					'key3' => 'value3',
+					'key4' => 'value4',
+					'key5' => 'value5',
+					'key6' => 'value6'
+				)
+			),
+		);
+
+		$get_parsed_field_contents_of_post_map = array(
+			array( 15, array( '_feedback_subject' => 'subj1' ) ),
+			array( 16, array( '_feedback_subject' => 'subj2' ) ),
+		);
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_post_meta_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
+
+
+		$mock->expects( $this->exactly( 1 ) )
+		     ->method( 'get_parsed_field_contents_of_post' )
+		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
+
+		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
+
+		$expected_result = array(
+			'Contact Form' => array( 'subj2' ),
+			'key3'         => array( 'value3' ),
+			'key4'         => array( 'value4' ),
+			'key5'         => array( 'value5' ),
+			'key6'         => array( 'value6' ),
+		);
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
+	/**
+	 * Test get_export_data_for_posts with invalid all entries for post meta
+	 *
+	 * @group csvexport
+	 */
+	public function test_get_export_data_for_posts_invalid_all_entries_meta() {
+		/** @var Grunion_Contact_Form_Plugin $mock */
+		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		             ->setMethods( array(
+			                           'get_post_meta_for_csv_export',
+			                           'get_parsed_field_contents_of_post',
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+
+		$get_post_meta_for_csv_export_map = array(
+			array( 15, null ),
+			array( 16, null ),
+		);
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_post_meta_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
+
+
+		$mock->expects( $this->never() )
+		     ->method( 'get_parsed_field_contents_of_post' );
+
+		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
+
+		$expected_result = array();
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
+	/**
+	 * Test get_export_data_for_posts with single invalid entry for parsed fields.
+	 *
+	 * @group csvexport
+	 */
+	public function test_get_export_data_for_posts_single_invalid_entry_for_parse_fields() {
+		/** @var Grunion_Contact_Form_Plugin $mock */
+		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		             ->setMethods( array(
+			                           'get_post_meta_for_csv_export',
+			                           'get_parsed_field_contents_of_post',
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+
+		$get_post_meta_for_csv_export_map = array(
+			array(
+				15,
+				array(
+					'key1' => 'value1',
+					'key2' => 'value2',
+					'key3' => 'value3',
+					'key4' => 'value4',
+
+				)
+			),
+			array(
+				16,
+				array(
+					'key3' => 'value3',
+					'key4' => 'value4',
+					'key5' => 'value5',
+					'key6' => 'value6'
+				)
+			),
+		);
+
+		$get_parsed_field_contents_of_post_map = array(
+			array( 15, array() ),
+			array( 16, array( '_feedback_subject' => 'subj2' ) ),
+		);
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_post_meta_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
+
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_parsed_field_contents_of_post' )
+		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
+
+		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
+
+		$expected_result = array(
+			'Contact Form' => array( 'subj2' ),
+			'key3'         => array( 'value3' ),
+			'key4'         => array( 'value4' ),
+			'key5'         => array( 'value5' ),
+			'key6'         => array( 'value6' ),
+		);
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
+	/**
+	 * Test get_export_data_for_posts with all entries for parsed fields invalid.
+	 *
+	 * @group csvexport
+	 */
+	public function test_get_export_data_for_posts_all_entries_for_parse_fields_invalid() {
+		/** @var Grunion_Contact_Form_Plugin $mock */
+		$mock = $this->getMockBuilder( 'Grunion_Contact_Form_Plugin' )
+		             ->setMethods( array(
+			                           'get_post_meta_for_csv_export',
+			                           'get_parsed_field_contents_of_post',
+		                           ) )
+		             ->disableOriginalConstructor()
+		             ->getMock();
+
+
+		$get_post_meta_for_csv_export_map = array(
+			array(
+				15,
+				array(
+					'key1' => 'value1',
+					'key2' => 'value2',
+					'key3' => 'value3',
+					'key4' => 'value4',
+
+				)
+			),
+			array(
+				16,
+				array(
+					'key3' => 'value3',
+					'key4' => 'value4',
+					'key5' => 'value5',
+					'key6' => 'value6'
+				)
+			),
+		);
+
+		$get_parsed_field_contents_of_post_map = array(
+			array( 15, array() ),
+			array( 16, array() ),
+		);
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_post_meta_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
+
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_parsed_field_contents_of_post' )
+		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
+
+		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
+
+		$expected_result = array();
+
+		$this->assertEquals( $expected_result, $result );
+	}
+
+
 } // end class


### PR DESCRIPTION
This pull request should fix the problem behind #3130 .

The problem was that the CSV export relied on getting all the field information by parsing the array data, that is `print_r`'d in the feedback post. If the feedback form contained multiple options question, the text parsing didn't work correctly at all.

Now the CSV export uses the form information, that is saved in post meta data and it doesn't suffer from that problem anymore.

Unit tests cover the methods that make the conversion and preparation of the data.