### PR TITLE
Slideshow: add filter to customize speed of the Slideshow

### DIFF
--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -96,6 +96,7 @@ JetpackSlideshow.prototype.finishInit_ = function() {
 			fx: this.transition,
 			prev: this.controls.prev,
 			next: this.controls.next,
+			speed: jetpackSlideshowSettings.speed,
 			slideExpr: '.slideshow-slide',
 			onPrevNextEvent: function() {
 				return self.onCyclePrevNextClick_.apply( self, arguments );

--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -96,7 +96,7 @@ JetpackSlideshow.prototype.finishInit_ = function() {
 			fx: this.transition,
 			prev: this.controls.prev,
 			next: this.controls.next,
-			speed: jetpackSlideshowSettings.speed,
+			timeout: jetpackSlideshowSettings.speed,
 			slideExpr: '.slideshow-slide',
 			onPrevNextEvent: function() {
 				return self.onCyclePrevNextClick_.apply( self, arguments );

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -286,15 +286,16 @@ class Jetpack_Slideshow_Shortcode {
 			 * @module shortcodes
 			 *
 			 * @since 2.1.0
+			 * @since 4.0.0 Added the `speed` option to the array of options.
 			 *
 			 * @param array $args
 			 * - string - spinner - URL of the spinner image.
+			 * - string - speed   - Speed of the slideshow. Defaults to 1000.
 			 */
-			apply_filters(
-				'jetpack_js_slideshow_settings', array(
-					'spinner' => plugins_url( '/img/slideshow-loader.gif', __FILE__ ),
-				)
-			)
+			apply_filters( 'jetpack_js_slideshow_settings', array(
+				'spinner' => plugins_url( '/img/slideshow-loader.gif', __FILE__ ),
+				'speed'   => '1000',
+			) )
 		);
 	}
 

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -290,11 +290,11 @@ class Jetpack_Slideshow_Shortcode {
 			 *
 			 * @param array $args
 			 * - string - spinner - URL of the spinner image.
-			 * - string - speed   - Speed of the slideshow. Defaults to 1000.
+			 * - string - speed   - Speed of the slideshow. Defaults to 4000.
 			 */
 			apply_filters( 'jetpack_js_slideshow_settings', array(
 				'spinner' => plugins_url( '/img/slideshow-loader.gif', __FILE__ ),
-				'speed'   => '1000',
+				'speed'   => '4000',
 			) )
 		);
 	}

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -286,7 +286,7 @@ class Jetpack_Slideshow_Shortcode {
 			 * @module shortcodes
 			 *
 			 * @since 2.1.0
-			 * @since 4.0.0 Added the `speed` option to the array of options.
+			 * @since 4.7.0 Added the `speed` option to the array of options.
 			 *
 			 * @param array $args
 			 * - string - spinner - URL of the spinner image.

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -270,7 +270,7 @@ class Jetpack_Slideshow_Shortcode {
 	function enqueue_scripts() {
 
 		wp_enqueue_script( 'jquery-cycle', plugins_url( '/js/jquery.cycle.min.js', __FILE__ ), array( 'jquery' ), '20161231', true );
-		wp_enqueue_script( 'jetpack-slideshow', plugins_url( '/js/slideshow-shortcode.js', __FILE__ ), array( 'jquery-cycle' ), '20121214.1', true );
+		wp_enqueue_script( 'jetpack-slideshow', plugins_url( '/js/slideshow-shortcode.js', __FILE__ ), array( 'jquery-cycle' ), '20160119.1', true );
 		if ( is_rtl() ) {
 			wp_enqueue_style( 'jetpack-slideshow', plugins_url( '/css/rtl/slideshow-shortcode-rtl.css', __FILE__ ) );
 		} else {


### PR DESCRIPTION
This filter change should allow site owners to change the speed of all slideshows on their site, like so:

``` php
function jeherve_fast_slideshow( $args ) {
    $new_speed = array(
        'speed' => '10'
    );
    return array_replace( $args, $new_speed );
}
add_filter( 'jetpack_js_slideshow_settings', 'jeherve_fast_slideshow' );
```

Suggested in https://wordpress.org/support/topic/gallery-slideshow-settings-editable-somehow
