### PR TITLE
Sync Comments: Add tests that show comments ids are being synced when…

### DIFF
--- a/class.jetpack-comments-sync.php
+++ b/class.jetpack-comments-sync.php
@@ -1,0 +1,47 @@
+<?php
+
+class Jetpack_Comments_Sync {
+
+	static $sync = array();
+	static $delete = array();
+
+	static $jetpack_sync = null;
+
+	static function init() {
+
+		$jetpack = Jetpack::init();
+		self::$jetpack_sync = $jetpack->sync;
+
+		add_action( 'wp_insert_comment',         array( __CLASS__, 'wp_insert_comment' ),         10, 2 );
+		add_action( 'transition_comment_status', array( __CLASS__, 'transition_comment_status' ), 10, 3 );
+		add_action( 'edit_comment',              array( __CLASS__, 'edit_comment' ) );
+		add_action( 'delete_comment',              array( __CLASS__, 'delete_comment' ) );
+	}
+	static function sync( $comment_id ) {
+		self::$sync[] = $comment_id;
+	}
+	static function get_comment_ids_to_sync() {
+		return array_unique( self::$sync );
+	}
+
+	static function get_comment_ids_to_delete() {
+		return array_unique( self::$delete );
+	}
+
+	static function wp_insert_comment( $comment_id, $comment ) {
+		self::sync( $comment_id );
+	}
+
+	static function transition_comment_status( $new_status, $old_status, $comment ) {
+		self::sync( $comment->comment_ID );
+	}
+
+	static function edit_comment( $comment_id ) {
+		self::sync( $comment_id );
+	}
+
+	static function delete_comment( $comment_id ) {
+		self::$delete[] = $comment_id;
+	}
+
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -39,6 +39,9 @@
 		<testsuite name="widgets">
 			<directory prefix="test_" suffix=".php">tests/php/modules/widgets</directory>
 		</testsuite>
+		<testsuite name="sync">
+			<file>tests/php/test_class.jetpack-comments-sync.php</file>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/tests/php/test_class.jetpack-comments-sync.php
+++ b/tests/php/test_class.jetpack-comments-sync.php
@@ -1,0 +1,123 @@
+<?php
+// phpunit --testsuite sync
+
+class WP_Test_Jetpack_Sync extends WP_UnitTestCase {
+
+	protected $post_id;
+
+	public function setUp() {
+		require_once dirname( __FILE__ ) . '/../../class.jetpack-comments-sync.php';
+		parent::setUp();
+
+		Jetpack_Comments_Sync::init();
+		Jetpack_Comments_Sync::$sync = array();
+		// Set the current user to user_id 1 which is equal to admin.
+		wp_set_current_user( 1 );
+		$this->post_id = wp_insert_post( self::get_new_post_array() );
+
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		wp_delete_post( $this->post_id );
+	}
+
+
+	public function test_sync_comments_new_comment() {
+		$comment_id = wp_insert_comment( self::get_new_comment_array() );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+	}
+
+	public function test_sync_comments_updated_comment() {
+		$comment_array = self::get_new_comment_array();
+		$comment_id = wp_insert_comment( $comment_array );
+		Jetpack_Comments_Sync::$sync = array();
+
+		$comment_array['comment_content'] = 'updated comment content';
+		$comment_array['comment_ID'] = $comment_id;
+		wp_update_comment( $comment_array );
+
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+	}
+
+	public function test_sync_comments_delete() {
+		$comment_id = self::add_new_comment();
+		wp_delete_comment( $comment_id );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+	}
+
+	public function test_sync_comments_force_delete() {
+		$comment_id = self::add_new_comment();
+		wp_delete_comment( $comment_id, true );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_delete() );
+	}
+
+
+	public function test_sync_comments_trash() {
+		$comment_id = self::add_new_comment();
+		wp_trash_comment( $comment_id );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+	}
+
+	public function test_sync_comments_untrash() {
+		$comment_id = self::add_new_comment();
+		wp_untrash_comment( $comment_id );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+	}
+
+	public function test_sync_comments_spam() {
+		$comment_id = self::add_new_comment();
+		wp_spam_comment( $comment_id );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+	}
+
+	public function test_sync_comments_unspam() {
+		$comment_id = self::add_new_comment();
+		wp_unspam_comment( $comment_id );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+	}
+
+	public function test_sync_comments_approve_and_unapprove() {
+		$comment_id = self::add_new_comment();
+		wp_set_comment_status( $comment_id, 'hold' );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+
+		Jetpack_Comments_Sync::$sync = array();
+		wp_set_comment_status( $comment_id, 1 );
+		$this->assertContains( $comment_id, Jetpack_Comments_Sync::get_comment_ids_to_sync() );
+	}
+
+	private function get_new_post_array() {
+		return array (
+			'post_title'    => 'this is the title',
+			'post_content'  => 'this is the content',
+			'post_status'   => 'publish',
+			'post_author'   => 1
+		);
+	}
+
+	private function get_new_comment_array() {
+		return array (
+			'comment_post_ID' => $this->post_id,
+			'comment_author' => 'admin',
+			'comment_author_email' => 'admin@admin.com',
+			'comment_author_url' => 'http://',
+			'comment_content' => 'content here',
+			'comment_type' => '',
+			'comment_parent' => 0,
+			'user_id' => 1,
+			'comment_author_IP' => '127.0.0.1',
+			'comment_agent' => 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.10) Gecko/2009042316 Firefox/3.0.10 (.NET CLR 3.5.30729)',
+			'comment_date' => current_time('mysql'),
+			'comment_approved' => 1,
+		);
+	}
+
+	private function add_new_comment(){
+		$comment_array = self::get_new_comment_array();
+		$comment_id = wp_insert_comment( $comment_array );
+		Jetpack_Comments_Sync::$sync = array();
+		return $comment_id;
+	}
+
+}


### PR DESCRIPTION
**Do NOT merge**

Improves to comments syncing. 

#### Changes proposed in this Pull Request:
The idea here is to improve comments syncing when data related to the comments changes. 
So that we can better reconstruct the rest api endpoint. 
