### PR TITLE
Related Posts: add new filter to change each RP's heading

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1223,8 +1223,20 @@ EOT;
 	 * @return null
 	 */
 	protected function _enqueue_assets( $script, $style ) {
-		if ( $script )
+		if ( $script ) {
 			wp_enqueue_script( 'jetpack_related-posts', plugins_url( 'related-posts.js', __FILE__ ), array( 'jquery' ), self::VERSION );
+			$related_posts_js_options = array(
+				/**
+				 * Filter each Related Post Heading structure.
+				 *
+				 * @since 4.0.0
+				 *
+				 * @param string $str Related Post Heading structure. Default to h4.
+				 */
+				'post_heading' => apply_filters( 'jetpack_relatedposts_filter_post_heading', esc_attr( 'h4' ) ),
+			);
+			wp_localize_script( 'jetpack_related-posts', 'related_posts_js_options', $related_posts_js_options );
+		}
 		if ( $style ){
 			if( is_rtl() ) {
 				wp_enqueue_style( 'jetpack_related-posts', plugins_url( 'rtl/related-posts-rtl.css', __FILE__ ), array(), self::VERSION );

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -1,5 +1,6 @@
 /* jshint onevar: false */
 
+var $related_posts_js_options;
 /**
  * Load related posts
  */
@@ -108,7 +109,7 @@
 					var anchor_overlay = self.getAnchor( post, 'jp-relatedposts-post-a jp-relatedposts-post-aoverlay' );
 					html += anchor_overlay[0] + anchor_overlay[1];
 				}
-				html += '<h4 class="jp-relatedposts-post-title">' + anchor[0] + post.title + anchor[1] + '</h4>';
+				html += '<' + related_posts_js_options.post_heading + ' class="jp-relatedposts-post-title">' + anchor[0] + post.title + anchor[1] + '</' + related_posts_js_options.post_heading + '>';
 				html += '<p class="jp-relatedposts-post-excerpt">' + $( '<p>' ).text( post.excerpt ).html() + '</p>';
 				html += '<p class="jp-relatedposts-post-date">' + post.date + '</p>';
 				html += '<p class="jp-relatedposts-post-context">' + post.context + '</p>';

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -1,6 +1,6 @@
 /* jshint onevar: false */
+/* globals related_posts_js_options */
 
-var $related_posts_js_options;
 /**
  * Load related posts
  */


### PR DESCRIPTION
Once the filter is added, you can define a custom heading like so:

```php
function jeherve_custom_related_post_heading() {
	return 'h3';
}
add_filter( 'jetpack_relatedposts_filter_post_heading', 'jeherve_custom_related_post_heading' );
```

Suggested here:
https://wordpress.org/support/topic/headings-structure-good-for-accessibility