### PR TITLE
Markdown: filter to define a custom pattern that won't be processed

### DIFF
--- a/_inc/lib/markdown/gfm.php
+++ b/_inc/lib/markdown/gfm.php
@@ -94,17 +94,19 @@ class WPCom_GHF_Markdown_Parser extends MarkdownExtra_Parser {
 		$text = preg_replace_callback( '|^#{1,6}( )?|um', array( $this, '_doEscapeForHashWithoutSpacing' ), $text );
 
 		/**
-		 * Allow third-party plugins to define a custom pattern that won't be processed by Markdown.
+		 * Allow third-party plugins to define custom patterns that won't be processed by Markdown.
 		 *
 		 * @module markdown
 		 *
 		 * @since 3.9.2
 		 *
-		 * @return string $custom_pattern Custom pattern to be ignored by Markdown.
+		 * @param array $custom_patterns Array of custom patterns to be ignored by Markdown.
 		 */
-		$custom_pattern = apply_filters( 'jetpack_markdown_preserve_pattern', '' );
-		if ( ! empty( $custom_pattern ) ) {
-			$text = preg_replace_callback( $custom_pattern, array( $this, '_doRemoveText'), $text );
+		$custom_patterns = apply_filters( 'jetpack_markdown_preserve_pattern', array() );
+		if ( is_array( $custom_patterns ) && ! empty( $custom_patterns ) ) {
+			foreach ( $custom_patterns as $pattern ) {
+				$text = preg_replace_callback( $pattern, array( $this, '_doRemoveText'), $text );
+			}
 		}
 
 		// run through core Markdown

--- a/_inc/lib/markdown/gfm.php
+++ b/_inc/lib/markdown/gfm.php
@@ -93,6 +93,20 @@ class WPCom_GHF_Markdown_Parser extends MarkdownExtra_Parser {
 		// escape line-beginning # chars that do not have a space after them.
 		$text = preg_replace_callback( '|^#{1,6}( )?|um', array( $this, '_doEscapeForHashWithoutSpacing' ), $text );
 
+		/**
+		 * Allow third-party plugins to define a custom pattern that won't be processed by Markdown.
+		 *
+		 * @module markdown
+		 *
+		 * @since 3.9.2
+		 *
+		 * @return string $custom_pattern Custom pattern to be ignored by Markdown.
+		 */
+		$custom_pattern = apply_filters( 'jetpack_markdown_preserve_pattern', '' );
+		if ( ! empty( $custom_pattern ) ) {
+			$text = preg_replace_callback( $custom_pattern, array( $this, '_doRemoveText'), $text );
+		}
+
 		// run through core Markdown
 		$text = parent::transform( $text );
 


### PR DESCRIPTION
Plugin authors can use this new `jetpack_markdown_preserve_pattern` to define custom patterns that will be ignored by Markdown.

See the example here: https://wordpress.org/support/topic/photon-prevents-svg-images-to-be-shown-properly?replies=4&view=all#post-8034089

The plugin author could then make sure their LaTeX code is not processed by Jetpack Markdown like so:

```php
function jeherve_custom_md_pattern( $patterns ) {
	$patterns[] = '/(!*\\\\\[.*?\\\\\])/s';

	return $patterns;
}
add_filter( 'jetpack_markdown_preserve_pattern', 'jeherve_custom_md_pattern' );
```