### PR TITLE
Carousel: compare image title and description using their decoded string as plain text

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1083,8 +1083,8 @@ jQuery(document).ready(function($) {
 			desc  = gallery.jp_carousel('parseTitleDesc', data.desc)  || '';
 
 			if ( title.length || desc.length ) {
-				// $('<div />').text(sometext).html() is a trick to go to HTML to plain text (including HTML entities decode, etc)
-				if ( $('<div />').text(title).html() === $('<div />').text(desc).html() ) {
+				// Convert from HTML to plain text (including HTML entities decode, etc)
+				if ( $('<div />').html( title ).text() === $('<div />').html( desc ).text() ) {
 					title = '';
 				}
 


### PR DESCRIPTION
Fixes #3036.

#### Changes proposed in this Pull Request:
- compare image title and description as a decoded plain text string, instead of an encoded HTML string.

This fixes the comparison that was broken before when using an encoded string as HTML since description has paragraphs added and title doesn't.

For example, before with the encoded HTML string, we had:
**title**: `Image &amp; Gallery`
**description**: `&lt;p&gt;Image &amp; Gallery&lt;/p&gt;`

Now, with the decoded plain text string, we have:
**title**: `Image & Gallery`
**description**: `Image & Gallery`