### PR TITLE
Display Posts Widget: Don't show empty URL error for new instances of the widget

### DIFF
--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -926,7 +926,12 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 				<?php _e( "Enter a WordPress.com or Jetpack WordPress site URL.", 'jetpack' ); ?>
 			</i>
 			<?php
-			if ( empty( $url ) ) {
+			/**
+			 * Show an error if the URL field was left empty.
+			 *
+			 * The error is shown only when the widget was already saved.
+			 */
+			if ( empty( $url ) && ! preg_match( '/__i__|%i%/', $this->id ) ) {
 				?>
 				<br />
 				<i class="error-message"><?php echo __( 'You must specify a valid blog URL!', 'jetpack' ); ?></i>


### PR DESCRIPTION
Empty URL error was shown for new instances, which were not yet saved. This means that the error was visible from the moment the widget was dragged from the Available Widgets area to the Widget Area.

Now the error checks if the widget has been already saved, before showing the error.