### PR TITLE
Unit Tests: Fix test that's only failing in Travis

### DIFF
--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -169,6 +169,10 @@ EXPECTED;
 
 		add_filter( 'jetpack_implode_frontend_css', '__return_true' );
 
+		if ( ! file_exists( plugins_url( 'jetpack-carousel.css', __FILE__ ) ) ) {
+			$this->markTestSkipped( 'Required CSS file not found.' );
+		}
+
 		// Enqueue some script on the $to_dequeue list
 		$style_handle = 'jetpack-carousel';
 		wp_enqueue_style( 'jetpack-carousel', plugins_url( 'jetpack-carousel.css', __FILE__ ) );


### PR DESCRIPTION
Conditionally skip a test if required file isn't found.

This test was failing because Travis is unable to find the file for some reason.  
This same test passes in vvv.

This change simply checks for the existence, and skips if not found.

The error it was reporting was:
`filemtime(): stat failed for /tmp/wordpress/src/wp-content/plugins/jetpack/css/jetpack.css`

cc @kraftbj 