### PR TITLE
Remove broken legacy methods from jetpack XMLRPC server.

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -28,10 +28,6 @@ class Jetpack_XMLRPC_Server {
 				'jetpack.testAPIUserCode'   => array( $this, 'test_api_user_code' ),
 				'jetpack.featuresAvailable' => array( $this, 'features_available' ),
 				'jetpack.featuresEnabled'   => array( $this, 'features_enabled' ),
-				'jetpack.getPost'           => array( $this, 'get_post' ),
-				'jetpack.getPosts'          => array( $this, 'get_posts' ),
-				'jetpack.getComment'        => array( $this, 'get_comment' ),
-				'jetpack.getComments'       => array( $this, 'get_comments' ),
 				'jetpack.disconnectBlog'    => array( $this, 'disconnect_blog' ),
 				'jetpack.unlinkUser'        => array( $this, 'unlink_user' ),
 			) );
@@ -357,54 +353,6 @@ class Jetpack_XMLRPC_Server {
 		}
 
 		return $modules;
-	}
-
-	function get_post( $id ) {
-		if ( !$id = (int) $id ) {
-			return false;
-		}
-
-		$jetpack = Jetpack::init();
-
-		$post = $jetpack->sync->get_post( $id );
-		return $post;
-	}
-
-	function get_posts( $args ) {
-		list( $post_ids ) = $args;
-		$post_ids = array_map( 'intval', (array) $post_ids );
-		$jp = Jetpack::init();
-		$sync_data = $jp->sync->get_content( array( 'posts' => $post_ids ) );
-
-		return $sync_data;
-	}
-
-	function get_comment( $id ) {
-		if ( !$id = (int) $id ) {
-			return false;
-		}
-
-		$jetpack = Jetpack::init();
-
-		$comment = $jetpack->sync->get_comment( $id );
-		if ( !is_array( $comment ) )
-			return false;
-
-		$post = $jetpack->sync->get_post( $comment['comment_post_ID'] );
-		if ( !$post ) {
-			return false;
-		}
-
-		return $comment;
-	}
-
-	function get_comments( $args ) {
-		list( $comment_ids ) = $args;
-		$comment_ids = array_map( 'intval', (array) $comment_ids );
-		$jp = Jetpack::init();
-		$sync_data = $jp->sync->get_content( array( 'comments' => $comment_ids ) );
-
-		return $sync_data;
 	}
 
 	function update_attachment_parent( $args ) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
 			<file>tests/php/test_class.functions.compat.php</file>
 			<file>tests/php/test_class.jetpack-network.php</file>
 			<file>tests/php/test_class.jetpack-client-server.php</file>
+			<file>tests/php/test_class.jetpack-xmlrpc-server.php</file>
 			<file>tests/php/test_class.jetpack-heartbeat.php</file>
 		</testsuite>
 		<testsuite name="media">

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -172,7 +172,6 @@ class Jetpack_Sync_Client {
 			add_action( 'jetpack_full_sync_network_options', $handler );
 		}
 
-
 		// Module Activation
 		add_action( 'jetpack_activate_module', $handler );
 		add_action( 'jetpack_deactivate_module', $handler );

--- a/tests/php/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/test_class.jetpack-xmlrpc-server.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/../../class.jetpack-xmlrpc-server.php';
+
+class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
+	function test_xmlrpc_features_available() {
+		$server = new Jetpack_XMLRPC_Server();
+		$response = $server->features_available();
+		
+		// trivial assertion
+		$this->assertTrue( in_array( 'publicize', $response ) );
+	}
+}
+	


### PR DESCRIPTION
This PR removes the getPost(s) and getComment(s) XMLRPC methods. The method signature was going to change anyway, and we're more focused on having a complete and accurate shadow DB than cherry-picking posts from the remote site.

Scripts that try to call these methods have been modified to return an error on sites using new sync.

In addition, since I had already created and deleted some XMLRPC tests, I added a trivial test for one of the existing XMLRPC methods.

cc @lezama 