### PR TITLE
Update/late init sync actions

### DIFF
--- a/3rd-party/polldaddy.php
+++ b/3rd-party/polldaddy.php
@@ -2,6 +2,6 @@
 
 class Jetpack_Sync {
 	static function sync_options() {
-		_deprecated_function( __METHOD__, '4.1.0', 'jetpack_whitelist_options filter' );
+		_deprecated_function( __METHOD__, '4.1.0', 'jetpack_options_whitelist filter' );
 	}
 }

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -38,5 +38,5 @@ class Jetpack_Sync_Actions {
 	}
 
 }
-
-Jetpack_Sync_Actions::init();
+// Allow other plugins to add filters before we initalize the actions.
+add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 11, 0 );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -74,6 +74,16 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( '123', $this->server_replica_storage->get_option( 'foo_option_bar' ) );
 	}
 
+	public function test_sync_initalize_Jetpack_Sync_Action_on_init() {
+		// prioroty should be set to 11 so that Plugins by default (10) initialize the whitelist_filter before.
+		$this->assertEquals( 11, has_action('init', array( 'Jetpack_Sync_Actions', 'init' ) ) );
+	}
+
+
+	function add_fiter_on_init() {
+		add_filter( 'jetpack_options_whitelist', array( $this, 'add_jetpack_options_whitelist_filter' ) );
+	}
+
 	public function add_jetpack_options_whitelist_filter( $options ) {
 		$options[] = 'foo_option_bar';
 		return $options;


### PR DESCRIPTION
This PR make the jetpack_options_whitelist filter more useful since it allows plugins such as VaultPress to add to the filter. 

#### Changes proposed in this Pull Request:
- Update code to allow plugins to add to the whitelist filter. 
- Minor type fix.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
