### PR TITLE
Add missing double quotes to key in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,7 @@
 		"no-lonely-if": 1,
 		"no-mixed-requires": 0,
 		"no-mixed-spaces-and-tabs": 1,
-		"no-multiple-empty-lines": [ 1, { max: 1 } ],
+		"no-multiple-empty-lines": [ 1, { "max": 1 } ],
 		"no-multi-spaces": 1,
 		"no-nested-ternary": 1,
 		"no-new": 1,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Add missing double quotes to the `max` option key inside the `no-multiple-empty-lines` directive in `.eslintrc`