### PR TITLE
Jetpack Connect: When the user is trying to connect a site to .com fr…

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3592,9 +3592,14 @@ p {
 				wp_redirect( $connect_url );
 				exit;
 			} else {
-				Jetpack::state( 'message', 'already_authorized' );
-				wp_safe_redirect( Jetpack::admin_url() );
-				exit;
+				if ( ! isset( $_GET['calypso_env'] ) ) {
+					Jetpack::state( 'message', 'already_authorized' );
+					wp_safe_redirect( Jetpack::admin_url() );
+				} else {
+					$connect_url = $this->build_connect_url( true, false, 'iframe' );
+					$connect_url .= '&already_authorized=true';
+					wp_redirect( $connect_url );
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR adds a redirection back to calypso for the cases where a user is trying to connect a site that is already connected using jetpack-connect. We want to return to calypso to manage there the error and being able to show some friendly instructions of what's going on.

ping @roccotripaldi 