### PR TITLE
AAG Stats: Format the dates of the stats labels.

### DIFF
--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -50,7 +50,7 @@ const DashPluginUpdates = React.createClass( {
 						<strong>
 							{
 								__( '%(number)s plugin needs updating.', '%(number)s plugins need updating.', {
-									count: number,
+									count: pluginUpdates.count,
 									args: {
 										number: pluginUpdates.count
 									}

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -36,7 +36,7 @@ const DashStats = React.createClass( {
 				label = moment( v[0] ).format( 'MMM D' );
 			} else if ( 'week' === unit ) {
 				label = label.replace( /W/g, '-' );
-				label = __( 'Week of ' ) + moment( label ).format( 'MMM D' );
+				label = __( 'Week of %(date)s', { args: { date: moment( label ).format( 'MMM D' ) } } );
 			} else if ( 'month' ) {
 				label = moment( label ).format( 'MMMM' );
 			}
@@ -49,7 +49,7 @@ const DashStats = React.createClass( {
 				data: {},
 				tooltipData: [ {
 					label: label,
-					value: __( 'Views: ' ) + views,
+					value: __( 'Views: %(numberOfViews)s', { args: { numberOfViews: views } } ),
 					link: null,
 					icon: '',
 					className: 'tooltip class'

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -31,6 +31,16 @@ const DashStats = React.createClass( {
 		forEach( window.Initial_State.statsData[unit].data, function( v ) {
 			let label = v[0];
 			let views = v[1];
+
+			if ( 'day' === unit ) {
+				label = i18n.moment( v[0] ).format( 'MMM D' );
+			} else if ( 'week' === unit ) {
+				label = label.replace( /W/g, '-' );
+				label = i18n.moment( label ).format( 'MMM D' );
+			} else if ( 'month' ) {
+				label = i18n.moment( label ).format( 'MMMM' );
+			}
+
 			s.push( {
 				label: label,
 				value: views,

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -159,6 +159,7 @@ const DashStatsBottom = React.createClass( {
 
 	render: function() {
 		const s = this.statsBottom()[0];
+		const bestDay = s.bestDay.day;
 		return (
 		<div>
 			<div className="jp-at-a-glance__stats-summary">
@@ -172,7 +173,7 @@ const DashStatsBottom = React.createClass( {
 						{
 							__( '%(number)s View', '%(number)s Views',
 								{
-									count: number,
+									count: s.bestDay.count,
 									args: {
 										number: s.bestDay.count
 									}
@@ -180,7 +181,7 @@ const DashStatsBottom = React.createClass( {
 							)
 						}
 					</h3>
-					<p className="jp-at-a-glance__stat-details">{ s.bestDay.day }</p>
+					<p className="jp-at-a-glance__stat-details">{ moment( bestDay ).format( 'MMMM Do, YYYY' ) }</p>
 				</div>
 				<div className="jp-at-a-glance__stats-summary-alltime">
 					<div className="jp-at-a-glance__stats-alltime-views">

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -8,7 +8,7 @@ import Chart from 'components/chart';
 import { connect } from 'react-redux';
 import DashSectionHeader from 'components/dash-section-header';
 import Button from 'components/button';
-import { translate as __ } from 'lib/mixins/i18n';
+import { moment, translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -33,12 +33,12 @@ const DashStats = React.createClass( {
 			let views = v[1];
 
 			if ( 'day' === unit ) {
-				label = i18n.moment( v[0] ).format( 'MMM D' );
+				label = moment( v[0] ).format( 'MMM D' );
 			} else if ( 'week' === unit ) {
 				label = label.replace( /W/g, '-' );
-				label = i18n.moment( label ).format( 'MMM D' );
+				label = __( 'Week of ' ) + moment( label ).format( 'MMM D' );
 			} else if ( 'month' ) {
-				label = i18n.moment( label ).format( 'MMMM' );
+				label = moment( label ).format( 'MMMM' );
 			}
 
 			s.push( {
@@ -49,7 +49,7 @@ const DashStats = React.createClass( {
 				data: {},
 				tooltipData: [ {
 					label: label,
-					value: 'Views: ' + views,
+					value: __( 'Views: ' ) + views,
 					link: null,
 					icon: '',
 					className: 'tooltip class'


### PR DESCRIPTION
Fixes: #3873 

To test: 
- Activate stats and view the tooltips and x-axis labels for days, weeks, and months. 