### PR TITLE
Add tests that and implement jetpack_sync::sync_options() method for backwards compatibility with VaultPress

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -11,9 +11,5 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
 
-if ( class_exists( 'WP_Polldaddy' ) ) {
-	global $polldaddy_object;
-	if ( is_object( $polldaddy_object ) && isset( $polldaddy_object->version ) && version_compare('2.0.32', $polldaddy_object->version , '>' ) ) {
-		require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );
-	}
-}
+// We can't load this conditionally since polldaddy add the call in class constuctor.
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );

--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -10,3 +10,10 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/wpml.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
+
+if ( class_exists( 'WP_Polldaddy' ) ) {
+	global $polldaddy_object;
+	if ( is_object( $polldaddy_object ) && isset( $polldaddy_object->version ) && version_compare('2.0.32', $polldaddy_object->version , '>' ) ) {
+		require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );
+	}
+}

--- a/3rd-party/polldaddy.php
+++ b/3rd-party/polldaddy.php
@@ -1,0 +1,14 @@
+<?php
+
+class Jetpack_Sync {
+	static function sync_options() {
+		_deprecated_function( __METHOD__, '4.1.0', 'jetpack_whitelist_options filter' );
+		$options = func_get_args();
+		// first argument is the file but we don't care about that any more.
+		$file = array_shift( $options );
+		if ( is_array( $options ) ) {
+			$client_sync = Jetpack_Sync_Client::getInstance();
+			$client_sync->set_options_whitelist( array_merge( $options, $client_sync->get_options_whitelist() ) );
+		}
+	}
+}

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -81,7 +81,7 @@ class Jetpack_Sync_Client {
 		add_action( 'trashed_comment', $handler, 10 );
 		add_action( 'spammed_comment', $handler, 10 );
 
-		// even though it's messy, we implement these hooks because 
+		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data
 		// so this saves us a DB read for every comment event
 		foreach ( array( '', 'trackback', 'pingback' ) as $comment_type ) {
@@ -176,6 +176,10 @@ class Jetpack_Sync_Client {
 	// TODO: Refactor to use one set whitelist function, with one is_whitelisted.
 	function set_options_whitelist( $options ) {
 		$this->options_whitelist = $options;
+	}
+
+	function get_options_whitelist() {
+		return $this->options_whitelist;
 	}
 
 	function set_constants_whitelist( $constants ) {
@@ -318,7 +322,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * Fires when the client needs to sync theme support info
 		 * Only sends theme support attributes whitelisted in Jetpack_Sync_Defaults::$default_theme_support_whitelist
-		 * 
+		 *
 		 * @since 4.1.0
 		 *
 		 * @param object the theme support hash
@@ -332,7 +336,7 @@ class Jetpack_Sync_Client {
 
 			/**
 			 * Fires when the client needs to sync WordPress version
-			 * 
+			 *
 			 * @since 4.1.0
 			 *
 			 * @param string The WordPress version number
@@ -350,7 +354,7 @@ class Jetpack_Sync_Client {
 
 		/**
 		 * Fires when the client needs to sync a new term
-		 * 
+		 *
 		 * @since 4.1.0
 		 *
 		 * @param object the Term object
@@ -363,7 +367,7 @@ class Jetpack_Sync_Client {
 
 		/**
 		 * Fires when the client needs to sync an attachment for a post
-		 * 
+		 *
 		 * @since 4.1.0
 		 *
 		 * @param int The attachment ID
@@ -391,7 +395,7 @@ class Jetpack_Sync_Client {
 
 		/**
 		 * Fires when the client needs to sync an updated user
-		 * 
+		 *
 		 * @since 4.1.0
 		 *
 		 * @param object The WP_User object
@@ -404,7 +408,7 @@ class Jetpack_Sync_Client {
 
 		/**
 		 * Fires when the client needs to sync an updated user
-		 * 
+		 *
 		 * @since 4.1.0
 		 *
 		 * @param object The WP_User object
@@ -417,7 +421,7 @@ class Jetpack_Sync_Client {
 		if ( $meta_key === $user->cap_key ) {
 			/**
 			 * Fires when the client needs to sync an updated user
-			 * 
+			 *
 			 * @since 4.1.0
 			 *
 			 * @param object The WP_User object
@@ -480,7 +484,7 @@ class Jetpack_Sync_Client {
 			 * Modify the data within an action before it is serialized and sent to the server
 			 * For example, during full sync this expands Post ID's into full Post objects,
 			 * so that we don't have to serialize the whole object into the queue.
-			 * 
+			 *
 			 * @since 4.1.0
 			 *
 			 * @param array The action parameters
@@ -777,5 +781,19 @@ class Jetpack_Sync_Client {
 
 	function reset_data() {
 		$this->reset_sync_queue();
+	}
+}
+
+class Jetpack_Sync {
+	static function sync_options() {
+		$options = func_get_args();
+		// first argument is the file but we don't care about that any more.
+		$file = array_shift( $options );
+		if ( is_array( $options ) ) {
+			$client_sync = Jetpack_Sync_Client::getInstance();
+			$client_sync->set_options_whitelist( array_merge( $options, $client_sync->get_options_whitelist() ) );
+		}
+
+
 	}
 }

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -783,17 +783,3 @@ class Jetpack_Sync_Client {
 		$this->reset_sync_queue();
 	}
 }
-
-class Jetpack_Sync {
-	static function sync_options() {
-		$options = func_get_args();
-		// first argument is the file but we don't care about that any more.
-		$file = array_shift( $options );
-		if ( is_array( $options ) ) {
-			$client_sync = Jetpack_Sync_Client::getInstance();
-			$client_sync->set_options_whitelist( array_merge( $options, $client_sync->get_options_whitelist() ) );
-		}
-
-
-	}
-}

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -765,7 +765,10 @@ class Jetpack_Sync_Client {
 		$this->set_full_sync_client( Jetpack_Sync_Full::getInstance() );
 		$this->codec                     = new Jetpack_Sync_Deflate_Codec();
 		$this->constants_whitelist       = Jetpack_Sync_Defaults::$default_constants_whitelist;
-		$this->options_whitelist         = Jetpack_Sync_Defaults::$default_options_whitelist;
+		/**
+		 * This filter is already documented class.wpcom-json-api-get-option-endpoint.php
+		 */
+		$this->options_whitelist         = apply_filters( 'jetpack_options_whitelist', Jetpack_Sync_Defaults::$default_options_whitelist );
 		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
 		$this->taxonomy_whitelist        = Jetpack_Sync_Defaults::$default_taxonomy_whitelist;
 		$this->is_multisite              = is_multisite();

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -65,6 +65,19 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 		}
 	}
 
+
+	public function test_backwards_compatibility_sync_options() {
+		Jetpack_Sync::sync_options( __FILE__, 'foo_option', 'bar_option' );
+
+		update_option( 'foo_option', '123' );
+		update_option( 'bar_option', '456' );
+		$this->client->do_sync();
+
+		$this->assertEquals( '123', $this->server_replica_storage->get_option( 'foo_option' ) );
+		$this->assertEquals( '456', $this->server_replica_storage->get_option( 'bar_option' ) );
+
+	}
+
 	function _get_site_icon( $url, $size, $blog_id ) {
 		return 'http://foo.com/icon.gif';
 	}

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -65,19 +65,6 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 		}
 	}
 
-
-	public function test_backwards_compatibility_sync_options() {
-		Jetpack_Sync::sync_options( __FILE__, 'foo_option', 'bar_option' );
-
-		update_option( 'foo_option', '123' );
-		update_option( 'bar_option', '456' );
-		$this->client->do_sync();
-
-		$this->assertEquals( '123', $this->server_replica_storage->get_option( 'foo_option' ) );
-		$this->assertEquals( '456', $this->server_replica_storage->get_option( 'bar_option' ) );
-
-	}
-
 	function _get_site_icon( $url, $size, $blog_id ) {
 		return 'http://foo.com/icon.gif';
 	}

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -65,6 +65,20 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 		}
 	}
 
