### PR TITLE
SSO: Fixes undefined redirect variable

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -995,12 +995,12 @@ class Jetpack_SSO {
 	 */
 	function build_reauth_and_sso_url( $args = array() ) {
 		$sso_nonce = ! empty( $args['sso_nonce'] ) ? $args['sso_nonce'] : self::request_initial_nonce();
+		$redirect = $this->build_sso_url( array( 'force_auth' => '1', 'sso_nonce' => $sso_nonce ) );
 
 		if ( is_wp_error( $redirect ) ) {
 			return $redirect;
 		}
 
-		$redirect = $this->build_sso_url( array( 'force_auth' => '1', 'sso_nonce' => $sso_nonce ) );
 		$defaults = array(
 			'action'      => 'jetpack-sso',
 			'site_id'     => Jetpack_Options::get_option( 'id' ),


### PR DESCRIPTION
After logging in via SSO at least one time, you should be shown this UI.

![screen shot 2016-05-16 at 2 33 42 pm](https://cloud.githubusercontent.com/assets/1126811/15301444/52096a1e-1b73-11e6-989b-3aee08298b07.png)

If you click the "Log in with a different WP.com user" link, you likely will get an undefined variable error.

This is because we were checking if `$redirect` was a `WP_Error` before ever trying to get the redirect. 

To test:
- Checkout `fix/sso-undefined-redirect-var` branch
- On a site that is already connected, login via SSO at least once
- Log out
- When logging in again, click "Log in with a different WP.com user" link
- Are you shown a login UI on WordPress.com? If so, good.

cc @lezama for review.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Grunt](http://gruntjs.com/) is installed on your testing environment, run `grunt jshint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

