### PR TITLE
Remove Jetpack_Network::wp_get_sites in favor of core's wp_get_sites

### DIFF
--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -25,9 +25,8 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		// Deal with bulk actions if any were requested by the user
 		$this->process_bulk_action();
 
-		// Get sites
-		$sites = wp_get_sites( array(
-			'offset'   => 1,
+		$sites = get_sites( array( 
+			'offset' => 1, 
 			'archived' => false,
 		) );
 
@@ -50,26 +49,26 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 	public function column_blogname( $item ) {
 		// http://jpms/wp-admin/network/site-info.php?id=1
-		switch_to_blog( $item['blog_id'] );
+		switch_to_blog( $item->blog_id );
 		$jp_url = admin_url( 'admin.php?page=jetpack' );
 		restore_current_blog();
 
 		$actions = array(
-            		'edit'      	=> '<a href="' . network_admin_url( 'site-info.php?id=' . $item['blog_id'] )  .  '">' . esc_html__( 'Edit', 'jetpack' ) . '</a>',
-        		'dashboard'	=> '<a href="' . get_admin_url( $item['blog_id'], '', 'admin' ) . '">' . esc_html__( 'Dashboard', 'jetpack' ) . '</a>',
-			'view'		=> '<a href="' . get_site_url( $item['blog_id'], '', 'admin' ) . '">' . esc_html__( 'View', 'jetpack' ) . '</a>',
-			'jetpack-' . $item['blog_id']	=> '<a href="' . $jp_url . '">Jetpack</a>',
+			'edit'      => '<a href="' . network_admin_url( 'site-info.php?id=' . $item->blog_id )  .  '">' . esc_html__( 'Edit', 'jetpack' ) . '</a>',
+			'dashboard' => '<a href="' . get_admin_url( $item->blog_id, '', 'admin' ) . '">' . esc_html__( 'Dashboard', 'jetpack' ) . '</a>',
+			'view'      => '<a href="' . get_site_url( $item->blog_id, '', 'admin' ) . '">' . esc_html__( 'View', 'jetpack' ) . '</a>',
+			'jetpack-' . $item->blog_id => '<a href="' . $jp_url . '">Jetpack</a>',
 		);
 
-  		return sprintf('%1$s %2$s', '<strong>' . get_blog_option( $item['blog_id'], 'blogname' ) . '</strong>', $this->row_actions($actions) );
+  		return sprintf('%1$s %2$s', '<strong>' . get_blog_option( $item->blog_id, 'blogname' ) . '</strong>', $this->row_actions($actions) );
 	}
 
 	public function column_blog_path( $item ) {
 		return
                          '<a href="' .
-                         get_site_url( $item['blog_id'], '', 'admin' ) .
+                         get_site_url( $item->blog_id, '', 'admin' ) .
                          '">' .
-                         str_replace( array( 'http://', 'https://' ), '', get_site_url( $item['blog_id'], '', 'admin' ) ) .
+                         str_replace( array( 'http://', 'https://' ), '', get_site_url( $item->blog_id, '', 'admin' ) ) .
                          '</a>';
 	}
 
@@ -77,7 +76,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		$jpms = Jetpack_Network::init();
 		$jp = Jetpack::init();
 
-		switch_to_blog( $item['blog_id'] );
+		switch_to_blog( $item->blog_id );
 
 		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
 			$title = __( 'Jetpack is not active on this site.', 'jetpack' );
@@ -92,7 +91,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		   // Build url for disconnecting
 		    $url = $jpms->get_url( array(
 			'name'	    => 'subsitedisconnect',
-			'site_id'   => $item['blog_id'],
+			'site_id'   => $item->blog_id,
 
 		    ) );
 		    restore_current_blog();
@@ -103,7 +102,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		// Build URL for connecting
 		$url = $jpms->get_url( array(
 		    'name'	=> 'subsiteregister',
-		    'site_id'	=> $item['blog_id'],
+		    'site_id'	=> $item->blog_id,
 		) );
 		return '<a href="' . $url . '">' . esc_html__( 'Connect', 'jetpack' ) . '</a>';
 	}
@@ -119,7 +118,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 	function column_cb($item) {
         	return sprintf(
-            		'<input type="checkbox" name="bulk[]" value="%s" />', $item['blog_id']
+            		'<input type="checkbox" name="bulk[]" value="%s" />', $item->blog_id
         	);
     	}
 

--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -55,9 +55,9 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		restore_current_blog();
 
 		$actions = array(
-            		'edit'      	=> '<a href="' . network_admin_url( 'site-info.php?id=' . $item['blog_id'] )  .  '">' . __( 'Edit', 'jetpack' ) . '</a>',
-        		'dashboard'	=> '<a href="' . get_admin_url( $item['blog_id'], '', 'admin' ) . '">Dashboard</a>',
-			'view'		=> '<a href="' . get_site_url( $item['blog_id'], '', 'admin' ) . '">View</a>',
+            		'edit'      	=> '<a href="' . network_admin_url( 'site-info.php?id=' . $item['blog_id'] )  .  '">' . esc_html__( 'Edit', 'jetpack' ) . '</a>',
+        		'dashboard'	=> '<a href="' . get_admin_url( $item['blog_id'], '', 'admin' ) . '">' . esc_html__( 'Dashboard', 'jetpack' ) . '</a>',
+			'view'		=> '<a href="' . get_site_url( $item['blog_id'], '', 'admin' ) . '">' . esc_html__( 'View', 'jetpack' ) . '</a>',
 			'jetpack-' . $item['blog_id']	=> '<a href="' . $jp_url . '">Jetpack</a>',
 		);
 
@@ -96,7 +96,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 		    ) );
 		    restore_current_blog();
