### PR TITLE
Contact Form: check that datepicker is available before calling it

### DIFF
--- a/modules/contact-form/js/grunion-frontend.js
+++ b/modules/contact-form/js/grunion-frontend.js
@@ -1,3 +1,5 @@
 jQuery( function ( $ ) {
-	$( '.contact-form input[type="date"]' ).datepicker( { dateFormat : 'yy-mm-dd' } );
+	if ( 'function' === typeof $.fn.datepicker ) {
+		$( '.contact-form input[type="date"]' ).datepicker( { dateFormat : 'yy-mm-dd' } );
+	}
 } );


### PR DESCRIPTION
Fixes #3550 .

#### Changes proposed in this Pull Request:
- for forms that include a date field, checks that jQuery.fn.datepicker is available before calling it. This fixes a JS error when form is in an entry loaded through Infinite Scroll.