### PR TITLE
Carousel: revert change that broke direct link to carousel image

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1466,9 +1466,6 @@ jQuery(document).ready(function($) {
 
 	// Makes carousel work on page load and when back button leads to same URL with carousel hash (ie: no actual document.ready trigger)
 	$( window ).on( 'hashchange', function () {
-		if ( 'undefined' === typeof gallery ) {
-			return;
-		}
 
 		var hashRegExp = /jp-carousel-(\d+)/,
 			matches, attachmentId, galleries, selectedThumbnail;


### PR DESCRIPTION
fixes #3248

I simply reverted the patch, as neither myself nor @jeherve were able to reproduce the original issue reported in https://wordpress.org/support/topic/jetpack-carouseljs-hashtag-issues