-		    return '<a href="' . $url . '">Disconnect</a>';
+		    return '<a href="' . $url . '">' . esc_html__( 'Disconnect', 'jetpack' ) . '</a>';
 		}
 		restore_current_blog();
 
@@ -105,13 +105,13 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		    'name'	=> 'subsiteregister',
 		    'site_id'	=> $item['blog_id'],
 		) );
-		return '<a href="' . $url . '">Connect</a>';
+		return '<a href="' . $url . '">' . esc_html__( 'Connect', 'jetpack' ) . '</a>';
 	}
 
 	public function get_bulk_actions() {
 	    $actions = array(
-		'connect'	=> 'Connect',
-		'disconnect'	=> 'Disconnect'
+		'connect'    => esc_html__( 'Connect', 'jetpack' ),
+		'disconnect' => esc_html__( 'Disconnect', 'jetpack' )
 	    );
 
 	    return $actions;

--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -26,9 +26,9 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		$this->process_bulk_action();
 
 		// Get sites
-		$sites = $jpms->wp_get_sites( array(
-			'exclude_blogs' => array( 1 ),
-			'archived'      => false,
+		$sites = wp_get_sites( array(
+			'offset'   => 1,
+			'archived' => false,
 		) );
 
 		// Setup pagination
@@ -50,26 +50,26 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 	public function column_blogname( $item ) {
 		// http://jpms/wp-admin/network/site-info.php?id=1
-		switch_to_blog( $item->blog_id );
+		switch_to_blog( $item['blog_id'] );
 		$jp_url = admin_url( 'admin.php?page=jetpack' );
 		restore_current_blog();
 
 		$actions = array(
-            		'edit'      	=> '<a href="' . network_admin_url( 'site-info.php?id=' . $item->blog_id )  .  '">' . __( 'Edit', 'jetpack' ) . '</a>',
-        		'dashboard'	=> '<a href="' . get_admin_url( $item->blog_id, '', 'admin' ) . '">Dashboard</a>',
-			'view'		=> '<a href="' . get_site_url( $item->blog_id, '', 'admin' ) . '">View</a>',
-			'jetpack-' . $item->blog_id	=> '<a href="' . $jp_url . '">Jetpack</a>',
+            		'edit'      	=> '<a href="' . network_admin_url( 'site-info.php?id=' . $item['blog_id'] )  .  '">' . __( 'Edit', 'jetpack' ) . '</a>',
+        		'dashboard'	=> '<a href="' . get_admin_url( $item['blog_id'], '', 'admin' ) . '">Dashboard</a>',
+			'view'		=> '<a href="' . get_site_url( $item['blog_id'], '', 'admin' ) . '">View</a>',
+			'jetpack-' . $item['blog_id']	=> '<a href="' . $jp_url . '">Jetpack</a>',
 		);
 
-  		return sprintf('%1$s %2$s', '<strong>' . get_blog_option( $item->blog_id, 'blogname' ) . '</strong>', $this->row_actions($actions) );
+  		return sprintf('%1$s %2$s', '<strong>' . get_blog_option( $item['blog_id'], 'blogname' ) . '</strong>', $this->row_actions($actions) );
 	}
 
 	public function column_blog_path( $item ) {
 		return
                          '<a href="' .
-                         get_site_url( $item->blog_id, '', 'admin' ) .
+                         get_site_url( $item['blog_id'], '', 'admin' ) .
                          '">' .
-                         str_replace( array( 'http://', 'https://' ), '', get_site_url( $item->blog_id, '', 'admin' ) ) .
+                         str_replace( array( 'http://', 'https://' ), '', get_site_url( $item['blog_id'], '', 'admin' ) ) .
                          '</a>';
 	}
 
@@ -77,7 +77,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		$jpms = Jetpack_Network::init();
 		$jp = Jetpack::init();
 
-		switch_to_blog( $item->blog_id );
+		switch_to_blog( $item['blog_id'] );
 
 		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
 			$title = __( 'Jetpack is not active on this site.', 'jetpack' );
@@ -92,7 +92,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		   // Build url for disconnecting
 		    $url = $jpms->get_url( array(
 			'name'	    => 'subsitedisconnect',
-			'site_id'   => $item->blog_id,
+			'site_id'   => $item['blog_id'],
 
 		    ) );
 		    restore_current_blog();
@@ -103,7 +103,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		// Build URL for connecting
 		$url = $jpms->get_url( array(
 		    'name'	=> 'subsiteregister',
-		    'site_id'	=> $item->blog_id,
+		    'site_id'	=> $item['blog_id'],
 		) );
 		return '<a href="' . $url . '">Connect</a>';
 	}
@@ -119,7 +119,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 	function column_cb($item) {
         	return sprintf(
-            		'<input type="checkbox" name="bulk[]" value="%s" />', $item->blog_id
+            		'<input type="checkbox" name="bulk[]" value="%s" />', $item['blog_id']
         	);
     	}
 

--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -54,10 +54,10 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		restore_current_blog();
 
 		$actions = array(
-			'edit'      => '<a href="' . network_admin_url( 'site-info.php?id=' . $item->blog_id )  .  '">' . esc_html__( 'Edit', 'jetpack' ) . '</a>',
-			'dashboard' => '<a href="' . get_admin_url( $item->blog_id, '', 'admin' ) . '">' . esc_html__( 'Dashboard', 'jetpack' ) . '</a>',
-			'view'      => '<a href="' . get_site_url( $item->blog_id, '', 'admin' ) . '">' . esc_html__( 'View', 'jetpack' ) . '</a>',
-			'jetpack-' . $item->blog_id => '<a href="' . $jp_url . '">Jetpack</a>',
+			'edit'      => '<a href="' . esc_url( network_admin_url( 'site-info.php?id=' . $item->blog_id ) )  .  '">' . esc_html__( 'Edit', 'jetpack' ) . '</a>',
+			'dashboard' => '<a href="' . esc_url( get_admin_url( $item->blog_id, '', 'admin' ) ) . '">' . esc_html__( 'Dashboard', 'jetpack' ) . '</a>',
+			'view'      => '<a href="' . esc_url( get_site_url( $item->blog_id, '', 'admin' ) ) . '">' . esc_html__( 'View', 'jetpack' ) . '</a>',
+			'jetpack-' . $item->blog_id => '<a href="' . esc_url( $jp_url ) . '">Jetpack</a>',
 		);
 
   		return sprintf('%1$s %2$s', '<strong>' . get_blog_option( $item->blog_id, 'blogname' ) . '</strong>', $this->row_actions($actions) );
@@ -95,7 +95,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 		    ) );
 		    restore_current_blog();
