### PR TITLE
i18n: Prepare At A Glance page for translations. 

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -31,13 +31,13 @@ const DashAkismet = React.createClass( {
 		const akismetData = this.props.getAkismetData();
 		const akismetSettingsUrl = window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config';
 		const manageActive = this.props.isModuleActivated( 'manage' );
-		const labelName = __( 'Anti-spam' ) + ' (Akismet)';
+		const labelName = __( 'Anti-spam %(akismet)s', { args: { akismet: '(Akismet)' } } );
 
 		if ( akismetData === 'N/A' ) {
 			return(
 				<DashItem label="Anti-spam (Akismet)">
 					<p className="jp-dash-item__description">
-						{ __( 'Loading' ) }&#8230;
+						{ __( 'Loading…' ) }
 					</p>
 				</DashItem>
 			);
@@ -113,10 +113,14 @@ const DashAkismet = React.createClass( {
 			return(
 				<DashItem label="Anti-spam (Akismet)" className="jp-dash-item__is-inactive" status="is-warning">
 					<p className="jp-dash-item__description">
-						{ __( 'Whoops! It appears your Akismet key is missing or invalid.' ) }<br/>
-						<a href={ akismetSettingsUrl }>
-							{ __( 'Go to Akismet settings to fix' ) }
-						</a></p>
+						{
+							__( 'Whoops! It appears your Akismet key is missing or invalid. {{akismetSettings}}Go to Akismet settings to fix{{/akismetSettings}}.', {
+								components: {
+									akismetSettings: <a href={ akismetSettingsUrl } />
+								}
+							} )
+						}
+					</p>
 				</DashItem>
 			);
 		}
@@ -127,7 +131,7 @@ const DashAkismet = React.createClass( {
 				<p className="jp-dash-item__description">
 					{
 						__( 'Spam comments blocked.', {
-							comment: 'Referring to a number of how many comments were blocked. Example "412 Spam comments blocked"'
+							context: 'Example: "412 Spam comments blocked"'
 						} )
 					}
 				</p>

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -30,11 +31,14 @@ const DashAkismet = React.createClass( {
 		const akismetData = this.props.getAkismetData();
 		const akismetSettingsUrl = window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config';
 		const manageActive = this.props.isModuleActivated( 'manage' );
+		const labelName = __( 'Anti-spam' ) + ' (Akismet)';
 
 		if ( akismetData === 'N/A' ) {
 			return(
 				<DashItem label="Anti-spam (Akismet)">
-					<p className="jp-dash-item__description">Loading&#8230;</p>
+					<p className="jp-dash-item__description">
+						{ __( 'Loading' ) }&#8230;
+					</p>
 				</DashItem>
 			);
 		}
@@ -42,32 +46,64 @@ const DashAkismet = React.createClass( {
 		if ( manageActive ) {
 			if ( akismetData === 'not_active' ) {
 				return(
-					<DashItem label="Anti-spam (Akismet)" className="jp-dash-item__is-inactive">
-						<p className="jp-dash-item__description"><a href={ 'https://wordpress.com/plugins/akismet/' + window.Initial_State.rawUrl }>Activate Akismet</a> to automatically block spam comments and more.</p>
+					<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+						<p className="jp-dash-item__description">
+							{
+								__( '{{a}}Activate Akismet{{/a}} to automatically block spam comments and more.', {
+									components: {
+										a: <a href={ 'https://wordpress.com/plugins/akismet/' + window.Initial_State.rawUrl } target="_blank" />
+									}
+								} )
+							}
+						</p>
 					</DashItem>
 				);
 			}
 
 			if ( akismetData === 'not_installed' ) {
 				return(
-					<DashItem label="Anti-spam (Akismet)" className="jp-dash-item__is-inactive">
-						<p className="jp-dash-item__description"><a href={ 'https://wordpress.com/plugins/akismet/' + window.Initial_State.rawUrl }>Install Akismet</a> to automatically block spam comments and more.</p>
+					<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+						<p className="jp-dash-item__description">
+							{
+								__( '{{a}}Install Akismet{{/a}} to automatically block spam comments and more.', {
+									components: {
+										a: <a href={ 'https://wordpress.com/plugins/akismet/' + window.Initial_State.rawUrl } target="_blank" />
+									}
+								} )
+							}
+						</p>
 					</DashItem>
 				);
 			}
 		} else {
 			if ( akismetData === 'not_active' ) {
 				return(
-					<DashItem label="Anti-spam (Akismet)" className="jp-dash-item__is-inactive">
-						<p className="jp-dash-item__description"><a onClick={ this.activateManageAndRedirect } href='#'>Activate Manage and Akismet</a> to automatically block spam comments and more.</p>
+					<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+						<p className="jp-dash-item__description">
+							{
+								__( '{{a}}Activate Manage and Akismet{{/a}} to automatically block spam comments and more.', {
+									components: {
+										a: <a onClick={ this.activateManageAndRedirect } href='#' />
+									}
+								} )
+							}
+						</p>
 					</DashItem>
 				);
 			}
 
 			if ( akismetData === 'not_installed' ) {
 				return(
-					<DashItem label="Anti-spam (Akismet)" className="jp-dash-item__is-inactive">
-						<p className="jp-dash-item__description"><a onClick={ this.activateManageAndRedirect } href='#'>Activate Manage and Install Akismet</a> to automatically block spam comments and more.</p>
+					<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+						<p className="jp-dash-item__description">
+							{
+								__( '{{a}}Activate Manage and Install Akismet{{/a}} to automatically block spam comments and more.', {
+									components: {
+										a: <a onClick={ this.activateManageAndRedirect } href='#' />
+									}
+								} )
+							}
+						</p>
 					</DashItem>
 				);
 			}
@@ -77,8 +113,10 @@ const DashAkismet = React.createClass( {
 			return(
 				<DashItem label="Anti-spam (Akismet)" className="jp-dash-item__is-inactive" status="is-warning">
 					<p className="jp-dash-item__description">
-						Whoops! It appears your Akismet key is missing or invalid. <br/>
-						<a href={ akismetSettingsUrl }>Go to Akismet settings to fix</a></p>
+						{ __( 'Whoops! It appears your Akismet key is missing or invalid.' ) }<br/>
+						<a href={ akismetSettingsUrl }>
+							{ __( 'Go to Akismet settings to fix' ) }
+						</a></p>
 				</DashItem>
 			);
 		}
@@ -86,7 +124,13 @@ const DashAkismet = React.createClass( {
 		return(
 			<DashItem label="Anti-spam (Akismet)" status="is-working">
 				<h2 className="jp-dash-item__count">{ akismetData.all.spam }</h2>
-				<p className="jp-dash-item__description">Spam comments blocked.</p>
+				<p className="jp-dash-item__description">
+					{
+						__( 'Spam comments blocked.', {
+							comment: 'Referring to a number of how many comments were blocked. Example "412 Spam comments blocked"'
+						} )
+					}
+				</p>
 				{/*
 				<strong>This is the data we could show here: </strong> <br/>
 				Spam blocked all-time: { akismetData.all.spam } <br/>

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -20,13 +21,15 @@ import {
 
 const DashBackups = React.createClass( {
 	getContent: function() {
+		const labelName = __( 'Site Backups' ) + ' (VaultPress)';
+
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			const vpData = this.props.getVaultPressData();
 
 			if ( vpData === 'N/A' ) {
 				return(
-					<DashItem label="Site Backups (VaultPress)">
-						<p className="jp-dash-item__description">Loading&#8230;</p>
+					<DashItem label={ labelName }>
+						{ __( 'Loading' ) }&#8230;
 					</DashItem>
 				);
 			}
@@ -35,10 +38,10 @@ const DashBackups = React.createClass( {
 
 			if ( vpData.code === 'success' && backupData.has_full_backup ) {
 				return(
-					<DashItem label="Site Backups (VaultPress)" status="is-working">
-						<h3>Your site is completely backed up!</h3>
-						<p className="jp-dash-item__description">Full Backup Status: { backupData.full_backup_status } </p>
-						<p className="jp-dash-item__description">Last Backup: { backupData.last_backup } </p>
+					<DashItem label={ labelName } status="is-working">
+						<h3>{ __( 'Your site is completely backed up!' ) }</h3>
+						<p className="jp-dash-item__description">{ __( 'Full Backup Status:' ) } { backupData.full_backup_status } </p>
+						<p className="jp-dash-item__description">{ __( 'Last Backup:' ) } { backupData.last_backup } </p>
 					</DashItem>
 				);
 			}
@@ -46,18 +49,26 @@ const DashBackups = React.createClass( {
 			// All good
 			if ( vpData.code === 'success' && backupData.full_backup_status !== '100% complete' ) {
 				return(
-					<DashItem label="Site Backups (VaultPress)" status="is-working">
-						<h3>Currently backing up your site...</h3>
-						<p className="jp-dash-item__description">Full Backup Status: { backupData.full_backup_status } </p>
-						<p className="jp-dash-item__description">Last Backup: { backupData.last_backup }</p>
+					<DashItem label={ labelName } status="is-working">
+						<h3>{ __( 'Currently backing up your site.' ) }</h3>
+						<p className="jp-dash-item__description">{ __( 'Full Backup Status:' ) } { backupData.full_backup_status } </p>
+						<p className="jp-dash-item__description">{ __( 'Last Backup:' ) } { backupData.last_backup }</p>
 					</DashItem>
 				);
 			}
 		}
 
 		return(
-			<DashItem label="Site Backups (VaultPress)" className="jp-dash-item__is-inactive" status="is-premium-inactive">
-				<p className="jp-dash-item__description">To automatically back up your site, please <a href="#">upgrade your account (null)</a> or <a href="#">learn more (null)</a>.</p>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive">
+				<p className="jp-dash-item__description">
+					{
+						__( 'To automatically back up your site, please {{a}}upgrade your account{{/a}}', {
+							components: {
+								a: <a href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl } target="_blank" />
+							}
+						} )
+					}
+				</p>
 			</DashItem>
 		);
 	},

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -21,7 +21,7 @@ import {
 
 const DashBackups = React.createClass( {
 	getContent: function() {
-		const labelName = __( 'Site Backups' ) + ' (VaultPress)';
+		const labelName = __( 'Site Backups %(vaultpress)s', { args: { vaultpress: '(VaultPress)' } } );
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			const vpData = this.props.getVaultPressData();
@@ -29,7 +29,7 @@ const DashBackups = React.createClass( {
 			if ( vpData === 'N/A' ) {
 				return(
 					<DashItem label={ labelName }>
-						{ __( 'Loading' ) }&#8230;
+						{ __( 'Loading…' ) }
 					</DashItem>
 				);
 			}

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -18,6 +18,7 @@ import DashPluginUpdates from './plugins';
 import DashPhoton from './photon';
 import DashSiteVerify from './site-verification';
 import FeedbackDashRequest from 'components/jetpack-notices/feedback-dash-request';
+import { translate as __ } from 'lib/mixins/i18n';
 
 export default ( props ) =>
 	<div>
@@ -28,9 +29,9 @@ export default ( props ) =>
 		}
 
 		<DashSectionHeader
-			label="Site Security"
+			label={ __( 'Site Security' ) }
 			settingsPath="#security"
-			externalLink="Manage Security on WordPress.com"
+			externalLink={ __( 'Manage Security on WordPress.com' ) }
 			externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } />
 		<div className="jp-at-a-glance__item-grid">
 			<div className="jp-at-a-glance__left">
@@ -47,7 +48,7 @@ export default ( props ) =>
 		}
 
 		<DashSectionHeader
-			label="Site Health"
+			label={ __( 'Site Health' ) }
 			settingsPath="#health" />
 
 		<div className="jp-at-a-glance__item-grid">
@@ -65,7 +66,7 @@ export default ( props ) =>
 		}
 
 		<DashSectionHeader
-			label="Traffic Tools"
+			label={ __( 'Traffic Tools' ) }
 			settingsPath="#engagement" />
 
 		<div className="jp-at-a-glance__item-grid">
@@ -78,5 +79,4 @@ export default ( props ) =>
 		</div>
 
 		<FeedbackDashRequest { ...props } />
-
 	</div>

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -18,29 +19,47 @@ import { getLastDownTime as _getLastDownTime } from 'state/at-a-glance';
 
 const DashMonitor = React.createClass( {
 	getContent: function() {
+		const labelName = __( 'Downtime Monitoring' );
+
 		if ( this.props.isModuleActivated( 'monitor' ) ) {
 			const lastDowntime = this.props.getLastDownTime();
 
 			if ( lastDowntime === 'N/A' ) {
 				return(
-					<DashItem label="Downtime Monitoring" status="is-working">
+					<DashItem label={ labelName } status="is-working">
 						<QueryLastDownTime />
-						<p className="jp-dash-item__description">Loading&#8230;</p>
+						<p className="jp-dash-item__description">{ __( 'Loading' ) }&#8230;</p>
 					</DashItem>
 				);
 			}
 
 			return(
-				<DashItem label="Downtime Monitoring" status="is-working">
-					<p className="jp-dash-item__description">Monitor is on and is watching your site.</p>
-					<p className="jp-dash-item__description">Last downtime was { lastDowntime.date } ago.</p>
+				<DashItem label={ labelName } status="is-working">
+					<p className="jp-dash-item__description">{ __( 'Monitor is on and is watching your site.' ) }</p>
+					<p className="jp-dash-item__description">
+						{
+							__( 'Last downtime was %(time)s ago.', {
+								args: {
+									time: lastDowntime.date
+								}
+							} )
+						}
+					</p>
 				</DashItem>
 			);
 		}
 
 		return(
-			<DashItem label="Downtime Monitoring" className="jp-dash-item__is-inactive">
-				<p className="jp-dash-item__description"><a href="javascript:void(0)" onClick={ this.props.activateMonitor }>Activate Monitor</a> to receive notifications if your site goes down.</p>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+				<p className="jp-dash-item__description">
+					{
+						__( '{{a}}Activate Monitor{{/a}} to receive notifications if your site goes down.', {
+							components: {
+								a:<a href="javascript:void(0)" onClick={ this.props.activateMonitor } />
+							}
+						} )
+					}
+				</p>
 			</DashItem>
 		);
 	},

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -28,7 +28,7 @@ const DashMonitor = React.createClass( {
 				return(
 					<DashItem label={ labelName } status="is-working">
 						<QueryLastDownTime />
-						<p className="jp-dash-item__description">{ __( 'Loading' ) }&#8230;</p>
+						<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 					</DashItem>
 				);
 			}

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -16,7 +16,7 @@ import {
 
 const DashPhoton = React.createClass( {
 	getContent: function() {
-		const labelName = __( 'Image Performance' ) + ' (Photon)';
+		const labelName = __( 'Image Performance %(photon)s', { args: { photon: '(Photon)' } } );
 
 		if ( this.props.isModuleActivated( 'photon' ) ) {
 			return(

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -15,17 +16,27 @@ import {
 
 const DashPhoton = React.createClass( {
 	getContent: function() {
+		const labelName = __( 'Image Performance' ) + ' (Photon)';
+
 		if ( this.props.isModuleActivated( 'photon' ) ) {
 			return(
-				<DashItem label="Image Performance (Photon)" status="is-working">
-					<p className="jp-dash-item__description">Photon is active and currently improving image performance.</p>
+				<DashItem label={ labelName } status="is-working">
+					<p className="jp-dash-item__description">{ __( 'Photon is active and currently improving image performance.' ) }</p>
 				</DashItem>
 			);
 		}
 
 		return(
-			<DashItem label="Image Performance (Photon)" className="jp-dash-item__is-inactive">
-				<p className="jp-dash-item__description"><a href="javascript:void(0)" onClick={ this.props.activatePhoton }>Activate Photon</a> to enhance the performance of your images.</p>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+				<p className="jp-dash-item__description">
+					{
+						__( '{{a}}Activate Photon{{/a}} to enhance the performance of your images.', {
+							components: {
+								a: <a href="javascript:void(0)" onClick={ this.props.activatePhoton } />
+							}
+						} )
+					}
+				</p>
 			</DashItem>
 		);
 	},

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -38,7 +38,7 @@ const DashPluginUpdates = React.createClass( {
 			return(
 				<DashItem label={ labelName } status="is-working">
 					<QueryPluginUpdates />
-					<p className="jp-dash-item__description">{ __( 'Loading' ) }&#8230;</p>
+					<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 				</DashItem>
 			);
 		}
@@ -49,7 +49,8 @@ const DashPluginUpdates = React.createClass( {
 					<p className="jp-dash-item__description">
 						<strong>
 							{
-								__( '%(number)s plugins need updating.', {
+								__( '%(number)s plugin needs updating.', '%(number)s plugins need updating.', {
+									count: number,
 									args: {
 										number: pluginUpdates.count
 									}

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ const DashPluginUpdates = React.createClass( {
 	},
 
 	getContent: function() {
+		const labelName = __( 'Plugin Updates' );
 		const pluginUpdates = this.props.getPluginUpdates();
 		const manageActive = this.props.isModuleActivated( 'manage' );
 		const ctaLink = manageActive ?
@@ -34,22 +36,31 @@ const DashPluginUpdates = React.createClass( {
 
 		if ( 'N/A' === pluginUpdates ) {
 			return(
-				<DashItem label="Plugin Updates" status="is-working">
+				<DashItem label={ labelName } status="is-working">
 					<QueryPluginUpdates />
-					<p className="jp-dash-item__description">Loading&#8230;</p>
+					<p className="jp-dash-item__description">{ __( 'Loading' ) }&#8230;</p>
 				</DashItem>
 			);
 		}
 
 		if ( 'updates-available' === pluginUpdates.code ) {
 			return(
-				<DashItem label="Plugin Updates" status="is-warning">
+				<DashItem label={ labelName } status="is-warning">
 					<p className="jp-dash-item__description">
-						<strong>{ pluginUpdates.count } plugins need updating.</strong><br/>
+						<strong>
+							{
+								__( '%(number)s plugins need updating.', {
+									args: {
+										number: pluginUpdates.count
+									}
+								} )
+							}
+						</strong>
+						<br/>
 						{
 							manageActive ?
-								<a href={ ctaLink }>Turn on plugin auto updates</a> :
-								<a onClick={ this.activateAndRedirect } href="#" >Activate Manage and turn on auto updates</a>
+								__( '{{a}}Turn on plugin auto updates{{/a}}', { components: { a: <a href={ ctaLink } /> } } ):
+								__( '{{a}}Activate Manage and turn on auto updates{{/a}}', { components: { a: <a onClick={ this.activateAndRedirect } href="#" /> } } )
 						}
 					</p>
 				</DashItem>
@@ -57,9 +68,9 @@ const DashPluginUpdates = React.createClass( {
 		}
 
 		return(
-			<DashItem label="Plugin Updates" status="is-working">
+			<DashItem label={ labelName } status="is-working">
 				<p className="jp-dash-item__description">
-					All plugins are up-to-date. Keep up the good work!
+					{ __( 'All plugins are up-to-date. Keep up the good work!' ) }
 				</p>
 			</DashItem>
 		);

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -22,7 +22,7 @@ import {
 
 const DashScan = React.createClass( {
 	getContent: function() {
-		const labelName = __( 'Security Scan' ) + ' (VaultPress)';
+		const labelName = __( 'Security Scan %(vaultpress)s', { args: { vaultpress: '(VaultPress)' } } );
 		const vpData = this.props.getVaultPressData();
 		let vpActive = typeof vpData.data !== 'undefined' && vpData.data.active;
 
@@ -34,7 +34,7 @@ const DashScan = React.createClass( {
 			if ( vpData === 'N/A' ) {
 				return(
 					<DashItem label={ labelName }>
-						<p className="jp-dash-item__description">{ __( 'Loading' ) }&#8230;</p>
+						<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 					</DashItem>
 				);
 			}
@@ -55,7 +55,7 @@ const DashScan = React.createClass( {
 								} )
 						}</h3>
 						<p className="jp-dash-item__description">
-							{ __( '{{a}}Go to VaultPress.com to do something.{{/a}}', { components: { a: <a href={ ctaLink } /> } } ) }
+							{ __( '{{a}}View details at VaultPress.com{{/a}}', { components: { a: <a href={ ctaLink } /> } } ) }
 							<br/>
 							{ __( '{{a}}Contact Support{{/a}}', { components: { a: <a href='https://jetpack.com/support' /> } } ) }
 						</p>
@@ -67,7 +67,7 @@ const DashScan = React.createClass( {
 			if ( vpData.code === 'success' ) {
 				return(
 					<DashItem label={ labelName } status="is-working">
-						<h3>{ __( 'No threats found, you\'re good to go!' ) }</h3>
+						<h3>{ __( "No threats found, you're good to go!" ) }</h3>
 					</DashItem>
 				);
 			}

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import {
 
 const DashScan = React.createClass( {
 	getContent: function() {
+		const labelName = __( 'Security Scan' ) + ' (VaultPress)';
 		const vpData = this.props.getVaultPressData();
 		let vpActive = typeof vpData.data !== 'undefined' && vpData.data.active;
 
@@ -31,8 +33,8 @@ const DashScan = React.createClass( {
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {
 				return(
-					<DashItem label="Security Scan (VaultPress)">
-						<p className="jp-dash-item__description">Loading&#8230;</p>
+					<DashItem label={ labelName }>
+						<p className="jp-dash-item__description">{ __( 'Loading' ) }&#8230;</p>
 					</DashItem>
 				);
 			}
@@ -41,9 +43,22 @@ const DashScan = React.createClass( {
 			const threats = this.props.getScanThreats();
 			if ( threats !== 0 ) {
 				return(
-					<DashItem label="Security Scan (VaultPress)" status="is-error">
-						<h3>Uh oh, { threats } found!</h3>
-						<p className="jp-dash-item__description"><a href={ ctaLink }>Do something.</a></p>
+					<DashItem label={ labelName } status="is-error">
+						<h3>{
+							__(
+								'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.',
+								{
+									count: threats,
+									args: {
+										number: threats
+									}
+								} )
+						}</h3>
+						<p className="jp-dash-item__description">
+							{ __( '{{a}}Go to VaultPress.com to do something.{{/a}}', { components: { a: <a href={ ctaLink } /> } } ) }
+							<br/>
+							{ __( '{{a}}Contact Support{{/a}}', { components: { a: <a href='https://jetpack.com/support' /> } } ) }
+						</p>
 					</DashItem>
 				);
 			}
@@ -51,16 +66,24 @@ const DashScan = React.createClass( {
 			// All good
 			if ( vpData.code === 'success' ) {
 				return(
-					<DashItem label="Security Scan (VaultPress)" status="is-working">
-						<h3>No threats found, you're good to go!</h3>
+					<DashItem label={ labelName } status="is-working">
+						<h3>{ __( 'No threats found, you\'re good to go!' ) }</h3>
 					</DashItem>
 				);
 			}
 		}
 
 		return(
-			<DashItem label="Security Scan (VaultPress)" className="jp-dash-item__is-inactive" status="is-premium-inactive">
-				<p className="jp-dash-item__description">To automatically scan your site for malicious threats, please <a href={ ctaLink }>upgrade your account</a> or <a href={ ctaLink }>learn more</a>.</p>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive">
+				<p className="jp-dash-item__description">
+					{
+						__( 'To automatically scan your site for malicious threats, please {{a}}upgrade your account{{/a}}', {
+							components: {
+								a: <a href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl } target="_blank" />
+							}
+						} )
+					}
+				</p>
 			</DashItem>
 		);
 	},

--- a/_inc/client/at-a-glance/site-verification.jsx
+++ b/_inc/client/at-a-glance/site-verification.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -15,17 +16,35 @@ import {
 
 const DashSiteVerify = React.createClass( {
 	getContent: function() {
+		const labelName = __( 'Site Verification Tools' );
 		if ( this.props.isModuleActivated( 'verification-tools' ) ) {
 			return(
-				<DashItem label="Site Verification Tools" status="is-working">
-					<p className="jp-dash-item__description">Site Verification Tools are active. Ensure your site is verified with Google, Bing, &amp; Pinterest for more accurate indexing and ranking. <a href={ window.Initial_State.adminUrl + 'tools.php' }>Verify now</a></p>
+				<DashItem label={ labelName } status="is-working">
+					<p className="jp-dash-item__description">
+						{
+							__( 'Site Verification Tools are active. Ensure your site is verified with Google, ' +
+								'Bing, and Pinterest for more accurate indexing and ranking. {{a}}Verify now{{/a}}', {
+								components: {
+									a: <a href={ window.Initial_State.adminUrl + 'tools.php' } />
+								}
+							} )
+						}
+					</p>
 				</DashItem>
 			);
 		}
 
 		return(
-			<DashItem label="Site Verification Tools" className="jp-dash-item__is-inactive">
-				<p className="jp-dash-item__description"><a onClick={ this.props.activateVerificationTools } href="javascript:void(0)">Activate Site Verification</a> to verify your site and increase ranking with Google, Bing, and Pinterest.</p>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+				<p className="jp-dash-item__description">
+					{
+						__( '{{a}}Activate Site Verification{{/a}} to verify your site and increase ranking with Google, Bing, and Pinterest.', {
+							components: {
+								a: <a onClick={ this.props.activateVerificationTools } href="javascript:void(0)" />
+							}
+						} )
+					}
+				</p>
 			</DashItem>
 		);
 	},

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -158,7 +158,18 @@ const DashStatsBottom = React.createClass( {
 				</div>
 				<div className="jp-at-a-glance__stats-summary-bestday">
 					<p className="jp-at-a-glance__stat-details">{ __( 'Best overall day', { comment: 'Referring to a number of page views' } ) }</p>
-					<h3 className="jp-at-a-glance__stat-number">{ __( '%(number)s Views', { args: { number: s.bestDay.count } } ) }</h3>
+					<h3 className="jp-at-a-glance__stat-number">
+						{
+							__( '%(number)s View', '%(number)s Views',
+								{
+									count: number,
+									args: {
+										number: s.bestDay.count
+									}
+								}
+							)
+						}
+					</h3>
 					<p className="jp-at-a-glance__stat-details">{ s.bestDay.day }</p>
 				</div>
 				<div className="jp-at-a-glance__stats-summary-alltime">

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -8,6 +8,7 @@ import Chart from 'components/chart';
 import { connect } from 'react-redux';
 import DashSectionHeader from 'components/dash-section-header';
 import Button from 'components/button';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -63,7 +64,15 @@ const DashStats = React.createClass( {
 			);
 		} else {
 			return (
-				<div><a href="javascript:void(0)" onClick={ this.props.activateStats } >Activate Site Statistics</a> to see detailed stats, likes, followers, subscribers, and more!</div>
+				<div>
+					{
+						__( '{{a}}Activate Site Statistics{{/a}} to see detailed stats, likes, followers, subscribers, and more!', {
+							components: {
+								a: <a href="javascript:void(0)" onClick={ this.props.activateStats } />
+							}
+						} )
+					}
+				</div>
 			);
 		}
 	},
@@ -75,17 +84,17 @@ const DashStats = React.createClass( {
 					<li tabIndex="0" className="jp-at-a-glance__stats-view">
 						<a href="javascript:void(0)" onClick={ this.handleSwitchStatsView.bind( this, 'day' ) }
 							className={ this.getClass( 'day' ) }
-						>Days</a>
+						>{ __( 'Days' ) }</a>
 					</li>
 					<li tabIndex="0" className="jp-at-a-glance__stats-view">
 						<a href="javascript:void(0)" onClick={ this.handleSwitchStatsView.bind( this, 'week' ) }
 							className={ this.getClass( 'week' ) }
-						>Weeks</a>
+						>{ __( 'Weeks' ) }</a>
 					</li>
 					<li tabIndex="0" className="jp-at-a-glance__stats-view">
 						<a href="javascript:void(0)" onClick={ this.handleSwitchStatsView.bind( this, 'month' ) }
 							className={ this.getClass( 'month' ) }
-						>Months</a>
+						>{ __( 'Months' ) }</a>
 					</li>
 				</ul>
 			);
@@ -144,32 +153,34 @@ const DashStatsBottom = React.createClass( {
 		<div>
 			<div className="jp-at-a-glance__stats-summary">
 				<div className="jp-at-a-glance__stats-summary-today">
-					<p className="jp-at-a-glance__stat-details">Views today</p>
+					<p className="jp-at-a-glance__stat-details">{ __( 'Views today', { comment: 'Referring to a number of page views' } ) }</p>
 					<h3 className="jp-at-a-glance__stat-number">{ s.viewsToday }</h3>
 				</div>
 				<div className="jp-at-a-glance__stats-summary-bestday">
-					<p className="jp-at-a-glance__stat-details">Best overall day</p>
-					<h3 className="jp-at-a-glance__stat-number">{ s.bestDay.count } Views</h3>
+					<p className="jp-at-a-glance__stat-details">{ __( 'Best overall day', { comment: 'Referring to a number of page views' } ) }</p>
+					<h3 className="jp-at-a-glance__stat-number">{ __( '%(number)s Views', { args: { number: s.bestDay.count } } ) }</h3>
 					<p className="jp-at-a-glance__stat-details">{ s.bestDay.day }</p>
 				</div>
 				<div className="jp-at-a-glance__stats-summary-alltime">
 					<div className="jp-at-a-glance__stats-alltime-views">
-						<p className="jp-at-a-glance__stat-details">All-time views</p>
+						<p className="jp-at-a-glance__stat-details">{ __( 'All-time views', { comment: 'Referring to a number of page views' } ) }</p>
 						<h3 className="jp-at-a-glance__stat-number">{ s.allTime.views }</h3>
 					</div>
 					<div className="jp-at-a-glance__stats-alltime-comments">
-						<p className="jp-at-a-glance__stat-details">All-time comments</p>
+						<p className="jp-at-a-glance__stat-details">{ __( 'All-time comments', { comment: 'Referring to a number of comments' } ) }</p>
 						<h3 className="jp-at-a-glance__stat-number">{ s.allTime.comments }</h3>
 					</div>
 				</div>
 			</div>
 			<div className="jp-at-a-glance__stats-cta">
 				<div className="jp-at-a-glance__stats-cta-description">
-					<p>Need to see more stats, likes, followers, subscribers, and more?</p>
+					<p>{ __( 'Need to see more stats, likes, followers, subscribers, and more?' ) }</p>
 				</div>
 				<div className="jp-at-a-glance__stats-cta-buttons">
-					<Button href="?page=stats">View old stats</Button>
-					<Button className="is-primary" href={ 'https://wordpress.com/stats/insights/' + window.Initial_State.rawUrl }>View enhanced stats on WordPress.com</Button>
+					{ __( '{{button}}View old stats{{/button}}', { components: { button: <Button href="?page=stats" /> } } ) }
+					{ __( '{{button}}View enhanced stats on WordPress.com{{/button}}', {
+						components: { button: <Button className="is-primary" href={ 'https://wordpress.com/stats/insights/' + window.Initial_State.rawUrl } /> }
+					} ) }
 				</div>
 			</div>
 		</div>

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import sample from 'lodash/sample';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -26,16 +27,45 @@ export default React.createClass( {
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
 					<div className="jp-support-card__happiness-engineer">
-						<img src={ 'https://secure.gravatar.com/avatar/' + randomGravID } alt="Jetpack Happiness Engineer" className="jp-support-card__happiness-engineer-img" />
+						<img src={ 'https://secure.gravatar.com/avatar/' + randomGravID } alt={ __( 'Jetpack Happiness Engineer' ) } className="jp-support-card__happiness-engineer-img" />
 					</div>
 					<div className="jp-support-card__happiness-contact">
-						<h4 className="jp-support-card__header">Need help? The Jetpack team is here for you.</h4>
-						<p className="jp-support-card__description">We offer free, full support to all of our Jetpack users. Our support team is always around to help you. </p>
-						<p className="jp-support-card__description"><a className="jp-support-card__link" href="http://jetpack.com/support/" title="Go to Jetpack.com/support">View our support page</a><span className="jp-hidden-on-mobile">,</span> <a className="jp-support-card__link" href="https://wordpress.org/support/plugin/jetpack" title="Go to the WordPress.org support forums">check the forums for answers</a><span className="jp-hidden-on-mobile">, or </span><a className="jp-support-card__link" href="https://jetpack.com/contact-support/" title="Contact Jetpack support staff directly">contact us directly</a><span className="jp-hidden-on-mobile">.</span></p>
+						<h4 className="jp-support-card__header">
+							{ __( 'Need help? The Jetpack team is here for you.' ) }
+						</h4>
+						<p className="jp-support-card__description">
+							{ __( 'We offer free, full support to all of our Jetpack users. Our support team is always around to help you.' ) }
+						</p>
+						<p className="jp-support-card__description">
+							<a className="jp-support-card__link" href="http://jetpack.com/support/" title={ __( 'Go to Jetpack.com/support' ) }>
+								{ __( 'View our support page' ) }
+							</a>
+							<span className="jp-hidden-on-mobile">,</span>
+							<a className="jp-support-card__link" href="https://wordpress.org/support/plugin/jetpack" title={ __( 'Go to the WordPress.org support forums' ) }>
+								{ __( 'check the forums for answers' ) }
+							</a>
+							<span className="jp-hidden-on-mobile">, or </span>
+							<a className="jp-support-card__link" href="https://jetpack.com/contact-support/" title={ __( 'Contact Jetpack support staff directly' ) }>
+								{ __( 'contact us directly' ) }
+							</a>
+							<span className="jp-hidden-on-mobile">.</span></p>
 					</div>
 				</Card>
 				<Card className="jp-support-card__social">
-					<p className="jp-support-card__description"><span className="jp-hidden-on-mobile">Enjoying Jetpack or have feedback? </span><a className="jp-support-card__link" href="https://wordpress.org/support/view/plugin-reviews/jetpack" title="Leave a Jetpack review" target="_blank">Leave us a review</a><span className="jp-hidden-on-mobile">, </span><a className="jp-support-card__link" href="http://twitter.com/jetpack" title="Follow Jetpack on Twitter" target="_blank">follow us on twitter</a><span className="jp-hidden-on-mobile">, or </span><a className="jp-support-card__link" href="https://www.facebook.com/jetpackme" title="Like us on facebook" target="_blank">like us on facebook</a><span className="jp-hidden-on-mobile">.</span></p>
+					<p className="jp-support-card__description">
+						<span className="jp-hidden-on-mobile">{ __( 'Enjoying Jetpack or have feedback?' ) }</span>
+						<a className="jp-support-card__link" href="https://wordpress.org/support/view/plugin-reviews/jetpack" title={ __( 'Leave a Jetpack review' ) } target="_blank">
+							{ __( 'Leave us a review' ) }
+						</a>
+						<span className="jp-hidden-on-mobile">, </span>
+						<a className="jp-support-card__link" href="http://twitter.com/jetpack" title={ __( 'Follow Jetpack on Twitter' ) } target="_blank">
+							{ __( 'follow us on twitter' ) }
+						</a>
+						<span className="jp-hidden-on-mobile">, or </span>
+						<a className="jp-support-card__link" href="https://www.facebook.com/jetpackme" title={ __( 'Like us on facebook' ) } target="_blank">
+							{ __( 'like us on facebook' ) }
+						</a>
+						<span className="jp-hidden-on-mobile">.</span></p>
 				</Card>
 			</div>
 		);

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import classNames from 'classnames';
 import sample from 'lodash/sample';
-import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -27,45 +26,16 @@ export default React.createClass( {
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
 					<div className="jp-support-card__happiness-engineer">
-						<img src={ 'https://secure.gravatar.com/avatar/' + randomGravID } alt={ __( 'Jetpack Happiness Engineer' ) } className="jp-support-card__happiness-engineer-img" />
+						<img src={ 'https://secure.gravatar.com/avatar/' + randomGravID } alt="Jetpack Happiness Engineer" className="jp-support-card__happiness-engineer-img" />
 					</div>
 					<div className="jp-support-card__happiness-contact">
-						<h4 className="jp-support-card__header">
-							{ __( 'Need help? The Jetpack team is here for you.' ) }
-						</h4>
-						<p className="jp-support-card__description">
-							{ __( 'We offer free, full support to all of our Jetpack users. Our support team is always around to help you.' ) }
-						</p>
-						<p className="jp-support-card__description">
-							<a className="jp-support-card__link" href="http://jetpack.com/support/" title={ __( 'Go to Jetpack.com/support' ) }>
-								{ __( 'View our support page' ) }
-							</a>
-							<span className="jp-hidden-on-mobile">,</span>
-							<a className="jp-support-card__link" href="https://wordpress.org/support/plugin/jetpack" title={ __( 'Go to the WordPress.org support forums' ) }>
-								{ __( 'check the forums for answers' ) }
-							</a>
-							<span className="jp-hidden-on-mobile">, or </span>
-							<a className="jp-support-card__link" href="https://jetpack.com/contact-support/" title={ __( 'Contact Jetpack support staff directly' ) }>
-								{ __( 'contact us directly' ) }
-							</a>
-							<span className="jp-hidden-on-mobile">.</span></p>
+						<h4 className="jp-support-card__header">Need help? The Jetpack team is here for you.</h4>
+						<p className="jp-support-card__description">We offer free, full support to all of our Jetpack users. Our support team is always around to help you. </p>
+						<p className="jp-support-card__description"><a className="jp-support-card__link" href="http://jetpack.com/support/" title="Go to Jetpack.com/support">View our support page</a><span className="jp-hidden-on-mobile">,</span> <a className="jp-support-card__link" href="https://wordpress.org/support/plugin/jetpack" title="Go to the WordPress.org support forums">check the forums for answers</a><span className="jp-hidden-on-mobile">, or </span><a className="jp-support-card__link" href="https://jetpack.com/contact-support/" title="Contact Jetpack support staff directly">contact us directly</a><span className="jp-hidden-on-mobile">.</span></p>
 					</div>
 				</Card>
 				<Card className="jp-support-card__social">
-					<p className="jp-support-card__description">
-						<span className="jp-hidden-on-mobile">{ __( 'Enjoying Jetpack or have feedback?' ) }</span>
-						<a className="jp-support-card__link" href="https://wordpress.org/support/view/plugin-reviews/jetpack" title={ __( 'Leave a Jetpack review' ) } target="_blank">
-							{ __( 'Leave us a review' ) }
-						</a>
-						<span className="jp-hidden-on-mobile">, </span>
-						<a className="jp-support-card__link" href="http://twitter.com/jetpack" title={ __( 'Follow Jetpack on Twitter' ) } target="_blank">
-							{ __( 'follow us on twitter' ) }
-						</a>
-						<span className="jp-hidden-on-mobile">, or </span>
-						<a className="jp-support-card__link" href="https://www.facebook.com/jetpackme" title={ __( 'Like us on facebook' ) } target="_blank">
-							{ __( 'like us on facebook' ) }
-						</a>
-						<span className="jp-hidden-on-mobile">.</span></p>
+					<p className="jp-support-card__description"><span className="jp-hidden-on-mobile">Enjoying Jetpack or have feedback? </span><a className="jp-support-card__link" href="https://wordpress.org/support/view/plugin-reviews/jetpack" title="Leave a Jetpack review" target="_blank">Leave us a review</a><span className="jp-hidden-on-mobile">, </span><a className="jp-support-card__link" href="http://twitter.com/jetpack" title="Follow Jetpack on Twitter" target="_blank">follow us on twitter</a><span className="jp-hidden-on-mobile">, or </span><a className="jp-support-card__link" href="https://www.facebook.com/jetpackme" title="Like us on facebook" target="_blank">like us on facebook</a><span className="jp-hidden-on-mobile">.</span></p>
 				</Card>
 			</div>
 		);


### PR DESCRIPTION
This wraps everything on the "At A Glance" page, as well as the Support Card in the i18n function, to prep for translations.  

to test: 
- Run `npm run build`
- Run `npm run build-i18n`
- Check `_inc/jetpack-strings.php` to make sure that the strings on At A Glance and Support card
- Make sure all links and stuff still works.  