### PR TITLE
Fallback Admin for noJS or Old WP versions.

### DIFF
--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -1,6 +1,7 @@
 .jp-masthead {
 	background-color: $green-secondary;
 	text-align: center;
+	display: block !important; // Hack for showing what is hidden in _inc/header.php
 
 	@media (max-width: rem( 720px ) ) {
 		padding: 0 rem( 20px );

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -35,3 +35,7 @@
 
 // Page Templates
 @import '../at-a-glance/style';
+
+.jp-masthead, #hide-for-now {
+	display: block !important;
+}

--- a/_inc/footer.php
+++ b/_inc/footer.php
@@ -1,44 +1,16 @@
-	</div><!-- .wrapper -->
-		<div class="footer">
-
-			<nav class="primary nav-horizontal">
-				<div class="a8c-attribution">
-					<span>
-						<?php echo sprintf( __( 'An %s Airline', 'jetpack' ),
-						'<a href="http://automattic.com/" class="a8c-logo" target="_blank">Automattic</a>'
-						); ?>
-					</span>
-				</div>
-			</nav><!-- .primary -->
-
-			<nav class="secondary nav-horizontal">
-				<div class="secondary-footer">
-					<a href="http://jetpack.com" target="_blank">Jetpack <?php echo JETPACK__VERSION; ?></a>
-					<a href="http://wordpress.com/tos/" target="_blank"><?php esc_html_e( 'Terms', 'jetpack' ); ?></a>
-					<a href="http://automattic.com/privacy/" target="_blank"><?php esc_html_e( 'Privacy', 'jetpack' ); ?></a>
-					<?php if ( current_user_can( 'jetpack_manage_modules' ) ) : ?><a href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack-debugger' ) ); ?>" title="<?php esc_attr_e( 'Test your site&#8217;s compatibility with Jetpack.', 'jetpack' ); ?>"><?php _e( 'Debug', 'jetpack' ); ?><?php endif; ?></a>
-					<a href="http://jetpack.com/contact-support/" target="_blank" title="<?php esc_attr_e( 'Contact the Jetpack Happiness Squad.', 'jetpack' ); ?>"><?php _e( 'Support', 'jetpack' ); ?></a>
-					<a href="http://jetpack.com/survey/?rel=<?php echo JETPACK__VERSION; ?>" target="_blank" title="<?php esc_attr_e( 'Take a survey.  Tell us how we&#8217;re doing.', 'jetpack' ); ?>"><?php _e( 'Give Us Feedback', 'jetpack' ); ?></a>
-					<?php if ( Jetpack::is_active() && current_user_can( 'jetpack_disconnect' ) ) : ?>
-						<a href="<?php echo esc_url( Jetpack::admin_url( 'page=my_jetpack#disconnect' ) ); ?>"><?php esc_html_e( 'Disconnect Jetpack', 'jetpack' ); ?></a>
-					<?php endif; ?>
-				</div>
-			</nav><!-- .secondary -->
-		</div><!-- .footer -->
-
-		<div class="modal" aria-labelledby="modal-label">
-			<header>
-				<a href="#" class="close">&times;</a>
-				<ul>
-					<li class="learn-more"><a href="javascript:;" data-tab="learn-more"><?php esc_html_e( 'Learn More', 'jetpack' ); ?></a></li>
-					<li class="config"><a href="javascript:;" data-tab="config"><?php esc_html_e( 'Config', 'jetpack' ); ?></a></li>
-				</ul>
-			</header>
-			<div class="content-container"><div class="content"></div></div>
-		</div>
-		<div class="shade"></div>
-
-	</div><!-- .jp-frame -->
-</div><!-- .jp-content -->
-
-<?php if ( 'jetpack_modules' == $_GET['page'] ) return; ?>
+<div class="jp-footer">
+	<div class="jp-footer__a8c-attr-container">
+		<a href="http://automattic.com" target="_blank">
+			<svg class="jp-footer__a8c-attr" x="0" y="0" viewBox="0 0 935 38.2" enable-background="new 0 0 935 38.2">
+				<path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z"/>
+				<path d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z"/>
+				<path d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z"/>
+			</svg></a>
+	</div>
+	<div class="jp-footer__links">
+		<a href="http://jetpack.com" target="_blank" class="jp-footer__link" title="<?php echo JETPACK__VERSION ?>"><?php echo JETPACK__VERSION ?></a>
+		<a href="http://wordpress.com/tos/" target="_blank" title="WordPress.com Terms of Service" class="jp-footer__link">Terms</a>
+		<a href="http://automattic.com/privacy/" target="_blank" title="Automattic's Privacy Policy" class="jp-footer__link">Privacy</a>
+		<a href="/wp-admin/admin.php?page=jetpack-debugger" title="Test your site’s compatibility with Jetpack." class="jp-footer__link">Debug</a>
+	</div>
+</div>

--- a/_inc/footer.php
+++ b/_inc/footer.php
@@ -8,9 +8,9 @@
 			</svg></a>
 	</div>
 	<div class="jp-footer__links">
-		<a href="http://jetpack.com" target="_blank" class="jp-footer__link" title="<?php echo JETPACK__VERSION ?>"><?php echo JETPACK__VERSION ?></a>
-		<a href="http://wordpress.com/tos/" target="_blank" title="WordPress.com Terms of Service" class="jp-footer__link">Terms</a>
-		<a href="http://automattic.com/privacy/" target="_blank" title="Automattic's Privacy Policy" class="jp-footer__link">Privacy</a>
-		<a href="/wp-admin/admin.php?page=jetpack-debugger" title="Test your site’s compatibility with Jetpack." class="jp-footer__link">Debug</a>
+		<a href="https://jetpack.com" target="_blank" class="jp-footer__link" title="<?php echo JETPACK__VERSION ?>"><?php echo JETPACK__VERSION ?></a>
+		<a href="https://wordpress.com/tos/" target="_blank"><?php esc_html_e( 'Terms', 'jetpack' ); ?></a>
+		<a href="https://automattic.com/privacy/" target="_blank"><?php esc_html_e( 'Privacy', 'jetpack' ); ?></a>
+		<?php if ( current_user_can( 'jetpack_manage_modules' ) ) : ?><a href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack-debugger' ) ); ?>" title="<?php esc_attr_e( 'Test your site&#8217;s compatibility with Jetpack.', 'jetpack' ); ?>"><?php _e( 'Debug', 'jetpack' ); ?><?php endif; ?></a>
 	</div>
 </div>

--- a/_inc/header.php
+++ b/_inc/header.php
@@ -1,5 +1,5 @@
 <?php $current = $_GET['page']; ?>
-<div class="jp-masthead">
+<div class="jp-masthead" style="display: none;">
 	<div class="jp-masthead__inside-container">
 		<div class="jp-masthead__logo-container">
 			<svg class="jp-masthead__logo" x="0" y="0" viewBox="0 0 183 32" enable-background="new 0 0 183 32">

--- a/_inc/header.php
+++ b/_inc/header.php
@@ -1,29 +1,15 @@
 <?php $current = $_GET['page']; ?>
-<div class="jp-content">
-	<div class="jp-frame">
-		<div class="header">
-			<nav role="navigation" class="header-nav drawer-nav nav-horizontal">
+<div class="jp-masthead">
+	<div class="jp-masthead__inside-container">
+		<div class="jp-masthead__logo-container">
+			<svg class="jp-masthead__logo" x="0" y="0" viewBox="0 0 183 32" enable-background="new 0 0 183 32">
+				<path d="M54 10.9v4.8 2.6c0 2.2-0.5 4.3-1.5 5.4 -1.3 1.4-3.3 1.9-5.5 1.9 -3.4 0-5.9-2.6-6-2.7l2-4c0.2 0.2 0.7 1.1 2 1.7 1.2 0.6 2.2 0.8 3 0.3 0.8-0.5 1-2 1-3v-6.1L44 7h6C52.2 7 54 8.7 54 10.9zM81 10.9h5V25h5V10.9h5V7H81V10.9zM115 8.9c1.1 1.1 2 2.8 2 4.6 0 2.1-1 3.8-2.2 4.9 -1.2 1.1-3 1.6-5.1 1.6h-2.6v5H102V7h7.8C112.1 7 113.8 7.7 115 8.9zM112.4 13.4c0-0.9-0.6-1.5-1-1.9 -0.6-0.5-1.4-0.6-2.1-0.6h-2.3V16h2.3c0.7 0 1.4-0.1 2-0.5C111.8 15.1 112.4 14.4 112.4 13.4zM135.8 8.9c1.4 1.4 2.1 3.5 2.1 5.4V25h-5v-5h-6v5h-5V14.3c0-1.9 0.7-4 2.1-5.4 1.3-1.3 3.4-2.4 5.9-2.4C132.5 6.5 134.6 7.7 135.8 8.9zM132.5 12c-0.7-0.7-1.6-1-2.5-1 -0.9 0-1.9 0.3-2.5 1 -0.5 0.6-0.5 1.5-0.5 2.6V16h6v-1.4C132.9 13.5 133 12.6 132.5 12zM61.1 25H75v-3.9h-9v-3.2h7V14h-7v-3.1h9V7H61.1V25zM157.6 20c-0.1 0-0.2 0.1-0.3 0.1 0 0 0 0 0 0 -1 0.5-2.1 0.8-3.4 0.8 -1.5 0-2.9-0.5-3.8-1.5 -1-0.9-1.5-2.2-1.5-3.8 0-1.3 0.5-2.5 1.2-3.4 0.9-1.1 2.3-1.8 4.1-1.8 1 0 1.8 0.2 2.7 0.5 0 0 0.1 0 0.2 0.1 0.1 0 0.2 0.1 0.3 0.1 0 0 0.1 0 0.1 0.1 0.1 0 0.1 0.1 0.2 0.1 0.2 0.1 0.4 0.2 0.6 0.3l1.7-3.6c-0.3-0.2-0.7-0.4-1.1-0.6 -1.3-0.6-2.8-1-4.9-1 -2.8 0-5.5 1.2-7.3 3.1 -1.5 1.6-2.4 3.7-2.4 6.1 0 2.9 1.1 5.2 2.8 6.8 1.7 1.6 4.1 2.5 6.9 2.5 2.3 0 4-0.5 5.4-1.3 0 0 0.1 0 0.1 0 0 0 0 0 0 0 0.2-0.1 0.5-0.3 0.7-0.4l-1.8-3.6C157.9 19.8 157.7 19.9 157.6 20zM182 7h-5.8l-5.2 5.7V7h-3v0h-2v18h2 2.4 0.6v-6.5l0.5-0.5 5.3 7h5.2l-7.5-10.1L182 7zM32 16c0 8.8-7.2 16-16 16S0 24.8 0 16C0 7.2 7.2 0 16 0S32 7.2 32 16zM15 4.7L8.7 15.5c-0.7 1.1 0 2.6 1.2 2.9l5 1.3V4.7zM22 13.5l-5-1.3v15l6.3-10.8C23.9 15.3 23.3 13.9 22 13.5z"/>
+			</svg>
+		</div>
 
-				<ul class="main-nav">
-					<li class="jetpack-logo"><a href="<?php echo Jetpack::admin_url(); ?>" title="<?php esc_attr_e( 'Jetpack', 'jetpack' ); ?>" <?php if ( 'jetpack' == $current ) { echo 'class="current"'; } ?>><span><?php esc_html_e( 'Jetpack', 'jetpack' ); ?></span></a></li>
-					<?php if ( ( Jetpack::is_active() || Jetpack::is_development_mode() ) && current_user_can( 'jetpack_manage_modules' ) ) : ?>
-						<li class="jetpack-modules">
-							<a href="<?php echo Jetpack::admin_url( 'page=jetpack_modules' ); ?>" class="jp-button--settings <?php if ( 'jetpack_modules' == $current ) { echo 'current'; } ?>"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a>
-						</li>
-						<li class="jetpack-modules">
-							<a href="http://jetpack.com/survey/?rel=<?php echo JETPACK__VERSION; ?>" target="_blank" class="jp-button--settings"><?php esc_html_e( 'Feedback', 'jetpack' ); ?></a>
-						</li>
-					<?php endif; // End if connected or dev mode and is admin ?>
-
-					<?php if ( Jetpack::is_active() && ! Jetpack::is_development_mode() ) : ?>
-						<li class="jetpack-modules">
-							<a href="<?php echo Jetpack::admin_url( 'page=my_jetpack' ); ?>" class="jp-button--settings <?php if ( 'my_jetpack' == $current ) { echo 'current'; } ?>"><?php esc_html_e( 'My Jetpack', 'jetpack' ); ?></a>
-						</li>
-					<?php endif; ?>
-				</ul>
-
-			</nav>
-		</div><!-- .header -->
-		<div class="wrapper">
-			<div class="clouds-sm"></div>
-			<div class="wrap configure-module">
+		<ul class="jp-masthead__links">
+			<li><a href="http://jetpack.com/support/" target="_blank" class="jp-masthead__link"><span class="dashicons dashicons-editor-help" title="Need Help?"></span><span>Need Help?</span></a></li>
+			<li><a href="http://surveys.jetpack.me/research-plugin?rel=3.9.4" target="_blank" class="jp-masthead__link"><span className="dashicons dashicons-admin-comments" title="Send us Feedback"></span><span>Send us Feedback</span></a></li>
+		</ul>
+	</div>
+</div>

--- a/_inc/header.php
+++ b/_inc/header.php
@@ -8,8 +8,18 @@
 		</div>
 
 		<ul class="jp-masthead__links">
-			<li><a href="http://jetpack.com/support/" target="_blank" class="jp-masthead__link"><span class="dashicons dashicons-editor-help" title="Need Help?"></span><span>Need Help?</span></a></li>
-			<li><a href="http://surveys.jetpack.me/research-plugin?rel=3.9.4" target="_blank" class="jp-masthead__link"><span className="dashicons dashicons-admin-comments" title="Send us Feedback"></span><span>Send us Feedback</span></a></li>
+			<li>
+				<a href="http://jetpack.com/support/" target="_blank" class="jp-masthead__link">
+					<span class="dashicons dashicons-editor-help" title="<?php esc_attr_e( 'Need Help?', 'jetpack' ); ?>"></span>
+					<span><?php _e( 'Need Help?', 'jetpack' ); ?></span>
+				</a>
+			</li>
+			<li>
+				<a href="http://surveys.jetpack.me/research-plugin?rel=<?php echo esc_attr( JETPACK__VERSION ); ?>" target="_blank" class="jp-masthead__link">
+					<span className="dashicons dashicons-admin-comments" title="<?php esc_attr_e( 'Send us Feedback', 'jetpack' ); ?>"></span>
+					<span><?php esc_attr_e( 'Send us Feedback', 'jetpack' ); ?></span>
+				</a>
+			</li>
 		</ul>
 	</div>
 </div>

--- a/_inc/header.php
+++ b/_inc/header.php
@@ -25,3 +25,5 @@
 			</nav>
 		</div><!-- .header -->
 		<div class="wrapper">
+			<div class="clouds-sm"></div>
+			<div class="wrap configure-module">

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -63,9 +63,7 @@ abstract class Jetpack_Admin_Page {
 	// Render the page with a common top and bottom part, and page specific
 	// content
 	function render() {
-//		$this->admin_page_top();
 		$this->page_render();
-//		$this->admin_page_bottom();
 	}
 
 	function admin_help() {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -57,7 +57,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	// screen if the module is not configurable
 	// @todo remove when real settings are in place
 	function render_nojs_configurable() {
-		include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' );
 		echo '<div class="clouds-sm"></div>';
 		echo '<div class="wrap configure-module">';
 
@@ -74,15 +73,15 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	function page_render() {
 		// Handle redirects to configuration pages
 		if ( ! empty( $_GET['configure'] ) ) {
-			return $this->render_nojs_configurable();
+			include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' );
+			$this->render_nojs_configurable();
 		}
-		?>
-		<?php
-			/** This action is already documented in views/admin/admin-page.php */
-			do_action( 'jetpack_notices' );
-		?>
-		<div id="jp-plugin-container"></div>
-	<?php }
+
+		/** This action is already documented in views/admin/admin-page.php */
+		do_action( 'jetpack_notices' );
+
+		?> <div id="jp-plugin-container"></div> <?php
+	}
 
 	function get_i18n_data() {
 		$locale_data = @file_get_contents( JETPACK__PLUGIN_DIR . '/languages/json/jetpack-' . get_locale() . '.json' );
@@ -113,6 +112,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	function page_admin_scripts() {
+		if ( true !== jetpack_can_load_react_page() ) {
+			return;
+		}
+
 		// Enqueue jp.js and localize it
 		wp_enqueue_script( 'react-plugin', plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ), array(), time(), true );
 		wp_enqueue_style( 'dops-css', plugins_url( '_inc/build/dops-style.css', JETPACK__PLUGIN_FILE ), array(), time() );
@@ -156,6 +159,23 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'localeSlug' => $localeSlug,
 		) );
 	}
+}
+
+/*
+ * We will render a "basic", non-js page if any of the following:
+ *
+ * - WP version <= 4.4
+ * - JavaScript disabled
+ *
+ * @return mixed |
+ */
+function jetpack_can_load_react_page() {
+	global $wp_version;
+	if ( version_compare( $wp_version, '4.4-z', '<=' ) ) {
+		return true;
+	}
+
+	return true;
 }
 
 function build_initial_stats_shape() {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -57,30 +57,33 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	// screen if the module is not configurable
 	// @todo remove when real settings are in place
 	function render_nojs_configurable() {
-		echo '<div class="clouds-sm"></div>';
-		echo '<div class="wrap configure-module">';
+		include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' );
+		$configure = empty( $_GET['configure'] ) ? 'all' : $_GET['configure'];
+		$module_name = preg_replace( '/[^\da-z\-]+/', '', $configure );
 
-		$module_name = preg_replace( '/[^\da-z\-]+/', '', $_GET['configure'] );
-		if ( Jetpack::is_module( $module_name ) && current_user_can( 'jetpack_configure_modules' ) ) {
+		if ( 'all' === $module_name ) {
+			include_once( 'jetpack-admin-unsupported.php' );
+		} else if ( Jetpack::is_module( $module_name ) && current_user_can( 'jetpack_configure_modules' ) ) {
 			Jetpack::admin_screen_configure_module( $module_name );
 		} else {
 			echo '<h2>' . esc_html__( 'Error, bad module.', 'jetpack' ) . '</h2>';
 		}
 
 		echo '</div><!-- /wrap -->';
+
+		include_once( JETPACK__PLUGIN_DIR . '_inc/footer.php' );
 	}
 
 	function page_render() {
-		// Handle redirects to configuration pages
-		if ( ! empty( $_GET['configure'] ) ) {
-			include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' );
-			$this->render_nojs_configurable();
+		if ( empty( $_GET['configure'] ) && jetpack_can_load_react_page() ) {
+			?><div id="jp-plugin-container"></div><?php
+			return;
 		}
+
+		$this->render_nojs_configurable();
 
 		/** This action is already documented in views/admin/admin-page.php */
 		do_action( 'jetpack_notices' );
-
-		?> <div id="jp-plugin-container"></div> <?php
 	}
 
 	function get_i18n_data() {
@@ -112,7 +115,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	function page_admin_scripts() {
-		if ( true !== jetpack_can_load_react_page() ) {
+		if ( ! jetpack_can_load_react_page() ) {
 			return;
 		}
 
@@ -172,10 +175,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 function jetpack_can_load_react_page() {
 	global $wp_version;
 	if ( version_compare( $wp_version, '4.4-z', '<=' ) ) {
-		return true;
+		return false;
 	}
 
-	return true;
+	return false;
 }
 
 function build_initial_stats_shape() {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -61,7 +61,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 	function maybe_render_nojs() { ?>
 		<div id="show-if-no-js" style="display: block;">
-			<?php $this->render_old_admin(); ?>
+			<div id="hide-for-now" style="display: none;" >
+				<?php $this->render_old_admin(); ?>
+			</div>
 		</div>
 		<script>document.getElementById( 'show-if-no-js' ).style.display='none';</script>
 	<?php }
@@ -69,6 +71,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	function page_render() {
 		if ( wp_version_too_old() || isset( $_GET[ 'configure' ] ) ) {
 			$this->render_old_admin();
+			return;
 		} ?>
 
 		<div id="jp-plugin-container" class="hide-if-no-js"></div>

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -57,7 +57,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	// screen if the module is not configurable
 	// @todo remove when real settings are in place
 	function render_nojs_configurable() {
-		include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' );
 		$configure = empty( $_GET['configure'] ) ? 'all' : $_GET['configure'];
 		$module_name = preg_replace( '/[^\da-z\-]+/', '', $configure );
 
@@ -70,15 +69,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		}
 
 		echo '</div><!-- /wrap -->';
-
-		include_once( JETPACK__PLUGIN_DIR . '_inc/footer.php' );
 	}
 
 	function page_render() {
-		if ( empty( $_GET['configure'] ) && jetpack_can_load_react_page() ) {
-			?><div id="jp-plugin-container"></div><?php
-			return;
-		}
+		if ( empty( $_GET['configure'] ) && ! wp_version_too_old() ) { ?>
+			<div id="jp-plugin-container" class="hide-if-no-js"></div>
+		<?php }
 
 		$this->render_nojs_configurable();
 
@@ -115,7 +111,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	function page_admin_scripts() {
-		if ( ! jetpack_can_load_react_page() ) {
+		if ( wp_version_too_old() ) {
 			return;
 		}
 
@@ -172,13 +168,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
  *
  * @return mixed |
  */
-function jetpack_can_load_react_page() {
+function wp_version_too_old() {
 	global $wp_version;
-	if ( version_compare( $wp_version, '4.4-z', '<=' ) ) {
-		return false;
-	}
-
 	return false;
+	return version_compare( $wp_version, '4.4-z', '<=' );
 }
 
 function build_initial_stats_shape() {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -53,7 +53,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		return $jp_menu_order;
 	}
 
-	function render_old_admin() {
+	function render_old_admin(  ) {
 		include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' );
 		include_once( 'jetpack-admin-unsupported.php' );
 		include_once( JETPACK__PLUGIN_DIR . '_inc/footer.php' );
@@ -66,7 +66,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	function page_render() {
-		if ( wp_version_too_old() ) {
+		if ( wp_version_too_old() || isset( $_GET[ 'configure' ] ) ) {
 			$this->render_old_admin();
 		}
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -59,20 +59,21 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		include_once( JETPACK__PLUGIN_DIR . '_inc/footer.php' );
 	}
 
-	function maybe_render_nojs() {
-		echo '<noscript>';
-		$this->render_old_admin();
-		echo '</noscript>';
-	}
+	function maybe_render_nojs() { ?>
+		<div id="show-if-no-js" style="display: block;">
+			<?php $this->render_old_admin(); ?>
+		</div>
+		<script>document.getElementById( 'show-if-no-js' ).style.display='none';</script>
+	<?php }
 
 	function page_render() {
 		if ( wp_version_too_old() || isset( $_GET[ 'configure' ] ) ) {
 			$this->render_old_admin();
-		}
+		} ?>
 
-		?><div id="jp-plugin-container"></div><?php
+		<div id="jp-plugin-container" class="hide-if-no-js"></div>
 
-		$this->maybe_render_nojs();
+		<?php $this->maybe_render_nojs();
 
 		/** This action is already documented in views/admin/admin-page.php */
 		do_action( 'jetpack_notices' );

--- a/_inc/lib/admin-pages/jetpack-admin-unsupported.php
+++ b/_inc/lib/admin-pages/jetpack-admin-unsupported.php
@@ -14,6 +14,10 @@
 	if ( wp_version_too_old() ) {
 		echo 'Update WordPress to unlock Jetpack\'s full potential!';
 	}
+
+	if ( maybe_load_old_jetpack_config_page() ) {
+		return;
+	}
 ?>
 	<noscript>
 		<p>Turn on Javascript to unlock Jetpack's full potential!</p>

--- a/_inc/lib/admin-pages/jetpack-admin-unsupported.php
+++ b/_inc/lib/admin-pages/jetpack-admin-unsupported.php
@@ -11,10 +11,13 @@
 	include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
 	$list_table = new Jetpack_Modules_List_Table;
 
-	if ( maybe_load_old_jetpack_config_page() ) {
-		return;
+	if ( wp_version_too_old() ) {
+		echo 'Update WordPress to unlock Jetpack\'s full potential!';
 	}
 ?>
+	<noscript>
+		<p>Turn on Javascript to unlock Jetpack's full potential!</p>
+	</noscript>
 	<div class="page-content configure">
 		<div class="frame bottom">
 			<div class="wrap">

--- a/_inc/lib/admin-pages/jetpack-admin-unsupported.php
+++ b/_inc/lib/admin-pages/jetpack-admin-unsupported.php
@@ -13,7 +13,14 @@ include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
 $list_table = new Jetpack_Modules_List_Table;
 
 if ( wp_version_too_old() ) {
-	echo 'Update WordPress to unlock Jetpack\'s full potential!';
+	?>
+	<div id="message" class="jetpack-message jetpack-err">
+		<div class="squeezer">
+			<h2><?php esc_html_e( 'You are using an outdated version of WordPress', 'jetpack' ); ?></h2>
+			<p><?php esc_html_e( "Update WordPress to unlock Jetpack's full potential!", 'jetpack' ); ?></p>
+		</div>
+	</div>
+	<?php
 }
 
 if ( maybe_load_old_jetpack_config_page() ) {

--- a/_inc/lib/admin-pages/jetpack-admin-unsupported.php
+++ b/_inc/lib/admin-pages/jetpack-admin-unsupported.php
@@ -5,66 +5,28 @@
  * Renders the module list table where you can use bulk action or row
  * actions to activate/deactivate and configure modules
  */
-
-include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
-$list_table = new Jetpack_Modules_List_Table;
-?>
-<?php /** This action is already documented in views/admin/admin-page.php */
-do_action( 'jetpack_notices' ) ?>
-<div class="page-content configure">
-	<div class="frame top hide-if-no-js">
-		<div class="wrap">
-			<div class="manage-left">
-				<table class="table table-bordered fixed-top">
-					<thead>
-					<tr>
-						<th class="check-column"><input type="checkbox" class="checkall"></th>
-						<th colspan="2">
-							<?php $list_table->unprotected_display_tablenav( 'top' ); ?>
-							<span class="filter-search">
-								<button type="button" class="button">Filter</button>
-							</span>
-						</th>
-					</tr>
-					</thead>
-				</table>
-			</div>
-		</div><!-- /.wrap -->
-	</div><!-- /.frame -->
-	<div class="frame bottom">
-		<div class="wrap">
-			<div class="manage-right">
-				<div class="bumper">
-					<form class="navbar-form" role="search">
-						<input type="hidden" name="page" value="jetpack_modules" />
-						<?php $list_table->search_box( __( 'Search', 'jetpack' ), 'srch-term' ); ?>
-						<p><?php esc_html_e( 'View:', 'jetpack' ); ?></p>
-						<div class="button-group filter-active">
-							<button type="button" class="button <?php if ( empty( $_GET['activated'] ) ) echo 'active'; ?>"><?php esc_html_e( 'All', 'jetpack' ); ?></button>
-							<button type="button" class="button <?php if ( ! empty( $_GET['activated'] ) && 'true' == $_GET['activated'] ) echo 'active'; ?>" data-filter-by="activated" data-filter-value="true"><?php esc_html_e( 'Active', 'jetpack' ); ?></button>
-							<button type="button" class="button <?php if ( ! empty( $_GET['activated'] ) && 'false' == $_GET['activated'] ) echo 'active'; ?>" data-filter-by="activated" data-filter-value="false"><?php esc_html_e( 'Inactive', 'jetpack' ); ?></button>
-						</div>
-						<p><?php esc_html_e( 'Sort by:', 'jetpack' ); ?></p>
-						<div class="button-group sort">
-							<button type="button" class="button <?php if ( empty( $_GET['sort_by'] ) ) echo 'active'; ?>" data-sort-by="name"><?php esc_html_e( 'Alphabetical', 'jetpack' ); ?></button>
-							<button type="button" class="button <?php if ( ! empty( $_GET['sort_by'] ) && 'introduced' == $_GET['sort_by'] ) echo 'active'; ?>" data-sort-by="introduced" data-sort-order="reverse"><?php esc_html_e( 'Newest', 'jetpack' ); ?></button>
-							<button type="button" class="button <?php if ( ! empty( $_GET['sort_by'] ) && 'sort' == $_GET['sort_by'] ) echo 'active'; ?>" data-sort-by="sort"><?php esc_html_e( 'Popular', 'jetpack' ); ?></button>
-						</div>
-						<p><?php esc_html_e( 'Show:', 'jetpack' ); ?></p>
-						<?php $list_table->views(); ?>
+include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' ); ?>
+<noscript>
+	<?php /** This action is already documented in views/admin/admin-page.php */
+		do_action( 'jetpack_notices' );
+		include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
+		$list_table = new Jetpack_Modules_List_Table;
+	?>
+	<div class="page-content configure">
+		<div class="frame bottom">
+			<div class="wrap">
+				<div class="manage-left">
+					<form class="jetpack-modules-list-table-form" onsubmit="return false;">
+						<table class="<?php echo implode( ' ', $list_table->get_table_classes() ); ?>">
+							<tbody id="the-list">
+							<?php $list_table->display_rows_or_placeholder(); ?>
+							</tbody>
+						</table>
 					</form>
 				</div>
-			</div>
-			<div class="manage-left">
-				<form class="jetpack-modules-list-table-form" onsubmit="return false;">
-					<table class="<?php echo implode( ' ', $list_table->get_table_classes() ); ?>">
-						<tbody id="the-list">
-						<?php $list_table->display_rows_or_placeholder(); ?>
-						</tbody>
-					</table>
-				</form>
-			</div>
-		</div><!-- /.wrap -->
-	</div><!-- /.frame -->
-</div><!-- /.content -->
+			</div><!-- /.wrap -->
+		</div><!-- /.frame -->
+	</div><!-- /.content -->
+</noscript>
+<?php include_once( JETPACK__PLUGIN_DIR . '_inc/footer.php' ); ?>
 

--- a/_inc/lib/admin-pages/jetpack-admin-unsupported.php
+++ b/_inc/lib/admin-pages/jetpack-admin-unsupported.php
@@ -5,22 +5,23 @@
  * Renders the module list table where you can use bulk action or row
  * actions to activate/deactivate and configure modules
  */
-?>
-<?php /** This action is already documented in views/admin/admin-page.php */
-	do_action( 'jetpack_notices' );
-	include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
-	$list_table = new Jetpack_Modules_List_Table;
 
-	if ( wp_version_too_old() ) {
-		echo 'Update WordPress to unlock Jetpack\'s full potential!';
-	}
+/** This action is already documented in views/admin/admin-page.php */
+do_action( 'jetpack_notices' );
 
-	if ( maybe_load_old_jetpack_config_page() ) {
-		return;
-	}
+include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
+$list_table = new Jetpack_Modules_List_Table;
+
+if ( wp_version_too_old() ) {
+	echo 'Update WordPress to unlock Jetpack\'s full potential!';
+}
+
+if ( maybe_load_old_jetpack_config_page() ) {
+	return;
+}
 ?>
 	<noscript>
-		<p>Turn on Javascript to unlock Jetpack's full potential!</p>
+		<p><?php esc_html_e( "Turn on JavaScript to unlock Jetpack's full potential!" ) ?></p>
 	</noscript>
 	<div class="page-content configure">
 		<div class="frame bottom">

--- a/_inc/lib/admin-pages/jetpack-admin-unsupported.php
+++ b/_inc/lib/admin-pages/jetpack-admin-unsupported.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * No-JS and unsupported WP versions view.
+ *
+ * Renders the module list table where you can use bulk action or row
+ * actions to activate/deactivate and configure modules
+ */
+
+include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
+$list_table = new Jetpack_Modules_List_Table;
+?>
+<?php /** This action is already documented in views/admin/admin-page.php */
+do_action( 'jetpack_notices' ) ?>
+<div class="page-content configure">
+	<div class="frame top hide-if-no-js">
+		<div class="wrap">
+			<div class="manage-left">
+				<table class="table table-bordered fixed-top">
+					<thead>
+					<tr>
+						<th class="check-column"><input type="checkbox" class="checkall"></th>
+						<th colspan="2">
+							<?php $list_table->unprotected_display_tablenav( 'top' ); ?>
+							<span class="filter-search">
+								<button type="button" class="button">Filter</button>
+							</span>
+						</th>
+					</tr>
+					</thead>
+				</table>
+			</div>
+		</div><!-- /.wrap -->
+	</div><!-- /.frame -->
+	<div class="frame bottom">
+		<div class="wrap">
+			<div class="manage-right">
+				<div class="bumper">
+					<form class="navbar-form" role="search">
+						<input type="hidden" name="page" value="jetpack_modules" />
+						<?php $list_table->search_box( __( 'Search', 'jetpack' ), 'srch-term' ); ?>
+						<p><?php esc_html_e( 'View:', 'jetpack' ); ?></p>
+						<div class="button-group filter-active">
+							<button type="button" class="button <?php if ( empty( $_GET['activated'] ) ) echo 'active'; ?>"><?php esc_html_e( 'All', 'jetpack' ); ?></button>
+							<button type="button" class="button <?php if ( ! empty( $_GET['activated'] ) && 'true' == $_GET['activated'] ) echo 'active'; ?>" data-filter-by="activated" data-filter-value="true"><?php esc_html_e( 'Active', 'jetpack' ); ?></button>
+							<button type="button" class="button <?php if ( ! empty( $_GET['activated'] ) && 'false' == $_GET['activated'] ) echo 'active'; ?>" data-filter-by="activated" data-filter-value="false"><?php esc_html_e( 'Inactive', 'jetpack' ); ?></button>
+						</div>
+						<p><?php esc_html_e( 'Sort by:', 'jetpack' ); ?></p>
+						<div class="button-group sort">
+							<button type="button" class="button <?php if ( empty( $_GET['sort_by'] ) ) echo 'active'; ?>" data-sort-by="name"><?php esc_html_e( 'Alphabetical', 'jetpack' ); ?></button>
+							<button type="button" class="button <?php if ( ! empty( $_GET['sort_by'] ) && 'introduced' == $_GET['sort_by'] ) echo 'active'; ?>" data-sort-by="introduced" data-sort-order="reverse"><?php esc_html_e( 'Newest', 'jetpack' ); ?></button>
+							<button type="button" class="button <?php if ( ! empty( $_GET['sort_by'] ) && 'sort' == $_GET['sort_by'] ) echo 'active'; ?>" data-sort-by="sort"><?php esc_html_e( 'Popular', 'jetpack' ); ?></button>
+						</div>
+						<p><?php esc_html_e( 'Show:', 'jetpack' ); ?></p>
+						<?php $list_table->views(); ?>
+					</form>
+				</div>
+			</div>
+			<div class="manage-left">
+				<form class="jetpack-modules-list-table-form" onsubmit="return false;">
+					<table class="<?php echo implode( ' ', $list_table->get_table_classes() ); ?>">
+						<tbody id="the-list">
+						<?php $list_table->display_rows_or_placeholder(); ?>
+						</tbody>
+					</table>
+				</form>
+			</div>
+		</div><!-- /.wrap -->
+	</div><!-- /.frame -->
+</div><!-- /.content -->
+

--- a/_inc/lib/admin-pages/jetpack-admin-unsupported.php
+++ b/_inc/lib/admin-pages/jetpack-admin-unsupported.php
@@ -5,13 +5,16 @@
  * Renders the module list table where you can use bulk action or row
  * actions to activate/deactivate and configure modules
  */
-include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' ); ?>
-<noscript>
-	<?php /** This action is already documented in views/admin/admin-page.php */
-		do_action( 'jetpack_notices' );
-		include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
-		$list_table = new Jetpack_Modules_List_Table;
-	?>
+?>
+<?php /** This action is already documented in views/admin/admin-page.php */
+	do_action( 'jetpack_notices' );
+	include_once( JETPACK__PLUGIN_DIR . 'class.jetpack-modules-list-table.php' );
+	$list_table = new Jetpack_Modules_List_Table;
+
+	if ( maybe_load_old_jetpack_config_page() ) {
+		return;
+	}
+?>
 	<div class="page-content configure">
 		<div class="frame bottom">
 			<div class="wrap">
@@ -27,6 +30,16 @@ include_once( JETPACK__PLUGIN_DIR . '_inc/header.php' ); ?>
 			</div><!-- /.wrap -->
 		</div><!-- /.frame -->
 	</div><!-- /.content -->
-</noscript>
-<?php include_once( JETPACK__PLUGIN_DIR . '_inc/footer.php' ); ?>
 
+<?php
+
+function maybe_load_old_jetpack_config_page() {
+	$configure = empty( $_GET['configure'] ) ? 'all' : $_GET['configure'];
+	$module_name = preg_replace( '/[^\da-z\-]+/', '', $configure );
+	if ( Jetpack::is_module( $module_name ) && current_user_can( 'jetpack_configure_modules' ) ) {
+		Jetpack::admin_screen_configure_module( $module_name );
+		return true;
+	}
+
+	return false;
+}

--- a/_inc/lib/admin-pages/jetpack-admin-unsupported.php
+++ b/_inc/lib/admin-pages/jetpack-admin-unsupported.php
@@ -21,7 +21,12 @@ if ( maybe_load_old_jetpack_config_page() ) {
 }
 ?>
 	<noscript>
-		<p><?php esc_html_e( "Turn on JavaScript to unlock Jetpack's full potential!" ) ?></p>
+		<div id="message" class="jetpack-message jetpack-err">
+			<div class="squeezer">
+				<h2><?php esc_html_e( 'You have JavaScript disabled', 'jetpack' ); ?></h2>
+				<p><?php esc_html_e( "Turn on JavaScript to unlock Jetpack's full potential!", 'jetpack' ); ?></p>
+			</div>
+		</div>
 	</noscript>
 	<div class="page-content configure">
 		<div class="frame bottom">

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -12,17 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// This would fatal on versions below WP 4.4
-global $wp_version;
-if ( ! function_exists( 'rest_api_init' ) || version_compare( $wp_version, '4.4-z', '<=' ) ) {
-	wp_die( __( 'Minimum WordPress version 4.4 required to unlock the power of the WP REST API', 'jetpack' ) );
-}
-
 // Load WP_Error for error messages.
 require_once ABSPATH . '/wp-includes/class-wp-error.php';
-
-// Register endpoints when WP REST API is initialized.
-add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register_endpoints' ) );
 
 /**
  * Class Jetpack_Core_Json_Api_Endpoints
@@ -32,6 +23,21 @@ add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register
 class Jetpack_Core_Json_Api_Endpoints {
 
 	public static $user_permissions_error_msg;
+
+	/**
+	 * WordPress REST API is only available starting with version 4.4, so we don't do anything
+	 * if the current installation is older than that.
+	 */
+	public static function init() {
+		global $wp_version;
+		if ( ! function_exists( 'rest_api_init' ) || version_compare( $wp_version, '4.4-z', '<=' ) ) {
+
+			return;
+		}
+
+		// Register endpoints when WP REST API is initialized.
+		add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register_endpoints' ) );
+	}
 
 	function __construct() {
 		self::$user_permissions_error_msg = esc_html__(
@@ -2475,3 +2481,5 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 } // class end
+
+Jetpack_Core_Json_Api_Endpoints::init();

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -12,6 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// This would fatal on versions below WP 4.4
+global $wp_version;
+if ( ! function_exists( 'rest_api_init' ) || version_compare( $wp_version, '4.4-z', '<=' ) ) {
+	wp_die( __( 'Minimum WordPress version 4.4 required to unlock the power of the WP REST API', 'jetpack' ) );
+}
+
 // Load WP_Error for error messages.
 require_once ABSPATH . '/wp-includes/class-wp-error.php';
 

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -27,45 +27,45 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		 */
 		$this->items = apply_filters( 'jetpack_modules_list_table_items', $this->items );
 		$this->_column_headers = array( $this->get_columns(), array(), array(), 'name' );
-		$modal_info = isset( $_GET['info'] ) ? $_GET['info'] : false;
+//		$modal_info = isset( $_GET['info'] ) ? $_GET['info'] : false;
 
-		wp_register_script(
-			'models.jetpack-modules',
-			plugins_url( '_inc/jetpack-modules.models.js', JETPACK__PLUGIN_FILE ),
-			array( 'backbone', 'underscore' ),
-			JETPACK__VERSION
-		);
-		wp_register_script(
-			'views.jetpack-modules',
-			plugins_url( '_inc/jetpack-modules.views.js', JETPACK__PLUGIN_FILE ),
-			array( 'backbone', 'underscore', 'wp-util' ),
-			JETPACK__VERSION
-		);
-		wp_register_script(
-			'jetpack-modules-list-table',
-			plugins_url( '_inc/jetpack-modules.js', JETPACK__PLUGIN_FILE ),
-			array(
-				'views.jetpack-modules',
-				'models.jetpack-modules',
-				'jquery',
-			),
-			JETPACK__VERSION,
-			true
-		);
-
-		wp_localize_script( 'jetpack-modules-list-table', 'jetpackModulesData', array(
-			'modules' => Jetpack::get_translated_modules( $this->all_items ),
-			'i18n'    => array(
-				'search_placeholder' => __( 'Search Modules…', 'jetpack' ),
-			),
-			'modalinfo' => $this->module_info_check( $modal_info, $this->all_items ),
-			'nonces'  => array(
-				'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
-			),
-			'coreIconAvailable' => Jetpack::jetpack_site_icon_available_in_core(),
-		) );
-
-		wp_enqueue_script( 'jetpack-modules-list-table' );
+//		wp_register_script(
+//			'models.jetpack-modules',
+//			plugins_url( '_inc/jetpack-modules.models.js', JETPACK__PLUGIN_FILE ),
+//			array( 'backbone', 'underscore' ),
+//			JETPACK__VERSION
+//		);
+//		wp_register_script(
+//			'views.jetpack-modules',
+//			plugins_url( '_inc/jetpack-modules.views.js', JETPACK__PLUGIN_FILE ),
+//			array( 'backbone', 'underscore', 'wp-util' ),
+//			JETPACK__VERSION
+//		);
+//		wp_register_script(
+//			'jetpack-modules-list-table',
+//			plugins_url( '_inc/jetpack-modules.js', JETPACK__PLUGIN_FILE ),
+//			array(
+//				'views.jetpack-modules',
+//				'models.jetpack-modules',
+//				'jquery',
+//			),
+//			JETPACK__VERSION,
+//			true
+//		);
+//
+//		wp_localize_script( 'jetpack-modules-list-table', 'jetpackModulesData', array(
+//			'modules' => Jetpack::get_translated_modules( $this->all_items ),
+//			'i18n'    => array(
+//				'search_placeholder' => __( 'Search Modules…', 'jetpack' ),
+//			),
+//			'modalinfo' => $this->module_info_check( $modal_info, $this->all_items ),
+//			'nonces'  => array(
+//				'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
+//			),
+//			'coreIconAvailable' => Jetpack::jetpack_site_icon_available_in_core(),
+//		) );
+//
+//		wp_enqueue_script( 'jetpack-modules-list-table' );
 
 		/**
 		 * Filters the js_templates callback value.
@@ -74,9 +74,10 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		 *
 		 * @param array array( $this, 'js_templates' ) js_templates callback.
 		 */
-		add_action( 'admin_footer', apply_filters( 'jetpack_modules_list_table_js_template_callback', array( $this, 'js_templates' ) ), 9 );
+//		add_action( 'admin_footer', apply_filters( 'jetpack_modules_list_table_js_template_callback', array( $this, 'js_templates' ) ), 9 );
 	}
 
+	/*
 	function js_templates() {
 		?>
 		<script type="text/html" id="tmpl-Jetpack_Modules_List_Table_Template">
@@ -129,6 +130,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		</script>
 		<?php
 	}
+	*/
 
 	function get_views() {
 		$modules              = Jetpack_Admin::init()->get_modules();
@@ -266,9 +268,9 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	}
 
 	function column_name( $item ) {
-		$actions = array(
-			'info' => sprintf( '<a href="%s">%s</a>', esc_url( '#' ), esc_html__( 'Module Info', 'jetpack' ) ),
-		);
+//		$actions = array(
+//			'info' => sprintf( '<a href="%s">%s</a>', esc_url( '#' ), esc_html__( 'Module Info', 'jetpack' ) ),
+//		);
 
 		if ( ! empty( $item['configurable'] ) ) {
 			$actions['configure'] = $item['configurable'];

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -27,110 +27,17 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		 */
 		$this->items = apply_filters( 'jetpack_modules_list_table_items', $this->items );
 		$this->_column_headers = array( $this->get_columns(), array(), array(), 'name' );
-//		$modal_info = isset( $_GET['info'] ) ? $_GET['info'] : false;
-
-//		wp_register_script(
-//			'models.jetpack-modules',
-//			plugins_url( '_inc/jetpack-modules.models.js', JETPACK__PLUGIN_FILE ),
-//			array( 'backbone', 'underscore' ),
-//			JETPACK__VERSION
-//		);
-//		wp_register_script(
-//			'views.jetpack-modules',
-//			plugins_url( '_inc/jetpack-modules.views.js', JETPACK__PLUGIN_FILE ),
-//			array( 'backbone', 'underscore', 'wp-util' ),
-//			JETPACK__VERSION
-//		);
-//		wp_register_script(
-//			'jetpack-modules-list-table',
-//			plugins_url( '_inc/jetpack-modules.js', JETPACK__PLUGIN_FILE ),
-//			array(
-//				'views.jetpack-modules',
-//				'models.jetpack-modules',
-//				'jquery',
-//			),
-//			JETPACK__VERSION,
-//			true
-//		);
-//
-//		wp_localize_script( 'jetpack-modules-list-table', 'jetpackModulesData', array(
-//			'modules' => Jetpack::get_translated_modules( $this->all_items ),
-//			'i18n'    => array(
-//				'search_placeholder' => __( 'Search Modules…', 'jetpack' ),
-//			),
-//			'modalinfo' => $this->module_info_check( $modal_info, $this->all_items ),
-//			'nonces'  => array(
-//				'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
-//			),
-//			'coreIconAvailable' => Jetpack::jetpack_site_icon_available_in_core(),
-//		) );
-//
-//		wp_enqueue_script( 'jetpack-modules-list-table' );
 
 		/**
 		 * Filters the js_templates callback value.
 		 *
 		 * @since 3.6.0
+		 * @deprecated
 		 *
 		 * @param array array( $this, 'js_templates' ) js_templates callback.
 		 */
-//		add_action( 'admin_footer', apply_filters( 'jetpack_modules_list_table_js_template_callback', array( $this, 'js_templates' ) ), 9 );
+		apply_filters( 'jetpack_modules_list_table_js_template_callback', null );
 	}
-
-	/*
-	function js_templates() {
-		?>
-		<script type="text/html" id="tmpl-Jetpack_Modules_List_Table_Template">
-			<# var i = 0;
-			if ( data.items.length ) {
-			_.each( data.items, function( item, key, list ) {
-				if ( item === undefined ) return;
-				if ( jetpackModulesData.coreIconAvailable && 'site-icon' == item.module ) { #>
-				<tr class="jetpack-module deprecated <# if ( ++i % 2 ) { #> alternate<# } #>" id="site-icon-deprecated">
-					<th scope="row" class="check-column">
-					<input type="checkbox" name="modules[]" value="{{{ item.module }}}" disabled />
-					</th>
-					<td class='name column-name'>
-						<span class='info'>{{{ item.name }}}</span>
-						<div class="row-actions">
-							<span class="dep-msg"><?php _ex( 'WordPress now has Site Icon built in!', '"Site Icon" is the feature name.', 'jetpack' ); ?></span>
-							<span class='configure'><a href="<?php esc_html_e( admin_url( 'customize.php?autofocus[control]=site_icon' ), 'jetpack' ); ?>"><?php _e( 'Configure' , 'jetpack' ); ?></a></span>
-						</div>
-					</td>
-				</tr>
-				<# return; } #>
-				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
-					<th scope="row" class="check-column">
-						<input type="checkbox" name="modules[]" value="{{{ item.module }}}" />
-					</th>
-					<td class='name column-name'>
-						<span class='info'><a href="#">{{{ item.name }}}</a></span>
-						<div class="row-actions">
-						<# if ( item.configurable ) { #>
-							<span class='configure'>{{{ item.configurable }}}</span>
-						<# } #>
-						<# if ( item.activated && 'vaultpress' !== item.module && item.available ) { #>
-							<span class='delete'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=deactivate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.deactivate_nonce }}}"><?php _e( 'Deactivate', 'jetpack' ); ?></a></span>
-						<# } else if ( item.available ) { #>
-							<span class='activate'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=activate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.activate_nonce }}}"><?php _e( 'Activate', 'jetpack' ); ?></a></span>
-						<# } #>
-						</div>
-					</td>
-				</tr>
-				<#
-			});
-			} else {
-				#>
-				<tr class="no-modules-found">
-					<td colspan="2"><?php esc_html_e( 'No Modules Found' , 'jetpack' ); ?></td>
-				</tr>
-				<#
-			}
-			#>
-		</script>
-		<?php
-	}
-	*/
 
 	function get_views() {
 		$modules              = Jetpack_Admin::init()->get_modules();
@@ -212,19 +119,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	}
 
 	function get_columns() {
-		$columns = array(
-			'cb'          => '<input type="checkbox" />',
-			'name'        => __( 'Name', 'jetpack' ),
-		);
-		return $columns;
-	}
-
-	function get_bulk_actions() {
-		$actions = array(
-			'bulk-activate'   => __( 'Activate',   'jetpack' ),
-			'bulk-deactivate' => __( 'Deactivate', 'jetpack' ),
-		);
-		return $actions;
+		return array( 'name' => __( 'Name', 'jetpack' ) );
 	}
 
 	function single_row( $item ) {
@@ -246,31 +141,8 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		return array( 'table', 'table-bordered', 'wp-list-table', 'widefat', 'fixed', 'jetpack-modules' );
 	}
 
-	function column_cb( $item ) {
-		if ( ! $this->is_module_available( $item ) )
-			return '';
-
-		return sprintf( '<input type="checkbox" name="modules[]" value="%s" />', $item['module'] );
-	}
-
-	function column_icon( $item ) {
-		$badge_text = $free_text = '';
-		ob_start();
-		?>
-		<a href="#TB_inline?width=600&height=550&inlineId=more-info-module-settings-modal" class="thickbox">
-			<div class="module-image">
-				<p><span class="module-image-badge"><?php echo $badge_text; ?></span><span class="module-image-free" style="display: none"><?php echo $free_text; ?></span></p>
-			</div>
-		</a>
-		<?php
-		return ob_get_clean();
-
-	}
-
 	function column_name( $item ) {
-//		$actions = array(
-//			'info' => sprintf( '<a href="%s">%s</a>', esc_url( '#' ), esc_html__( 'Module Info', 'jetpack' ) ),
-//		);
+		$actions = array();
 
 		if ( ! empty( $item['configurable'] ) ) {
 			$actions['configure'] = $item['configurable'];
@@ -298,28 +170,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			$actions['delete'] = sprintf( '<a href="%s">%s</a>', esc_url( $url ), esc_html__( 'Deactivate', 'jetpack' ) );
 		}
 
-		return $this->row_actions( $actions ) . wptexturize( $item['name'] );
-	}
-
-	function column_description( $item ) {
-		ob_start();
-		/** This action is documented in class.jetpack-admin.php */
-		echo apply_filters( 'jetpack_short_module_description', $item['description'], $item['module'] );
-		/** This action is documented in class.jetpack-admin.php */
-		do_action( 'jetpack_learn_more_button_' . $item['module'] );
-		echo '<div id="more-info-' . $item['module'] . '" class="more-info">';
-		/** This action is documented in class.jetpack-admin.php */
-		do_action( 'jetpack_module_more_info_' . $item['module'] );
-		echo '</div>';
-		return ob_get_clean();
-	}
-
-	function column_module_tags( $item ) {
-		$module_tags = array();
-		foreach( $item['module_tags'] as $module_tag ) {
-			$module_tags[] = sprintf( '<a href="%3$s" data-title="%2$s">%1$s</a>', esc_html( $module_tag ), esc_attr( $module_tag ), esc_url( add_query_arg( 'module_tag', urlencode( $module_tag ) ) ) );
-		}
-		return implode( ', ', $module_tags );
+		return $this->row_actions( $actions) . wptexturize( $item['name'] );
 	}
 
 	function column_default( $item, $column_name ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6273,6 +6273,7 @@ p {
 			'jetpack-tools-to-include'                 => 'jetpack_tools_to_include',
 			'jetpack_identity_crisis_options_to_check' => null,
 			'update_option_jetpack_single_user_site'   => null,
+			'jetpack_modules_list_table_js_template_callback' => null,
 		);
 
 		// This is a silly loop depth. Better way?

--- a/scss/templates/_main.scss
+++ b/scss/templates/_main.scss
@@ -28,7 +28,7 @@
 
 .wrap.inner,
 .page-content  {
-	max-width: 950px;
+	max-width: 720px;
 	margin: 0 auto;
 
 	li {

--- a/scss/templates/_settings.scss
+++ b/scss/templates/_settings.scss
@@ -59,8 +59,9 @@
 
 .table-bordered.jetpack-modules {
 	border: none;
-	margin-top: 10px;
+	margin-top: 33px;
 	margin-bottom: 0;
+
 	tr.jetpack-module {
 
 		th {
@@ -219,7 +220,6 @@
 		float: left;
 		margin: 0;
 		padding: 0;
-		width: 63%;
 
 		table {
 			width: 100%;

--- a/scss/templates/_settings.scss
+++ b/scss/templates/_settings.scss
@@ -59,6 +59,7 @@
 
 .table-bordered.jetpack-modules {
 	border: none;
+	margin-top: 10px;
 	margin-bottom: 0;
 	tr.jetpack-module {
 


### PR DESCRIPTION
This works, but it's barely readable.  If someone can improve this, I'll buy you some poutine at the GM. 

**_This branch has fallbacks for all of these situations:_**

- Current WP + JS (obviously)
- Current WP + noJS 
- Old WP + JS 
- Old WP + noJS
- All of the above hold functionality for activating/deactivating modules, and also allows the old `&configure=` params to still work, when linking to old settings.  
- It shows a custom message (would need to be styled) in relation to what the problem is (noJS? oldWP?)

To test: test all of the above ^.  You can test old version by hacking `wp_version_too_old()` to return `true`.  You can test the configuration by going to `wp-admin/admin.php?page=jetpack&configure=protect`

The awkward styling `display` hacks are because the html was being rendered before the CSS and it looked weird for a second in any configuration.

I was trying to achieve 100% coverage of all of this, and succeeded, but I have some concerns -- especially the readability, as I mentioned above. 

It looks like this: 
![screen shot 2016-05-14 at 5 04 47 pm](https://cloud.githubusercontent.com/assets/7129409/15270680/ffe5d8a4-19f5-11e6-8023-acd80e0a4223.png)


