### PR TITLE
Admin Page: Internationalize non-admin-view component of admin page

### DIFF
--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Card from 'components/card';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -18,14 +19,19 @@ const NonAdminView = React.createClass( {
 	renderContent: function() {
 		const userData = window.Initial_State.userData.currentUser;
 		const isLinked = this.props.isLinked( this.props );
-		let headerText = userData.permissions.edit_posts
-			? 'Write posts via email, get notifications about your site activity, and log in with a single click.'
-			: 'Get notifications about your site activity and log in with a single click.';
-		let descriptionText = 'Sign in to your WordPress.com account to unlock these features.';
-		let belowText = 'No WordPress.com account? Create one for free.';
+		const headerText = userData.permissions.edit_posts
+			? __( 'Write posts via email, get notifications about your site activity, and log in with a single click.' )
+			: __( 'Get notifications about your site activity and log in with a single click.' );
+		let descriptionText = __( 'Sign in to your WordPress.com account to unlock these features.' );
+		let belowText = __( 'No WordPress.com account? Create one for free.' );
 
 		if ( isLinked ) {
-			descriptionText = `Connected as user ${ userData.wpcomUser.login } / ${ userData.wpcomUser.email }`;
+			descriptionText = __( 'Connected as user %(userLogin)s / %(userEmail)s', {
+				args: {
+					userLogin: userData.wpcomUser.login,
+					userEmail: userData.wpcomUser.email
+				}
+			} );
 			belowText = '';
 		}
 


### PR DESCRIPTION
Prepares the `non-admin-view` component to be internationalized.

To test:

- Checkout `update/non-admin-view-i18n` branch
- Login to your site with a user that is not an admin. Example: `Subscriber`.
- Does everything work? 

Note: The strings will not appear translated. But, I believe that's because the strings have not yet actually been translated. 😝 

cc @dereksmart or @lezama for review.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

