### PR TITLE
SSO: Remove user profile UI and commented code

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3043,6 +3043,15 @@ p {
 
 		Jetpack_Options::update_option( 'user_tokens', $tokens );
 
+		/**
+		 * Fires after the current user has been unlinked from WordPress.com.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param int $user_id The current user's ID.
+		 */
+		do_action( 'jetpack_unlinked_user', $user_id );
+
 		return true;
 	}
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -639,20 +639,6 @@ class Jetpack_SSO {
 			return;
 		}
 
-		if ( isset( $_GET['state'] ) && ( 0 < strpos( $_GET['state'], '|' ) ) ) {
-			list( $state, $nonce ) = explode( '|', $_GET['state'] );
-
-			if ( wp_verify_nonce( $nonce, $state ) ) {
-				if ( 'sso-link-user' == $state ) {
-					$user = wp_get_current_user();
-					update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
-					add_filter( 'login_redirect', array( __CLASS__, 'profile_page_url' ) );
-				}
-			} else {
-				wp_nonce_ays();
-			}
-		}
-
 		if ( empty( $user ) ) {
 			$user = $this->get_user_by_wpcom_id( $user_data->ID );
 		}
@@ -911,10 +897,6 @@ class Jetpack_SSO {
 			'site_id'   => Jetpack_Options::get_option( 'id' ),
 			'sso_nonce' => $sso_nonce,
 		);
