### PR TITLE
Avoids that admin notices are moved inside the text.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-landing-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-landing-page.php
@@ -201,7 +201,7 @@ class Jetpack_Landing_Page extends Jetpack_Admin_Page {
 			?>
 			<div id="message" class="jetpack-message">
 				<div class="squeezer">
-					<h2><?php echo wp_kses( $message, array( 'strong' => array(), 'a' => array( 'href' => true ), 'br' => true ) ); ?></h2>
+					<h3><?php echo wp_kses( $message, array( 'strong' => array(), 'a' => array( 'href' => true ), 'br' => true ) ); ?></h3>
 					<?php
 					/**
 					 * Fires within the displayed message when a feature configuation is updated.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3832,7 +3832,7 @@ p {
 		?>
 		<div id="message" class="updated jetpack-message">
 			<div class="squeezer">
-				<h2><?php _e( '<strong>Jetpack is activated!</strong> Each site on your network must be connected individually by an admin on that site.', 'jetpack' ) ?></h2>
+				<h3><?php _e( '<strong>Jetpack is activated!</strong> Each site on your network must be connected individually by an admin on that site.', 'jetpack' ) ?></h3>
 			</div>
 		</div>
 		<?php
@@ -3882,7 +3882,7 @@ p {
 		<div class="wrap">
 			<div id="message" class="jetpack-message stay-visible">
 				<div class="squeezer">
-					<h2>
+					<h3>
 						<?php _e( 'You have successfully disconnected Jetpack.', 'jetpack' ); ?>
 						<br />
 						<?php echo sprintf(
@@ -3890,7 +3890,7 @@ p {
 							'https://jetpack.com/survey-disconnected/',
 							'_blank'
 						); ?>
-					</h2>
+					</h3>
 				</div>
 			</div>
 		</div>
@@ -4392,7 +4392,7 @@ p {
 ?>
 <div id="message" class="jetpack-message jetpack-err">
 	<div class="squeezer">
-		<h2><?php echo wp_kses( $this->error, array( 'a' => array( 'href' => array() ), 'small' => true, 'code' => true, 'strong' => true, 'br' => true, 'b' => true ) ); ?></h2>
+		<h3><?php echo wp_kses( $this->error, array( 'a' => array( 'href' => array() ), 'small' => true, 'code' => true, 'strong' => true, 'br' => true, 'b' => true ) ); ?></h3>
 <?php	if ( $desc = Jetpack::state( 'error_description' ) ) : ?>
 		<p><?php echo esc_html( stripslashes( $desc ) ); ?></p>
 <?php	endif; ?>
@@ -4430,7 +4430,7 @@ p {
 ?>
 <div id="message" class="jetpack-message jetpack-err">
 	<div class="squeezer">
-		<h2><strong><?php esc_html_e( 'Is this site private?', 'jetpack' ); ?></strong></h2><br />
+		<h3><strong><?php esc_html_e( 'Is this site private?', 'jetpack' ); ?></strong></h3><br />
 		<p><?php
 			echo wp_kses(
 				wptexturize(

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -237,7 +237,7 @@ class Publicize extends Publicize_Base {
 		?>
 		<div id="message" class="jetpack-message jetpack-err">
 			<div class="squeezer">
-				<h2><?php echo wp_kses( $error, array( 'a' => array( 'href' => true ), 'code' => true, 'strong' => true, 'br' => true, 'b' => true ) ); ?></h2>
+				<h3><?php echo wp_kses( $error, array( 'a' => array( 'href' => true ), 'code' => true, 'strong' => true, 'br' => true, 'b' => true ) ); ?></h3>
 				<?php if ( $code ) : ?>
 				<p><?php printf( __( 'Error code: %s', 'jetpack' ), esc_html( stripslashes( $code ) ) ); ?></p>
 				<?php endif; ?>

--- a/scss/templates/_main.scss
+++ b/scss/templates/_main.scss
@@ -1338,12 +1338,7 @@ body {
 			display: none;
 		}
 	}
-	.squeezer {
-		h2 {
-			font-size: 1em;
-		}
-	}
-	h2 {
+	h3 {
 		color: #fff;
 		margin: 0;
 	}
@@ -1356,6 +1351,11 @@ body {
 		padding: 23px 23px 23px 80px;
 		position: relative;
 		text-align: left;
+
+		h3 {
+			font-size: 1em;
+			font-weight: 400;
+		}
 
 		&:before {
 			color: #fff;


### PR DESCRIPTION
Fixes #3045.
#### Changes proposed in this Pull Request:
- Converts h2 to h3 in Jetpack messages so notices aren't moved below them them thus inheriting styles and breaking everything .
#### Before testing:

run `grunt sass` in console
