### PR TITLE
Sync site_url and home_url as callables

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -130,6 +130,8 @@ class Jetpack_Sync_Defaults {
 		'is_main_network'                 => array( 'Jetpack', 'is_multi_network' ),
 		'is_multi_site'                   => 'is_multisite',
 		'main_network_site'               => 'network_site_url',
+		'site_url'                        => 'site_url',
+		'home_url'                        => 'home_url',
 		'single_user_site'                => array( 'Jetpack', 'is_single_user_site' ),
 		'updates'                         => array( 'Jetpack', 'get_updates' ),
 		'has_file_system_write_access'    => array( 'Jetpack_Sync_Functions', 'file_system_write_access' ),

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -52,6 +52,8 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 			'main_network_site'               => network_site_url(),
 			'single_user_site'                => Jetpack::is_single_user_site(),
 			'updates'                         => Jetpack::get_updates(),
+			'home_url'                        => home_url(),
+			'site_url'                        => site_url(),
 			'has_file_system_write_access'    => Jetpack_Sync_Functions::file_system_write_access(),
 			'is_version_controlled'           => Jetpack_Sync_Functions::is_version_controlled(),
 			'taxonomies'                      => Jetpack_Sync_Functions::get_taxonomies(),


### PR DESCRIPTION
Fixes issue where we synced the option, but it can be filtered by plugins.

cc @lezama 

