### PR TITLE
Call actions prior to running upgrades

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
@@ -34,6 +34,8 @@ class Jetpack_JSON_API_Core_Modify_Endpoint extends Jetpack_JSON_API_Core_Endpoi
 			$update = $this->find_latest_update_offer();
 		}
 
+		do_action('jetpack_pre_core_upgrade', $update);
+
 		$skin     = new Automatic_Upgrader_Skin();
 		$upgrader = new Core_Upgrader( $skin );
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
@@ -34,6 +34,13 @@ class Jetpack_JSON_API_Core_Modify_Endpoint extends Jetpack_JSON_API_Core_Endpoi
 			$update = $this->find_latest_update_offer();
 		}
 
+		/**
+		 * Pre-upgrade action
+		 * 
+		 * @since 3.9.1
+		 * 
+		 * @param object|array $update as returned by find_core_update() or find_core_auto_update()
+		 */
 		do_action('jetpack_pre_core_upgrade', $update);
 
 		$skin     = new Automatic_Upgrader_Skin();

--- a/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
@@ -37,7 +37,7 @@ class Jetpack_JSON_API_Core_Modify_Endpoint extends Jetpack_JSON_API_Core_Endpoi
 		/**
 		 * Pre-upgrade action
 		 * 
-		 * @since 3.9.1
+		 * @since 3.9.3
 		 * 
 		 * @param object|array $update as returned by find_core_update() or find_core_auto_update()
 		 */

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -155,6 +155,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				continue;
 			}
 
+			do_action('jetpack_pre_plugin_upgrade', $plugin, $this->plugins, $update_attempted);
+
 			$update_attempted = true;
 
 			// Object created inside the for loop to clean the messages for each plugin

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -158,7 +158,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			/**
 			 * Pre-upgrade action
 			 * 
-			 * @since 3.9.1
+			 * @since 3.9.3
 			 * 
 			 * @param array $plugin Plugin data
 			 * @param array $plugin Array of plugin objects

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -155,6 +155,15 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				continue;
 			}
 
+			/**
+			 * Pre-upgrade action
+			 * 
+			 * @since 3.9.1
+			 * 
+			 * @param array $plugin Plugin data
+			 * @param array $plugin Array of plugin objects
+			 * @param bool $updated_attempted false for the first update, true subsequently
+			 */
 			do_action('jetpack_pre_plugin_upgrade', $plugin, $this->plugins, $update_attempted);
 
 			$update_attempted = true;

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
@@ -40,6 +40,7 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 		wp_update_themes();
 
 		foreach ( $this->themes as $theme ) {
+			do_action('jetpack_pre_theme_upgrade', $theme, $this->themes);
 			// Objects created inside the for loop to clean the messages for each theme
 			$skin = new Automatic_Upgrader_Skin();
 			$upgrader = new Theme_Upgrader( $skin );

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
@@ -40,6 +40,14 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 		wp_update_themes();
 
 		foreach ( $this->themes as $theme ) {
+			/**
+			 * Pre-upgrade action
+			 * 
+			 * @since 3.9.1
+			 * 
+			 * @param object $theme WP_Theme object
+			 * @param array $themes Array of theme objects
+			 */
 			do_action('jetpack_pre_theme_upgrade', $theme, $this->themes);
 			// Objects created inside the for loop to clean the messages for each theme
 			$skin = new Automatic_Upgrader_Skin();

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
@@ -43,7 +43,7 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 			/**
 			 * Pre-upgrade action
 			 * 
-			 * @since 3.9.1
+			 * @since 3.9.3
 			 * 
 			 * @param object $theme WP_Theme object
 			 * @param array $themes Array of theme objects


### PR DESCRIPTION
Explained at: https://wordpress.org/support/topic/requesting-an-action-hook
