### PR TITLE
Admin Page: i18n for navigation component

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -28,12 +28,36 @@ const Navigation = React.createClass( {
 				<QueryModules />
 				<SectionNav>
 					<NavTabs>
-						<NavItem path="#dashboard" selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>At a Glance</NavItem>
-						<NavItem path="#engagement" selected={ this.props.route.path === '/engagement' }>Engagement</NavItem>
-						<NavItem path="#security" selected={ this.props.route.path === '/security' }>Security</NavItem>
-						<NavItem path="#health" selected={ this.props.route.path === '/health' }>Site Health</NavItem>
-						<NavItem path="#more" selected={ this.props.route.path === '/more' }>More</NavItem>
-						<NavItem path="#general" selected={ this.props.route.path === '/general' }>General</NavItem>
+						<NavItem
+							path="#dashboard"
+							selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
+							{ __( 'At a Glance', { context: 'Navigation item.' } ) }
+						</NavItem>
+						<NavItem
+							path="#engagement"
+							selected={ this.props.route.path === '/engagement' }>
+							{ __( 'Engagement', { context: 'Navigation item.' } ) }
+						</NavItem>
+						<NavItem
+							path="#security"
+							selected={ this.props.route.path === '/security' }>
+							{ __( 'Security', { context: 'Navigation item.' } ) }
+						</NavItem>
+						<NavItem
+							path="#health"
+							selected={ this.props.route.path === '/health' }>Site
+							{ __( 'Health', { context: 'Navigation item.' } ) }
+						</NavItem>
+						<NavItem
+							path="#more"
+							selected={ this.props.route.path === '/more' }>
+							{ __( 'More', { context: 'Navigation item.' } ) }
+						</NavItem>
+						<NavItem
+							path="#general"
+							selected={ this.props.route.path === '/general' }>
+							{ __( 'General', { context: 'Navigation item.' } ) }
+						</NavItem>
 					</NavTabs>
 
 					<Search


### PR DESCRIPTION
Prepares admin page navigation for i18n.

To test:

- Checkout `update/i18n-navigation` branch
- `npm run build`
- npm run build-i18n`
- Make sure that `_inc/jetpack-strings.php` now has the navigation strings
- Go to Jetpack admin page
- Test navigation
- Does everything work without errors?

cc @dereksmart for review.