### PR TITLE
Open Graph: Ensure show_on_front option is set to page.

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -61,7 +61,7 @@ function jetpack_og_tags() {
 		$tags['og:description'] = get_bloginfo( 'description' );
 
 		$front_page_id = get_option( 'page_for_posts' );
-		if ( $front_page_id && is_home() )
+		if ( 'page' == get_option( 'show_on_front' ) && $front_page_id && is_home() )
 			$tags['og:url'] = get_permalink( $front_page_id );
 		else
 			$tags['og:url'] = home_url( '/' );


### PR DESCRIPTION
Previously, if you had previously set show_on_front to page and chosen a posts page, then switched back to show_on_front == posts, Jetpack would still use the value of your "posts" page.

Testing Plan:
0. Settings->Writing, set "Front Page Displays" to a static page and set two pages as the front and the posts pages. Save
1. Change the Front Page Displays to Latest posts and saves. The dropdown for the pages for front and posts remain set, but greyed. 
2. Visit the home page and check the og tags. The og:url will be set to the URL of the page set for the posts page instead of the home page.