### PR TITLE
Enhancement: layout sizing adjustments based on new max-width

### DIFF
--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -3,7 +3,7 @@
 	text-align: center;
 
 	@media (max-width: rem( 720px ) ) {
-		padding: 0 rem( 10px );
+		padding: 0 rem( 20px );
 	}
 }
 

--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -9,7 +9,7 @@
 	padding: rem( 10px );
 	margin: 0 auto;
 	width: 100%;
-	max-width: rem( 960px );
+	max-width: rem( 720px );
 	display: flex;
 	flex-flow: row nowrap;
 

--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -1,25 +1,29 @@
 .jp-masthead {
 	background-color: $green-secondary;
 	text-align: center;
+
+	@media (max-width: rem( 720px ) ) {
+		padding: 0 rem( 10px );
+	}
 }
 
 .jp-masthead__inside-container {
 	background: transparent url('../../images/jp-4/mast-bg.svg') no-repeat 100%;
 	background-size: 648px 125px;
-	padding: rem( 10px );
+	padding: rem( 10px ) 0;
 	margin: 0 auto;
 	width: 100%;
 	max-width: rem( 720px );
 	display: flex;
 	flex-flow: row nowrap;
 
-	@include breakpoint( "<480px" ) { 
+	@media (max-width: rem( 720px ) ) {
 		background-image: none; 
 	}
 }
 
 .jp-masthead__logo-container {
-	padding: rem( 5px ) rem( 5px ) rem( 2px );
+	padding: rem( 5px ) 0 0;
 }
 
 .jp-masthead__logo {
@@ -36,11 +40,15 @@
 	flex: 2 50%;
 	justify-content: flex-end;
 	margin: 0;
+
+	@include breakpoint( "<480px" ) {
+		padding-right: rem( 10px );
+	}
 }
 
 .jp-masthead__link-li {
 	margin: 0;
-	padding: 0 rem( 8px );
+	padding: 0;
 }
 
 .jp-masthead__link {
@@ -64,7 +72,6 @@
 	}
 
 	@include breakpoint( "<480px" ) {
-		padding: rem( 10px ) rem( 15px );
 
 		&:hover,
 		&:active {
@@ -77,5 +84,11 @@
 		span + span {
 			display: none;
 		}
+	}
+}
+
+.jp-masthead__link-li {
+	&:last-of-type .jp-masthead__link {
+		padding-right: 0;
 	}
 }

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -24,7 +24,7 @@
 .jp-lower {
 	margin: 0 auto;
 	text-align: left;
-	max-width: rem( 960px );
+	max-width: rem( 720px );
 	padding: rem( 20px );
 }
 


### PR DESCRIPTION
Adjusting the new max-width of jetpack to 720px (following calypsos lead). In doing so, I had to make some adjustments to the masthead elements styling. 

Fixes: https://github.com/Automattic/jetpack/issues/3923

Visuals:
![screen shot 2016-05-24 at 1 59 23 pm](https://cloud.githubusercontent.com/assets/214813/15514406/e6fd626c-21b6-11e6-9634-bb8d7d6994a8.png)


Smaller screens:
![photo may 24 13 37 40](https://cloud.githubusercontent.com/assets/214813/15514368/caa4321c-21b6-11e6-8f73-e60dcc5d6850.jpg)
![photo may 24 13 38 02](https://cloud.githubusercontent.com/assets/214813/15514367/caa11654-21b6-11e6-8667-3dbe4e548b6d.jpg)
![photo may 24 13 57 50](https://cloud.githubusercontent.com/assets/214813/15514565/a1255258-21b7-11e6-8c43-524724752b0b.png)

