### PR TITLE
Add Sitemaps foldable card to Engagement tab

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
 import { ModuleToggle } from 'components/module-toggle';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -33,7 +34,8 @@ export const Page = ( { toggleModule, isModuleActivated, isTogglingModule, getMo
 		[ 'verification-tools', getModule( 'verification-tools' ).name, getModule( 'verification-tools' ).description, getModule( 'verification-tools' ).learn_more_button ],
 		[ 'subscriptions', getModule( 'subscriptions' ).name, getModule( 'subscriptions' ).description, getModule( 'subscriptions' ).learn_more_button ],
 		[ 'comments', getModule( 'comments' ).name, getModule( 'comments' ).description, getModule( 'comments' ).learn_more_button ],
-		[ 'notes', getModule( 'notes' ).name, getModule( 'notes' ).description, getModule( 'notes' ).learn_more_button ]
+		[ 'notes', getModule( 'notes' ).name, getModule( 'notes' ).description, getModule( 'notes' ).learn_more_button ],
+		[ 'sitemaps', getModule( 'sitemaps' ).name, getModule( 'sitemaps' ).description, getModule( 'sitemaps' ).learn_more_button ]
 	].map( ( element ) => (
 		<FoldableCard key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
 			header={ element[1] }
@@ -52,8 +54,9 @@ export const Page = ( { toggleModule, isModuleActivated, isTogglingModule, getMo
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
-			<br/>
-			<a href={ element[3] } target="_blank">Learm More</a>
+			<p>
+				<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
+			</p>
 		</FoldableCard>
 	) );
 	return (
@@ -75,14 +78,18 @@ function renderSettings( module ) {
 			return(
 				<div>
 					{ renderStatsSettings( module ) }
-					<a href={ module.configure_url }>Link to old settings</a>
+					<a href={ module.configure_url }>{ __( 'Link to old settings' ) }</a>
 				</div>
 			);
+
+		case 'enhanced-distribution':
+		case 'sitemaps':
+			return null;
 
 		default:
 			return (
 				<div>
-					<a href={ module.configure_url }>Link to old settings</a>
+					<a href={ module.configure_url }>{ __( 'Link to old settings' ) }</a>
 				</div>
 			);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Add Sitemaps foldable card to Engagement tab.
When it's activated it shows no link to old settings since they don't exist.

- Eliminates a `<br/>` that was applied to separate the link to old settings from the Learn More link. Since Sitemaps doesn't have settings, the spacing was inconsistent. It was removed and the Learn More link wrapped in a `<p>` tag that inherits proper spacing from WP core.
For consistent spacing, this PR should be applied to DOPS Components
https://github.com/Automattic/dops-components/pull/18
and fetch in the linked package in node_modules.

#### Other changes:
- introduces the corresponding i18n calls
- removes the link to old settings when Enhanced Distribution is active since it doesn't have any settings
- fixes typo "Learm" to "Learn"

#### To test:
In WP Admin, go to Jetpack > Dashboard > Engagement tab.

- The Sitemaps card should be visible at the bottom. If it's active, it should show no link to old settings.
- Verify that Enhanced Distribution doesn't have a link to old settings when it's active.
- Verify that the links read "Learn More" instead of "Learm More".