### PR TITLE
Make is_development_mode() value "static"

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1491,6 +1491,14 @@ class Jetpack {
 	 * Is Jetpack in development (offline) mode?
 	 */
 	public static function is_development_mode() {
+		
+		// Once we have this value, maintain it.
+		static $development_mode = null;
+		
+		if ( ! is_null( $development_mode ) ) {
+			return $development_mode;
+		}
+		
 		$development_mode = false;
 
 		if ( defined( 'JETPACK_DEV_DEBUG' ) ) {
@@ -1509,7 +1517,9 @@ class Jetpack {
 		 *
 		 * @param bool $development_mode Is Jetpack's development mode active.
 		 */
-		return apply_filters( 'jetpack_development_mode', $development_mode );
+		$development_mode =  apply_filters( 'jetpack_development_mode', $development_mode );
+		
+		return $development_mode;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1462
Fixes #3827  .

This is an attempt at a fix for issue #1462.

I confess I don't know your coding standards. You may not like static variables. You may want to add more commenting on this to make is less obscure. But this change does work and may fix the problem described in the issue.

The issue is that if the jetpack_development_mode filter is defined too late - perhaps in a theme's functions.php by someone who's not read the doc's correctly - the modules won't be loaded, but the "In development mode" notice will still be displayed and you will still be able to activate the modules in the admin GUI.

This is because the return value of is_development_mode() would be different depending on when it is called. In the case cited above, it would return false before the theme was loaded and true after the theme is loaded.

This change that I'm proposing ensures that development mode is reported consistently regardless of when it is called by saving the value returned the first time it is called and returning it again in future.
