### PR TITLE
Show only one Photon JITM when multiple images are dropped to be uploaded

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -110,15 +110,13 @@
 						var jitmTemplate = wp.template( 'jitm-photon' ),
 							$menu = wp.media.frame.$el.find( '.media-menu' ),
 							$jitm;
-						if ( $menu.length > 0 ) {
-							if ( 0 === $menu.find( '.jp-jitm' ).length ) {
-								$jitm = $menu.append( jitmTemplate() ).find( '.jp-jitm' );
+						if ( $menu.length > 0 && 0 === $menu.find( '.jp-jitm' ).length ) {
+							$jitm = $menu.append( jitmTemplate() ).find( '.jp-jitm' );
 
-								// JITM is visible to user, track it.
-								data.jitmActionToTake = 'viewed';
-								data.jitmModule = $jitm.data( 'track' );
-								$.post( jitmL10n.ajaxurl, data );
-							}
+							// JITM is visible to user, track it.
+							data.jitmActionToTake = 'viewed';
+							data.jitmModule = $jitm.data( 'track' );
+							$.post( jitmL10n.ajaxurl, data );
 						}
 					} else {
 						$( '.media-menu' ).find( '.jp-jitm' ).remove();

--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -111,12 +111,14 @@
 							$menu = wp.media.frame.$el.find( '.media-menu' ),
 							$jitm;
 						if ( $menu.length > 0 ) {
-							$jitm = $menu.append( jitmTemplate() ).find( '.jp-jitm' );
+							if ( 0 === $menu.find( '.jp-jitm' ).length ) {
+								$jitm = $menu.append( jitmTemplate() ).find( '.jp-jitm' );
 
-							// JITM is visible to user, track it.
-							data.jitmActionToTake = 'viewed';
-							data.jitmModule = $jitm.data( 'track' );
-							$.post( jitmL10n.ajaxurl, data );
+								// JITM is visible to user, track it.
+								data.jitmActionToTake = 'viewed';
+								data.jitmModule = $jitm.data( 'track' );
+								$.post( jitmL10n.ajaxurl, data );
+							}
 						}
 					} else {
 						$( '.media-menu' ).find( '.jp-jitm' ).remove();


### PR DESCRIPTION
Make sure only one Photon JITM is displayed when attempts to upload multiple images dropping them into Editor or Media Library.

fixes #3344