### PR TITLE
JITM: only display the Vault notice when VaultPress isn't active.

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -59,7 +59,11 @@ class Jetpack_JITM {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'akismet_msg' ) );
 		}
-		elseif ( 'post' == $screen->base && ( isset( $_GET['message'] ) && 6 == $_GET['message'] ) ) {
+		elseif (
+			'post' == $screen->base
+			&& ( isset( $_GET['message'] ) && 6 == $_GET['message'] )
+			&& ! Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' )
+		) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'edit_form_top', array( $this, 'backups_after_publish_msg' ) );
 		}


### PR DESCRIPTION
Steps to reproduce:

1. Enable VaultPress on your site.
2. Go to Posts > Add New, and write a new post.
3. Publish the post.
4. The JITM notice shouldn't appear, once you apply this PR.

cc @jessefriedman