### PR TITLE
SSO: Escape reauth and SSO URL

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -490,7 +490,7 @@ class Jetpack_SSO {
 				<?php echo $this->build_sso_button( array(), 'is_primary' ); ?>
 
 				<?php if ( $display_name && $gravatar ) : ?>
-					<a class="jetpack-sso-wrap__reauth" href="<?php echo $this->build_sso_button_url( array( 'reauth' => '1' ) ); ?>">
+					<a class="jetpack-sso-wrap__reauth" href="<?php echo esc_url( $this->build_sso_button_url( array( 'reauth' => '1' ) ) ); ?>">
 						<?php esc_html_e( 'Log in as a different WordPress.com user', 'jetpack' ); ?>
 					</a>
 				<?php else : ?>


### PR DESCRIPTION
In [this comment](https://github.com/Automattic/jetpack/pull/3939#discussion-diff-64419919), @lezama pointed out that we were not escaping a URL in the new SSO UI.

This PR fixes that. To test:

- Checkout `update/sso-esc-audit` branch
- Login to WP.com
- Go to `$site/wp-admin`
- Click "Log in as a different WordPress.com user" link
- Are you forced to login on WP.com
- After that, are you logged in to your remote site?