### PR TITLE
Add highlander meta to new sync for comments

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -80,13 +80,16 @@ class Jetpack_Sync_Client {
 		add_action( 'deleted_comment', $handler, 10 );
 		add_action( 'trashed_comment', $handler, 10 );
 		add_action( 'spammed_comment', $handler, 10 );
+		add_filter( 'jetpack_sync_before_send_wp_insert_comment', array( $this, 'expand_wp_insert_comment' ) );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data
 		// so this saves us a DB read for every comment event
 		foreach ( array( '', 'trackback', 'pingback' ) as $comment_type ) {
 			foreach ( array( 'unapproved', 'approved' ) as $comment_status ) {
-				add_action( "comment_{$comment_status}_{$comment_type}", $handler, 10, 2 );
+				$comment_action_name = "comment_{$comment_status}_{$comment_type}";
+				add_action( $comment_action_name, $handler, 10, 2 );
+				add_filter( "jetpack_sync_before_send_$comment_action_name", array( $this, 'expand_wp_comment_status_change' ) );
 			}
 		}
 
@@ -554,7 +557,6 @@ class Jetpack_Sync_Client {
 	}
 
 	function expand_wp_insert_post( $args ) {
-		// list( $post_ID, $post, $update ) = $args;
 		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2] );
 	}
 
