### PR TITLE
Background Style: optimize for admin notices.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -77,10 +77,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return $this->render_nojs_configurable();
 		}
 		?>
-		<?php
-			/** This action is already documented in views/admin/admin-page.php */
-			do_action( 'jetpack_notices' );
-		?>
+		<style>
+			.jetpack-pagestyles #wpbody-content {
+				background: #72af3a !important;
+			}
+			#jp-plugin-container {
+				background: #f3f6f8 !important;
+			}
+		</style>
 		<div id="jp-plugin-container"></div>
 	<?php }
 


### PR DESCRIPTION
To be clear, this is only for `admin_notices`, and not jetpack-specific ones.  Those will be handled differently and properly within the app. 

This is a proposal to solve the ugly admin_notce problem in the simplest way possible.  I had [written an entire (semi-)working solution](https://github.com/Automattic/jetpack/compare/add/admin-notices) to including these in the app, but I found that it will be unstable and also inherently non-functional (could not dismiss.)

It's just not worth the effort to put together a complete working solution for showing notices we don't control within the app.  

![greenbg](https://cloud.githubusercontent.com/assets/7129409/15449158/e459095a-1f43-11e6-86bb-7d5e4cf6a9bc.png)

**To Test:** 
paste this in a functionality plugin and load the Jetpack page: 
```
function sample_admin_notice__success() {
	?>
	<div class="notice notice-success is-dismissible">
		<p><?php _e( 'This is what a regular success admin_notice will look like.', 'sample-text-domain' ); ?></p>
	</div>
	<div class="notice notice-error is-dismissible">
		<p><?php _e( 'This is what a regular error admin_notice will look like.', 'sample-text-domain' ); ?></p>
	</div>
	<?php
}
add_action( 'admin_notices', 'sample_admin_notice__success' );
```
