### PR TITLE
Fix: Stats - IE 10 fix for stats details over hanging parent container

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -41,11 +41,11 @@
 
 .jp-at-a-glance__stats-summary-alltime {
 	flex-basis: 50%;
-	//align-items: center;
 	padding: rem( 16px );
 	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px lighten( $gray, 30% );
 
 	@include breakpoint( ">660px" ) {
+		max-width: 40%; // for IE 10 since it doesn't recognize flex-basis
 		display: flex;
 	}
 }

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -47,6 +47,8 @@
 	@include breakpoint( ">660px" ) {
 		max-width: 40%; // for IE 10 since it doesn't recognize flex-basis
 		display: flex;
+		flex-grow: 1;
+		flex-shrink: 1;
 	}
 }
 
@@ -70,6 +72,13 @@
 	}
 }
 
+/* .jp-at-a-glance__stats-cta-description,
+.jp-at-a-glance__stats-cta-buttons {
+	@include breakpoint( ">660px" ) {
+		flex-basis: 50%;
+	}
+} */
+
 .jp-at-a-glance__stats-cta-description {
 	padding-right: rem( 16px );
 }
@@ -86,11 +95,19 @@
 
 .jp-at-a-glance__stats-cta-buttons {
 
-	@include breakpoint( ">480px" ) {
+		@media (max-width: rem( 720px ) ) {
+			text-align: right;
+			display: flex;
+			flex-direction: column;
+		}
+
+	/* @include breakpoint( ">660px" ) {
+		max-width: 70%; for IE 10 since it doesn't recognize flex-basis
 		display: flex;
-		flex-shrink: 0;
+		flex-grow: 1;
+		flex-shrink: 1;
 		align-items: center;
-	}
+	} */
 
 	@include breakpoint( "<660px" ) {
 		text-align: center;
@@ -101,8 +118,13 @@
 		}
 	}
 
-	.dops-button:first-of-type {
-		margin-right: rem( 8px );
+	.dops-button {
+		text-align: center;
+		margin: rem( 4px );
+
+		/*&:first-of-type {
+			margin-right: rem( 8px );
+		}*/
 	}
 }
 

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -65,22 +65,18 @@
 		display: flex;
 		flex-direction: row;
 		flex-wrap: nowrap;
-		justify-content: space-between;
+		align-items: center;
 	}
 	@include breakpoint( "<660px" ) {
 		display: block;
 	}
 }
 
-/* .jp-at-a-glance__stats-cta-description,
-.jp-at-a-glance__stats-cta-buttons {
-	@include breakpoint( ">660px" ) {
-		flex-basis: 50%;
-	}
-} */
-
 .jp-at-a-glance__stats-cta-description {
-	padding-right: rem( 16px );
+
+	@include breakpoint( ">660px" ) {
+		flex-basis: 30%;
+	}
 }
 
 .jp-at-a-glance__stat-details {
@@ -95,19 +91,10 @@
 
 .jp-at-a-glance__stats-cta-buttons {
 
-		@media (max-width: rem( 720px ) ) {
-			text-align: right;
-			display: flex;
-			flex-direction: column;
-		}
-
-	/* @include breakpoint( ">660px" ) {
-		max-width: 70%; for IE 10 since it doesn't recognize flex-basis
-		display: flex;
-		flex-grow: 1;
-		flex-shrink: 1;
-		align-items: center;
-	} */
+	@include breakpoint( ">660px" ) {
+		text-align: right;
+		flex-basis: 70%;
+	} 
 
 	@include breakpoint( "<660px" ) {
 		text-align: center;
@@ -121,10 +108,6 @@
 	.dops-button {
 		text-align: center;
 		margin: rem( 4px );
-
-		/*&:first-of-type {
-			margin-right: rem( 8px );
-		}*/
 	}
 }
 

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -24,7 +24,7 @@
 .jp-lower {
 	margin: 0 auto;
 	text-align: left;
-	max-width: rem( 960px );
+	max-width: rem( 720px );
 	padding: rem( 20px );
 }
 


### PR DESCRIPTION
IE 10 fix for stats details over hanging parent container.

IE10 doesn't recognize `flex-basis`, so I've assigned a max-width fallback for it. 

Tested in IE10, IE11 (not originally affected), latest chrome, firefox, and safari on mac.

Before:
![screen shot 2016-05-24 at 5 31 05 pm](https://cloud.githubusercontent.com/assets/214813/15522109/1685f46e-21de-11e6-84cf-bec8a88775c9.png)

On smaller screens the buttons overhang as well:
![screen shot 2016-05-24 at 7 17 00 pm](https://cloud.githubusercontent.com/assets/214813/15522854/58a3eba8-21e3-11e6-8314-15278848953d.png)


After:
![screen shot 2016-05-24 at 8 26 54 pm](https://cloud.githubusercontent.com/assets/214813/15524059/0d8c778e-21ed-11e6-9a38-31e94518cd04.png)



