### PR TITLE
WordPress Post Widget: account for Jetpack dependency

### DIFF
--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -597,21 +597,22 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 			return false;
 		}
 
-		/**
-		 * If Jetpack is not active or in development mode, we don't want to update widget data.
-		 */
-		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
-			return false;
+		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+			/**
+			 * If Jetpack is not active or in development mode, we don't want to update widget data.
+			 */
+			if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
+				return false;
+			}
+
+			/**
+			 * If Extra Sidebar Widgets module is not active, we don't need to update widget data.
+			 */
+			if ( ! Jetpack::is_module_active( 'widgets' ) ) {
+				return false;
+			}
 		}
-
-		/**
-		 * If Extra Sidebar Widgets module is not active, we don't need to update widget data.
-		 */
-		if ( ! Jetpack::is_module_active( 'widgets' ) ) {
-			return false;
-		}
-
-
+		
 		/**
 		 * If none of the above checks failed, then we definitely want to update widget data.
 		 */


### PR DESCRIPTION
wpcom doesn't have, nor has any use for, these methods.

This is for the D1160 that has yet to be merged.