### PR TITLE
Subscription to comments: hide checkbox if user is commenting on a CPT entry

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -607,7 +607,7 @@ class Jetpack_Subscriptions {
 
 		$str = '';
 
-		if ( FALSE === has_filter( 'comment_form', 'show_subscription_checkbox' ) && 1 == get_option( 'stc_enabled', 1 ) && empty( $post->post_password ) ) {
+		if ( FALSE === has_filter( 'comment_form', 'show_subscription_checkbox' ) && 1 == get_option( 'stc_enabled', 1 ) && empty( $post->post_password ) && 'post' == get_post_type() ) {
 			// Subscribe to comments checkbox
 			$str .= '<p class="comment-subscription-form"><input type="checkbox" name="subscribe_comments" id="subscribe_comments" value="subscribe" style="width: auto; -moz-appearance: checkbox; -webkit-appearance: checkbox;"' . $comments_checked . ' /> ';
 			$comment_sub_text = __( 'Notify me of follow-up comments by email.', 'jetpack' );


### PR DESCRIPTION
Fixes #3522

#### Changes proposed in this Pull Request:
- Hide the _Notify me of follow-up comments by email._ checkbox for comments in CPTs since this feature is only available to comments in posts.

Note: to test this, keep Jetpack Subscriptions enabled and disable Jetpack Comments.