### PR TITLE
Publicize/Jetpack: Enhance from_thumbnail to account for thumbnail meta

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -232,6 +232,29 @@ class Jetpack_PostImages {
 				'href'       => get_permalink( $thumb ),
 			) );
 		}
+
+		if ( empty( $images ) && ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+			$meta_thumbnail = get_post_meta( $post_id, '_jetpack_post_thumbnail', true );
+			if ( ! empty( $meta_thumbnail ) ) {
+				if ( ! isset( $meta_thumbnail['width'] ) || $meta_thumbnail['width'] < $width ) {
+					return $images;
+				}
+
+				if ( ! isset( $meta_thumbnail['height'] ) || $meta_thumbnail['height'] < $height ) {
+					return $images;
+				}
+
+				$images = array( array( // Other methods below all return an array of arrays
+					'type'       => 'image',
+					'from'       => 'thumbnail',
+					'src'        => $meta_thumbnail['URL'],
+					'src_width'  => $meta_thumbnail['width'],
+					'src_height' => $meta_thumbnail['height'],
+					'href'       => $meta_thumbnail['URL'],
+				) );
+			}
+		}
+
 		return $images;
 	}
 


### PR DESCRIPTION
Resolves issue where featured image was not accounted for in Jetpack posts when processed via `Jetpack_PostImages` when run on WordPress.com. The post thumbnail is not synced to WordPress.com, so attempts to call `get_post_thumbnail_id` will result in an empty value. As such, the post is treated as though it has no featured image. However, details about the post's featured image are synced to WordPress.com via the `_jetpack_post_thumbnail` meta value. The changes here improve Jetpack_PostImages::from_thumbnail to account for this post meta if a thumbnail ID cannot be determined via get_post_thumbnail_id.

See: Automattic/io#415
See: Automattic/io#458
See: Automattic/io#370

Merges r129729-wpcom.