### PR TITLE
Debug link: Fix URL for sub-directory installs.

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { getCurrentVersion, isDevVersion } from 'state/initial-state';
+import { getCurrentVersion, isDevVersion, adminUrl } from 'state/initial-state';
 import { resetOptions } from 'state/dev-version';
 
 export const Footer = React.createClass( {
@@ -47,7 +47,7 @@ export const Footer = React.createClass( {
 					<li className="jp-footer__link-item"><a href="http://jetpack.com" target="_blank" className="jp-footer__link" title={ version } >{ version }</a></li>
 					<li className="jp-footer__link-item"><a href="http://wordpress.com/tos/" target="_blank" title="WordPress.com Terms of Service" className="jp-footer__link">Terms</a></li>
 					<li className="jp-footer__link-item"><a href="http://automattic.com/privacy/" target="_blank" title="Automattic's Privacy Policy" className="jp-footer__link">Privacy</a></li>
-					<li className="jp-footer__link-item"><a href="/wp-admin/admin.php?page=jetpack-debugger" title="Test your site’s compatibility with Jetpack." className="jp-footer__link">Debug</a></li>
+					<li className="jp-footer__link-item"><a href={ adminUrl( this.props ) + 'admin.php?page=jetpack-debugger' } title="Test your site’s compatibility with Jetpack." className="jp-footer__link">Debug</a></li>
 					{ maybeShowReset() }
 				</ul>
 			</div>

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { getCurrentVersion, isDevVersion, adminUrl } from 'state/initial-state';
+import { getCurrentVersion, isDevVersion } from 'state/initial-state';
 import { resetOptions } from 'state/dev-version';
 
 export const Footer = React.createClass( {
@@ -47,7 +47,7 @@ export const Footer = React.createClass( {
 					<li className="jp-footer__link-item"><a href="http://jetpack.com" target="_blank" className="jp-footer__link" title={ version } >{ version }</a></li>
 					<li className="jp-footer__link-item"><a href="http://wordpress.com/tos/" target="_blank" title="WordPress.com Terms of Service" className="jp-footer__link">Terms</a></li>
 					<li className="jp-footer__link-item"><a href="http://automattic.com/privacy/" target="_blank" title="Automattic's Privacy Policy" className="jp-footer__link">Privacy</a></li>
-					<li className="jp-footer__link-item"><a href={ adminUrl( this.props ) + 'admin.php?page=jetpack-debugger' } title="Test your site’s compatibility with Jetpack." className="jp-footer__link">Debug</a></li>
+					<li className="jp-footer__link-item"><a href={ window.Initial_State.adminUrl + 'admin.php?page=jetpack-debugger' } title="Test your site’s compatibility with Jetpack." className="jp-footer__link">Debug</a></li>
 					{ maybeShowReset() }
 				</ul>
 			</div>

--- a/_inc/client/state/initial-state/actions.js
+++ b/_inc/client/state/initial-state/actions.js
@@ -54,13 +54,3 @@ export function getHappinessGravatarIds( state ) {
 export function isDevVersion( state ) {
 	return state.jetpack.initialState.isDevVersion;
 }
-
-/**
- * Returns the URL to wp-admin for this install
- *
- * @param  {Object}  state  Global state tree
- * @return {string} URL to wp-admin
- */
-export function adminUrl( state ) {
-	return state.jetpack.initialState.adminUrl;
-}

--- a/_inc/client/state/initial-state/actions.js
+++ b/_inc/client/state/initial-state/actions.js
@@ -4,12 +4,12 @@
 import { JETPACK_SET_INITIAL_STATE } from 'state/action-types';
 
 export const setInitialState = () => {
-    return ( dispatch ) => {
-        dispatch( {
-            type: JETPACK_SET_INITIAL_STATE,
-            initialState: window.Initial_State
-        } );
-    }
+	return ( dispatch ) => {
+		dispatch( {
+			type: JETPACK_SET_INITIAL_STATE,
+			initialState: window.Initial_State
+		} );
+	}
 }
 
 /**
@@ -49,8 +49,18 @@ export function getHappinessGravatarIds( state ) {
  * Which means -alpha, -beta, etc...
  *
  * @param  {Object}  state  Global state tree
- * @return {bool}
+ * @return {bool} true if dev version
  */
 export function isDevVersion( state ) {
 	return state.jetpack.initialState.isDevVersion;
+}
+
+/**
+ * Returns the URL to wp-admin for this install
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {string} URL to wp-admin
+ */
+export function adminUrl( state ) {
+	return state.jetpack.initialState.adminUrl;
 }


### PR DESCRIPTION
For installs which are in a sub-directory, the Debug link in the footer was incorrect (assumed root directory).

This fixes the URL by adding a `adminUrl` function to the `initial-state` component. Feels like a bit of over-kill, but I was just following the existing pattern for accessing those properties. Open to suggestions on better ways to do it.

Also fixes some jslint errors while I was there.