### PR TITLE
VideoPress: make sure wp.media.coerce is available

### DIFF
--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -150,7 +150,7 @@ function videopress_handle_editor_view_js() {
 
 	add_action( 'admin_print_footer_scripts', 'videopress_editor_view_js_templates' );
 
-	wp_enqueue_script( 'videopress-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'jquery' ), false, true );
+	wp_enqueue_script( 'videopress-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'media-editor', 'jquery' ), false, true );
 	wp_localize_script( 'videopress-editor-view', 'vpEditorView', array(
 		'home_url_host'     => parse_url( home_url(), PHP_URL_HOST ),
 		'min_content_width' => VIDEOPRESS_MIN_WIDTH,


### PR DESCRIPTION
Fixes #3799

When using the VideoPress Editor View, we should make sure media-editor is included as a dependency.