-
-		if ( isset( $_GET['state'] ) && check_admin_referer( $_GET['state'] ) ) {
-			$defaults['state'] = rawurlencode( $_GET['state'] . '|' . $_GET['_wpnonce'] );
-		}
 
 		$args = wp_parse_args( $args, $defaults );
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -589,7 +589,6 @@ class Jetpack_SSO {
 	function handle_login() {
 		$wpcom_nonce   = sanitize_key( $_GET['sso_nonce'] );
 		$wpcom_user_id = (int) $_GET['user_id'];
-		$result        = sanitize_key( $_GET['result'] );
 
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
@@ -639,8 +638,11 @@ class Jetpack_SSO {
 			return;
 		}
 
-		if ( empty( $user ) ) {
-			$user = $this->get_user_by_wpcom_id( $user_data->ID );
+		if ( empty( $user ) && isset( $user_data->external_user_id ) ) {
+			$user = get_user_by( 'id', intval( $user_data->external_user_id ) );
+			if ( $user ) {
+				update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
+			}
 		}
 
 		// If we don't have one by wpcom_user_id, try by the email?

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -22,7 +22,6 @@ class Jetpack_SSO {
 		self::$instance = $this;
 
 		add_action( 'admin_init',             array( $this, 'maybe_authorize_user_after_sso' ), 1 );
-		add_action( 'admin_init',             array( $this, 'admin_init' ) );
 		add_action( 'admin_init',             array( $this, 'register_settings' ) );
 		add_action( 'login_init',             array( $this, 'login_init' ) );
 		add_action( 'delete_user',            array( $this, 'delete_connection_for_user' ) );
@@ -78,10 +77,7 @@ class Jetpack_SSO {
 		Jetpack::module_configuration_screen( __FILE__, array( __CLASS__, 'module_configuration_screen' ) );
 	}
 
-	public static function module_configuration_load() {
-		// wp_safe_redirect( admin_url( 'options-general.php#configure-sso' ) );
-		// exit;
-	}
+	public static function module_configuration_load() {}
 
 	public static function module_configuration_head() {}
 
@@ -212,26 +208,6 @@ class Jetpack_SSO {
 
 		/*
 		 * Settings > General > Single Sign On
-		 * Checkbox for Remove default login form
-		 */
-		 /* Hide in 2.9
-		register_setting(
-			'general',
-			'jetpack_sso_remove_login_form',
-			array( $this, 'validate_settings_remove_login_form_checkbox' )
-		);
-
-		add_settings_field(
-			'jetpack_sso_remove_login_form',
-			__( 'Remove default login form?' , 'jetpack' ),
-			array( $this, 'render_remove_login_form_checkbox' ),
-			'general',
-			'jetpack_sso_settings'
-		);
-		*/
-
-		/*
-		 * Settings > General > Single Sign On
 		 * Require two step authentication
 		 */
 		register_setting(
@@ -315,33 +291,6 @@ class Jetpack_SSO {
 	 **/
 	public function validate_jetpack_sso_match_by_email( $input ) {
 		return ( ! empty( $input ) ) ? 1 : 0;
-	}
-
-	/**
-	 * Builds the display for the checkbox allowing users to remove the default
-	 * WordPress login form from wp-login.php. Displays in Settings > General
-	 *
-	 * @since 2.7
-	 **/
-	public function render_remove_login_form_checkbox() {
-		if ( $this->is_user_connected( get_current_user_id() ) ) {
-			echo '<a name="configure-sso"></a>';
-			echo '<input type="checkbox" name="jetpack_sso_remove_login_form[remove_login_form]" ' . checked( 1 == get_option( 'jetpack_sso_remove_login_form' ), true, false ) . '>';
-			echo '<p class="description">Removes default login form and disallows login via POST</p>';
-		} else {
-			echo 'Your account must be connected to WordPress.com before disabling the login form.';
-			echo '<br/>' . $this->button();
-		}
-	}
-
-	/**
-	 * Validate settings input from Settings > General
-	 *
-	 * @since 2.7
-	 * @return boolean
-	 **/
-	public function validate_settings_remove_login_form_checkbox( $input ) {
-		return ( isset( $input['remove_login_form'] ) )? 1: 0;
 	}
 
 	/**
@@ -1179,26 +1128,6 @@ class Jetpack_SSO {
 	}
 
 	/**
-	 * Deal with user connections...
-	 */
-	function admin_init() {
-		add_action( 'show_user_profile', array( $this, 'edit_profile_fields' ) ); // For their own profile
-		add_action( 'edit_user_profile', array( $this, 'edit_profile_fields' ) ); // For folks editing others profiles
-
-		if ( isset( $_GET['jetpack_sso'] ) && 'purge' == $_GET['jetpack_sso'] && check_admin_referer( 'jetpack_sso_purge' ) ) {
-			$user = wp_get_current_user();
-			// Remove the connection on the wpcom end.
-			self::delete_connection_for_user( $user->ID );
-			// Clear it locally.
-			delete_user_meta( $user->ID, 'wpcom_user_id' );
-			delete_user_meta( $user->ID, 'wpcom_user_data' );
-			// Forward back to the profile page.
-			wp_safe_redirect( remove_query_arg( array( 'jetpack_sso', '_wpnonce' ) ) );
-			exit;
-		}
-	}
-
-	/**
 	 * Determines if a local user is connected to WordPress.com
 	 *
 	 * @since 2.8
@@ -1218,50 +1147,6 @@ class Jetpack_SSO {
 	 **/
 	public function get_user_data( $user_id ) {
 		return get_user_meta( $user_id, 'wpcom_user_data', true );
-	}
-
-	function edit_profile_fields( $user ) {
-		?>
-
-		<h3 id="single-sign-on"><?php _e( 'Single Sign On', 'jetpack' ); ?></h3>
-		<p><?php _e( 'Connecting with Single Sign On enables you to log in via your WordPress.com account.', 'jetpack' ); ?></p>
-
-		<?php if ( $this->is_user_connected( $user->ID ) ) : /* If the user is currently connected... */ ?>
-			<?php $user_data = $this->get_user_data( $user->ID ); ?>
-			<table class="form-table jetpack-sso-form-table">
-				<tbody>
-					<tr>
-						<td>
-							<div class="profile-card">
-								<?php echo get_avatar( $user_data->email ); ?>
-								<p class="connected"><strong><?php _e( 'Connected', 'jetpack' ); ?></strong></p>
-								<p><?php echo esc_html( $user_data->login ); ?></p>
-								<span class="two_step">
-									<?php
-										if ( $user_data->two_step_enabled ) {
-											?> <p class="enabled"><a href="https://wordpress.com/me/security/two-step" target="_blank"><?php _e( 'Two-Step Authentication Enabled', 'jetpack' ); ?></a></p> <?php
-										} else {
-											?> <p class="disabled"><a href="https://wordpress.com/me/security/two-step" target="_blank"><?php _e( 'Two-Step Authentication Disabled', 'jetpack' ); ?></a></p> <?php
-										}
-									?>
-								</span>
-
-							</div>
-							<p><a class="button button-secondary" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'jetpack_sso', 'purge' ), 'jetpack_sso_purge' ) ); ?>"><?php _e( 'Unlink This Account', 'jetpack' ); ?></a></p>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-		<?php elseif ( get_current_user_id() == $user->ID && Jetpack::is_user_connected( $user->ID ) ) : ?>
-
-			<?php echo $this->build_sso_button( 'state=sso-link-user&_wpnonce=' . wp_create_nonce( 'sso-link-user' ) ); ?>
-
-		<?php else : ?>
-
-			<p><?php esc_html_e( wptexturize( __( "If you don't have a WordPress.com account yet, you can sign up for free in just a few seconds.", 'jetpack' ) ) ); ?></p>
-			<a href="<?php echo Jetpack::init()->build_connect_url( false, get_edit_profile_url( get_current_user_id() ) . '#single-sign-on' ); ?>" class="button button-connector" id="wpcom-connect"><?php esc_html_e( 'Link account with WordPress.com', 'jetpack' ); ?></a>
-
-		<?php endif;
 	}
 }
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -31,7 +31,7 @@ class Jetpack_SSO {
 		add_action( 'admin_enqueue_scripts',  array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'login_form_logout',      array( $this, 'store_wpcom_profile_cookies_on_logout' ) );
 		add_action( 'wp_login',               array( 'Jetpack_SSO', 'clear_wpcom_profile_cookies' ) );
-
+		add_action( 'jetpack_unlinked_user',  array( $this, 'delete_connection_for_user') );
 
 		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
 		add_action( 'login_form_jetpack-sso', '__return_true' );
@@ -561,6 +561,9 @@ class Jetpack_SSO {
 			return false;
 		}
 
+		// Clean up local data stored for SSO
+		delete_user_meta( $user_id, 'wpcom_user_id' );
+		delete_user_meta( $user_id, 'wpcom_user_data'  );
 		self::clear_wpcom_profile_cookies();
 
 		return $xml->getResponse();


### PR DESCRIPTION
Now that we've updated SSO authorization to use a user level connection, we can remove the user profile UI that handled connecting and purging a connection. The user can now connect and purge a connection by linking/unlinking to WordPress.com

After r135995-wpcom, we now pass `external_user_id` with the data returned while logging in via SSO. This allows us to rely on user level connections for SSO instead, which also allows us to remove the user profile UI.

To test:

- Checkout `update/sso-user-profile-ui` branch
- Go to remote Jetpack site and ensure it is connected to WordPress.com
- Test these flows
    - SSO with a remote site user where the email address is the same as your WP.com user and your user is not connected to WP.com. This should be successful.
    - SSO where the email is different and your user is not connected to WP.com yet. This should show a match-by-email error.
    - SSO where the email is different, but your user is already connected to WP.com. This should be successful.

cc @lezama for review

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
