### PR TITLE
Widget Visibility: fix issue with undefined index in rule

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -252,6 +252,7 @@ class Jetpack_Widget_Conditions {
 					<?php
 
 					foreach ( $conditions['rules'] as $rule ) {
+						$rule = wp_parse_args( $rule, array( 'major' => '', 'minor' => '', 'has_children' => '' ) );
 						?>
 						<div class="condition">
 							<div class="selection alignleft">


### PR DESCRIPTION
This fixes issue #3070.

- Some users get an error that `has_children` is an undefined index in a rule.  This seems to happen when a site is using newer Jetpack source, but the database has yet been updated to include the `has_children` index.

This is related to Pull Request #3210.  This original Pull Request contained several fixes that are being broken out into several smaller requests.
