### PR TITLE
Publicize: Do not load UI loader until init hook

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -18,6 +18,10 @@ class Publicize_UI {
 
 		$this->publicize = $publicize = new Publicize;
 
+		add_action( 'init', array( &$this, 'init' ) );
+	}
+
+	function init() {
 		// Show only to users with the capability required to create/delete global connections.
 		if ( ! current_user_can( $this->publicize->GLOBAL_CAP ) ) {
 			return;

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -18,7 +18,7 @@ class Publicize_UI {
 
 		$this->publicize = $publicize = new Publicize;
 
-		add_action( 'init', array( &$this, 'init' ) );
+		add_action( 'init', array( $this, 'init' ) );
 	}
 
 	function init() {


### PR DESCRIPTION
`Publicize_UI::_construct()` directly calls `current_user_can`, which ends up throwing notices when bbPress or BuddyPress are installed.

```
Notice: bbp_setup_current_user was called incorrectly. The current user is being initialized without using $wp->init(). Please see Debugging in WordPress for more information. (This message was added in version 2.3.) in /var/www/wp-includes/functions.php on line 3628

Notice: bp_setup_current_user was called incorrectly. The current user is being initialized without using $wp->init(). Please see Debugging in WordPress for more information. (This message was added in version 1.7.) in /var/www/wp-includes/functions.php on line 3628
```

We can avoid this by waiting until `init` to continue the construct, which is only needed for admins that can modify global publicize connections.

Reported via 47994-z cc: @ryanmarkel 