### PR TITLE
Admin Page: only display landing page if site is not connected and is not in dev mode

### DIFF
--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -23,7 +23,7 @@ import {
 	UNLINK_USER_SUCCESS
 } from 'state/action-types';
 
-export const status = ( state = { siteConnected: window.Initial_State.connectionStatus.isActive }, action ) => {
+export const status = ( state = { siteConnected: window.Initial_State.connectionStatus }, action ) => {
 	switch ( action.type ) {
 		case JETPACK_CONNECTION_STATUS_FETCH:
 			return assign( {}, state, { siteConnected: action.siteConnected } );
@@ -108,11 +108,17 @@ export const reducer = combineReducers( {
 /**
  * Returns true if site is connected to WordPress.com
  *
- * @param  {Object} state Global state tree
- * @return {bool}         True if site is connected, False if it is not.
+ * @param  {Object}      state Global state tree
+ * @return {bool|string} True if site is connected, False if it is not, 'dev' if site is in development mode.
  */
 export function getSiteConnectionStatus( state ) {
-	return state.jetpack.connection.status.siteConnected;
+	if ( 'object' !== typeof state.jetpack.connection.status.siteConnected ) {
+		return false;
+	}
+	if ( state.jetpack.connection.status.siteConnected.devMode.isActive ) {
+		return 'dev';
+	}
+	return state.jetpack.connection.status.siteConnected.isActive;
 }
 
 /**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -419,10 +419,17 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool True if site is connected
 	 */
 	public static function jetpack_connection_status() {
-		if ( Jetpack::is_development_mode() ) {
-			return rest_ensure_response( 'dev' );
-		}
-		return Jetpack::is_active();
+		return rest_ensure_response( array(
+				'isActive'  => Jetpack::is_active(),
+				'isStaging' => Jetpack::is_staging_site(),
+				'devMode'   => array(
+					'isActive' => Jetpack::is_development_mode(),
+					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
+					'url'      => site_url() && false === strpos( site_url(), '.' ),
+					'filter'   => apply_filters( 'jetpack_development_mode', false ),
+				),
+			)
+		);
 	}
 
 	public static function recheck_ssl() {


### PR DESCRIPTION
#### To test

Go into Development Mode either in your local server or online adding `define( 'JETPACK_DEV_DEBUG', true);` to `jetpack.php` to your org sandbox, go to Jetpack > Dashboard.
- [ ] The tabs and all controls should be displayed.

In regular mode in your org sandbox, go to Jetpack > Dashboard.
- [ ] If the site is not connected, it should display the connection landing page.
- [ ] If the site is connected, it should display the tabs and all controls.