### PR TITLE
readme.md: Add JS testing and stable branch instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,17 @@ To install the Jetpack plugin on your site, [follow the instructions on this pag
 
 Do you need help installing Jetpack, or do you have questions about one of the Jetpack modules? You can [search through our documentation here](http://jetpack.com/support/). If you don't find the answers you're looking for, you can [send us an email](http://jetpack.com/contact-support/) or [start a new thread in the WordPress.org support forums](https://wordpress.org/support/plugin/jetpack#postform).
 
+## Installation from  git repo
+
+The `master-stable` branch of this repo contains an stable version with every JS file pre-built.
+
+```
+$ cd wp-content/plugins
+$ git clone https://github.com/Automattic/jetpack
+$ cd jetpack
+$ git checkout master-stable
+```
+
 ## Contribute
 
 Developers of all levels can help — whether you can barely recognize a filter (or don’t know what that means) or you’ve already authored your own plugins, there are ways for you to pitch in. Blast off:
@@ -60,6 +71,13 @@ Known Issues:
 #### Development build
 
 Running `npm run watch` instead of `npm run build` will build all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly. Before running `npm run watch` you may need to `npm install` the npm dependencies first.
+
+```
+$ cd wp-content/plugins
+$ git clone https://github.com/Automattic/jetpack.git
+$ npm install
+$ npm run watch
+```
 
 ## Monitor our activity on this repository
 

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,11 @@ Do you need help installing Jetpack, or do you have questions about one of the J
 
 ## Installation from  git repo
 
-The `master-stable` branch of this repo contains an stable version with every JS file pre-built.
+The `master-stable` branch of this repo contains an stable version with every JS and CSS file pre-built.
 
 ```
 $ cd wp-content/plugins
-$ git clone https://github.com/Automattic/jetpack
+$ git clone git@github.com:Automattic/jetpack.git
 $ cd jetpack
 $ git checkout master-stable
 ```
@@ -74,7 +74,7 @@ Running `npm run watch` instead of `npm run build` will build all the code and c
 
 ```
 $ cd wp-content/plugins
-$ git clone https://github.com/Automattic/jetpack.git
+$ git clone git@github.com:Automattic/jetpack.git
 $ cd jetpack
 $ npm install
 $ npm run watch

--- a/readme.md
+++ b/readme.md
@@ -16,14 +16,14 @@ Do you need help installing Jetpack, or do you have questions about one of the J
 
 ## Installation from  git repo
 
-The `master-stable` branch of this repo contains an stable version with every JS and CSS file pre-built.
+The `jetpack-built` branch of this repo contains an stable version with every JS and CSS file pre-built.
 
 CD into your Plugins directory
 
 ```
 $ git clone git@github.com:Automattic/jetpack.git
 $ cd jetpack
-$ git checkout master-stable
+$ git checkout jetpack-built
 ```
 
 ## Contribute

--- a/readme.md
+++ b/readme.md
@@ -75,8 +75,19 @@ Running `npm run watch` instead of `npm run build` will build all the code and c
 ```
 $ cd wp-content/plugins
 $ git clone https://github.com/Automattic/jetpack.git
+$ cd jetpack
 $ npm install
 $ npm run watch
+```
+
+#### Unit-testing the JS Admin Page
+
+You can run Mocha based tests for the Admin Page source code with `npm run test-client`
+
+```
+$ cd wp-content/plugins/jetpack
+$ npm install
+$ npm run test-client
 ```
 
 ## Monitor our activity on this repository

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,9 @@ Do you need help installing Jetpack, or do you have questions about one of the J
 
 The `master-stable` branch of this repo contains an stable version with every JS and CSS file pre-built.
 
+CD into your Plugins directory
+
 ```
-$ cd wp-content/plugins
 $ git clone git@github.com:Automattic/jetpack.git
 $ cd jetpack
 $ git checkout master-stable
@@ -72,8 +73,9 @@ Known Issues:
 
 Running `npm run watch` instead of `npm run build` will build all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly. Before running `npm run watch` you may need to `npm install` the npm dependencies first.
 
+Clone this repository inside your Plugins directory.
+
 ```
-$ cd wp-content/plugins
 $ git clone git@github.com:Automattic/jetpack.git
 $ cd jetpack
 $ npm install
@@ -82,10 +84,11 @@ $ npm run watch
 
 #### Unit-testing the JS Admin Page
 
-You can run Mocha based tests for the Admin Page source code with `npm run test-client`
+You can run [Mocha](https://mochajs.org/) based tests for the Admin Page source code with `npm run test-client`
+
+Standing on your jetpack directory, run
 
 ```
-$ cd wp-content/plugins/jetpack
 $ npm install
 $ npm run test-client
 ```


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Adds reference to installation from git repo with mention to the `master-stable` branch.
- Adds instructions for running Admin Page unit tests. 

#### Testing instructions

1. View the new [README.md as updated by this branch](https://github.com/Automattic/jetpack/blob/add/testing-and-stable-instructions/readme.md).
1. Check the new 2nd level section **Installation from git repo**.
1. Check the new 4th level section **Unit-testing the JS Admin Page**.