### PR TITLE
Admin Page: Fix broken admin page undefined nunmber

### DIFF
--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -162,7 +162,7 @@ const DashStatsBottom = React.createClass( {
 						{
 							__( '%(number)s View', '%(number)s Views',
 								{
-									count: number,
+									count: s.bestDay.count,
 									args: {
 										number: s.bestDay.count
 									}


### PR DESCRIPTION
Fixes #3911.

Fixes an undefined `number` error in the `stats.jsx` component. As this is currently breaking admin page, going to go ahead and merge this.
