### PR TITLE
Update/add sync constants tests

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -89,4 +89,22 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( $value, $this->server_replica_storage->get_callable( $name ), 'Function '. $name .' didn\'t have the expected value of ' . json_encode( $value ) );
 	}
 
+
+	function test_white_listed_callables_doesnt_get_synced_twice() {
+		delete_transient( $this->client::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( $this->client::CALLABLES_CHECKSUM_OPTION_NAME );
+		$this->client->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable' ) );
+		$this->client->do_sync();
+
+		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
+		$this->assertEquals( 'bar', $synced_value );
+
+		$this->server_replica_storage->reset();
+
+		delete_transient( $this->client::CALLABLES_AWAIT_TRANSIENT_NAME );
+		$this->client->do_sync();
+
+		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
+	}
+
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -91,8 +91,8 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 
 
 	function test_white_listed_callables_doesnt_get_synced_twice() {
-		delete_transient( $this->client::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_option( $this->client::CALLABLES_CHECKSUM_OPTION_NAME );
+		delete_transient( Jetpack_Sync_Client::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( Jetpack_Sync_Client::CALLABLES_CHECKSUM_OPTION_NAME );
 		$this->client->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable' ) );
 		$this->client->do_sync();
 
@@ -101,7 +101,7 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 
 		$this->server_replica_storage->reset();
 
-		delete_transient( $this->client::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_transient( Jetpack_Sync_Client::CALLABLES_AWAIT_TRANSIENT_NAME );
 		$this->client->do_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'jetpack_foo' ) );

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -60,7 +60,7 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 
 		$this->server_replica_storage->reset();
 		
-		delete_transient( $this->client::CONSTANTS_AWAIT_TRANSIENT_NAME );
+		delete_transient( Jetpack_Sync_Client::CONSTANTS_AWAIT_TRANSIENT_NAME );
 		$this->client->do_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'TEST_ABC' ) );

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -49,4 +49,20 @@ class WP_Test_Jetpack_New_Constants extends WP_Test_Jetpack_New_Sync_Base {
 			$this->assertEquals( null, $this->server_replica_storage->get_constant( $constant ) );
 		}
 	}
+
+	function test_white_listed_constant_doesnt_get_synced_twice() {
+		$this->client->set_constants_whitelist( array( 'TEST_ABC' ) );
+		define( 'TEST_ABC', microtime(true) );
+		$this->client->do_sync();
+
+		$synced_value = $this->server_replica_storage->get_constant( 'TEST_ABC' );
+		$this->assertEquals( TEST_ABC, $synced_value );
+
+		$this->server_replica_storage->reset();
+		
+		delete_transient( $this->client::CONSTANTS_AWAIT_TRANSIENT_NAME );
+		$this->client->do_sync();
+
+		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'TEST_ABC' ) );
+	}
 }


### PR DESCRIPTION
Adding a few more tests for syncing constants and callables. 


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
