### PR TITLE
SSO: Do not display SSO UI if no access token

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -23,17 +23,24 @@ class Jetpack_SSO {
 
 		add_action( 'admin_init',  array( $this, 'admin_init' ) );
 		add_action( 'admin_init',  array( $this, 'register_settings' ) );
-		add_action( 'login_init',  array( $this, 'login_init' ) );
 		add_action( 'delete_user', array( $this, 'delete_connection_for_user' ) );
 		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'xmlrpc_methods' ) );
 		add_action( 'init', array( $this, 'maybe_logout_user' ), 5 );
 		add_action( 'jetpack_modules_loaded', array( $this, 'module_configure_button' ) );
-		add_action( 'login_enqueue_scripts', array( $this, 'login_enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
-		add_filter( 'login_body_class', array( $this, 'login_body_class' ) );
 
-		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
-		add_action( 'login_form_jetpack-sso', '__return_true' );
+		/**
+		 * Because logging in via SSO requires an active access token, don't show the
+		 * SSO UI on the login form unless there is a token.
+		 */
+		if ( ! empty( Jetpack_Data::get_access_token() ) ) {
+			add_action( 'login_init',  array( $this, 'login_init' ) );
+			add_action( 'login_enqueue_scripts', array( $this, 'login_enqueue_scripts' ) );
+			add_filter( 'login_body_class', array( $this, 'login_body_class' ) );
+
+			// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
+			add_action( 'login_form_jetpack-sso', '__return_true' );
+		}
 
 		if (
 			$this->should_hide_login_form() &&


### PR DESCRIPTION
Currently, if the SSO module is turned on and then all Jetpack connections are removed, a user will receive an `-10520: Jetpack: [missing_token]` error when clicking the "Login with WordPress.com" button.

This PR adds a check in the SSO constructor that checks to make sure there is a valid access token. If the access token is not valid, then we don't show the UI.

Test existence of bug:
- On a site with Jetpack enabled and connected to WP.com, enable SSO.
- Disconnect all Jetpack connections
- Logout
- Go to `/wp-admin`
- Click "Log in with WordPress.com"
- Do you get a `missing_token` error?

Test fix:
- Checkout `update/sso-bail-no-token` branch
- Go to `/wp-admin`
- You should not see the "Login with WordPress.com" button

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).