### PR TITLE
Site properties in wp_blogs must be integers

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -769,23 +769,23 @@ class Jetpack_Network {
 		}
 
 		if ( isset( $args['public'] ) ) {
-			$query .= $wpdb->prepare( "AND public = %s ", $args['public'] );
+			$query .= $wpdb->prepare( "AND public = %d ", $args['public'] );
 		}
 
 		if ( isset( $args['archived'] ) ) {
-			$query .= $wpdb->prepare( "AND archived = %s ", $args['archived'] );
+			$query .= $wpdb->prepare( "AND archived = %d ", $args['archived'] );
 		}
 
 		if ( isset( $args['mature'] ) ) {
-			$query .= $wpdb->prepare( "AND mature = %s ", $args['mature'] );
+			$query .= $wpdb->prepare( "AND mature = %d ", $args['mature'] );
 		}
 
 		if ( isset( $args['spam'] ) ) {
-			$query .= $wpdb->prepare( "AND spam = %s ", $args['spam'] );
+			$query .= $wpdb->prepare( "AND spam = %d ", $args['spam'] );
 		}
 
 		if ( isset( $args['deleted'] ) ) {
-			$query .= $wpdb->prepare( "AND deleted = %s ", $args['deleted'] );
+			$query .= $wpdb->prepare( "AND deleted = %d ", $args['deleted'] );
 		}
 
 		if ( isset( $args['exclude_blogs'] ) ) {


### PR DESCRIPTION
It looks like #2381 broke some WordPress installations with outdated database schemas.

The archived column used to be an enum and not a tinyint, so when selecting `archived = ''` it returns no rows. A couple of ALTER TABLE statements fixes the bug (though I haven't tested with strict SQL mode) but it's easy enough for us to take care of that by providing integer values instead of empty strings. It's what core does in `wp_get_sites()` too.