### PR TITLE
Add/sync progress api endpoints

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -364,10 +364,6 @@ class Jetpack {
 		 */
 		add_action( 'init', array( $this, 'deprecated_hooks' ) );
 
-		/**
-		 * Trigger a wp_version sync when updating WP versions
-		 **/
-		add_action( 'upgrader_process_complete', array( 'Jetpack', 'update_get_wp_version' ), 10, 2 );
 
 		/*
 		 * Load things that should only be in Network Admin.
@@ -1087,29 +1083,7 @@ class Jetpack {
 	public static function featured_images_enabled() {
 		return current_theme_supports( 'post-thumbnails' ) ? '1' : '0';
 	}
-
-	/*
-	 * Sync back wp_version
-	 */
-	public static function get_wp_version() {
-		global $wp_version;
-		return $wp_version;
-	}
-
-	/**
-	 * Keeps wp_version in sync with .com when WordPress core updates
-	 **/
-	public static function update_get_wp_version( $update, $meta_data ) {
-		if ( 'update' === $meta_data['action'] && 'core' === $meta_data['type'] ) {
-			/** This action is documented in wp-includes/option.php */
-			/**
-			 * This triggers the sync for the jetpack version
-			 * See Jetpack_Sync options method for more info.
-			 */
-			do_action( 'add_option_jetpack_wp_version', 'jetpack_wp_version', (string) Jetpack::get_wp_version() );
-		}
-	}
-
+	
 	/**
 	 * jetpack_updates is saved in the following schema:
 	 *

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -15,8 +15,18 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 	}
 }
 
+class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// GET /sites/%s/sync-status
+	protected $needed_capabilities = 'manage_options';
+
+	protected function result() {
+		$client = Jetpack_Sync_Client::getInstance();
+		return $client->get_full_sync_client()->get_status();
+	}
+}
+
 class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// POST /sites/%s/cached-data-check
+	// GET /sites/%s/cached-data-check
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -16,7 +16,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 }
 
 class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// GET /sites/%s/sync-status
+	// GET /sites/%s/sync/status
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -580,7 +580,28 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync'
 ) );
 
-// POST /sites/%s/cached-data-check
+// GET /sites/%s/sync-progress
+new Jetpack_JSON_API_Sync_Status_Endpoint( array(
+	'description'     => 'Status of the current full sync or the previous full sync',
+	'method'          => 'GET',
+	'path'            => '/sites/%s/sync-status',
+	'stat'            => 'sync-status',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'response_format' => array(
+		'started' => '(int|null) The unix timestamp when the last sync started',
+		'queue_finished' => '(int|null) The unix timestamp when the enqueuing was done for the last sync',
+		'sent_started' => '(int|null) The unix timestamp when the last sent process started',
+		'finished' => '(int|null) The unix timestamp when the last sync finished',
+		'queue'  => '(array) Count of actions that have been added to the queue',
+		'sent'  => '(array) Count of actions that have been sent',
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync-status'
+) );
+
+
+// GET /sites/%s/cached-data-check
 new Jetpack_JSON_API_Sync_Check_Endpoint( array(
 	'description'     => 'Check that cacheable data on the site is in sync with wordpress.com',
 	'group'           => '__do_not_document',

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -580,11 +580,11 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync'
 ) );
 
-// GET /sites/%s/sync-progress
+// GET /sites/%s/sync/status
 new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 	'description'     => 'Status of the current full sync or the previous full sync',
 	'method'          => 'GET',
-	'path'            => '/sites/%s/sync-status',
+	'path'            => '/sites/%s/sync/status',
 	'stat'            => 'sync-status',
 	'path_labels' => array(
 		'$site' => '(int|string) The site ID, The site domain'
@@ -597,7 +597,7 @@ new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 		'queue'  => '(array) Count of actions that have been added to the queue',
 		'sent'  => '(array) Count of actions that have been sent',
 	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync-status'
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status'
 ) );
 
 

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -377,7 +377,7 @@ class Jetpack_Sync_Client {
 		 * @param object the theme support hash
 		 */
 		do_action( 'jetpack_sync_current_theme_support', $theme_support );
-		return 1;
+		return 1; // The number of actions enqueued
 	}
 
 	function send_wp_version( $update, $meta_data ) {
@@ -678,7 +678,7 @@ class Jetpack_Sync_Client {
 		 * @param boolean Whether to expand constants (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_constants', true );
-		return 1;
+		return 1; // The number of actions enqueued
 	}
 
 	function force_sync_options() {
@@ -690,7 +690,7 @@ class Jetpack_Sync_Client {
 		 * @param boolean Whether to expand options (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_options', true );
-		return 1;
+		return 1; // The number of actions enqueued
 	}
 
 	function force_sync_network_options() {
@@ -702,7 +702,7 @@ class Jetpack_Sync_Client {
 		 * @param boolean Whether to expand options (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_network_options', true );
-		return 1;
+		return 1; // The number of actions enqueued
 	}
 
 	public function full_sync_callables() {
@@ -714,7 +714,7 @@ class Jetpack_Sync_Client {
 		 * @param boolean Whether to expand callables (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_callables', true );
-		return 1;
+		return 1; // The number of actions enqueued
 	}
 
 	public function full_sync_updates() {
@@ -726,7 +726,7 @@ class Jetpack_Sync_Client {
 		 * @param boolean Whether to expand callables (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_updates', true );
-		return 1;
+		return 1; // The number of actions enqueued
 	}
 
 	private function maybe_sync_constants() {
@@ -762,7 +762,7 @@ class Jetpack_Sync_Client {
 
 		update_option( self::CONSTANTS_CHECKSUM_OPTION_NAME, $constants_checksums );
 	}
-	// public so that we don't have to store an optio for each constant
+	// public so that we don't have to store an option for each constant
 	function get_all_constants() {
 		return array_combine(
 			$this->constants_whitelist,
@@ -942,8 +942,8 @@ class Jetpack_Sync_Client {
 
 	function reset_data() {
 		$this->reset_sync_queue();
-		// Lets delete all the other fun stuff like transints.
 
+		// Lets delete all the other fun stuff like transient and option.
 		delete_option( self::CONSTANTS_CHECKSUM_OPTION_NAME );
 		delete_option( self::CALLABLES_CHECKSUM_OPTION_NAME );
 

--- a/sync/class.jetpack-sync-dashboard.php
+++ b/sync/class.jetpack-sync-dashboard.php
@@ -118,7 +118,6 @@ class Jetpack_Sync_Dashboard extends Jetpack_Admin_Page {
 
 	function full_sync_status() {
 		$client = Jetpack_Sync_Client::getInstance();
-
 		return $client->get_full_sync_client()->get_status();
 	}
 
@@ -146,16 +145,20 @@ class Jetpack_Sync_Dashboard extends Jetpack_Admin_Page {
 	function js_progress_template() { ?>
 		<script type="text/html" id="tmpl-sync-progress">
 			<div>
-				Sync Status: {{ data.phase }}
+				Sync started: {{ data.started }} <br />
+
+				Queing Duration: {{ data.queue_finished - data.started }}  <br />
+				Finished: {{ data.finished }}
+				Total Duration: {{ data.finished - data.started }}
 			</div>
 			<div>
-				<p>Posts: {{ data.posts && data.posts.progress }} %</p>
-				<p>Comments: {{ data.comments && data.comments.progress }} %</p>
-				<p>Terms: {{ data.terms && data.terms.progress }} %</p>
-				<p>Users: {{ data.users && data.users.progress }} %</p>
-				<p>Functions: {{ data.functions && data.functions.progress }} %</p>
-				<p>Constants: {{ data.constants && data.constants.progress }} %</p>
-				<p>Options: {{ data.options && data.options.progress }} %</p>
+				<p>Posts: {{ data.queue && data.sent.posts }} / {{ data.queue && data.queue.posts }} </p>
+				<p>Comments: {{ data.queue && data.sent.comments }} /  {{ data.queue && data.queue.comments }}</p>
+				<p>Terms: {{ data.queue && data.sent.terms }} / {{ data.queue && data.queue.terms }}</p>
+				<p>Users: {{ data.queue && data.sent.users }} / {{ data.queue && data.queue.users }}</p>
+				<p>Functions: {{ data.queue && data.sent.functions }} / {{ data.queue && data.queue.functions }}</p>
+				<p>Constants: {{ data.queue && data.sent.constants }} / {{ data.queue && data.queue.constants }}</p>
+				<p>Options: {{ data.queue && data.sent.options }} / {{ data.queue && data.queue.options }}</p>
 			</div>
 		</script>
 		<?php

--- a/sync/class.jetpack-sync-dashboard.php
+++ b/sync/class.jetpack-sync-dashboard.php
@@ -119,7 +119,7 @@ class Jetpack_Sync_Dashboard extends Jetpack_Admin_Page {
 	function full_sync_status() {
 		$client = Jetpack_Sync_Client::getInstance();
 
-		return $client->get_full_sync_client()->get_complete_status();
+		return $client->get_full_sync_client()->get_status();
 	}
 
 	function dashboard_ui() {

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -141,6 +141,7 @@ class Jetpack_Sync_Defaults {
 		'sso_match_by_email'              => array( 'Jetpack_SSO_Helpers', 'match_by_email' ),
 		'sso_new_user_override'           => array( 'Jetpack_SSO_Helpers', 'new_user_override' ),
 		'sso_bypass_default_login_form'   => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
+		'wp_version'                   => array( 'Jetpack_Sync_Functions', 'wp_version' ),
 	);
 
 	static $blacklisted_post_types = array(

--- a/sync/class.jetpack-sync-full.php
+++ b/sync/class.jetpack-sync-full.php
@@ -17,6 +17,7 @@ require_once 'class.jetpack-sync-wp-replicastore.php';
 class Jetpack_Sync_Full {
 	const ARRAY_CHUNK_SIZE = 10;
 	static $status_transient_name = 'jetpack_full_sync_progress';
+	static $status_option = 'jetpack_full_sync_status';
 	static $transient_timeout = 3600; // an hour
 	static $modules = array(
 		'wp_version',
@@ -52,15 +53,24 @@ class Jetpack_Sync_Full {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'expand_comment_ids' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_options', array( $this, 'expand_options' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_constants', array( $this, 'expand_constants' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_callables', array( $this, 'expand_callables' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_users', array( $this, 'expand_users' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_network_options', array(
 			$this,
 			'expand_network_options'
 		) );
+
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_terms', array( $this, 'expand_term_ids' ) );
+
+		add_action( 'jetpack_sync_actions_to_send', array( $this, 'update_sent_progress_action' ) );
 	}
 
 	function start() {
+		if( ! $this->should_start_full_sync() ) {
+			return;
+		}
 		/**
 		 * Fires when a full sync begins. This action is serialized
 		 * and sent to the server so that it can clear the replica storage,
@@ -69,10 +79,8 @@ class Jetpack_Sync_Full {
 		 * @since 4.1
 		 */
 		do_action( 'jetpack_full_sync_start' );
-
 		$this->set_status_queuing_started();
 
-		$this->enqueue_wp_version();
 		$this->enqueue_all_constants();
 		$this->enqueue_all_functions();
 		$this->enqueue_all_options();
@@ -94,6 +102,15 @@ class Jetpack_Sync_Full {
 		do_action( 'jetpack_full_sync_end', $store->checksum_all() );
 	}
 
+	private function should_start_full_sync() {
+		$status = $this->get_status();
+		// We should try sync if we haven't started it yet or if we have finished it.
+		if( is_null( $status['started'] ) || is_integer( $status['finished'] ) ) {
+			return true;
+		}
+		return false;
+	}
+
 	private function get_client() {
 		if ( ! $this->client ) {
 			$this->client = Jetpack_Sync_Client::getInstance();
@@ -102,95 +119,74 @@ class Jetpack_Sync_Full {
 		return $this->client;
 	}
 
-	private function enqueue_wp_version() {
-		$this->set_status( 'wp_version', 0 );
-		global $wp_version;
-		do_action( 'jetpack_sync_wp_version', $wp_version );
-		$this->set_status( 'wp_version', 100 );
-	}
-
 	private function enqueue_all_constants() {
-		$this->set_status( 'constants', 0 );
-		$this->get_client()->force_sync_constants();
-		$this->set_status( 'constants', 100 );
+		$total = $this->get_client()->full_sync_constants();
+		$this->update_queue_progress( 'constants', $total );
 	}
 
 	private function enqueue_all_functions() {
-		$this->set_status( 'functions', 0 );
-		$this->get_client()->force_sync_callables();
-		$this->set_status( 'functions', 100 );
+		$total = $this->get_client()->full_sync_callables();
+		$this->update_queue_progress( 'functions', $total );
 	}
 
 	private function enqueue_all_options() {
-		$this->set_status( 'options', 0 );
-		$this->get_client()->force_sync_options();
-		$this->set_status( 'options', 100 );
+		$total = $this->get_client()->force_sync_options();
+		$this->update_queue_progress( 'options', $total );
 	}
 
 	private function enqueue_all_network_options() {
-		$this->set_status( 'network_options', 0 );
-		$this->get_client()->force_sync_network_options();
-		$this->set_status( 'network_options', 100 );
+		$total = $this->get_client()->force_sync_network_options();
+		$this->update_queue_progress( 'network_options', $total );
 	}
 
 	private function enqueue_all_terms() {
-		$this->set_status( 'terms', 0 );
 		global $wpdb;
 
 		$taxonomies = get_taxonomies();
-
-		$taxonomy_counter = 0;
-		$total_count      = count( $taxonomies );
-
+		$total_chunks_counter = 0;
 		foreach ( $taxonomies as $taxonomy ) {
-
 			// I hope this is never bigger than RAM...
 			$term_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s", $taxonomy ) ); // Should we set a limit here?
 			// Request posts in groups of N for efficiency
 			$chunked_term_ids = array_chunk( $term_ids, self::ARRAY_CHUNK_SIZE );
 
-			$total_chunks  = count( $chunked_term_ids );
-			$chunk_counter = 0;
 			// Send each chunk as an array of objects
 			foreach ( $chunked_term_ids as $chunk ) {
-				$this->set_status( 'terms', ( ( $taxonomy_counter / $total_count ) + ( ( $chunk_counter / $total_chunks ) / $total_count ) ) * 100 );
 				do_action( 'jetpack_full_sync_terms', $chunk, $taxonomy );
-				$chunk_counter ++;
+				$total_chunks_counter++;
 			}
-			$taxonomy_counter ++;
 		}
-		$this->set_status( 'terms', 100 );
+
+		$this->update_queue_progress( 'terms', $total_chunks_counter );
+
 	}
 
 	private function enqueue_all_posts() {
 		global $wpdb;
-		$this->set_status( 'posts', 0 );
+
 		$post_type_sql = Jetpack_Sync_Defaults::get_blacklisted_post_types_sql();
-		$this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $post_type_sql, 'posts' );
-		$this->set_status( 'posts', 100 );
+		$total = $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $post_type_sql );
+		$this->update_queue_progress( 'posts', $total );
+
 	}
 
-	private function enqueue_all_ids_as_action( $action_name, $table_name, $id_field, $where_sql, $status_name ) {
+	private function enqueue_all_ids_as_action( $action_name, $table_name, $id_field, $where_sql ) {
 		global $wpdb;
 
 		if ( ! $where_sql ) {
 			$where_sql = "1 = 1";
 		}
 
-		$total = $wpdb->get_var( "SELECT count(*) FROM {$table_name} WHERE {$where_sql}" );
 		$items_per_page = 500;
 		$page = 1;
-		$counter = 1;
 		$offset = ( $page * $items_per_page ) - $items_per_page;
-
+		$chunk_count = 0;
 		while( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} ORDER BY {$id_field} asc LIMIT {$offset}, {$items_per_page}" ) ) {
-			print_r($ids, true);
 			// Request posts in groups of N for efficiency
 			$chunked_ids = array_chunk( $ids, self::ARRAY_CHUNK_SIZE );
 
 			// Send each chunk as an array of objects
 			foreach ( $chunked_ids as $chunk ) {
-				$this->set_status( $status_name, ( $counter / $total ) * 100 );
 				/**
 			 	 * Fires with a chunk of object IDs during full sync.
 			 	 * These are expanded to full objects before upload
@@ -198,12 +194,13 @@ class Jetpack_Sync_Full {
 			 	 * @since 4.1
 			 	 */
 				do_action( $action_name, $chunk );
-				$counter += count( $chunked_ids );
+				$chunk_count++;
 			}
 
 			$page += 1;
 			$offset = ( $page * $items_per_page ) - $items_per_page;
 		}
+		return $chunk_count;
 	}
 
 	public function expand_post_ids( $args ) {
@@ -221,9 +218,9 @@ class Jetpack_Sync_Full {
 
 	private function enqueue_all_comments() {
 		global $wpdb;
-		$this->set_status( 'comments', 0 );
-		$this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', null, 'comments' );
-		$this->set_status( 'comments', 100 );
+
+		$total = $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', null );
+		$this->update_queue_progress( 'comments', $total );
 	}
 
 	public function expand_comment_ids( $args ) {
@@ -269,16 +266,28 @@ class Jetpack_Sync_Full {
 		return $args;
 	}
 
+	public function expand_constants( $args ) {
+		if ( $args[0] ) {
+			return $this->get_client()->get_all_constants();
+		}
+		return $args;
+	}
+
+	public function expand_callables( $args ) {
+		if ( $args[0] ) {
+			return $this->get_client()->get_all_callables();
+		}
+		return $args;
+	}
+
 	private function enqueue_all_users() {
 		global $wpdb;
-		$this->set_status( 'users', 0 );
-		$this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->users, 'ID', null, 'users' );
-		$this->set_status( 'users', 100 );
+		$total = $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->users, 'ID', null );
+		$this->update_queue_progress( 'users', $total );
 	}
 
 	public function expand_users( $args ) {
 		$user_ids = $args[0];
-
 		return array_map( array( $this->get_client(), 'sanitize_user' ), get_users( array( 'include' => $user_ids ) ) );
 	}
 
@@ -309,37 +318,97 @@ class Jetpack_Sync_Full {
 
 	// TODO:
 	private function enqueue_all_theme_info() {
-		$this->set_status( 'themes', 0 );
-		$this->get_client()->send_theme_info();
-		$this->set_status( 'themes', 100 );
+		$total = $this->get_client()->send_theme_info();
+		$this->update_queue_progress( 'themes', $total );
 	}
 
 	private function enqueue_all_updates() {
-		$this->set_status( 'updates', 0 );
+
 		// check for updates
-		wp_update_plugins();
-		wp_update_themes();
-		_maybe_update_core();
-		$this->set_status( 'updates', 100 );
+		$total = $this->get_client()->full_sync_updates();
+		$this->update_queue_progress( 'updates', $total );
 	}
 
-	private function set_status( $name, $percent, $count = 1, $total = 1 ) {
-		set_transient( self::$status_transient_name . '_' . $name,
-			array(
-				'progress' => $percent,
-				// 'count' => $count, 
-				// 'total' => $total 
-			),
-			self::$transient_timeout
-		);
+	public function expand_updates( $args ) {
+		if ( $args[0] ) {
+			return $this->get_client()->get_all_updates();
+		}
+
+		return $args;
+	}
+	
+	function update_sent_progress_action( $action_to_send ) {
+		$modules_count = array();
+		$status = $this->get_status();
+		if ( is_null( $status['started'] ) || $status['finished'] ) {
+			return;
+		}
+		foreach( $action_to_send as $action ) {
+			$module_key = $this->action_to_modules( $action );
+			if ( $module_key ) {
+				$modules_count[ $module_key ] = isset( $modules_count[ $module_key ] ) ?  $modules_count[ $module_key ] + 1 : 1;
+			}
+
+		}
+		foreach( $modules_count as $module => $count ) {
+			$this->update_sent_progress( $module, $count );
+		}
+	}
+
+	function action_to_modules( $action ) {
+		switch( $action ) {
+			case 'jetpack_full_sync_constants':
+				return 'constants';
+				break;
+
+			case 'jetpack_full_sync_callables':
+				return 'functions';
+				break;
+
+			case 'jetpack_full_sync_options':
+				return 'options';
+				break;
+
+			case 'jetpack_full_sync_network_options':
+				return 'network_options';
+				break;
+
+			case 'jetpack_full_sync_terms':
+				return 'terms';
+				break;
+
+			case 'jetpack_sync_current_theme_support':
+				return 'themes';
+				break;
+
+			case 'jetpack_full_sync_users':
+				return 'users';
+				break;
+
+			case 'jetpack_full_sync_posts':
+				return 'posts';
+				break;
+
+			case 'jetpack_full_sync_comments':
+				return 'comments';
+				break;
+
+			case 'jetpack_full_sync_updates':
+				return 'updates';
+				break;
+
+		}
+		return null;
 	}
 
 	private function set_status_queuing_started() {
-		set_transient( self::$status_transient_name, array( 'phase' => 'queuing started' ), self::$transient_timeout );
+		$status = $this->initial_status;
+		$status[ 'started' ] = time();
+		$this->update_status( $status );
 	}
 
 	private function set_status_queuing_finished() {
-		set_transient( self::$status_transient_name, array( 'phase' => 'queuing finished' ), self::$transient_timeout );
+		$this->update_status( array( 'queue_finished' => time() ) );
 	}
 
 	// these are called by the Sync Client when it sees that the full sync start/end actions have actually been transmitted
@@ -350,8 +419,10 @@ class Jetpack_Sync_Full {
 		 *
 		 * @since 4.1
 		 */
+
 		do_action( 'jetpack_full_sync_start_sent' );
-		set_transient( self::$status_transient_name, array( 'phase' => 'sending started' ), self::$transient_timeout );
+		$this->update_status( array( 'sent_started' => time() ) );
+
 	}
 
 	public function set_status_sending_finished() {
@@ -362,29 +433,44 @@ class Jetpack_Sync_Full {
 		 * @since 4.1
 		 */
 		do_action( 'jetpack_full_sync_end_sent' );
-		set_transient( self::$status_transient_name, array( 'phase' => 'sending finished' ), self::$transient_timeout );
+		$this->update_status( array( 'finished' => time() ) );
 	}
+	
+	private $initial_status = array(
+		'started' => null,
+		'queue_finished' => null,
+		'sent_started' => null,
+		'finished' => null,
+		'sent' => array(),
+		'queue' => array(),
+	);
 
 	public function get_status() {
-		$status = get_transient( self::$status_transient_name );
-		if ( ! is_array( $status ) ) {
-			return array( 'phase' => 'not started' );
-		}
-
-		return $status;
+		return get_option( self::$status_option, $this->initial_status );
 	}
 
-	public function get_module_status( $module ) {
-		return get_transient( self::$status_transient_name . '_' . $module );
-	}
 
-	public function get_complete_status() {
-		return array_merge(
-			$this->get_status(),
-			array_combine(
-				Jetpack_Sync_Full::$modules,
-				array_map( array( $this, 'get_module_status' ), Jetpack_Sync_Full::$modules )
-			)
+	public function update_status( $status ) {
+		return update_option(
+			self::$status_option,
+			array_merge( $this->get_status(), $status )
 		);
 	}
+
+	private function clear_status() {
+		delete_option( self::$status_option );
+	}
+
+	public function update_queue_progress( $module, $data ) {
+		$status = $this->get_status();
+		$status['queue'][ $module ] = $data;
+		return $this->update_status( $status );
+	}
+
+	public function update_sent_progress( $module, $data ) {
+		$status = $this->get_status();
+		$status['sent'][ $module ] = $data;
+		return $this->update_status( $status );
+	}
+	
 }

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -67,4 +67,9 @@ class Jetpack_Sync_Functions {
 
 		return 0;
 	}
+
+	public static function wp_version() {
+		global $wp_version;
+		return $wp_version;
+	}
 }

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -7,15 +7,6 @@ require_once 'interface.jetpack-sync-replicastore.php';
  * This is useful to compare values in the local WP DB to values in the synced replica store
  */
 class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
-	public function set_wp_version( $version ) {
-		// makes no sense here?
-	}
-
-	public function get_wp_version() {
-		global $wp_version;
-
-		return $wp_version;
-	}
 
 	public function reset() {
 		global $wpdb;

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -11,11 +11,6 @@
  * required semantics for storing all the data that we sync
  */
 interface iJetpack_Sync_Replicastore {
-	// synced wp version
-	public function get_wp_version();
-
-	public function set_wp_version( $version );
-
 	// remove all data
 	public function reset();
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -176,16 +176,32 @@ class Jetpack_Sync_Server_Replicator {
 					$this->store->update_site_option( $option, $value );
 				}
 				break;
+			case 'jetpack_full_sync_constants':
+				foreach( $args as $name => $value ) {
+					$this->store->set_constant( $name, $value );
+				}
+				break;
+			case 'jetpack_full_sync_callables':
+				foreach( $args as $name => $value ) {
+					$this->store->set_callable( $name, $value );
+				}
+				break;
 			case 'jetpack_full_sync_users':
 				foreach( $args as $user ) {
 					$this->store->upsert_user( $user );
 				}
 				break;
-			case 'jetpack_full_sync_terms': {
+			case 'jetpack_full_sync_terms':
 				foreach( $args as $term_object ) {
 					$this->store->update_term( $term_object );
 				}
-			}
+				break;
+			case 'jetpack_full_sync_updates':
+				foreach ($args as $update_name => $update_value ) {
+					$this->store->set_updates( $update_name, $update_value );
+				}
+				break;
+
 			// terms
 			case 'jetpack_sync_save_term':
 				list( $term_object ) = $args;

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -133,12 +133,6 @@ class Jetpack_Sync_Server_Replicator {
 				$this->store->delete_site_option( $option );
 				break;
 
-			// wp version
-			case 'jetpack_sync_wp_version':
-				list( $wp_version ) = $args;
-				$this->store->set_wp_version( $wp_version );
-				break;
-
 			// full sync
 			case 'jetpack_full_sync_start':
 				$this->store->full_sync_start();

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -8,7 +8,6 @@ require_once dirname( __FILE__ ) . '/../../../../sync/interface.jetpack-sync-rep
  */
 class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
-	private $wp_version;
 	private $posts;
 	private $post_status;
 	private $comments;
@@ -30,7 +29,6 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	function reset() {
-		$wp_version = null;
 		$this->posts = array();
 		$this->comments = array();
 		$this->options = array();
@@ -53,13 +51,6 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		// noop right now
 	}
 
-	function get_wp_version() {
-		return $this->wp_version;
-	}
-	
-	function set_wp_version( $version ) {
-		$this->wp_version = $version;
-	}
 
 	function post_count( $status = null ) {
 		return count( $this->get_posts( $status ) );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -33,4 +33,11 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 		$updates = $this->server_replica_storage->get_callable( 'updates' );
 		$this->assertEquals( Jetpack::get_updates(), $updates );
 	}
+
+	function test_wp_version_is_synced() {
+		global $wp_version;
+		$this->client->do_sync();
+		$synced_value = $this->server_replica_storage->get_callable( 'wp_version' );
+		$this->assertEquals( $synced_value, $wp_version );
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -52,7 +52,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 
 		global $wp_version;
-		$this->assertEquals( $wp_version, $this->server_replica_storage->get_wp_version() );
+		$this->assertEquals( $wp_version, $this->server_replica_storage->get_callable( 'wp_version' ) );
 	}
 
 	function test_full_sync_sends_all_posts_except_revisions() {

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -39,14 +39,14 @@ class WP_Test_Jetpack_New_Sync_Updates extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	public function test_sync_wp_version() {
-		$this->assertEquals( null, $this->server_replica_storage->get_wp_version() );
-
-		do_action( 'upgrader_process_complete', null, array( 'action' => 'update', 'type' => 'core' ) );
-
-		$this->client->do_sync();
-
 		global $wp_version;
-		$this->assertEquals( $wp_version, $this->server_replica_storage->get_wp_version() );
+		$this->assertEquals( $wp_version, $this->server_replica_storage->get_callable( 'wp_version' ) );
+
+		// Lets pretend that we updated the wp_version to bar.
+		$wp_version = 'bar';
+		do_action( 'upgrader_process_complete', null, array( 'action' => 'update', 'type' => 'core' ) );
+		$this->client->do_sync();
+		$this->assertEquals( $wp_version, $this->server_replica_storage->get_callable( 'wp_version' ) );
 	}
 
 }

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -213,7 +213,10 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		unset($comment->comment_date_gmt);
 		unset($retrieved_comment->comment_date);
 		unset($retrieved_comment->comment_date_gmt);
-
+	
+		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
+			$this->markTestIncomplete("The WP replicastore doesn't support setting comments post_fields");
+		}
 		$this->assertEquals( $comment, $retrieved_comment );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Refactors some of the full sync implementation. 
- Functions, updates and constants to expand on send.
- Updates don't try to get the latest updates from .org on full sync but send the site transitent instead.
- Added status to the full sync that records the timestamps when full sync start, queuing finishes, start of send and finish of send happens as well as an array of the items in the que and an array of the times that got sent. 
- Wp_version now gets sent via callables.
- Added the sync-progress api endpoint that returns the full sync status. 


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).

- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
