### PR TITLE
Admin - Connection Button: add the proper default so it matches the required data type

### DIFF
--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -35,7 +35,7 @@ export const status = ( state = { siteConnected: window.Initial_State.connection
 	}
 };
 
-export const connectUrl = ( state = {}, action ) => {
+export const connectUrl = ( state = '', action ) => {
 	switch ( action.type ) {
 		case CONNECT_URL_FETCH_SUCCESS:
 			return action.connectUrl;


### PR DESCRIPTION
Fixes #3919.

#### Changes proposed in this Pull Request:
- change the default value of `connectUrl` reducer to `''` instead of the previous '{}' that was throwing a notice in JS console due to the mismatching data type