### PR TITLE
Notices: Updating text and styles of notices

### DIFF
--- a/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
+++ b/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
@@ -25,6 +25,7 @@ const FeedbackDashRequest = React.createClass( {
 		return (
 			<div>
 				<SimpleNotice
+					className="jp-dash-item__feedback-request"
 					status="is-basic"
 					onClick={ this.props.dismissNotice }
 				>

--- a/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
+++ b/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'lib/mixins/i18n';
 import Card from 'components/card';
+import SimpleNotice from 'components/notice';
 
 /**
  * Internal dependencies
@@ -22,23 +23,20 @@ const FeedbackDashRequest = React.createClass( {
 		}
 
 		return (
-			<Card className="jp-dash-item__feedback-request">
-				<p className="jp-dash-item__description">
-					<a
-						onClick={ this.props.dismissNotice }
-						href="#"
-					>
-						[dismiss] 
-					</a>
-					{
-						__( 'What would you like to see on your Jetpack Dashboard? {{a}}Send us some feedback and let us know!{{/a}}', {
-							components: {
-								a: <a href="https://jetpack.com/contact" target="_blank" />
-							}
-						} )
-					}
-				</p>
-			</Card>
+			<div>
+				<SimpleNotice
+					status="is-basic"
+					onClick={ this.props.dismissNotice }
+				>
+				{
+					__( 'What would you like to see on your Jetpack Dashboard? {{a}}Let us know!{{/a}}', {
+						components: {
+							a: <a href="https://jetpack.com/contact" target="_blank" />
+						}
+					} )
+				}
+				</SimpleNotice>
+			</div>
 		);
 	},
 

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -28,10 +28,16 @@ export const WelcomeNotice = React.createClass( {
 		return (
 			<div>
 				<SimpleNotice
-					status="is-success"
+					status="is-info"
 					onClick={ this.props.dismissWelcomeNotice }
 				>
-					Welcome to Jetpack in React! (this message is not complete)
+					{
+						__( 'Welcome to your new Jetpack dashboard! Now you can quickly manage all of Jetpack’s great features from one central location. {{a}}Learn more (link to updated docs).{{/a}}', {
+							components: {
+								a:<a href={ 'https://jetpack.com/support/' } target="_blank" />
+							}
+						} )
+					}
 				</SimpleNotice>
 			</div>
 		);

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -59,7 +59,10 @@ export const DevVersionNotice = React.createClass( {
 			);
 
 			return (
-				<SimpleNotice showDismiss={ false }>
+				<SimpleNotice 
+					showDismiss={ false }
+					status="is-basic"
+				>
 					{ text }
 				</SimpleNotice>
 			);
@@ -84,7 +87,10 @@ export const StagingSiteNotice = React.createClass( {
 			);
 
 			return (
-				<SimpleNotice showDismiss={ false }>
+				<SimpleNotice 
+					showDismiss={ false }
+					status="is-basic"
+				>
 					{ text }
 				</SimpleNotice>
 			);
@@ -121,7 +127,10 @@ export const DevModeNotice = React.createClass( {
 			);
 
 			return (
-				<SimpleNotice showDismiss={ false }>
+				<SimpleNotice 
+					showDismiss={ false }
+					status="is-basic"
+				>
 					{ text }
 				</SimpleNotice>
 			);
@@ -154,7 +163,7 @@ export const ActionNotices = React.createClass( {
 				<div>
 					<SimpleNotice>
 						{ __( 'You have successfully disconnected Jetpack' ) }
-						<br/>
+						<br />
 						{
 							__(	'Would you tell us why? Just {{a}}answering two simple questions{{/a}} would help us improve Jetpack.',
 								{

--- a/_inc/client/components/jetpack-notices/style.scss
+++ b/_inc/client/components/jetpack-notices/style.scss
@@ -1,0 +1,1 @@
+// Nothing here yet. 


### PR DESCRIPTION
Updating the various verbiage and overall styles of Notices within Jetpack React. 

Sister `dops-component` PR that fixes overall notice styles: https://github.com/Automattic/dops-components/pull/22 (required to test properly)
Fixes: https://github.com/Automattic/jetpack/issues/3925 & https://github.com/Automattic/jetpack/issues/3831

**To-do:**
- [ ] Ensure "Welcome Notice" is only displayed after a user connects and surpasses Jumpstart (doesn't matter if they utilize or skip it)
- [ ] Ensure "Welcome Notice" is only displayed **once** on the dashboard after a user connects
- [x] Change "Welcome Notice" verbiage
- [x] Add `is-basic` class to development mode, version and staging notices
- [x] Turn Feedback card into dismissible `is-basic` notice
- [ ] Fix notice styling in IE10

**Welcome Notice:**
<img width="761" alt="screen shot 2016-05-25 at 11 04 34 pm" src="https://cloud.githubusercontent.com/assets/214813/15562321/3b371ce0-22cc-11e6-9663-a66a98acd5fd.png">

**Added `is-basic` Notices:**
Unobtrusive styled notice for the development version & mode, staging, and other basic notices:
<img width="739" alt="screen shot 2016-05-25 at 11 50 35 pm" src="https://cloud.githubusercontent.com/assets/214813/15563033/b93d771e-22d2-11e6-9b63-cfc522ae34b3.png">
<img width="743" alt="screen shot 2016-05-25 at 11 50 50 pm" src="https://cloud.githubusercontent.com/assets/214813/15563034/b9403d5a-22d2-11e6-9232-cb460796c19a.png">

(Styled properly in https://github.com/Automattic/dops-components/pull/22)