### PR TITLE
Admin Page: Update getSiteConnectionStatus state selector test after a state schema update

### DIFF
--- a/_inc/client/state/connection/test/selectors.js
+++ b/_inc/client/state/connection/test/selectors.js
@@ -20,7 +20,12 @@ let state = {
 				fetchingUserData: true,
 			},
 			status: {
-				siteConnected: true
+				siteConnected: {
+					isActive: true,
+					devMode: {
+						isActive: false
+					}
+				}
 			},
 			connectUrl: '/asd',
 			user: {
@@ -71,7 +76,7 @@ describe( 'status selectors', () => {
 		it( 'should return state.jetpack.connection.status.siteConnected', () => {
 			const stateIn = state;
 			const output = getSiteConnectionStatus( stateIn );
-			expect( output ).to.be.equal( state.jetpack.connection.status.siteConnected );
+			expect( output ).to.be.equal( state.jetpack.connection.status.siteConnected.isActive );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes failing test .

#### Changes proposed in this Pull Request:

- Update the sample state schema to comply with new schema introduced by #3907 

#### Testing instructions
Run 
```
npm run test-client -- -g "selectors"
```

Expect to see **20 passing** tests
