### PR TITLE
Admin Page: Remove unnecessary binding to redux state in Navigation component

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -15,7 +15,6 @@ injectTapEventPlugin();
  * Internal dependencies
  */
 import QueryModules from 'components/data/query-modules';
-import { getModules } from 'state/modules';
 
 const Navigation = React.createClass( {
 	demoSearch: function( keywords ) {
@@ -73,8 +72,4 @@ const Navigation = React.createClass( {
 	}
 } );
 
-export default connect( ( state ) => {
-	return {
-		modules: getModules( state )
-	};
-} )( Navigation );
+export default Navigation;


### PR DESCRIPTION
Fixes unnecessary re-render of every Navigation's children when `state.jetpack.modules.items` is updated by any means.

#### Changes proposed in this Pull Request:

- Removes unnecessary binding to the `modules` state key in the `Navigation` component

#### Testing instructions

* Just load thee Jetpack Admin Page and expect to see no errors in console. 