### PR TITLE
Update Travis CI build and job configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,37 +25,39 @@ env:
 
 matrix:
   include:
+   - php: "5.6"
+     env: WP_VERSION=4.4 WP_TRAVISCI=travis:js
    - php: "5.2"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.2"
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.3 WP_TRAVISCI=travis:phpunit
    - php: "5.2"
-     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
    - php: "5.3"
-     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
    - php: "5.4"
-     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.5"
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.3 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
-     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
      # 5.6 / master already included above as first build.
    - php: "5.6"
-     env: WP_VERSION=4.3.0 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.3 WP_TRAVISCI=travis:phpunit
    - php: "5.6"
-     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "nightly"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
-   - php: "5.6"
-     env: WP_VERSION=4.4.0 WP_TRAVISCI=travis:js
   allow_failures:
-   # - php: "nightly"
+   - php: "hhvm"
+   - php: "nightly"
+  fast_finish: true
 
 # Clones WordPress and configures our testing environment.
 before_script:


### PR DESCRIPTION
Based on #3001 and WordPress #core Travis CI which this appears to be based on here's a few tweaks to make Travis CI play nice:

• `HHVM` and `nightly` (aka PHP 7.x) should be _allowed to fail_ jobs, the PHP 7.0 job is *not* allowed to fail
• Promotes the JavaScript only job `travis:js` to the first Travis CI job run and adds `fast_finish: true` so that and JavaScript tests are returned quickly and build failure notifications are sent to notification recipients or Slack channels much faster than waiting for the PHP tests to finish.
• Updates the WordPress versions tested to use the "branch" versions rather than "tag" versions, this ensures that the latest 4.3.x and 4.4.x branches are tested against rather than the (what is currently configured) 4.3.0 and 4.4.0 tags.