### PR TITLE
Exclude the FI locale during po/mo generation

### DIFF
--- a/tools/export-translations.php
+++ b/tools/export-translations.php
@@ -9,7 +9,7 @@
 require dirname( dirname( __FILE__ ) ) . '/locales.php';
 
 $language_packs = array(
-	'ar', 'de', 'en-au', 'en-ca', 'eo', 'es', 'fr', 'he', 'id', 'it', 'ja', 'ko', 'nl', 'pt-br', 'ro', 'ru', 'sq', 'sv', 'tr', 'zh-cn', 'zh-tw'
+	'ar', 'de', 'en-au', 'en-ca', 'eo', 'es', 'fi', 'fr', 'he', 'id', 'it', 'ja', 'ko', 'nl', 'pt-br', 'ro', 'ru', 'sq', 'sv', 'tr', 'zh-cn', 'zh-tw'
 );
 
 /**


### PR DESCRIPTION
FI has reached 100% on https://translate.wordpress.org/projects/wp-plugins/jetpack and can now be switched over to language packs.

Replaces #3342.