### PR TITLE
Tiled Galleries: Add new filter 'jetpack_gallery_attachments'

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -16,6 +16,7 @@ class Jetpack_Tiled_Gallery {
 		add_action( 'admin_init', array( $this, 'settings_api_init' ) );
 		add_filter( 'jetpack_gallery_types', array( $this, 'jetpack_gallery_types' ), 9 );
 		add_filter( 'jetpack_default_gallery_type', array( $this, 'jetpack_default_gallery_type' ) );
+		add_filter( 'jetpack_gallery_attachments', array( $this, 'get_attachments' ) );
 	}
 
 	public function tiles_enabled() {
@@ -103,7 +104,7 @@ class Jetpack_Tiled_Gallery {
 
 		$this->set_atts( $atts );
 
-		$attachments = $this->get_attachments();
+		$attachments = apply_filters( 'jetpack_gallery_attachments', array(), $this->atts );
 		if ( empty( $attachments ) )
 			return '';
 

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -104,6 +104,16 @@ class Jetpack_Tiled_Gallery {
 
 		$this->set_atts( $atts );
 
+		/**
+	         * Filters array of attachments for Tiled Gallery template.
+	         *
+	         * @module tiled-gallery
+	         *
+	         * @since 3.9.0
+	         *
+	         * @param array Array of attachments.
+	         * @param array Array of gallery shortcode attributes.
+	         */
 		$attachments = apply_filters( 'jetpack_gallery_attachments', array(), $this->atts );
 		if ( empty( $attachments ) )
 			return '';


### PR DESCRIPTION
In short: let other plugins to override the query for attachments for Tiled Galleries gallery template.

See detailed explanation at https://wordpress.org/support/topic/tiled-galleries-4