### PR TITLE
mime_content_type is deprecated

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1998,7 +1998,17 @@ abstract class WPCOM_JSON_API_Endpoint {
 	 * @return bool
 	 */
 	protected function is_file_supported_for_sideloading( $file ) {
-		$type = mime_content_type( $file );
+		if ( class_exists( 'finfo' ) ) { // php 5.3+
+			$finfo = new finfo( FILEINFO_MIME );
+			$mime = explode( '; ', $finfo->file( $file ) );
+			$type = $mime[0];
+
+		} elseif ( function_exists( 'mime_content_type' ) ) { // PHP 5.2
+			$type = mime_content_type( $file );
+
+		} else {
+			return false;
+		}
 
 		/**
 		 * Filter the list of supported mime types for media sideloading.


### PR DESCRIPTION
It appears the the function `mime_content_type` is deprecated and the proper usage is to use the `finfo` class itself. This updates to have some better fallbacks.