### PR TITLE
XMLRPC: public jetpack method

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -595,11 +595,10 @@ class Jetpack {
 		} elseif ( is_admin() && isset( $_POST['action'] ) && 'jetpack_upload_file' == $_POST['action'] ) {
 			$this->require_jetpack_authentication();
 			$this->add_remote_request_handlers();
+		} elseif ( Jetpack::is_active() ) {
+			add_action( 'login_form_jetpack_json_api_authorization', array( &$this, 'login_form_json_api_authorization' ) );
 		} else {
-			if ( Jetpack::is_active() ) {
-				add_action( 'login_form_jetpack_json_api_authorization', array( &$this, 'login_form_json_api_authorization' ) );
-				add_filter( 'xmlrpc_methods', array( $this, 'public_xmlrpc_methods' ) );
-			}
+			add_filter( 'xmlrpc_methods', array( $this, 'public_xmlrpc_methods' ) );
 		}
 
 		if ( Jetpack::is_active() ) {
@@ -5347,10 +5346,15 @@ p {
 	}
 
 	function public_xmlrpc_methods( $methods ) {
-		if ( array_key_exists( 'wp.getOptions', $methods ) ) {
+		if ( array_key_exists( 'wp.getOptions', $methods ) && Jetpack::is_active() ) {
 			$methods['wp.getOptions'] = array( $this, 'jetpack_getOptions' );
 		}
+		$methods['jetpack.sayHowdy'] = array( $this, 'say_howdy' );
 		return $methods;
+	}
+
+	function say_howdy() {
+		return 'Howdy!';
 	}
 
 	function jetpack_getOptions( $args ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5345,6 +5345,13 @@ p {
 		return $methods;
 	}
 
+	/**
+	 * For connected sites, this filters XMLRPC method wp.getOptions and replaces it with jetpack_getOptions.
+	 * Also adds XMLRPC method jetpack.sayHowdy.
+	 * 
+	 * @param $methods
+	 * @return mixed
+	 */
 	function public_xmlrpc_methods( $methods ) {
 		if ( array_key_exists( 'wp.getOptions', $methods ) && Jetpack::is_active() ) {
 			$methods['wp.getOptions'] = array( $this, 'jetpack_getOptions' );
@@ -5353,6 +5360,11 @@ p {
 		return $methods;
 	}
 
+	/**
+	 * An XMLRPC method that demonstrates that Jetpack is active.
+	 *
+	 * @return string
+	 */
 	function say_howdy() {
 		return 'Howdy!';
 	}


### PR DESCRIPTION
This PR will make the bootstrap jetpack xmlrpc methods always available, and add a new method `sayHowdy` that will signify that jetpack is active.

To test:
1. checkout this branch on a testing site
2. with the jetpack plugin active send a curl request to your site. example:
`curl -d '<?xml version="1.0"?> <methodCall> <methodName>jetpack.sayHowdy</methodName> </methodCall>' http://yoursite.com/xmlrpc.php`
You should get 'Howdy!' in the response
3. deactivate the Jetpack plugin and repeat the request. ensure that the `jetpack.sayHowdy` method is not found

cc: @lezama @johnHackworth 