### PR TITLE
SSO: Factor out methods into helper class

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -632,7 +632,7 @@ class Jetpack_SSO {
 		 */
 		do_action( 'jetpack_sso_pre_handle_login', $user_data );
 
-		if ( Jetpack_SSO_Helpers::is_two_step_required() && 0 == (int) $user_data->two_step_enabled ) {
+		if ( Jetpack_SSO_Helpers::is_two_step_required() && 0 === (int) $user_data->two_step_enabled ) {
 			$this->user_data = $user_data;
 
 			JetpackTracking::record_user_event( 'sso_login_failed', array(

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1023,7 +1023,7 @@ class Jetpack_SSO {
 	/**
 	 * Builds the translation ready string that is to be used when the site hides the default login form.
 	 *
-	 * @since 4.1
+	 * @since 4.1.0
 	 * 
 	 * @return string
 	 */

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -56,7 +56,7 @@ class Jetpack_SSO_Helpers {
 	/**
 	 * Returns a boolean value for whether two-step authentication is required for SSO.
 	 *
-	 * @since 4.1
+	 * @since 4.1.0
 	 *
 	 * @return bool
 	 */

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -1,0 +1,88 @@
+<?php
+
+class Jetpack_SSO_Helpers {
+	/**
+	 * Determine if the login form should be hidden or not
+	 *
+	 * Method is private only because it is only used in this class so far.
+	 * Feel free to change it later
+	 *
+	 * @return bool
+	 **/
+	static function should_hide_login_form() {
+		/**
+		 * Remove the default log in form, only leave the WordPress.com log in button.
+		 *
+		 * @module sso
+		 *
+		 * @since 3.1.0
+		 *
+		 * @param bool get_option( 'jetpack_sso_remove_login_form', false ) Should the default log in form be removed. Default to false.
+		 */
+		return (bool) apply_filters( 'jetpack_remove_login_form', get_option( 'jetpack_sso_remove_login_form', false ) );
+	}
+
+	static function match_by_email() {
+		$match_by_email = ( 1 == get_option( 'jetpack_sso_match_by_email', true ) ) ? true: false;
+		$match_by_email = defined( 'WPCC_MATCH_BY_EMAIL' ) ? WPCC_MATCH_BY_EMAIL : $match_by_email;
+
+		/**
+		 * Link the local account to an account on WordPress.com using the same email address.
+		 *
+		 * @module sso
+		 *
+		 * @since 2.6.0
+		 *
+		 * @param bool $match_by_email Should we link the local account to an account on WordPress.com using the same email address. Default to false.
+		 */
+		return (bool) apply_filters( 'jetpack_sso_match_by_email', $match_by_email );
+	}
+
+	static function new_user_override() {
+		$new_user_override = defined( 'WPCC_NEW_USER_OVERRIDE' ) ? WPCC_NEW_USER_OVERRIDE : false;
+
+		/**
+		 * Allow users to register on your site with a WordPress.com account, even though you disallow normal registrations.
+		 *
+		 * @module sso
+		 *
+		 * @since 2.6.0
+		 *
+		 * @param bool $new_user_override Allow users to register on your site with a WordPress.com account. Default to false.
+		 */
+		return (bool) apply_filters( 'jetpack_sso_new_user_override', $new_user_override );
+	}
+
+	/**
+	 * Returns a boolean value for whether two-step authentication is required for SSO.
+	 *
+	 * @since 4.1
+	 *
+	 * @return bool
+	 */
+	static function is_two_step_required() {
+		/**
+		 * Is it required to have 2-step authentication enabled on WordPress.com to use SSO?
+		 *
+		 * @module sso
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param bool get_option( 'jetpack_sso_require_two_step' ) Does SSO require 2-step authentication?
+		 */
+		return (bool) apply_filters( 'jetpack_sso_require_two_step', get_option( 'jetpack_sso_require_two_step', false ) );
+	}
+
+	static function bypass_login_forward_wpcom() {
+		/**
+		 * Redirect the site's log in form to WordPress.com's log in form.
+		 *
+		 * @module sso
+		 *
+		 * @since 3.1.0
+		 *
+		 * @param bool false Should the site's log in form be automatically forwarded to WordPress.com's log in form.
+		 */
+		return (bool) apply_filters( 'jetpack_sso_bypass_login_forward_wpcom', false );
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -42,6 +42,9 @@
 		<testsuite name="widgets">
 			<directory prefix="test_" suffix=".php">tests/php/modules/widgets</directory>
 		</testsuite>
+		<testsuite name="sso">
+			<directory prefix="test_" suffix=".php">tests/php/modules/sso</directory>
+		</testsuite>
 		<testsuite name="sync">
 			<directory prefix="test_" suffix=".php">tests/php/sync</directory>
 			<exclude>tests/php/sync/test_interface.jetpack-sync-replicastore.php</exclude>

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -4,7 +4,7 @@ require dirname( __FILE__ ) . '/../../../../modules/sso/class.jetpack-sso-helper
 /**
  * Testing functions in Jetpack_SSO_Helpers class.
  *
- * @since 4.1
+ * @since 4.1.0
  */
 class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 	function test_sso_helpers_is_two_step_required_filter_true() {

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Testing functions in Jetpack_SSO_Helpers class.
+ *
+ * @since 4.1
+ */
+class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
+	function test_sso_helpers_is_two_step_required_filter_true() {
+		add_filter( 'jetpack_sso_require_two_step', '__return_true' );
+		$this->assertTrue( Jetpack_SSO_Helpers::is_two_step_required() );
+		remove_filter( 'jetpack_sso_require_two_step', '__return_true' );
+	}
+
+	function test_sso_helpers_is_two_step_required_filter_false() {
+		add_filter( 'jetpack_sso_require_two_step', '__return_false' );
+		$this->assertFalse( Jetpack_SSO_Helpers::is_two_step_required() );
+		remove_filter( 'jetpack_sso_require_two_step', '__return_false' );
+	}
+
+	function test_sso_helpers_is_two_step_required_option_true() {
+		update_option( 'jetpack_sso_require_two_step', true );
+		$this->assertTrue( Jetpack_SSO_Helpers::is_two_step_required() );
+		delete_option( 'jetpack_sso_require_two_step' );
+	}
+
+	function test_sso_helpers_is_two_step_required_option_false() {
+		update_option( 'jetpack_sso_require_two_step', false );
+		$this->assertFalse( Jetpack_SSO_Helpers::is_two_step_required() );
+		delete_option( 'jetpack_sso_require_two_step' );
+	}
+
+	function test_sso_helpers_should_hide_login_form_filter_true() {
+		add_filter( 'jetpack_remove_login_form', '__return_true' );
+		$this->assertTrue( Jetpack_SSO_Helpers::should_hide_login_form() );
+		remove_filter( 'jetpack_remove_login_form', '__return_true' );
+	}
+
+	function test_sso_helpers_should_hide_login_form_filter_false() {
+		add_filter( 'jetpack_remove_login_form', '__return_false' );
+		$this->assertFalse( Jetpack_SSO_Helpers::should_hide_login_form() );
+		remove_filter( 'jetpack_remove_login_form', '__return_false' );
+	}
+
+	function test_sso_helpers_match_by_email_filter_true() {
+		add_filter( 'jetpack_sso_match_by_email', '__return_true' );
+		$this->assertTrue( Jetpack_SSO_Helpers::match_by_email() );
+		remove_filter( 'jetpack_sso_match_by_email', '__return_true' );
+	}
+
+	function test_sso_helpers_match_by_email_filter_false() {
+		add_filter( 'jetpack_sso_match_by_email', '__return_false' );
+		$this->assertFalse( Jetpack_SSO_Helpers::match_by_email() );
+		remove_filter( 'jetpack_sso_match_by_email', '__return_false' );
+	}
+
+	function test_sso_helpers_new_user_override_filter_true() {
+		add_filter( 'jetpack_sso_new_user_override', '__return_true' );
+		$this->assertTrue( Jetpack_SSO_Helpers::new_user_override() );
+		remove_filter( 'jetpack_sso_new_user_override', '__return_true' );
+	}
+
+	function test_sso_helpers_new_user_override_filter_false() {
+		add_filter( 'jetpack_sso_new_user_override', '__return_false' );
+		$this->assertFalse( Jetpack_SSO_Helpers::new_user_override() );
+		remove_filter( 'jetpack_sso_new_user_override', '__return_false' );
+	}
+
+	function test_sso_helpers_sso_bypass_default_login_form_filter_true() {
+		add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
+		$this->assertTrue( Jetpack_SSO_Helpers::bypass_login_forward_wpcom() );
+		remove_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
+	}
+
+	function test_sso_helpers_sso_bypass_default_login_form_filter_false() {
+		add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_false' );
+		$this->assertFalse( Jetpack_SSO_Helpers::bypass_login_forward_wpcom() );
+		remove_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_false' );
+	}
+}

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -1,4 +1,5 @@
 <?php
+require dirname( __FILE__ ) . '/../../../../modules/sso/class.jetpack-sso-helpers.php';
 
 /**
  * Testing functions in Jetpack_SSO_Helpers class.


### PR DESCRIPTION
This PR factors out several SSO module helper functions into a separate class, `Jetpack_SSO_Helpers` within the SSO module directory.

cc @lezama and @enejb for code review.

This should make it easier to test these methods as well as sync the values in another PR: #4085.

To test:

- Checkout `update/sso-refactor-helpers-class` branch
- In `vagrant-local` directory
- `vagrant up`
- `vagrant ssh`
- `cd /srv/www/wordpress-develop/src/wp-content/plugins/jetpack`
- `phpunit --filter=WP_Test_Jetpack_SSO_Helpers --debug`

You can also do some regression testing by testing the SSO flow:

- Go to `/wp-admin`
- Click "Log in with WordPress.com" button
- Once on WP.com, click "Log in"
- Does it work?