### PR TITLE
Use a class to target Twitter Timeline in Twenty Sixteen compat style

### DIFF
--- a/modules/theme-tools/compat/twentysixteen-rtl.css
+++ b/modules/theme-tools/compat/twentysixteen-rtl.css
@@ -450,7 +450,7 @@ iframe[src^="http://api.mixcloud.com/"] {
 }
 
 /* Twitter-timeline */
-.entry-content iframe[id*="twitter-widget-"] {
+.twitter-timeline {
 	margin-bottom: 1.75em !important;
 }
 

--- a/modules/theme-tools/compat/twentysixteen.css
+++ b/modules/theme-tools/compat/twentysixteen.css
@@ -450,7 +450,7 @@ iframe[src^="http://api.mixcloud.com/"] {
 }
 
 /* Twitter-timeline */
-.entry-content iframe[id*="twitter-widget-"] {
+.twitter-timeline {
 	margin-bottom: 1.75em !important;
 }
 


### PR DESCRIPTION
Twitter Timeline iframe has a CSS class and there is no need to use a slow attribute selector. We had a report from WP.com user.

The fix has already been applied in the compat files in WP.com.

Thanks!