### PR TITLE
Versioning: don't reference versions that will never exist

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -991,7 +991,7 @@ class Jetpack {
 		}
 
 		if ( ! wp_script_is( 'jetpack-twitter-timeline', 'registered' ) ) {
-			wp_register_script( 'jetpack-twitter-timeline', plugins_url( '_inc/twitter-timeline.js', JETPACK__PLUGIN_FILE ) , array( 'jquery' ), '3.10', true );
+			wp_register_script( 'jetpack-twitter-timeline', plugins_url( '_inc/twitter-timeline.js', JETPACK__PLUGIN_FILE ) , array( 'jquery' ), '4.0.0', true );
 		}
 
 		if ( ! wp_script_is( 'jetpack-facebook-embed', 'registered' ) ) {

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -2013,7 +2013,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		/**
 		 * Filter the list of supported mime types for media sideloading.
 		 *
-		 * @since 4.0
+		 * @since 4.0.0
 		 *
 		 * @module json-api
 		 *

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -376,7 +376,7 @@ class The_Neverending_Home_Page {
 		add_filter( 'body_class', array( $this, 'body_class' ) );
 
 		// Add our scripts.
-		wp_enqueue_script( 'the-neverending-homepage', plugins_url( 'infinity.js', __FILE__ ), array( 'jquery' ), '3.10', true );
+		wp_enqueue_script( 'the-neverending-homepage', plugins_url( 'infinity.js', __FILE__ ), array( 'jquery' ), '4.0.0', true );
 
 		// Add our default styles.
 		wp_enqueue_style( 'the-neverending-homepage', plugins_url( 'infinity.css', __FILE__ ), array(), '20140422' );

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -154,7 +154,7 @@ class Jetpack_Monitor {
 	/*
 	 * Returns date of the last downtime.
 	 *
-	 * @since 4.0
+	 * @since 4.0.0
 	 * @return date in YYYY-MM-DD HH:mm:ss format
 	 */
 	public function monitor_get_last_downtime() {

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -37,7 +37,7 @@ function videopress_get_video_details( $guid ) {
 	 * about a given video.  It may involve swapping some data out or
 	 * adding new parameters.
 	 *
-	 * @since 3.10
+	 * @since 4.0.0
 	 *
 	 * @param object $data The data returned by the WPCOM API. See: https://developer.wordpress.com/docs/api/1.1/get/videos/%24guid/
 	 * @param string $guid The GUID of the VideoPress video in question.

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -59,7 +59,7 @@ jetpack_load_widgets();
 /**
  * Enqueue utilities to work with widgets in Customizer.
  *
- * @since 3.10
+ * @since 4.0.0
  */
 function jetpack_widgets_customizer_assets() {
 	wp_enqueue_script( 'jetpack-customizer-widget-utils', plugins_url( '/widgets/customizer-utils.js', __FILE__ ), array( 'jquery' ) );

--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -288,7 +288,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 	 * @deprecated
 	 */
 	function guess_locale_from_lang( $lang ) {
-		_deprecated_function( __METHOD__, '3.10', 'Jetpack::guess_locale_from_lang()' );
+		_deprecated_function( __METHOD__, '4.0.0', 'Jetpack::guess_locale_from_lang()' );
 		Jetpack::$instance->get_locale_from_lang( $lang );
 	}
 
@@ -296,7 +296,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 	 * @deprecated
 	 */
 	function get_locale() {
-		_deprecated_function( __METHOD__, '3.10', 'Jetpack::get_locale()' );
+		_deprecated_function( __METHOD__, '4.0.0', 'Jetpack::get_locale()' );
 		Jetpack::$instance->get_locale();
 	}
 }

--- a/modules/widgets/gravatar-profile.php
+++ b/modules/widgets/gravatar-profile.php
@@ -218,7 +218,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 	/**
 	 * Enqueue CSS and JavaScript.
 	 *
-	 * @since 3.10
+	 * @since 4.0.0
 	 */
 	function enqueue_scripts() {
 		wp_enqueue_style(

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -48,7 +48,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	 * @deprecated
 	 */
 	public function library() {
-		_deprecated_function( __METHOD__, '3.10' );
+		_deprecated_function( __METHOD__, '4.0.0' );
 		wp_print_scripts( array( 'jetpack-twitter-timeline' ) );
 	}
 

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -891,7 +891,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 	/**
 	 * Enqueue CSS and JavaScript.
 	 *
-	 * @since 3.10
+	 * @since 4.0.0
 	 */
 	public function enqueue_scripts() {
 		wp_enqueue_style( 'jetpack_display_posts_widget', plugins_url( 'wordpress-post-widget/style.css', __FILE__ ) );

--- a/tests/php/modules/shortcodes/test_class.vimeo.php
+++ b/tests/php/modules/shortcodes/test_class.vimeo.php
@@ -114,7 +114,7 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 	/**
 	 * @author Automattic
 	 * @covers ::vimeo_shortcode
-	 * @since 3.10.0
+	 * @since 4.0.0
 	 */
 	public function test_replace_in_comments() {
 		$video_id = '141358';


### PR DESCRIPTION
We're not doing a 3.10 anymore

I think it should be 4.0.0 to stay consistent with how we've been doing it since [`3.8.0`](https://plugins.trac.wordpress.org/browser/jetpack/tags/)