### PR TITLE
Remove the get_mock_option function from SAL

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1066,17 +1066,8 @@ class Jetpack {
 	 * @return string ( '1' | '0' )
 	 **/
 	public static function is_version_controlled() {
-
-		if ( !class_exists( 'WP_Automatic_Updater' ) ) {
-			require_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
-		}
-		$updater = new WP_Automatic_Updater();
-		$is_version_controlled = strval( $updater->is_vcs_checkout( $context = ABSPATH ) );
-		// transients should not be empty
-		if ( empty( $is_version_controlled ) ) {
-			$is_version_controlled = '0';
-		}
-		return $is_version_controlled;
+		_deprecated_function( 'Jetpack::is_version_controlled', '4.1', 'Jetpack_Sync_Functions::is_version_controlled' );
+		return (string) (int) Jetpack_Sync_Functions::is_version_controlled();
 	}
 
 	/**

--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -10,11 +10,23 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 
 	abstract protected function get_theme_support( $feature_name );
 
-	abstract protected function get_mock_option( $name );
-
 	abstract protected function get_jetpack_version();
 
 	abstract protected function get_updates();
+
+	abstract protected function main_network_site();
+
+	abstract protected function wp_version();
+
+	abstract protected function max_upload_size();
+
+	abstract protected function is_main_network();
+
+	abstract protected function is_multi_site();
+
+	abstract protected function is_version_controlled();
+
+	abstract protected function file_system_write_access();
 
 	function before_render() {
 	}
@@ -35,9 +47,10 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 	}
 
 	function after_render_options( &$options ) {
+
 		$options['jetpack_version'] = $this->get_jetpack_version();
 
-		if ( $main_network_site = $this->get_mock_option( 'main_network_site' ) ) {
+		if ( $main_network_site = $this->main_network_site() ) {
 			$options['main_network_site'] = (string) rtrim( $main_network_site, '/' );
 		}
 
@@ -45,22 +58,22 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 			$options['active_modules'] = (array) array_values( $active_modules );
 		}
 
-		$options['software_version'] = (string) $this->get_mock_option( 'wp_version' );
-		$options['max_upload_size']  = $this->get_mock_option( 'max_upload_size', false );
+		$options['software_version'] = (string) $this->wp_version();
+		$options['max_upload_size']  = $this->max_upload_size();
 
 		// Sites have to prove that they are not main_network site.
 		// If the sync happends right then we should be able to see that we are not dealing with a network site
-		$options['is_multi_network'] = (bool) $this->get_mock_option( 'is_main_network', true );
-		$options['is_multi_site']    = (bool) $this->get_mock_option( 'is_multi_site', true );
+		$options['is_multi_network'] = (bool) $this->is_main_network();
+		$options['is_multi_site']    = (bool) $this->is_multi_site();
 
 		$file_mod_disabled_reasons = array_keys( array_filter( array(
 			'automatic_updater_disabled'      => (bool) $this->get_constant( 'AUTOMATIC_UPDATER_DISABLED' ),
 			// WP AUTO UPDATE CORE defaults to minor, '1' if true and '0' if set to false.
-			'wp_auto_update_core_disabled'    => ! ( (bool) $this->get_constant( 'WP_AUTO_UPDATE_CORE' ) ),
-			'is_version_controlled'           => (bool) $this->get_mock_option( 'is_version_controlled' ),
+			'wp_auto_update_core_disabled'    => ! ( (bool)  $this->get_constant( 'WP_AUTO_UPDATE_CORE' ) ),
+			'is_version_controlled'           => (bool) $this->is_version_controlled(),
 			// By default we assume that site does have system write access if the value is not set yet.
-			'has_no_file_system_write_access' => ! (bool) ( $this->get_mock_option( 'has_file_system_write_access' ) ),
-			'disallow_file_mods'              => (bool) $this->get_constant( 'DISALLOW_FILE_MODS' ),
+			'has_no_file_system_write_access' => ! (bool) $this->file_system_write_access(),
+			'disallow_file_mods'              => (bool)  $this->get_constant( 'DISALLOW_FILE_MODS' ),
 		) ) );
 
 		$options['file_mod_disabled'] = empty( $file_mod_disabled_reasons ) ? false : $file_mod_disabled_reasons;
@@ -79,11 +92,11 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 	}
 
 	function is_multisite() {
-		return (bool) $this->get_mock_option( 'is_multi_site' );
+		return (bool) is_multisite();
 	}
 
 	function is_single_user_site() {
-		return (bool) $this->get_mock_option( 'single_user_site' );
+		return (bool) Jetpack::is_single_user_site();
 	}
 
 	function featured_images_enabled() {

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -6,15 +6,40 @@ require_once dirname( __FILE__ ) . '/class.json-api-post-jetpack.php';
 // this code runs on Jetpack (.org) sites
 class Jetpack_Site extends Abstract_Jetpack_Site {
 
-	protected function get_mock_option( $name ) {
-		return get_option( 'jetpack_'.$name );
-	}
-
 	protected function get_constant( $name ) {
 		if ( defined( $name) ) {
 			return constant( $name );
 		}
 		return null;
+	}
+
+	protected function main_network_site() {
+		return network_site_url();
+	}
+
+	protected function wp_version() {
+		global $wp_version;
+		return $wp_version;
+	}
+
+	protected function max_upload_size() {
+		return wp_max_upload_size();
+	}
+
+	protected function is_main_network() {
+		return Jetpack::is_multi_network();
+	}
+
+	protected function is_multi_site() {
+		return is_multisite();
+	}
+
+	protected function is_version_controlled() {
+		return Jetpack_Sync_Functions::is_version_controlled();
+	}
+
+	protected function file_system_write_access() {
+		return Jetpack_Sync_Functions::file_system_write_access();
 	}
 
 	protected function current_theme_supports( $feature_name ) {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -25,7 +25,7 @@ class Jetpack_Sync_Functions {
 
 	/**
 	 * Finds out if a site is using a version control system.
-	 * @return string ( '1' | '0' )
+	 * @return bool
 	 **/
 	public static function is_version_controlled() {
 
@@ -33,18 +33,12 @@ class Jetpack_Sync_Functions {
 			require_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 		}
 		$updater               = new WP_Automatic_Updater();
-		$is_version_controlled = strval( $updater->is_vcs_checkout( $context = ABSPATH ) );
-		// transients should not be empty
-		if ( empty( $is_version_controlled ) ) {
-			$is_version_controlled = '0';
-		}
-
-		return $is_version_controlled;
+		return (bool) strval( $updater->is_vcs_checkout( $context = ABSPATH ) );
 	}
 
 	/**
 	 * Returns true if the site has file write access false otherwise.
-	 * @return string ( '1' | '0' )
+	 * @return bool
 	 **/
 	public static function file_system_write_access() {
 		if ( ! function_exists( 'get_filesystem_method' ) ) {
@@ -55,16 +49,16 @@ class Jetpack_Sync_Functions {
 
 		$filesystem_method = get_filesystem_method();
 		if ( $filesystem_method === 'direct' ) {
-			return '1';
+			return true;
 		}
 
 		ob_start();
 		$filesystem_credentials_are_stored = request_filesystem_credentials( self_admin_url() );
 		ob_end_clean();
 		if ( $filesystem_credentials_are_stored ) {
-			return '1';
+			return true;
 		}
 
-		return '0';
+		return false;
 	}
 }

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -55,16 +55,16 @@ class Jetpack_Sync_Functions {
 
 		$filesystem_method = get_filesystem_method();
 		if ( $filesystem_method === 'direct' ) {
-			return 1;
+			return '1';
 		}
 
 		ob_start();
 		$filesystem_credentials_are_stored = request_filesystem_credentials( self_admin_url() );
 		ob_end_clean();
 		if ( $filesystem_credentials_are_stored ) {
-			return 1;
+			return '1';
 		}
 
-		return 0;
+		return '0';
 	}
 }


### PR DESCRIPTION
Since we are not adding the filters that create mock options any more we should be removing that concept completely even from the api. 

This will make thins much more clearer and more efficient. 

#### Changes proposed in this Pull Request:
Removes the mock_option method. 
Also fixed an issue brought up by @ebinnion. 

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).

cc: @lezama, @gravityrail 