### PR TITLE
Sitemaps: set post as global when parsing each post

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -241,7 +241,7 @@ function jetpack_print_news_sitemap_xsl() {
  * @link http://sitemaps.org/protocol.php Sitemaps.org protocol.
  */
 function jetpack_print_sitemap() {
-	global $wpdb;
+	global $wpdb, $post;
 
 	$xml = get_transient( 'jetpack_sitemap' );
 
@@ -291,6 +291,7 @@ function jetpack_print_sitemap() {
 	unset( $initstr );
 	$latest_mod = '';
 	foreach ( $posts as $post ) {
+		setup_postdata( $post );
 
 		/**
 		 * Filter condition to allow skipping specific posts in sitemap.
@@ -397,6 +398,7 @@ function jetpack_print_sitemap() {
 		jetpack_sitemap_array_to_simplexml( array( 'url' => $url_node ), $tree );
 		unset( $url );
 	}
+	wp_reset_postdata();
 	$blog_home = array(
 		'loc'        => esc_url( get_option( 'home' ) ),
 		'changefreq' => 'daily',
@@ -459,7 +461,7 @@ function jetpack_print_news_sitemap() {
 		die();
 	}
 
-	global $wpdb;
+	global $wpdb, $post;
 
 	/**
 	 * Filter post types to be included in news sitemap.
@@ -532,6 +534,7 @@ function jetpack_print_news_sitemap() {
 		<?php
 		$posts = $wpdb->get_results( $query );
 		foreach ( $posts as $post ):
+			setup_postdata( $post );
 
 			/**
 			 * Filter condition to allow skipping specific posts in news sitemap.
@@ -584,6 +587,7 @@ function jetpack_print_news_sitemap() {
 
 			jetpack_print_sitemap_item( $url );
 		endforeach;
+		wp_reset_postdata();
 		?>
 	</urlset>
 	<?php


### PR DESCRIPTION
Fixes #4046

#### Issue
The custom loop created when each post is read to be parsed and added to the sitemap wasn't setting the post as global and the slideshow shortcode was throwing a notice due to this explained in #4046 

#### Changes
The post being read is now set as the global post to solve this. It's reset afterwards. The change is applied to sitemap.xml and news-sitemap.xml.

#### To test
Reproduce the bug before checking out the branch:

1. Add a gallery in Slideshow mode in a post or enter it manually.

2. edit `modules/sitemaps/sitemaps.php` and after
```php
function jetpack_sitemap_initialize() {
```
add
```php
delete_transient( 'jetpack_sitemap' );
delete_transient( 'jetpack_news_sitemap' );
```
this is merely to delete the transient and be able to reproduce the issue quickly.

3. Go to example.tld/sitemap.xml, it will not be able render it.
The dump can be found in `wp-content/debug.log` similar to
```
call_user_func_array:{/siteroot/wp-includes/plugin.php:525}() /siteroot/wp-includes/plugin.php:525
jetpack_print_sitemap() /siteroot/wp-includes/plugin.php:525
Jetpack_PostImages::get_images() /siteroot/wp-content/plugins/jetpack/modules/sitemaps/sitemaps.php:334
Jetpack_PostImages::from_gallery() /siteroot/wp-content/plugins/jetpack/class.jetpack-post-images.php:470
get_post_galleries_images() /siteroot/wp-content/plugins/jetpack/class.jetpack-post-images.php:94
get_post_galleries() /siteroot/wp-includes/media.php:3683
do_shortcode_tag() /siteroot/wp-includes/media.php:3617
call_user_func:{/siteroot/wp-includes/shortcodes.php:326}() /siteroot/wp-includes/shortcodes.php:326
gallery_shortcode() /siteroot/wp-includes/shortcodes.php:326
apply_filters() /siteroot/wp-includes/media.php:1606
call_user_func_array:{/siteroot/wp-includes/plugin.php:235}() /siteroot/wp-includes/plugin.php:235
Jetpack_Slideshow_Shortcode->post_gallery() /siteroot/wp-includes/plugin.php:235
Jetpack_Slideshow_Shortcode->shortcode_callback() /siteroot/wp-content/plugins/jetpack/modules/shortcodes/slideshow.php:55
Cannot modify header information - headers already sent by (output started at /siteroot/wp-content/plugins/jetpack/modules/shortcodes/slideshow.php:125) in /siteroot/wp-content/plugins/jetpack/modules/sitemaps/sitemaps.php on line 407
```

4. checkout the branch (you might need to repeat step 2) and try again. It should render correctly.

Note that images count in the post will still be missing the images in the slideshow and that's because of a separate issue with the methods `from_slideshow` `from_gallery` from `Jetpack_PostImages` as explained in #4069.