### PR TITLE
Introduces methods to pause and resume infinite scrolling

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -619,6 +619,20 @@ Scroller.prototype.updateURL = function( page ) {
 }
 
 /**
+ * Pause scrolling.
+ */
+Scroller.prototype.pause = function() {
+	this.disabled = true;
+};
+
+/**
+ * Resume scrolling.
+ */
+Scroller.prototype.resume = function() {
+	this.disabled = false;
+};
+
+/**
  * Ready, set, go!
  */
 $( document ).ready( function() {


### PR DESCRIPTION
Closes #3536.

#### Changes proposed in this Pull Request:
Two methods are introduced to pause and resume infinite scrolling. Internally, these methods modify the state of the `.disabled` property in Scroller class.
- To pause scrolling:
```js
infiniteScroll.scroller.pause();
```
To resume scrolling:
```js
infiniteScroll.scroller.resume();
```
Example:
```js
if ( 'object' === typeof window.infiniteScroll && 'object' === typeof window.infiniteScroll.scroller && 'function' === typeof window.infiniteScroll.scroller.pause ) {
	window.infiniteScroll.scroller.pause();
}
```