### PR TITLE
I18n: removed unneeded translation calls.

### DIFF
--- a/modules/manage/confirm-admin.php
+++ b/modules/manage/confirm-admin.php
@@ -93,12 +93,12 @@ switch( $section ) {
 	</div>
 	<h1 class="manage__title"><span class="genericon genericon-checkmark"></span><?php esc_html_e( __( 'Jetpack Manage Enabled', 'jetpack' ) ); ?></h1>
 	<p class="manage__description">
-		<?php esc_html_e( $description, 'jetpack' ); ?>
+		<?php echo esc_html( $description ); ?>
 	</p>
 	<p class="manage__description">
 		<a class="manage__link"  href="<?php echo esc_url( $link ); ?>">
 			<span class="genericon genericon-previous"></span>
-			<?php esc_html_e( $link_title, 'jetpack' ); ?>
+			<?php echo esc_html( $link_title ); ?>
 		</a>
 	</p>
 </div>


### PR DESCRIPTION
This changes `esc_html_e` to simply `echo esc_html` in places where the variables were already translated, but not escaped.