### PR TITLE
SSO: Add the action later to not impact tab order with Protect math form

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -443,7 +443,7 @@ class Jetpack_SSO {
 			return;
 		}
 
-		add_action( 'login_form',            array( $this, 'login_form' ) );
+		add_action( 'login_form',            array( $this, 'login_form' ), 20 );
 		add_filter( 'login_body_class',      array( $this, 'login_body_class' ) );
 		add_action( 'login_enqueue_scripts', array( $this, 'login_enqueue_scripts' ) );
 	}


### PR DESCRIPTION
Fixes #3796 .

Instead of trying to micromanage tab order, let's just add it later.