### PR TITLE
Update .sharedaddy style for Twenty Sixteen

### DIFF
--- a/modules/theme-tools/compat/twentysixteen-rtl.css
+++ b/modules/theme-tools/compat/twentysixteen-rtl.css
@@ -603,6 +603,7 @@ iframe[src^="http://api.mixcloud.com/"] {
 	opacity: 0.2;
 	position: absolute;
 	top: 0;
+	left: 0;
 	width: 100%;
 }
 

--- a/modules/theme-tools/compat/twentysixteen.css
+++ b/modules/theme-tools/compat/twentysixteen.css
@@ -603,6 +603,7 @@ iframe[src^="http://api.mixcloud.com/"] {
 	opacity: 0.2;
 	position: absolute;
 	top: 0;
+	left: 0;
 	width: 100%;
 }
 


### PR DESCRIPTION
Fixes #3724

`modules/theme-tools/compact/twenty-sixteen.css`
`modules/theme-tools/compact/twenty-sixteen-rtl.css`
-> line:598

```
.sharedaddy:before,
.sharedaddy:last-child:after {
  background-color: currentColor;
  content: "";
  height: 1px;
  opacity: 0.2;
  position: absolute;
  top: 0;
  width: 100%;
}
```
You need to add the following properties to the above-mentioned style.

`left: 0;`

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).