### PR TITLE
Style enhancement and fix for Top Posts & Pages widget in Twenty Sixteen

### DIFF
--- a/modules/theme-tools/compat/twentysixteen-rtl.css
+++ b/modules/theme-tools/compat/twentysixteen-rtl.css
@@ -163,27 +163,20 @@
 
 /* Top Posts & Pages Widget */
 .widget_top-posts .widgets-list-layout .widgets-list-layout-blavatar {
-	border-radius: 50%;
-	margin-left: 0.4375em;
-	max-width: 2.625em;
+	margin-top: 0.25em;
 }
 
 .widget_top-posts .widgets-list-layout-links {
-	width: auto;
-	float: right;
-	padding-top: 0.4375em;
+	width: -webkit-calc(100% - 3.375em);
+	width: calc(100% - 3.375em);
 }
 
 .widget_top-posts .widgets-list-layout li {
-	margin-bottom: 0.4375em;
+	margin-bottom: 0.875em;
 }
 
 .widget_top-posts .widgets-list-layout li:last-child {
 	margin-bottom: 0;
-}
-
-.widget_top-posts .widgets-grid-layout img {
-	border-radius: 50%;
 }
 
 .widget-grid-view-image:nth-child(odd) {
@@ -730,16 +723,16 @@ iframe[src^="http://api.mixcloud.com/"] {
 	}
 
 	.widget_top-posts .widgets-list-layout .widgets-list-layout-blavatar {
-		margin-left: 0.538461538em;
-		max-width: 3.230769231em;
+		margin-top: 0.153846154em;
 	}
 
 	.widget_top-posts .widgets-list-layout-links {
-		padding-top: 0.807692308em;
+		width: -webkit-calc(100% - 4.153846154em);
+		width: calc(100% - 4.153846154em);
 	}
 
 	.widget_top-posts .widgets-list-layout li {
-		margin-bottom: 0.538461538em;
+		margin-bottom: 1.076923077em;
 	}
 
 	.widget_upcoming_events_widget .upcoming-events li {

--- a/modules/theme-tools/compat/twentysixteen.css
+++ b/modules/theme-tools/compat/twentysixteen.css
@@ -163,27 +163,20 @@
 
 /* Top Posts & Pages Widget */
 .widget_top-posts .widgets-list-layout .widgets-list-layout-blavatar {
-	border-radius: 50%;
-	margin-right: 0.4375em;
-	max-width: 2.625em;
+	margin-top: 0.25em;
 }
 
 .widget_top-posts .widgets-list-layout-links {
-	width: auto;
-	float: left;
-	padding-top: 0.4375em;
+	width: -webkit-calc(100% - 3.375em);
+	width: calc(100% - 3.375em);
 }
 
 .widget_top-posts .widgets-list-layout li {
-	margin-bottom: 0.4375em;
+	margin-bottom: 0.875em;
 }
 
 .widget_top-posts .widgets-list-layout li:last-child {
 	margin-bottom: 0;
-}
-
-.widget_top-posts .widgets-grid-layout img {
-	border-radius: 50%;
 }
 
 .widget-grid-view-image:nth-child(odd) {
@@ -730,16 +723,16 @@ iframe[src^="http://api.mixcloud.com/"] {
 	}
 
 	.widget_top-posts .widgets-list-layout .widgets-list-layout-blavatar {
-		margin-right: 0.538461538em;
-		max-width: 3.230769231em;
+		margin-top: 0.153846154em;
 	}
 
 	.widget_top-posts .widgets-list-layout-links {
-		padding-top: 0.807692308em;
+		width: -webkit-calc(100% - 4.153846154em);
+		width: calc(100% - 4.153846154em);
 	}
 
 	.widget_top-posts .widgets-list-layout li {
-		margin-bottom: 0.538461538em;
+		margin-bottom: 1.076923077em;
 	}
 
 	.widget_upcoming_events_widget .upcoming-events li {


### PR DESCRIPTION
**With this change,**
* Longer title won't drop underneath of featured image.
* Featured Image will be square instead of round since they are not avatars
* Titles align to the top of featured image to accommodate longer titles 
* Lists will have consistent spacing that matches with the theme.

**Before:**
![screen shot 2016-01-06 at 22 08 49](https://cloud.githubusercontent.com/assets/908665/12173894/683fe192-b551-11e5-8c4e-d8e97071ebe4.png)

**After:**
![screen shot 2016-01-06 at 22 06 00](https://cloud.githubusercontent.com/assets/908665/12173899/6da18b9a-b551-11e5-85e2-326f94237606.png)