### PR TITLE
Site Verification: fix up a few things in the AAG card

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -3,10 +3,7 @@
  */
 import React from 'react';
 import Card from 'components/card';
-import SectionHeader from 'components/section-header';
-import DashItem from 'components/dash-item';
 import DashSectionHeader from 'components/dash-section-header';
-import ExpandedCard from 'components/expanded-card';
 
 /**
  * Internal dependencies
@@ -34,7 +31,6 @@ export default ( props ) =>
 			settingsPath="#security"
 			externalLink="Manage Security on WordPress.com"
 			externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } />
-		
 		<div className="jp-at-a-glance__item-grid">
 			<div className="jp-at-a-glance__left">
 				<DashProtect { ...props } />

--- a/_inc/client/at-a-glance/site-verification.jsx
+++ b/_inc/client/at-a-glance/site-verification.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
-import DashSectionHeader from 'components/dash-section-header';
 
 /**
  * Internal dependencies
@@ -16,17 +15,17 @@ import {
 
 const DashSiteVerify = React.createClass( {
 	getContent: function() {
-		if ( this.props.isModuleActivated( 'verification-tools' )  ) {
+		if ( this.props.isModuleActivated( 'verification-tools' ) ) {
 			return(
 				<DashItem label="Site Verification Tools" status="is-working">
-					<p className="jp-dash-item__description">Site verification tools is active. Ensure your site is verifed with Google, Bing, &amp; Pinterest for more accurate indexing and ranking. <a href="#">Verify now (null)</a></p>
+					<p className="jp-dash-item__description">Site verification tools is active. Ensure your site is verifed with Google, Bing, &amp; Pinterest for more accurate indexing and ranking. <a href={ window.Initial_State.adminUrl + 'tools.php' }>Verify now</a></p>
 				</DashItem>
 			);
 		}
 
 		return(
 			<DashItem label="Site Verification Tools" className="jp-dash-item__is-inactive">
-				<p className="jp-dash-item__description"><a onClick={ this.props.activatePhoton }>Activate Site Verification</a> to verify your site and increase ranking with Google, Bing, and Pinterest.</p>
+				<p className="jp-dash-item__description"><a onClick={ this.props.activateVerificationTools } href="javascript:void(0)">Activate Site Verification</a> to verify your site and increase ranking with Google, Bing, and Pinterest.</p>
 			</DashItem>
 		);
 	},
@@ -48,7 +47,7 @@ export default connect(
 	},
 	( dispatch ) => {
 		return {
-			activatePhoton: () => {
+			activateVerificationTools: () => {
 				return dispatch( activateModule( 'verification-tools' ) );
 			}
 		};


### PR DESCRIPTION
Clean up some jslint warnings, and the Site Verification card on the AAG dashboard.

- add `href` so that it's treated like a link properly
- link to the correct location in wp-admin once enabled
- rename function to match what it actually does.