### PR TITLE
SSO: consider filters and constant when rendering the checkboxes in admin page

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -219,8 +219,11 @@ class Jetpack_SSO {
 	 * @since 2.7
 	 **/
 	public function render_require_two_step() {
+		/** This filter is documented in modules/sso.php */
+		$require_two_step = 1 == apply_filters( 'jetpack_sso_require_two_step', get_option( 'jetpack_sso_require_two_step' ) );
+		$disabled = $require_two_step ? ' disabled="disabled"' : '';
 		echo '<label>';
-		echo '<input type="checkbox" name="jetpack_sso_require_two_step" ' . checked( 1 == get_option( 'jetpack_sso_require_two_step' ), true, false ) . '> ';
+		echo '<input type="checkbox" name="jetpack_sso_require_two_step" ' . checked( $require_two_step, true, false ) . "$disabled>";
 		esc_html_e( 'Require Two-Step Authentication' , 'jetpack' );
 		echo '</label>';
 	}
@@ -242,8 +245,10 @@ class Jetpack_SSO {
 	 * @since 2.9
 	 **/
 	public function render_match_by_email() {
+		$match_by_email = 1 == $this->match_by_email();
+		$disabled = $match_by_email ? ' disabled="disabled"' : '';
 		echo '<label>';
-		echo '<input type="checkbox" name="jetpack_sso_match_by_email"' . checked( 1 == get_option( 'jetpack_sso_match_by_email' ), true, false) . '> ';
+		echo '<input type="checkbox" name="jetpack_sso_match_by_email"' . checked( $match_by_email, true, false ) . "$disabled>";
 		esc_html_e( 'Match by Email', 'jetpack' );
 		echo '</label>';
 	}


### PR DESCRIPTION
Fixes #3526.

#### Changes proposed in this Pull Request:
Considers `jetpack_sso_require_two_step` and `jetpack_sso_match_by_email` filters when rendering the 	_Require Two-Step Authentication_ and _Match by Email_ checkboxes in SSO admin page. If the filters return true, they will be always checked and disabled.

If `WPCC_MATCH_BY_EMAIL` constant is defined, the _Match by Mail_ will always be checked and disabled.