### PR TITLE
SSO: Better alignment of "W" icon

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,7 +117,9 @@ gulp.task( 'react:watch', function() {
 	webpack( config ).watch( 100, onBuild() );
 } );
 
-/* (Pre-4.1) Admin CSS to be minified, autoprefixed, rtl */
+// Admin CSS to be minified, autoprefixed, rtl
+//
+// Note: Once the Jetpack React UI lands, many of these will likely be able to be removed.
 var admincss = [
 	'modules/after-the-deadline/atd.css',
 	'modules/after-the-deadline/tinymce/css/content.css',
@@ -135,7 +137,8 @@ var admincss = [
 	'modules/sharedaddy/admin-sharing.css',
 	'modules/videopress/videopress-admin.css',
 	'modules/widget-visibility/widget-conditions/widget-conditions.css',
-	'modules/widgets/gallery/css/admin.css'
+	'modules/widgets/gallery/css/admin.css',
+	'modules/sso/jetpack-sso-login.css' // Displayed when logging into the site.
 ];
 
 /* Front-end CSS to be concatenated */

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -182,7 +182,12 @@ class Jetpack_SSO {
 			return;
 		}
 
-		wp_enqueue_style( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login.css', JETPACK__PLUGIN_FILE ), array( 'login', 'genericons' ), JETPACK__VERSION );
+		if( is_rtl() ){
+			wp_enqueue_style( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login-rtl.css', JETPACK__PLUGIN_FILE ), array( 'login', 'genericons' ), JETPACK__VERSION );
+		} else {
+			wp_enqueue_style( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login.css', JETPACK__PLUGIN_FILE ), array( 'login', 'genericons' ), JETPACK__VERSION );
+		}
+
 		wp_enqueue_script( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION );
 	}
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -182,7 +182,7 @@ class Jetpack_SSO {
 			return;
 		}
 
-		if( is_rtl() ){
+		if ( is_rtl() ) {
 			wp_enqueue_style( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login-rtl.css', JETPACK__PLUGIN_FILE ), array( 'login', 'genericons' ), JETPACK__VERSION );
 		} else {
 			wp_enqueue_style( 'jetpack-sso-login', plugins_url( 'modules/sso/jetpack-sso-login.css', JETPACK__PLUGIN_FILE ), array( 'login', 'genericons' ), JETPACK__VERSION );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -838,9 +838,10 @@ class Jetpack_SSO {
 			: 'jetpack-sso button';
 
 		return sprintf(
-			'<a rel="nofollow" href="%1$s" class="%2$s">%3$s</a>',
+			'<a rel="nofollow" href="%1$s" class="%2$s"><span>%3$s %4$s</span></a>',
 			esc_url( $url ),
 			$classes,
+			'<span class="genericon genericon-wordpress"></span>',
 			esc_html__( 'Log in with WordPress.com', 'jetpack' )
 		);
 	}

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -119,33 +119,29 @@
 	float: none;
 	margin-bottom: 16px;
 	position: relative;
-	padding-left: 48px;
 	width: 100%;
+}
+
+.jetpack-sso.button > span {
+	position: relative;
+	padding-left: 30px;
+}
+
+.jetpack-sso.button .genericon-wordpress {
+	position: absolute;
+		left: 0;
+		top: -4px;
+	font-size: 24px;
 }
 
 @media screen and ( max-width: 782px ) {
 	.jetpack-sso.button {
 		line-height: 22px;
 	}
-}
 
-.jetpack-sso.button:before {
-	display: block;
-	box-sizing: border-box;
-	padding: 7px 0 0;
-	text-align: center;
-	position: absolute;
-	top: -1px;
-	left: -1px;
-	border-radius: 2px 0 0 2px;
-	content: '\f205';
-	color: #fff;
-	-webkit-font-smoothing: antialiased;
-	width: 48px;
-	height: 107%;
-	height: calc( 100% + 2px );
-	font: normal 24px/1 Genericons !important;
-	text-shadow: none;
+	.jetpack-sso.button .genericon-wordpress {
+		top: -2px;
+	}
 }
 
 #jetpack-sso-wrap__user img {

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -130,7 +130,7 @@
 .jetpack-sso.button .genericon-wordpress {
 	position: absolute;
 		left: 0;
-		top: -4px;
+		top: -3px;
 	font-size: 24px;
 }
 

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -152,7 +152,7 @@
 
 #jetpack-sso-wrap__user h2 {
 	font-size: 21px;
-	font-weight: lighter;
+	font-weight: 300;
 	margin-bottom: 16px;
 	text-align: center;
 }

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -138,10 +138,6 @@
 	.jetpack-sso.button {
 		line-height: 22px;
 	}
-
-	.jetpack-sso.button .genericon-wordpress {
-		top: -2px;
-	}
 }
 
 #jetpack-sso-wrap__user img {


### PR DESCRIPTION
This PR fixes the align of the WordPress icon so that it is center with the "Login with WordPress.com" text. Also, this PR adds `modules/sso/jetpack-sso-login.css' to the build process so that we create an RTL stylesheet for the SSO CSS that is loaded on `wp-login.php`

cc @lezama and @dereksmart to test. Pinging @dereksmart since I am changing the `gulpfile.js`, and when blaming, it looked like he was the last to touch a section I changed.

cc @michaelarestad for design review.

To test:

- Checkout `update/jetpack-sso-styles` branch
- Run `gulp` to build RTL stylehseets
- Ensure that site is connected to WP.com and you have SSO enabled
- Go to `$site/wp-admin`
- You should see something a bit like the first screenshot below (without the logged out notice, of course)
- Once logged in, go to settings and change your site's language to an RTL language (Hebrew, for example
- Log out
- You should now see something like the second screenshot below
  
### After: SSO form

#### Not RTL
![screen shot 2016-06-08 at 5 14 08 pm](https://cloud.githubusercontent.com/assets/1126811/15913290/aa1af712-2d9e-11e6-9a9f-34f9df43d309.png)
#### RTL
![screen shot 2016-06-08 at 5 14 31 pm](https://cloud.githubusercontent.com/assets/1126811/15913326/e62e4aba-2d9e-11e6-8f2a-d070c19b00f1.png)

### After: Default login form

#### Not RTL
![screen shot 2016-06-08 at 5 15 50 pm](https://cloud.githubusercontent.com/assets/1126811/15913353/1bd03c6e-2d9f-11e6-8c90-77b68d4fffa3.png)

#### RTL
![screen shot 2016-06-08 at 5 14 58 pm](https://cloud.githubusercontent.com/assets/1126811/15913352/1bce1bdc-2d9f-11e6-82d6-fe956de07c44.png)
