### PR TITLE
At a Glance - Stats: only render if data received has no errors

### DIFF
--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -59,8 +59,47 @@ const DashStats = React.createClass( {
 		return ( getSiteConnectionStatus( this.props ) === 'dev' ) ? demoStatsData : s;
 	},
 
+	/**
+	 * Checks that the stats fetching didn't return errors.
+	 *
+	 * @returns {object|bool}
+	 */
+	statsErrors() {
+		let checkStats = window.Initial_State.statsData.general;
+		if ( 'object' === typeof checkStats.errors ) {
+			return checkStats.errors;
+		}
+		return false;
+	},
+
 	renderStatsArea: function() {
 		if ( this.props.isModuleActivated( 'stats' ) ) {
+			let statsErrors = this.statsErrors();
+			if ( statsErrors ) {
+				forEach( statsErrors, function( error ) {
+					console.log( error );
+				} );
+				if ( getSiteConnectionStatus( this.props ) === 'dev' ) {
+					return (
+						<p>
+							{
+								__( 'Error loading stats. See JavaScript console for logs.' )
+							}
+						</p>
+					);
+				}
+				return (
+					<p>
+						{
+							__( 'Something happened while loading stats. Please try again later or {{a}}view your stats now on WordPress.com{{/a}}', {
+								components: {
+									a: <a href="{ 'https://wordpress.com/stats/insights/' + window.Initial_State.rawUrl }" />
+								}
+							} )
+						}
+					</p>
+				);
+			}
 			const activeTab = this.props.activeTab();
 			return (
 				<div className="jp-at-a-glance__stats-container">
@@ -88,7 +127,7 @@ const DashStats = React.createClass( {
 	},
 
 	maybeShowStatsTabs: function() {
-		if ( this.props.isModuleActivated( 'stats' ) ) {
+		if ( this.props.isModuleActivated( 'stats' ) && ! this.statsErrors() ) {
 			return(
 				<ul className="jp-at-a-glance__stats-views">
 					<li tabIndex="0" className="jp-at-a-glance__stats-view">


### PR DESCRIPTION
### Issue
When there are errors fetching stats data, the initial status object includes them like this:

<img width="357" alt="stats-error-0" src="https://cloud.githubusercontent.com/assets/1041600/15509997/fcb71f68-21ab-11e6-9ade-c4b24ed365b9.png">

so when some property was accessed, like
```js
viewsToday: generalStats.views_today,
```
it was throwing an error:
```
Uncaught TypeError: Cannot read property 'views_today' of undefined
```
which broke the entire app.

### Changes
This PR introduces a checking of the data received to render the stats before any of the components, the chart or the bottom numbers are rendered. If there are errors, messages are displayed.
For a regular user/site:
<img width="698" alt="stats-error1" src="https://cloud.githubusercontent.com/assets/1041600/15509923/ac98a22c-21ab-11e6-986e-7b73a35a6012.png">
For a site in development mode:
<img width="699" alt="stats-error2" src="https://cloud.githubusercontent.com/assets/1041600/15509924/ac9a6f8a-21ab-11e6-91e4-a38d3f74cedf.png">

### To test
In your org sandbox, edit `jetpack.php` and point `JETPACK__WPCOM_JSON_API_HOST` to whatever place:
```php
defined( 'JETPACK__WPCOM_JSON_API_HOST' )    or define( 'JETPACK__WPCOM_JSON_API_HOST', 'example.tld' );
```
You can put your com sandbox here and _not_ connect to it through ssh which will cause the same effect.
Note that stats fetching is cached so if you already had stats data, you'll have to wait until they're cleared.

The non-dev mode message is simple to verify. To see the dev mode message, apply https://github.com/Automattic/jetpack/pull/3907/commits/2a7eaa4c1172f4f601fc3c5b66fc4165fdcb3df1 that fixes the connection statuses.