### PR TITLE
VideoPress: Attachment Editor

### DIFF
--- a/modules/videopress.php
+++ b/modules/videopress.php
@@ -17,4 +17,5 @@ include_once dirname( __FILE__ ) . '/videopress/videopress.php';
 
 if ( is_admin() ) {
 	include_once dirname(__FILE__) . '/videopress/editor-media-view.php';
+	require dirname( __FILE__ ) . '/videopress/videopress-edit-attachment.php';
 }

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -250,7 +250,7 @@ function videopress_get_transcoding_status( $post_id ) {
  *
  * @return string
  */
-function videopress_get_url( $guid ) {
+function videopress_build_url( $guid ) {
 	return 'https://videopress.com/v/' . $guid;
 }
 

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -99,6 +99,7 @@ function videopress_get_attachment_id_by_url( $url ) {
 		}
 
 	}
+
 	return false;
 }
 
@@ -201,4 +202,22 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		}
 	}
 	WP_CLI::add_command( 'videopress', 'VideoPress_CLI' );
+}
+
+/**
+ * Return an absolute URI for a given filename and guid on the CDN.
+ * No check is performed to ensure the guid exists or the file is present. Simple centralized string builder.
+ *
+ * @param string $guid     VideoPress identifier
+ * @param string $filename name of file associated with the guid (video file name or thumbnail file name)
+ *
+ * @return string Absolute URL of VideoPress file for the given guid.
+ */
+function video_cdn_file_url( $guid, $filename ) {
+	if ( is_ssl() ) {
+		return "https://videos.files.wordpress.com/{$guid}/{$filename}";
+
+	} else {
+		return "http://videos.videopress.com/{$guid}/{$filename}";
+	}
 }

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -214,12 +214,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
  * @return string Absolute URL of VideoPress file for the given guid.
  */
 function videopress_cdn_file_url( $guid, $filename ) {
-	if ( is_ssl() ) {
-		return "https://videos.files.wordpress.com/{$guid}/{$filename}";
-
-	} else {
-		return "http://videos.videopress.com/{$guid}/{$filename}";
-	}
+	return "https://videos.files.wordpress.com/{$guid}/{$filename}";
 }
 
 /**

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -234,10 +234,10 @@ function videopress_get_transcoding_status( $post_id ) {
 	$info = (object) $meta['videopress'];
 
 	$status = array(
-		'std_mp4' => isset( $info->files_status ) ? $info->files_status['std']['mp4'] : null,
-		'std_ogg' => isset( $info->files_status ) ? $info->files_status['std']['ogg'] : null,
-		'dvd_mp4' => isset( $info->files_status ) ? $info->files_status['dvd']['mp4'] : null,
-		'hd_mp4'  => isset( $info->files_status ) ? $info->files_status['hd']['mp4'] : null,
+		'std_mp4' => isset( $info->files_status['std']['mp4'] ) ? $info->files_status['std']['mp4'] : null,
+		'std_ogg' => isset( $info->files_status['std']['ogg'] ) ? $info->files_status['std']['ogg'] : null,
+		'dvd_mp4' => isset( $info->files_status['dvd']['mp4'] ) ? $info->files_status['dvd']['mp4'] : null,
+		'hd_mp4'  => isset( $info->files_status['hd']['mp4'] )  ? $info->files_status['hd']['mp4']  : null,
 	);
 
 	return $status;

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -241,8 +241,8 @@ function videopress_get_transcoding_status( $post_id ) {
 	$status = array(
 		'std_mp4' => isset( $info->files_status ) ? $info->files_status['std']['mp4'] : null,
 		'std_ogg' => isset( $info->files_status ) ? $info->files_status['std']['ogg'] : null,
-		'dvd'     => isset( $info->files_status ) ? $info->files_status['dvd'] : null,
-		'hd'      => isset( $info->files_status ) ? $info->files_status['hd'] : null,
+		'dvd_mp4' => isset( $info->files_status ) ? $info->files_status['dvd']['mp4'] : null,
+		'hd_mp4'  => isset( $info->files_status ) ? $info->files_status['hd']['mp4'] : null,
 	);
 
 	return $status;

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -248,3 +248,14 @@ function videopress_get_transcoding_status( $post_id ) {
 	return $status;
 }
 
+/**
+ * Get the direct url to the video.
+ *
+ * @param string $guid
+ *
+ * @return string
+ */
+function videopress_get_url( $guid ) {
+	return 'https://videopress.com/v/' . $guid;
+}
+

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -213,7 +213,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
  *
  * @return string Absolute URL of VideoPress file for the given guid.
  */
