### PR TITLE
Adds a mechanism to check if the site is private before activating a module.

### DIFF
--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -109,7 +109,7 @@ export const activateModule = ( slug ) => {
 			dispatch( removeNotice( `module-${ slug }` ) );
 			dispatch( createNotice(
 				'is-error',
-				__( '%(slug)s failed to activate.  Error: %(error)d', {
+				__( '%(slug)s failed to activate. %(error)s', {
 					args: {
 						slug: getModule( getState(), slug ).name,
 						error: error

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -15,6 +15,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Load WP_Error for error messages.
 require_once ABSPATH . '/wp-includes/class-wp-error.php';
 
+// Load API endpoint base classes
+require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
+
+// Load API endpoints
+require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
+
 // Register endpoints when WP REST API is initialized.
 add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register_endpoints' ) );
 
@@ -111,10 +117,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Activate a module
+		Jetpack::load_xml_rpc_client();
+		$xmlrpc = new Jetpack_IXR_Client();
+		$module_activate = new Jetpack_Core_API_Module_Activate_Endpoint( $xmlrpc );
 		register_rest_route( 'jetpack/v4', '/module/(?P<slug>[a-z\-]+)/activate', array(
 			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::activate_module',
-			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
+			'callback' => array( $module_activate, 'process' ),
+			'permission_callback' => array( $module_activate, 'can_write' ),
 		) );
 
 		// Deactivate a module

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -15,12 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Load WP_Error for error messages.
 require_once ABSPATH . '/wp-includes/class-wp-error.php';
 
-// Load API endpoint base classes
-require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
-
-// Load API endpoints
-require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
-
 // Register endpoints when WP REST API is initialized.
 add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register_endpoints' ) );
 
@@ -47,6 +41,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.1.0
 	 */
 	public static function register_endpoints() {
+
+		// Load API endpoint base classes
+		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
+
+		// Load API endpoints
+		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
+
 		self::$user_permissions_error_msg = esc_html__(
 			'You do not have the correct user permissions to perform this action.
 			Please contact your site admin if you think this is a mistake.',

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -18,7 +18,7 @@ class Jetpack_Core_API_Module_Activate_Endpoint
 		return new WP_Error(
 			'rest_cannot_publish',
 			__( 'This module requires your site to be set to publicly accessible.' ),
-			array( 'status' => 404 ) );;
+			array( 'status' => 404 ) );
 	}
 
 	public function can_write() {

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This is the base class for every Core API endpoint Jetpack uses.
+ *
+ */
+class Jetpack_Core_API_Module_Activate_Endpoint
+	extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
+
+	private $modules_requiring_public = array( 'sitemaps', 'photon', 'enhanced-distribution', 'sharedaddy' );
+
+	public function process( $data ) {
+		if (
+			! in_array( $data['slug'], $this->modules_requiring_public )
+			|| $this->is_site_public()
+		) {
+			return Jetpack::activate_module( $data['slug'], false, false );
+		}
+		return new WP_Error(
+			'rest_cannot_publish',
+			__( 'This module requires your site to be set to publicly accessible.' ),
+			array( 'status' => 404 ) );;
+	}
+
+	public function can_write() {
+		return current_user_can( 'jetpack_manage_modules' );
+	}
+}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -23,7 +23,7 @@ class Jetpack_Core_API_Module_Activate_Endpoint
 		}
 		return new WP_Error(
 			'rest_cannot_publish',
-			__( 'This module requires your site to be set to publicly accessible.' ),
+			__( 'This module requires your site to be set to publicly accessible.', 'jetpack' ),
 			array( 'status' => 404 ) );
 	}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -6,7 +6,13 @@
 class Jetpack_Core_API_Module_Activate_Endpoint
 	extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
-	private $modules_requiring_public = array( 'sitemaps', 'photon', 'enhanced-distribution', 'sharedaddy' );
+	private $modules_requiring_public = array(
+		'sitemaps',
+		'photon',
+		'enhanced-distribution',
+		'sharedaddy',
+		'json-api',
+	);
 
 	public function process( $data ) {
 		if (

--- a/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This is the base class for every Core API endpoint Jetpack uses.
+ *
+ */
+abstract class Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
+
+	/**
+	 * An instance of the Jetpack XMLRPC client to make WordPress.com requests
+	 *
+	 * @private
+	 * @var Jetpack_IXR_Client
+	 */
+	private $xmlrpc;
+
+	/**
+	 * @param Jetpack_IXR_Client $xmlrpc
+	 */
+	public function __construct( $xmlrpc ) {
+		$this->xmlrpc = $xmlrpc;
+	}
+
+	/**
+	 * Checks if the site is public and returns the result.
+	 * @return Boolean $is_public
+	 */
+	protected function is_site_public() {
+		if ( $this->xmlrpc->query( 'jetpack.isSitePubliclyAccessible', home_url() ) ) {
+			return $this->xmlrpc->getResponse();
+		}
+		return false;
+	}
+}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2364,7 +2364,8 @@ class Jetpack {
 		Jetpack::catch_errors( true );
 		ob_start();
 		require Jetpack::get_module_path( $module );
-
+		/** This action is documented in class.jetpack.php */
+		do_action( 'jetpack_activate_module', $module );
 		$active[] = $module;
 		Jetpack::update_active_modules( $active );
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,9 @@
 			<file>tests/php/test_class.jetpack-xmlrpc-server.php</file>
 			<file>tests/php/test_class.jetpack-heartbeat.php</file>
 		</testsuite>
+		<testsuite name="core-api">
+			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>
+		</testsuite>
 		<testsuite name="media">
 			<file>tests/php/test_class.jetpack-media-extractor.php</file>
 			<file>tests/php/test_class.jetpack-media-summary.php</file>

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -38,7 +38,6 @@ if ( ! ( in_running_uninstall_group() ) ) {
 }
 
 
-
 require $test_root . '/includes/bootstrap.php';
 
 

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -1,0 +1,43 @@
+<?php
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-rest-controller-testcase.php';
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server.php';
+
+class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Controller_Testcase {
+
+	public function setUp() {
+		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class.core-rest-api-endpoints.php';
+
+		parent::setUp();
+
+		Jetpack::load_xml_rpc_client();
+	}
+
+	/**
+	 * @author zinigor
+	 * @covers Jetpack_Core_API_Module_Activate_Endpoint
+	 * @requires PHP 5.2
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/activate', $routes );
+
+		$route = $routes['/jetpack/v4/module/(?P<slug>[a-z\-]+)/activate'][0];
+		$this->assertInstanceOf(
+			'Jetpack_Core_API_Module_Activate_Endpoint',
+			$route['callback'][0]
+		);
+		$this->assertInstanceOf(
+			'Jetpack_Core_API_Module_Activate_Endpoint',
+			$route['permission_callback'][0]
+		);
+	}
+
+	public function test_update_item() {}
+	public function test_context_param() {}
+	public function test_get_items() {}
+	public function test_get_item() {}
+	public function test_create_item() {}
+	public function test_delete_item() {}
+	public function test_prepare_item() {}
+	public function test_get_item_schema() {}
+}

--- a/tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -1,0 +1,68 @@
+<?php
+require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
+
+class WP_Test_Jetpack_Core_Api_Xmlrpc_Consumer_Endpoint extends WP_UnitTestCase {
+
+	private $home_url = 'http://example.com';
+
+	public function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * @author zinigor
+	 * @covers Jetpack_Core_XMLRPC_Consumer_Endpoint
+	 * @requires PHP 5.2
+	 * @dataProvider _true_false_provider
+	 */
+	public function test_Jetpack_Core_API_XMLRPC_Consumer_Endpoint_privacy_check( $query_success, $result ) {
+		Jetpack::load_xml_rpc_client();
+
+		$xmlrpc_mock = $this->getMockBuilder( 'Jetpack_IXR_Client' )
+					 ->setMethods( array( 'query', 'getResponse' ) )
+					 ->getMock();
+
+		$endpoint = new WP_Test_Dummy_Xmlrpc_Consumer_Endpoint( $xmlrpc_mock );
+
+		$xmlrpc_mock->expects( $this->once() )
+			->method( 'query' )
+			->with( 'jetpack.isSitePubliclyAccessible', home_url() )
+			->willReturn( $query_success );
+
+		if ( $query_success ) {
+			$xmlrpc_mock->expects( $this->once() )
+				->method( 'getResponse' )
+				->willReturn( $result );
+		} else {
+			$xmlrpc_mock->expects( $this->never() )
+				->method( 'getResponse' );
+		}
+
+		$this->assertEquals( $result, $endpoint->process( null ) );
+	}
+
+	public function _true_false_provider() {
+		return array(
+			array( true, true ),
+			array( true, false ),
+			array( false, false ),
+		);
+	}
+
+}
+
+/**
+ * Dummy testing class that will extend the testable endpoint and try to execute a privacy check
+ */
+class WP_Test_Dummy_Xmlrpc_Consumer_Endpoint extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
+
+	public function __construct( $xmlrpc ) {
+		parent::__construct( $xmlrpc );
+	}
+
+	public function process( $data ) {
+
+		// Running a protected method in order to test that it's doing what it needs to do
+		return $this->is_site_public();
+	}
+}

--- a/tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Core_Api_Xmlrpc_Consumer_Endpoint extends WP_UnitTestCase 
 	 * @author zinigor
 	 * @covers Jetpack_Core_XMLRPC_Consumer_Endpoint
 	 * @requires PHP 5.2
-	 * @dataProvider _true_false_provider
+	 * @dataProvider true_false_provider
 	 */
 	public function test_Jetpack_Core_API_XMLRPC_Consumer_Endpoint_privacy_check( $query_success, $result ) {
 		Jetpack::load_xml_rpc_client();
@@ -41,7 +41,7 @@ class WP_Test_Jetpack_Core_Api_Xmlrpc_Consumer_Endpoint extends WP_UnitTestCase 
 		$this->assertEquals( $result, $endpoint->process( null ) );
 	}
 
-	public function _true_false_provider() {
+	public function true_false_provider() {
 		return array(
 			array( true, true ),
 			array( true, false ),

--- a/tests/php/lib/class-wp-test-rest-controller-testcase.php
+++ b/tests/php/lib/class-wp-test-rest-controller-testcase.php
@@ -1,0 +1,42 @@
+<?php
+
+abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
+
+	protected $server;
+
+	public function setUp() {
+		parent::setUp();
+
+		/** @var WP_REST_Server $wp_rest_server */
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_Test_Spy_REST_Server;
+		do_action( 'rest_api_init' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		/** @var WP_REST_Server $wp_rest_server */
+		global $wp_rest_server;
+		$wp_rest_server = null;
+	}
+
+	abstract public function test_register_routes();
+
+	abstract public function test_context_param();
+
+	abstract public function test_get_items();
+
+	abstract public function test_get_item();
+
+	abstract public function test_create_item();
+
+	abstract public function test_update_item();
+
+	abstract public function test_delete_item();
+
+	abstract public function test_prepare_item();
+
+	abstract public function test_get_item_schema();
+
+}

--- a/tests/php/lib/class-wp-test-spy-rest-server.php
+++ b/tests/php/lib/class-wp-test-spy-rest-server.php
@@ -1,0 +1,35 @@
+<?php
+
+class WP_Test_Spy_REST_Server extends WP_REST_Server {
+	/**
+	 * Get the raw $endpoints data from the server
+	 *
+	 * @return array
+	 */
+	public function get_raw_endpoint_data() {
+		return $this->endpoints;
+	}
+
+	/**
+	 * Allow calling protected methods from tests
+	 *
+	 * @param string $method Method to call
+	 * @param array $args Arguments to pass to the method
+	 * @return mixed
+	 */
+	public function __call( $method, $args ) {
+		return call_user_func_array( array( $this, $method ), $args );
+	}
+
+	/**
+	 * Call dispatch() with the rest_post_dispatch filter
+	 */
+	public function dispatch( $request ) {
+		$result = parent::dispatch( $request );
+		$result = rest_ensure_response( $result );
+		if ( is_wp_error( $result ) ) {
+			$result = $this->error_to_response( $result );
+		}
+		return apply_filters( 'rest_post_dispatch', rest_ensure_response( $result ), $this, $request );
+	}
+}


### PR DESCRIPTION
## Testing instructions
- [ ] Check the branch out and build it as usual.
- [ ] Make sure that your site is reported as not public or edit the method that checks for it here: https://github.com/Automattic/jetpack/pull/4055/files#diff-539948a08cc7703904b7ac0ee001b33fR28
- [ ] Try to enable any of the modules that are listed as requiring your site to be public: https://github.com/Automattic/jetpack/pull/4055/files#diff-2ccec9069213650359171727de9a2471R9 
- [ ] You should get a notice that your site is not publicly accessible.

## Problems with this PR:
- [x] Not every module that actually requires your site to be public is listed in the enpoint's array.
- [x] The notice is not dismissable, we need to add a `dismissJetpackStateNotice` handler to the button click.
- [ ] ~~The failure event slug needs to be more precise, something like `module_activate_fail_public`~~ No longer relevant thanks to Derek's work on global notices.