### PR TITLE
Jetpack PostImages: fix methods from_gallery and from_slideshow

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -91,19 +91,38 @@ class Jetpack_PostImages {
 
 		$permalink = get_permalink( $post->ID );
 
-		$gallery_images = get_post_galleries_images( $post->ID, false );
+		$galleries = get_post_galleries( $post->ID, false );
 
-		foreach ( $gallery_images as $galleries ) {
-			foreach ( $galleries as $src ) {
-				list( $raw_src ) = explode( '?', $src ); // pull off any Query string (?w=250)
-				$raw_src = wp_specialchars_decode( $raw_src ); // rawify it
-				$raw_src = esc_url_raw( $raw_src ); // clean it
-				$images[] = array(
-					'type'  => 'image',
-					'from'  => 'gallery',
-					'src'   => $raw_src,
-					'href'  => $permalink,
-				);
+		foreach ( $galleries as $gallery ) {
+			if ( isset( $gallery['type'] ) && 'slideshow' === $gallery['type'] && ! empty( $gallery['ids'] ) ) {
+				$image_ids = explode( ',', $gallery['ids'] );
+				$image_size = isset( $gallery['size'] ) ? $gallery['size'] : 'thumbnail';
+				foreach ( $image_ids as $image_id ) {
+					$image = wp_get_attachment_image_src( $image_id, $image_size );
+					if ( ! empty( $image[0] ) ) {
+						list( $raw_src ) = explode( '?', $image[0] ); // pull off any Query string (?w=250)
+						$raw_src = wp_specialchars_decode( $raw_src ); // rawify it
+						$raw_src = esc_url_raw( $raw_src ); // clean it
+						$images[] = array(
+							'type'  => 'image',
+							'from'  => 'gallery',
+							'src'   => $raw_src,
+							'href'  => $permalink,
+						);
+					}
+				}
+			} elseif ( ! empty( $gallery['src'] ) ) {
+				foreach ( $gallery['src'] as $src ) {
+					list( $raw_src ) = explode( '?', $src ); // pull off any Query string (?w=250)
+					$raw_src = wp_specialchars_decode( $raw_src ); // rawify it
+					$raw_src = esc_url_raw( $raw_src ); // clean it
+					$images[] = array(
+						'type'  => 'image',
+						'from'  => 'gallery',
+						'src'   => $raw_src,
+						'href'  => $permalink,
+					);
+				}
 			}
 		}
 

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -40,11 +40,11 @@ class Jetpack_PostImages {
 
 		foreach ( $slideshow_matches as $slideshow_match ) {
 			$slideshow = do_shortcode_tag( $slideshow_match );
-			if ( false === $pos = stripos( $slideshow, 'slideShow.images' ) ) // must be something wrong - or we changed the output format in which case none of the following will work
+			if ( false === $pos = stripos( $slideshow, 'jetpack-slideshow' ) ) // must be something wrong - or we changed the output format in which case none of the following will work
 				continue;
 			$start = strpos( $slideshow, '[', $pos );
 			$end = strpos( $slideshow, ']', $start );
-			$post_images = json_decode( str_replace( "'", '"', substr( $slideshow, $start, $end - $start + 1 ) ) ); // parse via JSON
+			$post_images = json_decode( wp_specialchars_decode( str_replace( "'", '"', substr( $slideshow, $start, $end - $start + 1 ) ), ENT_QUOTES ) ); // parse via JSON
 			foreach ( $post_images as $post_image ) {
 				if ( !$post_image_id = absint( $post_image->id ) )
 					continue;


### PR DESCRIPTION
Fixes #4069

#### Changes proposed in this Pull Request:
- `from_slideshow`
	- Don't look for `slideShow.images` but for `jetpack-slideshow`.
	- Convert HTML entities to characters before decoding as JSON

    This fixes the issue where the method `from_slideshow` can't find the images because 1) was looking for an outdated format and 2) the `json_decode` was trying to parse HTML entities like `&quot;` and was failing.

- `from_gallery`
	- Check if the `type` parameter in `gallery` shortcode is 'slideshow' type and extract its images in a suitable way. If it's a regular gallery, continue working like before.

    This fixes the issue where the method `from_gallery` can't find the images when the gallery `type` is `slideshow` because the `Jetpack_Slideshow_Shortcode` class added a `post_filter` that modified the gallery output and the core function `get_post_galleries` can't find the `src` of the images.