### PR TITLE
Site Logo: Core compat

### DIFF
--- a/modules/theme-tools/site-logo.php
+++ b/modules/theme-tools/site-logo.php
@@ -25,6 +25,12 @@
  * @since 3.2
  */
 function site_logo_init() {
+	// For transferring existing site logo from Jetpack -> Core
+	if ( current_theme_supports( 'custom-logo' ) && ! get_theme_mod( 'custom_logo' ) && $jp_logo = get_option( 'site_logo' ) ) {
+		set_theme_mod( 'custom_logo', $jp_logo['id'] );
+		delete_option( 'site_logo' );
+	}
+
 	// Only load our code if our theme declares support, and the standalone plugin is not activated.
 	if ( current_theme_supports( 'site-logo' ) && ! class_exists( 'Site_Logo', false ) ) {
 		// Load our class for namespacing.

--- a/modules/theme-tools/site-logo/inc/class-site-logo.php
+++ b/modules/theme-tools/site-logo/inc/class-site-logo.php
@@ -55,7 +55,7 @@ class Site_Logo {
 		if ( version_compare( $wp_version, '4.5-beta' ) >= 0 ) {
 
 			// Transfer logo to theme_mod() for core
-			if ( $this->logo ) {
+			if ( $this->logo && ! get_theme_mod( 'site_logo' ) ) {
 				set_theme_mod( 'site_logo', $this->logo['id'] );
 			}
 

--- a/modules/theme-tools/site-logo/inc/class-site-logo.php
+++ b/modules/theme-tools/site-logo/inc/class-site-logo.php
@@ -52,11 +52,11 @@ class Site_Logo {
 	 */
 	public function register_hooks() {
 		global $wp_version;
-		if ( version_compare( $wp_version, '4.5-beta' ) >= 0 ) {
+		if ( current_theme_supports( 'custom-logo' ) && version_compare( $wp_version, '4.5-beta' ) >= 0 ) {
 
 			// Transfer logo to theme_mod() for core
-			if ( $this->logo && ! get_theme_mod( 'site_logo' ) ) {
-				set_theme_mod( 'site_logo', $this->logo['id'] );
+			if ( $this->logo && ! get_theme_mod( 'custom_logo' ) ) {
+				set_theme_mod( 'custom_logo', $this->logo['id'] );
 			}
 
 			return;

--- a/modules/theme-tools/site-logo/inc/class-site-logo.php
+++ b/modules/theme-tools/site-logo/inc/class-site-logo.php
@@ -51,14 +51,8 @@ class Site_Logo {
 	 * @uses add_filter
 	 */
 	public function register_hooks() {
-		global $wp_version;
-		if ( current_theme_supports( 'custom-logo' ) && version_compare( $wp_version, '4.5-beta' ) >= 0 ) {
-
-			// Transfer logo to theme_mod() for core
-			if ( $this->logo && ! get_theme_mod( 'custom_logo' ) ) {
-				set_theme_mod( 'custom_logo', $this->logo['id'] );
-			}
-
+		// This would only happen if a theme supports BOTH site-logo and custom-logo for some reason
+		if ( current_theme_supports( 'custom-logo' ) ) {
 			return;
 		}
 

--- a/modules/theme-tools/site-logo/inc/class-site-logo.php
+++ b/modules/theme-tools/site-logo/inc/class-site-logo.php
@@ -51,6 +51,17 @@ class Site_Logo {
 	 * @uses add_filter
 	 */
 	public function register_hooks() {
+		global $wp_version;
+		if ( version_compare( $wp_version, '4.5-beta' ) >= 0 ) {
+
+			// Transfer logo to theme_mod() for core
+			if ( $this->logo ) {
+				set_theme_mod( 'site_logo', $this->logo['id'] );
+			}
+
+			return;
+		}
+
 		add_action( 'wp_head', array( $this, 'head_text_styles' ) );
 		add_action( 'customize_register', array( $this, 'customize_register' ) );
 		add_action( 'customize_preview_init', array( $this, 'preview_enqueue' ) );

--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -102,6 +102,7 @@ function jetpack_has_site_logo() {
  */
 function jetpack_the_site_logo() {
 	$logo = site_logo()->logo;
+	$logo_id = get_theme_mod( 'site_logo' ) ?: $logo['id'];
 	$size = site_logo()->theme_size();
 	$html = '';
 
@@ -120,7 +121,7 @@ function jetpack_the_site_logo() {
 		$html = sprintf( '<a href="%1$s" class="site-logo-link" rel="home" itemprop="url">%2$s</a>',
 			esc_url( home_url( '/' ) ),
 			wp_get_attachment_image(
-				$logo['id'],
+				$logo_id,
 				$size,
 				false,
 				array(

--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -102,7 +102,7 @@ function jetpack_has_site_logo() {
  */
 function jetpack_the_site_logo() {
 	$logo = site_logo()->logo;
-	$logo_id = get_theme_mod( 'site_logo' ); // Check for WP 4.5 Site Logo
+	$logo_id = get_theme_mod( 'custom_logo' ); // Check for WP 4.5 Site Logo
 	$logo_id = $logo_id ? $logo_id : $logo['id']; // Use WP Core logo if present, otherwise use Jetpack's.
 	$size = site_logo()->theme_size();
 	$html = '';

--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -102,7 +102,8 @@ function jetpack_has_site_logo() {
  */
 function jetpack_the_site_logo() {
 	$logo = site_logo()->logo;
-	$logo_id = get_theme_mod( 'site_logo' ) ?: $logo['id'];
+	$logo_id = get_theme_mod( 'site_logo' ); // Check for WP 4.5 Site Logo
+	$logo_id = $logo_id ? $logo_id : $logo['id']; // Use WP Core logo if present, otherwise use Jetpack's.
 	$size = site_logo()->theme_size();
 	$html = '';
 


### PR DESCRIPTION
#Fixes #3447

This acts as a Minimal Viable Product to make Jetpack's Site Logo code compatible with Core.  It also makes it so that themes currently using Jetpack's Site Logo will "work" with core's logo.  

Basically all we're doing here is transferring the site_logo ID to the theme_mod() that core uses, and if it's there we use that in the `jetpack_the_site_logo()` function that themes use to get the logo.  We also kill all the customizer/settings hooks that Jetpack registers, in favor of core's setting section.  

It's kinda weird in that we're using core's settings code, but our display code right now.  BUT this is totally up to the theme authors to change their themes to use core.  

cc @obenland 