### PR TITLE
Add basic tracking ability.

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -6,6 +6,15 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { Route, Router, hashHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
+import analytics from 'lib/analytics';
+
+const tracksUser = window.Initial_State.tracksUserData;
+if ( tracksUser ) {
+	analytics.initialize(
+		tracksUser.userid,
+		tracksUser.username
+	);
+}
 
 /**
  * Internal dependencies

--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+
+/**
  * Internal dependencies
  */
 import {
@@ -35,6 +40,7 @@ export const jumpStartSkip = () => {
 		dispatch( {
 			type: JUMPSTART_SKIP
 		} );
+		analytics.tracks.recordEvent( 'jetpack_jumpstart_skip', {} );
 		return restApi.jumpStart( 'deactivate' ).then( () => {
 			dispatch( {
 				type: JUMPSTART_SKIP_SUCCESS,

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -112,11 +112,25 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		return $dismissed_notices;
 	}
 
+	function jetpack_get_tracks_user_data() {
+		if ( ! $user_data = Jetpack::get_connected_user_data() ) {
+			return false;
+		}
+
+		return array(
+			'userid' => $user_data['ID'],
+			'username' => $user_data['login'],
+		);
+	}
+
 	function page_admin_scripts() {
 		// Enqueue jp.js and localize it
 		wp_enqueue_script( 'react-plugin', plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ), array(), time(), true );
 		wp_enqueue_style( 'dops-css', plugins_url( '_inc/build/dops-style.css', JETPACK__PLUGIN_FILE ), array(), time() );
 		wp_enqueue_style( 'components-css', plugins_url( '_inc/build/style.min.css', JETPACK__PLUGIN_FILE ), array(), time() );
+
+		// Required for Analytics
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js?48' );
 
 		$localeSlug = explode( '_', get_locale() );
 		$localeSlug = $localeSlug[0];
@@ -154,6 +168,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			),
 			'locale' => $this->get_i18n_data(),
 			'localeSlug' => $localeSlug,
+			'tracksUserData' => $this->jetpack_get_tracks_user_data(),
 		) );
 	}
 }


### PR DESCRIPTION
Pass tracks data (wpcom user ID / username) via window.Initial_State.tracksUserData.  It will be false if the user is not connected, therefore we are not currently tracking any unconnected user.  

Initialize on load, and trigger in the action.

To Test: 
- `npm run build` to get the latest dops-components
- make sure Jetpack is connected
- click "reset options" in the footer 
- click "skip jumpstart"
- Find the live event view in MC for event name `jetpack_jumpstart_skip` (sometimes this took up to 15 minutes for it to show)
- you should see your wpcom username/ID in the event props.  