### PR TITLE
deploy-to-jetpack-built: Exit on error.

### DIFF
--- a/tools/deploy-to-jetpack-built-branch.sh
+++ b/tools/deploy-to-jetpack-built-branch.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+RED='\033[0;31m'
+trap 'exit_build' ERR
+
+function exit_build {
+    echo -e "${RED}Something went wrong and the build has stopped.  See error above for more details."
+    exit 1
+}
 
 # Currently a one-off script to push a built version to GitHub.
 # @todo: Setup a webhook to capture merges and automatically built/push.


### PR DESCRIPTION
To prevent pushing broken code to the `jetpack-built` branch, this will exit the script on error.  

To Test: 
- Force an error in the script, like change a git branch name to something that doesn't exist. 
- You should see an error message and the build should stop. 

Will even fail on npm install error after #4030 is merged. 