### PR TITLE
Connection Settings: fix logic that shows unlink button

### DIFF
--- a/_inc/client/general-settings/connection-settings.jsx
+++ b/_inc/client/general-settings/connection-settings.jsx
@@ -22,7 +22,7 @@ const ConnectionSettings = React.createClass( {
 			? <ConnectButton />
 			: null;
 
-		const maybeShowLinkUnlinkBtn = userData.currentUser.isMaster || isLinked
+		const maybeShowLinkUnlinkBtn = userData.currentUser.isMaster
 			? null
 			: <ConnectButton connectUser={ true } />;
 


### PR DESCRIPTION
reported by @ebinnion 

before, linked admins were not shown the unlink button in General -> Connection area.  This fixes that.  