### PR TITLE
Connect a site from the network admin

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -401,9 +401,6 @@ class Jetpack_Network {
 		// Figure out what site we are working on
 		$site_id = ( is_null( $site_id ) ) ? $_GET['site_id'] : $site_id;
 
-		// Build secrets to sent to wpcom for verification
-		$secrets = $jp->generate_secrets();
-
 		// Remote query timeout limit
 		$timeout = $jp->get_remote_query_timeout_limit();
 
@@ -419,9 +416,11 @@ class Jetpack_Network {
 
 		// Save the secrets in the subsite so when the wpcom server does a pingback it
 		// will be able to validate the connection
-		Jetpack_Options::update_option( 'register',
-			$secrets[0] . ':' . $secrets[1] . ':' . $secrets[2]
-		);
+		$secrets = $jp->generate_secrets( 'register' );
+		@list( $secret_1, $secret_2, $secret_eol ) = explode( ':', $secrets );
+		if ( empty( $secret_1 ) || empty( $secret_2 ) || empty( $secret_eol ) || $secret_eol < time() ) {
+			return new Jetpack_Error( 'missing_secrets' );
+		}
 
 		// Gra info for gmt offset
 		$gmt_offset = get_option( 'gmt_offset' );
@@ -438,6 +437,7 @@ class Jetpack_Network {
 		 */
 		$stat_options = get_option( 'stats_options' );
 		$stat_id = $stat_options = isset( $stats_options['blog_id'] ) ? $stats_options['blog_id'] : null;
+		$user_id = get_current_user_id();
 
 		$args = array(
 			'method'  => 'POST',
@@ -449,12 +449,13 @@ class Jetpack_Network {
 				'gmt_offset'            => $gmt_offset,
 				'timezone_string'       => (string) get_option( 'timezone_string' ),
 				'site_name'             => (string) get_option( 'blogname' ),
-				'secret_1'              => $secrets[0],
-				'secret_2'              => $secrets[1],
+				'secret_1'              => $secret_1,
+				'secret_2'              => $secret_2,
 				'site_lang'             => get_locale(),
 				'timeout'               => $timeout,
 				'stats_id'              => $stat_id, // Is this still required?
-				'user_id'               => get_current_user_id(),
+				'user_id'               => $user_id,
+				'state'                 => $user_id
 			),
 			'headers' => array(
 				'Accept' => 'application/json',

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -439,6 +439,12 @@ class Jetpack_Network {
 		$stat_id = $stat_options = isset( $stats_options['blog_id'] ) ? $stats_options['blog_id'] : null;
 		$user_id = get_current_user_id();
 
+		/**
+		 * Both `state` and `user_id` need to be sent in the request, even though they are the same value.
+		 * Connecting via the network admin combines `register()` and `authorize()` methods into one step,
+		 * because we assume the main site is already authorized. `state` is used to verify the `register()`
+		 * request, while `user_id()` is used to create the token in the `authorize()` request.
+		 */
 		$args = array(
 			'method'  => 'POST',
 			'body'    => array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4510,10 +4510,8 @@ p {
 				$redirect = Jetpack_Network::init()->get_url( 'network_admin_page' );
 			}
 
-			$secrets = Jetpack::init()->generate_secrets();
-			Jetpack_Options::update_option( 'authorize', $secrets[0] . ':' . $secrets[1] . ':' . $secrets[2] . ':' . $secrets[3] );
-
-			@list( $secret ) = explode( ':', Jetpack_Options::get_option( 'authorize' ) );
+			$secrets = Jetpack::init()->generate_secrets( 'authorize' );
+			@list( $secret ) = explode( ':', $secrets );
 
 			$args = urlencode_deep(
 				array(
@@ -4936,15 +4934,14 @@ p {
 	 * @since 2.6
 	 * @return array
 	 */
-	public function generate_secrets() {
-	    $secrets = array(
-			wp_generate_password( 32, false ), // secret_1
-			wp_generate_password( 32, false ), // secret_2
-			( time() + 600 ), // eol ( End of Life )
-			get_current_user_id(), // ties the secrets to the current user
-	    );
+	public function generate_secrets( $action ) {
+	    $secret = wp_generate_password( 32, false ) // secret_1
+	    		. ':' . wp_generate_password( 32, false ) // secret_2
+	    		. ':' . ( time() + 600 ) // eol ( End of Life )
+	    		. ':' . get_current_user_id(); // ties the secrets to the current user
+		Jetpack_Options::update_option( $action, $secret );
 
-	    return $secrets;
+	    return Jetpack_Options::get_option( $action );
 	}
 
 	/**
@@ -5010,11 +5007,9 @@ p {
 	 */
 	public static function register() {
 		add_action( 'pre_update_jetpack_option_register', array( 'Jetpack_Options', 'delete_option' ) );
-		$secrets = Jetpack::init()->generate_secrets();
+		$secrets = Jetpack::init()->generate_secrets( 'register' );
 
-		Jetpack_Options::update_option( 'register', $secrets[0] . ':' . $secrets[1] . ':' . $secrets[2] . ':' . $secrets[3] );
-
-		@list( $secret_1, $secret_2, $secret_eol ) = explode( ':', Jetpack_Options::get_option( 'register' ) );
+		@list( $secret_1, $secret_2, $secret_eol ) = explode( ':', $secrets );
 		if ( empty( $secret_1 ) || empty( $secret_2 ) || empty( $secret_eol ) || $secret_eol < time() ) {
 			return new Jetpack_Error( 'missing_secrets' );
 		}


### PR DESCRIPTION
Fixes #3641 

In Jetpack version over 4.0, the remote registration action requires
an additional 'state' parameter so that secrets can be tied to users.

This was handled in `Jetpack::register`, but was missed in the network admin.

This PR refactors `Jetpack::generate_secrets` so that it is used consistently
between single site dashboards, and the network admin.

To test:
- ensure you can replicate #3641 on your multisite
- apply this patch, and ensure that you can connect sites from both the network admin, and from the sub-site's dashboard.