### PR TITLE
Jetpack Auth: Calypso Env

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4655,6 +4655,11 @@ p {
 		if ( $from ) {
 			$url = add_query_arg( 'from', $from, $url );
 		}
+
+		if ( isset( $_GET['calypso_env'] ) ) {
+			$url = add_query_arg( 'calypso_env', $_GET['calypso_env'], $url );
+		}
+
 		return $raw ? $url : esc_url( $url );
 	}
 


### PR DESCRIPTION
Add `calypso_env` to the connection url if it is present in the initial request.
This will ensure that connection requests coming from different calypso environments will get sent back to the correct environment.