-		    return '<a href="' . $url . '">' . esc_html__( 'Disconnect', 'jetpack' ) . '</a>';
+		    return '<a href="' . esc_url( $url ) . '">' . esc_html__( 'Disconnect', 'jetpack' ) . '</a>';
 		}
 		restore_current_blog();
 
@@ -104,7 +104,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		    'name'	=> 'subsiteregister',
 		    'site_id'	=> $item->blog_id,
 		) );
-		return '<a href="' . $url . '">' . esc_html__( 'Connect', 'jetpack' ) . '</a>';
+		return '<a href="' . esc_url( $url ) . '">' . esc_html__( 'Connect', 'jetpack' ) . '</a>';
 	}
 
 	public function get_bulk_actions() {

--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -26,7 +26,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		$this->process_bulk_action();
 
 		$sites = get_sites( array( 
-			'offset' => 1, 
+			'site__not_in' => array( get_current_blog_id() ),
 			'archived' => false,
 		) );
 

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -167,10 +167,10 @@ class Jetpack_Network {
 			return;
 		}
 
-		$sites = wp_get_sites();
+		$sites = get_sites();
 
 		foreach ( $sites as $s ) {
-			switch_to_blog( $s['blog_id'] );
+			switch_to_blog( $s->blog_id );
 			$active_plugins = get_option( 'active_plugins' );
 
 			/*

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -167,10 +167,10 @@ class Jetpack_Network {
 			return;
 		}
 
-		$sites = $this->wp_get_sites();
+		$sites = wp_get_sites();
 
 		foreach ( $sites as $s ) {
-			switch_to_blog( $s->blog_id );
+			switch_to_blog( $s['blog_id'] );
 			$active_plugins = get_option( 'active_plugins' );
 
 			/*
@@ -746,68 +746,6 @@ class Jetpack_Network {
 		return $options[ $name ];
 	}
 
-	/**
-	 * Return an array of sites on the specified network. If no network is specified,
-	 * return all sites, regardless of network.
-	 *
-	 * @todo REMOVE THIS FUNCTION! This function is moving to core. Use that one in favor of this. WordPress::wp_get_sites(). http://codex.wordpress.org/Function_Reference/wp_get_sites NOTE, This returns an array instead of stdClass. Be sure to update class.network-sites-list-table.php
-	 * @since 2.9
-	 * @deprecated 2.4.5
-	 *
-	 * @param array|string $args Optional. Specify the status of the sites to return.
-	 *
-	 * @return array An array of site data
-	 */
-	public function wp_get_sites( $args = array() ) {
-		global $wpdb;
-
-		if ( wp_is_large_network() ) {
-			return;
-		}
-
-		$defaults = array( 'network_id' => $wpdb->siteid );
-		$args     = wp_parse_args( $args, $defaults );
-		$query    = "SELECT * FROM $wpdb->blogs WHERE 1=1 ";
-
-		if ( isset( $args['network_id'] ) && ( is_array( $args['network_id'] ) || is_numeric( $args['network_id'] ) ) ) {
-			$network_ids = array_map( 'intval', (array) $args['network_id'] );
-			$network_ids = implode( ',', $network_ids );
-			$query .= "AND site_id IN ($network_ids) ";
-		}
-
-		if ( isset( $args['public'] ) ) {
-			$query .= $wpdb->prepare( "AND public = %d ", $args['public'] );
-		}
-
-		if ( isset( $args['archived'] ) ) {
-			$query .= $wpdb->prepare( "AND archived = %d ", $args['archived'] );
-		}
-
-		if ( isset( $args['mature'] ) ) {
-			$query .= $wpdb->prepare( "AND mature = %d ", $args['mature'] );
-		}
-
-		if ( isset( $args['spam'] ) ) {
-			$query .= $wpdb->prepare( "AND spam = %d ", $args['spam'] );
-		}
-
-		if ( isset( $args['deleted'] ) ) {
-			$query .= $wpdb->prepare( "AND deleted = %d ", $args['deleted'] );
-		}
-
-		if ( isset( $args['exclude_blogs'] ) ) {
-			$query .= "AND blog_id NOT IN (" . implode( ',', $args['exclude_blogs'] ) . ")";
-		}
-
-		$key = 'wp_get_sites:' . md5( $query );
-
-		if ( ! $site_results = wp_cache_get( $key, 'site-id-cache' ) ) {
-			$site_results = (array) $wpdb->get_results( $query );
-			wp_cache_set( $key, $site_results, 'site-id-cache' );
-		}
-
-		return $site_results;
-	}
 }
 
 // end class

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -318,7 +318,7 @@ class Jetpack_Network {
 						/**
 						 * @todo Make state messages show on Jetpack NA pages
 						 **/
-						Jetpack::state( 'missing_site_id', 'Site ID must be provided to register a sub-site' );
+						Jetpack::state( 'missing_site_id', esc_html__( 'Site ID must be provided to register a sub-site.', 'jetpack' ) );
 						break;
 					}
 
@@ -339,7 +339,7 @@ class Jetpack_Network {
 					Jetpack::log( 'subsitedisconnect' );
 
 					if ( ! isset( $_GET['site_id'] ) || empty( $_GET['site_id'] ) ) {
-						Jetpack::state( 'missing_site_id', 'Site ID must be provided to disconnect a sub-site' );
+						Jetpack::state( 'missing_site_id', esc_html__( 'Site ID must be provided to disconnect a sub-site.', 'jetpack' ) );
 						break;
 					}
 


### PR DESCRIPTION
Changes usages of returned array since the method in Jetpack returned an array of objects while the function in core returns an array of arrays.

Call to wp_get_sites has offset set to 1 to dismiss the first site since Function in Jetpack excluded the first site as well.

Some strings weren't available for translation, it has been solved as well.

closes #3379 
