### PR TITLE
Infinite Scroll: in auto scroll mode or on page load, don't run if there are no entries to load.

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -252,15 +252,8 @@ Scroller.prototype.refresh = function() {
 				return;
 			}
 
-			// If there are no remaining posts...
-			if ( response.type == 'empty' ) {
-				// Disable the scroller.
-				self.disabled = true;
-				// Update body classes, allowing the footer to return to static positioning
-				self.body.addClass( 'infinity-end' ).removeClass( 'infinity-success' );
-
 			// If we've succeeded...
-			} else if ( response.type == 'success' ) {
+			if ( response.type == 'success' ) {
 				// If additional scripts are required by the incoming set of posts, parse them
 				if ( response.scripts ) {
 					$( response.scripts ).each( function() {
@@ -356,6 +349,9 @@ Scroller.prototype.refresh = function() {
 							self.body.trigger( 'infinite-scroll-posts-more' );
 						}
 					}
+				} else if ( response.lastbatch ) {
+					self.disabled = true;
+					self.body.addClass( 'infinity-end' ).removeClass( 'infinity-success' );
 				}
 
 				// Update currentday to the latest value returned from the server


### PR DESCRIPTION
Closes #3549.
Improvements to scroll behavior for better UX.

#### Changes proposed in this Pull Request:
- in auto scroll mode, if there are no more posts to fetch, don't attempt to fetch posts one more time. This avoids the spinner quick show/hide, which is a bit confusing, since up to this point, after the spinner is shown and hidden, new posts load.

- when there are fewer posts than the posts to load on each scroll, disable IS. Example: if there are only 3 published posts and IS is set to display 7 on each time, we don't need to run IS looking for posts since we know there aren't others to display. Like before, this avoid the spinner quick show/hide.
For this, the `::is_last_batch` method [was rewritten](https://github.com/Automattic/jetpack/pull/3553/files#diff-a56d2e4ea84f298403a898fbd92f8e12R293) to more reliably reflect if it's the last batch. There were cases where it failed, for example: when there were 15 posts and IS displayed 3 posts per page, the last `::is_last_batch` compared `3 (posts returned from db) > 3 (posts per page)`, which was false, that is, not the last batch, so IS thought there were most posts to fetch. It ran one more time returning nothing, which is a confusing UX.

- This commit also addresses an issue of a missing dependency: when there were 3 posts and IS displayed 3 posts per page, it didn't enqueued the main assets in `::action_template_redirect` but the theme compatibility still required them. They are now registered separately from their enqueuing, which solves the dependency issue.