### PR TITLE
My Jetpack: primary user description text

### DIFF
--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -132,12 +132,12 @@
 							</form>
 						<?php else : ?>
 							<p>{{{ data.masterUser.masterUser.data.user_login }}} <?php echo $primary_text; ?></p>
-							<p><em><?php
-                                    printf(
-                                        __( '<a href="%s">Create additional Administrators</a> to change primary user.', 'jetpack' ),
-                                        admin_url( 'users.php' )
-                                    );
-                                ?></p>
+							 <p><em><?php
+									printf(
+										__( '<a href="%s">Create additional Administrators</a> to change primary user.', 'jetpack' ),
+										admin_url( 'users.php' )
+									);
+								?></p>
 						<?php endif; ?>
 					</div>
 					<div class="j-col j-lrg-6 j-md-6 j-sm-12">

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -132,7 +132,12 @@
 							</form>
 						<?php else : ?>
 							<p>{{{ data.masterUser.masterUser.data.user_login }}} <?php echo $primary_text; ?></p>
-							<p><em><?php _e( 'Create additional admins to change primary user.', 'jetpack' ); ?></em></p>
+							<p><em><?php
+                                    printf(
+                                        __( '<a href="%s">Create additional admins</a> to change primary user.', 'jetpack' ),
+                                        admin_url( 'users.php' )
+                                    );
+                                ?></p>
 						<?php endif; ?>
 					</div>
 					<div class="j-col j-lrg-6 j-md-6 j-sm-12">

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -133,9 +133,9 @@
 						<?php else : ?>
 							<p>{{{ data.masterUser.masterUser.data.user_login }}} <?php echo $primary_text; ?></p>
 							<p><em><?php
-									printf(
-										__( 'Create <a href="%s">additional Administrators</a> to change primary user.', 'jetpack' ),
-										admin_url( 'users.php' )
+								printf(
+									__( 'Create <a href="%s">additional Administrators</a> to change primary user.', 'jetpack' ),
+									admin_url( 'users.php' )
 									);
 								?></p>
 						<?php endif; ?>

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -134,7 +134,7 @@
 							<p>{{{ data.masterUser.masterUser.data.user_login }}} <?php echo $primary_text; ?></p>
 							<p><em><?php
                                     printf(
-                                        __( '<a href="%s">Create additional admins</a> to change primary user.', 'jetpack' ),
+                                        __( '<a href="%s">Create additional Administrators</a> to change primary user.', 'jetpack' ),
                                         admin_url( 'users.php' )
                                     );
                                 ?></p>

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -135,7 +135,7 @@
 							<p><em><?php
 								echo wp_kses(
 									sprintf(
-										__( 'Create <a href="%s" title="Go to Users → All Users.">additional Administrators</a> to change primary user.', 'jetpack' ),
+										__( 'Create <a href="%s" title="Go to Users → All Users">additional Administrators</a> to change primary user.', 'jetpack' ),
 										admin_url( 'users.php' ) ),
 									array( 'a' => array( 'href' => true, 'title' => true ) )
 								);

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -132,7 +132,7 @@
 							</form>
 						<?php else : ?>
 							<p>{{{ data.masterUser.masterUser.data.user_login }}} <?php echo $primary_text; ?></p>
-							 <p><em><?php
+                            <p><em><?php
 									printf(
 										__( '<a href="%s">Create additional Administrators</a> to change primary user.', 'jetpack' ),
 										admin_url( 'users.php' )

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -133,10 +133,12 @@
 						<?php else : ?>
 							<p>{{{ data.masterUser.masterUser.data.user_login }}} <?php echo $primary_text; ?></p>
 							<p><em><?php
-								printf(
-									__( 'Create <a href="%s">additional Administrators</a> to change primary user.', 'jetpack' ),
-									admin_url( 'users.php' )
-									);
+								echo wp_kses(
+									sprintf(
+										__( 'Create <a href="%s" title="Go to Users → All Users.">additional Administrators</a> to change primary user.', 'jetpack' ),
+										admin_url( 'users.php' ) ),
+									array( 'a' => array( 'href' => true, 'title' => true ) )
+								);
 								?></p>
 						<?php endif; ?>
 					</div>

--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -132,9 +132,9 @@
 							</form>
 						<?php else : ?>
 							<p>{{{ data.masterUser.masterUser.data.user_login }}} <?php echo $primary_text; ?></p>
-                            <p><em><?php
+							<p><em><?php
 									printf(
-										__( '<a href="%s">Create additional Administrators</a> to change primary user.', 'jetpack' ),
+										__( 'Create <a href="%s">additional Administrators</a> to change primary user.', 'jetpack' ),
 										admin_url( 'users.php' )
 									);
 								?></p>


### PR DESCRIPTION
On the _Jetpack → My Jetpack_ screen, the description text under _Jetpack Primary User_ reads:

> Create additional admins to change primary user.

1) Ideally, we should refer to 'admins' as _Administrators_, to be consistent with standard WordPress terminology for this user role. 

2) It would also be good to link to _Users → All Users_ from here, as it will make the process of adding other admins much clearer for newer users who are not yet familiar with the WordPress interface.

This PR addresses both these issues, and I think these changes make the UX of this particular interface element a little better.
