### PR TITLE
Module info: hide link to CPT settings unless CPT module is enabled

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -818,11 +818,11 @@ function jetpack_custom_content_types_more_info() { ?>
 		<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/custom-content-types.jpg' ) ?>" alt="<?php esc_attr_e( 'Custom Content Type', 'jetpack' ) ?>" width="300" height="150" />
 	</div>
 
-	<p><?php esc_html_e( 'Organize and display different types of content on your site, such as Portfolio items and Testimonials. These content types are separate from Posts and Pages.', 'jetpack' ); ?></p>
+	<p><?php esc_html_e( 'Organize and display different types of content on your site, such as Portfolio Projects and Testimonials. These content types are separate from Posts and Pages.', 'jetpack' ); ?></p>
 
-	<?php if ( Jetpack::is_module_active( 'custom-content-types' ) ) { ?>
+	<?php if ( Jetpack::is_module_active( 'custom-content-types' ) ) : ?>
 
-		<p><?php printf( __( 'To enable a custom content type, head over to <a href="%s">Settings &rarr; Writing &rarr; Your Custom Content Types</a> to activate either "Portfolio Projects” or “Testimonials” by checking the corresponding checkbox. You can now add projects and testimonials under the new "Portfolio” or “Testimonials” menu item in your sidebar.', 'jetpack' ), admin_url( 'options-writing.php#cpt-options' ) ); ?></p>
+		<p><?php printf( __( 'To enable a custom content type, head over to <a href="%s">Settings &rarr; Writing &rarr; Your Custom Content Types</a> and activate either "Portfolio Projects” or “Testimonials” by checking the corresponding checkbox. You can now add projects and testimonials under the new "Portfolio” and “Testimonials” menu items in your sidebar.', 'jetpack' ), admin_url( 'options-writing.php#cpt-options' ) ); ?></p>
 
 		<p><?php
 			/* translators: all variables are URLs */
@@ -837,8 +837,11 @@ function jetpack_custom_content_types_more_info() { ?>
 			);
 		?></p>
 
-	<?php } ?>
-<?php
+	<?php else : ?>
+
+			<p><?php printf( __( 'Once activated, you can head to Settings &#8594; Writing &#8594; Your Custom Content Types to activate the Portfolio Project and Testimonial content types. Full details can be found on the <a href="%s">Custom Content Types support page</a>.', 'jetpack' ), 'https://jetpack.me/support/custom-content-types/' ); ?></p>
+
+	<?php endif;
 }
 add_action( 'jetpack_module_more_info_custom-content-types', 'jetpack_custom_content_types_more_info' );
 

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -839,7 +839,9 @@ function jetpack_custom_content_types_more_info() { ?>
 
 	<?php else : ?>
 
-			<p><?php printf( __( 'Once activated, you can head to Settings &#8594; Writing &#8594; Your Custom Content Types to activate the Portfolio Project and Testimonial content types. Full details can be found on the <a href="%s">Custom Content Types support page</a>.', 'jetpack' ), 'https://jetpack.me/support/custom-content-types/' ); ?></p>
+			<p><?php esc_html_e( 'Once activated, you can selectively activate the content types you need at Settings &rarr; Writing &rarr; Your Custom Content Types.'); ?></p>
+
+            <p><?php echo wp_kses( sprintf( __( 'Full details can be found on the <a href="%s" title="Custom Content Types support page" target="_blank">Custom Content Types support page</a>.', 'jetpack' ), 'https://jetpack.me/support/custom-content-types/' ), array( 'a' => array( 'href' => true, 'title' => true, 'target' => true ) ) ); ?></p>
 
 	<?php endif;
 }

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -818,20 +818,26 @@ function jetpack_custom_content_types_more_info() { ?>
 		<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/custom-content-types.jpg' ) ?>" alt="<?php esc_attr_e( 'Custom Content Type', 'jetpack' ) ?>" width="300" height="150" />
 	</div>
 
-	<p><?php esc_html_e( 'Organize and display different types of content on your site, separate from posts and pages.', 'jetpack' ); ?></p>
-	<p><?php printf( __( 'To enable a custom content type, head over to <a href="%s">Settings &rarr; Writing &rarr; Your Custom Content Types</a> to activate either "Portfolio Projects” or “Testimonials” by checking the corresponding checkbox. You can now add projects and testimonials under the new "Portfolio” or “Testimonials” menu item in your sidebar.', 'jetpack' ), admin_url( 'options-writing.php#cpt-options' ) ); ?></p>
-	<p><?php
-		/* translators: all variables are URLs */
-		printf(
-			__(
-				'Once added, your custom content will be visible on your website at <a href="%1$s">%1$s</a> or <a href="%2$s">%2$s</a>, or you may add them with <a href="%3$s" target="_blank">shortcodes</a>.',
-				'jetpack'
-			),
-			get_site_url() . '/portfolio/',
-			get_site_url() . '/testimonial/',
-			'http://jetpack.me/support/custom-content-types/'
-		);
-	?></p>
+	<p><?php esc_html_e( 'Organize and display different types of content on your site, such as Portfolio items and Testimonials. These content types are separate from Posts and Pages.', 'jetpack' ); ?></p>
+
+	<?php if ( Jetpack::is_module_active( 'custom-content-types' ) ) { ?>
+
+		<p><?php printf( __( 'To enable a custom content type, head over to <a href="%s">Settings &rarr; Writing &rarr; Your Custom Content Types</a> to activate either "Portfolio Projects” or “Testimonials” by checking the corresponding checkbox. You can now add projects and testimonials under the new "Portfolio” or “Testimonials” menu item in your sidebar.', 'jetpack' ), admin_url( 'options-writing.php#cpt-options' ) ); ?></p>
+
+		<p><?php
+			/* translators: all variables are URLs */
+			printf(
+				__(
+					'Once added, your custom content will be visible on your website at <a href="%1$s">%1$s</a> or <a href="%2$s">%2$s</a>, or you may add them with <a href="%3$s" target="_blank">shortcodes</a>.',
+					'jetpack'
+				),
+				get_site_url() . '/portfolio/',
+				get_site_url() . '/testimonial/',
+				'http://jetpack.me/support/custom-content-types/'
+			);
+		?></p>
+
+	<?php } ?>
 <?php
 }
 add_action( 'jetpack_module_more_info_custom-content-types', 'jetpack_custom_content_types_more_info' );

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -824,7 +824,7 @@ function jetpack_custom_content_types_more_info() { ?>
 		/* translators: all variables are URLs */
 		printf(
 			__(
-				'Once added, your custom content will be visible on your website at %1$s or %2$s, or you may add them with <a href="%3$s" target="_blank">shortcodes</a>.',
+				'Once added, your custom content will be visible on your website at <a href="%1$s">%1$s</a> or <a href="%2$s">%2$s</a>, or you may add them with <a href="%3$s" target="_blank">shortcodes</a>.',
 				'jetpack'
 			),
 			get_site_url() . '/portfolio/',


### PR DESCRIPTION
Currently under _Jetpack → Settings_, the Custom Content Types module's intro text displays a link to _Settings → Writing → Your Custom Content Types_. However, the _Your Custom Content Types_ section of that admin page doesn't exist until the CPT module has been enabled, and this can lead to confusion on the part of the user if they do click through to _Settings → Writing_ without first enabling the module.

![screen shot 2016-01-21 at 3 57 55 pm](https://cloud.githubusercontent.com/assets/10125810/12477826/c4e1c242-c057-11e5-855b-2b77995dd9bd.png)

Like in #3319, we can fix this issue by only displaying the link, and accompanying _howto_ text if the module is in fact enabled. Else, by default we just display a shorter, more general intro to Custom Content Types and what they are.

This PR also converts the `/portfolio/` and `/testimonial/` URLs we display in the last paragraph of the intro into hyperlinks, so users can click on them.