### PR TITLE
SSO: Adds tracks events

### DIFF
--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -58,7 +58,7 @@ class JetpackTracking {
 		self::record_user_event( 'module_deactivated', array( 'module' => $module ) );
 	}
 
-	static function record_user_event( $event_type, $data ) {
+	static function record_user_event( $event_type, $data= array() ) {
 
 		$user = wp_get_current_user();
 		$site_url = get_option( 'siteurl' );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -768,6 +768,8 @@ class Jetpack_SSO {
 			/** This filter is documented in core/src/wp-includes/user.php */
 			do_action( 'wp_login', $user->user_login, $user );
 
+			wp_set_current_user( $user->ID );
+
 			$_request_redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( $_REQUEST['redirect_to'] ) : '';
 			$redirect_to = user_can( $user, 'edit_posts' ) ? admin_url() : self::profile_page_url();
 
@@ -782,7 +784,8 @@ class Jetpack_SSO {
 			$is_user_connected = Jetpack::is_user_connected( $user->ID );
 			JetpackTracking::record_user_event( 'sso_user_logged_in', array(
 				'user_found_with' => $user_found_with,
-				'user_connected'  => (bool) $is_user_connected
+				'user_connected'  => (bool) $is_user_connected,
+				'user_role'       => Jetpack::init()->translate_current_user_to_role()
 			) );
 
 			if ( ! $is_user_connected ) {

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -357,7 +357,9 @@ class Jetpack_SSO {
 			add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 			$this->maybe_save_cookie_redirect();
 			$reauth = ! empty( $_GET['reauth'] );
-			wp_safe_redirect( $this->get_sso_url_or_die( $reauth ) );
+			$sso_url = $this->get_sso_url_or_die( $reauth );
+			JetpackTracking::record_user_event( 'sso_login_redirect_bypass_success' );
+			wp_safe_redirect( $sso_url );
 			exit;
 		}
 
@@ -369,13 +371,18 @@ class Jetpack_SSO {
 				$this->display_sso_login_form();
 			} else {
 				if ( Jetpack::check_identity_crisis() ) {
+					JetpackTracking::record_user_event( 'sso_login_redirect_failed', array(
+						'error_message' => 'identity_crisis'
+					) );
 					wp_die( __( "Error: This site's Jetpack connection is currently experiencing problems.", 'jetpack' ) );
 				} else {
 					$this->maybe_save_cookie_redirect();
 					// Is it wiser to just use wp_redirect than do this runaround to wp_safe_redirect?
 					add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 					$reauth = ! empty( $_GET['reauth'] );
-					wp_safe_redirect( $this->get_sso_url_or_die( $reauth ) );
+					$sso_url = $this->get_sso_url_or_die( $reauth );
+					JetpackTracking::record_user_event( 'sso_login_redirect_success' );
+					wp_safe_redirect( $sso_url );
 					exit;
 				}
 			}
@@ -597,12 +604,21 @@ class Jetpack_SSO {
 		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
 
 		if ( $xml->isError() ) {
-			wp_die( sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() ) );
+			$error_message = sanitize_text_field(
+				sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() )
+			);
+			JetpackTracking::record_user_event( 'sso_login_failed', array(
+				'error_message' => $error_message
+			) );
+			wp_die( $error_message );
 		}
 
 		$user_data = $xml->getResponse();
 
 		if ( empty( $user_data ) ) {
+			JetpackTracking::record_user_event( 'sso_login_failed', array(
+				'error_message' => 'invalid_response_data'
+			) );
 			wp_die( __( 'Error, invalid response data.', 'jetpack' ) );
 		}
 
@@ -632,13 +648,20 @@ class Jetpack_SSO {
 		$require_two_step = apply_filters( 'jetpack_sso_require_two_step', get_option( 'jetpack_sso_require_two_step' ) );
 		if ( $require_two_step && 0 == (int) $user_data->two_step_enabled ) {
 			$this->user_data = $user_data;
+
+			JetpackTracking::record_user_event( 'sso_login_failed', array(
+				'error_message' => 'error_msg_enable_two_step'
+			) );
+			
 			/** This filter is documented in core/src/wp-includes/pluggable.php */
 			do_action( 'wp_login_failed', $user_data->login );
 			add_filter( 'login_message', array( $this, 'error_msg_enable_two_step' ) );
 			return;
 		}
 
+		$user_found_with = '';
 		if ( empty( $user ) && isset( $user_data->external_user_id ) ) {
+			$user_found_with = 'external_user_id';
 			$user = get_user_by( 'id', intval( $user_data->external_user_id ) );
 			if ( $user ) {
 				update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
@@ -647,6 +670,7 @@ class Jetpack_SSO {
 
 		// If we don't have one by wpcom_user_id, try by the email?
 		if ( empty( $user ) && self::match_by_email() ) {
+			$user_found_with = 'match_by_email';
 			$user = get_user_by( 'email', $user_data->email );
 			if ( $user ) {
 				update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
@@ -673,9 +697,16 @@ class Jetpack_SSO {
 				while ( username_exists( $username ) ) {
 					$username = $user_data->login . '_' . $user_data->ID . '_' . mt_rand();
 					if ( $tries++ >= 5 ) {
+						JetpackTracking::record_user_event( 'sso_login_failed', array(
+							'error_message' => 'could_not_create_username'
+						) );
 						wp_die( __( "Error: Couldn't create suitable username.", 'jetpack' ) );
 					}
 				}
+
+				$user_found_with = self::new_user_override()
+					? 'user_created_new_user_override'
+					: 'user_created_users_can_register';
 
 				$password = wp_generate_password( 20 );
 				$user_id  = wp_create_user( $username, $password, $user_data->email );
@@ -690,9 +721,12 @@ class Jetpack_SSO {
 
 				update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
 			} else {
+				JetpackTracking::record_user_event( 'sso_login_failed', array(
+					'error_message' => 'error_msg_email_already_exists'
+				) );
+
 				$this->user_data = $user_data;
-				// do_action( 'wp_login_failed', $user_data->login );
-				add_filter( 'login_message', array( $this, 'error_msg_email_already_exists' ) );
+				add_action( 'login_message', array( $this, 'error_msg_email_already_exists' ) );
 				return;
 			}
 		}
@@ -745,7 +779,13 @@ class Jetpack_SSO {
 				setcookie( 'jetpack_sso_redirect_to', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
 			}
 
-			if ( ! Jetpack::is_user_connected( $user->ID ) ) {
+			$is_user_connected = Jetpack::is_user_connected( $user->ID );
+			JetpackTracking::record_user_event( 'sso_user_logged_in', array(
+				'user_found_with' => $user_found_with,
+				'user_connected'  => (bool) $is_user_connected
+			) );
+
+			if ( ! $is_user_connected ) {
 				$calypso_env = ! empty( $_GET['calypso_env'] )
 					? sanitize_key( $_GET['calypso_env'] )
 					: '';
@@ -770,6 +810,10 @@ class Jetpack_SSO {
 			);
 			exit;
 		}
+
+		JetpackTracking::record_user_event( 'sso_login_failed', array(
+			'error_message' => 'cant_find_user'
+		) );
 
 		$this->user_data = $user_data;
 		/** This filter is documented in core/src/wp-includes/pluggable.php */
@@ -880,7 +924,13 @@ class Jetpack_SSO {
 
 		// If there was an error retrieving the SSO URL, then error.
 		if ( is_wp_error( $sso_redirect ) ) {
-			wp_die( sprintf( '%s: %s', $sso_redirect->get_error_code(), $sso_redirect->get_error_message() ) );
+			$error_message = sanitize_text_field(
+				sprintf( '%s: %s', $sso_redirect->get_error_code(), $sso_redirect->get_error_message() )
+			);
+			JetpackTracking::record_user_event( 'sso_login_redirect_failed', array(
+				'error_message' => $error_message
+			) );
+			wp_die( $error_message );
 		}
 
 		return $sso_redirect;


### PR DESCRIPTION
This PR adds tracks events to the SSO module. This will help us better understand how SSO fails for users as well as how often different features are used. Examples: How often are users automatically redirected? How often is the match by email error shown?

To test:

- Checkout `add/sso-analytics` branch
- Go to remote site and attempt to SSO. Here are flows to test:
    - User is connected to WP.com
    - User is not connected to WP.com
        - Match by email. Does user's WP.org email match the WP.com email address?
        - Registrations allowed. Enable/disable [new user registrations on remote site](https://codex.wordpress.org/Network_Admin_Settings_Screen#Registration_Settings).
        - [WPCC_NEW_USER_OVERRIDE](https://jetpack.com/support/sso/#custom-settings) is true and new user is allowed for SSO.
    - [WP.org login form is bypassed](https://jetpack.com/support/sso/#custom-settings) and user is redirected to WP.com
    - Errors
        - Can't find user. 
            - Make sure user is not connected to WP.com. Also, make sure WP.org email doesn't match WP.com user's email. Attempt to SSO.
        - Nonce not created. 
            - Intentionally break `request_initial_nonce()` by setting [user_id](https://github.com/Automattic/jetpack/blob/master/modules/sso.php#L575) to a non-existent user or user that is not connected to WP.com. You should be able to trigger an invalid token error.
        - Identity crisis.
        - 2fa required.
            - In compat plugin, `add_filter( 'jetpack_sso_require_two_step', '__return_true' );`
            - Attempt to SSO with a WP.com user that does not have 2fa enabled.
        
- After testing flows, check Tracks live events (after a bit of a delay) and make sure events were tracked

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

