### PR TITLE
Carousel: Prevent error when accessing undefined variable

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1398,8 +1398,8 @@ jQuery(document).ready(function($) {
 			matches, attachmentId, galleries, selectedThumbnail;
 
 		if ( ! window.location.hash || ! hashRegExp.test( window.location.hash ) ) {
-			if ( gallery.opened ) {
-				container.jp_carousel('close');
+			if ( gallery && gallery.opened ) {
+				container.jp_carousel( 'close' );
 			}
 
 			return;


### PR DESCRIPTION
When visiting a post on my blog with a URL hash defined ( http://nylen.io/blog/2016/04/04/sf-golden-gate-bridge-skyline-etc/#something ) I get this error:

```
Uncaught TypeError: Cannot read property 'opened' of undefined
```

This prevents other code from executing (the Likes widgets do not load, for example).

I'm not sure exactly why this is happening, but this PR provides a simple workaround.