### PR TITLE
Social Menu: Add new theme tool from WordPress.com

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,7 @@ var frontendcss = [
 	'modules/shortcodes/css/style.css', // TODO: Should be renamed to shortcode-presentations
 	'modules/subscriptions/subscriptions.css',
 	'modules/theme-tools/responsive-videos/responsive-videos.css',
+	'modules/theme-tools/social-menu/social-menu.css',
 	'modules/tiled-gallery/tiled-gallery/tiled-gallery.css',
 	'modules/widgets/wordpress-post-widget/style.css',
 	'modules/widgets/gravatar-profile.css',

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -14,6 +14,7 @@ $tools = array(
 	'theme-tools/responsive-videos.php',
 	'theme-tools/site-logo.php',
 	'theme-tools/site-breadcrumbs.php',
+	'theme-tools/social-menu.php',
 	'custom-post-types/comics.php',
 	'custom-post-types/testimonial.php',
 	'custom-post-types/nova.php',

--- a/modules/theme-tools/social-menu.php
+++ b/modules/theme-tools/social-menu.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Social Menu.
+ *
+ * This feature will only be activated for themes that declare their support.
+ * This can be done by adding code similar to the following during the
+ * 'after_setup_theme' action:
+ *
+ * add_theme_support( 'jetpack-social-menu' );
+ */
+
+/**
+ * Activate the Social Menu plugin.
+ *
+ * @uses current_theme_supports()
+ */
+function jetpack_social_menu_init() {
+	// Only load our code if our theme declares support
+	if ( ! current_theme_supports( 'jetpack-social-menu' ) ) {
+		return;
+	}
+
+	/*
+	 * Social Menu description.
+	 *
+	 * Rename the social menu description.
+	 *
+	 * @module theme-tools
+	 */
+	$social_menu_description = apply_filters( 'jetpack_social_menu_description', __( 'Social Menu', 'jetpack' ) );
+
+	// Register a new menu location
+	register_nav_menus( array(
+		'jetpack-social-menu' => esc_html( $social_menu_description ),
+	) );
+
+	// Enqueue CSS
+	add_action( 'wp_enqueue_scripts', 'jetpack_social_menu_script' );
+}
+add_action( 'after_setup_theme', 'jetpack_social_menu_init', 99 );
+
+/* Function to enqueue CSS */
+function jetpack_social_menu_script() {
+	if ( has_nav_menu( 'jetpack-social-menu' ) ) {
+		wp_enqueue_style( 'jetpack-social-menu', plugins_url( 'social-menu/social-menu.css', __FILE__ ), array( 'genericons' ), '1.0' );
+	}
+}
+
+/* Create the function */
+function jetpack_social_menu() {
+	if ( has_nav_menu( 'jetpack-social-menu' ) ) : ?>
+		<nav class="jetpack-social-navigation" role="navigation">
+			<?php
+				wp_nav_menu( array(
+					'theme_location'  => 'jetpack-social-menu',
+					'link_before'     => '<span class="screen-reader-text">',
+					'link_after'      => '</span>',
+					'depth'           => 1,
+				) );
+			?>
+		</nav><!-- .jetpack-social-navigation -->
+	<?php endif;
+}

--- a/modules/theme-tools/social-menu.php
+++ b/modules/theme-tools/social-menu.php
@@ -26,6 +26,10 @@ function jetpack_social_menu_init() {
 	 * Rename the social menu description.
 	 *
 	 * @module theme-tools
+	 *
+	 * @since 3.9.0
+	 *
+	 * @param string $social_menu_description Social Menu description
 	 */
 	$social_menu_description = apply_filters( 'jetpack_social_menu_description', __( 'Social Menu', 'jetpack' ) );
 
@@ -35,12 +39,12 @@ function jetpack_social_menu_init() {
 	) );
 
 	// Enqueue CSS
-	add_action( 'wp_enqueue_scripts', 'jetpack_social_menu_script' );
+	add_action( 'wp_enqueue_scripts', 'jetpack_social_menu_style' );
 }
 add_action( 'after_setup_theme', 'jetpack_social_menu_init', 99 );
 
 /* Function to enqueue CSS */
-function jetpack_social_menu_script() {
+function jetpack_social_menu_style() {
 	if ( has_nav_menu( 'jetpack-social-menu' ) ) {
 		wp_enqueue_style( 'jetpack-social-menu', plugins_url( 'social-menu/social-menu.css', __FILE__ ), array( 'genericons' ), '1.0' );
 	}

--- a/modules/theme-tools/social-menu/social-menu.css
+++ b/modules/theme-tools/social-menu/social-menu.css
@@ -1,0 +1,180 @@
+.jetpack-social-navigation ul {
+	display: block;
+	margin: 0 0 1.5em;
+	padding: 0;
+}
+
+.jetpack-social-navigation li {
+	display: inline-block;
+	margin: 0;
+	line-height: 1;
+}
+
+.jetpack-social-navigation a {
+	border: 0;
+	height: 1em;
+	text-decoration: none;
+	width: 1em;
+}
+
+.jetpack-social-navigation a:before {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: inline-block;
+	font-family: Genericons;
+	font-size: 1em;
+	font-style: normal;
+	font-weight: normal;
+	height: 1em;
+	line-height: 1;
+	speak: none;
+	text-decoration: inherit;
+	vertical-align: top;
+	width: 1em;
+}
+
+/* Default */
+.jetpack-social-navigation a:before {
+	content: "\f415";
+}
+
+/* CodePen */
+.jetpack-social-navigation a[href*="codepen.io"]:before {
+	content: "\f216";
+}
+
+/* Digg */
+.jetpack-social-navigation a[href*="digg.com"]:before {
+	content: "\f221";
+}
+
+/* Dribbble */
+.jetpack-social-navigation a[href*="dribbble.com"]:before {
+	content: "\f201";
+}
+
+/* Dropbox */
+.jetpack-social-navigation a[href*="dropbox.com"]:before {
+	content: "\f225";
+}
+
+/* Email */
+.jetpack-social-navigation a[href*="mailto:"]:before {
+	content: "\f410";
+}
+
+/* Facebook */
+.jetpack-social-navigation a[href*="facebook.com"]:before {
+	content: "\f203";
+}
+
+/* Flickr */
+.jetpack-social-navigation a[href*="flickr.com"]:before {
+	content: "\f211";
+}
+
+/* Foursquare */
+.jetpack-social-navigation a[href*="foursquare.com"]:before {
+	content: "\f226";
+}
+
+/* GitHub */
+.jetpack-social-navigation a[href*="github.com"]:before {
+	content: "\f200";
+}
+
+/* Google Plus */
+.jetpack-social-navigation a[href*="plus.google.com"]:before {
+	content: "\f206";
+}
+
+/* Instagram */
+.jetpack-social-navigation a[href*="instagram.com"]:before {
+	content: "\f215";
+}
+
+/* LinkedIn */
+.jetpack-social-navigation a[href*="linkedin.com"]:before {
+	content: "\f208";
+}
+
+/* Path */
+.jetpack-social-navigation a[href*="path.com"]:before {
+	content: "\f219";
+}
+
+/* Pinterest */
+.jetpack-social-navigation a[href*="pinterest.com"]:before {
+	content: "\f210";
+}
+
+/* Pocket */
+.jetpack-social-navigation a[href*="getpocket.com"]:before {
+	content: "\f224";
+}
+
+/* Polldaddy */
+.jetpack-social-navigation a[href*="polldaddy.com"]:before {
+	content: "\f217";
+}
+
+/* Reddit */
+.jetpack-social-navigation a[href*="reddit.com"]:before {
+	content: "\f222";
+}
+
+/* RSS Feed */
+.jetpack-social-navigation a[href$="/feed/"]:before {
+	content: "\f413";
+}
+
+/* Skype */
+.jetpack-social-navigation a[href*="skype:"]:before {
+	content: "\f220";
+}
+
+/* Spotify */
+.jetpack-social-navigation a[href*="spotify.com"]:before {
+	content: "\f515";
+}
+
+/* StumbleUpon */
+.jetpack-social-navigation a[href*="stumbleupon.com"]:before {
+	content: "\f223";
+}
+
+/* Tumblr */
+.jetpack-social-navigation a[href*="tumblr.com"]:before {
+	content: "\f214";
+}
+
+/* Twitch */
+.jetpack-social-navigation a[href*="twitch.tv"]:before {
+	content: "\f516";
+}
+
+/* Twitter */
+.jetpack-social-navigation a[href*="twitter.com"]:before {
+	content: "\f202";
+}
+
+/* Vimeo */
+.jetpack-social-navigation a[href*="vimeo.com"]:before {
+	content: "\f212";
+}
+
+/* Vine */
+.jetpack-social-navigation a[href*="vine.co"]:before {
+	content: "\f517";
+}
+
+/* WordPress */
+.jetpack-social-navigation a[href*="wordpress.com"]:before,
+.jetpack-social-navigation a[href*="wordpress.org"]:before {
+	content: "\f205";
+}
+
+/* YouTube */
+.jetpack-social-navigation a[href*="youtube.com"]:before {
+	content: "\f213";
+}


### PR DESCRIPTION
Already being used on WordPress.com by a bunch of new themes. Will
replace “Social Links” in the long term.