### PR TITLE
Gulp php:unit - make sure travis will exit on fail and other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,6 @@ before_script:
     - npm install
 
 script:
-    - gulp
     - $WP_TRAVISCI
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
   include:
   - php: "5.6"
     env: WP_VERSION=4.5 WP_TRAVISCI="gulp travis:js"
+  - php: "5.6"
+    env: WP_VERSION=4.5 WP_TRAVISCI="npm run test-client"
   - php: "5.2"
     env: WP_VERSION=master
   - php: "5.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,12 +87,7 @@ before_script:
     - sed -i "s/yourusernamehere/root/" wp-tests-config.php
     - sed -i "s/yourpasswordhere//" wp-tests-config.php
     - cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-    - gem install sass
-    - gem install compass
-    - nvm install 5
-    - npm install -g npm@'3.8.9'
-    - npm install -g gulp-cli
-    - npm install
+    - ./tests/load-travis.sh
 
 script:
     - $WP_TRAVISCI

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: php
 # Setup a global environemnt and overide as needed
 env:
   global:
-    - WP_TRAVISCI=travis:phpunit
+    - WP_TRAVISCI=phpunit
 
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,
@@ -23,7 +23,7 @@ env:
 matrix:
   include:
   - php: "5.6"
-    env: WP_VERSION=4.5 WP_TRAVISCI=travis:js
+    env: WP_VERSION=4.5 WP_TRAVISCI="gulp travis:js"
   - php: "5.2"
     env: WP_VERSION=master
   - php: "5.2"
@@ -94,7 +94,9 @@ before_script:
     - npm install -g gulp-cli
     - npm install
 
-script: gulp $WP_TRAVISCI
+script:
+    - gulp
+    - $WP_TRAVISCI
 
 sudo: false
 

--- a/_inc/jetpack-sync.js
+++ b/_inc/jetpack-sync.js
@@ -1,4 +1,4 @@
-/* global ajaxurl, sync_dashboard, wp */
+/* global ajaxurl, sync_dashboard, wp, JSON */
 
 jQuery( document ).ready( function($) {
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,6 @@ var autoprefixer = require( 'gulp-autoprefixer' ),
 	rename = require( 'gulp-rename' ),
 	rtlcss = require( 'gulp-rtlcss' ),
 	sass = require( 'gulp-sass' ),
-	shell = require( 'gulp-shell' ),
 	sourcemaps = require( 'gulp-sourcemaps' ),
 	stylish = require( 'jshint-stylish'),
 	util = require( 'gulp-util' ),
@@ -240,13 +239,6 @@ gulp.task( 'old-sass:rtl', function() {
 			console.log( 'Global admin RTL CSS finished.' );
 		} );
 } );
-
-/*
-	Shell commands
- */
-gulp.task( 'shell', shell.task( [
-	'echo hello'
-], { verbose: true } ) );
 
 /*
 	"Check" task

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -367,5 +367,4 @@ gulp.task( 'old-styles',   ['frontendcss', 'admincss', 'admincss:rtl', 'old-sass
 gulp.task( 'languages',    ['languages:get', 'languages:build', 'languages:cleanup'] );
 
 // travis CI tasks.
-gulp.task( 'travis:phpunit', ['php:unit'] );
 gulp.task( 'travis:js', ['js:hint', 'js:qunit'] );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -293,7 +293,8 @@ gulp.task( 'js:hint', function() {
 		'!modules/**/*.min.js'
 	] )
 		.pipe( jshint( '.jshintrc' ) )
