### PR TITLE
Admin - Dev Mode: grey out unavailable modules. Make items in At A Glance unclickable and faded

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -39,7 +39,7 @@ const DashBackups = React.createClass( {
 
 			if ( vpData.code === 'success' && backupData.has_full_backup ) {
 				return(
-					<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
+					<DashItem label={ labelName } status="is-working">
 						<h3>{ __( 'Your site is completely backed up!' ) }</h3>
 						<p className="jp-dash-item__description">{ __( 'Full Backup Status:' ) } { backupData.full_backup_status } </p>
 						<p className="jp-dash-item__description">{ __( 'Last Backup:' ) } { backupData.last_backup } </p>
@@ -50,7 +50,7 @@ const DashBackups = React.createClass( {
 			// All good
 			if ( vpData.code === 'success' && backupData.full_backup_status !== '100% complete' ) {
 				return(
-					<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
+					<DashItem label={ labelName } status="is-working">
 						<h3>{ __( 'Currently backing up your site.' ) }</h3>
 						<p className="jp-dash-item__description">{ __( 'Full Backup Status:' ) } { backupData.full_backup_status } </p>
 						<p className="jp-dash-item__description">{ __( 'Last Backup:' ) } { backupData.last_backup }</p>
@@ -60,9 +60,10 @@ const DashBackups = React.createClass( {
 		}
 
 		return(
-			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive" disabled={ isDevMode( this.props ) }>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive">
 				<p className="jp-dash-item__description">
 					{
+						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode.' ) :
 						__( 'To automatically back up your site, please {{a}}upgrade your account{{/a}}', {
 							components: {
 								a: <a href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl } target="_blank" />

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -18,6 +18,7 @@ import {
 import {
 	getVaultPressData as _getVaultPressData
 } from 'state/at-a-glance';
+import { isDevMode } from 'state/connection';
 
 const DashBackups = React.createClass( {
 	getContent: function() {
@@ -38,7 +39,7 @@ const DashBackups = React.createClass( {
 
 			if ( vpData.code === 'success' && backupData.has_full_backup ) {
 				return(
-					<DashItem label={ labelName } status="is-working">
+					<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
 						<h3>{ __( 'Your site is completely backed up!' ) }</h3>
 						<p className="jp-dash-item__description">{ __( 'Full Backup Status:' ) } { backupData.full_backup_status } </p>
 						<p className="jp-dash-item__description">{ __( 'Last Backup:' ) } { backupData.last_backup } </p>
@@ -49,7 +50,7 @@ const DashBackups = React.createClass( {
 			// All good
 			if ( vpData.code === 'success' && backupData.full_backup_status !== '100% complete' ) {
 				return(
-					<DashItem label={ labelName } status="is-working">
+					<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
 						<h3>{ __( 'Currently backing up your site.' ) }</h3>
 						<p className="jp-dash-item__description">{ __( 'Full Backup Status:' ) } { backupData.full_backup_status } </p>
 						<p className="jp-dash-item__description">{ __( 'Last Backup:' ) } { backupData.last_backup }</p>
@@ -59,7 +60,7 @@ const DashBackups = React.createClass( {
 		}
 
 		return(
-			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive">
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive" disabled={ isDevMode( this.props ) }>
 				<p className="jp-dash-item__description">
 					{
 						__( 'To automatically back up your site, please {{a}}upgrade your account{{/a}}', {

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -27,7 +27,7 @@ const DashMonitor = React.createClass( {
 
 			if ( lastDowntime === 'N/A' ) {
 				return(
-					<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
+					<DashItem label={ labelName } status="is-working">
 						<QueryLastDownTime />
 						<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 					</DashItem>
@@ -35,7 +35,7 @@ const DashMonitor = React.createClass( {
 			}
 
 			return(
-				<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
+				<DashItem label={ labelName } status="is-working">
 					<p className="jp-dash-item__description">{ __( 'Monitor is on and is watching your site.' ) }</p>
 					<p className="jp-dash-item__description">
 						{
@@ -51,9 +51,10 @@ const DashMonitor = React.createClass( {
 		}
 
 		return(
-			<DashItem label={ labelName } className="jp-dash-item__is-inactive" disabled={ isDevMode( this.props ) }>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive">
 				<p className="jp-dash-item__description">
 					{
+						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode.' ) :
 						__( '{{a}}Activate Monitor{{/a}} to receive notifications if your site goes down.', {
 							components: {
 								a:<a href="javascript:void(0)" onClick={ this.props.activateMonitor } />

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -16,6 +16,7 @@ import {
 	isFetchingModulesList as _isFetchingModulesList
 } from 'state/modules';
 import { getLastDownTime as _getLastDownTime } from 'state/at-a-glance';
+import { isDevMode } from 'state/connection';
 
 const DashMonitor = React.createClass( {
 	getContent: function() {
@@ -26,7 +27,7 @@ const DashMonitor = React.createClass( {
 
 			if ( lastDowntime === 'N/A' ) {
 				return(
-					<DashItem label={ labelName } status="is-working">
+					<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
 						<QueryLastDownTime />
 						<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 					</DashItem>
@@ -34,7 +35,7 @@ const DashMonitor = React.createClass( {
 			}
 
 			return(
-				<DashItem label={ labelName } status="is-working">
+				<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
 					<p className="jp-dash-item__description">{ __( 'Monitor is on and is watching your site.' ) }</p>
 					<p className="jp-dash-item__description">
 						{
@@ -50,7 +51,7 @@ const DashMonitor = React.createClass( {
 		}
 
 		return(
-			<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive" disabled={ isDevMode( this.props ) }>
 				<p className="jp-dash-item__description">
 					{
 						__( '{{a}}Activate Monitor{{/a}} to receive notifications if your site goes down.', {

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -21,16 +21,17 @@ const DashPhoton = React.createClass( {
 
 		if ( this.props.isModuleActivated( 'photon' ) ) {
 			return(
-				<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
+				<DashItem label={ labelName } status="is-working">
 					<p className="jp-dash-item__description">{ __( 'Photon is active and currently improving image performance.' ) }</p>
 				</DashItem>
 			);
 		}
 
 		return(
-			<DashItem label={ labelName } className="jp-dash-item__is-inactive" disabled={ isDevMode( this.props ) }>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive">
 				<p className="jp-dash-item__description">
 					{
+						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode' ) :
 						__( '{{a}}Activate Photon{{/a}} to enhance the performance of your images.', {
 							components: {
 								a: <a href="javascript:void(0)" onClick={ this.props.activatePhoton } />

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -13,6 +13,7 @@ import {
 	isModuleActivated as _isModuleActivated,
 	activateModule
 } from 'state/modules';
+import { isDevMode } from 'state/connection';
 
 const DashPhoton = React.createClass( {
 	getContent: function() {
@@ -20,14 +21,14 @@ const DashPhoton = React.createClass( {
 
 		if ( this.props.isModuleActivated( 'photon' ) ) {
 			return(
-				<DashItem label={ labelName } status="is-working">
+				<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
 					<p className="jp-dash-item__description">{ __( 'Photon is active and currently improving image performance.' ) }</p>
 				</DashItem>
 			);
 		}
 
 		return(
-			<DashItem label={ labelName } className="jp-dash-item__is-inactive">
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive" disabled={ isDevMode( this.props ) }>
 				<p className="jp-dash-item__description">
 					{
 						__( '{{a}}Activate Photon{{/a}} to enhance the performance of your images.', {

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -37,7 +37,7 @@ const DashPluginUpdates = React.createClass( {
 
 		if ( 'N/A' === pluginUpdates ) {
 			return(
-				<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
+				<DashItem label={ labelName } status="is-working">
 					<QueryPluginUpdates />
 					<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 				</DashItem>
@@ -46,7 +46,7 @@ const DashPluginUpdates = React.createClass( {
 
 		if ( 'updates-available' === pluginUpdates.code ) {
 			return(
-				<DashItem label={ labelName } status="is-warning" disabled={ isDevMode( this.props ) }>
+				<DashItem label={ labelName } status="is-warning">
 					<p className="jp-dash-item__description">
 						<strong>
 							{
@@ -60,6 +60,7 @@ const DashPluginUpdates = React.createClass( {
 						</strong>
 						<br/>
 						{
+							isDevMode( this.props ) ? '' :
 							manageActive ?
 								__( '{{a}}Turn on plugin auto updates{{/a}}', { components: { a: <a href={ ctaLink } /> } } ):
 								__( '{{a}}Activate Manage and turn on auto updates{{/a}}', { components: { a: <a onClick={ this.activateAndRedirect } href="#" /> } } )
@@ -70,7 +71,7 @@ const DashPluginUpdates = React.createClass( {
 		}
 
 		return(
-			<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
+			<DashItem label={ labelName } status="is-working">
 				<p className="jp-dash-item__description">
 					{ __( 'All plugins are up-to-date. Keep up the good work!' ) }
 				</p>

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -17,6 +17,7 @@ import {
 	isModuleActivated as _isModuleActivated,
 	activateModule
 } from 'state/modules';
+import { isDevMode } from 'state/connection';
 
 const DashPluginUpdates = React.createClass( {
 	activateAndRedirect: function( e ) {
@@ -36,7 +37,7 @@ const DashPluginUpdates = React.createClass( {
 
 		if ( 'N/A' === pluginUpdates ) {
 			return(
-				<DashItem label={ labelName } status="is-working">
+				<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
 					<QueryPluginUpdates />
 					<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 				</DashItem>
@@ -45,7 +46,7 @@ const DashPluginUpdates = React.createClass( {
 
 		if ( 'updates-available' === pluginUpdates.code ) {
 			return(
-				<DashItem label={ labelName } status="is-warning">
+				<DashItem label={ labelName } status="is-warning" disabled={ isDevMode( this.props ) }>
 					<p className="jp-dash-item__description">
 						<strong>
 							{
@@ -69,7 +70,7 @@ const DashPluginUpdates = React.createClass( {
 		}
 
 		return(
-			<DashItem label={ labelName } status="is-working">
+			<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
 				<p className="jp-dash-item__description">
 					{ __( 'All plugins are up-to-date. Keep up the good work!' ) }
 				</p>

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -27,26 +28,32 @@ const DashProtect = React.createClass( {
 
 			if ( false === protectCount || '0' === protectCount || 'N/A' === protectCount ) {
 				return(
-					<DashItem label="Protect" status="is-working" className="jp-dash-item__recently-activated" disabled={ isDevMode( this.props ) }>
+					<DashItem label="Protect" status="is-working" className="jp-dash-item__recently-activated">
 						<div className="jp-dash-item__recently-activated-lower">
 							<QueryProtectCount />
-							<p className="jp-dash-item__description">Sit back and relax. Protect is on and actively blocking malicious login attempts. Data will display here soon!</p>
+							<p className="jp-dash-item__description">{ __( 'Sit back and relax. Protect is on and actively blocking malicious login attempts. Data will display here soon!' ) }</p>
 						</div>
 					</DashItem>
 				);
 			}
 			return(
-				<DashItem label="Protect" status="is-working" disabled={ isDevMode( this.props ) }>
+				<DashItem label="Protect" status="is-working">
 					<h2 className="jp-dash-item__count">{ protectCount }</h2>
-					<p className="jp-dash-item__description">Total malicious attacks blocked on your site.</p>
+					<p className="jp-dash-item__description">{ __( 'Total malicious attacks blocked on your site.' ) }</p>
 				</DashItem>
 			);
 		}
 
 		return(
-			<DashItem label="Protect" className="jp-dash-item__is-inactive" disabled={ isDevMode( this.props ) }>
-				<p className="jp-dash-item__description"><a href="javascript:void(0)" onClick={ this.props.activateProtect }>Activate Protect</a> to keep your
-site protected from malicious attacks.</p>
+			<DashItem label="Protect" className="jp-dash-item__is-inactive">
+				<p className="jp-dash-item__description">{
+					isDevMode( this.props ) ? __( 'Unavailable in Dev Mode' ) :
+					__( '{{a}}Activate Protect{{/a}} to keep your site protected from malicious attacks.', {
+						components: {
+							a: <a href="javascript:void(0)" onClick={ this.props.activateProtect } />
+						}
+					} )
+				}</p>
 			</DashItem>
 		);
 	},

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -18,6 +18,7 @@ import {
 	fetchProtectCount,
 	getProtectCount as _getProtectCount
 } from 'state/at-a-glance';
+import { isDevMode } from 'state/connection';
 
 const DashProtect = React.createClass( {
 	getContent: function() {
@@ -26,7 +27,7 @@ const DashProtect = React.createClass( {
 
 			if ( false === protectCount || '0' === protectCount || 'N/A' === protectCount ) {
 				return(
-					<DashItem label="Protect" status="is-working" className="jp-dash-item__recently-activated">
+					<DashItem label="Protect" status="is-working" className="jp-dash-item__recently-activated" disabled={ isDevMode( this.props ) }>
 						<div className="jp-dash-item__recently-activated-lower">
 							<QueryProtectCount />
 							<p className="jp-dash-item__description">Sit back and relax. Protect is on and actively blocking malicious login attempts. Data will display here soon!</p>
@@ -35,7 +36,7 @@ const DashProtect = React.createClass( {
 				);
 			}
 			return(
-				<DashItem label="Protect" status="is-working">
+				<DashItem label="Protect" status="is-working" disabled={ isDevMode( this.props ) }>
 					<h2 className="jp-dash-item__count">{ protectCount }</h2>
 					<p className="jp-dash-item__description">Total malicious attacks blocked on your site.</p>
 				</DashItem>
@@ -43,7 +44,7 @@ const DashProtect = React.createClass( {
 		}
 
 		return(
-			<DashItem label="Protect" className="jp-dash-item__is-inactive">
+			<DashItem label="Protect" className="jp-dash-item__is-inactive" disabled={ isDevMode( this.props ) }>
 				<p className="jp-dash-item__description"><a href="javascript:void(0)" onClick={ this.props.activateProtect }>Activate Protect</a> to keep your
 site protected from malicious attacks.</p>
 			</DashItem>

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -34,7 +34,7 @@ const DashScan = React.createClass( {
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {
 				return(
-					<DashItem label={ labelName } disabled={ isDevMode( this.props ) }>
+					<DashItem label={ labelName }>
 						<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 					</DashItem>
 				);
@@ -44,7 +44,7 @@ const DashScan = React.createClass( {
 			const threats = this.props.getScanThreats();
 			if ( threats !== 0 ) {
 				return(
-					<DashItem label={ labelName } status="is-error" disabled={ isDevMode( this.props ) }>
+					<DashItem label={ labelName } status="is-error">
 						<h3>{
 							__(
 								'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.',
@@ -67,7 +67,7 @@ const DashScan = React.createClass( {
 			// All good
 			if ( vpData.code === 'success' ) {
 				return(
-					<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
+					<DashItem label={ labelName } status="is-working">
 						<h3>{ __( "No threats found, you're good to go!" ) }</h3>
 					</DashItem>
 				);
@@ -75,9 +75,10 @@ const DashScan = React.createClass( {
 		}
 
 		return(
-			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive" disabled={ isDevMode( this.props ) }>
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive">
 				<p className="jp-dash-item__description">
 					{
+						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode.' ) :
 						__( 'To automatically scan your site for malicious threats, please {{a}}upgrade your account{{/a}}', {
 							components: {
 								a: <a href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl } target="_blank" />

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -19,6 +19,7 @@ import {
 	getVaultPressScanThreatCount as _getVaultPressScanThreatCount,
 	getVaultPressData as _getVaultPressData
 } from 'state/at-a-glance';
+import { isDevMode } from 'state/connection';
 
 const DashScan = React.createClass( {
 	getContent: function() {
@@ -33,7 +34,7 @@ const DashScan = React.createClass( {
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {
 				return(
-					<DashItem label={ labelName }>
+					<DashItem label={ labelName } disabled={ isDevMode( this.props ) }>
 						<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 					</DashItem>
 				);
@@ -43,7 +44,7 @@ const DashScan = React.createClass( {
 			const threats = this.props.getScanThreats();
 			if ( threats !== 0 ) {
 				return(
-					<DashItem label={ labelName } status="is-error">
+					<DashItem label={ labelName } status="is-error" disabled={ isDevMode( this.props ) }>
 						<h3>{
 							__(
 								'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.',
@@ -66,7 +67,7 @@ const DashScan = React.createClass( {
 			// All good
 			if ( vpData.code === 'success' ) {
 				return(
-					<DashItem label={ labelName } status="is-working">
+					<DashItem label={ labelName } status="is-working" disabled={ isDevMode( this.props ) }>
 						<h3>{ __( "No threats found, you're good to go!" ) }</h3>
 					</DashItem>
 				);
@@ -74,7 +75,7 @@ const DashScan = React.createClass( {
 		}
 
 		return(
-			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive">
+			<DashItem label={ labelName } className="jp-dash-item__is-inactive" status="is-premium-inactive" disabled={ isDevMode( this.props ) }>
 				<p className="jp-dash-item__description">
 					{
 						__( 'To automatically scan your site for malicious threats, please {{a}}upgrade your account{{/a}}', {

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -132,6 +132,7 @@ const DashStats = React.createClass( {
 			return (
 				<div>
 					{
+						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode' ) :
 						__( '{{a}}Activate Site Statistics{{/a}} to see detailed stats, likes, followers, subscribers, and more!', {
 							components: {
 								a: <a href="javascript:void(0)" onClick={ this.props.activateStats } />

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -13,7 +13,7 @@ import { numberFormat, moment, translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getSiteConnectionStatus } from 'state/connection';
+import { getSiteConnectionStatus, isDevMode } from 'state/connection';
 import { demoStatsData, demoStatsBottom } from 'devmode';
 import {
 	statsSwitchTab,
@@ -186,7 +186,7 @@ const DashStats = React.createClass( {
 				>
 					{ this.maybeShowStatsTabs() }
 				</DashSectionHeader>
-				<Card className="jp-at-a-glance__stats-card">
+				<Card className={ 'jp-at-a-glance__stats-card ' + ( isDevMode( this.props ) ? 'is-inactive': '' ) }>
 					{ this.renderStatsArea() }
 				</Card>
 			</div>

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -16,12 +16,13 @@ export default React.createClass( {
 
 	propTypes: {
 		label: React.PropTypes.string,
-		status: React.PropTypes.string
+		status: React.PropTypes.string,
+		disabled: React.PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
-			label: '',
+			label: ''
 		};
 	},
 
@@ -60,7 +61,8 @@ export default React.createClass( {
 
 		const classes = classNames(
 			this.props.className,
-			'jp-dash-item'
+			'jp-dash-item',
+			this.props.disabled ? 'jp-dash-item__disabled' : ''
 		);
 
 		if ( this.props.status ) {

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -85,6 +85,22 @@
 	}
 }
 
+.jp-dash-item__disabled {
+	opacity: .5;
+	position: relative;
+
+	&::before {
+		content: "";
+		width: 100%;
+		height: 100%;
+		display: block;
+		position: absolute;
+		top: 0;
+		left: 0;
+		z-index: 1;
+	}
+}
+
 .jp-dash-item__recently-activated .dops-card:last-of-type {
 	padding: 0;
 }

--- a/_inc/client/components/foldable-card/style.scss
+++ b/_inc/client/components/foldable-card/style.scss
@@ -13,4 +13,11 @@
 			display: none;
 		}
 	}
+
+	&.devmode-disabled {
+		.dops-foldable-card__summary,
+		.dops-foldable-card__summary_expanded {
+			width: 100px;
+		}
+	}
 }

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -119,10 +119,11 @@ export const DevModeNotice = React.createClass( {
 				devModeType += __('your site URL lacking a dot (e.g. http://localhost).');
 			}
 
-			const text = __('Currently in {{a}}Development Mode{{/a}} VIA ' + devModeType,
+			const text = __('Currently in {{a}}Development Mode{{/a}} VIA ' + devModeType + '{{br/}}Some features are disabled.',
 				{
 					components: {
-						a: <a href="https://jetpack.com/support/development-mode/" target="_blank"/>
+						a: <a href="https://jetpack.com/support/development-mode/" target="_blank"/>,
+						br: <br />
 					}
 				}
 			);

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -22,7 +22,8 @@ import { EngagementModulesSettings } from 'components/module-options/moduleoptio
 import { isUnavailableInDevMode } from 'state/connection';
 
 export const Page = ( props ) => {
-	let { toggleModule,
+	let {
+		toggleModule,
 		isModuleActivated,
 		isTogglingModule,
 		getModule

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -43,33 +43,35 @@ export const Page = ( props ) => {
 		[ 'comments', getModule( 'comments' ).name, getModule( 'comments' ).description, getModule( 'comments' ).learn_more_button ],
 		[ 'notes', getModule( 'notes' ).name, getModule( 'notes' ).description, getModule( 'notes' ).learn_more_button ],
 		[ 'sitemaps', getModule( 'sitemaps' ).name, getModule( 'sitemaps' ).description, getModule( 'sitemaps' ).learn_more_button ]
-	].map( ( element ) => (
-		<FoldableCard key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
-			header={ element[1] }
-			subheader={ element[2] }
-			summary={
-				<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-					toggling={ isTogglingModule( element[0] ) }
-					toggleModule={ toggleModule } />
-			}
-			expandedSummary={
-				<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-					toggling={ isTogglingModule( element[0] ) }
-					toggleModule={ toggleModule } />
-			}
-			clickableHeaderText={ true }
-			disabled={ isUnavailableInDevMode( props, element[0] ) }
-		>
-			{ isModuleActivated( element[0] ) ?
-				<EngagementModulesSettings module={ getModule( element[0] ) } /> :
-				// Render the long_description if module is deactivated
-				<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
-			}
-			<p>
-				<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
-			</p>
-		</FoldableCard>
-	) );
+	].map( ( element ) => {
+		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+			toggle = (
+				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
+					<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
+								  toggling={ isTogglingModule( element[0] ) }
+								  toggleModule={ toggleModule } />
+			),
+			customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
+
+		return (
+			<FoldableCard className={ customClasses } key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
+				header={ element[1] }
+				subheader={ element[2] }
+				summary={ toggle }
+				expandedSummary={ toggle }
+				clickableHeaderText={ true }
+			>
+				{ isModuleActivated( element[0] ) ?
+					<EngagementModulesSettings module={ getModule( element[0] ) } /> :
+					// Render the long_description if module is deactivated
+					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
+				}
+				<p>
+					<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
+				</p>
+			</FoldableCard>
+		);
+	});
 	return (
 		<div>
 			{ cards }

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -19,6 +19,7 @@ import {
 } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import { EngagementModulesSettings } from 'components/module-options/moduleoptions';
+import { isUnavailableInDevMode } from 'state/connection';
 
 export const Page = ( props ) => {
 	let { toggleModule,
@@ -57,6 +58,7 @@ export const Page = ( props ) => {
 					toggleModule={ toggleModule } />
 			}
 			clickableHeaderText={ true }
+			disabled={ isUnavailableInDevMode( props, element[0] ) }
 		>
 			{ isModuleActivated( element[0] ) ?
 				<EngagementModulesSettings module={ getModule( element[0] ) } /> :

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -13,6 +13,7 @@ import Settings from 'components/settings';
 import ConnectionSettings from './connection-settings';
 import SitePlan from './site-plan';
 import { disconnectSite } from 'state/connection';
+import { isDevMode } from 'state/connection';
 
 const GeneralSettings = React.createClass( {
 	render() {
@@ -22,6 +23,7 @@ const GeneralSettings = React.createClass( {
 					header="Jetpack Add-ons"
 					subheader="Manage your Jetpack account and premium add-ons."
 					clickableHeaderText={ true }
+					disabled={ isDevMode( this.props ) }
 				>
 					<SitePlan />
 				</FoldableCard>
@@ -29,6 +31,7 @@ const GeneralSettings = React.createClass( {
 					header="Jetpack Connection Settings"
 					subheader="Manage your connected user accounts or disconnect."
 					clickableHeaderText={ true }
+					disabled={ isDevMode( this.props ) }
 				>
 					<ConnectionSettings { ...this.props } />
 				</FoldableCard>

--- a/_inc/client/more/index.jsx
+++ b/_inc/client/more/index.jsx
@@ -22,7 +22,8 @@ import { MoreModulesSettings } from 'components/module-options/moduleoptions';
 import { isUnavailableInDevMode } from 'state/connection';
 
 export const Page = ( props ) => {
-	let { toggleModule,
+	let {
+		toggleModule,
 		isModuleActivated,
 		isTogglingModule,
 		getModule

--- a/_inc/client/more/index.jsx
+++ b/_inc/client/more/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -55,24 +56,26 @@ export const Page = ( props ) => {
 		[ 'json-api', getModule( 'json-api' ).name, getModule( 'json-api' ).description, getModule( 'json-api' ).learn_more_button ],
 		[ 'omnisearch', getModule( 'omnisearch' ).name, getModule( 'omnisearch' ).description, getModule( 'omnisearch' ).learn_more_button ]
 	].map( ( element, i ) => {
-		var toggle = (
-			<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-				toggling={ isTogglingModule( element[0] ) }
-				toggleModule={ toggleModule } />
-		);
+		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+			toggle = (
+				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
+					<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
+								  toggling={ isTogglingModule( element[0] ) }
+								  toggleModule={ toggleModule } />
+			),
+			customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
 
 		if ( 1 === element.length ) {
 			return ( <h1 key={ `section-header-${ i }` /* https://fb.me/react-warning-keys */ } >{ element[0] }</h1> );
 		}
 
 		return (
-			<FoldableCard key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
+			<FoldableCard className={ customClasses } key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
 				header={ element[1] }
 				subheader={ element[2] }
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
-				disabled={ isUnavailableInDevMode( props, element[0] ) }
 			>
 				{ isModuleActivated( element[0] ) || 'scan' === element[0] ?
 					<MoreModulesSettings module={ getModule( element[0] ) } /> :

--- a/_inc/client/more/index.jsx
+++ b/_inc/client/more/index.jsx
@@ -18,8 +18,14 @@ import {
 } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import { MoreModulesSettings } from 'components/module-options/moduleoptions';
+import { isUnavailableInDevMode } from 'state/connection';
 
-export const Page = ( { toggleModule, isModuleActivated, isTogglingModule, getModule } ) => {
+export const Page = ( props ) => {
+	let { toggleModule,
+		isModuleActivated,
+		isTogglingModule,
+		getModule
+		} = props;
 	var cards = [
 		[ 'Appearance & Customization Tools' ],
 		[ 'custom-css', getModule( 'custom-css' ).name, getModule( 'custom-css' ).description, getModule( 'custom-css' ).learn_more_button ],
@@ -66,6 +72,7 @@ export const Page = ( { toggleModule, isModuleActivated, isTogglingModule, getMo
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
+				disabled={ isUnavailableInDevMode( props, element[0] ) }
 			>
 				{ isModuleActivated( element[0] ) || 'scan' === element[0] ?
 					<MoreModulesSettings module={ getModule( element[0] ) } /> :

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -27,6 +27,7 @@
 @import '../components/dash-item/style';
 @import '../components/dash-section-header/style';
 @import '../components/expanded-card/style';
+@import '../components/foldable-card/style';
 @import '../components/footer/style';
 @import '../components/jetpack-connect/style';
 @import '../components/jumpstart/style';

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -41,15 +41,18 @@ export const Page = ( props ) => {
 		[ 'scan', __( 'Security Scanning' ), __( 'Automatically scan your site for common threats and attacks.' ) ],
 		[ 'sso', getModule( 'sso' ).name, getModule( 'sso' ).description, getModule( 'sso' ).learn_more_button ]
 	].map( ( element ) => {
-		var toggle = (
-			<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-				toggling={ isTogglingModule( element[0] ) }
-				toggleModule={ toggleModule } />
+		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+			toggle = (
+				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
+				<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
+					toggling={ isTogglingModule( element[0] ) }
+					toggleModule={ toggleModule } />
 			),
+			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			isScan = 'scan' === element[0],
 			scanProps = {};
 
-		if ( 'scan' === element[0] ) {
+		if ( isScan ) {
 			toggle = '';
 			scanProps = {
 				module: 'scan',
@@ -60,13 +63,12 @@ export const Page = ( props ) => {
 		}
 
 		return (
-			<FoldableCard key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
+			<FoldableCard className={ customClasses } key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
 				header={ element[1] }
 				subheader={ element[2] }
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
-				disabled={ isUnavailableInDevMode( props, element[0] ) }
 			>
 				{ isModuleActivated( element[0] ) || isScan ?
 					<SecurityModulesSettings module={ isScan ? scanProps : getModule( element[ 0 ] ) } /> :

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -26,6 +26,7 @@ import {
 	isPluginInstalled
 } from 'state/site/plugins';
 import QuerySitePlugins from 'components/data/query-site-plugins';
+import { isUnavailableInDevMode } from 'state/connection';
 
 export const Page = ( props ) => {
 	let {
@@ -65,6 +66,7 @@ export const Page = ( props ) => {
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
+				disabled={ isUnavailableInDevMode( props, element[0] ) }
 			>
 				{ isModuleActivated( element[0] ) || isScan ?
 					<SecurityModulesSettings module={ isScan ? scanProps : getModule( element[ 0 ] ) } /> :

--- a/_inc/client/site-health/index.jsx
+++ b/_inc/client/site-health/index.jsx
@@ -39,24 +39,26 @@ export const Page = ( props ) => {
 		[ 'backups', __( 'Site Backups' ), __( 'Keep your site backed up!' ) ],
 		[ 'akismet', 'Akismet', __( 'Keep those spammers away!' ) ]
 	].map( ( element ) => {
-		var toggle = (
-			<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-				toggling={ isTogglingModule( element[0] ) }
-				toggleModule={ toggleModule } />
-		);
+		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+			toggle = (
+				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
+					<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
+								  toggling={ isTogglingModule( element[0] ) }
+								  toggleModule={ toggleModule } />
+			),
+			customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
 
 		if ( 'backups' === element[0] || 'akismet' === element[0] ) {
 			toggle = '';
 		}
 
 		return (
-			<FoldableCard key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
+			<FoldableCard className={ customClasses } key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
 				header={ element[1] }
 				subheader={ element[2] }
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
-				disabled={ isUnavailableInDevMode( props, element[0] ) }
 			>
 				{ isModuleActivated( element[0] ) || 'akismet' === element[0] || 'backups' === element[0] ? renderSettings( element[0], props ) :
 					// Render the long_description if module is deactivated

--- a/_inc/client/site-health/index.jsx
+++ b/_inc/client/site-health/index.jsx
@@ -25,6 +25,7 @@ import {
 	isPluginInstalled
 } from 'state/site/plugins';
 import QuerySitePlugins from 'components/data/query-site-plugins';
+import { isUnavailableInDevMode } from 'state/connection';
 
 export const Page = ( props ) => {
 	let {
@@ -55,6 +56,7 @@ export const Page = ( props ) => {
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
+				disabled={ isUnavailableInDevMode( props, element[0] ) }
 			>
 				{ isModuleActivated( element[0] ) || 'akismet' === element[0] || 'backups' === element[0] ? renderSettings( element[0], props ) :
 					// Render the long_description if module is deactivated

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -22,6 +22,7 @@ import {
 	UNLINK_USER_FAIL,
 	UNLINK_USER_SUCCESS
 } from 'state/action-types';
+import { getModulesThatRequireConnection } from 'state/modules';
 
 export const status = ( state = { siteConnected: window.Initial_State.connectionStatus }, action ) => {
 	switch ( action.type ) {
@@ -179,4 +180,39 @@ export function isFetchingUserData( state ) {
  */
 export function isCurrentUserLinked( state ) {
 	return !! state.jetpack.connection.user.currentUser.isConnected;
+}
+
+/**
+ * Checks if the site is currently in development mode.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {boolean} True if site is in dev mode. False otherwise.
+ */
+export function isDevMode( state ) {
+	return 'dev' === getSiteConnectionStatus( state );
+}
+
+/**
+ * Checks if the module requires connection.
+ *
+ * @param  {Object}  state Global state tree
+ * @param  {String}  slug Module slug.
+ * @return {boolean} True if module requires connection.
+ */
+export function requiresConnection( state, slug ) {
+	return getModulesThatRequireConnection( state ).concat( [
+		'backups',
+		'scan'
+	] ).includes( slug );
+}
+
+/**
+ * Checks if the current module is unavailable in development mode.
+ *
+ * @param  {Object}  state Global state tree
+ * @param  {String}  module Module slug.
+ * @return {boolean} True if site is in dev mode and module requires connection. False otherwise.
+ */
+export function isUnavailableInDevMode( state, module ) {
+	return isDevMode( state ) && requiresConnection( state, module );
 }

--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -214,6 +214,21 @@ export function getModulesByFeature( state, feature ) {
 }
 
 /**
+ * Returns an array of modules that require connection.
+ *
+ * The module's header comments indicates if it requires connection or not.
+ *
+ * @param  {Object} state   Global state tree
+ * @return {Array}          Array of modules that require connection.
+ */
+export function getModulesThatRequireConnection( state ) {
+	return Object.keys( state.jetpack.modules.items ).filter( ( module_slug ) =>
+		state.jetpack.modules.items[ module_slug ].requires_connection
+	);
+}
+
+
+/**
  * Returns true if the module is activated
  * @param  {Object}  state Global state tree
  * @param  {String}  name  A module's name


### PR DESCRIPTION
Fixes #4006.

#### Changes proposed in this Pull Request:
- if a module isn't available in dev mode, its toggle is hidden and the legend _Unavailable in Dev Mode_ is displayed. They receive the CSS class `devmode-disabled`.
<img width="732" alt="module" src="https://cloud.githubusercontent.com/assets/1041600/15719244/7280b6aa-2805-11e6-827e-bda92033675c.png">

- if an element in At A Glance requires connection to work and site is in dev mode, it will display the legend _Unavailable in Dev Mode_
<img width="753" alt="dashboard" src="https://cloud.githubusercontent.com/assets/1041600/15719245/728d1ea4-2805-11e6-82ba-edd4b09e3d37.png">

- Makes some strings [available for translation](https://github.com/Automattic/jetpack/pull/4026/files#diff-7d41d2825e41836777e5ff2b874d9099R34) that were missing in `protect.jsx`

#### New functions
- `isDevMode`: receives the global state tree, returns a boolean value stating whether the site is in dev mode or not
- `requiresConnection`: receives a slug-like string, for example, a module slug, and checks if it's in a list of elements that require connection.
- `isUnavailableInDevMode`: receives the global state tree and a slug-like string, and checks if the site is in dev mode and if the element requires connection to be available.
- `getModulesThatRequireConnection`: receives the global state tree and returns all modules that require a connection.

#### Component Update
- DashItem now accepts a `disabled` property that makes it unclickable and faded.