### PR TITLE
Sharing: Add WhatsApp-Sharebuttons

### DIFF
--- a/modules/sharedaddy/admin-sharing.js
+++ b/modules/sharedaddy/admin-sharing.js
@@ -123,7 +123,7 @@
 				$( '#live-preview div.sharedaddy' ).addClass( 'sd-social-icon' );
 			} else if ( 'official' === button_style ) {
 				$( '#live-preview ul.preview .advanced, .sharing-hidden .inner ul .advanced' ).each( function( /*i*/ ) {
-					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'share-custom' ) ) {
+					if ( !$( this ).hasClass( 'preview-press-this' ) && !$( this ).hasClass( 'preview-email' ) && !$( this ).hasClass( 'preview-print' ) && !$( this ).hasClass( 'preview-whatsapp' ) && !$( this ).hasClass( 'share-custom' ) ) {
 						$( this ).find( '.option a span' ).html( '' ).parent().removeClass( 'sd-button' ).parent().attr( 'class', 'option option-smart-on' );
 					}
 				} );
@@ -346,7 +346,7 @@
 				// Add focus
 				nextSibling.next().focus();
 			}
-			
+
 			//Save changes
 			save_services();
 		}
@@ -370,7 +370,7 @@
 
 			// Move it to the appropriate area and add focus back to service
 			$( '.' + dropzone ).prepend( thisService ).find( 'li:first-child' ).focus();
-			
+
 			//Save changes
 			save_services();
 		}

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -55,6 +55,7 @@ class Sharing_Service {
 			'tumblr'        => 'Share_Tumblr',
 			'pinterest'     => 'Share_Pinterest',
 			'pocket'        => 'Share_Pocket',
+			'whatsapp'      => 'Share_WhatsApp',
 		);
 
 		if ( $include_custom ) {

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1601,3 +1601,21 @@ class Share_Pocket extends Sharing_Source {
 	}
 
 }
+
+class Share_WhatsApp extends Sharing_Source {
+	public $shortname = 'whatsapp';
+	public $genericon = '\f224';
+
+	public function __construct( $id, array $settings ) {
+		parent::__construct( $id, $settings );
+	}
+
+	public function get_name() {
+		return __( 'WhatsApp', 'jetpack' );
+	}
+
+	public function get_display( $post ) {
+		return $this->get_link( 'whatsapp://send?'. rawurlencode( $this->get_process_request_url( $post->ID ) ), _x( 'WhatsApp', 'share to', 'jetpack' ), __( 'Click to share on WhatsApp', 'jetpack' ) );
+	}
+}
+


### PR DESCRIPTION
Things to do
- [ ] Add icons to font. 
- [ ] Make sure that the plugin works nicely with the WhatsApp ShareButtons plugin that are out there already.
- [ ] Test across more devices. 

**Question**
Do we show the icon to to users that are not on mobile? The whatsapp:// protocol only work in mobile safari for me. 

**To Test**
Add the button to you page. Make sure that the button shows up. And when the user clicks on it will create a url in the WhatsApp app. 

