### PR TITLE
React Build Script: Only checkout depth of 1

### DIFF
--- a/tools/deploy-to-jetpack-built-branch.sh
+++ b/tools/deploy-to-jetpack-built-branch.sh
@@ -50,7 +50,7 @@ done
 echo "Done!"
 
 echo "Pulling latest from jetpack-built branch"
-git clone -b jetpack-built --single-branch git@github.com:Automattic/jetpack.git $JETPACK_TMP_DIR
+git clone --depth 1 -b jetpack-built --single-branch git@github.com:Automattic/jetpack.git $JETPACK_TMP_DIR
 echo "Done!"
 
 echo "Rsync'ing everything over remote version"


### PR DESCRIPTION
We only need the latest commit, so let's do a shallow checkout. My quick look, checking out the branch pre-patch requires ~50MB of bandwidth down. After ~9.