### PR TITLE
Unit Tests: Use PHPUnit's @requires instead of manual skips

### DIFF
--- a/tests/php/_inc/lib/test_class.jetpack-media-extractor.php
+++ b/tests/php/_inc/lib/test_class.jetpack-media-extractor.php
@@ -385,6 +385,8 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	 * @author scotchfield
 	 * @covers Jetpack_Media_Meta_Extractor::extract
 	 * @since 3.2
+	 * @requires PHP 5.4.0
+	 * @todo  This test is failing in 5.2 and 5.3 for unknown reasons. Figure it out.
 	 */
 	function test_extract_mentions() {
 		$post_id = $this->add_test_post();
@@ -400,13 +402,6 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 		);
 
 		$result = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id, Jetpack_Media_Meta_Extractor::MENTIONS );
-
-		if ( version_compare( PHP_VERSION, '5.4.0' ) == -1 ) {
-			$this->markTestSkipped(
-				'This test is failing in PHP 5.2 and PHP 5.3 for unknown reasons. Skipping pending further verification.'
-				);
-			return;
-		}
 
 		$this->assertEquals( $expected, $result );
 	}

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -31,6 +31,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	/**
 	 * @author lezama
 	 * @covers Jetpack_JSON_API_Plugins_Modify_Endpoint
+	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_JSON_API_Plugins_Modify_Endpoint() {
 
@@ -58,12 +59,6 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 		 */
 		$class = new ReflectionClass('Jetpack_JSON_API_Plugins_Modify_Endpoint');
 		$update_plugin_method = $class->getMethod( 'update' );
-		if ( ! method_exists($update_plugin_method, 'setAccessible') ) {
-			$this->markTestSkipped(
-				'This test uses ReflectionMethod->setAccessible which is not available until PHP 5.3.2.'
-				);
-			return;
-		}
 		$update_plugin_method->setAccessible( true );
 
 		$plugin_property = $class->getProperty( 'plugins' );
@@ -106,6 +101,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	/**
 	 * @author tonykova
 	 * @covers Jetpack_API_Plugins_Install_Endpoint
+	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_API_Plugins_Install_Endpoint() {
 		$endpoint = new Jetpack_JSON_API_Plugins_Install_Endpoint( array(
@@ -143,12 +139,6 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 		$class = new ReflectionClass('Jetpack_JSON_API_Plugins_Install_Endpoint');
 
 		$plugins_property = $class->getProperty( 'plugins' );
-		if ( ! method_exists($plugins_property, 'setAccessible') ) {
-			$this->markTestSkipped(
-				'This test uses ReflectionMethod->setAccessible which is not available until PHP 5.3.2.'
-				);
-			return;
-		}
 		$plugins_property->setAccessible( true );
 		$plugins_property->setValue ( $endpoint , array( $the_plugin_slug ) );
 


### PR DESCRIPTION
When updating Travis to use multiple PHP versions in #2784, we skipped a few tests that couldn't be reasonably rewritten to work in 5.2 and skipped one test that failed for unknown reasons in 5.2 and 5.3 (without any reports of failures in the field).

We skipped it manually, via `function_exists` and comparing PHP versions. PHPUnit does this by itself. Let's leverage the built-in API for it instead of hacking it ourselves.