### PR TITLE
Jetpack Connect URL

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3985,8 +3985,10 @@ p {
 					Jetpack::state( 'error_description', $registered->get_error_message() );
 					break;
 				}
+				
+				$from = isset( $_GET['from'] ) ? $_GET['from'] : false;
 
-				wp_redirect( $this->build_connect_url( true, false, 'error-desc' ) );
+				wp_redirect( $this->build_connect_url( true, false, $from ) );
 				exit;
 			case 'activate' :
 				if ( ! current_user_can( 'jetpack_activate_modules' ) ) {


### PR DESCRIPTION
Include the `$from` parameter, if it exists, when redirecting after jetpack-register. This will ensure events are properly tracked. props @jessefriedman for reporting this, and @dereksmart for helping to debug.