### PR TITLE
Photon: Add ssl=1 query string for HTTPS sourced images.

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -39,7 +39,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	 * @param array|string $args Array of Photon arguments.
 	 * @param string|null $scheme Image scheme. Default to null.
 	 */
-	$image_url = apply_filters( 'jetpack_photon_pre_image_url', $image_url, $args,      $scheme );
+	$image_url = apply_filters( 'jetpack_photon_pre_image_url', $image_url, $args, $scheme );
 	/**
 	 * Filter the original Photon image parameters before Photon is applied to an image.
 	 *
@@ -51,7 +51,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	 * @param string $image_url Image URL.
 	 * @param string|null $scheme Image scheme. Default to null.
 	 */
-	$args      = apply_filters( 'jetpack_photon_pre_args',      $args,      $image_url, $scheme );
+	$args = apply_filters( 'jetpack_photon_pre_args', $args, $image_url, $scheme );
 
 	if ( empty( $image_url ) )
 		return $image_url;

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -62,6 +62,10 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	if ( ! is_array( $image_url_parts ) || empty( $image_url_parts['host'] ) || empty( $image_url_parts['path'] ) )
 		return $image_url;
 
+	if ( isset( $image_url_parts['scheme'] ) && 'https' == $image_url_parts['scheme'] ) {
+		$args['ssl'] = '1';
+	}
+
 	if ( is_array( $args ) ){
 		// Convert values that are arrays into strings
 		foreach ( $args as $arg => $value ) {

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -1,0 +1,26 @@
+<?php
+
+class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
+
+	/**
+	 * @author kraftbj
+	 * @covers jetpack_photon_url
+	 * @since 3.9.2
+	 */
+	public function test_photonizing_https_image_adds_ssl_query_arg() {
+		$url = jetpack_photon_url( 'https://example.com/images/photon.jpg' );
+		parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
+		$this->assertEquals( '1', $args['ssl'], 'HTTPS image sources should have a ?ssl=1 query string.' );
+	}
+
+	/**
+	 * @author kraftbj
+	 * @covers jetpack_photon_url
+	 * @since  3.9.2
+	 */
+	public function test_photonizing_http_image_no_ssl_query_arg() {
+		$url = jetpack_photon_url( 'http://example.com/images/photon.jpg' );
+		parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
+		$this->assertArrayNotHasKey( 'ssl', $args, 'HTTP image source should not have an ssl query string.' );
+	}
+}


### PR DESCRIPTION
As of 3.9, Photon will accept https images by default; however, server side, Photon will still attempt to pull the image via http. This adds the `ssl=1' query string instructing Photon to pull via https.

Adds unit tests for both http and https images to ensure `ssl` is set correctly.

Fixes #3298