### PR TITLE
Remove YouTube alignment CSS in feeds

### DIFF
--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -292,22 +292,32 @@ function youtube_id( $url ) {
 	if ( apply_filters( 'jetpack_youtube_allow_autoplay', false ) && isset( $qargs['autoplay'] ) )
 		$autoplay = '&autoplay=' . (int)$qargs['autoplay'];
 
-	$alignmentcss = 'text-align:center;';
-	if ( isset( $qargs['align'] ) ) {
-		switch ( $qargs['align'] ) {
-			case 'left':
-				$alignmentcss = "float:left; width:{$w}px; height:{$h}px; margin-right:10px; margin-bottom: 10px;";
-				break;
-			case 'right':
-				$alignmentcss = "float:right; width:{$w}px; height:{$h}px; margin-left:10px; margin-bottom: 10px;";
-				break;
-		}
+	if ( ( isset( $url['path'] ) && '/videoseries' == $url['path'] ) || isset( $qargs['list'] ) ) {
+		$html = "<iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/videoseries?list=$id&hl=en_US" ) ) . "' frameborder='0' allowfullscreen='true'></iframe>";
+	} else {
+		$html = "<iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/$id?version=3&rel=$rel&fs=1$fmt$autohide&showsearch=$search&showinfo=$info&iv_load_policy=$iv$start$end$hd&wmode=$wmode$theme$autoplay{$cc}{$cc_lang}" ) ) . "' frameborder='0' allowfullscreen='true'></iframe>";
 	}
 
-	if ( ( isset( $url['path'] ) && '/videoseries' == $url['path'] ) || isset( $qargs['list'] ) ) {
-		$html = "<span class='embed-youtube' style='$alignmentcss display: block;'><iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/videoseries?list=$id&hl=en_US" ) ) . "' frameborder='0' allowfullscreen='true'></iframe></span>";
-	} else {
-		$html = "<span class='embed-youtube' style='$alignmentcss display: block;'><iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( set_url_scheme( "http://www.youtube.com/embed/$id?version=3&rel=$rel&fs=1$fmt$autohide&showsearch=$search&showinfo=$info&iv_load_policy=$iv$start$end$hd&wmode=$wmode$theme$autoplay{$cc}{$cc_lang}" ) ) . "' frameborder='0' allowfullscreen='true'></iframe></span>";
+	// Let's do some alignment wonder in a span, unless we're producing a feed
+	if ( ! is_feed() ) {
+		$alignmentcss = 'text-align:center;';
+		if ( isset( $qargs['align'] ) ) {
+			switch ( $qargs['align'] ) {
+				case 'left':
+					$alignmentcss = "float:left; width:{$w}px; height:{$h}px; margin-right:10px; margin-bottom: 10px;";
+					break;
+				case 'right':
+					$alignmentcss = "float:right; width:{$w}px; height:{$h}px; margin-left:10px; margin-bottom: 10px;";
+					break;
+			}
+		}
+
+		$html = sprintf(
+			'<span class="embed-youtube" style="%s display: block;">%s</span>',
+			esc_attr( $alignmentcss ),
+			$html
+		);
+
 	}
 
 	/**

--- a/tests/php/modules/shortcodes/test_class.youtube.php
+++ b/tests/php/modules/shortcodes/test_class.youtube.php
@@ -57,7 +57,7 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 		the_content();
 		$actual = ob_get_clean();
 		wp_reset_postdata();
-		$this->assertContains( "<span class='embed-youtube'", $actual );
+		$this->assertContains( '<span class="embed-youtube"', $actual );
 		$this->assertContains( "<iframe class='youtube-player'", $actual );
 		$this->assertContains( "http://www.youtube.com/embed/$youtube_id", $actual );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Remove the span wrapped around YouTube videos when outputting feeds

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
