### PR TITLE
Manage: fix issue where post saved as draft in shadow site is not saved in Jetpack site

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -616,7 +616,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		if ( ! empty( $media_results['errors'] ) )
 			$return['media_errors'] = $media_results['errors'];
 
-		if ( 'publish' !== $post->post_status && isset( $input['title'] )) {
+		if ( ! $new && 'publish' !== $post->post_status && isset( $input['title'] ) ) {
 			$return['other_URLs'] = (object) $this->get_post_permalink_suggestions( $post_id, $input['title'] );
 		}
 


### PR DESCRIPTION
Fixes #3589 .

#### Changes proposed in this Pull Request:
- Check if a new post wasn't created, in which case end condition checking.
If the /new endpoint was accessed, a new entry was created, so the post object and its status property will be available. Otherwise, we don't need to check any further.