### PR TITLE
Retrieve comments form using the locale, not the bloginfo-language

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -257,7 +257,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			 */
 			'greeting_reply'       => apply_filters( 'jetpack_comment_form_prompt_reply', __( 'Leave a Reply to %s' , 'jetpack' ) ),
 			'color_scheme'         => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
-			'lang'                 => get_bloginfo( 'language' ),
+			'lang'                 => get_locale(),
 			'jetpack_version'      => JETPACK__VERSION,
 		);
 


### PR DESCRIPTION
Fixes #3761.

#### Changes proposed in this Pull Request:
For example in Dutch currently the translation of `html_lang_attribute` is being sent instead of the locale, this causes the comments form to be displayed in the fallback language English.

Testing:
 - set blog language to Dutch
 - Open a page with the Jetpack comments form
 - it should appear in Dutch