### PR TITLE
Domain Check: Add filter to bypass JP's check

### DIFF
--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -55,6 +55,19 @@ class Jetpack_Data {
 			return new WP_Error( 'fail_domain_empty', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as it is empty.', 'jetpack' ), $domain ) );
 		}
 
+		/**
+		 * Skips the usuable domain check when connecting a site.
+		 *
+		 * Allows site administrators with domains that fail gethostname-based checks to pass the request to WP.com
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param bool If the check should be skipped. Default false.
+		 */
+		if ( apply_filters( 'jetpack_skip_usuable_domain_check', false ) ){
+			return true;
+		}
+
 		// None of the explicit localhosts.
 		$forbidden_domains = array(
 			'wordpress.com',

--- a/class.jetpack-data.php
+++ b/class.jetpack-data.php
@@ -64,7 +64,7 @@ class Jetpack_Data {
 		 *
 		 * @param bool If the check should be skipped. Default false.
 		 */
-		if ( apply_filters( 'jetpack_skip_usuable_domain_check', false ) ){
+		if ( apply_filters( 'jetpack_skip_usuable_domain_check', false ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
Adds a filter to bypass the `is_usuable_domain` check on the JP side. The primary use case would be when a server is setup in such a way that `gethostname` returns an internal IP while the site is still accessible via an external IP to bypass the check.

WP.com has a mirrored check that would still stop a site from registering if it doesn't pass the tests.

See 2671287-t and poqVs-dhn-p2