### PR TITLE
Shortcodes: add Codepen

### DIFF
--- a/modules/shortcodes/codepen.php
+++ b/modules/shortcodes/codepen.php
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * CodePen embed
+ *
+ * example URL: http://codepen.io/css-tricks/pen/wFeaG
+*/
+
+// Register oEmbed provider
+wp_oembed_add_provider( '#http[s]{0,1}://codepen.io/([^/]+)/pen/([^/]+)[/]{0,1}#', 'https://codepen.io/api/oembed', true );

--- a/modules/shortcodes/codepen.php
+++ b/modules/shortcodes/codepen.php
@@ -7,4 +7,4 @@
 */
 
 // Register oEmbed provider
-wp_oembed_add_provider( '#http[s]{0,1}://codepen.io/([^/]+)/pen/([^/]+)[/]{0,1}#', 'https://codepen.io/api/oembed', true );
+wp_oembed_add_provider( '#https?://codepen.io/([^/]+)/pen/([^/]+)/?#', 'https://codepen.io/api/oembed', true );


### PR DESCRIPTION
Ported from WordPress.com

To embed a Codepen, paste a Codepen URL on a separate line, e.g.

```
http://codepen.io/css-tricks/pen/wFeaG
```