### PR TITLE
Monitor: new xml request that returns date of last downtime

### DIFF
--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -166,7 +166,7 @@ class Jetpack_Monitor {
 		$xml->query( 'jetpack.monitor.getLastDowntime' );
 
 		if ( $xml->isError() ) {
-			wp_die( sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() ) );
+			return new WP_Error( 'monitor-downtime', $xml->getErrorMessage() );
 		}
 		return $xml->getResponse();
 	}

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -151,6 +151,26 @@ class Jetpack_Monitor {
 		return true;
 	}
 
+	/*
+	 * Returns date of the last downtime.
+	 *
+	 * @since 4.0
+	 * @return date in YYYY-MM-DD HH:mm:ss format
+	 */
+	public function monitor_get_last_downtime() {
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client( array(
+			'user_id' => get_current_user_id()
+		) );
+
+		$xml->query( 'jetpack.monitor.getLastDowntime' );
+
+		if ( $xml->isError() ) {
+			wp_die( sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() ) );
+		}
+		return $xml->getResponse();
+	}
+
 }
 
 new Jetpack_Monitor;


### PR DESCRIPTION
Endpoint will return date in `YYYY-MM-DD HH:mm:ss` format, which is how it's stored on wpcom.

The end game is to calculate this into "days since last downtime" to display on jp4 At A Glance dashboard.  

Will use with somethign that looks like: 

```
// Calculate "Days Since" last downtime.
		$monitor       = new Jetpack_Monitor();
		$last_downtime = $monitor->monitor_get_last_downtime();
		if ( is_wp_error( $last_downtime ) ) {
			$time_since = $last_downtime->get_error_message();
		} else {
			$time_since = human_time_diff( strtotime( $last_downtime ), strtotime( 'now' ) );
		}
```