### PR TITLE
SSO: Handle notice positioning with more than 1 notice

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -217,6 +217,9 @@ class Jetpack_SSO {
 			return $classes;
 		}
 
+		//Always add the jetpack-sso class so that we can add SSO specific styling even when the SSO form isn't being displayed.
+		$classes[] = 'jetpack-sso';
+
 		// If jetpack-sso-default-form, show the default login form.
 		if ( isset( $_GET['jetpack-sso-default-form'] ) && 1 == $_GET['jetpack-sso-default-form'] ) {
 			return $classes;

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -222,7 +222,7 @@ class Jetpack_SSO {
 			return $classes;
 		}
 
-		$classes[] = 'jetpack-sso-body';
+		$classes[] = 'jetpack-sso-form-display';
 		return $classes;
 	}
 

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -4,6 +4,15 @@
 	padding-bottom: 92px;
 }
 
+.message {
+	margin-top: 20px;
+}
+
+#login .message:first-child,
+#login h1 + .message {
+	margin-top: 0;
+}
+
 .jetpack-sso-repositioned #loginform {
 	padding-bottom: 26px;
 }

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -4,12 +4,12 @@
 	padding-bottom: 92px;
 }
 
-.message {
+.jetpack-sso .message {
 	margin-top: 20px;
 }
 
-#login .message:first-child,
-#login h1 + .message {
+.jetpack-sso #login .message:first-child,
+.jetpack-sso #login h1 + .message {
 	margin-top: 0;
 }
 

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -28,8 +28,8 @@
 	display: none;
 }
 
-.jetpack-sso-body #jetpack-sso-wrap__action,
-.jetpack-sso-body #jetpack-sso-wrap__user {
+.jetpack-sso-form-display #jetpack-sso-wrap__action,
+.jetpack-sso-form-display #jetpack-sso-wrap__user {
 	display: block;
 }
 
@@ -51,7 +51,7 @@
 	margin-right: 0;
 }
 
-.jetpack-sso-body #jetpack-sso-wrap {
+.jetpack-sso-form-display #jetpack-sso-wrap {
 	position: relative;
 		bottom: auto;
 	padding: 0;
@@ -76,26 +76,26 @@
 	display: none;
 }
 
-.jetpack-sso-body #jetpack-sso-wrap .jetpack-sso-toggle.wpcom {
+.jetpack-sso-form-display #jetpack-sso-wrap .jetpack-sso-toggle.wpcom {
 	display: block;
 }
 
 
-.jetpack-sso-body #jetpack-sso-wrap .jetpack-sso-toggle.default {
+.jetpack-sso-form-display #jetpack-sso-wrap .jetpack-sso-toggle.default {
 	display: none;
 }
 
 
-.jetpack-sso-body #loginform > p,
-.jetpack-sso-body #loginform > div {
+.jetpack-sso-form-display #loginform > p,
+.jetpack-sso-form-display #loginform > div {
 	display: none;
 }
 
-.jetpack-sso-body #loginform #jetpack-sso-wrap {
+.jetpack-sso-form-display #loginform #jetpack-sso-wrap {
 	display: block;
 }
 
-.jetpack-sso-body #loginform {
+.jetpack-sso-form-display #loginform {
 	padding: 26px 24px;
 }
 
@@ -170,10 +170,10 @@
 	margin-bottom: 16px;
 }
 
-.jetpack-sso-body #nav {
+.jetpack-sso-form-display #nav {
 	display: none;
 }
 
-.jetpack-sso-body #backtoblog {
+.jetpack-sso-form-display #backtoblog {
 	margin: 24px 0 0;
 }

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -39,8 +39,8 @@ jQuery( document ).ready( function( $ ) {
 
 	toggleSSO.on( 'click', function( e ) {
 		e.preventDefault();
-		body.toggleClass( 'jetpack-sso-body' );
-		if ( ! body.hasClass( 'jetpack-sso-body' ) ) {
+		body.toggleClass( 'jetpack-sso-form-display' );
+		if ( ! body.hasClass( 'jetpack-sso-form-display' ) ) {
 			userLogin.focus();
 		}
 	} );


### PR DESCRIPTION
With certain combinations of SSO filters, it is possible to have more than one notice at a time on the login page.

That currently looks like this:

![screen shot 2016-06-10 at 3 08 30 pm](https://cloud.githubusercontent.com/assets/1126811/15977275/6564f5ca-2f1d-11e6-8eba-58413230730a.png)

I think that we should add some distance between those notices. So, this PR adds a `margin-top: 20px;` to the top of all but the first `.message` notices.

Here's an after screenshot:

![screen shot 2016-06-10 at 3 08 06 pm](https://cloud.githubusercontent.com/assets/1126811/15978151/0bee5504-2f22-11e6-90a8-04c7111200cc.png)


cc @MichaelArestad for a design review and a quick CSS approach review.