### PR TITLE
Widgets: load script only after selective refresh is ready to ensure wp exists

### DIFF
--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -62,6 +62,6 @@ jetpack_load_widgets();
  * @since 4.0.0
  */
 function jetpack_widgets_customizer_assets() {
-	wp_enqueue_script( 'jetpack-customizer-widget-utils', plugins_url( '/widgets/customizer-utils.js', __FILE__ ), array( 'jquery' ) );
+	wp_enqueue_script( 'jetpack-customizer-widget-utils', plugins_url( '/widgets/customizer-utils.js', __FILE__ ), array( 'wp-util' ) );
 }
 add_action( 'customize_preview_init', 'jetpack_widgets_customizer_assets' );


### PR DESCRIPTION
fixes #3716