### PR TITLE
Widget Visibility: fixes a possible fatal when get_term returns an instance of an error.

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -530,7 +530,7 @@ class Jetpack_Widget_Conditions {
 								$condition_result = true;
 							} else {
 								$tag = get_tag( $rule['minor'] );
-								if ( $tag && is_tag( $tag->slug ) ) {
+								if ( $tag && ! is_wp_error( $tag ) && is_tag( $tag->slug ) ) {
 									$condition_result = true;
 								}
 							}


### PR DESCRIPTION
Replays #2714.

> I couldn't reproduce the case when `get_term` would return an error, but this check should do the trick in case it ever does.