### PR TITLE
Custom CSS: allow backslashes in css (for icon fonts)

### DIFF
--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -108,7 +108,7 @@ class Jetpack_Custom_CSS {
 			check_admin_referer( 'safecss' );
 
 			$save_result = self::save( array(
-				'css' => stripslashes( $_POST['safecss'] ),
+				'css' => $_POST['safecss'],
 				'is_preview' => isset( $_POST['action'] ) && $_POST['action'] == 'preview',
 				'preprocessor' => isset( $_POST['custom_css_preprocessor'] ) ? $_POST['custom_css_preprocessor'] : '',
 				'add_to_existing' => isset( $_POST['add_to_existing'] ) ? $_POST['add_to_existing'] == 'true' : true,
@@ -618,7 +618,6 @@ class Jetpack_Custom_CSS {
 		else if ( 'safecss_preview' == $option ) {
 			$safecss_post = Jetpack_Custom_CSS::get_current_revision();
 			$css = $safecss_post['post_content'];
-			$css = stripslashes( $css );
 			$css = Jetpack_Custom_CSS::minify( $css, get_post_meta( $safecss_post['ID'], 'custom_css_preprocessor', true ) );
 		}
 


### PR DESCRIPTION
Backslashes currently get stripped out from user-generated css in the Custom CSS module.

I think this is accidental since the csstidy library is set to not remove backslashes, while the save code is actively removing them.

Use case: The divi theme uses an icon font called ETModules (https://divi.space/using-the-etmodules-icon-font/). In order to use icons from this and other fonts in css, users need the ability to use backslashes.

This also closes a bug where escaping the backslash by entering `\\` would produce the desired `\` on save, but subsequent saves would remove `\` entirely.