### PR TITLE
Issue template: add title and new comments

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,16 @@
-> What I expected
+<!-- Thanks for contributing to Jetpack! Pick a clear title ("Sharing: add new Facebook button") and proceed. -->
 
-> What happened
+#### What I expected
 
-> Steps to reproduce the issue
+#### What happened instead
 
-### Are you in the right place?
+#### Steps to reproduce the issue
 
+<!--
+PLEASE NOTE
+- These comments won't show up when you submit the issue.
+- Everything is optional, but try to add as many details as possible.
+- If requesting a new feature, explain why you'd like to see it added.
 - This issue tracker is not for support. If you have questions about Jetpack, you can [start a new thread in the Jetpack support forums](http://wordpress.org/support/plugin/jetpack#postform), or [send us an email](http://jetpack.me/contact-support/).
-
 - Do not report potential security vulnerabilities here. For responsible disclosure of security issues and to be eligible for our bug bounty program, please submit your report via [the HackerOne portal](https://hackerone.com/automattic).
+-->


### PR DESCRIPTION
- Comments should only appear for the author of the issue. They are nown commented out.
- Add title to welcome contributors.
- Switch from blockquotes to headings to make formatting easier for the person creating the issue.