### PR TITLE
REST API: Comments: Use comment object when retrieving author avatar

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1009,6 +1009,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$first_name  = '';
 			$last_name   = '';
 			$URL         = $author->comment_author_url;
+			$avatar_URL  = $this->api->get_avatar_url( $author );
 			$profile_URL = 'http://en.gravatar.com/' . md5( strtolower( trim( $email ) ) );
 			$nice        = '';
 			$site_id     = -1;
@@ -1077,9 +1078,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$profile_URL = 'http://en.gravatar.com/' . md5( strtolower( trim( $email ) ) );
 				$site_id     = -1;
 			}
-		}
 
-		$avatar_URL = $this->api->get_avatar_url( $email );
+			$avatar_URL = $this->api->get_avatar_url( $email );
+		}
 
 		$email = $show_email ? (string) $email : false;
 


### PR DESCRIPTION
This pull request seeks to resolve an issue where the REST API comments endpoints would not return the correct avatar URL for comments made using the Jetpack Comments module. Specifically, the [filter function for returning an external avatar](https://github.com/Automattic/jetpack/blob/b0f83af69da7b8fe6c79983c1e8928e104acc76f/modules/comments/comments.php#L139-L169) assumed to have received a comment object, whereas the REST API would only ever attempt to retrieve the URL by the comment author's email address. The changes here resolve this by passing the comment object `$author` if it's determined to be a comment.

See: r130019-wpcom, p58i-3rA-p2