### PR TITLE
Migrate SSL check to wp-ajax

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -81,11 +81,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 		) );
 
-		register_rest_route( 'jetpack/v4', '/recheck-ssl', array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::recheck_ssl',
-		) );
-
 		// Get current site data
 		register_rest_route( 'jetpack/v4', '/site', array(
 			'methods' => WP_REST_Server::READABLE,
@@ -458,14 +453,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),
 				),
 			)
-		);
-	}
-
-	public static function recheck_ssl() {
-		$result = Jetpack::permit_ssl( true );
-		return array(
-			'enabled' => $result,
-			'message' => get_transient( 'jetpack_https_test_message' )
 		);
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -441,6 +441,9 @@ class Jetpack {
 		add_action( 'wp_ajax_jetpack-sync-reindex-trigger', array( $this, 'sync_reindex_trigger' ) );
 		add_action( 'wp_ajax_jetpack-sync-reindex-status', array( $this, 'sync_reindex_status' ) );
 
+		// returns HTTPS support status
+		add_action( 'wp_ajax_jetpack-recheck-ssl', array( $this, 'ajax_recheck_ssl' ) );
+
 		// If any module option is updated before Jump Start is dismissed, hide Jump Start.
 		add_action( 'update_option', array( $this, 'jumpstart_has_updated_module_option' ) );
 
@@ -4315,6 +4318,15 @@ p {
 		exit;
 	}
 
+	function ajax_recheck_ssl() {
+		check_ajax_referer( 'recheck-ssl', 'ajax-nonce' );
+		$result = Jetpack::permit_ssl( true );
+		wp_send_json( array(
+			'enabled' => $result,
+			'message' => get_transient( 'jetpack_https_test_message' )
+		) );
+	}
+
 /* Client API */
 
 	/**
@@ -4401,6 +4413,8 @@ p {
 	public function alert_auto_ssl_fail() {
 		if ( ! current_user_can( 'manage_options' ) )
 			return;
+
+		$ajax_nonce = wp_create_nonce( 'recheck-ssl' );
 		?>
 
 		<div id="jetpack-ssl-warning" class="error jp-identity-crisis">
@@ -4429,7 +4443,8 @@ p {
 					$this.html( <?php echo json_encode( __( 'Checking', 'jetpack' ) ); ?> );
 					$( '#jetpack-recheck-ssl-output' ).html( '' );
 					e.preventDefault();
-					$.post( '/wp-json/jetpack/v4/recheck-ssl' )
+					var data = { action: 'jetpack-recheck-ssl', 'ajax-nonce': '<?php echo $ajax_nonce; ?>' };
+					$.post( ajaxurl, data )
 					  .done( function( response ) {
 					  	if ( response.enabled ) {
 					  		$( '#jetpack-ssl-warning' ).hide();


### PR DESCRIPTION
Removes WP REST API dependency for better SSL check, allowing it to be shipped in Jetpack sooner.

cc @lezama @jeherve 