### PR TITLE
Tonesque: Use `imagecreatefromstring()` rather than attempting to detect file type manually

### DIFF
--- a/_inc/lib/tonesque.php
+++ b/_inc/lib/tonesque.php
@@ -37,27 +37,7 @@ class Tonesque {
 	}
 
 	public static function imagecreatefromurl( $image_url ) {
-	 	// Grab the extension
-		$file = strtolower( pathinfo( $image_url, PATHINFO_EXTENSION ) );
-		$file = explode( '?', $file );
-		$file = $file[ 0 ];
-
-		switch ( $file ) {
-			case 'gif' :
-				$image_obj = imagecreatefromgif( $image_url );
-				break;
-			case 'png' :
-				$image_obj = imagecreatefrompng( $image_url );
-				break;
-			case 'jpg' :
-			case 'jpeg' :
-				$image_obj = imagecreatefromjpeg( $image_url );
-				break;
-			default:
-				return false;
-		}
-
-		return $image_obj;
+		return imagecreatefromstring( file_get_contents( $image_url ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3741.

#### Changes proposed in this Pull Request:
- Uses `imagecreatefromstring()` rather than calling individual PHP functions directly, allowing PHP to do the detection using the file contents (and each image types bytemark) instead of based on the filename.