### PR TITLE
Admin Page: i18n for admin page footer

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -25,7 +26,11 @@ export const Footer = React.createClass( {
 			if ( isDevVersion( this.props ) ) {
 				return(
 					<li className="jp-footer__link-item">
-						<a onClick={ this.props.resetOptions } className="jp-footer__link">Reset Options (dev versions only)</a>
+						<a
+							onClick={ this.props.resetOptions }
+							className="jp-footer__link">
+							{ __( 'Reset Options (dev versions only)', { context: 'Navigation item.' } ) }
+						</a>
 					</li>
 				);
 			}
@@ -43,10 +48,37 @@ export const Footer = React.createClass( {
 					</svg></a>
 				</div>
 				<ul className="jp-footer__links">
-					<li className="jp-footer__link-item"><a href="http://jetpack.com" target="_blank" className="jp-footer__link" title={ version } >{ version }</a></li>
-					<li className="jp-footer__link-item"><a href="http://wordpress.com/tos/" target="_blank" title="WordPress.com Terms of Service" className="jp-footer__link">Terms</a></li>
-					<li className="jp-footer__link-item"><a href="http://automattic.com/privacy/" target="_blank" title="Automattic's Privacy Policy" className="jp-footer__link">Privacy</a></li>
-					<li className="jp-footer__link-item"><a href={ window.Initial_State.adminUrl + 'admin.php?page=jetpack-debugger' } title="Test your site’s compatibility with Jetpack." className="jp-footer__link">Debug</a></li>
+					<li className="jp-footer__link-item">
+						<a href="http://jetpack.com" target="_blank" className="jp-footer__link" title={ version } >
+							{ version }
+						</a>
+					</li>
+					<li className="jp-footer__link-item">
+						<a
+							href="http://wordpress.com/tos/"
+							target="_blank"
+							title={ __( 'WordPress.com Terms of Service' ) }
+							className="jp-footer__link">
+							{ __( 'Terms', { context: 'Shorthand for Terms of Service.' } ) }
+						</a>
+					</li>
+					<li className="jp-footer__link-item">
+						<a
+							href="http://automattic.com/privacy/"
+							target="_blank"
+							title={ __( "Automattic's Privacy Policy" ) }
+							className="jp-footer__link">
+							{ __( 'Privacy', { context: 'Shorthand for Privacy Policy.' } ) }
+						</a>
+					</li>
+					<li className="jp-footer__link-item">
+						<a
+							href={ window.Initial_State.adminUrl + 'admin.php?page=jetpack-debugger' }
+							title={ __( "Test your site’s compatibility with Jetpack." ) }
+							className="jp-footer__link">
+							{ __( 'Debug', { context: 'Navigation item. Noun. Links to a debugger tool for Jetpack.' } ) }
+						</a>
+					</li>
 					{ maybeShowReset() }
 				</ul>
 			</div>


### PR DESCRIPTION
Prepares footer of admin page for i18n.

To test:

- Checkout `update/i18n-footer` branch
- `npm run build`
- `npm run build-i18n`
- Check `_inc/jetpack-strings.php` for updated strings
- Go to Jetpack admin page
- Make sure there are no errors

cc @dereksmart for review.

