### PR TITLE
Connect Landing: removing large breakpoints. no longer needed

### DIFF
--- a/_inc/client/components/jetpack-connect/style.scss
+++ b/_inc/client/components/jetpack-connect/style.scss
@@ -3,7 +3,7 @@
 
 	// modding header__label specifically on the connection page.
 	.dops-section-header__label {
-		margin: 1px; // allows box-shadow of parent to display properly.
+		margin: rem( 1px) ; // allows box-shadow of parent to display properly.
 		padding: rem( 16px );
 		font-size: rem( 16px );
 		font-weight: 400;
@@ -77,10 +77,6 @@
 			padding-bottom: rem( 50px );
 		}
 
-		@include breakpoint( ">1040px" ) {
-			background-position: 50% 108%;
-		}
-
 		@include breakpoint( "<960px" ) {
 			border-bottom: 1px lighten( $gray, 30% ) solid;
 			background-image: none;
@@ -118,7 +114,6 @@
 	&:first-of-type {
 
 		@include breakpoint( ">960px" ) { bottom: -15px; }
-		@include breakpoint( ">1040px" ) { bottom: -12px; }
 	}
 	&:last-of-type {
 		z-index: 999;


### PR DESCRIPTION
Since we're implemented a small max width (720px) the connection landing page no longer needs the largest breakpoints. Those have been removed and proper image alignment restored!

Fixes: https://github.com/Automattic/jetpack/issues/3962

Before:
![screen shot 2016-05-25 at 12 02 35 pm](https://cloud.githubusercontent.com/assets/214813/15547462/ea533ae8-2271-11e6-8dde-02df0883f566.png)


After: 
![screen shot 2016-05-25 at 12 17 02 pm](https://cloud.githubusercontent.com/assets/214813/15547469/f11c966c-2271-11e6-97bf-d30f1e2ac274.png)