### PR TITLE
VideoPress: Update Jetpack signatures to handle array bodies properly.

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -64,14 +64,19 @@ class Jetpack_Client {
 		// Kind of annoying.  Maybe refactor Jetpack_Signature to handle body-hashing
 		if ( is_null( $body ) ) {
 			$body_hash = '';
+
 		} else {
 			// Allow arrays to be used in passing data.
 			$body_to_hash = $body;
-			if ( is_array( $body ) ) {
 
+			if ( is_array( $body ) ) {
 				// We cast this to a new variable, because the array form of $body needs to be
 				// maintained so it can be passed into the request later on in the code.
-				$body_to_hash = json_encode( self::_stringify_data( $body ) );
+				if ( count( $body ) > 0 ) {
+					$body_to_hash = json_encode( self::_stringify_data( $body ) );
+				} else {
+					$body_to_hash = '';
+				}
 			}
 
 			if ( !is_string( $body_to_hash ) ) {

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -107,7 +107,12 @@ class Jetpack_Signature {
 
 		// If we got an array at this point, let's encode it, so we can see what it looks like as a string.
 		if ( is_array( $body ) ) {
-			$body = json_encode( $body );
+			if ( count( $body ) > 0 ) {
+				$body = json_encode( $body );
+
+			} else {
+				$body = '';
+			}
 		}
 
 		$required_parameters = array( 'token', 'timestamp', 'nonce', 'method', 'url' );
@@ -128,7 +133,7 @@ class Jetpack_Signature {
 			}
 		}
 
-		if ( is_null( $body ) ) {
+		if ( empty( $body ) ) {
 			if ( $body_hash ) {
 				return new Jetpack_Error( 'invalid_body_hash', 'The body hash does not match.' );
 			}

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -63,6 +63,15 @@ class Jetpack_Signature {
 			$body = $override['body'];
 		} else if ( 'POST' == strtoupper( $_SERVER['REQUEST_METHOD'] ) ) {
 			$body = isset( $GLOBALS['HTTP_RAW_POST_DATA'] ) ? $GLOBALS['HTTP_RAW_POST_DATA'] : null;
+
+			// Convert the $_POST to the body, if the body was empty. This is how arrays are hashed
+			// and encoded on the Jetpack side.
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				if ( empty( $body ) && is_array( $_POST ) && count( $_POST ) > 0 ) {
+					$body = $_POST;
+				}
+			}
+
 		} else {
 			$body = null;
 		}
@@ -94,6 +103,11 @@ class Jetpack_Signature {
 
 		if ( 0 !== strpos( $token, "$this->token:" ) ) {
 			return new Jetpack_Error( 'token_mismatch', 'Incorrect token' );
+		}
+
+		// If we got an array at this point, let's encode it, so we can see what it looks like as a string.
+		if ( is_array( $body ) ) {
+			$body = json_encode( $body );
 		}
 
 		$required_parameters = array( 'token', 'timestamp', 'nonce', 'method', 'url' );


### PR DESCRIPTION
Currently, when Jetpack Signatures are used to sync data with the WPCOM API, only plain text bodies are allowed to be used. Unfortunately, this limits the interactions that are allowed to be had on the WPCOM side of things.

This change looks to update the Jetpack signature itself to check for the existence of an array and to properly serialize it into text using standard JSON strings. By doing this, we can create a hash that is representative of the data in the $_POST array and verify that it was not tampered with on the other side.

It appears that this is this way because it is a hold-over from how the XML-RPC connection signed requests. Since we're looking to use WPCOM API endpoints in similar ways now and need to use non-text-only bodies it is useful to expand how the signature works.

## WPCOM Dependencies

- [x] Deploy signature updates to WPCOM

## Testing

The new functionality will be testable with the following PR:

- [x] #4145 VideoPress Attachment Editor

The following should all continue to work as before with no more changes required:

- [ ] XML RPC requests
- [ ] `login_form_json_api_authorization`
- [ ] stats
- [ ] monitor
- [ ] disconnect
- [ ] unlink user
- [ ] check privacy
- [ ] switch blog owner
- [ ] post by email
- [ ] protect
- [ ] sso
- [ ] subscriptions
- [ ] publicize 
- [ ] sync
- [ ] autoupdate

## Notes

1) One consideration that was made in this, and can be seen with the `Jetpack_Client::_stringify_data()` method, is that when data is sent to the server, no matter its type, it will arrive as flat arrays and strings. The idea is to try to mimic the transformation that will occur when the data is serialized into an HTTP request.
2) I chose `json_encode()` instead of `serialize()` because it a simpler standard and the conversion into a hash does not need to maintain type safety in the same way as a serialize implies. This is especially true since we're never unserializing the data.