### PR TITLE
Jetpack-connect: propose to redirect the user to WordPress.com

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -247,24 +247,6 @@ class Jetpack_Client_Server {
 		return (string) $json->access_token;
 	}
 
-	public function get_jetpack_connect_redirect_info( $url ) {
-		$client_secret = Jetpack_Data::get_access_token();
-		$body = array(
-			'client_id' => Jetpack_Options::get_option( 'id' ),
-			'client_secret' => $client_secret->secret,
-		);
-
-		$args = array(
-			'method' => 'GET',
-			'body' => $body,
-			'headers' => array(
-				'Accept' => 'application/json',
-			),
-		);
-		return Jetpack_Client::_wp_remote_request( $url, $args );
-
-	}
-
 	public function get_jetpack() {
 		return Jetpack::init();
 	}

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -247,6 +247,24 @@ class Jetpack_Client_Server {
 		return (string) $json->access_token;
 	}
 
+	public function get_jetpack_connect_redirect_info( $url ) {
+		$client_secret = Jetpack_Data::get_access_token();
+		$body = array(
+			'client_id' => Jetpack_Options::get_option( 'id' ),
+			'client_secret' => $client_secret->secret,
+		);
+
+		$args = array(
+			'method' => 'GET',
+			'body' => $body,
+			'headers' => array(
+				'Accept' => 'application/json',
+			),
+		);
+		return Jetpack_Client::_wp_remote_request( $url, $args );
+
+	}
+
 	public function get_jetpack() {
 		return Jetpack::init();
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3915,13 +3915,19 @@ p {
 	function get_jetpack_connect_redirect_data() {
 		$user = $this->get_connected_user_data();
 		$parsed_site = parse_url( get_site_url() );
+		if ( ! isset( $parsed_site['path'] ) ) {
+			$parsed_site['path'] = '';
+		}
 
 		if ( isset( $user['jetpack_connect'] ) && is_array( $user['jetpack_connect'] ) ) {
 			foreach ( $user['jetpack_connect'] as $jetpack_connect_request ) {
-				$parsed_jetpack_connect_site = $jetpack_connect_request['site_url'];
+				$parsed_jetpack_connect_site = parse_url( $jetpack_connect_request['site_url'] );
+				if ( ! isset( $parsed_jetpack_connect_site['path'] ) ) {
+					$parsed_jetpack_connect_site['path'] = '';
+				}
 
-				if ( $parsed_jetpack_connect_site->domain == $parsed_site->domain
-					&& $parsed_jetpack_connect_site->path == $parsed_site->path
+				if ( $parsed_jetpack_connect_site['host'] === $parsed_site['host']
+					&& $parsed_jetpack_connect_site['path'] === $parsed_site['path']
 					&& ( time() - $this->JETPACK_CONNECT_TIMEOUT ) < strtotime( $jetpack_connect_request['date'] ) ) {
 					// the user started a flow from calypso registering this site url in the last 24 hours
 					$redirect_data = array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3900,19 +3900,19 @@ p {
 	/**
 	 * Checks if the user have started a register flow from calypso in the last day, and if so, redirect them there
 	 */
-	function check_jetpack_connect_redirection() {
+	function maybe_redirect_back_to_calypso() {
 		$user = $this->get_connected_user_data();
 		$parsed_site = parse_url( get_site_url() );
 
-		if ( isset( $user[ 'jetpack_connect' ] ) && is_array( $user[ 'jetpack_connect' ] ) ) {
-			foreach ($user[ 'jetpack_connect' ] as $jetpack_connect_request ) {
-				$parsed_jetpack_connect_site = $jetpack_connect_request[ 'site_url' ];
+		if ( isset( $user['jetpack_connect'] ) && is_array( $user['jetpack_connect'] ) ) {
+			foreach ( $user['jetpack_connect'] as $jetpack_connect_request ) {
+				$parsed_jetpack_connect_site = $jetpack_connect_request['site_url'];
 
 				if ( $parsed_jetpack_connect_site->domain == $parsed_site->domain
 					&& $parsed_jetpack_connect_site->path == $parsed_site->path
-					&& ( time() - $this->JETPACK_CONNECT_TIMEOUT ) < strtotime( $jetpack_connect_request[ 'date' ] ) ) {
+					&& ( time() - $this->JETPACK_CONNECT_TIMEOUT ) < strtotime( $jetpack_connect_request['date'] ) ) {
 					// the user started a flow from calypso registering this site url in the last 24 hours
-					$this->message .= __( '<div> Let us take you back to WordPress.com.</div>' );
+					$this->message .= '<div>' . __( 'Let us take you back to WordPress.com.', 'jetpack' ) . '</div>';
 					echo '<script> setTimeout( function() { window.location = "' . $this->JETPACK_CONNECT_FLOW_URL . $this->build_raw_urls( get_site_url() ) . '" }, 1000 ); </script>';
 
 					return;
@@ -4324,13 +4324,13 @@ p {
 
 		case 'already_authorized' :
 			$this->message = __( '<strong>Your Jetpack is already connected.</strong> ', 'jetpack' );
-			$this->check_jetpack_connect_redirection();
+			$this->maybe_redirect_back_to_calypso();
 			break;
 
 		case 'authorized' :
 			$this->message  = __( '<strong>You&#8217;re fueled up and ready to go, Jetpack is now active.</strong> ', 'jetpack' );
 			$this->message .= Jetpack::jetpack_comment_notice();
-			$this->check_jetpack_connect_redirection();
+			$this->maybe_redirect_back_to_calypso();
 			break;
 
 		case 'linked' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -29,9 +29,9 @@ class Jetpack {
 
 	public $HTTP_RAW_POST_DATA = null; // copy of $GLOBALS['HTTP_RAW_POST_DATA']
 
-	private $JETPACK_CONNECT_FLOW_URL = 'https://wordpress.com';
+	private $JETPACK_CONNECT_FLOW_URL = 'https://wordpress.com/plans/';
 
-	private $JETPACK_CONNECT_TIMEOUT = 86400; // a day
+	private $JETPACK_CONNECT_TIMEOUT = 286400; // a day
 
 	/**
 	 * @var array The handles of styles that are concatenated into jetpack.css
@@ -4316,7 +4316,7 @@ p {
 						$this->message .= __( '<div> Let us take you back to WordPress.com.</div>' );
 						?>
 						<script>
-							setTimeout( function() { window.location = "<?php echo $this->JETPACK_CONNECT_FLOW_URL; ?>" }, 1000 );
+							setTimeout( function() { window.location = "<?php echo $this->JETPACK_CONNECT_FLOW_URL . $this->build_raw_urls( get_site_url() ); ?>" }, 1000 );
 						</script>
 						<?php
 						break;

--- a/scss/templates/_nux-landing-2015.scss
+++ b/scss/templates/_nux-landing-2015.scss
@@ -1,4 +1,4 @@
-// Needs to be cleaned. Let's remove those important tags and unneeded classes that we can utilize from core. Properly nest elements. migrate into _main.scss 
+// Needs to be cleaned. Let's remove those important tags and unneeded classes that we can utilize from core. Properly nest elements. migrate into _main.scss
 // Once everything is tested, I'll remove all the comments below as well. - @jeffgolenski
 
 
@@ -114,7 +114,7 @@
 
 #jumpstart-cta {
 	text-align: center;
-	display:inline-block; 
+	display:inline-block;
 	float:none
 }
 
@@ -373,7 +373,7 @@
 			 	width: 100%;
 				padding: .25em;
 				height: auto;
-			} 
+			}
 
 			.button {
 				height: auto;
@@ -474,34 +474,34 @@
 	vertical-align: middle;
 	outline: 0;
 	cursor: pointer;
-	transition: all .4s ease; 
+	transition: all .4s ease;
 
 	&:before, &:after {
 		position: relative;
 		display: block;
 		content: "";
 		width: 20px;
-		height: 20px; 
+		height: 20px;
 	}
 
 	&:after {
 		left: 0;
 		border-radius: 50%;
 		background: #fff;
-		transition: all .2s ease; 
+		transition: all .2s ease;
 	}
 
 	&:before {
-		display: none; 
+		display: none;
 	}
 
 	&:hover {
-		background: lighten($green, 25%); 
+		background: lighten($green, 25%);
 	}
-} // __switch 
+} // __switch
 
 .form-toggle__label {
-	cursor: pointer; 
+	cursor: pointer;
 }
 
 .plugin-action__label {
@@ -517,49 +517,119 @@
 
 .form-toggle:focus + .form-toggle__label .form-toggle__switch,
 .form-toggle:focus:checked + .form-toggle__label .form-toggle__switch {
-	box-shadow: 0 0 0 2px $wpcom; 
+	box-shadow: 0 0 0 2px $wpcom;
 }
 
 .form-toggle:checked + .form-toggle__label .form-toggle__switch {
-	background: $green; 
+	background: $green;
 		&:after {
-			left: 16px; 
+			left: 16px;
 		}
 }
 
 .form-toggle:checked:hover + .form-toggle__label .form-toggle__switch {
-	background: lighten($green, 25%); 
+	background: lighten($green, 25%);
 }
 
 
-.form-toggle:disabled + .form-toggle__label .form-toggle__switch, 
+.form-toggle:disabled + .form-toggle__label .form-toggle__switch,
 .form-toggle:disabled:hover + .form-toggle__label .form-toggle__switch {
-	background: #e9eff3; 
+	background: #e9eff3;
 }
 
 .form-toggle.is-toggling + .form-toggle__label .form-toggle__switch {
-	background: $green; 
+	background: $green;
 }
 
 .form-toggle.is-toggling:checked + .form-toggle__label .form-toggle__switch {
-	background: lighten($green, 25%); 
+	background: lighten($green, 25%);
 }
 
 .form-toggle.is-compact + .form-toggle__label .form-toggle__switch {
 	border-radius: 8px;
 	width: 24px;
-	height: 16px; 
+	height: 16px;
 	&:before, &:after {
 		width: 12px;
-		height: 12px; 
+		height: 12px;
 	}
 }
 
 .form-toggle.is-compact:checked + .form-toggle__label .form-toggle__switch:after {
-	left: 8px; 
+	left: 8px;
 }
 // end toggle
 
+
+
+.jetpack-connect__modal {
+	background: rgba( 234, 240, 244, 0.9 );
+	height: 100%;
+	width: 100%;
+	position: fixed;
+		top: 0px;
+		left: 0px;
+	z-index: 9999;
+
+	.jetpack-connect__logo {
+		background: url(../images/jetpack-logo.svg) 544px center no-repeat;
+		display: block;
+		width: 100%;
+		height: 150px;
+		position: relative;
+			left: -272px;
+	}
+
+	.jetpack-connect__message {
+		margin: 7em auto;
+		width: 100%;
+		max-width: 660px;
+		text-align: center;
+	}
+
+	.jetpack-connect__title {
+		font-size: 28px;
+		line-height: 100%;
+	}
+
+	.jetpack-connect__subtitle {
+		margin-top: 16px;
+		line-height: 100%;
+		color: #686f72;
+	}
+
+	.actions {
+		margin-top: 44px;
+
+		a {
+			padding: 16px 96px;
+			height: inherit;
+			font-size: 16px;
+		}
+	}
+
+	.jetpack-connect__dismiss {
+		width: 100%;
+		position: fixed;
+			bottom: 166px;
+			left: 0;
+		z-index: 9;
+
+		a {
+			color: #686f72;
+			text-decoration: none;
+		}
+	}
+
+	.jetpack-connect__footer {
+		background: url("../images/the-cloud.svg") center top repeat-x;
+		width: 100%;
+		height: 200px;
+		position: fixed;
+			bottom: 0;
+			left: 0;
+	}
+}
 
 // Breakpoints
 
@@ -588,7 +658,7 @@
 		}
 		.wpcom {
 			padding: 0;
-			
+
 			.j-row {
 				width: 50%;
 				float: left;
@@ -599,7 +669,7 @@
 					float: none;
 					clear: both;
 					border: none;
-					border-top: 1px $clouds solid; 
+					border-top: 1px $clouds solid;
 					position: relative; // hides border of 2nd to last j-row
 					top: -1px;
 				}
@@ -692,3 +762,4 @@
 	}
 
 } // large-phone
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/3498

~~Requires to run against a WordPress.com sandbox with #D3158-code applied to work.4~~

This PR adds a check when the user completes their WordPress.com connection process to see if they have started this connection flow from wp-calypso in the last day, and, if they did, redirects users automatically or show a modal window prompting the user to get back to the WordPress.com flow (depending on a value returned by .com API).

You can read about the motivation for this change in the issue it solves.

The address where the user is going to be redirected may change once we set up a more complex jetpack-connect flow in calypso.

How to test
========
~~You need to apply #D3158-code patch to your WordPress.com sandbox. After that~~ you can create a jetpack-connect request sending a POST request to `/v1.1/me/settings` with `jetpack_connect=url-of-your-site` in the body. Once you do this, during the next day, if you connect jetpack to your WordPress.com account in said site, you should be redirected back to WordPress.com plas page once you finish the connection proccess

