### PR TITLE
Top Posts Widget: new filters

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -44,6 +44,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		if ( is_active_widget( false, false, $this->id_base ) ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 		}
+
+		add_action( 'jetpack_widget_top_posts_after_fields', array( $this, 'stats_explanation' ) );
 	}
 
 	function enqueue_style() {
@@ -124,11 +126,18 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 				<li><label><input id="<?php echo $this->get_field_id( 'display' ); ?>-list" name="<?php echo $this->get_field_name( 'display' ); ?>" type="radio" value="list" <?php checked( 'list', $display ); ?> /> <?php esc_html_e( 'Image List', 'jetpack' ); ?></label></li>
 				<li><label><input id="<?php echo $this->get_field_id( 'display' ); ?>-grid" name="<?php echo $this->get_field_name( 'display' ); ?>" type="radio" value="grid" <?php checked( 'grid', $display ); ?> /> <?php esc_html_e( 'Image Grid', 'jetpack' ); ?></label></li>
 			</ul>
-		</p>
+		</p><?php
 
-		<p><?php esc_html_e( 'Top Posts &amp; Pages by views are calculated from 24-48 hours of stats. They take a while to change.', 'jetpack' ); ?></p>
+		do_action( 'jetpack_widget_top_posts_after_fields', array( $instance, $this ) );
+	}
 
-		<?php
+	/**
+	 * Explains how the statics are calculated.
+	 */
+	function stats_explanation() {
+		?>
+
+		<p><?php esc_html_e( 'Top Posts &amp; Pages by views are calculated from 24-48 hours of stats. They take a while to change.', 'jetpack' ); ?></p><?php
 	}
 
 	function update( $new_instance, $old_instance ) {
@@ -159,6 +168,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		} else {
 			$instance['display'] = 'text';
 		}
+
+		$instance = apply_filters( 'jetpack_top_posts_saving', $instance, $new_instance );
 
 		return $instance;
 	}
@@ -230,7 +241,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		if ( function_exists( 'wpl_get_blogs_most_liked_posts' ) && 'likes' == $ordering ) {
 			$posts = $this->get_by_likes( $count );
 		} else {
-			$posts = $this->get_by_views( $count );
+			$posts = $this->get_by_views( $count, $args );
 		}
 
 		// Filter the returned posts. Remove all posts that do not match the chosen Post Types.
@@ -391,7 +402,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		return $this->get_posts( array_keys( $post_likes ), $count );
 	}
 
-	function get_by_views( $count ) {
+	function get_by_views( $count, $args ) {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			global $wpdb;
 
@@ -414,7 +425,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		 *
 		 * @param int 2 Number of days. Default is 2.
 		 */
-		$days = (int) apply_filters( 'jetpack_top_posts_days', 2 );
+		$days = (int) apply_filters( 'jetpack_top_posts_days', 2, $args );
 
 		if ( $days < 1 ) {
 			$days = 2;

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -45,6 +45,13 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 		}
 
+		/**
+		 * Add explanation about how the statistics are calculated.
+		 *
+		 * @module widgets
+		 *
+		 * @since 4.0.0
+		 */
 		add_action( 'jetpack_widget_top_posts_after_fields', array( $this, 'stats_explanation' ) );
 	}
 
@@ -169,6 +176,16 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			$instance['display'] = 'text';
 		}
 
+		/**
+		 * Control the number of displayed posts.
+		 *
+		 * @module widgets
+		 *
+		 * @since 4.0.0
+		 *
+		 * @param string $instance The santized widget instance. Only contains data processed by the current widget.
+		 * @param string $new_instance The new widget instance before sanitization.
+		 */
 		$instance = apply_filters( 'jetpack_top_posts_saving', $instance, $new_instance );
 
 		return $instance;
@@ -421,9 +438,10 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		 *
 		 * @module widgets
 		 *
-		 * @since 2.8.0
+		 * @since 4.0.0
 		 *
 		 * @param int 2 Number of days. Default is 2.
+		 * @param array $args The widget arguments.
 		 */
 		$days = (int) apply_filters( 'jetpack_top_posts_days', 2, $args );
 

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -135,6 +135,16 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			</ul>
 		</p><?php
 
+		/**
+		 * Add extra content after the fields are displayed.
+		 *
+		 * @module widgets
+		 *
+		 * @since 4.0.0
+		 *
+		 * @param array $instance The widget instance.
+		 * @param object $this The class object
+		 */
 		do_action( 'jetpack_widget_top_posts_after_fields', array( $instance, $this ) );
 	}
 


### PR DESCRIPTION
We need to implement some extra features into the Jetpack Top Posts widget. To avoid us forking the code, we'd appreciate if some extra hooks and filters could be added to enable us to do this.

We need to add (and save) extra fields, and to be able to modify the number of days the statistics are set for on a per widget basis (the current filter limits us to only changing the number of days across all widgets in use on a page).

#### Changes proposed in this Pull Request:
Adding ability to:
1. Inject extra fields (and save them) into the top posts widget.
2. Filter the number of days on a per-widget basis.