### PR TITLE
Remove line which explicitly set NODE_ENV env variable to 'production…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,8 +90,6 @@ gulp.task( 'react:build', function( done ) {
 } );
 
 gulp.task( 'react:watch', function() {
-	process.env.NODE_ENV = "production";
-
 	var config = getWebpackConfig();
 
 	webpack( config ).watch( 100, onBuild() );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
- Remove from `gulpfile.js` a line which explicitly set NODE_ENV env variable to 'production'.