### PR TITLE
Jetpack Connect URL

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4343,6 +4343,10 @@ p {
 
 			$secrets = Jetpack::init()->generate_secrets( 'authorize' );
 			@list( $secret ) = explode( ':', $secrets );
+			
+			$site_icon = ( function_exists( 'has_site_icon') && has_site_icon() )
+				? get_site_icon_url()
+				: false;
 
 			$args = urlencode_deep(
 				array(
@@ -4366,6 +4370,9 @@ p {
 					'secret'        => $secret,
 					'locale'        => isset( $gp_locale->slug ) ? $gp_locale->slug : '',
 					'blogname'      => get_option( 'blogname' ),
+					'site_url'      => site_url(),
+					'home_url'      => home_url(),
+					'site_icon'     => $site_icon,
 				)
 			);
 


### PR DESCRIPTION
Simply adds more info to the connect URL, which will be used in the Calypso connection UI.

This will allow us to show the UI described here:
https://github.com/Automattic/wp-calypso/issues/4963

It will also fix connection issues where site_url and home_url are different.

cc: @dereksmart @johnHackworth 