### PR TITLE
Add selective refresh support for Twitter, Facebook, Contact Info, Social Media Icon widgets (WP 4.5)

### DIFF
--- a/_inc/facebook-embed.js
+++ b/_inc/facebook-embed.js
@@ -32,5 +32,26 @@
 		jQuery( document.body ).on( 'post-load', facebookEmbed );
 	}
 
+	// Re-render Facebook XFBML when partials are re-rendered in the Customizer.
+	jQuery( function() {
+		var hasSelectiveRefresh = (
+			'undefined' !== typeof wp &&
+			wp.customize &&
+			wp.customize.selectiveRefresh &&
+			wp.customize.widgetsPreview &&
+			wp.customize.widgetsPreview.WidgetPartial
+		);
+		if ( ! hasSelectiveRefresh ) {
+			return;
+		}
+
+		// Render Facebook widget in rendered partial.
+		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
+			if ( placement.container ) {
+				FB.XFBML.parse( placement.container[0] );
+			}
+		} );
+	} );
+
 	facebookEmbed();
 })( this );

--- a/_inc/facebook-embed.js
+++ b/_inc/facebook-embed.js
@@ -1,14 +1,21 @@
 /* global FB, jpfbembed */
 (function( window ) {
 	var facebookEmbed = function() {
+		var fbroot, src;
+
 		if ( 'undefined' !== typeof FB && FB.XFBML ) {
 			FB.XFBML.parse();
 		} else {
-			var fbroot = document.createElement( 'div' );
+			fbroot = document.createElement( 'div' );
 			fbroot.id = 'fb-root';
 			document.getElementsByTagName( 'body' )[0].appendChild( fbroot );
 
-			jQuery.getScript( '//connect.facebook.net/en_US/sdk.js' );
+			src = '//connect.facebook.net/' + jpfbembed.locale + '/sdk.js#xfbml=1';
+			if ( jpfbembed.appid ) {
+				src += '&appId=' + jpfbembed.appid;
+			}
+			src += '&version=v2.3';
+			jQuery.getScript( src );
 		}
 	};
 

--- a/_inc/twitter-timeline.js
+++ b/_inc/twitter-timeline.js
@@ -1,0 +1,39 @@
+/* global twttr */
+
+/* jshint ignore:start */
+!function(d,s,id){
+	var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
+	if(!d.getElementById(id)){
+		js=d.createElement(s);
+		js.id=id;js.src=p+"://platform.twitter.com/widgets.js";
+		fjs.parentNode.insertBefore(js,fjs);
+	}
+}(document,"script","twitter-wjs");
+/* jshint ignore:end */
+
+jQuery( function() {
+	var hasSelectiveRefresh = (
+		'undefined' !== typeof wp &&
+		wp.customize &&
+		wp.customize.selectiveRefresh &&
+		wp.customize.widgetsPreview &&
+		wp.customize.widgetsPreview.WidgetPartial
+	);
+	if ( ! hasSelectiveRefresh ) {
+		return;
+	}
+
+	// Re-load Twitter widgets when a partial is rendered.
+	wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
+		if ( placement.container ) {
+			twttr.widgets.load( placement.container[0] );
+		}
+	} );
+
+	// Refresh a moved partial containing a Twitter timeline iframe, since it has to be re-built.
+	wp.customize.selectiveRefresh.bind( 'partial-content-moved', function( placement ) {
+		if ( placement.container && placement.container.find( 'iframe.twitter-timeline:not([src]):first' ).length ) {
+			placement.partial.refresh();
+		}
+	} );
+} );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1074,6 +1074,10 @@ class Jetpack {
 			wp_register_script( 'jetpack-gallery-settings', plugins_url( '_inc/gallery-settings.js', JETPACK__PLUGIN_FILE ), array( 'media-views' ), '20121225' );
 		}
 
