### PR TITLE
SSO: Fixes an issue where bypassing login form always logged out user from WP.com

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -356,7 +356,7 @@ class Jetpack_SSO {
 		) {
 			add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
 			$this->maybe_save_cookie_redirect();
-			$reauth = ! empty( $_GET['reauth'] );
+			$reauth = ! empty( $_GET['force_reauth'] );
 			$sso_url = $this->get_sso_url_or_die( $reauth );
 			JetpackTracking::record_user_event( 'sso_login_redirect_bypass_success' );
 			wp_safe_redirect( $sso_url );
@@ -379,7 +379,7 @@ class Jetpack_SSO {
 					$this->maybe_save_cookie_redirect();
 					// Is it wiser to just use wp_redirect than do this runaround to wp_safe_redirect?
 					add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
-					$reauth = ! empty( $_GET['reauth'] );
+					$reauth = ! empty( $_GET['force_reauth'] );
 					$sso_url = $this->get_sso_url_or_die( $reauth );
 					JetpackTracking::record_user_event( 'sso_login_redirect_success' );
 					wp_safe_redirect( $sso_url );
@@ -490,7 +490,7 @@ class Jetpack_SSO {
 				<?php echo $this->build_sso_button( array(), 'is_primary' ); ?>
 
 				<?php if ( $display_name && $gravatar ) : ?>
-					<a class="jetpack-sso-wrap__reauth" href="<?php echo esc_url( $this->build_sso_button_url( array( 'reauth' => '1' ) ) ); ?>">
+					<a class="jetpack-sso-wrap__reauth" href="<?php echo esc_url( $this->build_sso_button_url( array( 'force_reauth' => '1' ) ) ); ?>">
 						<?php esc_html_e( 'Log in as a different WordPress.com user', 'jetpack' ); ?>
 					</a>
 				<?php else : ?>


### PR DESCRIPTION
Fixes #3934.

In #3934, @jeherve pointed out an issue where the user was always forced to log in to WordPress.com when bypassing the default log in form like this:

`add_filter(  'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );`

I was able to narrow down the issue to the fact that WP.org also uses the `$_GET['reauth']` parameter. To fix, the link to login as a different WP.com user now uses `force_reauth`.

To test:

- Checkout `fix/sso-bypass-reauth` branch
- In a compat plugin: `add_filter(  'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );`
- Go to `$site/wp-admin`
- You should be automatically redirected to WP.com, and maybe even automatically redirected to the wp-admin of your site
- Remove the filter above
- Go to `$site/wp-admin`
- Click the "Login with WordPress.com" button. You should be logged in to your wp-admin.
- Click the "Login as a different WP.com user" link. You should have to login again on WP.com

cc @lezama for review and @jeherve in case he'd like to test.