### PR TITLE
Jetpack Signature: Check both 80 and 443

### DIFF
--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -31,11 +31,7 @@ class Jetpack_Signature {
 			}
 		}
 
-		if ( is_ssl() ) {
-			$port = JETPACK_SIGNATURE__HTTPS_PORT == $_SERVER['SERVER_PORT'] ? '' : $_SERVER['SERVER_PORT'];
-		} else {
-			$port = JETPACK_SIGNATURE__HTTP_PORT  == $_SERVER['SERVER_PORT'] ? '' : $_SERVER['SERVER_PORT'];
-		}
+		$port = ( JETPACK_SIGNATURE__HTTPS_PORT == $_SERVER['SERVER_PORT'] ) || ( JETPACK_SIGNATURE__HTTP_PORT  == $_SERVER['SERVER_PORT'] ) ? '' : $_SERVER['SERVER_PORT'];
 
 		$url = "{$scheme}://{$_SERVER['HTTP_HOST']}:{$port}" . stripslashes( $_SERVER['REQUEST_URI'] );
 

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -1,5 +1,8 @@
 <?php
 
+// These constants can be set in wp-config.php to ensure sites behind proxies will still work.
+// Setting these constants, though, is *not* the preferred method. It's better to configure
+// the proxy to send the X-Forwarded-Port header.
 defined( 'JETPACK_SIGNATURE__HTTP_PORT'  ) or define( 'JETPACK_SIGNATURE__HTTP_PORT' , 80  );
 defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) or define( 'JETPACK_SIGNATURE__HTTPS_PORT', 443 );
 
@@ -31,7 +34,27 @@ class Jetpack_Signature {
 			}
 		}
 
-		$port = ( JETPACK_SIGNATURE__HTTPS_PORT == $_SERVER['SERVER_PORT'] ) || ( JETPACK_SIGNATURE__HTTP_PORT  == $_SERVER['SERVER_PORT'] ) ? '' : $_SERVER['SERVER_PORT'];
+		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : $_SERVER['SERVER_PORT'];
+
+		if ( is_ssl() ) {
+			// 443: Standard Port
+			// 80: Assume we're behind a proxy without X-Forwarded-Port. Hardcoding "80" here means most sites
+			//     with SSL termination proxies (self-served, Cloudflare, etc.) don't need to fiddle with
+			//     the JETPACK_SIGNATURE__HTTPS_PORT constant. The code also implies we can't talk to a
+			//     site at https://example.com:80/ (which would be a strange configuration).
+			// JETPACK_SIGNATURE__HTTPS_PORT: Set this constant in wp-config.php to the backend webserver's port
+			//                                if the site is behind a proxy running on port 443 without
+			//                                X-Forwarded-Port and the backend's port is *not* 80. It's better,
+			//                                though, to configure the proxy to send X-Forwarded-Port.
+			$port = in_array( $host_port, array( 443, 80, JETPACK_SIGNATURE__HTTPS_PORT ) ) ? '' : $host_port;
+		} else {
+			// 80: Standard Port
+			// JETPACK_SIGNATURE__HTTPS_PORT: Set this constant in wp-config.php to the backend webserver's port
+			//                                if the site is behind a proxy running on port 80 without
+			//                                X-Forwarded-Port. It's better, though, to configure the proxy to
+			//                                send X-Forwarded-Port.
+			$port = in_array( $host_port, array( 80, JETPACK_SIGNATURE__HTTP_PORT ) ) ? '' : $host_port;
+		}
 
 		$url = "{$scheme}://{$_SERVER['HTTP_HOST']}:{$port}" . stripslashes( $_SERVER['REQUEST_URI'] );
 


### PR DESCRIPTION
Previously, Jetpack used is_ssl() to determine if the port used as part of the signature verification process would be either 80 or 443 (or the corresponding constant values).

With the rise of CloudFlare SSL, Let's Encrypt, etc and the way that HTTPS sites operate when they terminate SSL on the edge (reverse proxy, load balancer, etc), there is an increase of situations where a site is SSL but the server port is 80.

This situation currently always fails and requires user intervention: either overriding the $_SERVER global or setting a PHP constant.

This change will not pass the port number if it is either 80 or 443 while still allowing the constants to be set, to retain BC.

cc: @mdawaffe this is the issue I was asking about in Belize. Can you check out this approach and offer any suggestions.

pitcrew: Do not merge unless Mike gives a green light :).