### PR TITLE
JSON API: Do not add wpcom only filter

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -437,7 +437,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 				}
 			}
-			add_filter( 'option_stylesheet', 'fix_theme_location' );
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				add_filter( 'option_stylesheet', 'fix_theme_location' );
+			}
 			if ( 'https' !== parse_url( $site_url, PHP_URL_SCHEME ) ) {
 				remove_filter( 'set_url_scheme', array( $this, 'force_http' ), 10, 3 );
 			}


### PR DESCRIPTION
`PHP message: PHP Warning:  call_user_func_array() expects parameter 1 to be a valid callback, function 'fix_theme_location' not found or invalid function name in /srv/www/html/wp-includes/plugin.php on line 235`

cc: @dereksmart since you did a lot of API merging.