### PR TITLE
Fix plaintext message formatting

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1928,7 +1928,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			array_push( $message, __( 'Sent by an unverified visitor to your site.', 'jetpack' ) );
 		}
 
-		$message = join( $message, "" );
+		$message = join( $message, "\n" );
 		/**
 		 * Filters the message sent via email after a successfull form submission.
 		 *

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -331,6 +331,8 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertContains( 'john@example.com', $args['to'] );
 		$this->assertEquals( 'Hello there!', $args['subject'] );
 
+		$this->assertContains( "<br /><br />\n", $args['message'], 'lines should be separated by newline characters' );
+
 		$expected = '<b>Name:</b> John Doe<br /><br />';
 		$expected .= '<b>Dropdown:</b> First option<br /><br />';
 		$expected .= '<b>Radio:</b> Second option<br /><br />';


### PR DESCRIPTION
Some email clients do not substitute newlines for BR tags when formatting a message for a reply, resulting in the entire email body ending up on one line.

This restores the newline that previously joined the message array to provide better formatting for plaintext clients.