### PR TITLE
Fix LinkedIn count when using unofficial buttons

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -1,4 +1,5 @@
 /* global WPCOM_sharing_counts, grecaptcha */
+/* jshint unused:false */
 var sharing_js_options;
 if ( sharing_js_options && sharing_js_options.counts ) {
 	var WPCOMSharing = {
@@ -20,7 +21,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 				requests = {
 					// LinkedIn actually gets the share count for both the http and https version automatically -- so we don't need to do extra magic
 					linkedin: [
-							'https://www.linkedin.com/countserv/count/share?format=jsonp&callback=WPCOMSharing.update_linkedin_count&url=' +
+							'https://www.linkedin.com/countserv/count/share?format=jsonp&callback=updateLinkedInCount&url=' +
 							encodeURIComponent( url )
 					],
 					// Pinterest, like LinkedIn, handles share counts for both http and https
@@ -113,6 +114,10 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 		}
 	};
 }
+
+var updateLinkedInCount = function( data ) {
+	WPCOMSharing.update_linkedin_count( data );
+};
 
 (function($){
 	var $body, $sharing_email;


### PR DESCRIPTION
Merges r135817-wpcom.

Steps to reproduce:
* Activate unofficial sharing buttons on a WPCOM or Jetpack blog, including LinkedIn button.
* Share a post to LinkedIn.
* No share counts show up on the LinkedIn button
* Switch to official sharing buttons.
* Share count shows correctly.

See p47NkD-zd-p2 for more info.

Props @dllh for the patch.

Had to add `/* jshint unused:false */` to bypass jshint warning.