### PR TITLE
Network Admin: Remove "Connect" button from sites list if Jetpack not active on sub-site

### DIFF
--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -78,6 +78,16 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		$jp = Jetpack::init();
 
 		switch_to_blog( $item->blog_id );
+
+		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
+			$title = __( 'Jetpack not active.', 'jetpack' );
+			$action = array(
+				'manage-plugins' => '<a href="' . get_admin_url( $item->blog_id, 'plugins.php', 'admin' ) . '">' . __( 'Manage Plugins', 'jetpack' ) . '</a>',
+			);
+			restore_current_blog();
+			return sprintf( '%1$s %2$s', $title, $this->row_actions( $action ) );
+		}
+
 		if( $jp->is_active() ) {
 		   // Build url for disconnecting
 		    $url = $jpms->get_url( array(

--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -80,7 +80,7 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		switch_to_blog( $item->blog_id );
 
 		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
-			$title = __( 'Jetpack not active.', 'jetpack' );
+			$title = __( 'Jetpack is not active on this site.', 'jetpack' );
 			$action = array(
 				'manage-plugins' => '<a href="' . get_admin_url( $item->blog_id, 'plugins.php', 'admin' ) . '">' . __( 'Manage Plugins', 'jetpack' ) . '</a>',
 			);


### PR DESCRIPTION
Fixes #3641 
If Jetpack is not active on a sub-site, do not show a 'Connect' button in the network admin site's list table.

This PR will show this instead:

![jetpack-network-admin](https://cloud.githubusercontent.com/assets/2694219/15935602/d83a3742-2e35-11e6-8791-5c5280d29290.png)

To test:
- On your multisite, checkout `network-admin-subsite-jetpack-inactive`
- Ensure that Jetpack is not network activated, and that some sub-sites have Jetpack deactivated
- Go to Network Admin -> Jetpack
- Ensure that deactivated sites are reported properly in the table, and that the 'Manage Plugins' button links to the proper place.

cc: @jeherve 