### PR TITLE
VideoPress: Delay loading actions to init.

### DIFF
--- a/modules/videopress/videopress.php
+++ b/modules/videopress/videopress.php
@@ -22,7 +22,7 @@ class Jetpack_VideoPress {
 
 	function __construct() {
 		$this->version = time(); // <s>ghost</s> cache busters!
-		add_action( 'jetpack_modules_loaded', array( $this, 'jetpack_modules_loaded' ) );
+		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'jetpack_activate_module_videopress', array( $this, 'jetpack_module_activated' ) );
 		add_action( 'jetpack_deactivate_module_videopress', array( $this, 'jetpack_module_deactivated' ) );
 
@@ -30,9 +30,9 @@ class Jetpack_VideoPress {
 	}
 
 	/**
-	 * After all modules have been loaded.
+	 * Fires in init since is_connection_owner should wait until the user is initialized by $wp->init();
 	 */
-	function jetpack_modules_loaded() {
+	function init() {
 		$options = $this->get_options();
 
 		// Only the connection owner can configure this module.


### PR DESCRIPTION
Resolves a pair of notices reported by VIP Go when bbPress/BuddyPress are used on a site with VideoPress active.

Fixes #3252