### PR TITLE
Foldable Cards: Make header text clickable via a prop

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -49,7 +49,9 @@ export const Page = ( { toggleModule, isModuleActivated, isTogglingModule, getMo
 				<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
 					toggling={ isTogglingModule( element[0] ) }
 					toggleModule={ toggleModule } />
-			} >
+			}
+			clickableHeaderText={ true }
+		>
 				{ isModuleActivated( element[0] ) ? renderSettings( getModule( element[0] ) ) :
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -21,18 +21,21 @@ const GeneralSettings = React.createClass( {
 				<FoldableCard
 					header="Jetpack Add-ons"
 					subheader="Manage your Jetpack account and premium add-ons."
+					clickableHeaderText={ true }
 				>
 					<SitePlan />
 				</FoldableCard>
 				<FoldableCard
 					header="Jetpack Connection Settings"
 					subheader="Manage your connected user accounts or disconnect."
+					clickableHeaderText={ true }
 				>
 					<ConnectionSettings { ...this.props } />
 				</FoldableCard>
 				<FoldableCard
 					header="Miscellaneous Settings"
 					subheader="Manage Snow and other fun things for your site."
+					clickableHeaderText={ true }
 				>
 					<Settings />
 				</FoldableCard>

--- a/_inc/client/more/index.jsx
+++ b/_inc/client/more/index.jsx
@@ -63,7 +63,9 @@ export const Page = ( { toggleModule, isModuleActivated, isTogglingModule, getMo
 				header={ element[1] }
 				subheader={ element[2] }
 				summary={ toggle }
-				expandedSummary={ toggle } >
+				expandedSummary={ toggle }
+				clickableHeaderText={ true }
+			>
 				{ isModuleActivated( element[0] ) || 'scan' === element[0] ? renderSettings( getModule( element[0] ) ) :
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -40,7 +40,9 @@ export const Page = ( { toggleModule, isModuleActivated, isTogglingModule, getMo
 				header={ element[1] }
 				subheader={ element[2] }
 				summary={ toggle }
-				expandedSummary={ toggle } >
+				expandedSummary={ toggle }
+				clickableHeaderText={ true }
+			>
 				{ isModuleActivated( element[0] ) || 'scan' === element[0] ? renderSettings( getModule( element[0] ) ) :
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />

--- a/_inc/client/site-health/index.jsx
+++ b/_inc/client/site-health/index.jsx
@@ -39,7 +39,9 @@ export const Page = ( { toggleModule, isModuleActivated, isTogglingModule, getMo
 				header={ element[1] }
 				subheader={ element[2] }
 				summary={ toggle }
-				expandedSummary={ toggle } >
+				expandedSummary={ toggle }
+				clickableHeaderText={ true }
+			>
 				{ isModuleActivated( element[0] ) || 'akismet' === element[0] || 'backups' === element[0] ? renderSettings( element[0] ) :
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />


### PR DESCRIPTION
FIxes: #3928
cc @beaulebens 

This makes the Header and Subheader text clickable in all of our foldable cards.  We don't want the entire thing clickable, because it's awkward with the toggle item already being clickable.

To Test: 
- `npm link` to [this branch](https://github.com/Automattic/dops-components/pull/20) and click on the text to unfurl the card.  