### PR TITLE
Notices: Add welcome notice and Jumpstart notice 

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -21,24 +21,55 @@ import {
 
 export const WelcomeNotice = React.createClass( {
 	displayName: 'WelcomeNotice',
+	getInitialState: function() {
+		return { showNotice: true };
+	},
+
+	dismissWelcomeNotice: function() {
+		this.setState( { showNotice: false } );
+	},
+
+	propTypes: {
+		jumpstarted: React.PropTypes.bool
+	},
+
+	getDefaultProps() {
+		return {
+			jumpstarted: false
+		};
+	},
+
+	getWelcomeMessageText: function() {
+		if ( this.props.jumpstarted ) {
+			return(
+				__( '(NEED BETTER TEXT) Great choice! By Jumpstarting your site, you have unlocked even more power of wordpress.com! {{a}}Learn more{{/a}}', {
+					components: {
+						a: <a href={ 'https://jetpack.com/support/' } target="_blank" />
+					}
+				} )
+			);
+		} else {
+			return(
+				__( 'Welcome to your Jetpack dashboard! Now you can quickly manage all of Jetpack’s great features from one central location. {{a}}Learn more{{/a}}.', {
+					components: {
+						a: <a href={ 'https://jetpack.com/support/' } target="_blank" />
+					}
+				} )
+			);
+		}
+	},
 
 	render() {
-		if ( this.props.isDismissed( 'welcome' ) ) {
+		if ( ! this.state.showNotice ) {
 			return false;
 		}
 		return (
 			<div>
 				<SimpleNotice
 					status="is-info"
-					onClick={ this.props.dismissWelcomeNotice }
+					onClick={ this.dismissWelcomeNotice }
 				>
-					{
-						__( 'Welcome to your new Jetpack dashboard! Now you can quickly manage all of Jetpack’s great features from one central location. {{a}}Learn more (link to updated docs).{{/a}}', {
-							components: {
-								a:<a href={ 'https://jetpack.com/support/' } target="_blank" />
-							}
-						} )
-					}
+					{ this.getWelcomeMessageText() }
 				</SimpleNotice>
 			</div>
 		);
@@ -159,27 +190,34 @@ export const ActionNotices = React.createClass( {
 	render() {
 		const notices = this.props.jetpackNotices( this.props );
 
-		if ( 'disconnected' === notices ) {
-			return (
-				<div>
-					<SimpleNotice>
-						{ __( 'You have successfully disconnected Jetpack' ) }
-						<br />
-						{
-							__(	'Would you tell us why? Just {{a}}answering two simple questions{{/a}} would help us improve Jetpack.',
-								{
-									components: {
-										a: <a href="https://jetpack.com/survey-disconnected/" target="_blank" />
+		switch ( notices ) {
+			case 'disconnected' :
+				return (
+					<div>
+						<SimpleNotice>
+							{ __( 'You have successfully disconnected Jetpack' ) }
+							<br />
+							{
+								__(	'Would you tell us why? Just {{a}}answering two simple questions{{/a}} would help us improve Jetpack.',
+									{
+										components: {
+											a: <a href="https://jetpack.com/survey-disconnected/" target="_blank" />
+										}
 									}
-								}
-							)
-						}
-					</SimpleNotice>
-				</div>
-			);
-		}
+								)
+							}
+						</SimpleNotice>
+					</div>
+				);
 
-		return false;
+			case 'new_connection_jumpstart' :
+				return <WelcomeNotice jumpstarted={ true } />;
+			case 'new_connection_no_jumpstart' :
+				return <WelcomeNotice jumpstarted={ false } />;
+
+			default:
+				return false;
+		}
 	}
 
 } );
@@ -192,7 +230,6 @@ const JetpackNotices = React.createClass( {
 		return (
 			<div>
 				<JetpackStateNotices />
-				<WelcomeNotice { ...this.props } />
 				<DevVersionNotice { ...this.props } />
 				<DevModeNotice { ...this.props } />
 				<StagingSiteNotice { ...this.props } />
@@ -207,13 +244,6 @@ export default connect(
 		return {
 			jetpackNotices: () => _getJetpackNotices( state ),
 			isDismissed: ( notice ) => _isNoticeDismissed( state, notice )
-		};
-	},
-	( dispatch ) => {
-		return {
-			dismissWelcomeNotice: () => {
-				return dispatch( dismissJetpackNotice( 'welcome' ) );
-			}
 		};
 	}
 )( JetpackNotices );

--- a/_inc/client/state/jetpack-notices/reducer.js
+++ b/_inc/client/state/jetpack-notices/reducer.js
@@ -14,7 +14,9 @@ import {
 	JETPACK_NOTICES_DISMISS_FAIL,
 	JETPACK_NOTICES_DISMISS_SUCCESS,
 	DISCONNECT_SITE_SUCCESS,
-	RESET_OPTIONS_SUCCESS
+	RESET_OPTIONS_SUCCESS,
+	JUMPSTART_ACTIVATE_SUCCESS,
+	JUMPSTART_SKIP
 } from 'state/action-types';
 import restApi from 'rest-api';
 
@@ -22,6 +24,12 @@ const status = ( state = false , action ) => {
 	switch ( action.type ) {
 		case DISCONNECT_SITE_SUCCESS:
 			return 'disconnected';
+
+		case JUMPSTART_ACTIVATE_SUCCESS:
+			return 'new_connection_jumpstart';
+
+		case JUMPSTART_SKIP:
+			return 'new_connection_no_jumpstart';
 
 		default:
 			return state;


### PR DESCRIPTION
Fixes #3831

![screen shot 2016-06-01 at 2 31 30 pm 1](https://cloud.githubusercontent.com/assets/7129409/15721161/bad50f3c-2805-11e6-981b-918a9e27cc63.png)

If Jumpstart is either skipped or activated, we can trust that this is a first-time connection.  This commit displays specific text after jumpstart welcoming the user and introducing them to the new Jetpack.

The notices are triggered by the Jumpstart actions.  

The text is not final, but can be changed in another branch.  

**To Test:** 
- Click `reset options`
- Click jumpstart
- You should see a notice with Jumpstart text. 
- Repeat the process but skip Jumpstart. 
- You should see different text
- You should also be able to dismiss these. 
