### PR TITLE
REST API Endpoints: fix fatal error when, in dev mode, fetching remote values through active modules

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2265,7 +2265,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		// If the module is inactive, load the class to use the method.
-		if ( ! Jetpack::is_module_active( $module ) ) {
+		if ( ! did_action( 'jetpack_module_loaded_' . $module ) ) {
 			// Class can't be found so do nothing.
 			if ( ! @include( Jetpack::get_module_path( $module ) ) ) {
 				return false;


### PR DESCRIPTION
#### Current issue
When a site is in dev mode, modules requiring a connection are not loaded, but they continue to be active, so the current approach of checking if a module is active is misleading.

#### Changes
This PR now checks if a certain action was fired. When modules are loaded, those requiring connection are discarded, so their action is never fired. Only modules that are currently loaded have their action fired.
This PR solves the issue where, in a site in dev mode, fetching the Post By Email or Monitor options resulted in a response containing a fatal error.

#### To test
1. In your sandbox, edit `jetpack.php` and set `JETPACK_DEV_DEBUG` to true.
2. activate Posts By Email and/or Monitor modules.
3. Go to WP Admin > Jetpack > Dashboard
4. In Chrome Dev Tools, open the console and enter the following, replacing `%YOUR-SANDBOX%` with your own sandbox host. Change `monitor` to `post-by-email` to check it too:
```js
jQuery.ajax( {
    url: 'https://%YOUR-SANDBOX%/wp-json/jetpack/v4/module/monitor',
    method: 'GET',
    beforeSend: function ( xhr ) {
        xhr.setRequestHeader( 'X-WP-Nonce', Initial_State.WP_API_nonce );
    },
    contentType: "application/json",
    dataType: "json"
} ).done( function ( response ) {
    console.log( response );
} ).error( function ( error ) {
    console.log( error );
} );
```
Before applying this PR, you would get a fatal error. After this PR, you would get the correct module data including its options.