### PR TITLE
Publicize: allow authors to access their Publicize settings.

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -22,8 +22,8 @@ class Publicize_UI {
 	}
 
 	function init() {
-		// Show only to users with the capability required to create/delete global connections.
-		if ( ! current_user_can( $this->publicize->GLOBAL_CAP ) ) {
+		// Show only to users with the capability required to manage their Publicize connections.
+		if ( ! current_user_can( 'publish_posts' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #3126 again.

`GLOBAL_CAP` works a bit too well. It's currently set to `edit_others_posts`, and authors can't do that, although they should still be able to manage their Publicize settings.

Related: #3204 for the previous fix.