### PR TITLE
CF module intro text: added link to Plugin search for 'akismet'

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -430,7 +430,10 @@ function jetpack_contact_form_more_info() {
 	echo '</p>';
 
 	echo '<p>';
-	_e( 'Each contact form can easily be customized to fit your needs. When a user submits your contact form, the feedback will be filtered through <a href="http://akismet.com/">Akismet</a> (if it is active on your site) to make sure it’s not spam. Any legitimate feedback will then be emailed to you, and added to your feedback management area.', 'jetpack' );
+	printf(
+		__( 'Each contact form can easily be customized to fit your needs. When a user submits your contact form, the feedback will be filtered through <a href="http://akismet.com/">Akismet</a> (if it is <a href="%s">active on your site</a>) to make sure it’s not spam. Any legitimate feedback will then be emailed to you, and added to your feedback management area.', 'jetpack' ),
+		admin_url( 'plugin-install.php?tab=search&s=akismet' )
+	);
 	echo '</p>';
 }
 add_action( 'jetpack_module_more_info_contact-form', 'jetpack_contact_form_more_info' );


### PR DESCRIPTION
Currently under _Jetpack → Settings_, the Contact Form module's intro text links to Akismet.com.

![screen shot 2016-01-21 at 12 15 49 pm](https://cloud.githubusercontent.com/assets/10125810/12473506/be2c9310-c038-11e5-9ec5-2cf52a1619cc.png)

However, since many users will have versions of WordPress that ship with Akismet, and most others will be able to install it from within WordPress itself, should we also consider modifying the following text and linking it to a plugin directory search for "akismet"? 
> (if it is **active on your site**) 

This way, if someone's WordPress install doesn't have Akismet, they can install the plugin very quickly, and if they do have it already, it will appear as 'Installed'. I think this provides a more direct path to Akismet for most users.

Thank you @jeherve for the suggestion to link to a search instead of just _Plugins →  Installed Plugins_.