### PR TITLE
Related Posts: avoid notices in Woocommerce setup screen.

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -361,6 +361,11 @@ EOT;
 
 		// only dislay the Related Posts JavaScript on the Reading Settings Admin Page
 		$current_screen =  get_current_screen();
+
+		if ( is_null( $current_screen ) ) {
+			return;
+		}
+
 		if( 'options-reading' != $current_screen->id )
 			return;
 


### PR DESCRIPTION
Fix Notices thrown on `admin_init` hook.

![screen shot 2016-04-19 at 5 49 15 pm](https://cloud.githubusercontent.com/assets/426388/14646024/3e11e75a-0658-11e6-9ee3-b3cc88ef9b0e.png)


Related: #3077