### PR TITLE
General: Cleanup code in class.jetpack-client-server.php

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -42,7 +42,7 @@ class Jetpack_Client_Server {
 			$jetpack_unique_connection = array(
 				'connected'     => 0,
 				'disconnected'  => 0,
-				'version'       => '3.6.1'
+				'version'       => '3.6.1',
 			);
 
 			update_option( 'jetpack_unique_connection', $jetpack_unique_connection );
@@ -58,81 +58,78 @@ class Jetpack_Client_Server {
 		$jetpack_unique_connection['connected'] += 1;
 		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
 
-		do {
-			$jetpack = $this->get_jetpack();
-			$role = $jetpack->translate_current_user_to_role();
+		$jetpack = $this->get_jetpack();
+		$role = $jetpack->translate_current_user_to_role();
 
-			if ( ! $role ) {
-				return new Jetpack_Error( 'no_role', 'Invalid request.', 400 );
+		if ( ! $role ) {
+			return new Jetpack_Error( 'no_role', 'Invalid request.', 400 );
+		}
+
+		$cap = $jetpack->translate_role_to_cap( $role );
+		if ( ! $cap ) {
+			return new Jetpack_Error( 'no_cap', 'Invalid request.', 400 );
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			return new Jetpack_Error( $data['error'], 'Error included in the request.', 400 );
+		}
+
+		if ( ! isset( $data['state'] ) ) {
+			return new Jetpack_Error( 'no_state', 'Request must include state.', 400 );
+		}
+
+		if ( ! ctype_digit( $data['state'] ) ) {
+			return new Jetpack_Error( $data['error'], 'State must be an integer.', 400 );
+		}
+
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id != $data['state'] ) {
+			return new Jetpack_Error( 'wrong_state', 'State does not match current user.', 400 );
+		}
+
+		if ( empty( $data['code'] ) ) {
+			return new Jetpack_Error( 'no_code', 'Request must include an authorization code.', 400 );
+		}
+
+		$token = $this->get_token( $data );
+
+		if ( is_wp_error( $token ) ) {
+			$code = $token->get_error_code();
+			if ( empty( $code ) ) {
+				$code = 'invalid_token';
 			}
+			return new Jetpack_Error( $code, $token->get_error_message(), 400 );
+		}
 
-			$cap = $jetpack->translate_role_to_cap( $role );
-			if ( !$cap ) {
-				return new Jetpack_Error( 'no_cap', 'Invalid request.', 400 );
-			}
+		if ( ! $token ) {
+			return new Jetpack_Error( 'no_token', 'Error generating token.', 400 );
+		}
 
-			if ( ! empty( $data['error'] ) ) {
-				return new Jetpack_Error( $data['error'], 'Error included in the request.', 400 );
-			}
+		$is_master_user = ! Jetpack::is_active();
 
-			if ( ! isset( $data['state'] ) ) {
-				return new Jetpack_Error( 'no_state', 'Request must include state.', 400 );
-			}
+		Jetpack::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
 
-			if ( ! ctype_digit( $data['state'] ) ) {
-				return new Jetpack_Error( $data['error'], 'State must be an integer.', 400 );
-			}
+		if ( ! $is_master_user ) {
+			// Don't activate anything since we are just connecting a user.
+			return 'linked';
+		}
 
-			$current_user_id = get_current_user_id();
-			if ( $current_user_id != $data['state'] ) {
-				return new Jetpack_Error( 'wrong_state', 'State does not match current user.', 400 );
-			}
+		$redirect_on_activation_error = ( 'client' === $data['auth_type'] ) ? true : false;
+		if ( $active_modules = Jetpack_Options::get_option( 'active_modules' ) ) {
+			Jetpack_Options::delete_option( 'active_modules' );
 
-			if ( empty( $data['code'] ) ) {
-				return new Jetpack_Error( 'no_code', 'Request must include an authorization code.', 400 );
-			}
+			Jetpack::activate_default_modules( 999, 1, $active_modules, $redirect_on_activation_error );
+		} else {
+			Jetpack::activate_default_modules( false, false, array(), $redirect_on_activation_error );
+		}
 
-			$token = $this->get_token( $data );
+		// Sync all registers options and constants
+		/** This action is documented in class.jetpack.php */
+		do_action( 'jetpack_sync_all_registered_options' );
 
-			if ( is_wp_error( $token ) ) {
-				$code = $token->get_error_code();
-				if ( empty( $code ) ) {
-					$code = 'invalid_token';
-				}
-				return new Jetpack_Error( $code, $token->get_error_message(), 400 );
-			}
-
-			if ( ! $token ) {
-				return new Jetpack_Error( 'no_token', 'Error generating token.', 400 );
-			}
-
-			$is_master_user = ! Jetpack::is_active();
-
-			Jetpack::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
-
-
-			if ( ! $is_master_user ) {
-				// Don't activate anything since we are just connecting a user.
-				return 'linked';
-			}
-
-			$redirect_on_activation_error = ( 'client' === $data['auth_type'] ) ? true : false;
-			if ( $active_modules = Jetpack_Options::get_option( 'active_modules' ) ) {
-				Jetpack_Options::delete_option( 'active_modules' );
-
-				Jetpack::activate_default_modules( 999, 1, $active_modules, $redirect_on_activation_error );
-			} else {
-				Jetpack::activate_default_modules( false, false, array(), $redirect_on_activation_error );
-			}
-
-			// Sync all registers options and constants
-			/** This action is documented in class.jetpack.php */
-			do_action( 'jetpack_sync_all_registered_options' );
-
-			// Start nonce cleaner
-			wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
-			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
-		} while ( false );
+		// Start nonce cleaner
+		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
+		wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 
 		return 'authorized';
 	}
@@ -169,7 +166,7 @@ class Jetpack_Client_Server {
 		}
 
 		$client_secret = Jetpack_Data::get_access_token();
-		if ( !$client_secret ) {
+		if ( ! $client_secret ) {
 			return new Jetpack_Error( 'client_secret', __( 'You need to register your Jetpack before connecting it.', 'jetpack' ) );
 		}
 
@@ -206,21 +203,23 @@ class Jetpack_Client_Server {
 		$code = wp_remote_retrieve_response_code( $response );
 		$entity = wp_remote_retrieve_body( $response );
 
-		if ( $entity )
+		if ( $entity ) {
 			$json = json_decode( $entity );
-		else
+		} else {
 			$json = false;
+		}
 
-		if ( 200 != $code || !empty( $json->error ) ) {
-			if ( empty( $json->error ) )
+		if ( 200 != $code || ! empty( $json->error ) ) {
+			if ( empty( $json->error ) ) {
 				return new Jetpack_Error( 'unknown', '', $code );
+			}
 
 			$error_description = isset( $json->error_description ) ? sprintf( __( 'Error Details: %s', 'jetpack' ), (string) $json->error_description ) : '';
 
 			return new Jetpack_Error( (string) $json->error, $error_description, $code );
 		}
 
-		if ( empty( $json->access_token ) || !is_scalar( $json->access_token ) ) {
+		if ( empty( $json->access_token ) || ! is_scalar( $json->access_token ) ) {
 			return new Jetpack_Error( 'access_token', '', $code );
 		}
 
@@ -231,18 +230,23 @@ class Jetpack_Client_Server {
 		if ( empty( $json->scope ) ) {
 			return new Jetpack_Error( 'scope', 'No Scope', $code );
 		}
+
 		@list( $role, $hmac ) = explode( ':', $json->scope );
 		if ( empty( $role ) || empty( $hmac ) ) {
 			return new Jetpack_Error( 'scope', 'Malformed Scope', $code );
 		}
+
 		if ( $jetpack->sign_role( $role ) !== $json->scope ) {
 			return new Jetpack_Error( 'scope', 'Invalid Scope', $code );
 		}
 
-		if ( !$cap = $jetpack->translate_role_to_cap( $role ) )
+		if ( ! $cap = $jetpack->translate_role_to_cap( $role ) ) {
 			return new Jetpack_Error( 'scope', 'No Cap', $code );
-		if ( ! current_user_can( $cap ) )
+		}
+
+		if ( ! current_user_can( $cap ) ) {
 			return new Jetpack_Error( 'scope', 'current_user_cannot', $code );
+		}
 
 		/**
 		 * Fires after user has successfully received an auth token.
@@ -269,5 +273,4 @@ class Jetpack_Client_Server {
 	public function do_exit() {
 		exit;
 	}
-
 }


### PR DESCRIPTION
Earlier today, I noticed that there was a [do {} while ( false ) loop in class.jetack-client-server.php](https://github.com/Automattic/jetpack/blame/master/class.jetpack-client-server.php#L135). 

My guess is that it was perhaps committed after some testing or refactoring was done. But, unless there is a reason for keeping it, I suggest we just get rid of it since it's confusing.

After removing that loop, I went ahead and addressed some WordPress coding standards throughout the file.

To test
- Checkout `update/jetpack-client-server-cleanup` branch
- On your test site, with a non-master account, link your account
- Does it work?

I'm sure there's more to test, so pinging some potential reviewers. cc @roccotripaldi @georgestephanis 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
