### PR TITLE
REST-API: Add permissions check on GET Post for post-types

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-post-endpoint.php
@@ -22,6 +22,10 @@ class WPCOM_JSON_API_Get_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			return $return;
 		}
 
+		if ( ! $this->current_user_can_access_post_type( $return['type'], $args['context'] ) ) {
+			return new WP_Error( 'unknown_post', 'Unknown post', 404 );
+		}
+
 		/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
 		do_action( 'wpcom_json_api_objects', 'posts' );
 

--- a/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
@@ -17,8 +17,13 @@ class WPCOM_JSON_API_Get_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_End
 		}
 
 		$return = $this->get_post_by( $get_by, $post_id, $args['context'] );
+
 		if ( !$return || is_wp_error( $return ) ) {
 			return $return;
+		}
+
+		if ( ! $this->current_user_can_access_post_type( $return['type'], $args['context'] ) ) {
+			return new WP_Error( 'unknown_post', 'Unknown post', 404 );
 		}
 
 		/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */


### PR DESCRIPTION
Feedback post types were available via the /sites/%s/posts/%d endpoint
As such this patch uses the logic added in r114224-wpcom to do a permissions check based upon the post type.

- p3hLNG-HH-p2
- D1989
- Merges r137143-wpcom