### PR TITLE
Admin Page: i18n for the dash-section-header component

### DIFF
--- a/_inc/client/components/dash-section-header/index.jsx
+++ b/_inc/client/components/dash-section-header/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
+import { translate as __ } from 'lib/mixins/i18n';
 
 export default React.createClass( {
 	displayName: 'DashSectionHeader',
@@ -37,7 +38,9 @@ export default React.createClass( {
 		if ( this.props.settingsPath ) {
 			settingsIcon = (
 				<a className="jp-dash-section-header__settings" href={ this.props.settingsPath }>
-					<span className="screen-reader-text">Settings</span>
+					<span className="screen-reader-text">
+						{ __( 'Settings', { context: 'Noun. Displayed to screen readers.' } ) }
+					</span>
 					<Gridicon icon="cog" size={ 16 } />
 				</a>
 			);
@@ -56,7 +59,7 @@ export default React.createClass( {
 		if ( this.props.children ) {
 			children = (
 				<div className="jp-dash-section-header__children" >
-						{ this.props.children }
+					{ this.props.children }
 				</div>
 			);
 		}


### PR DESCRIPTION
Prepares the `dash-section-header` component for i18n by internationalizing the "Settings" screen reader text. All other strings will be passed into this component, and thus will not be internationalized by this component.

To test:

- Checkout `update/i18n-dash-section-header` branch
- `npm run build`
- `npm run build-i18n`
- Check `_inc/jetpack-strings.php` for something like this: `_x( 'Settings', 'Noun. Displayed to screen readers.' )`
- Go to Jetpack admin page while logged in. Make sure there are no errors.

cc @dereksmart for review.