### PR TITLE
Add DNT support in stats module

### DIFF
--- a/class.jetpack-dnt.php
+++ b/class.jetpack-dnt.php
@@ -1,0 +1,12 @@
+<?php
+class Jetpack_DNT {
+        static function is_dnt_enabled() {
+                foreach ($_SERVER as $name => $value) {
+                        if ( strtolower( $name ) == 'http_dnt' && $value == 1 ) {
+                                return true;
+                        }
+                }
+
+                return false;
+        }
+}

--- a/jetpack.php
+++ b/jetpack.php
@@ -63,6 +63,7 @@ require_once( JETPACK__PLUGIN_DIR . 'functions.gallery.php'           );
 require_once( JETPACK__PLUGIN_DIR . 'require-lib.php'                 );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php'    );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-tracks.php'        );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-dnt.php'           );
 require_once( JETPACK__PLUGIN_DIR . 'modules/module-headings.php');
 
 if ( is_admin() ) {

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -149,7 +149,9 @@ function stats_template_redirect() {
 	$data = stats_build_view_data();
 	$data_stats_array = stats_array( $data );
 
-	$stats_footer = <<<END
+	// Check if user is requesting DNT.
+	if ( !Jetpack_DNT::is_dnt_enabled() ) {
+		$stats_footer = <<<END
 <script type='text/javascript' src='{$script}' async defer></script>
 <script type='text/javascript'>
 	_stq = window._stq || [];
@@ -158,6 +160,7 @@ function stats_template_redirect() {
 </script>
 
 END;
+	}
 }
 
 function stats_build_view_data() {


### PR DESCRIPTION
Related issue: #727

It adds class Jetpack_DNT and it checks HTTP_DNT in $_SERVER global variable. If client sent DNT: 1, Jetpack_DNT::is_dnt_enabled() returns true, in other cases, it returns false. 

If DNT header is set to 1, modules/stats.php does not add tracking script in $stats_footer.