### PR TITLE
Enable side loading of video types

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -2014,7 +2014,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 		/**
 		 * Filter the list of supported mime types for media sideloading.
 		 *
-		 * @since 3.9.3
+		 * @since 4.0
+		 *
+		 * @module json-api
 		 *
 		 * @param array $supported_mime_types Array of the supported mime types for media sideloading.
 		 */

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1990,9 +1990,26 @@ abstract class WPCOM_JSON_API_Endpoint {
 		return $id;
 	}
 
+	/**
+	 * Checks that the mime type of the specified file is among those in a filterable list of mime types.
+	 *
+	 * @param string $file Path to file to get its mime type.
+	 *
+	 * @return bool
+	 */
 	protected function is_file_supported_for_sideloading( $file ) {
 		$type = mime_content_type( $file );
-		$supported_mime_types = array(
+
+		/**
+		 * Filter the list of supported mime types for media sideloading.
+		 *
+		 * @since 4.0
+		 *
+		 * @module json-api
+		 *
+		 * @param array $supported_mime_types Array of the supported mime types for media sideloading.
+		 */
+		$supported_mime_types = apply_filters( 'jetpack_supported_media_sideload_types', array(
 			'image/png',
 			'image/jpeg',
 			'image/gif',
@@ -2009,18 +2026,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			'video/x-msvideo',
 			'video/x-ms-wmv',
 			'video/x-ms-asf',
-		);
-
-		/**
-		 * Filter the list of supported mime types for media sideloading.
-		 *
-		 * @since 4.0
-		 *
-		 * @module json-api
-		 *
-		 * @param array $supported_mime_types Array of the supported mime types for media sideloading.
-		 */
-		$supported_mime_types = apply_filters( 'rest_api_supported_media_sideload_types', $supported_mime_types );
+		) );
 
 		// If the type returned was not an array as expected, then we know we don't have a match.
 		if ( ! is_array( $supported_mime_types ) ) {

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1963,8 +1963,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 			return $tmp;
 		}
 
-		if ( ! file_is_displayable_image( $tmp ) ) {
-			@unlink( $tmp );
+		// First check to see if we get a mime-type match by file, otherwise, check to
+		// see if WordPress supports this file as an image. If neither, then it is not supported.
+		if ( ! $this->is_file_supported_for_sideloading( $tmp ) && ! file_is_displayable_image( $tmp ) ) {
+			unlink( $tmp );
 			return false;
 		}
 
@@ -1986,6 +1988,44 @@ abstract class WPCOM_JSON_API_Endpoint {
 		}
 
 		return $id;
+	}
+
+	protected function is_file_supported_for_sideloading( $file ) {
+		$type = mime_content_type( $file );
+		$supported_mime_types = array(
+			'image/png',
+			'image/jpeg',
+			'image/gif',
+			'image/bmp',
+			'video/quicktime',
+			'video/mp4',
+			'video/mpeg',
+			'video/ogg',
+			'video/3gpp',
+			'video/3gpp2',
+			'video/h261',
+			'video/h262',
+			'video/h264',
+			'video/x-msvideo',
+			'video/x-ms-wmv',
+			'video/x-ms-asf',
+		);
+
+		/**
+		 * Filter the list of supported mime types for media sideloading.
+		 *
+		 * @since 3.9.3
+		 *
+		 * @param array $supported_mime_types Array of the supported mime types for media sideloading.
+		 */
+		$supported_mime_types = apply_filters( 'rest_api_supported_media_sideload_types', $supported_mime_types );
+
+		// If the type returned was not an array as expected, then we know we don't have a match.
+		if ( ! is_array( $supported_mime_types ) ) {
+			return false;
+		}
+
+		return in_array( $type, $supported_mime_types );
 	}
 
 	function allow_video_uploads( $mimes ) {


### PR DESCRIPTION
Currently, we block outside loading based on the result from the `file_is_displayable_image` function, which uses the built-in image processing checks to look for BMP, JPEG, GIF, or PNG file types. Instead of doing this, we should use a direct mime type check, which will allow us to check for many different types of uploads.

This was originally intended to be merged into the v2/videopress branch but has been pulled out to go directly into master.