### PR TITLE
Manage: check that results and total items exist before accessing them

### DIFF
--- a/class.jetpack-sync.php
+++ b/class.jetpack-sync.php
@@ -1010,7 +1010,7 @@ EOT;
 
 		$results = json_decode( wp_remote_retrieve_body( $response ), true );
 
-		return (int) $results['results']['total'];
+		return isset( $results['results'] ) && isset( $results['results']['total'] ) ? (int) $results['results']['total'] : 0;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3583.

#### Changes proposed in this Pull Request:
- before returning the totals item in results item, check that both exist and results item is an array.