### PR TITLE
Sync Jetpack get_updates() as callable

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -131,6 +131,7 @@ class Jetpack_Sync_Defaults {
 		'is_multi_site'                   => 'is_multisite',
 		'main_network_site'               => 'network_site_url',
 		'single_user_site'                => array( 'Jetpack', 'is_single_user_site' ),
+		'updates'                         => array( 'Jetpack', 'get_updates' ),
 		'has_file_system_write_access'    => array( 'Jetpack_Sync_Functions', 'file_system_write_access' ),
 		'is_version_controlled'           => array( 'Jetpack_Sync_Functions', 'is_version_controlled' ),
 		'taxonomies'                      => array( 'Jetpack_Sync_Functions', 'get_taxonomies' ),

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -27,4 +27,10 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
 		$this->assertEquals( jetpack_foo_is_callable(), 'bar' );
 	}
+
+	public function test_sync_jetpack_updates() {
+		$this->client->do_sync();
+		$updates = $this->server_replica_storage->get_callable( 'updates' );
+		$this->assertEquals( Jetpack::get_updates(), $updates );
+	}
 }


### PR DESCRIPTION
Allows us to easily implement the get_updates API on the WPCOM side.