### PR TITLE
Infinite Scroll: edit css_pattern regex to support multiple classes

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -57,7 +57,7 @@ class The_Neverending_Home_Page {
 	 */
 	static function get_settings() {
 		if ( is_null( self::$settings ) ) {
-			$css_pattern = '#[^A-Z\d\-_]#i';
+			$css_pattern = '#[^A-Z\d\-_ ]#i';
 
 			$settings = $defaults = array(
 				'type'            => 'scroll', // scroll | click


### PR DESCRIPTION
Fixes #3659
#### Changes proposed in this Pull Request:
- Support multiple css classes in infinity scroll settings by allowing spaces.
