### PR TITLE
Ignore user abort if we enqueue items for sync

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -298,6 +298,13 @@ class Jetpack_Sync_Client {
 			return;
 		}
 
+		// if we add any items to the queue, we should 
+		// try to ensure that our script can't be killed before
+		// they are sent
+		if ( function_exists( 'ignore_user_abort' ) ) {
+			ignore_user_abort( true );
+		}
+
 		$this->sync_queue->add( array(
 			$current_filter,
 			$args,

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -468,6 +468,13 @@ class Jetpack_Sync_Client {
 			return false;
 		}
 
+		// now that we're sure we are about to sync, try to
+		// ignore user abort so we can avoid getting into a
+		// bad state
+		if ( function_exists( 'ignore_user_abort' ) ) {
+			ignore_user_abort( true );
+		}
+
 		$buffer = $this->sync_queue->checkout_with_memory_limit( $this->checkout_memory_size, $this->upload_max_rows );
 
 		if ( ! $buffer ) {


### PR DESCRIPTION
Adds a feature from previous sync: Ignore user abort if we have data to sync on this request, and also right before sync occurs.

Previous implementation: https://github.com/Automattic/jetpack/blob/branch-4.0/class.jetpack-sync.php#L101

#### Changes proposed in this Pull Request:
- set ignore_user_abort(true) if the function exists and we've had data enqueued
- set ignore_user_abort(true) if the function exists and we're about to check out data from queue

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

