### PR TITLE
Add breadcrumb support for any hierarchical post type or taxonomy

### DIFF
--- a/modules/theme-tools/site-breadcrumbs.php
+++ b/modules/theme-tools/site-breadcrumbs.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Site Breadcrumbs
  * Plugin URI: http://wordpress.com
- * Description: Quickly add breadcrumbs to the single view of a hierarchical post type
+ * Description: Quickly add breadcrumbs to the single view of a hierarchical post type or a hierarchical taxonomy.
  * Author: Automattic
  * Version: 1.0
  * Author URI: http://wordpress.com
@@ -10,28 +10,71 @@
  */
 
 function jetpack_breadcrumbs() {
-	if ( ! is_page() || is_front_page() ) {
+	$taxonomy = is_category() ? 'category' : get_query_var( 'taxonomy' );
+	$is_taxonomy_hierarchical = is_taxonomy_hierarchical( $taxonomy );
+
+	$post_type = is_page() ? 'page' : get_query_var( 'post_type' );
+	$is_post_type_hierarchical = is_post_type_hierarchical( $post_type );
+
+	if ( ! ( $is_post_type_hierarchical || $is_taxonomy_hierarchical ) || is_front_page() ) {
 		return;
 	}
 
-	global $post;
-
-	$ancestors = array_reverse( get_post_ancestors( $post->ID ) );
-
-	$before = '<nav class="entry-breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">';
-	$after = '</nav>';
-
-	$home = '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="' . esc_url( home_url( "/" ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . __( 'Home', 'jetpack' ) . '</span></a></span>';
-
 	$breadcrumb = '';
 
-	if ( $ancestors ) {
-		foreach ( $ancestors as $ancestor ) {
-			$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
+	if ( $is_post_type_hierarchical ) {
+		$post_id = get_queried_object_id();
+		$ancestors = array_reverse( get_post_ancestors( $post_id ) );
+		if ( $ancestors ) {
+			foreach ( $ancestors as $ancestor ) {
+				$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
+			}
 		}
+		$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
+	} elseif ( $is_taxonomy_hierarchical ) {
+		$current = get_term( get_queried_object_id(), $taxonomy );
+
+		if ( is_wp_error( $current ) ) {
+			return;
+		}
+
+		if ( $current->parent ) {
+			$breadcrumb = jetpack_get_term_parents( $current->parent, $taxonomy );
+		}
+
+		$breadcrumb .= '<span class="current-category">' . esc_html( $current->name ) . '</span>';
 	}
 
-	$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">' . esc_html( get_the_title( $post->ID ) ) . '</span></span>';
+	$home = '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack' ) . '</span></a></span>';
 
-	echo $before . $home . $breadcrumb . $after;
+	echo '<nav class="entry-breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">' . $home . $breadcrumb . '</nav>';
 }
+
+/**
+ * Return the parents for a given taxonomy term ID.
+ *
+ * @param int $term Taxonomy term whose parents will be returned.
+ * @param string $taxonomy Taxonomy name that the term belongs to.
+ * @param array $visited Terms already added to prevent duplicates.
+ *
+ * @return string A list of links to the term parents.
+ */
+function jetpack_get_term_parents( $term, $taxonomy, $visited = array() ) {
+	$parent = get_term( $term, $taxonomy );
+
+	if ( is_wp_error( $parent ) ) {
+		return $parent;
+	}
+
+	$chain = '';
+
+	if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
+		$visited[] = $parent->parent;
+		$chain .= jetpack_get_term_parents( $parent->parent, $taxonomy, $visited );
+	}
+
+	$chain .= '<a href="' . esc_url( get_category_link( $parent->term_id ) ) . '">' . $parent->name . '</a>';
+
+	return $chain;
+}
+>>>>>>> Add breadcrumb support for any hierarchical post type or any hierarchical taxonomy.

--- a/modules/theme-tools/site-breadcrumbs.php
+++ b/modules/theme-tools/site-breadcrumbs.php
@@ -77,4 +77,3 @@ function jetpack_get_term_parents( $term, $taxonomy, $visited = array() ) {
 
 	return $chain;
 }
->>>>>>> Add breadcrumb support for any hierarchical post type or any hierarchical taxonomy.

--- a/modules/theme-tools/site-breadcrumbs.php
+++ b/modules/theme-tools/site-breadcrumbs.php
@@ -42,7 +42,7 @@ function jetpack_breadcrumbs() {
 			$breadcrumb = jetpack_get_term_parents( $current->parent, $taxonomy );
 		}
 
-		$breadcrumb .= '<span class="current-category">' . esc_html( $current->name ) . '</span>';
+		$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
 	}
 
 	$home = '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack' ) . '</span></a></span>';


### PR DESCRIPTION
Previously breadcrumbs were only available for pages. This PR adds makes them available to any hierarchical post type.
It also introduces support for category views or any hierarchical taxonomy.