### PR TITLE
Set https scheme to the `gravatar_url` for the SSL connection

### DIFF
--- a/modules/widgets/gravatar-profile.php
+++ b/modules/widgets/gravatar-profile.php
@@ -68,7 +68,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 				'accounts'     => array(),
 			) );
 			$gravatar_url = add_query_arg( 's', 320, $profile['thumbnailUrl'] ); // the default grav returned by grofiles is super small
-
+			$gravatar_url = is_ssl() ? set_url_scheme( $gravatar_url, 'https' ) : $gravatar_url;
 			wp_enqueue_style(
 				'gravatar-profile-widget',
 				plugins_url( 'gravatar-profile.css', __FILE__ ),


### PR DESCRIPTION
There's no related issues as I checked, though 'mixed content error' occurs while loading Gravatar's image on browser with https.

#### Changes proposed in this Pull Request:
- Set https scheme to Gravatar's `'thumbnailUrl'` if SSL is used.
  - NOTE: This patch doesn't fully solve 'mixed content error' if srcset is set by Photon.

-------------------
- [X] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [X] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

