### PR TITLE
Responsive videos: default `$url` parameter to null …

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -45,11 +45,11 @@ function jetpack_responsive_videos_embed_html( $html ) {
 }
 
 /**
- * Check if oEmbed is YouTube or Vimeo before wrapping.
+ * Check if oEmbed is a `$video_patterns` provider video before wrapping.
  *
  * @return string
  */
-function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url ) {
+function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url = null ) {
 	if ( empty( $html ) || ! is_string( $html ) || ! $url ) {
 		return $html;
 	}


### PR DESCRIPTION
… to avoid missing argument warnings. Fixes #3048.