-		.pipe( jshint.reporter('jshint-stylish') );
+		.pipe( jshint.reporter('jshint-stylish') )
+		.pipe( jshint.reporter('fail') );
 } );
 
 /*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -367,4 +367,4 @@ gulp.task( 'old-styles',   ['frontendcss', 'admincss', 'admincss:rtl', 'old-sass
 gulp.task( 'languages',    ['languages:get', 'languages:build', 'languages:cleanup'] );
 
 // travis CI tasks.
-gulp.task( 'travis:js', ['js:hint', 'js:qunit'] );
+gulp.task( 'travis:js', ['react:build', 'js:hint', 'js:qunit'] );

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "gulp-rtlcss": "^1.0.0",
     "gulp-sass": "^2.0.4",
     "gulp-sftp": "^0.1.5",
-    "gulp-shell": "^0.5.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.6",
     "jshint": "2.9.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -44,6 +44,8 @@
 		</testsuite>
 		<testsuite name="sync">
 			<directory prefix="test_" suffix=".php">tests/php/sync</directory>
+			<exclude>tests/php/sync/test_interface.jetpack-sync-replicastore.php</exclude>
+			<file phpVersion="5.3.0" phpVersionOperator=">=">tests/php/sync/test_interface.jetpack-sync-replicastore.php</file>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/tests/load-travis.sh
+++ b/tests/load-travis.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "$WP_TRAVISCI" != "phpunit" ]; then
+	gem install sass
+	gem install compass
+	nvm install 5
+    npm install -g npm@'3.8.9'
+    npm install -g gulp-cli
+    npm install
+fi

--- a/tests/load-travis.sh
+++ b/tests/load-travis.sh
@@ -4,7 +4,7 @@ if [ "$WP_TRAVISCI" != "phpunit" ]; then
 	gem install sass
 	gem install compass
 	nvm install 5
-    npm install -g npm@'3.8.9'
-    npm install -g gulp-cli
-    npm install
+	npm install -g npm@'3.8.9'
+	npm install -g gulp-cli
+	npm install
 fi

--- a/tests/php/_inc/lib/test_class.jetpack-media-extractor.php
+++ b/tests/php/_inc/lib/test_class.jetpack-media-extractor.php
@@ -384,7 +384,9 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	/**
 	 * @author scotchfield
 	 * @covers Jetpack_Media_Meta_Extractor::extract
+	 * @todo This test is failing in 5.2 and 5.3 for unknown reasons. Figure it out.
 	 * @since 3.2
+	 * @requires PHP 5.4.0
 	 */
 	function test_extract_mentions() {
 		$post_id = $this->add_test_post();
@@ -400,13 +402,6 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 		);
 
 		$result = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id, Jetpack_Media_Meta_Extractor::MENTIONS );
-
-		if ( version_compare( PHP_VERSION, '5.4.0' ) == -1 ) {
-			$this->markTestSkipped(
-				'This test is failing in PHP 5.2 and PHP 5.3 for unknown reasons. Skipping pending further verification.'
-				);
-			return;
-		}
 
 		$this->assertEquals( $expected, $result );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -39,7 +39,7 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 				$value = constant( $constant );
 				$this->assertEquals( $value, $this->server_replica_storage->get_constant( $constant ) );
 			} catch( Exception $e ) {
-				error_log( "Warning: No such constant: ".$constant );
+				$this->markTestSkipped( $constant . ' not defined.');
 			}
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -31,7 +31,7 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 
 	function test_does_not_fire_if_constants_havent_changed() {
 		$this->client->set_defaults(); // use the default constants
-		
+
 		$this->client->do_sync();
 
 		foreach( Jetpack_Sync_Defaults::$default_constants_whitelist as $constant ) {
@@ -42,7 +42,7 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 				error_log( "Warning: No such constant: ".$constant );
 			}
 		}
