### PR TITLE
Send filtered excerpt in synced posts

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -615,6 +615,7 @@ class Jetpack_Sync_Client {
 		}
 		/** This filter is already documented in core. wp-includes/post-template.php */
 		$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
+		$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
 		$post->permalink               = get_permalink( $post->ID );
 		$post->shortlink               = wp_get_shortlink( $post->ID );
 		

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -289,6 +289,18 @@ class WP_Test_Jetpack_New_Sync_Post extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( trim( $post_on_server->post_content_filtered ),  'bar' );
 	}
 
+	function test_sync_post_filtered_excerpt_was_filtered() {
+		add_shortcode( 'foo', array( $this, 'foo_shortcode' ) );
+		$this->post->post_excerpt = "[foo]";
+
+		wp_update_post( $this->post );
+		$this->client->do_sync();
+
+		$post_on_server = $this->server_replica_storage->get_post( $this->post->ID );
+		$this->assertEquals( $post_on_server->post_excerpt, '[foo]' );
+		$this->assertEquals( trim( $post_on_server->post_excerpt_filtered ),  'bar' );
+	}	
+
 	function test_sync_changed_post_password() {
 		// Don't set the password if there is non.
 		$post_on_server = $this->server_replica_storage->get_post( $this->post->ID );


### PR DESCRIPTION
In order to correctly render individual posts from the `/site/%s/posts/%d` endpoint, we need to sync filtered excerpt content.

cc @lezama 