### PR TITLE
Contact Form: Properly handle `tel` field. 

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1610,13 +1610,13 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		);
 
 		foreach ( $this->fields as $id => $field ) {
-			$field_ids['all'][] = $id;
+			$field_ids[ 'all' ][] = $id;
 
 			$type = $field->get_attribute( 'type' );
-			if ( isset( $field_ids[$type] ) ) {
+			if ( isset( $field_ids[ $type ] ) ) {
 				// This type of field is already present in our whitelist of "standard" fields for this form
 				// Put it in extra
-				$field_ids['extra'][] = $id;
+				$field_ids[ 'extra' ][] = $id;
 				continue;
 			}
 
@@ -1629,11 +1629,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				case 'url' :
 				case 'subject' :
 				case 'textarea' :
-					$field_ids[$type] = $id;
+					$field_ids[ $type ] = $id;
 					break;
 			default :
 				// Put everything else in extra
-				$field_ids['extra'][] = $id;
+				$field_ids[ 'extra' ][] = $id;
 			}
 		}
 


### PR DESCRIPTION
This PR fixes a long standing problem with the `telephone` field, which was suggested as an addition in #269 .

There was a missing break statement when rendering the field, which made it appear as both an `input` field and a `textarea`. Additionally the field was marked as a whitelisted field, which made it not appear in both the admin Feedback view and the CSV Export. 

This PR just makes the field work properly. It doesn't add it to the dropdown to be selected by users.

Additionally I added a comment that describes what are the best ways to add new fields types for future reference to developers, so they can skip all the digging through the code to see why something works or doesn't work. 