### PR TITLE
VideoPress: Remove Legacy Interface

### DIFF
--- a/modules/videopress/js/videopress-admin.js
+++ b/modules/videopress/js/videopress-admin.js
@@ -413,17 +413,6 @@
 	});
 
 	/**
-	 * Extend the post editor media frame with our own
-	 */
-	MediaFrame.Post = media.view.MediaFrame.Post;
-	media.view.MediaFrame.Post = MediaFrame.Post.extend({
-		createStates: function() {
-			MediaFrame.Post.prototype.createStates.apply( this, arguments );
-			this.states.add([ new media.controller.VideoPress() ]);
-		}
-	});
-
-	/**
 	 * A VideoPress Modal view that we can use to preview videos.
 	 * Expects a controller object on render.
 	 */
@@ -488,15 +477,4 @@
 		$access.trigger( 'change' );
 	});
 
-	// Media -> VideoPress menu
-	$(document).on( 'click', '#videopress-browse', function() {
-
-		wp.media({
-			state: 'videopress',
-			states: [ new media.controller.VideoPress() ],
-			VideoPress: { hideToolbar: true }
-		}).open();
-
-		return false;
-	});
 })(jQuery);


### PR DESCRIPTION
With the launch of the new uploader, this looks to remove a few legacy interfaces.
- [x] VideoPress sidebar item in the media library
- [x] VideoPress uploader from the admin sidebar
- [x] VideoPress config items for blog_id and access (no longer needed, as we now upload directly to the current Jetpack blog)
