### PR TITLE
When changing route/re-rendering, scroll back to the top of the page.

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -21,8 +21,6 @@ import Security from 'security/index.jsx';
 import Health from 'site-health/index.jsx';
 import GeneralSettings from 'general-settings/index.jsx';
 import More from 'more/index.jsx';
-import QueryModules from 'components/data/query-modules';
-import { getModules } from 'state/modules';
 import Footer from 'components/footer';
 import SupportCard from 'components/support-card';
 import NonAdminView from 'components/non-admin-view';
@@ -50,6 +48,9 @@ const Main = React.createClass( {
 		const showJumpStart = getJumpStartStatus( this.props );
 		const canManageModules = window.Initial_State.userData.currentUser.permissions.manage_modules;
 
+		// On any route change/re-render, jump back to the top of the page
+		window.scrollTo( 0, 0 );
+
 		if ( ! canManageModules ) {
 			return <NonAdminView { ...this.props } />
 		}
@@ -63,7 +64,7 @@ const Main = React.createClass( {
 		}
 
 		let pageComponent;
-		switch( route ) {
+		switch ( route ) {
 			case '/dashboard':
 				pageComponent = <AtAGlance { ...this.props } />;
 				break;


### PR DESCRIPTION
Without this, if you are scrolled down, and click to go to a different route, the browser doesn't scroll anything, so you're left half-way down the page (e.g scroll down on AAG, click the cog next to the Traffic Tools header).

It's possible this will cause some unexpected behavior if there are "non-standard" re-renders or route changes going on, but I haven't found any yet.

Also cleans up some jslint.