### PR TITLE
SSO: Fixes SSO redirects by exiting after redirect

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -104,6 +104,7 @@ class Jetpack_SSO {
 			self::delete_connection_for_user( $current_user->ID );
 			wp_logout();
 			wp_safe_redirect( wp_login_url() );
+			exit;
 		}
 	}
 
@@ -397,6 +398,7 @@ class Jetpack_SSO {
 			add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 			$this->maybe_save_cookie_redirect();
 			wp_safe_redirect( $this->build_sso_url() );
+			exit;
 		}
 
 		if ( 'login' === $action ) {
@@ -424,6 +426,7 @@ class Jetpack_SSO {
 					// Is it wiser to just use wp_redirect than do this runaround to wp_safe_redirect?
 					add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 					wp_safe_redirect( $this->build_sso_url() );
+					exit;
 				}
 			}
 		}
@@ -899,6 +902,7 @@ class Jetpack_SSO {
 			delete_user_meta( $user->ID, 'wpcom_user_data' );
 			// Forward back to the profile page.
 			wp_safe_redirect( remove_query_arg( array( 'jetpack_sso', '_wpnonce' ) ) );
+			exit;
 		}
 	}
 


### PR DESCRIPTION
Fixes #3661

Previously, we noticed that when a user was on their profile page (on a multisite), that the user couldn't click the "Log in with WordPress.com" button to setup an SSO connection. 😞 

In my testing, it seems that this was caused by not exiting after redirecting to WordPress.com to authorize SSO. I fixed this by adding an `exit;`.

After looking a bit further, this seems to be because `wp_safe_redirect()` calls `wp_redirect()` which uses a `location` header to redirect. Source: https://core.trac.wordpress.org/browser/tags/4.5/src/wp-includes/pluggable.php#L1171

What I've read suggests that if we redirect with a header and then continue to output the body of the page, that the redirect could not work. Link: http://stackoverflow.com/questions/2747791/why-i-have-to-call-exit-after-redirection-through-headerlocation-in-php

I went ahead and added an `exit;` directly after any calls to `wp_safe_redirect()`. So, we'll want to test these flows as well as the one originally reported in the above issue.

To test:

- Checkout `update/fix-mu-sso` branch
- Test reported issue:
    - Go to `/wp-admin/profile.php`
    - Click "Login with WordPress.com" button
    - Are you able to connect? 
- Test auto-redirect to WP.com:
    - Bypass `bypass_login_forward_wpcom()` by returning `true` in the top of that method.
    - Log out of self-hosted site
    - Go to `$site/wp-admin`
    - Make sure that you're automatically redirected to WordPress.com
- Test purge SSO connection
    - Ensure that you have setup SSO with your user
    - Go to `/wp-admin/profile.php`
    - Click "Unlink This Account"
    - Do you arrive back on `/wp-admin/profile.php` with your WP.com unlinked?
- Test force logout
    - Login to site with SSO
    - Ensure you have wp-cli installed
    - Go to root of your site, enter `wp user meta update $username 'jetpack_force_logout' 1`
    - Reload `$site/wp-admin`
    - Are you logged out and redirected to the login page?

Lots of testing for 4 lines of code, eh? 😝 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).