### PR TITLE
Widget Visibility: Ensure that the current page ID matches the stored page ID

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -513,7 +513,8 @@ class Jetpack_Widget_Conditions {
 									$condition_result = $wp_query->is_posts_page;
 								} else {
 									// $rule['minor'] is a page ID
-									$condition_result = is_page( $rule['minor'] );
+									$condition_result = is_page() && ( $rule['minor'] == get_the_ID() );
+									
 									// Check if $rule['minor'] is parent of page ID
 									if ( ! $condition_result && isset( $rule['has_children'] ) && $rule['has_children'] )
 										$condition_result = wp_get_post_parent_id( get_the_ID() ) == $rule['minor'];


### PR DESCRIPTION
`is_page( $arg )` checks the argument against the current page's ID, title, and slug, but we always want to only check the ID.

This fixes a situation where a page with the title `"123"` will match the conditions for a page with the ID `(int) 123`.