### PR TITLE
SSO: Add support for calypso_env

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4546,7 +4546,7 @@ p {
 		}
 
 		if ( isset( $_GET['calypso_env'] ) ) {
-			$url = add_query_arg( 'calypso_env', $_GET['calypso_env'], $url );
+			$url = add_query_arg( 'calypso_env', sanitize_key( $_GET['calypso_env'] ), $url );
 		}
 
 		return $raw ? $url : esc_url( $url );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -823,11 +823,16 @@ class Jetpack_SSO {
 			}
 
 			if ( ! Jetpack::is_user_connected( $user->ID ) ) {
+				$calypso_env = ! empty( $_GET['calypso_env'] )
+					? $_GET['calypso_env']
+					: '';
+
 				wp_safe_redirect(
 					add_query_arg(
 						array(
 							'redirect_to'               => $redirect_to,
 							'request_redirect_to'       => $_request_redirect_to,
+							'calypso_env'               => $calypso_env,
 							'jetpack-sso-auth-redirect' => '1',
 						),
 						admin_url()

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -824,7 +824,7 @@ class Jetpack_SSO {
 
 			if ( ! Jetpack::is_user_connected( $user->ID ) ) {
 				$calypso_env = ! empty( $_GET['calypso_env'] )
-					? $_GET['calypso_env']
+					? sanitize_key( $_GET['calypso_env'] )
 					: '';
 
 				wp_safe_redirect(
@@ -1138,8 +1138,8 @@ class Jetpack_SSO {
 			return;
 		}
 
-		$redirect_to = ! empty( $_GET['redirect_to'] ) ? $_GET['redirect_to'] : admin_url();
-		$request_redirect_to = ! empty( $_GET['request_redirect_to'] ) ? $_GET['request_redirect_to'] : $redirect_to;
+		$redirect_to = ! empty( $_GET['redirect_to'] ) ? esc_url_raw( $_GET['redirect_to'] ) : admin_url();
+		$request_redirect_to = ! empty( $_GET['request_redirect_to'] ) ? esc_url_raw( $_GET['request_redirect_to'] ) : $redirect_to;
 
 		/** This filter is documented in core/src/wp-login.php */
 		$redirect_after_auth = apply_filters( 'login_redirect', $redirect_to, $request_redirect_to, wp_get_current_user() );


### PR DESCRIPTION
Now that we redirect users who do not have a connection to Calypso, we need to be sure to send the user to the correct Calypso environment. This is mainly applicable to testers that are using `wpcalypso` or `development` environments of Calypso.

To test, follow instructions on Automattic/wp-calypso#5364.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

