### PR TITLE
Fix docs in README.md for module-toggle component

### DIFF
--- a/_inc/client/components/module-toggle/README.md
+++ b/_inc/client/components/module-toggle/README.md
@@ -1,18 +1,19 @@
-Connect Button
+ModuleToggle
 =========
 
-This component is used to Connect/Disconnect the site or a user to WordPress.com
+This component is used to in module cards presenting a toggle for activating/deactivating a toggle
 
 #### How to use:
 
 ```js
-var Connectbutton = require( 'components/connect-button' );
+var ModuleToggle = require( 'components/module-toggle' );
 
 render: function() {
 	return (
 		<div className="you-rock">
-		  <Connectbutton
-			connectingUser={ this.props.checked }
+		  <ModuleToggle
+			activated={ this.props.activated }
+			toggleModule={ () => console.log( 'toggled' ) }
 		  />
 		</div>
 	);
@@ -21,4 +22,9 @@ render: function() {
 
 #### Props
 
-* `connectingUser`: (bool) If this is for linking/connecting the USER, rather than the site.  Will show different text and unlinking actions.
+* `activated`: (bool) - Defines wether the toggle is in the on or the off position
+* `toggleModule`: (function) - A callback to be called when the toggle changes it state (`onChage`)
+* `disabled`: (bool) - If true, the toggle is not actionable.
+* `toggling`: (bool) - If true, the toggle is rendered in a transition state style.
+* `className`: (string) - A CSS class to append
+


### PR DESCRIPTION
Fixes wrong documentation in `module-toggle`s README.md .

#### Changes proposed in this Pull Request:

- Documents component usage properly.