### PR TITLE
Contact Info Widget: add 2 hooks to add data to the widget.

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -74,6 +74,8 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			/**
 			 * Fires at the beginning of the Contact Info widget, after the title.
 			 *
+			 * @module widgets
+			 *
 			 * @since 3.9.2
 			 */
 			do_action( 'jetpack_contact_info_widget_start' );
@@ -119,6 +121,8 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 
 			/**
 			 * Fires at the end of Contact Info widget.
+			 *
+			 * @module widgets
 			 *
 			 * @since 3.9.2
 			 */

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -71,6 +71,12 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			if ( $instance['title'] != '' )
 				echo $before_title . $instance['title'] . $after_title;
 
+			/**
+			 * Fires at the beginning of the Contact Info widget, after the title.
+			 *
+			 * @since 3.9.2
+			 */
+			do_action( 'jetpack_contact_info_widget_beginning' );
 
 			$map_link = 0;
 
@@ -109,6 +115,14 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			if ( $instance['hours'] != '' ) {
 				echo '<div class="confit-hours">' . str_replace( "\n", "<br/>", esc_html( $instance['hours'] ) ) . "</div>";
 			}
+
+
+			/**
+			 * Fires at the end of Contact Info widget.
+			 *
+			 * @since 3.9.2
+			 */
+			do_action( 'jetpack_contact_info_widget_end' );
 
 
 			echo $after_widget;

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			 *
 			 * @since 3.9.2
 			 */
-			do_action( 'jetpack_contact_info_widget_beginning' );
+			do_action( 'jetpack_contact_info_widget_start' );
 
 			$map_link = 0;
 


### PR DESCRIPTION
Once the hooks are added, a site owner could add data to the form like so:

```php
function jeherve_add_mailto_widget() {
	echo "<a href='mailto:me@example.com'>Contact us!</a>";
}
add_action( 'jetpack_contact_info_widget_end', 'jeherve_add_mailto_widget' );
```

Suggested here:
https://wordpress.org/support/topic/add-an-email-link-to-contact-info-jetpack-hours-info-widget?replies=1&view=all