+		if ( ! wp_script_is( 'jetpack-twitter-timeline', 'registered' ) ) {
+			wp_register_script( 'jetpack-twitter-timeline', plugins_url( '_inc/twitter-timeline.js', JETPACK__PLUGIN_FILE ) , array( 'jquery' ), '3.10', true );
+		}
+
 		/**
 		 * As jetpack_register_genericons is by default fired off a hook,
 		 * the hook may have already fired by this point.

--- a/modules/shortcodes/facebook.php
+++ b/modules/shortcodes/facebook.php
@@ -37,21 +37,9 @@ function jetpack_facebook_embed_handler( $matches, $attr, $url ) {
 
 	// since Facebook is a faux embed, we need to load the JS SDK in the wpview embed iframe
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX && ! empty( $_POST['action'] ) && 'parse-embed' == $_POST['action'] ) {
-		return $embed . '<script src="//connect.facebook.net/en_US/all.js#xfbml=1"></script>';
+		return $embed . wp_scripts()->do_items( array( 'jetpack-facebook-embed' ) );
 	} else {
-		wp_enqueue_script( 'jetpack-facebook-embed', plugins_url( 'js/facebook.js', __FILE__ ), array( 'jquery' ), null, true );
-		/** This filter is documented in modules/sharedaddy/sharing-sources.php */
-		$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );
-		if ( ! is_numeric( $fb_app_id ) ) {
-			$fb_app_id = '';
-		}
-		wp_localize_script(
-			'jetpack-facebook-embed',
-			'jpfbembed',
-			array(
-				'appid' => $fb_app_id
-			)
-		);
+		wp_enqueue_script( 'jetpack-facebook-embed' );
 		return $embed;
 	}
 }

--- a/modules/shortcodes/twitter-timeline.php
+++ b/modules/shortcodes/twitter-timeline.php
@@ -25,11 +25,14 @@ function twitter_timeline_shortcode( $attr ) {
 	$tweets_by = sprintf( __( 'Tweets by @%s', 'jetpack' ), $attr['username'] );
 	$output    = '<a class="twitter-timeline" width="' . esc_attr( $attr['width'] ) . '" height="' . esc_attr( $attr['height'] ) . '" href="' . esc_url( 'https://twitter.com/' . $attr['username'] ) . '/" data-widget-id="' . esc_attr( $attr['id'] ) . '">' . esc_html( $tweets_by ) . '</a>';
 
-	add_action( 'wp_footer', 'twitter_timeline_js' );
+	wp_enqueue_script( 'jetpack-twitter-timeline' );
 
 	return $output;
 }
 
 function twitter_timeline_js() {
-	echo '<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>';
+	if ( is_customize_preview() ) {
+		wp_enqueue_script( 'jetpack-twitter-timeline' );
+	}
 }
+add_action( 'wp_enqueue_scripts', 'twitter_timeline_js' );

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -24,7 +24,8 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		function __construct() {
 			$widget_ops = array(
 				'classname' => 'widget_contact_info',
-				'description' => __( 'Display your location, hours, and contact information.', 'jetpack' )
+				'description' => __( 'Display your location, hours, and contact information.', 'jetpack' ),
+				'customize_selective_refresh' => true,
 			);
 			parent::__construct(
 				'widget_contact_info',

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -33,8 +33,21 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				$widget_ops
 			);
 			$this->alt_option_name = 'widget_contact_info';
+
+			if ( is_customize_preview() ) {
+				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+			}
 		}
 
