### PR TITLE
Add Customizer support to Infinite Scroll

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -664,6 +664,54 @@ $( document ).ready( function() {
             } , 250 );
         });
     }
+
+	// Integrate with Selective Refresh in the Customizer.
+	if ( 'undefined' !== typeof wp && wp.customize && wp.customize.selectiveRefresh ) {
+
+		/**
+		 * Handle rendering of selective refresh partials.
+		 *
+		 * Make sure that when a partial is rendered, the Jetpack post-load event
+		 * will be triggered so that any dynamic elements will be re-constructed,
+		 * such as ME.js elements, Photon replacements, social sharing, and more.
+		 * Note that this is applying here not strictly to posts being loaded.
+		 * If a widget contains a ME.js element and it is previewed via selective
+		 * refresh, the post-load would get triggered allowing any dynamic elements
+		 * therein to also be re-constructed.
+		 *
+		 * @param {wp.customize.selectiveRefresh.Placement} placement
+		 */
+		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
+			var content;
+			if ( 'string' === typeof placement.addedContent ) {
+				content = placement.addedContent;
+			} else if ( placement.container ) {
+				content = $( placement.container ).html();
+			}
+
+			if ( content ) {
+				$( document.body ).trigger( 'post-load', { html: content } );
+			}
+		} );
+
+		/*
+		 * Add partials for posts added via infinite scroll.
+		 *
+		 * This is unnecessary when MutationObserver is supported by the browser
+		 * since then this will be handled by Selective Refresh in core.
+		 */
+		if ( 'undefined' === typeof MutationObserver ) {
+			$( document.body ).on( 'post-load', function( e, response ) {
+				var rootElement = null;
+				if ( response.html && -1 !== response.html.indexOf( 'data-customize-partial' ) ) {
+					if ( infiniteScroll.settings.id ) {
+						rootElement = $( '#' + infiniteScroll.settings.id );
+					}
+					wp.customize.selectiveRefresh.addPartials( rootElement );
+				}
+			} );
+		}
+	}
 });
 
 

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -234,13 +234,9 @@ Scroller.prototype.refresh = function() {
 			}
 
 			// Check for and parse our response.
-			if ( ! response )
+			if ( ! response || ! response.type ) {
 				return;
-
-			response = $.parseJSON( response );
-
-			if ( ! response || ! response.type )
-				return;
+			}
 
 			// If there are no remaining posts...
 			if ( response.type == 'empty' ) {

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -186,7 +186,7 @@ Scroller.prototype.thefooter = function() {
  */
 Scroller.prototype.refresh = function() {
 	var	self   = this,
-		query, jqxhr, load, loader, color;
+		query, jqxhr, load, loader, color, customized;
 
 	// If we're disabled, ready, or don't pass the check, bail.
 	if ( this.disabled || ! this.ready || ! this.check() )
@@ -213,6 +213,20 @@ Scroller.prototype.refresh = function() {
 	query = $.extend({
 		action: 'infinite_scroll'
 	}, this.query() );
+
+	// Inject Customizer state.
+	if ( 'undefined' !== typeof wp && wp.customize && wp.customize.settings.theme ) {
+		customized = {};
+		query.wp_customize = 'on';
+		query.theme = wp.customize.settings.theme.stylesheet;
+		wp.customize.each( function( setting ) {
+			if ( setting._dirty ) {
+				customized[ setting.id ] = setting();
+			}
+		} );
+		query.customized = JSON.stringify( customized );
+		query.nonce = wp.customize.settings.nonce.preview;
+	}
 
 	// Fire the ajax request.
 	jqxhr = $.post( infiniteScroll.settings.ajaxurl, query );

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -367,7 +367,7 @@ class The_Neverending_Home_Page {
 		add_filter( 'body_class', array( $this, 'body_class' ) );
 
 		// Add our scripts.
-		wp_enqueue_script( 'the-neverending-homepage', plugins_url( 'infinity.js', __FILE__ ), array( 'jquery' ), 20141016, true );
+		wp_enqueue_script( 'the-neverending-homepage', plugins_url( 'infinity.js', __FILE__ ), array( 'jquery' ), '3.10', true );
 
 		// Add our default styles.
 		wp_enqueue_style( 'the-neverending-homepage', plugins_url( 'infinity.css', __FILE__ ), array(), '20140422' );

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1098,6 +1098,7 @@ class The_Neverending_Home_Page {
 	 * @return string or null
 	 */
 	function query() {
+		global $wp_customize;
 		if ( ! isset( $_REQUEST['page'] ) || ! current_theme_supports( 'infinite-scroll' ) )
 			die;
 
@@ -1246,6 +1247,10 @@ class The_Neverending_Home_Page {
 			/** This action is already documented in modules/infinite-scroll/infinity.php */
 			do_action( 'infinite_scroll_empty' );
 			$results['type'] = 'empty';
+		}
+
+		if ( is_customize_preview() ) {
+			$wp_customize->remove_preview_signature();
 		}
 
 		wp_send_json(

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1248,7 +1248,7 @@ class The_Neverending_Home_Page {
 			$results['type'] = 'empty';
 		}
 
-		echo wp_json_encode(
+		wp_send_json(
 			/**
 			 * Filter the Infinite Scroll results.
 			 *
@@ -1262,7 +1262,6 @@ class The_Neverending_Home_Page {
 			 */
 			apply_filters( 'infinite_scroll_results', $results, $query_args, self::wp_query() )
 		);
-		die;
 	}
 
 	/**


### PR DESCRIPTION
* Fix sending back infinite scroll responses to be proper JSON.
* When infinite scroll Ajax request happens in Customizer preview, include Customizer state so that any previewed changes will apply in the response.
* Add support for Selective Refresh in WP 4.5, ensuring that dynamically-constructed elements (e.g. ME.js audio/video elements) get constructed in any refreshed partials by leveraging the existing `post-load` event. This includes some code from the Customize Partial Refresh feature plugin which was not included in the core merge (since it was specific for Jetpack): https://github.com/xwp/wp-customize-partial-refresh/blob/master/js/plugin-support/jetpack.js#L178-L227