### PR TITLE
XML-RPC Server: Fixes undefined variable when setting en locale for API

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -406,7 +406,7 @@ class Jetpack_XMLRPC_Server {
 			// .org mo files are named slightly different from .com, and all we have is this the locale -- try to guess them.
 			$new_locale = $locale;
 			if ( strpos( $locale, '-' ) !== false ) {
-				$pieces = explode( '-', $locale );
+				$locale_pieces = explode( '-', $locale );
 				$new_locale = $locale_pieces[0];
 				$new_locale .= ( ! empty( $locale_pieces[1] ) ) ? '_' . strtoupper( $locale_pieces[1] ) : '';
 			} else {


### PR DESCRIPTION
I'm not yet sure how to test this, but today I noticed there was an undefined variable in the `class.jetpack-xmlrpc-server.php` file.

Notice how we try to build `$new_locale` by relying on `$locale_pieces`. But, previously, `$locale_pieces` hadn't been defined.

I believe the original intent was for `$locale` to be `$locale_pieces`, so I updated it to that. I am not yet sure how to test though, so I will mark as "In Progress".
