### PR TITLE
Replace deprecated `get_currentuserinfo()` for WordPress 4.5

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -22,8 +22,7 @@ class Jetpack_Debugger {
 		if ( ! current_user_can( 'manage_options' ) )
 			wp_die( esc_html__('You do not have sufficient permissions to access this page.', 'jetpack' ) );
 
-		global $current_user;
-		get_currentuserinfo();
+		$current_user = wp_get_current_user();
 
 		$user_id = get_current_user_id();
 		$user_tokens = Jetpack_Options::get_option( 'user_tokens' );

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -564,8 +564,7 @@ class Jetpack_Widget_Conditions {
 					break;
 					case 'role':
 						if( is_user_logged_in() ) {
-							global $current_user;
-							get_currentuserinfo();
+							$current_user = wp_get_current_user();
 
 							$user_roles = $current_user->roles;
 


### PR DESCRIPTION
`get_currentuserinfo()` should be replaced by `wp_get_current_user()` to
prevent deprecated notices.

Fixes #3284 