### PR TITLE
Update sync server from WPCOM

### DIFF
--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -9,8 +9,8 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-deflate-codec.php';
 class Jetpack_Sync_Server {
 	private $codec;
 	const MAX_TIME_PER_REQUEST_IN_SECONDS = 15;
-	const BLOG_LOCK_TRANSIENT_PREFIX = 'jetpack_sync_request_lock_';
-	const BLOG_LOCK_TRANSIENT_EXPIRY = 60;
+	const BLOG_LOCK_TRANSIENT_PREFIX = 'jp_sync_req_lock_';
+	const BLOG_LOCK_TRANSIENT_EXPIRY = 60; // seconds
 
 	// this is necessary because you can't use "new" when you declare instance properties >:(
 	function __construct() {
@@ -23,12 +23,11 @@ class Jetpack_Sync_Server {
 
 	function attempt_request_lock( $blog_id, $expiry = self::BLOG_LOCK_TRANSIENT_EXPIRY ) {
 		$transient_name = $this->get_concurrent_request_transient_name( $blog_id );
-		$locked_time = get_transient( $transient_name );
+		$locked_time = get_site_transient( $transient_name );
 		if ( $locked_time ) {
 			return false;
 		}
-		// for some reason set_transient isn't returning TRUE like it's supposed to...
-		set_transient( $transient_name, microtime( true ), $expiry );
+		set_site_transient( $transient_name, microtime(true), $expiry );
 		return true;
 	}
 
@@ -37,7 +36,7 @@ class Jetpack_Sync_Server {
 	}
 
 	function remove_request_lock( $blog_id ) {
-		delete_transient( $this->get_concurrent_request_transient_name( $blog_id ) );
+		delete_site_transient( $this->get_concurrent_request_transient_name( $blog_id ) );
 	}
 
 	function receive( $data, $token = null ) {


### PR DESCRIPTION
Updates the sync server file.

#### Changes proposed in this Pull Request:
- update sync server with fixed locking

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

