### PR TITLE
Jetpack REST API (WP-API extensions): Add API reference

### DIFF
--- a/_inc/client/README.md
+++ b/_inc/client/README.md
@@ -5,25 +5,10 @@ This UI is built on React, redux and the fetch API.
 
 ### Data fetching
 
-The data is being made available to the UI by usage of the WordPress REST API.
-Jetpack extends the Core API adding some specific methods.
+The data is being made available to the UI by usage of the **Jetpack HTTP API**.
+Jetpack extends the Core API adding some specific endpoints.
 
-#### API Authentication
-
-The API requests rely on [cookie-based authentication and a specific nonce](http://v2.wp-api.org/guide/authentication/#cookie-authentication)
-for requests to be authorized.
-
-The nonce is being served on the Jetpack admin page by usage of the [wp_localize_script](https://codex.wordpress.org/Function_Reference/wp_localize_script) mechanism for passing values from PHP code to the JS scope.
-
-This nonce is created with the action `wp_rest`.
-
-The nonce and the API root URL are made available on
-
-```
-window.Initial_State.WP_API_nonce;
-window.Initial_State.WP_API_root;
-```
-
+You may find additional reference for the Jetpack's HTTP API on the [rest-api.md](../../rest-api.md) file.
 
 ## Internal API
 
@@ -50,7 +35,7 @@ window.Initial_State.WP_API_root;
 
 Action types dispatched during the UI lifecycle are listed in `state/action-types.js`.
 
-####How to use selectors and actions creators from a component file
+#### How to use selectors and actions creators from a component file
 
 ```javascript
 import { getModules, isModuleActivated, activateModule } from 'state/modules';

--- a/rest-api.md
+++ b/rest-api.md
@@ -37,6 +37,12 @@ WP-API-compatible [capabilities document](http://v2.wp-api.org/guide/discovery/)
 
 ## API Reference
 
+All endpoints return and accept JSON. Make sure you add the proper content-type to your PUT/POST requests sending JSON objects.
+
+```
+'Content-type': 'application/json'
+```
+
 ### Jetpack connection related operations
 
 Operations related to Jetpack's connection to WordPress.com
@@ -57,9 +63,13 @@ Fetch the data of the current's user WordPress.com account.
 
 Disconnect the Jetpack installation from WordPress.com servers.
 
+**This endpoint does not take POST parameters**
+
 #### POST /wp-json/jetpack/v4/recheck-ssl
 
 Check if the site has SSL enabled.
+
+**This endpoint does not take POST parameters**
 
 ### Jetpack modules related operations
 
@@ -79,13 +89,18 @@ Get a single module description and properties by its slug.
 
 Activate a module by its slug
 
+
 **URL parameters**
 
 * `module-slug`: {String} The identifier of the module on which to act.
 
+**This endpoint does not take POST parameters**
+
 #### POST /wp-json/jetpack/v4/module/:module-slug/deactivate
 
 Deactivate a module by its slug
+
+**This endpoint does not take POST parameters**
 
 **URL parameters**
 
@@ -100,6 +115,11 @@ Activate several modules at a time by their slug
 
 * `modules`: {Array} An array of strings of identifiers of the modules to activate
 
+```
+{
+	modules: [ 'protect', 'monitor', 'likes' ]
+}
+```
 
 #### POST /wp-json/jetpack/v4/module/:module-slug/update
 
@@ -109,6 +129,16 @@ Update an option's value for a module
 
 * `module-slug`: {String} The identifier of the module on which to act.
 
+**POST parameters**
+
+* Accepts a simple object with the key of the option to update and the new value.
+
+Accepts a JSON object in the body like:
+```
+{
+	'option-key': 'new-option-value'
+}
+```
 
 ### Jetpack miscellaneous settings related operations
 
@@ -120,15 +150,30 @@ Fetch a list of Jetpack settings not related to a particular module.
 
 Update a setting value
 
+**POST parameters**
+
+* Accepts a simple object with the key of the setting to update and the new value.
+
+Accepts a JSON object in the body like:
+```
+{
+	'setting-key': 'new-setting-value'
+}
+```
+
 #### POST /wp-json/jetpack/v4/jumpstart/activate
 
 Activate Jumpstart turning on some options and settings to a recommended state.
+
+**This endpoint does not take POST parameters**
 
 #### POST /wp-json/jetpack/v4/jumpstart/deactivate
 
 Deactivate Jumpstart reverting options to their default state.
 
-#### /wp-json/jetpack/v4/reset/:options_or_modules
+**This endpoint does not take POST parameters**
+
+#### POST /wp-json/jetpack/v4/reset/:options_or_modules
 
 Reset  Jetpack module options or Jetpack modules activation state to default values.
 
@@ -138,13 +183,18 @@ Reset  Jetpack module options or Jetpack modules activation state to default val
 	* `"options"`: all the modules' options will be re-set to their default values.
 	* `"modules"`: the modules activation state will be reset to their defaults.
 
+	**This endpoint does not take POST parameters**
+
+
 ### Users
 
 Operations related to the site's users linked to WordPress.com accounts.
 
 #### POST /wp-json/jetpack/v4/unlink
 
-Unlink a site's user from the related WordPress.com account.
+Unlink current user from the related WordPress.com account.
+
+**This endpoint does not take POST parameters**
 
 ### Site information
 
@@ -163,6 +213,8 @@ Dismiss a Jetpack notice by Id.
 	* `"welcome"`.
 
 #### GET /wp-json/jetpack/v4/site
+
+Get current site data
 
 ### Protect module related operations
 

--- a/rest-api.md
+++ b/rest-api.md
@@ -212,6 +212,10 @@ Dismiss a Jetpack notice by Id.
 	* `"feedback_dash_request"`
 	* `"welcome"`.
 
+** HTTP Status codes**
+
+* `404` - When `:notice` is not valid or absent
+
 #### GET /wp-json/jetpack/v4/site
 
 Get current site data

--- a/rest-api.md
+++ b/rest-api.md
@@ -1,0 +1,201 @@
+# Jetpack HTTP API
+
+Jetpack's HTTP API is built as an [extension to the WP-API](http://v2.wp-api.org/extending/adding/). Thus, you may find additional information on approaching the API in the [WP API Docs](http://v2.wp-api.org/).
+
+## API Authentication and authorization
+
+The API requests rely on [cookie-based authentication and a specific nonce](http://v2.wp-api.org/guide/authentication/#cookie-authentication)
+for requests to be authorized.
+
+### API Request Authorization via nonces
+
+The WP REST API infrastructure requires a nonce for authorizing of the request itself.
+
+Ensure to use the `X-WP-Nonce` header on your request.
+
+```
+X-WP-Nonce: e1cff122e1
+```
+
+The nonce is being served on the Jetpack admin page by usage of the [wp_localize_script](https://codex.wordpress.org/Function_Reference/wp_localize_script) mechanism for passing values from PHP code to the JS scope. It's created for the action `wp_rest` and made available in the Jetpack Admin Page as:
+
+```
+window.Initial_State.WP_API_nonce;
+```
+
+The root URL for the the API is found on the same page as:
+
+```
+window.Initial_State.WP_API_root;
+```
+
+## Discovery
+
+WP-API-compatible [capabilities document](http://v2.wp-api.org/guide/discovery/) for the endpoints registered by Jetpack.
+
+`GET /wp-json/jetpack/v4`
+
+## API Reference
+
+### Jetpack connection related operations
+
+Operations related to Jetpack's connection to WordPress.com
+
+#### GET /wp-json/jetpack/v4/connection-status
+
+Fetch Jetpack's current connection status.
+
+#### GET /wp-json/jetpack/v4/connect-url
+
+Fetch a fresh WordPress.com URL for connecting the Jetpack installation.
+
+#### GET /wp-json/jetpack/v4/user-connection-data
+
+Fetch the data of the current's user WordPress.com account.
+
+#### POST /wp-json/jetpack/v4/disconnect/site
+
+Disconnect the Jetpack installation from WordPress.com servers.
+
+#### POST /wp-json/jetpack/v4/recheck-ssl
+
+Check if the site has SSL enabled.
+
+### Jetpack modules related operations
+
+#### GET /wp-json/jetpack/v4/modules/
+
+Get a list of all Jetpacks modules, its description, other properties and the module's options
+
+#### GET /wp-json/jetpack/v4/modules/:module-slug
+
+Get a single module description and properties by its slug.
+
+**URL parameters**
+
+* `module-slug`: {String} The identifier of the module to get info about.
+
+#### POST /wp-json/jetpack/v4/module/:module-slug/activate
+
+Activate a module by its slug
+
+**URL parameters**
+
+* `module-slug`: {String} The identifier of the module on which to act.
+
+#### POST /wp-json/jetpack/v4/module/:module-slug/deactivate
+
+Deactivate a module by its slug
+
+**URL parameters**
+
+* `module-slug`: {String} The identifier of the module on which to act.
+
+
+#### POST /wp-json/jetpack/v4/modules/activate
+
+Activate several modules at a time by their slug
+
+**POST parameters**
+
+* `modules`: {Array} An array of strings of identifiers of the modules to activate
+
+
+#### POST /wp-json/jetpack/v4/module/:module-slug/update
+
+Update an option's value for a module
+
+**URL parameters**
+
+* `module-slug`: {String} The identifier of the module on which to act.
+
+
+### Jetpack miscellaneous settings related operations
+
+### GET /wp-json/jetpack/v4/settings
+
+Fetch a list of Jetpack settings not related to a particular module.
+
+### POST /wp-json/jetpack/v4/settings/update
+
+Update a setting value
+
+#### POST /wp-json/jetpack/v4/jumpstart/activate
+
+Activate Jumpstart turning on some options and settings to a recommended state.
+
+#### POST /wp-json/jetpack/v4/jumpstart/deactivate
+
+Deactivate Jumpstart reverting options to their default state.
+
+#### /wp-json/jetpack/v4/reset/:options_or_modules
+
+Reset  Jetpack module options or Jetpack modules activation state to default values.
+
+**URL parameters**
+
+* `options_or_modules`: {String} Available values:
+	* `"options"`: all the modules' options will be re-set to their default values.
+	* `"modules"`: the modules activation state will be reset to their defaults.
+
+### Users
+
+Operations related to the site's users linked to WordPress.com accounts.
+
+#### POST /wp-json/jetpack/v4/unlink
+
+Unlink a site's user from the related WordPress.com account.
+
+### Site information
+
+Operations related to information about the site.
+
+### Jetpack notices
+
+#### POST /wp-json/jetpack/v4/notice/:notice/dismiss
+
+Dismiss a Jetpack notice by Id.
+
+**URL parameters**
+
+* `notice`: {String} The identifier of the notice to dismiss. Possible values:
+	* `"feedback_dash_request"`
+	* `"welcome"`.
+
+#### GET /wp-json/jetpack/v4/site
+
+### Protect module related operations
+
+##### GET /wp-json/jetpack/v4/module/protect/count/get
+
+Get count of blocked attacks by Protect.
+
+### Monitor module related operations
+
+#### GET /wp-json/jetpack/v4/module/monitor/downtime/last
+
+Get from the Monitor module, the last time the site was down.
+
+### Verification Tools module related operations
+
+#### GET /wp-json/jetpack/v4/module/verification-tools/services
+
+Get services that this site is verified with.
+
+### Site's plugins related operations
+
+#### GET /wp-json/jetpack/v4/updates/plugins
+
+Get number of updated available for currently installed WordPress plugins.
+
+### Akismet related operations
+
+#### GET /wp-json/jetpack/v4/akismet/stats/get
+
+Get stats from Akismet filtered spam.
+
+### VaultPress options
+
+#### GET /wp-json/jetpack/v4/module/vaultpress/data
+
+get date of last backup or status and information about actions for user to take.

--- a/rest-api.md
+++ b/rest-api.md
@@ -37,13 +37,13 @@ WP-API-compatible [capabilities document](http://v2.wp-api.org/guide/discovery/)
 
 ## API Reference
 
-All endpoints return and accept JSON. Make sure you add the proper content-type to your PUT/POST requests sending JSON objects.
+All endpoints return and accept JSON. Make sure you add the proper `content-type` header to your PUT/POST requests sending JSON objects.
 
 ```
 'Content-type': 'application/json'
 ```
 
-### Jetpack connection related operations
+### Jetpack connection
 
 Operations related to Jetpack's connection to WordPress.com
 
@@ -63,21 +63,21 @@ Fetch the data of the current's user WordPress.com account.
 
 Disconnect the Jetpack installation from WordPress.com servers.
 
-**This endpoint does not take POST parameters**
+**This endpoint does not take Body parameters**
 
 #### POST /wp-json/jetpack/v4/recheck-ssl
 
 Check if the site has SSL enabled.
 
-**This endpoint does not take POST parameters**
+**This endpoint does not take Body parameters**
 
-### Jetpack modules related operations
+### Jetpack modules
 
-#### GET /wp-json/jetpack/v4/modules/
+#### GET /wp-json/jetpack/v4/module/all
 
 Get a list of all Jetpacks modules, its description, other properties and the module's options
 
-#### GET /wp-json/jetpack/v4/modules/:module-slug
+#### GET /wp-json/jetpack/v4/module/:module-slug
 
 Get a single module description and properties by its slug.
 
@@ -85,43 +85,41 @@ Get a single module description and properties by its slug.
 
 * `module-slug`: {String} The identifier of the module to get info about.
 
-#### POST /wp-json/jetpack/v4/module/:module-slug/activate
+#### POST /wp-json/jetpack/v4/module/:module-slug/active
 
-Activate a module by its slug
+Activate or deactivate a module by its slug
 
-
-**URL parameters**
-
-* `module-slug`: {String} The identifier of the module on which to act.
-
-**This endpoint does not take POST parameters**
-
-#### POST /wp-json/jetpack/v4/module/:module-slug/deactivate
-
-Deactivate a module by its slug
-
-**This endpoint does not take POST parameters**
+Accepts a JSON object in the body like:
+```
+{
+	"active": true
+}
+```
 
 **URL parameters**
 
 * `module-slug`: {String} The identifier of the module on which to act.
 
+**Body parameters**
 
-#### POST /wp-json/jetpack/v4/modules/activate
+* `active`: {Boolean} Send false to deactivate the module.
+
+
+#### POST /wp-json/jetpack/v4/module/activate
 
 Activate several modules at a time by their slug
 
-**POST parameters**
+**Body parameters**
 
 * `modules`: {Array} An array of strings of identifiers of the modules to activate
 
 ```
 {
-	modules: [ 'protect', 'monitor', 'likes' ]
+	"modules": [ "protect", "monitor", "likes" ]
 }
 ```
 
-#### POST /wp-json/jetpack/v4/module/:module-slug/update
+#### POST /wp-json/jetpack/v4/module/:module-slug
 
 Update an option's value for a module
 
@@ -129,18 +127,18 @@ Update an option's value for a module
 
 * `module-slug`: {String} The identifier of the module on which to act.
 
-**POST parameters**
+**Body parameters**
 
 * Accepts a simple object with the key of the option to update and the new value.
 
 Accepts a JSON object in the body like:
 ```
 {
-	'option-key': 'new-option-value'
+	"option-key": "new-option-value"
 }
 ```
 
-### Jetpack miscellaneous settings related operations
+### Jetpack miscellaneous settings
 
 ### GET /wp-json/jetpack/v4/settings
 
@@ -150,14 +148,14 @@ Fetch a list of Jetpack settings not related to a particular module.
 
 Update a setting value
 
-**POST parameters**
+**Body parameters**
 
 * Accepts a simple object with the key of the setting to update and the new value.
 
 Accepts a JSON object in the body like:
 ```
 {
-	'setting-key': 'new-setting-value'
+	"setting-key": "new-setting-value"
 }
 ```
 
@@ -165,13 +163,13 @@ Accepts a JSON object in the body like:
 
 Activate Jumpstart turning on some options and settings to a recommended state.
 
-**This endpoint does not take POST parameters**
+**This endpoint does not take Body parameters**
 
 #### POST /wp-json/jetpack/v4/jumpstart/deactivate
 
 Deactivate Jumpstart reverting options to their default state.
 
-**This endpoint does not take POST parameters**
+**This endpoint does not take Body parameters**
 
 #### POST /wp-json/jetpack/v4/reset/:options_or_modules
 
@@ -183,7 +181,7 @@ Reset  Jetpack module options or Jetpack modules activation state to default val
 	* `"options"`: all the modules' options will be re-set to their default values.
 	* `"modules"`: the modules activation state will be reset to their defaults.
 
-	**This endpoint does not take POST parameters**
+	**This endpoint does not take Body parameters**
 
 
 ### Users
@@ -194,7 +192,7 @@ Operations related to the site's users linked to WordPress.com accounts.
 
 Unlink current user from the related WordPress.com account.
 
-**This endpoint does not take POST parameters**
+**This endpoint does not take Body parameters**
 
 ### Site information
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Adds some API reference  for the Jetpack HTTP API

#### TODO
- [x] Add `rest-api.md` document.
- [x] Update `_inc/client/README.md` to link to rest-api.md.
- [x] Document endpoints and description.
- [x] Document URL parameters
- [x] Document POST parameters
- [ ] Document HTTP status codes about each endpoint's response.
- [ ] Document example response about each endpoint.