### PR TITLE
Nova menus: when a new row is created, start with a clean description text box

### DIFF
--- a/modules/custom-post-types/js/many-items.js
+++ b/modules/custom-post-types/js/many-items.js
@@ -97,7 +97,7 @@
 		var tbody = this.find( 'tbody:last' ),
 			row = tbody.find( 'tr:first' ).clone();
 
-		$( row ).find( 'input' ).attr( 'value', '' );
+		$( row ).find( 'input, textarea' ).val( '' );
 		$( row ).appendTo( tbody );
 	};
 


### PR DESCRIPTION
Solves an issue when adding Many Items, where after creating a new row, the description text box was created containing the text of the previous row.

fixes #3378