### PR TITLE
VideoPress: Enqueue dependent media scripts

### DIFF
--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -150,9 +150,7 @@ function videopress_handle_editor_view_js() {
 
 	add_action( 'admin_print_footer_scripts', 'videopress_editor_view_js_templates' );
 
-	wp_enqueue_media();
-
-	wp_enqueue_script( 'videopress-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'jquery' ), false, true );
+	wp_enqueue_script( 'videopress-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'mce-views', 'jquery' ), false, true );
 	wp_localize_script( 'videopress-editor-view', 'vpEditorView', array(
 		'home_url_host'     => parse_url( home_url(), PHP_URL_HOST ),
 		'min_content_width' => VIDEOPRESS_MIN_WIDTH,

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -150,6 +150,8 @@ function videopress_handle_editor_view_js() {
 
 	add_action( 'admin_print_footer_scripts', 'videopress_editor_view_js_templates' );
 
+	wp_enqueue_media();
+
 	wp_enqueue_script( 'videopress-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'jquery' ), false, true );
 	wp_localize_script( 'videopress-editor-view', 'vpEditorView', array(
 		'home_url_host'     => parse_url( home_url(), PHP_URL_HOST ),


### PR DESCRIPTION
`editor-view.js` is dependent on `wp.mce.views`, `wp.media`, etc. Those are already enqueued by Core for the `post` and `page` post types, but not always for custom post types.

For those custom post types, enqueueing `editor-view.js` without the dependent scripts results in errors being logged to the browser console. For example, `TypeError: wp.mce.views is undefined`.