### PR TITLE
Admin Page: Add state reducers tests

### DIFF
--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -23,7 +23,7 @@ import {
 	UNLINK_USER_SUCCESS
 } from 'state/action-types';
 
-const status = ( state = { siteConnected: window.Initial_State.connectionStatus }, action ) => {
+export const status = ( state = { siteConnected: window.Initial_State.connectionStatus }, action ) => {
 	switch ( action.type ) {
 		case JETPACK_CONNECTION_STATUS_FETCH:
 			return assign( {}, state, { siteConnected: action.siteConnected } );
@@ -35,7 +35,7 @@ const status = ( state = { siteConnected: window.Initial_State.connectionStatus 
 	}
 };
 
-const connectUrl = ( state = {}, action ) => {
+export const connectUrl = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case CONNECT_URL_FETCH_SUCCESS:
 			return action.connectUrl;
@@ -45,7 +45,7 @@ const connectUrl = ( state = {}, action ) => {
 	}
 };
 
-const user = ( state = window.Initial_State.userData, action ) => {
+export const user = ( state = window.Initial_State.userData, action ) => {
 	switch ( action.type ) {
 		case USER_CONNECTION_DATA_FETCH_SUCCESS:
 			return assign( {}, state, action.userConnectionData );
@@ -59,14 +59,14 @@ const user = ( state = window.Initial_State.userData, action ) => {
 	}
 };
 
-const connectionRequests = {
+export const connectionRequests = {
 	disconnectingSite: false,
 	unlinkingUser: false,
 	fetchingConnectUrl: false,
 	fetchingUserData: false
 };
 
-const requests = ( state = connectionRequests, action ) => {
+export const requests = ( state = connectionRequests, action ) => {
 	switch ( action.type ) {
 		case DISCONNECT_SITE:
 			return assign( {}, state, { disconnectingSite: true } );

--- a/_inc/client/state/connection/test/reducer.js
+++ b/_inc/client/state/connection/test/reducer.js
@@ -1,0 +1,184 @@
+import { expect } from 'chai';
+
+import {
+	connectUrl as connectUrlReducer,
+	status as statusReducer,
+	user as userReducer,
+	requests as requestsReducer,
+	connectionRequests
+} from '../reducer';
+
+describe( 'status reducer', () => {
+	describe( '#disconnectSite', () => {
+		it( 'should set siteConnected to false when disconnecting site', () => {
+			const stateIn = {};
+			const action = {
+				type: 'DISCONNECT_SITE_SUCCESS',
+				siteConnected: false
+			};
+			let stateOut = statusReducer( stateIn, action );
+			expect( stateOut.siteConnected ).to.be.false;
+		} );
+
+		it( 'should set siteConnected to action.siteConnected\'s value when fetching connection status', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JETPACK_CONNECTION_STATUS_FETCH',
+				siteConnected: true
+			};
+			let stateOut = statusReducer( stateIn, action );
+			expect( stateOut.siteConnected ).to.equal( action.siteConnected );
+		} );
+	} );
+} );
+
+describe( 'connect url reducer', () => {
+	describe( '#fetchConnectUrl', () => {
+		it( 'should set connectUrl to action.connectUrl\'s value when fetching connect url', () => {
+			const stateIn = {};
+			const action = {
+				type: 'CONNECT_URL_FETCH_SUCCESS',
+				connectUrl: '/asdf'
+			};
+			let stateOut = connectUrlReducer( stateIn, action );
+			expect( stateOut ).to.equal( action.connectUrl );
+		} );
+	} );
+} );
+
+describe( 'user reducer', () => {
+	describe( '#fetchConnectUrl', () => {
+		it( 'should set state.user to action.userConnectionData when fetching connect url', () => {
+			const stateIn = {};
+			const action = {
+				type: 'USER_CONNECTION_DATA_FETCH_SUCCESS',
+				userConnectionData: { a: 'b' }
+			};
+			let stateOut = userReducer( stateIn, action );
+			expect( stateOut ).to.eql( action.userConnectionData );
+		} );
+	} );
+} );
+
+describe( 'requests reducer', () => {
+	it( 'state should default to connectionRequests', () => {
+		const state = requestsReducer( undefined, {} );
+		expect( state ).to.equal( connectionRequests );
+	} );
+
+	describe( '#disconnectSite', () => {
+		it( 'should set disconnectingSite to true when disconnecting site', () => {
+			const stateIn = {};
+			const action = {
+				type: 'DISCONNECT_SITE'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.disconnectingSite ).to.be.true;
+		} );
+
+		it( 'should set disconnectingSite to false when site was disconnected', () => {
+			const stateIn = {};
+			const action = {
+				type: 'DISCONNECT_SITE_SUCCESS'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.disconnectingSite ).to.be.false;
+		} );
+
+		it( 'should set disconnectingSite to false when disconnecting site failed', () => {
+			const stateIn = {};
+			const action = {
+				type: 'DISCONNECT_SITE_FAIL'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.disconnectingSite ).to.be.false;
+		} );
+	} );
+
+	describe( '#unlinkUser', () => {
+		it( 'should set unlinkingUser to true when unliking user', () => {
+			const stateIn = {};
+			const action = {
+				type: 'UNLINK_USER'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.unlinkingUser ).to.be.true;
+		} );
+
+		it( 'should set unlinkingUser to false when user was unlinked', () => {
+			const stateIn = {};
+			const action = {
+				type: 'UNLINK_USER_SUCCESS'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.unlinkingUser ).to.be.false;
+		} );
+
+		it( 'should set unlinkingUser to false when unlinking a user failed', () => {
+			const stateIn = {};
+			const action = {
+				type: 'UNLINK_USER_FAIL'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.unlinkingUser ).to.be.false;
+		} );
+	} );
+
+	describe( '#fetchConnectUrl', () => {
+		it( 'should set fetchingConnectUrl to true when fetching connect URL', () => {
+			const stateIn = {};
+			const action = {
+				type: 'CONNECT_URL_FETCH'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingConnectUrl ).to.be.true;
+		} );
+
+		it( 'should set fetchingConnectUrl to false when connect URL was fetched', () => {
+			const stateIn = {};
+			const action = {
+				type: 'CONNECT_URL_FETCH_SUCCESS'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingConnectUrl ).to.be.false;
+		} );
+
+		it( 'should set fetchingConnectUrl to false when fecthing the connect URL', () => {
+			const stateIn = {};
+			const action = {
+				type: 'CONNECT_URL_FETCH_FAIL'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingConnectUrl ).to.be.false;
+		} );
+	} );
+
+	describe( '#fetchUSerConnectionData', () => {
+		it( 'should set fetchingUserData to true when fetching User\'s connection data', () => {
+			const stateIn = {};
+			const action = {
+				type: 'USER_CONNECTION_DATA_FETCH'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingUserData ).to.be.true;
+		} );
+
+		it( 'should set fetchingUserData to false when User\'s connection data was fetched', () => {
+			const stateIn = {};
+			const action = {
+				type: 'USER_CONNECTION_DATA_FETCH_SUCCESS'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingUserData ).to.be.false;
+		} );
+
+		it( 'should set fetchingUserData to false when fecthing the User\'s connection data', () => {
+			const stateIn = {};
+			const action = {
+				type: 'USER_CONNECTION_DATA_FETCH_FAIL'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingUserData ).to.be.false;
+		} );
+	} );
+} );

--- a/_inc/client/state/jumpstart/reducer.js
+++ b/_inc/client/state/jumpstart/reducer.js
@@ -16,11 +16,13 @@ import {
 } from 'state/action-types';
 
 const jumpstartState = {
-	showJumpStart: window.Initial_State.showJumpstart,
+	showJumpStart: typeof window !== 'undefined' && typeof window.Initial_State === 'object' ?
+		window.Initial_State.showJumpstart :
+		{},
 	isJumpstarting: false
 };
 
-const status = ( state = jumpstartState, action ) => {
+export const status = ( state = jumpstartState, action ) => {
 	switch ( action.type ) {
 		case JUMPSTART_ACTIVATE:
 			return assign( {}, state, { isJumpstarting: true } );

--- a/_inc/client/state/jumpstart/test/reducer.js
+++ b/_inc/client/state/jumpstart/test/reducer.js
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+
+import {
+	status as statusReducer
+} from '../reducer';
+
+const jumpstartState = {
+	showJumpStart: {},
+	isJumpstarting: false
+};
+
+describe( 'status reducer', () => {
+	it( 'state should default to empty object', () => {
+		const stateOut = statusReducer( undefined, {} );
+		expect( stateOut ).to.eql( jumpstartState );
+	} );
+
+	describe( '#jumpstartActivation', () => {
+		it( 'should set isJumpstarting to true when activating jumpstart', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JUMPSTART_ACTIVATE'
+			};
+			let stateOut = statusReducer( stateIn, action );
+			expect( stateOut.isJumpstarting ).to.be.true;
+		} );
+
+		it( 'should set isJumpstarting and showJumpStart to false when jumpstart activation suceeds', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JUMPSTART_ACTIVATE_SUCCESS'
+			};
+			let stateOut = statusReducer( stateIn, action );
+			expect( stateOut.isJumpstarting ).to.be.false;
+			expect( stateOut.showJumpStart ).to.be.false;
+		} );
+
+		it( 'should set isJumpstarting and showJumpStart to false when jumpstart is skipped', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JUMPSTART_SKIP'
+			};
+			let stateOut = statusReducer( stateIn, action );
+			expect( stateOut.isJumpstarting ).to.be.false;
+			expect( stateOut.showJumpStart ).to.be.false;
+		} );
+
+		it( 'should set isJumpstarting to false when jumpstart activation fails', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JUMPSTART_ACTIVATE_FAIL'
+			};
+			let stateOut = statusReducer( stateIn, action );
+			expect( stateOut.isJumpstarting ).to.be.false;
+		} );
+	} );
+
+	describe( '#optionsReset', () => {
+		it( 'should set showJumpStart to true when resetting options', () => {
+			const stateIn = {};
+			const action = {
+				type: 'RESET_OPTIONS_SUCCESS'
+			};
+			let stateOut = statusReducer( stateIn, action );
+			expect( stateOut.showJumpStart ).to.be.true;
+		} );
+	} );
+} );

--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -25,7 +25,7 @@ import {
 
 } from 'state/action-types';
 
-const items = ( state = window.Initial_State.getModules, action ) => {
+export const items = ( state = window.Initial_State.getModules, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SET_INITIAL_STATE:
 		case JETPACK_MODULES_LIST_RECEIVE:
@@ -49,14 +49,14 @@ const items = ( state = window.Initial_State.getModules, action ) => {
 	}
 };
 
-const initialRequestsState = {
+export const initialRequestsState = {
 	fetchingModulesList: false,
 	activating: {},
 	deactivating: {},
 	updatingOption: {}
 };
 
-const requests = ( state = initialRequestsState, action ) => {
+export const requests = ( state = initialRequestsState, action ) => {
 	switch ( action.type ) {
 		case JETPACK_MODULES_LIST_FETCH:
 			return assign( {}, state, { fetchingModulesList: true} );
@@ -92,14 +92,18 @@ const requests = ( state = initialRequestsState, action ) => {
 		case JETPACK_MODULE_UPDATE_OPTION:
 			return assign( {}, state, {
 				updatingOption: assign( {}, state.updatingOption, {
-					[ action.module ]: true
+					[ action.module ]: Object.assign( {}, get( state.updatingOption, action.module, {} ), {
+						[ action.option_name ]: true
+					} )
 				}
 			) } );
 		case JETPACK_MODULE_UPDATE_OPTION_FAIL:
 		case JETPACK_MODULE_UPDATE_OPTION_SUCCESS:
 			return assign( {}, state, {
 				updatingOption: assign( {}, state.updatingOption, {
-					[ action.module ]: false
+					[ action.module ]: Object.assign( {}, get( state.updatingOption, action.module, {} ), {
+						[ action.option_name ]: false
+					} )
 				}
 			) } );
 		default:

--- a/_inc/client/state/modules/test/reducer.js
+++ b/_inc/client/state/modules/test/reducer.js
@@ -1,0 +1,183 @@
+import { expect } from 'chai';
+
+import {
+	items as itemsReducer,
+	requests as requestsReducer,
+	initialRequestsState
+} from '../reducer';
+
+
+describe( 'items reducer', () => {
+	it( 'state should default to empty object', () => {
+		const state = itemsReducer( undefined, {} );
+		expect( state ).to.equal( {} );
+	} );
+
+	let modules = {
+		a: {
+			module: 'module-a',
+			activated: false
+		},
+		b: {
+			module: 'module-b',
+			activated: true,
+			options: {
+				c: {
+					currentValue: 2
+				}
+			}
+		},
+	};
+
+	describe( '#modulesFetch', () => {
+		it( 'should replace .items with the modules list', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULES_LIST_RECEIVE',
+				modules: modules
+			};
+			let stateOut = itemsReducer( stateIn, action );
+			expect( Object.keys( stateOut ).length ).to.equal( Object.keys( action.modules ).length );
+		} );
+	} );
+
+	describe( '#modulesActivation', () => {
+		it( 'should activate a module', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULE_ACTIVATE_SUCCESS',
+				module: 'module-a'
+			};
+			let stateOut = itemsReducer( stateIn, action );
+			expect( stateOut[ 'module-a' ].activated ).to.be.true;
+		} );
+
+		it( 'should deactivate a module', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULE_DEACTIVATE_SUCCESS',
+				module: 'module-b'
+			};
+			let stateOut = itemsReducer( stateIn, action );
+			expect( stateOut[ 'module-b' ].activated ).to.be.false;
+		} );
+	} );
+
+	describe( '#modulesOptionsUpdate', () => {
+		it( 'should update a module\'s option', () => {
+			const stateIn = modules;
+			const action = {
+				type: 'JETPACK_MODULE_UPDATE_OPTION_SUCCESS',
+				module: 'module-b',
+				option_name: 'c',
+				option_value: 30
+			};
+			let stateOut = itemsReducer( stateIn, action );
+			expect( stateOut[ action.module ].options[ action.option_name ].currentValue ).to.eql( action.option_value );
+		} );
+	} );
+} );
+
+describe( 'requests reducer', () => {
+	it( 'state should default to initialState', () => {
+		const state = requestsReducer( undefined, {} );
+		expect( state ).to.equal( initialRequestsState );
+	} );
+
+	describe( '#modulesFetch', () => {
+		it( 'should set fetchingModulesList to true when fetching', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULES_LIST_FETCH'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingModulesList ).to.be.true;
+		} );
+
+		it( 'should set fetchingModulesList to false when receeiving module list', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULES_LIST_RECEIVE'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingModulesList ).to.be.false;
+		} );
+
+		it( 'should set fetchingModulesList to false when fetching fails', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULES_LIST_FETCH_FAIL'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingModulesList ).to.be.false;
+		} );
+
+	} );
+
+	describe( '#modulesActivation', () => {
+		it( 'should set activating[ module_slug ] to true when activating a module', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULE_ACTIVATE',
+				module: 'module_slug'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.activating[ action.module ] ).to.be.true;
+		} );
+
+		it( 'should set activating[ module_slug ] to false when module has been activated', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULE_ACTIVATE_SUCCESS',
+				module: 'module_slug'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.activating[ action.module ] ).to.be.false;
+		} );
+
+		it( 'should set activating[ module_slug ] to false when activating a module fails', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULE_ACTIVATE_FAIL',
+				module: 'module_slug'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.activating[ action.module ] ).to.be.false;
+		} );
+	} );
+
+	describe( '#moduleOptionsUpdate', () => {
+		it( 'should set updatingOption[ module_slug ][ option_name ] to true when updating a module\'s option', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULE_UPDATE_OPTION',
+				module: 'module_slug',
+				option_name: 'option_name'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.updatingOption[ action.module ][ action.option_name] ).to.be.true;
+		} );
+
+		it( 'should set updatingOption[ module_slug ][ option_name ] to false when a module\'s option has been updated', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULE_UPDATE_OPTION_SUCCESS',
+				module: 'module_slug',
+				option_name: 'option_name'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.updatingOption[ action.module ][ action.option_name] ).to.be.false;
+		} );
+
+		it( 'should set updatingOption[ module_slug ][ option_name ] to false when updating a module\'s option fails', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_MODULE_UPDATE_OPTION_FAIL',
+				module: 'module_slug',
+				option_name: 'option_name'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.updatingOption[ action.module ][ action.option_name] ).to.be.false;
+		} );
+	} );
+} );

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -17,7 +17,7 @@ import {
 	JETPACK_SETTING_UPDATE_FAIL
 } from 'state/action-types';
 
