### PR TITLE
VideoPress: avoid JavaScript errors on CPT editor that do not include the Media editor

### DIFF
--- a/modules/videopress/js/editor-view.js
+++ b/modules/videopress/js/editor-view.js
@@ -1,6 +1,9 @@
 /* global tinyMCE, vpEditorView */
 (function( $, wp, vpEditorView ){
 	wp.mce = wp.mce || {};
+	if ( 'undefined' === typeof wp.mce.views ) {
+		return;
+	}
 	wp.mce.videopress_wp_view_renderer = {
 		shortcode_string : 'videopress',
 		shortcode_data : {},


### PR DESCRIPTION
If `wp.mce.views` is undefined, don't bother.
Not worth doing anything in this case.  Bail early.

Fixes #3799

Closes #4044
Closes #3862