### PR TITLE
SSO: Remove UI for managing other user SSO connections

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -890,8 +890,7 @@ class Jetpack_SSO {
 	 * Deal with user connections...
 	 */
 	function admin_init() {
-		add_action( 'show_user_profile', array( $this, 'edit_profile_fields' ) ); // For their own profile
-		add_action( 'edit_user_profile', array( $this, 'edit_profile_fields' ) ); // For folks editing others profiles
+		add_action( 'show_user_profile', array( $this, 'edit_profile_fields' ) );
 
 		if ( isset( $_GET['jetpack_sso'] ) && 'purge' == $_GET['jetpack_sso'] && check_admin_referer( 'jetpack_sso_purge' ) ) {
 			$user = wp_get_current_user();


### PR DESCRIPTION
Currently, UI is displayed for an admin to link and unlink another user to WordPress.com. There are two issues with this:

1. Should an admin be able to link a user to a WordPress.com account? I don't think so. That being said, perhaps the admin could unlink the user in case the user loses access somehow?
2. The functionality doesn't work. When I tried to link another user on one of my sites, it failed and showed me this:

    ![screen-shot-2016-04-21-at-3-02-56-pm](https://cloud.githubusercontent.com/assets/1126811/14754101/da7744da-089e-11e6-9fb5-6bb520947e68.png)

For we plan on removing the UI for linking another user to WordPress.com, keeping the unlink button if the other user is connected to WordPress.com.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).