### PR TITLE
Vimeo: don't remove i characters from a comment with a video URL

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -242,7 +242,7 @@ function vimeo_link( $content ) {
 	if ( has_shortcode( $content, 'vimeo' ) ) {
 		return preg_replace_callback( '#\[vimeo (https?://vimeo.com/)?(\d+)\]#', 'vimeo_link_callback', $content );
 	}
-	return preg_replace_callback( '#(https://vimeo.com/)(\d+)/?$|i#', 'vimeo_link_callback', $content );
+	return preg_replace_callback( '#(https://vimeo.com/)(\d+)/?$#', 'vimeo_link_callback', $content );
 }
 
 /**


### PR DESCRIPTION
Fixes #3532

#### Changes proposed in this Pull Request:
- Fixes an issue in the regular expression used when only a Vimeo video URL is found in the comment, without using a shortcode.