### PR TITLE
SSO: Fixes failing unlink user when user not connected

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -601,7 +601,7 @@ class Jetpack_SSO {
 		}
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => $user_id,
+			'wpcom_user_id' => $user_id,
 		) );
 		$xml->query( 'jetpack.sso.removeUser', $wpcom_user_id );
 


### PR DESCRIPTION
When attempting to unlink SSO for a user that is not connected to WordPress.com, the information was cleared locally, but the user was not unlinked on WP.com. This was caused by a `missing_token` error.

Because the [removeUser XML request](https://github.com/Automattic/jetpack/blob/master/modules/sso.php#L603) was setting `user_id` as a parameter, [Jetpack_Client](https://github.com/Automattic/jetpack/blob/master/class.jetpack-client.php#L31-L34) was using that to get an access token to make the XML-RPC request. Since the user was not connected to WP.com, that request failed.

By renaming the `user_id` parameter to `wpcom_user_id`, we are using the blog token which shouldn't cause errors.

To test existence of bug
- On a self-hosted site
- Connect Jetpack with a primary user
- Log out
- Login with secondary user that hasn't used SSO
- SSO with secondary user
    - Note that you will have to approve the connection on WP.com
    - Go to "Your Profile" and unlink your account
    - Note that your profile no longer shows up
- Log out
- Log in with SSO again
- This time you shouldn't have been asked to approve the connection

To test fix:
- Checkout `update/sso-unlink-failure` branch
- Follow steps above
- Both times you use SSO to login, you should be asked to approve the connection

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

