### PR TITLE
Stats: update Stats script to be valid XHTML

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -173,7 +173,7 @@ function stats_template_redirect() {
 	$data = stats_array( compact( 'v', 'j', 'blog', 'post', 'tz', 'srv' ) );
 
 	$stats_footer = <<<END
-<script type='text/javascript' src='{$script}' async defer></script>
+<script type='text/javascript' src='{$script}' async='async' defer='defer'></script>
 <script type='text/javascript'>
 	_stq = window._stq || [];
 	_stq.push([ 'view', {{$data}} ]);


### PR DESCRIPTION
In XHTML, attribute minimization is forbidden.
`async` and `defer` must be defined as `<script async='async' defer='defer'>`.

Suggested here:
https://wordpress.org/support/topic/doesnt-work-with-xhtml-2