### PR TITLE
Nova menus: check that the term exists before trying to access a property in it.

### DIFF
--- a/modules/custom-post-types/js/menu-checkboxes.js
+++ b/modules/custom-post-types/js/menu-checkboxes.js
@@ -32,7 +32,6 @@
 		},
 
 		checkFirst: function() {
-			console.log( 'first!' );
 			NovaCheckBoxes.inputs.first().prop( 'checked', true );
 		},
 
@@ -40,6 +39,9 @@
 			if ( $( this ).is( ':checked' ) ) {
 				return NovaCheckBoxes.inputs.not( this ).prop( 'checked', false );
 			} else {
+				if ( $( this ).closest( '#nova_menuchecklist' ).find( ':checked' ).length > 0 ) {
+					return $( this ).prop( 'checked', false );
+				}
 				return NovaCheckBoxes.checkFirst();
 			}
 		}

--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -728,26 +728,25 @@ class Nova_Restaurant {
 
 		$term = $this->get_menu_item_menu_leaf( $post->ID );
 
-		if ( false !== $last_term_id && $last_term_id === $term->term_id ) {
+		$term_id = $term instanceof WP_Term ? $term->term_id : null;
+
+		if ( false !== $last_term_id && $last_term_id === $term_id ) {
 			return;
 		}
 
-		if ( false !== $term ) {
+		if ( is_null( $term_id ) ) {
+			$last_term_id = null;
+			$term_name = '';
+			$parent_count = 0;
+		} else {
 			$last_term_id = $term->term_id;
-			$term_id = $term->id;
 			$term_name = $term->name;
-
 			$parent_count = 0;
 			$current_term = $term;
 			while ( $current_term->parent ) {
 				$parent_count++;
 				$current_term = get_term( $current_term->parent, self::MENU_TAX );
 			}
-		} else {
-			$last_term_id = null;
-			$term_id = null;
-			$term_name = '';
-			$parent_count = 0;
 		}
 
 		$non_order_column_count = $wp_list_table->get_column_count() - 1;
@@ -772,7 +771,7 @@ class Nova_Restaurant {
 				<h3><?php
 					echo str_repeat( ' &mdash; ', (int) $parent_count );
 
-					if ( ! is_wp_error( $term ) ) {
+					if ( $term instanceof WP_Term ) {
 						echo esc_html( sanitize_term_field( 'name', $term_name, $term_id, self::MENU_TAX, 'display' ) );
 						edit_term_link( __( 'edit', 'jetpack' ), '<span class="edit-nova-section"><span class="dashicon dashicon-edit"></span>', '</span>', $term );
 
@@ -782,7 +781,7 @@ class Nova_Restaurant {
 				?></h3>
 			</td>
 			<td>
-				<?php if ( ! is_wp_error( $term ) ) { ?>
+				<?php if ( $term instanceof WP_Term ) { ?>
 				<a class="nova-move-menu-up" title="<?php esc_attr_e( 'Move menu section up', 'jetpack' ); ?>" href="<?php echo esc_url( $up_url ); ?>"><?php esc_html_e( 'UP', 'jetpack' ); ?></a>
 				<br />
 				<a class="nova-move-menu-down" title="<?php esc_attr_e( 'Move menu section down', 'jetpack' ); ?>" href="<?php echo esc_url( $down_url ); ?>"><?php esc_html_e( 'DOWN', 'jetpack' ); ?></a>

--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -485,9 +485,12 @@ class Nova_Restaurant {
 				), wp_nonce_url( $url, 'nova_move_item_down_' . $post_id ) );
 				$menu_item = get_post($post_id);
 				$this->get_menu_by_post_id( $post_id );
+				if ( $term_id = $this->get_menu_by_post_id( $post_id ) ) {
+					$term_id = $term_id->term_id;
+				}
 	?>
 				<input type="hidden" class="menu-order-value" name="nova_order[<?php echo (int) $post_id ?>]" value="<?php echo esc_attr( $menu_item->menu_order ) ?>" />
-				<input type="hidden" class='nova-menu-term' name="nova_menu_term[<?php echo (int) $post_id ?>]" value="<?php echo esc_attr( $this->get_menu_by_post_id( $post_id )->term_id ); ?>">
+				<input type="hidden" class='nova-menu-term' name="nova_menu_term[<?php echo (int) $post_id ?>]" value="<?php echo esc_attr( $term_id ); ?>">
 
 				<span class="hide-if-js">
 				&nbsp; &nbsp; &mdash; <a class="nova-move-item-up" data-post-id="<?php echo (int) $post_id; ?>" href="<?php echo esc_url( $up_url ); ?>">up</a>
@@ -725,16 +728,26 @@ class Nova_Restaurant {
 
 		$term = $this->get_menu_item_menu_leaf( $post->ID );
 
-		if ( false !== $last_term_id && $last_term_id === $term->term_id )
+		if ( false !== $last_term_id && $last_term_id === $term->term_id ) {
 			return;
+		}
 
-		$last_term_id = $term->term_id;
+		if ( false !== $term ) {
+			$last_term_id = $term->term_id;
+			$term_id = $term->id;
+			$term_name = $term->name;
 
-		$parent_count = 0;
-		$current_term = $term;
-		while ( $current_term->parent ) {
-			$parent_count++;
-			$current_term = get_term( $current_term->parent, self::MENU_TAX );
+			$parent_count = 0;
+			$current_term = $term;
+			while ( $current_term->parent ) {
+				$parent_count++;
+				$current_term = get_term( $current_term->parent, self::MENU_TAX );
+			}
+		} else {
+			$last_term_id = null;
+			$term_id = null;
+			$term_name = '';
+			$parent_count = 0;
 		}
 
 		$non_order_column_count = $wp_list_table->get_column_count() - 1;
@@ -745,22 +758,22 @@ class Nova_Restaurant {
 
 		$up_url = add_query_arg( array(
 			'action'  => 'move-menu-up',
-			'term_id' => (int) $term->term_id,
-		), wp_nonce_url( $url, 'nova_move_menu_up_' . $term->term_id ) );
+			'term_id' => (int) $term_id,
+		), wp_nonce_url( $url, 'nova_move_menu_up_' . $term_id ) );
 
 		$down_url = add_query_arg( array(
 			'action'  => 'move-menu-down',
-			'term_id' => (int) $term->term_id,
-		), wp_nonce_url( $url, 'nova_move_menu_down_' . $term->term_id ) );
+			'term_id' => (int) $term_id,
+		), wp_nonce_url( $url, 'nova_move_menu_down_' . $term_id ) );
 
 ?>
-		<tr class="no-items menu-label-row" data-term_id="<?php echo esc_attr( $term->term_id ) ?>">
+		<tr class="no-items menu-label-row" data-term_id="<?php echo esc_attr( $term_id ) ?>">
 			<td class="colspanchange" colspan="<?php echo (int) $non_order_column_count; ?>">
 				<h3><?php
 					echo str_repeat( ' &mdash; ', (int) $parent_count );
 
 					if ( ! is_wp_error( $term ) ) {
-						echo esc_html( sanitize_term_field( 'name', $term->name, $term->term_id, self::MENU_TAX, 'display' ) );
+						echo esc_html( sanitize_term_field( 'name', $term_name, $term_id, self::MENU_TAX, 'display' ) );
 						edit_term_link( __( 'edit', 'jetpack' ), '<span class="edit-nova-section"><span class="dashicon dashicon-edit"></span>', '</span>', $term );
 
 					} else {


### PR DESCRIPTION
This PR:

- avoids displaying a bunch of PHP notices in the menu list view in admin when no terms exist.

- the UP/DOWN buttons now work as expected, moving the group of items upwards or downwards. Previously they led to a blank page asking if user wanted to do it and they never work anyway.

- while editing an item, the first category in the list can now be deselected _if and when_ there is another category that user wants to select. Previously, you couldn't deselect the first category, even if there was another category already checked.

fixes #3407