### PR TITLE
Load modules safely avoiding PHP errors, fixes #3331

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1713,7 +1713,7 @@ class Jetpack {
 
 			if ( ! @include( Jetpack::get_module_path( $module ) ) ) {
 				unset( $modules[ $index ] );
-				Jetpack_Options::update_option( 'active_modules', $modules );
+				Jetpack_Options::update_option( 'active_modules', array_values( $modules ) );
 				continue;
 			}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1711,16 +1711,8 @@ class Jetpack {
 				continue;
 			}
 
-			// Follow wp-admin/includes/plugin.php::activate_plugin approach
-			$module_fail = false;
-			ob_start();
-			include_once Jetpack::get_module_path( $module );
-			if ( ob_get_length() > 0 ) {
-				$module_fail = true;
-			}
-			ob_end_clean();
-			if ( $module_fail ) {
-				unset( $modules[$index] );
+			if ( ! @include( Jetpack::get_module_path( $module ) ) ) {
+				unset( $modules[ $index ] );
 				Jetpack_Options::update_option( 'active_modules', $modules );
 				continue;
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -398,6 +398,14 @@ class Jetpack {
 		if ( Jetpack::is_active() ) {
 			list( $version ) = explode( ':', Jetpack_Options::get_option( 'version' ) );
 			if ( JETPACK__VERSION != $version ) {
+
+				// Check which active modules actually exist and remove others from active_modules list
+				$unfiltered_modules = Jetpack::get_active_modules();
+				$modules = array_filter( $unfiltered_modules, array( 'Jetpack', 'is_module' ) );
+				if ( array_diff( $unfiltered_modules, $modules ) ) {
+					Jetpack_Options::update_option( 'active_modules', $modules );
+				}
+
 				add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
 				/**
 				 * Fires when synchronizing all registered options and constants.


### PR DESCRIPTION
If a module doesn't exist, the hook `jetpack_module_loaded_$module` won't be fired.
The missing module will be removed from the list of `active_modules`.
fixes #3331