### PR TITLE
Widgets: check that wp is defined before to use it.

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery.js
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery.js
@@ -160,7 +160,7 @@
 			attachPlainResize( tiledGalleries );
 		}
 
-		if ( wp && wp.customize && wp.customizerHasPartialWidgetRefresh() ) {
+		if ( 'undefined' !== typeof wp && wp.customize && wp.customize.selectiveRefresh ) {
 			wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
 				if ( wp.isJetpackWidgetPlaced( placement, 'gallery' ) ) {
 					tiledGalleries.findAndSetupNewGalleries();

--- a/modules/widgets/contact-info/contact-info-map.js
+++ b/modules/widgets/contact-info/contact-info-map.js
@@ -31,7 +31,7 @@ jQuery( function( $ ) {
 
 	setupContactMaps();
 
-	if ( wp && wp.customize && wp.customizerHasPartialWidgetRefresh() ) {
+	if ( 'undefined' !== typeof wp && wp.customize && wp.customize.selectiveRefresh ) {
 		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
 			if ( wp.isJetpackWidgetPlaced( placement, 'widget_contact_info' ) ) {
 				setupContactMaps( placement.container );


### PR DESCRIPTION
Fixes #4179

Related: #3607

cc @eliorivero I'm not sure if I should use `wp.customizerHasPartialWidgetRefresh()` instead of `wp.customize.selectiveRefresh`. We appear to be using `wp.customize.selectiveRefresh` in Infinite Scroll already.