### PR TITLE
Admin Page: Allow subscribers to connect to WP.com

### DIFF
--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -18,7 +18,9 @@ const NonAdminView = React.createClass( {
 	renderContent: function() {
 		const userData = window.Initial_State.userData.currentUser;
 		const isLinked = this.props.isLinked( this.props );
-		let headerText = 'Write posts via email, get notifications about your site activity, and log in with a single click.';
+		let headerText = userData.permissions.edit_posts
+			? 'Write posts via email, get notifications about your site activity, and log in with a single click.'
+			: 'Get notifications about your site activity and log in with a single click.';
 		let descriptionText = 'Sign in to your WordPress.com account to unlock these features.';
 		let belowText = 'No WordPress.com account? Create one for free.';
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -283,6 +283,7 @@ function jetpack_current_user_data() {
 			'manage_modules'     => current_user_can( 'jetpack_manage_modules' ),
 			'network_admin'      => current_user_can( 'jetpack_network_admin_page' ),
 			'network_sites_page' => current_user_can( 'jetpack_network_sites_page' ),
+			'edit_posts'         => current_user_can( 'edit_posts' ),
 		),
 	);
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -805,28 +805,10 @@ class Jetpack {
 				if ( Jetpack::is_development_mode() ) {
 					$caps = array( 'manage_options' );
 					break;
+				} else {
+					$caps = array( 'read' );
 				}
-
-				// Don't ever show to subscribers, but allow access to the page if they're trying to unlink.
-				if ( ! current_user_can( 'edit_posts' ) ) {
-					if ( isset( $_GET['redirect'] ) && 'sub-unlink' == $_GET['redirect'] ) {
-						// We need this in order to unlink the user.
-						$this->admin_page_load();
-					}
-					if ( ! wp_verify_nonce( 'jetpack-unlink' ) ) {
-						$caps = array( 'do_not_allow' );
-						break;
-					}
-				}
-
-				if ( ! self::is_active() && ! current_user_can( 'jetpack_connect' ) ) {
-					$caps = array( 'do_not_allow' );
-					break;
-				}
-				/**
-				 * Pass through. If it's not development mode, these should match the admin page.
-				 * Let users disconnect if it's development mode, just in case things glitch.
-				 */
+				break;
 			case 'jetpack_connect_user' :
 				if ( Jetpack::is_development_mode() ) {
 					$caps = array( 'do_not_allow' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6941,11 +6941,6 @@ p {
 			<?php endif; ?>
 		</div>
 
-
-		<?php if ( ! current_user_can( 'edit_posts' ) && self::is_user_connected() ) : ?>
-			<div style="width: 100%; text-align: center; padding-top: 20px; clear: both;"><a class="button" title="<?php esc_attr_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?>" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'unlink', 'redirect' => 'sub-unlink' ), admin_url( 'index.php' ) ), 'jetpack-unlink' ) ); ?>"><?php esc_html_e( 'Unlink your account from WordPress.com', 'jetpack' ); ?></a></div>
-		<?php endif; ?>
-
 		</footer>
 		<?php
 	}


### PR DESCRIPTION
Subscribers were allowed access to the admin page to connect until #2441.

Now that we've modified SSO to rely on a connection to WP.com, we should allow subscribers access to the admin page so that they can connect their remote account to WordPress.com.

To test:
- Checkout `update/subscriber-allowed-admin-page` branch
- Log in on the remote site with a subscriber account
- Go to Jetpack admin page.
- Link account to WP.com
- Go to dasboard and make sure unlink widget is not there
- Go to Jetpack admin page and attempt to unlink
- Does everything work? Good 😄 

cc @lezama. Also, @dereksmart who originally removed the functionality. Also, for his help in figuring out where to update this header text for subscriber users:

![d42dc974-1e82-11e6-982f-b0159522bd24](https://cloud.githubusercontent.com/assets/1126811/15438080/1a22056e-1e90-11e6-9aee-64b9ffa8b120.png)



-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
