### PR TITLE
Remove sync options on deleting of Jetpack.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ matrix:
   - php: "5.2"
     env: WP_VERSION=master
   - php: "5.2"
+    env: WP_VERSION=master WP_TRAVIS="phpunit --group=uninstall --testsuite=uninstall"
+  - php: "5.2"
     env: WP_VERSION=4.4
   - php: "5.2"
     env: WP_VERSION=4.5
@@ -63,6 +65,7 @@ matrix:
     env: WP_VERSION=4.5
   - php: "7.0"
     env: WP_VERSION=master
+
   allow_failures:
   - php: "hhvm"
   - php: "nightly"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -54,10 +54,14 @@
 			<exclude>tests/php/sync/test_interface.jetpack-sync-replicastore.php</exclude>
 			<file phpVersion="5.3.0" phpVersionOperator=">=">tests/php/sync/test_interface.jetpack-sync-replicastore.php</file>
 		</testsuite>
+		<testsuite name="uninstall">
+			<directory prefix="test_" suffix=".php">tests/php/uninstall</directory>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>
 			<group>external-http</group>
+			<group>uninstall</group>
 		</exclude>
 	</groups>
 	<filter>

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -924,11 +924,31 @@ class Jetpack_Sync_Client {
 	function reset_data() {
 		$this->reset_sync_queue();
 
-		// Lets delete all the other fun stuff like transient and option.
+
 		delete_option( self::CONSTANTS_CHECKSUM_OPTION_NAME );
 		delete_option( self::CALLABLES_CHECKSUM_OPTION_NAME );
 
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
 		delete_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME );
+
+		delete_option( self::SYNC_THROTTLE_OPTION_NAME );
+		delete_option( self::LAST_SYNC_TIME_OPTION_NAME );
+
+		$valid_settings  = self::$valid_settings;
+		$settings_prefix =  self::SETTINGS_OPTION_PREFIX;
+		foreach ( $valid_settings as $option => $value ) {
+			delete_option( $settings_prefix . $option );
+		}
+	}
+
+	function uninstall() {
+		// Lets delete all the other fun stuff like transient and option and the sync queue
+		$this->reset_data();
+
+		// delete the full sync status
+		delete_option( 'jetpack_full_sync_status' );
+
+		// clear the sync cron.
+		wp_clear_scheduled_hook( 'jetpack_sync_actions' );
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -31,14 +31,28 @@ require $test_root . '/includes/functions.php';
 function _manually_load_plugin() {
 	require dirname( __FILE__ ) . '/../../jetpack.php';
 }
-tests_add_filter( 'plugins_loaded', '_manually_load_plugin' );
+
+// If we are running the uninstall tests don't load jepack.
+if ( ! ( in_running_uninstall_group() ) ) {
+	tests_add_filter( 'plugins_loaded', '_manually_load_plugin' );
+}
+
+
 
 require $test_root . '/includes/bootstrap.php';
 
+
 // Load the shortcodes module to test properly.
-if ( ! function_exists( 'shortcode_new_to_old_params' ) ) {
+if ( ! function_exists( 'shortcode_new_to_old_params' ) && ! in_running_uninstall_group() ) {
 	require dirname( __FILE__ ) . '/../../modules/shortcodes.php';
+
 }
+
 
 // Load attachment helper methods.
 require dirname( __FILE__ ) . '/attachment_test_case.php';
+
+function in_running_uninstall_group() {
+	global  $argv;
+	return is_array( $argv ) && in_array( '--group=uninstall', $argv );
+}

--- a/tests/php/uninstall/test_uninstall.php
+++ b/tests/php/uninstall/test_uninstall.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Plugin uninstall test case.
+ *
+ * @group uninstall
+ */
+class WP_Test_Unistall_Jetpack extends WP_UnitTestCase {
+
+	public function test_uninstall() {
+		define( 'WP_UNINSTALL_PLUGIN', 'jetpack/jetpack' );
+		$this->assertTrue( file_exists( plugin_dir_path( __FILE__ )  . '../../../' . 'uninstall.php' ) );
+		require plugin_dir_path( __FILE__ )  . '../../../' . 'uninstall.php';
+		$this->assertTrue( defined( 'JETPACK__PLUGIN_DIR' ) );
+
+	}
+
+} // end class

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,3 +24,39 @@ delete_option( 'jetpack_do_activate'    );
 delete_option( 'jetpack_was_activated'  );
 delete_option( 'jetpack_auto_installed' );
 delete_transient( 'jetpack_register'    );
+
+// Jetpack Sync
+/**
+ * Remove the sync queue
+ */
+function jetpack_remove_sync_queue() {
+	global $wpdb;
+	$wpdb->query( $wpdb->prepare(
+		"DELETE FROM $wpdb->options WHERE option_name LIKE %s", "jpsq_sync-%"
+	);
+}
+
+/**
+ * Remove the default sync settings
+ */
+function jetpack_remove_sync_settings() {
+	$valid_settings = array( 'dequeue_max_bytes' => true, 'upload_max_bytes' => true, 'upload_max_rows' => true, 'sync_wait_time' => true );
+	$settings_prefix = 'jetpack_sync_settings_';
+	foreach( $valid_settings as $option => $value ) {
+		delete_option( $settings_prefix . $option );
+	}
+}
+
+delete_option( 'jetpack_full_sync_status' );
+delete_option( 'jetpack_constants_sync_checksum' );
+delete_option( 'jetpack_callables_sync_checksum' );
+
+delete_option( 'jetpack_sync_min_wait' );
+delete_option( 'jetpack_sync_constants_await' );
+delete_option( 'jetpack_sync_callables_await' );
+
+delete_transient( 'jetpack_sync_callables_await' );
+delete_transient( 'jetpack_sync_constants_await' );
+
+jetpack_remove_sync_settings();
+jetpack_remove_sync_queue();

--- a/uninstall.php
+++ b/uninstall.php
@@ -2,14 +2,16 @@
 
 if (
 	!defined( 'WP_UNINSTALL_PLUGIN' )
-||
+	||
 	!WP_UNINSTALL_PLUGIN
-||
+	||
 	dirname( WP_UNINSTALL_PLUGIN ) != dirname( plugin_basename( __FILE__ ) )
 ) {
 	status_header( 404 );
 	exit;
 }
+
+define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ )  );
 
 // Delete all compact options
 delete_option( 'jetpack_options'        );
@@ -26,37 +28,5 @@ delete_option( 'jetpack_auto_installed' );
 delete_transient( 'jetpack_register'    );
 
 // Jetpack Sync
-/**
- * Remove the sync queue
- */
-function jetpack_remove_sync_queue() {
-	global $wpdb;
-	$wpdb->query( $wpdb->prepare(
-		"DELETE FROM $wpdb->options WHERE option_name LIKE %s", "jpsq_sync-%"
-	);
-}
-
-/**
- * Remove the default sync settings
- */
-function jetpack_remove_sync_settings() {
-	$valid_settings = array( 'dequeue_max_bytes' => true, 'upload_max_bytes' => true, 'upload_max_rows' => true, 'sync_wait_time' => true );
-	$settings_prefix = 'jetpack_sync_settings_';
-	foreach( $valid_settings as $option => $value ) {
-		delete_option( $settings_prefix . $option );
-	}
-}
-
-delete_option( 'jetpack_full_sync_status' );
-delete_option( 'jetpack_constants_sync_checksum' );
-delete_option( 'jetpack_callables_sync_checksum' );
-
-delete_option( 'jetpack_sync_min_wait' );
-delete_option( 'jetpack_sync_constants_await' );
-delete_option( 'jetpack_sync_callables_await' );
-
-delete_transient( 'jetpack_sync_callables_await' );
-delete_transient( 'jetpack_sync_constants_await' );
-
-jetpack_remove_sync_settings();
-jetpack_remove_sync_queue();
+require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-client.php';
+Jetpack_Sync_Client::getInstance()->uninstall();


### PR DESCRIPTION
We should clean up any options in the DB as a result of the new sync process. 
This PR Makes sure that we delete any options, transients and the queue on deletion of Jetpack.

-------------------
To test: 
Do a full sync of Jetpack which should generate all the options. 
Then delete the Jetpack via the admin. 
All the options should be gone that were added as a result of Jetpack Sync. 

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

