### PR TITLE
Preventing a db UPDATE query on every page load if it's not needed.

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -64,19 +64,16 @@ class Jetpack_Protect_Module {
 		// Runs a script every day to clean up expired transients so they don't
 		// clog up our users' databases
 		require_once( JETPACK__PLUGIN_DIR . '/modules/protect/transient-cleanup.php' );
-
-		//this should move into on_activation in 3.8, but, for now, we want to make sure all sites get this option set
-		if ( is_multisite() && is_main_site() ) {
-			update_site_option( 'jetpack_protect_active', 1 );
-		}
-
-
 	}
 
 	/**
 	 * On module activation, try to get an api key
 	 */
 	public function on_activation() {
+		if ( is_multisite() && is_main_site() && get_site_option( 'jetpack_protect_active', 0 ) == 0 ) {
+			update_site_option( 'jetpack_protect_active', 1 );
+		}
+
 		update_site_option( 'jetpack_protect_activating', 'activating' );
 
 		// Get BruteProtect's counter number


### PR DESCRIPTION
Props @mqudsi for spotting and fixing the issue. It's now moved to the `on_activation` hook.

> Previously the code was blindly issuing an UPDATE against the db
> (and thrashing the object cache) on each and every page view for
> the main site in a WPMU installation.
> 
> This is a variable that is really only ever set once, it makes
> absolutely no sense to write to the database on every page view.
> 
> Now testing for current value of jetpack_protect_active before
> setting it to 1. The call to get_site_option() shouldn't add any
> overhead because site options are always cached (if I'm not
> mistaken).