### PR TITLE
If image selected in Media isn't an image, don't assign it, fixes #3282

### DIFF
--- a/modules/theme-tools/site-logo/js/site-logo-control.js
+++ b/modules/theme-tools/site-logo/js/site-logo-control.js
@@ -87,10 +87,11 @@
 		 */
 		pick: function() {
 			// get the attachment from the modal frame
-			var attachment = this.frame.state().get( 'selection' ).first().toJSON();
-			attachment = this.reduceMembers( attachment );
-			// set the setting - the callback will take care of rendering
-			this.setting( attachment );
+			var attachment = this.frame.state().get( 'selection' ).single();
+			if ( 'image' === attachment.get( 'type' ) ) {
+				// set the setting - the callback will take care of rendering
+				this.setting( this.reduceMembers( attachment.toJSON() ) );
+			}
 		},
 		/**
 		 * Reduces the attachment object to just the few desired members.


### PR DESCRIPTION
I was surprised to find that you can also upload anything when selecting a Featured Image in a post. That said, you can't assign it as one, so I replicated that behavior for Site Logo.
Anything other than an image won't be assigned as Site Logo and related customizer setting won't be modified.