### PR TITLE
Markdown: Remove obsolete attributes

### DIFF
--- a/_inc/lib/markdown/extra.php
+++ b/_inc/lib/markdown/extra.php
@@ -2949,7 +2949,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 			$text .= "<hr". $this->empty_element_suffix ."\n";
 			$text .= "<ol>\n\n";
 
-			$attr = " rev=\"footnote\"";
+			$attr = "";
 			if ($this->fn_backlink_class != "") {
 				$class = $this->fn_backlink_class;
 				$class = $this->encodeAttribute($class);
@@ -3018,7 +3018,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 				$ref_count_mark = $this->footnotes_ref_count[$node_id] += 1;
 			}
 
-			$attr = " rel=\"footnote\"";
+			$attr = "";
 			if ($this->fn_link_class != "") {
 				$class = $this->fn_link_class;
 				$class = $this->encodeAttribute($class);


### PR DESCRIPTION
HTML5 made the `rel="footnote"` and `rev` attributes obsolete.

W3 suggests no special markup for footnotes: https://www.w3.org/TR/html5/common-idioms.html#footnotes

Suggesting a local fix versus upstream since we're using the version that is no longer supported. (The new version requires PHP 5.3.)

See https://github.com/Automattic/amp-wp/pull/231
