### PR TITLE
Add general filter that Devs can use to skip some actions from syncing

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -300,7 +300,7 @@ class Jetpack_Sync_Client {
 		) {
 			return;
 		}
-
+		
 		$this->sync_queue->add( array(
 			$current_filter,
 			$args,

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -300,7 +300,7 @@ class Jetpack_Sync_Client {
 		) {
 			return;
 		}
-		
+
 		$this->sync_queue->add( array(
 			$current_filter,
 			$args,

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -81,7 +81,9 @@ class Jetpack_Sync_Defaults {
 		'disabled_reblogs',
 		'jetpack_comment_likes_enabled',
 		'twitter_via',
-		'twitter-cards-site-tag'
+		'twitter-cards-site-tag',
+		'jetpack_skipped_sync_post_ids',
+		'jetpack_skipped_sync_comment_ids',
 	);
 
 	static $default_constants_whitelist = array(

--- a/tests/php/sync/test_class.jetpack-sync-client.php
+++ b/tests/php/sync/test_class.jetpack-sync-client.php
@@ -344,6 +344,14 @@ class WP_Test_Jetpack_New_Sync_Client extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertTrue( $event->timestamp < microtime(true) );
 	}
 
+	function test_stop_sync_filter_stops_syncing() {
+		add_filter( 'jetpack_skip_sync_item', '__return_true' );
+		$this->factory->post->create();
+		$this->client->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$this->assertFalse( $event );
+	}
+
 	function action_ran( $data ) {
 		$this->action_ran = true;
 		return $data;

--- a/tests/php/sync/test_class.jetpack-sync-client.php
+++ b/tests/php/sync/test_class.jetpack-sync-client.php
@@ -350,32 +350,7 @@ class WP_Test_Jetpack_New_Sync_Client extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
 		$this->assertFalse( $event );
-
 	}
-
-	function test_syncing_of_blacklist_of_posts_we_do_not_sync() {
-		add_filter( 'jetpack_skip_sync_item', '__return_true' );
-		$post_id = $this->factory->post->create();
-		$this->client->do_sync();
-
-		$blacklist = $this->server_replica_storage->get_option( 'jetpack_skipped_sync_post_ids', array() );
-		$this->assertContains( $post_id, $blacklist );
-	}
-
-	function test_syncing_of_blacklist_of_comments_we_do_not_sync() {
-		add_filter( 'jetpack_skip_sync_item', '__return_true' );
-		$comment_ids = $this->factory->comment->create_post_comments(
-			$this->factory->post->create()
-		);
-
-		$this->client->do_sync();
-
-		$blacklist = $this->server_replica_storage->get_option( 'jetpack_skipped_sync_comment_ids' );
-		$this->assertContains( $comment_ids[0], $blacklist );
-	}
-
-
-
 
 	function action_ran( $data ) {
 		$this->action_ran = true;

--- a/tests/php/sync/test_class.jetpack-sync-queue.php
+++ b/tests/php/sync/test_class.jetpack-sync-queue.php
@@ -232,6 +232,26 @@ class WP_Test_Jetpack_New_Sync_Queue extends WP_UnitTestCase {
 		$this->assertEquals( 0, $this->queue->size() );
 	}
 
+	function test_skip_adding_actions_filter() {
+		$this->assertEquals( 0, $this->queue->size() );
+		add_filter( 'jetpack_skip_sync_item', array( $this, 'skip_sync_action' ), 10, 2 );
+
+		$this->queue->add( 'skip_me' );
+		$this->assertEquals( 0, $this->queue->size() );
+		$this->queue->reset();
+
+		$this->queue->add_all( array( 'don\'t skip me','skip_me' ) );
+		$this->assertEquals( 1, $this->queue->size() );
+		$this->queue->reset();
+	}
+
+	function skip_sync_action( $skip, $item ) {
+		if ( 'skip_me' === $item ) {
+			return true;
+		}
+		return false;
+	}
+
 	function test_checkout_returns_false_if_checkout_zero_items() {
 		$this->queue->add_all( array(1, 2, 3) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Adds a filter that devs can use to stop an item from being send over to .com. 
-------------------
TODO
- [ ] create a way for devs to not sync posts and comments during full sync. 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
