### PR TITLE
Widget Visibility: replace text labels with × and + icons

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -351,7 +351,7 @@ class Jetpack_Widget_Conditions {
 							<div class="condition-control">
 								<span class="condition-conjunction"><?php echo esc_html_x( 'or', 'Shown between widget visibility conditions.', 'jetpack' ); ?></span>
 								<div class="actions alignright">
-									<a href="#" class="delete-condition"><?php esc_html_e( 'Delete', 'jetpack' ); ?></a> | <a href="#" class="add-condition"><?php esc_html_e( 'Add', 'jetpack' ); ?></a>
+									<a href="#" class="delete-condition dashicons dashicons-no"><?php esc_html_e( 'Delete', 'jetpack' ); ?></a><a href="#" class="add-condition dashicons dashicons-plus"><?php esc_html_e( 'Add', 'jetpack' ); ?></a>
 								</div>
 							</div>
 

--- a/modules/widget-visibility/widget-conditions/widget-conditions.css
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.css
@@ -33,9 +33,12 @@
 }
 .widget-conditional .condition {
 	padding-top: 12px;
+	position: relative;
 }
 .widget-conditional .condition select {
 	width: 120px;
+	position: relative;
+	z-index: 2;
 }
 .widget-conditional .condition-top select {
 	width: auto;
@@ -46,17 +49,36 @@
 	margin-top: -20px;
 }
 .widget-conditional .selection {
-	margin-right: 70px;
+	margin-right: 50px;
+	margin-left: 20px;
 }
 .widget-conditional .conditions-rule-has-children {
 	display: block;
 }
 .widget-conditional .condition .actions {
 	margin-top: -28px;
+}.widget-conditional .condition .actions {
+	margin-top: -28px;
 }
 
 .widget-conditional .condition-control a {
 	text-decoration: none;
+	position: absolute;
+	top: 17px;
+	text-indent: -9999px;
+	z-index: 1;
+}
+.widget-conditional .condition-control a:before {
+	position: absolute;
+	text-indent: 0;
+	left: 0;
+}
+.widget-conditional .condition-control .delete-condition {
+	left: 0;
+	color: #f11;
+}
+.widget-conditional .condition-control .add-condition {
+	right: 0;
 }
 .widget-conditional .condition:last-child .condition-conjunction {
 	display: none;
@@ -73,4 +95,12 @@
 	min-width: 0;
 	max-width: none;
 	height: auto;
+}
+.wp-customizer .widget-conditional .condition-control a {
+	top: 15px;
+}
+@media screen and ( max-width: 782px ) {
+	.widget-conditional .condition-control a {
+		top: 20px;
+	}
 }


### PR DESCRIPTION
Small screen sizes have been taken into account, as well as its display in Customize.
Previous text labels "Delete" and "Add" were kept, albeit hidden, to preserve accesibility.

:exclamation: **_Note**_: before testing this, run `gulp old-styles` to build the minified `css` file used in Widgets and Customize

fixes #3382
