### PR TITLE
Add test for the connectUrl reducer to assert that it defaults to an empty string

### DIFF
--- a/_inc/client/state/connection/test/reducer.js
+++ b/_inc/client/state/connection/test/reducer.js
@@ -33,6 +33,10 @@ describe( 'status reducer', () => {
 } );
 
 describe( 'connect url reducer', () => {
+	it( 'state should default to empty string', () => {
+		const state = connectUrlReducer( undefined, {} );
+		expect( state ).to.eql( '' );
+	} );
 	describe( '#fetchConnectUrl', () => {
 		it( 'should set connectUrl to action.connectUrl\'s value when fetching connect url', () => {
 			const stateIn = {};


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
- Adds default state test for when #4076   is merged

Testing instructions
```
$ npm run test-client --  -g connection
```

**before #4076 is merged**: 

Test `state should default to empty string` should fail until the mentioned PR is merged. 

```
  state
    connection
      status reducer
        #disconnectSite
          ✓ should set siteConnected to false when disconnecting site
          ✓ should set siteConnected to action.siteConnected's value when fetching connection status
      connect url reducer
        1) state should default to empty string
```

**After #4076 is merged**: 

Test should pass.

```
  state
    connection
      status reducer
        #disconnectSite
          ✓ should set siteConnected to false when disconnecting site
          ✓ should set siteConnected to action.siteConnected's value when fetching connection status
      connect url reducer
        ✓ state should default to empty string
```