### PR TITLE
Added event namespace to Carousel triggers

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1376,7 +1376,7 @@ jQuery(document).ready(function($) {
 	};
 
 	// register the event listener for starting the gallery
-	$( document.body ).on( 'click', 'div.gallery,div.tiled-gallery', function(e) {
+	$( document.body ).on( 'click.jp-carousel', 'div.gallery,div.tiled-gallery', function(e) {
 		if ( ! $(this).jp_carousel( 'testForData', e.currentTarget ) ) {
 			return;
 		}
@@ -1392,7 +1392,7 @@ jQuery(document).ready(function($) {
 	});
 
 	// Makes carousel work on page load and when back button leads to same URL with carousel hash (ie: no actual document.ready trigger)
-	$( window ).on( 'hashchange', function () {
+	$( window ).on( 'hashchange.jp-carousel', function () {
 
 		var hashRegExp = /jp-carousel-(\d+)/,
 			matches, attachmentId, galleries, selectedThumbnail;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Added jp-carousel namespace to Carousel jQuery triggers to allow wp-themes to disable the default open behavior.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

Integration example with [Flickity](https://github.com/metafizzy/flickity)  : 
```
...
$( document.body ).off( 'click.jp-carousel');
 		
if(typeof $.fn.jp_carousel !== 'undefined'){
   $('.js-flickity').on( 'staticClick', function( event, pointer, cellElement, cellIndex ) {
        if ( !cellElement ) { return; }
        $(this).jp_carousel('open', {start_index: cellIndex});
   }); 		
}
...
```