### PR TITLE
Optimization: load class.jetpack-debugger.php only when is_admin()

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -53,7 +53,6 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-options.php'       );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-user-agent.php'    );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-post-images.php'   );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-error.php'         );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-debugger.php'      );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-heartbeat.php'     );
 require_once( JETPACK__PLUGIN_DIR . 'class.photon.php'                );
 require_once( JETPACK__PLUGIN_DIR . 'functions.photon.php'            );
@@ -67,6 +66,7 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/module-headings.php');
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php'      );
+	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-debugger.php'  );
 }
 
 // Play nice with http://wp-cli.org/


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Only `require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-debugger.php'      );` if `is_admin()`

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

…request