### PR TITLE
Contact Form: fix fatal error when no post meta exists for forms

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -624,19 +624,6 @@ class Grunion_Contact_Form_Plugin {
 		foreach ( $post_ids as $post_id ) {
 
 			/**
-			 * Fetch post meta data.
-			 */
-			$post_meta_data = $this->get_post_meta_for_csv_export( $post_id );
-
-			/**
-			 * If `$post_meta_data` is not an array or if it is empty, then there is no
-			 * feedback to work with. Skip it.
-			 */
-			if ( ! is_array( $post_meta_data ) || empty( $post_meta_data ) ) {
-				continue;
-			}
-
-			/**
 			 * Fetch post main data, because we need the subject and author data for the feedback form.
 			 */
 			$post_real_data = $this->get_parsed_field_contents_of_post( $post_id );
@@ -662,6 +649,19 @@ class Grunion_Contact_Form_Plugin {
 			 * Map parsed fields to proper field names
 			 */
 			$mapped_fields = $this->map_parsed_field_contents_of_post_to_field_names( $post_real_data );
+
+			/**
+			 * Fetch post meta data.
+			 */
+			$post_meta_data = $this->get_post_meta_for_csv_export( $post_id );
+
+			/**
+			 * If `$post_meta_data` is not an array or if it is empty, then there is no
+			 * extra feedback to work with. Create an empty array.
+			 */
+			if ( ! is_array( $post_meta_data ) || empty( $post_meta_data ) ) {
+				$post_meta_data = array();
+			}
 
 			/**
 			 * Prepend the feedback subject to the list of fields.

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -697,32 +697,33 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			),
 		);
 
+		// Even though there is no post meta for the first, we don't stop the cycle
+		// and each mock expects two calls
 		$mock->expects( $this->exactly( 2 ) )
-		     ->method( 'get_post_meta_for_csv_export' )
-		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
+			->method( 'get_post_meta_for_csv_export' )
+			->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
 
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'get_parsed_field_contents_of_post' )
+			->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
 
-		$mock->expects( $this->exactly( 1 ) )
-		     ->method( 'get_parsed_field_contents_of_post' )
-		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'get_post_content_for_csv_export' )
+			->will( $this->returnValueMap( $get_post_content_for_csv_export_map ) );
 
-		$mock->expects( $this->exactly( 1 ) )
-		     ->method( 'get_post_content_for_csv_export' )
-		     ->will( $this->returnValueMap( $get_post_content_for_csv_export_map ) );
-
-		$mock->expects( $this->exactly( 1 ) )
-		     ->method( 'map_parsed_field_contents_of_post_to_field_names' )
-		     ->will( $this->returnValueMap( $mapped_fields_contents_map ) );
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'map_parsed_field_contents_of_post_to_field_names' )
+			->will( $this->returnValueMap( $mapped_fields_contents_map ) );
 
 		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
 
 		$expected_result = array(
-			'Contact Form' => array( 'subj2' ),
-			'key3'         => array( 'value3' ),
-			'key4'         => array( 'value4' ),
-			'key5'         => array( 'value5' ),
-			'key6'         => array( 'value6' ),
-			'4_Comment'    => array( 'This is my test 16' ),
+			'Contact Form' => array( 'subj1', 'subj2' ),
+			'key3'         => array( '', 'value3' ),
+			'key4'         => array( '', 'value4' ),
+			'key5'         => array( '', 'value5' ),
+			'key6'         => array( '', 'value6' ),
+			'4_Comment'    => array( 'This is my test 15', 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -752,24 +753,59 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			array( 16, null ),
 		);
 
+		$get_parsed_field_contents_of_post_map = array(
+			array( 15, array( '_feedback_subject' => 'subj1' ) ),
+			array( 16, array( '_feedback_subject' => 'subj2' ) ),
+		);
+
+
+		$get_post_content_for_csv_export_map = array(
+			array( 15, 'This is my test 15' ),
+			array( 16, 'This is my test 16' ),
+		);
+
+		$mapped_fields_contents_map = array(
+			array(
+				array( '_feedback_subject' => 'subj1', '_feedback_main_comment' => 'This is my test 15' ),
+				array(
+					'Contact Form' => 'subj1',
+					'4_Comment'    => 'This is my test 15'
+				)
+			),
+			array(
+				array( '_feedback_subject' => 'subj2', '_feedback_main_comment' => 'This is my test 16' ),
+				array(
+					'Contact Form' => 'subj2',
+					'4_Comment'    => 'This is my test 16'
+				)
+			),
+		);
+
 		$mock->expects( $this->exactly( 2 ) )
 		     ->method( 'get_post_meta_for_csv_export' )
 		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
 
 
-		$mock->expects( $this->never() )
-		     ->method( 'get_parsed_field_contents_of_post' );
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_parsed_field_contents_of_post' )
+		     ->will( $this->returnValueMap( $get_parsed_field_contents_of_post_map ) );
 
-		$mock->expects( $this->never() )
-		     ->method( 'get_post_content_for_csv_export' );
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'get_post_content_for_csv_export' )
+		     ->will( $this->returnValueMap( $get_post_content_for_csv_export_map ) );
 
-		$mock->expects( $this->never() )
-		     ->method( 'map_parsed_field_contents_of_post_to_field_names' );
+
+		$mock->expects( $this->exactly( 2 ) )
+		     ->method( 'map_parsed_field_contents_of_post_to_field_names' )
+		     ->will( $this->returnValueMap( $mapped_fields_contents_map ) );
 
 
 		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
 
-		$expected_result = array();
+		$expected_result = array(
+			'Contact Form' => array( 'subj1', 'subj2' ),
+			'4_Comment'    => array( 'This is my test 15', 'This is my test 16' ),
+		);
 
 		$this->assertEquals( $expected_result, $result );
 	}
@@ -843,10 +879,9 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			),
 		);
 
-		$mock->expects( $this->exactly( 2 ) )
+		$mock->expects( $this->exactly( 1 ) )
 		     ->method( 'get_post_meta_for_csv_export' )
 		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
-
 
 		$mock->expects( $this->exactly( 2 ) )
 		     ->method( 'get_parsed_field_contents_of_post' )
@@ -892,37 +927,13 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		             ->disableOriginalConstructor()
 		             ->getMock();
 
-
-		$get_post_meta_for_csv_export_map = array(
-			array(
-				15,
-				array(
-					'key1' => 'value1',
-					'key2' => 'value2',
-					'key3' => 'value3',
-					'key4' => 'value4',
-
-				)
-			),
-			array(
-				16,
-				array(
-					'key3' => 'value3',
-					'key4' => 'value4',
-					'key5' => 'value5',
-					'key6' => 'value6'
-				)
-			),
-		);
-
 		$get_parsed_field_contents_of_post_map = array(
 			array( 15, array() ),
 			array( 16, array() ),
 		);
 
-		$mock->expects( $this->exactly( 2 ) )
-		     ->method( 'get_post_meta_for_csv_export' )
-		     ->will( $this->returnValueMap( $get_post_meta_for_csv_export_map ) );
+		$mock->expects( $this->never() )
+		     ->method( 'get_post_meta_for_csv_export' );
 
 
 		$mock->expects( $this->exactly( 2 ) )


### PR DESCRIPTION
When creating a very simple form, no data is saved in post meta when the form is submitted.
This PR creates an enpty `$post_meta_data` array to avoid errors when there is no post meta data.

Fixes #3460