### PR TITLE
Likes: Update version of WPCOM-side Likes widget code

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -19,7 +19,7 @@ Jetpack::dns_prefetch( array(
 ) );
 
 class Jetpack_Likes {
-	public $version = '20151215';
+	public $version = '20160429';
 
 	public static function init() {
 		static $instance = NULL;


### PR DESCRIPTION
This change updates the version of the Likes iframe widget code loaded from WPCOM.  The code was using a deprecated feature of Underscore's `_.template` function that was removed in WordPress 4.5 (https://make.wordpress.org/core/2016/02/17/backbone-and-underscore-updated-to-latest-versions/).  It was never broken because we were loading an old version of Underscore through the same versioning mechanism, so this is preventative maintenance.

Already deployed on WPCOM; see also:

- r135019-wpcom
- r135028-wpcom
- p47NkD-yK-p2

### To test

Visit a page with one or more posts, and make sure the new version of the Likes widget code is loaded:

![image](https://cloud.githubusercontent.com/assets/227022/14867604/e6cc0f1a-0c8e-11e6-8d32-22f45330dbde.png)

Make sure the Like widgets appear correctly on the admin bar, next to posts, and any other locations:

![image](https://cloud.githubusercontent.com/assets/227022/14867564/ba2e66ec-0c8e-11e6-881d-173abf15022c.png)