### PR TITLE
XMLRPC server: provide a secret to activate Manage during authorizations

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -41,6 +41,7 @@ class Jetpack_Options {
 			return array(
 				'register',
 				'authorize',
+				'activate_manage',
 				'blog_token',                  // (string) The Client Secret/Blog Token of this site.
 				'user_token',                  // (string) The User Token of this site. (deprecated)
 				'user_tokens'                  // (array)  User Tokens for each user of this site who has connected to jetpack.wordpress.com.

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -75,7 +75,27 @@ class Jetpack_XMLRPC_Server {
 	}
 
 	function authorize_xmlrpc_methods() {
-		return array( 'jetpack.remoteAuthorize' => array( $this, 'remote_authorize' ) );
+		return array(
+			'jetpack.remoteAuthorize' => array( $this, 'remote_authorize' ),
+			'jetpack.activateManage'    => array( $this, 'activate_manage' ),
+		);
+	}
+
+	function activate_manage( $request ) {
+		foreach( array( 'secret', 'state' ) as $required ) {
+			if ( ! isset( $request[ $required ] ) || empty( $request[ $required ] ) ) {
+				return $this->error( new Jetpack_Error( 'missing_parameter', 'One or more parameters is missing from the request.', 400 ) );
+			}
+		}
+		$verified = $this->verify_action( array( 'activate_manage', $request['secret'], $request['state'] ) );
+		if ( is_a( $verified, 'IXR_Error' ) ) {
+			return $verified;
+		}
+		$activated = Jetpack::activate_module( 'manage', false, false );
+		if ( false === $activated || ! Jetpack::is_module_active( 'manage' ) ) {
+			return $this->error( new Jetpack_Error( 'activation_error', 'There was an error while activating the module.', 500 ) );
+		}
+		return 'active';
 	}
 
 	function remote_authorize( $request ) {
@@ -107,8 +127,15 @@ class Jetpack_XMLRPC_Server {
 		if ( is_wp_error( $result ) ) {
 			return $this->error( $result );
 		}
-		
-		return $result;
+		// Creates a new secret, allowing someone to activate the manage module for up to 10 minutes after authorization.
+		$secrets = Jetpack::init()->generate_secrets( DAY_IN_SECONDS );
+		Jetpack_Options::update_option( 'activate_manage', $secrets[0] . ':' . $secrets[1] . ':' . $secrets[2] . ':' . $secrets[3] );
+		@list( $secret ) = explode( ':', Jetpack_Options::get_option( 'activate_manage' ) );
+		$response = array(
+			'result' => $result,
+			'activate_manage' => $secret,
+		);
+		return $response;
 	}
 
 	/**

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -127,7 +127,7 @@ class Jetpack_XMLRPC_Server {
 		if ( is_wp_error( $result ) ) {
 			return $this->error( $result );
 		}
-		// Creates a new secret, allowing someone to activate the manage module for up to 10 minutes after authorization.
+		// Creates a new secret, allowing someone to activate the manage module for up to 1 day after authorization.
 		$secrets = Jetpack::init()->generate_secrets( 'activate_manage', DAY_IN_SECONDS );
 		@list( $secret ) = explode( ':', $secrets );
 		$response = array(

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -128,9 +128,8 @@ class Jetpack_XMLRPC_Server {
 			return $this->error( $result );
 		}
 		// Creates a new secret, allowing someone to activate the manage module for up to 10 minutes after authorization.
-		$secrets = Jetpack::init()->generate_secrets( DAY_IN_SECONDS );
-		Jetpack_Options::update_option( 'activate_manage', $secrets[0] . ':' . $secrets[1] . ':' . $secrets[2] . ':' . $secrets[3] );
-		@list( $secret ) = explode( ':', Jetpack_Options::get_option( 'activate_manage' ) );
+		$secrets = Jetpack::init()->generate_secrets( 'activate_manage', DAY_IN_SECONDS );
+		@list( $secret ) = explode( ':', $secrets );
 		$response = array(
 			'result' => $result,
 			'activate_manage' => $secret,

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4948,13 +4948,12 @@ p {
 	 * @since 2.6
 	 * @return array
 	 */
-	public function generate_secrets( $action ) {
+	public function generate_secrets( $action, $exp = 600 ) {
 	    $secret = wp_generate_password( 32, false ) // secret_1
 	    		. ':' . wp_generate_password( 32, false ) // secret_2
-	    		. ':' . ( time() + 600 ) // eol ( End of Life )
+	    		. ':' . ( time() + $exp ) // eol ( End of Life )
 	    		. ':' . get_current_user_id(); // ties the secrets to the current user
 		Jetpack_Options::update_option( $action, $secret );
-
 	    return Jetpack_Options::get_option( $action );
 	}
 


### PR DESCRIPTION
Adding a new method to activate the manage module. This method will
fail if the request does not provide a valid secret. The secret is
generated at the end of the connection authorization process. The
secret is valid for up to 24 hours. It will allow our users who decide
to purchase a premium plan to activate the manage module, so they
can configure their premium settings remotely.

Testing instructions: https://github.com/Automattic/wp-calypso/pull/5056