@@ -576,6 +578,29 @@ class Jetpack_Sync_Client {
 		$post->extra = $extra;
 
 		return $post;
+	}
+
+	function expand_wp_comment_status_change( $args ) {
+		return array( $args[0], $this->filter_comment_and_add_hc_meta( $args[1] ) );
+	}
+
+	function expand_wp_insert_comment( $args ) {
+		return array( $args[0], $this->filter_comment_and_add_hc_meta( $args[1] ) );
+	}
+
+	private function filter_comment_and_add_hc_meta( $comment ) {
+		// add meta-property with Highlander Comment meta, which we 
+		// we need to process synchronously on .com
+		$hc_post_as = get_comment_meta( $comment->comment_ID, 'hc_post_as', true );
+		if ( $hc_post_as === 'wordpress' ) {
+			$meta = array();
+			$meta['hc_post_as']         = $hc_post_as;
+			$meta['hc_wpcom_id_sig']    = get_comment_meta( $comment->comment_ID, 'hc_wpcom_id_sig', true );
+			$meta['hc_foreign_user_id'] = get_comment_meta( $comment->comment_ID, 'hc_foreign_user_id', true );
+			$comment->meta = $meta;	
+		}
+
+		return $comment;
 	}
 
 	private function schedule_sync( $when ) {

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -592,7 +592,7 @@ class Jetpack_Sync_Client {
 		// add meta-property with Highlander Comment meta, which we 
 		// we need to process synchronously on .com
 		$hc_post_as = get_comment_meta( $comment->comment_ID, 'hc_post_as', true );
-		if ( $hc_post_as === 'wordpress' ) {
+		if ( 'wordpress' === $hc_post_as ) {
 			$meta = array();
 			$meta['hc_post_as']         = $hc_post_as;
 			$meta['hc_wpcom_id_sig']    = get_comment_meta( $comment->comment_ID, 'hc_wpcom_id_sig', true );

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -588,7 +588,7 @@ class Jetpack_Sync_Client {
 		return array( $args[0], $this->filter_comment_and_add_hc_meta( $args[1] ) );
 	}
 
-	private function filter_comment_and_add_hc_meta( $comment ) {
+	function filter_comment_and_add_hc_meta( $comment ) {
 		// add meta-property with Highlander Comment meta, which we 
 		// we need to process synchronously on .com
 		$hc_post_as = get_comment_meta( $comment->comment_ID, 'hc_post_as', true );

--- a/sync/class.jetpack-sync-full.php
+++ b/sync/class.jetpack-sync-full.php
@@ -225,6 +225,7 @@ class Jetpack_Sync_Full {
 			'include_unapproved' => true,
 			'comment__in'        => $comment_ids,
 		) );
+		$comments = array_map( array( $this->get_client(), 'filter_comment_and_add_hc_meta' ), $comments );
 
 		return array(
 			'comments'      => $comments,

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -114,7 +114,7 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertObjectHasAttribute( 'meta', $synced_comment );
 		$this->assertEquals( 'wordpress', $synced_comment->meta['hc_post_as'] );
 		$this->assertEquals( 'abcd1234', $synced_comment->meta['hc_wpcom_id_sig'] );
-		$this->assertEquals( 55, $synced_comment->meta['hc_foreign_user_id'] );
+		$this->assertEquals( 101, $synced_comment->meta['hc_foreign_user_id'] );
 		
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -93,6 +93,34 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( 0, $this->server_replica_storage->comment_count( 'trash' ) );
 	}
 
+	public function test_sends_highlander_comment_meta_with_comment() {
+		$wpcom_user_id = 101;
+		$sig = 'abcd1234';
+		$comment_ID = $this->comment->comment_ID;
+
+		add_comment_meta( $comment_ID, 'hc_post_as', 'wordpress', true );
+		add_comment_meta( $comment_ID, 'hc_wpcom_id_sig', $sig, true );
+		add_comment_meta( $comment_ID, 'hc_foreign_user_id', $wpcom_user_id, true );
+
+		// re-save the comment
+		wp_set_comment_status( $comment_ID, 'hold' );
+
+		$this->client->do_sync();
+		$this->client->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event();
+
+		error_log(print_r($event, 1));
+
+		$synced_comment = $event->args[1];
+
+		error_log(print_r($synced_comment, 1));
+
+		$this->assertObjectHasAttribute( 'meta', $synced_comment );
+
+		
+	}
+
 	public function test_wp_spam_comment() {
 		wp_spam_comment( $this->comment->comment_ID );
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -111,9 +111,10 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event();
 
 		$synced_comment = $event->args[1];
-
 		$this->assertObjectHasAttribute( 'meta', $synced_comment );
-
+		$this->assertEquals( 'wordpress', $synced_comment->meta['hc_post_as'] );
+		$this->assertEquals( 'abcd1234', $synced_comment->meta['hc_wpcom_id_sig'] );
+		$this->assertEquals( 55, $synced_comment->meta['hc_foreign_user_id'] );
 		
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -110,11 +110,7 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event();
 
-		error_log(print_r($event, 1));
-
 		$synced_comment = $event->args[1];
-
-		error_log(print_r($synced_comment, 1));
 
 		$this->assertObjectHasAttribute( 'meta', $synced_comment );
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -128,7 +128,8 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->full_sync->start();
 		$this->client->do_sync();
 
-		$comment = $this->server_replica_storage->get_comments()[0];
+		$comments = $this->server_replica_storage->get_comments();
+		$comment = $comments[0];
 		$this->assertObjectHasAttribute( 'meta', $comment );
 		$this->assertEquals( 'wordpress', $comment->meta['hc_post_as'] );
 		$this->assertEquals( 'abcd1234', $comment->meta['hc_wpcom_id_sig'] );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -101,11 +101,8 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 
 	function test_full_sync_sends_all_comments() {
 		$post = $this->factory->post->create();
-
-		for( $i = 0; $i < 11; $i += 1 ) {
-			$this->factory->comment->create_post_comments( $post );
-		}
-
+		$this->factory->comment->create_post_comments( $post, 11 );
+	
 		// simulate emptying the server storage
 		$this->server_replica_storage->reset();
 		$this->client->reset_data();
@@ -115,6 +112,27 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 
 		$comments = $this->server_replica_storage->get_comments();
 		$this->assertEquals( 11, count( $comments ) );
+	}
+
+	function test_full_sync_expands_comment_meta() {
+		$post_id = $this->factory->post->create();
+		list( $comment_ID ) = $this->factory->comment->create_post_comments( $post_id );
+
+		add_comment_meta( $comment_ID, 'hc_post_as', 'wordpress', true );
+		add_comment_meta( $comment_ID, 'hc_wpcom_id_sig', 'abcd1234', true );
+		add_comment_meta( $comment_ID, 'hc_foreign_user_id', 55, true );
+
+		$this->server_replica_storage->reset();
+		$this->client->reset_data();
+
+		$this->full_sync->start();
+		$this->client->do_sync();
+
+		$comment = $this->server_replica_storage->get_comments()[0];
+		$this->assertObjectHasAttribute( 'meta', $comment );
+		$this->assertEquals( 'wordpress', $comment->meta['hc_post_as'] );
+		$this->assertEquals( 'abcd1234', $comment->meta['hc_wpcom_id_sig'] );
+		$this->assertEquals( 55, $comment->meta['hc_foreign_user_id'] );
 	}
 
 	function test_full_sync_sends_all_terms() {


### PR DESCRIPTION
In order to correctly set the WPCOM user ID on synced comments, we require the highlander meta.

Adding it to the comment in transit is the simplest way to accomplish this.

#### Changes proposed in this Pull Request:
- add highlander meta to comment if the comment was authorized using wordpress.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

