### PR TITLE
FoldableCard: updating styles for very small screens

### DIFF
--- a/_inc/client/components/foldable-card/style.scss
+++ b/_inc/client/components/foldable-card/style.scss
@@ -1,0 +1,16 @@
+.dops-foldable-card.dops-card {
+
+	.dops-foldable-card__header-text {
+
+		@include breakpoint( "<480px" ) {
+			font-size: rem( 14px );
+		}
+	}
+
+	.dops-foldable-card__subheader {
+
+		@include breakpoint( "<480px" ) {
+			display: none;
+		}
+	}
+}


### PR DESCRIPTION
The FoldableCards within the setting areas get a little clumsy on small screens (<480px). In order to make them more efficient and easier to navigate through, I've modded the titles and subtitle of the FoldableCards here, instead of `dops-components` just because it may not be necessary for the general components. 

Fixes: https://github.com/Automattic/jetpack/issues/3908

Before:
![image](https://cloud.githubusercontent.com/assets/214813/15622880/9150e866-243b-11e6-901d-6baa15852c42.png)


After: 
![foldable-card-01](https://cloud.githubusercontent.com/assets/214813/15623014/0ad0bc06-243d-11e6-8b23-159446a1ce43.png)
![foldable-card-02](https://cloud.githubusercontent.com/assets/214813/15623015/0ad23216-243d-11e6-836d-2a30ff9ed25a.png)