-const items = ( state = {}, action ) => {
+export const items = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SETTINGS_FETCH_RECEIVE:
 			return assign( {}, action.settings );
@@ -31,12 +31,12 @@ const items = ( state = {}, action ) => {
 	}
 };
 
-const initialRequestsState = {
+export const initialRequestsState = {
 	fetchingSettingsList: false,
 	updatingSetting: {}
 };
 
-const requests = ( state = initialRequestsState, action ) => {
+export const requests = ( state = initialRequestsState, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SETTINGS_FETCH:
 			return assign( {}, state, {

--- a/_inc/client/state/settings/test/reducer.js
+++ b/_inc/client/state/settings/test/reducer.js
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+
+import {
+	items as itemsReducer,
+	requests as requestsReducer,
+	initialRequestsState
+} from '../reducer';
+
+describe( 'items reducer', () => {
+	it( 'state should default to empty object', () => {
+		const stateOut = itemsReducer( undefined, {} );
+		expect( stateOut ).to.be.empty;
+	} );
+
+	let settings = {
+		a: {
+			name: 'setting-a'
+		},
+		b: {
+			name: 'setting-b',
+		},
+	};
+
+	describe( '#settingsFetch', () => {
+		it( 'should replace .items with the settings list', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JETPACK_SETTINGS_FETCH_RECEIVE',
+				settings: settings
+			};
+			let stateOut = itemsReducer( stateIn, action );
+			expect( Object.keys( stateOut ).length ).to.equal( Object.keys( action.settings ).length );
+		} );
+	} );
+
+	describe( '#settingsUpdate', () => {
+		it( 'should update a setting', () => {
+			const stateIn = settings;
+			const action = {
+				type: 'JETPACK_SETTING_UPDATE_SUCCESS',
+				updatedOption: {
+					setting_name: 'new-value'
+				}
+			};
+			let stateOut = itemsReducer( stateIn, action );
+			expect( stateOut[ 'setting_name' ] ).to.equal( 'new-value' );
+		} );
+	} );
+
+} );
+
+describe( 'requests reducer', () => {
+	it( 'state should default to initialRequestsState', () => {
+		const state = requestsReducer( undefined, {} );
+		expect( state ).to.equal( initialRequestsState );
+	} );
+
+	describe( '#settingsFetch', () => {
+		it( 'should set fetchingSettingsList to true when fetching', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JETPACK_SETTINGS_FETCH'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingSettingsList ).to.be.true;
+		} );
+
+		it( 'should set fetchingSettingsList to false when setting was updated', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JETPACK_SETTINGS_FETCH_RECEIVE'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingSettingsList ).to.be.false;
+		} );
+
+		it( 'should set fetchingSettingsList to false when updating a setting failed', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JETPACK_SETTINGS_FETCH_FAIL'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.fetchingSettingsList ).to.be.false;
+		} );
+	} );
+
+	describe( '#settingUpdate', () => {
+		it( 'should set updatingSetting to true when updating a setting', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JETPACK_SETTING_UPDATE'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.updatingSetting ).to.be.true;
+		} );
+
+		it( 'should set updatingSetting to false when a setting was updated', () => {
+			const stateIn = {};
+			const action = {
+				type: 'JETPACK_SETTING_UPDATE_SUCCESS'
+			};
+			let stateOut = requestsReducer( stateIn, action );
+			expect( stateOut.updatingSetting ).to.be.false;
+		} );
+	} );
+} );
+

--- a/_inc/client/tests.json
+++ b/_inc/client/tests.json
@@ -1,7 +1,17 @@
 {
-	"components": {
-		"navigation": {
-			"test": [ "index" ]
+	"state": {
+		"modules": {
+			"test": [ "reducer" ]
+		},
+		"settings": {
+			"test": [ "reducer" ]
+		},
+		"jumpstart": {
+			"test": [ "reducer" ]
+		},
+		"connection": {
+			"test": [ "reducer" ]
 		}
 	}
+
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Removes the `navigation` test from `tests.json` until this test doesn't crash
- Adds test for modules/reducer
- Adds test for settings/reducer
- Adds test for jumpstart/reducer
- Adds test for connection/reducer


_Some of these tests are failing now. Due to bugs mainly_ 
* Module options update requests flags are fixed by this branch
* Settings update requests flags are left to be fixed by another branch
* Module items default state from `window.InitialState`, needs to be replaced for something that allows the items reducer to be a pure function we can test without depending on the `window.InitialState` variable.

#### Testing instructions

1. Run
  ```shell
  $ npm run test-client
  ```

1. Expect to see **44 tests passing** and **3 tests failing**