### PR TITLE
SSO: Add calypso_auth query parameter to SSO URL

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -912,9 +912,10 @@ class Jetpack_SSO {
 	function build_sso_url( $args = array() ) {
 		$sso_nonce = ! empty( $args['sso_nonce'] ) ? $args['sso_nonce'] : self::request_initial_nonce();
 		$defaults = array(
-			'action'    => 'jetpack-sso',
-			'site_id'   => Jetpack_Options::get_option( 'id' ),
-			'sso_nonce' => $sso_nonce,
+			'action'       => 'jetpack-sso',
+			'site_id'      => Jetpack_Options::get_option( 'id' ),
+			'sso_nonce'    => $sso_nonce,
+			'calypso_auth' => '1',
 		);
 
 		$args = wp_parse_args( $args, $defaults );
@@ -943,11 +944,12 @@ class Jetpack_SSO {
 		}
 
 		$defaults = array(
-			'action'      => 'jetpack-sso',
-			'site_id'     => Jetpack_Options::get_option( 'id' ),
-			'sso_nonce'   => $sso_nonce,
-			'reauth'      => '1',
-			'redirect_to' => urlencode( $redirect ),
+			'action'       => 'jetpack-sso',
+			'site_id'      => Jetpack_Options::get_option( 'id' ),
+			'sso_nonce'    => $sso_nonce,
+			'reauth'       => '1',
+			'redirect_to'  => urlencode( $redirect ),
+			'calypso_auth' => '1',
 		);
 
 		$args = wp_parse_args( $args, $defaults );


### PR DESCRIPTION
Previously, we redirected SSO users to the new Calypso SSO flow when the version was `>= 4.1.0-alpha`. That relies on sync working properly and, in my experience, is prone to error at times.

This PR sends a `calypso_auth` parameter so that we can redirect when `calypso_auth` is set and truthy.

cc @lezama for code review

To test:

- Checkout `update/sso-calypso-param` branch
- Go to `$site/wp-admin`
- Click the "Log in with WordPress.com" button
- Make sure your WP.com user is not already connected to WP.com on the remote Jetpack site
- Are you shown a Calypso UI?

