### PR TITLE
fix incorrect condition for related posts exclusions

### DIFF
--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -22,7 +22,7 @@
 			}
 
 			var args = 'relatedposts=1';
-			if ( ! $( '#jp-relatedposts' ).data( 'exclude' ) ) {
+			if ( $( '#jp-relatedposts' ).data( 'exclude' ) ) {
 				args += '&relatedposts_exclude=' + $( '#jp-relatedposts' ).data( 'exclude' );
 			}
 


### PR DESCRIPTION
the relatedposts_exclude will always get false, null or undefined if the condition is negating the data('exclude').
I think that, if the data('exclude') exists, then send it.