### PR TITLE
Remove site icon from WP.com shadow blog after it's been removed on Jetpack-powered blog

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -522,7 +522,7 @@ class Jetpack {
 		if ( ! empty( $url ) && $url !== jetpack_site_icon_url() ) {
 			// This is the option that is synced with dotcom
 			Jetpack_Options::update_option( 'site_icon_url', $url );
-		} else if ( empty( $url ) && did_action( 'delete_option_site_icon' ) ) {
+		} else if ( empty( $url ) ) {
 			Jetpack_Options::delete_option( 'site_icon_url' );
 		}
 	}


### PR DESCRIPTION
Fixes #3969 .

#### Changes proposed in this Pull Request:
- Instead of checking whether both the site icon's URL is empty and action `delete_option_site_icon` has run, check only for the empty URL to begin deleting the site icon from WP.com shadow blog.

#### Testing (A12n only)

1. Add site icon through self-hosted site Customizer and close Customizer;
2. Check `jetpack_site_icon_url` option at Network Admin of the WP.com shadow blog;
3. It should point to the site icon (up till now working before this PR);
4. Remove the site icon through self-hosted site Customizer and close Customizer;
5. Look into the Network Admin of WP.com shadow blog again and the Jetpack site icon url option should not be there anymore.

**Note**: This PR doesn't fix issue in Calypso that the site icon is not removed as that's an additional issue of Calypso itself and will be worked on in Calypso GitHub.

**Note2**: My proposed solution is very quick and hasn't been tested much. I'm not sure whether I don't break something by removing the `did_action( 'delete_option_site_icon' )`



