### PR TITLE
Unit Tests: Reorder travis tests to save time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,19 @@ env:
 
 matrix:
   include:
+  - php: hhvm
+    env: WP_VERSION=master
+    sudo: required
+    dist: trusty
+    group: edge
+    addons:
+      apt:
+        packages:
+        - mysql-server-5.6
+        - mysql-client-core-5.6
+        - mysql-client-5.6
+  - php: "nightly"
+    env: WP_VERSION=master
   - php: "5.6"
     env: WP_VERSION=4.5 WP_TRAVISCI="gulp travis:js"
   - php: "5.6"
@@ -49,19 +62,6 @@ matrix:
   - php: "5.6"
     env: WP_VERSION=4.5
   - php: "7.0"
-    env: WP_VERSION=master
-  - php: hhvm
-    env: WP_VERSION=master
-    sudo: required
-    dist: trusty
-    group: edge
-    addons:
-      apt:
-        packages:
-        - mysql-server-5.6
-        - mysql-client-core-5.6
-        - mysql-client-5.6
-  - php: "nightly"
     env: WP_VERSION=master
   allow_failures:
   - php: "hhvm"


### PR DESCRIPTION
The hhvm test takes considerably longer, so let's start with that one so it can do it's thing while the others are running.  

This should help shave off some minutes to each build.

cc @kraftbj 