### PR TITLE
Unit Tests: Skip when the constant is not defined instead of writing …

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -31,7 +31,7 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 
 	function test_does_not_fire_if_constants_havent_changed() {
 		$this->client->set_defaults(); // use the default constants
-		
+
 		$this->client->do_sync();
 
 		foreach( Jetpack_Sync_Defaults::$default_constants_whitelist as $constant ) {
@@ -39,10 +39,10 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 				$value = constant( $constant );
 				$this->assertEquals( $value, $this->server_replica_storage->get_constant( $constant ) );
 			} catch( Exception $e ) {
-				error_log( "Warning: No such constant: ".$constant );
+				$this->markTestSkipped( $constant . ' not defined.');
 			}
 		}
-		
+
 		$this->server_replica_storage->reset();
 		$this->client->do_sync();
 


### PR DESCRIPTION
Fixes #3930 .

Skips if constant is not defined instead of error_log'ing