### PR TITLE
JSON API: Enable trash as valid status for post update endpoints

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -784,6 +784,7 @@ new WPCOM_JSON_API_Update_Post_Endpoint( array(
 			'private' => 'Privately publish the post.',
 			'draft'   => 'Save the post as a draft.',
 			'pending' => 'Mark the post as pending editorial approval.',
+			'trash'   => 'Set the post as trashed.',
 		),
 		'sticky'    => array(
 			'false'   => 'Post is not marked as sticky.',
@@ -851,6 +852,7 @@ new WPCOM_JSON_API_Update_Post_v1_1_Endpoint( array(
 			'draft'   => 'Save the post as a draft.',
 			'future'  => 'Schedule the post (alias for publish; you must also set a future date).',
 			'pending' => 'Mark the post as pending editorial approval.',
+			'trash'   => 'Set the post as trashed.',
 		),
 		'sticky'    => array(
 			'false'   => 'Post is not marked as sticky.',
@@ -918,6 +920,7 @@ new WPCOM_JSON_API_Update_Post_v1_2_Endpoint( array(
 			'draft'   => 'Save the post as a draft.',
 			'future'  => 'Schedule the post (alias for publish; you must also set a future date).',
 			'pending' => 'Mark the post as pending editorial approval.',
+			'trash'   => 'Set the post as trashed.',
 		),
 		'sticky'    => array(
 			'false'   => 'Post is not marked as sticky.',

--- a/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -89,6 +89,10 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 				return new WP_Error( 'invalid_input', 'Invalid request input', 400 );
 			}
 
+			if ( isset( $input['status'] ) && 'trash' === $input['status'] && ! current_user_can( 'delete_post', $post_id ) ) {
+				return new WP_Error( 'unauthorized', 'User cannot delete post', 403 );
+			}
+
 			$post = get_post( $post_id );
 			$_post_type = ( ! empty( $input['type'] ) ) ? $input['type'] : $post->post_type;
 			$post_type = get_post_type_object( $_post_type );

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -99,6 +99,10 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 				return new WP_Error( 'invalid_input', 'Invalid request input', 400 );
 			}
 
+			if ( isset( $input['status'] ) && 'trash' === $input['status'] && ! current_user_can( 'delete_post', $post_id ) ) {
+				return new WP_Error( 'unauthorized', 'User cannot delete post', 403 );
+			}
+
 			// 'future' is an alias for 'publish' for now
 			if ( isset( $input['status'] ) && 'future' === $input['status'] ) {
 				$input['status'] = 'publish';

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -73,6 +73,10 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				return new WP_Error( 'invalid_input', 'Invalid request input', 400 );
 			}
 
+			if ( isset( $input['status'] ) && 'trash' === $input['status'] && ! current_user_can( 'delete_post', $post_id ) ) {
+				return new WP_Error( 'unauthorized', 'User cannot delete post', 403 );
+			}
+
 			// 'future' is an alias for 'publish' for now
 			if ( isset( $input['status'] ) && 'future' === $input['status'] ) {
 				$input['status'] = 'publish';


### PR DESCRIPTION
This pull request seeks to enable `trash` as a valid `status` value on the `POST /sites/%s/post/%d` endpoints (v1, v1.1, v1.2). It includes a check to ensure that the user has the capability `delete_post` for that post item before allowing the trash action, similar to [checks performed in WordPress core](https://github.com/WordPress/WordPress/blob/2eae9d3f46c0ed31597d3d57c4791dc7ee88c3d7/wp-admin/edit.php#L105-L106).

/cc @jeherve 