### PR TITLE
Remove jetpack-sync options

### DIFF
--- a/3rd-party/polldaddy.php
+++ b/3rd-party/polldaddy.php
@@ -3,12 +3,5 @@
 class Jetpack_Sync {
 	static function sync_options() {
 		_deprecated_function( __METHOD__, '4.1.0', 'jetpack_whitelist_options filter' );
-		$options = func_get_args();
-		// first argument is the file but we don't care about that any more.
-		$file = array_shift( $options );
-		if ( is_array( $options ) ) {
-			$client_sync = Jetpack_Sync_Client::getInstance();
-			$client_sync->set_options_whitelist( array_merge( $options, $client_sync->get_options_whitelist() ) );
-		}
 	}
 }

--- a/tests/php/sync/test_class.jetpack_sync_backward_compatibility.php
+++ b/tests/php/sync/test_class.jetpack_sync_backward_compatibility.php
@@ -13,14 +13,5 @@ class WP_Test_Jetpack_Sync_Backward_Compatibility extends WP_Test_Jetpack_New_Sy
 		require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );
 		$this->setExpectedDeprecated( 'Jetpack_Sync::sync_options' );
 		Jetpack_Sync::sync_options( __FILE__, 'foo_option', 'bar_option' );
-
-		update_option( 'foo_option', '123' );
-		update_option( 'bar_option', '456' );
-
-		$this->client->do_sync();
-
-		$this->assertEquals( '123', $this->server_replica_storage->get_option( 'foo_option' ) );
-		$this->assertEquals( '456', $this->server_replica_storage->get_option( 'bar_option' ) );
 	}
-
 }


### PR DESCRIPTION
Fixes issue where a fatal error was being though by VaultPress. 
I have simplified the Jetpack_Sync::sync_options() code to just though a depreciation notice.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

