### PR TITLE
XMLRPC Server

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -74,6 +74,10 @@ class Jetpack_XMLRPC_Server {
 		);
 	}
 
+	function authorize_xmlrpc_methods() {
+		return array( 'jetpack.remoteAuthorize' => array( $this, 'remote_authorize' ) );
+	}
+
 	function remote_authorize( $request ) {
 		foreach( array( 'secret', 'state', 'redirect_uri', 'code' ) as $required ) {
 			if ( ! isset( $request[ $required ] ) || empty( $request[ $required ] ) ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -497,9 +497,9 @@ class Jetpack {
 					// The actual API methods.
 					add_filter( 'xmlrpc_methods', array( $this->xmlrpc_server, 'xmlrpc_methods' ) );
 				} else {
-					// Bootstrap methods should be available for unauthenticated users with an active jetpack connection,
-					// so that additional users can link their account
-					add_filter( 'xmlrpc_methods', array( $this->xmlrpc_server, 'bootstrap_xmlrpc_methods' ) );
+					// The jetpack.authorize method should be available for unauthenticated users on a site with an
+					// active Jetpack connection, so that additional users can link their account.
+					add_filter( 'xmlrpc_methods', array( $this->xmlrpc_server, 'authorize_xmlrpc_methods' ) );
 				}
 			} else {
 				// The bootstrap API methods.


### PR DESCRIPTION
Only the jetpack.authorize method should be available to unconnected users
on a site with an existing connection. This will allow additional users to
link their account remotely via Calypso. However the jetpack.verifyRegistration
method should not be available. Otherwise, our debug scripts throw unexpected errors.

props @kraftbj for catching this