### PR TITLE
Infinite Scroll: allow `get_settings` to be filtered at later points than just `__construct`

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -247,7 +247,7 @@ class The_Neverending_Home_Page {
 			self::$settings = apply_filters( 'infinite_scroll_settings', $settings );
 		}
 
-		return (object) self::$settings;
+		return (object) apply_filters( 'infinite_scroll_settings', self::$settings );
 	}
 
 	/**

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -247,6 +247,7 @@ class The_Neverending_Home_Page {
 			self::$settings = apply_filters( 'infinite_scroll_settings', $settings );
 		}
 
+		/** This filter is documented in modules/infinite-scroll/inifinity.php */
 		return (object) apply_filters( 'infinite_scroll_settings', self::$settings );
 	}
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -247,7 +247,7 @@ class The_Neverending_Home_Page {
 			self::$settings = apply_filters( 'infinite_scroll_settings', $settings );
 		}
 
-		/** This filter is documented in modules/infinite-scroll/inifinity.php */
+		/** This filter is documented in modules/infinite-scroll/infinity.php */
 		return (object) apply_filters( 'infinite_scroll_settings', self::$settings );
 	}
 


### PR DESCRIPTION
Merges r123819-wpcom.