### PR TITLE
Carousel: remove vestiges of Likes support.

### DIFF
--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -281,7 +281,6 @@ div.jp-carousel-buttons a:hover {
 	border-color: #fff;
 }
 
-div.jp-carousel-buttons a.jp-carousel-like,
 div.jp-carousel-buttons a.jp-carousel-reblog,
 div.jp-carousel-buttons a.jp-carousel-commentlink,
 a.jp-carousel-image-download {
@@ -294,8 +293,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 	margin: 0 14px 0 0 !important;
 }
 
-div.jp-carousel-buttons a.jp-carousel-reblog.reblogged,
-div.jp-carousel-buttons a.jp-carousel-like.liked {
+div.jp-carousel-buttons a.jp-carousel-reblog.reblogged {
 	background-color: #303030;
 	padding-right: 8px !important;
 	border-radius: 2px;
@@ -332,21 +330,11 @@ div.jp-carousel-buttons a.jp-carousel-reblog:hover {
 	color: #68c9e8;
 }
 
-div.jp-carousel-buttons a.jp-carousel-like {
-	background-position: 5px 5px;
-	padding-left: 24px !important;
-}
-
-div.jp-carousel-buttons a.jp-carousel-like:hover {
-	background-position: 5px -15px;
-}
-
 @media
 only screen and (-webkit-min-device-pixel-ratio: 1.5),
 only screen and (-o-min-device-pixel-ratio: 3/2),
 only screen and (min--moz-device-pixel-ratio: 1.5),
 only screen and (min-device-pixel-ratio: 1.5) {
-	div.jp-carousel-buttons a.jp-carousel-like,
 	div.jp-carousel-buttons a.jp-carousel-reblog,
 	div.jp-carousel-buttons a.jp-carousel-commentlink,
 	a.jp-carousel-image-download {
@@ -938,8 +926,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	padding-left: 24px !important;
 }
 
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-reblog.reblogged,
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-like.liked {
+.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-reblog.reblogged {
 	background-color: #2ea2cc;
 	color: #fff;
 }
@@ -948,18 +935,8 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	background-position: 0px -176px;
 }
 
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-like,
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-like:hover {
-	background-position: 5px -15px;
-	padding-left: 23px !important;
-}
-
 .jp-carousel-light div.jp-carousel-buttons a.jp-carousel-reblog.reblogged {
 	background-position: 5px -36px;
-}
-
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-like.liked {
-	background-position: 5px 5px;
 }
 
 .jp-carousel-light div#carousel-reblog-box {

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1,5 +1,5 @@
 /* jshint sub: true, onevar: false, multistr: true, devel: true, smarttabs: true */
-/* global jetpackCarouselStrings, DocumentTouch, jetpackLikesWidgetQueue */
+/* global jetpackCarouselStrings, DocumentTouch */
 
 
 jQuery(document).ready(function($) {
@@ -424,10 +424,6 @@ jQuery(document).ready(function($) {
 					preventDefaultEvents : false
 				} );
 
-			$( '.jetpack-likes-widget-unloaded' ).each( function() {
-				jetpackLikesWidgetQueue.push( this.id );
-				});
-
 			nextButton.add(previousButton).click(function(e){
 				e.preventDefault();
 				e.stopPropagation();
@@ -489,11 +485,6 @@ jQuery(document).ready(function($) {
 			originalHOverflow = $('html').css('overflow');
 			$('html').css('overflow', 'hidden');
 			scrollPos = $( window ).scrollTop();
-
-			// Re-apply inline-block style here and give an initial value for the width
-			// This value will get replaced with a more appropriate value once the slide is loaded
-			// This avoids the likes widget appearing initially full width below the comment button and then shuffling up
-			jQuery( '.slim-likes-widget' ).find( 'iframe' ).css( 'display', 'inline-block' ).css( 'width', '60px' );
 
 			container.data('carousel-extra', data);
 
@@ -558,14 +549,6 @@ jQuery(document).ready(function($) {
 
 			if ( slide ) {
 				this.jp_carousel('selectSlide', slide);
-			}
-		},
-
-		resetButtons : function(current) {
-			if ( current.data('liked') ) {
-				$('.jp-carousel-buttons a.jp-carousel-like').addClass('liked').text(jetpackCarouselStrings.unlike);
-			} else {
-				$('.jp-carousel-buttons a.jp-carousel-like').removeClass('liked').text(jetpackCarouselStrings.like);
 			}
 		},
 
@@ -672,25 +655,12 @@ jQuery(document).ready(function($) {
 
 			gallery.jp_carousel( 'updateSlidePositions', animate );
 
-			gallery.jp_carousel( 'resetButtons', current );
 			container.trigger( 'jp_carousel.selectSlide', [current] );
 
 			gallery.jp_carousel( 'getTitleDesc', {
 				title: current.data( 'title' ),
 				desc: current.data( 'desc' )
 			});
-
-			// Lazy-load the Likes iframe for the current, next, and previous slides.
-			gallery.jp_carousel( 'loadLikes', attachmentId );
-			gallery.jp_carousel( 'updateLikesWidgetVisibility', attachmentId );
-
-			if ( next.length > 0 ) {
-				gallery.jp_carousel( 'loadLikes', next.data( 'attachment-id' ) );
-			}
-
-			if ( previous.length > 0 ) {
-				gallery.jp_carousel( 'loadLikes', previous.data( 'attachment-id' ) );
-			}
 
 			var imageMeta = current.data( 'image-meta' );
 			gallery.jp_carousel( 'updateExif', imageMeta );
@@ -1126,74 +1096,6 @@ jQuery(document).ready(function($) {
 
 			$( 'div#jp-carousel-comment-form-container' ).css('margin-top', '20px');
 			$( 'div#jp-carousel-comments-loading' ).css('margin-top', '20px');
-		},
-
-		updateLikesWidgetVisibility: function ( attachmentId ) {
-			// Only do this if likes is enabled
-			if ( 'undefined' === typeof jetpackLikesWidgetQueue ) {
-				return;
-			}
-
-			// Hide all likes widgets except for the one for the attachmentId passed in
-			$( '.jp-carousel-buttons .jetpack-likes-widget-wrapper' ).css( 'display', 'none' ).each( function () {
-				var widgetWrapper = $( this );
-				if ( widgetWrapper.attr( 'data-attachment-id' ) == attachmentId ) { // jshint ignore:line
-					widgetWrapper.css( 'display', 'inline-block' );
-					return false;
-				}
-			});
-		},
-
-		loadLikes : function ( attachmentId ) {
-			var dataCarouselExtra = $( '.jp-carousel-wrap' ).data( 'carousel-extra' );
-			var blogId = dataCarouselExtra.likes_blog_id;
-
-			if ( $( '#like-post-wrapper-' + blogId + '-' + attachmentId ).length === 0 ) {
-				// Add the iframe the first time the slide is shown.
-				var protocol = 'http';
-				var originDomain = 'http://wordpress.com';
-
-				if ( dataCarouselExtra.permalink.length ) {
-					protocol = dataCarouselExtra.permalink.split( ':' )[0];
-
-					if ( ( protocol !== 'http' ) && ( protocol !== 'https' ) ) {
-						protocol = 'http';
-					}
-
-					var parts = dataCarouselExtra.permalink.split( '/' );
-
-					if ( parts.length >= 2 ) {
-						originDomain = protocol + '://' + parts[2];
-					}
-				}
-
-				var dataSource = protocol + '://widgets.wp.com/likes/#blog_id=' + encodeURIComponent( blogId ) +
-					'&post_id=' + encodeURIComponent( attachmentId ) +
-					'&slim=1&origin=' + encodeURIComponent( originDomain );
-
-				if ( 'en' !== jetpackCarouselStrings.lang ) {
-					dataSource += '&lang=' + encodeURIComponent( jetpackCarouselStrings.lang );
-				}
-
-				var likesWidget = $( '<iframe class=\'post-likes-widget jetpack-likes-widget jetpack-resizeable\'></iframe>' )
-					.attr( 'name', 'like-post-frame-' + blogId + '-' + attachmentId )
-					.attr( 'src', dataSource )
-					.css( 'display', 'inline-block' );
-
-				var likesWidgetWrapper = $( '<div/>' )
-					.addClass( 'jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded slim-likes-widget' )
-					.attr( 'id', 'like-post-wrapper-' + blogId + '-' + attachmentId )
-					.attr( 'data-src', dataSource )
-					.attr( 'data-name', 'like-post-frame-' + blogId + '-' + attachmentId )
-					.attr( 'data-attachment-id', attachmentId )
-					.css( 'display', 'none' )
-					.css( 'vertical-align', 'middle' )
-					.append( likesWidget )
-					.append( '<div class=\'post-likes-widget-placeholder\'></div>' );
-
-				$( '.jp-carousel-buttons' ).append( likesWidgetWrapper );
-			}
-
 		},
 
 		// updateExif updates the contents of the exif UL (.jp-carousel-image-exif)

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -152,7 +152,7 @@ class Jetpack_Carousel {
 		do_action( 'jp_carousel_thumbnails_shown' );
 
 		if ( $this->first_run ) {
-			wp_enqueue_script( 'jetpack-carousel', plugins_url( 'jetpack-carousel.js', __FILE__ ), array( 'jquery.spin' ), $this->asset_version( '20140505' ), true );
+			wp_enqueue_script( 'jetpack-carousel', plugins_url( 'jetpack-carousel.js', __FILE__ ), array( 'jquery.spin' ), $this->asset_version( '20160325' ), true );
 
 			// Note: using  home_url() instead of admin_url() for ajaxurl to be sure  to get same domain on wpcom when using mapped domains (also works on self-hosted)
 			// Also: not hardcoding path since there is no guarantee site is running on site root in self-hosted context.
@@ -330,17 +330,10 @@ class Jetpack_Carousel {
 		if ( isset( $post ) ) {
 			$blog_id = (int) get_current_blog_id();
 
-			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				$likes_blog_id = $blog_id;
-			} else {
-				$likes_blog_id = Jetpack_Options::get_option( 'id' );
-			}
-
 			$extra_data = array(
 				'data-carousel-extra' => array(
 					'blog_id' => $blog_id,
 					'permalink' => get_permalink( $post->ID ),
-					'likes_blog_id' => $likes_blog_id
 					)
 				);
 

--- a/modules/carousel/rtl/jetpack-carousel-rtl.css
+++ b/modules/carousel/rtl/jetpack-carousel-rtl.css
@@ -283,7 +283,6 @@ div.jp-carousel-buttons a:hover {
 	border-color: #fff;
 }
 
-div.jp-carousel-buttons a.jp-carousel-like,
 div.jp-carousel-buttons a.jp-carousel-reblog,
 div.jp-carousel-buttons a.jp-carousel-commentlink,
 a.jp-carousel-image-download {
@@ -296,8 +295,7 @@ div.jp-carousel-buttons a.jp-carousel-commentlink {
 	margin: 0 0 0 14px !important;
 }
 
-div.jp-carousel-buttons a.jp-carousel-reblog.reblogged,
-div.jp-carousel-buttons a.jp-carousel-like.liked {
+div.jp-carousel-buttons a.jp-carousel-reblog.reblogged {
 	background-color: #303030;
 	padding-left: 8px !important;
 	border-radius: 2px;
@@ -334,21 +332,11 @@ div.jp-carousel-buttons a.jp-carousel-reblog:hover {
 	color: #68c9e8;
 }
 
-div.jp-carousel-buttons a.jp-carousel-like {
-	background-position: 5px 5px;
-	padding-right: 24px !important;
-}
-
-div.jp-carousel-buttons a.jp-carousel-like:hover {
-	background-position: 5px -15px;
-}
-
 @media
 only screen and (-webkit-min-device-pixel-ratio: 1.5),
 only screen and (-o-min-device-pixel-ratio: 3/2),
 only screen and (min--moz-device-pixel-ratio: 1.5),
 only screen and (min-device-pixel-ratio: 1.5) {
-	div.jp-carousel-buttons a.jp-carousel-like,
 	div.jp-carousel-buttons a.jp-carousel-reblog,
 	div.jp-carousel-buttons a.jp-carousel-commentlink,
 	a.jp-carousel-image-download {
@@ -940,8 +928,7 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	padding-right: 24px !important;
 }
 
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-reblog.reblogged,
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-like.liked {
+.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-reblog.reblogged {
 	background-color: #2ea2cc;
 	color: #fff;
 }
@@ -950,18 +937,8 @@ textarea#jp-carousel-comment-form-comment-field:focus::-webkit-input-placeholder
 	background-position: 0px -176px;
 }
 
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-like,
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-like:hover {
-	background-position: 5px -15px;
-	padding-right: 23px !important;
-}
-
 .jp-carousel-light div.jp-carousel-buttons a.jp-carousel-reblog.reblogged {
 	background-position: 5px -36px;
-}
-
-.jp-carousel-light div.jp-carousel-buttons a.jp-carousel-like.liked {
-	background-position: 5px 5px;
 }
 
 .jp-carousel-light div#carousel-reblog-box {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Cleanup.

Since the Like button is not visible in Carousel, this removes JS and CSS that were used previously to style and modify the behavior of the Like button there.

#### Test notes

To test, load a Carousel view and ensure no JS errors in console.