### PR TITLE
WP-API: Enable Custom Post Types

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -107,6 +107,7 @@ class Grunion_Contact_Form_Plugin {
 			'rewrite'           => FALSE,
 			'query_var'         => FALSE,
 			'capability_type'   => 'page',
+			'show_in_rest'      => true,
 			'capabilities'		=> array(
 				'create_posts'        => false,
 				'publish_posts'       => 'publish_pages',

--- a/modules/custom-post-types/comics.php
+++ b/modules/custom-post-types/comics.php
@@ -257,6 +257,7 @@ class Jetpack_Comic {
 			'map_meta_cap'    => true,
 			'has_archive'     => true,
 			'query_var'       => 'comic',
+			'show_in_rest'    => true,
 		) );
 	}
 

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -263,6 +263,7 @@ class Jetpack_Portfolio {
 			'taxonomies'      => array( self::CUSTOM_TAXONOMY_TYPE, self::CUSTOM_TAXONOMY_TAG ),
 			'has_archive'     => true,
 			'query_var'       => 'portfolio',
+			'show_in_rest'    => true,
 		) );
 
 		register_taxonomy( self::CUSTOM_TAXONOMY_TYPE, self::CUSTOM_POST_TYPE, array(

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -327,6 +327,7 @@ class Jetpack_Testimonial {
 			'map_meta_cap'    => true,
 			'has_archive'     => true,
 			'query_var'       => 'testimonial',
+			'show_in_rest'    => true,
 		) );
 	}
 


### PR DESCRIPTION
This diff adds in the `show_in_rest` option to custom post types on wpcom, which is akin to `rest_api_allowed_post_types` for the wpcom API.
More details [private link] and [private link]

Merges r130796-wpcom