### PR TITLE
Fix Publicize to Facebook for en_AU and en_CA locales

### DIFF
--- a/locales.php
+++ b/locales.php
@@ -554,7 +554,6 @@ class GP_Locales {
 		$en_au->wp_locale = 'en_AU';
 		$en_au->slug = 'en-au';
 		$en_au->google_code = 'en';
-		$en_au->facebook_locale = 'en_AU';
 
 		$en_ca = new GP_Locale();
 		$en_ca->english_name = 'English (Canada)';
@@ -566,7 +565,6 @@ class GP_Locales {
 		$en_ca->wp_locale = 'en_CA';
 		$en_ca->slug = 'en-ca';
 		$en_ca->google_code = 'en';
-		$en_ca->facebook_locale = 'en_CA';
 
 		$en_gb = new GP_Locale();
 		$en_gb->english_name = 'English (UK)';


### PR DESCRIPTION
This fixes an issue where Publicize to Facebook silently fails for blogs in the `en_AU` and `en_CA` locales.  The failures are due to #2117 and the fix is to revert it.  As a bonus this also brings `locales.php` closer to being in sync with WPCOM.

If a locale has a `facebook_locale` value, we [send that value to Facebook via the `og:locale` tag](https://github.com/Automattic/jetpack/blob/0b8322ab267f59fe425834abaaff108ea03675a0/functions.opengraph.php#L203), which, for these two locales, causes Publicize to fail, presumably because neither of these two codes are in [Facebook's list of supported locales](https://www.facebook.com/translations/FacebookLocales.xml).  Ref: 471-gh-io

With https://github.com/Automattic/jetpack/commit/af8e40fbbcf764e04ba458279f7266ea41b4eb47 the desired effect of #2117 is still preserved after this change (the Facebook sharing buttons will still show up for these locales).