### PR TITLE
JSON API: Add custom taxonomies support

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -650,6 +650,18 @@ abstract class WPCOM_JSON_API_Endpoint {
 			);
 			$return[$key] = (array) $this->cast_and_filter( $value, $docs, false, $for_output );
 			break;
+		case 'taxonomy':
+			$docs = array(
+				'name'         => '(string) The taxonomy slug',
+				'label'        => '(string) The taxonomy human-readable name',
+				'labels'       => '(object) Mapping of labels for the taxonomy',
+				'description'  => '(string) The taxonomy description',
+				'hierarchical' => '(bool) Whether the taxonomy is hierarchical',
+				'public'       => '(bool) Whether the taxonomy is public',
+				'capabilities' => '(object) Mapping of current user capabilities for the taxonomy',
+			);
+			$return[$key] = (array) $this->cast_and_filter( $value, $docs, false, $for_output );
+			break;
 
 		default :
 			$method_name = $type['type'] . '_docs';
@@ -1306,8 +1318,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$response['description'] = (string) $taxonomy->description;
 		$response['post_count']  = (int) $taxonomy->count;
 
-		if ( 'category' === $taxonomy_type )
+		if ( is_taxonomy_hierarchical( $taxonomy_type ) ) {
 			$response['parent'] = (int) $taxonomy->parent;
+		}
 
 		$response['meta'] = (object) array(
 			'links' => (object) array(

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -31,17 +31,21 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-embeds-endpoint.p
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-taxonomies-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-taxonomy-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-term-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-comments-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-post-types-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-post-type-taxonomies-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-posts-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-roles-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-terms-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-list-users-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-user-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-comment-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-post-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-taxonomy-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-term-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-user-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-upload-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-settings-endpoint.php' );
@@ -198,6 +202,22 @@ new WPCOM_JSON_API_List_Post_Types_Endpoint( array (
 	'response_format' => array(
 		'found'      => '(int) The number of post types found',
 		'post_types' => '(array) A list of available post types',
+	)
+) );
+
+new WPCOM_JSON_API_List_Post_Type_Taxonomies_Endpoint( array (
+	'description' => 'Get a list of taxonomies associated with a post type.',
+	'group'       => 'taxonomy',
+	'stat'        => 'sites:X:post-types:X:taxonomies',
+	'method'      => 'GET',
+	'path'        => '/sites/%s/post-types/%s/taxonomies',
+	'path_labels' => array(
+		'$site'      => '(int|string) Site ID or domain',
+		'$post_type' => '(string) Post type',
+	),
+	'response_format' => array(
+		'found'      => '(int) The number of taxonomies found',
+		'taxonomies' => '(array:taxonomy) A list of available taxonomies',
 	)
 ) );
 
@@ -528,7 +548,7 @@ new WPCOM_JSON_API_Update_Post_Endpoint( array(
 	'description' => 'Create a post.',
 	'group'       => 'posts',
 	'stat'        => 'posts:new',
-	'new_version' => '1.1',
+	'new_version' => '1.2',
 	'max_version' => '1',
 	'method'      => 'POST',
 	'path'        => '/sites/%s/posts/new',
@@ -595,6 +615,7 @@ new WPCOM_JSON_API_Update_Post_v1_1_Endpoint( array(
 	'description' => 'Create a post.',
 	'group'       => 'posts',
 	'stat'        => 'posts:new',
+	'new_version' => '1.2',
 	'min_version' => '1.1',
 	'max_version' => '1.1',
 	'method'      => 'POST',
@@ -628,6 +649,7 @@ new WPCOM_JSON_API_Update_Post_v1_1_Endpoint( array(
 		'password'  => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
 		'parent'    => "(int) The post ID of the new post's parent.",
 		'type'      => "(string) The post type. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+		'terms'      => '(object) Mapping of taxonomy to comma-separated list or array of terms (name or id)',
 		'categories' => "(array|string) Comma-separated list or array of categories (name or id)",
 		'tags'       => "(array|string) Comma-separated list or array of tags (name or id)",
 		'format'     => array_merge( array( 'default' => 'Use default post format' ), get_post_format_strings() ),
@@ -698,8 +720,10 @@ new WPCOM_JSON_API_Update_Post_v1_2_Endpoint( array(
 		'password'  => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
 		'parent'    => "(int) The post ID of the new post's parent.",
 		'type'      => "(string) The post type. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+		'terms'      => '(object) Mapping of taxonomy to comma-separated list or array of term names',
 		'categories' => "(array|string) Comma-separated list or array of category names",
 		'tags'       => "(array|string) Comma-separated list or array of tag names",
+		'terms_by_id'      => '(object) Mapping of taxonomy to comma-separated list or array of term IDs',
 		'categories_by_id' => "(array|string) Comma-separated list or array of category IDs",
 		'tags_by_id'       => "(array|string) Comma-separated list or array of tag IDs",
 		'format'     => array_merge( array( 'default' => 'Use default post format' ), get_post_format_strings() ),
@@ -737,7 +761,7 @@ new WPCOM_JSON_API_Update_Post_Endpoint( array(
 	'description' => 'Edit a post.',
 	'group'       => 'posts',
 	'stat'        => 'posts:1:POST',
-	'new_version' => '1.1',
+	'new_version' => '1.2',
 	'max_version' => '1',
 	'method'      => 'POST',
 	'path'        => '/sites/%s/posts/%d',
@@ -802,6 +826,7 @@ new WPCOM_JSON_API_Update_Post_v1_1_Endpoint( array(
 	'description' => 'Edit a post.',
 	'group'       => 'posts',
 	'stat'        => 'posts:1:POST',
+	'new_version' => '1.2',
 	'min_version' => '1.1',
 	'max_version' => '1.1',
 	'method'      => 'POST',
@@ -833,6 +858,7 @@ new WPCOM_JSON_API_Update_Post_v1_1_Endpoint( array(
 		),
 		'password'   => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
 		'parent'     => "(int) The post ID of the new post's parent.",
+		'terms'      => '(object) Mapping of taxonomy to comma-separated list or array of terms (name or id)',
 		'categories' => "(array|string) Comma-separated list or array of categories (name or id)",
 		'tags'       => "(array|string) Comma-separated list or array of tags (name or id)",
 		'format'     => array_merge( array( 'default' => 'Use default post format' ), get_post_format_strings() ),
@@ -899,6 +925,8 @@ new WPCOM_JSON_API_Update_Post_v1_2_Endpoint( array(
 		),
 		'password'   => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
 		'parent'     => "(int) The post ID of the new post's parent.",
+		'terms'      => '(object) Mapping of taxonomy to comma-separated list or array of term names',
+		'terms_by_id' => '(object) Mapping of taxonomy to comma-separated list or array of term IDs',
 		'categories' => "(array|string) Comma-separated list or array of category names",
 		'categories_by_id' => "(array|string) Comma-separated list or array of category IDs",
 		'tags'       => "(array|string) Comma-separated list or array of tag names",
@@ -1902,6 +1930,133 @@ new WPCOM_JSON_API_Update_Taxonomy_Endpoint( array(
 	),
 
 	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/tags/slug:$tag/delete',
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	)
+) );
+
+new WPCOM_JSON_API_List_Terms_Endpoint( array(
+	'description' => 'Get a list of a site\'s terms by taxonomy.',
+	'group'       => 'taxonomy',
+	'stat'        => 'terms',
+	'method'      => 'GET',
+	'path'        => '/sites/%s/taxonomies/%s/terms',
+	'path_labels' => array(
+		'$site'     => '(int|string) Site ID or domain',
+		'$taxonomy' => '(string) Taxonomy',
+	),
+	'query_parameters' => array(
+		'number'   => '(int=100) The number of terms to return. Limit: 1000.',
+		'offset'   => '(int=0) 0-indexed offset.',
+		'page'     => '(int) Return the Nth 1-indexed page of terms. Takes precedence over the <code>offset</code> parameter.',
+		'search'   => '(string) Limit response to include only terms whose names or slugs match the provided search query.',
+		'order'    => array(
+			'ASC'  => 'Return terms in ascending order.',
+			'DESC' => 'Return terms in descending order.',
+		),
+		'order_by' => array(
+			'name'  => 'Order by the name of each tag.',
+			'count' => 'Order by the number of posts in each tag.',
+		),
+	),
+	'response_format' => array(
+		'found' => '(int) The number of terms returned.',
+		'terms' => '(array) Array of tag objects.',
+	),
+	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/taxonomies/post_tags/terms?number=5'
+) );
+
+new WPCOM_JSON_API_Get_Term_Endpoint( array(
+	'description' => 'Get information about a single term.',
+	'group'       => 'taxonomy',
+	'stat'        => 'terms:1',
+	'method'      => 'GET',
+	'path'        => '/sites/%s/taxonomies/%s/terms/slug:%s',
+	'path_labels' => array(
+		'$site'     => '(int|string) Site ID or domain',
+		'$taxonomy' => '(string) Taxonomy',
+		'$slug'     => '(string) Term slug',
+	),
+	'response_format' => array(
+		'ID'          => '(int) The term ID.',
+		'name'        => '(string) The name of the term.',
+		'slug'        => '(string) The slug of the term.',
+		'description' => '(string) The description of the term.',
+		'post_count'  => '(int) The number of posts using this term.',
+		'parent'      => '(int) The parent ID for the term, if hierarchical.',
+	),
+	'example_request'  => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/taxonomies/post_tag/terms/slug:wordpresscom'
+) );
+
+new WPCOM_JSON_API_Update_Term_Endpoint( array(
+	'description' => 'Create a new term.',
+	'group'       => 'taxonomy',
+	'stat'        => 'terms:new',
+	'method'      => 'POST',
+	'path'        => '/sites/%s/taxonomies/%s/terms/new',
+	'path_labels' => array(
+		'$site'     => '(int|string) Site ID or domain',
+		'$taxonomy' => '(string) Taxonomy',
+	),
+	'request_format' => array(
+		'name'        => '(string) Name of the term',
+		'description' => '(string) A description of the term',
+	),
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/taxonomies/post_tag/terms/new',
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+		'body' => array(
+			'name' => 'Ribs & Chicken'
+		)
+	)
+) );
+
+new WPCOM_JSON_API_Update_Term_Endpoint( array(
+	'description' => 'Edit a term.',
+	'group'       => 'taxonomy',
+	'stat'        => 'terms:1:POST',
+	'method'      => 'POST',
+	'path'        => '/sites/%s/taxonomies/%s/terms/slug:%s',
+	'path_labels' => array(
+		'$site'     => '(int|string) Site ID or domain',
+		'$taxonomy' => '(string) Taxonomy',
+		'$slug'     => '(string) The term slug',
+	),
+	'request_format' => array(
+		'name'        => '(string) Name of the term',
+		'description' => '(string) A description of the term',
+	),
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/taxonomies/post_tag/terms/slug:testing-term',
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+		'body' => array(
+			'description' => 'The most delicious'
+		)
+	)
+) );
+
+new WPCOM_JSON_API_Update_Term_Endpoint( array(
+	'description' => 'Delete a term.',
+	'group'       => 'taxonomy',
+	'stat'        => 'terms:1:delete',
+	'method'      => 'POST',
+	'path'        => '/sites/%s/taxonomies/%s/terms/slug:%s/delete',
+	'path_labels' => array(
+		'$site'     => '(int|string) Site ID or domain',
+		'$taxonomy' => '(string) Taxonomy',
+		'$slug'     => '(string) The term slug',
+	),
+	'response_format' => array(
+		'slug'    => '(string) The slug of the deleted term',
+		'success' => '(bool) Whether the operation was successful',
+	),
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/taxonomies/post_tag/terms/slug:$term/delete',
 	'example_request_data' => array(
 		'headers' => array(
 			'authorization' => 'Bearer YOUR_API_TOKEN'

--- a/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
@@ -10,13 +10,19 @@ class WPCOM_JSON_API_Get_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_End
 
 		$args = $this->query_args();
 
-		if ( false === strpos( $path, '/posts/slug:' ) ) {
-			$get_by = 'ID';
-		} else {
-			$get_by = 'name';
+		if ( false !== strpos( $path, '/posts/slug:' ) ) {
+			$post_id = $this->get_platform()->get_site( $blog_id )->get_post_id_by_name( $post_id );
+			if ( is_wp_error( $post_id ) ) {
+				return $post_id;
+			}
 		}
 
-		$return = $this->get_post_by( $get_by, $post_id, $args['context'] );
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM &&
+				! in_array( get_post_type( $post_id ), array( false, 'post', 'page', 'revision' ) ) ) {
+			$this->load_theme_functions();
+		}
+
+		$return = $this->get_post_by( 'ID', $post_id, $args['context'] );
 
 		if ( !$return || is_wp_error( $return ) ) {
 			return $return;

--- a/json-endpoints/class.wpcom-json-api-get-term-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-term-endpoint.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+class WPCOM_JSON_API_Get_Term_Endpoint extends WPCOM_JSON_API_Endpoint {
+	// /sites/%s/taxonomies/%s/terms/slug:%s -> $blog_id, $taxonomy, $slug
+	function callback( $path = '', $blog_id = 0, $taxonomy = 'category', $slug = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->load_theme_functions();
+		}
+
+		$taxonomy_meta = get_taxonomy( $taxonomy );
+		if ( false === $taxonomy_meta || ( ! $taxonomy_meta->public && 
+				! current_user_can( $taxonomy_meta->cap->assign_terms ) ) ) {
+			return new WP_Error( 'invalid_taxonomy', 'The taxonomy does not exist', 400 );
+		}
+
+		$args = $this->query_args();
+		$term = $this->get_taxonomy( $slug, $taxonomy, $args['context'] );
+		if ( ! $term || is_wp_error( $term ) ) {
+			return $term;
+		}
+
+		/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
+		do_action( 'wpcom_json_api_objects', 'terms' );
+
+		return $term;
+	}
+}

--- a/json-endpoints/class.wpcom-json-api-list-post-type-taxonomies-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-post-type-taxonomies-endpoint.php
@@ -28,9 +28,10 @@ class WPCOM_JSON_API_List_Post_Type_Taxonomies_Endpoint extends WPCOM_JSON_API_E
 			$this->load_theme_functions();
 		}
 
-		// API localization occurs after the initial taxonomies have been
-		// registered, so re-register if localizing response
+		/** This filter is documented in jetpack/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php */
 		if ( apply_filters( 'rest_api_localize_response', false ) ) {
+			// API localization occurs after the initial taxonomies have been
+			// registered, so re-register if localizing response
 			create_initial_taxonomies();
 		}
 

--- a/json-endpoints/class.wpcom-json-api-list-post-type-taxonomies-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-post-type-taxonomies-endpoint.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+class WPCOM_JSON_API_List_Post_Type_Taxonomies_Endpoint extends WPCOM_JSON_API_Endpoint {
+	static $taxonomy_keys_to_include = array(
+		'name'         => 'name',
+		'label'        => 'label',
+		'labels'       => 'labels',
+		'description'  => 'description',
+		'hierarchical' => 'hierarchical',
+		'public'       => 'public',
+		'cap'          => 'capabilities',
+	);
+
+	// /sites/%s/post-types/%s/taxonomies -> $blog_id, $post_type
+	function callback( $path = '', $blog_id = 0, $post_type = 'post' ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->load_theme_functions();
+		}
+
+		// API localization occurs after the initial taxonomies have been
+		// registered, so re-register if localizing response
+		if ( apply_filters( 'rest_api_localize_response', false ) ) {
+			create_initial_taxonomies();
+		}
+
+		$args = $this->query_args();
+
+		$post_type_object = get_post_type_object( $post_type );
+		if ( ! $post_type_object || ( ! $post_type_object->publicly_queryable && (
+				! current_user_can( $post_type_object->cap->edit_posts ) ) ) ) {
+			return new WP_Error( 'unknown_post_type', 'Unknown post type', 404 );
+		}
+
+		// Get a list of available taxonomies
+		$taxonomy_objects = get_object_taxonomies( $post_type, 'objects' );
+
+		// Construct array of formatted objects
+		$formatted_taxonomy_objects = array();
+		foreach ( $taxonomy_objects as $taxonomy_object ) {
+			// Omit private taxonomies unless user has assign capability
+			if ( ! $taxonomy_object->public && ! current_user_can( $taxonomy_object->cap->assign_terms ) ) {
+				continue;
+			}
+
+			// Include only the desired keys in the response
+			$formatted_taxonomy_object = array();
+			foreach ( self::$taxonomy_keys_to_include as $key => $value ) {
+				$formatted_taxonomy_object[ $value ] = $taxonomy_object->{ $key };
+			}
+
+			$formatted_taxonomy_objects[] = $formatted_taxonomy_object;
+		}
+
+		return array(
+			'found'      => count( $formatted_taxonomy_objects ),
+			'taxonomies' => $formatted_taxonomy_objects,
+		);
+	}
+}

--- a/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
@@ -24,9 +24,15 @@ class WPCOM_JSON_API_List_Post_Types_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		$args = $this->query_args();
 
-		// API localization occurs after the initial post types have been 
-		// registered, so re-register if localizing response
+		/**
+		 * Whether API responses should be returned in a custom locale.  False
+		 * for Jetpack; may be true for WP.com requests.
+		 *
+		 * @since 3.9.2
+		 */
 		if ( apply_filters( 'rest_api_localize_response', false ) ) {
+			// API localization occurs after the initial post types have been
+			// registered, so re-register if localizing response
 			create_initial_post_types();
 		}
 

--- a/json-endpoints/class.wpcom-json-api-list-terms-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-terms-endpoint.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+class WPCOM_JSON_API_List_Terms_Endpoint extends WPCOM_JSON_API_Endpoint {
+	// /sites/%s/taxonomies/%s/terms -> $blog_id, $taxonomy
+	function callback( $path = '', $blog_id = 0, $taxonomy = 'category' ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->load_theme_functions();
+		}
+
+		$taxonomy_meta = get_taxonomy( $taxonomy );
+		if ( false === $taxonomy_meta || ( ! $taxonomy_meta->public && 
+				! current_user_can( $taxonomy_meta->cap->assign_terms ) ) ) {
+			return new WP_Error( 'invalid_taxonomy', 'The taxonomy does not exist', 400 );
+		}
+
+		$args = $this->query_args();
+		$args = $this->process_args( $args );
+
+		$formatted_terms = $this->get_formatted_terms( $taxonomy, $args );
+
+		if ( ! empty( $formatted_terms ) ) {
+			/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
+			do_action( 'wpcom_json_api_objects', 'terms', count( $formatted_terms ) );
+		}
+
+		return array(
+			'found' => (int) $this->get_found( $taxonomy, $args ),
+			'terms' => (array) $formatted_terms
+		);
+	}
+
+	function process_args( $args ) {
+		$args['get'] = 'all';
+
+		if ( $args['number'] < 1 ) {
+			$args['number'] = 100;
+		} elseif ( 1000 < $args['number'] ) {
+			return new WP_Error( 'invalid_number', 'The number parameter must be less than or equal to 1000.', 400 );
+		}
+
+		if ( isset( $args['page'] ) ) {
+			if ( $args['page'] < 1 ) {
+				$args['page'] = 1;
+			}
+
+			$args['offset'] = ( $args['page'] - 1 ) * $args['number'];
+			unset( $args['page'] );
+		}
+
+		if ( $args['offset'] < 0 ) {
+			$args['offset'] = 0;
+		}
+
+		$args['orderby'] = $args['order_by'];
+		unset( $args['order_by'] );
+
+		unset( $args['context'], $args['pretty'], $args['http_envelope'], $args['fields'] );
+		return $args;
+	}
+
+	function get_found( $taxonomy, $args ) {
+		unset( $args['offset'] );
+		return wp_count_terms( $taxonomy, $args );
+	}
+
+	function get_formatted_terms( $taxonomy, $args ) {
+		$terms = get_terms( $taxonomy, $args );
+
+		$formatted_terms = array();
+		foreach ( $terms as $term ) {
+			$formatted_terms[] = $this->format_taxonomy( $term, $taxonomy, 'display' );
+		}
+
+		return $formatted_terms;
+	}
+}

--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -662,7 +662,11 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return new WP_Error( 'invalid_post', 'Invalid post', 400 );
 		}
 
-		$posts = get_posts( array( 'name' => $name ) );
+		$posts = get_posts( array(
+			'name' => $name,
+			'numberposts' => 1,
+			'post_type' => $this->_get_whitelisted_post_types(),
+		) );
 
 		if ( ! $posts || ! isset( $posts[0]->ID ) || ! $posts[0]->ID ) {
 			$page = get_page_by_path( $name );

--- a/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -43,6 +43,7 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 		'menu_order'        => '(int) (Pages Only) The order pages should appear in.',
 		'page_template'     => '(string) (Pages Only) The page template this page is using.',
 		'publicize_URLs'    => '(array:URL) Array of Twitter and Facebook URLs published by this post.',
+		'terms'             => '(object) Hash of taxonomy names mapping to a hash of terms keyed by term name.',
 		'tags'              => '(object:tag) Hash of tags (keyed by tag name) applied to the post.',
 		'categories'        => '(object:category) Hash of categories (keyed by category name) applied to the post.',
 		'attachments'	    => '(object:attachment) Hash of post attachments (keyed by attachment ID). Returns the most recent 20 attachments. Use the `/sites/$site/media` endpoint to query the attachments beyond the default of 20 that are returned here.',
@@ -229,6 +230,9 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 				break;
 			case 'publicize_URLs' :
 				$response[$key] = $post->get_publicize_urls();
+				break;
+			case 'terms':
+				$response[$key] = $post->get_terms();
 				break;
 			case 'tags' :
 				$response[$key] = $post->get_tags();

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -38,7 +38,7 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			add_action( 'rest_api_inserted_post', array( $GLOBALS['publicize_ui']->publicize, 'async_publicize_post' ) );
 
 			if ( $this->should_load_theme_functions( $post_id ) ) {
-				$this->load_theme_functions();				
+				$this->load_theme_functions();
 			}
 		}
 

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -100,7 +100,7 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			}
 
 			// 'future' is an alias for 'publish' for now
-			if ( 'future' === $input['status'] ) {
+			if ( isset( $input['status'] ) && 'future' === $input['status'] ) {
 				$input['status'] = 'publish';
 			}
 

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -135,7 +135,11 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 		foreach ( array( '', '_by_id' ) as $term_key_suffix ) {
 			$term_input_key = 'terms' . $term_key_suffix;
-			$input[ $term_input_key ] = (array) $input[ $term_input_key ];
+			if ( isset( $input[ $term_input_key ] ) ) {
+				$input[ $term_input_key ] = (array) $input[ $term_input_key ];
+			} else {
+				$input[ $term_input_key ] = array();
+			}
 
 			// Convert comma-separated terms to array before attempting to
 			// merge with hardcoded taxonomies

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -11,6 +11,10 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			remove_action( 'save_post', array( $GLOBALS['publicize_ui']->publicize, 'async_publicize_post' ), 100, 2 );
 			add_action( 'rest_api_inserted_post', array( $GLOBALS['publicize_ui']->publicize, 'async_publicize_post' ) );
+
+			if ( $this->should_load_theme_functions( $post_id ) ) {
+				$this->load_theme_functions();				
+			}
 		}
 
 		if ( $new ) {
@@ -129,22 +133,50 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			unset( $input['parent'] );
 		}
 
-		/* add taxonomies by name */
+		foreach ( array( '', '_by_id' ) as $term_key_suffix ) {
+			$term_input_key = 'terms' . $term_key_suffix;
+			$input[ $term_input_key ] = (array) $input[ $term_input_key ];
+
+			// Convert comma-separated terms to array before attempting to
+			// merge with hardcoded taxonomies
+			foreach ( $input[ $term_input_key ] as $taxonomy => $terms ) {
+				if ( is_string( $terms ) ) {
+					$input[ $term_input_key ][ $taxonomy ] = explode( ',', $terms );
+				} else if ( ! is_array( $terms ) ) {
+					$input[ $term_input_key ][ $taxonomy ] = array();
+				}
+			}
+
+			// For each hard-coded taxonomy, merge into terms object
+			foreach ( array( 'categories' => 'category', 'tags' => 'post_tag' ) as $key_prefix => $taxonomy ) {
+				$taxonomy_key = $key_prefix . $term_key_suffix;
+				if ( ! isset( $input[ $taxonomy_key ] ) ) {
+					continue;
+				}
+
+				if ( ! isset( $input[ $term_input_key ][ $taxonomy ] ) ) {
+					$input[ $term_input_key ][ $taxonomy ] = array();
+				}
+
+				$terms = $input[ $taxonomy_key ];
+				if ( is_string( $terms ) ) {
+					$terms = explode( ',', $terms );
+				} else if ( ! is_array( $terms ) ) {
+					continue;
+				}
+
+				$input[ $term_input_key ][ $taxonomy ] = array_merge(
+					$input[ $term_input_key ][ $taxonomy ],
+					$terms
+				);
+			}
+		}
+
+		/* add terms by name */
 		$tax_input = array();
-		foreach ( array( 'categories' => 'category', 'tags' => 'post_tag' ) as $key => $taxonomy ) {
-			if ( ! isset( $input[ $key ] ) ) {
-				continue;
-			}
-
+		foreach ( $input['terms'] as $taxonomy => $terms ) {
 			$tax_input[ $taxonomy ] = array();
-
 			$is_hierarchical = is_taxonomy_hierarchical( $taxonomy );
-
-			if ( is_array( $input[$key] ) ) {
-				$terms = $input[$key];
-			} else {
-				$terms = explode( ',', $input[$key] );
-			}
 
 			foreach ( $terms as $term ) {
 				/**
@@ -159,7 +191,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 					$tax = get_taxonomy( $taxonomy );
 
 					// see https://core.trac.wordpress.org/ticket/26409
-					if ( 'category' === $taxonomy && ! current_user_can( $tax->cap->edit_terms ) ) {
+					if ( $is_hierarchical && ! current_user_can( $tax->cap->edit_terms ) ) {
 						continue;
 					} else if ( ! current_user_can( $tax->cap->assign_terms ) ) {
 						continue;
@@ -170,34 +202,24 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 				if ( ! is_wp_error( $term_info ) ) {
 					if ( $is_hierarchical ) {
-						// Categories must be added by ID
+						// Hierarchical terms must be added by ID
 						$tax_input[$taxonomy][] = (int) $term_info['term_id'];
 					} else {
-						// Tags must be added by name
+						// Non-hierarchical terms must be added by name
 						$tax_input[$taxonomy][] = $term;
 					}
 				}
 			}
 		}
 
-		/* add taxonomies by ID */
-		foreach ( array( 'categories_by_id' => 'category', 'tags_by_id' => 'post_tag' ) as $key => $taxonomy ) {
-			if ( ! isset( $input[ $key ] ) ) {
-				continue;
-			}
-
+		/* add terms by ID */
+		foreach ( $input['terms_by_id'] as $taxonomy => $terms ) {
 			// combine with any previous selections
 			if ( ! isset( $tax_input[ $taxonomy ] ) || ! is_array( $tax_input[ $taxonomy ] ) ) {
 				$tax_input[ $taxonomy ] = array();
 			}
 
 			$is_hierarchical = is_taxonomy_hierarchical( $taxonomy );
-
-			if ( is_array( $input[$key] ) ) {
-				$terms = $input[$key];
-			} else {
-				$terms = explode( ',', $input[$key] );
-			}
 
 			foreach ( $terms as $term ) {
 				$term = (string) $term; // ctype_digit compat
@@ -220,12 +242,12 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			}
 		}
 
-		if ( ( isset( $input['categories'] ) || isset( $input['categories_by_id'] ) )
-			&& empty( $tax_input['category'] ) && 'revision' !== $post_type->name ) {
+		if ( ( isset( $input['terms']['category'] ) || isset( $input['terms_by_id']['category'] ) )
+				&& empty( $tax_input['category'] ) && 'revision' !== $post_type->name ) {
 			$tax_input['category'][] = get_option( 'default_category' );
 		}
 
-		unset( $input['tags'], $input['categories'], $input['tags_by_id'], $input['categories_by_id'] );
+		unset( $input['terms'], $input['tags'], $input['categories'], $input['terms_by_id'], $input['tags_by_id'], $input['categories_by_id'] );
 
 		$insert = array();
 
@@ -630,5 +652,16 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		do_action( 'wpcom_json_api_objects', 'posts' );
 
 		return $return;
+	}
+
+	protected function should_load_theme_functions( $post_id = null ) {
+		if ( empty( $post_id ) ) {
+			$input = $this->input( true );
+			$type = $input['type'];
+		} else {
+			$type = get_post_type( $post_id );
+		}
+
+		return ! empty( $type ) && ! in_array( $type, array( 'post', 'page', 'revision' ) );
 	}
 }

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -13,7 +13,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			add_action( 'rest_api_inserted_post', array( $GLOBALS['publicize_ui']->publicize, 'async_publicize_post' ) );
 
 			if ( $this->should_load_theme_functions( $post_id ) ) {
-				$this->load_theme_functions();				
+				$this->load_theme_functions();
 			}
 		}
 

--- a/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
@@ -1,0 +1,164 @@
+<?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+class WPCOM_JSON_API_Update_Term_Endpoint extends WPCOM_JSON_API_Taxonomy_Endpoint {
+	// /sites/%s/taxonomies/%s/terms/new            -> $blog_id, $taxonomy
+	// /sites/%s/taxonomies/%s/terms/slug:%s        -> $blog_id, $taxonomy, $slug
+	// /sites/%s/taxonomies/%s/terms/slug:%s/delete -> $blog_id, $taxonomy, $slug
+	function callback( $path = '', $blog_id = 0, $taxonomy = 'category', $slug = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->load_theme_functions();
+		}
+
+		$user = wp_get_current_user();
+		if ( ! $user || is_wp_error( $user ) || ! $user->ID ) {
+			return new WP_Error( 'authorization_required', 'An active access token must be used to manage taxonomies.', 403 );
+		}
+
+		$taxonomy_meta = get_taxonomy( $taxonomy );
+		if ( false === $taxonomy_meta || (
+				! $taxonomy_meta->public && 
+				! current_user_can( $taxonomy_meta->cap->manage_terms ) &&
+				! current_user_can( $taxonomy_meta->cap->edit_terms ) &&
+				! current_user_can( $taxonomy_meta->cap->delete_terms ) ) ) {
+			return new WP_Error( 'invalid_taxonomy', 'The taxonomy does not exist', 400 );
+		}
+
+		if ( $this->api->ends_with( $path, '/delete' ) ) {
+			return $this->delete_term( $path, $blog_id, $slug, $taxonomy );
+		} else if ( $this->api->ends_with( $path, '/new' ) ) {
+			return $this->new_term( $path, $blog_id, $taxonomy );
+		}
+
+		return $this->update_term( $path, $blog_id, $slug, $taxonomy );
+	}
+
+	// /sites/%s/taxonomies/%s/terms/new -> $blog_id, $taxonomy
+	function new_term( $path, $blog_id, $taxonomy ) {
+		$args = $this->query_args();
+		$input = $this->input();
+		if ( ! is_array( $input ) || ! $input || ! strlen( $input['name'] ) ) {
+			return new WP_Error( 'invalid_input', 'Unknown data passed', 400 );
+		}
+
+		$tax = get_taxonomy( $taxonomy );
+		if ( ! current_user_can( $tax->cap->manage_terms ) ) {
+			return new WP_Error( 'unauthorized', 'User cannot edit taxonomy', 403 );
+		}
+
+		if ( ! isset( $input['parent'] ) || ! is_taxonomy_hierarchical( $taxonomy ) ) {
+			$input['parent'] = 0;
+		}
+
+		if ( $term = get_term_by( 'name', $input['name'], $taxonomy ) ) {
+			// get_term_by is not case-sensitive, but a name with different casing is allowed
+			// also, the exact same name is allowed as long as the parents are different
+			if ( $input['name'] === $term->name && $input['parent'] === $term->parent ) {
+				return new WP_Error( 'duplicate', 'A taxonomy with that name already exists', 409 );
+			}
+		}
+
+		$data = wp_insert_term( addslashes( $input['name'] ), $taxonomy, array(
+	  		'description' => addslashes( $input['description'] ),
+	  		'parent'      => $input['parent']
+		) );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		$term = get_term_by( 'id', $data['term_id'], $taxonomy );
+
+		$return = $this->get_taxonomy( $term->slug, $taxonomy, $args['context'] );
+		if ( ! $return || is_wp_error( $return ) ) {
+			return $return;
+		}
+
+		/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
+		do_action( 'wpcom_json_api_objects', 'terms' );
+		return $return;
+	}
+
+	// /sites/%s/taxonomies/%s/terms/slug:%s -> $blog_id, $taxonomy, $slug
+	function update_term( $path, $blog_id, $slug, $taxonomy ) {
+		$tax = get_taxonomy( $taxonomy );
+		if ( ! current_user_can( $tax->cap->edit_terms ) ) {
+			return new WP_Error( 'unauthorized', 'User cannot edit taxonomy', 403 );
+		}
+
+		$term = get_term_by( 'slug', $slug, $taxonomy );
+		if ( ! $term || is_wp_error( $term ) ) {
+			return new WP_Error( 'unknown_taxonomy', 'Unknown taxonomy', 404 );
+		}
+
+		$args = $this->query_args();
+		$input = $this->input( false );
+		if ( ! is_array( $input ) || ! $input ) {
+			return new WP_Error( 'invalid_input', 'Invalid request input', 400 );
+		}
+
+		$update = array();
+		if ( ! empty( $input['parent'] ) || is_taxonomy_hierarchical( $taxonomy ) ) {
+			$update['parent'] = $input['parent'];
+		}
+
+		if ( ! empty( $input['description'] ) ) {
+			$update['description'] = addslashes( $input['description'] );
+		}
+
+		if ( ! empty( $input['name'] ) ) {
+			$update['name'] = addslashes( $input['name'] );
+		}
+
+		$data = wp_update_term( $term->term_id, $taxonomy, $update );
+		$term = get_term_by( 'id', $data['term_id'], $taxonomy );
+
+		$return = $this->get_taxonomy( $term->slug, $taxonomy, $args['context'] );
+		if ( ! $return || is_wp_error( $return ) ) {
+			return $return;
+		}
+
+		/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
+		do_action( 'wpcom_json_api_objects', 'terms' );
+		return $return;
+	}
+
+	// /sites/%s/taxonomies/%s/terms/slug:%s/delete -> $blog_id, $taxonomy, $slug
+	function delete_term( $path, $blog_id, $slug, $taxonomy ) {
+		$term = get_term_by( 'slug', $slug, $taxonomy );
+		$tax = get_taxonomy( $taxonomy );
+		if ( ! current_user_can( $tax->cap->delete_terms ) ) {
+			return new WP_Error( 'unauthorized', 'User cannot edit taxonomy', 403 );
+		}
+
+		if ( ! $term || is_wp_error( $term ) ) {
+			return new WP_Error( 'unknown_taxonomy', 'Unknown taxonomy', 404 );
+		}
+
+		$args = $this->query_args();
+		$return = $this->get_taxonomy( $term->slug, $taxonomy, $args['context'] );
+		if ( ! $return || is_wp_error( $return ) ) {
+			return $return;
+		}
+
+		/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
+		do_action( 'wpcom_json_api_objects', 'terms' );
+
+		wp_delete_term( $term->term_id, $taxonomy );
+
+		return array(
+			'slug'    => (string) $term->slug,
+			'success' => true
+		);
+	}
+}

--- a/sal/class.json-api-links.php
+++ b/sal/class.json-api-links.php
@@ -68,10 +68,16 @@ class WPCOM_JSON_API_Links {
 	}
 
 	function get_taxonomy_link( $blog_id, $taxonomy_id, $taxonomy_type, $path = '' ) {
-		if ( 'category' === $taxonomy_type )
-			return $this->get_link( '/sites/%d/categories/slug:%s', $blog_id, $taxonomy_id, $path );
-		else
-			return $this->get_link( '/sites/%d/tags/slug:%s', $blog_id, $taxonomy_id, $path );
+		switch ( $taxonomy_type ) {
+			case 'category':
+				return $this->get_link( '/sites/%d/categories/slug:%s', $blog_id, $taxonomy_id, $path );
+
+			case 'post_tag':
+				return $this->get_link( '/sites/%d/tags/slug:%s', $blog_id, $taxonomy_id, $path );
+
+			default:
+				return $this->get_link( '/sites/%d/taxonomies/%s/terms/slug:%s', $blog_id, $taxonomy_type, $taxonomy_id, $path );
+		}
 	}
 
 	function get_media_link( $blog_id, $media_id, $path = '' ) {


### PR DESCRIPTION
This PR adds support for custom taxonomies to the JSON API.  This is a port of @aduth's equivalent changes from WP.com and is required for Jetpack support for the upcoming custom post types features in Calypso.

New API endpoints:

- `GET /rest/v1.1/sites/$site/post-types/$type/taxonomies` - list taxonomies associated with a post type
- `GET /rest/v1.1/sites/$site/taxonomies/$taxonomy/terms` - list terms in a taxonomy
- `GET /rest/v1.1/sites/$site/taxonomies/$taxonomy/terms/slug:$slug` - get a term
- `POST /rest/v1.1/sites/$site/taxonomies/$taxonomy/terms/new` - create a new term
- `POST /rest/v1.1/sites/$site/taxonomies/$taxonomy/terms/slug:$slug` - edit a term
- `POST /rest/v1.1/sites/$site/taxonomies/$taxonomy/terms/slug:$slug/delete` - delete a term

Also, the endpoints to create and update a post support a new `terms` property which is a map of taxonomies to arrays of term names.

The new API features have unit tests on WP.com, but this is a massive PR, so I've created a test script to  run though the new capabilities on a Jetpack site.  Here's the script:  https://gist.github.com/nylen/246da68b6f309ff8392e0321e462bf12

Here's how to use it to test this PR:

- Obtain an OAuth2 token that is valid for your Jetpack site.  See the [documentation](https://developer.wordpress.com/docs/oauth2/) or use [this tool](http://nylen.io/get-wpcom-token/) to help.
- Install and activate [this simple plugin](https://cloudup.com/cIsFtBaQaGA) on your Jetpack site.  It registers a `book` custom post type with a `genre` taxonomy.
- Run the test script, passing it your site ID and token secret on the command line.

More info: p3hLNG-G9-p2