### PR TITLE
Add tracking for connected users.

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -7,6 +7,15 @@ import { Provider } from 'react-redux';
 import { Route, Router, useRouterHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import { createHashHistory } from 'history'
+import analytics from 'lib/analytics';
+
+const tracksUser = window.Initial_State.tracksUserData;
+if ( tracksUser ) {
+	analytics.initialize(
+		tracksUser.userid,
+		tracksUser.username
+	);
+}
 
 /**
  * Internal dependencies

--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -7,6 +7,7 @@ import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -69,12 +70,21 @@ export const Page = ( props ) => {
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
 
 		return (
-			<FoldableCard className={ customClasses } key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
+			<FoldableCard
+				className={ customClasses }
+				key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
 				header={ element[1] }
 				subheader={ element[2] }
 				summary={ toggle }
 				expandedSummary={ toggle }
-				clickableHeaderText={ true } >
+				clickableHeaderText={ true }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: element[0],
+						path: props.route.path
+					}
+				) }
+			>
 				{
 					isModuleActivated( element[0] ) ?
 						<AllModuleSettings module={ getModule( element[0] ) } /> :

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import Card from 'components/card';
 import DashSectionHeader from 'components/dash-section-header';
 import { translate as __ } from 'i18n-calypso';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -32,6 +33,7 @@ const AtAGlance = React.createClass( {
 					settingsPath="#security"
 					externalLink={ __( 'Manage security on WordPress.com' ) }
 					externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl }
+					externalLinkClick={ () => analytics.tracks.recordEvent( 'jetpack_aag_security_wpcom_click', {} ) }
 				/>,
 			performanceHeader =
 				<DashSectionHeader

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -33,7 +33,7 @@ const AtAGlance = React.createClass( {
 					settingsPath="#security"
 					externalLink={ __( 'Manage security on WordPress.com' ) }
 					externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl }
-					externalLinkClick={ () => analytics.tracks.recordEvent( 'jetpack_aag_security_wpcom_click', {} ) }
+					externalLinkClick={ () => analytics.tracks.recordEvent( 'jetpack_wpa_aag_security_wpcom_click', {} ) }
 				/>,
 			performanceHeader =
 				<DashSectionHeader

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -33,7 +33,7 @@ import {
 const DashStats = React.createClass( {
 	barClick: function( bar ) {
 		if ( bar.data.link ) {
-			analytics.tracks.recordEvent( 'jetpack_aag_stats_bar_click', {} );
+			analytics.tracks.recordEvent( 'jetpack_wpa_aag_stats_bar_click', {} );
 			window.open(
 				bar.data.link,
 				'_blank'
@@ -191,7 +191,7 @@ const DashStats = React.createClass( {
 	},
 
 	handleSwitchStatsView: function( view ) {
-		analytics.tracks.recordEvent( 'jetpack_aag_stats_switch_view', { view: view } );
+		analytics.tracks.recordEvent( 'jetpack_wpa_aag_stats_switch_view', { view: view } );
 		this.props.switchView( view );
 		this.props.fetchStatsData( view );
 	},
@@ -313,7 +313,7 @@ const DashStatsBottom = React.createClass( {
 						components: {
 							button:
 								<Button
-									onClick={ () => analytics.tracks.recordEvent( 'jetpack_aag_stats_wpcom_click', {} ) }
+									onClick={ () => analytics.tracks.recordEvent( 'jetpack_wpa_aag_stats_wpcom_click', {} ) }
 									className="is-primary"
 									href={ 'https://wordpress.com/stats/insights/' + window.Initial_State.rawUrl }
 								/>

--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -10,6 +10,7 @@ import DashSectionHeader from 'components/dash-section-header';
 import Button from 'components/button';
 import Spinner from 'components/spinner';
 import { numberFormat, moment, translate as __ } from 'i18n-calypso';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -32,6 +33,7 @@ import {
 const DashStats = React.createClass( {
 	barClick: function( bar ) {
 		if ( bar.data.link ) {
+			analytics.tracks.recordEvent( 'jetpack_aag_stats_bar_click', {} );
 			window.open(
 				bar.data.link,
 				'_blank'
@@ -189,6 +191,7 @@ const DashStats = React.createClass( {
 	},
 
 	handleSwitchStatsView: function( view ) {
+		analytics.tracks.recordEvent( 'jetpack_aag_stats_switch_view', { view: view } );
 		this.props.switchView( view );
 		this.props.fetchStatsData( view );
 	},
@@ -307,7 +310,14 @@ const DashStatsBottom = React.createClass( {
 				</div>
 				<div className="jp-at-a-glance__stats-cta-buttons">
 					{ __( '{{button}}View More Stats{{/button}}', {
-						components: { button: <Button className="is-primary" href={ 'https://wordpress.com/stats/insights/' + window.Initial_State.rawUrl } /> }
+						components: {
+							button:
+								<Button
+									onClick={ () => analytics.tracks.recordEvent( 'jetpack_aag_stats_wpcom_click', {} ) }
+									className="is-primary"
+									href={ 'https://wordpress.com/stats/insights/' + window.Initial_State.rawUrl }
+								/>
+						}
 					} ) }
 				</div>
 			</div>

--- a/_inc/client/components/dash-section-header/index.jsx
+++ b/_inc/client/components/dash-section-header/index.jsx
@@ -13,7 +13,8 @@ export default React.createClass( {
 		label: React.PropTypes.string.isRequired,
 		settingsPath: React.PropTypes.string,
 		externalLinkPath: React.PropTypes.string,
-		externalLink: React.PropTypes.string
+		externalLink: React.PropTypes.string,
+		externalLinkClick: React.PropTypes.func
 	},
 
 	getDefaultProps() {
@@ -50,7 +51,9 @@ export default React.createClass( {
 			externalLink = (
 				<a
 					className="jp-dash-section-header__external-link"
-					href={ this.props.externalLinkPath }>
+					href={ this.props.externalLinkPath }
+					onClick={ this.props.externalLinkClick }
+				>
 						{ this.props.externalLink }
 				</a>
 			);

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -9,6 +9,7 @@ import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Spinner from 'components/spinner';
 import { translate as __ } from 'i18n-calypso';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ const JumpStart = React.createClass( {
 	displayName: 'JumpStart',
 
 	render: function() {
+		const trackLearnMore = () => analytics.tracks.recordEvent( 'jetpack_jumpstart_learn_more', {} );
 		let jumpstartModules = this.props.jumpstartFeatures( this.props ).map( ( module ) => (
 			<div
 				className="jp-jumpstart__feature-list-column"
@@ -60,6 +62,7 @@ const JumpStart = React.createClass( {
 						className="jp-jumpstart__features"
 						clickableHeaderText={ true }
 						subheader="Learn more"
+						onOpen={ trackLearnMore }
 					>
 						<p className="jp-jumpstart__description">
 							{ __( "Jetpack's recommended features include:" ) }

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -28,7 +28,7 @@ const NavigationSettings = React.createClass( {
 
 	onSearch( term ) {
 		if ( term.length >= 3 ) {
-			analytics.tracks.recordEvent( 'jetpack_admin_search_term', { term: term.toLowerCase() } );
+			analytics.tracks.recordEvent( 'jetpack_wpa_search_term', { term: term.toLowerCase() } );
 		}
 		this.props.searchForTerm( trim( term || '' ).toLowerCase() );
 	},

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -9,6 +9,7 @@ import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 import { translate as __ } from 'i18n-calypso';
 import trim from 'lodash/trim';
+import analytics from 'lib/analytics';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
 
@@ -26,6 +27,9 @@ const NavigationSettings = React.createClass( {
 	},
 
 	onSearch( term ) {
+		if ( term.length >= 3 ) {
+			analytics.tracks.recordEvent( 'jetpack_admin_search_term', { term: term.toLowerCase() } );
+		}
 		this.props.searchForTerm( trim( term || '' ).toLowerCase() );
 	},
 
@@ -45,6 +49,7 @@ const NavigationSettings = React.createClass( {
 					pinned={ true }
 					placeholder={ __( 'Search for a Jetpack feature.' ) }
 					delaySearch={ true }
+					delayTimeout={ 500 }
 					onSearchOpen={ this.openSearch }
 					onSearch={ this.onSearch }
 					onSearchClose={ this.onClose }

--- a/_inc/client/config.js
+++ b/_inc/client/config.js
@@ -1,0 +1,13 @@
+var data = {
+	"i18n_default_locale_slug": "en",
+	"mc_analytics_enabled": true,
+	"google_analytics_enabled": false,
+	"google_analytics_key": null
+};
+function config( key ) {
+	if ( key in data ) {
+		return data[ key ];
+	}
+	throw new Error( 'config key `' + key + '` does not exist' );
+}
+module.exports = config;

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -8,6 +8,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
 import includes from 'lodash/includes';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -107,7 +108,14 @@ export const Page = ( props ) => {
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
-				disabled={ ! adminAndNonAdmin } >
+				disabled={ ! adminAndNonAdmin }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: element[0],
+						path: props.route.path
+					}
+				) }
+			>
 				{
 					isModuleActive ?
 						<AllModuleSettings module={ getModule( element[0] ) } /> :

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -8,6 +8,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Settings from 'components/settings';
 import { translate as __ } from 'i18n-calypso';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -58,6 +59,12 @@ export const Page = ( props ) => {
 				disabled={ ! isAdmin }
 				summary={ isAdmin ? toggle( module_slug ) : '' }
 				expandedSummary={ isAdmin ? toggle( module_slug ) : '' }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: module_slug,
+						path: props.route.path
+					}
+				) }
 			>
 				<div dangerouslySetInnerHTML={ renderLongDescription( getModule( module_slug ) ) } />
 				<div className="jp-module-settings__read-more">
@@ -75,6 +82,12 @@ export const Page = ( props ) => {
 					subheader={ __( 'Manage your connection or disconnect Jetpack.' ) }
 					clickableHeaderText={ true }
 					disabled={ ! isAdmin }
+					onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+						{
+							card: 'connection_settings',
+							path: props.route.path
+						}
+					) }
 				>
 					<ConnectionSettings { ...props } />
 				</FoldableCard> : ''
@@ -87,6 +100,12 @@ export const Page = ( props ) => {
 				subheader={ __( 'Show falling snow in the holiday period.' ) }
 				clickableHeaderText={ true }
 				disabled={ ! isAdmin }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: 'misc_settings',
+						path: props.route.path
+					}
+				) }
 			>
 				<Settings />
 			</FoldableCard>

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -50,7 +50,7 @@ const Main = React.createClass( {
 		const canManageModules = window.Initial_State.userData.currentUser.permissions.manage_modules;
 
 		// Track page views
-		analytics.tracks.recordEvent( 'jetpack_page_view', { path: route } );
+		analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: route } );
 
 		// On any route change/re-render, jump back to the top of the page
 		window.scrollTo( 0, 0 );

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -32,6 +32,7 @@ import SupportCard from 'components/support-card';
 import NonAdminView from 'components/non-admin-view';
 import JetpackNotices from 'components/jetpack-notices';
 import SearchPage from 'search/index.jsx';
+import analytics from 'lib/analytics';
 
 const Main = React.createClass( {
 	componentWillMount: function() {
@@ -47,6 +48,9 @@ const Main = React.createClass( {
 	renderMainContent: function( route ) {
 		const showJumpStart = getJumpStartStatus( this.props );
 		const canManageModules = window.Initial_State.userData.currentUser.permissions.manage_modules;
+
+		// Track page views
+		analytics.tracks.recordEvent( 'jetpack_page_view', { path: route } );
 
 		// On any route change/re-render, jump back to the top of the page
 		window.scrollTo( 0, 0 );

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -10,6 +10,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Collection from 'components/search/search-collection.jsx';
 import { translate as __ } from 'i18n-calypso';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -128,6 +129,12 @@ export const Page = ( {
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: element[0],
+						path: '/search'
+					}
+				) }
 			>
 				{
 					isModuleActivated( element[0] ) ?

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -8,6 +8,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
 import SimpleNotice from 'components/notice';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -75,7 +76,14 @@ export const Page = ( props ) => {
 				subheader={ element[2] }
 				summary={ toggle }
 				expandedSummary={ toggle }
-				clickableHeaderText={ true } >
+				clickableHeaderText={ true }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: element[0],
+						path: props.route.path
+					}
+				) }
+			>
 				{
 					isModuleActivated( element[0] ) || isPro ?
 						<AllModuleSettings module={ isPro ? proProps : getModule( element[ 0 ] ) } /> :

--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -4,6 +4,7 @@
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import { translate as __ } from 'i18n-calypso';
 import { createHistory } from 'history';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -58,6 +59,7 @@ export const jumpStartSkip = () => {
 		dispatch( {
 			type: JUMPSTART_SKIP
 		} );
+		analytics.tracks.recordEvent( 'jetpack_jumpstart_skip', {} );
 		history.push( '/wp-admin/admin.php?page=jetpack#/dashboard' );
 		return restApi.jumpStart( 'deactivate' ).then( () => {
 			dispatch( {

--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -31,6 +31,7 @@ export const jumpStartActivate = () => {
 				type: JUMPSTART_ACTIVATE_SUCCESS,
 				jumpStart: true
 			} );
+			analytics.tracks.recordEvent( 'jetpack_jumpstart_submit', {} );
 			dispatch( removeNotice( 'jumpstart-activate' ) );
 			dispatch( createNotice( 'is-success', __( 'Recommended features active.' ), { id: 'jumpstart-activate' } ) );
 		} )['catch']( error => {

--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -31,7 +31,7 @@ export const jumpStartActivate = () => {
 				type: JUMPSTART_ACTIVATE_SUCCESS,
 				jumpStart: true
 			} );
-			analytics.tracks.recordEvent( 'jetpack_jumpstart_submit', {} );
+			analytics.tracks.recordEvent( 'jetpack_wpa_jumpstart_submit', {} );
 			dispatch( removeNotice( 'jumpstart-activate' ) );
 			dispatch( createNotice( 'is-success', __( 'Recommended features active.' ), { id: 'jumpstart-activate' } ) );
 		} )['catch']( error => {
@@ -60,7 +60,7 @@ export const jumpStartSkip = () => {
 		dispatch( {
 			type: JUMPSTART_SKIP
 		} );
-		analytics.tracks.recordEvent( 'jetpack_jumpstart_skip', {} );
+		analytics.tracks.recordEvent( 'jetpack_wpa_jumpstart_skip', {} );
 		history.push( '/wp-admin/admin.php?page=jetpack#/dashboard' );
 		return restApi.jumpStart( 'deactivate' ).then( () => {
 			dispatch( {

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -8,6 +8,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
 import includes from 'lodash/includes';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -87,7 +88,14 @@ export const Page = ( props ) => {
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
-				disabled={ ! adminAndNonAdmin } >
+				disabled={ ! adminAndNonAdmin }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: element[0],
+						path: props.route.path
+					}
+				) }
+			>
 				{ isModuleActivated( element[0] ) || 'scan' === element[0] ?
 					<AllModuleSettings module={ getModule( element[0] ) } /> :
 					// Render the long_description if module is deactivated

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -164,6 +164,17 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		return $dismissed_notices;
 	}
 
+	function jetpack_get_tracks_user_data() {
+		if ( ! $user_data = Jetpack::get_connected_user_data() ) {
+			return false;
+		}
+
+		return array(
+			'userid' => $user_data['ID'],
+			'username' => $user_data['login'],
+		);
+	}
+
 	function page_admin_scripts() {
 		if ( $this->is_redirecting ) {
 			return; // No need for scripts on a fallback page
@@ -175,6 +186,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		wp_enqueue_script( 'react-plugin', plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
 		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/admin.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+
+		// Required for Analytics
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js?48' );
 
 		$localeSlug = explode( '_', get_locale() );
 		$localeSlug = $localeSlug[0];
@@ -237,6 +251,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'errorCode' => Jetpack::state( 'error' ),
 				'errorDescription' => Jetpack::state( 'error_description' ),
 			),
+			'tracksUserData' => $this->jetpack_get_tracks_user_data(),
 		) );
 	}
 }

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -137,7 +137,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			$static_html
 		);
 
-		JetpackTracking::record_user_event( 'page_view', array( 'path' => 'old_settings' ) );
+		JetpackTracking::record_user_event( 'page_view', array( 'path' => 'wpa_old_settings' ) );
 	}
 
 	// Javascript logic specific to the list table

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -136,6 +136,8 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			$page_content,
 			$static_html
 		);
+
+		JetpackTracking::record_user_event( 'page_view', array( 'path' => 'old_settings' ) );
 	}
 
 	// Javascript logic specific to the list table

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -45,17 +45,17 @@ class JetpackTracking {
 		$wpcom_user_data = Jetpack::get_connected_user_data( $user_id );
 		update_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'] );
 
-		self::record_user_event( 'user_linked', array() );
+		self::record_user_event( 'wpa_user_linked', array() );
 	}
 
 	/* Activated module */
 	static function track_activate_module( $module ) {
-		self::record_user_event( 'module_activated', array( 'module' => $module ) );
+		self::record_user_event( 'wpa_module_activated', array( 'module' => $module ) );
 	}
 
 	/* Deactivated module */
 	static function track_deactivate_module( $module ) {
-		self::record_user_event( 'module_deactivated', array( 'module' => $module ) );
+		self::record_user_event( 'wpa_module_deactivated', array( 'module' => $module ) );
 	}
 
 	static function record_user_event( $event_type, $data= array() ) {

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -357,6 +357,8 @@ function stats_reports_page( $main_chart_only = false ) {
 	$blog_id = stats_get_option( 'blog_id' );
 	$domain = Jetpack::build_raw_urls( get_home_url() );
 
+	JetpackTracking::record_user_event( 'page_view', array( 'path' => 'old_stats' ) );
+
 	if ( ! $main_chart_only && !isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) {
 		$nojs_url = add_query_arg( 'nojs', '1' );
 		$http = is_ssl() ? 'https' : 'http';

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -357,7 +357,7 @@ function stats_reports_page( $main_chart_only = false ) {
 	$blog_id = stats_get_option( 'blog_id' );
 	$domain = Jetpack::build_raw_urls( get_home_url() );
 
-	JetpackTracking::record_user_event( 'page_view', array( 'path' => 'old_stats' ) );
+	JetpackTracking::record_user_event( 'page_view', array( 'path' => 'wpa_old_stats' ) );
 
 	if ( ! $main_chart_only && !isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) {
 		$nojs_url = add_query_arg( 'nojs', '1' );


### PR DESCRIPTION
Re-do of #3888 

Pass tracks data (wpcom user ID / username) via window.Initial_State.tracksUserData. It will be false if the user is not connected, therefore we are not currently tracking any unconnected user.

Initialize on load, and trigger in the action.

**To Test:**
- Make sure Jetpack is connected
- Watch the events being tracked in the console by adding `console.log( eventName, eventProperties );` to [this line in dops-components](https://github.com/Automattic/dops-components/blob/master/client/lib/analytics/index.js#L120) **Note: you must link dops-components to see it.**
- Make sure events only fire once 
- List of events to watch for are listed [here](https://docs.google.com/spreadsheets/d/1R4BGbIS4kzfTkL8eg1xtT9abgxgjv0Oi4IjvFb1QqLc/edit#gid=0)
- Check in MC that the events came over as expected.  You can do a wildcard search for `jetpack_wpa_%` with your wpcom username to see your events.  **Events sometimes take up to 20 minutes to record**