### PR TITLE
SSO: Update error and informational notices

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -998,7 +998,7 @@ class Jetpack_SSO {
 		$error = sprintf(
 			wp_kses(
 				__(
-					'You already have an account on this site. Please visit your <a href="%1$s">profile page</a> page to link your account to WordPress.com!',
+					'You already have an account on this site. Please visit your <a href="%1$s">profile page</a> page to link your account to WordPress.com.',
 					'jetpack'
 				),
 				array(  'a' => array( 'href' => array() ) )

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -973,12 +973,13 @@ class Jetpack_SSO {
 		$error = sprintf(
 			wp_kses(
 				__(
-					'This site requires two step authentication be enabled for your user account on WordPress.com. Please visit the <a href="%1$s" target="_blank"> Security Settings</a> page to enable two step.',
+					'Two-Step Authentication is required to access this site. Please visit your <a href="%1$s" target="_blank">Security Settings</a> to configure <a href="%2$S" target="_blank">Two-step Authentication</a> for your account.',
 					'jetpack'
 				),
 				array(  'a' => array( 'href' => array() ) )
 			),
-			'https://wordpress.com/me/security/two-step'
+			'https://wordpress.com/me/security/two-step',
+			'https://support.wordpress.com/security/two-step-authentication/'
 		);
 
 		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );
@@ -998,7 +999,7 @@ class Jetpack_SSO {
 		$error = sprintf(
 			wp_kses(
 				__(
-					'You already have an account on this site. Please log in <a href="%1$s">with your username and password</a> and connect your account to WordPress.com.',
+					'You already have an account on this site. Please <a href="%1$s">sign in</a> with your username and password and then connect to WordPress.com.',
 					'jetpack'
 				),
 				array(  'a' => array( 'href' => array() ) )
@@ -1058,7 +1059,7 @@ class Jetpack_SSO {
 	 */
 	function cant_find_user( $message ) {
 		$error = esc_html__(
-			"We couldn't find an account to log you in with. If you already have an account, please make sure that you have connected it to WordPress.com.",
+			"We couldn't find your account. If you already have an account, make sure you have connected to WordPress.com.",
 			'jetpack'
 		);
 		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1023,12 +1023,12 @@ class Jetpack_SSO {
 		$msg = sprintf(
 			wp_kses(
 				__(
-					'Jetpack authenticates through WordPress.com — to log in, enter your WordPress.com username and password, or <a href="%1$s" target="_blank">visit WordPress.com</a> to create a free account now.',
+					'Jetpack authenticates through WordPress.com. To log in, enter your WordPress.com username and password, or <a href="%1$s" target="_blank">visit WordPress.com</a> to create a free account now.',
 					'jetpack'
 				),
 				array(  'a' => array( 'href' => array() ) )
 			),
-			'http://wordpress.com/signup'
+			'http://wordpress.com/start/jetpack'
 		);
 
 		/**

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -970,9 +970,18 @@ class Jetpack_SSO {
 	 * @return string
 	 **/
 	public function error_msg_enable_two_step( $message ) {
-		$err = __( sprintf( 'This site requires two step authentication be enabled for your user account on WordPress.com. Please visit the <a href="%1$s" target="_blank"> Security Settings</a> page to enable two step', 'https://wordpress.com/me/security/two-step' ) , 'jetpack' );
+		$error = sprintf(
+			wp_kses(
+				__(
+					'This site requires two step authentication be enabled for your user account on WordPress.com. Please visit the <a href="%1$s" target="_blank"> Security Settings</a> page to enable two step.',
+					'jetpack'
+				),
+				array(  'a' => array( 'href' => array() ) )
+			),
+			'https://wordpress.com/me/security/two-step'
+		);
 
-		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $err );
+		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );
 
 		return $message;
 	}
@@ -986,9 +995,18 @@ class Jetpack_SSO {
 	 * @return string
 	 */
 	public function error_msg_email_already_exists( $message ) {
-		$err = __( sprintf( 'You already have an account on this site. Please visit your <a href="%1$s">profile page</a> page to link your account to WordPress.com!', admin_url( 'profile.php' ) ) , 'jetpack' );
+		$error = sprintf(
+			wp_kses(
+				__(
+					'You already have an account on this site. Please visit your <a href="%1$s">profile page</a> page to link your account to WordPress.com!',
+					'jetpack'
+				),
+				array(  'a' => array( 'href' => array() ) )
+			),
+			admin_url( 'profile.php' )
+		);
 
-		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $err );
+		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );
 
 		return $message;
 	}
@@ -1002,8 +1020,16 @@ class Jetpack_SSO {
 	 * @return string
 	 **/
 	public function msg_login_by_jetpack( $message ) {
-
-		$msg = __( sprintf( 'Jetpack authenticates through WordPress.com — to log in, enter your WordPress.com username and password, or <a href="%1$s" target="_blank">visit WordPress.com</a> to create a free account now.', 'http://wordpress.com/signup' ) , 'jetpack' );
+		$msg = sprintf(
+			wp_kses(
+				__(
+					'Jetpack authenticates through WordPress.com — to log in, enter your WordPress.com username and password, or <a href="%1$s" target="_blank">visit WordPress.com</a> to create a free account now.',
+					'jetpack'
+				),
+				array(  'a' => array( 'href' => array() ) )
+			),
+			'http://wordpress.com/signup'
+		);
 
 		/**
 		 * Filter the message displayed when the default WordPress login form is disabled.
@@ -1016,18 +1042,27 @@ class Jetpack_SSO {
 		 */
 		$msg = apply_filters( 'jetpack_sso_disclaimer_message', $msg );
 
+		if ( empty( $msg ) ) {
+			return $message;
+		}
+
 		$message .= sprintf( '<p class="message">%s</p>', $msg );
 		return $message;
 	}
 
+	/**
+	 * Message displayed when the user can not be found after approving the SSO process on WordPress.com
+	 *
+	 * @param string $message
+	 * @return string
+	 */
 	function cant_find_user( $message ) {
-		if ( self::match_by_email() ) {
-			$err_format = __( 'We couldn\'t find an account with the email <strong><code>%1$s</code></strong> to log you in with.  If you already have an account on <strong>%2$s</strong>, please make sure that <strong><code>%1$s</code></strong> is configured as the email address, or that you have connected to WordPress.com on your profile page.', 'jetpack' );
-		} else {
-			$err_format = __( 'We couldn\'t find any account on <strong>%2$s</strong> that is linked to your WordPress.com account to log you in with.  If you already have an account on <strong>%2$s</strong>, please make sure that you have connected to WordPress.com on your profile page.', 'jetpack' );
-		}
-		$err = sprintf( $err_format, $this->user_data->email, get_bloginfo( 'name' ) );
-		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $err );
+		$error = esc_html__(
+			"We couldn't find an account to log you in with. If you already have an account, please make sure that you have connected it to WordPress.com.",
+			'jetpack'
+		);
+		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );
+
 		return $message;
 	}
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1004,7 +1004,7 @@ class Jetpack_SSO {
 				),
 				array(  'a' => array( 'href' => array() ) )
 			),
-			add_query_arg( 'jetpack-sso-default-form', '1', wp_login_url() )
+			esc_url_raw( add_query_arg( 'jetpack-sso-default-form', '1', wp_login_url() ) )
 		);
 
 		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -998,12 +998,12 @@ class Jetpack_SSO {
 		$error = sprintf(
 			wp_kses(
 				__(
-					'You already have an account on this site. Please visit your <a href="%1$s">profile page</a> page to link your account to WordPress.com.',
+					'You already have an account on this site. Please log in <a href="%1$s">with your username and password</a> and connect your account to WordPress.com.',
 					'jetpack'
 				),
 				array(  'a' => array( 'href' => array() ) )
 			),
-			admin_url( 'profile.php' )
+			add_query_arg( 'jetpack-sso-default-form', '1', wp_login_url() )
 		);
 
 		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -49,7 +49,7 @@ class Jetpack_SSO {
 			 */
 			apply_filters( 'jetpack_sso_display_disclaimer', true )
 		) {
-			add_action( 'login_message', array( $this, 'msg_login_by_jetpack' ) );
+			add_filter( 'login_message', array( $this, 'msg_login_by_jetpack' ) );
 		}
 	}
 
@@ -634,7 +634,7 @@ class Jetpack_SSO {
 			$this->user_data = $user_data;
 			/** This filter is documented in core/src/wp-includes/pluggable.php */
 			do_action( 'wp_login_failed', $user_data->login );
-			add_action( 'login_message', array( $this, 'error_msg_enable_two_step' ) );
+			add_filter( 'login_message', array( $this, 'error_msg_enable_two_step' ) );
 			return;
 		}
 
@@ -692,7 +692,7 @@ class Jetpack_SSO {
 			} else {
 				$this->user_data = $user_data;
 				// do_action( 'wp_login_failed', $user_data->login );
-				add_action( 'login_message', array( $this, 'error_msg_email_already_exists' ) );
+				add_filter( 'login_message', array( $this, 'error_msg_email_already_exists' ) );
 				return;
 			}
 		}
@@ -774,7 +774,7 @@ class Jetpack_SSO {
 		$this->user_data = $user_data;
 		/** This filter is documented in core/src/wp-includes/pluggable.php */
 		do_action( 'wp_login_failed', $user_data->login );
-		add_action( 'login_message', array( $this, 'cant_find_user' ) );
+		add_filter( 'login_message', array( $this, 'cant_find_user' ) );
 	}
 
 	static function profile_page_url() {

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1020,20 +1020,6 @@ class Jetpack_SSO {
 		return $message;
 	}
 
-	/**
-	 * Error message displayed on the login form when the user attempts
-	 * to post to the login form and it is disabled.
-	 *
-	 * @since 2.8
-	 * @param string $message
-	 * @param string
-	 **/
-	public function error_msg_login_method_not_allowed( $message ) {
-		$err = __( 'Login method not allowed' , 'jetpack' );
-		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $err );
-
-		return $message;
-	}
 	function cant_find_user( $message ) {
 		if ( self::match_by_email() ) {
 			$err_format = __( 'We couldn\'t find an account with the email <strong><code>%1$s</code></strong> to log you in with.  If you already have an account on <strong>%2$s</strong>, please make sure that <strong><code>%1$s</code></strong> is configured as the email address, or that you have connected to WordPress.com on your profile page.', 'jetpack' );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1021,16 +1021,7 @@ class Jetpack_SSO {
 	 * @return string
 	 **/
 	public function msg_login_by_jetpack( $message ) {
-		$msg = sprintf(
-			wp_kses(
-				__(
-					'Jetpack authenticates through WordPress.com. To log in, enter your WordPress.com username and password, or <a href="%1$s" target="_blank">visit WordPress.com</a> to create a free account now.',
-					'jetpack'
-				),
-				array(  'a' => array( 'href' => array() ) )
-			),
-			'http://wordpress.com/start/jetpack'
-		);
+		$msg = esc_html__( 'A WordPress.com account is required to access this site. Click the button below to sign in or create a free WordPress.com account.', 'jetpack' );
 
 		/**
 		 * Filter the message displayed when the default WordPress login form is disabled.


### PR DESCRIPTION
This PR cleans up and improves wording for the error and informational notices shown when SSO fails.

To test, you'll follow similar instructions as on #3845:

- Checkout `update/sso-error-notices` branch
- Go to remote site and attempt to SSO. Here are flows to test:
    - User is connected to WP.com
    - User is not connected to WP.com
        - Match by email. Does user's WP.org email match the WP.com email address?
        - Registrations allowed. Enable/disable [new user registrations on remote site](https://codex.wordpress.org/Network_Admin_Settings_Screen#Registration_Settings).
        - [WPCC_NEW_USER_OVERRIDE](https://jetpack.com/support/sso/#custom-settings) is true and new user is allowed for SSO.
    - [WP.org login form is bypassed](https://jetpack.com/support/sso/#custom-settings) and user is redirected to WP.com
    - Errors
        - Can't find user. 
            - Make sure user is not connected to WP.com. Also, make sure WP.org email doesn't match WP.com user's email. Attempt to SSO.
        - Nonce not created. 
            - Intentionally break `request_initial_nonce()` by setting [user_id](https://github.com/Automattic/jetpack/blob/master/modules/sso.php#L575) to a non-existent user or user that is not connected to WP.com. You should be able to trigger an invalid token error.
        - Identity crisis.
        - 2fa required.
            - In compat plugin, `add_filter( 'jetpack_sso_require_two_step', '__return_true' );`
            - Attempt to SSO with a WP.com user that does not have 2fa enabled.
        

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
