### PR TITLE
Module info: hide Edit CSS link unless Custom CSS module is active

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -493,8 +493,16 @@ function jetpack_custom_css_more_info() { ?>
 	</div>
 
 	<p><?php esc_html_e( "The Custom CSS editor gives you the ability to add to or replace your theme's CSS, all while supplying syntax coloring, auto-indentation, and immediate feedback on the validity of the CSS you're writing.", 'jetpack' ); ?></p>
-	<p><?php printf( __( 'To use the CSS editor, go to Appearance &#8594; <a href="%s">Edit CSS</a>.', 'jetpack' ), admin_url( 'themes.php?page=editcss' ) ); ?></p>
-<?php
+
+	<?php if ( Jetpack::is_module_active( 'custom-css' ) ) : ?>
+
+		<p><?php printf( __( 'To use the CSS editor, go to Appearance &#8594; <a href="%s">Edit CSS</a>.', 'jetpack' ), admin_url( 'themes.php?page=editcss' ) ); ?></p>
+
+	<?php else : ?>
+
+		<p><?php esc_html_e( 'After activating this module, find the editor in Appearance &#8594; Edit CSS.', 'jetpack' ); ?></p>
+
+	<?php endif;
 }
 add_action( 'jetpack_module_more_info_custom-css', 'jetpack_custom_css_more_info' );
 


### PR DESCRIPTION
Currently under _Jetpack → Settings_, the Custom CSS module's intro text displays a link to the _Appearance → Edit CSS_ admin page. 

![screen shot 2016-01-21 at 3 11 55 pm](https://cloud.githubusercontent.com/assets/10125810/12476755/544196f8-c051-11e5-8652-2d4fff1a4927.png)

As seen above, this link is displayed even when the module is not yet enabled. If the user clicks on _Edit CSS_ when the module is not yet activated, they see:

> You do not have sufficient permissions to access this page.

We can fix this issue by only showing the _Edit CSS_ link if the Custom CSS module is enabled.
