### PR TITLE
Connect URL: Add locale and blogname

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4629,9 +4629,9 @@ p {
 					'is_active'     => Jetpack::is_active(),
 					'jp_version'    => JETPACK__VERSION,
 					'auth_type'     => 'calypso',
-					'secret'		=> $secret,
-					'locale'		=> get_locale(),
-					'blogname'		=> get_option( 'blogname' ),
+					'secret'        => $secret,
+					'locale'        => get_locale(),
+					'blogname'      => get_option( 'blogname' ),
 				)
 			);
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4630,6 +4630,8 @@ p {
 					'jp_version'    => JETPACK__VERSION,
 					'auth_type'     => 'calypso',
 					'secret'		=> $secret,
+					'locale'		=> get_locale(),
+					'blogname'		=> get_option( 'blogname' ),
 				)
 			);
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4601,6 +4601,8 @@ p {
 
 			$redirect = $redirect ? esc_url_raw( $redirect ) : esc_url_raw( menu_page_url( 'jetpack', false ) );
 
+			$gp_locale = GP_Locales::by_field( 'wp_locale', get_locale() );
+
 			if( isset( $_REQUEST['is_multisite'] ) ) {
 				$redirect = Jetpack_Network::init()->get_url( 'network_admin_page' );
 			}
@@ -4630,7 +4632,7 @@ p {
 					'jp_version'    => JETPACK__VERSION,
 					'auth_type'     => 'calypso',
 					'secret'        => $secret,
-					'locale'        => get_locale(),
+					'locale'        => isset( $gp_locale->slug ) ? $gp_locale->slug : '',
 					'blogname'      => get_option( 'blogname' ),
 				)
 			);

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4594,6 +4594,7 @@ p {
 			    'admin.php?page=jetpack-settings' ), $url );
 			}
 		} else {
+			require_once JETPACK__GLOTPRESS_LOCALES_PATH;
 			$role = $this->translate_current_user_to_role();
 			$signed_role = $this->sign_role( $role );
 


### PR DESCRIPTION
This PR adds `locale` and `blogname` to the Connect URL

`locale` will help us with localization for users not logged in to a wpcom account.
`blogname` will allow us to present a more personalized UI.

For testing, see instructions here: Automattic/wp-calypso#5343