### PR TITLE
Add Constant so that it is easier for Jetpack to talk to .com sandbox…

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -1,7 +1,6 @@
 <?php
 
 class Jetpack_Client {
-	const WPCOM_JSON_API_HOST    = 'public-api.wordpress.com';
 	const WPCOM_JSON_API_VERSION = '1.1';
 
 	/**
@@ -110,6 +109,12 @@ class Jetpack_Client {
 		$request['headers'] = array(
 			'Authorization' => "X_JETPACK " . join( ' ', $header_pieces ),
 		);
+
+		// Make sure we keep the host when we do JETPACK__WPCOM_JSON_API_HOST requests.
+		$host = parse_url( $url, PHP_URL_HOST );
+		if ( $host === JETPACK__WPCOM_JSON_API_HOST ) {
+			$request['headers']['Host'] = 'public-api.wordpress.com';
+		}
 
 		if ( 'header' != $args['auth_location'] ) {
 			$url = add_query_arg( 'signature', urlencode( $signature ), $url );
@@ -271,7 +276,7 @@ class Jetpack_Client {
 		}
 
 		$validated_args = array_merge( $filtered_args, array(
-			'url'     => sprintf( '%s://%s/rest/v%s/%s', $proto, self::WPCOM_JSON_API_HOST, $version, $_path ),
+			'url'     => sprintf( '%s://%s/rest/v%s/%s', $proto, JETPACK__WPCOM_JSON_API_HOST, $version, $_path ),
 			'blog_id' => (int) Jetpack_Options::get_option( 'id' ),
 			'method'  => $request_method,
 		) );

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -109,6 +109,10 @@ class Jetpack_Signature {
 			return new Jetpack_Error( 'invalid_signature', sprintf( 'The required "%s" parameter is malformed.', 'url' ) );
 		}
 
+		if ( $parsed['host'] === JETPACK__WPCOM_JSON_API_HOST ) {
+			$parsed['host'] = 'public-api.wordpress.com';
+		}
+
 		if ( !empty( $parsed['port'] ) ) {
 			$port = $parsed['port'];
 		} else {

--- a/jetpack.php
+++ b/jetpack.php
@@ -25,6 +25,7 @@ defined( 'JETPACK_CLIENT__HTTPS' )           or define( 'JETPACK_CLIENT__HTTPS',
 defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) or define( 'JETPACK__GLOTPRESS_LOCALES_PATH', JETPACK__PLUGIN_DIR . 'locales.php' );
 defined( 'JETPACK__API_BASE' )               or define( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
 defined( 'JETPACK_PROTECT__API_HOST' )       or define( 'JETPACK_PROTECT__API_HOST', 'https://api.bruteprotect.com/' );
+defined( 'JETPACK__WPCOM_JSON_API_HOST' )    or define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
 
 // @todo: Abstract out the admin functions, and only include them if is_admin()
 // @todo: Only include things like class.jetpack-sync.php if we're connected.


### PR DESCRIPTION
Currently I wasn't able to find a easy way to setup my dev environment so that my .org sandbox is able to talk to my .com sandbox via the REST API. 
This PR fixes this. 

The problem was that when talking to my public .com sandbox url the host wasn't being set as `public-api.wordpress.com` which is needed for the sandbox to respond as the rest api endpoint. 

**To test**:

Update the new constant `JETPACK__WPCOM_JSON_API_HOST`  to the be the same as your sandbox host. 

`define( 'JETPACK__WPCOM_JSON_API_HOST', 'your.com.sandbox.public.url' );

make a api call. 
```
var_dump( Jetpack_Client::wpcom_json_api_request_as_blog( '/me/sites' ) );
```

The api call return the expected result. 

Also fixed issues reported in #3443
cc: @lezama
