### PR TITLE
Custom Post Types: Rename current theme options of the Testimonials CPT

### DIFF
--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -470,7 +470,7 @@ class Jetpack_Testimonial {
 		) );
 		$wp_customize->add_control( 'jetpack_testimonials[page-title]', array(
 			'section' => 'jetpack_testimonials',
-			'label'   => esc_html__( 'Testimonial Page Title', 'jetpack' ),
+			'label'   => esc_html__( 'Testimonial Archive Title', 'jetpack' ),
 			'type'    => 'text',
 		) );
 
@@ -482,7 +482,7 @@ class Jetpack_Testimonial {
 		$wp_customize->add_control( new Jetpack_Testimonial_Textarea_Control( $wp_customize, 'jetpack_testimonials[page-content]', array(
 			'section'  => 'jetpack_testimonials',
 			'settings' => 'jetpack_testimonials[page-content]',
-			'label'    => esc_html__( 'Testimonial Page Content', 'jetpack' ),
+			'label'    => esc_html__( 'Testimonial Archive Content', 'jetpack' ),
 		) ) );
 
 		$wp_customize->add_setting( 'jetpack_testimonials[featured-image]', array(
@@ -493,7 +493,7 @@ class Jetpack_Testimonial {
 		) );
 		$wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'jetpack_testimonials[featured-image]', array(
 			'section' => 'jetpack_testimonials',
-			'label'   => esc_html__( 'Testimonial Page Featured Image', 'jetpack' ),
+			'label'   => esc_html__( 'Testimonial Archive Featured Image', 'jetpack' ),
 		) ) );
 
 		// The featured image control doesn't display properly in the Customizer unless we coerce


### PR DESCRIPTION
So it’s clearer for users it’s for the Archive and so it matches the
label of the Portfolio CPT’s theme options