### PR TITLE
Debugger: Avoid a 301

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -6,7 +6,7 @@ class Jetpack_Debugger {
 
 	private static function is_jetpack_support_open() {
 		try {
-			$url = add_query_arg( 'ver', JETPACK__VERSION, 'https://jetpack.com/is-support-open' );
+			$url = add_query_arg( 'ver', JETPACK__VERSION, 'https://jetpack.com/is-support-open/' );
 			$response = wp_remote_request( esc_url_raw( $url ) );
 			if ( is_wp_error( $response ) ) {
 				return false;


### PR DESCRIPTION
```
curl -I https://jetpack.com/is-support-open
HTTP/1.1 301 Moved Permanently
Location: https://jetpack.com/is-support-open/
X-ac: 3.dca _dca
```