### PR TITLE
Jetpack::activate_module: return true at the end of the method.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2882,6 +2882,7 @@ class Jetpack {
 		if ( $exit ) {
 			exit;
 		}
+		return true;
 	}
 
 	function activate_module_actions( $module ) {


### PR DESCRIPTION
This will be used in the endpoint in 4.0 that activates a module.

Otherwise we have different functioning when the method ends with the module activation, nothing is returned, and when the method ends earlier due to incorrect module or module already activated.