### PR TITLE
Detect Akismet checking for a constant

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1900,7 +1900,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 
-		if ( Jetpack::is_plugin_active( 'akismet/akismet.php' ) ) {
+		if ( defined( 'AKISMET_VERSION' ) ) {
 			update_post_meta( $post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );
 		}
 


### PR DESCRIPTION
Akismet won't show up as an active plugin in wpcom while the constant method is reliable in Jetpack sites and wpcom sites.