### PR TITLE
Merge wpcom get site and site settings v1.2 endpoints

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -56,7 +56,17 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		global $wpdb, $wp_version;
 
-		$response_format = static::$site_format;
+		// Allow update in later versions
+		/**
+		 * Filter the structure of information about the site to return.
+		 *
+		 * @module json-api
+		 *
+		 * @since 3.9.3
+		 *
+		 * @param array $site_format Data structure.
+		 */
+		$response_format = apply_filters( 'sites_site_format', self::$site_format );
 
 		$is_user_logged_in = is_user_logged_in();
 

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -28,15 +28,25 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'meta'              => '(object) Meta data',
 	);
 
+	function callback( $path = '', $blog_id = 0 ) {
+		add_filter( 'sites_site_format', array( $this, 'site_format' ) );
+
+		return parent::callback( $path, $blog_id );
+	}
+
 	//V1.2 renames lang to locale
 	protected function process_locale( $key, $is_user_logged_in ) {
 		if ( $is_user_logged_in && 'locale' == $key ) {
-			if ( is_jetpack_site() ) {
-				return (string) get_bloginfo( 'language' );
-			} elseif ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				return (string) get_blog_lang_code();
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				if ( ! is_jetpack_site() ) {
+					return (string) get_blog_lang_code();
+				}
 			}
 		}
 		return false;
+	}
+
+	public function site_format( $format ) {
+		return self::$site_format;
 	}
 }

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endpoint {
+
+	public static $site_format = array(
+ 		'ID'                => '(int) Site ID',
+ 		'name'              => '(string) Title of site',
+ 		'description'       => '(string) Tagline or description of site',
+ 		'URL'               => '(string) Full URL to the site',
+ 		'jetpack'           => '(bool)  Whether the site is a Jetpack site or not',
+ 		'post_count'        => '(int) The number of posts the site has',
+		'subscribers_count' => '(int) The number of subscribers the site has',
+		'locale'            => '(string) Primary locale code of the site',
+		'icon'              => '(array) An array of icon formats for the site',
+		'logo'              => '(array) The site logo, set in the Customizer',
+		'visible'           => '(bool) If this site is visible in the user\'s site list',
+		'is_private'        => '(bool) If the site is a private site or not',
+		'is_following'      => '(bool) If the current user is subscribed to this site in the reader',
+		'options'           => '(array) An array of options/settings for the blog. Only viewable by users with post editing rights to the site. Note: Post formats is deprecated, please see /sites/$id/post-formats/',
+		'updates'           => '(array) An array of available updates for plugins, themes, wordpress, and languages.',
+		'jetpack_modules'   => '(array) A list of active Jetpack modules.',
+		'meta'              => '(object) Meta data',
+	);
+
+	//V1.2 renames lang to locale
+	protected function process_locale( $key, $is_user_logged_in ) {
+		if ( $is_user_logged_in && 'locale' == $key ) {
+			if ( is_jetpack_site() ) {
+				return (string) get_bloginfo( 'language' );
+			} elseif ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				return (string) get_blog_lang_code();
+			}
+		}
+		return false;
+	}
+}

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -83,7 +83,18 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	public function get_settings_response() {
 
-		$response_format = static::$site_format;
+		// Allow update in later versions
+		/**
+		 * Filter the structure of site settings to return.
+		 *
+		 * @module json-api
+		 *
+		 * @since 3.9.3
+		 *
+		 * @param array $site_format Data structure.
+		 */
+		$response_format = apply_filters( 'site_settings_site_format', self::$site_format );
+
 		$blog_id = (int) $this->api->get_blog_id_for_output();
 		/** This filter is documented in class.json-api-endpoints.php */
 		$is_jetpack = true === apply_filters( 'is_jetpack_site', false, $blog_id );

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -22,6 +22,7 @@ class WPCOM_JSON_API_Site_Settings_V1_2_endpoint extends WPCOM_JSON_API_Site_Set
 	function callback( $path = '', $blog_id = 0 ) {
 		add_filter( 'site_settings_endpoint_update_locale', array( $this, 'update_locale' ) );
 		add_filter( 'site_settings_endpoint_get',           array( $this, 'return_locale' ) );
+		add_filter( 'site_settings_site_format',            array( $this, 'site_format' ) );
 		return parent::callback( $path, $blog_id );
 	}
 
@@ -52,5 +53,9 @@ class WPCOM_JSON_API_Site_Settings_V1_2_endpoint extends WPCOM_JSON_API_Site_Set
 			}
 		}
 		return false;
+	}
+
+	public function site_format( $format ) {
+		return self::$site_format;
 	}
 }

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ * @autounit api site-settings
+ */
+
+class WPCOM_JSON_API_Site_Settings_V1_2_endpoint extends WPCOM_JSON_API_Site_Settings_Endpoint {
+
+	public static $site_format = array(
+		'ID'          => '(int) Site ID',
+		'name'        => '(string) Title of site',
+		'description' => '(string) Tagline or description of site',
+		'URL'         => '(string) Full URL to the site',
+		'locale'      => '(string) Locale code of the site',
+		'settings'    => '(array) An array of options/settings for the blog. Only viewable by users with post editing rights to the site.',
+	);
+
+
+	function callback( $path = '', $blog_id = 0 ) {
+		add_filter( 'site_settings_endpoint_update_locale', array( $this, 'update_locale' ) );
+		add_filter( 'site_settings_endpoint_get',           array( $this, 'return_locale' ) );
+		return parent::callback( $path, $blog_id );
+	}
+
+
+	protected function get_locale( $key ) {
+		if ( 'locale' == $key ) {
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				return (string) get_blog_lang_code();
+			} else {
+				return get_locale();
+			}
+		}
+
+		return false;
+	}
+
+	public function return_locale( $settings ) {
+		return $settings + array( 'locale' => $this->get_locale( 'locale' ) );
+	}
+
+	public function update_locale( $value ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$lang_id = get_lang_id_by_code( $value );
+			if ( ! empty( $lang_id ) ) {
+				if ( update_option( 'lang_id', $lang_id ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
Add to plugin the new files with endpoints to get site and site settings that were first introduced in r131418-wpcom and r131419-wpcom.
Includes updates from r132024-wpcom to remove usage of `static::`, which is PHP 5.3 in d4d0faa0d145b2eb93cebdd475aa069974eea249 and 91680f9e30258b3a33a47b2553bd714595fe7d92

:pushpin: Once this is merged and the new files introduced, **D1237** should land too to keep the build list updated.