### PR TITLE
Debugger: Add JP version to support open check URL

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -6,7 +6,7 @@ class Jetpack_Debugger {
 
 	private static function is_jetpack_support_open() {
 		try {
-			$url = add_query_arg( 'ver', JETPACK__VERSION, 'http://jetpack.com/is-support-open' );
+			$url = add_query_arg( 'ver', JETPACK__VERSION, 'https://jetpack.com/is-support-open' );
 			$response = wp_remote_request( $url );
 			if ( is_wp_error( $response ) ) {
 				return false;

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -6,7 +6,8 @@ class Jetpack_Debugger {
 
 	private static function is_jetpack_support_open() {
 		try {
-			$response = wp_remote_request( "http://jetpack.com/is-support-open" );
+			$url = add_query_arg( 'ver', JETPACK__VERSION, 'http://jetpack.com/is-support-open' );
+			$response = wp_remote_request( $url );
 			if ( is_wp_error( $response ) ) {
 				return false;
 			}

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -7,7 +7,7 @@ class Jetpack_Debugger {
 	private static function is_jetpack_support_open() {
 		try {
 			$url = add_query_arg( 'ver', JETPACK__VERSION, 'https://jetpack.com/is-support-open' );
-			$response = wp_remote_request( $url );
+			$response = wp_remote_request( esc_url_raw( $url ) );
 			if ( is_wp_error( $response ) ) {
 				return false;
 			}


### PR DESCRIPTION
Fixes #4171 

Add a simple version to the URL so WP.com can use that and conditionally open/close support.