### PR TITLE
Moving the Social Share Icons for WooCommerce Product Page

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -9,3 +9,4 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/buddypress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/wpml.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );

--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -1,0 +1,14 @@
+<?php
+
+add_action( 'woocommerce_share', 'jetpack_woocommerce_social_share_icons', 10 );
+
+/*
+ * Make sure the social sharing icons show up under the product's short description
+ */
+function jetpack_woocommerce_social_share_icons() {
+	if ( function_exists( 'sharing_display' ) ) {
+		remove_filter( 'the_content', 'sharing_display', 19 );
+		remove_filter( 'the_excerpt', 'sharing_display', 19 );
+		echo sharing_display();
+	}
+}


### PR DESCRIPTION
Fixes #3609 .

#### Changes proposed in this Pull Request:
- Move the social sharing icons to the `woocommerce_share` action.

This is a better experience for the user for two reasons:

1. If they don't have a description for the product it won't show up at all
1. The social sharing icons are easier to see

**Before:**
![woothemes_hoodie___patrick_s_baller_test_site](https://cloud.githubusercontent.com/assets/1065372/14159618/f8343f36-f693-11e5-9b07-de75beda546a.jpg)

**After:**
![woothemes_hoodie___patrick_s_baller_test_site 2](https://cloud.githubusercontent.com/assets/1065372/14159625/fee65954-f693-11e5-8e11-b7eace003513.jpg)