### PR TITLE
Add rate limiting

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -17,14 +17,14 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
 	// POST /sites/%s/cached-data-check
-	protected $needed_capabilities = array();
+	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
 
 		Jetpack::init();
-		/** This action is documented in class.jetpack.php */
 
-		$sync_queue = Jetpack_Sync_Client::getInstance()->get_sync_queue();
+		$client = Jetpack_Sync_Client::getInstance();
+		$sync_queue = $client->get_sync_queue();
 
 		// lock sending from the queue while we compare checksums with the server
 		$result = $sync_queue->lock( 30 ); // tries to acquire the lock for up to 30 seconds
@@ -47,5 +47,41 @@ class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		return $result;
 
+	}
+}
+
+class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// POST /sites/%s/sync/settings
+	protected $needed_capabilities = 'manage_options';
+
+	protected function result() {
+		$args = $this->input();
+
+		$client = Jetpack_Sync_Client::getInstance();
+		$sync_settings = $client->get_settings();
+
+		foreach( $args as $key => $value ) {
+			if ( $value !== false ) {
+				if ( is_numeric( $value ) ) {
+					$value = (int) $value;
+				}
+				$sync_settings[ $key ] = $value;
+			}
+		}
+
+		$client->update_settings( $sync_settings );
+
+		// re-fetch so we see what's really being stored
+		return $client->get_settings();
+	}
+}
+
+class Jetpack_JSON_API_Sync_Get_Settings_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// GET /sites/%s/sync/settings
+	protected $needed_capabilities = 'manage_options';
+
+	protected function result() {
+		$client = Jetpack_Sync_Client::getInstance();
+		return $client->get_settings();
 	}
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -597,6 +597,42 @@ new Jetpack_JSON_API_Sync_Check_Endpoint( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/cached-data-check'
 ) );
 
