### PR TITLE
General: check that server vars are set before using them

### DIFF
--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -63,9 +63,9 @@ class JetpackTracking {
 		$user = wp_get_current_user();
 		$site_url = get_option( 'siteurl' );
 
-		$data['_via_ua']  = $_SERVER['HTTP_USER_AGENT'];
-		$data['_via_ip']  = $_SERVER['REMOTE_ADDR'];
-		$data['_lg']      = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+		$data['_via_ua']  = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+		$data['_via_ip']  = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
+		$data['_lg']      = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
 		$data['blog_url'] = $site_url;
 		$data['blog_id']  = Jetpack_Options::get_option( 'id' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- checks that server vars are set before using them.

I got `Notice: Undefined index: HTTP_ACCEPT_LANGUAGE in /wp-content/plugins/jetpack/class.jetpack-tracks.php on line 68` when I was working with an endpoint in my sandbox so this checks that the vars exist to avoid the notice.

cc @dereksmart 