### PR TITLE
My Jetpack: Call correct method 

### DIFF
--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -145,7 +145,7 @@
 					<div class="j-row">
 						<div class="j-col j-lrg-12 j-md-12 j-sm-12">
 
-							<?php if ( ! Jetpack::jetpack_is_staging_site() ) : ?>
+							<?php if ( ! Jetpack::is_staging_site() ) : ?>
 								<h2><?php _e( 'Disconnecting Jetpack', 'jetpack' ); ?></h2>
 								<p><?php _e( 'Before you completely disconnect Jetpack is there anything we can do to help?', 'jetpack' ); ?></p>
 								<a class="button" id="confirm-disconnect" title="<?php esc_attr_e( 'Disconnect Jetpack', 'jetpack' ); ?>" href="<?php echo wp_nonce_url( Jetpack::admin_url( 'action=disconnect' ), 'jetpack-disconnect' ); ?>"><?php _e( 'Confirm Disconnect', 'jetpack' ); ?></a>


### PR DESCRIPTION
Call correct method that was renamed in a59cb3fbbff558e758e032f039eed4bdd844192d

was breaking the footer of My Jetpack 