### PR TITLE
Locales: avoid Fatal Errors when GlotPress is active.

### DIFF
--- a/locales.php
+++ b/locales.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! class_exists( 'GP_Locale' ) ) :
+
 class GP_Locale {
 	public $english_name;
 	public $native_name;
@@ -84,6 +87,10 @@ class GP_Locale {
 	}
 
 }
+
+endif;
+
+if ( ! class_exists( 'GP_Locales' ) ) :
 
 class GP_Locales {
 
@@ -2105,3 +2112,5 @@ class GP_Locales {
 		return $result;
 	}
 }
+
+endif;

--- a/locales.php
+++ b/locales.php
@@ -1,6 +1,8 @@
 <?php
 
-if ( ! class_exists( 'GP_Locale' ) ) :
+if ( class_exists( 'GP_Locale' ) ) {
+	return;
+}
 
 class GP_Locale {
 	public $english_name;
@@ -87,10 +89,6 @@ class GP_Locale {
 	}
 
 }
-
-endif;
-
-if ( ! class_exists( 'GP_Locales' ) ) :
 
 class GP_Locales {
 
@@ -2112,5 +2110,3 @@ class GP_Locales {
 		return $result;
 	}
 }
-
-endif;


### PR DESCRIPTION
Reported here:
https://wordpress.org/support/topic/fatal-error-with-glotpress-activated