### PR TITLE
Admin Page: Clean build toolchain output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,8 @@ function onBuild( done ) {
 			cached: false,
 			reasons: false,
 			source: false,
-			errorDetails: true
+			errorDetails: true,
+			children: false
 		} ), "\nJS finished at", Date.now() );
 
 		if ( done ) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,18 @@ function onBuild( done ) {
 		}
 
 		gutil.log( 'Building JS…', stats.toString( {
-			colors: true
+			colors: true,
+			hash: true,
+			version: false,
+			timings: true,
+			assets: true,
+			chunks: true,
+			chunkModules: false,
+			modules: false,
+			cached: false,
+			reasons: false,
+			source: false,
+			errorDetails: true
 		} ), "\nJS finished at", Date.now() );
 
 		if ( done ) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,7 +80,11 @@ gulp.task( 'react:build', function( done ) {
 	var config = getWebpackConfig();
 	config.plugins = config.plugins.concat(
 		new webpack.optimize.DedupePlugin(),
-		new webpack.optimize.UglifyJsPlugin()
+		new webpack.optimize.UglifyJsPlugin( {
+			compress: {
+				warnings: false
+			}
+		} )
 	);
 
 	config.devtool = 'source-map';


### PR DESCRIPTION
Fixes verbosity when running `npm run build-client` or `npm run watch` .

#### Changes proposed in this Pull Request:
- **gulpfile.js**: Make Uglify only show errors (`warning:false`) 
- **gulpfile.js**: Removes Webpack's `chunkModules` information from `stats.toString()` call and adds some options resembling the options Calypso uses for this step. (https://webpack.github.io/docs/node.js-api.html#stats-tostring ).
- **gulpfile.js**: Removes `children` from webpack's stats output. The text extract plugin was offering information about its chunks).

#### Testing instructions
1. Run `npm run build-client` or `npm run watch`
2. Expect the output to be just this:

```
$ npm run build-client
[09:44:48] Starting 'react:build'...
[09:44:48] Starting 'sass:build'...
Building Dashboard CSS bundle...
[09:44:48] Finished 'sass:build' after 9.74 ms
[09:44:48] Starting 'frontendcss'...
[09:44:48] Starting 'admincss'...
[09:44:48] Starting 'admincss:rtl'...
[09:44:48] Starting 'old-sass'...
[09:44:48] Starting 'old-sass:rtl'...
[09:44:48] Starting 'check:DIR'...
[09:44:48] Starting 'php:lint'...
[09:44:48] Starting 'js:hint'...
Dashboard CSS finished.
Global admin RTL CSS finished.
[09:45:10] Finished 'old-sass:rtl' after 22 s
Front end modules CSS finished.
[09:45:10] Finished 'frontendcss' after 22 s
Global admin CSS finished.
[09:45:12] Finished 'old-sass' after 23 s
Admin modules CSS finished.
[09:45:12] Finished 'admincss' after 24 s
Admin modules RTL CSS finished.
[09:45:12] Finished 'admincss:rtl' after 24 s
[09:45:12] Starting 'old-styles'...
[09:45:12] Finished 'old-styles' after 7.4 μs
[09:45:15] Building JS… Hash: 95d63685859873c08e45
Time: 27304ms
             Asset      Size  Chunks             Chunk Names
          admin.js   2.57 MB       0  [emitted]  admin
    dops-style.css   47.8 kB       0  [emitted]  admin
      admin.js.map   3.13 MB       0  [emitted]  admin
dops-style.css.map  91 bytes       0  [emitted]  admin
chunk    {0} admin.js, dops-style.css, admin.js.map, dops-style.css.map (admin) 2.53 MB [rendered]
JS finished at 1464266715956
[09:45:15] Finished 'react:build' after 27 s
[09:45:16] Finished 'js:hint' after 28 s
[09:45:17] Finished 'check:DIR' after 28 s
[09:45:17] Starting 'checkstrings'...
[09:45:17] Finished 'checkstrings' after 15 μs
[09:45:44] Finished 'php:lint' after 56 s
[09:45:44] Starting 'default'...
[09:45:44] Finished 'default' after 15 μs
$ 