### PR TITLE
Limit posts_per_page when checking for revisions

### DIFF
--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -958,7 +958,7 @@ class Jetpack_Custom_CSS {
 
 		$safecss_post = Jetpack_Custom_CSS::get_post();
 
-		if ( ! empty( $safecss_post ) && 0 < $safecss_post['ID'] && wp_get_post_revisions( $safecss_post['ID'] ) )
+		if ( ! empty( $safecss_post ) && 0 < $safecss_post['ID'] && wp_get_post_revisions( $safecss_post['ID'],  array( 'posts_per_page' => 1 ) ) )
 			add_meta_box( 'revisionsdiv', __( 'CSS Revisions', 'jetpack' ), array( __CLASS__, 'revisions_meta_box' ), 'editcss', 'side' );
 		?>
 		<div class="wrap">

--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -958,7 +958,7 @@ class Jetpack_Custom_CSS {
 
 		$safecss_post = Jetpack_Custom_CSS::get_post();
 
-		if ( ! empty( $safecss_post ) && 0 < $safecss_post['ID'] && wp_get_post_revisions( $safecss_post['ID'],  array( 'posts_per_page' => 1 ) ) )
+		if ( ! empty( $safecss_post ) && 0 < $safecss_post['ID'] && wp_get_post_revisions( $safecss_post['ID'], array( 'posts_per_page' => 1 ) ) )
 			add_meta_box( 'revisionsdiv', __( 'CSS Revisions', 'jetpack' ), array( __CLASS__, 'revisions_meta_box' ), 'editcss', 'side' );
 		?>
 		<div class="wrap">


### PR DESCRIPTION
Fixes part 1 of #3651.

#### Changes proposed in this Pull Request:
As described in #3651, this call to `wp_get_post_revisions()` will exceed PHP `memory_limit` constraints
when there are many many revisions to Custom CSS. For example, over 1GB of memory when there are
9,000+ revisions to the Custom CSS. Since this check is a simple check to see if any revisions exist, 
limiting the number of posts returned to 1 will all the check to run without using excessive resource fetching data that will not be utilized.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).