### PR TITLE
Comments: Remove comment author URL shortcutting

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -152,10 +152,11 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			return $avatar;
 		}
 
-		// It's a FB or Twitter avatar
+		// Detect whether it's a Facebook or Twitter avatar
 		$foreign_avatar = get_comment_meta( $comment->comment_ID, 'hc_avatar', true );
-		if ( empty( $foreign_avatar ) ) {
-			// Can't find the avatar details - bail
+		$foreign_avatar_hostname = parse_url( $foreign_avatar, PHP_URL_HOST );
+		if ( ! $foreign_avatar_hostname ||
+				! preg_match( '/\.?(graph\.facebook\.com|twimg\.com)$/', $foreign_avatar_hostname ) ) {
 			return $avatar;
 		}
 

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -152,11 +152,6 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			return $avatar;
 		}
 
-		if ( false === strpos( $comment->comment_author_url, '/www.facebook.com/' ) && false === strpos( $comment->comment_author_url, '/twitter.com/' ) ) {
-			// It's neither FB nor Twitter - bail
-			return $avatar;
-		}
-
 		// It's a FB or Twitter avatar
 		$foreign_avatar = get_comment_meta( $comment->comment_ID, 'hc_avatar', true );
 		if ( empty( $foreign_avatar ) ) {


### PR DESCRIPTION
This pull request seeks to remove a condition which is used to shortcut the return of the Jetpack Comments author avatar if the comment author URL does not contain either a Facebook or Twitter domain. It's assumed that this condition was added to prevent an unnecessary meta lookup, since the comment object is already known, but the meta may not have been retrieved. However, we'd like to consider ignoring author URLs for Facebook URLs containing an app-scoped user ID, since these are not useful in the sense of being the comment author's canonical website. If we were to remove tracking of the `comment_author_URL` without removing this check, the commenter avatar would also not be shown. With these changes, the comment author avatar should still display while the `comment_author_url` field is empty.

__Testing instructions:__

Verify that Jetpack Comments author avatars display as expected, for comments originating from a guest, a logged in user, or from a connected social media account.