### PR TITLE
Admin Page: Add tests for redux state selectors

### DIFF
--- a/_inc/client/state/connection/test/selectors.js
+++ b/_inc/client/state/connection/test/selectors.js
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+
+import {
+	isDisconnectingSite,
+	isFetchingConnectUrl,
+	isUnlinkingUser,
+	isFetchingUserData,
+	getSiteConnectionStatus,
+	getConnectUrl,
+	isCurrentUserLinked
+} from '../reducer';
+
+let state = {
+	jetpack: {
+		connection: {
+			requests: {
+				disconnectingSite: true,
+				fetchingConnectUrl: false,
+				unlinkingUser: true,
+				fetchingUserData: true,
+			},
+			status: {
+				siteConnected: true
+			},
+			connectUrl: '/asd',
+			user: {
+				currentUser: {
+					isConnected: true
+				}
+			}
+		},
+	}
+};
+
+describe( 'requests selectors', () => {
+	describe( '#isDisconnectingSite', () => {
+		it( 'should return state.jetpack.connection.requests.disconnectingSite', () => {
+			const stateIn = state;
+			const output = isDisconnectingSite( stateIn );
+			expect( output ).to.be.equal( state.jetpack.connection.requests.disconnectingSite );
+		} );
+	} );
+
+	describe( '#isFetchingConnectUrl', () => {
+		it( 'should return state.jetpack.connection.requests.fetchingConnectUrl', () => {
+			const stateIn = state;
+			const output = isFetchingConnectUrl( stateIn );
+			expect( output ).to.be.equal( state.jetpack.connection.requests.fetchingConnectUrl );
+		} );
+	} );
+
+	describe( '#isUnlinkingUser', () => {
+		it( 'should return state.jetpack.connection.requests.unlinkingUser', () => {
+			const stateIn = state;
+			const output = isUnlinkingUser( stateIn );
+			expect( output ).to.be.equal( state.jetpack.connection.requests.unlinkingUser );
+		} );
+	} );
+
+	describe( '#fetchingUserData', () => {
+		it( 'should return state.jetpack.connection.requests.fetchingUserData', () => {
+			const stateIn = state;
+			const output = isFetchingUserData( stateIn );
+			expect( output ).to.be.equal( state.jetpack.connection.requests.fetchingUserData );
+		} );
+	} );
+} );
+
+describe( 'status selectors', () => {
+	describe( '#getSiteConnectionStatus', () => {
+		it( 'should return state.jetpack.connection.status.siteConnected', () => {
+			const stateIn = state;
+			const output = getSiteConnectionStatus( stateIn );
+			expect( output ).to.be.equal( state.jetpack.connection.status.siteConnected );
+		} );
+	} );
+} );
+
+describe( 'connectUrl selectors', () => {
+	describe( '#getConnectUrl', () => {
+		it( 'should return state.jetpack.connection.connectUrl', () => {
+			const stateIn = state;
+			const output = getConnectUrl( stateIn );
+			expect( output ).to.be.equal( state.jetpack.connection.connectUrl );
+		} );
+	} );
+} );
+
+describe( 'user selectors', () => {
+	describe( '#isCurrentUserLinked', () => {
+		it( 'should return state.jetpack.connection.user.currentUser.isConnected', () => {
+			const stateIn = state;
+			const output = isCurrentUserLinked( stateIn );
+			expect( output ).to.be.equal( state.jetpack.connection.user.currentUser.isConnected );
+		} );
+	} );
+} );

