### PR TITLE
Add some extra classes conditionally to the VideoPress modal.

### DIFF
--- a/modules/videopress/js/editor-view.js
+++ b/modules/videopress/js/editor-view.js
@@ -154,6 +154,8 @@
 			editor.windowManager.open( {
 				title : vpEditorView.modal_labels.title,
 				id    : 'videopress-shortcode-settings-modal',
+				width : 600,
+				height : 300,
 				body  : [
 					{
 						type     : 'textbox',
@@ -230,6 +232,12 @@
 					}, renderer );
 
 					editor.insertContent( wp.shortcode.string( args ) );
+				},
+				onopen : function ( e ) {
+					var prefix = 'mce-videopress-field-';
+					_.each( ['w', 'at'], function( value ) {
+						e.target.$el.find( '.' + prefix + value + ' .mce-container-body' ).append( '<span class="' + prefix + 'unit ' + prefix + 'unit-' + value + '">' + vpEditorView.modal_labels[ value + '_unit' ] );
+					} );
 				}
 			} );
 

--- a/modules/videopress/js/editor-view.js
+++ b/modules/videopress/js/editor-view.js
@@ -61,6 +61,8 @@
 				}
 			}
 
+			options.ratio = 100 * ( options.height / options.width );
+
 			return this.template( options );
 		},
 		edit: function( data ) {

--- a/modules/videopress/js/editor-view.js
+++ b/modules/videopress/js/editor-view.js
@@ -240,6 +240,10 @@
 					_.each( ['w', 'at'], function( value ) {
 						e.target.$el.find( '.' + prefix + value + ' .mce-container-body' ).append( '<span class="' + prefix + 'unit ' + prefix + 'unit-' + value + '">' + vpEditorView.modal_labels[ value + '_unit' ] );
 					} );
+					$('body').addClass( 'modal-open' );
+				},
+				onclose: function () {
+					$('body').removeClass( 'modal-open' );
 				}
 			} );
 

--- a/modules/videopress/js/editor-view.js
+++ b/modules/videopress/js/editor-view.js
@@ -120,6 +120,27 @@
 				return element.outerHTML;
 			};
 
+			var oldRenderFormItem = tinyMCE.ui.FormItem.prototype.renderHtml;
+			tinyMCE.ui.FormItem.prototype.renderHtml = function() {
+				_.each( vpEditorView.modal_labels, function( value, key ) {
+					if ( value === this.settings.items.text ) {
+						this.classes.add( 'videopress-field-' + key );
+					}
+				}, this );
+
+				if ( _.contains( [
+						vpEditorView.modal_labels.hd,
+						vpEditorView.modal_labels.permalink,
+						vpEditorView.modal_labels.autoplay,
+						vpEditorView.modal_labels.loop,
+						vpEditorView.modal_labels.freedom,
+						vpEditorView.modal_labels.flashonly
+					], this.settings.items.text ) ) {
+					this.classes.add( 'videopress-checkbox' );
+				}
+				return oldRenderFormItem.call( this );
+			};
+
 			/**
 			 * Populate the defaults.
 			 */
@@ -211,6 +232,9 @@
 					editor.insertContent( wp.shortcode.string( args ) );
 				}
 			} );
+
+			// Set it back to its original renderer.
+			tinyMCE.ui.FormItem.prototype.renderHtml = oldRenderFormItem;
 		}
 	};
 	wp.mce.views.register( 'videopress', wp.mce.videopress_wp_view_renderer );

