### PR TITLE
SSO: Store WPOM user gravatar and display name on logout

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -504,11 +504,11 @@ class Jetpack_SSO {
 			$site_name = get_bloginfo( 'url' );
 		}
 
-		$display_name = ! empty( $_COOKIE[ 'jetpack_sso_wpcom_name' . COOKIEHASH ] )
-			? $_COOKIE[ 'jetpack_sso_wpcom_name' . COOKIEHASH ]
+		$display_name = ! empty( $_COOKIE[ 'jetpack_sso_wpcom_name_' . COOKIEHASH ] )
+			? $_COOKIE[ 'jetpack_sso_wpcom_name_' . COOKIEHASH ]
 			: false;
-		$gravatar = ! empty( $_COOKIE[ 'jetpack_sso_wpcom_gravatar' . COOKIEHASH ] )
-			? $_COOKIE[ 'jetpack_sso_wpcom_gravatar' . COOKIEHASH ]
+		$gravatar = ! empty( $_COOKIE[ 'jetpack_sso_wpcom_gravatar_' . COOKIEHASH ] )
+			? $_COOKIE[ 'jetpack_sso_wpcom_gravatar_' . COOKIEHASH ]
 			: false;
 
 		?>
@@ -577,9 +577,9 @@ class Jetpack_SSO {
 	 * WPCOM user to connect.
 	 */
 	static function clear_wpcom_profile_cookies() {
-		if ( isset( $_COOKIE[ 'jetpack_sso_wpcom_name' . COOKIEHASH ] ) ) {
+		if ( isset( $_COOKIE[ 'jetpack_sso_wpcom_name_' . COOKIEHASH ] ) ) {
 			setcookie(
-				'jetpack_sso_wpcom_name' . COOKIEHASH,
+				'jetpack_sso_wpcom_name_' . COOKIEHASH,
 				' ',
 				time() - YEAR_IN_SECONDS,
 				COOKIEPATH,
@@ -587,9 +587,9 @@ class Jetpack_SSO {
 			);
 		}
 
-		if ( isset( $_COOKIE[ 'jetpack_sso_wpcom_gravatar' . COOKIEHASH ] ) ) {
+		if ( isset( $_COOKIE[ 'jetpack_sso_wpcom_gravatar_' . COOKIEHASH ] ) ) {
 			setcookie(
-				'jetpack_sso_wpcom_gravatar' . COOKIEHASH,
+				'jetpack_sso_wpcom_gravatar_' . COOKIEHASH,
 				' ',
 				time() - YEAR_IN_SECONDS,
 				COOKIEPATH,
@@ -1159,7 +1159,7 @@ class Jetpack_SSO {
 		}
 
 		setcookie(
-			'jetpack_sso_wpcom_name' . COOKIEHASH,
+			'jetpack_sso_wpcom_name_' . COOKIEHASH,
 			$user_data->display_name,
 			time() + WEEK_IN_SECONDS,
 			COOKIEPATH,
@@ -1167,7 +1167,7 @@ class Jetpack_SSO {
 		);
 
 		setcookie(
-			'jetpack_sso_wpcom_gravatar' . COOKIEHASH,
+			'jetpack_sso_wpcom_gravatar_' . COOKIEHASH,
 			get_avatar_url(
 				$user_data->email,
 				array( 'size' => 72, 'default' => 'mystery' )


### PR DESCRIPTION
Now that we've made the decision to modify SSO such that a user must create a user connection to SSO, we shouldn't store the user's profile details unless the user has a connection.

To do this, I decided to store the profile cookies on logout and then delete those cookies on login. 

To test:

- Checkout `update/sso-profile-cache` branch
- Use SSO to login to your site once
- Log out
- You should see profile details similar to this: <br> <img src="https://cloud.githubusercontent.com/assets/1126811/15326722/afd01e30-1c14-11e6-9b11-8ca25cb4b5be.png" width=250 />
- Log in
- If you look at your cookies, you should not see any `jetpack_sso*` cookies now.

cc @lezama for code review.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).