### PR TITLE
Added the `from` param to the bottom landing page button url

### DIFF
--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -379,7 +379,7 @@
 		<div class="connect-card j-row">
 			<div class="connect-btn j-col j-sm-12 j-md-12">
 				<?php if ( ! $data['is_connected'] && current_user_can( 'jetpack_connect' ) ) : ?>
-					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect Jetpack', 'jetpack' ); ?></a>
+					<a href="<?php echo Jetpack::init()->build_connect_url( false, false, 'landing-page-bottom' ) ?>" class="download-jetpack"><?php esc_html_e( 'Connect Jetpack', 'jetpack' ); ?></a>
 				<?php elseif ( $data['is_connected'] && ! $data['is_user_connected'] && current_user_can( 'jetpack_connect_user' ) ) : ?>
 					<a href="<?php echo Jetpack::init()->build_connect_url() ?>" class="download-jetpack"><?php esc_html_e( 'Connect your account', 'jetpack' ); ?></a>
 				<?php endif; ?>

--- a/views/admin/admin-page.php
+++ b/views/admin/admin-page.php
@@ -387,7 +387,7 @@
 		</div> <?php // connect-card ?>
 
 
-		</div> <php // connection landing ?>
+		</div> <?php // connection landing ?>
 
 
 	<?php endif; ?>


### PR DESCRIPTION
The `from` param helps us understand which button is clicked by the user to initiate the connection process. 

On the new landing page when you click/press `Connect Jetpack` a `&from=landing-page-bottom` should be added to the end of the auth url.