### PR TITLE
Admin Page: i18n for masthead

### DIFF
--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from'react';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -25,8 +26,22 @@ const Masthead = React.createClass( {
 					</div>
 
 					<ul className="jp-masthead__links">
-						<li className="jp-masthead__link-li"><a href="http://jetpack.com/support/" target="_blank" className="jp-masthead__link"><span className="dashicons dashicons-editor-help" title="Need Help?"></span><span>Need Help?</span></a></li>
-						<li className="jp-masthead__link-li"><a href="http://surveys.jetpack.me/research-plugin?rel=3.9.4" target="_blank" className="jp-masthead__link"><span className="dashicons dashicons-admin-comments" title="Send us Feedback"></span><span>Send us Feedback</span></a></li>
+						<li className="jp-masthead__link-li">
+							<a href="http://jetpack.com/support/" target="_blank" className="jp-masthead__link">
+								<span className="dashicons dashicons-editor-help" title={ __( 'Need Help?' ) } />
+								<span>
+									{ __( 'Need Help?' ) }
+								</span>
+							</a>
+						</li>
+						<li className="jp-masthead__link-li">
+							<a href="http://surveys.jetpack.me/research-plugin?rel=3.9.4" target="_blank" className="jp-masthead__link">
+								<span className="dashicons dashicons-admin-comments" title={ __( 'Send us Feedback' ) } />
+								<span>
+									{ __( 'Send us Feedback' ) }
+								</span>
+							</a>
+						</li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
Prepares Jetpack masthead for i18n.

To test:
- Checkout `update/i18n-masthead` branch
- `npm run build`
- `npm run build-i18n`
- In `_inc/jetpack-strings.php`, make sure new strings are present
- Go to Jetpack admin page. Make sure there are no errors.

cc @dereksmart for review

Screenshot:

<img width="707" alt="screen shot 2016-05-22 at 7 23 20 pm" src="https://cloud.githubusercontent.com/assets/1126811/15457856/83146af8-2057-11e6-9e34-4b90babb9955.png">
