### PR TITLE
Travis CI: Remove `fast_finish` notification option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ matrix:
   allow_failures:
    - php: "hhvm"
    - php: "nightly"
-  fast_finish: true
 
 # Clones WordPress and configures our testing environment.
 before_script:


### PR DESCRIPTION
Notifications are being sent per job rather than per build sadly, see https://github.com/travis-ci/travis-ci/issues/4928