### PR TITLE
Add/tracks ajaxified

### DIFF
--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -116,6 +116,9 @@ function jetpack_tracks_get_identity( $user_id ) {
 function jetpack_tracks_record_event( $user, $event_name, $properties = array(), $event_timestamp_millis = false ) {
 	$event_obj = jetpack_tracks_build_event_obj( $user, $event_name, $properties, $event_timestamp_millis );
 
+	error_log( print_r( $event_obj, 1 ) );
+	return;
+
 	if ( is_wp_error( $event_obj->error ) ) {
 		return $event_obj->error;
 	}

--- a/_inc/lib/tracks/tracks-ajax.js
+++ b/_inc/lib/tracks/tracks-ajax.js
@@ -33,17 +33,18 @@
 				var newTabWindow = window.open( '', target );
 			}
 
-			$.post( jpTracksAJAX.ajaxurl, data, function ( response ) {
-				if ( response.success ) {
-
-					// Continue on to whatever url they were trying to get to.
-					if ( url ) {
-						if ( newTabWindow ) {
-							newTabWindow.location = url;
-							return;
-						}
-						window.location = url;
+			$.ajax( {
+				type: 'POST',
+				url: jpTracksAJAX.ajaxurl,
+				data: data
+			} ).always( function() {
+				// Continue on to whatever url they were trying to get to.
+				if ( url ) {
+					if ( newTabWindow ) {
+						newTabWindow.location = url;
+						return;
 					}
+					window.location = url;
 				}
 			} );
 		});

--- a/_inc/lib/tracks/tracks-ajax.js
+++ b/_inc/lib/tracks/tracks-ajax.js
@@ -2,36 +2,32 @@
 
 (function( $, jpTracksAJAX ) {
 
-	var data;
-
 	$( document ).ready( function () {
+		$( 'body' ).on( 'click', '.jptracks a, a.jptracks', function( event ) {
 
-		data = {
-			'tracksNonce' : jpTracksAJAX.jpTracksAJAX_nonce
-		};
+			// We know that the jptracks element is either this, or its ancestor
+			var $jptracks = $( this ).closest( '.jptracks' );
 
-		jetpackTracksAJAX();
-	});
-
-	function jetpackTracksAJAX() {
-		$( '.jptracks' ).click( function( e ) {
-			data.action           = 'jetpack_tracks';
-			data.tracksEventType  = 'click';
-			data.tracksEventName  = $( this ).attr( 'data-jptracks-name' );
-			data.tracksEventProp  = $( this ).attr( 'data-jptracks-prop' ) || false;
+			var data = {
+				tracksNonce: jpTracksAJAX.jpTracksAJAX_nonce,
+				action: 'jetpack_tracks',
+				tracksEventType: 'click',
+				tracksEventName: $jptracks.attr( 'data-jptracks-name' ),
+				tracksEventProp: $jptracks.attr( 'data-jptracks-prop' ) || false
+			};
 
 			// We need an event name at least
 			if ( undefined === data.tracksEventName ) {
 				return;
 			}
 
-			e.preventDefault();
-
-			var url    = e.srcElement.href;
-			var target = e.srcElement.target;
+			var url    = $( this ).attr( 'href' );
+			var target = $( this ).get( 0 ).target;
 			if ( url && target && '_self' !== target ) {
 				var newTabWindow = window.open( '', target );
 			}
+
+			event.preventDefault();
 
 			$.ajax( {
 				type: 'POST',
@@ -48,6 +44,6 @@
 				}
 			} );
 		});
-	}
+	});
 
 })( jQuery, jpTracksAJAX );

--- a/_inc/lib/tracks/tracks-ajax.js
+++ b/_inc/lib/tracks/tracks-ajax.js
@@ -15,14 +15,35 @@
 
 	function jetpackTracksAJAX() {
 		$( '.jptracks' ).click( function( e ) {
+			data.action           = 'jetpack_tracks';
+			data.tracksEventType  = 'click';
+			data.tracksEventName  = $( this ).attr( 'data-jptracks-name' );
+			data.tracksEventProp  = $( this ).attr( 'data-jptracks-prop' ) || false;
+
+			// We need an event name at least
+			if ( undefined === data.tracksEventName ) {
+				return;
+			}
+
 			e.preventDefault();
 
-			data.action          = 'jetpack_tracks';
-			data.tracksEventName = $( this ).attr( 'data-jptracks-name' );
+			var url    = e.srcElement.href;
+			var target = e.srcElement.target;
+			if ( url && target && '_self' !== target ) {
+				var newTabWindow = window.open( '', target );
+			}
 
 			$.post( jpTracksAJAX.ajaxurl, data, function ( response ) {
-				if ( 0 !== response ) {
-					alert( response );
+				if ( response.success ) {
+
+					// Continue on to whatever url they were trying to get to.
+					if ( url ) {
+						if ( newTabWindow ) {
+							newTabWindow.location = url;
+							return;
+						}
+						window.location = url;
+					}
 				}
 			} );
 		});

--- a/_inc/lib/tracks/tracks-ajax.js
+++ b/_inc/lib/tracks/tracks-ajax.js
@@ -1,0 +1,31 @@
+/* global jpTracksAJAX, jQuery */
+
+(function( $, jpTracksAJAX ) {
+
+	var data;
+
+	$( document ).ready( function () {
+
+		data = {
+			'tracksNonce' : jpTracksAJAX.jpTracksAJAX_nonce
+		};
+
+		jetpackTracksAJAX();
+	});
+
+	function jetpackTracksAJAX() {
+		$( '.jptracks' ).click( function( e ) {
+			e.preventDefault();
+
+			data.action          = 'jetpack_tracks';
+			data.tracksEventName = $( this ).attr( 'data-jptracks-name' );
+
+			$.post( jpTracksAJAX.ajaxurl, data, function ( response ) {
+				if ( 0 !== response ) {
+					alert( response );
+				}
+			} );
+		});
+	}
+
+})( jQuery, jpTracksAJAX );

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -13,9 +13,20 @@ class JetpackTracking {
 			return;
 		}
 
+		// For tracking stuff via js/ajax
+		add_action( 'admin_enqueue_scripts',         array( __CLASS__, 'enqueue_tracks_scripts' ) );
+
 		add_action( 'jetpack_pre_activate_module',   array( __CLASS__, 'track_activate_module'), 1, 1 );
 		add_action( 'jetpack_pre_deactivate_module', array( __CLASS__, 'track_deactivate_module'), 1, 1 );
 		add_action( 'jetpack_user_authorized',       array( __CLASS__, 'track_user_linked' ) );
+	}
+
+	static function enqueue_tracks_scripts() {
+		wp_enqueue_script( 'jptracks', plugins_url( '_inc/lib/tracks/tracks-ajax.js', JETPACK__PLUGIN_FILE ) );
+		wp_localize_script( 'jptracks', 'jpTracksAJAX', array(
+			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
+			'jpTracksAJAX_nonce' => wp_create_nonce( 'jp-tracks-ajax-nonce' ),
+		) );
 	}
 
 	/* User has linked their account */

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -22,7 +22,7 @@ class JetpackTracking {
 	}
 
 	static function enqueue_tracks_scripts() {
-		wp_enqueue_script( 'jptracks', plugins_url( '_inc/lib/tracks/tracks-ajax.js', JETPACK__PLUGIN_FILE ) );
+		wp_enqueue_script( 'jptracks', plugins_url( '_inc/lib/tracks/tracks-ajax.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
 		wp_localize_script( 'jptracks', 'jpTracksAJAX', array(
 			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
 			'jpTracksAJAX_nonce' => wp_create_nonce( 'jp-tracks-ajax-nonce' ),

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -714,10 +714,20 @@ class Jetpack {
 	function jetpack_admin_ajax_tracks_callback() {
 		// Check for nonce
 		if ( ! isset( $_REQUEST['tracksNonce'] ) || ! wp_verify_nonce( $_REQUEST['tracksNonce'], 'jp-tracks-ajax-nonce' ) ) {
-			wp_die( 'permissions check failed' );
+			wp_die( 'Permissions check failed.' );
 		}
 
-		echo 'request made!';
+		if ( ! isset( $_REQUEST['tracksEventName'] ) || ! is_string( $_REQUEST['tracksEventName'] ) ) {
+			wp_die( 'No valid event name.' );
+		}
+
+		if ( isset( $_REQUEST['tracksEventProp'] ) && is_string( $_REQUEST['tracksEventProp'] ) ) {
+			JetpackTracking::record_user_event( $_REQUEST['tracksEventName'], array( 'nudge_click_prop' => $_REQUEST['tracksEventProp'] ) );
+		} else {
+			JetpackTracking::record_user_event( $_REQUEST['tracksEventName'], array() );
+		}
+
+		wp_send_json_success();
 		wp_die();
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -638,6 +638,9 @@ class Jetpack {
 		add_action( 'wp_ajax_jetpack_admin_ajax',          array( $this, 'jetpack_admin_ajax_callback' ) );
 		add_action( 'wp_ajax_jetpack_admin_ajax_refresh',  array( $this, 'jetpack_admin_ajax_refresh_data' ) );
 
+		// Universal ajax callback for all tracking events triggered via js
+		add_action( 'wp_ajax_jetpack_tracks', array( $this, 'jetpack_admin_ajax_tracks_callback' ) );
+
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'devicepx' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'devicepx' ) );
@@ -706,6 +709,16 @@ class Jetpack {
 		} else if ( empty( $url ) && did_action( 'delete_option_site_icon' ) ) {
 			Jetpack_Options::delete_option( 'site_icon_url' );
 		}
+	}
+
+	function jetpack_admin_ajax_tracks_callback() {
+		// Check for nonce
+		if ( ! isset( $_REQUEST['tracksNonce'] ) || ! wp_verify_nonce( $_REQUEST['tracksNonce'], 'jp-tracks-ajax-nonce' ) ) {
+			wp_die( 'permissions check failed' );
+		}
+
+		echo 'request made!';
+		wp_die();
 	}
 
 	function jetpack_admin_ajax_callback() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -717,16 +717,16 @@ class Jetpack {
 			wp_die( 'Permissions check failed.' );
 		}
 
-		if ( ! isset( $_REQUEST['tracksEventName'] ) || ! is_string( $_REQUEST['tracksEventName'] ) ) {
-			wp_die( 'No valid event name.' );
+		if ( ! isset( $_REQUEST['tracksEventName'] ) || ! isset( $_REQUEST['tracksEventType'] )  ) {
+			wp_die( 'No valid event name or type.' );
 		}
 
-		if ( isset( $_REQUEST['tracksEventProp'] ) && is_string( $_REQUEST['tracksEventProp'] ) ) {
-			JetpackTracking::record_user_event( $_REQUEST['tracksEventName'], array( 'nudge_click_prop' => $_REQUEST['tracksEventProp'] ) );
-		} else {
-			JetpackTracking::record_user_event( $_REQUEST['tracksEventName'], array() );
+		$tracks_data = array();
+		if ( 'click' === $_REQUEST['tracksEventType'] && isset( $_REQUEST['tracksEventProp'] ) ) {
+			$tracks_data = array( 'clicked' => $_REQUEST['tracksEventProp'] );
 		}
 
+		JetpackTracking::record_user_event( $_REQUEST['tracksEventName'], $tracks_data );
 		wp_send_json_success();
 		wp_die();
 	}

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -221,7 +221,7 @@
 				<p><?php esc_html_e( 'Business site? Safeguard it with real-time backups, security scans, and anti-spam.', 'jetpack' ); ?></p>
 				<p>&nbsp;</p>
 				<?php $normalized_site_url = Jetpack::build_raw_urls( get_home_url() ); ?>
-				<div class="actions jptracks" data-jptracks-name="compare-plans"><a href="<?php echo esc_url( 'https://wordpress.com/plans/' . $normalized_site_url ); ?>" target="_blank" class="button"><?php esc_html_e( 'Compare Options', 'jetpack' ); ?></a></div>
+				<div class="actions jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="nux-addons"><a href="<?php echo esc_url( 'https://wordpress.com/plans/' . $normalized_site_url ); ?>" target="_blank" class="button"><?php esc_html_e( 'Compare Options', 'jetpack' ); ?></a></div>
 			</div>
 		</div><?php // nux-foot ?>
 

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -221,7 +221,7 @@
 				<p><?php esc_html_e( 'Business site? Safeguard it with real-time backups, security scans, and anti-spam.', 'jetpack' ); ?></p>
 				<p>&nbsp;</p>
 				<?php $normalized_site_url = Jetpack::build_raw_urls( get_home_url() ); ?>
-				<div class="actions"><a href="<?php echo esc_url( 'https://wordpress.com/plans/' . $normalized_site_url ); ?>" target="_blank" class="button"><?php esc_html_e( 'Compare Options', 'jetpack' ); ?></a></div>
+				<div class="actions jptracks" data-jptracks-name="compare-plans"><a href="<?php echo esc_url( 'https://wordpress.com/plans/' . $normalized_site_url ); ?>" target="_blank" class="button"><?php esc_html_e( 'Compare Options', 'jetpack' ); ?></a></div>
 			</div>
 		</div><?php // nux-foot ?>
 

--- a/views/admin/landing-page-templates.php
+++ b/views/admin/landing-page-templates.php
@@ -83,9 +83,9 @@
 
 					<# if ( 'vaultpress' == data.module ) { #>
 						<?php if ( is_plugin_active( 'vaultpress/vaultpress.php' ) ) : ?>
-							<a href="<?php echo esc_url( $vp_link ); ?>" class="dashicons dashicons-external" title="<?php esc_attr_e( 'Configure', 'jetpack' ); ?>" target="<?php echo $target; ?>"></a>
+							<a href="<?php echo esc_url( $vp_link ); ?>" class="dashicons dashicons-external jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="nux-vaultpress-configure" title="<?php esc_attr_e( 'Configure', 'jetpack' ); ?>" target="<?php echo $target; ?>"></a>
 						<?php else : ?>
-							<a href="<?php echo esc_url( $vp_link ); ?>" class="lmore" title="<?php esc_attr_e( 'Learn More', 'jetpack' ); ?>" target="<?php echo $target; ?>"><?php _e( 'Learn More', 'jetpack' ); ?></a>
+							<a href="<?php echo esc_url( $vp_link ); ?>" class="lmore jptracks" data-jptracks-name="nudge_click" data-jptracks-prop="nux-vaultpress-learnmore" title="<?php esc_attr_e( 'Learn More', 'jetpack' ); ?>" target="<?php echo $target; ?>"><?php _e( 'Learn More', 'jetpack' ); ?></a>
 						<?php endif; ?>
 					<# } else { #>
 						<span class="form-toggle__switch"></span>


### PR DESCRIPTION
This allows us to use tracks to send js events (click only for now) for certain elements.  We can track any element clicked that has the class `.jptracks` and a `data-jptracks-name` attribute set, which acts as the event name.  An optional `data-jptracks-prop` can also be set to provide additional information.  

This PR tracks clicks on the "Compare Options" and VaultPress links within the table in the main Jetpack admin page. 

To Test: 
- make sure you're logging your error_logs somewhere
- click those links/buttons
- make sure links work properly (target attributes...) 
- check your error_log to see the object that would have been sent over, you'll look for `[_en] => jetpack_nudge_click` and if it has a prop set, something like `[clicked] => nux-vaultpress-configure`.

If you want to test in real time, comment out the error_log & `return` in `jetpack_tracks_record_event()`, wait like 5-10 minutes and you should see the event in tracks.  

cc @richardmuscat 