### PR TITLE
Admin Page: load modules into the state from the initial state when action JETPACK_SET_INITIAL_STATE is dispatched

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -2,19 +2,13 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
-import i18n, { translate as __ } from 'i18n-calypso';
+import { translate as __ } from 'i18n-calypso';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
-
-/**
- * Internal dependencies
- */
-import QueryModules from 'components/data/query-modules';
 
 const Navigation = React.createClass( {
 	demoSearch: function( keywords ) {
@@ -24,7 +18,6 @@ const Navigation = React.createClass( {
 	render: function() {
 		return (
 			<div className='dops-navigation'>
-				<QueryModules />
 				<SectionNav>
 					<NavTabs>
 						<NavItem

--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -22,16 +22,12 @@ import {
 	JETPACK_MODULE_UPDATE_OPTION,
 	JETPACK_MODULE_UPDATE_OPTION_FAIL,
 	JETPACK_MODULE_UPDATE_OPTION_SUCCESS
-
 } from 'state/action-types';
 
-export const initialItemsState = typeof window !== 'undefined' && typeof window.Initial_State === 'object' ?
-	window.Initial_State.getModules :
-	{};
-
-export const items = ( state = initialItemsState, action ) => {
+export const items = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SET_INITIAL_STATE:
+			return assign( {}, action.initialState.getModules );
 		case JETPACK_MODULES_LIST_RECEIVE:
 			return assign( {}, state, action.modules );
 		case JETPACK_MODULE_ACTIVATE_SUCCESS:

--- a/_inc/client/state/modules/test/reducer.js
+++ b/_inc/client/state/modules/test/reducer.js
@@ -6,7 +6,6 @@ import {
 	initialRequestsState
 } from '../reducer';
 
-
 describe( 'items reducer', () => {
 	it( 'state should default to empty object', () => {
 		const state = itemsReducer( undefined, {} );
@@ -75,6 +74,20 @@ describe( 'items reducer', () => {
 			let stateOut = itemsReducer( stateIn, action );
 
 			expect( stateOut[ action.module ].options[ action.optionName ].current_value ).to.equal( action.optionValue );
+		} );
+	} );
+
+	describe( '#initialState', () => {
+		it( 'should replace .items with the initial state\'s modules list', () => {
+			const stateIn = {}
+			const action = {
+				type: 'JETPACK_SET_INITIAL_STATE',
+				initialState: {
+					getModules: modules
+				}
+			};
+			let stateOut = itemsReducer( stateIn, action );
+			expect( stateOut ).to.eql( action.initialState.getModules );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Makes the module items reducer react to `JETPACK_SET_INITIAL_STATE` by loading into the state the value of `window.Initial_state.getModules`.
- A few style fixes
- Removes usage of `<QueryModules/>` from `<Navigation />` as there's no need for a initial API query if we're loading modules list from the `window.Initial_state` variable. 

