### PR TITLE
Debug Link: make sure current user has permissions to view debug page

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -37,6 +37,21 @@ export const Footer = React.createClass( {
 			return '';
 		};
 
+		const maybeShowDebug = () =>  {
+			if ( window.Initial_State.userData.currentUser.permissions.manage_options ) {
+				return (
+					<li className="jp-footer__link-item">
+						<a
+							href={ window.Initial_State.adminUrl + 'admin.php?page=jetpack-debugger' }
+							title={ __( "Test your site’s compatibility with Jetpack." ) }
+							className="jp-footer__link">
+							{ __( 'Debug', { context: 'Navigation item. Noun. Links to a debugger tool for Jetpack.' } ) }
+						</a>
+					</li>
+				);
+			}
+		};
+
 		return (
 			<div className={ classes }>
 				<div className="jp-footer__a8c-attr-container">
@@ -71,14 +86,7 @@ export const Footer = React.createClass( {
 							{ __( 'Privacy', { context: 'Shorthand for Privacy Policy.' } ) }
 						</a>
 					</li>
-					<li className="jp-footer__link-item">
-						<a
-							href={ window.Initial_State.adminUrl + 'admin.php?page=jetpack-debugger' }
-							title={ __( "Test your site’s compatibility with Jetpack." ) }
-							className="jp-footer__link">
-							{ __( 'Debug', { context: 'Navigation item. Noun. Links to a debugger tool for Jetpack.' } ) }
-						</a>
-					</li>
+					{ maybeShowDebug() }
 					{ maybeShowReset() }
 				</ul>
 			</div>

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -313,6 +313,7 @@ function jetpack_current_user_data() {
 			'network_admin'      => current_user_can( 'jetpack_network_admin_page' ),
 			'network_sites_page' => current_user_can( 'jetpack_network_sites_page' ),
 			'edit_posts'         => current_user_can( 'edit_posts' ),
+			'manage_options'     => current_user_can( 'manage_options' ),
 		),
 	);
 


### PR DESCRIPTION
Fixes #3916
cc @beaulebens 

Makes sure users who cannot `manage_options` (which is what the debug page requires), doesn't see the debug link.  