-		
+
 		$this->server_replica_storage->reset();
 		$this->client->do_sync();
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -4,7 +4,7 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	require_once ABSPATH . 'wp-content/mu-plugins/jetpack/sync/class.jetpack-sync-test-object-factory.php';
 } else {
 	// is running in jetpack
-	require_once dirname( __FILE__ ) . '/server/class.jetpack-sync-test-object-factory.php';    
+	require_once dirname( __FILE__ ) . '/server/class.jetpack-sync-test-object-factory.php';
 }
 
 /*
@@ -30,23 +30,23 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		self::$factory = new JetpackSyncTestObjectFactory();
 	}
-	
+
 	function setUp() {
 		parent::setUp();
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			switch_to_blog( self::$token->blog_id );
-		} 
+		}
 
 		// this is a hack so that our setUp method can access the $store instance and call reset()
 		$prop = new ReflectionProperty( 'PHPUnit_Framework_TestCase', 'data' );
 		$prop->setAccessible( true );
 		$test_data = $prop->getValue( $this );
-		
+
 		if ( isset( $test_data[0] ) && $test_data[0] ) {
 			$store = $test_data[0];
-			$store->reset();    
-		}   
+			$store->reset();
+		}
 	}
 
 	function tearDown() {
@@ -72,7 +72,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				if ( method_exists( $className, 'getInstance' ) ) {
 					$all_replicastores[] = call_user_func( array( $className, 'getInstance' ) );
 				} else {
-					$all_replicastores[] = new $className();  
+					$all_replicastores[] = new $className();
 				}
 			}
 		}
@@ -207,7 +207,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 1, $store->comment_count() );
 
 		$retrieved_comment = $store->get_comment( $comment->comment_ID );
-		
+
 		// insane hack because sometimes MySQL retrurns dates that are off by a second or so. WTF?
 		unset($comment->comment_date);
 		unset($comment->comment_date_gmt);
@@ -448,8 +448,8 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 * Determine if two associative arrays are similar
 	 *
 	 * Both arrays must have the same indexes with identical values
-	 * without respect to key ordering 
-	 * 
+	 * without respect to key ordering
+	 *
 	 * @param array $a
 	 * @param array $b
 	 * @return bool
@@ -519,7 +519,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		$store->set_callable( 'is_main_network', 'yes' );
 
-		$this->assertEquals( 'yes', $store->get_callable( 'is_main_network' ) );	
+		$this->assertEquals( 'yes', $store->get_callable( 'is_main_network' ) );
 	}
 
 	/**
@@ -599,7 +599,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				'term_taxonomy_id' => 22,
 				'taxonomy' => $taxonomy,
 			)
-		); 
+		);
 
 		$this->assertNull( $store->get_term( $term_object->taxonomy, $term_object->term_id ) );
 
@@ -626,7 +626,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				'term_taxonomy_id' => 22,
 				'taxonomy' => $taxonomy,
 			)
-		); 
+		);
 
 		$store->update_term( $term_object );
 
@@ -650,7 +650,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				'term_taxonomy_id' => 22,
 				'taxonomy' => $taxonomy,
 			)
-		); 
+		);
 
 		$store->update_term( $term_object );
 
@@ -707,7 +707,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 1, $terms[0]->count );
 
 		$store->delete_object_terms( $replica_post->ID, array( 22 ) );
-		
+
 		$this->assertEquals( null, $wpdb->get_row( "SELECT * FROM $wpdb->term_relationships WHERE object_id = 5 ") );
 
 		$terms = get_the_terms( $replica_post->ID, $taxonomy );
@@ -733,9 +733,9 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 			if ( method_exists( $replicastore_class, 'getInstance' ) ) {
 				$instance = call_user_func( array( $replicastore_class, 'getInstance' ) );
 			} else {
-				$instance = new $replicastore_class();  
+				$instance = new $replicastore_class();
 			}
-			
+
 			$return[] = array( $instance );
 		}
 

--- a/tests/php/test_class.json-api-jetpack-endpoints.php
+++ b/tests/php/test_class.json-api-jetpack-endpoints.php
@@ -31,6 +31,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	/**
 	 * @author lezama
 	 * @covers Jetpack_JSON_API_Plugins_Modify_Endpoint
+	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_JSON_API_Plugins_Modify_Endpoint() {
 
@@ -58,12 +59,6 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 		 */
 		$class = new ReflectionClass('Jetpack_JSON_API_Plugins_Modify_Endpoint');
 		$update_plugin_method = $class->getMethod( 'update' );
-		if ( ! method_exists($update_plugin_method, 'setAccessible') ) {
-			$this->markTestSkipped(
-				'This test uses ReflectionMethod->setAccessible which is not available until PHP 5.3.2.'
-				);
-			return;
-		}
 		$update_plugin_method->setAccessible( true );
 
 		$plugin_property = $class->getProperty( 'plugins' );
@@ -106,6 +101,7 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 	/**
 	 * @author tonykova
 	 * @covers Jetpack_API_Plugins_Install_Endpoint
+	 * @requires PHP 5.3.2
 	 */
 	public function test_Jetpack_API_Plugins_Install_Endpoint() {
 		$endpoint = new Jetpack_JSON_API_Plugins_Install_Endpoint( array(
@@ -143,12 +139,6 @@ class WP_Test_Jetpack_Json_Api_endpoints extends WP_UnitTestCase {
 		$class = new ReflectionClass('Jetpack_JSON_API_Plugins_Install_Endpoint');
 
 		$plugins_property = $class->getProperty( 'plugins' );
-		if ( ! method_exists($plugins_property, 'setAccessible') ) {
-			$this->markTestSkipped(
-				'This test uses ReflectionMethod->setAccessible which is not available until PHP 5.3.2.'
-				);
-			return;
-		}
 		$plugins_property->setAccessible( true );
 		$plugins_property->setValue ( $endpoint , array( $the_plugin_slug ) );
 


### PR DESCRIPTION
fixes #3955 (you should expect to see these tests failing)

This branch holds a lot of travis/unit test improvements.  

- Failing tests actually report as failing in travis
- Failing jshint tests actually reports as failing in travis 
- No longer running unnecessary npm builds when testing only PHP
- Travis now runs a new test `tests/runner.js` that will test React stuff
- Fixes a PHP syntax error in an unit test

@kraftbj :highfive: x1,000.  Major kudos good sir. 

See it: https://travis-ci.org/Automattic/jetpack/builds/132992939