### PR TITLE
Sync: SSO: Begin syncing SSO specific options and filters

### DIFF
--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
+
 /**
  * A collection of helper functions used in the SSO module.
  *
@@ -106,3 +108,5 @@ class Jetpack_SSO_Helpers {
 		return (bool) apply_filters( 'jetpack_sso_bypass_login_forward_wpcom', false );
 	}
 }
+
+endif;

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -1,11 +1,13 @@
 <?php
 
+/**
+ * A collection of helper functions used in the SSO module.
+ *
+ * @since 4.1.0
+ */
 class Jetpack_SSO_Helpers {
 	/**
 	 * Determine if the login form should be hidden or not
-	 *
-	 * Method is private only because it is only used in this class so far.
-	 * Feel free to change it later
 	 *
 	 * @return bool
 	 **/
@@ -22,6 +24,12 @@ class Jetpack_SSO_Helpers {
 		return (bool) apply_filters( 'jetpack_remove_login_form', get_option( 'jetpack_sso_remove_login_form', false ) );
 	}
 
+	/**
+	 * Returns a boolean value for whether logging in by matching the WordPress.com user email to a
+	 * Jetpack site user's email is allowed.
+	 *
+	 * @return bool
+	 */
 	static function match_by_email() {
 		$match_by_email = ( 1 == get_option( 'jetpack_sso_match_by_email', true ) ) ? true: false;
 		$match_by_email = defined( 'WPCC_MATCH_BY_EMAIL' ) ? WPCC_MATCH_BY_EMAIL : $match_by_email;
@@ -38,6 +46,12 @@ class Jetpack_SSO_Helpers {
 		return (bool) apply_filters( 'jetpack_sso_match_by_email', $match_by_email );
 	}
 
+	/**
+	 * Returns a boolean for whether users are allowed to register on the Jetpack site with SSO,
+	 * even though the site disallows normal registrations.
+	 *
+	 * @return bool
+	 */
 	static function new_user_override() {
 		$new_user_override = defined( 'WPCC_NEW_USER_OVERRIDE' ) ? WPCC_NEW_USER_OVERRIDE : false;
 
@@ -73,6 +87,12 @@ class Jetpack_SSO_Helpers {
 		return (bool) apply_filters( 'jetpack_sso_require_two_step', get_option( 'jetpack_sso_require_two_step', false ) );
 	}
 
+	/**
+	 * Returns a boolean for whether a user that is attempting to log in will be automatically
+	 * redirected to WordPress.com to begin the SSO flow.
+	 *
+	 * @return bool
+	 */
 	static function bypass_login_forward_wpcom() {
 		/**
 		 * Redirect the site's log in form to WordPress.com's log in form.

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -1,4 +1,5 @@
 <?php
+require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' );
 
 /**
  * Just some defaults that we share with the server
@@ -106,6 +107,7 @@ class Jetpack_Sync_Defaults {
 		'jetpack_sso_require_two_step',
 		'jetpack_relatedposts',
 		'verification_services_codes',
+		'users_can_register',
 	);
 
 	static $default_constants_whitelist = array(
@@ -124,15 +126,20 @@ class Jetpack_Sync_Defaults {
 	);
 
 	static $default_callable_whitelist = array(
-		'wp_max_upload_size'           => 'wp_max_upload_size',
-		'is_main_network'              => array( 'Jetpack', 'is_multi_network' ),
-		'is_multi_site'                => 'is_multisite',
-		'main_network_site'            => 'network_site_url',
-		'single_user_site'             => array( 'Jetpack', 'is_single_user_site' ),
-		'has_file_system_write_access' => array( 'Jetpack_Sync_Functions', 'file_system_write_access' ),
-		'is_version_controlled'        => array( 'Jetpack_Sync_Functions', 'is_version_controlled' ),
-		'taxonomies'                   => array( 'Jetpack_Sync_Functions', 'get_taxonomies' ),
-		'post_types'                   => array( 'Jetpack_Sync_Functions', 'get_post_types' ),
+		'wp_max_upload_size'              => 'wp_max_upload_size',
+		'is_main_network'                 => array( 'Jetpack', 'is_multi_network' ),
+		'is_multi_site'                   => 'is_multisite',
+		'main_network_site'               => 'network_site_url',
+		'single_user_site'                => array( 'Jetpack', 'is_single_user_site' ),
+		'has_file_system_write_access'    => array( 'Jetpack_Sync_Functions', 'file_system_write_access' ),
+		'is_version_controlled'           => array( 'Jetpack_Sync_Functions', 'is_version_controlled' ),
+		'taxonomies'                      => array( 'Jetpack_Sync_Functions', 'get_taxonomies' ),
+		'post_types'                      => array( 'Jetpack_Sync_Functions', 'get_post_types' ),
+		'sso_is_two_step_required'        => array( 'Jetpack_SSO_Helpers', 'is_two_step_required' ),
+		'sso_should_hide_login_form'      => array( 'Jetpack_SSO_Helpers', 'should_hide_login_form' ),
+		'sso_match_by_email'              => array( 'Jetpack_SSO_Helpers', 'match_by_email' ),
+		'sso_new_user_override'           => array( 'Jetpack_SSO_Helpers', 'new_user_override' ),
+		'sso_bypass_default_login_form'   => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
 	);
 
 	static $blacklisted_post_types = array(

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -1,5 +1,5 @@
 <?php
-require dirname( __FILE__ ) . '/../../../../modules/sso/class.jetpack-sso-helpers.php';
+require_once( dirname( __FILE__ ) . '/../../../../modules/sso/class.jetpack-sso-helpers.php' );
 
 /**
  * Testing functions in Jetpack_SSO_Helpers class.

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -161,6 +161,7 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 			'jetpack_sso_require_two_step'=> 'pineapple',
 			'jetpack_relatedposts'=> 'pineapple',
 			'verification_services_codes'=> 'pineapple',
+			'users_can_register' => '1'
 		);
 		
 		$theme_mod_key = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-sso.php
+++ b/tests/php/sync/test_class.jetpack-sync-sso.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Testing sync of values for SSO.
+ */
+class WP_Test_Jetpack_Sync_SSO extends WP_Test_Jetpack_New_Sync_Base {
+	function test_sync_sso_is_two_step_required_filter_true() {
+		add_filter( 'jetpack_sso_require_two_step', '__return_true' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_is_two_step_required' );
+		$this->assertTrue( $callableValue );
+		remove_filter( 'jetpack_sso_require_two_step', '__return_true' );
+	}
+
+	function test_sync_sso_should_hide_login_form_filter_true() {
+		add_filter( 'jetpack_remove_login_form', '__return_true' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_should_hide_login_form' );
+		$this->assertTrue( $callableValue );
+		remove_filter( 'jetpack_remove_login_form', '__return_true' );
+	}
+
+	function test_sync_sso_match_by_email_filter_true() {
+		add_filter( 'jetpack_sso_match_by_email', '__return_true' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_match_by_email' );
+		$this->assertTrue( $callableValue );
+		remove_filter( 'jetpack_sso_match_by_email', '__return_true' );
+	}
+
+	function test_sync_sso_new_user_override_filter_true() {
+		add_filter( 'jetpack_sso_new_user_override', '__return_true' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_new_user_override' );
+		$this->assertTrue( $callableValue );
+		remove_filter( 'jetpack_sso_new_user_override', '__return_true' );
+	}
+
+	function test_sync_sso_sso_bypass_default_login_form_filter_true() {
+		add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_bypass_default_login_form' );
+		$this->assertTrue( $callableValue );
+		remove_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
+	}
+
+	function test_sync_sso_is_two_step_required_filter_false() {
+		add_filter( 'jetpack_sso_require_two_step', '__return_false' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_is_two_step_required' );
+		$this->assertFalse( $callableValue );
+		remove_filter( 'jetpack_sso_require_two_step', '__return_false' );
+	}
+
+	function test_sync_sso_should_hide_login_form_filter_false() {
+		add_filter( 'jetpack_remove_login_form', '__return_false' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_should_hide_login_form' );
+		$this->assertFalse( $callableValue );
+		remove_filter( 'jetpack_remove_login_form', '__return_false' );
+	}
+
+	function test_sync_sso_match_by_email_filter_false() {
+		add_filter( 'jetpack_sso_match_by_email', '__return_false' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_match_by_email' );
+		$this->assertFalse( $callableValue );
+		remove_filter( 'jetpack_sso_match_by_email', '__return_false' );
+	}
+
+	function test_sync_sso_new_user_override_filter_false() {
+		add_filter( 'jetpack_sso_new_user_override', '__return_false' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_new_user_override' );
+		$this->assertFalse( $callableValue );
+		remove_filter( 'jetpack_sso_new_user_override', '__return_false' );
+	}
+
+	function test_sync_sso_sso_bypass_default_login_form_filter_false() {
+		add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_false' );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_bypass_default_login_form' );
+		$this->assertFalse( $callableValue );
+		remove_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_false' );
+	}
+
+	function test_sync_sso_is_two_step_required_option_true() {
+		update_option( 'jetpack_sso_require_two_step', true );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_is_two_step_required' );
+		$this->assertTrue( $callableValue );
+		delete_option( 'jetpack_sso_require_two_step' );
+	}
+
+	function test_sync_sso_should_hide_login_form_option_true() {
+		update_option( 'jetpack_sso_remove_login_form', true );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_should_hide_login_form' );
+		$this->assertTrue( $callableValue );
+		delete_option( 'jetpack_sso_remove_login_form' );
+	}
+
+	function test_sync_sso_is_two_step_required_option_false() {
+		update_option( 'jetpack_sso_require_two_step', false );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_is_two_step_required' );
+		$this->assertFalse( $callableValue );
+		delete_option( 'jetpack_sso_require_two_step' );
+	}
+
+	function test_sync_sso_should_hide_login_form_option_false() {
+		update_option( 'jetpack_sso_remove_login_form', false );
+		$this->client->do_sync();
+		$callableValue = $this->server_replica_storage->get_callable( 'sso_should_hide_login_form' );
+		$this->assertFalse( $callableValue );
+		delete_option( 'jetpack_sso_remove_login_form' );
+	}
+}


### PR DESCRIPTION
This PR factors out some SSO helpers functions into a separate file and then adds SSO specific options and filters to what is synced.

To test:

- Checkout `add/sync-sso-options-filters` branch
- In `vagrant-local` directory
- `vagrant up`
- `vagrant ssh`
- `cd /srv/www/wordpress-develop/src/wp-content/plugins/jetpack`
- `phpunit --filter=WP_Test_Jetpack_Sync_SSO --debug`
- `phpunit --filter=WP_Test_Jetpack_New_Sync_Options --debug`

You can also do some regression testing by testing the SSO flow:

- Go to `/wp-admin`
- Click "Log in with WordPress.com" button
- Once on WP.com, click "Log in"
- Does it work?