### PR TITLE
Removes default WordPress admin focus styles so that ours can shine t…

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -1,4 +1,4 @@
-// This document contains styles that influence the styles of Stats & At a Glance, overall. 
+// This document contains styles that influence the styles of Stats & At a Glance, overall.
 // For more precise styles, dig into the styles of each component. ie. dash-item
 
 .jp-at-a-glance__stats-card {
@@ -114,7 +114,7 @@
 	@include breakpoint( ">660px" ) {
 		text-align: right;
 		flex-basis: 70%;
-	} 
+	}
 
 	@include breakpoint( "<660px" ) {
 		text-align: center;
@@ -141,6 +141,10 @@
 	margin-top: 0;
 	margin-bottom: 0;
 	margin-left: rem( 16px );
+
+	&:focus {
+		outline: 0;
+	}
 }
 
 .jp-at-a-glance__stats-view-link,
@@ -152,6 +156,11 @@
 		font-weight: 600;
 		text-decoration: none;
 	}
+}
+
+.jp-at-a-glance__stats-view-link:focus {
+	outline: 0;
+	box-shadow: none;
 }
 
 // heavy flexbox nesting below, careful! – @jeffgolenski
@@ -167,7 +176,7 @@
 .jp-at-a-glance__right {
 	@include breakpoint( ">660px" ) {
 		flex-basis: 50%;
-	} 
+	}
 }
 
 .jp-at-a-glance__left {

--- a/_inc/client/components/dash-section-header/style.scss
+++ b/_inc/client/components/dash-section-header/style.scss
@@ -24,6 +24,14 @@
 	text-align: center;
 	color: darken( $gray, 10% );
 
+	&:focus {
+		outline: 0;
+		box-shadow: none;
+
+		.gridicon {
+			color: $blue-wordpress;
+		}
+	}
 	.gridicon {
 		position: relative;
 		top: 1px;


### PR DESCRIPTION
Helps resolve https://github.com/Automattic/jetpack/issues/3900

Fixes:
* `.jp-at-a-glance__stats-card `
* `.jp-dash-section-header__settings`

Note: leaves normal link focus styles in tact for now.