### PR TITLE
Unit Tests: Test HHVM on newer version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ matrix:
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
    - php: hhvm
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
+     sudo: required
+     dist: trusty
    - php: "nightly"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,13 @@ matrix:
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
      sudo: required
      dist: trusty
+     group: edge
+     addons:
+       apt:
+         packages:
+         - mysql-server-5.6
+         - mysql-client-core-5.6
+         - mysql-client-5.6
    - php: "nightly"
      env: WP_VERSION=master WP_TRAVISCI=travis:phpunit
   allow_failures:


### PR DESCRIPTION
Travis uses an older version of Ubuntu for testing so we need to use a different distro to test the latest versions of HHVM.

See https://core.trac.wordpress.org/ticket/36930 for additional information.