### PR TITLE
Run Jetpack class before init to avoid fatals.

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -63,7 +63,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 register_activation_hook( __FILE__, array( 'Jetpack', 'plugin_activation' ) );
 register_deactivation_hook( __FILE__, array( 'Jetpack', 'plugin_deactivation' ) );
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
-add_action( 'init', array( 'Jetpack', 'init' ) );
+add_action( 'plugins_loaded', array( 'Jetpack', 'init' ) );
 add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 add_filter( 'jetpack_static_url', array( 'Jetpack', 'staticize_subdomain' ) );
 add_filter( 'is_jetpack_site', '__return_true' );


### PR DESCRIPTION
Fixes #3697 

First pass at fixing this issue. Work in progress.