### PR TITLE
Downgrade babel-core.  We're not quite ready for 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
     "@automattic/dops-components": "automattic/dops-components",
-    "babel-core": "6.8.0",
+    "babel-core": "5.8.25",
     "babel-eslint": "4.1.7",
     "babel-loader": "5.3.2",
     "babel-register": "^6.7.2",


### PR DESCRIPTION
To Reproduce problem: 
- `npm run test-client` should fail and throw errors. 

To test: 
- `npm run distclean`
- `npm run build`
- `npm run test-client` should now succeed in running the tests
- Ignore the (known) failed tests. 

Related discussion around this:
Automattic/wp-calypso#1515
p1HpG7-3eK-p2

cc @oskosk 