### PR TITLE
Sitemaps: Support PATHINFO permalinks

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -169,8 +169,15 @@ function jetpack_sitemap_namespaces() {
  * @return string
  */
 function jetpack_sitemap_initstr( $charset ) {
+	global $wp_rewrite;
 	// URL to XSLT
-	$xsl = get_option( 'permalink_structure' ) ? home_url( '/sitemap.xsl' ) : home_url( '/?jetpack-sitemap-xsl=true' );
+	if ( $wp_rewrite->using_index_permalinks() ){
+		$xsl = home_url( '/index.php/sitemap.xsl' );
+	} else if ( $wp_rewrite->using_permalinks() ) {
+		$xsl = home_url( '/sitemap.xsl' );
+	} else {
+		$xsl = home_url( '/?jetpack-sitemap-xsl=true' );
+	}
 
 	$initstr = '<?xml version="1.0" encoding="' . $charset . '"?>' . "\n";
 	$initstr .= '<?xml-stylesheet type="text/xsl" href="' . esc_url( $xsl ) . '"?>' . "\n";
@@ -605,11 +612,16 @@ function jetpack_print_news_sitemap() {
  * @return string Sitemap URL.
  */
 function jetpack_sitemap_uri() {
-	if ( get_option( 'permalink_structure' ) ) {
+	global $wp_rewrite;
+
+	if ( $wp_rewrite->using_index_permalinks() ){
+		$sitemap_url = home_url( '/index.php/sitemap.xml' );
+	} else if ( $wp_rewrite->using_permalinks() ) {
 		$sitemap_url = home_url( '/sitemap.xml' );
 	} else {
 		$sitemap_url = home_url( '/?jetpack-sitemap=true' );
 	}
+
 	/**
 	 * Filter sitemap URL relative to home URL.
 	 *
@@ -628,11 +640,16 @@ function jetpack_sitemap_uri() {
  * @module sitemaps
  */
 function jetpack_news_sitemap_uri() {
-	if ( get_option( 'permalink_structure' ) ) {
+	global $wp_rewrite;
+
+	if ( $wp_rewrite->using_index_permalinks() ){
+		$news_sitemap_url = home_url( '/index.php/news-sitemap.xml' );
+	} else if ( $wp_rewrite->using_permalinks() ) {
 		$news_sitemap_url = home_url( '/news-sitemap.xml' );
 	} else {
 		$news_sitemap_url = home_url( '/?jetpack-news-sitemap=true' );
 	}
+
 	/**
 	 * Filter news sitemap URL relative to home URL.
 	 *

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -171,7 +171,7 @@ function jetpack_sitemap_namespaces() {
 function jetpack_sitemap_initstr( $charset ) {
 	global $wp_rewrite;
 	// URL to XSLT
-	if ( $wp_rewrite->using_index_permalinks() ){
+	if ( $wp_rewrite->using_index_permalinks() ) {
 		$xsl = home_url( '/index.php/sitemap.xsl' );
 	} else if ( $wp_rewrite->using_permalinks() ) {
 		$xsl = home_url( '/sitemap.xsl' );
@@ -614,7 +614,7 @@ function jetpack_print_news_sitemap() {
 function jetpack_sitemap_uri() {
 	global $wp_rewrite;
 
-	if ( $wp_rewrite->using_index_permalinks() ){
+	if ( $wp_rewrite->using_index_permalinks() ) {
 		$sitemap_url = home_url( '/index.php/sitemap.xml' );
 	} else if ( $wp_rewrite->using_permalinks() ) {
 		$sitemap_url = home_url( '/sitemap.xml' );
@@ -642,7 +642,7 @@ function jetpack_sitemap_uri() {
 function jetpack_news_sitemap_uri() {
 	global $wp_rewrite;
 
-	if ( $wp_rewrite->using_index_permalinks() ){
+	if ( $wp_rewrite->using_index_permalinks() ) {
 		$news_sitemap_url = home_url( '/index.php/news-sitemap.xml' );
 	} else if ( $wp_rewrite->using_permalinks() ) {
 		$news_sitemap_url = home_url( '/news-sitemap.xml' );


### PR DESCRIPTION
This PR adds the other possibility for WP permalinks: PATHINFO via `index.php`. 

To test:
1. Set your permalink structure to a custom one beginning with `/index.php/`
2. Verify `/index.php/sitemap.xml` loads as does the stylesheet. Repeat for the news sitemap.
3. Set permalink to a normal pretty one, repeat 2 at `sitemap.xml`.
4. Set to default permalinks `?p=123`, repeat 2 at `/?jetpack-sitemap=true`

Verify all load.