### PR TITLE
Options Endpoint: Fix json_decode warning for updating options

### DIFF
--- a/json-endpoints/jetpack/class.wpcom-json-api-update-option-endpoint.php
+++ b/json-endpoints/jetpack/class.wpcom-json-api-update-option-endpoint.php
@@ -19,8 +19,9 @@ class WPCOM_JSON_API_Update_Option_Endpoint extends WPCOM_JSON_API_Get_Option_En
 			return new WP_Error( 'option_value_not_set', __( 'You must specify an option_value', 'jetpack' ) );
 		}
 		if ( $query_args['is_array'] ) {
-			// We may need to decode an incoming JSON string, and cast it as an array
-			$this->option_value = (array) json_decode( $input['option_value'] );
+			// When converted back from JSON, the value is an object.
+			// Cast it to an array for options that expect arrays.
+			$this->option_value = (array) $input['option_value'];
 		} else {
 			$this->option_value = $input['option_value'];
 		}

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -658,7 +658,7 @@ new WPCOM_JSON_API_Update_Option_Endpoint( array (
 		'is_array' => '(bool=false) True if the value should be converted to an array before saving.',
 	),
 	'request_format' => array(
-		'option_value' => '(string|object) The new value of the option. Can be a JSON string.',
+		'option_value' => '(string|object) The new value of the option.',
 	),
 	'response_format' => array(
 		'option_value' => '(string|object) The value of the updated option.',

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -635,7 +635,7 @@ new WPCOM_JSON_API_Get_Option_Endpoint( array (
 	'response_format' => array(
 		'option_value' => '(string|object) The value of the option.',
 	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/options?option_name=blogname',
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/option?option_name=blogname',
 	'example_request_data' => array(
 		'headers' => array( 'authorization' => 'Bearer YOUR_API_TOKEN' ),
 	),
@@ -663,7 +663,7 @@ new WPCOM_JSON_API_Update_Option_Endpoint( array (
 	'response_format' => array(
 		'option_value' => '(string|object) The value of the updated option.',
 	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/options',
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/option',
 	'example_request_data' => array(
 		'headers' => array( 'authorization' => 'Bearer YOUR_API_TOKEN' ),
 		'body' => array(

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -658,7 +658,7 @@ new WPCOM_JSON_API_Update_Option_Endpoint( array (
 		'is_array' => '(bool=false) True if the value should be converted to an array before saving.',
 	),
 	'request_format' => array(
-		'option_value' => '(string) The new value of the option. Can be a JSON string.',
+		'option_value' => '(string|object) The new value of the option. Can be a JSON string.',
 	),
 	'response_format' => array(
 		'option_value' => '(string|object) The value of the updated option.',


### PR DESCRIPTION
The request body has already been decoded into an object by `WPCOM_JSON_API_Endpoint::input`, so running it again causes a PHP Warning. Additionally, this is run before `cast_and_filter`, so option_value can also be an object.

This is a follow-up to #3259