### PR TITLE
Sync/add test that show site icon syncing

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -498,35 +498,8 @@ class Jetpack {
 			add_action( 'wp_print_footer_scripts', array( $this, 'implode_frontend_css' ), -1 ); // Run first to trigger before `print_late_styles`
 		}
 
-		// Sync Core Icon: Detect changes in Core's Site Icon and make it syncable.
-		add_action( 'add_option_site_icon',    array( $this, 'jetpack_sync_core_icon' ) );
-		add_action( 'update_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
-		add_action( 'delete_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
-		add_action( 'jetpack_heartbeat',       array( $this, 'jetpack_sync_core_icon' ) );
-
 	}
-
-	/*
-	 * Make sure any site icon added to core can get
-	 * synced back to dotcom, so we can display it there.
-	 */
-	function jetpack_sync_core_icon() {
-		if ( function_exists( 'get_site_icon_url' ) ) {
-			$url = get_site_icon_url();
-		} else {
-			return;
-		}
-
-		require_once( JETPACK__PLUGIN_DIR . 'modules/site-icon/site-icon-functions.php' );
-		// If there's a core icon, maybe update the option.  If not, fall back to Jetpack's.
-		if ( ! empty( $url ) && $url !== jetpack_site_icon_url() ) {
-			// This is the option that is synced with dotcom
-			Jetpack_Options::update_option( 'site_icon_url', $url );
-		} else if ( empty( $url ) && did_action( 'delete_option_site_icon' ) ) {
-			Jetpack_Options::delete_option( 'site_icon_url' );
-		}
-	}
-
+	
 	function jetpack_admin_ajax_tracks_callback() {
 		// Check for nonce
 		if ( ! isset( $_REQUEST['tracksNonce'] ) || ! wp_verify_nonce( $_REQUEST['tracksNonce'], 'jp-tracks-ajax-nonce' ) ) {

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -771,7 +771,7 @@ class Jetpack_Sync_Client {
 		if ( ! empty( $url ) && $url !== jetpack_site_icon_url() ) {
 			// This is the option that is synced with dotcom
 			Jetpack_Options::update_option( 'site_icon_url', $url );
-		} else if ( empty( $url ) && did_action( 'delete_option_site_icon' ) ) {
+		} else if ( empty( $url ) ) {
 			Jetpack_Options::delete_option( 'site_icon_url' );
 		}
 	}

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -41,30 +41,7 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 		$synced_option_value = $this->server_replica_storage->get_option( 'don_t_sync_test_option' );
 		$this->assertEquals( false, $synced_option_value );
 	}
-
-	public function test_site_icon_is_synced_using_jetpack_function() {
-		global $wp_version;
-		$this->client->set_defaults();
-
-		if ( version_compare( $wp_version, '4.4', '>=' ) ) {
-			$this->client->set_defaults();
-
-			add_filter( 'get_site_icon_url', array( $this, '_get_site_icon' ), 99, 3 );
-			update_option( 'site_icon', '5' );
-
-			$this->client->do_sync();
-
-			$this->assertEquals( 'http://foo.com/icon.gif', $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
-		} else {
-			// wp 4.3 or less
-			Jetpack_Options::update_option( 'site_icon_url', 'http://foo.com/icon.gif' );
-
-			$this->client->do_sync();
-
-			$this->assertEquals( 'http://foo.com/icon.gif', $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
-		}
-	}
-
+	
 	public function test_sync_options_that_use_filter() {
 		add_filter( 'jetpack_options_whitelist', array( $this, 'add_jetpack_options_whitelist_filter' ) );
 		$this->client->set_defaults();
@@ -87,9 +64,5 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 	public function add_jetpack_options_whitelist_filter( $options ) {
 		$options[] = 'foo_option_bar';
 		return $options;
-	}
-
-	function _get_site_icon( $url, $size, $blog_id ) {
-		return 'http://foo.com/icon.gif';
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-site-icon-url.php
+++ b/tests/php/sync/test_class.jetpack-sync-site-icon-url.php
@@ -47,6 +47,24 @@ class WP_Test_Jetpack_Sync_Site_Icon_Url extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( Jetpack_Options::get_option( 'site_icon_url' ), $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
 	}
 
+	public function test_site_icon_update_to_null_is_synced_using_jetpack_function() {
+		global $wp_version;
+
+		// verify that we started with an icon.
+		$this->assertEquals( 'http://foo.com/icon.gif', $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
+
+		if ( version_compare( $wp_version, '4.4', '>=' ) ) {
+			remove_filter( 'get_site_icon_url', array( $this, '_get_site_icon' ), 99, 3 );
+			update_option( 'site_icon', 0 );
+		} else {
+			// wp 4.3 or less
+			Jetpack_Options::delete_option( 'site_icon_url' );
+		}
+		$this->client->do_sync();
+		$this->assertEmpty( $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
+		$this->assertEquals( Jetpack_Options::get_option( 'site_icon_url' ), $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
+	}
+
 	function _get_site_icon( $url, $size, $blog_id ) {
 		return 'http://foo.com/icon.gif';
 	}

--- a/tests/php/sync/test_class.jetpack-sync-site-icon-url.php
+++ b/tests/php/sync/test_class.jetpack-sync-site-icon-url.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Testing Crud Site icon
+ */
+class WP_Test_Jetpack_Sync_Site_Icon_Url extends WP_Test_Jetpack_New_Sync_Base {
+	protected $post;
+
+	public function setUp() {
+		global $wp_version;
+		parent::setUp();
+
+		$this->client->set_defaults();
+
+		if ( version_compare( $wp_version, '4.4', '>=' ) ) {
+			$this->client->set_defaults();
+			add_filter( 'get_site_icon_url', array( $this, '_get_site_icon' ), 99, 3 );
+			update_option( 'site_icon', '5' );
+		} else {
+			// wp 4.3 or less
+			Jetpack_Options::update_option( 'site_icon_url', 'http://foo.com/icon.gif' );
+		}
+		$this->client->do_sync();
+	}
+
+
+	public function test_site_icon_is_synced_using_jetpack_function() {
+		$this->assertEquals( 'http://foo.com/icon.gif', $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
+		$this->assertEquals( Jetpack_Options::get_option( 'site_icon_url' ), $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
+	}
+
+	public function test_site_icon_delete_is_synced_using_jetpack_function() {
+		global $wp_version;
+		
+		// verify that we started with an icon.
+		$this->assertEquals( 'http://foo.com/icon.gif', $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
+
+		if ( version_compare( $wp_version, '4.4', '>=' ) ) {
+			remove_filter( 'get_site_icon_url', array( $this, '_get_site_icon' ), 99, 3 );
+			delete_option( 'site_icon' );
+		} else {
+			// wp 4.3 or less
+			Jetpack_Options::delete_option( 'site_icon_url' );
+		}
+		$this->client->do_sync();
+		$this->assertEmpty( $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
+		$this->assertEquals( Jetpack_Options::get_option( 'site_icon_url' ), $this->server_replica_storage->get_option( 'jetpack_site_icon_url' ) );
+	}
+
+	function _get_site_icon( $url, $size, $blog_id ) {
+		return 'http://foo.com/icon.gif';
+	}
+}


### PR DESCRIPTION
Fixes #3969

#### Changes proposed in this Pull Request:
- Added tests that site_icon_url should be synced when it changes and is deleted. 
- Removes some redundant code.

@lamosty  can you test this branch and see if it works as expected for you? 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).