### PR TITLE
Admin Page: Several fixes for passing reducer tests

### DIFF
--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -43,9 +43,15 @@ export const items = ( state = initialItemsState, action ) => {
 				[ action.module ]: assign( {}, state[ action.module ], { activated: false } )
 			} );
 		case JETPACK_MODULE_UPDATE_OPTION_SUCCESS:
+			let module = state[ action.module ];
+			let newOptions = assign( {}, module.options, {
+				[ action.optionName ]: Object.assign( {}, module.options[ action.optionName ], {
+					current_value: action.optionValue
+				} )
+			} );
 			return assign( {}, state, {
 				[ action.module ]: assign( {}, state[ action.module ], {
-					[ action.option_name ]: action.option_value
+					options: newOptions
 				} )
 			} );
 		default:

--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -25,7 +25,11 @@ import {
 
 } from 'state/action-types';
 
-export const items = ( state = window.Initial_State.getModules, action ) => {
+export const initialItemsState = typeof window !== 'undefined' && typeof window.Initial_State === 'object' ?
+	window.Initial_State.getModules :
+	{};
+
+export const items = ( state = initialItemsState, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SET_INITIAL_STATE:
 		case JETPACK_MODULES_LIST_RECEIVE:

--- a/_inc/client/state/modules/test/reducer.js
+++ b/_inc/client/state/modules/test/reducer.js
@@ -10,7 +10,7 @@ import {
 describe( 'items reducer', () => {
 	it( 'state should default to empty object', () => {
 		const state = itemsReducer( undefined, {} );
-		expect( state ).to.equal( {} );
+		expect( state ).to.eql( {} );
 	} );
 
 	let modules = {

--- a/_inc/client/state/modules/test/reducer.js
+++ b/_inc/client/state/modules/test/reducer.js
@@ -14,11 +14,11 @@ describe( 'items reducer', () => {
 	} );
 
 	let modules = {
-		a: {
+		'module-a': {
 			module: 'module-a',
 			activated: false
 		},
-		b: {
+		'module-b': {
 			module: 'module-b',
 			activated: true,
 			options: {
@@ -69,11 +69,12 @@ describe( 'items reducer', () => {
 			const action = {
 				type: 'JETPACK_MODULE_UPDATE_OPTION_SUCCESS',
 				module: 'module-b',
-				option_name: 'c',
-				option_value: 30
+				optionName: 'c',
+				optionValue: 30
 			};
 			let stateOut = itemsReducer( stateIn, action );
-			expect( stateOut[ action.module ].options[ action.option_name ].currentValue ).to.eql( action.option_value );
+
+			expect( stateOut[ action.module ].options[ action.optionName ].current_value ).to.equal( action.optionValue );
 		} );
 	} );
 } );

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -55,7 +55,7 @@ export const requests = ( state = initialRequestsState, action ) => {
 		case JETPACK_SETTING_UPDATE_FAIL:
 		case JETPACK_SETTING_UPDATE_SUCCESS:
 			return assign( {}, state, {
-				updatingSetting: true
+				updatingSetting: false
 			} );
 		default:
 			return state;


### PR DESCRIPTION
Fixes failing reducer tests (fixing also #3881).

#### Changes proposed in this Pull Request:
- Updates settings' reducer to correctly handle request flags in the state when updating a setting
- Updates modules' items reducer test to effectively test a module's option update.
- Updates modules' items reducer to no pick the initial state from a local variable that depended on `window.InitialState`. It uses `window.InitialState` if defined, otherwise use `{}` as default value for the state argument.

#### Testing instructions

1. Run
  ```shell
  $ npm run test-client
  ```

1. Expect to see **47 tests passing** and no test failing