+	public function test_sync_options_that_use_filter() {
+		add_filter( 'jetpack_options_whitelist', array( $this, 'add_jetpack_options_whitelist_filter' ) );
+		$this->client->set_defaults();
+		update_option( 'foo_option_bar', '123' );
+		$this->client->do_sync();
+
+		$this->assertEquals( '123', $this->server_replica_storage->get_option( 'foo_option_bar' ) );
+	}
+
+	public function add_jetpack_options_whitelist_filter( $options ) {
+		$options[] = 'foo_option_bar';
+		return $options;
+	}
+
 	function _get_site_icon( $url, $size, $blog_id ) {
 		return 'http://foo.com/icon.gif';
 	}

--- a/tests/php/sync/test_class.jetpack_sync_backward_compatibility.php
+++ b/tests/php/sync/test_class.jetpack_sync_backward_compatibility.php
@@ -7,7 +7,6 @@ class WP_Test_Jetpack_Sync_Backward_Compatibility extends WP_Test_Jetpack_New_Sy
 
 	public function setUp() {
 		parent::setUp();
-
 	}
 
 	public function test_backwards_compatibility_sync_options() {

--- a/tests/php/sync/test_class.jetpack_sync_backward_compatibility.php
+++ b/tests/php/sync/test_class.jetpack_sync_backward_compatibility.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Testing Backward Compatibility with Olter plugins.
+ */
+class WP_Test_Jetpack_Sync_Backward_Compatibility extends WP_Test_Jetpack_New_Sync_Base {
+
+	public function setUp() {
+		parent::setUp();
+
+	}
+
+	public function test_backwards_compatibility_sync_options() {
+		require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );
+		$this->setExpectedDeprecated( 'Jetpack_Sync::sync_options' );
+		Jetpack_Sync::sync_options( __FILE__, 'foo_option', 'bar_option' );
+
+		update_option( 'foo_option', '123' );
+		update_option( 'bar_option', '456' );
+
+		$this->client->do_sync();
+
+		$this->assertEquals( '123', $this->server_replica_storage->get_option( 'foo_option' ) );
+		$this->assertEquals( '456', $this->server_replica_storage->get_option( 'bar_option' ) );
+	}
+
+}


### PR DESCRIPTION
Currently we have some plugins for example ValutPress that use the `Jetpack_Sync::sync_options` method to set options that it wants to sync to .com.

In the future they options would be just added to the white list directly but this way we we can push updated to plugins that would work  with older version of Jetpack and still sync certain options. 

cc: @lezama and @gravityrail 

**How to test**
Update to this branch. 
- Use the current version of VaultPress, PollDaddy and Akismet. Do you see any fatal errors? 
- Are the options being synced to the shadow site? 


