### PR TITLE
Jetpack_Client::remote_request: add ability to pass in headers

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -17,6 +17,7 @@ class Jetpack_Client {
 			'method' => 'POST',
 			'timeout' => 10,
 			'redirection' => 0,
+			'headers' => array(),
 		);
 
 		$args = wp_parse_args( $args, $defaults );
@@ -106,9 +107,9 @@ class Jetpack_Client {
 		foreach ( $auth as $key => $value ) {
 			$header_pieces[] = sprintf( '%s="%s"', $key, $value );
 		}
-		$request['headers'] = array(
+		$request['headers'] = array_merge( $args['headers'], array(
 			'Authorization' => "X_JETPACK " . join( ' ', $header_pieces ),
-		);
+		) );
 
 		// Make sure we keep the host when we do JETPACK__WPCOM_JSON_API_HOST requests.
 		$host = parse_url( $url, PHP_URL_HOST );


### PR DESCRIPTION
This small PR seeks to augment the accepted arguments of the `Jetpack_Client::remote_request()` method to accept custom headers. 

There are some possible scenarios where we need to make authenticated remote requests and pass in additional headers. Currently one would have to do something like this:

```php
<?php

remote_request_wrapper( array(
	'url' => 'something.com',
) );

function remote_request_wrapper( $args ) {
	add_filter( 'http_request_args', array( 'header_filter' ), 10, 2 );
	Jetpack_Client::remote_request( $args );
	remove_filter( 'http_request_args', array( 'header_filter' ) );
}

function header_filter( $args, $url ) {
	if ( $url !== 'something.com' ) {
		return $args;
	}
	
	$args['headers']['X-Custom'] = 'foo-bar';
	return $args;
}
```
Which is pretty complex for just adding a header. This PR enables simply passing in the header as part of the call to `Jetpack_Client::remote_request`, like so:

```php
<?php

Jetpack_Client::remote_request( array(
	'url' => 'something.com',
	'headers' => array(
		'X-Custom' => 'foo-bar',
	);
) );
```

cc @allendav @nabsul @mdawaffe @roccotripaldi (based on previous conversations about this)