+		/**
+		 * Enqueue scripts and styles.
+		 */
+		public function enqueue_scripts() {
+			wp_enqueue_script( 'jquery' );
+			wp_enqueue_script( 'google-maps', 'https://maps.googleapis.com/maps/api/js?sensor=false' );
+			wp_enqueue_script( 'contact-info-map-js', plugins_url( 'contact-info/contact-info-map.js', __FILE__ ), array( 'jquery', 'google-maps' ), 20150127 );
+			wp_enqueue_style( 'contact-info-map-css', plugins_url( 'contact-info/contact-info-map.css', __FILE__ ), null, 20150127 );
+		}
 
 		/**
 		 * Return an associative array of default values
@@ -245,11 +258,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 
 
 		function build_map( $lat, $lon ) {
-
-			wp_enqueue_script( "jquery" );
-			wp_enqueue_script( "google-maps", "https://maps.googleapis.com/maps/api/js?sensor=false" );
-			wp_enqueue_script( "contact-info-map-js", plugins_url( 'contact-info/contact-info-map.js', __FILE__ ), array( 'jquery', 'google-maps' ), 20150127 );
-			wp_enqueue_style( "contact-info-map-css", plugins_url( 'contact-info/contact-info-map.css', __FILE__ ), null, 20150127 );
+			$this->enqueue_scripts();
 
 			$lat = esc_attr( $lat );
 			$lon = esc_attr( $lon );

--- a/modules/widgets/contact-info/contact-info-map.js
+++ b/modules/widgets/contact-info/contact-info-map.js
@@ -1,8 +1,13 @@
 /* global google */
 /* jshint unused:false */
-if (jQuery) {
-	jQuery().ready(function() {
-		jQuery('div.contact-map').each(function(){
+jQuery( function( $ ) {
+	var hasSelectiveRefresh;
+
+	function setupContactMaps( rootElement ) {
+		rootElement = $( rootElement || document.body );
+
+		rootElement.find( 'div.contact-map' ).each( function() {
+
 			// get lat and lon from hidden input values
 			var lat = jQuery(this).find('.contact-info-map-lat').val(),
 				lon = jQuery(this).find('.contact-info-map-lon').val(),
@@ -18,10 +23,27 @@ if (jQuery) {
 					position: lat_lon
 				});
 
-				google.maps.event.addListenerOnce(map, 'mouseover', function() {
-					google.maps.event.trigger(map, 'resize');
-				});
+			google.maps.event.addListenerOnce(map, 'mouseover', function() {
+				google.maps.event.trigger(map, 'resize');
+			});
 
 		});
-	});
-}
+	}
+
+	setupContactMaps();
+
+	hasSelectiveRefresh = (
+		'undefined' !== typeof wp &&
+		wp.customize &&
+		wp.customize.selectiveRefresh &&
+		wp.customize.widgetsPreview &&
+		wp.customize.widgetsPreview.WidgetPartial
+	);
+	if ( hasSelectiveRefresh ) {
+		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
+			if ( placement.partial.widgetId && /^widget_contact_info-\d+$/.test( placement.partial.widgetId ) ) {
+				setupContactMaps( placement.container );
+			}
+		} );
+	}
+} );

--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -38,7 +38,8 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 			apply_filters( 'jetpack_widget_name', __( 'Facebook Page Plugin', 'jetpack' ) ),
 			array(
 				'classname' => 'widget_facebook_likebox',
-				'description' => __( 'Use the Facebook Page Plugin to connect visitors to your Facebook Page', 'jetpack' )
+				'description' => __( 'Use the Facebook Page Plugin to connect visitors to your Facebook Page', 'jetpack' ),
+				'customize_selective_refresh' => true,
 			)
 		);
 

--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -41,6 +41,19 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 				'description' => __( 'Use the Facebook Page Plugin to connect visitors to your Facebook Page', 'jetpack' )
 			)
 		);
