### PR TITLE
Admin Page: i18n for support card

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import sample from 'lodash/sample';
+import { translate as __ } from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -26,16 +27,90 @@ export default React.createClass( {
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
 					<div className="jp-support-card__happiness-engineer">
-						<img src={ 'https://secure.gravatar.com/avatar/' + randomGravID } alt="Jetpack Happiness Engineer" className="jp-support-card__happiness-engineer-img" />
+						<img
+							src={ 'https://secure.gravatar.com/avatar/' + randomGravID }
+							alt={ __( 'Jetpack Happiness Engineer' ) }
+							className="jp-support-card__happiness-engineer-img"
+						/>
 					</div>
 					<div className="jp-support-card__happiness-contact">
-						<h4 className="jp-support-card__header">Need help? The Jetpack team is here for you.</h4>
-						<p className="jp-support-card__description">We offer free, full support to all of our Jetpack users. Our support team is always around to help you. </p>
-						<p className="jp-support-card__description"><a className="jp-support-card__link" href="http://jetpack.com/support/" title="Go to Jetpack.com/support">View our support page</a><span className="jp-hidden-on-mobile">,</span> <a className="jp-support-card__link" href="https://wordpress.org/support/plugin/jetpack" title="Go to the WordPress.org support forums">check the forums for answers</a><span className="jp-hidden-on-mobile">, or </span><a className="jp-support-card__link" href="https://jetpack.com/contact-support/" title="Contact Jetpack support staff directly">contact us directly</a><span className="jp-hidden-on-mobile">.</span></p>
+						<h4 className="jp-support-card__header">
+							{ __( 'Need help? The Jetpack team is here for you.' ) }
+						</h4>
+						<p className="jp-support-card__description">
+							{ __( 'We offer free, full support to all of our Jetpack users. Our support team is always around to help you.' ) }
+						</p>
+						<p className="jp-support-card__description">
+							{ __(
+								'{{supportLink}}View our support page{{/supportLink}}{{hideOnMobile}},{{/hideOnMobile}} ' +
+								'{{forumLink}}check the forums for answers{{/forumLink}}{{hideOnMobile}}, or{{/hideOnMobile}} ' +
+								'{{contactLink}}contact us directly{{/contactLink}}{{hideOnMobile}}.{{/hideOnMobile}}', {
+									components: {
+										hideOnMobile: <span className="jp-hidden-on-mobile" />,
+										supportLink: (
+											<a
+												className="jp-support-card__link"
+												href="https://jetpack.com/support/"
+												title={ __( 'Go to Jetpack.com/support' ) }
+											/>
+										),
+										forumLink: (
+											<a
+												className="jp-support-card__link"
+												href="https://wordpress.org/support/plugin/jetpack"
+												title={ __( 'Go to the WordPress.org support forums' ) }
+											/>
+										),
+										contactLink: (
+											<a
+												className="jp-support-card__link"
+												href="https://jetpack.com/contact-support/"
+												title={ __( 'Contact Jetpack support staff directly' ) }
+											/>
+										)
+									}
+								}
+							) }
+						</p>
 					</div>
 				</Card>
 				<Card className="jp-support-card__social">
-					<p className="jp-support-card__description"><span className="jp-hidden-on-mobile">Enjoying Jetpack or have feedback? </span><a className="jp-support-card__link" href="https://wordpress.org/support/view/plugin-reviews/jetpack" title="Leave a Jetpack review" target="_blank">Leave us a review</a><span className="jp-hidden-on-mobile">, </span><a className="jp-support-card__link" href="http://twitter.com/jetpack" title="Follow Jetpack on Twitter" target="_blank">follow us on twitter</a><span className="jp-hidden-on-mobile">, or </span><a className="jp-support-card__link" href="https://www.facebook.com/jetpackme" title="Like us on facebook" target="_blank">like us on facebook</a><span className="jp-hidden-on-mobile">.</span></p>
+					<p className="jp-support-card__description">
+						{ __(
+							'{{hideOnMobile}}Enjoying Jetpack or have feedback?{{/hideOnMobile}} ' +
+							'{{reviewLink}}Leave us a review{{/reviewLink}}{{hideOnMobile}},{{/hideOnMobile}} ' +
+							'{{twitterLink}}follow us on twitter{{/twitterLink}} {{hideOnMobile}}, or{{/hideOnMobile}} ' +
+							'{{facebookLink}}like us on facebook{{/facebookLink}}{{hideOnMobile}}.{{/hideOnMobile}}', {
+								components: {
+									hideOnMobile: <span className="jp-hidden-on-mobile" />,
+									reviewLink: (
+										<a
+											className="jp-support-card__link"
+											href="https://wordpress.org/support/view/plugin-reviews/jetpack"
+											title={ __( 'Leave a Jetpack review' ) }
+											target="_blank"
+										/>
+									),
+									twitterLink: (
+										<a
+											className="jp-support-card__link"
+											href="http://twitter.com/jetpack"
+											title={ __( 'Follow Jetpack on Twitter' ) }
+											target="_blank"
+										/>
+									),
+									facebookLink: (
+										<a
+											className="jp-support-card__link"
+											href="https://www.facebook.com/jetpackme"
+											title={ __( 'Like us on facebook' ) }
+											target="_blank"
+										/>
+									)
+								}
+							}
+						) }
+					</p>
 				</Card>
 			</div>
 		);


### PR DESCRIPTION
Prepares support card component for i18n.

To test:

 - Checkout `update/i18n-support-card` branch
- `npm run build`
- `npm run build-i18n`
- Check `_inc/jetpack-strings.php` file to make sure new strings are present
- Go to Jetpack admin page
- Make sure there are no errors
- Make sure links in support card work properly

cc @dereksmart for review.

## Screenshots:


### Mobile
<img width="530" alt="screen shot 2016-05-22 at 7 55 37 pm" src="https://cloud.githubusercontent.com/assets/1126811/15457851/7a507088-2057-11e6-9687-b3bd35a4a3ee.png">

### Desktop
<img width="862" alt="screen shot 2016-05-22 at 7 55 29 pm" src="https://cloud.githubusercontent.com/assets/1126811/15457852/7a54311e-2057-11e6-9e29-1ec9fa0fe4af.png">
