### PR TITLE
Stats: adding className to dops-card container to target small screens

### DIFF
--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -182,7 +182,7 @@ const DashStats = React.createClass( {
 				>
 					{ this.maybeShowStatsTabs() }
 				</DashSectionHeader>
-				<Card>
+				<Card className="jp-at-a-glance__stats-card">
 					{ this.renderStatsArea() }
 				</Card>
 			</div>

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -2,6 +2,7 @@
 // For more precise styles, dig into the styles of each component. ie. dash-item
 
 .jp-at-a-glance__stats-card {
+	
 	@include breakpoint( "<480px" ) {
 		padding: 0;
 	}

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -1,8 +1,10 @@
 // This document contains styles that influence the styles of Stats & At a Glance, overall. 
 // For more precise styles, dig into the styles of each component. ie. dash-item
 
-.jp-at-a-glance__stats-container {
-	margin: rem( -24px );
+.jp-at-a-glance__stats-card {
+	@include breakpoint( "<480px" ) {
+		padding: 0;
+	}
 }
 
 .jp-at-a-glance__stats-chart {
@@ -13,7 +15,6 @@
 	margin: rem( 32px ) 0 0;
 
 	@include breakpoint( "<480px" ) {
-		margin: rem( 16px ) 0;
 		box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px lighten( $gray, 30% );
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/3950

Before:
![screen shot 2016-05-24 at 9 09 30 pm](https://cloud.githubusercontent.com/assets/214813/15525171/a88f77e2-21f5-11e6-825b-47e870c4e236.png)


After:
![screen shot 2016-05-24 at 9 27 02 pm](https://cloud.githubusercontent.com/assets/214813/15525168/a19729f8-21f5-11e6-8cca-d5a02715951f.png)
