### PR TITLE
Layout: adjusting max-width of entire layout

### DIFF
--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -9,7 +9,7 @@
 	padding: rem( 10px );
 	margin: 0 auto;
 	width: 100%;
-	max-width: rem( 1220px );
+	max-width: rem( 960px );
 	display: flex;
 	flex-flow: row nowrap;
 

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -24,7 +24,7 @@
 .jp-lower {
 	margin: 0 auto;
 	text-align: left;
-	max-width: rem( 1200px );
+	max-width: rem( 960px );
 	padding: rem( 20px );
 }
 


### PR DESCRIPTION
Changing max-width of Jetpack width from `1200px` to `960px`, which will enhance the overall usability of the app (less mouse movement within areas) and bring it closer to calypso's design. 

Fixes: https://github.com/Automattic/jetpack/issues/3906

Visuals:
![screen shot 2016-05-23 at 2 00 05 pm](https://cloud.githubusercontent.com/assets/214813/15479369/dfbcf856-20ed-11e6-8454-9bd33d05acdf.png)
![screen shot 2016-05-23 at 2 00 18 pm](https://cloud.githubusercontent.com/assets/214813/15479368/dfbc9d52-20ed-11e6-83fd-f7ba307c45d1.png)
