### PR TITLE
Protect: Change math check to init hook

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -51,7 +51,7 @@ class Jetpack_Protect_Module {
 		add_action( 'jetpack_deactivate_module_protect', array ( $this, 'on_deactivation' ) );
 		add_action( 'init', array ( $this, 'maybe_get_protect_key' ) );
 		add_action( 'jetpack_modules_loaded', array ( $this, 'modules_loaded' ) );
-		add_action( 'login_head', array ( $this, 'check_use_math' ) );
+		add_action( 'init', array ( $this, 'check_use_math' ) );
 		add_filter( 'authenticate', array ( $this, 'check_preauth' ), 10, 3 );
 		add_action( 'wp_login', array ( $this, 'log_successful_login' ), 10, 2 );
 		add_action( 'wp_login_failed', array ( $this, 'log_failed_attempt' ) );


### PR DESCRIPTION
Fixes an issue where the Protect math form doesn't show up on front end login forms

#### Changes proposed in this Pull Request:
- Changes math check from login_head to init hook