### PR TITLE
Vimeo: set default width if $content_width isn't set

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -87,7 +87,10 @@ function vimeo_shortcode( $atts ) {
 
 	if ( ! $width && ! empty( $content_width ) ) {
 		$width = absint( $content_width );
-	} else {
+	}
+
+	// If setting the width with content_width has failed, defaulting
+	if ( ! $width ) {
 		$width = 640;
 	}
 

--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -85,8 +85,10 @@ function vimeo_shortcode( $atts ) {
 		}
 	}
 
-	if ( ! $width ) {
+	if ( ! $width && ! empty( $content_width ) ) {
 		$width = absint( $content_width );
+	} else {
+		$width = 640;
 	}
 
 	if ( ! $height ) {


### PR DESCRIPTION
Fixes #3495

If the theme doesn't set `$content_width`, we set a default, `640`, like for YouTube.