### PR TITLE
Module Info: img spacing.

### DIFF
--- a/scss/templates/_main.scss
+++ b/scss/templates/_main.scss
@@ -314,7 +314,7 @@
 }
 .jp-info-img {
 	float: right;
-	margin: 0 0 30px 30px;
+	margin: 0 0 8px 30px;
 
 	img {
 		border: 1px solid #ddd;


### PR DESCRIPTION
Reduces bottom margin so it looks consistent with the surrounding padding in the Foldable Card component.

This aims to provide consistent bottom spacing for module info images inserted in the Foldable Card component. Right now the bottom margin adds up to the card padding resulting in:

<img width="891" alt="before" src="https://cloud.githubusercontent.com/assets/1041600/15449613/f56cbb1e-1f58-11e6-85d8-9e5a648fdc8e.png">

with this change, the bottom spacing is even with the left and top spacing.

<img width="894" alt="after" src="https://cloud.githubusercontent.com/assets/1041600/15449612/f5692dfa-1f58-11e6-8708-c9d430be9f5c.png">