+
+		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		}
+	}
+
+	/**
+	 * Enqueue scripts.
+	 */
+	public function enqueue_scripts() {
+		wp_enqueue_script( 'jetpack-facebook-embed' );
+		wp_enqueue_style( 'jetpack_facebook_likebox', plugins_url( 'facebook-likebox/style.css', __FILE__ ) );
+		wp_style_add_data( 'jetpack_facebook_likebox', 'jetpack-inline', true );
 	}
 
 	function widget( $args, $instance ) {
@@ -48,9 +61,6 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		extract( $args );
 
 		$like_args = $this->normalize_facebook_args( $instance['like_args'] );
-
-		wp_enqueue_style( 'jetpack_facebook_likebox', plugins_url( 'facebook-likebox/style.css', __FILE__ ) );
-		wp_style_add_data( 'jetpack_facebook_likebox', 'jetpack-inline', true );
 
 		if ( empty( $like_args['href'] ) || ! $this->is_valid_facebook_url( $like_args['href'] ) ) {
 			if ( current_user_can('edit_theme_options') ) {
@@ -69,16 +79,6 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		$like_args['show_faces'] = (bool) $like_args['show_faces'] ? 'true'  : 'false';
 		$like_args['stream']     = (bool) $like_args['stream']     ? 'true'  : 'false';
 		$like_args['cover']      = (bool) $like_args['cover']      ? 'false' : 'true';
-
-		$locale = $this->get_locale();
-
-		/** This filter is documented in modules/sharedaddy/sharing-sources.php */
-		$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );
-		if ( is_numeric( $fb_app_id ) ) {
-			$fb_app_id = '&appId=' . $fb_app_id;
-		} else {
-			$fb_app_id = '';
-		}
 
 		echo $before_widget;
 
@@ -108,8 +108,8 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		<div class="fb-page" data-href="<?php echo esc_url( $page_url ); ?>" data-width="<?php echo intval( $like_args['width'] ); ?>"  data-height="<?php echo intval( $like_args['height'] ); ?>" data-hide-cover="<?php echo esc_attr( $like_args['cover'] ); ?>" data-show-facepile="<?php echo esc_attr( $like_args['show_faces'] ); ?>" data-show-posts="<?php echo esc_attr( $like_args['stream'] ); ?>">
 		<div class="fb-xfbml-parse-ignore"><blockquote cite="<?php echo esc_url( $page_url ); ?>"><a href="<?php echo esc_url( $page_url ); ?>"><?php echo esc_html( $title ); ?></a></blockquote></div>
 		</div>
-		<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = '//connect.facebook.net/<?php echo esc_html( $locale ); ?>/sdk.js#xfbml=1<?php echo $fb_app_id; ?>&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
 		<?php
+		wp_enqueue_script( 'jetpack-facebook-embed' );
 		echo $after_widget;
 
 		/** This action is already documented in modules/widgets/gravatar-profile.php */
@@ -283,54 +283,20 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		return $value;
 	}
 
+	/**
+	 * @deprecated
+	 */
 	function guess_locale_from_lang( $lang ) {
-		if ( 'en' == $lang || 'en_US' == $lang || !$lang ) {
-			return 'en_US';
-		}
-
-		if ( !class_exists( 'GP_Locales' ) ) {
-			if ( !defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) || !file_exists( JETPACK__GLOTPRESS_LOCALES_PATH ) ) {
-				return false;
-			}
-
-			require JETPACK__GLOTPRESS_LOCALES_PATH;
-		}
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			// WP.com: get_locale() returns 'it'
-			$locale = GP_Locales::by_slug( $lang );
-		} else {
-			// Jetpack: get_locale() returns 'it_IT';
-			$locale = GP_Locales::by_field( 'facebook_locale', $lang );
-		}
-
-		if ( ! $locale ) {
-			return false;
-		}
-
-		if ( empty( $locale->facebook_locale ) ) {
-			if ( empty( $locale->wp_locale ) ) {
-				return false;
-			} else {
-				// Facebook SDK is smart enough to fall back to en_US if a
-				// locale isn't supported. Since supported Facebook locales
-				// can fall out of sync, we'll attempt to use the known
-				// wp_locale value and rely on said fallback.
-				return $locale->wp_locale;
-			}
-		}
-
-		return $locale->facebook_locale;
+		_deprecated_function( __METHOD__, '3.10', 'Jetpack::guess_locale_from_lang()' );
+		Jetpack::$instance->get_locale_from_lang( $lang );
 	}
 
