### PR TITLE
Remove bulky and unnecessary keys from synced updates

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -322,7 +322,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * Modify the data within an action before it is enqueued locally.
 		 *
-		 * @since 4.1.0
+		 * @since 4.2.0
 		 *
 		 * @param array The action parameters
 		 */
@@ -360,7 +360,7 @@ class Jetpack_Sync_Client {
 		 * Fires when the client needs to sync theme support info
 		 * Only sends theme support attributes whitelisted in Jetpack_Sync_Defaults::$default_theme_support_whitelist
 		 *
-		 * @since 4.1.0
+		 * @since 4.2.0
 		 *
 		 * @param object the theme support hash
 		 */
@@ -374,7 +374,7 @@ class Jetpack_Sync_Client {
 			/**
 			 * Fires when the client needs to sync WordPress version
 			 *
-			 * @since 4.1.0
+			 * @since 4.2.0
 			 *
 			 * @param string The WordPress version number
 			 */
@@ -392,7 +392,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * Fires when the client needs to sync a new term
 		 *
-		 * @since 4.1.0
+		 * @since 4.2.0
 		 *
 		 * @param object the Term object
 		 */
@@ -405,7 +405,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * Fires when the client needs to sync an attachment for a post
 		 *
-		 * @since 4.1.0
+		 * @since 4.2.0
 		 *
 		 * @param int The attachment ID
 		 * @param object The attachment
@@ -433,7 +433,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * Fires when the client needs to sync an updated user
 		 *
-		 * @since 4.1.0
+		 * @since 4.2.0
 		 *
 		 * @param object The WP_User object
 		 */
@@ -446,7 +446,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * Fires when the client needs to sync an updated user
 		 *
-		 * @since 4.1.0
+		 * @since 4.2.0
 		 *
 		 * @param object The WP_User object
 		 */
@@ -459,7 +459,7 @@ class Jetpack_Sync_Client {
 			/**
 			 * Fires when the client needs to sync an updated user
 			 *
-			 * @since 4.1.0
+			 * @since 4.2.0
 			 *
 			 * @param object The WP_User object
 			 */
@@ -529,7 +529,7 @@ class Jetpack_Sync_Client {
 			 * For example, during full sync this expands Post ID's into full Post objects,
 			 * so that we don't have to serialize the whole object into the queue.
 			 *
-			 * @since 4.1.0
+			 * @since 4.2.0
 			 *
 			 * @param array The action parameters
 			 */
@@ -550,7 +550,7 @@ class Jetpack_Sync_Client {
 		 * Return false or WP_Error to abort the sync (e.g. if there's an error)
 		 * The items will be automatically re-sent later
 		 *
-		 * @since 4.1
+		 * @since 4.2.0
 		 *
 		 * @param array $data The action buffer
 		 */
@@ -661,7 +661,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * Tells the client to sync all options to the server
 		 *
-		 * @since 4.1
+		 * @since 4.2.0
 		 *
 		 * @param boolean Whether to expand options (should always be true)
 		 */
@@ -672,7 +672,7 @@ class Jetpack_Sync_Client {
 		/**
 		 * Tells the client to sync all network options to the server
 		 *
-		 * @since 4.1
+		 * @since 4.2.0
 		 *
 		 * @param boolean Whether to expand options (should always be true)
 		 */
@@ -700,7 +700,7 @@ class Jetpack_Sync_Client {
 				/**
 				 * Tells the client to sync a constant to the server
 				 *
-				 * @since 4.1
+				 * @since 4.2.0
 				 *
 				 * @param string The name of the constant
 				 * @param mixed The value of the constant
@@ -755,7 +755,7 @@ class Jetpack_Sync_Client {
 				/**
 				 * Tells the client to sync a callable (aka function) to the server
 				 *
-				 * @since 4.1
+				 * @since 4.2.0
 				 *
 				 * @param string The name of the callable
 				 * @param mixed The value of the callable

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -319,7 +319,13 @@ class Jetpack_Sync_Client {
 			return;
 		}
 
-		// run data to enqueue through a filter
+		/**
+		 * Modify the data within an action before it is enqueued locally.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param array The action parameters
+		 */
 		apply_filters( "jetpack_sync_before_enqueue_$current_filter", $args );
 
 		// if we add any items to the queue, we should 

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -151,6 +151,8 @@ class Jetpack_Sync_Client {
 		add_action( 'set_site_transient_update_themes', $handler, 10, 1 );
 		add_action( 'set_site_transient_update_core', $handler, 10, 1 );
 
+		add_filter( 'jetpack_sync_before_enqueue_set_site_transient_update_plugins', array( $this, 'filter_update_keys' ), 10, 2 );
+
 		// multi site network options
 		if ( $this->is_multisite ) {
 			add_action( 'add_site_option', $handler, 10, 2 );
@@ -179,6 +181,17 @@ class Jetpack_Sync_Client {
 		 * Sync all pending actions with server
 		 */
 		add_action( 'jetpack_sync_actions', array( $this, 'do_sync' ) );
+	}
+
+	// removes unnecessary keys from synced updates data
+	function filter_update_keys( $args ) {
+		$updates = $args[0];
+
+		if ( isset( $updates->no_update ) ) {
+			unset( $updates->no_update );
+		}
+
+		return $args;
 	}
 
 	// TODO: Refactor to use one set whitelist function, with one is_whitelisted.
@@ -305,6 +318,9 @@ class Jetpack_Sync_Client {
 		) {
 			return;
 		}
+
+		// run data to enqueue through a filter
+		apply_filters( "jetpack_sync_before_enqueue_$current_filter", $args );
 
 		// if we add any items to the queue, we should 
 		// try to ensure that our script can't be killed before

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -326,7 +326,7 @@ class Jetpack_Sync_Client {
 		 *
 		 * @param array The action parameters
 		 */
-		apply_filters( "jetpack_sync_before_enqueue_$current_filter", $args );
+		$args = apply_filters( "jetpack_sync_before_enqueue_$current_filter", $args );
 
 		// if we add any items to the queue, we should 
 		// try to ensure that our script can't be killed before

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -17,6 +17,10 @@ class WP_Test_Jetpack_New_Sync_Updates extends WP_Test_Jetpack_New_Sync_Base {
 		wp_update_plugins();
 		$this->client->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
+
+		$this->assertFalse( isset( $updates->no_update ) );
+		$this->assertTrue( isset( $updates->response ) );
+
 		$this->assertTrue( is_int( $updates->last_checked ) );
 	}
 


### PR DESCRIPTION
Fixes sending repetitive data not used on WPCOM when pushing plugins updates.

Adds a handy filter for modifying data to be sent before enqueuing.