### PR TITLE
JSON API: Fix a variable naming conflict.

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1592,7 +1592,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$endpoint_path = untrailingslashit( $endpoint['path'] );
 				$endpoint_path_regex = str_replace( array( '%s', '%d' ), array( '([^/?&]+)', '(\d+)' ), $endpoint_path );
 
-				if ( ! preg_match( "#^$endpoint_path_regex\$#", $path, $matches ) ) {
+				if ( ! preg_match( "#^$endpoint_path_regex\$#", $path ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Before the `preg_replace` call would overwrite the static `$matches` variable with string matches, thus causing `trying to access a property of a non-object` warnings. Changing the name of the never used variable fixes the problem.
