### PR TITLE
[Contact Form] Properly check if a variable is an array.

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1234,22 +1234,29 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		if ( $field_ids['extra'] ) {
 			// array indexed by field label (not field id)
 			$extra_fields = get_post_meta( $feedback_id, '_feedback_extra_fields', true );
-			$extra_field_keys = array_keys( $extra_fields );
 
-			$i = 0;
-			foreach ( $field_ids['extra'] as $field_id ) {
-				$field = $form->fields[$field_id];
-				$field_index = array_search( $field_id, $field_ids['all'] );
+			/**
+			 * Only get data for the compiled form if `$extra_fields` is a valid and non-empty array.
+			 */
+			if ( is_array( $extra_fields ) && ! empty( $extra_fields ) ) {
 
-				$label = $field->get_attribute( 'label' );
+				$extra_field_keys = array_keys( $extra_fields );
 
-				$compiled_form[ $field_index ] = sprintf(
-					'<b>%1$s:</b> %2$s<br /><br />',
-					wp_kses( $label, array() ),
-					nl2br( wp_kses( $extra_fields[$extra_field_keys[$i]], array() ) )
-				);
+				$i = 0;
+				foreach ( $field_ids['extra'] as $field_id ) {
+					$field       = $form->fields[ $field_id ];
+					$field_index = array_search( $field_id, $field_ids['all'] );
 
-				$i++;
+					$label = $field->get_attribute( 'label' );
+
+					$compiled_form[ $field_index ] = sprintf(
+						'<b>%1$s:</b> %2$s<br /><br />',
+						wp_kses( $label, array() ),
+						nl2br( wp_kses( $extra_fields[ $extra_field_keys[ $i ] ], array() ) )
+					);
+
+					$i++;
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR should fix issue #2991. 

There was no type checking on the variable, before sending it to `array_keys()`, which in some edge cases generated E_NOTICE.

Type checking was added and if this case occurs, the relevant code is not executed. 