### PR TITLE
Jumpstart: Adding proper features & style adjustments

### DIFF
--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -72,7 +72,9 @@ const JumpStart = React.createClass( {
 							{ __( "Jetpack's recommended features include:" ) }
 						</p>
 
-						{ jumpstartModules }
+						<div className="jp-jumpstart__feature-list">
+							{ jumpstartModules }
+						</div>
 
 						<p className="jp-jumpstart__note">
 							{ __( 'Features can be activated or deactivated at any time.' ) }

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -18,12 +18,36 @@ import {
 	jumpStartSkip,
 	isJumpstarting as _isJumpstarting
 } from 'state/jumpstart';
+import { getModulesByFeature as _getModulesByFeature } from 'state/modules';
 
 const JumpStart = React.createClass( {
 
 	displayName: 'JumpStart',
 
 	render: function() {
+		let jumpstartModules = this.props.jumpstartFeatures( this.props ).map( ( module ) => (
+			<div
+				className="jp-jumpstart__feature-list-column"
+				key={ `module-card_${ module.name }` /* https://fb.me/react-warning-keys */ }
+			>
+				<div className="jp-jumpstart__feature-content">
+					<h4
+						className="jp-jumpstart__feature-content-title"
+						title={ module.name }>
+						{ module.name }
+					</h4>
+					<p dangerouslySetInnerHTML={ renderJumpstartDescription( module ) } />
+					{ __( '{{a}}Learn More{{/a}}',
+						{
+							components: {
+								a: <a href={ module.learn_more_button } target="_blank" />
+							}
+						}
+					) }
+				</div>
+			</div>
+		) );
+
 		return (
 			<div className="jp-jumpstart">
 				<h2 className="jp-jumpstart__title">
@@ -48,92 +72,7 @@ const JumpStart = React.createClass( {
 							{ __( "Jetpack's recommended features include:" ) }
 						</p>
 
-					<div className="jp-jumpstart__feature-list">
-							<div className="jp-jumpstart__feature-list-column">
-								<div className="jp-jumpstart__feature-content">
-									<h4 className="jp-jumpstart__feature-content-title" title="Automated social marketing">
-										{ __( 'Photon' ) }
-									</h4>
-									<p>
-										{
-											__( 'Mirrors and serves your images from our free and fast image Content Delivery Network (CDN), improving your site’s performance with no additional load on your servers. {{a}}Learn more.{{/a}}', {
-												components: {
-													a: <a href={ 'https://jetpack.com/support/photon/' } target="_blank" />
-												}
-											} )
-										}
-									</p>
-								</div>
-							</div>
-							<div className="jp-jumpstart__feature-list-column">
-								<div className="jp-jumpstart__feature-content">
-									<h4 className="jp-jumpstart__feature-content-title" title="Build a community">
-										{ __( 'Manage' ) }
-									</h4>
-									<p>
-										{
-											__( 'Helps you remotely manage plugins, turn on automated updates, and more from WordPress.com. {{a}}Learn more.{{/a}}', {
-												components: {
-													a: <a href={ 'https://jetpack.com/support/site-management/' } target="_blank" />
-												}
-											} )
-										}
-									</p>
-								</div>
-							</div>
-					</div>
-					<div className="jp-jumpstart__feature-list">
-							<div className="jp-jumpstart__feature-list-column">
-								<div className="jp-jumpstart__feature-content">
-									<h4 className="jp-jumpstart__feature-content-title" title="Increase page views">
-									{ __( 'Single Sign On' ) }
-									</h4>
-									<p>
-										{
-											__( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account. {{a}}Learn more.{{/a}}', {
-												components: {
-													a: <a href={ 'https://jetpack.com/support/sso/' } target="_blank" />
-												}
-											} )
-										}
-									</p>
-								</div>
-							</div>
-							<div className="jp-jumpstart__feature-list-column">
-								<div className="jp-jumpstart__feature-content">
-									<h4 className="jp-jumpstart__feature-content-title" title="Increase page views">
-									{ __( 'Image Carousel' ) }
-									</h4>
-									<p>
-										{
-											__( 'Brings your photos and images to life as full-size, easily navigable galleries. {{a}}Learn more.{{/a}}', {
-												components: {
-													a: <a href={ 'https://jetpack.com/support/carousel/' } target="_blank" />
-												}
-											} )
-										}
-									</p>
-								</div>
-							</div>
-					</div>
-					<div className="jp-jumpstart__feature-list">
-							<div className="jp-jumpstart__feature-list-column">
-								<div className="jp-jumpstart__feature-content">
-									<h4 className="jp-jumpstart__feature-content-title" title="Increase page views">
-									{ __( 'Related Posts' ) }
-									</h4>
-									<p>
-										{
-											__( 'Keep visitors engaged on your blog by highlighting relevant and new content at the bottom of each published post. {{a}}Learn more.{{/a}}', {
-												components: {
-													a: <a href={ 'https://jetpack.com/support/related-posts/' } target="_blank" />
-												}
-											} )
-										}
-									</p>
-								</div>
-							</div>
-						</div>
+						{ jumpstartModules }
 
 						<p className="jp-jumpstart__note">
 							{ __( 'Features can be activated or deactivated at any time.' ) }
@@ -154,8 +93,15 @@ const JumpStart = React.createClass( {
 export default connect(
 	state => {
 		return {
-			jumpstarting: () => _isJumpstarting( state )
+			jumpstarting: () => _isJumpstarting( state ),
+			jumpstartFeatures: () => _getModulesByFeature( state, 'Jumpstart' )
 		};
 	},
 	dispatch => bindActionCreators( { jumpStartActivate, jumpStartSkip }, dispatch )
 )( JumpStart );
+
+function renderJumpstartDescription( module ) {
+	// Rationale behind returning an object and not just the string
+	// https://facebook.github.io/react/tips/dangerously-set-inner-html.html
+	return { __html: module.jumpstart_desc };
+}

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -30,8 +30,8 @@ const JumpStart = React.createClass( {
 					{ __( 'Jump Start your Website' ) }
 				</h2>
 				<Card className="jp-jumpstart__cta-container">
-					{ this.props.jumpstarting( this.props ) ? <Spinner /> : null }
 					<Card className="jp-jumpstart__cta">
+						{ this.props.jumpstarting( this.props ) ? <Spinner /> : null }
 						<p className="jp-jumpstart__description">
 							{ __( "Quickly enhance your site by activating Jetpack's recommended features." ) }
 						</p>

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -37,13 +37,6 @@ const JumpStart = React.createClass( {
 						{ module.name }
 					</h4>
 					<p dangerouslySetInnerHTML={ renderJumpstartDescription( module ) } />
-					{ __( '{{a}}Learn More{{/a}}',
-						{
-							components: {
-								a: <a href={ module.learn_more_button } target="_blank" />
-							}
-						}
-					) }
 				</div>
 			</div>
 		) );

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -39,7 +39,7 @@ const JumpStart = React.createClass( {
 							{ __( 'Activate Recommended Features' ) }
 						</Button>
 					</Card>
-					<FoldableCard 
+					<FoldableCard
 						className="jp-jumpstart__features"
 						clickableHeaderText={ true }
 						subheader="Learn more"
@@ -134,7 +134,7 @@ const JumpStart = React.createClass( {
 								</div>
 							</div>
 						</div>
-						
+
 						<p className="jp-jumpstart__note">
 							{ __( 'Features can be activated or deactivated at any time.' ) }
 						</p>

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -30,8 +30,8 @@ const JumpStart = React.createClass( {
 					{ __( 'Jump Start your Website' ) }
 				</h2>
 				<Card className="jp-jumpstart__cta-container">
+					{ this.props.jumpstarting( this.props ) ? <Spinner /> : null }
 					<Card className="jp-jumpstart__cta">
-						{ this.props.jumpstarting( this.props ) ? <Spinner /> : null }
 						<p className="jp-jumpstart__description">
 							{ __( "Quickly enhance your site by activating Jetpack's recommended features." ) }
 						</p>

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -43,37 +43,63 @@ const JumpStart = React.createClass( {
 							{ __( "Jetpack's recommended features include:" ) }
 						</p>
 
-						<ul className="jp-jumpstart__feature-list">
-							<li>
-								{ __( 'Social Sharing Tools' ) }
-							</li>
-							<li>
-								{ __( 'Image Performance (Photon)' ) }
-							</li>
-							<li>
-								{ __( 'Single Sign On' ) }
-							</li>
-							<li>
-								{ __( 'Contact Form' ) }
-							</li>
-							<li>
-								{ __( 'Related Posts' ) }
-							</li>
-						</ul>
-						<ul className="jp-jumpstart__feature-list">
-							<li>
-								{ __( 'Automatic Updates (Site Manangement)' ) }
-							</li>
-							<li>
-								{ __( 'Image Carousel' ) }
-							</li>
-							<li>
-								{ __( 'Gravatar Hovercards' ) }
-							</li>
-							<li>
-								{ __( 'Visitor Subscriptions' ) }
-							</li>
-						</ul>
+					<div className="jp-jumpstart__feature-list">
+							<div className="jp-jumpstart__feature-list-column">
+								<div className="jp-jumpstart__feature-content">
+									<h4 className="jp-jumpstart__feature-content-title" title="Automated social marketing">
+										{ __( 'Photon' ) }
+									</h4>
+									<p>
+										{ __( 'Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.' ) }
+									</p>
+								</div>
+							</div>
+							<div className="jp-jumpstart__feature-list-column">
+								<div className="jp-jumpstart__feature-content">
+									<h4 className="jp-jumpstart__feature-content-title" title="Build a community">
+										{ __( 'Manage' ) }
+									</h4>
+									<p>
+										{ __( 'Helps you remotely manage plugins, turn on automated updates, and more from WordPress.com.' ) }
+									</p>
+								</div>
+							</div>
+					</div>
+					<div className="jp-jumpstart__feature-list">
+							<div className="jp-jumpstart__feature-list-column">
+								<div className="jp-jumpstart__feature-content">
+									<h4 className="jp-jumpstart__feature-content-title" title="Increase page views">
+									{ __( 'Single Sign On' ) }
+									</h4>
+									<p>
+										{ __( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.' ) }
+									</p>
+								</div>
+							</div>
+							<div className="jp-jumpstart__feature-list-column">
+								<div className="jp-jumpstart__feature-content">
+									<h4 className="jp-jumpstart__feature-content-title" title="Increase page views">
+									{ __( 'Image Carousel' ) }
+									</h4>
+									<p>
+										{ __( 'Brings your photos and images to life as full-size, easily navigable galleries.' ) }
+									</p>
+								</div>
+							</div>
+					</div>
+					<div className="jp-jumpstart__feature-list">
+							<div className="jp-jumpstart__feature-list-column">
+								<div className="jp-jumpstart__feature-content">
+									<h4 className="jp-jumpstart__feature-content-title" title="Increase page views">
+									{ __( 'Related Posts' ) }
+									</h4>
+									<p>
+										{ __( 'Keep visitors engaged on your blog by highlighting relevant and new content at the bottom of each published post.' ) }
+									</p>
+								</div>
+							</div>
+						</div>
+						
 						<p className="jp-jumpstart__note">
 							{ __( 'Features can be activated or deactivated at any time.' ) }
 						</p>

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -50,7 +50,13 @@ const JumpStart = React.createClass( {
 										{ __( 'Photon' ) }
 									</h4>
 									<p>
-										{ __( 'Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.' ) }
+										{
+											__( 'Mirrors and serves your images from our free and fast image Content Delivery Network (CDN), improving your site’s performance with no additional load on your servers. {{a}}Learn more.{{/a}}', {
+												components: {
+													a: <a href={ 'https://jetpack.com/support/photon/' } target="_blank" />
+												}
+											} )
+										}
 									</p>
 								</div>
 							</div>
@@ -60,7 +66,13 @@ const JumpStart = React.createClass( {
 										{ __( 'Manage' ) }
 									</h4>
 									<p>
-										{ __( 'Helps you remotely manage plugins, turn on automated updates, and more from WordPress.com.' ) }
+										{
+											__( 'Helps you remotely manage plugins, turn on automated updates, and more from WordPress.com. {{a}}Learn more.{{/a}}', {
+												components: {
+													a: <a href={ 'https://jetpack.com/support/site-management/' } target="_blank" />
+												}
+											} )
+										}
 									</p>
 								</div>
 							</div>
@@ -72,7 +84,13 @@ const JumpStart = React.createClass( {
 									{ __( 'Single Sign On' ) }
 									</h4>
 									<p>
-										{ __( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.' ) }
+										{
+											__( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account. {{a}}Learn more.{{/a}}', {
+												components: {
+													a: <a href={ 'https://jetpack.com/support/sso/' } target="_blank" />
+												}
+											} )
+										}
 									</p>
 								</div>
 							</div>
@@ -82,7 +100,13 @@ const JumpStart = React.createClass( {
 									{ __( 'Image Carousel' ) }
 									</h4>
 									<p>
-										{ __( 'Brings your photos and images to life as full-size, easily navigable galleries.' ) }
+										{
+											__( 'Brings your photos and images to life as full-size, easily navigable galleries. {{a}}Learn more.{{/a}}', {
+												components: {
+													a: <a href={ 'https://jetpack.com/support/carousel/' } target="_blank" />
+												}
+											} )
+										}
 									</p>
 								</div>
 							</div>
@@ -94,7 +118,13 @@ const JumpStart = React.createClass( {
 									{ __( 'Related Posts' ) }
 									</h4>
 									<p>
-										{ __( 'Keep visitors engaged on your blog by highlighting relevant and new content at the bottom of each published post.' ) }
+										{
+											__( 'Keep visitors engaged on your blog by highlighting relevant and new content at the bottom of each published post. {{a}}Learn more.{{/a}}', {
+												components: {
+													a: <a href={ 'https://jetpack.com/support/related-posts/' } target="_blank" />
+												}
+											} )
+										}
 									</p>
 								</div>
 							</div>

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Card from 'components/card';
+import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Spinner from 'components/spinner';
 import { translate as __ } from 'i18n-calypso';
@@ -29,8 +30,8 @@ const JumpStart = React.createClass( {
 					{ __( 'Jump Start your Website' ) }
 				</h2>
 				<Card className="jp-jumpstart__cta-container">
-					{ this.props.jumpstarting( this.props ) ? <Spinner /> : null }
 					<Card className="jp-jumpstart__cta">
+						{ this.props.jumpstarting( this.props ) ? <Spinner /> : null }
 						<p className="jp-jumpstart__description">
 							{ __( "Quickly enhance your site by activating Jetpack's recommended features." ) }
 						</p>
@@ -38,7 +39,11 @@ const JumpStart = React.createClass( {
 							{ __( 'Activate Recommended Features' ) }
 						</Button>
 					</Card>
-					<Card className="jp-jumpstart__features">
+					<FoldableCard 
+						className="jp-jumpstart__features"
+						clickableHeaderText={ true }
+						subheader="Learn more"
+					>
 						<p className="jp-jumpstart__description">
 							{ __( "Jetpack's recommended features include:" ) }
 						</p>
@@ -133,7 +138,7 @@ const JumpStart = React.createClass( {
 						<p className="jp-jumpstart__note">
 							{ __( 'Features can be activated or deactivated at any time.' ) }
 						</p>
-					</Card>
+					</FoldableCard>
 				</Card>
 				<a
 					onClick={ this.props.jumpStartSkip }

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -36,6 +36,7 @@
 
 .jp-jumpstart__cta {
 	margin-bottom: 0;
+	padding-bottom: 0;
 }
 
 .jp-jumpstart__title {
@@ -56,7 +57,38 @@
 .jp-jumpstart__features {
 	margin: 0;
 	padding: rem( 16px );
-	background-color: lighten( $gray, 35% );
+
+	// overriding general FoldableCard styles for special use here
+	&.dops-foldable-card {
+		box-shadow: none;
+	}
+
+	&.dops-foldable-card.is-expanded {
+		margin-bottom: 0;
+	}
+
+	.dops-foldable-card__header,
+	&.dops-foldable-card.is-expanded .dops-foldable-card__header {
+		min-height: auto;
+	}
+
+	.dops-foldable-card__main {
+		max-width: 100%;
+		margin-right: 0;
+	}
+
+	.dops-foldable-card__secondary {
+		display: none;
+	}
+
+	.dops-foldable-card__subheader {
+		color: $blue-wordpress;
+		font-style: italic;
+	}
+
+	.dops-foldable-card__content {
+		background-color: lighten( $gray, 35% );
+	}
 }
 
 .jp-jumpstart__feature-list {

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -55,44 +55,58 @@
 
 .jp-jumpstart__features {
 	margin: 0;
-	padding: rem( 16px ) rem( 48px );
+	padding: rem( 16px );
 	background-color: lighten( $gray, 35% );
-
-	@include breakpoint( ">960px" ) {
-		padding: rem( 16px ) 20% rem( 24px );
-	}
-
-	@include breakpoint( "<660px" ) {
-		padding: rem( 16px ) rem( 24px );
-	}
 }
 
 .jp-jumpstart__feature-list {
-	text-align: left;
-	list-style: disc;
-	list-style-position: inside;
-	padding: 0;
 	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
 
-	@include breakpoint( ">660px" ) {
-		width: 50%;
-		float: left;
+	@include breakpoint( ">660px" ) { 
+		flex-wrap: nowrap;
 	}
-
 	@include breakpoint( "<660px" ) {
-		margin-left: rem( 16px );
+		margin: rem( -8px ) rem( -16px ) 0; // to avoid altering multiple other elements
 	}
+}
+
+.jp-jumpstart__feature-list-column {
+	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px lighten( $gray, 30% );
+	text-align: left;
+	background: $white;
+
+	@include breakpoint( ">660px" ) { 
+		flex-grow: 1;
+		flex-shrink: 0;
+		flex-basis: 50%;
+	}
+
+	@include breakpoint( "<660px" ) { 
+		flex-basis: 100%;
+	}
+}
+
+.jp-jumpstart__feature-content {
+	padding: rem( 16px );
+}
+
+.jp-jumpstart__feature-content-title {
+	margin: 0;
 }
 
 .jp-jumpstart__note {
 	margin: 0;
-	padding: rem( 24px ) rem( 16px ) 0;
+	padding: rem( 16px ) 0;
 	font-size: rem( 14px );
 	clear: both;
 	font-style: italic;
 
-	@include breakpoint( "<660px" ) {
-		padding: rem( 24px ) 0 0;
+	@include breakpoint( "<660px" ) { 
+		padding-bottom: 0;
 	}
 }
 

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -100,14 +100,10 @@
 
 .jp-jumpstart__note {
 	margin: 0;
-	padding: rem( 16px ) 0;
+	padding: rem( 16px ) 0 0;
 	font-size: rem( 14px );
 	clear: both;
 	font-style: italic;
-
-	@include breakpoint( "<660px" ) { 
-		padding-bottom: 0;
-	}
 }
 
 .jp-jumpstart__skip-step {

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -112,6 +112,11 @@
 		flex-grow: 1;
 		flex-shrink: 0;
 		flex-basis: 50%;
+
+		&:last-of-type {
+			margin-top: 1px;
+			max-width: 49.9%;
+		}
 	}
 
 	@include breakpoint( "<660px" ) { 

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -98,9 +98,6 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 
-	@include breakpoint( ">660px" ) { 
-		flex-wrap: nowrap;
-	}
 	@include breakpoint( "<660px" ) {
 		margin: rem( -8px ) rem( -16px ) 0; // to avoid altering multiple other elements
 	}

--- a/_inc/client/components/jumpstart/style.scss
+++ b/_inc/client/components/jumpstart/style.scss
@@ -45,12 +45,12 @@
 }
 
 .jp-jumpstart__description {
+	margin-top: 0;
 	padding: 0 rem( 16px ) rem( 16px );
 	font-size: rem( 16px );
 
 	@include breakpoint( "<660px" ) {
 		padding: 0 0 rem( 16px );
-		margin-top: 0;
 	}
 }
 

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import assign from 'lodash/assign';
 
 /**
  * Internal dependencies
@@ -96,7 +97,11 @@ const Main = React.createClass( {
 					<div className="jp-lower">
 						<JetpackNotices { ...this.props } />
 						{ this.renderMainContent( this.props.route.path ) }
-						<SupportCard { ...this.props } />
+						{
+							this.props.getJumpStartStatus ?
+							null :
+							<SupportCard { ...this.props } />
+						}
 					</div>
 				<Footer { ...this.props } />
 			</div>
@@ -107,7 +112,9 @@ const Main = React.createClass( {
 
 export default connect(
 	state => {
-		return state;
+		return assign( {}, state, {
+			getJumpStartStatus: getJumpStartStatus( state )
+		} );
 	},
 	dispatch => bindActionCreators( { setInitialState }, dispatch )
 )( Main );

--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -209,7 +209,7 @@ export function getModule( state, name ) {
  */
 export function getModulesByFeature( state, feature ) {
 	return Object.keys( state.jetpack.modules.items ).filter( ( name ) =>
-		state.jetpack.modules[ name ].feature.indexOf( feature ) !== -1
+		state.jetpack.modules.items[ name ].feature.indexOf( feature ) !== -1
 	).map( ( name ) => state.jetpack.modules.items[ name ] );
 }
 


### PR DESCRIPTION
Adding the correct list of Jumpstart features and styling them to match the rest of Jetpack React.

To-do:
- [x] Remove the Happiness card at the bottom ( @dereksmart can you write a conditional for this? )
- [x] List of features should be the same as current Jetpack ()
- [x] Make sure we're actually activating the list we're saying we are
- [x] Links on/next to each listed feature to find out more (link to support docs)

(Fixes: https://github.com/Automattic/jetpack/issues/3924)

**Visuals:** 

Before:
Coming soon...

After:

Collapsed
![screen shot 2016-05-25 at 4 40 07 pm](https://cloud.githubusercontent.com/assets/214813/15555405/9cdd0f80-2296-11e6-94c3-cb907ccae222.png)

Expanded:
![screen shot 2016-05-25 at 4 41 26 pm](https://cloud.githubusercontent.com/assets/214813/15555427/b8fd5e04-2296-11e6-97d0-ce3b85cc5e13.png)

Loading:
![screen shot 2016-05-25 at 4 59 10 pm](https://cloud.githubusercontent.com/assets/214813/15555948/343b6f50-2299-11e6-9cf1-fa5bb257aab0.png)


Smaller screens:
![screen shot 2016-05-25 at 4 42 47 pm](https://cloud.githubusercontent.com/assets/214813/15555502/ff482b1e-2296-11e6-8f2a-29a698619c23.png)



