### PR TITLE
Admin Page: Fix connect URL 

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -418,7 +418,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function build_connect_url() {
 		if ( require_once( ABSPATH . 'wp-admin/includes/plugin.php' ) ) {
-			$url = Jetpack::init()->build_connect_url( true, true, false );
+			$url = Jetpack::init()->build_connect_url( true, false, false );
 			return rest_ensure_response( $url );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4358,7 +4358,10 @@ p {
 
 			$user = wp_get_current_user();
 
-			$redirect = $redirect ? esc_url_raw( $redirect ) : esc_url_raw( admin_url( 'admin.php?page=jetpack' ) );
+			$jetpack_admin_page = esc_url_raw( admin_url( 'admin.php?page=jetpack' ) );
+			$redirect = $redirect
+				? wp_validate_redirect( esc_url_raw( $redirect ), $jetpack_admin_page )
+				: $jetpack_admin_page;
 
 			$gp_locale = GP_Locales::by_field( 'wp_locale', get_locale() );
 


### PR DESCRIPTION
We've been noticing quite a few redirects to `0.0.0.1` since the admin page landed. After digging into this, I narrowed the problem down to here:

https://github.com/Automattic/jetpack/blob/master/_inc/lib/class.core-rest-api-endpoints.php#L421

Notice how the second argument there is `true`. That is for the redirect. 

Here's where we build the redirect in [build_connect_url()](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L4361). Note, that when `$redirect` is truthy, we call `esc_url_raw( $redirect );`.

And if you run `esc_url_raw( true );` in `wpsh` on your sandbox or a WP environment, you'll get `http://1`. If you find yourself asking, "well, that explains `http://1`, but what about `0.0.0.1`"? Open a new tab in Chrome, and in the console enter `window.location.href = 'http://1';`;

You'll probably get something like this:

![screen shot 2016-05-20 at 11 40 28 pm](https://cloud.githubusercontent.com/assets/1126811/15446366/6947d1d8-1ee4-11e6-9968-991903271855.png)

How do we fix it? Well, I started off by making `build_connect_url` a bit more resistant to redirect failure. Now, on top of escaping the URL, we also validate the URL. That makes sure that the redirect is an allowed host if it has an absolute path. If not, we just redirect to the Jetpack admin page.

Next, I decided to set the second argument in the core API to `false` so that we don't even touch that logic 😝 

cc @beaulebens, @roccotripaldi, @lezama, @dereksmart who are probably most interested.

To test:
- Checkout `fix/build-connect-url-bad-redirect` branch
- Go to Jetpack admin page
- Make sure your user is not connected to WP.com
- Check the link address of the "Link to WordPress.com" button and make sure the `redirect_uri` parameter looks a bit like this:
    - `https%3A%2F%2Fwebsite.com%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack%26action%3Dauthorize%26_wpnonce%3D123456%26redirect%3Dhttps%253A%252F%252Fwebsite.com%252Fwp-admin%252Fadmin.php%253Fpage%253Djetpack`
    - Note that the `redirect` query parameter is not empty

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
