### PR TITLE
Debugger: Various improvements

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -58,10 +58,11 @@ class Jetpack_Debugger {
 		$debug_info .= "\r\n" . esc_html( "JETPACK__PLUGIN_DIR: " . JETPACK__PLUGIN_DIR );
 		$debug_info .= "\r\n" . esc_html( "SITE_URL: " . site_url() );
 		$debug_info .= "\r\n" . esc_html( "HOME_URL: " . home_url() );
-		$debug_info .= "\r\n" . esc_html( "SERVER_PORT: " . $_SERVER['SERVER_PORT'] );
-
 
 		foreach ( array (
+					  'HTTP_HOST',
+					  'SERVER_PORT',
+					  'HTTPS',
 					  'GD_PHP_HANDLER',
 					  'HTTP_AKAMAI_ORIGIN_HOP',
 					  'HTTP_CF_CONNECTING_IP',
@@ -80,13 +81,10 @@ class Jetpack_Debugger {
 					  'HTTP_X_VARNISH',
 					  'REMOTE_ADDR'
 				  ) as $header ) {
-			if( isset( $_SERVER[$header] ) ) {
-				$debug_info .= "\r\n" . esc_html( 'IP HEADER: '.$header . ": " . $_SERVER[$header] );
-			} else {
-				$debug_info .= "\r\n" . esc_html( 'IP HEADER: '.$header . ": Not Set" );
+			if ( isset( $_SERVER[$header] ) ) {
+				$debug_info .= "\r\n" . esc_html( $header . ": " . $_SERVER[$header] );
 			}
 		}
-
 
 		$debug_info .= "\r\n" . esc_html( "PROTECT_TRUSTED_HEADER: " . json_encode(get_site_option( 'trusted_ip_header' )));
 

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -121,7 +121,11 @@ class Jetpack_Debugger {
 		add_filter( 'http_request_timeout', array( 'Jetpack_Debugger', 'jetpack_increase_timeout' ) );
 
 		$tests['SELF']['result'] = wp_remote_get( $testsite_url . $self_xml_rpc_url );
-		$tests['SELF']['fail_message'] = esc_html__( 'It looks like your site can not communicate properly with Jetpack.', 'jetpack' );
+		if ( is_wp_error( $tests['SELF']['result'] ) && 0 == strpos( $tests['SELF']['result']->get_error_message(), 'Operation timed out' ) ){
+			$tests['SELF']['fail_message'] = esc_html__( 'Your site did not get a response from our debugging service in the expected timeframe. If you are not experiencing other issues, this could be due to a slow connection between your site and our server.', 'jetpack' );
+		} else {
+			$tests['SELF']['fail_message'] = esc_html__( 'It looks like your site can not communicate properly with Jetpack.', 'jetpack' );
+		}
 
 		remove_filter( 'http_request_timeout', array( 'Jetpack_Debugger', 'jetpack_increase_timeout' ) );
 

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -5,6 +5,9 @@ class Jetpack_Debugger {
 	private static function is_jetpack_support_open() {
 		try {
 			$response = wp_remote_request( "http://jetpack.com/is-support-open" );
+			if ( is_wp_error( $response ) ) {
+				return false;
+			}
 			$body = wp_remote_retrieve_body( $response );
 			$json = json_decode( $body );
 			return ( ( bool ) $json->is_support_open );

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -248,13 +248,13 @@ class Jetpack_Debugger {
 						<input name="your_email" type="text" id="your_email" value="<?php esc_html_e( $current_user->user_email, 'jetpack'); ?>" size="40">
 					</div>
 
-					<div id="toggle_debug_info" class="formbox">
+					<div id="toggle_debug_form_info" class="formbox">
 						<p><?php _e( 'The test results and some other useful debug information will be sent to the support team. Please feel free to <a href="#">review/modify</a> this information.', 'jetpack' ); ?></p>
 					</div>
 
-					<div id="debug_info_div" class="formbox" style="display:none">
+					<div id="debug_info_form_div" class="formbox" style="display:none">
 						<label class="h" for="debug_info"><?php esc_html_e( 'Debug Info', 'jetpack' ); ?></label>
-			  			<textarea name="debug_info" cols="40" rows="7" id="debug_info"><?php echo esc_attr( $debug_info ); ?></textarea>
+			  			<textarea name="debug_info" cols="40" rows="7" id="debug_form_info"><?php echo esc_attr( $debug_info ); ?></textarea>
 					</div>
 
 					<div style="clear: both;"></div>
@@ -267,7 +267,12 @@ class Jetpack_Debugger {
 					<div style="clear: both;"></div>
 				</form>
 			<?php endif; ?>
-			</div>
+		</div> <!-- contact-message, hidden by default. -->
+		<div id="toggle_debug_info"><a href="#"><?php _e( 'View Advanced Debug Results', 'jetpack' ); ?></a></div>
+			<div id="debug_info_div" style="display:none">
+			<h4><?php esc_html_e( 'Debug Info', 'jetpack' ); ?></h4>
+			<div id="debug_info"><?php echo wpautop( esc_html( $debug_info ) ); ?></div>
+		</div>
 		</div>
 	<?php
 	}
@@ -339,7 +344,7 @@ class Jetpack_Debugger {
 				margin: 0 0 25px 0;
 			}
 
-			.formbox input[type="text"], .formbox input[type="email"], .formbox input[type="url"], .formbox textarea {
+			.formbox input[type="text"], .formbox input[type="email"], .formbox input[type="url"], .formbox textarea, #debug_info_div {
 				border: 1px solid #e5e5e5;
 				border-radius: 11px;
 				box-shadow: inset 0 1px 1px rgba(0,0,0,0.1);
@@ -388,11 +393,16 @@ class Jetpack_Debugger {
 				display: list-item;
 			}
 
+			#debug_info_div, #toggle_debug_info, #debug_info_div p {
+				font-size: smaller;
+			}
+
 		</style>
 		<script type="text/javascript">
 		jQuery( document ).ready( function($) {
 
 			$('#debug_info').prepend('jQuery version: ' + jQuery.fn.jquery + "\r\n");
+			$('#debug_form_info').prepend('jQuery version: ' + jQuery.fn.jquery + "\r\n");
 
 			$( '.jetpack-test-error .jetpack-test-heading' ).on( 'click', function() {
 				$( this ).parents( '.jetpack-test-error' ).find( '.jetpack-test-details' ).slideToggle();
@@ -406,6 +416,11 @@ class Jetpack_Debugger {
 
 			$( '#toggle_debug_info a' ).on( 'click', function() {
 				$('#debug_info_div').slideToggle();
+				return false;
+			} );
+
+			$( '#toggle_debug_form_info a' ).on( 'click', function() {
+				$('#debug_info_form_div').slideToggle();
 				return false;
 			} );
 

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -213,7 +213,7 @@ class Jetpack_Debugger {
 			</div>
 			<div id="contact-message" <?php if( ! isset( $_GET['contact'] ) ) {?>  style="display:none" <?php } ?>>
 			<?php if ( self::is_jetpack_support_open() ): ?>
-				<form id="contactme" method="post" action="http://jetpack.com/contact-support/">
+				<form id="contactme" method="post" action="https://jetpack.com/contact-support/">
 					<input type="hidden" name="action" value="submit">
 					<input type="hidden" name="jetpack" value="needs-service">
 

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -81,12 +81,12 @@ class Jetpack_Debugger {
 					  'HTTP_X_VARNISH',
 					  'REMOTE_ADDR'
 				  ) as $header ) {
-			if ( isset( $_SERVER[$header] ) ) {
-				$debug_info .= "\r\n" . esc_html( $header . ": " . $_SERVER[$header] );
+			if ( isset( $_SERVER[ $header ] ) ) {
+				$debug_info .= "\r\n" . esc_html( $header . ": " . $_SERVER[ $header ] );
 			}
 		}
 
-		$debug_info .= "\r\n" . esc_html( "PROTECT_TRUSTED_HEADER: " . json_encode(get_site_option( 'trusted_ip_header' )));
+		$debug_info .= "\r\n" . esc_html( "PROTECT_TRUSTED_HEADER: " . json_encode( get_site_option( 'trusted_ip_header' ) ) );
 
 		$debug_info .= "\r\n\r\nTEST RESULTS:\r\n\r\n";
 		$debug_raw_info = '';
@@ -403,8 +403,8 @@ class Jetpack_Debugger {
 		<script type="text/javascript">
 		jQuery( document ).ready( function($) {
 
-			$('#debug_info').prepend('jQuery version: ' + jQuery.fn.jquery + "\r\n");
-			$('#debug_form_info').prepend('jQuery version: ' + jQuery.fn.jquery + "\r\n");
+			$( '#debug_info' ).prepend( 'jQuery version: ' + jQuery.fn.jquery + "\r\n" );
+			$( '#debug_form_info' ).prepend( 'jQuery version: ' + jQuery.fn.jquery + "\r\n" );
 
 			$( '.jetpack-test-error .jetpack-test-heading' ).on( 'click', function() {
 				$( this ).parents( '.jetpack-test-error' ).find( '.jetpack-test-details' ).slideToggle();
@@ -412,38 +412,38 @@ class Jetpack_Debugger {
 			} );
 
 			$( '.jetpack-show-contact-form a' ).on( 'click', function() {
-				$('#contact-message').slideToggle();
+				$( '#contact-message' ).slideToggle();
 				return false;
 			} );
 
 			$( '#toggle_debug_info a' ).on( 'click', function() {
-				$('#debug_info_div').slideToggle();
+				$( '#debug_info_div' ).slideToggle();
 				return false;
 			} );
 
 			$( '#toggle_debug_form_info a' ).on( 'click', function() {
-				$('#debug_info_form_div').slideToggle();
+				$( '#debug_info_form_div' ).slideToggle();
 				return false;
 			} );
 
-			$('form#contactme').on("submit", function(e){
-				var form = $(this);
-				var message = form.find('#did');
-				var name = form.find('#your_name');
-				var email = form.find('#your_email')
+			$( 'form#contactme' ).on( "submit", function(e){
+				var form = $( this );
+				var message = form.find( '#did' );
+				var name = form.find( '#your_name' );
+				var email = form.find( '#your_email' )
 				var validation_error = false;
 				if( !name.val() ) {
-					name.parents('.formbox').addClass('error');
+					name.parents( '.formbox' ).addClass( 'error' );
 					validation_error = true;
 				}
 				if( !email.val() ) {
-					email.parents('.formbox').addClass('error');
+					email.parents( '.formbox' ).addClass( 'error' );
 					validation_error = true;
 				}
 				if ( validation_error ) {
 					return false;
 				}
-				message.val(message.val() + "\r\n\r\n----------------------------------------------\r\n\r\nDEBUG INFO:\r\n" + $('#debug_info').val()  );
+				message.val( message.val() + "\r\n\r\n----------------------------------------------\r\n\r\nDEBUG INFO:\r\n" + $('#debug_info').val()  );
 				return true;
 	    	});
 


### PR DESCRIPTION
- Debugger: Handle situations when the server has no online access or otherwise cannot reached jetpack.com == When there is no Internet access for the server, the debugger would throw a PHP notice. This commit prevents the notice.
- Debugger: Provides an 'Advanced Debug Results' link that is always available. Fixes #3611
- Debugger: Detect a SELF timeout and soften the error message. Fixes #3493
- Debugger: Update form action to https. Now required. Fixes #3711
- Debugger: Including specific `$_SERVER` values and squash unset keys to have a cleaner response. Fixes #624