--- a/_inc/client/state/jumpstart/test/selectors.js
+++ b/_inc/client/state/jumpstart/test/selectors.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+
+import {
+	getJumpStartStatus,
+	isJumpstarting
+} from '../reducer';
+
+let state = {
+	jetpack: {
+		jumpstart: {
+			status: {
+				showJumpStart: true
+			}
+		}
+	}
+};
+
+describe( 'status selectors', () => {
+	describe( '#getJumpStartStatus', () => {
+		it( 'should return state.jetpack.jumpstart.status.showJumpStart ', () => {
+			const stateIn = state;
+			const output = getJumpStartStatus( stateIn );
+			expect( output ).to.equal( state.jetpack.jumpstart.status.showJumpStart );
+		} );
+	} );
+
+	describe( '#isJumpstarting', () => {
+		it( 'should return state.jetpack.jumpstart.status.isJumpstarting ', () => {
+			const stateIn = state;
+			const output = isJumpstarting( stateIn );
+			expect( output ).to.equal( state.jetpack.jumpstart.status.isJumpstarting );
+		} );
+	} );
+} )

--- a/_inc/client/state/modules/test/selectors.js
+++ b/_inc/client/state/modules/test/selectors.js
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+
+import {
+	isFetchingModulesList,
+	isActivatingModule,
+	isDeactivatingModule,
+	isUpdatingModuleOption,
+	getModules,
+	getModule,
+	isModuleActivated
+} from '../reducer';
+
+let state = {
+	jetpack: {
+		modules: {
+			items: {
+				'module-a': {
+					module: 'module-a',
+					activated: false
+				},
+				'module-b': {
+					module: 'module-b',
+					activated: true,
+					options: {
+						c: {
+							currentValue: 2
+						}
+					}
+				}
+			},
+			requests: {
+				fetchingModulesList: true,
+				activating: {
+					'module-a': true
+				},
+				deactivating: {
+					'module-b': true
+				},
+				updatingOption: {
+					'module-c': {
+						n_per_minute: true
+					}
+				}
+			}
+		}
+	}
+};
+
+describe( 'requests selectors', () => {
+
+	describe( '#isFetchingModulesList', () => {
+		it( 'should return state.jetpack.modules.requests.fetchingModulesList', () => {
+			const stateIn = state;
+			const output = isFetchingModulesList( stateIn );
+			expect( output ).to.be.true;
+		} );
+	} );
+
+	describe( '#isActivatingModule', () => {
+		it( 'should return state.jetpack.modules.requests.activating[ module_slug ]', () => {
+			const stateIn = state;
+			const output = isActivatingModule( stateIn, 'module-a' );
+			expect( output ).to.be.true;
+		} );
+	} );
+
+	describe( '#isDeactivatingModule', () => {
+		it( 'should return state.jetpack.modules.requests.deactivating[ module_slug ]', () => {
+			const stateIn = state;
+			const output = isDeactivatingModule( stateIn, 'module-b' );
+			expect( output ).to.be.true;
+		} );
+	} );
+
+	describe( '#isUpdatingModuleOption', () => {
+		it( 'should return state.jetpack.modules.requests.updatingOpton[ module_slug ][ option_name ]', () => {
+			const stateIn = state;
+			const output = isUpdatingModuleOption( stateIn, 'module-c', 'n_per_minute' );
+			expect( output ).to.be.true;
+		} );
+	} );
+
+
+} );
+
+describe( 'items selectors', () => {
+	describe( '#getModules', () => {
+		it( 'should return state.jetpack.modules.items', () => {
+			const stateIn = state;
+			const output = getModules( stateIn );
+			expect( output ).to.eql( stateIn.jetpack.modules.items );
+		} );
+	} );
+
+	describe( '#getModule', () => {
+		it( 'should return state.jetpack.modules.items[ module_slug ]', () => {
+			const stateIn = state;
+			const output = getModule( stateIn, 'module-a' );
+			expect( output ).to.eql( stateIn.jetpack.modules.items[ 'module-a' ] );
+		} );
+	} );
+
+	describe( '#isModuleActivated', () => {
+		it( 'should return state.jetpack.modules.items[ module_slug ].activated', () => {
+			const stateIn = state;
+			const output = isModuleActivated( stateIn, 'module-a' );
+			expect( output ).to.eql( stateIn.jetpack.modules.items[ 'module-a' ].activated );
+		} );
+	} );
+
+} );

