### PR TITLE
Unit Tests: Allow PHP nightly (7.1) failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
    - php: "5.6"
      env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:js
   allow_failures:
-   # - php: "nightly"
+    - php: "nightly"
 
 # Clones WordPress and configures our testing environment.
 before_script:


### PR DESCRIPTION
We can set Travis to test PHP nightly (currently 7.1) without throwing all of the alarms and making Travis' result more actionable.