### PR TITLE
Improve Full Sync status endpoint

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -593,17 +593,6 @@ class Jetpack_Sync_Client {
 		}
 	}
 
-
-	private function buffer_includes_action( $buffer, $action_name ) {
-		foreach ( $buffer->get_items() as $item ) {
-			if ( $item[0] === $action_name ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
 	function expand_wp_insert_post( $args ) {
 		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2] );
 	}

--- a/sync/class.jetpack-sync-dashboard.php
+++ b/sync/class.jetpack-sync-dashboard.php
@@ -82,7 +82,9 @@ class Jetpack_Sync_Dashboard extends Jetpack_Admin_Page {
 
 	function ajax_reset_queue() {
 		Jetpack_Sync_Client::getInstance()->reset_sync_queue();
+		delete_option( Jetpack_Sync_Full::$status_option );
 		echo json_encode( array( 'success' => true ) );
+
 		exit;
 	}
 
@@ -160,6 +162,7 @@ class Jetpack_Sync_Dashboard extends Jetpack_Admin_Page {
 				<p>Functions: {{ data.queue && data.sent.functions }} / {{ data.queue && data.queue.functions }}</p>
 				<p>Constants: {{ data.queue && data.sent.constants }} / {{ data.queue && data.queue.constants }}</p>
 				<p>Options: {{ data.queue && data.sent.options }} / {{ data.queue && data.queue.options }}</p>
+				<p>Updates: {{ data.queue && data.sent.updates }} / {{ data.queue && data.queue.updates }}</p>
 			</div>
 		</script>
 		<?php


### PR DESCRIPTION
We improved the full sync status by making sure that we only record the data that gets sent successfully. Previously the system would say that it was finished sending even though that wasn't always the case. 

We also updated the dashboard to be able to reset the queue and added the updates to the list of items in the Dashboard. 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

We now more accurately record what data got sent by making sure that we
update the status with the data got successfully got received.