### PR TITLE
SSO: UI improvements by separating default login form and SSO

### DIFF
--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -1,12 +1,120 @@
 #loginform {
-	overflow: hidden;
-	padding-bottom: 26px;
+	/* We set !important because sometimes static is added inline */
+	position: relative !important;
+	padding-bottom: 92px;
+}
+
+#loginform #jetpack-sso-wrap,
+#loginform #jetpack-sso-wrap * {
+	box-sizing: border-box;
+}
+
+
+#jetpack-sso-wrap__action,
+#jetpack-sso-wrap__user{
+	display: none;
+}
+
+.jetpack-sso-body #jetpack-sso-wrap__action,
+.jetpack-sso-body #jetpack-sso-wrap__user {
+	display: block;
+}
+
+#jetpack-sso-wrap {
+	position: absolute;
+		bottom: 20px;
+	padding: 0 24px;
+	margin-left: -24px;
+	margin-right: -24px;
+	width: 100%;
+}
+
+.jetpack-sso-body #jetpack-sso-wrap {
+	position: relative;
+		bottom: auto;
+	padding: 0;
+	margin-left: 0;
+	margin-right: 0;
+}
+
+#loginform #jetpack-sso-wrap p {
+	color: #777777;
+	margin-bottom: 16px;
+}
+
+#jetpack-sso-wrap a {
+	display: block;
+	width: 100%;
+	text-align: center;
+	text-decoration: none;
+}
+
+#jetpack-sso-wrap .jetpack-sso-toggle.wpcom {
+	display: none;
+}
+
+.jetpack-sso-body #jetpack-sso-wrap .jetpack-sso-toggle.wpcom {
+	display: block;
+}
+
+
+.jetpack-sso-body #jetpack-sso-wrap .jetpack-sso-toggle.default {
+	display: none;
+}
+
+
+.jetpack-sso-body #loginform > p,
+.jetpack-sso-body #loginform > div {
+	display: none;
+}
+
+.jetpack-sso-body #loginform #jetpack-sso-wrap {
+	display: block;
+}
+
+.jetpack-sso-body #loginform {
+	padding: 26px 24px;
+}
+
+.jetpack-sso-or {
+	margin-bottom: 16px;
+	position: relative;
+	text-align: center;
+}
+
+.jetpack-sso-or:before {
+	background: #E5E5E5;
+	content: '';
+	height: 1px;
+	position: absolute;
+		left: 0;
+		top: 50%;
+	width: 100%;
+}
+.jetpack-sso-or span {
+	background: #fff;
+	color: #777;
+	position: relative;
+	padding: 0 8px;
+	text-transform: uppercase
 }
 
 .jetpack-sso.button {
+	height: 36px;
+	line-height: 34px;
+	float: none;
+	margin-bottom: 16px;
 	position: relative;
-	padding-left: 37px;
+	padding-left: 48px;
+	width: 100%;
 }
+
+@media screen and ( max-width: 782px ) {
+	.jetpack-sso.button {
+		line-height: 22px;
+	}
+}
+
 .jetpack-sso.button:before {
 	display: block;
 	box-sizing: border-box;
@@ -17,49 +125,40 @@
 	left: -1px;
 	border-radius: 2px 0 0 2px;
 	content: '\f205';
-	background: #0074a2;
 	color: #fff;
 	-webkit-font-smoothing: antialiased;
-	width: 30px;
+	width: 48px;
 	height: 107%;
 	height: calc( 100% + 2px );
-	font: normal 22px/1 Genericons !important;
+	font: normal 24px/1 Genericons !important;
 	text-shadow: none;
 }
 
-@media screen and (min-width: 783px) {
-	.jetpack-sso.button:before {
-		padding-top: 3px;
-	}
-}
-
-.jetpack-sso.button:hover {
-	border: 1px solid #aaa;
-}
-
-#jetpack-sso-wrap {
-	text-align: center;
-	float: right;
-	margin: 1em 0 0;
-	clear: right;
+#jetpack-sso-wrap__user img {
+	border-radius: 50%;
 	display: block;
+	margin: 0 auto 16px;
 }
 
-#jetpack-sso-wrap.forced-sso {
-	float: none;
+#jetpack-sso-wrap__user h2 {
+	font-size: 21px;
+	font-weight: lighter;
+	margin-bottom: 16px;
 	text-align: center;
 }
 
-.forced-sso .jetpack-sso.button {
-	font-size: 16px;
-	line-height: 27px;
-	height: 37px;
-	padding: 5px 12px 6px 47px;
+#jetpack-sso-wrap__user h2 span {
+	font-weight: bold;
 }
 
-.forced-sso .jetpack-sso.button:before {
-	font-size: 28px !important;
-	height: 37px;
-	padding: 5px 5px 4px;
-	width: 37px;
+.jetpack-sso-wrap__reauth {
+	margin-bottom: 16px;
+}
+
+.jetpack-sso-body #nav {
+	display: none;
+}
+
+.jetpack-sso-body #backtoblog {
+	margin: 24px 0 0;
 }

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -1,14 +1,9 @@
 jQuery( document ).ready( function( $ ) {
-	var ssoWrap = $( '#jetpack-sso-wrap' ),
+	var body = $( 'body' ),
 		rememberMe = $( '#rememberme' ),
-		ssoButton  = $( 'a.jetpack-sso.button' );
-
-	// If forcing SSO, then let's remove the default login form
-	if ( ssoWrap.hasClass( 'forced-sso' ) ) {
-		$( '#loginform' ).empty();
-	}
-
-	$( '#loginform' ).append( ssoWrap );
+		ssoButton = $( 'a.jetpack-sso.button' ),
+		toggleSSO = $( '.jetpack-sso-toggle' ),
+		userLogin = $( '#user_login' );
 
 	rememberMe.on( 'change', function() {
 		var url       = ssoButton.prop( 'href' ),
@@ -22,4 +17,12 @@ jQuery( document ).ready( function( $ ) {
 
 		ssoButton.prop( 'href', url );
 	} ).change();
+
+	toggleSSO.on( 'click', function( e ) {
+		e.preventDefault();
+		body.toggleClass( 'jetpack-sso-body' );
+		if ( ! body.hasClass( 'jetpack-sso-body' ) ) {
+			userLogin.focus();
+		}
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Currently, Jetpack SSO can be a bit confusing since the SSO button is included with the default login form. This PR separate the SSO functionality from the default form.

Also, to add some visual appeal, this PR adds the user's WPCOM gravatar and display name to the SSO login page if the user has already approved the site for SSO.

Fixes #3689. Fixes #1553.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).