-function video_cdn_file_url( $guid, $filename ) {
+function videopress_cdn_file_url( $guid, $filename ) {
 	if ( is_ssl() ) {
 		return "https://videos.files.wordpress.com/{$guid}/{$filename}";
 
@@ -221,3 +221,27 @@ function video_cdn_file_url( $guid, $filename ) {
 		return "http://videos.videopress.com/{$guid}/{$filename}";
 	}
 }
+
+/**
+ * Get an array of the transcoding status for the given video post.
+ *
+ * @param int $post_id
+ * @return array|bool Returns an array of statuses if this is a VideoPress post, otherwise it returns false.
+ */
+function videopress_get_transcoding_status( $post_id ) {
+	$meta = wp_get_attachment_metadata( $post_id );
+
+	// If this has not been processed by videopress, we can skip the rest.
+	if ( !$meta || ! isset( $meta['videopress'] ) ) {
+		return false;
+	}
+
+	$info = (object) $meta['videopress'];
+
+	// Turn the transcoding statuses into an array.
+
+	$status = array();
+
+	return $status;
+}
+

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -238,9 +238,12 @@ function videopress_get_transcoding_status( $post_id ) {
 
 	$info = (object) $meta['videopress'];
 
-	// Turn the transcoding statuses into an array.
-
-	$status = array();
+	$status = array(
+		'std_mp4' => isset( $info->files_status ) ? $info->files_status['std']['mp4'] : null,
+		'std_ogg' => isset( $info->files_status ) ? $info->files_status['std']['ogg'] : null,
+		'dvd'     => isset( $info->files_status ) ? $info->files_status['dvd'] : null,
+		'hd'      => isset( $info->files_status ) ? $info->files_status['hd'] : null,
+	);
 
 	return $status;
 }

--- a/modules/videopress/videopress-edit-attachment.php
+++ b/modules/videopress/videopress-edit-attachment.php
@@ -224,32 +224,52 @@ class VideoPress_Edit_Attachment {
 		$shortcode = '<input type="text" id="plugin-embed" readonly="readonly" style="width:180px;" value="' . esc_attr( $embed ) . '" onclick="this.focus();this.select();" />';
 
 		$trans_status = '';
+		$all_trans_done = true;
 		foreach ( $formats as $status_key => $name ) {
-			$trans_status .= '<strong>' . $name . ":</strong> <span id=\"status_$status_key\">" . ( 'DONE' === $status[ $status_key ]  ? 'Done' : 'Processing' ) . '</span><br>';
+			if ( 'DONE' !== $status[ $status_key ] ) {
+				$all_trans_done = false;
+			}
+
+			$trans_status .= '- <strong>' . $name . ":</strong> <span id=\"status_$status_key\">" . ( 'DONE' === $status[ $status_key ]  ? 'Done' : 'Processing' ) . '</span><br>';
 		}
 
 		$nonce = wp_create_nonce( 'videopress-update-transcoding-status' );
 
 		$url = 'empty';
-		if ( ! empty( $info->url ) ) {
-			$url = "<a href=\"{$info->url}\">{$info->url}</a>";
+		if ( ! empty( $info->guid ) ) {
+			$url = videopress_get_url( $info->guid );
+			$url = "<a href=\"{$url}\">{$url}</a>";
 		}
 
-		$poster = 'empty';
+		$poster = '<em>Still Processing</em>';
 		if ( ! empty( $info->poster ) ) {
-			$poster = "<img src=\"{$info->poster}\" width=\"175px\">";
+			$poster = "<br><img src=\"{$info->poster}\" width=\"175px\">";
+		}
+
+		$status_update = '';
+		if ( ! $all_trans_done ) {
+			$status_update = ' (<a href="javascript:;" id="videopress-update-transcoding-status">update</a>)';
 		}
 
 		$html = <<< HTML
 
-<div class="misc-pub-section misc-pub-shortcode">Shortcode:</div>
-<strong>{$shortcode}</strong>
-<div class="misc-pub-section misc-pub-url">Url:</div>
-<strong>{$url}</strong>
-<div class="misc-pub-section misc-pub-poster">Poster:</div>
-<strong>{$poster}</strong>
-<div class="misc-pub-section misc-pub-status">Status (<a href="javascript:;" id="videopress-update-transcoding-status">update</a>):</div>
-<div id="videopress-transcoding-status">{$trans_status}</div>
+<div class="misc-pub-section misc-pub-shortcode">
+	<strong>Shortcode</strong><br>
+	{$shortcode}
+</div> 
+<div class="misc-pub-section misc-pub-url">
+	<strong>Url</strong>
+	{$url}
+</div> 
+<div class="misc-pub-section misc-pub-poster">
+	<strong>Poster</strong>
+	{$poster}
+</div>
+<div class="misc-pub-section misc-pub-status">
+	<strong>Transcoding Status$status_update:</strong>
+	<div id="videopress-transcoding-status">{$trans_status}</div>
+</div>
+
 
 
 <script>

--- a/modules/videopress/videopress-edit-attachment.php
+++ b/modules/videopress/videopress-edit-attachment.php
@@ -237,7 +237,7 @@ class VideoPress_Edit_Attachment {
 
 		$url = 'empty';
 		if ( ! empty( $info->guid ) ) {
-			$url = videopress_get_url( $info->guid );
+			$url = videopress_build_url( $info->guid );
 			$url = "<a href=\"{$url}\">{$url}</a>";
 		}
 

--- a/modules/videopress/videopress-edit-attachment.php
+++ b/modules/videopress/videopress-edit-attachment.php
@@ -215,8 +215,8 @@ class VideoPress_Edit_Attachment {
 		$formats = array(
 			'std_mp4' => 'Standard MP4',
 			'std_ogg' => 'OGG Vorbis',
-			'dvd'     => 'DVD',
-			'hd'      => 'High Definition',
+			'dvd_mp4' => 'DVD',
+			'hd_mp4'  => 'High Definition',
 		);
 
 		$embed = "[wpvideo {$info->guid}]";
@@ -225,7 +225,7 @@ class VideoPress_Edit_Attachment {
 
 		$trans_status = '';
 		foreach ( $formats as $status_key => $name ) {
-			$trans_status .= '<strong>' . $name . ':</strong> ' . ( 'done' === $status[ $status_key ]  ? 'Done' : 'Processing' ) . '<br>';
+			$trans_status .= '<strong>' . $name . ":</strong> <span id=\"status_$status_key\">" . ( 'DONE' === $status[ $status_key ]  ? 'Done' : 'Processing' ) . '</span><br>';
 		}
 
 		$nonce = wp_create_nonce( 'videopress-update-transcoding-status' );
@@ -249,7 +249,7 @@ class VideoPress_Edit_Attachment {
 <div class="misc-pub-section misc-pub-poster">Poster:</div>
 <strong>{$poster}</strong>
 <div class="misc-pub-section misc-pub-status">Status (<a href="javascript:;" id="videopress-update-transcoding-status">update</a>):</div>
-<strong id="videopress-transcoding-status">{$trans_status}</strong>
+<div id="videopress-transcoding-status">{$trans_status}</div>
 
 
 <script>
@@ -262,6 +262,15 @@ class VideoPress_Edit_Attachment {
 					action: 'videopress-update-transcoding-status',
 					post_id: '{$post_id}',
 					_ajax_nonce: '{$nonce}' 
+				},
+				complete: function( response ) {
+					if ( 200 === response.status ) {
+						var statuses = response.responseJSON.data.status;
+
+						for (var key in statuses) {
+							$('#status_' + key).text( 'DONE' === statuses[key] ? 'Done' : 'Processing' );
+						}
+					}
 				}
 			});
 		} );

--- a/modules/videopress/videopress-edit-attachment.php
+++ b/modules/videopress/videopress-edit-attachment.php
@@ -164,7 +164,7 @@ class VideoPress_Edit_Attachment {
 		if ( isset( $info->files_status['std']['ogg'] ) && 'done' ===  $info->files_status['std']['ogg'] ) {
 			$v_name  = preg_replace( '/\.\w+/', '', basename( $info->path ) );
 			$video_name = $v_name . '_fmt1.ogv';
-			$ogg_url  = video_cdn_file_url( $info->guid, $video_name );
+			$ogg_url  = videopress_cdn_file_url( $info->guid, $video_name );
 
 			$fields['video-ogg'] = array(
 				'label' => __('Ogg File URL'),

--- a/modules/videopress/videopress-edit-attachment.php
+++ b/modules/videopress/videopress-edit-attachment.php
@@ -208,22 +208,24 @@ class VideoPress_Edit_Attachment {
 			return;
 		}
 
-		$info = (object) $meta['videopress'];
+		$info = (object)$meta['videopress'];
+
+		$status = videopress_get_transcoding_status( $post_id );
 
 		$formats = array(
-			'Standard' => isset( $info->files_status ) ? $info->files_status['std']['mp4'] : null,
-			'Ogg Vorbis' => isset( $info->files_status ) ? $info->files_status['std']['ogg'] : null,
-			'DVD' => isset( $info->files_status ) ? $info->files_status['dvd'] : null,
-			'HD' => isset( $info->files_status ) ? $info->files_status['hd'] : null,
+			'std_mp4' => 'Standard MP4',
+			'std_ogg' => 'OGG Vorbis',
+			'dvd'     => 'DVD',
+			'hd'      => 'High Definition',
 		);
 
 		$embed = "[wpvideo {$info->guid}]";
 
-		$shortcode = '<input type="text" id="plugin-embed" readonly="readonly" style="width:180px;" value="' . esc_attr($embed) . '" onclick="this.focus();this.select();" />';
+		$shortcode = '<input type="text" id="plugin-embed" readonly="readonly" style="width:180px;" value="' . esc_attr( $embed ) . '" onclick="this.focus();this.select();" />';
 
 		$trans_status = '';
-		foreach ( $formats as $name => $status) {
-			$trans_status .= '<strong>' . $name . ':</strong> ' . ( 'done' === $status  ? 'Done' : 'Processing' ) . '<br>';
+		foreach ( $formats as $status_key => $name ) {
+			$trans_status .= '<strong>' . $name . ':</strong> ' . ( 'done' === $status[ $status_key ]  ? 'Done' : 'Processing' ) . '<br>';
 		}
 
 		$nonce = wp_create_nonce( 'videopress-update-transcoding-status' );

--- a/modules/videopress/videopress-edit-attachment.php
+++ b/modules/videopress/videopress-edit-attachment.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * VideoPress edit attachment screen
+ *
+ * @since 4.1
+ */
+class VideoPress_Edit_Attachment {
+
+	/**
+	 * Singleton method to initialize the object only once.
+	 *
+	 * @return VideoPress_Edit_Attachment
+	 */
+	public static function init() {
+		static $instance = null;
+
+		if ( !$instance ) {
+			$instance = new VideoPress_Edit_Attachment();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * VideoPress_Edit_Attachment constructor.
+	 *
+	 * Adds in appropriate actions for attachment fields editor, meta boxes and saving.
+	 */
+	public function __construct() {
+		add_filter( 'attachment_fields_to_edit', array( $this, 'fields_to_edit' ), 10, 2 );
+		add_filter( 'attachment_fields_to_save', array( $this, 'save_fields' ), 10, 2 );
+
+		add_action( 'add_meta_boxes', array( $this, 'configure_meta_boxes' ), 10, 2 );
+	}
+
+	/**
+	 * @param string  $post_type
+	 * @param object  $post
+	 */
+	public function configure_meta_boxes( $post_type = 'unknown', $post = NULL ) {
+		if ( NULL == $post ) {
+			$post = (object) array ( 'ID' => 0 );
+		}
+
+		if ( 'attachment' != $post_type ) {
+			return;
+		}
+
+		$meta = wp_get_attachment_metadata( $post->ID );
+
+		// If this has not been processed by videopress, we can skip the rest.
+		if ( ! isset( $meta['videopress'] ) ) {
+			return;
+		}
+
+		add_meta_box( 'videopress-media-info', __( 'VideoPress Information', 'jetpack' ), array( $this, 'videopress_information_box' ), 'attachment', 'side', 'core' );
+	}
+
+	/**
+	 * @param array $post
+	 * @param array $attachment
+	 *
+	 * @return array
+	 */
+	public function save_fields( $post, $attachment ) {
+
+		$post_id = absint( $post['ID'] );
+
+		$meta = wp_get_attachment_metadata( $post_id );
+
+		// If this has not been processed by videopress, we can skip the rest.
+		if ( ! isset( $meta['videopress'] ) ) {
+			return $post;
+		}
+
+		$values = array();
+
+		// Add the video title & description in, so that we save it properly.
+		if ( isset( $_POST['post_title'] ) ) {
+			$values['title'] = trim( strip_tags( $_POST['post_title'] ) );
+		}
+
+		if ( isset( $_POST['post_excerpt'] ) ) {
+			$values['description'] = trim( strip_tags( $_POST['post_excerpt'] ) );
+		}
+
+		if ( isset( $attachment['rating'] ) ) {
+			$rating = $attachment['rating'];
+
+			if ( ! empty( $value ) && in_array( $rating, array( 'G', 'PG-13', 'R-17', 'X-18' ) ) ) {
+				$values['rating'] = $rating;
+			}
+		}
+
+		// We set a default here, as if it isn't selected, then we'll turn it off.
+		$attachment['display_embed'] = 0;
+		if ( isset( $attachment['display_embed'] ) ) {
+			$display_embed = $attachment['display_embed'];
+
+			$values['display_embed'] = 'on' === $display_embed  ? 1 : 0;
+		}
+
+		$args = array(
+			'method'  => 'POST',
+		);
+
+		$endpoint = "videos/{$meta['videopress']['guid']}";
+		$result = Jetpack_Client::wpcom_json_api_request_as_blog( $endpoint, Jetpack_Client::WPCOM_JSON_API_VERSION, $args, $values );
+
+		if ( is_wp_error( $result ) ) {
+			$post['errors']['videopress']['errors'][] = __( 'There was an issue saving your updates to the VideoPress service. Please try again later.' );
+			return $post;
+		}
+
+		$response = json_decode( $result['body'], true );
+
+		if ( 'true' !== $response ) {
+			return $post;
+		}
+
+		return $post;
+	}
+
+
+	/**
+	 * Get the upload api path.
+	 *
+	 * @param string $guid
+	 * @return string
+	 */
+	public function make_video_api_path( $guid ) {
+		return sprintf(
+			'%s://%s/rest/v%s/videos/%s',
+			'https',
+			'public-api.wordpress.com', //JETPACK__WPCOM_JSON_API_HOST,
+			Jetpack_Client::WPCOM_JSON_API_VERSION,
+			$guid
+		);
+	}
+
+
+	/**
+	 * Creates an array of video fields to edit based on transcoded videos.
+	 *
+	 * @param array $fields video fields of interest
+	 * @param stdClass $post post object
+	 * @return array modified version of video fields for administrative interface display
+	 */
+	public function fields_to_edit( $fields, $post ) {
+		$post_id = absint( $post->ID );
+
+		$meta = wp_get_attachment_metadata( $post_id );
+
+		// If this has not been processed by videopress, we can skip the rest.
+		if ( ! isset( $meta['videopress'] ) ) {
+			return $fields;
+		}
+
+		$info = (object) $meta['videopress'];
+
+		unset( $fields['url'] );
+		unset( $fields['post_content'] );
+
+		if ( isset( $info->files_status['std']['ogg'] ) && 'done' ===  $info->files_status['std']['ogg'] ) {
+			$v_name  = preg_replace( '/\.\w+/', '', basename( $info->path ) );
+			$video_name = $v_name . '_fmt1.ogv';
+			$ogg_url  = video_cdn_file_url( $info->guid, $video_name );
+
+			$fields['video-ogg'] = array(
+				'label' => __('Ogg File URL'),
+				'input' => 'html',
+				'html'  => "<input type='text' class='urlfield' readonly='readonly' name='attachments[$post_id][oggurl]' value='" . esc_url( $ogg_url, array( 'http', 'https' ) ) . "' />",
+				'helps' => __('Location of the Ogg video file.'),
+			);
+		}
+
+		$fields['post_title']['helps'] = __( 'Title will appear on the first frame of your video' );
+
+		$fields['post_excerpt']['label'] = __( 'Description' );
+		$fields['post_excerpt']['input'] = 'textarea';
+		$fields['post_excerpt']['value'] = $info->description;
+
+		$fields['display_embed'] = array(
+			'label' => __( 'Share' ),
+			'input' => 'html',
+			'html'  => $this->display_embed_choice( $info )
+		);
+
+		$fields['video-rating'] = array(
+			'label' => __( 'Rating' ),
+			'input' => 'html',
+			'html'  => $this->display_rating( $info )
+		);
+
+		return $fields;
+	}
+
+	/**
+	 * @param stdClass $post
+	 */
+	public function videopress_information_box( $post ) {
+		$post_id = absint( $post->ID );
+
+		$meta = wp_get_attachment_metadata( $post_id );
+
+		// If this has not been processed by videopress, we can skip the rest.
+		if ( ! isset( $meta['videopress'] ) ) {
+			return;
+		}
+
+		$info = (object) $meta['videopress'];
+
+		$formats = array(
+			'Standard' => isset( $info->files_status ) ? $info->files_status['std']['mp4'] : null,
+			'Ogg Vorbis' => isset( $info->files_status ) ? $info->files_status['std']['ogg'] : null,
+			'DVD' => isset( $info->files_status ) ? $info->files_status['dvd'] : null,
+			'HD' => isset( $info->files_status ) ? $info->files_status['hd'] : null,
+		);
+
+		$embed = "[wpvideo {$info->guid}]";
+
+		$shortcode = '<input type="text" id="plugin-embed" readonly="readonly" style="width:180px;" value="' . esc_attr($embed) . '" onclick="this.focus();this.select();" />';
+
+		$trans_status = '';
+		foreach ( $formats as $name => $status) {
+			$trans_status .= '<strong>' . $name . ':</strong> ' . ( 'done' === $status  ? 'Done' : 'Processing' ) . '<br>';
+		}
+
+		$nonce = wp_create_nonce( 'videopress-update-transcoding-status' );
+
+		$url = 'empty';
+		if ( ! empty( $info->url ) ) {
+			$url = "<a href=\"{$info->url}\">{$info->url}</a>";
+		}
+
+		$poster = 'empty';
+		if ( ! empty( $info->poster ) ) {
+			$poster = "<img src=\"{$info->poster}\" width=\"175px\">";
+		}
+
+		$html = <<< HTML
+
+<div class="misc-pub-section misc-pub-shortcode">Shortcode:</div>
+<strong>{$shortcode}</strong>
+<div class="misc-pub-section misc-pub-url">Url:</div>
+<strong>{$url}</strong>
+<div class="misc-pub-section misc-pub-poster">Poster:</div>
+<strong>{$poster}</strong>
+<div class="misc-pub-section misc-pub-status">Status (<a href="javascript:;" id="videopress-update-transcoding-status">update</a>):</div>
+<strong id="videopress-transcoding-status">{$trans_status}</strong>
+
+
+<script>
+	jQuery( function($) {
+		$( '#videopress-update-transcoding-status' ).on( "click", function() {
+			jQuery.ajax( {
+				type: 'post',
+				url: 'admin-ajax.php',
+				data: { 
+					action: 'videopress-update-transcoding-status',
+					post_id: '{$post_id}',
+					_ajax_nonce: '{$nonce}' 
+				}
+			});
+		} );
+	} );
+</script>
+HTML;
+
+		echo $html;
+	}
+
+	/**
+	 * Build HTML to display a form checkbox for embedcode display preference
+	 *
+	 * @param object $info database row from the videos table
+	 * @return string input element of type checkbox set to checked state based on stored embed preference
+	 */
+	protected function display_embed_choice( $info ) {
+		$id = "attachments-{$info->post_id}-displayembed";
+		$out  = "<input type='checkbox' name='attachments[{$info->post_id}][display_embed]' id='$id'";
+		if ( $info->display_embed )
+			$out .= ' checked="checked"';
+		$out .= " /><label for='$id'>" . __( 'Display share menu and allow viewers to embed or download this video' ) . '</label>';
+		return $out;
+	}
+
+	/**
+	 * Build HTML to display a form input radio button for video ratings
+	 *
+	 * @param object $info database row from the videos table
+	 * @return string input elements of type radio with existing stored value selected
+	 */
+	protected function display_rating( $info ) {
+		$out = '';
+
+		$ratings = array(
+			'G'     => 'G',
+			'PG-13' => 'PG-13',
+			'R-17'  => 'R',
+			'X-18'  => 'X',
+		);
+
+		foreach( $ratings as $r => $label ) {
+			$id = "attachments-{$info->post_id}-rating-$r";
+			$out .= "<input type='radio' name='attachments[{$info->post_id}][rating]' id='$id' value='$r'";
+			if ( $info->rating == $r )
+				$out .= ' checked="checked"';
+			$out .= " /><label for='$id'>$label</label>";
+			unset( $id );
+		}
+		return $out;
+	}
+}
+
+// Let's start this thing up.
+VideoPress_Edit_Attachment::init();

--- a/modules/videopress/videopress.php
+++ b/modules/videopress/videopress.php
@@ -855,7 +855,7 @@ class Jetpack_VideoPress {
 
 		$post_id = (int)$_POST['post_id'];
 
-		if ( ! $this->update_video_status( $post_id ) ) {
+		if ( ! $this->update_video_meta_date( $post_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'That post does not have a VideoPress video associated to it..', 'jetpack' ) ) );
 			return;
 		}
@@ -869,7 +869,7 @@ class Jetpack_VideoPress {
 	 * @param int $post_id
 	 * @return bool
 	 */
-	public function update_video_status( $post_id ) {
+	public function update_video_meta_date( $post_id ) {
 
         $meta = wp_get_attachment_metadata( $post_id );
 
@@ -883,7 +883,7 @@ class Jetpack_VideoPress {
         $result = wp_remote_get( $this->make_video_get_path( $info->guid ) );
 
         if ( is_wp_error( $result ) ) {
-			return true;
+			return false;
         }
 
         $response = json_decode( $result['body'], true );

--- a/modules/videopress/videopress.php
+++ b/modules/videopress/videopress.php
@@ -855,7 +855,7 @@ class Jetpack_VideoPress {
 
 		$post_id = (int)$_POST['post_id'];
 
-		if ( ! $this->update_video_meta_date( $post_id ) ) {
+		if ( ! $this->update_video_meta_data( $post_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'That post does not have a VideoPress video associated to it..', 'jetpack' ) ) );
 			return;
 		}
@@ -869,7 +869,7 @@ class Jetpack_VideoPress {
 	 * @param int $post_id
 	 * @return bool
 	 */
-	public function update_video_meta_date( $post_id ) {
+	public function update_video_meta_data( $post_id ) {
 
         $meta = wp_get_attachment_metadata( $post_id );
 
@@ -888,7 +888,10 @@ class Jetpack_VideoPress {
 
         $response = json_decode( $result['body'], true );
 
-		// TODO: save the new video status to the meta information.
+		// Update the attachment metadata.
+		$meta['videopress'] = $response;
+
+		wp_update_attachment_metadata( $post_id, $meta );
 
 		return true;
 	}


### PR DESCRIPTION
Currently, attachment data can only be edited on the WPCOM side. This change starts us on the road of being able to edit attachment data from the Jetpack blog itself.

Notably, this change leaves out the screenshot picker, which needs to be rewritten as an HTML5 solution in order to work here (the current one only works from the context of the WPCOM blog, because it relies on the WPCOM cookie authentication to work). This will be added in a further PR.

## TODO

- [x] Deploy WPCOM side API update
- [x] Transcoding status update

