### PR TITLE
Use jetpack native function to get updates (master version)

### DIFF
--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -14,20 +14,22 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 
 	abstract protected function get_jetpack_version();
 
+	abstract protected function get_updates();
+
 	function before_render() {
 	}
 
 	function after_render( &$response ) {
 		// Add the updates only make them visible if the user has manage options permission and the site is the main site of the network
 		if ( current_user_can( 'manage_options' ) && $this->is_main_site( $response ) ) {
-			$jetpack_update = (array) get_option( 'jetpack_updates' );
+			$jetpack_update = $this->get_updates();
 			if ( ! empty( $jetpack_update ) ) {
 				// In previous version of Jetpack 3.4, 3.5, 3.6 we synced the wp_version into to jetpack_updates
 				unset( $jetpack_update['wp_version'] );
 				// In previous version of Jetpack 3.4, 3.5, 3.6 we synced the site_is_version_controlled into to jetpack_updates
 				unset( $jetpack_update['site_is_version_controlled'] );
 
-				$response['updates'] = (array) $jetpack_update;
+				$response['updates'] = $jetpack_update;
 			}
 		}
 	}

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -25,6 +25,10 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return get_theme_support( $feature_name );
 	}
 
+	protected function get_updates() {
+		return (array) Jetpack::get_updates();
+	}
+
 	function get_id() {
 		return $this->platform->token->blog_id;	
 	}


### PR DESCRIPTION
Fixes issue where Jetpack sites weren't rendering the updates part of the `/site/$id` API response.

#### Changes proposed in this Pull Request:
- return response using Jetpack's native `::get_updates()` function.