### PR TITLE
Fix Customizer JS errors: Define customize-base as a dependency for jetpack-customizer-widget-utils

### DIFF
--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -62,6 +62,6 @@ jetpack_load_widgets();
  * @since 4.0.0
  */
 function jetpack_widgets_customizer_assets() {
-	wp_enqueue_script( 'jetpack-customizer-widget-utils', plugins_url( '/widgets/customizer-utils.js', __FILE__ ), array( 'jquery', 'customize-base' ) );
+	wp_enqueue_script( 'jetpack-customizer-widget-utils', plugins_url( '/widgets/customizer-utils.js', __FILE__ ), array( 'customize-base' ) );
 }
 add_action( 'customize_preview_init', 'jetpack_widgets_customizer_assets' );

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -62,6 +62,6 @@ jetpack_load_widgets();
  * @since 4.0.0
  */
 function jetpack_widgets_customizer_assets() {
-	wp_enqueue_script( 'jetpack-customizer-widget-utils', plugins_url( '/widgets/customizer-utils.js', __FILE__ ), array( 'jquery' ) );
+	wp_enqueue_script( 'jetpack-customizer-widget-utils', plugins_url( '/widgets/customizer-utils.js', __FILE__ ), array( 'jquery', 'customize-base' ) );
 }
 add_action( 'customize_preview_init', 'jetpack_widgets_customizer_assets' );


### PR DESCRIPTION
Fixes a couple JS errors in the Customizer:

* `customizer-utils.js:11` Uncaught ReferenceError: wp is not defined
* `contact-info-map.js:34` Uncaught TypeError: wp.customizerHasPartialWidgetRefresh is not a function