### PR TITLE
Sync: Fixes an issue where the POST /sites/%s/sync endpoint did not t…

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -41,7 +41,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function schedule_full_sync() {
-		wp_schedule_single_event( strftime( '+1 second' ), 'jetpack_sync_full' );
+		wp_schedule_single_event( time() + 1, 'jetpack_sync_full' );
 	}
 
 }


### PR DESCRIPTION
Previously, making a `POST` request to `sites/%s/sync` did not trigger a full sync. 

The issue seems to be that `wp_schedule_single_event` expects a timestamp for the first argument, and `strftime( '+1 second' )` returns `+1 second`.

To test bug:

- Checkout latest master
- Go to `$site/wp-admin/admin.php?page=jetpack-sync` and make note of queue size
- Go to [REST console](https://developer.wordpress.com/docs/api/console/)
- Make request to `POST /sites/%s/sync`
- Go to `$site/wp-admin/admin.php?page=jetpack-sync` and observe queue size didn't increase

To test fix:
- Checkout `fix/sync-endpoint` branch
- Go to `$site/wp-admin/admin.php?page=jetpack-sync` and make note of queue size
- Go to [REST console](https://developer.wordpress.com/docs/api/console/)
- Make request to `POST /sites/%s/sync`
- Go to `$site/wp-admin/admin.php?page=jetpack-sync` and observe queue size *did* increase

cc @lezama for review
