### PR TITLE
Merge: update api site settings endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -83,12 +83,19 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	public function get_settings_response() {
 
-		$response_format = self::$site_format;
+		$response_format = static::$site_format;
 		$blog_id = (int) $this->api->get_blog_id_for_output();
 		/** This filter is documented in class.json-api-endpoints.php */
 		$is_jetpack = true === apply_filters( 'is_jetpack_site', false, $blog_id );
 
 		foreach ( array_keys( $response_format ) as $key ) {
+
+			// refactoring to change lang parameter to locale in 1.2
+			if ( $lang_or_locale = $this->get_locale( $key ) ) {
+				$response[$key] = $lang_or_locale;
+				continue;
+			}
+
 			switch ( $key ) {
 			case 'ID' :
 				$response[$key] = $blog_id;
@@ -101,9 +108,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'URL' :
 				$response[$key] = (string) home_url();
-				break;
-			case 'lang' :
-				$response[$key] = (string) get_bloginfo( 'language' );
 				break;
 			case 'settings':
 
@@ -131,7 +135,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$holiday_snow = (bool) get_option( jetpack_holiday_snow_option_name() );
 				}
 
-				$response[$key] = array(
+				$response[ $key ] = array(
 
 					// also exists as "options"
 					'admin_url'               => get_admin_url(),
@@ -180,6 +184,9 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'holidaysnow'             => $holiday_snow
 				);
 
+				//allow future versions of this endpoint to support additional settings keys
+				$response[ $key ] = apply_filters( 'site_settings_endpoint_get', $response[ $key ] );
+
 				if ( class_exists( 'Sharing_Service' ) ) {
 					$ss = new Sharing_Service();
 					$sharing = $ss->get_global_options();
@@ -202,6 +209,19 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		return $response;
 
 	}
+
+	protected function get_locale( $key ) {
+		if ( 'lang' == $key ) {
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				return (string) get_blog_lang_code();
+			} else {
+				return get_locale();
+			}
+		}
+
+		return false;
+	}
+
 
 	/**
 	 * Updates site settings for authorized users
@@ -348,8 +368,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 					break;
 
-				// no worries, we've already whitelisted and casted arguments above
+
 				default:
+					//allow future versions of this endpoint to support additional settings keys
+					if ( has_filter( 'site_settings_endpoint_update_' . $key ) ) {
+						$value = apply_filters( 'site_settings_endpoint_update_' . $key, $value );
+						$updated[ $key ] = $value;
+						continue;
+					}
+
+					// no worries, we've already whitelisted and casted arguments above
 					if ( update_option( $key, $value ) ) {
 						$updated[ $key ] = $value;
 					}


### PR DESCRIPTION
Syncs file class.wpcom-json-api-site-settings-endpoint.php with its wpcom counterpart.

___
API: allow setting a blog locale using a locale code rather than lang_id

This changeset does the following:
- Add a v1.2 site/xx/settings endpoint
- Refactor v1 endpoint to allow renaming lang->locale in response of v1.2
- Refactor v1 endpoint to allow future endpoints version to accept or return additional settings without needing to duplicate code
- Add specific test for new endpoint version

Merges r131418-wpcom.