### PR TITLE
Protect: escape URL link.

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -174,7 +174,7 @@ class Jetpack_Protect_Module {
 				<p><?php printf( __( 'Thanks for activating Protect! To start protecting your site, please network activate Jetpack on your Multisite installation and activate Protect on your primary site. Due to the way logins are handled on WordPress Multisite, Jetpack must be network-enabled in order for Protect to work properly. <a href="%s" target="_blank">Learn More</a>', 'jetpack' ), 'http://jetpack.com/support/multisite-protect' ); ?></p>
 			</div>
 			<div class="jp-banner__action-container is-opt-in">
-				<a href="<?php echo network_admin_url( 'plugins.php' ); ?>" class="jp-banner__button"
+				<a href="<?php echo esc_url( network_admin_url( 'plugins.php' ) ); ?>" class="jp-banner__button"
 				   id="wpcom-connect"><?php _e( 'View Network Admin', 'jetpack' ); ?></a>
 			</div>
 		</div>


### PR DESCRIPTION
Addresses comment in the original commit: https://github.com/Automattic/jetpack/commit/4d33d50ef013436e0df824da84fcd91dae4dc6db#commitcomment-12050433