### PR TITLE
SSO: Factors user profile CSS into separate file

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -29,6 +29,7 @@ class Jetpack_SSO {
 		add_action( 'init', array( $this, 'maybe_logout_user' ), 5 );
 		add_action( 'jetpack_modules_loaded', array( $this, 'module_configure_button' ) );
 		add_action( 'login_enqueue_scripts', array( $this, 'login_enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 
 		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
 		add_action( 'login_form_jetpack-sso', '__return_true' );
@@ -153,6 +154,19 @@ class Jetpack_SSO {
 
 		wp_enqueue_style( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login.css', JETPACK__PLUGIN_FILE ), array( 'login', 'genericons' ), JETPACK__VERSION );
 		wp_enqueue_script( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION );
+	}
+
+	/**
+	 * Enqueue styles neceessary for Jetpack SSO on users' profiles
+	 */
+	public function admin_enqueue_scripts() {
+		$screen = get_current_screen();
+
+		if ( empty( $screen ) || ! in_array( $screen->base, array( 'edit-user', 'profile' ) ) ) {
+			return;
+		}
+
+		wp_enqueue_style( 'jetpack-sso-profile', plugins_url( 'modules/sso/jetpack-sso-profile.css', JETPACK__PLUGIN_FILE ), array( 'genericons' ), JETPACK__VERSION );
 	}
 
 	/**
@@ -911,7 +925,6 @@ class Jetpack_SSO {
 	}
 
 	function edit_profile_fields( $user ) {
-		wp_enqueue_style( 'genericons' );
 		?>
 
 		<h3 id="single-sign-on"><?php _e( 'Single Sign On', 'jetpack' ); ?></h3>
@@ -943,50 +956,6 @@ class Jetpack_SSO {
 					</tr>
 				</tbody>
 			</table>
-
-			<style>
-			.jetpack-sso-form-table td {
-				padding-left: 0;
-			}
-
-			.jetpack-sso-form-table .profile-card {
-				padding: 10px;
-				background: #fff;
-				overflow: hidden;
-				max-width: 400px;
-				box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.1 );
-				margin-bottom: 1em;
-			}
-
-			.jetpack-sso-form-table .profile-card img {
-				float: left;
-				margin-right: 1em;
-				width: 48px;
-				height: 48px;
-			}
-
-			.jetpack-sso-form-table .profile-card .connected {
-				float: right;
-				margin-right: 0.5em;
-				color: #0a0;
-			}
-
-			.jetpack-sso-form-table .profile-card p {
-				margin-top: 0.7em;
-				font-size: 1.2em;
-			}
-
-			.jetpack-sso-form-table .profile-card .two_step .enabled a {
-				float: right;
-				color: #0a0;
-			}
-
-			.jetpack-sso-form-table .profile-card .two_step .disabled a {
-				float: right;
-				color: red;
-			}
-			</style>
-
 		<?php elseif ( get_current_user_id() == $user->ID && Jetpack::is_user_connected( $user->ID ) ) : ?>
 
 			<?php echo $this->button( 'state=sso-link-user&_wpnonce=' . wp_create_nonce( 'sso-link-user' ) ); // update ?>

--- a/modules/sso/jetpack-sso-profile.css
+++ b/modules/sso/jetpack-sso-profile.css
@@ -1,3 +1,35 @@
+.jetpack-sso.button {
+	position: relative;
+	padding-left: 37px;
+}
+.jetpack-sso.button:before {
+	display: block;
+	box-sizing: border-box;
+	padding: 7px 0 0;
+	text-align: center;
+	position: absolute;
+	top: -1px;
+	left: -1px;
+	border-radius: 2px 0 0 2px;
+	content: '\f205';
+	background: #0074a2;
+	color: #fff;
+	-webkit-font-smoothing: antialiased;
+	width: 30px;
+	height: 107%;
+	height: calc( 100% + 2px );
+	font: normal 22px/1 Genericons !important;
+	text-shadow: none;
+}
+@media screen and (min-width: 783px) {
+	.jetpack-sso.button:before {
+		padding-top: 3px;
+	}
+}
+.jetpack-sso.button:hover {
+	border: 1px solid #aaa;
+}
+
 .jetpack-sso-form-table td {
 	padding-left: 0;
 }

--- a/modules/sso/jetpack-sso-profile.css
+++ b/modules/sso/jetpack-sso-profile.css
@@ -1,0 +1,40 @@
+.jetpack-sso-form-table td {
+	padding-left: 0;
+}
+
+.jetpack-sso-form-table .profile-card {
+	padding: 10px;
+	background: #fff;
+	overflow: hidden;
+	max-width: 400px;
+	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.1 );
+	margin-bottom: 1em;
+}
+
+.jetpack-sso-form-table .profile-card img {
+	float: left;
+	margin-right: 1em;
+	width: 48px;
+	height: 48px;
+}
+
+.jetpack-sso-form-table .profile-card .connected {
+	float: right;
+	margin-right: 0.5em;
+	color: #0a0;
+}
+
+.jetpack-sso-form-table .profile-card p {
+	margin-top: 0.7em;
+	font-size: 1.2em;
+}
+
+.jetpack-sso-form-table .profile-card .two_step .enabled a {
+	float: right;
+	color: #0a0;
+}
+
+.jetpack-sso-form-table .profile-card .two_step .disabled a {
+	float: right;
+	color: red;
+}


### PR DESCRIPTION
As Poseidon continues our work on SSO, I'd like to go ahead and factor out the CSS we add to user profile pages into a separate file.

There should be no functional changes in this PR.

To test:
- Checkout `update/jetpack-sso-profile` branch
- Go to `/wp-admin/profile.php` on a site where your user is connected via SSO. You should see something like this:
    
    ![screen shot 2016-04-21 at 1 03 37 pm](https://cloud.githubusercontent.com/assets/1126811/14719383/8709f384-07c1-11e6-98b3-8d5110f857c3.png)

- Unlink account. You should see this:

    ![screen shot 2016-04-21 at 1 03 49 pm](https://cloud.githubusercontent.com/assets/1126811/14719389/909fe4e4-07c1-11e6-837b-a60b52265160.png)


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).