### PR TITLE
WPCONTENT: cleaning up some jetpack styles that override core styling

### DIFF
--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -13,32 +13,8 @@
 
 // General Elements
 
-#wpbody-content {
-	padding-bottom: 0;
-}
-
-#wpcontent {
-	margin-left: 160px;
-	padding: 0;
-}
-
-.folded #wpcontent {
-	margin-left: 36px;
-}
-
-#wpcontent,
-.auto-fold #wpcontent,
-.auto-fold #wpfooter,
-.modal,
-.configure .frame.top.fixed {
-	@media ( max-width: 900px ) {
-		margin-left: 36px;
-		padding-left: 0;
-	};
-
-	@media ( max-width: 782px ) {
-		margin-left: 0;
-	};
+.jetpack-pagestyles #wpcontent {
+	padding-left: 0;
 }
 
 .jetpack-pagestyles #wpbody-content {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/3815 reported by @ebinnion 

Problem: when you collapse / expand the `wp-admin` sidebar navigation on medium and small screens, the sidebar overlaps the jetpack dashboard instead of pushing it to the side.

Example: 
![image](https://cloud.githubusercontent.com/assets/214813/15443031/16656b64-1eb3-11e6-8bbd-75a2eb8f5333.png)

This was caused by some css added to Jetpack that override some core styles.

Effects Jetpack React and currently released versions of Jetpack. 

Solution: removed those styles and made a slight padding tweak that only effects `wpcontent` within the jetpack dashboard

![screen shot 2016-05-20 at 5 56 40 pm](https://cloud.githubusercontent.com/assets/214813/15443068/68ac7e3a-1eb3-11e6-8a80-7f004fdfc81a.png)
