### PR TITLE
Staging Mode: introduce generic staging constant

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6035,6 +6035,7 @@ p {
 				),
 			'constants' => array(
 				'IS_WPE_SNAPSHOT',
+				'JETPACK_STAGING_MODE',
 				)
 			);
 		/**


### PR DESCRIPTION
This constant could be used by site owners or plugin authors implementing their own staging solution,
without wanting to use a plugin and the `jetpack_is_staging_site` filter.

cc @kraftbj 