### PR TITLE
Update/plugins install endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -63,18 +63,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 	}
 
 	protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
-		// Locally, we use the following format for $plugin_slug, %folder/$main-file.php
-		// eg 'jetpack/jetpack.php'
-		// The external download link however will use a simpler identifier, eg 'jetpack'
-		// which could be either the folder name, or the main file minus the '.php'
-		if ( strpos( $plugin_slug, '/' ) !== false ) {
-			$plugin_id = substr( $plugin_slug, 0, strpos( $plugin_slug, '/' ) );
-		} else if (  strpos( $plugin_slug, '.' ) !== false ) {
-			$plugin_id = substr( $plugin_slug, 0, strpos( $plugin_slug, '.' ) );
-		} else {
-			$plugin_id = $plugin_slug;
-		}
-		return "https://downloads.wordpress.org/plugin/{$plugin_id}.latest-stable.zip";
+		return "https://downloads.wordpress.org/plugin/{$plugin_slug}.latest-stable.zip";
 	}
 
 	protected static function get_plugin_id_by_slug( $slug ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -38,6 +38,12 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 		}
 
 		if ( ! $this->bulk && isset( $error ) ) {
+
+			if ( $error_code === 'download_failed' && $error === 'Download failed.' ) {
+				// For backwards compatibility: versions prior to 3.9 would return no_package instead of download_failed.
+				$error_code = 'no_package';
+			}
+
 			return new WP_Error( $error_code, $this->log[ $slug ]['error'], 400 );
 		}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -63,7 +63,17 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 	}
 
 	protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
-		$plugin_id = substr( $plugin_slug, 0, strpos( $plugin_slug, '/' ) );
+		// Locally, we use the following format for $plugin_slug, %folder/$main-file.php
+		// eg 'jetpack/jetpack.php'
+		// The external download link however will use a simpler identifier, eg 'jetpack'
+		// which could be either the folder name, or the main file minus the '.php'
+		if ( strpos( $plugin_slug, '/' ) !== false ) {
+			$plugin_id = substr( $plugin_slug, 0, strpos( $plugin_slug, '/' ) );
+		} else if (  strpos( $plugin_slug, '.' ) !== false ) {
+			$plugin_id = substr( $plugin_slug, 0, strpos( $plugin_slug, '.' ) );
+		} else {
+			$plugin_id = $plugin_slug;
+		}
 		return "https://downloads.wordpress.org/plugin/{$plugin_id}.latest-stable.zip";
 	}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -39,7 +39,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 
 		if ( ! $this->bulk && isset( $error ) ) {
 
-			if ( $error_code === 'download_failed' ) {
+			if ( 'download_failed' === $error_code ) {
 				// For backwards compatibility: versions prior to 3.9 would return no_package instead of download_failed.
 				$error_code = 'no_package';
 			}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -39,10 +39,16 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 
 		if ( ! $this->bulk && isset( $error ) ) {
 
-			if ( $error_code === 'download_failed' && $error === 'Download failed.' ) {
+			if ( $error_code === 'download_failed' ) {
 				// For backwards compatibility: versions prior to 3.9 would return no_package instead of download_failed.
 				$error_code = 'no_package';
 			}
+
+			error_log( print_r( array(
+				'code' => $error_code,
+				'message' => $error,
+				'log' => $upgrader->skin->get_upgrade_messages()
+			) ) );
 
 			return new WP_Error( $error_code, $this->log[ $slug ]['error'], 400 );
 		}

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -62,7 +62,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 		return true;
 	}
 
-	protected statuc function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
+	protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
 		return "https://downloads.wordpress.org/plugin/{$plugin_slug}.latest-stable.zip";
 	}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -63,7 +63,8 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 	}
 
 	protected static function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
-		return "https://downloads.wordpress.org/plugin/{$plugin_slug}.latest-stable.zip";
+		$plugin_id = substr( $plugin_slug, 0, strpos( $plugin_slug, '/' ) );
+		return "https://downloads.wordpress.org/plugin/{$plugin_id}.latest-stable.zip";
 	}
 
 	protected static function get_plugin_id_by_slug( $slug ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -8,15 +8,15 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 	// POST /sites/%s/plugins/%s/install
 	protected $needed_capabilities = 'install_plugins';
 	protected $action              = 'install';
-	protected $download_links      = array();
 
 	protected function install() {
 		foreach ( $this->plugins as $index => $slug ) {
 
 			$skin      = new Jetpack_Automatic_Plugin_Install_Skin();
 			$upgrader  = new Plugin_Upgrader( $skin );
+			$zip_url   = self::generate_wordpress_org_plugin_download_link( $slug );
 
-			$result = $upgrader->install( $this->download_links[ $slug ] );
+			$result = $upgrader->install( $zip_url );
 
 			if ( ! $this->bulk && is_wp_error( $result ) ) {
 				return $result;
@@ -58,16 +58,12 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 				return new WP_Error( 'plugin_already_installed', __( 'The plugin is already installed', 'jetpack' ) );
 			}
 
-			$response    = wp_remote_get( "http://api.wordpress.org/plugins/info/1.0/$slug" );
-			$plugin_data = unserialize( $response['body'] );
-			if ( is_wp_error( $plugin_data ) ) {
-				return $plugin_data;
-			}
-
-			$this->download_links[ $slug ] = $plugin_data->download_link;
-
 		}
 		return true;
+	}
+
+	protected statuc function generate_wordpress_org_plugin_download_link( $plugin_slug ) {
+		return "https://downloads.wordpress.org/plugin/{$plugin_slug}.latest-stable.zip";
 	}
 
 	protected static function get_plugin_id_by_slug( $slug ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -44,12 +44,6 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 				$error_code = 'no_package';
 			}
 
-			error_log( print_r( array(
-				'code' => $error_code,
-				'message' => $error,
-				'log' => $upgrader->skin->get_upgrade_messages()
-			) ) );
-
 			return new WP_Error( $error_code, $this->log[ $slug ]['error'], 400 );
 		}
 

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -133,6 +133,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 		$the_plugin_file = 'the/the.php';
 		$the_real_folder = WP_PLUGIN_DIR . '/the';
 		$the_real_file = WP_PLUGIN_DIR . '/' . $the_plugin_file;
+		$the_plugin_slug = 'the';
 
 		// Check if 'The' plugin folder is already there.
 		if ( file_exists( $the_real_folder ) ) {
@@ -149,7 +150,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 			return;
 		}
 		$plugins_property->setAccessible( true );
-		$plugins_property->setValue ( $endpoint , array( $the_plugin_file ) );
+		$plugins_property->setValue ( $endpoint , array( $the_plugin_slug ) );
 
 		$validate_plugins_method = $class->getMethod( 'validate_plugins' );
 		$validate_plugins_method->setAccessible( true );


### PR DESCRIPTION
From @dd32 : 
> The WordPress.org download links for plugins are in a standard format, the version number can be replaced with latest-stable to return the latest stable release download url (which /plugins/info/ would otherwise return).
This will remove a redundant API call to WordPress.org, speeding up the process and reducing the number of API requests WordPress.org has to handle.

To test:
- apply this patch to one of your Jetpack testing sites
- ensure you can use wordpress.com to install plugins to the site

cc: @enejb @johnHackworth 