### PR TITLE
Sitemaps: Don't activatate when MSM Sitemaps is active.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -176,6 +176,7 @@ class Jetpack {
 			'Simple Wp Sitemap'                    => 'simple-wp-sitemap/simple-wp-sitemap.php',
 			'Simple Sitemap'                       => 'simple-sitemap/simple-sitemap.php',
 			'XML Sitemaps'                         => 'xml-sitemaps/xml-sitemaps.php',
+			'MSM Sitemaps'                         => 'msm-sitemap/msm-sitemap.php',
 		),
 	);
 


### PR DESCRIPTION
Without regard to #3314, we should not activate Sitemaps when MSM Sitemaps are active.