### PR TITLE
Add JSON as global to dismiss jshint warning.

### DIFF
--- a/_inc/jetpack-sync.js
+++ b/_inc/jetpack-sync.js
@@ -1,4 +1,4 @@
-/* global ajaxurl, sync_dashboard, wp */
+/* global ajaxurl, sync_dashboard, wp, JSON */
 
 jQuery( document ).ready( function($) {
 


### PR DESCRIPTION
Fixes Gulp JSHint warning:
```
_inc/jetpack-sync.js
  line 33  col 32  'JSON' is not defined.
```
introduced at https://github.com/Automattic/jetpack/pull/3729/files#diff-092a8c457e7ef68daf3bcde0e4b910abR33 of #3729 