### PR TITLE
Exclude the FI locale during po/mo generation

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -818,21 +818,32 @@ function jetpack_custom_content_types_more_info() { ?>
 		<img class="jp-info-img" src="<?php echo plugins_url( basename( dirname( dirname( __FILE__ ) ) ) . '/images/screenshots/custom-content-types.jpg' ) ?>" alt="<?php esc_attr_e( 'Custom Content Type', 'jetpack' ) ?>" width="300" height="150" />
 	</div>
 
-	<p><?php esc_html_e( 'Organize and display different types of content on your site, separate from posts and pages.', 'jetpack' ); ?></p>
-	<p><?php printf( __( 'To enable a custom content type, head over to <a href="%s">Settings &rarr; Writing &rarr; Your Custom Content Types</a> to activate either "Portfolio Projects” or “Testimonials” by checking the corresponding checkbox. You can now add projects and testimonials under the new "Portfolio” or “Testimonials” menu item in your sidebar.', 'jetpack' ), admin_url( 'options-writing.php#cpt-options' ) ); ?></p>
-	<p><?php
-		/* translators: all variables are URLs */
-		printf(
-			__(
-				'Once added, your custom content will be visible on your website at %1$s or %2$s, or you may add them with <a href="%3$s" target="_blank">shortcodes</a>.',
-				'jetpack'
-			),
-			get_site_url() . '/portfolio/',
-			get_site_url() . '/testimonial/',
-			'http://jetpack.me/support/custom-content-types/'
-		);
-	?></p>
-<?php
+	<p><?php esc_html_e( 'Organize and display different types of content on your site, such as Portfolio Projects and Testimonials. These content types are separate from Posts and Pages.', 'jetpack' ); ?></p>
+
+	<?php if ( Jetpack::is_module_active( 'custom-content-types' ) ) : ?>
+
+		<p><?php printf( __( 'To enable a custom content type, head over to <a href="%s">Settings &rarr; Writing &rarr; Your Custom Content Types</a> and activate either "Portfolio Projects” or “Testimonials” by checking the corresponding checkbox. You can now add projects and testimonials under the new "Portfolio” and “Testimonials” menu items in your sidebar.', 'jetpack' ), admin_url( 'options-writing.php#cpt-options' ) ); ?></p>
+
+		<p><?php
+			/* translators: all variables are URLs */
+			printf(
+				__(
+					'Once added, your custom content will be visible on your website at <a href="%1$s">%1$s</a> or <a href="%2$s">%2$s</a>, or you may add them with <a href="%3$s" target="_blank">shortcodes</a>.',
+					'jetpack'
+				),
+				get_site_url() . '/portfolio/',
+				get_site_url() . '/testimonial/',
+				'http://jetpack.me/support/custom-content-types/'
+			);
+		?></p>
+
+	<?php else : ?>
+
+			<p><?php esc_html_e( 'Once activated, you can selectively activate the content types you need at Settings &rarr; Writing &rarr; Your Custom Content Types.'); ?></p>
+
+            <p><?php echo wp_kses( sprintf( __( 'Full details can be found on the <a href="%s" title="Custom Content Types support page" target="_blank">Custom Content Types support page</a>.', 'jetpack' ), 'https://jetpack.me/support/custom-content-types/' ), array( 'a' => array( 'href' => true, 'title' => true, 'target' => true ) ) ); ?></p>
+
+	<?php endif;
 }
 add_action( 'jetpack_module_more_info_custom-content-types', 'jetpack_custom_content_types_more_info' );
 

--- a/tools/export-translations.php
+++ b/tools/export-translations.php
@@ -9,7 +9,7 @@
 require dirname( dirname( __FILE__ ) ) . '/locales.php';
 
 $language_packs = array(
-	'ar', 'de', 'en-au', 'en-ca', 'eo', 'es', 'fr', 'he', 'id', 'it', 'ja', 'ko', 'nl', 'pt-br', 'ro', 'ru', 'sq', 'sv', 'tr', 'zh-cn', 'zh-tw'
+	'ar', 'de', 'en-au', 'en-ca', 'eo', 'es', 'fi', 'fr', 'he', 'id', 'it', 'ja', 'ko', 'nl', 'pt-br', 'ro', 'ru', 'sq', 'sv', 'tr', 'zh-cn', 'zh-tw'
 );
 
 /**


### PR DESCRIPTION
FI has reached 100% on https://translate.wordpress.org/projects/wp-plugins/jetpack and can now be switched over to language packs.