--- a/_inc/client/state/settings/test/selectors.js
+++ b/_inc/client/state/settings/test/selectors.js
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+
+import {
+	isFetchingSettingsList,
+	isUpdatingSetting,
+	isSettingActivated,
+	getSettings
+} from '../reducer';
+
+let state = {
+	jetpack: {
+		settings: {
+			items: {
+				'setting-a': false,
+				'setting-b': true
+			},
+			requests: {
+				fetchingSettingsList: true,
+				updatingSetting: true
+			}
+		}
+	}
+};
+
+describe( 'requests selectors', () => {
+	describe( '#isFetchingSettingsList', () => {
+		it( 'should return state.jetpack.settings.requests.fetchingSettingsList', () => {
+			const stateIn = state;
+			const output = isFetchingSettingsList( stateIn );
+			expect( output ).to.equal( state.jetpack.settings.requests.fetchingSettingsList );
+		} );
+	} );
+
+	describe( '#isUpdatingSetting', () => {
+		it( 'should return state.jetpack.settings.requests.updatingSetting', () => {
+			const stateIn = state;
+			const output = isUpdatingSetting( stateIn );
+			expect( output ).to.equal( state.jetpack.settings.requests.updatingSetting );
+		} );
+	} );
+} );
+
+describe( 'items selectors', () => {
+	describe( '#isSettingActivated', () => {
+		it( 'should return state.jetpack.settings.items[ setting-slug ]', () => {
+			const stateIn = state;
+			const output = isSettingActivated( stateIn, 'setting-a' );
+			expect( output ).to.equal( state.jetpack.settings.items[ 'setting-a' ] );
+			const output2 = isSettingActivated( stateIn, 'setting-b' );
+			expect( output2 ).to.equal( state.jetpack.settings.items[ 'setting-b' ] );
+		} );
+	} );
+
+	describe( '#getSettings', () => {
+		it( 'should return state.jetpack.settings.items', () => {
+			const stateIn = state;
+			const output2 = getSettings( stateIn );
+			expect( output2 ).to.eql( state.jetpack.settings.items );
+		} );
+	} );
+} );

--- a/_inc/client/tests.json
+++ b/_inc/client/tests.json
@@ -7,7 +7,7 @@
 			"test": [ "reducer", "selectors" ]
 		},
 		"jumpstart": {
-			"test": [ "reducer" ]
+			"test": [ "reducer", "selectors" ]
 		},
 		"connection": {
 			"test": [ "reducer", "selectors" ]

--- a/_inc/client/tests.json
+++ b/_inc/client/tests.json
@@ -10,7 +10,7 @@
 			"test": [ "reducer" ]
 		},
 		"connection": {
-			"test": [ "reducer" ]
+			"test": [ "reducer", "selectors" ]
 		}
 	}
 

--- a/_inc/client/tests.json
+++ b/_inc/client/tests.json
@@ -4,7 +4,7 @@
 			"test": [ "reducer", "selectors" ]
 		},
 		"settings": {
-			"test": [ "reducer" ]
+			"test": [ "reducer", "selectors" ]
 		},
 		"jumpstart": {
 			"test": [ "reducer" ]

--- a/_inc/client/tests.json
+++ b/_inc/client/tests.json
@@ -1,7 +1,7 @@
 {
 	"state": {
 		"modules": {
-			"test": [ "reducer" ]
+			"test": [ "reducer", "selectors" ]
 		},
 		"settings": {
 			"test": [ "reducer" ]


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Add tests for module-related state selectors
- Add tests for connection-related state selectors
- Add tests for settings-related state selectors
- Add tests for jumpstart-related state selectors


#### Testing instructions

* Run
```
npm run test-client -- -g "selectors"
```
Expect to see **20 passing** tests
