### PR TITLE
Apply sitemap URL filter when rendering sitemap

### DIFF
--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -913,8 +913,17 @@ function jetpack_xml_sitemap_more_info() { ?>
 	<?php if ( '0' == get_option( 'blog_public' ) ) : ?>
 		<p><strong><?php esc_html_e( 'Your site is currently set to discourage search engines from indexing it so the sitemap will not be accessible.', 'jetpack' ); ?></strong></p>
 	<?php else :
-		$sitemap_url = home_url( get_option( 'permalink_structure' ) ? '/sitemap.xml' : '/?jetpack-sitemap=true' );
-		$news_sitemap_url = home_url( get_option( 'permalink_structure' ) ? '/news-sitemap.xml' : '/?jetpack-news-sitemap=true' );
+		if ( get_option( 'permalink_structure' ) ) {
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$sitemap_url = apply_filters( 'jetpack_sitemap_location', home_url( '/sitemap.xml' ) );
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$news_sitemap_url = apply_filters( 'jetpack_news_sitemap_location', home_url( '/news-sitemap.xml' ) );
+		} else {
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$sitemap_url = apply_filters( 'jetpack_sitemap_location', home_url( '/?jetpack-sitemap=true' ) );
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$news_sitemap_url = apply_filters( 'jetpack_news_sitemap_location', home_url( '/?jetpack-news-sitemap=true' ) );
+		}
 		if ( Jetpack::is_module_active( 'sitemaps' ) ) : ?>
 			<p><?php esc_html_e( 'Your sitemaps are accessible at:', 'jetpack' ); ?></p>
 		<?php else : ?>

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -709,8 +709,18 @@ function jetpack_sitemap_initialize() {
 	if ( $discover_sitemap ) {
 		add_action( 'do_robotstxt', 'jetpack_sitemap_discovery', 5, 0 );
 
+		if ( get_option( 'permalink_structure' ) ) {
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$sitemap = apply_filters( 'jetpack_sitemap_location', home_url( '/sitemap.xml' ) );
+			$sitemap = parse_url( $sitemap, PHP_URL_PATH );
+		} else {
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$sitemap = apply_filters( 'jetpack_sitemap_location', home_url( '/?jetpack-sitemap=true' ) );
+			$sitemap = preg_replace( '/(=.*?)$/i', '', parse_url( $sitemap, PHP_URL_QUERY ) );
+		}
+
 		// Sitemap XML
-		if ( preg_match( '#(/sitemap\.xml)$#i', $_SERVER['REQUEST_URI'] ) || ( isset( $_GET['jetpack-sitemap'] ) && 'true' == $_GET['jetpack-sitemap'] ) ) {
+		if ( preg_match( '#(' . $sitemap . ')$#i', $_SERVER['REQUEST_URI'] ) || ( isset( $_GET[ $sitemap ] ) && 'true' == $_GET[ $sitemap ] ) ) {
 			// run later so things like custom post types have been registered
 			add_action( 'init', 'jetpack_print_sitemap', 999 );
 		}
@@ -734,8 +744,18 @@ function jetpack_sitemap_initialize() {
 	if ( $discover_news_sitemap ) {
 		add_action( 'do_robotstxt', 'jetpack_news_sitemap_discovery', 5, 0 );
 
+		if ( get_option( 'permalink_structure' ) ) {
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$sitemap = apply_filters( 'jetpack_news_sitemap_location', home_url( '/news-sitemap.xml' ) );
+			$sitemap = parse_url( $sitemap, PHP_URL_PATH );
+		} else {
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$sitemap = apply_filters( 'jetpack_news_sitemap_location', home_url( '/?jetpack-news-sitemap=true' ) );
+			$sitemap = preg_replace( '/(=.*?)$/i', '', parse_url( $sitemap, PHP_URL_QUERY ) );
+		}
+
 		// News Sitemap XML
-		if ( preg_match( '#(/news-sitemap\.xml)$#i', $_SERVER['REQUEST_URI'] ) || ( isset( $_GET['jetpack-news-sitemap'] ) && 'true' == $_GET['jetpack-news-sitemap'] ) ) {
+		if ( preg_match( '#(' . $sitemap . ')$#i', $_SERVER['REQUEST_URI'] ) || ( isset( $_GET[ $sitemap ] ) && 'true' == $_GET[ $sitemap ] ) ) {
 			// run later so things like custom post types have been registered
 			add_action( 'init', 'jetpack_print_news_sitemap', 999 );
 		}


### PR DESCRIPTION
Now the URL filtered by `jetpack_sitemap_location` or `jetpack_news_sitemap_location` not only works for robots but also for humans when sitemaps are accessed in the browser.

fixes #3367

This PR was updated after #3329 was merged to modify the URLs displayed in module info so they display and point to the correct URL.