### PR TITLE
Add Tracks to Jetpack

### DIFF
--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Tracks_Client
+ * @autounit nosara tracks-client
+ *
+ * Send Tracks events on behalf of a user
+ *
+ * Example Usage:
+```php
+	require( dirname(__FILE__).'path/to/tracks/class.tracks-client' );
+
+	$result = Tracks_Client::record_event( array(
+		'_en'        => $event_name,       // required
+		'_ui'        => $user_id,          // required unless _ul is provided
+		'_ul'        => $user_login,       // required unless _ui is provided
+
+		// Optional, but recommended
+		'_ts'        => $ts_in_ms,         // Default: now
+		'_via_ip'    => $client_ip,        // we use it for geo, etc.
+
+		// Possibly useful to set some context for the event
+		'_via_ua'    => $client_user_agent,
+		'_via_url'   => $client_url,
+		'_via_ref'   => $client_referrer,
+
+		// For user-targeted tests
+		'abtest_name'        => $abtest_name,
+		'abtest_variation'   => $abtest_variation,
+
+		// Your application-specific properties
+		'custom_property'    => $some_value,
+	) );
+
+	if ( is_wp_error( $result ) ) {
+		// Handle the error in your app
+	}
+```
+ */
+
+require_once( dirname(__FILE__).'/class.tracks-client.php' );
+
+class Tracks_Client {
+	const PIXEL = 'http://pixel.wp.com/t.gif';
+	// const API_URL = 'https://public-api.wordpress.com/rest/v1.1/tracks/record';
+	const BROWSER_TYPE = 'php-agent';
+	const USER_AGENT_SLUG = 'tracks-client';
+	const VERSION = '0.3';
+
+	/**
+	 * record_event
+	 * @param  mixed  $event Event object to send to Tracks. An array will be cast to object. Required.
+	 *                       Properties are included directly in the pixel query string after light validation.
+	 * @return mixed         True on success, WP_Error on failure
+	 */
+	static function record_event( $event ) {
+		if ( ! $event instanceof Tracks_Event ) {
+			$event = new Tracks_Event( $event );
+		}
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		$pixel = $event->build_pixel_url( $event );
+
+		error_log( $pixel );
+
+		if ( ! $pixel ) {
+			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );
+		}
+
+		return self::record_pixel( $pixel );
+	}
+
+	/**
+	 * Synchronously request the pixel
+	 */
+	static function record_pixel( $pixel ) {
+		// Add the Request Timestamp and URL terminator just before the HTTP request.
+		$pixel .= '&_rt=' . self::build_timestamp() . '&_=_';
+
+		$response = wp_remote_get( $pixel, array(
+			'blocking'    => true, // The default, but being explicit here :)
+			'timeout'     => 1,
+			'redirection' => 2,
+			'httpversion' => '1.1',
+			'user-agent'  => self::get_user_agent(),
+		) );
+
+		error_log( print_r( $pixel, 1 ) );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = isset( $response['response']['code'] ) ? $response['response']['code'] : 0;
+
+		if ( $code !== 200 ) {
+			return new WP_Error( 'request_failed', 'Tracks pixel request failed', $code );
+		}
+
+		return true;
+	}
+
+	static function get_user_agent() {
+		return Tracks_Client::USER_AGENT_SLUG . '-v' . Tracks_Client::VERSION;
+	}
+
+	/**
+	 * Build an event and return its tracking URL
+	 * @deprecated          Call the `build_pixel_url` method on a Tracks_Event object instead.
+	 * @param  array $event Event keys and values
+	 * @return string       URL of a tracking pixel
+	 */
+	static function build_pixel_url( $event ) {
+		$_event = new Tracks_Event( $event );
+		return $_event->build_pixel_url();
+	}
+
+	/**
+	 * Validate input for a tracks event.
+	 * @deprecated          Instantiate a Tracks_Event object instead
+	 * @param  array $event Event keys and values
+	 * @return mixed        Validated keys and values or WP_Error on failure
+	 */
+	private static function validate_and_sanitize( $event ) {
+		$_event = new Tracks_Event( $event );
+		if ( is_wp_error( $_event ) ) {
+			return $_event;
+		}
+		return get_object_vars( $_event );
+	}
+
+	// Milliseconds since 1970-01-01
+	static function build_timestamp() {
+		$ts = round( microtime( true ) * 1000 );
+		return number_format($ts, 0, '', '');
+	}
+
+	/**
+	 * Grabs the user's anon id from cookies, or generates and sets a new one
+	 *
+	 * @return string An anon id for the user
+	 */
+	static function get_anon_id() {
+		static $anon_id = null;
+
+		if ( ! isset( $anon_id ) ) {
+
+			// Did the browser send us a cookie?
+			if ( isset( $_COOKIE[ 'tk_ai' ] ) && preg_match( '#^[A-Za-z0-9+/=]{24}$#', $_COOKIE[ 'tk_ai' ] ) ) {
+				$anon_id = $_COOKIE[ 'tk_ai' ];
+			} else {
+
+				$binary = '';
+				
+				// Generate a new anonId and try to save it in the browser's cookies
+				// Note that base64-encoding an 18 character string generates a 24-character anon id
+				for ( $i = 0; $i < 18; ++$i ) {
+					$binary .= chr( mt_rand( 0, 255 ) );
+				}
+
+				$anon_id = 'jetpack:'.base64_encode( $binary );
+
+				if ( ! headers_sent() ) {
+					setcookie( 'tk_ai', $anon_id );
+				}
+			}
+		}
+
+		return $anon_id;
+	}
+}

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -77,8 +77,6 @@ class Tracks_Client {
 		// Add the Request Timestamp and URL terminator just before the HTTP request.
 		$pixel .= '&_rt=' . self::build_timestamp() . '&_=_';
 
-		return;
-
 		$response = wp_remote_get( $pixel, array(
 			'blocking'    => true, // The default, but being explicit here :)
 			'timeout'     => 1,

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -63,8 +63,6 @@ class Tracks_Client {
 
 		$pixel = $event->build_pixel_url( $event );
 
-		error_log( $pixel );
-
 		if ( ! $pixel ) {
 			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );
 		}
@@ -79,6 +77,8 @@ class Tracks_Client {
 		// Add the Request Timestamp and URL terminator just before the HTTP request.
 		$pixel .= '&_rt=' . self::build_timestamp() . '&_=_';
 
+		return;
+
 		$response = wp_remote_get( $pixel, array(
 			'blocking'    => true, // The default, but being explicit here :)
 			'timeout'     => 1,
@@ -86,8 +86,6 @@ class Tracks_Client {
 			'httpversion' => '1.1',
 			'user-agent'  => self::get_user_agent(),
 		) );
-
-		error_log( print_r( $pixel, 1 ) );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -42,7 +42,6 @@ require_once( dirname(__FILE__).'/class.tracks-client.php' );
 
 class Tracks_Client {
 	const PIXEL = 'http://pixel.wp.com/t.gif';
-	// const API_URL = 'https://public-api.wordpress.com/rest/v1.1/tracks/record';
 	const BROWSER_TYPE = 'php-agent';
 	const USER_AGENT_SLUG = 'tracks-client';
 	const VERSION = '0.3';
@@ -130,7 +129,7 @@ class Tracks_Client {
 	// Milliseconds since 1970-01-01
 	static function build_timestamp() {
 		$ts = round( microtime( true ) * 1000 );
-		return number_format($ts, 0, '', '');
+		return number_format( $ts, 0, '', '' );
 	}
 
 	/**
@@ -156,7 +155,7 @@ class Tracks_Client {
 					$binary .= chr( mt_rand( 0, 255 ) );
 				}
 
-				$anon_id = 'jetpack:'.base64_encode( $binary );
+				$anon_id = 'jetpack:' . base64_encode( $binary );
 
 				if ( ! headers_sent() ) {
 					setcookie( 'tk_ai', $anon_id );

--- a/_inc/lib/tracks/class.tracks-event.php
+++ b/_inc/lib/tracks/class.tracks-event.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * @autounit nosara tracks-client
+ *
+ * Example Usage:
+```php
+	require_once( dirname(__FILE__) . 'path/to/tracks/class.tracks-event' );
+
+	$event = new Tracks_Event( array(
+		'_en'        => $event_name,       // required
+		'_ui'        => $user_id,          // required unless _ul is provided
+		'_ul'        => $user_login,       // required unless _ui is provided
+
+		// Optional, but recommended
+		'_via_ip'    => $client_ip,        // for geo, etc.
+
+		// Possibly useful to set some context for the event
+		'_via_ua'    => $client_user_agent,
+		'_via_url'   => $client_url,
+		'_via_ref'   => $client_referrer,
+
+		// For user-targeted tests
+		'abtest_name'        => $abtest_name,
+		'abtest_variation'   => $abtest_variation,
+
+		// Your application-specific properties
+		'custom_property'    => $some_value,
+	) );
+
+	if ( is_wp_error( $event->error ) ) {
+		// Handle the error in your app
+	}
+
+	$bump_and_redirect_pixel = $event->build_signed_pixel_url();
+```
+ */
+
+require_once( dirname(__FILE__).'/class.tracks-client.php' );
+
+class Tracks_Event {
+	const EVENT_NAME_REGEX = '/^(([a-z0-9]+)_){2}([a-z0-9_]+)$/';
+	const PROP_NAME_REGEX = '/^[a-z_][a-z0-9_]*$/';
+	public $error;
+
+	function __construct( $event ) {
+		$_event = self::validate_and_sanitize( $event );
+		if ( is_wp_error( $_event ) ) {
+			$this->error = $_event;
+			return;
+		}
+
+		foreach( $_event as $key => $value ) {
+			$this->{$key} = $value;
+		}
+	}
+
+	function record() {
+		return Tracks_Client::record_event( $this );
+	}
+
+	/**
+	 * Annotate the event with all relevant info.
+	 * @param  mixed		$event Object or (flat) array
+	 * @return mixed        The transformed event array or WP_Error on failure.
+	 */
+	static function validate_and_sanitize( $event ) {
+		$event = (object) $event;
+
+		// Required
+		if ( ! $event->_en ) {
+			return new WP_Error( 'invalid_event', 'A valid event must be specified via `_en`', 400 );
+		}
+
+		// delete non-routable addresses otherwise geoip will discard the record entirely
+		if ( property_exists( $event, '_via_ip' ) && preg_match( '/^192\.168|^10\./', $event->_via_ip ) ) {
+			unset($event->_via_ip);
+		}
+
+		$validated = array(
+			'browser_type'      => Tracks_Client::BROWSER_TYPE,
+			'_aua'              => Tracks_Client::get_user_agent(),
+		);
+
+		$_event = (object) array_merge( (array) $event, $validated );
+
+		// If you want to blacklist property names, do it here.
+
+		// Make sure we have an event timestamp.
+		if ( ! isset( $_event->_ts ) ) {
+			$_event->_ts = Tracks_Client::build_timestamp();
+		}
+
+		return $_event;
+	}
+
+	/**
+	 * Build a pixel URL that will send a Tracks event when fired.
+	 * On error, returns an empty string ('').
+	 *
+	 * @return string A pixel URL or empty string ('') if there were invalid args.
+	 */
+	function build_pixel_url() {
+		if ( $this->error ) {
+			return '';
+		}
+
+		$args = get_object_vars( $this );
+
+		// Request Timestamp and URL Terminator must be added just before the HTTP request or not at all.
+		unset( $args['_rt'] );
+		unset( $args['_'] );
+
+		$validated = self::validate_and_sanitize( $args );
+
+		if ( is_wp_error( $validated ) )
+			return '';
+
+		return Tracks_Client::PIXEL . '?' . http_build_query( $validated );
+	}
+ 
+	static function event_name_is_valid( $name ) {
+		return preg_match( Tracks_Event::EVENT_NAME_REGEX, $name );
+	}
+
+	static function prop_name_is_valid( $name ) {
+		return preg_match( Tracks_Event::PROP_NAME_REGEX, $name );
+	}
+
+	static function scrutinize_event_names( $event ) {
+		if ( ! Tracks_Event::event_name_is_valid( $event->_en ) ) {
+			error_log( '[Tracks_Event] Event `' . $event->_en . '` is likely destined for the `tracks_rejects` table because of its name'  );
+			return;
+		}
+
+		$whitelisted_key_names = array(
+			'anonId',
+			'Browser_Type',
+		);
+
+		foreach ( array_keys( (array) $event ) as $key ) {
+			if ( in_array( $key, $whitelisted_key_names ) ) {
+				continue;
+			}
+			if ( ! Tracks_Event::prop_name_is_valid( $key ) ) {
+				error_log( '[Tracks_Event] Event `' . $event->_en . '` is likely destined for the `tracks_rejects` table because of key: ' . $key );
+				return;
+			}
+		}
+	}
+}
+

--- a/_inc/lib/tracks/class.tracks-event.php
+++ b/_inc/lib/tracks/class.tracks-event.php
@@ -36,7 +36,7 @@
 ```
  */
 
-require_once( dirname(__FILE__).'/class.tracks-client.php' );
+require_once( dirname(__FILE__) . '/class.tracks-client.php' );
 
 class Tracks_Event {
 	const EVENT_NAME_REGEX = '/^(([a-z0-9]+)_){2}([a-z0-9_]+)$/';

--- a/_inc/lib/tracks/class.tracks-event.php
+++ b/_inc/lib/tracks/class.tracks-event.php
@@ -129,7 +129,6 @@ class Tracks_Event {
 
 	static function scrutinize_event_names( $event ) {
 		if ( ! Tracks_Event::event_name_is_valid( $event->_en ) ) {
-			error_log( '[Tracks_Event] Event `' . $event->_en . '` is likely destined for the `tracks_rejects` table because of its name'  );
 			return;
 		}
 
@@ -143,7 +142,6 @@ class Tracks_Event {
 				continue;
 			}
 			if ( ! Tracks_Event::prop_name_is_valid( $key ) ) {
-				error_log( '[Tracks_Event] Event `' . $event->_en . '` is likely destined for the `tracks_rejects` table because of key: ' . $key );
 				return;
 			}
 		}

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -122,8 +122,6 @@ function tracks_record_event( $user
 							, $event_timestamp_millis = false ) {
 	$event_obj = tracks_build_event_obj( $user, $event_name, $properties, $event_timestamp_millis );
 
-	error_log( print_r( $event_obj, 1 ) );
-
 	if ( is_wp_error( $event_obj->error ) ) {
 		return $event_obj->error;
 	}

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -44,45 +44,7 @@ function tracks_build_event_obj( $user
 								, $properties = array()
 								, $event_timestamp_millis = false ) {
 
-	// We have their wpcom user ID, use that.
-	$wpcom_id = get_user_meta( $user->ID, 'jetpack_tracks_wpcom_id', true );
-
-	if ( $wpcom_id && Jetpack::is_user_connected( $user->ID ) ) {
-		$identity = array(
-			'_ut' => 'wpcom:user_id',
-			'_ui' => $wpcom_id
-		);
-	} else {
-		if ( Jetpack::is_user_connected( $user->ID ) ) {
-
-			$wpcom_user_data = Jetpack::get_connected_user_data( $user->ID );
-
-			// Save the ID for future use.
-			add_user_meta( $user->ID, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'], true );
-
-			$identity = array(
-				'_ut' => 'wpcom:user_id',
-				'_ui' => $wpcom_user_data['ID']
-			);
-		} else {
-			// User isn't linked.  Fall back to anonymous ID.
-			$anon_id = get_user_meta( $user->ID, 'jetpack_tracks_anon_id', true );
-
-			if ( ! $anon_id ) {
-				$anon_id = Tracks_Client::get_anon_id();
-				add_user_meta( $user->ID, 'jetpack_tracks_anon_id', $anon_id, false );
-			}
-
-			if ( !isset( $_COOKIE[ 'tk_ai' ] ) && !headers_sent() ) {
-				setcookie( 'tk_ai', $anon_id );
-			}
-
-			$identity = array(
-				'_ut' => 'anon',
-				'_ui' => $anon_id
-			);
-		}
-	}
+	$identity = tracks_get_identity( $user->ID );
 
 	$properties['user_lang'] = $user->get('WPLANG');
 
@@ -97,6 +59,52 @@ function tracks_build_event_obj( $user
 		'_en' => $event_name,
 		'_ts' => $timestamp_string
 	) ) );
+}
+
+/*
+ * Get the identity to send to tracks.
+ *
+ * @param int $user_id The user id of the local user
+ * @return array $identity
+ */
+function tracks_get_identity( $user_id ) {
+
+	// Meta is set, and user is still connected.  Use WPCOM ID
+	$wpcom_id = get_user_meta( $user_id, 'jetpack_tracks_wpcom_id', true );
+	if ( $wpcom_id && Jetpack::is_user_connected( $user_id ) ) {
+		return array(
+			'_ut' => 'wpcom:user_id',
+			'_ui' => $wpcom_id
+		);
+	}
+
+	// User is connected, but no meta is set yet.  Use WPCOM ID and set meta.
+	if ( Jetpack::is_user_connected( $user_id ) ) {
+		$wpcom_user_data = Jetpack::get_connected_user_data( $user_id );
+		add_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'], true );
+
+		return array(
+			'_ut' => 'wpcom:user_id',
+			'_ui' => $wpcom_user_data['ID']
+		);
+	}
+
+	// User isn't linked at all.  Fall back to anonymous ID.
+	$anon_id = get_user_meta( $user_id, 'jetpack_tracks_anon_id', true );
+	if ( ! $anon_id ) {
+		$anon_id = Tracks_Client::get_anon_id();
+		add_user_meta( $user_id, 'jetpack_tracks_anon_id', $anon_id, false );
+	}
+
+	if ( ! isset( $_COOKIE[ 'tk_ai' ] ) && ! headers_sent() ) {
+		setcookie( 'tk_ai', $anon_id );
+	}
+
+	return array(
+		'_ut' => 'anon',
+		'_ui' => $anon_id
+	);
+
 }
 
 /**

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * PHP Tracks Client
+ * @autounit nosara tracks-client
+ * Example Usage:
+ *
+```php
+	include( plugin_dir_path( __FILE__ ) . 'lib/tracks/client.php');
+	$result = tracks_record_event( $user, $event_name, $properties );
+
+	if ( is_wp_error( $result ) ) {
+		// Handle the error in your app
+	}
+```
+ */
+
+// Load the client classes
+require_once( dirname(__FILE__).'/class.tracks-event.php' );
+require_once( dirname(__FILE__).'/class.tracks-client.php' );
+
+// Now, let's export a sprinkling of syntactic sugar!
+
+/**
+ * Procedurally (vs. Object-oriented), track an event object (or flat array)
+ * NOTE: Use this only when the simpler tracks_record_event() function won't work for you.
+ * @param \Tracks_Event $event The event object.
+ * @return \Tracks_Event|\WP_Error
+ */
+function tracks_record_event_raw( $event ) {
+	return Tracks_Client::record_event( $event );
+}
+
+/**
+ * Procedurally build a Tracks Event Object.
+ * NOTE: Use this only when the simpler tracks_record_event() function won't work for you.
+ * @param $identity WP_user object
+ * @param string $event_name The name of the event
+ * @param array $properties Custom properties to send with the event
+ * @param int $event_timestamp_millis The time in millis since 1970-01-01 00:00:00 when the event occurred
+ * @return \Tracks_Event|\WP_Error
+ */
+function tracks_build_event_obj( $user
+								, $event_name
+								, $properties = array()
+								, $event_timestamp_millis = false ) {
+
+	$anon_id = get_user_meta($user->ID, 'jetpack_tracks_anon_id', true);
+
+	if ( ! $anon_id ) {
+		$anon_id = Tracks_Client::get_anon_id();
+		add_user_meta($user->ID, 'jetpack_tracks_anon_id', $anon_id, false);
+	}
+
+	if ( !isset( $_COOKIE[ 'tk_ai' ] ) && !headers_sent() ) {
+		setcookie( 'tk_ai', $anon_id );
+	}
+
+	$identity = array(
+		'_ut' => 'anon',
+		'_ui' => $anon_id
+	);
+	
+	$properties['user_lang'] = $user->get('WPLANG');
+
+	$blog_details = array(
+		'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' )
+	);
+
+	$timestamp = ( $event_timestamp_millis !== false ) ? $event_timestamp_millis : round( microtime( true ) * 1000 );
+	$timestamp_string = is_string($timestamp) ? $timestamp : number_format($timestamp, 0, '', '');
+
+	return new Tracks_Event( array_merge( $blog_details, (array) $properties, $identity, array(
+		'_en' => $event_name,
+		'_ts' => $timestamp_string
+	) ) );
+}
+
+/**
+ * Record an event in Tracks - this is the preferred way to record events from PHP.
+ *
+ * @param mixed $identity username, user_id, or WP_user object
+ * @param string $event_name The name of the event
+ * @param array $properties Custom properties to send with the event
+ * @param int $event_timestamp_millis The time in millis since 1970-01-01 00:00:00 when the event occurred
+ * @return bool true for success | \WP_Error if the event pixel could not be fired
+ */
+function tracks_record_event( $user
+							, $event_name
+							, $properties = array()
+							, $event_timestamp_millis = false ) {
+	$event_obj = tracks_build_event_obj( $user, $event_name, $properties, $event_timestamp_millis );
+	if ( is_wp_error( $event_obj->error ) ) {
+		return $event_obj->error;
+	}
+
+	return $event_obj->record();
+}

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -15,8 +15,8 @@
  */
 
 // Load the client classes
-require_once( dirname(__FILE__).'/class.tracks-event.php' );
-require_once( dirname(__FILE__).'/class.tracks-client.php' );
+require_once( dirname(__FILE__) . '/class.tracks-event.php' );
+require_once( dirname(__FILE__) . '/class.tracks-client.php' );
 
 // Now, let's export a sprinkling of syntactic sugar!
 
@@ -46,14 +46,14 @@ function tracks_build_event_obj( $user
 
 	$identity = tracks_get_identity( $user->ID );
 
-	$properties['user_lang'] = $user->get('WPLANG');
+	$properties['user_lang'] = $user->get( 'WPLANG' );
 
 	$blog_details = array(
 		'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' )
 	);
 
 	$timestamp = ( $event_timestamp_millis !== false ) ? $event_timestamp_millis : round( microtime( true ) * 1000 );
-	$timestamp_string = is_string($timestamp) ? $timestamp : number_format($timestamp, 0, '', '');
+	$timestamp_string = is_string( $timestamp ) ? $timestamp : number_format( $timestamp, 0, '', '' );
 
 	return new Tracks_Event( array_merge( $blog_details, (array) $properties, $identity, array(
 		'_en' => $event_name,

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -39,10 +39,7 @@ function tracks_record_event_raw( $event ) {
  * @param int $event_timestamp_millis The time in millis since 1970-01-01 00:00:00 when the event occurred
  * @return \Tracks_Event|\WP_Error
  */
-function tracks_build_event_obj( $user
-								, $event_name
-								, $properties = array()
-								, $event_timestamp_millis = false ) {
+function tracks_build_event_obj( $user, $event_name, $properties = array(), $event_timestamp_millis = false ) {
 
 	$identity = tracks_get_identity( $user->ID );
 
@@ -116,10 +113,7 @@ function tracks_get_identity( $user_id ) {
  * @param int $event_timestamp_millis The time in millis since 1970-01-01 00:00:00 when the event occurred
  * @return bool true for success | \WP_Error if the event pixel could not be fired
  */
-function tracks_record_event( $user
-							, $event_name
-							, $properties = array()
-							, $event_timestamp_millis = false ) {
+function tracks_record_event( $user, $event_name, $properties = array(), $event_timestamp_millis = false ) {
 	$event_obj = tracks_build_event_obj( $user, $event_name, $properties, $event_timestamp_millis );
 
 	if ( is_wp_error( $event_obj->error ) ) {

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -234,7 +234,7 @@ class Jetpack_Client_Server {
 
 		if ( !$cap = $jetpack->translate_role_to_cap( $role ) )
 			return new Jetpack_Error( 'scope', 'No Cap', $code );
-		if ( !current_user_can( $cap ) )
+		if ( ! current_user_can( $cap ) )
 			return new Jetpack_Error( 'scope', 'current_user_cannot', $code );
 
 		/**

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -124,13 +124,6 @@ class Jetpack_Client_Server {
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 		} while ( false );
 
-		/**
-		 * Fires after a user links their WordPress.com account
-		 *
-		 * @since 3.9
-		 */
-		do_action( 'jetpack_user_authorized' );
-
 		if ( wp_validate_redirect( $redirect ) ) {
 			$this->wp_safe_redirect( $redirect );
 		} else {
@@ -243,6 +236,13 @@ class Jetpack_Client_Server {
 			return new Jetpack_Error( 'scope', 'No Cap', $code );
 		if ( !current_user_can( $cap ) )
 			return new Jetpack_Error( 'scope', 'current_user_cannot', $code );
+
+		/**
+		 * Fires after user has successfully received an auth token.
+		 *
+		 * @since 3.9
+		 */
+		do_action( 'jetpack_user_authorized' );
 
 		return (string) $json->access_token;
 	}

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -119,6 +119,13 @@ class Jetpack_Client_Server {
 			/** This action is documented in class.jetpack.php */
 			do_action( 'jetpack_sync_all_registered_options' );
 
+			/**
+			 * Fires after a user connects their site to WordPress.com
+			 *
+			 * @since 3.9
+			 */
+			do_action( 'jetpack_user_authorized' );
+
 			// Start nonce cleaner
 			wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -119,17 +119,17 @@ class Jetpack_Client_Server {
 			/** This action is documented in class.jetpack.php */
 			do_action( 'jetpack_sync_all_registered_options' );
 
-			/**
-			 * Fires after a user connects their site to WordPress.com
-			 *
-			 * @since 3.9
-			 */
-			do_action( 'jetpack_user_authorized' );
-
 			// Start nonce cleaner
 			wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 		} while ( false );
+
+		/**
+		 * Fires after a user links their WordPress.com account
+		 *
+		 * @since 3.9
+		 */
+		do_action( 'jetpack_user_authorized' );
 
 		if ( wp_validate_redirect( $redirect ) ) {
 			$this->wp_safe_redirect( $redirect );

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -240,7 +240,7 @@ class Jetpack_Client_Server {
 		/**
 		 * Fires after user has successfully received an auth token.
 		 *
-		 * @since 3.9
+		 * @since 3.9.0
 		 */
 		do_action( 'jetpack_user_authorized' );
 

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -16,6 +16,14 @@ class JetpackTracking {
 
 	/* User has linked their account */
 	static function track_user_linked() {
+		$user_id = get_current_user_id();
+		$anon_id = get_user_meta( $user_id, 'jetpack_tracks_anon_id' );
+
+		if ( $anon_id ) {
+			self::record_user_event( '_aliasUser', array( 'anonId' => $anon_id ) );
+			delete_user_meta( $user_id, 'jetpack_tracks_anon_id' );
+		}
+
 		self::record_user_event( 'user_linked', array() );
 	}
 

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -60,13 +60,13 @@ class JetpackTracking {
 
 		$top_level_events = array( '_aliasUser' );
 
-		$event_name = self::$product_name.'_'.$event_type;
+		$event_name = self::$product_name . '_' . $event_type;
 
 		if ( in_array( $event_type, $top_level_events ) ) {
 			$event_name = $event_type;
 		}
 
-		$data['jetpack_version'] = defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : "0";
+		$data['jetpack_version'] = defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '0';
 
 		$response = tracks_record_event( $user, $event_name, $data );
 

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -68,11 +68,7 @@ class JetpackTracking {
 
 		$data['jetpack_version'] = defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '0';
 
-		$response = tracks_record_event( $user, $event_name, $data );
-
-		if ( is_wp_error( $response ) ) {
-			error_log( "There was an error: ".$response->get_error_message() );
-		}
+		tracks_record_event( $user, $event_name, $data );
 	}
 }
 

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -48,10 +48,11 @@ class JetpackTracking {
 		$user = wp_get_current_user();
 		$site_url = get_option( 'siteurl' );
 
-		$data['_via_ua'] = $_SERVER['HTTP_USER_AGENT'];
-		$data['_via_ip'] = $_SERVER['REMOTE_ADDR'];
-		$data['_lg']     = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+		$data['_via_ua']  = $_SERVER['HTTP_USER_AGENT'];
+		$data['_via_ip']  = $_SERVER['REMOTE_ADDR'];
+		$data['_lg']      = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
 		$data['blog_url'] = $site_url;
+		$data['blod_id']  = Jetpack_Options::get_option( 'id' );
 
 		$top_level_events = array( '_aliasUser' );
 

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -20,7 +20,7 @@ class JetpackTracking {
 		$anon_id = get_user_meta( $user_id, 'jetpack_tracks_anon_id' );
 
 		if ( $anon_id ) {
-			self::record_user_event( '_aliasUser', array( 'anonId' => $anon_id ) );
+			self::record_user_event( 'aliasUser', array( 'anonId' => $anon_id ) );
 			delete_user_meta( $user_id, 'jetpack_tracks_anon_id' );
 		}
 

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -9,14 +9,22 @@ class JetpackTracking {
 	static $product_name = 'jetpack';
 
 	static function track_jetpack_usage() {
-		add_action( 'jetpack_activate_module',   array(__CLASS__, 'track_activate_module'), 1, 1 );
-		add_action( 'jetpack_deactivate_module', array(__CLASS__, 'track_deactivate_module'), 1, 1 );
+		add_action( 'jetpack_activate_module',       array( __CLASS__, 'track_activate_module'), 1, 1 );
+		add_action( 'jetpack_pre_deactivate_module', array( __CLASS__, 'track_deactivate_module'), 1, 1 );
+		add_action( 'jetpack_user_authorized',       array( __CLASS__, 'track_user_linked' ) );
 	}
 
+	/* User has linked their account */
+	static function track_user_linked() {
+		self::record_user_event( 'user_linked', array() );
+	}
+
+	/* Activated module */
 	static function track_activate_module( $module ) {
 		self::record_user_event( 'module_activated', array( 'module' => $module ) );
 	}
 
+	/* Deactivated module */
 	static function track_deactivate_module( $module ) {
 		self::record_user_event( 'module_deactivated', array( 'module' => $module ) );
 	}

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -22,13 +22,13 @@ class JetpackTracking {
 		if ( $anon_id ) {
 			self::record_user_event( '_aliasUser', array( 'anonId' => $anon_id ) );
 			delete_user_meta( $user_id, 'jetpack_tracks_anon_id' );
-			if( ! headers_sent() ) {
+			if ( ! headers_sent() ) {
 				setcookie( 'tk_ai', 'expired', time() - 1000 );
 			}
 		}
 
 		$wpcom_user_data = Jetpack::get_connected_user_data( $user_id );
-		update_user_meta( $user_id, $wpcom_user_data['ID'] );
+		update_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'] );
 
 		self::record_user_event( 'user_linked', array() );
 	}

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -9,6 +9,10 @@ class JetpackTracking {
 	static $product_name = 'jetpack';
 
 	static function track_jetpack_usage() {
+		if ( ! Jetpack::is_active() ) {
+			return;
+		}
+
 		add_action( 'jetpack_pre_activate_module',   array( __CLASS__, 'track_activate_module'), 1, 1 );
 		add_action( 'jetpack_pre_deactivate_module', array( __CLASS__, 'track_deactivate_module'), 1, 1 );
 		add_action( 'jetpack_user_authorized',       array( __CLASS__, 'track_user_linked' ) );

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -9,7 +9,7 @@ class JetpackTracking {
 	static $product_name = 'jetpack';
 
 	static function track_jetpack_usage() {
-		add_action( 'jetpack_activate_module',       array( __CLASS__, 'track_activate_module'), 1, 1 );
+		add_action( 'jetpack_pre_activate_module',   array( __CLASS__, 'track_activate_module'), 1, 1 );
 		add_action( 'jetpack_pre_deactivate_module', array( __CLASS__, 'track_deactivate_module'), 1, 1 );
 		add_action( 'jetpack_user_authorized',       array( __CLASS__, 'track_user_linked' ) );
 	}

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -56,7 +56,7 @@ class JetpackTracking {
 		$data['_via_ip']  = $_SERVER['REMOTE_ADDR'];
 		$data['_lg']      = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
 		$data['blog_url'] = $site_url;
-		$data['blod_id']  = Jetpack_Options::get_option( 'id' );
+		$data['blog_id']  = Jetpack_Options::get_option( 'id' );
 
 		$top_level_events = array( '_aliasUser' );
 

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -58,17 +58,14 @@ class JetpackTracking {
 		$data['blog_url'] = $site_url;
 		$data['blog_id']  = Jetpack_Options::get_option( 'id' );
 
-		$top_level_events = array( '_aliasUser' );
-
-		$event_name = self::$product_name . '_' . $event_type;
-
-		if ( in_array( $event_type, $top_level_events ) ) {
-			$event_name = $event_type;
+		// Top level events should not be namespaced
+		if ( '_aliasUser' != $event_type ) {
+			$event_type = self::$product_name . '_' . $event_type;
 		}
 
 		$data['jetpack_version'] = defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '0';
 
-		tracks_record_event( $user, $event_name, $data );
+		tracks_record_event( $user, $event_type, $data );
 	}
 }
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4533,6 +4533,8 @@ p {
 			$url = add_query_arg( $args, Jetpack::api_url( 'authorize' ) );
 		}
 
+		error_log( $url );
+
 		return $raw ? $url : esc_url( $url );
 	}
 
@@ -5000,7 +5002,6 @@ p {
 		if( is_wp_error( $valid_response ) || !$valid_response ) {
 		    return $valid_response;
 		}
-
 
 		// Grab the response values to work with
 		$code   = wp_remote_retrieve_response_code( $response );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4533,8 +4533,6 @@ p {
 			$url = add_query_arg( $args, Jetpack::api_url( 'authorize' ) );
 		}
 
-		error_log( $url );
-
 		return $raw ? $url : esc_url( $url );
 	}
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -48,6 +48,7 @@ require_once( JETPACK__PLUGIN_DIR . 'functions.compat.php'            );
 require_once( JETPACK__PLUGIN_DIR . 'functions.gallery.php'           );
 require_once( JETPACK__PLUGIN_DIR . 'require-lib.php'                 );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php'    );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-tracks.php'        );
 
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );


### PR DESCRIPTION
Adds the PHP library for Tracks, and lays the foundation to track more things later.  

This branch adds some basic tracking for: 
- When a user links
- Module activation/deactivation 

Notable things: 
- Added a new action that fires when a user successfully receives an auth token.  
- No events will be tracked if the site is not connected.  This includes sites in dev mode.  
- We're using a randomly generated ID for users who aren't yet linked to wpcom.  When they link, we send an alias event and after we send an event about the user linking with the correct wpcom ID.  
- We send shadow blog ID along with events. 

To Test: 
- Connect/disconnect site
- Link/unlink users.  
- Activate/deactivate modules 

You should start to see actions come through in the "Live" feed of our internal tracking.  You can also check the event object being sent by error logging the `$event_obj` in `tracks_record_event()`