### PR TITLE
Random Post: if a static page is set as home, show a random post, fixes #6949

### DIFF
--- a/modules/theme-tools/random-redirect.php
+++ b/modules/theme-tools/random-redirect.php
@@ -17,21 +17,21 @@ function jetpack_matt_random_redirect() {
 	}
 
 	// Set default post type.
-		$post_type = get_post_type();
+	$post_type = get_post_type();
 
 	// Set default category type
-		if ( is_category() ) {
-			$category = get_the_category();
-			if ( isset( $category ) && ! empty( $category ) ) {
-				$random_cat_id = $category[0]->term_id;
-			}
+	if ( is_category() ) {
+		$category = get_the_category();
+		if ( isset( $category ) && ! empty( $category ) ) {
+			$random_cat_id = $category[0]->term_id;
 		}
+	}
 
 	// Set author name if we're on an author archive.
-		if ( is_author() ) {
-			$random_author_name = get_the_author_meta( 'user_login' );
-			$random_author_query = 'AND user_login = "' . $random_author_name . '"';
-		}
+	if ( is_author() ) {
+		$random_author_name = get_the_author_meta( 'user_login' );
+		$random_author_query = 'AND user_login = "' . $random_author_name . '"';
+	}
 
 	// Acceptable URL formats: /[...]/?random=[post type], /?random, /&random, /&random=1
 	if ( ! isset( $_GET['random'] ) && ! in_array( strtolower( $_SERVER['REQUEST_URI'] ), array( '/&random', '/&random=1' ) ) )
@@ -52,6 +52,11 @@ function jetpack_matt_random_redirect() {
 	// Change the post type if the parameter is set.
 	if ( isset( $_GET['random_post_type'] ) && post_type_exists( $_GET['random_post_type'] ) )
 		$post_type = $_GET['random_post_type'];
+
+	// Don't show a random page if 'page' isn't specified as the post type specifically.
+	if ( 'page' === $post_type && is_front_page() && ! isset( $_GET['random_post_type'] ) ) {
+		$post_type = 'post';
+	}
 
 	global $wpdb;
 


### PR DESCRIPTION
If a static page is set as home, show a random post instead of a random page when accessing `?random` from the home page.

Merges r128609-wpcom.

cc @lancewillett 