### PR TITLE
Tiled Galleries: apply filter to default gallery type in shortcode

### DIFF
--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -42,8 +42,10 @@ class Jetpack_Tiled_Gallery {
 		$this->float = is_rtl() ? 'right' : 'left';
 
 		// Default to rectangular is tiled galleries are checked
-		if ( $this->tiles_enabled() && ( ! $this->atts['type'] || 'default' == $this->atts['type'] ) )
-			$this->atts['type'] = 'rectangular';
+		if ( $this->tiles_enabled() && ( ! $this->atts['type'] || 'default' == $this->atts['type'] ) ) {
+			/** This filter is already documented in functions.gallery.php */
+			$this->atts['type'] = apply_filters( 'jetpack_default_gallery_type', 'rectangular' );
+		}
 
 		if ( !$this->atts['orderby'] ) {
 			$this->atts['orderby'] = sanitize_sql_orderby( $this->atts['orderby'] );


### PR DESCRIPTION
We have a `jetpack_default_gallery_type` filter to allow folks to overwrite the default gallery type, but we hardcoded the default gallery type in the shortcode.