### PR TITLE
Add more default callables tests.

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -34,10 +34,56 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( Jetpack::get_updates(), $updates );
 	}
 
+
 	function test_wp_version_is_synced() {
 		global $wp_version;
 		$this->client->do_sync();
 		$synced_value = $this->server_replica_storage->get_callable( 'wp_version' );
 		$this->assertEquals( $synced_value, $wp_version );
 	}
+
+	public function test_sync_callable_whitelist() {
+		$this->setSyncClientDefaults();
+
+		$callables = array(
+			'wp_max_upload_size'              => wp_max_upload_size(),
+			'is_main_network'                 => Jetpack::is_multi_network(),
+			'is_multi_site'                   => is_multisite(),
+			'main_network_site'               => network_site_url(),
+			'single_user_site'                => Jetpack::is_single_user_site(),
+			'updates'                         => Jetpack::get_updates(),
+			'has_file_system_write_access'    => Jetpack_Sync_Functions::file_system_write_access(),
+			'is_version_controlled'           => Jetpack_Sync_Functions::is_version_controlled(),
+			'taxonomies'                      => Jetpack_Sync_Functions::get_taxonomies(),
+			'post_types'                      => Jetpack_Sync_Functions::get_post_types(),
+			'sso_is_two_step_required'        => Jetpack_SSO_Helpers::is_two_step_required(),
+			'sso_should_hide_login_form'      => Jetpack_SSO_Helpers::should_hide_login_form(),
+			'sso_match_by_email'              => Jetpack_SSO_Helpers::match_by_email(),
+			'sso_new_user_override'           => Jetpack_SSO_Helpers::new_user_override(),
+			'sso_bypass_default_login_form'   => Jetpack_SSO_Helpers::bypass_login_forward_wpcom(),
+		);
+
+		$this->client->do_sync();
+
+		foreach( $callables as $name => $value ) {
+			$this->assertCallableIsSynced( $name, $value );
+		}
+
+		$whitelist_keys = array_keys( $this->client->get_callable_whitelist() );
+		$callables_keys = array_keys( $callables );
+		
+		// Are we testing all the callables in the defaults?
+		$whitelist_and_callable_keys_difference = array_diff( $whitelist_keys, $callables_keys );
+		$this->assertTrue( empty( $whitelist_and_callable_keys_difference ), 'Some whitelisted options don\'t have a test: ' . print_r( $whitelist_and_callable_keys_difference, 1 )  );
+
+		// Are there any duplicate keys?
+		$unique_whitelist = array_unique( $whitelist_keys );
+		$this->assertEquals( count( $unique_whitelist ), count( $whitelist_keys ), 'The duplicate keys are: '. print_r( array_diff_key( $whitelist_keys , array_unique( $whitelist_keys ) ) ,1 ) );
+
+	}
+
+	function assertCallableIsSynced( $name, $value ) {
+		$this->assertEquals( $value, $this->server_replica_storage->get_callable( $name ), 'Function '. $name .' did\'t have the extected value of ' . json_encode( $value ) );
+	}
+	
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -61,6 +61,7 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 			'sso_match_by_email'              => Jetpack_SSO_Helpers::match_by_email(),
 			'sso_new_user_override'           => Jetpack_SSO_Helpers::new_user_override(),
 			'sso_bypass_default_login_form'   => Jetpack_SSO_Helpers::bypass_login_forward_wpcom(),
+			'wp_version'                      => Jetpack_Sync_Functions::wp_version(),
 		);
 
 		$this->client->do_sync();
@@ -85,5 +86,5 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 	function assertCallableIsSynced( $name, $value ) {
 		$this->assertEquals( $value, $this->server_replica_storage->get_callable( $name ), 'Function '. $name .' did\'t have the extected value of ' . json_encode( $value ) );
 	}
-	
+
 }


### PR DESCRIPTION
Add some more test for the default callables. Make sure that we have a test for each of them.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

