### PR TITLE
Move to JSON encoding and remove no-longer-needed extra metas

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -46,7 +46,7 @@ class Jetpack_Sync_Actions {
 	static function send_data( $data, $codec_name ) {
 		Jetpack::load_xml_rpc_client();
 
-		add_query_arg( array(
+		$url = add_query_arg( array(
 			'sync' => '1', // add an extra parameter to the URL so we can tell it's a sync action
 			'codec' => $codec_name, // send the name of the codec used to encode the data
 		), Jetpack::xmlrpc_api_url() );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -37,17 +37,19 @@ class Jetpack_Sync_Actions {
 		add_action( 'shutdown', array( self::$client, 'do_sync' ) );
 
 		// bind the sending process
-		add_filter( 'jetpack_sync_client_send_data', array( __CLASS__, 'send_data' ) );
+		add_filter( 'jetpack_sync_client_send_data', array( __CLASS__, 'send_data' ), 10, 2 );
 
 		// On jetpack registration
 		add_action( 'jetpack_site_registered', array( __CLASS__, 'schedule_full_sync' ) );
 	}
 
-	static function send_data( $data ) {
+	static function send_data( $data, $codec_name ) {
 		Jetpack::load_xml_rpc_client();
 
 		// add an extra parameter to the URL so we can tell it's a sync action
 		$url = add_query_arg( 'sync', '1', Jetpack::xmlrpc_api_url() );
+		// send the name of the codec used to encode the data
+		$url = add_query_arg( 'codec', $codec_name, $url );
 
 		$rpc = new Jetpack_IXR_Client( array(
 			'url'     => $url,

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -46,10 +46,10 @@ class Jetpack_Sync_Actions {
 	static function send_data( $data, $codec_name ) {
 		Jetpack::load_xml_rpc_client();
 
-		// add an extra parameter to the URL so we can tell it's a sync action
-		$url = add_query_arg( 'sync', '1', Jetpack::xmlrpc_api_url() );
-		// send the name of the codec used to encode the data
-		$url = add_query_arg( 'codec', $codec_name, $url );
+		add_query_arg( array(
+			'sync' => '1', // add an extra parameter to the URL so we can tell it's a sync action
+			'codec' => $codec_name, // send the name of the codec used to encode the data
+		), Jetpack::xmlrpc_api_url() );
 
 		$rpc = new Jetpack_IXR_Client( array(
 			'url'     => $url,

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -1,5 +1,5 @@
 <?php
-require_once dirname( __FILE__ ) . '/class.jetpack-sync-deflate-codec.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-json-deflate-codec.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-queue.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-functions.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-full.php';
@@ -546,11 +546,9 @@ class Jetpack_Sync_Client {
 		 *
 		 * @param array $data The action buffer
 		 */
-		$result = apply_filters( 'jetpack_sync_client_send_data', $items_to_send );
+		$result = apply_filters( 'jetpack_sync_client_send_data', $items_to_send, $this->codec->name() );
 
 		if ( ! $result || is_wp_error( $result ) ) {
-			// error_log("There was an error sending data:");
-			// error_log(print_r($result, 1));
 			$result = $this->sync_queue->checkin( $buffer );
 
 			if ( is_wp_error( $result ) ) {
@@ -870,7 +868,7 @@ class Jetpack_Sync_Client {
 		$this->set_sync_wait_time( $settings['sync_wait_time'] );
 
 		$this->set_full_sync_client( Jetpack_Sync_Full::getInstance() );
-		$this->codec                     = new Jetpack_Sync_Deflate_Codec();
+		$this->codec                     = new Jetpack_Sync_JSON_Deflate_Codec();
 		$this->constants_whitelist       = Jetpack_Sync_Defaults::$default_constants_whitelist;
 		$this->update_options_whitelist();
 		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;

--- a/sync/class.jetpack-sync-deflate-codec.php
+++ b/sync/class.jetpack-sync-deflate-codec.php
@@ -9,10 +9,43 @@ require_once dirname( __FILE__ ) . '/interface.jetpack-sync-codec.php';
  */
 class Jetpack_Sync_Deflate_Codec implements iJetpack_Sync_Codec {
 	public function encode( $object ) {
-		return base64_encode( gzdeflate( json_encode( $object ) ) );
+		return base64_encode( gzdeflate( $this->json_serialize( $object ) ) );
 	}
 
 	public function decode( $input ) {
-		return json_decode( gzinflate( base64_decode( $input ) ) );
+		return $this->json_unserialize( gzinflate( base64_decode( $input ) ) );
+	}
+
+	// @see https://gist.github.com/muhqu/820694
+	private function json_serialize( $any ) {
+		return json_encode( $this->json_wrap( $any ) );
+	}
+
+	private function json_unserialize( $str ) {
+		return $this->json_unwrap( json_decode( $str ) );
+	}
+
+	private function json_wrap( $any, $skipAssoc = false ) {
+		if ( !$skipAssoc && is_array( $any ) && is_string( key( $any ) ) ) {
+			return (object) array( "_PHP_ASSOC" => $this->json_wrap( $any, true ) );
+		}
+		if ( is_array( $any ) || is_object( $any ) ) {
+			foreach ( $any as &$v ) {
+				$v = $this->json_wrap( $v );
+			}
+		}
+		return $any;
+	}
+
+	private function json_unwrap( $any, $skipAssoc = false ) {
+		if ( !$skipAssoc && is_object( $any ) && isset( $any->_PHP_ASSOC ) && count( (array) $any ) == 1 ) {
+			return (array) $this->json_unwrap( $any->_PHP_ASSOC );
+		}
+		if ( is_array( $any ) || is_object( $any ) ) {
+			foreach ( $any as &$v ) {
+				$v = $this->json_unwrap( $v );
+			}
+		}
+		return $any;
 	}
 }

--- a/sync/class.jetpack-sync-deflate-codec.php
+++ b/sync/class.jetpack-sync-deflate-codec.php
@@ -9,10 +9,10 @@ require_once dirname( __FILE__ ) . '/interface.jetpack-sync-codec.php';
  */
 class Jetpack_Sync_Deflate_Codec implements iJetpack_Sync_Codec {
 	public function encode( $object ) {
-		return base64_encode( gzdeflate( serialize( $object ) ) );
+		return base64_encode( gzdeflate( json_encode( $object ) ) );
 	}
 
 	public function decode( $input ) {
-		return unserialize( gzinflate( base64_decode( $input ) ) );
+		return json_decode( gzinflate( base64_decode( $input ) ) );
 	}
 }

--- a/sync/class.jetpack-sync-full.php
+++ b/sync/class.jetpack-sync-full.php
@@ -209,9 +209,9 @@ class Jetpack_Sync_Full {
 		$posts = array_map( array( $this->get_client(), 'filter_post_content_and_add_links' ), $posts );
 
 		return array(
-			'posts'      => $posts,
-			'post_metas' => $this->get_metadata( $post_ids, 'post' ),
-			'terms'      => $this->get_term_relationships( $post_ids )
+			$posts,
+			$this->get_metadata( $post_ids, 'post' ),
+			$this->get_term_relationships( $post_ids )
 		);
 	}
 
@@ -228,11 +228,10 @@ class Jetpack_Sync_Full {
 			'include_unapproved' => true,
 			'comment__in'        => $comment_ids,
 		) );
-		$comments = array_map( array( $this->get_client(), 'filter_comment_and_add_hc_meta' ), $comments );
 
 		return array(
-			'comments'      => $comments,
-			'comment_metas' => $this->get_metadata( $comment_ids, 'comment' ),
+			$comments,
+			$this->get_metadata( $comment_ids, 'comment' ),
 		);
 	}
 

--- a/sync/class.jetpack-sync-json-deflate-codec.php
+++ b/sync/class.jetpack-sync-json-deflate-codec.php
@@ -4,10 +4,15 @@ require_once dirname( __FILE__ ) . '/interface.jetpack-sync-codec.php';
 
 /**
  * An implementation of iJetpack_Sync_Codec that uses gzip's DEFLATE
- * algorithm to compress objects serialized using PHP's default
- * serializer
+ * algorithm to compress objects serialized using json_encode
  */
-class Jetpack_Sync_Deflate_Codec implements iJetpack_Sync_Codec {
+class Jetpack_Sync_JSON_Deflate_Codec implements iJetpack_Sync_Codec {
+	const CODEC_NAME = "deflate-json";
+
+	public function name() {
+		return self::CODEC_NAME;
+	}
+	
 	public function encode( $object ) {
 		return base64_encode( gzdeflate( $this->json_serialize( $object ) ) );
 	}

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/class.jetpack-sync-deflate-codec.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-json-deflate-codec.php';
 
 /**
  * Simple version of a Jetpack Sync Server - just receives arrays of events and
@@ -14,7 +14,7 @@ class Jetpack_Sync_Server {
 
 	// this is necessary because you can't use "new" when you declare instance properties >:(
 	function __construct() {
-		$this->codec            = new Jetpack_Sync_Deflate_Codec();
+		$this->codec = new Jetpack_Sync_JSON_Deflate_Codec();
 	}
 
 	function set_codec( iJetpack_Sync_Codec $codec ) {

--- a/sync/interface.jetpack-sync-codec.php
+++ b/sync/interface.jetpack-sync-codec.php
@@ -5,6 +5,9 @@
  * This is used to provide compression and serialization to messages
  **/
 interface iJetpack_Sync_Codec {
+	// we send this with the payload so we can select the appropriate decoder at the other end
+	public function name(); 
+
 	public function encode( $object );
 
 	public function decode( $input );

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -144,14 +144,15 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			case 'jetpack_full_sync_posts':
-				foreach( $args['posts'] as $post ) {
+				list( $posts, $post_metas, $terms ) = $args;
+				foreach( $posts as $post ) {
 					$this->store->upsert_post( $post, true ); // upsert silently
 				}
-				foreach ( $args['post_metas'] as $meta ) {
+				foreach ( $post_metas as $meta ) {
 					$this->store->upsert_metadata( 'post', $meta->post_id, $meta->meta_key, $meta->meta_value, $meta->meta_id );
 				}
 			
-				foreach ( $args['terms'] as $term_object ) {
+				foreach ( $terms as $term_object ) {
 					$term = $this->store->get_term( false, $term_object->term_taxonomy_id, 'term_taxonomy_id' );
 					if ( isset( $term->taxonomy ) ) {
 						$this->store->update_object_terms( $term_object->object_id, $term->taxonomy, array( $term->term_id ), true );
@@ -159,10 +160,12 @@ class Jetpack_Sync_Server_Replicator {
 				}
 				break;
 			case 'jetpack_full_sync_comments':
-				foreach( $args['comments'] as $comment ) {
+				list( $comments, $comment_metas ) = $args;
+
+				foreach( $comments as $comment ) {
 					$this->store->upsert_comment( $comment );
 				}
-				foreach ( $args['comment_metas'] as $meta ) {
+				foreach ( $comment_metas as $meta ) {
 					$this->store->upsert_metadata( 'comment', $meta->comment_id, $meta->meta_key, $meta->meta_value, $meta->meta_id );
 				}
 				break;

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -452,32 +452,4 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		$post = new WP_Post( $object );
 		return $post;
 	}
-
-	// /**
-	//  * recast stdClass object to an object with type
-	//  *
-	//  * @param string $className
-	//  * @param stdClass $object
-	//  * @throws InvalidArgumentException
-	//  * @return mixed new, typed object
-	//  */
-	// private function recast( $className, stdClass &$object )
-	// {
-	// 	if ( ! class_exists( $className) ) {
-	// 		throw new InvalidArgumentException( sprintf( 'Nonexistant class %s.', $className ) );
-	// 	}
-
-	// 	$constructor_args = 
-
-	// 	$new = new $className();
-
-	// 	foreach( $object as $property => &$value ) {
-	// 		$new->$property = &$value;
-	// 		unset( $object->$property );
-	// 	}
-	// 	unset( $value );
-	// 	$object = (unset) $object;
-	// 	return $new;
-	// }
-
 }

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -29,18 +29,18 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	function reset() {
-		$this->posts = array();
-		$this->comments = array();
-		$this->options = array();
-		$this->theme_support = array();
-		$this->meta = array();
-		$this->constants = array();
-		$this->updates = array();
-		$this->callable = array();
-		$this->network_options = array();
-		$this->terms = array();
-		$this->object_terms = array();
-		$this->users = array();
+		$this->posts           = array();
+        $this->comments        = array();
+        $this->options         = array();
+        $this->theme_support   = array();
+        $this->meta            = array();
+        $this->constants       = array();
+        $this->updates         = array();
+        $this->callable        = array();
+        $this->network_options = array();
+        $this->terms           = array();
+        $this->object_terms    = array();
+        $this->users           = array();
 	}
 
 	function full_sync_start() {
@@ -66,7 +66,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	private function post_checksum( $carry, $post ) {
-		return $carry ^ sprintf( '%u', crc32( $post->ID.$post->post_modified ) )+0;
+		return $carry ^ sprintf( '%u', crc32( $post->ID . $post->post_modified ) ) + 0;
 	}
 
 	function filter_post_status( $post ) {
@@ -103,7 +103,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	private function comment_checksum( $carry, $comment ) {
-		return $carry ^ sprintf( '%u', crc32( $comment->comment_ID.$comment->comment_content ) )+0;
+		return $carry ^ sprintf( '%u', crc32( $comment->comment_ID . $comment->comment_content ) ) + 0;
 	}
 
 	function filter_comment_status( $comment ) {
@@ -182,10 +182,11 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 		if ( count( $meta_entries ) === 0 ) {
 			// match return signature of WP code
-			if ($single)
+			if ($single) {
 				return '';
-			else
+			} else {
 				return array();
+			}
 		}
 
 		$meta_values = array_map( array( $this, 'get_meta_valued' ), $meta_entries );
@@ -441,7 +442,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function checksum_all() {
 		return array(
-			'posts' => $this->posts_checksum(),
+			'posts'    => $this->posts_checksum(),
 			'comments' => $this->comments_checksum()
 		);
 	}

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -81,7 +81,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	function upsert_post( $post, $silent = false ) {
-		$this->posts[ $post->ID ] = $post;
+		$this->posts[ $post->ID ] = $this->cast_to_post( $post );
 	}
 
 	function delete_post( $post_id ) {
@@ -163,11 +163,11 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	// theme functions
 	function set_theme_support( $theme_support ) {
-		$this->theme_support = $theme_support;
+		$this->theme_support = (object) $theme_support;
 	}
 
 	function current_theme_supports( $feature ) {
-		return isset( $this->theme_support[ $feature ] );
+		return isset( $this->theme_support->{ $feature } );
 	}
 
 	// meta
@@ -411,7 +411,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	function update_object_terms( $object_id, $taxonomy, $term_ids, $append ) {
 		if ( $append ) {
 			$previous_array = isset( $this->object_terms[ $taxonomy ] )
-			                 && isset( $this->object_terms[ $taxonomy ][ $object_id ] )
+							 && isset( $this->object_terms[ $taxonomy ][ $object_id ] )
 				? $this->object_terms[ $taxonomy ][ $object_id ] : array();
 			$this->object_terms[ $taxonomy ][ $object_id ] = array_merge ( $previous_array , $term_ids );
 		} else {
@@ -445,5 +445,39 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 			'comments' => $this->comments_checksum()
 		);
 	}
+
+	function cast_to_post( $object ) {
+		if ( isset( $object->extra ) )
+			$object->extra = (array) $object->extra;
+		$post = new WP_Post( $object );
+		return $post;
+	}
+
+	// /**
+	//  * recast stdClass object to an object with type
+	//  *
+	//  * @param string $className
+	//  * @param stdClass $object
+	//  * @throws InvalidArgumentException
+	//  * @return mixed new, typed object
+	//  */
+	// private function recast( $className, stdClass &$object )
+	// {
+	// 	if ( ! class_exists( $className) ) {
+	// 		throw new InvalidArgumentException( sprintf( 'Nonexistant class %s.', $className ) );
+	// 	}
+
+	// 	$constructor_args = 
+
+	// 	$new = new $className();
+
+	// 	foreach( $object as $property => &$value ) {
+	// 		$new->$property = &$value;
+	// 		unset( $object->$property );
+	// 	}
+	// 	unset( $value );
+	// 	$object = (unset) $object;
+	// 	return $new;
+	// }
 
 }

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/../../../../sync/interface.jetpack-sync-replicastore.php';
-
 /**
  * A simple in-memory implementation of iJetpack_Sync_Replicastore
  * used for development and testing
@@ -30,27 +28,26 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function reset() {
 		$this->posts           = array();
-        $this->comments        = array();
-        $this->options         = array();
-        $this->theme_support   = array();
-        $this->meta            = array();
-        $this->constants       = array();
-        $this->updates         = array();
-        $this->callable        = array();
-        $this->network_options = array();
-        $this->terms           = array();
-        $this->object_terms    = array();
-        $this->users           = array();
+		$this->comments        = array();
+		$this->options         = array();
+		$this->theme_support   = array();
+		$this->meta            = array();
+		$this->constants       = array();
+		$this->updates         = array();
+		$this->callable        = array();
+		$this->network_options = array();
+		$this->terms           = array();
+		$this->object_terms    = array();
+		$this->users           = array();
 	}
 
 	function full_sync_start() {
 		$this->reset();
 	}
-	
+
 	function full_sync_end( $checksum ) {
 		// noop right now
 	}
-
 
 	function post_count( $status = null ) {
 		return count( $this->get_posts( $status ) );
@@ -58,6 +55,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function get_posts( $status = null ) {
 		$this->post_status = $status;
+
 		return array_filter( array_values( $this->posts ), array( $this, 'filter_post_status' ) );
 	}
 
@@ -71,13 +69,13 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function filter_post_status( $post ) {
 		$matched_status = ! in_array( $post->post_status, array( 'inherit' ) )
-						  && ( $this->post_status ? $post->post_status === $this->post_status : true );
+		                  && ( $this->post_status ? $post->post_status === $this->post_status : true );
 
 		return $matched_status;
 	}
 
 	function get_post( $id ) {
-		return isset( $this->posts[ $id ] ) ? $this->posts[ $id ] : false ;
+		return isset( $this->posts[ $id ] ) ? $this->posts[ $id ] : false;
 	}
 
 	function upsert_post( $post, $silent = false ) {
@@ -94,6 +92,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function get_comments( $status = null ) {
 		$this->comment_status = $status;
+
 		// valid statuses: 'hold', 'approve', 'spam', or 'trash'.
 		return array_filter( array_values( $this->comments ), array( $this, 'filter_comment_status' ) );
 	}
@@ -127,12 +126,13 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function get_comment( $id ) {
 		if ( isset( $this->comments[ $id ] ) ) {
-			return $this->comments[ $id ];	
+			return $this->comments[ $id ];
 		}
-		return false;		
+
+		return false;
 	}
 
-	function upsert_comment( $comment ) {
+	function upsert_comment( $comment, $silent = false ) {
 		$this->comments[ $comment->comment_ID ] = $comment;
 	}
 
@@ -173,16 +173,16 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	// meta
 	public function get_metadata( $type, $object_id, $meta_key = '', $single = false ) {
 
-		$object_id = absint( $object_id );
-		$this->meta_filter['type'] = $type;
+		$object_id                      = absint( $object_id );
+		$this->meta_filter['type']      = $type;
 		$this->meta_filter['object_id'] = $object_id;
-		$this->meta_filter['meta_key'] = $meta_key;
+		$this->meta_filter['meta_key']  = $meta_key;
 
 		$meta_entries = array_values( array_filter( $this->meta, array( $this, 'find_meta' ) ) );
 
 		if ( count( $meta_entries ) === 0 ) {
 			// match return signature of WP code
-			if ($single) {
+			if ( $single ) {
 				return '';
 			} else {
 				return array();
@@ -203,8 +203,9 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		$match = ( $this->meta_filter['type'] === $meta->type && $this->meta_filter['object_id'] === $meta->object_id );
 
 		// match key if given
-		if ( $match && $this->meta_filter['meta_key'] )
+		if ( $match && $this->meta_filter['meta_key'] ) {
 			$match = ( $meta->meta_key === $this->meta_filter['meta_key'] );
+		}
 
 		return $match;
 	}
@@ -214,12 +215,12 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	public function upsert_metadata( $type, $object_id, $meta_key, $meta_value, $meta_id ) {
-		$this->meta[ $meta_id ] = (object) array( 
-			'meta_id'   => $meta_id,
-			'type'      => $type,
-			'object_id' => absint( $object_id ),
-			'meta_key'  => $meta_key,
-			'meta_value'  => $meta_value,
+		$this->meta[ $meta_id ] = (object) array(
+			'meta_id'    => $meta_id,
+			'type'       => $type,
+			'object_id'  => absint( $object_id ),
+			'meta_key'   => $meta_key,
+			'meta_value' => $meta_value,
 		);
 	}
 
@@ -234,6 +235,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		if ( ! isset( $this->constants[ $constant ] ) ) {
 			return null;
 		}
+
 		return $this->constants[ $constant ];
 	}
 
@@ -246,6 +248,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		if ( ! isset( $this->updates[ $type ] ) ) {
 			return null;
 		}
+
 		return $this->updates[ $type ];
 	}
 
@@ -254,11 +257,12 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	// updates
-	public function get_callable( $name ) {
-		if ( ! isset( $this->callable[ $name ] ) ) {
+	public function get_callable( $function ) {
+		if ( ! isset( $this->callable[ $function ] ) ) {
 			return null;
 		}
-		return $this->callable[ $name ];
+
+		return $this->callable[ $function ];
 	}
 
 	public function set_callable( $name, $value ) {
@@ -286,15 +290,15 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function get_term( $taxonomy, $term_id, $term_key = 'term_id' ) {
 		if ( ! $taxonomy && $term_key === 'term_taxonomy_id' ) {
-			foreach(  $this->terms as $tax => $terms_array ) {
-				 $term = $this->get_term( $tax, $term_id, 'term_taxonomy_id' );
-				 if( $term ) {
+			foreach ( $this->terms as $tax => $terms_array ) {
+				$term = $this->get_term( $tax, $term_id, 'term_taxonomy_id' );
+				if ( $term ) {
 					return $term;
 				}
 			}
 		}
-		if ( !  isset( $this->terms[ $taxonomy ] ) ) {
-			return null;
+		if ( ! isset( $this->terms[ $taxonomy ] ) ) {
+			return array();
 		}
 		foreach ( $this->terms[ $taxonomy ] as $term_object ) {
 			switch ( $term_key ) {
@@ -302,7 +306,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 					$term = ( $term_id == $term_object->term_id ) ? $term_object : null;
 					break;
 				case 'term_taxonomy_id':
-					$term =( $term_id == $term_object->term_taxonomy_id ) ? $term_object : null;
+					$term = ( $term_id == $term_object->term_taxonomy_id ) ? $term_object : null;
 					break;
 				case 'slug':
 					$term = ( $term_id === $term_object->slug ) ? $term_object : null;
@@ -313,37 +317,39 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 				return $term;
 			}
 		}
-		return null;
+
+		return array();
 	}
 
 	function get_the_terms( $object_id, $taxonomy ) {
 		$terms = array();
-		if ( !isset( $this->object_terms[ $taxonomy ] ) ) {
+		if ( ! isset( $this->object_terms[ $taxonomy ] ) ) {
 			return false;
 		}
-		foreach( $this->object_terms[ $taxonomy ][ $object_id ] as $term_id ) {
+		foreach ( $this->object_terms[ $taxonomy ][ $object_id ] as $term_id ) {
 			$term_key = is_numeric( $term_id ) ? 'term_id' : 'slug';
-			$terms[] = $this->get_term( $taxonomy, $term_id, $term_key );
+			$terms[]  = $this->get_term( $taxonomy, $term_id, $term_key );
 		}
+
 		return $terms;
 	}
 
 	function update_term( $term_object ) {
 		$taxonomy = $term_object->taxonomy;
-		
+
 		if ( ! isset( $this->terms[ $taxonomy ] ) ) {
 			// empty 
-			$this->terms[ $taxonomy ] = array();
+			$this->terms[ $taxonomy ]   = array();
 			$this->terms[ $taxonomy ][] = $term_object;
 		}
-		$terms = array();
+		$terms  = array();
 		$action = 'none';
 
 		// Note: array_map might be better for this but didn't want to write a callback
 		foreach ( $this->terms[ $taxonomy ] as $saved_term_object ) {
 			if ( $saved_term_object->term_id === $term_object->term_id ) {
 				$terms[] = $term_object;
-				$action = 'updated';
+				$action  = 'updated';
 			} else {
 				$terms[] = $saved_term_object;
 			}
@@ -356,13 +362,13 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	private function update_term_count( $taxonomy, $term_id ) {
-		$term_key = is_numeric($term_id) ? 'term_id' : 'slug';
+		$term_key    = is_numeric( $term_id ) ? 'term_id' : 'slug';
 		$term_object = $this->get_term( $taxonomy, $term_id, $term_key );
-		$count = 0;
+		$count       = 0;
 		foreach ( $this->object_terms[ $taxonomy ] as $object_id => $term_ids ) {
-			foreach( $term_ids as $saved_term_id ) {
+			foreach ( $term_ids as $saved_term_id ) {
 				if ( $saved_term_id === $term_id ) {
-					$count++;
+					$count ++;
 				}
 			}
 		}
@@ -379,7 +385,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 			$this->terms[ $taxonomy ] = array();
 		}
 		$terms = array();
-		
+
 		// Note: array_map might be better for this but didn't want to write a callback
 		foreach ( $this->terms[ $taxonomy ] as $saved_term_object ) {
 			if ( $saved_term_object->term_id !== $term_id ) {
@@ -394,13 +400,13 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function delete_object_terms( $object_id, $tt_ids ) {
 		$saved_data = array();
-		foreach( $this->object_terms as $taxonomy => $taxonomy_object_terms ) {
+		foreach ( $this->object_terms as $taxonomy => $taxonomy_object_terms ) {
 			foreach ( $taxonomy_object_terms as $saved_object_id => $term_ids ) {
-				foreach( $term_ids as $saved_term_id ) {
+				foreach ( $term_ids as $saved_term_id ) {
 					$term = $this->get_term( $taxonomy, $saved_term_id, 'term_id' );
 					if ( isset( $term->term_taxonomy_id ) && ! in_array( $term->term_taxonomy_id, $tt_ids ) && $object_id === $saved_object_id ) {
 						$saved_data[ $taxonomy ] [ $saved_object_id ][] = $saved_term_id;
-					} else if( isset( $term->term_taxonomy_id ) && in_array( $term->term_taxonomy_id, $tt_ids ) && $object_id === $saved_object_id ) {
+					} else if ( isset( $term->term_taxonomy_id ) && in_array( $term->term_taxonomy_id, $tt_ids ) && $object_id === $saved_object_id ) {
 						$this->update_term_count( $taxonomy, $term->term_id );
 					}
 				}
@@ -411,10 +417,10 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function update_object_terms( $object_id, $taxonomy, $term_ids, $append ) {
 		if ( $append ) {
-			$previous_array = isset( $this->object_terms[ $taxonomy ] )
-							 && isset( $this->object_terms[ $taxonomy ][ $object_id ] )
+			$previous_array                                = isset( $this->object_terms[ $taxonomy ] )
+			                                                 && isset( $this->object_terms[ $taxonomy ][ $object_id ] )
 				? $this->object_terms[ $taxonomy ][ $object_id ] : array();
-			$this->object_terms[ $taxonomy ][ $object_id ] = array_merge ( $previous_array , $term_ids );
+			$this->object_terms[ $taxonomy ][ $object_id ] = array_merge( $previous_array, $term_ids );
 		} else {
 			$this->object_terms[ $taxonomy ][ $object_id ] = $term_ids;
 		}
@@ -425,13 +431,13 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	function user_count() {
-		return count( $this->users );	
+		return count( $this->users );
 	}
 
 	function get_user( $user_id ) {
 		return isset( $this->users[ $user_id ] ) ? $this->users[ $user_id ] : null;
 	}
-	
+
 	function upsert_user( $user ) {
 		$this->users[ $user->ID ] = $user;
 	}
@@ -448,9 +454,11 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	function cast_to_post( $object ) {
-		if ( isset( $object->extra ) )
+		if ( isset( $object->extra ) ) {
 			$object->extra = (array) $object->extra;
+		}
 		$post = new WP_Post( $object );
 		return $post;
 	}
+
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -31,7 +31,7 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 	public function test_sync_jetpack_updates() {
 		$this->client->do_sync();
 		$updates = $this->server_replica_storage->get_callable( 'updates' );
-		$this->assertEquals( Jetpack::get_updates(), $updates );
+		$this->assertEqualsObject( Jetpack::get_updates(), $updates );
 	}
 
 
@@ -86,7 +86,7 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	function assertCallableIsSynced( $name, $value ) {
-		$this->assertEquals( $value, $this->server_replica_storage->get_callable( $name ), 'Function '. $name .' didn\'t have the expected value of ' . json_encode( $value ) );
+		$this->assertEqualsObject( $value, $this->server_replica_storage->get_callable( $name ), 'Function '. $name .' didn\'t have the expected value of ' . json_encode( $value ) );
 	}
 
 

--- a/tests/php/sync/test_class.jetpack-sync-client.php
+++ b/tests/php/sync/test_class.jetpack-sync-client.php
@@ -75,6 +75,17 @@ class WP_Test_Jetpack_New_Sync_Base extends WP_UnitTestCase {
 
 	}
 
+	// asserts that two objects are the same if they're both "objectified",
+	// i.e. json_encoded and then json_decoded
+	// this is useful because we json encode everything sent to the server
+	protected function assertEqualsObject( $object_1, $object_2 ) {
+		$this->assertEquals( $this->objectify( $object_1 ), $this->objectify( $object_2 ) );
+	}
+
+	protected function objectify( $instance ) {
+		return json_decode( json_encode( $instance ) );
+	}
+
 	function serverReceive( $data ) {
 		return $this->server->receive( $data );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-client.php
+++ b/tests/php/sync/test_class.jetpack-sync-client.php
@@ -98,14 +98,16 @@ class WP_Test_Jetpack_New_Sync_Client extends WP_Test_Jetpack_New_Sync_Base {
 	protected $action_ran;
 	protected $encoded_data;
 
-	function test_add_post_fires_sync_data_action_on_do_sync() {
+	function test_add_post_fires_sync_data_action_with_codec_on_do_sync() {
 		$this->action_ran = false;
+		$this->action_codec = null;
 
-		add_filter( 'jetpack_sync_client_send_data', array( $this, 'action_ran' ) );
+		add_filter( 'jetpack_sync_client_send_data', array( $this, 'action_ran' ), 10, 2 );
 
 		$this->client->do_sync();
 
 		$this->assertEquals( true, $this->action_ran );
+		$this->assertEquals( 'deflate-json', $this->action_codec );
 	}
 
 	function test_clear_actions_on_client() {
@@ -378,8 +380,9 @@ class WP_Test_Jetpack_New_Sync_Client extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertTrue( $event->timestamp < microtime(true) );
 	}
 
-	function action_ran( $data ) {
+	function action_ran( $data, $codec ) {
 		$this->action_ran = true;
+		$this->action_codec = $codec;
 		return $data;
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -26,13 +26,13 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertNotEquals( false, $event );
 		$this->assertEquals( 'wp_insert_comment', $event->action );
 		$this->assertEquals( $this->comment->comment_ID, $event->args[0] );
-		$this->assertEquals( $this->comment, $event->args[1] );
+		$this->assertEqualsObject( $this->comment, $event->args[1] );
 	}
 
 	public function test_add_comment_syncs_comment_data() {
 		// post stored by server should equal post in client
 		$this->assertEquals( 1, $this->server_replica_storage->comment_count() );
-		$this->assertEquals( $this->comment, $this->server_replica_storage->get_comment( $this->comment->comment_ID ) );
+		$this->assertEqualsObject( $this->comment, $this->server_replica_storage->get_comment( $this->comment->comment_ID ) );
 	}
 
 	public function test_update_comment() {
@@ -91,31 +91,6 @@ class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
 
 		$this->assertEquals( 1, $this->server_replica_storage->comment_count( 'approve' ) );
 		$this->assertEquals( 0, $this->server_replica_storage->comment_count( 'trash' ) );
-	}
-
-	public function test_sends_highlander_comment_meta_with_comment() {
-		$wpcom_user_id = 101;
-		$sig = 'abcd1234';
-		$comment_ID = $this->comment->comment_ID;
-
-		add_comment_meta( $comment_ID, 'hc_post_as', 'wordpress', true );
-		add_comment_meta( $comment_ID, 'hc_wpcom_id_sig', $sig, true );
-		add_comment_meta( $comment_ID, 'hc_foreign_user_id', $wpcom_user_id, true );
-
-		// re-save the comment
-		wp_set_comment_status( $comment_ID, 'hold' );
-
-		$this->client->do_sync();
-		$this->client->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event();
-
-		$synced_comment = $event->args[1];
-		$this->assertObjectHasAttribute( 'meta', $synced_comment );
-		$this->assertEquals( 'wordpress', $synced_comment->meta['hc_post_as'] );
-		$this->assertEquals( 'abcd1234', $synced_comment->meta['hc_wpcom_id_sig'] );
-		$this->assertEquals( 101, $synced_comment->meta['hc_foreign_user_id'] );
-		
 	}
 
 	public function test_wp_spam_comment() {

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -56,7 +56,7 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 
 		$synced_value = $this->server_replica_storage->get_constant( 'TEST_ABC' );
-		$this->assertEquals( TEST_ABC, $synced_value );
+		$this->assertEquals( sprintf("%.4f", TEST_ABC), sprintf("%.4f", $synced_value ) );
 
 		$this->server_replica_storage->reset();
 		

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -17,8 +17,8 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 
 		$this->client->set_constants_whitelist( array( 'TEST_FOO' ) );
 
-		define( 'TEST_FOO', microtime(true) );
-		define( 'TEST_BAR', microtime(true) );
+		define( 'TEST_FOO', sprintf( "%.8f", microtime(true) ) );
+		define( 'TEST_BAR', sprintf( "%.8f", microtime(true) ) );
 
 		$this->client->do_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -56,7 +56,7 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 
 		$synced_value = $this->server_replica_storage->get_constant( 'TEST_ABC' );
-		$this->assertEquals( sprintf("%.4f", TEST_ABC), sprintf("%.4f", $synced_value ) );
+		$this->assertEquals( sprintf("%.2f", TEST_ABC), sprintf("%.2f", $synced_value ) );
 
 		$this->server_replica_storage->reset();
 		

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -91,28 +91,6 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( 11, count( $comments ) );
 	}
 
-	function test_full_sync_expands_comment_meta() {
-		$post_id = $this->factory->post->create();
-		list( $comment_ID ) = $this->factory->comment->create_post_comments( $post_id );
-
-		add_comment_meta( $comment_ID, 'hc_post_as', 'wordpress', true );
-		add_comment_meta( $comment_ID, 'hc_wpcom_id_sig', 'abcd1234', true );
-		add_comment_meta( $comment_ID, 'hc_foreign_user_id', 55, true );
-
-		$this->server_replica_storage->reset();
-		$this->client->reset_data();
-
-		$this->full_sync->start();
-		$this->client->do_sync();
-
-		$comments = $this->server_replica_storage->get_comments();
-		$comment = $comments[0];
-		$this->assertObjectHasAttribute( 'meta', $comment );
-		$this->assertEquals( 'wordpress', $comment->meta['hc_post_as'] );
-		$this->assertEquals( 'abcd1234', $comment->meta['hc_wpcom_id_sig'] );
-		$this->assertEquals( 55, $comment->meta['hc_foreign_user_id'] );
-	}
-
 	function test_full_sync_sends_all_terms() {
 
 		for( $i = 0; $i < 11; $i += 1 ) {
@@ -268,7 +246,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 		$terms = get_the_terms( $post_id, 'post_tag' );
 
-		$this->assertEquals( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Initial sync doesn\'t work' );
+		$this->assertEqualsObject( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Initial sync doesn\'t work' );
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
 
@@ -277,7 +255,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 
 		$terms = array_map( array( $this, 'upgrade_terms_to_pass_test' ), $terms );
-		$this->assertEquals( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Full sync doesn\'t work' );
+		$this->assertEqualsObject( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Full sync doesn\'t work' );
 	}
 
 	function test_full_sync_sends_all_comment_meta() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -189,7 +189,7 @@ class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	function assertOptionIsSynced( $option_name, $value ) {
-		$this->assertEquals( $value, $this->server_replica_storage->get_option( $option_name ), 'Option '. $option_name .' did\'t have the extected value of ' . json_encode( $value ) );
+		$this->assertEqualsObject( $value, $this->server_replica_storage->get_option( $option_name ), 'Option '. $option_name .' did\'t have the extected value of ' . json_encode( $value ) );
 	}
 
 	function add_fiter_on_init() {

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -35,7 +35,7 @@ class WP_Test_Jetpack_New_Sync_Terms extends WP_Test_Jetpack_New_Sync_Base {
 	public function test_insert_term_is_synced() {
 		$terms = $this->get_terms();
 		$server_terms = $this->server_replica_storage->get_terms( $this->taxonomy );
-		$this->assertEquals( $terms, $server_terms );
+		$this->assertEqualsObject( $terms, $server_terms );
 	}
 
 	public function test_update_term_is_synced() {
@@ -48,7 +48,7 @@ class WP_Test_Jetpack_New_Sync_Terms extends WP_Test_Jetpack_New_Sync_Base {
 
 		$terms = $this->get_terms();
 		$server_terms = $this->server_replica_storage->get_terms( $this->taxonomy );
-		$this->assertEquals( $terms, $server_terms );
+		$this->assertEqualsObject( $terms, $server_terms );
 	}
 
 	public function test_delete_term_is_synced() {
@@ -67,7 +67,7 @@ class WP_Test_Jetpack_New_Sync_Terms extends WP_Test_Jetpack_New_Sync_Base {
 
 		$object_terms = get_the_terms ( $this->post_id, $this->taxonomy );
 		$server_object_terms = $this->server_replica_storage->get_the_terms( $this->post_id, $this->taxonomy );
-		$this->assertEquals( $object_terms, $server_object_terms );
+		$this->assertEqualsObject( $object_terms, $server_object_terms );
 	}
 
 	public function test_added_terms_to_post_is_synced_appended() {
@@ -81,7 +81,7 @@ class WP_Test_Jetpack_New_Sync_Terms extends WP_Test_Jetpack_New_Sync_Base {
 		$object_terms = get_the_terms ( $this->post_id, $this->taxonomy );
 		$server_object_terms = $this->server_replica_storage->get_the_terms( $this->post_id, $this->taxonomy );
 		$server_object_terms = array_reverse( $server_object_terms );
-		$this->assertEquals( $object_terms, $server_object_terms );
+		$this->assertEqualsObject( $object_terms, $server_object_terms );
 	}
 
 	public function test_deleted_terms_to_post_is_synced() {
@@ -99,7 +99,7 @@ class WP_Test_Jetpack_New_Sync_Terms extends WP_Test_Jetpack_New_Sync_Base {
 		$server_object_terms = $this->server_replica_storage->get_the_terms( $this->post_id, $this->taxonomy );
 		$server_object_terms = array_reverse( $server_object_terms );
 
-		$this->assertEquals( $object_terms, $server_object_terms );
+		$this->assertEqualsObject( $object_terms, $server_object_terms );
 	}
 
 	public function test_delete_object_term_relationships() {

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -21,7 +21,7 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 		// make sure that we don't have a password
 		unset( $user->data->user_pass );
 		$this->assertFalse(  isset( $server_user->data->user_pass ) );
-		$this->assertEquals( $user, $server_user );
+		$this->assertEqualsObject( $user, $server_user );
 	}
 
 	public function test_update_user_url_is_synced() {
@@ -211,7 +211,7 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 
 		$client_user = get_user_by( 'id', $this->user_id );
 		unset( $client_user->data->user_pass );
-		$this->assertEquals( $client_user, $server_user );
+		$this->assertEqualsObject( $client_user, $server_user );
 
 	}
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -430,7 +430,9 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$store->upsert_post( self::$factory->post( 1 ) );
 		$store->upsert_metadata( 'post', 1, 'colors', $meta_array, 3 );
 
-		$this->assertTrue( $this->arrays_are_similar( $meta_array, $store->get_metadata( 'post', 1, 'colors' )[0] ) );
+		$color_meta = $store->get_metadata( 'post', 1, 'colors' );
+		
+		$this->assertTrue( $this->arrays_are_similar( $meta_array, $color_meta[0] ) );
 	}
 
 	/**

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -431,7 +431,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$store->upsert_metadata( 'post', 1, 'colors', $meta_array, 3 );
 
 		$color_meta = $store->get_metadata( 'post', 1, 'colors' );
-		
+
 		$this->assertTrue( $this->arrays_are_similar( $meta_array, $color_meta[0] ) );
 	}
 
@@ -611,7 +611,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 			)
 		); 
 
-		$this->assertNull( $store->get_term( $term_object->taxonomy, $term_object->term_id ) );
+		$this->assertEmpty( $store->get_term( $term_object->taxonomy, $term_object->term_id ) );
 
 		$store->update_term( $term_object );
 
@@ -642,7 +642,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		$store->delete_term( $term_object->term_id, $taxonomy );
 
-		$this->assertNull( $store->get_term( $term_object->taxonomy, $term_object->term_id ) );
+		$this->assertEmpty( $store->get_term( $term_object->taxonomy, $term_object->term_id ) );
 	}
 
 	/**

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -4,7 +4,7 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	require_once ABSPATH . 'wp-content/mu-plugins/jetpack/sync/class.jetpack-sync-test-object-factory.php';
 } else {
 	// is running in jetpack
-	require_once dirname( __FILE__ ) . '/server/class.jetpack-sync-test-object-factory.php';
+	require_once dirname( __FILE__ ) . '/server/class.jetpack-sync-test-object-factory.php';    
 }
 
 /*
@@ -30,23 +30,23 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		self::$factory = new JetpackSyncTestObjectFactory();
 	}
-
+	
 	function setUp() {
 		parent::setUp();
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			switch_to_blog( self::$token->blog_id );
-		}
+		} 
 
 		// this is a hack so that our setUp method can access the $store instance and call reset()
 		$prop = new ReflectionProperty( 'PHPUnit_Framework_TestCase', 'data' );
 		$prop->setAccessible( true );
 		$test_data = $prop->getValue( $this );
-
+		
 		if ( isset( $test_data[0] ) && $test_data[0] ) {
 			$store = $test_data[0];
-			$store->reset();
-		}
+			$store->reset();    
+		}   
 	}
 
 	function tearDown() {
@@ -72,7 +72,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				if ( method_exists( $className, 'getInstance' ) ) {
 					$all_replicastores[] = call_user_func( array( $className, 'getInstance' ) );
 				} else {
-					$all_replicastores[] = new $className();
+					$all_replicastores[] = new $className();  
 				}
 			}
 		}
@@ -192,16 +192,17 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 1, $store->comment_count() );
 
 		$retrieved_comment = $store->get_comment( $comment->comment_ID );
-
+		
 		// insane hack because sometimes MySQL retrurns dates that are off by a second or so. WTF?
 		unset($comment->comment_date);
 		unset($comment->comment_date_gmt);
 		unset($retrieved_comment->comment_date);
 		unset($retrieved_comment->comment_date_gmt);
-	
+
 		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
 			$this->markTestIncomplete("The WP replicastore doesn't support setting comments post_fields");
 		}
+
 		$this->assertEquals( $comment, $retrieved_comment );
 	}
 
@@ -429,16 +430,15 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$store->upsert_post( self::$factory->post( 1 ) );
 		$store->upsert_metadata( 'post', 1, 'colors', $meta_array, 3 );
 
-		$colors = $store->get_metadata( 'post', 1, 'colors' );
-		$this->assertTrue( $this->arrays_are_similar( $meta_array, $colors[0] ) );
+		$this->assertTrue( $this->arrays_are_similar( $meta_array, $store->get_metadata( 'post', 1, 'colors' )[0] ) );
 	}
 
 	/**
 	 * Determine if two associative arrays are similar
 	 *
 	 * Both arrays must have the same indexes with identical values
-	 * without respect to key ordering
-	 *
+	 * without respect to key ordering 
+	 * 
 	 * @param array $a
 	 * @param array $b
 	 * @return bool
@@ -508,7 +508,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		$store->set_callable( 'is_main_network', 'yes' );
 
-		$this->assertEquals( 'yes', $store->get_callable( 'is_main_network' ) );
+		$this->assertEquals( 'yes', $store->get_callable( 'is_main_network' ) );	
 	}
 
 	/**
@@ -561,7 +561,26 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$store->upsert_user( $user );
 
 		$this->assertNotNull( $store->get_user( 12 ) );
-		$this->assertEquals( $user, $store->get_user( 12 ) );
+
+		// delete stuff that shouldn't be included because we don't sync that data
+		unset( $user->data->user_activation_key );
+
+		$stored_user = $store->get_user( 12 );
+
+		if ( $store instanceof Jetpack_Sync_WPCOM_Shadow_Replicastore ) {
+			$this->assertEquals( $user->ID, $stored_user->external_user_id );
+			$this->assertFalse( isset( $user->data->user_activation_key ) );
+		} else {
+			$this->assertEquals( $user->ID, $stored_user->ID );
+		}
+
+		$this->assertEquals( $user->data->user_login,      $stored_user->data->user_login );
+		$this->assertEquals( $user->data->user_nicename,   $stored_user->data->user_nicename );
+		$this->assertEquals( $user->data->user_email,      $stored_user->data->user_email );
+		$this->assertEquals( $user->data->user_url,        $stored_user->data->user_url );
+		$this->assertEquals( $user->data->user_registered, $stored_user->data->user_registered );
+		$this->assertEquals( $user->data->user_status,     $stored_user->data->user_status );
+		$this->assertEquals( $user->data->display_name,    $stored_user->data->display_name );
 
 		$store->delete_user( 12 );
 
@@ -588,7 +607,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				'term_taxonomy_id' => 22,
 				'taxonomy' => $taxonomy,
 			)
-		);
+		); 
 
 		$this->assertNull( $store->get_term( $term_object->taxonomy, $term_object->term_id ) );
 
@@ -615,7 +634,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				'term_taxonomy_id' => 22,
 				'taxonomy' => $taxonomy,
 			)
-		);
+		); 
 
 		$store->update_term( $term_object );
 
@@ -639,7 +658,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 				'term_taxonomy_id' => 22,
 				'taxonomy' => $taxonomy,
 			)
-		);
+		); 
 
 		$store->update_term( $term_object );
 
@@ -696,7 +715,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 1, $terms[0]->count );
 
 		$store->delete_object_terms( $replica_post->ID, array( 22 ) );
-
+		
 		$this->assertEquals( null, $wpdb->get_row( "SELECT * FROM $wpdb->term_relationships WHERE object_id = 5 ") );
 
 		$terms = get_the_terms( $replica_post->ID, $taxonomy );
@@ -722,9 +741,9 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 			if ( method_exists( $replicastore_class, 'getInstance' ) ) {
 				$instance = call_user_func( array( $replicastore_class, 'getInstance' ) );
 			} else {
-				$instance = new $replicastore_class();
+				$instance = new $replicastore_class();  
 			}
-
+			
 			$return[] = array( $instance );
 		}
 


### PR DESCRIPTION
This is intended to address two quite separate issues that happened to get worked on at the same time.

1. Move from using PHP's `serialize` to `json_encode`. Serialize is insecure - we should not unserialize data within WPCOM from an untrusted source.

2. Remove additional metadata we were sending with posts and comments. It's no longer necessary due to some changes on WPCOM.

Note that the json_encode method overrides the default behaviour of PHP in one important respect: It nests an additional "_PHP_ASSOC" key above any objects that should be decoded as an associative array. This will hopefully allow our synced data to more closely resemble the original.