### PR TITLE
Remove bulky data from update sync

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -144,9 +144,13 @@ class Jetpack_Sync_Client {
 		add_action( 'deleted_user_meta', array( $this, 'save_user_cap_handler' ), 10, 4 );
 
 		// themes
-		add_action( 'set_site_transient_update_plugins', $handler, 10, 1 );
-		add_action( 'set_site_transient_update_themes', $handler, 10, 1 );
-		add_action( 'set_site_transient_update_core', $handler, 10, 1 );
+		add_action( 'set_site_transient_update_plugins', array( $this, 'extract_update_response' ), 10, 3 );
+		add_action( 'set_site_transient_update_themes', array( $this, 'extract_update_response' ), 10, 3 );
+		add_action( 'set_site_transient_update_core', array( $this, 'extract_update_response' ), 10, 3 );
+
+		add_action( 'jetpack_sync_update_plugins', $handler );
+		add_action( 'jetpack_sync_update_themes', $handler );
+		add_action( 'jetpack_sync_update_core', $handler );
 
 		// multi site network options
 		if ( $this->is_multisite ) {
@@ -601,6 +605,12 @@ class Jetpack_Sync_Client {
 		}
 
 		return $comment;
+	}
+
+	function extract_update_response( $value, $expires, $name ) {
+		$response = property_exists( $value, 'response' ) ? $value->response : array();
+		// e.g. jetpack_sync_update_plugins
+		do_action( "jetpack_sync_$name", $response );
 	}
 
 	private function schedule_sync( $when ) {

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -99,15 +99,15 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			// updates
-			case 'set_site_transient_update_plugins':
+			case 'jetpack_sync_update_plugins':
 				list( $updates ) = $args;
 				$this->store->set_updates( 'plugins', $updates );
 				break;
-			case 'set_site_transient_update_themes':
+			case 'jetpack_sync_update_themes':
 				list( $updates ) = $args;
 				$this->store->set_updates( 'themes', $updates );
 				break;
-			case 'set_site_transient_update_core':
+			case 'jetpack_sync_update_core':
 				list( $updates ) = $args;
 				$this->store->set_updates( 'core', $updates );
 				break;

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -353,7 +353,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
-		$this->assertTrue( $updates->last_checked > strtotime("-10 seconds") );
+		$this->assertTrue( is_array( $updates ) );
 		
 		delete_site_transient( 'update_plugins' );
 		$this->server_replica_storage->reset();
@@ -366,8 +366,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
 
-		$this->assertNotNull( $updates );
-		$this->assertTrue( $updates->last_checked > strtotime("-10 seconds"), 'Last checked is less then 2 seconds: ' . $updates->last_checked . ' - lest then 10 sec:' . strtotime( "-10 seconds" ) );
+		$this->assertTrue( is_array( $updates ) );
 	}
 
 	function test_full_sync_sends_theme_updates() {
@@ -378,7 +377,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
-		$this->assertTrue( $updates->last_checked > strtotime("-2 seconds") );
+		$this->assertTrue( is_array( $updates ) );
 
 		// we need to do this because there's a check for elapsed time since last update
 		// in the wp_update_themes() function		
@@ -392,8 +391,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
-		$this->assertNotNull( $updates );
-		$this->assertTrue( $updates->last_checked > strtotime("-10 seconds") );
+		$this->assertTrue( is_array( $updates ) );
 	}
 
 	function test_full_sync_sends_core_updates() {
@@ -404,7 +402,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'core' );
-		$this->assertTrue( $updates->last_checked > strtotime("-10 seconds") );
+		$this->assertTrue( is_array( $updates ) );
 
 		// we need to do this because there's a check for elapsed time since last update
 		// in the wp_update_core() function		
@@ -418,8 +416,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 
 		$updates = $this->server_replica_storage->get_updates( 'core' );
-		$this->assertNotNull( $updates );
-		$this->assertTrue( $updates->last_checked > strtotime("-10 seconds") );
+		$this->assertTrue( is_array( $updates ) );
 	}
 
 	function test_full_sync_fires_events_on_send_start_and_end() {

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -15,24 +15,35 @@ class WP_Test_Jetpack_New_Sync_Updates extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	public function test_update_plugins_is_synced() {
+		$this->assertNull( $this->server_replica_storage->get_updates( 'plugins' ) );
 		wp_update_plugins();
 		$this->client->do_sync();
-		$updates = $this->server_replica_storage->get_updates( 'plugins' );
-		$this->assertTrue( is_int( $updates->last_checked ) );
+		$this->assertTrue( is_array( $this->server_replica_storage->get_updates( 'plugins' ) ) );
+	}
+
+	public function test_update_plugins_syncs_response_data() {
+		$this->assertNull( $this->server_replica_storage->get_updates( 'plugins' ) );
+
+		// some fake update data
+		$update_data = (object) array( 'response' => array( 'foo' ) );
+		set_site_transient( 'update_plugins', $update_data );
+
+		$this->client->do_sync();
+		$this->assertEquals( array( 'foo' ), $this->server_replica_storage->get_updates( 'plugins' ) );
 	}
 
 	public function test_sync_update_themes() {
 		wp_update_themes();
 		$this->client->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
-		$this->assertTrue( is_int( $updates->last_checked ) );
+		$this->assertTrue( is_array( $updates ) );
 	}
 
 	public function test_sync_maybe_update_core() {
 		_maybe_update_core();
 		$this->client->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'core' );
-		$this->assertTrue( is_int( $updates->last_checked ) );
+		$this->assertTrue( is_array( $updates ) );
 	}
 
 	public function test_sync_wp_version() {


### PR DESCRIPTION
Removes a lot of duplicate data that would just be noise in our shadow DB.

#### Changes proposed in this Pull Request:
- remove everything except update response from synced update info

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

