### PR TITLE
i18n: Fixed quoteless domain

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1531,7 +1531,7 @@ class Jetpack {
 		// Throw up a notice if using staging mode
 		if ( Jetpack::is_staging_site() ) {
 			/* translators: %s is a URL */
-			$notice = sprintf( __( 'You are running Jetpack on a <a href="%s" target="_blank">staging server</a>.', jetpack ), 'https://jetpack.me/support/staging-sites/' );
+			$notice = sprintf( __( 'You are running Jetpack on a <a href="%s" target="_blank">staging server</a>.', 'jetpack' ), 'https://jetpack.me/support/staging-sites/' );
 
 			echo '<div class="updated" style="border-color: #f0821e;"><p>' . $notice . '</p></div>';
 		}


### PR DESCRIPTION
I didn't include quotes around the `jetpack` domain on a translation function. Will throw a warning if PHP is set to display errors when on JP wp-admin pages.