### PR TITLE
Publicize: Revert new filter

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -322,21 +322,6 @@ abstract class Publicize_Base {
 			$submit_post = false;
 		}
 
-		/**
-		 * Filter if a post should be skipped during Publicize.
-		 *
-		 * @module publicize
-		 *
-		 * @since 3.9.0
-		 *
-		 * @param bool   $skip    Should the post be skipped? Default false.
-		 * @param int    $post_id The post ID being considered.
-		 * @param object $post    The post object being considered.
-		 */
-		if ( apply_filters( 'jetpack_skip_all_publicize', false, $post_id, $post ) ) {
-			$submit_post = false;
-		}
-
 		// Did this request happen via wp-admin?
 		$from_web = 'post' == strtolower( $_SERVER['REQUEST_METHOD'] ) && isset( $_POST[$this->ADMIN_PAGE] );
 


### PR DESCRIPTION
tl;dr: It doesn't work. It suffers the same problems as the failure of `wpas_submit_post?`. I tried a quick other related methods, but it needs a bit more time to get right. Suggesting to revert for 3.9 and kick it down the road.

Reopens #7 