### PR TITLE
Admin Page: Prepare Jetpack connect component for i18n

### DIFF
--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Card from 'components/card';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -17,19 +18,31 @@ const JetpackConnect = React.createClass( {
 	render: function() {
 		return (
 			<div className="jp-jetpack-connect__container">
-				<h1 className="jp-jetpack-connect__container-title" title="Please connect Jetpack to WordPress.com">Please Connect Jetpack</h1>
+				<h1 className="jp-jetpack-connect__container-title" title="Please connect Jetpack to WordPress.com">
+					{ __( 'Please Connect Jetpack' ) }
+				</h1>
 
 				<Card className="jp-jetpack-connect__cta">
-					<p className="jp-jetpack-connect__description">Please connect to or create a WordPress.com account to enable Jetpack, including powerful security, traffic, and customization services.</p>
+					<p className="jp-jetpack-connect__description">
+						{ __( 'Please connect to or create a WordPress.com account to enable Jetpack, including powerful security, traffic, and customization services.' ) }
+					</p>
 					<ConnectButton />
-					<p><a href="https://wordpress.com/start/jetpack/" className="jp-jetpack-connect__link">No WordPress.com account? Create one for free.</a></p>
+					<p>
+						<a href="https://wordpress.com/start/jetpack/" className="jp-jetpack-connect__link">
+							{ __( 'No WordPress.com account? Create one for free.' ) }
+						</a>
+					</p>
 				</Card>
 
 				<Card className="jp-jetpack-connect__feature jp-jetpack-connect__traffic">
 
 					<header className="jp-jetpack-connect__header">
-						<h2 className="jp-jetpack-connect__container-subtitle" title="Drive more traffic to your site with Jetpack">Drive more traffic to your site</h2>
-						<p className="jp-jetpack-connect__description">Jetpack has many traffic and engagement tools to help you get more viewers to your site and keep them there.</p>
+						<h2 className="jp-jetpack-connect__container-subtitle" title="Drive more traffic to your site with Jetpack">
+							{ __( 'Drive more traffic to your site' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __( 'Jetpack has many traffic and engagement tools to help you get more viewers to your site and keep them there.' ) }
+						</p>
 						<div className="jp-jetpack-connect__header-img-container">
 							<img src={ imagePath + 'long-clouds.svg' } width="1160" height="63" alt="Decoration: Jetpack clouds" className="jp-jetpack-connect__header-img" /> {/* defining width and height for IE here */}
 							<img src={ imagePath + 'stat-bars.svg' } width="400" alt="Decoration: Jetpack bar graph" className="jp-jetpack-connect__header-img" />
@@ -39,30 +52,55 @@ const JetpackConnect = React.createClass( {
 					<div className="jp-jetpack-connect__interior-container">
 						<div className="jp-jetpack-connect__feature-list">
 							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title="Jetpack's Publicize feature" className="dops-section-header__label">Publicize</h3>
+								<h3 title="Jetpack's Publicize feature" className="dops-section-header__label">
+									{ __( 'Publicize', { context: 'Header. Noun: Publicize is a module of Jetpack' } ) }
+								</h3>
 								<div className="jp-jetpack-connect__feature-content">
-									<h4 className="jp-jetpack-connect__feature-content-title" title="Automated social marketing">Automated social marketing.</h4>
-									<p>Use Publicize to automatically share your posts with friends, followers, and the world.</p>
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Automated social marketing">
+										{ __( 'Automated social marketing.' ) }
+									</h4>
+									<p>
+										{ __( 'Use Publicize to automatically share your posts with friends, followers, and the world.' ) }
+									</p>
 								</div>
 							</div>
 							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title="Jetpack's Sharing and Like features" className="dops-section-header__label">Sharing &amp; Like Buttons</h3>
+								<h3 title="Jetpack's Sharing and Like features" className="dops-section-header__label">
+									{ __( 'Sharing & Like Buttons' ) }
+								</h3>
 								<div className="jp-jetpack-connect__feature-content">
-									<h4 className="jp-jetpack-connect__feature-content-title" title="Build a community">Build a community.</h4>
-									<p>Give visitors the tools to share and subscribe to your content.</p>
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Build a community">
+										{ __( 'Build a community.' ) }
+									</h4>
+									<p>
+										{ __( 'Give visitors the tools to share and subscribe to your content.' ) }
+									</p>
 								</div>
 							</div>
 							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title="Jetpack's Related Posts feature" className="dops-section-header__label">Related Posts</h3>
+								<h3 title="Jetpack's Related Posts feature" className="dops-section-header__label">
+									{ __( 'Related Posts', { context: 'Header. Noun: Related posts is a module of Jetpack.' } ) }
+								</h3>
 								<div className="jp-jetpack-connect__feature-content">
-									<h4 className="jp-jetpack-connect__feature-content-title" title="Increase page views">Increase page views.</h4>
-									<p>Keep visitors engaged by giving them more to share and read with Related Posts.</p>
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Increase page views">
+									{ __( 'Increase page views.' ) }
+									</h4>
+									<p>
+										{ __( 'Keep visitors engaged by giving them more to share and read with Related Posts.' ) }
+									</p>
 								</div>
 							</div>
 						</div>
 
-						<h2 className="jp-jetpack-connect__container-subtitle" title="Track your growth">Track your growth</h2>
-						<p className="jp-jetpack-connect__description">Jetpack harnesses the power of WordPress.com to show you detailed insights about your visitors, what they’re reading, and where they’re coming from.</p>
+						<h2 className="jp-jetpack-connect__container-subtitle" title="Track your growth">
+							{ __( 'Track your growth' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __(
+								'Jetpack harnesses the power of WordPress.com to show you detailed insights about your visitors, ' +
+								'what they’re reading, and where they’re coming from.'
+							) }
+						</p>
 
 						<img src={ imagePath + 'stats-example-med.png' }
 							srcSet={ `${imagePath}stats-example-sm.png 445w, ${imagePath}stats-example-med.png 770w, ${imagePath}stats-example-lrg.png 1200w` }
@@ -72,31 +110,59 @@ const JetpackConnect = React.createClass( {
 				<Card className="jp-jetpack-connect__feature">
 
 					<header className="jp-jetpack-connect__header">
-						<h2 className="jp-jetpack-connect__container-subtitle" title="Site security and peace of mind with Jetpack">Site security and peace of mind</h2>
-						<p className="jp-jetpack-connect__description">Jetpack blocks malicious log in attempts, lets you know if your site goes down, and can automatically update your plugins, so you don’t have to worry.</p>
+						<h2 className="jp-jetpack-connect__container-subtitle" title="Site security and peace of mind with Jetpack">
+							{ __( 'Site security and peace of mind' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __(
+								'Jetpack blocks malicious log in attempts, lets you know if your site goes down, ' +
+								'and can automatically update your plugins, so you don’t have to worry.'
+							) }
+						</p>
 					</header>
 
 					<div className="jp-jetpack-connect__interior-container">
 						<div className="jp-jetpack-connect__feature-list">
 							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title="Jetpack's Protect feature" className="dops-section-header__label">Protect</h3>
+								<h3 title="Jetpack's Protect feature" className="dops-section-header__label">
+									{ __( 'Protect', { context: 'Header. Noun: Protect is a module of Jetpack.' } ) }
+								</h3>
 								<div className="jp-jetpack-connect__feature-content">
-									<h4 className="jp-jetpack-connect__feature-content-title" title="Block site attacks">Block site attacks.</h4>
-									<p>Gain peace of mind with Protect, the tool that has blocked billions of login attacks across millions of sites.</p>
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Block site attacks">
+									{ __( 'Block site attacks.' ) }
+									</h4>
+									<p>
+										{ __(
+											'Gain peace of mind with Protect, the tool that has blocked billions of ' +
+											'login attacks across millions of sites.'
+										) }
+									</p>
 								</div>
 							</div>
 							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title="Jetpack's Monitor features" className="dops-section-header__label">Monitor</h3>
+								<h3 title="Jetpack's Monitor features" className="dops-section-header__label">
+									{ __( 'Monitor', { context: 'Header. Noun: Monitor is a module of Jetpack.' } ) }
+								</h3>
 								<div className="jp-jetpack-connect__feature-content">
-									<h4 className="jp-jetpack-connect__feature-content-title" title="Live site monitoring">Live site monitoring.</h4>
-									<p>Stress less. Monitor will send you real-time alerts if your site ever goes down.</p>
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Live site monitoring">
+										{ __( 'Live site monitoring.' ) }
+									</h4>
+									<p>
+										{ __( 'Stress less. Monitor will send you real-time alerts if your site ever goes down.' ) }
+									</p>
 								</div>
 							</div>
 							<div className="jp-jetpack-connect__feature-list-column">
-								<h3 title="Jetpack's Manage feature" className="dops-section-header__label">Manage</h3>
+								<h3 title="Jetpack's Manage feature" className="dops-section-header__label">
+									{ __( 'Manage', { context: 'Header. Noun: Manage is a module of Jetpack.' } ) }
+								</h3>
 								<div className="jp-jetpack-connect__feature-content">
-									<h4 className="jp-jetpack-connect__feature-content-title" title="Automatic site updates">Automatic site updates.</h4>
-									<p>Never fall behind on a security release or waste time updating multiple sites.</p>
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Automatic site updates">
+										{ __( 'Automatic site updates.' ) }
+									</h4>
+									<p>
+										{ __( 'Never fall behind on a security release or waste time updating multiple sites.' ) }
+									</p>
 								</div>
 							</div>
 						</div>
@@ -104,8 +170,15 @@ const JetpackConnect = React.createClass( {
 				</Card>
 				<Card className="jp-jetpack-connect__feature">
 					<header className="jp-jetpack-connect__header">
-						<h2 className="jp-jetpack-connect__container-subtitle" title="lightning fast optimized images with Jetpack Photon">Lightning fast, optimized images</h2>
-						<p className="jp-jetpack-connect__description">Jetpack utilizes the state-of-the-art WordPress.com content delivery network to load your gorgeous imagery super fast. Optimized for any device, and its completely free.</p>
+						<h2 className="jp-jetpack-connect__container-subtitle" title="lightning fast optimized images with Jetpack Photon">
+							{ __( 'Lightning fast, optimized images' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __(
+								'Jetpack utilizes the state-of-the-art WordPress.com content delivery network to load your ' +
+								'gorgeous imagery super fast. Optimized for any device, and its completely free.'
+							) }
+						</p>
 					</header>
 
 					<div className="jp-jetpack-connect__interior-container">
@@ -116,8 +189,15 @@ const JetpackConnect = React.createClass( {
 				</Card>
 				<Card className="jp-jetpack-connect__feature">
 					<header className="jp-jetpack-connect__header">
-						<h2 className="jp-jetpack-connect__container-subtitle" title="Jetpack offers free, professional support">Did we mention free, professional support?</h2>
-						<p className="jp-jetpack-connect__description">Jetpack is supported by some of the most technical and passionate people in the community. They&#8217;re located around the globe and ready to help you.</p>
+						<h2 className="jp-jetpack-connect__container-subtitle" title="Jetpack offers free, professional support">
+							{ __( 'Did we mention free, professional support?' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __(
+								'Jetpack is supported by some of the most technical and passionate people in the community. ' +
+								"They're located around the globe and ready to help you."
+							) }
+						</p>
 					</header>
 
 					<div className="jp-jetpack-connect__interior-container">
@@ -127,7 +207,12 @@ const JetpackConnect = React.createClass( {
 					</div>
 				</Card>
 				<Card className="jp-jetpack-connect__cta">
-					<p className="jp-jetpack-connect__description">Join the millions of users who rely on Jetpack to enhance and secure their sites. We’re passionate about WordPress and here to make your life easier.</p>
+					<p className="jp-jetpack-connect__description">
+						{ __(
+							'Join the millions of users who rely on Jetpack to enhance and secure their sites. ' +
+							"We’re passionate about WordPress and here to make your life easier."
+						) }
+					</p>
 					<ConnectButton />
 				</Card>
 			</div>


### PR DESCRIPTION
As the title of the PR says, this PR prepares the Jetpack connect component for translation. This component is displayed when:

- User is an admin
- User navigates to Jetpack admin page
- Site is not connected to WP.com

To test:
- Checkout `update/i18n-for-connect-page` branch
- `npm run build`
- `npm run build-i18n`
- Check `_inc/jetpack-strings.php` to make sure that the new Jetpack connect page strings were generated. See changeset for an example of strings you should see.
- Disconnect your Jetpack site from WordPress.com
- Go to Jetpack admin page
- Does everything load correctly?

cc @dereksmart for review.
