### PR TITLE
Photon: Bail on URL creation when in JP Development Mode

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -12,6 +12,21 @@
 function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	$image_url = trim( $image_url );
 
+	if ( class_exists( 'Jetpack') ) {
+		/**
+		 * Disables Photon URL processing for local development
+	 	 *
+	 	 * @module photon
+	 	 *
+	 	 * @since 4.1.0
+	 	 *
+	 	 * @param bool false Result of Jetpack::is_development_mode.
+	 	 */
+		if ( true === apply_filters( 'jetpack_photon_development_mode', Jetpack::is_development_mode() ) ) {
+			return $image_url;
+		}
+	}
+
 	/**
 	 * Allow specific image URls to avoid going through Photon.
 	 *


### PR DESCRIPTION
When in Jetpack Development Mode, let's not create Photon URLs since they can not be used in localhost environments.

Provides a filter to override if someone is using Development Mode on an Internet-connected system.

h/t to #3673 & @jeherve for inspiration.