### PR TITLE
Top Posts Widget: remove limitation preventing the number of days being extended

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -458,6 +458,11 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		 */
 		$days = (int) apply_filters( 'jetpack_top_posts_days', 2, $args );
 
+		/** Handling situations where the number of days makes no sense - allows for unlimited days where $days = -1 */
+		if ( 0 == $days || false == $days ) {
+			$days = 2;
+		}
+
 		$post_view_posts = stats_get_csv( 'postviews', array( 'days' => absint( $days ), 'limit' => 11 ) );
 		if ( ! $post_view_posts ) {
 			return array();

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -445,6 +445,9 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 
 		/**
 		 * Filter the number of days used to calculate Top Posts for the Top Posts widget.
+		 * We do not recommend accessing more than 10 days of results at one.
+		 * When more than 10 days of results are accessed at once, results should be cached via the WordPress transients API.
+		 * Querying for -1 days will give results for an infinite number of days.
 		 *
 		 * @module widgets
 		 *
@@ -454,14 +457,6 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		 * @param array $args The widget arguments.
 		 */
 		$days = (int) apply_filters( 'jetpack_top_posts_days', 2, $args );
-
-		if ( $days < 1 ) {
-			$days = 2;
-		}
-
-		if ( $days > 10 ) {
-			$days = 10;
-		}
 
 		$post_view_posts = stats_get_csv( 'postviews', array( 'days' => absint( $days ), 'limit' => 11 ) );
 		if ( ! $post_view_posts ) {


### PR DESCRIPTION
Fixes #3977 .

I expected the top posts to be able to pull in data from the past week, month and year. But instead, there is a limitation in place which prevents it going past 10 days or below two days, although the API is able to access this extra data.
https://github.com/Automattic/jetpack/blob/master/modules/widgets/top-posts.php#L467


#### Changes proposed in this Pull Request:
Remove the limtitation prevent the number of days being extended.
Add additional inline documentation explaining when and how to use caching to prevent excessively long queries from being run frequently.
Add additional inline documentation explaining that -1 gives access to an infinite number of days.
