### PR TITLE
Admin - Notices: fix loading of noticons used in Jetpack notices

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -117,6 +117,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		wp_enqueue_script( 'react-plugin', plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ), array(), time(), true );
 		wp_enqueue_style( 'dops-css', plugins_url( '_inc/build/dops-style.css', JETPACK__PLUGIN_FILE ), array(), time() );
 		wp_enqueue_style( 'components-css', plugins_url( '_inc/build/style.min.css', JETPACK__PLUGIN_FILE ), array(), time() );
+		// modules/notes.php also attemps to load this but since the handler is the same it won't load it twice.
+		wp_enqueue_style( 'noticons', Jetpack::wpcom_static_url( '/i/noticons/noticons.css' ), array(), time() );
 
 		$localeSlug = explode( '_', get_locale() );
 		$localeSlug = $localeSlug[0];

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6554,4 +6554,19 @@ p {
 		return true;
 	}
 
+	/**
+	 * Build WPCOM static URL and return it with the proper scheme.
+	 *
+	 * @since 4.1.0 Moved from modules/notes.php to this location so it's always available.
+	 *
+	 * @param string $file File to load from WPCOM. Should include slash at the beginning.
+	 *
+	 * @return string
+	 */
+	public static function wpcom_static_url( $file ) {
+		$i = hexdec( substr( md5( $file ), -1 ) ) % 2;
+		$url = esc_url( "http://s$i.wp.com$file" );
+		return set_url_scheme( $url );
+	}
+
 }

--- a/modules/notes.php
+++ b/modules/notes.php
@@ -36,12 +36,6 @@ class Jetpack_Notifications {
 		add_action( 'init', array( &$this, 'action_init' ) );
 	}
 
-	function wpcom_static_url($file) {
-		$i = hexdec( substr( md5( $file ), -1 ) ) % 2;
-		$url = 'http://s' . $i . '.wp.com' . $file;
-		return set_url_scheme( $url );
-	}
-
 	// return the major version of Internet Explorer the viewer is using or false if it's not IE
 	public static function get_internet_explorer_version() {
 		static $version;
@@ -105,27 +99,27 @@ class Jetpack_Notifications {
 
 	function styles_and_scripts() {
 		if ( !is_rtl() ) {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'wpcom-notes-admin-bar', Jetpack::wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		} else {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'wpcom-notes-admin-bar', Jetpack::wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		}
-		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+		wp_enqueue_style( 'noticons', Jetpack::wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 
 		$this->print_js();
 
 		// attempt to use core or plugin libraries if registered
 		if ( !wp_script_is( 'mustache', 'registered' ) ) {
-			wp_register_script( 'mustache', $this->wpcom_static_url( '/wp-content/js/mustache.js' ), null, JETPACK_NOTES__CACHE_BUSTER );
+			wp_register_script( 'mustache', Jetpack::wpcom_static_url( '/wp-content/js/mustache.js' ), null, JETPACK_NOTES__CACHE_BUSTER );
 		}
 		if ( !wp_script_is( 'underscore', 'registered' ) ) {
-			wp_register_script( 'underscore', $this->wpcom_static_url( '/wp-includes/js/underscore.min.js' ), null, JETPACK_NOTES__CACHE_BUSTER );
+			wp_register_script( 'underscore', Jetpack::wpcom_static_url( '/wp-includes/js/underscore.min.js' ), null, JETPACK_NOTES__CACHE_BUSTER );
 		}
 		if ( !wp_script_is( 'backbone', 'registered' ) ) {
-			wp_register_script( 'backbone', $this->wpcom_static_url( '/wp-includes/js/backbone.min.js' ), array( 'underscore' ), JETPACK_NOTES__CACHE_BUSTER );
+			wp_register_script( 'backbone', Jetpack::wpcom_static_url( '/wp-includes/js/backbone.min.js' ), array( 'underscore' ), JETPACK_NOTES__CACHE_BUSTER );
 		}
 
-		wp_register_script( 'wpcom-notes-common', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/notes-common-v2.js' ), array( 'jquery', 'underscore', 'backbone', 'mustache' ), JETPACK_NOTES__CACHE_BUSTER );
-		wp_enqueue_script( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.js' ), array( 'wpcom-notes-common' ), JETPACK_NOTES__CACHE_BUSTER );
+		wp_register_script( 'wpcom-notes-common', Jetpack::wpcom_static_url( '/wp-content/mu-plugins/notes/notes-common-v2.js' ), array( 'jquery', 'underscore', 'backbone', 'mustache' ), JETPACK_NOTES__CACHE_BUSTER );
+		wp_enqueue_script( 'wpcom-notes-admin-bar', Jetpack::wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.js' ), array( 'wpcom-notes-common' ), JETPACK_NOTES__CACHE_BUSTER );
 	}
 
 	function admin_bar_menu() {


### PR DESCRIPTION
Fixes #3901

<img width="708" alt="noticons" src="https://cloud.githubusercontent.com/assets/1041600/15722032/1156486a-2812-11e6-8467-7af385053107.png">

#### Changes proposed in this Pull Request:
- the function `wpcom_static_url` was moved from `modules/notes.php` to `Jetpack` class as a method so it's always available and icons can be loaded.
- Noticons were only loaded by the Notifications module, so to avoid issues when Notifications was deactivated, they are now loaded independently with the same handler to prevent loading them twice.