### PR TITLE
Fix: PHP Notice when jetpack.php is not updates but we are class.jetpack-signature.php

### DIFF
--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -2,6 +2,7 @@
 
 defined( 'JETPACK_SIGNATURE__HTTP_PORT'  ) or define( 'JETPACK_SIGNATURE__HTTP_PORT' , 80  );
 defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) or define( 'JETPACK_SIGNATURE__HTTPS_PORT', 443 );
+defined( 'JETPACK__WPCOM_JSON_API_HOST' )  or define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
 
 class Jetpack_Signature {
 	public $token;


### PR DESCRIPTION
Fixes #3579 by making sure that the constant is defined.

#### Changes proposed in this Pull Request:
- Add the constant to the file directory this way we shouldn't see a notice in the logs.