--- a/modules/videopress/js/editor-view.js
+++ b/modules/videopress/js/editor-view.js
@@ -64,10 +64,11 @@
 			return this.template( options );
 		},
 		edit: function( data ) {
-			var shortcode_data = wp.shortcode.next( this.shortcode_string, data),
-				named          = shortcode_data.shortcode.attrs.named,
-				editor         = tinyMCE.activeEditor,
-				renderer       = this;
+			var shortcode_data    = wp.shortcode.next( this.shortcode_string, data),
+				named             = shortcode_data.shortcode.attrs.named,
+				editor            = tinyMCE.activeEditor,
+				renderer          = this,
+				oldRenderFormItem = tinyMCE.ui.FormItem.prototype.renderHtml;
 
 			/**
 			 * Override TextBox renderHtml to support html5 attrs.
@@ -120,7 +121,6 @@
 				return element.outerHTML;
 			};
 
-			var oldRenderFormItem = tinyMCE.ui.FormItem.prototype.renderHtml;
 			tinyMCE.ui.FormItem.prototype.renderHtml = function() {
 				_.each( vpEditorView.modal_labels, function( value, key ) {
 					if ( value === this.settings.items.text ) {

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -195,16 +195,44 @@ function videopress_editor_view_js_templates() {
 
 	<!-- VideoPress Settings Modal style overrides -->
 	<style type="text/css">
-	.mce-videopress-field-guid {
-		display: none;
-	}
+		.mce-videopress-field-guid {
+			display: none;
+		}
 		.mce-videopress-checkbox .mce-checkbox {
-			left: 0 !important;
+			left: 120px !important;
 			width: 100% !important; /* assigning a full width so the label area is clickable */
 		}
 
 		.mce-videopress-checkbox .mce-label {
-			left: 30px !important;
+			left: 150px !important;
+		}
+		.mce-videopress-checkbox .mce-label-unit {
+			position: absolute;
+			left: 210px;
+			top: 5px;
+		}
+		.mce-videopress-checkbox i.mce-i-checkbox {
+			border: 1px solid #b4b9be;
+			background: #fff;
+			color: #555;
+			height: 16px;
+			width: 16px;
+			margin: -4px 4px 0 0;
+			vertical-align: middle;
+		}
+
+		.mce-videopress-checkbox .mce-i-checkbox:before { {
+			float: left;
+			display: inline-block;
+			vertical-align: middle;
+			width: 16px;
+			font: 400 21px/1 dashicons;
+			speak: none;
+			-webkit-font-smoothing: antialiased;
+			-moz-osx-font-smoothing: grayscale;
+			margin: -2px 0 0 -3px;
+			content: "\f147";
+			color: #1e8cbe;
 		}
 	</style>
 	<?php

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -212,17 +212,10 @@ function videopress_editor_view_js_templates() {
 			top: 5px;
 		}
 		.mce-videopress-checkbox i.mce-i-checkbox {
-			border: 1px solid #b4b9be;
-			background: #fff;
-			color: #555;
-			height: 16px;
-			width: 16px;
-			margin: -4px 4px 0 0;
-			vertical-align: middle;
+			background-color: #fff;
+			color: #1e8cbe;
 		}
-
-		.mce-videopress-checkbox .mce-i-checkbox:before { {
-			float: left;
+		.mce-videopress-checkbox .mce-i-checkbox:before {
 			display: inline-block;
 			vertical-align: middle;
 			width: 16px;
@@ -230,9 +223,11 @@ function videopress_editor_view_js_templates() {
 			speak: none;
 			-webkit-font-smoothing: antialiased;
 			-moz-osx-font-smoothing: grayscale;
-			margin: -2px 0 0 -3px;
+			margin: -3px 0 0 -3px;
 			content: "\f147";
-			color: #1e8cbe;
+		}
+		.mce-videopress-checkbox .mce-i-checkbox.mce-checked:before {
+			content: "\f147";
 		}
 	</style>
 	<?php

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -195,6 +195,9 @@ function videopress_editor_view_js_templates() {
 
 	<!-- VideoPress Settings Modal style overrides -->
 	<style type="text/css">
+	.mce-videopress-field-guid {
+		display: none;
+	}
 		.mce-videopress-checkbox .mce-checkbox {
 			left: 0 !important;
 		}

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -192,5 +192,16 @@ function videopress_editor_view_js_templates() {
 			<iframe style="display: block;" width="{{ data.width }}" height="{{ data.height }}" src="https://videopress.com/embed/{{ data.guid }}?{{ data.urlargs }}" frameborder='0' allowfullscreen></iframe>
 		</div>
 	</script>
+
+	<!-- VideoPress Settings Modal style overrides -->
+	<style type="text/css">
+		.mce-videopress-checkbox .mce-checkbox {
+			left: 0 !important;
+		}
+
+		.mce-videopress-checkbox .mce-label {
+			left: 30px !important;
+		}
+	</style>
 	<?php
 }

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -158,8 +158,10 @@ function videopress_handle_editor_view_js() {
 		'modal_labels'      => array(
 			'title'     => __( 'VideoPress Shortcode', 'jetpack' ),
 			'guid'      => __( 'Video ID', 'jetpack' ),
-			'w'         => __( 'Video width (in pixels)', 'jetpack' ),
-			'at'        => __( 'Start video after (in seconds)', 'jetpack' ),
+			'w'         => __( 'Video Width', 'jetpack' ),
+			'w_unit'	=> __( 'pixels', 'jetpack' ),
+			'at'        => __( 'Start Video After', 'jetpack' ),
+			'at_unit'	=> __( 'seconds', 'jetpack' ),
 			'hd'        => __( 'High definition on by default', 'jetpack' ),
 			'permalink' => __( 'Link the video title to its URL on VideoPress.com', 'jetpack' ),
 			'autoplay'  => __( 'Autoplay video on page load', 'jetpack' ),
@@ -228,6 +230,20 @@ function videopress_editor_view_js_templates() {
 		}
 		.mce-videopress-checkbox .mce-i-checkbox.mce-checked:before {
 			content: "\f147";
+		}
+		div[class*=mce-videopress-field] input[type=number] {
+			width: 70px !important;
+			left: 120px !important;
+		}
+		.mce-videopress-field-w .mce-label,
+		.mce-videopress-field-at .mce-label {
+			width: 115px !important;
+			text-align: right;
+		}
+		.mce-videopress-field-unit {
+			position: absolute;
+			left: 210px;
+			top: 5px;
 		}
 	</style>
 	<?php

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -200,6 +200,7 @@ function videopress_editor_view_js_templates() {
 	}
 		.mce-videopress-checkbox .mce-checkbox {
 			left: 0 !important;
+			width: 100% !important; /* assigning a full width so the label area is clickable */
 		}
 
 		.mce-videopress-checkbox .mce-label {

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -159,9 +159,9 @@ function videopress_handle_editor_view_js() {
 			'title'     => __( 'VideoPress Shortcode', 'jetpack' ),
 			'guid'      => __( 'Video ID', 'jetpack' ),
 			'w'         => __( 'Video Width', 'jetpack' ),
-			'w_unit'	=> __( 'pixels', 'jetpack' ),
+			'w_unit'    => __( 'pixels', 'jetpack' ),
 			'at'        => __( 'Start Video After', 'jetpack' ),
-			'at_unit'	=> __( 'seconds', 'jetpack' ),
+			'at_unit'   => __( 'seconds', 'jetpack' ),
 			'hd'        => __( 'High definition on by default', 'jetpack' ),
 			'permalink' => __( 'Link the video title to its URL on VideoPress.com', 'jetpack' ),
 			'autoplay'  => __( 'Autoplay video on page load', 'jetpack' ),
@@ -170,6 +170,8 @@ function videopress_handle_editor_view_js() {
 			'flashonly' => __( 'Use legacy Flash Player (not recommended)', 'jetpack' ),
 		)
 	) );
+
+	add_editor_style( plugins_url( 'videopress-editor-style.css', __FILE__ ) );
 }
 add_action( 'admin_notices', 'videopress_handle_editor_view_js' );
 
@@ -190,8 +192,10 @@ function videopress_editor_view_js_templates() {
 	 */
 	?>
 	<script type="text/html" id="tmpl-videopress_iframe_vnext">
-		<div class="tmpl-videopress_iframe_next">
-			<iframe style="display: block;" width="{{ data.width }}" height="{{ data.height }}" src="https://videopress.com/embed/{{ data.guid }}?{{ data.urlargs }}" frameborder='0' allowfullscreen></iframe>
+		<div class="tmpl-videopress_iframe_next" style="max-height:{{ data.height }}px;">
+			<div class="videopress-editor-wrapper" style="padding-top:{{ data.ratio }}%;">
+				<iframe style="display: block;" width="{{ data.width }}" height="{{ data.height }}" src="https://videopress.com/embed/{{ data.guid }}?{{ data.urlargs }}" frameborder='0' allowfullscreen></iframe>
+			</div>
 		</div>
 	</script>
 

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -156,18 +156,19 @@ function videopress_handle_editor_view_js() {
 		'min_content_width' => VIDEOPRESS_MIN_WIDTH,
 		'content_width'     => $content_width,
 		'modal_labels'      => array(
-			'title'     => __( 'VideoPress Shortcode', 'jetpack' ),
-			'guid'      => __( 'Video ID', 'jetpack' ),
-			'w'         => __( 'Video Width', 'jetpack' ),
-			'w_unit'    => __( 'pixels', 'jetpack' ),
-			'at'        => __( 'Start Video After', 'jetpack' ),
-			'at_unit'   => __( 'seconds', 'jetpack' ),
-			'hd'        => __( 'High definition on by default', 'jetpack' ),
-			'permalink' => __( 'Link the video title to its URL on VideoPress.com', 'jetpack' ),
-			'autoplay'  => __( 'Autoplay video on page load', 'jetpack' ),
-			'loop'      => __( 'Loop video playback', 'jetpack' ),
-			'freedom'   => __( 'Use only Open Source codecs (may degrade performance)', 'jetpack' ),
-			'flashonly' => __( 'Use legacy Flash Player (not recommended)', 'jetpack' ),
+			'title'     => esc_html__( 'VideoPress Shortcode', 'jetpack' ),
+			'guid'      => esc_html__( 'Video ID', 'jetpack' ),
+			'w'         => esc_html__( 'Video Width', 'jetpack' ),
+			'w_unit'    => esc_html__( 'pixels', 'jetpack' ),
+			/* Translators: example of usage of this is "Start Video After 10 seconds" */
+			'at'        => esc_html__( 'Start Video After', 'jetpack' ),
+			'at_unit'   => esc_html__( 'seconds', 'jetpack' ),
+			'hd'        => esc_html__( 'High definition on by default', 'jetpack' ),
+			'permalink' => esc_html__( 'Link the video title to its URL on VideoPress.com', 'jetpack' ),
+			'autoplay'  => esc_html__( 'Autoplay video on page load', 'jetpack' ),
+			'loop'      => esc_html__( 'Loop video playback', 'jetpack' ),
+			'freedom'   => esc_html__( 'Use only Open Source codecs (may degrade performance)', 'jetpack' ),
+			'flashonly' => esc_html__( 'Use legacy Flash Player (not recommended)', 'jetpack' ),
 		)
 	) );
 

--- a/modules/videopress/videopress-editor-style.css
+++ b/modules/videopress/videopress-editor-style.css
@@ -1,0 +1,17 @@
+/**
+ * VideoPress styles for Editor
+ */
+.videopress-editor-wrapper {
+	position: relative;
+	max-width: 100%;
+	padding: 56.25% 0 0;
+	height: 0;
+	overflow: hidden;
+}
+.tmpl-videopress_iframe_next iframe {
+	position: absolute;
+	top: 0;
+	left: 0;
+	max-width: 100%;
+	max-height: 100%;
+}


### PR DESCRIPTION
Fixes #3636 

To each of the main `mce-container` field wrappers, this is adding either one or two classes.

The first is `mce-videopress-field-{$field_slug}` -- where slug is guid, w, at, hd, permalink, etc
The second is adding a `mce-videopress-checkbox` field to the fields that are checkboxes.

More coming from @jeffgolenski  as we consider overriding some styling and such -- this is just giving the selectors to base that work on top of.