### PR TITLE
Don't fall back to HTTP connection if SSL fails

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -77,6 +77,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return $this->render_nojs_configurable();
 		}
 		?>
+		<?php
+			/**
+			 * Fires when a notice is displayed in the Jetpack menu.
+			 *
+			 * @since 3.0.0
+			 */
+			do_action( 'jetpack_notices' );
+		?>
 		<div id="jp-plugin-container"></div>
 	<?php }
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -78,11 +78,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		}
 		?>
 		<?php
-			/**
-			 * Fires when a notice is displayed in the Jetpack menu.
-			 *
-			 * @since 3.0.0
-			 */
+			/** This action is already documented in views/admin/admin-page.php */
 			do_action( 'jetpack_notices' );
 		?>
 		<div id="jp-plugin-container"></div>

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -386,7 +386,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	public static function recheck_ssl() {
-		return Jetpack::permit_ssl( true );
+		$result = Jetpack::permit_ssl( true );
+		return array(
+			'enabled' => $result,
+			'message' => get_transient( 'jetpack_https_test_message' )
+		);
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -81,6 +81,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 		) );
 
+		register_rest_route( 'jetpack/v4', '/recheck-ssl', array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => __CLASS__ . '::recheck_ssl',
+		) );
+
 		// Return all modules
 		register_rest_route( 'jetpack/v4', '/modules', array(
 			'methods' => WP_REST_Server::READABLE,
@@ -378,6 +383,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return rest_ensure_response( 'dev' );
 		}
 		return Jetpack::is_active();
+	}
+
+	public static function recheck_ssl() {
+		return Jetpack::permit_ssl( true );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4886,7 +4886,8 @@ p {
 					<span id="jetpack-recheck-ssl-output"><?php echo get_transient( 'jetpack_https_test_message' ); ?></span>
 				</p>
 				<p>
-					<?php printf( __( 'For more help, see our <a href="%s" target="_blank">troubleshooting tips</a>', 'jetpack' ), 
+					<?php printf( __( 'For more help, try our <a href="%s">connection debugger</a> or <a href="%s" target="_blank">troubleshooting tips</a>', 'jetpack' ), 
+							esc_url( Jetpack::admin_url( array( 'page' => 'jetpack-debugger' )  ) ),
 							esc_url( "https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/" ) ); ?>
 				</p>
 			</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4882,7 +4882,7 @@ p {
 				<p><?php _e( 'Your site could not connect to WordPress.com via HTTPS. This could be due to any number of reasons, including faulty SSL certificates, misconfigured or missing SSL libraries, or network issues.', 'jetpack' ); ?></p>
 				<p>
 					<?php _e( 'Jetpack will re-test for HTTPS support once a day, but you can click here to try again immediately: ', 'jetpack' ); ?>
-					<a href="#" id="jetpack-recheck-ssl-button"><?php _e( 'Try again' ); ?></a>
+					<a href="#" id="jetpack-recheck-ssl-button"><?php _e( 'Try again', 'jetpack' ); ?></a>
 					<span id="jetpack-recheck-ssl-output"><?php echo get_transient( 'jetpack_https_test_message' ); ?></span>
 				</p>
 				<p>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4869,24 +4869,6 @@ p {
 	}
 
 	/*
-	 * Displays an admin_notice, alerting the user to their JETPACK_CLIENT__HTTPS constant being 'ALWAYS' but SSL isn't working.
-	 */
-	public function alert_required_ssl_fail() {
-		if ( ! current_user_can( 'manage_options' ) )
-			return;
-		?>
-
-		<div id="message" class="error jetpack-message jp-identity-crisis">
-			<div class="jp-banner__content">
-				<h2><?php _e( 'Something is being cranky!', 'jetpack' ); ?></h2>
-				<p><?php _e( 'Your site is configured to only permit SSL connections to Jetpack, but SSL connections don\'t seem to be functional!', 'jetpack' ); ?></p>
-			</div>
-		</div>
-
-		<?php
-	}
-
-	/*
 	 * Displays an admin_notice, alerting the user to their JETPACK_CLIENT__HTTPS constant being 'AUTO' but SSL isn't working.
 	 */
 	public function alert_auto_ssl_fail() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4888,7 +4888,7 @@ p {
 				<p>
 					<?php printf( __( 'For more help, try our <a href="$1%s">connection debugger</a> or <a href="$2%s" target="_blank">troubleshooting tips</a>', 'jetpack' ), 
 							esc_url( Jetpack::admin_url( array( 'page' => 'jetpack-debugger' )  ) ),
-							esc_url( "https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/" ) ); ?>
+							esc_url( 'https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/' ) ); ?>
 				</p>
 			</div>
 		</div>
@@ -4896,19 +4896,19 @@ p {
 			#jetpack-recheck-ssl-output { margin-left: 5px; color: red; }
 		</style>
 		<script type="text/javascript">
-			jQuery(document).ready( function( $ ) {
-				$('#jetpack-recheck-ssl-button').click( function( e ) {
+			jQuery( document ).ready( function( $ ) {
+				$( '#jetpack-recheck-ssl-button' ).click( function( e ) {
 					var $this = $( this );
-					$this.html( <?php echo json_encode(__( 'Checking', 'jetpack' )); ?> );
-					$( '#jetpack-recheck-ssl-output' ).html( "" );
+					$this.html( <?php echo json_encode( __( 'Checking', 'jetpack' ) ); ?> );
+					$( '#jetpack-recheck-ssl-output' ).html( '' );
 					e.preventDefault();
 					$.post( '/wp-json/jetpack/v4/recheck-ssl' )
 					  .done( function( response ) {
 					  	if ( response.enabled ) {
 					  		$( '#jetpack-ssl-warning' ).hide();
 					  	} else {
-					  		this.html( <?php echo json_encode(__( 'Try again', 'jetpack' )); ?> );
-					  		$( '#jetpack-recheck-ssl-output' ).html( "SSL Failed: "+response.message );
+					  		this.html( <?php echo json_encode( __( 'Try again', 'jetpack' ) ); ?> );
+					  		$( '#jetpack-recheck-ssl-output' ).html( 'SSL Failed: ' + response.message );
 					  	}
 					  }.bind( $this ) );
 				} );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4886,7 +4886,8 @@ p {
 					<span id="jetpack-recheck-ssl-output"><?php echo get_transient( 'jetpack_https_test_message' ); ?></span>
 				</p>
 				<p>
-					<?php _e( 'For more help, see our ', 'jetpack' ); ?><a href="https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/"><?php _e( 'troubleshooting tips', 'jetpack' ); ?></a>
+					<?php printf( __( 'For more help, see our <a href="%s" target="_blank">troubleshooting tips</a>', 'jetpack' ), 
+							esc_url( "https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/" ) ); ?>
 				</p>
 			</div>
 		</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4886,7 +4886,7 @@ p {
 					<span id="jetpack-recheck-ssl-output"><?php echo get_transient( 'jetpack_https_test_message' ); ?></span>
 				</p>
 				<p>
-					<?php printf( __( 'For more help, try our <a href="%s">connection debugger</a> or <a href="%s" target="_blank">troubleshooting tips</a>', 'jetpack' ), 
+					<?php printf( __( 'For more help, try our <a href="$1%s">connection debugger</a> or <a href="$2%s" target="_blank">troubleshooting tips</a>', 'jetpack' ), 
 							esc_url( Jetpack::admin_url( array( 'page' => 'jetpack-debugger' )  ) ),
 							esc_url( "https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/" ) ); ?>
 				</p>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4828,12 +4828,14 @@ p {
 	public static function permit_ssl( $force_recheck = false ) {
 		// Do some fancy tests to see if ssl is being supported
 		if ( $force_recheck || false === ( $ssl = get_transient( 'jetpack_https_test' ) ) ) {
+			$message = '';
 			if ( 'https' !== substr( JETPACK__API_BASE, 0, 5 ) ) {
 				$ssl = 0;
 			} else {
 				switch ( JETPACK_CLIENT__HTTPS ) {
 					case 'NEVER':
 						$ssl = 0;
+						$message = __( 'JETPACK_CLIENT__HTTPS is set to NEVER', 'jetpack' );
 						break;
 					case 'ALWAYS':
 					case 'AUTO':
@@ -4845,16 +4847,22 @@ p {
 				// If it's not 'NEVER', test to see
 				if ( $ssl ) {
 					if ( ! wp_http_supports( array( 'ssl' => true ) ) ) {
-						$ssl = 0;	
+						$ssl = 0;
+						$message = __( 'WordPress reports no SSL support', 'jetpack' );
 					} else {
 						$response = wp_remote_get( JETPACK__API_BASE . 'test/1/' );
-						if ( is_wp_error( $response ) || ( 'OK' !== wp_remote_retrieve_body( $response ) ) ) {
+						if ( is_wp_error( $response ) ) {
 							$ssl = 0;
+							$message = __( 'WordPress reports no SSL support', 'jetpack' );
+						} elseif ( 'OK' !== wp_remote_retrieve_body( $response ) ) {
+							$ssl = 0;
+							$message = __( 'Response was not OK: ', 'jetpack' ) . wp_remote_retrieve_body( $response );
 						}
 					}
 				}
 			}
 			set_transient( 'jetpack_https_test', $ssl, DAY_IN_SECONDS );
+			set_transient( 'jetpack_https_test_message', $message, DAY_IN_SECONDS );
 		}
 
 		return (bool) $ssl;
@@ -4893,7 +4901,7 @@ p {
 				<p>
 					<?php _e( 'Jetpack will re-test for HTTPS support once a day, but you can click here to try again immediately: ', 'jetpack' ); ?>
 					<a href="#" id="jetpack-recheck-ssl-button"><?php _e( 'Try again' ); ?></a>
-					<span id="jetpack-recheck-ssl-output"></span>
+					<span id="jetpack-recheck-ssl-output"><?php echo get_transient( 'jetpack_https_test_message' ); ?></span>
 				</p>
 			</div>
 		</div>
@@ -4909,11 +4917,11 @@ p {
 					e.preventDefault();
 					$.post( '/wp-json/jetpack/v4/recheck-ssl' )
 					  .done( function( response ) {
-					  	if ( response == true ) {
+					  	if ( response.enabled ) {
 					  		$( '#jetpack-ssl-warning' ).hide();
 					  	} else {
 					  		this.html( <?php echo json_encode(__( 'Try again', 'jetpack' )); ?> );
-					  		$( '#jetpack-recheck-ssl-output' ).html( "SSL Failed" );
+					  		$( '#jetpack-recheck-ssl-output' ).html( "SSL Failed: "+response.message );
 					  	}
 					  }.bind( $this ) );
 				} );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3245,7 +3245,7 @@ p {
 		}
 
 		if ( current_user_can( 'manage_options' ) && 'AUTO' == JETPACK_CLIENT__HTTPS && ! self::permit_ssl() ) {
-			add_action( 'admin_notices', array( $this, 'alert_auto_ssl_fail' ) );
+			add_action( 'jetpack_notices', array( $this, 'alert_auto_ssl_fail' ) );
 		}
 
 		add_action( 'load-plugins.php', array( $this, 'intercept_plugin_error_scrape_init' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4885,6 +4885,9 @@ p {
 					<a href="#" id="jetpack-recheck-ssl-button"><?php _e( 'Try again' ); ?></a>
 					<span id="jetpack-recheck-ssl-output"><?php echo get_transient( 'jetpack_https_test_message' ); ?></span>
 				</p>
+				<p>
+					<?php _e( 'For more help, see our ', 'jetpack' ); ?><a href="https://jetpack.com/support/getting-started-with-jetpack/troubleshooting-tips/"><?php _e( 'troubleshooting tips', 'jetpack' ); ?></a>
+				</p>
 			</div>
 		</div>
 		<style>


### PR DESCRIPTION
This change came out of thread p7rcWF-3B-p2, regarding SSL connections from WP sites to WordPress.com.

The basic idea is that we shouldn't silently fall back to HTTP if HTTPS isn't available - we should warn the user and let them override it with a constant in wp-config.php.

The functional change is very small - basically `Jetpack::fix_url_for_bad_hosts( $url )` now always returns the original URL passed in, UNLESS the constant `JETPACK_CLIENT__HTTPS` is set to `NEVER`.

This branch implements the UI change in a self-contained but possibly messy way, with style, JS and content all grouped together. Style suggestions welcome.

It also adds a REST API endpoint to check for SSL status, which is used by the JS.

To force a fake SSL error, just set the transients used to cache the result of the test:

```bash
$ wp shell
wp> set_transient( 'jetpack_https_test', 0, DAY_IN_SECONDS )
wp> set_transient( 'jetpack_https_test_message', 'Bad Things Happened', DAY_IN_SECONDS )
```

Then load any admin page and you should see a warning:

<img width="865" alt="big-fat-warning" src="https://cloud.githubusercontent.com/assets/51896/15311856/eb2c7610-1bb3-11e6-8962-4a3252cea679.png">

Clicking the "Try again" link (or waiting 24 hours) should make the warning go away. If there is an error trying again, it will be displayed in red next to the link.

It would be great if folks could test this on an actually-messed-up, no-HTTPS host. However, I'm fairly confident that it will work since it changes very little about the mechanisms used to detect SSL support.

cc @lezama @kraftbj @mdawaffe @beaulebens 