+$sync_settings_response = array(
+	'dequeue_max_bytes' => '(int|bool=false) Maximum bytes to read from queue in a single request',
+	'sync_wait_time'    => '(int|bool=false) Minimum time between requests in seconds',
+	'upload_max_bytes'  => '(int|bool=false) Maximum bytes to send in a single request',
+	'upload_max_rows'   => '(int|bool=false) Maximum rows to send in a single request',
+);
+
+// GET /sites/%s/sync/settings
+new Jetpack_JSON_API_Sync_Get_Settings_Endpoint( array(
+	'description'     => 'Update sync settings',
+	'method'          => 'GET',
+	'group'           => '__do_not_document',
+	'path'            => '/sites/%s/sync/settings',
+	'stat'            => 'write-sync-settings',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'response_format' => $sync_settings_response,
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/settings'
+) );
+
+// POST /sites/%s/sync/settings
+new Jetpack_JSON_API_Sync_Modify_Settings_Endpoint( array(
+	'description'     => 'Update sync settings',
+	'method'          => 'POST',
+	'group'           => '__do_not_document',
+	'path'            => '/sites/%s/sync/settings',
+	'stat'            => 'write-sync-settings',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'request_format' => $sync_settings_response,
+	'response_format' => $sync_settings_response,
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/settings'
+) );
+
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-log-endpoint.php' );
 
 new Jetpack_JSON_API_Jetpack_Log_Endpoint( array(

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -21,11 +21,18 @@ class Jetpack_Sync_Actions {
 
 	static function send_data( $data ) {
 		Jetpack::load_xml_rpc_client();
-		$rpc    = new Jetpack_IXR_Client( array(
+
+		// add an extra parameter to the URL so we can tell it's a sync action
+		$url = add_query_arg( 'sync', '1', Jetpack::xmlrpc_api_url() );
+
+		$rpc = new Jetpack_IXR_Client( array(
+			'url'     => $url,
 			'user_id' => get_current_user_id(),
 			'timeout' => 30
 		) );
+
 		$result = $rpc->query( 'jetpack.syncActions', $data );
+
 		if ( ! $result ) {
 			return $rpc->get_jetpack_error();
 		}

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -13,8 +13,11 @@ class Jetpack_Sync_Client {
 	const LAST_SYNC_TIME_OPTION_NAME = 'jetpack_last_sync_time';
 	const CALLABLES_AWAIT_TRANSIENT_NAME = 'jetpack_sync_callables_await';
 	const CONSTANTS_AWAIT_TRANSIENT_NAME = 'jetpack_sync_constants_await';
+	const SETTINGS_OPTION_PREFIX = 'jetpack_sync_settings_';
+	
+	private static $valid_settings = array( 'dequeue_max_bytes' => true, 'upload_max_bytes' => true, 'upload_max_rows' => true, 'sync_wait_time' => true );
 
-	private $checkout_memory_size;
+	private $dequeue_max_bytes;
 	private $upload_max_bytes;
 	private $upload_max_rows;
 	private $sync_queue;
@@ -89,7 +92,7 @@ class Jetpack_Sync_Client {
 			foreach ( array( 'unapproved', 'approved' ) as $comment_status ) {
 				$comment_action_name = "comment_{$comment_status}_{$comment_type}";
 				add_action( $comment_action_name, $handler, 10, 2 );
-				add_filter( "jetpack_sync_before_send_$comment_action_name", array( $this, 'expand_wp_comment_status_change' ) );
+				add_filter( "jetpack_sync_before_send_{$comment_action_name}", array( $this, 'expand_wp_comment_status_change' ) );
 			}
 		}
 
@@ -201,8 +204,8 @@ class Jetpack_Sync_Client {
 		$this->network_options_whitelist = $options;
 	}
 
-	function set_send_buffer_memory_size( $size ) {
-		$this->checkout_memory_size = $size;
+	function set_dequeue_max_bytes( $size ) {
+		$this->dequeue_max_bytes = $size;
 	}
 
 	// in bytes
@@ -216,11 +219,11 @@ class Jetpack_Sync_Client {
 	}
 
 	// in seconds
-	function set_min_sync_wait_time( $seconds ) {
+	function set_sync_wait_time( $seconds ) {
 		update_option( self::SYNC_THROTTLE_OPTION_NAME, $seconds, true );
 	}
 
-	function get_min_sync_wait_time() {
+	function get_sync_wait_time() {
 		return get_option( self::SYNC_THROTTLE_OPTION_NAME );
 	}
 
@@ -456,7 +459,7 @@ class Jetpack_Sync_Client {
 		}
 
 		// don't sync if we are throttled
-		$sync_wait = $this->get_min_sync_wait_time();
+		$sync_wait = $this->get_sync_wait_time();
 		$last_sync = $this->get_last_sync_time();
 
 		if ( $last_sync && $sync_wait && $last_sync + $sync_wait > microtime( true ) ) {
@@ -478,7 +481,7 @@ class Jetpack_Sync_Client {
 			ignore_user_abort( true );
 		}
 
-		$buffer = $this->sync_queue->checkout_with_memory_limit( $this->checkout_memory_size, $this->upload_max_rows );
+		$buffer = $this->sync_queue->checkout_with_memory_limit( $this->dequeue_max_bytes, $this->upload_max_rows );
 
 		if ( ! $buffer ) {
 			// buffer has no items
@@ -798,15 +801,35 @@ class Jetpack_Sync_Client {
 		$this->sync_queue->reset();
 	}
 
+	function get_settings() {
+		$settings = array();
+		foreach( array_keys( self::$valid_settings ) as $setting ) {
+			$default_name = "default_$setting"; // e.g. default_dequeue_max_bytes
+			$settings[ $setting ] = (int) get_option( self::SETTINGS_OPTION_PREFIX.$setting, Jetpack_Sync_Defaults::$$default_name );
+		}
+		return $settings;
+	}
+
+	function update_settings( $new_settings ) {
+		$validated_settings = array_intersect_key( $new_settings, self::$valid_settings );
+		foreach( $validated_settings as $setting => $value ) {
+			update_option( self::SETTINGS_OPTION_PREFIX.$setting, $value, true );
+		}
+	}
+
+	function update_options_whitelist() {
+		$this->options_whitelist = apply_filters( 'jetpack_options_whitelist', Jetpack_Sync_Defaults::$default_options_whitelist );
+	}
+
 	function set_defaults() {
 		$this->sync_queue = new Jetpack_Sync_Queue( 'sync' );
-		$this->set_send_buffer_memory_size( Jetpack_Sync_Defaults::$default_send_buffer_memory_size );
-		$this->set_upload_max_bytes( Jetpack_Sync_Defaults::$default_upload_max_bytes );
-		$this->set_upload_max_rows( Jetpack_Sync_Defaults::$default_upload_max_rows );
 
-		if ( $this->get_min_sync_wait_time() === false ) {
-			$this->set_min_sync_wait_time( Jetpack_Sync_Defaults::$default_sync_wait_time );
-		}
+		// saved settings
+		$settings = $this->get_settings();
+		$this->set_dequeue_max_bytes( $settings['dequeue_max_bytes'] );
+		$this->set_upload_max_bytes( $settings['upload_max_bytes'] );
+		$this->set_upload_max_rows( $settings['upload_max_rows'] );
+		$this->set_sync_wait_time( $settings['sync_wait_time'] );
 
 		$this->set_full_sync_client( Jetpack_Sync_Full::getInstance() );
 		$this->codec                     = new Jetpack_Sync_Deflate_Codec();
@@ -814,7 +837,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * This filter is already documented class.wpcom-json-api-get-option-endpoint.php
 		 */
-		$this->options_whitelist         = apply_filters( 'jetpack_options_whitelist', Jetpack_Sync_Defaults::$default_options_whitelist );
+		$this->update_options_whitelist();
 		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
 		$this->taxonomy_whitelist        = Jetpack_Sync_Defaults::$default_taxonomy_whitelist;
 		$this->is_multisite              = is_multisite();

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -818,6 +818,7 @@ class Jetpack_Sync_Client {
 	}
 
 	function update_options_whitelist() {
+		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
 		$this->options_whitelist = apply_filters( 'jetpack_options_whitelist', Jetpack_Sync_Defaults::$default_options_whitelist );
 	}
 
@@ -834,9 +835,6 @@ class Jetpack_Sync_Client {
 		$this->set_full_sync_client( Jetpack_Sync_Full::getInstance() );
 		$this->codec                     = new Jetpack_Sync_Deflate_Codec();
 		$this->constants_whitelist       = Jetpack_Sync_Defaults::$default_constants_whitelist;
-		/**
-		 * This filter is already documented class.wpcom-json-api-get-option-endpoint.php
-		 */
 		$this->update_options_whitelist();
 		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
 		$this->taxonomy_whitelist        = Jetpack_Sync_Defaults::$default_taxonomy_whitelist;

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -170,7 +170,7 @@ class Jetpack_Sync_Defaults {
 
 	static $default_network_options_whitelist = array( 'site_name' );
 	static $default_taxonomy_whitelist = array();
-	static $default_send_buffer_memory_size = 500000; // very conservative value, 1/2 MB
+	static $default_dequeue_max_bytes = 500000; // very conservative value, 1/2 MB
 	static $default_upload_max_bytes = 600000; // a little bigger than the upload limit to account for serialization
 	static $default_upload_max_rows = 500;
 	static $default_sync_wait_time = 10; // seconds, between syncs

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -47,7 +47,13 @@ class Jetpack_Sync_Server {
 		}
 
 		if ( $token && ! $this->attempt_request_lock( $token->blog_id ) ) {
-			// log multi-request
+			/**
+			 * Fires when the server receives two concurrent requests from the same blog
+			 *
+			 * @since 4.1
+			 *
+			 * @param token The token object of the misbehaving site
+			 */
 			do_action( "jetpack_sync_multi_request_fail", $token );
 			return new WP_Error( 'concurrent_request_error', 'There is another request running for the same blog ID' );
 		}

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -9,15 +9,35 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-deflate-codec.php';
 class Jetpack_Sync_Server {
 	private $codec;
 	const MAX_TIME_PER_REQUEST_IN_SECONDS = 15;
+	const BLOG_LOCK_TRANSIENT_PREFIX = 'jetpack_sync_request_lock_';
+	const BLOG_LOCK_TRANSIENT_EXPIRY = 60;
 
 	// this is necessary because you can't use "new" when you declare instance properties >:(
 	function __construct() {
 		$this->codec            = new Jetpack_Sync_Deflate_Codec();
-		$this->events_processed = array();
 	}
 
 	function set_codec( iJetpack_Sync_Codec $codec ) {
 		$this->codec = $codec;
+	}
+
+	function attempt_request_lock( $blog_id, $expiry = self::BLOG_LOCK_TRANSIENT_EXPIRY ) {
+		$transient_name = $this->get_concurrent_request_transient_name( $blog_id );
+		$locked_time = get_transient( $transient_name );
+		if ( $locked_time ) {
+			return false;
+		}
+		// for some reason set_transient isn't returning TRUE like it's supposed to...
+		set_transient( $transient_name, microtime( true ), $expiry );
+		return true;
+	}
+
+	private function get_concurrent_request_transient_name( $blog_id ) {
+		return self::BLOG_LOCK_TRANSIENT_PREFIX.$blog_id;
+	}
+
+	function remove_request_lock( $blog_id ) {
+		delete_transient( $this->get_concurrent_request_transient_name( $blog_id ) );
 	}
 
 	function receive( $data, $token = null ) {
@@ -26,7 +46,14 @@ class Jetpack_Sync_Server {
 			return new WP_Error( 'action_decoder_error', 'Events must be an array' );
 		}
 
+		if ( $token && ! $this->attempt_request_lock( $token->blog_id ) ) {
+			// log multi-request
+			do_action( "jetpack_sync_multi_request_fail", $token );
+			return new WP_Error( 'concurrent_request_error', 'There is another request running for the same blog ID' );
+		}
+
 		$events = wp_unslash( array_map( array( $this->codec, 'decode' ), $data ) );
+		$events_processed = array();
 
 		/**
 		 * Fires when an array of actions are received from a remote Jetpack site
@@ -39,6 +66,7 @@ class Jetpack_Sync_Server {
 
 		foreach ( $events as $key => $event ) {
 			list( $action_name, $args, $user_id, $timestamp ) = $event;
+
 			/**
 			 * Fires when an action is received from a remote Jetpack site
 			 *
@@ -64,14 +92,17 @@ class Jetpack_Sync_Server {
 			 */
 			do_action( 'jetpack_sync_' . $action_name, $args, $user_id, $timestamp, $token );
 
-			$this->events_processed[] = $key;
+			$events_processed[] = $key;
 
-			// TODO this can be improved to be more intelligent
 			if ( microtime( true ) - $start_time > self::MAX_TIME_PER_REQUEST_IN_SECONDS ) {
 				break;
 			}
 		}
 
-		return $this->events_processed;
+		if ( $token ) {
+			$this->remove_request_lock( $token->blog_id );
+		}
+
+		return $events_processed;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -8,7 +8,6 @@ class WP_Test_Jetpack_New_Sync_Meta extends WP_Test_Jetpack_New_Sync_Base {
 
 	public function setUp() {
 		parent::setUp();
-		$this->client->set_defaults();
 
 		// create a post
 		$this->post_id    = $this->factory->post->create();

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -44,7 +44,7 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 	
 	public function test_sync_options_that_use_filter() {
 		add_filter( 'jetpack_options_whitelist', array( $this, 'add_jetpack_options_whitelist_filter' ) );
-		$this->client->set_defaults();
+		$this->client->update_options_whitelist();
 		update_option( 'foo_option_bar', '123' );
 		$this->client->do_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-site-icon-url.php
+++ b/tests/php/sync/test_class.jetpack-sync-site-icon-url.php
@@ -10,10 +10,7 @@ class WP_Test_Jetpack_Sync_Site_Icon_Url extends WP_Test_Jetpack_New_Sync_Base {
 		global $wp_version;
 		parent::setUp();
 
-		$this->client->set_defaults();
-
 		if ( version_compare( $wp_version, '4.4', '>=' ) ) {
-			$this->client->set_defaults();
 			add_filter( 'get_site_icon_url', array( $this, '_get_site_icon' ), 99, 3 );
 			update_option( 'site_icon', '5' );
 		} else {

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -11,7 +11,6 @@ class WP_Test_Jetpack_New_Sync_Terms extends WP_Test_Jetpack_New_Sync_Base {
 
 	public function setUp() {
 		parent::setUp();
-		$this->client->set_defaults();
 		$this->client->reset_data();
 
 		$this->taxonomy = 'genre';

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -8,7 +8,6 @@ class WP_Test_Jetpack_New_Sync_Updates extends WP_Test_Jetpack_New_Sync_Base {
 
 	public function setUp() {
 		parent::setUp();
-		$this->client->set_defaults();
 		$this->client->reset_data();
 		wp_set_current_user( 1 );
 		$this->client->do_sync();


### PR DESCRIPTION
Adds rate limiting features for sync

#### Changes proposed in this Pull Request:
- Update test server implementation from WPCOM
- Add sync=1 parameter for server-side filtering
- Add API to post updated sync parameters, including send rate limit