### PR TITLE
Admin Page: Fix React render error on non-dashboard pages

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -36,20 +36,29 @@ i18n.setLocale( Initial_State.locale );
 
 const history = syncHistoryWithStore( hashHistory, store );
 
-ReactDOM.render(
-	<div>
-		<Provider store={ store }>
-			<Router history={ history }>
-				<Route path='/' component={ Main } />
-				<Route path='/dashboard' component={ Main } />
-				<Route path='/engagement' component={ Main } />
-				<Route path='/security' component={ Main } />
-				<Route path='/health' component={ Main } />
-				<Route path='/more' component={ Main } />
-				<Route path='/general' component={ Main } />
-			</Router>
-		</Provider>
+render();
 
-	</div>,
-	document.getElementById( 'jp-plugin-container' )
-);
+function render() {
+	const container = document.getElementById( 'jp-plugin-container' );
+
+	if ( container === null ) {
+		return;
+	}
+
+	ReactDOM.render(
+		<div>
+			<Provider store={ store }>
+				<Router history={ history }>
+					<Route path='/' component={ Main } />
+					<Route path='/dashboard' component={ Main } />
+					<Route path='/engagement' component={ Main } />
+					<Route path='/security' component={ Main } />
+					<Route path='/health' component={ Main } />
+					<Route path='/more' component={ Main } />
+					<Route path='/general' component={ Main } />
+				</Router>
+			</Provider>
+		</div>,
+		container
+	);
+}


### PR DESCRIPTION
Fixes #4077  .

#### Changes proposed in this Pull Request:
- Create a `render()` function in `admin.js` which checks if the React container element is present or not. If it's not present it just does nothing. Otherwise it renders the client app. 

#### Testing instructions

* Get to `/wp-admin/admin.php?page=jetpack&configure=stats`
* You should **not see** an error like this in the console
```
invariant.js:39Uncaught Invariant Violation: _registerComponent(...): Target container is not a DOM element.
```