### PR TITLE
Comments: Always use https for jetpack.wordpress.com

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -279,8 +279,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		}
 
 		$params['sig']    = $signature;
-		$url_origin       = set_url_scheme( 'http://jetpack.wordpress.com' );
-		$url              = "{$url_origin}/jetpack-comment/?" . http_build_query( $params );
+		$url              = "https://jetpack.wordpress.com/jetpack-comment/?" . http_build_query( $params );
 		$url              = "{$url}#parent=" . urlencode( set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) );
 		$this->signed_url = $url;
 		$height           = $params['comment_registration'] || is_user_logged_in() ? '315' : '430'; // Iframe can be shorter if we're not allowing guest commenting
@@ -313,7 +312,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * @since JetpackComments (1.4)
 	 */
 	public function watch_comment_parent() {
-		$url_origin = set_url_scheme( 'http://jetpack.wordpress.com' );
+		$url_origin = 'https://jetpack.wordpress.com';
 	?>
 
 		<!--[if IE]>


### PR DESCRIPTION
jetpack.wordpress.com forces https now. We can save an http request by always loading directly from https.