### PR TITLE
Shortcodes: for Vimeo URLs, use a single regex to replace shortcodes and plain text URLs

### DIFF
--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -230,19 +230,19 @@ function vimeo_embed_to_shortcode( $content ) {
 add_filter( 'pre_kses', 'vimeo_embed_to_shortcode' );
 
 /**
- * Replaces plain-text links to Vimeo videos with Vimeo embeds.
+ * Replaces shortcodes and plain-text URLs to Vimeo videos with Vimeo embeds.
+ * Covers shortcode usage [vimeo 1234] | [vimeo https://vimeo.com/1234] | [vimeo http://vimeo.com/1234]
+ * Or plain text URLs https://vimeo.com/1234 | vimeo.com/1234 | //vimeo.com/1234
+ * Links are left intact.
  *
  * @since 3.7.0
+ * @since 3.10.0 One regular expression matches shortcodes and plain URLs.
  *
  * @param string $content HTML content
  * @return string The content with embeds instead of URLs
  */
 function vimeo_link( $content ) {
-	// For cases of shortcode usage [vimeo 123456] || [vimeo https://vimeo.com/123456]
-	if ( has_shortcode( $content, 'vimeo' ) ) {
-		return preg_replace_callback( '#\[vimeo (https?://vimeo.com/)?(\d+)\]#', 'vimeo_link_callback', $content );
-	}
-	return preg_replace_callback( '#(https://vimeo.com/)(\d+)/?$#', 'vimeo_link_callback', $content );
+	return preg_replace_callback( '#(?<![\S"])(\[vimeo )?(https?:)?(//)?(vimeo.com/)?(\d+)(\])?(?![\S"])#i', 'vimeo_link_callback', $content );
 }
 
 /**
@@ -251,11 +251,11 @@ function vimeo_link( $content ) {
  * @since 3.7.0
  *
  * @param array $matches An array containing a Vimeo URL.
- * @return string THe Vimeo HTML embed code.
+ * @return string The Vimeo HTML embed code.
  */
 function vimeo_link_callback( $matches ) {
-	if ( isset( $matches[2] ) && ctype_digit( $matches[2] ) ) {
-		return "\n" . vimeo_shortcode( array( 'id' => $matches[2] ) ) . "\n";
+	if ( isset( $matches[5] ) && ctype_digit( $matches[5] ) ) {
+		return "\n" . vimeo_shortcode( array( 'id' => $matches[5] ) ) . "\n";
 	}
 	return '';
 }

--- a/tests/php/modules/shortcodes/test_class.vimeo.php
+++ b/tests/php/modules/shortcodes/test_class.vimeo.php
@@ -111,4 +111,34 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 		$this->assertContains( '<iframe src="https://player.vimeo.com/video/'.$video_id.'"', $actual );
 	}
 
+	/**
+	 * @author Automattic
+	 * @covers ::vimeo_shortcode
+	 * @since 3.10.0
+	 */
+	public function test_replace_in_comments() {
+		$video_id = '141358';
+		$player = '<iframe src="https://player.vimeo.com/video/' . $video_id . '"';
+		$text_link = 'Vimeo <a href="https://vimeo.com/123456">link</a>';
+		$url_link = 'Link <a href="https://vimeo.com/123456">https://vimeo.com/123456</a>';
+
+		$this->assertContains( $player, vimeo_link( "[vimeo $video_id]" ) );
+		$this->assertContains( $player, vimeo_link( "[vimeo http://vimeo.com/$video_id]" ) );
+		$this->assertContains( $player, vimeo_link( "[vimeo https://vimeo.com/$video_id]" ) );
+		$this->assertContains( $player, vimeo_link( "[vimeo //vimeo.com/$video_id]" ) );
+		$this->assertContains( $player, vimeo_link( "[vimeo vimeo.com/$video_id]" ) );
+		$this->assertContains( $player, vimeo_link( "http://vimeo.com/$video_id" ) );
+		$this->assertContains( $player, vimeo_link( "https://vimeo.com/$video_id" ) );
+		$this->assertContains( $player, vimeo_link( "//vimeo.com/$video_id" ) );
+		$this->assertContains( $player, vimeo_link( "vimeo.com/$video_id" ) );
+
+		$this->assertEquals( $text_link, vimeo_link( $text_link ) );
+		$this->assertEquals( $url_link, vimeo_link( $url_link ) );
+
+		$mixed = vimeo_link( "[vimeo $video_id]\nvimeo.com/$video_id\n$text_link\n$url_link" );
+		$this->assertContains( $player, $mixed );
+		$this->assertContains( $text_link, $mixed );
+		$this->assertContains( $url_link, $mixed );
+	}
+
 }


### PR DESCRIPTION
Fixes #3534.

Previously when there was mixed content including Vimeo shortcodes and plain text URLs, only the shortcodes were processed and converted.

This PR uses a single regex to catch all cases at once, parsing shortcodes, plain text URLs and leaving clickable links intact.

props @dereksmart for the idea of using one regex to rule them all.