### PR TITLE
Makes Webpack report a non-zero exit status on build failures.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,8 +30,9 @@ function onBuild( done ) {
 		// Webpack doesn't populate err in case the build fails
 		// @see https://github.com/webpack/webpack/issues/708
 		if ( stats.compilation.errors && stats.compilation.errors.length ) {
-			done( new gutil.PluginError( 'webpack', stats.compilation.errors[0] ) );
-			return;
+			if ( done ) {
+				done( new gutil.PluginError( 'webpack', stats.compilation.errors[0] ) );
+			}
 		}
 
 		gutil.log( 'Building JS…', stats.toString( {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,7 @@ function onBuild( done ) {
 		if ( stats.compilation.errors && stats.compilation.errors.length ) {
 			if ( done ) {
 				done( new gutil.PluginError( 'webpack', stats.compilation.errors[0] ) );
+				return; // Otherwise gulp complains about done called twice
 			}
 		}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,8 +26,12 @@ var language_packs = require( './language-packs.js' );
 
 function onBuild( done ) {
 	return function( err, stats ) {
-		if ( err ) {
-			throw new gutil.PluginError( 'webpack', err );
+
+		// Webpack doesn't populate err in case the build fails
+		// @see https://github.com/webpack/webpack/issues/708
+		if ( stats.compilation.errors && stats.compilation.errors.length ) {
+			done( new gutil.PluginError( 'webpack', stats.compilation.errors[0] ) );
+			return;
 		}
 
 		gutil.log( 'Building JS…', stats.toString( {


### PR DESCRIPTION
Fixes a problem where Travis would report a success on build failures. This is related to an issue in webpack: https://github.com/webpack/webpack/issues/708