### PR TITLE
Vimeo shortcode in comments: fix warning and allow [vimeo 123456] style embedding in comments

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -250,7 +250,9 @@ function vimeo_link( $content ) {
  * @return string THe Vimeo HTML embed code.
  */
 function vimeo_link_callback( $matches ) {
-	return "\n" . vimeo_shortcode( array( 'id' => $matches[1] ) ) . "\n";
+	if ( isset( $matches[1] ) ) {
+		return "\n" . vimeo_shortcode( array( 'id' => $matches[1] ) ) . "\n";
+	}
 }
 
 /** This filter is documented in modules/shortcodes/youtube.php */

--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -238,11 +238,11 @@ add_filter( 'pre_kses', 'vimeo_embed_to_shortcode' );
  * @return string The content with embeds instead of URLs
  */
 function vimeo_link( $content ) {
-	// For cases of shortcode style [vimeo 123456]
+	// For cases of shortcode usage [vimeo 123456] || [vimeo https://vimeo.com/123456]
 	if ( has_shortcode( $content, 'vimeo' ) ) {
-		return preg_replace_callback( '#\[vimeo (\d+)\]#', 'vimeo_link_callback', $content );
+		return preg_replace_callback( '#\[vimeo (https?://vimeo.com/)?(\d+)\]#', 'vimeo_link_callback', $content );
 	}
-	return preg_replace_callback( '#https://vimeo.com/(\d+)/?$|i#', 'vimeo_link_callback', $content );
+	return preg_replace_callback( '#(https://vimeo.com/)(\d+)/?$|i#', 'vimeo_link_callback', $content );
 }
 
 /**
@@ -254,9 +254,10 @@ function vimeo_link( $content ) {
  * @return string THe Vimeo HTML embed code.
  */
 function vimeo_link_callback( $matches ) {
-	if ( isset( $matches[1] ) ) {
-		return "\n" . vimeo_shortcode( array( 'id' => $matches[1] ) ) . "\n";
+	if ( isset( $matches[2] ) && ctype_digit( $matches[2] ) ) {
+		return "\n" . vimeo_shortcode( array( 'id' => $matches[2] ) ) . "\n";
 	}
+	return '';
 }
 
 /** This filter is documented in modules/shortcodes/youtube.php */

--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -238,6 +238,10 @@ add_filter( 'pre_kses', 'vimeo_embed_to_shortcode' );
  * @return string The content with embeds instead of URLs
  */
 function vimeo_link( $content ) {
+	// For cases of shortcode style [vimeo 123456]
+	if ( has_shortcode( $content, 'vimeo' ) ) {
+		return preg_replace_callback( '#\[vimeo (\d+)\]#', 'vimeo_link_callback', $content );
+	}
 	return preg_replace_callback( '#https://vimeo.com/(\d+)/?$|i#', 'vimeo_link_callback', $content );
 }
 


### PR DESCRIPTION
#3420 introduced php warnings if someone were to comment with a vimeo shortcode without a URL like `[vimeo 123456]`.  Before #3420, the video still wouldn't render, but would only show the shortcode text.  

Went one step further than the isset and added the actual ability to render `[vimeo 123456]` style shortcodes using the same regex callback.  

to test: 
Comment in Jetpack Comments these things in separate comments: 
`[vimeo https://vimeo.com/156684127]`
`[vimeo http://vimeo.com/156684127]`
`https://vimeo.com/156684127`
`regular comment with no vimeo`

...and make sure no errors. 