### PR TITLE
Update/remove unnecessary queries

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -178,7 +178,11 @@ class Jetpack_Twitter_Cards {
 	}
 
 	static function site_tag() {
-		$site_tag = get_option( 'jetpack-twitter-cards-site-tag' );
+		$site_tag = get_option( 'jetpack-twitter-cards-site-tag', false );
+		if ( false === $site_tag ) {
+			update_option( 'jetpack-twitter-cards-site-tag', '' );
+		}
+		
 		if ( empty( $site_tag ) ) {
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 				return 'wordpressdotcom';

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -335,6 +335,8 @@ class Jetpack {
 				}
 
 				add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
+				add_action( 'init', array( __CLASS__, 'set_default_options_values' ) );
+
 				/**
 				 * Fires when synchronizing all registered options and constants.
 				 *
@@ -342,6 +344,18 @@ class Jetpack {
 				 */
 				do_action( 'jetpack_sync_all_registered_options' );
 			}
+		}
+	}
+
+	static function set_default_options_values() {
+		$active_modules = Jetpack::get_active_modules();
+		foreach ( $active_modules as $active_module ) {
+			/**
+			 * Fires when upgrading to set options to its default state.
+			 *
+			 * @since 4.1.0
+			 */
+			do_action( "jetpack_update_default_options_module_$active_module" );
 		}
 	}
 

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -55,7 +55,10 @@ function jetpack_og_tags() {
 	$description_length = 197;
 
 	if ( is_home() || is_front_page() ) {
-		$site_type              = get_option( 'open_graph_protocol_site_type' );
+		$site_type              = get_option( 'open_graph_protocol_site_type', false );
+		if( false === $site_type ) {
+			update_option( 'open_graph_protocol_site_type', 'website' );
+		}
 		$tags['og:type']        = ! empty( $site_type ) ? $site_type : 'website';
 		$tags['og:title']       = get_bloginfo( 'name' );
 		$tags['og:description'] = get_bloginfo( 'description' );
@@ -67,7 +70,10 @@ function jetpack_og_tags() {
 			$tags['og:url'] = home_url( '/' );
 
 		// Associate a blog's root path with one or more Facebook accounts
-		$facebook_admins = get_option( 'facebook_admins' );
+		$facebook_admins = get_option( 'facebook_admins', false );
+		if ( false === $facebook_admins ) {
+			update_option( 'facebook_admins', '' );
+		}
 		if ( ! empty( $facebook_admins ) )
 			$tags['fb:admins'] = $facebook_admins;
 

--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -140,6 +140,20 @@ class Jetpack_Custom_CSS {
 			ob_start( array( 'Jetpack_Custom_CSS', 'buffer' ) );
 	}
 
+	public static function set_default_options() {
+		if ( false === get_option( 'safecss_add', false ) ) {
+			update_option( 'safecss_add', 'yes' );
+		}
+
+		if ( false === get_option( 'safecss_revision_migrated', false ) ) {
+			update_option( 'safecss_revision_migrated', 0 );
+		}
+
+		if ( false === get_option( 'safecss', false ) ) {
+			update_option( 'safecss', '' );
+		}
+	}
+
 	/**
 	 * Save new custom CSS. This should be the entry point for any third-party code using Jetpack_Custom_CSS
 	 * to save CSS.
@@ -1856,6 +1870,8 @@ if ( ! function_exists( 'safecss_filter_attr' ) ) {
 	}
 }
 
+add_action( 'jetpack_activate_module_custom-css', array( 'Jetpack_Custom_CSS', 'set_default_options' ) );
+add_action( 'jetpack_update_default_options_module_custom-css', array( 'Jetpack_Custom_CSS', 'set_default_options' ) );
 add_action( 'init', array( 'Jetpack_Custom_CSS', 'init' ) );
 
 include dirname( __FILE__ ) . '/custom-css/preprocessors.php';

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -192,9 +192,8 @@ class Jetpack_Portfolio {
 	 * On plugin/theme activation, check if current theme supports CPT
 	 */
 	static function activation_post_type_support() {
-		if ( current_theme_supports( self::CUSTOM_POST_TYPE ) ) {
-			update_option( self::OPTION_NAME, '1' );
-		}
+		$option_value = current_theme_supports( self::CUSTOM_POST_TYPE ) ? '1' : '0';
+		update_option( self::OPTION_NAME, $option_value );
 	}
 
 	/**

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -845,3 +845,4 @@ add_action( 'init', array( 'Jetpack_Portfolio', 'init' ) );
 // Check on plugin activation if theme supports CPT
 register_activation_hook( __FILE__,                         array( 'Jetpack_Portfolio', 'activation_post_type_support' ) );
 add_action( 'jetpack_activate_module_custom-content-types', array( 'Jetpack_Portfolio', 'activation_post_type_support' ) );
+add_action( 'jetpack_update_default_options_module_custom-content-types', array( 'Jetpack_Portfolio', 'activation_post_type_support' ) );

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -760,3 +760,4 @@ add_action( 'init', array( 'Jetpack_Testimonial', 'init' ) );
 // Check on plugin activation if theme supports CPT
 register_activation_hook( __FILE__,                         array( 'Jetpack_Testimonial', 'activation_post_type_support' ) );
 add_action( 'jetpack_activate_module_custom-content-types', array( 'Jetpack_Testimonial', 'activation_post_type_support' ) );
+add_action( 'jetpack_update_default_options_module_custom-content-types', array( 'Jetpack_Testimonial', 'activation_post_type_support' ) );

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -260,9 +260,8 @@ class Jetpack_Testimonial {
 	 * On plugin/theme activation, check if current theme supports CPT
 	 */
 	static function activation_post_type_support() {
-		if ( current_theme_supports( self::CUSTOM_POST_TYPE ) ) {
-			update_option( self::OPTION_NAME, '1' );
-		}
+		$option_value = current_theme_supports( self::CUSTOM_POST_TYPE ) ? '1' : '0';
+		update_option( self::OPTION_NAME, $option_value );
 	}
 
 	/**

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -53,6 +53,17 @@ function grofiles_add_settings() {
 }
 
 /**
+ * Sets default option upon activation.
+ */
+function grofiles_default_options() {
+	if ( false === get_option( 'gravatar_disable_hovercards', false ) ) {
+		update_option( 'gravatar_disable_hovercards', 'enabled' );
+	}
+}
+
+add_action( 'jetpack_activate_module_gravatar-hovercards', 'grofiles_default_options' );
+
+/**
  * HTML for Gravatar Hovercard setting
  */
 function grofiles_setting_callback() {

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -62,6 +62,7 @@ function grofiles_set_default_options() {
 }
 
 add_action( 'jetpack_activate_module_gravatar-hovercards', 'grofiles_set_default_options' );
+add_action( 'jetpack_update_default_options_module_gravatar-hovercards', 'grofiles_set_default_options' );
 
 /**
  * HTML for Gravatar Hovercard setting

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -55,13 +55,13 @@ function grofiles_add_settings() {
 /**
  * Sets default option upon activation.
  */
-function grofiles_default_options() {
+function grofiles_set_default_options() {
 	if ( false === get_option( 'gravatar_disable_hovercards', false ) ) {
 		update_option( 'gravatar_disable_hovercards', 'enabled' );
 	}
 }
 
-add_action( 'jetpack_activate_module_gravatar-hovercards', 'grofiles_default_options' );
+add_action( 'jetpack_activate_module_gravatar-hovercards', 'grofiles_set_default_options' );
 
 /**
  * HTML for Gravatar Hovercard setting

--- a/modules/manage.php
+++ b/modules/manage.php
@@ -14,6 +14,8 @@
  */
 add_action( 'customize_register', 'add_wpcom_to_allowed_redirect_hosts' );
 add_action( 'jetpack_activate_module_manage', 'jetpack_manage_set_default_options' );
+add_action( 'jetpack_update_default_options_module_manage', 'jetpack_manage_set_default_options' );
+
 
 // Add wordpress.com to the safe redirect whitelist if the Manage module is enabled
 // so the customizer can `return` to wordpress.com if invoked from there.

--- a/modules/manage.php
+++ b/modules/manage.php
@@ -13,7 +13,7 @@
  * Additional Search Queries: manage, management, remote
  */
 add_action( 'customize_register', 'add_wpcom_to_allowed_redirect_hosts' );
-add_action( 'jetpack_activate_module_manage', 'jetpack_manage_set_default_option' );
+add_action( 'jetpack_activate_module_manage', 'jetpack_manage_set_default_options' );
 
 // Add wordpress.com to the safe redirect whitelist if the Manage module is enabled
 // so the customizer can `return` to wordpress.com if invoked from there.
@@ -26,7 +26,7 @@ function add_wpcom_to_allowed_redirect_hosts( $domains ) {
 /**
  * Set default option upon activation
  */
-function jetpack_manage_set_default_option() {
+function jetpack_manage_set_default_options() {
 	if ( false === Jetpack_Options::get_option( 'sync_non_public_post_stati' ) ) {
 		Jetpack_Options::update_option( 'sync_non_public_post_stati', 0 );
 	}

--- a/modules/manage.php
+++ b/modules/manage.php
@@ -13,12 +13,22 @@
  * Additional Search Queries: manage, management, remote
  */
 add_action( 'customize_register', 'add_wpcom_to_allowed_redirect_hosts' );
+add_action( 'jetpack_activate_module_manage', 'jetpack_manage_set_default_option' );
 
 // Add wordpress.com to the safe redirect whitelist if the Manage module is enabled
 // so the customizer can `return` to wordpress.com if invoked from there.
 function add_wpcom_to_allowed_redirect_hosts( $domains ) {
 	if ( Jetpack::is_module_active( 'manage' ) ) {
 		add_filter( 'allowed_redirect_hosts', 'allow_wpcom_domain' );
+	}
+}
+
+/**
+ * Set default option upon activation
+ */
+function jetpack_manage_set_default_option() {
+	if ( false === Jetpack_Options::get_option( 'sync_non_public_post_stati' ) ) {
+		Jetpack_Options::update_option( 'sync_non_public_post_stati', 0 );
 	}
 }
 

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -38,6 +38,19 @@ class Jetpack_RelatedPosts_Module {
 	 */
 	private function __construct() {
 		add_action( 'jetpack_module_loaded_related-posts', array( $this, 'action_on_load' ) );
+		add_action( 'jetpack_activate_module_related-posts', array( $this, 'set_default_option' ) );
+	}
+
+	/**
+	 * This action triggers when module is activated.
+	 * It set the default option for this module.
+	 *
+	 * @uses Jetpack_Options::get_option, Jetpack_Options::update_option
+	 */
+	public function set_default_option() {
+		if ( false === Jetpack_Options::get_option( 'relatedposts' ) ) {
+			Jetpack_Options::update_option( 'relatedposts', 0 );
+		}
 	}
 
 	/**

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -38,7 +38,7 @@ class Jetpack_RelatedPosts_Module {
 	 */
 	private function __construct() {
 		add_action( 'jetpack_module_loaded_related-posts', array( $this, 'action_on_load' ) );
-		add_action( 'jetpack_activate_module_related-posts', array( $this, 'set_default_option' ) );
+		add_action( 'jetpack_activate_module_related-posts', array( $this, 'set_default_options' ) );
 	}
 
 	/**
@@ -47,7 +47,7 @@ class Jetpack_RelatedPosts_Module {
 	 *
 	 * @uses Jetpack_Options::get_option, Jetpack_Options::update_option
 	 */
-	public function set_default_option() {
+	public static function set_default_options() {
 		if ( false === Jetpack_Options::get_option( 'relatedposts' ) ) {
 			Jetpack_Options::update_option( 'relatedposts', 0 );
 		}

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -39,6 +39,7 @@ class Jetpack_RelatedPosts_Module {
 	private function __construct() {
 		add_action( 'jetpack_module_loaded_related-posts', array( $this, 'action_on_load' ) );
 		add_action( 'jetpack_activate_module_related-posts', array( $this, 'set_default_options' ) );
+		add_action( 'jetpack_update_default_options_module_related-posts', array( __CLASS__, 'set_default_options' ) );
 	}
 
 	/**

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -225,7 +225,7 @@ function sharing_global_resources() {
 /**
  * Sets default option upon activation.
  */
-function sharing_default_options() {
+function sharing_set_default_options() {
 	if ( false === get_option( 'sharedaddy_disable_resources', false ) ) {
 		update_option( 'sharedaddy_disable_resources', 0 );
 	}
@@ -258,7 +258,7 @@ add_action( 'save_post', 'sharing_meta_box_save' );
 add_action( 'sharing_email_send_post', 'sharing_email_send_post' );
 add_filter( 'sharing_email_can_send', 'sharing_email_check_for_spam_via_akismet' );
 add_action( 'sharing_global_options', 'sharing_global_resources', 30 );
-add_action( 'jetpack_activate_module_sharedaddy', 'sharing_default_options' );
+add_action( 'jetpack_activate_module_sharedaddy', 'sharing_set_default_options' );
 add_action( 'sharing_admin_update', 'sharing_global_resources_save' );
 add_filter( 'sharing_services', 'sharing_restrict_to_single' );
 add_action( 'plugin_action_links_'.basename( dirname( __FILE__ ) ).'/'.basename( __FILE__ ), 'sharing_plugin_settings', 10, 4 );

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -259,6 +259,7 @@ add_action( 'sharing_email_send_post', 'sharing_email_send_post' );
 add_filter( 'sharing_email_can_send', 'sharing_email_check_for_spam_via_akismet' );
 add_action( 'sharing_global_options', 'sharing_global_resources', 30 );
 add_action( 'jetpack_activate_module_sharedaddy', 'sharing_set_default_options' );
+add_action( 'jetpack_update_default_options_module_sharedaddy', 'sharing_set_default_options' );
 add_action( 'sharing_admin_update', 'sharing_global_resources_save' );
 add_filter( 'sharing_services', 'sharing_restrict_to_single' );
 add_action( 'plugin_action_links_'.basename( dirname( __FILE__ ) ).'/'.basename( __FILE__ ), 'sharing_plugin_settings', 10, 4 );

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -222,6 +222,15 @@ function sharing_global_resources() {
 <?php
 }
 
+/**
+ * Sets default option upon activation.
+ */
+function sharing_default_options() {
+	if ( false === get_option( 'sharedaddy_disable_resources', false ) ) {
+		update_option( 'sharedaddy_disable_resources', 0 );
+	}
+}
+
 function sharing_global_resources_save() {
 	update_option( 'sharedaddy_disable_resources', isset( $_POST['disable_resources'] ) ? 1 : 0 );
 }
@@ -249,6 +258,7 @@ add_action( 'save_post', 'sharing_meta_box_save' );
 add_action( 'sharing_email_send_post', 'sharing_email_send_post' );
 add_filter( 'sharing_email_can_send', 'sharing_email_check_for_spam_via_akismet' );
 add_action( 'sharing_global_options', 'sharing_global_resources', 30 );
+add_action( 'jetpack_activate_module_sharedaddy', 'sharing_default_options' );
 add_action( 'sharing_admin_update', 'sharing_global_resources_save' );
 add_filter( 'sharing_services', 'sharing_restrict_to_single' );
 add_action( 'plugin_action_links_'.basename( dirname( __FILE__ ) ).'/'.basename( __FILE__ ), 'sharing_plugin_settings', 10, 4 );

--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -293,7 +293,7 @@ function vimeo_link_callback( $matches ) {
 }
 
 /** This filter is documented in modules/shortcodes/youtube.php */
-if ( apply_filters( 'jetpack_comments_allow_oembed', get_option('embed_autourls') ) ) {
+if ( apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
 	// We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway, so the iframe gets filtered out.
 	if ( ! is_admin() ) {
 		// Higher priority because we need it before auto-link and autop get to it

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -363,7 +363,7 @@ add_action( 'init', 'wpcom_youtube_embed_crazy_url_init' );
  *
  * @param int get_option('embed_autourls') Option to automatically embed all plain text URLs.
  */
-if ( apply_filters( 'jetpack_comments_allow_oembed', get_option('embed_autourls') ) ) {
+if ( apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
 	// We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway, so the iframe gets filtered out.
 	if ( ! is_admin() ) {
 		// Higher priority because we need it before auto-link and autop get to it

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1159,6 +1159,15 @@ class Jetpack_SSO {
 	}
 
 	/**
+	 * Save default option upon activation
+	 */
+	static function activation_sso() {
+		if ( false === get_option( 'jetpack_sso_remove_login_form', false ) ) {
+			update_option( 'jetpack_sso_remove_login_form', '0' );
+		}
+	}
+
+	/**
 	 * Determines if a local user is connected to WordPress.com
 	 *
 	 * @since 2.8
@@ -1182,3 +1191,4 @@ class Jetpack_SSO {
 }
 
 Jetpack_SSO::get_instance();
+add_action( 'jetpack_activate_module_sso', array( 'Jetpack_SSO', 'activation_sso' ) );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1161,7 +1161,7 @@ class Jetpack_SSO {
 	/**
 	 * Save default option upon activation
 	 */
-	static function activation_sso() {
+	static function set_default_options() {
 		if ( false === get_option( 'jetpack_sso_remove_login_form', false ) ) {
 			update_option( 'jetpack_sso_remove_login_form', '0' );
 		}
@@ -1191,4 +1191,4 @@ class Jetpack_SSO {
 }
 
 Jetpack_SSO::get_instance();
-add_action( 'jetpack_activate_module_sso', array( 'Jetpack_SSO', 'activation_sso' ) );
+add_action( 'jetpack_activate_module_sso', array( 'Jetpack_SSO', 'set_default_options' ) );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1192,3 +1192,4 @@ class Jetpack_SSO {
 
 Jetpack_SSO::get_instance();
 add_action( 'jetpack_activate_module_sso', array( 'Jetpack_SSO', 'set_default_options' ) );
+add_action( 'jetpack_update_default_options_module_sso', array( 'Jetpack_SSO', 'set_default_options' ) );

--- a/modules/verification-tools.php
+++ b/modules/verification-tools.php
@@ -31,6 +31,7 @@ function jetpack_verification_tools_set_default_options() {
 }
 
 add_action( 'jetpack_activate_module_verification-tools', 'jetpack_verification_tools_set_default_options' );
+add_action( 'jetpack_update_default_options_module_verification-tools', 'jetpack_verification_tools_set_default_options' );
 
 function jetpack_verification_tools_configuration_load() {
 	wp_safe_redirect( admin_url( 'tools.php' ) );

--- a/modules/verification-tools.php
+++ b/modules/verification-tools.php
@@ -24,13 +24,13 @@ add_action( 'jetpack_modules_loaded', 'jetpack_verification_tools_loaded' );
 /**
  * Set default option on module activation
  */
-function jetpack_verification_tools_set_default_option() {
+function jetpack_verification_tools_set_default_options() {
 	if ( false === get_option( 'verification_services_codes' ) ) {
 		update_option( 'verification_services_codes', 0 );
 	}
 }
 
-add_action( 'jetpack_activate_module_verification-tools', 'jetpack_verification_tools_set_default_option' );
+add_action( 'jetpack_activate_module_verification-tools', 'jetpack_verification_tools_set_default_options' );
 
 function jetpack_verification_tools_configuration_load() {
 	wp_safe_redirect( admin_url( 'tools.php' ) );

--- a/modules/verification-tools.php
+++ b/modules/verification-tools.php
@@ -21,6 +21,17 @@ function jetpack_verification_tools_loaded() {
 }
 add_action( 'jetpack_modules_loaded', 'jetpack_verification_tools_loaded' );
 
+/**
+ * Set default option on module activation
+ */
+function jetpack_verification_tools_set_default_option() {
+	if ( false === get_option( 'verification_services_codes' ) ) {
+		update_option( 'verification_services_codes', 0 );
+	}
+}
+
+add_action( 'jetpack_activate_module_verification-tools', 'jetpack_verification_tools_set_default_option' );
+
 function jetpack_verification_tools_configuration_load() {
 	wp_safe_redirect( admin_url( 'tools.php' ) );
 	exit;


### PR DESCRIPTION
This is a work in progress, as an attempt to fix #3676 

#### Changes proposed in this Pull Request:

Many of the queries are triggered on every page only because the options don't exist yet in the database. 
When the option is set, it is autoloaded. So it makes sense to set defaults for these.

##### Affected options

 * `jetpack-twitter-cards-site-tag`
 * `open_graph_protocol_site_type`
 * `facebook_admins`
 * `safecss_add`
 * `safecss_revision_migrated`
 * `safecss`
 * `jetpack_portfolio`
 * `jetpack_testimonial`
 * `gravatar_disable_hovercards`
 * `sync_non_public_post_stati`
 * `relatedposts`
 * `sharedaddy_disable_resources`
 * `jetpack_sso_remove_login_form`
 * `verification_services_codes`
 * `embed_autourls`


The only exception is the `embed_autourls` option, that is replaced with `true`, as it's no longer used by WordPress (https://core.trac.wordpress.org/changeset/22070)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).