### PR TITLE
Load Photon resized images in gallery widget

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -21,8 +21,7 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
 		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
 
-		$this->img_src = add_query_arg( array( 'w' => $this->image->width, 'h' => $this->image->height, 'crop' => true ), $this->orig_file );
-
+		$this->img_src = jetpack_photon_url( $this->orig_file, array( 'resize' => sprintf( '%s,%s', $this->image->width, $this->image->height ) ) );
 	}
 
 	public function fuzzy_image_meta() {

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery-item.php
@@ -21,7 +21,7 @@ abstract class Jetpack_Tiled_Gallery_Item {
 		$this->orig_file = wp_get_attachment_url( $this->image->ID );
 		$this->link = $needs_attachment_link ? get_attachment_link( $this->image->ID ) : $this->orig_file;
 
-		$this->img_src = jetpack_photon_url( $this->orig_file, array( 'resize' => sprintf( '%s,%s', $this->image->width, $this->image->height ) ) );
+		$this->img_src = jetpack_photon_url( $this->orig_file, array( 'resize' => sprintf( '%d,%d', $this->image->width, $this->image->height ) ) );
 	}
 
 	public function fuzzy_image_meta() {

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -253,7 +253,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 
 		foreach ( $instance['attachments'] as $attachment ) {
 			$attachment_image_src = wp_get_attachment_image_src( $attachment->ID, 'full' );
-			$attachment_image_src = $attachment_image_src[0]; // [url, width, height]
+			$attachment_image_src = jetpack_photon_url( $attachment_image_src[0], array( 'w' => $this->_instance_width ) ); // [url, width, height]
 
 			$caption 	= wptexturize( strip_tags( $attachment->post_excerpt ) );
 


### PR DESCRIPTION
Fixes #1186 .

#### Changes proposed in this Pull Request:
- As it already happens for Tiled Galleries, the Gallery widget now loads images for galleries and slideshows from Photon, resizing them accordingly. 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).