+	/**
+	 * @deprecated
+	 */
 	function get_locale() {
-		$locale = $this->guess_locale_from_lang( get_locale() );
-
-		if ( ! $locale ) {
-			$locale = 'en_US';
-		}
-
-		return $locale;
+		_deprecated_function( __METHOD__, '3.10', 'Jetpack::get_locale()' );
+		Jetpack::$instance->get_locale();
 	}
 }
 

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -18,7 +18,10 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'wpcom_social_media_icons_widget',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', esc_html__( 'Social Media Icons', 'jetpack' ) ),
-			array( 'description' => __( 'A simple widget that displays social media icons.', 'jetpack' ), )
+			array(
+				'description' => __( 'A simple widget that displays social media icons.', 'jetpack' ),
+				'customize_selective_refresh' => true,
+			)
 		);
 
 		$this->defaults = array(
@@ -46,7 +49,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'googleplus' => array( 'Google+', 'https://plus.google.com/u/0/%s/' ),
 		);
 
-		if ( is_active_widget( false, false, $this->id_base ) ) {
+		if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 		}
 	}

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -29,27 +29,26 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			)
 		);
 
-		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) ) {
-			add_action( 'wp_footer', array( $this, 'library' ) );
+		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		}
 	}
 
 	/**
-	 * Enqueue Twitter's widget library
+	 * Enqueue scripts.
+	 */
+	public function enqueue_scripts() {
+		wp_enqueue_script( 'jetpack-twitter-timeline' );
+	}
+
+	/**
+	 * Enqueue Twitter's widget library.
+	 *
+	 * @deprecated
 	 */
 	public function library() {
-		?>
-		<script type="text/javascript">
-			!function(d,s,id){
-				var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
-				if(!d.getElementById(id)){
-					js=d.createElement(s);
-					js.id=id;js.src=p+"://platform.twitter.com/widgets.js";
-					fjs.parentNode.insertBefore(js,fjs);
-				}
-			}(document,"script","twitter-wjs");
-		</script>
-		<?php
+		_deprecated_function( __METHOD__, '3.10' );
+		wp_print_scripts( array( 'jetpack-twitter-timeline' ) );
 	}
 
 	/**

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -25,7 +25,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			apply_filters( 'jetpack_widget_name', esc_html__( 'Twitter Timeline', 'jetpack' ) ),
 			array(
 				'classname' => 'widget_twitter_timeline',
-				'description' => __( 'Display an official Twitter Embedded Timeline widget.', 'jetpack' )
+				'description' => __( 'Display an official Twitter Embedded Timeline widget.', 'jetpack' ),
+				'customize_selective_refresh' => true,
 			)
 		);
 


### PR DESCRIPTION
This PR is start implementing support for the new [Selective Refresh](https://make.wordpress.org/core/2016/02/16/selective-refresh-in-the-customizer/) feature coming in WordPress 4.5.

* De-duplicate Facebook and Twitter SDK inclusions between widget and shortcode integrations.
* Enqueue assets in Customizer preview even if not used (yet) for the sake of selective refresh, in case a widget or embed is added without a full page refresh (which is what selective refresh is supposed to minimize).
* Move locale methods from Facebook widget to Jetpack class.
* Re-invoke Facebook, Twitter, and Google Maps JS libraries when re-rendering partials so that elements can be re-constructed.

For Customizer support for infinite scroll, see #3542. This PR includes the [Jetpack widgets support](https://github.com/xwp/wp-customize-partial-refresh/blob/master/js/plugin-support/jetpack.js#L55-L176) from the Customize Partial Refresh plugin which was merged into Core for 4.5.

The `customize_selective_refresh` widget option is being introduced in https://github.com/xwp/wordpress-develop/pull/144 for [#35855](https://core.trac.wordpress.org/ticket/35855).