### PR TITLE
Open Graph: Correctly pull core's site icon

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -337,14 +337,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		}
 	}
 
-	// Third fall back, Site Icon
-	if ( empty( $image ) && ( function_exists( 'jetpack_has_site_icon' ) && jetpack_has_site_icon() ) ) {
-		$image['src']     = jetpack_site_icon_url( null, '512' );
-		$image['width']   = '512';
-		$image['height']  = '512';
-	}
-
-	// Fourth fall back, Core Site Icon. Added in WP 4.3.
+	// Third fall back, Core Site Icon. Added in WP 4.3.
 	if ( empty( $image ) && ( function_exists( 'has_site_icon') && has_site_icon() ) ) {
 		$image['src']     = get_site_icon_url( 512 );
 		$image['width']   = '512';

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -346,7 +346,9 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 	// Fourth fall back, Core Site Icon. Added in WP 4.3.
 	if ( empty( $image ) && ( function_exists( 'has_site_icon') && has_site_icon() ) ) {
-		$image['src'] = get_site_icon_url( null, '512' );
+		$image['src']     = get_site_icon_url( 512 );
+		$image['width']   = '512';
+		$image['height']  = '512';
 	}
 
 	// Finally fall back, blank image


### PR DESCRIPTION
In https://core.trac.wordpress.org/changeset/33605 (pre-4.3), the args for `get_site_icon_url` were rearranged to avoid the frequency of needing to pass null args. We did not account for this before shipping.

This PR:
* Rearranges the `get_site_icon_url()` call to use the correct args.
* Removes the `jetpack_site_icon` fallback as our minimum version is 4.3 so all sites will have access to Core's functionality.