### PR TITLE
SSO: Fix tab order accessibility issue

### DIFF
--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -4,6 +4,10 @@
 	padding-bottom: 92px;
 }
 
+.jetpack-sso-repositioned #loginform {
+	padding-bottom: 26px;
+}
+
 #loginform #jetpack-sso-wrap,
 #loginform #jetpack-sso-wrap * {
 	box-sizing: border-box;
@@ -29,10 +33,20 @@
 	width: 100%;
 }
 
+.jetpack-sso-repositioned #jetpack-sso-wrap {
+	position: relative;
+		bottom: auto;
+	padding: 0;
+	margin-top: 16px;
+	margin-left: 0;
+	margin-right: 0;
+}
+
 .jetpack-sso-body #jetpack-sso-wrap {
 	position: relative;
 		bottom: auto;
 	padding: 0;
+	margin-top: 0;
 	margin-left: 0;
 	margin-right: 0;
 }

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -12,6 +12,9 @@ jQuery( document ).ready( function( $ ) {
 	// checkbox and the submit button within that to clear the float on the
 	// remember me checkbox. This is important since we're positioning the SSO
 	// UI under the submit button.
+	//
+	// @TODO: Remove this approach once core ticket 28528 is in and we have more actions in wp-login.php.
+	// See - https://core.trac.wordpress.org/ticket/28528
 	loginForm.append( overflow );
 	overflow.append( $( 'p.forgetmenot' ), $( 'p.submit' ) );
 

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -8,7 +8,6 @@ jQuery( document ).ready( function( $ ) {
 		loginForm = $( '#loginform' ),
 		overflow  = $( '<div style="overflow: auto;"></div>' );
 
-
 	// The overflow div is a poor man's clearfloat. We reposition the remember me
 	// checkbox and the submit button within that to clear the float on the
 	// remember me checkbox. This is important since we're positioning the SSO

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -9,9 +9,16 @@ jQuery( document ).ready( function( $ ) {
 		overflow  = $( '<div style="overflow: auto;"></div>' );
 
 
+	// The overflow div is a poor man's clearfloat. We reposition the remember me
+	// checkbox and the submit button within that to clear the float on the
+	// remember me checkbox. This is important since we're positioning the SSO
+	// UI under the submit button.
 	loginForm.append( overflow );
 	overflow.append( $( 'p.forgetmenot' ), $( 'p.submit' ) );
 
+	// We reposition the SSO UI at the bottom of the login form which
+	// fixes a tab order issue. Then we override any styles for absolute
+	// positioning of the SSO UI.
 	loginForm.append( ssoWrap );
 	body.addClass( 'jetpack-sso-repositioned' );
 

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -3,7 +3,17 @@ jQuery( document ).ready( function( $ ) {
 		rememberMe = $( '#rememberme' ),
 		ssoButton = $( 'a.jetpack-sso.button' ),
 		toggleSSO = $( '.jetpack-sso-toggle' ),
-		userLogin = $( '#user_login' );
+		userLogin = $( '#user_login' ),
+		ssoWrap   = $( '#jetpack-sso-wrap' ),
+		loginForm = $( '#loginform' ),
+		overflow  = $( '<div style="overflow: auto;"></div>' );
+
+
+	loginForm.append( overflow );
+	overflow.append( $( 'p.forgetmenot' ), $( 'p.submit' ) );
+
+	loginForm.append( ssoWrap );
+	body.addClass( 'jetpack-sso-repositioned' );
 
 	rememberMe.on( 'change', function() {
 		var url       = ssoButton.prop( 'href' ),


### PR DESCRIPTION
Fixes #3796 and alternative solution to #3825.

Fixes a tab order accessibility issue with the new SSO UI by using JavaScript to move the SSO UI to the bottom of the login form in the source, as opposed to just using CSS to position the SSO UI at the bottom of the form.

I'm not super fond of the approach, but the login form provides limited options for customization via hooks. 😞 

cc @kraftbj for testing/review and @lezama for review.

To test:
- Checkout `update/sso-tab-order` branch
- Make sure `sso` module is on
- Go to `/wp-admin`
- Click "Login with username and password" at the bottom of the login form
- Tab through form. Does the order seem correct?
- Disable JavaScript. 😱 
    - I usually use this [Chrome extension](https://chrome.google.com/webstore/detail/quick-javascript-switcher/geddoclleiomckbhadiaipdggiiccfje?hl=en).
- Go to `/wp-admin`
- Click "Login with username and password" at the bottom of the login form
- Tab through form.  

With JavaScript disabled, you'll notice the tab order is a bit off since the `Login with WordPress.com` link. This is because the SSO link is before the submit button in the source. Unfortunately, we can't do too much about this since we have limited actions on the login form to insert the SSO UI. However, we can use JavaScript to enhance the accessibility of the form by preserving tab order.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
