### PR TITLE
Jump Start: Consistently handle errors, and import all constants

### DIFF
--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -5,7 +5,9 @@ import {
 	JUMPSTART_ACTIVATE,
 	JUMPSTART_ACTIVATE_FAIL,
 	JUMPSTART_ACTIVATE_SUCCESS,
-	JUMPSTART_SKIP
+	JUMPSTART_SKIP,
+	JUMPSTART_SKIP_SUCCESS,
+	JUMPSTART_SKIP_FAIL
 } from 'state/action-types';
 import restApi from 'rest-api';
 
@@ -41,7 +43,7 @@ export const jumpStartSkip = () => {
 		} )['catch']( error => {
 			dispatch( {
 				type: JUMPSTART_SKIP_FAIL,
-				jumpStart: false
+				error: error
 			} );
 		} );
 	}


### PR DESCRIPTION
While cleaning up some lint errors, I fixed the handling of `error` in Jump Start. Then when testing that, I realized that we weren't importing/using constants consistently, so that's fixed up in here as well. Confirmed that Jump Start works, or can be skipped, with this change applied.

Without this change, if you skip Jump Start it will work, but then the promise will throw an error:

`Uncaught (in promise) ReferenceError: JUMPSTART_SKIP_FAIL is not defined`