### PR TITLE
Endpoints: update notice dismiss endpoint syntax

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -165,7 +165,7 @@ const restApi = {
 		}
 	} )
 		.then( checkStatus ).then( response => response.json() ),
-	dismissJetpackNotice: ( notice ) => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/dismiss-jetpack-notice/${ notice }`, {
+	dismissJetpackNotice: ( notice ) => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/notice/${ notice }/dismiss`, {
 		method: 'put',
 		credentials: 'same-origin',
 		headers: {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -221,9 +221,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Dismiss Jetpack Notices
-		register_rest_route( 'jetpack/v4', '/dismiss-jetpack-notice/(?P<notice>[a-z\-_]+)', array(
+		register_rest_route( 'jetpack/v4', '/notice/(?P<notice>[a-z\-_]+)/dismiss', array(
 			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::dismiss_jetpack_notice',
+			'callback' => __CLASS__ . '::dismiss_notice',
 			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 		) );
 	}
@@ -235,7 +235,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return array|wp-error
 	 */
-	public static function dismiss_jetpack_notice( $data ) {
+	public static function dismiss_notice( $data ) {
 		$notice = $data['notice'];
 		if ( isset( $notice ) && ! empty( $notice ) ) {
 			switch( $notice ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- change endpoint to dismiss notices from
```
jetpack/v4/dismiss-jetpack-notice/:notice
```
to one more consistent with the endpoint to deactivate modules or update settings `
```
jetpack/v4/notice/:notice/dismiss
```