### PR TITLE
Issue 3432 - Don't use site icon as fallback if it's less than default size

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -321,27 +321,43 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 	if ( empty( $image ) && function_exists( 'blavatar_domain' ) ) {
 		$blavatar_domain = blavatar_domain( site_url() );
 		if ( blavatar_exists( $blavatar_domain ) ) {
-			$image['src']    = blavatar_url( $blavatar_domain, 'img', $width, false, true );
-			$image['width']  = $width;
-			$image['height'] = $height;
+			$image_url = blavatar_url( $blavatar_domain, 'img', $width, false, true );
+			$image_size = getimagesize( $image_url );
+			$img_width = $image_size[0];
+			$img_height = $image_size[1];
+			if (_jetpack_og_get_image_validate_size($img_width, $img_height, $width, $height)) {
+				$image['src']    = $image_url;
+				$image['width']  = $width;
+				$image['height'] = $height;
+			}
 		}
 	}
 
 	// Second fall back, Site Logo
 	if ( empty( $image ) && ( function_exists( 'jetpack_has_site_logo' ) && jetpack_has_site_logo() ) ) {
-		$image['src']        = jetpack_get_site_logo( 'url' );
 		$image_dimensions    = jetpack_get_site_logo_dimensions();
 		if ( ! empty( $image_dimensions ) ) {
-			$image['width']  = $image_dimensions['width'];
-			$image['height'] = $image_dimensions['height'];
+			$img_width = $image_dimensions['width'];
+			$img_height = $image_dimensions['height'];
+			if (_jetpack_og_get_image_validate_size($img_width, $img_height, $width, $height)) {
+				$image['src']    = jetpack_get_site_logo( 'url' );
+				$image['width']  = $width;
+				$image['height'] = $height;
+			}
 		}
 	}
 
-	// Third fall back, Core Site Icon. Added in WP 4.3.
+	// Third fall back, Core Site Icon, if valid in size. Added in WP 4.3.
 	if ( empty( $image ) && ( function_exists( 'has_site_icon') && has_site_icon() ) ) {
-		$image['src']     = get_site_icon_url( 512 );
-		$image['width']   = '512';
-		$image['height']  = '512';
+		$image_url = get_site_icon_url( max( $width, $height ) );
+		$image_size = getimagesize( $image_url );
+		$img_width = $image_size[0];
+		$img_height = $image_size[1];
+		if (_jetpack_og_get_image_validate_size($img_width, $img_height, $width, $height)) {
+			$image['src']     = $image_url;
+			$image['width']   = $width;
+			$image['height']  = $height;
+		}
 	}
 
 	// Finally fall back, blank image
@@ -357,6 +373,27 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 	}
 
 	return $image;
+}
+
+
+/**
+* Validate the width and height against required width and height
+*
+* @param $width      int  Width of the image
+* @param $height     int  Height of the image
+* @param $req_width  int  Required width to pass validation
+* @param $req_height int  Required height to pass validation 
+* @return bool - True if the image passed the required size validation
+*/
+function _jetpack_og_get_image_validate_size($width, $height, $req_width, $req_height) {
+	if (!$width || !$height) {
+		return false;
+	}
+
+	$valid_width = ( $width >= $req_width );
+	$valid_height = ( $height >= $req_height );
+	$is_image_acceptable = $valid_width && $valid_height;
+	return $is_image_acceptable;
 }
 
 /**


### PR DESCRIPTION
Fixes #3432 .

[Edited by @kraftbj]
This PR modified the OG image tag selection process to check for a 512 image and confirm the size is 512 before attaching.
