### PR TITLE
Remove filter: since there is no need for it and it was not being used.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6497,9 +6497,10 @@ p {
 		 * If there is no replacement us null for replacement_name
 		 */
 		$deprecated_list = array(
-			'jetpack_bail_on_shortcode' => 'jetpack_shortcodes_to_include',
-			'wpl_sharing_2014_1'        => null,
-			'jetpack-tools-to-include'  => 'jetpack_tools_to_include',
+			'jetpack_bail_on_shortcode'                => 'jetpack_shortcodes_to_include',
+			'wpl_sharing_2014_1'                       => null,
+			'jetpack-tools-to-include'                 => 'jetpack_tools_to_include',
+			'jetpack_identity_crisis_options_to_check' => null,
 		);
 
 		// This is a silly loop depth. Better way?

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5857,18 +5857,10 @@ p {
 	 * @return array An array of options to check.
 	 */
 	public static function identity_crisis_options_to_check() {
-		$options = array(
+		return array(
 			'siteurl',
 			'home',
 		);
-		/**
-		 * Filter the options that we should compare to determine an identity crisis.
-		 *
-		 * @since 2.5.0
-		 *
-		 * @param array $options Array of options to compare to determine an identity crisis.
-		 */
-		return apply_filters( 'jetpack_identity_crisis_options_to_check', $options );
 	}
 
 	/**


### PR DESCRIPTION
Since we are syncing everything now I didn't want to sync data that
wasn't being accounted for. If someone is using a filter to try to send
more data to be synced they are using it wrong. removing it will
prevent that case from ever happening.

The filter doesn't need to exits in code.