### PR TITLE
Stats: adjusting padding area of stats dops-card

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -38,6 +38,21 @@
 	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px lighten( $gray, 30% );
 }
 
+.jp-at-a-glance__stats-summary-today {
+
+	@include breakpoint( "<660px" ) {
+		margin-top: rem( -1px );
+	}
+}
+
+.jp-at-a-glance__stats-summary-bestday,
+.jp-at-a-glance__stats-summary-alltime {
+
+	@include breakpoint( "<660px" ) {
+		margin-top: rem( 1px );
+	}
+}
+
 .jp-at-a-glance__stats-summary-alltime {
 	flex-basis: 50%;
 	padding: rem( 16px );

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -2,10 +2,7 @@
 // For more precise styles, dig into the styles of each component. ie. dash-item
 
 .jp-at-a-glance__stats-card {
-	
-	@include breakpoint( "<480px" ) {
-		padding: 0;
-	}
+	padding: 0;
 }
 
 .jp-at-a-glance__stats-chart {

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -45,6 +45,12 @@
 	}
 }
 
+.jp-at-a-glance__stats-summary-bestday {
+	@include breakpoint( ">660px" ) {
+		margin: 0 rem( 1px );
+	}
+}
+
 .jp-at-a-glance__stats-summary-bestday,
 .jp-at-a-glance__stats-summary-alltime {
 


### PR DESCRIPTION
Accidentally merged an incorrect padding adjustment in a previous PR, fixing that here. But also fixing the visual border issues (box shadow) with the stats details.

Before: 
![screen shot 2016-05-24 at 10 30 22 pm](https://cloud.githubusercontent.com/assets/214813/15526261/a116d060-21fe-11e6-854e-52f6407e460c.png)

After: 
![screen shot 2016-05-24 at 11 35 18 pm](https://cloud.githubusercontent.com/assets/214813/15527317/58cab066-2207-11e6-92d5-59c61e211357.png)

![screen shot 2016-05-24 at 10 59 52 pm](https://cloud.githubusercontent.com/assets/214813/15526784/7b6f4b0e-2202-11e6-9606-a37234f02edf.png)


