### PR TITLE
Sync post revisions - needed for /site/%s/posts/%d API

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -298,10 +298,6 @@ class Jetpack_Sync_Client {
 		$current_filter = current_filter();
 		$args           = func_get_args();
 
-		if ( $current_filter === 'wp_insert_post' && $args[1]->post_type === 'revision' ) {
-			return;
-		}
-
 		if ( in_array( $current_filter, array( 'deleted_option', 'added_option', 'updated_option' ) )
 		     &&
 		     ! $this->is_whitelisted_option( $args[0] )

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -147,7 +147,6 @@ class Jetpack_Sync_Defaults {
 	);
 
 	static $blacklisted_post_types = array(
-		'revision', // "don't ever sync revisions, they overwrite post meta for the parent post."
 		'ai1ec_event' // https://irc.automattic.com/chanlog.php?channel=jetpack&day=2014-05-29&sort=asc#m71850
 	);
 

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -62,12 +62,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	function posts_checksum() {
-		$non_revisions = array_filter( $this->posts, array( $this, 'post_not_revision' ) );
-		return strtoupper( dechex( array_reduce( $non_revisions, array( $this, 'post_checksum' ), 0 ) ) );
-	}
-
-	private function post_not_revision( $post ) {
-		return $post->post_type !== 'revision';
+		return strtoupper( dechex( array_reduce( $this->posts, array( $this, 'post_checksum' ), 0 ) ) );
 	}
 
 	private function post_checksum( $carry, $post ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -86,7 +86,7 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	function assertCallableIsSynced( $name, $value ) {
-		$this->assertEquals( $value, $this->server_replica_storage->get_callable( $name ), 'Function '. $name .' did\'t have the extected value of ' . json_encode( $value ) );
+		$this->assertEquals( $value, $this->server_replica_storage->get_callable( $name ), 'Function '. $name .' didn\'t have the expected value of ' . json_encode( $value ) );
 	}
 
 }

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -55,29 +55,6 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( $wp_version, $this->server_replica_storage->get_callable( 'wp_version' ) );
 	}
 
-	function test_full_sync_sends_all_posts_except_revisions() {
-
-		register_post_type( 'random_post_type', array() );
-
-		for( $i = 0; $i < 10; $i += 1 ) {
-			$this->factory->post->create();
-		}
-
-		$this->factory->post->create( array( 'post_type' => 'revision' ) );
-		$post_id = $this->factory->post->create( array( 'post_type' => 'random_post_type' ) );
-
-		// simulate emptying the server storage
-		$this->server_replica_storage->reset();
-		$this->client->reset_data();
-
-		$this->full_sync->start();
-		$this->client->do_sync();
-
-		$posts = $this->server_replica_storage->get_posts();
-
-		$this->assertEquals( 11, count( $posts ) );
-	}
-
 	function test_sync_post_filtered_content_was_filtered_when_syncing_all() {
 		$post_id    = $this->factory->post->create();
 		$post = get_post( $post_id );

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -172,21 +172,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider store_provider
-	 * @requires PHP 5.3
-	 */
-	function test_replica_doesnt_checksum_post_revisions( $store ) {
-		// just add some data
-		$store->upsert_post( self::$factory->post( 5 ) );
-
-		$before_checksum = $store->posts_checksum();
-
-		$store->upsert_post( self::$factory->post( 6, array( 'post_type' => 'revision' ) ) );
-
-		$this->assertEquals( $before_checksum, $store->posts_checksum() );
-	}
-
-	/**
 	 * Comments
 	 *
 	 * @dataProvider store_provider


### PR DESCRIPTION
Syncs post revisions so that we can retrieve the IDs of revisions in the `/site/%s/posts/%d` endpoint.

cc @lezama 