### PR TITLE
Add filter that prevent the Sync from happening for posts and comments

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -84,6 +84,8 @@ class Jetpack_Sync_Client {
 		add_action( 'trashed_comment', $handler, 10 );
 		add_action( 'spammed_comment', $handler, 10 );
 
+		add_filter( 'jetpack_sync_before_send_wp_insert_comment', array( $this, 'expand_wp_insert_comment' ) );
+
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data
 		// so this saves us a DB read for every comment event
@@ -91,6 +93,7 @@ class Jetpack_Sync_Client {
 			foreach ( array( 'unapproved', 'approved' ) as $comment_status ) {
 				$comment_action_name = "comment_{$comment_status}_{$comment_type}";
 				add_action( $comment_action_name, $handler, 10, 2 );
+				add_filter( 'jetpack_sync_before_send_' . $comment_action_name, array( $this, 'expand_wp_insert_comment' ) );
 			}
 		}
 

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -633,14 +633,14 @@ class Jetpack_Sync_Client {
 
 
 	function expand_wp_comment_status_change( $args ) {
-		return array( $args[0], $this->filter_comment_and_add_hc_meta( $args[1] ) );
+		return array( $args[0], $this->filter_comment( $args[1] ) );
 	}
 
 	function expand_wp_insert_comment( $args ) {
-		return array( $args[0], $this->filter_comment_and_add_hc_meta( $args[1] ) );
+		return array( $args[0], $this->filter_comment( $args[1] ) );
 	}
 
-	function filter_comment_and_add_hc_meta( $comment ) {
+	function filter_comment( $comment ) {
 		/**
 		 * Filters whether to prevent sending comment data to .com
 		 *
@@ -661,17 +661,6 @@ class Jetpack_Sync_Client {
 			$blocked_comment->comment_date_gmt = $comment->comment_date_gmt;
 			$blocked_comment->comment_approved = 'jetpack_sync_blocked';
 			return $blocked_comment;
-		}
-		
-		// add meta-property with Highlander Comment meta, which we 
-		// we need to process synchronously on .com
-		$hc_post_as = get_comment_meta( $comment->comment_ID, 'hc_post_as', true );
-		if ( 'wordpress' === $hc_post_as ) {
-			$meta = array();
-			$meta['hc_post_as']         = $hc_post_as;
-			$meta['hc_wpcom_id_sig']    = get_comment_meta( $comment->comment_ID, 'hc_wpcom_id_sig', true );
-			$meta['hc_foreign_user_id'] = get_comment_meta( $comment->comment_ID, 'hc_foreign_user_id', true );
-			$comment->meta = $meta;	
 		}
 
 		return $comment;

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -93,28 +93,6 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( 0, $this->server_replica_storage->comment_count( 'trash' ) );
 	}
 
-	public function test_sends_highlander_comment_meta_with_comment() {
-		$wpcom_user_id = 101;
-		$sig = 'abcd1234';
-		$comment_ID = $this->comment->comment_ID;
-
-		add_comment_meta( $comment_ID, 'hc_post_as', 'wordpress', true );
-		add_comment_meta( $comment_ID, 'hc_wpcom_id_sig', $sig, true );
-		add_comment_meta( $comment_ID, 'hc_foreign_user_id', $wpcom_user_id, true );
-		// re-save the comment
-		wp_set_comment_status( $comment_ID, 'hold' );
-
-		$this->client->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event();
-
-		$synced_comment = $event->args[1];
-		$this->assertObjectHasAttribute( 'meta', $synced_comment );
-		$this->assertEquals( 'wordpress', $synced_comment->meta['hc_post_as'] );
-		$this->assertEquals( 'abcd1234', $synced_comment->meta['hc_wpcom_id_sig'] );
-		$this->assertEquals( 101, $synced_comment->meta['hc_foreign_user_id'] );
-	}
-
 	function test_sync_comment_jetpack_sync_prevent_sending_comment_data_filter() {
 		add_filter( 'jetpack_sync_prevent_sending_comment_data', '__return_true' );
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -93,6 +93,28 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( 0, $this->server_replica_storage->comment_count( 'trash' ) );
 	}
 
+	public function test_sends_highlander_comment_meta_with_comment() {
+		$wpcom_user_id = 101;
+		$sig = 'abcd1234';
+		$comment_ID = $this->comment->comment_ID;
+
+		add_comment_meta( $comment_ID, 'hc_post_as', 'wordpress', true );
+		add_comment_meta( $comment_ID, 'hc_wpcom_id_sig', $sig, true );
+		add_comment_meta( $comment_ID, 'hc_foreign_user_id', $wpcom_user_id, true );
+		// re-save the comment
+		wp_set_comment_status( $comment_ID, 'hold' );
+
+		$this->client->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event();
+
+		$synced_comment = $event->args[1];
+		$this->assertObjectHasAttribute( 'meta', $synced_comment );
+		$this->assertEquals( 'wordpress', $synced_comment->meta['hc_post_as'] );
+		$this->assertEquals( 'abcd1234', $synced_comment->meta['hc_wpcom_id_sig'] );
+		$this->assertEquals( 101, $synced_comment->meta['hc_foreign_user_id'] );
+	}
+
 	function test_sync_comment_jetpack_sync_prevent_sending_comment_data_filter() {
 		add_filter( 'jetpack_sync_prevent_sending_comment_data', '__return_true' );
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -112,8 +112,8 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 		$comment = $insert_comment_event->args[1];
 
 		$this->assertEquals( $this->comment->comment_ID, $comment->comment_ID );
-		$this->assertEquals( $this->comment->comment_date, $comment->comment_date );
-		$this->assertEquals( $this->comment->comment_date_gmt, $comment->comment_date_gmt );
+		$this->assertTrue( strtotime( $this->comment->comment_date ) <= strtotime( $comment->comment_date ) );
+		$this->assertTrue( strtotime( $this->comment->comment_date_gmt ) <= strtotime( $comment->comment_date_gmt ) );
 		$this->assertEquals( 'jetpack_sync_blocked', $comment->comment_approved );
 		$this->assertFalse( isset( $comment->comment_content ) );
 

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -52,11 +52,11 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 
 	function test_white_listed_constant_doesnt_get_synced_twice() {
 		$this->client->set_constants_whitelist( array( 'TEST_ABC' ) );
-		define( 'TEST_ABC', microtime(true) );
+		define( 'TEST_ABC', time() );
 		$this->client->do_sync();
 
 		$synced_value = $this->server_replica_storage->get_constant( 'TEST_ABC' );
-		$this->assertEquals( sprintf("%.2f", TEST_ABC), sprintf("%.2f", $synced_value ) );
+		$this->assertEquals( TEST_ABC, $synced_value );
 
 		$this->server_replica_storage->reset();
 		

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -538,7 +538,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
 
 		$this->assertEquals( 3, $this->server_replica_storage->comment_count( 'jetpack_sync_blocked' ) );
-		$blocked_post = $this->server_replica_storage->get_post( $post_id);
+		$blocked_post = $this->server_replica_storage->get_post( $post_id );
 		$this->assertEquals( 'jetpack_sync_blocked', $blocked_post->post_status );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -523,6 +523,24 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertInternalType( 'int', $full_sync_status['finished'] );
 
 	}
+	
+	function test_full_sync_respects_post_and_comment_filters() {
+		add_filter( 'jetpack_sync_prevent_sending_comment_data', '__return_true' );
+		add_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
+
+		$post_id = $this->factory->post->create();
+		$this->factory->comment->create_post_comments( $post_id, 3 );
+
+		$this->full_sync->start();
+		$this->client->do_sync();
+
+		remove_filter( 'jetpack_sync_prevent_sending_comment_data', '__return_true' );
+		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
+
+		$this->assertEquals( 3, $this->server_replica_storage->comment_count( 'jetpack_sync_blocked' ) );
+		$blocked_post = $this->server_replica_storage->get_post( $post_id);
+		$this->assertEquals( 'jetpack_sync_blocked', $blocked_post->post_status );
+	}
 
 	function test_full_sync_status_with_a_small_queue() {
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -345,6 +345,8 @@ class WP_Test_Jetpack_New_Sync_Post extends WP_Test_Jetpack_New_Sync_Base {
 		add_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
 
 		$this->server_replica_storage->reset();
+
+		$post_count = $this->server_replica_storage->post_count();
 		$this->post->post_content = "foo bar";
 		wp_update_post( $this->post );
 
@@ -352,7 +354,7 @@ class WP_Test_Jetpack_New_Sync_Post extends WP_Test_Jetpack_New_Sync_Base {
 
 		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
 		
-		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
+		$this->assertEquals( $post_count + 1, $this->server_replica_storage->post_count() );
 		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
 		$post = $insert_post_event->args[1];
 		// Instead of sending all the data we just send the post_id so that we can remove it on our end.

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -353,7 +353,7 @@ class WP_Test_Jetpack_New_Sync_Post extends WP_Test_Jetpack_New_Sync_Base {
 
 		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
 		
-		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
+		$this->assertEquals( 2, $this->server_replica_storage->post_count() ); // the post and its revision
 		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
 		$post = $insert_post_event->args[1];
 		// Instead of sending all the data we just send the post_id so that we can remove it on our end.

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -346,7 +346,6 @@ class WP_Test_Jetpack_New_Sync_Post extends WP_Test_Jetpack_New_Sync_Base {
 
 		$this->server_replica_storage->reset();
 
-		$post_count = $this->server_replica_storage->post_count();
 		$this->post->post_content = "foo bar";
 		wp_update_post( $this->post );
 
@@ -354,7 +353,7 @@ class WP_Test_Jetpack_New_Sync_Post extends WP_Test_Jetpack_New_Sync_Base {
 
 		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
 		
-		$this->assertEquals( $post_count + 1, $this->server_replica_storage->post_count() );
+		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 		$insert_post_event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
 		$post = $insert_post_event->args[1];
 		// Instead of sending all the data we just send the post_id so that we can remove it on our end.

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -358,8 +358,8 @@ class WP_Test_Jetpack_New_Sync_Post extends WP_Test_Jetpack_New_Sync_Base {
 		// Instead of sending all the data we just send the post_id so that we can remove it on our end.
 
 		$this->assertEquals( $this->post->ID, $post->ID );
-		$this->assertEquals( $this->post->post_modified, $post->post_modified, 'post modied' );
-		$this->assertEquals( $this->post->post_modified_gmt, $post->post_modified_gmt );
+		$this->assertTrue( strtotime( $this->post->post_modified ) <= strtotime( $post->post_modified ) );
+		$this->assertTrue( strtotime( $this->post->post_modified_gmt ) <= strtotime( $post->post_modified_gmt ) );
 		$this->assertEquals( 'jetpack_sync_blocked', $post->post_status );
 		$this->assertFalse( isset( $post->post_content ) );
 		$this->assertFalse( isset( $post->post_excerpt ) );


### PR DESCRIPTION
Add a couple of filters that allow plugin developers from sending data
to .com. This in place so that we can still attempt to do a checksums
and discourage other creative solutions to this problems.

We added 2 new filters that send much less data but still should enable to do checksums to make sure that we sync as much of the data as possible. 
 
-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

