### PR TITLE
SSO: Improve UX with button placement and profile information

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -373,7 +373,7 @@ class Jetpack_SSO {
 		if ( 'login' === $action ) {
 			wp_enqueue_script( 'jquery' );
 			wp_enqueue_style( 'genericons' );
-			add_action( 'login_message', array( $this, 'display_sso_button' ), 101 );
+			add_action( 'login_footer', array( $this, 'login_form' ) );
 			add_action( 'login_footer', array( $this, 'login_footer' ) );
 
 			/*
@@ -391,7 +391,7 @@ class Jetpack_SSO {
 				$this->handle_login();
 				wp_enqueue_script( 'jquery' );
 				wp_enqueue_style( 'genericons' );
-				add_action( 'login_message', array( $this, 'display_sso_button' ), 101 );
+				add_action( 'login_footer', array( $this, 'login_form' ) );
 				add_action( 'login_footer', array( $this, 'login_footer' ) );
 			} else {
 				if ( Jetpack::check_identity_crisis() ) {
@@ -399,7 +399,7 @@ class Jetpack_SSO {
 				} else {
 					$this->maybe_save_cookie_redirect();
 					// Is it wiser to just use wp_redirect than do this runaround to wp_safe_redirect?
-					add_action( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+					add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 					wp_safe_redirect( $this->build_sso_url() );
 				}
 			}
@@ -452,69 +452,56 @@ class Jetpack_SSO {
 		return apply_filters( 'jetpack_remove_login_form', get_option( 'jetpack_sso_remove_login_form', false ) );
 	}
 
-	function display_sso_button( $message ) {
+	function login_form() {
 		$classes = '';
-		$hide_login_form = $this->should_hide_login_form();
 
-		if ( $hide_login_form ) {
+		if ( $this->should_hide_login_form() ) {
 			$classes .= ' forced-sso';
 		}
-
-		$sso_button = '<div class="jetpack-sso-wrap' . $classes . '">' . $this->button() . '</div>';
-
-		if ( $hide_login_form ) {
-			$sso_or = '';
-		} else {
-			$sso_or = '<div class="jetpack-sso-or"><span class="jetpack-sso-or__text">';
-				$sso_or .= _x( 'Or', 'Displayed when a user has a choice between login options.', 'jetpack' );
-			$sso_or .= '</span></div>';
-		}
-
-		return $message . $sso_button . $sso_or;
+		echo '<div class="jetpack-sso-wrap' . $classes . '">' . $this->button() . '</div>';
 	}
 
 	function login_footer() {
 		$hide_login_form = $this->should_hide_login_form();
 		?>
 		<style>
+			#loginform {
+				overflow: hidden;
+				padding-bottom: 26px;
+			}
 			.jetpack-sso-wrap {
-				background: #fff;
-				box-shadow: 0 1px 3px rgba(0,0,0,.13);
-				margin-top: 20px;
-				margin-left: 0;
-				padding: 26px 24px;
-				text-align: center;
+				<?php if ( $hide_login_form ) : ?>
+					text-align: center;
+				<?php else : ?>
+					float: right;
+				<?php endif; ?>
+				margin: 1em 0 0;
+				clear: right;
+				display: block;
 			}
 
-			.jetpack-sso-or {
-				margin-top: 20px;
-				position: relative;
-				text-align: center;
+			<?php if ( $hide_login_form ) : ?>
+			.forced-sso .jetpack-sso.button {
+				font-size: 16px;
+				line-height: 27px;
+				height: 37px;
+				padding: 5px 12px 6px 47px;
 			}
-
-			.jetpack-sso-or:before {
-				background: #ccc;
-				content: '';
-				height: 1px;
-				position: absolute;
-					left: 0;
-					top: 50%;
-				width: 100%;
+			.forced-sso .jetpack-sso.button:before {
+				font-size: 28px !important;
+				height: 37px;
+				padding: 5px 5px 4px;
+				width: 37px;
 			}
-
-			.jetpack-sso-or__text {
-				background: #f1f1f1;
-				color: #ccc;
-				position: relative;
-				padding: 0 8px;
-				text-transform: uppercase
-			}
+			<?php endif; ?>
 		</style>
 		<script>
 			jQuery(document).ready(function($){
 			<?php if ( $hide_login_form ) : ?>
 				$( '#loginform' ).empty();
 			<?php endif; ?>
+				$( '#loginform' ).append( $( '.jetpack-sso-wrap' ) );
+
 				var $rememberme = $( '#rememberme' ),
 					$ssoButton  = $( 'a.jetpack-sso.button' );
 
@@ -530,6 +517,7 @@ class Jetpack_SSO {
 
 					$ssoButton.prop( 'href', url );
 				} ).change();
+
 			});
 		</script>
 		<?php

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -28,6 +28,7 @@ class Jetpack_SSO {
 		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'xmlrpc_methods' ) );
 		add_action( 'init', array( $this, 'maybe_logout_user' ), 5 );
 		add_action( 'jetpack_modules_loaded', array( $this, 'module_configure_button' ) );
+		add_action( 'login_enqueue_scripts', array( $this, 'login_enqueue_scripts' ) );
 
 		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
 		add_action( 'login_form_jetpack-sso', '__return_true' );
@@ -138,6 +139,20 @@ class Jetpack_SSO {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Enqueues scripts and styles necessary for SSO login.
+	 */
+	public function login_enqueue_scripts() {
+		global $action;
+
+		if ( ! in_array( $action, array( 'jetpack-sso', 'login' ) ) ) {
+			return;
+		}
+
+		wp_enqueue_style( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login.css', JETPACK__PLUGIN_FILE ), array( 'login', 'genericons' ), JETPACK__VERSION );
+		wp_enqueue_script( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION );
 	}
 
 	/**
@@ -371,10 +386,7 @@ class Jetpack_SSO {
 		}
 
 		if ( 'login' === $action ) {
-			wp_enqueue_script( 'jquery' );
-			wp_enqueue_style( 'genericons' );
 			add_action( 'login_footer', array( $this, 'login_form' ) );
-			add_action( 'login_footer', array( $this, 'login_footer' ) );
 
 			/*
 			if ( get_option( 'jetpack_sso_remove_login_form' ) ) {
@@ -389,10 +401,7 @@ class Jetpack_SSO {
 		} elseif ( 'jetpack-sso' === $action ) {
 			if ( isset( $_GET['result'], $_GET['user_id'], $_GET['sso_nonce'] ) && 'success' == $_GET['result'] ) {
 				$this->handle_login();
-				wp_enqueue_script( 'jquery' );
-				wp_enqueue_style( 'genericons' );
 				add_action( 'login_footer', array( $this, 'login_form' ) );
-				add_action( 'login_footer', array( $this, 'login_footer' ) );
 			} else {
 				if ( Jetpack::check_identity_crisis() ) {
 					wp_die( __( "Error: This site's Jetpack connection is currently experiencing problems.", 'jetpack' ) );
@@ -459,68 +468,6 @@ class Jetpack_SSO {
 			$classes .= ' forced-sso';
 		}
 		echo '<div class="jetpack-sso-wrap' . $classes . '">' . $this->button() . '</div>';
-	}
-
-	function login_footer() {
-		$hide_login_form = $this->should_hide_login_form();
-		?>
-		<style>
-			#loginform {
-				overflow: hidden;
-				padding-bottom: 26px;
-			}
-			.jetpack-sso-wrap {
-				<?php if ( $hide_login_form ) : ?>
-					text-align: center;
-				<?php else : ?>
-					float: right;
-				<?php endif; ?>
-				margin: 1em 0 0;
-				clear: right;
-				display: block;
-			}
-
-			<?php if ( $hide_login_form ) : ?>
-			.forced-sso .jetpack-sso.button {
-				font-size: 16px;
-				line-height: 27px;
-				height: 37px;
-				padding: 5px 12px 6px 47px;
-			}
-			.forced-sso .jetpack-sso.button:before {
-				font-size: 28px !important;
-				height: 37px;
-				padding: 5px 5px 4px;
-				width: 37px;
-			}
-			<?php endif; ?>
-		</style>
-		<script>
-			jQuery(document).ready(function($){
-			<?php if ( $hide_login_form ) : ?>
-				$( '#loginform' ).empty();
-			<?php endif; ?>
-				$( '#loginform' ).append( $( '.jetpack-sso-wrap' ) );
-
-				var $rememberme = $( '#rememberme' ),
-					$ssoButton  = $( 'a.jetpack-sso.button' );
-
-				$rememberme.on( 'change', function() {
-					var url       = $ssoButton.prop( 'href' ),
-						isChecked = $rememberme.prop( 'checked' ) ? 1 : 0;
-
-					if ( url.match( /&rememberme=\d/ ) ) {
-						url = url.replace( /&rememberme=\d/, '&rememberme=' + isChecked );
-					} else {
-						url += '&rememberme=' + isChecked;
-					}
-
-					$ssoButton.prop( 'href', url );
-				} ).change();
-
-			});
-		</script>
-		<?php
 	}
 
 	static function delete_connection_for_user( $user_id ) {
@@ -798,52 +745,8 @@ class Jetpack_SSO {
 
 		$url  = add_query_arg( $args, wp_login_url() );
 
-		$css = "<style>
-		.jetpack-sso.button {
-			position: relative;
-			padding-left: 37px;
-		}
-		.jetpack-sso.button:before {
-			display: block;
-			box-sizing: border-box;
-			padding: 7px 0 0;
-			text-align: center;
-			position: absolute;
-			top: -1px;
-			left: -1px;
-			border-radius: 2px 0 0 2px;
-			content: '\\f205';
-			background: #0074a2;
-			color: #fff;
-			-webkit-font-smoothing: antialiased;
-			width: 30px;
-			height: 107%;
-			height: calc( 100% + 2px );
-			font: normal 22px/1 Genericons !important;
-			text-shadow: none;
-		}
-		@media screen and (min-width: 783px) {
-			.jetpack-sso.button:before {
-				padding-top: 3px;
-			}
-		}
-		.jetpack-sso.button:hover {
-			border: 1px solid #aaa;
-		}";
-
-		if ( version_compare( $GLOBALS['wp_version'], '3.8-alpha', '<' ) ) {
-			$css .= '
-			.jetpack-sso.button:before {
-				width: 25px;
-				font-size: 18px !important;
-			}
-			';
-		}
-
-		$css .= '</style>';
-
 		$button = sprintf( '<a href="%1$s" class="jetpack-sso button">%2$s</a>', esc_url( $url ), esc_html__( 'Log in with WordPress.com', 'jetpack' ) );
-		return $button . $css;
+		return $button;
 	}
 
 	function build_sso_url( $args = array() ) {

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -56,8 +56,9 @@ class Jetpack_SSO {
 	 * @return Jetpack_SSO
 	 **/
 	public static function get_instance() {
-		if( !is_null( self::$instance ) )
+		if ( ! is_null( self::$instance ) ) {
 			return self::$instance;
+		}
 
 		return self::$instance = new Jetpack_SSO;
 	}
@@ -96,7 +97,7 @@ class Jetpack_SSO {
 	public function maybe_logout_user() {
 		global $current_user;
 
-		if( 1 == $current_user->jetpack_force_logout ) {
+		if ( 1 == $current_user->jetpack_force_logout ) {
 			delete_user_meta( $current_user->ID, 'jetpack_force_logout' );
 			self::delete_connection_for_user( $current_user->ID );
 			wp_logout();
@@ -124,14 +125,13 @@ class Jetpack_SSO {
 		$user_query = new WP_User_Query(
 			array(
 				'meta_key' => 'wpcom_user_id',
-				'meta_value' => $user_id
+				'meta_value' => $user_id,
 			)
 		);
 		$user = $user_query->get_results();
 		$user = $user[0];
 
-
-		if( $user instanceof WP_User ) {
+		if ( $user instanceof WP_User ) {
 			$user = wp_set_current_user( $user->ID );
 			update_user_meta( $user->ID, 'jetpack_force_logout', '1' );
 			self::delete_connection_for_user( $user->ID );
@@ -193,7 +193,6 @@ class Jetpack_SSO {
 			'jetpack_sso_settings'
 		);
 
-
 		/*
 		 * Settings > General > Single Sign On
 		 */
@@ -220,7 +219,7 @@ class Jetpack_SSO {
 	 **/
 	public function render_require_two_step() {
 		/** This filter is documented in modules/sso.php */
-		$require_two_step = 1 == apply_filters( 'jetpack_sso_require_two_step', get_option( 'jetpack_sso_require_two_step' ) );
+		$require_two_step = ( 1 == apply_filters( 'jetpack_sso_require_two_step', get_option( 'jetpack_sso_require_two_step' ) ) );
 		$disabled = $require_two_step ? ' disabled="disabled"' : '';
 		echo '<label>';
 		echo '<input type="checkbox" name="jetpack_sso_require_two_step" ' . checked( $require_two_step, true, false ) . "$disabled>";
@@ -270,7 +269,7 @@ class Jetpack_SSO {
 	 * @since 2.7
 	 **/
 	public function render_remove_login_form_checkbox() {
-		if( $this->is_user_connected( get_current_user_id() ) ) {
+		if ( $this->is_user_connected( get_current_user_id() ) ) {
 			echo '<a name="configure-sso"></a>';
 			echo '<input type="checkbox" name="jetpack_sso_remove_login_form[remove_login_form]" ' . checked( 1 == get_option( 'jetpack_sso_remove_login_form' ), true, false ) . '>';
 			echo '<p class="description">Removes default login form and disallows login via POST</p>';
@@ -298,8 +297,9 @@ class Jetpack_SSO {
 	 * @return string
 	 **/
 	public function remove_lost_password_text( $text ) {
-		if( 'Lost your password?' == $text )
+		if ( 'Lost your password?' == $text ) {
 			$text = '';
+		}
 		return $text;
 	}
 
@@ -318,12 +318,12 @@ class Jetpack_SSO {
 		$wants_to_login = false;
 
 		// Cover default WordPress behavior
-		$action = isset($_REQUEST['action']) ? $_REQUEST['action'] : 'login';
+		$action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : 'login';
 
 		// And now the exceptions
 		$action = isset( $_GET['loggedout'] ) ? 'loggedout' : $action;
 
-		if( 'login' == $action ) {
+		if ( 'login' == $action ) {
 			$wants_to_login = true;
 		}
 
@@ -347,13 +347,13 @@ class Jetpack_SSO {
 		global $action;
 
 		/**
- 		 * If the user is attempting to logout AND the auto-forward to WordPress.com
- 		 * login is set then we need to ensure we do not auto-forward the user and get
- 		 * them stuck in an infinite logout loop.
- 		 */
- 		if( isset( $_GET['loggedout'] ) && $this->bypass_login_forward_wpcom() ) {
- 			add_filter( 'jetpack_remove_login_form', '__return_true' );
- 			add_filter( 'gettext', array( $this, 'remove_lost_password_text' ) );
+		 * If the user is attempting to logout AND the auto-forward to WordPress.com
+		 * login is set then we need to ensure we do not auto-forward the user and get
+		 * them stuck in an infinite logout loop.
+		 */
+		if ( isset( $_GET['loggedout'] ) && $this->bypass_login_forward_wpcom() ) {
+			add_filter( 'jetpack_remove_login_form', '__return_true' );
+			add_filter( 'gettext', array( $this, 'remove_lost_password_text' ) );
 		}
 
 		/**
@@ -375,7 +375,8 @@ class Jetpack_SSO {
 			wp_enqueue_style( 'genericons' );
 			add_action( 'login_footer', array( $this, 'login_form' ) );
 			add_action( 'login_footer', array( $this, 'login_footer' ) );
-/*
+
+			/*
 			if ( get_option( 'jetpack_sso_remove_login_form' ) ) {
 				// Check to see if the user is attempting to login via the default login form.
 				// If so we need to deny it and forward elsewhere.
@@ -384,7 +385,7 @@ class Jetpack_SSO {
 				}
 				add_filter( 'gettext', array( $this, 'remove_lost_password_text' ) );
 			}
-*/
+			*/
 		} elseif ( 'jetpack-sso' === $action ) {
 			if ( isset( $_GET['result'], $_GET['user_id'], $_GET['sso_nonce'] ) && 'success' == $_GET['result'] ) {
 				$this->handle_login();
@@ -413,13 +414,13 @@ class Jetpack_SSO {
 			return new WP_Error( 'headers_sent', __( 'Cannot deal with cookie redirects, as headers are already sent.', 'jetpack' ) );
 		}
 
-		// If we have something to redirect to
 		if ( ! empty( $_GET['redirect_to'] ) ) {
+			// If we have something to redirect to
 			$url = esc_url_raw( $_GET['redirect_to'] );
 			setcookie( 'jetpack_sso_redirect_to', $url, time() + HOUR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false, true );
-		// Otherwise, if it's already set
+
 		} elseif ( ! empty( $_COOKIE['jetpack_sso_redirect_to'] ) ) {
-			// Purge it.
+			// Otherwise, if it's already set, purge it.
 			setcookie( 'jetpack_sso_redirect_to', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
 		}
 
@@ -454,7 +455,7 @@ class Jetpack_SSO {
 	function login_form() {
 		$classes = '';
 
-		if( $this->should_hide_login_form() ) {
+		if ( $this->should_hide_login_form() ) {
 			$classes .= ' forced-sso';
 		}
 		echo '<div class="jetpack-sso-wrap' . $classes . '">' . $this->button() . '</div>';
@@ -528,7 +529,7 @@ class Jetpack_SSO {
 		}
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => $user_id
+			'user_id' => $user_id,
 		) );
 		$xml->query( 'jetpack.sso.removeUser', $wpcom_user_id );
 
@@ -542,7 +543,7 @@ class Jetpack_SSO {
 	static function request_initial_nonce() {
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => get_current_user_id()
+			'user_id' => get_current_user_id(),
 		) );
 		$xml->query( 'jetpack.sso.requestNonce' );
 
@@ -563,7 +564,7 @@ class Jetpack_SSO {
 
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => get_current_user_id()
+			'user_id' => get_current_user_id(),
 		) );
 		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
 
@@ -601,7 +602,7 @@ class Jetpack_SSO {
 		 * @param bool get_option( 'jetpack_sso_require_two_step' ) Does SSO require 2-step authentication?
 		 */
 		$require_two_step = apply_filters( 'jetpack_sso_require_two_step', get_option( 'jetpack_sso_require_two_step' ) );
-		if( $require_two_step && 0 == (int) $user_data->two_step_enabled ) {
+		if ( $require_two_step && 0 == (int) $user_data->two_step_enabled ) {
 			$this->user_data = $user_data;
 			/** This filter is documented in core/src/wp-includes/pluggable.php */
 			do_action( 'wp_login_failed', $user_data->login );
@@ -618,7 +619,9 @@ class Jetpack_SSO {
 					update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
 					add_filter( 'login_redirect', array( __CLASS__, 'profile_page_url' ) );
 				}
-			} else wp_nonce_ays();
+			} else {
+				wp_nonce_ays();
+			}
 		}
 
 		if ( empty( $user ) ) {
@@ -829,15 +832,15 @@ class Jetpack_SSO {
 		}";
 
 		if ( version_compare( $GLOBALS['wp_version'], '3.8-alpha', '<' ) ) {
-			$css .= "
+			$css .= '
 			.jetpack-sso.button:before {
 				width: 25px;
 				font-size: 18px !important;
 			}
-			";
+			';
 		}
 
-		$css .= "</style>";
+		$css .= '</style>';
 
 		$button = sprintf( '<a href="%1$s" class="jetpack-sso button">%2$s</a>', esc_url( $url ), esc_html__( 'Log in with WordPress.com', 'jetpack' ) );
 		return $button . $css;
@@ -861,13 +864,13 @@ class Jetpack_SSO {
 	}
 
 	/**
- 	* Determines local user associated with a given WordPress.com user ID.
- 	*
- 	* @since 2.6.0
- 	*
- 	* @param int $wpcom_user_id User ID from WordPress.com
- 	* @return object Local user object if found, null if not.
-	*/
+	 * Determines local user associated with a given WordPress.com user ID.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param int $wpcom_user_id User ID from WordPress.com
+	 * @return object Local user object if found, null if not.
+	 */
 	static function get_user_by_wpcom_id( $wpcom_user_id ) {
 		$user_query = new WP_User_Query( array(
 			'meta_key'   => 'wpcom_user_id',
@@ -990,7 +993,7 @@ class Jetpack_SSO {
 	 * @return boolean
 	 **/
 	public function is_user_connected( $user_id ) {
-		return $this->get_user_data( $user_id ) ;
+		return $this->get_user_data( $user_id );
 	}
 
 	/**
@@ -1023,7 +1026,7 @@ class Jetpack_SSO {
 								<p><?php echo esc_html( $user_data->login ); ?></p>
 								<span class="two_step">
 									<?php
-										if( $user_data->two_step_enabled ) {
+										if ( $user_data->two_step_enabled ) {
 											?> <p class="enabled"><a href="https://wordpress.com/me/security/two-step" target="_blank"><?php _e( 'Two-Step Authentication Enabled', 'jetpack' ); ?></a></p> <?php
 										} else {
 											?> <p class="disabled"><a href="https://wordpress.com/me/security/two-step" target="_blank"><?php _e( 'Two-Step Authentication Disabled', 'jetpack' ); ?></a></p> <?php
@@ -1083,7 +1086,7 @@ class Jetpack_SSO {
 
 		<?php elseif ( get_current_user_id() == $user->ID && Jetpack::is_user_connected( $user->ID ) ) : ?>
 
-			<?php echo $this->button( 'state=sso-link-user&_wpnonce=' . wp_create_nonce('sso-link-user') ); // update ?>
+			<?php echo $this->button( 'state=sso-link-user&_wpnonce=' . wp_create_nonce( 'sso-link-user' ) ); // update ?>
 
 		<?php else : ?>
 

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -1,0 +1,65 @@
+#loginform {
+	overflow: hidden;
+	padding-bottom: 26px;
+}
+
+.jetpack-sso.button {
+	position: relative;
+	padding-left: 37px;
+}
+.jetpack-sso.button:before {
+	display: block;
+	box-sizing: border-box;
+	padding: 7px 0 0;
+	text-align: center;
+	position: absolute;
+	top: -1px;
+	left: -1px;
+	border-radius: 2px 0 0 2px;
+	content: '\f205';
+	background: #0074a2;
+	color: #fff;
+	-webkit-font-smoothing: antialiased;
+	width: 30px;
+	height: 107%;
+	height: calc( 100% + 2px );
+	font: normal 22px/1 Genericons !important;
+	text-shadow: none;
+}
+
+@media screen and (min-width: 783px) {
+	.jetpack-sso.button:before {
+		padding-top: 3px;
+	}
+}
+
+.jetpack-sso.button:hover {
+	border: 1px solid #aaa;
+}
+
+.jetpack-sso-wrap {
+	text-align: center;
+	float: right;
+	margin: 1em 0 0;
+	clear: right;
+	display: block;
+}
+
+.jetpack-sso-wrap.forced-sso {
+	float: none;
+	text-align: center;
+}
+
+.forced-sso .jetpack-sso.button {
+	font-size: 16px;
+	line-height: 27px;
+	height: 37px;
+	padding: 5px 12px 6px 47px;
+}
+
+.forced-sso .jetpack-sso.button:before {
+	font-size: 28px !important;
+	height: 37px;
+	padding: 5px 5px 4px;
+	width: 37px;
+}

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -1,0 +1,26 @@
+jQuery( document ).ready( function( $ ) {
+	var ssoWrap = $( '.jetpack-sso-wrap' );
+
+	// If forcing SSO, then let's remove the default login form
+	if ( ssoWrap.hasClass( 'forced-sso' ) ) {
+		$( '#loginform' ).empty();
+	}
+
+	$( '#loginform' ).append( ssoWrap );
+
+	var $rememberme = $( '#rememberme' ),
+		$ssoButton  = $( 'a.jetpack-sso.button' );
+
+	$rememberme.on( 'change', function() {
+		var url       = $ssoButton.prop( 'href' ),
+			isChecked = $rememberme.prop( 'checked' ) ? 1 : 0;
+
+		if ( url.match( /&rememberme=\d/ ) ) {
+			url = url.replace( /&rememberme=\d/, '&rememberme=' + isChecked );
+		} else {
+			url += '&rememberme=' + isChecked;
+		}
+
+		$ssoButton.prop( 'href', url );
+	} ).change();
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
As part of JPM, Mercury would like to revamp SSO. Part of this is improving the existing UX of Jetpack SSO. Two specific issues that this PR seeks to fix are:

- The current button placement below the form and "Log in" button is confusing. The button is simply a link, but its placement makes it feel like it's part of the form.
- We would like to show the user which account they are currently logged in to WordPress.com with.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).