### PR TITLE
Photon: exclude img attributes that end with ...src

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -91,7 +91,7 @@ class Jetpack_Photon {
 	public static function parse_images_from_html( $content ) {
 		$images = array();
 
-		if ( preg_match_all( '#(?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag><img[^>]+?\s+?src=["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:\s*</a>)?#is', $content, $images ) ) {
+		if ( preg_match_all( '#(?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag><img[^>]*?\s+?src=["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:\s*</a>)?#is', $content, $images ) ) {
 			foreach ( $images as $key => $unused ) {
 				// Simplify the output as much as possible, mostly for confirming test results.
 				if ( is_numeric( $key ) && $key > 0 )

--- a/class.photon.php
+++ b/class.photon.php
@@ -91,7 +91,7 @@ class Jetpack_Photon {
 	public static function parse_images_from_html( $content ) {
 		$images = array();
 
-		if ( preg_match_all( '#(?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag><img[^>]+?src=["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:\s*</a>)?#is', $content, $images ) ) {
+		if ( preg_match_all( '#(?:<a[^>]+?href=["|\'](?P<link_url>[^\s]+?)["|\'][^>]*?>\s*)?(?P<img_tag><img[^>]+?\s+?src=["|\'](?P<img_url>[^\s]+?)["|\'].*?>){1}(?:\s*</a>)?#is', $content, $images ) ) {
 			foreach ( $images as $key => $unused ) {
 				// Simplify the output as much as possible, mostly for confirming test results.
 				if ( is_numeric( $key ) && $key > 0 )

--- a/tests/php/modules/photon/sample-content/src-attribute.html
+++ b/tests/php/modules/photon/sample-content/src-attribute.html
@@ -1,0 +1,29 @@
+<img src="img_1"><img data-src="img_2"><img data-src="" src="img_3">
+--RESULTS--
+Array
+(
+    [0] => Array
+        (
+            [0] => <img src="img_1">
+            [1] => <img data-src="" src="img_3">
+        )
+
+    [link_url] => Array
+        (
+            [0] => 
+            [1] => 
+        )
+
+    [img_tag] => Array
+        (
+            [0] => <img src="img_1">
+            [1] => <img data-src="" src="img_3">
+        )
+
+    [img_url] => Array
+        (
+            [0] => img_1
+            [1] => img_3
+        )
+
+)

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -247,6 +247,16 @@ class WP_Test_Jetpack_Photon extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @author ccprog
+	 * @covers Jetpack_Photon::parse_images_from_html
+	 */
+	public function test_photon_parse_images_from_html_src_attribute() {
+		list( $sample_html, $expected ) = $this->get_photon_sample_content( 'src-attribute.html' );
+
+		$this->assertEquals( $expected, print_r( Jetpack_Photon::parse_images_from_html( $sample_html ), true ) );
+	}
+
+	/**
 	 * @author scotchfield
 	 * @covers Jetpack_Photon::parse_dimensions_from_filename
 	 * @since 3.2


### PR DESCRIPTION
In answer to Issue #3393:

Currently, attributes like `data-src` or `ng-src` are caught by Photon as if they were `<img src="">`. The values might have a different grammar from plain url schemes, so Photon should not interfere
