### PR TITLE
VideoPress: fix fatal error when module is disabled and Shortcodes module is enabled

### DIFF
--- a/modules/shortcodes/videopress.php
+++ b/modules/shortcodes/videopress.php
@@ -1,3 +1,23 @@
 <?php
-// Boom!
-require_once( JETPACK__PLUGIN_DIR . 'modules/videopress/shortcode.php' );
+/**
+ * Provides VideoPress videos support when module is disabled.
+ *
+ * @since 2.4
+ * @since 3.9.5 Added compatibility with refactored VideoPress module.
+ */
+
+if ( ! Jetpack::is_module_active( 'videopress' ) ) {
+
+	Jetpack::dns_prefetch( array(
+		'//v0.wordpress.com',
+	) );
+
+	/**
+	 * We won't have any videos less than sixty pixels wide. That would be silly.
+	 */
+	define( 'VIDEOPRESS_MIN_WIDTH', 60 );
+
+	include_once JETPACK__PLUGIN_DIR . 'modules/videopress/utility-functions.php';
+	include_once JETPACK__PLUGIN_DIR . 'modules/videopress/shortcode.php';
+
+}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -302,10 +302,10 @@ EXPECTED;
 	 * @since 3.3.0
 	 */
 	public function test_dns_prefetch() {
-		// Purge it for a clean start.
+		// Save URLs that are already in to remove them later and perform a clean test.
 		ob_start();
 		Jetpack::dns_prefetch();
-		ob_end_clean();
+		$remove_this = ob_get_clean();
 
 		Jetpack::dns_prefetch( 'http://example1.com/' );
 		Jetpack::dns_prefetch( array(
@@ -319,6 +319,6 @@ EXPECTED;
 		            "<link rel='dns-prefetch' href='//example2.com'>\r\n" .
 		            "<link rel='dns-prefetch' href='//example3.com'>\r\n";
 
-		$this->assertEquals( $expected, get_echo( array( 'Jetpack', 'dns_prefetch' ) ) );
+		$this->assertEquals( $expected, str_replace( $remove_this, "\r\n", get_echo( array( 'Jetpack', 'dns_prefetch' ) ) ) );
 	}
 } // end class


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Provides minimum support to embed VideoPress videos.

cc @georgestephanis 

Steps to reproduce the bug that this PR solves:

1- Enable VideoPress module and Shortcodes module

2- Add shortcode `[wpvideo OO4thna8]` in a post

Post looks good so far

3- Disable VideoPress module

Post displays `Fatal error: Call to undefined function videopress_is_valid_guid() in /wp-content/plugins/jetpack/modules/videopress/shortcode.php on line 32`