### PR TITLE
Admin Page - Jetpack Add Ons card: correctly fetch the site data plan

### DIFF
--- a/_inc/client/components/data/query-site/index.jsx
+++ b/_inc/client/components/data/query-site/index.jsx
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -28,7 +27,7 @@ export default connect(
 	( state ) => {
 		return {
 			isFetchingSiteData: isFetchingSiteData( state ),
-			siteData: fetchSiteData( state )
+			siteData: fetchSiteData()
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -23,7 +23,7 @@ const GeneralSettings = React.createClass( {
 					subheader="Manage your Jetpack account and premium add-ons."
 					clickableHeaderText={ true }
 				>
-					<SitePlan />
+					<SitePlan { ...this.props } />
 				</FoldableCard>
 				<FoldableCard
 					header="Jetpack Connection Settings"

--- a/_inc/client/general-settings/site-plan.jsx
+++ b/_inc/client/general-settings/site-plan.jsx
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -20,19 +19,21 @@ import QueryConnectionStatus from 'components/data/query-connection-status';
 
 export const SitePlan = React.createClass( {
 	render() {
-		let sitePlan = this.props.getSitePlan(),
-			sitePlanName = '';
+		let sitePlanName = '';
 
-		if ( 'dev' === this.props.getSiteConnectionStatus() ) {
+		if ( 'dev' === this.props.getSiteConnectionStatus( this.props ) ) {
 			sitePlanName = __( 'No plan available since site runs in development mode.' );
 		} else if ( this.props.isFetchingSiteData ) {
 			sitePlanName = __( 'Loading plan data...' );
-		} else if ( 'object' === typeof sitePlan ) {
-			sitePlanName = __( 'Your current plan is: %s', {
-				args: sitePlan.product_name_short
-			} );
 		} else {
-			sitePlanName = __( 'No plan information available.' );
+			let sitePlan = this.props.getSitePlan();
+			if ( 'object' === typeof sitePlan ) {
+				sitePlanName = __( 'Your current plan is: %s', {
+					args: sitePlan.product_name_short
+				} );
+			} else {
+				sitePlanName = __( 'No plan information available.' );
+			}
 		}
 
 		return (
@@ -50,9 +51,7 @@ export default connect(
 		return {
 			getSiteConnectionStatus: () => getSiteConnectionStatus( state ),
 			isFetchingSiteData: isFetchingSiteData( state ),
-			getSitePlan: () => {
-				return getSitePlan( state );
-			}
+			getSitePlan: () => getSitePlan( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -14,7 +14,7 @@ import {
 	JETPACK_SITE_DATA_FETCH_FAIL
 } from 'state/action-types';
 
-const items = ( state = {}, action ) => {
+export const items = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SITE_DATA_FETCH_RECEIVE:
 			return assign( {}, action.siteData );
@@ -23,11 +23,11 @@ const items = ( state = {}, action ) => {
 	}
 };
 
-const initialRequestsState = {
+export const initialRequestsState = {
 	isFetchingSiteData: false
 };
 
-const requests = ( state = initialRequestsState, action ) => {
+export const requests = ( state = initialRequestsState, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SITE_DATA_FETCH:
 			return assign( {}, state, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Send as little data as necessary to the reducer that checks site data.
- Only try to get plan if it's not dev mode and site data fetching ended.

#### To test
Requires D1857 applied in com sandbox and `JETPACK__WPCOM_JSON_API_HOST` to be pointed to your sandbox.

Go to Jetpack > Dashboard > General tab and expand the Jetpack Add Ons card:
- [x] It should display your plan.
- [x] Bug to check: while this card is open, open the Jetpack Connection Settings card and disconnect. Everything should continue working normally, app will switch to the "Please Connect" status showing the button to connect.

Apply `define( 'JETPACK_DEV_DEBUG', true);` to `jetpack.php` in your sandbox org and check again:
- [x] Now that you're in dev mode, it will display a message about it.

Close your sandbox com connection and check again (you might have to wait for a bit after closing):
- [x] If you're in dev mode, it will display a message stating it.