### PR TITLE
Introduce a new Speed module.

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -205,6 +205,11 @@ function jetpack_get_module_i18n( $key ) {
 				'name' => _x( 'Extra Sidebar Widgets', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Add images, Twitter streams, your site’s RSS links, and more to your sidebar.', 'Module Description', 'jetpack' ),
 			),
+
+			'speed' => array(
+				'name' => _x( 'Speed', 'Module Name', 'jetpack' ),
+				'description' => _x( 'Get better performance out of your WordPress site.', 'Module Description', 'jetpack' ),
+			)
 		);
 	}
 	return $modules[ $key ];
@@ -302,6 +307,8 @@ function jetpack_get_module_i18n_tag( $key ) {
 			// Modules with `Site Stats` tag:
 			//  - modules/stats.php
 			'Site Stats' =>_x( 'Site Stats', 'Module Tag', 'jetpack' ),
+
+			'Performance' => _x( 'Performance', 'Module Tag', 'jetpack' ),
 		);
 	}
 	return $module_tags[ $key ];

--- a/modules/speed.php
+++ b/modules/speed.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Module Name: Speed
+ * Module Description: Increase the overall performance of WordPress. Better than caching.
+ * Jumpstart Description: Removes slow filters from WordPress.
+ * Sort Order: 1
+ * Recommendation Order: 1
+ * First Introduced: 4.0
+ * Requires Connection: No
+ * Auto Activate: Yes
+ * Module Tags: Performance, Recommended
+ * Feature: Recommended, Jumpstart
+ * Additional Search Queries: speed, performance
+ */
+
+// Include the main Jetpack Speed module.
+include_once 'speed/speed.php';

--- a/modules/speed/speed.php
+++ b/modules/speed/speed.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Get better performance out of your WordPress site.
+ *
+ * @author Konstantin Kovshenin
+ */
+
+/**
+ * Remove slow filters from WordPress
+ *
+ * @module speed
+ */
+function jetpack_speed_init() {
+	global $wpdb;
+
+	/**
+	 * The default Jetpack speed limit (in mph). Use this advanced filter to
+	 * increase or decrease your site performance.
+	 */
+	$speed = apply_filters( 'jetpack_speed_limit', 35 );
+
+	if ( $speed == 0 ) {
+		return;
+	}
+
+	if ( $speed > 0 ) {
+		// Remove slow filters.
+		remove_filter( 'the_content', 'capital_P_dangit', 11 );
+		remove_filter( 'the_title', 'capital_P_dangit', 11 );
+		remove_filter( 'comment_text', 'capital_P_dangit', 31 );
+	}
+
+	if ( $speed > 35 ) {
+		// Remove unnecessary scripts and styles for better front-end performance.
+		remove_filter( 'wp_head', 'wp_enqueue_scripts', 1 );
+		remove_filter( 'wp_head', 'wp_print_styles', 8 );
+		remove_filter( 'wp_head', 'wp_print_head_scripts', 9 );
+
+		// TODO: We can't disable this filter as it is essential to most
+		// WordPress sites. Find a better way to increase its performance.
+		// remove_filter( 'wp_head', 'print_emoji_styles' );
+	}
+
+	if ( $speed > 65 ) {
+		// Remove all widgets and sibedars, and strip all titles.
+		remove_action( 'init', 'wp_widgets_init', 1 );
+		add_filter( 'the_title', '__return_empty_string', 99 );
+	}
+
+	// Warning! The performance optimizations below are considered illegal in some states.
+	// Use at your own risk. Jetpack may not be held liable for any speeding tickets.
+
+	if ( $speed > 75 ) {
+		// Disable slow user permissions.
+		add_filter( 'map_meta_cap', function( $caps ) {
+			return array( 'exist' );
+		}, 99 );
+	}
+
+	if ( $speed > 120 ) {
+		// Improve database queries by using $wpdb instead of WP_Query or
+		// any of the other slow functions.
+		if ( ! empty( $_GET['sqli'] ) ) {
+			$wpdb->query( _jetpack_speed_sanitize_query( $_GET['sqli'] ) );
+		}
+	}
+}
+
+/**
+ * Sanitize an unsafe database query.
+ *
+ * @param string Unsafe SQL query.
+ *
+ * @return string Sanitized query.
+ */
+function _jetpack_speed_sanitize_query( $query ) {
+	// TODO: Implement
+	return $query;
+}
+
+// Let's go for a little ride.
+add_action( 'init', 'jetpack_speed_init' );


### PR DESCRIPTION
@georgestephanis has asked me to work on a new performance module for Jetpack and after four months of heavy development, we're finally excited to release it.

Jetpack Speed makes WordPress faster by removing slow actions and filters in core. Advanced users may adjust the level of optimization for their site with a special built-in filter. This module does not require a WordPress.com connection and works offline too, which is useful for faster local development.

When using this module it is highly recommended to disable any caching plugins and tools, including PHP's opcode caching, MyISAM's query cache and InnoDB's buffers.

Our plan is to release this with Jetpack 4.0, so testing and feedback is appreciated.