### PR TITLE
Update Babel to 6.8.0 and fix gradient warnings. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
     "@automattic/dops-components": "automattic/dops-components",
-    "babel-core": "5.8.25",
+    "babel-core": "6.8.0",
     "babel-eslint": "4.1.7",
     "babel-loader": "5.3.2",
     "babel-register": "^6.7.2",

--- a/scss/templates/_main.scss
+++ b/scss/templates/_main.scss
@@ -167,12 +167,7 @@
 	text-align: center;
 	z-index: 1;
 	background-color: $start;
-	background-image: -webkit-gradient(linear, left top, left bottom, from($start),to($end));
-	background-image: -webkit-linear-gradient(top, $start, $end);
-	background-image: -moz-linear-gradient(top, $start, $end);
-	background-image: -o-linear-gradient(top, $start, $end);
-	background-image: -ms-linear-gradient(top, $start, $end);
-	background-image: linear-gradient(top, $start, $end);
+	background-image: linear-gradient(to bottom, $start, $end);
 
 	&:after {
 		content: '';


### PR DESCRIPTION
Fixes some warnings on build.  Babel 6.8.0 seems to work fine. 

You should no longer see gradient warnings on build.  

fixes what we can of #3818 