### PR TITLE
Add tests for plugins when the data changes.

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -155,6 +155,8 @@ class Jetpack_Sync_Client {
 		add_action( 'upgrader_process_complete', $handler, 10, 2 );
 		add_filter( 'jetpack_sync_before_send_upgrader_process_complete', array( $this, 'expand_upgrader_process_complete' ) );
 		add_action( 'deleted_plugin', $handler, 10, 2 );
+		add_action( 'activated_plugin', $handler, 10, 2 );
+		add_action( 'deactivated_plugin', $handler, 10, 2 );
 
 
 		// multi site network options
@@ -301,7 +303,6 @@ class Jetpack_Sync_Client {
 		
 		$current_filter = current_filter();
 		$args           = func_get_args();
-
 		if ( in_array( $current_filter, array( 'deleted_option', 'added_option', 'updated_option' ) )
 		     &&
 		     ! $this->is_whitelisted_option( $args[0] )

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -108,6 +108,8 @@ class Jetpack_Sync_Defaults {
 		'jetpack_relatedposts',
 		'verification_services_codes',
 		'users_can_register',
+		'active_plugins',
+		'uninstall_plugins',
 	);
 
 	static $default_constants_whitelist = array(
@@ -143,7 +145,7 @@ class Jetpack_Sync_Defaults {
 		'sso_match_by_email'              => array( 'Jetpack_SSO_Helpers', 'match_by_email' ),
 		'sso_new_user_override'           => array( 'Jetpack_SSO_Helpers', 'new_user_override' ),
 		'sso_bypass_default_login_form'   => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
-		'wp_version'                   => array( 'Jetpack_Sync_Functions', 'wp_version' ),
+		'wp_version'                      => array( 'Jetpack_Sync_Functions', 'wp_version' ),
 	);
 
 	static $blacklisted_post_types = array(

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -203,7 +203,7 @@ class Jetpack_Sync_Defaults {
 		return false;
 	}
 
-	static $default_network_options_whitelist = array( 'site_name', 'jetpack_protect_key', 'jetpack_protect_global_whitelist' );
+	static $default_network_options_whitelist = array( 'site_name', 'jetpack_protect_key', 'jetpack_protect_global_whitelist', 'active_sitewide_plugins' );
 	static $default_taxonomy_whitelist = array();
 	static $default_dequeue_max_bytes = 500000; // very conservative value, 1/2 MB
 	static $default_upload_max_bytes = 600000; // a little bigger than the upload limit to account for serialization

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -261,8 +261,8 @@ ENDSQL;
 		return update_option( $option, $value );
 	}
 
-	public function get_option( $option ) {
-		return get_option( $option );
+	public function get_option( $option, $default ) {
+		return get_option( $option, $default );
 	}
 
 	public function delete_option( $option ) {
@@ -539,6 +539,19 @@ ENDSQL;
 
 	public function delete_user( $user_id ) {
 		$this->invalid_call();
+	}
+	
+	// plugins
+	public function get_plugins() {
+		// TODO: Implement get_plugins() method.
+	}
+
+	public function get_active_plugins() {
+		// TODO: Implement get_active_plugins() method.
+	}
+
+	public function upsert_plugins( $plugins ) {
+		// TODO: Implement upsert_plugins() method.
 	}
 
 	public function checksum_all() {

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -261,7 +261,7 @@ ENDSQL;
 		return update_option( $option, $value );
 	}
 
-	public function get_option( $option, $default ) {
+	public function get_option( $option, $default = false ) {
 		return get_option( $option, $default );
 	}
 

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -7,6 +7,7 @@ require_once 'interface.jetpack-sync-replicastore.php';
  * This is useful to compare values in the local WP DB to values in the synced replica store
  */
 class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
+	
 
 	public function reset() {
 		global $wpdb;
@@ -544,10 +545,6 @@ ENDSQL;
 	// plugins
 	public function get_plugins() {
 		// TODO: Implement get_plugins() method.
-	}
-
-	public function get_active_plugins() {
-		// TODO: Implement get_active_plugins() method.
 	}
 
 	public function upsert_plugins( $plugins ) {

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -52,7 +52,7 @@ interface iJetpack_Sync_Replicastore {
 	// options
 	public function update_option( $option, $value );
 
-	public function get_option( $option );
+	public function get_option( $option, $default );
 
 	public function delete_option( $option );
 
@@ -113,6 +113,11 @@ interface iJetpack_Sync_Replicastore {
 	public function upsert_user( $user );
 
 	public function delete_user( $user_id );
+
+	// plugins
+	public function get_plugins();
+	public function get_active_plugins();
+	public function upsert_plugins( $plugins );
 
 	// full checksum
 	public function checksum_all();

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -52,7 +52,7 @@ interface iJetpack_Sync_Replicastore {
 	// options
 	public function update_option( $option, $value );
 
-	public function get_option( $option, $default );
+	public function get_option( $option, $default = false );
 
 	public function delete_option( $option );
 

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -116,7 +116,6 @@ interface iJetpack_Sync_Replicastore {
 
 	// plugins
 	public function get_plugins();
-	public function get_active_plugins();
 	public function upsert_plugins( $plugins );
 
 	// full checksum

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -238,9 +238,10 @@ class Jetpack_Sync_Server_Replicator {
 
 			// plugins
 			case 'upgrader_process_complete':
-				list( $process, $data ) = $args;
-				if ( $process['type'] == 'plugin' ) {
-					$this->store->upsert_plugins( $data );
+				$process = $args[ 0 ];
+				if ( is_array( $process ) && $process['type'] == 'plugin' ) {
+					$plugin_data = $args[1];
+					$this->store->upsert_plugins( $plugin_data );
 				}
 				break;
 			case 'deleted_plugin':

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -235,6 +235,21 @@ class Jetpack_Sync_Server_Replicator {
 				list( $user_id, $reassign ) = $args;
 				$this->store->delete_user( $user_id );
 				break;
+
+			// plugins
+			case 'upgrader_process_complete':
+				list( $process, $data ) = $args;
+				if ( $process['type'] == 'plugin' ) {
+					$this->store->upsert_plugins( $data );
+				}
+				break;
+			case 'deleted_plugin':
+				list( $plugin_file, $deleted ) = $args;
+				if ( $deleted ) {
+					$plugins = $this->store->get_plugins();
+					unset( $plugins[ $plugin_file ] );
+					$this->store->upsert_plugins( $plugins );
+				}
 		}
 	}
 }

--- a/tests/php/sync/server/class.jetpack-sync-test-object-factory.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-object-factory.php
@@ -111,6 +111,35 @@ class JetpackSyncTestObjectFactory {
 		return new WP_User( $user );
 	}
 
+	function plugins() {
+		return array(
+			'polldaddy/polldaddy.php' => array(
+				'Name' => 'Polldaddy Polls & Ratings',
+				'PluginURI' => 'http://wordpress.org/extend/plugins/polldaddy/',
+                'Version' => '2.0.31',
+                'Description' => 'Create and manage Polldaddy polls and ratings in WordPress',
+				'Author' => 'Automattic, Inc.',
+                'TextDomain' => 'polldaddy',
+                'Title' => 'Polldaddy Polls & Ratings',
+				'Network' => false,
+				'AuthorName' => 'Automattic, Inc.'
+            ),
+			'vaultpress/vaultpress.php' => array(
+				'Name' => 'VaultPress',
+				'PluginURI' => 'http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0',
+				'Version' => '1.8.2',
+                'Description' => 'Protect your content, themes, plugins, and settings with...',
+				'Author' => 'Automattic',
+				'AuthorURI' => 'http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0',
+                'TextDomain' => 'vaultpress',
+				'DomainPath' => '/languages/',
+				'Network' => false,
+                'Title' => 'VaultPress',
+				'AuthorName' => 'Automattic'
+			)
+		);
+	}
+
 	function term( $id, $props = array() ) {
 		$term = (object) array_merge(
 			self::$default_term_props,

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -448,15 +448,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	function upsert_plugins( $plugins ) {
 		$this->plugins = $plugins;
 	}
-
-	function get_active_plugins() {
-		return $this->options['active_plugins'];
-	}
-
-	function get_uninstallable_plugins() {
-		return $this->options['active_plugins'];
-	}
-
+	
 	function checksum_all() {
 		return array(
 			'posts' => $this->posts_checksum(),

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -23,6 +23,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	private $terms;
 	private $object_terms;
 	private $users;
+	private $plugins;
 
 	function __construct() {
 		$this->reset();
@@ -148,8 +149,8 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		unset( $this->comments[ $comment_id ] );
 	}
 
-	function get_option( $option ) {
-		return isset( $this->options[ $option ] ) ? $this->options[ $option ] : false;
+	function get_option( $option, $default = false ) {
+		return isset( $this->options[ $option ] ) ? $this->options[ $option ] : $default;
 	}
 
 	function update_option( $option, $value ) {
@@ -437,6 +438,23 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function delete_user( $user_id ) {
 		unset( $this->users[ $user_id ] );
+	}
+
+	// plugins
+	function get_plugins() {
+		return $this->plugins;
+	}
+	
+	function upsert_plugins( $plugins ) {
+		$this->plugins = $plugins;
+	}
+
+	function get_active_plugins() {
+		return $this->options['active_plugins'];
+	}
+
+	function get_uninstallable_plugins() {
+		return $this->options['active_plugins'];
 	}
 
 	function checksum_all() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -161,7 +161,9 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 			'jetpack_sso_require_two_step'=> 'pineapple',
 			'jetpack_relatedposts'=> 'pineapple',
 			'verification_services_codes'=> 'pineapple',
-			'users_can_register' => '1'
+			'users_can_register' => '1',
+			'active_plugins' => array( 'pineapple' ),
+			'uninstall_plugins' => 'banana'
 		);
 		
 		$theme_mod_key = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Testing CRUD on Plugins
+ */
+class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_New_Sync_Base {
+	protected $theme;
+
+	public function setUp() {
+		parent::setUp();
+
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function test_installing_and_removing_plugin_is_synced() {
+		$this->remove_plugin(); // make sure that we start with no plugin.
+		$this->install_wp_super_cache();
+		$this->client->do_sync();
+
+		$plugins = $this->server_replica_storage->get_plugins();
+		$this->assertEquals( get_plugins(), $plugins );
+		$this->assertTrue( isset( $plugins['wp-super-cache/wp-cache.php'] ) );
+		// gets called via callable.
+		$this->assertEquals( get_option( 'uninstall_plugins', array() ), $this->server_replica_storage->get_option( 'uninstall_plugins', array() ) );
+
+
+		// Remove plugin
+		$this->remove_plugin();
+		$this->client->do_sync();
+		$plugins = $this->server_replica_storage->get_plugins();
+		$this->assertEquals( get_plugins(), $plugins );
+		$this->assertFalse( isset( $plugins['wp-super-cache/wp-cache.php'] ) );
+
+	}
+
+	public function test_activate_and_deactivating_plugin_is_synced() {
+		activate_plugin( 'hello.php' );
+		$this->client->do_sync();
+		
+		$active_plugins = $this->server_replica_storage->get_option( 'active_plugins' );
+		$this->assertEquals( get_option( 'active_plugins' ), $active_plugins  );
+		$this->assertTrue( in_array( 'hello.php', $active_plugins ) );
+		
+		deactivate_plugins( 'hello.php' );
+		$this->client->do_sync();
+
+		$active_plugins = $this->server_replica_storage->get_option( 'active_plugins' );
+		$this->assertEquals( get_option( 'active_plugins' ), $active_plugins  );
+		$this->assertFalse( in_array( 'hello.php', $active_plugins ) );
+	}
+	
+	public function test_autoupdate_enabled_and_disabled_is_synced() {
+		// enable autoupdates
+		$autoupdate_plugins = Jetpack_Options::get_option( 'autoupdate_plugins', array() );
+		$autoupdate_plugins = array_unique( array_merge( $autoupdate_plugins, array( 'hello' ) ) );
+		Jetpack_Options::update_option( 'autoupdate_plugins', $autoupdate_plugins );
+		$this->client->do_sync();
+
+		$set_autoupdate_plugin =  $this->server_replica_storage->get_option( 'jetpack_autoupdate_plugins', array() );
+
+		$this->assertEquals( Jetpack_Options::get_option( 'autoupdate_plugins', array() ), $set_autoupdate_plugin );
+		$this->assertTrue( in_array( 'hello', $set_autoupdate_plugin ) );
+
+		// disable autoupdates
+		$autoupdate_plugins = Jetpack_Options::get_option( 'autoupdate_plugins', array() );
+		$autoupdate_plugins = array_diff( $autoupdate_plugins, array( 'hello' ) );
+		Jetpack_Options::update_option( 'autoupdate_plugins', $autoupdate_plugins );
+		$this->client->do_sync();
+
+		$set_autoupdate_plugin =  $this->server_replica_storage->get_option( 'jetpack_autoupdate_plugins' );
+		$this->assertEquals( Jetpack_Options::get_option( 'autoupdate_plugins', array() ), $set_autoupdate_plugin );
+		$this->assertFalse( in_array( 'hello', $set_autoupdate_plugin ) );
+	}
+
+	function install_wp_super_cache() {
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		// code from wp-admin/update.php
+		$api = plugins_api( 'plugin_information', array(
+			'slug' => 'wp-super-cache',
+			'fields' => array(
+				'short_description' => false,
+				'sections' => false,
+				'requires' => false,
+				'rating' => false,
+				'ratings' => false,
+				'downloaded' => false,
+				'last_updated' => false,
+				'added' => false,
+				'tags' => false,
+				'compatibility' => false,
+				'homepage' => false,
+				'donate_link' => false,
+			),
+		) );
+
+		if ( is_wp_error( $api ) ) {
+			wp_die( $api );
+		}
+		$upgrader = new Plugin_Upgrader( new Plugin_Installer_Skin( compact('title', 'url', 'nonce', 'plugin', 'api') ) );
+		$upgrader->install($api->download_link);
+
+	}
+
+	function remove_plugin() {
+		delete_plugins( array( 'wp-super-cache/wp-cache.php' ) );
+		wp_cache_delete( 'plugins', 'plugins' );
+	}
+
+}

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -106,6 +106,28 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_New_Sync_Base {
 
 	}
 
+	function test_plugin_activation_action_is_synced() {
+		activate_plugin( 'hello.php' );
+		$this->client->do_sync();
+
+		$activated_plugin = $this->server_event_storage->get_most_recent_event( 'activated_plugin' );
+
+		$this->assertTrue( isset( $activated_plugin->args ) );
+		$this->assertEquals( 'hello.php', $activated_plugin->args[0] );
+		$this->assertFalse( $activated_plugin->args[1] );
+	}
+
+	function test_plugin_deactivation_action_is_synced() {
+		activate_plugin( 'hello.php' );
+		deactivate_plugins( 'hello.php' );
+		$this->client->do_sync();
+
+		$deactivated_plugin = $this->server_event_storage->get_most_recent_event( 'deactivated_plugin' );
+		$this->assertTrue( isset( $deactivated_plugin->args ) );
+		$this->assertEquals( 'hello.php', $deactivated_plugin->args[0] );
+		$this->assertFalse( $deactivated_plugin->args[1] );
+	}
+
 	function remove_plugin() {
 		delete_plugins( array( 'wp-super-cache/wp-cache.php' ) );
 		wp_cache_delete( 'plugins', 'plugins' );

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -703,8 +703,27 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 0, $terms[0]->count );
 	}
 
-	public function store_provider( $name ) {
+	/**
+	 * @dataProvider store_provider
+	 * @requires PHP 5.3
+	 */
+	function test_replica_update_plugins( $store ) {
 
+		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
+			$this->markTestIncomplete( "The WP replicastore doesn't support setting plugins" );
+		}
+
+		$this->assertNull( $store->get_plugins() );
+
+		$plugins = self::$factory->plugins();
+
+		$store->upsert_plugins( $plugins );
+
+		$this->assertNotNull( $store->get_plugins() );
+		$this->assertEquals( $plugins, $store->get_plugins() );
+	}
+
+	public function store_provider( $name ) {
 		if ( !self::$all_replicastores ) {
 			// detect classes that implement iJetpack_Sync_Replicastore
 			self::$all_replicastores = array();


### PR DESCRIPTION
Adds test for plugins. Feedback from @gravityrail and @lezama 


#### Changes proposed in this Pull Request:
- Start syncing plugins data. So that we can reconstruct it on .com



-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

Added tests to show that we sync all the plugin info that we need to
recreate the api endpoint.