### PR TITLE
Remove unnecessary Jetpack::state() notices 

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -908,7 +908,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			} else {
 				$result['failed_modules'][] = $module_slug;
 			}
-			Jetpack::state( 'message', 'no_message' );
 		}
 
 		// Set the default sharing buttons and set to display on posts if none have been set.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2571,8 +2571,6 @@ class Jetpack {
 		$active[] = $module;
 		Jetpack_Options::update_option( 'active_modules', array_unique( $active ) );
 		Jetpack::state( 'error', false ); // the override
-		Jetpack::state( 'message', 'module_activated' );
-		Jetpack::state( 'module', $module );
 		ob_end_clean();
 		Jetpack::catch_errors( false );
 


### PR DESCRIPTION
**To reproduce the problem(s):** 
`no_message`:
- Reset options 
- Hit Jumpstart 
- Refresh the page
- You will see a `no_message` error. 

`module_activated`: 
- Activate a module 
- Refresh the page
- You will see a `module_actiavted` error. 

**To test this PR**
Follow the same steps, but you should NOT see those notices.  