### PR TITLE
Sharing: make sure we don't output sharing buttons on excerpts.

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -589,7 +589,10 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 
 	// Don't output flair on excerpts
-	if ( in_array( 'get_the_excerpt', (array) $wp_current_filter ) ) {
+	if (
+		in_array( 'get_the_excerpt', (array) $wp_current_filter )
+		|| in_array( 'the_excerpt', (array) $wp_current_filter )
+	) {
 		return $text;
 	}
 


### PR DESCRIPTION
This PR works by excluding the `the_excerpt` filter. This seems to work well for the list pages because `the_content` filter is used there instead. I may have overlooked some cases where it will break things, so I would appreciate a second and a third look.

Aims to fix #3290, cc @jeherve @dereksmart 