### PR TITLE
SSO: Fixes redirect with query args

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -868,7 +868,7 @@ class Jetpack_SSO {
 		$args = wp_parse_args( $args, $defaults );
 
 		if ( ! empty( $_GET['redirect_to'] ) ) {
-			$args['redirect_to'] = esc_url_raw( $_GET['redirect_to'] );
+			$args['redirect_to'] = urlencode( esc_url_raw( $_GET['redirect_to'] ) );
 		}
 
 		return add_query_arg( $args, wp_login_url() );


### PR DESCRIPTION
Fixes #1342

Previously, if a user tried to SSO after landing on a URL with a query arg in it, the query arg was stripped.

Example: `wp-admin/admin.php?page=jetpack&configure=minileven` became `wp-admin/admin.php?page=jetpack`

After a bit of debugging, I found that we weren't escaping the redirect_to param when building the SSO URL.

You can see this for yourself if you hover over the "Login with WordPress.com" button and view the URL:

![screen shot 2016-06-18 at 11 02 05 am](https://cloud.githubusercontent.com/assets/1126811/16174603/8a9822dc-358e-11e6-98e7-678f697cb469.png)


Note how the `configure=minileven` pair has an `&`. The `&` should be escape since it is used in a redirect.

cc @jeherve and @lezama for review.

To test:

- Checkout `update/sso-fix-redirect-with-query-params` branch
- Make sure you are logged out
- Go to `$site/wp-admin/admin.php?page=jetpack&configure=minileven`
- Click "Log in with WordPress.com" button
- Do you land on the mobile theme configuration page? 
