### PR TITLE
Travis: Whitelist branches to run on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,13 @@ matrix:
    - php: "hhvm"
    - php: "nightly"
 
+# whitelist branches for the "push" build check.
+branches:
+  only:
+    - master
+    - master-stable
+    - /^branch-.*$/
+
 # Clones WordPress and configures our testing environment.
 before_script:
     - export PLUGIN_SLUG=$(basename $(pwd))

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
 # so it doesn't need to be re-defined below.
 
 # Test WP trunk/master and two latest versions on minimum (5.2).
-# Test WP latest two versions (4.4, 4.4) on most popular (5.5, 5.6).
-# Test WP latest stable (4.4) on other supported PHP (5.3, 5.4).
+# Test WP latest two versions (4.5, 4.3) on most popular (5.5, 5.6).
+# Test WP latest stable (4.5) on other supported PHP (5.3, 5.4).
 # Test WP trunk/master on edge platforms (7.0, hhvm, PHP nightly).
 
 # WP_VERSION specifies the tag to use. The way these tests are configured to run
@@ -26,28 +26,28 @@ env:
 matrix:
   include:
    - php: "5.6"
-     env: WP_VERSION=4.4 WP_TRAVISCI=travis:js
+     env: WP_VERSION=4.5 WP_TRAVISCI=travis:js
    - php: "5.2"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.2"
-     env: WP_VERSION=4.3 WP_TRAVISCI=travis:phpunit
-   - php: "5.2"
      env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
+   - php: "5.2"
+     env: WP_VERSION=4.5 WP_TRAVISCI=travis:phpunit
    - php: "5.3"
-     env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.5 WP_TRAVISCI=travis:phpunit
    - php: "5.4"
-     env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
+     env: WP_VERSION=4.5 WP_TRAVISCI=travis:phpunit
    - php: "5.5"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: "5.5"
-     env: WP_VERSION=4.3 WP_TRAVISCI=travis:phpunit
-   - php: "5.5"
      env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
+   - php: "5.5"
+     env: WP_VERSION=4.5 WP_TRAVISCI=travis:phpunit
      # 5.6 / master already included above as first build.
    - php: "5.6"
-     env: WP_VERSION=4.3 WP_TRAVISCI=travis:phpunit
-   - php: "5.6"
      env: WP_VERSION=4.4 WP_TRAVISCI=travis:phpunit
+   - php: "5.6"
+     env: WP_VERSION=4.5 WP_TRAVISCI=travis:phpunit
    - php: "7.0"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: hhvm


### PR DESCRIPTION
`automattic/jetpack` is set to run Travis on PRs and Pushes, which result in two runs on every PR committed by an a11n who used a branch on `automattic/jetpack`.

By whitelisting `master`, `master-stable`, and `branch-*` we will now run Travis on the following:
- All PRs on what would be the merge commit into `master`, which should include updates to the branches that form the PR.
- On the actual commit on `master`, `master-stable`, and our version branches. 

The latter is a failsafe to double-check after we merge something that everything is actually good. This does mean, though, that Travis will *not* run on branch commits until a PR is made. If we have something that is on-going that needs to be checked, we can add it to the whitelist. (`add/sync-actions`?)

Additionally, Travis was checking WP 4.3 and 4.4. It should be 4.4 and 4.5 for `master`.