### PR TITLE
Widgets/Shortcodes: Twitter Timeline: remove widget ID requirement

### DIFF
--- a/modules/shortcodes/twitter-timeline.php
+++ b/modules/shortcodes/twitter-timeline.php
@@ -1,29 +1,42 @@
 <?php
 add_shortcode( 'twitter-timeline', 'twitter_timeline_shortcode' );
 
-function twitter_timeline_shortcode( $attr ) {
-
+function twitter_timeline_shortcode( $atts ) {
 	$default_atts = array(
 		'username' => '',
 		'id'       => '',
-		'height'   => '282',
 		'width'    => '450',
+		'height'   => '282',
 	);
 
-	$attr = shortcode_atts( $default_atts, $attr, 'twitter-timeline' );
+	$atts = shortcode_atts( $default_atts, $atts, 'twitter-timeline' );
 
-	$attr['username'] = preg_replace( '/[^A-Za-z0-9_]+/', '', $attr['username'] );
+	$atts['username'] = preg_replace( '/[^A-Za-z0-9_]+/', '', $atts['username'] );
 
-	if ( empty( $attr['username'] ) ) {
-		return '<!-- ' . __( 'Invalid Twitter Timeline username', 'jetpack' ) . ' -->';
+	if ( empty( $atts['username'] ) && ! is_numeric( $atts['id'] ) ) {
+		return '<!-- ' . __( 'Must specify Twitter Timeline id or username.', 'jetpack' ) . ' -->';
 	}
 
-	if ( ! is_numeric( $attr['id'] ) ) {
-		return '<!-- ' . __( 'Invalid Twitter Timeline id', 'jetpack' ) . ' -->';
+	$output = '<a class="twitter-timeline"';
+
+	if ( is_numeric( $atts['width'] ) ) {
+		$output .= ' data-width="' . esc_attr( $atts['width'] ) . '"';
+	}
+	if ( is_numeric( $atts['height'] ) ) {
+		$output .= ' data-height="' . esc_attr( $atts['height'] ) . '"';
+	}
+	if ( is_numeric( $atts['id'] ) ) {
+		$output .= ' data-widget-id="' . esc_attr( $atts['id'] ) . '"';
+	}
+	if ( ! empty( $atts['username'] ) ) {
+		$output .= ' href="' . esc_url( 'https://twitter.com/' . $atts['username'] ) . '"';
 	}
 
-	$tweets_by = sprintf( __( 'Tweets by @%s', 'jetpack' ), $attr['username'] );
-	$output    = '<a class="twitter-timeline" width="' . esc_attr( $attr['width'] ) . '" height="' . esc_attr( $attr['height'] ) . '" href="' . esc_url( 'https://twitter.com/' . $attr['username'] ) . '/" data-widget-id="' . esc_attr( $attr['id'] ) . '">' . esc_html( $tweets_by ) . '</a>';
+	$output .= '>';
+
+	$output .= sprintf( __( 'Tweets by @%s', 'jetpack' ), $atts['username'] );
+
+	$output .= '</a>';
 
 	wp_enqueue_script( 'jetpack-twitter-timeline' );
 

--- a/modules/widgets/twitter-timeline-admin.js
+++ b/modules/widgets/twitter-timeline-admin.js
@@ -1,0 +1,35 @@
+jQuery( function( $ ) {
+	function twitterWidgetTypeChanged( widgetTypeSelector ) {
+		var selectedType = $( widgetTypeSelector ).val();
+		$( widgetTypeSelector )
+			.closest( '.jetpack-twitter-timeline-widget-type-container' )
+			.next( '.jetpack-twitter-timeline-widget-id-container' )
+			.find( 'label' )
+			.css( 'display', function() {
+				var labelType = $( this ).data( 'widget-type' );
+				if ( selectedType === labelType ) {
+					return '';
+				} else {
+					return 'none';
+				}
+			} );
+	}
+
+	// We could either be in wp-admin/widgets.php or the Customizer.
+	var $container = $( '#customize-controls' );
+	if ( ! $container.length ) {
+		$container = $( '#wpbody' );
+	}
+
+	// Observe widget settings for 'change' events of the 'type' property for
+	// current and future Twitter timeline widgets.
+	$container.on( 'change', '.jetpack-twitter-timeline-widget-type', function() {
+		twitterWidgetTypeChanged( this );
+	} );
+
+	// Set the labels for currently existing widgets (including the "template"
+	// version that is copied when a new widget is added).
+	$container.find( '.jetpack-twitter-timeline-widget-type' ).each( function() {
+		twitterWidgetTypeChanged( this );
+	} );
+} );

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -109,7 +109,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			echo ' data-chrome="' . esc_attr( join( ' ', $instance['chrome'] ) ) . '"';
 		}
 
-		switch ( $instance['type'] ) {
+		$type = ( isset( $instance['type'] ) ? $instance['type'] : '' );
+		switch ( $type ) {
 			case 'profile':
 				echo ' href="https://twitter.com/' . esc_attr( $instance['widget-id'] ) . '"';
 				break;

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -1,8 +1,11 @@
 <?php
 
 /*
- * Based on Evolution Twitter Timeline (http://wordpress.org/extend/plugins/evolution-twitter-timeline/)
- * See: https://twitter.com/settings/widgets and https://dev.twitter.com/docs/embedded-timelines for details on Twitter Timelines
+ * Based on Evolution Twitter Timeline
+ * (http://wordpress.org/extend/plugins/evolution-twitter-timeline/)
+ * For details on Twitter Timelines see:
+ *  - https://twitter.com/settings/widgets
+ *  - https://dev.twitter.com/docs/embedded-timelines
  */
 
 /**
@@ -16,8 +19,8 @@ function jetpack_twitter_timeline_widget_init() {
 
 class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	/**
-	* Register widget with WordPress.
-	*/
+	 * Register widget with WordPress.
+	 */
 	public function __construct() {
 		parent::__construct(
 			'twitter_timeline',
@@ -33,6 +36,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		}
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 	}
 
 	/**
@@ -53,6 +58,16 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Enqueue script to improve admin UI
+	 */
+	public function admin_scripts( $hook ) {
+		// This is still 'widgets.php' when managing widgets via the Customizer.
+		if ( 'widgets.php' === $hook ) {
+			wp_enqueue_script( 'twitter-timeline-admin', plugins_url( 'twitter-timeline-admin.js', __FILE__ ) );
+		}
+	}
+
+	/**
 	 * Front-end display of widget.
 	 *
 	 * @see WP_Widget::widget()
@@ -61,7 +76,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	 * @param array $instance Saved values from database.
 	 */
 	public function widget( $args, $instance ) {
-		$instance['lang']  = substr( strtoupper( get_locale() ), 0, 2 );
+		$instance['lang'] = substr( strtoupper( get_locale() ), 0, 2 );
 
 		echo $args['before_widget'];
 
@@ -70,29 +85,41 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			echo $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'];
 		}
 
-		$data_attribs = array( 'widget-id', 'theme', 'link-color', 'border-color', 'chrome', 'tweet-limit' );
-		$attribs      = array( 'width', 'height', 'lang' );
-
 		// Start tag output
+		// This tag is transformed into the widget markup by Twitter's
+		// widgets.js code
 		echo '<a class="twitter-timeline"';
 
+		$data_attribs = array(
+			'width',
+			'height',
+			'theme',
+			'link-color',
+			'border-color',
+			'tweet-limit',
+			'lang'
+		);
 		foreach ( $data_attribs as $att ) {
-			if ( !empty( $instance[$att] ) ) {
-				if ( 'tweet-limit' == $att && 0 === $instance[$att] )
-					continue;
-
-				if ( is_array( $instance[$att] ) )
-					echo ' data-' . esc_attr( $att ) . '="' . esc_attr( join( ' ', $instance['chrome'] ) ) . '"';
-				else
-					echo ' data-' . esc_attr( $att ) . '="' . esc_attr( $instance[$att] ) . '"';
+			if ( ! empty( $instance[ $att ] ) && ! is_array( $instance[ $att ] ) ) {
+				echo ' data-' . esc_attr( $att ) . '="' . esc_attr( $instance[ $att ] ) . '"';
 			}
 		}
 
-		foreach ( $attribs as $att ) {
-			if ( !empty( $instance[$att] ) )
-				echo ' ' . esc_attr( $att ) . '="' . esc_attr( $instance[$att] ) . '"';
+		if ( ! empty( $instance['chrome'] ) && is_array( $instance['chrome'] ) ) {
+			echo ' data-chrome="' . esc_attr( join( ' ', $instance['chrome'] ) ) . '"';
 		}
 
+		switch ( $instance['type'] ) {
+			case 'profile':
+				echo ' href="https://twitter.com/' . esc_attr( $instance['widget-id'] ) . '"';
+				break;
+			case 'widget-id':
+			default:
+				echo ' data-widget-id="' . esc_attr( $instance['widget-id'] ) . '"';
+				break;
+		}
+
+		// End tag output
 		echo '>';
 
 		$timeline_placeholder = __( 'My Tweets', 'jetpack' );
@@ -130,41 +157,71 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	 * @return array Updated safe values to be saved.
 	 */
 	public function update( $new_instance, $old_instance ) {
-		$hex_regex             = '/#([a-f]|[A-F]|[0-9]){3}(([a-f]|[A-F]|[0-9]){3})?\b/';
-		$instance                  = array();
-		$instance['title']         = sanitize_text_field( $new_instance['title'] );
-		$instance['width']         = (int) $new_instance['width'];
-		$instance['height']        = (int) $new_instance['height'];
-		$instance['width']         = ( 0 !== (int) $new_instance['width'] )  ? (int) $new_instance['width']  : '';
-		$instance['height']        = ( 0 !== (int) $new_instance['height'] ) ? (int) $new_instance['height'] : '';
-		$instance['tweet-limit']   = ( 0 !== (int) $new_instance['tweet-limit'] ) ? (int) $new_instance['tweet-limit'] : null;
+		$instance = array();
+
+		$instance['title'] = sanitize_text_field( $new_instance['title'] );
+
+		$width = (int) $new_instance['width'];
+		if ( $width ) {
+			// From publish.twitter.com: 220 <= width <= 1200
+			$instance['width'] = min( max( $width, 220 ), 1200 );
+		} else {
+			$instance['width'] = '';
+		}
+
+		$height = (int) $new_instance['height'];
+		if ( $height ) {
+			// From publish.twitter.com: height >= 200
+			$instance['height'] = max( $height, 200 );
+		} else {
+			$instance['height'] = '';
+		}
+
+		$tweet_limit = (int) $new_instance['tweet-limit'];
+		$instance['tweet-limit'] = ( $tweet_limit ? $tweet_limit : null );
 
 		// If they entered something that might be a full URL, try to parse it out
 		if ( is_string( $new_instance['widget-id'] ) ) {
-			if ( preg_match( '#https?://twitter\.com/settings/widgets/(\d+)#s', $new_instance['widget-id'], $matches ) ) {
+			if ( preg_match(
+				'#https?://twitter\.com/settings/widgets/(\d+)#s',
+				$new_instance['widget-id'],
+				$matches
+			) ) {
 				$new_instance['widget-id'] = $matches[1];
 			}
 		}
 
 		$instance['widget-id'] = sanitize_text_field( $new_instance['widget-id'] );
-		$instance['widget-id'] = is_numeric( $instance['widget-id'] ) ? $instance['widget-id'] : '';
 
+		$hex_regex = '/#([a-f]|[A-F]|[0-9]){3}(([a-f]|[A-F]|[0-9]){3})?\b/';
 		foreach ( array( 'link-color', 'border-color' ) as $color ) {
-			$new_color = sanitize_text_field( $new_instance[$color] );
+			$new_color = sanitize_text_field( $new_instance[ $color ] );
 			if ( preg_match( $hex_regex, $new_color ) ) {
-				$instance[$color] = $new_color;
+				$instance[ $color ] = $new_color;
 			}
 
 		}
 
+		$instance['type'] = 'widget-id';
+		if ( in_array( $new_instance['type'], array( 'widget-id', 'profile' ) ) ) {
+			$instance['type'] = $new_instance['type'];
+		}
+
 		$instance['theme'] = 'light';
-		if ( in_array( $new_instance['theme'], array( 'light', 'dark' ) ) )
+		if ( in_array( $new_instance['theme'], array( 'light', 'dark' ) ) ) {
 			$instance['theme'] = $new_instance['theme'];
+		}
 
 		$instance['chrome'] = array();
+		$chrome_settings = array(
+			'noheader',
+			'nofooter',
+			'noborders',
+			'transparent'
+		);
 		if ( isset( $new_instance['chrome'] ) ) {
 			foreach ( $new_instance['chrome'] as $chrome ) {
-				if ( in_array( $chrome, array( 'noheader', 'nofooter', 'noborders', 'noscrollbar', 'transparent' ) ) ) {
+				if ( in_array( $chrome, $chrome_settings ) ) {
 					$instance['chrome'][] = $chrome;
 				}
 			}
@@ -173,6 +230,18 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		return $instance;
 	}
 
+	/**
+ 	 * Returns a link to the documentation for a feature of this widget on
+ 	 * Jetpack or WordPress.com.
+ 	 */
+	public function get_docs_link( $hash = '' ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$base_url = 'https://support.wordpress.com/widgets/twitter-timeline-widget/';
+		} else {
+			$base_url = 'https://jetpack.com/support/extra-sidebar-widgets/twitter-timeline-widget/';
+		}
+		return '<a href="' . $base_url . $hash . '" target="_blank">( ? )</a>';
+	}
 
 	/**
 	 * Back-end widget form.
@@ -195,68 +264,203 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		);
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
+
+		if ( empty( $instance['type'] ) ) {
+			// Decide the correct widget type.  If this is a pre-existing
+			// widget with a numeric widget ID, then the type should be
+			// 'widget-id', otherwise it should be 'profile'.
+			if ( ! empty( $instance['widget-id'] ) && is_numeric( $instance['widget-id'] ) ) {
+				$instance['type'] = 'widget-id';
+			} else {
+				$instance['type'] = 'profile';
+			}
+		}
 		?>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>">
+				<?php esc_html_e( 'Title:', 'jetpack' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo $this->get_field_id( 'title' ); ?>"
+				name="<?php echo $this->get_field_name( 'title' ); ?>"
+				type="text"
+				value="<?php echo esc_attr( $instance['title'] ); ?>"
+			/>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'width' ); ?>"><?php esc_html_e( 'Maximum Width (px):', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'width' ); ?>" name="<?php echo $this->get_field_name( 'width' ); ?>" type="text" value="<?php echo esc_attr( $instance['width'] ); ?>" />
-		</p>
-
-		 <p>
-			<label for="<?php echo $this->get_field_id( 'height' ); ?>"><?php esc_html_e( 'Height (px):', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'height' ); ?>" name="<?php echo $this->get_field_name( 'height' ); ?>" type="text" value="<?php echo esc_attr( $instance['height'] ); ?>" />
-		</p>
-
-		<p>
-			<label for="<?php echo $this->get_field_id( 'tweet-limit' ); ?>"><?php esc_html_e( '# of Tweets Shown:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'tweet-limit' ); ?>" name="<?php echo $this->get_field_name( 'tweet-limit' ); ?>" type="number" min="1" max="20" value="<?php echo esc_attr( $instance['tweet-limit'] ); ?>" />
-		</p>
-
-		<p><small>
-			<?php
-			echo wp_kses_post(
-				sprintf(
-					__( 'You need to <a href="%1$s" target="_blank">create a widget at Twitter.com</a>, and then enter your widget id (the long number found in the URL of your widget\'s config page) in the field below. <a href="%2$s" target="_blank">Read more</a>.', 'jetpack' ),
-					'https://twitter.com/settings/widgets/new/user',
-					'http://support.wordpress.com/widgets/twitter-timeline-widget/'
-				)
-			);
-			?>
-		</small></p>
-		<p>
-			<label for="<?php echo $this->get_field_id( 'widget-id' ); ?>"><?php esc_html_e( 'Widget ID:', 'jetpack' ); ?> <a href="http://support.wordpress.com/widgets/twitter-timeline-widget/#widget-id" target="_blank">( ? )</a></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'widget-id' ); ?>" name="<?php echo $this->get_field_name( 'widget-id' ); ?>" type="text" value="<?php echo esc_attr( $instance['widget-id'] ); ?>" />
+			<label for="<?php echo $this->get_field_id( 'width' ); ?>">
+				<?php esc_html_e( 'Maximum Width (px; 220 to 1200):', 'jetpack' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo $this->get_field_id( 'width' ); ?>"
+				name="<?php echo $this->get_field_name( 'width' ); ?>"
+				type="number" min="220" max="1200"
+				value="<?php echo esc_attr( $instance['width'] ); ?>"
+			/>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'chrome-noheader' ); ?>"><?php esc_html_e( 'Layout Options:', 'jetpack' ); ?></label><br />
-			<input type="checkbox"<?php checked( in_array( 'noheader', $instance['chrome'] ) ); ?> id="<?php echo $this->get_field_id( 'chrome-noheader' ); ?>" name="<?php echo $this->get_field_name( 'chrome' ); ?>[]" value="noheader" /> <label for="<?php echo $this->get_field_id( 'chrome-noheader' ); ?>"><?php esc_html_e( 'No Header', 'jetpack' ); ?></label><br />
-			<input type="checkbox"<?php checked( in_array( 'nofooter', $instance['chrome'] ) ); ?> id="<?php echo $this->get_field_id( 'chrome-nofooter' ); ?>" name="<?php echo $this->get_field_name( 'chrome' ); ?>[]" value="nofooter" /> <label for="<?php echo $this->get_field_id( 'chrome-nofooter' ); ?>"><?php esc_html_e( 'No Footer', 'jetpack' ); ?></label><br />
-			<input type="checkbox"<?php checked( in_array( 'noborders', $instance['chrome'] ) ); ?> id="<?php echo $this->get_field_id( 'chrome-noborders' ); ?>" name="<?php echo $this->get_field_name( 'chrome' ); ?>[]" value="noborders" /> <label for="<?php echo $this->get_field_id( 'chrome-noborders' ); ?>"><?php esc_html_e( 'No Borders', 'jetpack' ); ?></label><br />
-			<input type="checkbox"<?php checked( in_array( 'noscrollbar', $instance['chrome'] ) ); ?> id="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>" name="<?php echo $this->get_field_name( 'chrome' ); ?>[]" value="noscrollbar" /> <label for="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>"><?php esc_html_e( 'No Scrollbar', 'jetpack' ); ?></label><br />
-			<input type="checkbox"<?php checked( in_array( 'transparent', $instance['chrome'] ) ); ?> id="<?php echo $this->get_field_id( 'chrome-transparent' ); ?>" name="<?php echo $this->get_field_name( 'chrome' ); ?>[]" value="transparent" /> <label for="<?php echo $this->get_field_id( 'chrome-transparent' ); ?>"><?php esc_html_e( 'Transparent Background', 'jetpack' ); ?></label>
+			<label for="<?php echo $this->get_field_id( 'height' ); ?>">
+				<?php esc_html_e( 'Height (px; at least 200):', 'jetpack' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo $this->get_field_id( 'height' ); ?>"
+				name="<?php echo $this->get_field_name( 'height' ); ?>"
+				type="number" min="200"
+				value="<?php echo esc_attr( $instance['height'] ); ?>"
+			/>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'link-color' ); ?>"><?php _e( 'Link Color (hex):', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'link-color' ); ?>" name="<?php echo $this->get_field_name( 'link-color' ); ?>" type="text" value="<?php echo esc_attr( $instance['link-color'] ); ?>" />
+			<label for="<?php echo $this->get_field_id( 'tweet-limit' ); ?>">
+				<?php esc_html_e( '# of Tweets Shown:', 'jetpack' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo $this->get_field_id( 'tweet-limit' ); ?>"
+				name="<?php echo $this->get_field_name( 'tweet-limit' ); ?>"
+				type="number" min="1" max="20"
+				value="<?php echo esc_attr( $instance['tweet-limit'] ); ?>"
+			/>
+		</p>
+
+		<p class="jetpack-twitter-timeline-widget-type-container">
+			<label for="<?php echo $this->get_field_id( 'type' ); ?>">
+				<?php esc_html_e( 'Widget Type:', 'jetpack' ); ?>
+				<?php echo $this->get_docs_link( '#widget-type' ); ?>
+			</label>
+			<select
+				name="<?php echo $this->get_field_name( 'type' ); ?>"
+				id="<?php echo $this->get_field_id( 'type' ); ?>"
+				class="jetpack-twitter-timeline-widget-type widefat"
+			>
+				<option value="profile"<?php selected( $instance['type'], 'profile' ); ?>>
+					<?php esc_html_e( 'Profile', 'jetpack' ); ?>
+				</option>
+				<option value="widget-id"<?php selected( $instance['type'], 'widget-id' ); ?>>
+					<?php esc_html_e( 'Widget ID', 'jetpack' ); ?>
+				</option>
+			</select>
+		</p>
+
+		<p class="jetpack-twitter-timeline-widget-id-container">
+			<label
+				for="<?php echo $this->get_field_id( 'widget-id' ); ?>"
+				data-widget-type="widget-id"
+				<?php echo ( 'widget-id' === $instance['type'] ? '' : 'style="display: none;"' ); ?>
+			>
+				<?php esc_html_e( 'Widget ID:', 'jetpack' ); ?>
+				<?php echo $this->get_docs_link( '#widget-id' ); ?>
+			</label>
+			<label
+				for="<?php echo $this->get_field_id( 'widget-id' ); ?>"
+				data-widget-type="profile"
+				<?php echo ( 'profile' === $instance['type'] ? '' : 'style="display: none;"' ); ?>
+			>
+				<?php esc_html_e( 'Twitter Username:', 'jetpack' ); ?>
+				<?php echo $this->get_docs_link( '#twitter-username' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo $this->get_field_id( 'widget-id' ); ?>"
+				name="<?php echo $this->get_field_name( 'widget-id' ); ?>"
+				type="text"
+				value="<?php echo esc_attr( $instance['widget-id'] ); ?>"
+			/>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'border-color' ); ?>"><?php _e( 'Border Color (hex):', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'border-color' ); ?>" name="<?php echo $this->get_field_name( 'border-color' ); ?>" type="text" value="<?php echo esc_attr( $instance['border-color'] ); ?>" />
+			<label for="<?php echo $this->get_field_id( 'chrome-noheader' ); ?>">
+				<?php esc_html_e( 'Layout Options:', 'jetpack' ); ?>
+			</label>
+			<br />
+			<input
+				type="checkbox"<?php checked( in_array( 'noheader', $instance['chrome'] ) ); ?>
+				id="<?php echo $this->get_field_id( 'chrome-noheader' ); ?>"
+				name="<?php echo $this->get_field_name( 'chrome' ); ?>[]"
+				value="noheader"
+			/>
+			<label for="<?php echo $this->get_field_id( 'chrome-noheader' ); ?>">
+				<?php esc_html_e( 'No Header', 'jetpack' ); ?>
+			</label>
+			<br />
+			<input
+				type="checkbox"<?php checked( in_array( 'nofooter', $instance['chrome'] ) ); ?>
+				id="<?php echo $this->get_field_id( 'chrome-nofooter' ); ?>"
+				name="<?php echo $this->get_field_name( 'chrome' ); ?>[]"
+				value="nofooter"
+			/>
+			<label for="<?php echo $this->get_field_id( 'chrome-nofooter' ); ?>">
+				<?php esc_html_e( 'No Footer', 'jetpack' ); ?>
+			</label>
+			<br />
+			<input
+				type="checkbox"<?php checked( in_array( 'noborders', $instance['chrome'] ) ); ?>
+				id="<?php echo $this->get_field_id( 'chrome-noborders' ); ?>"
+				name="<?php echo $this->get_field_name( 'chrome' ); ?>[]"
+				value="noborders"
+			/>
+			<label for="<?php echo $this->get_field_id( 'chrome-noborders' ); ?>">
+				<?php esc_html_e( 'No Borders', 'jetpack' ); ?>
+			</label>
+			<br />
+			<input
+				type="checkbox"<?php checked( in_array( 'transparent', $instance['chrome'] ) ); ?>
+				id="<?php echo $this->get_field_id( 'chrome-transparent' ); ?>"
+				name="<?php echo $this->get_field_name( 'chrome' ); ?>[]"
+				value="transparent"
+			/>
+			<label for="<?php echo $this->get_field_id( 'chrome-transparent' ); ?>">
+				<?php esc_html_e( 'Transparent Background', 'jetpack' ); ?>
+			</label>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'theme' ); ?>"><?php _e( 'Timeline Theme:', 'jetpack' ); ?></label>
-			<select name="<?php echo $this->get_field_name( 'theme' ); ?>" id="<?php echo $this->get_field_id( 'theme' ); ?>" class="widefat">
-				<option value="light"<?php selected( $instance['theme'], 'light' ); ?>><?php esc_html_e( 'Light', 'jetpack' ); ?></option>
-				<option value="dark"<?php selected( $instance['theme'], 'dark' ); ?>><?php esc_html_e( 'Dark', 'jetpack' ); ?></option>
+			<label for="<?php echo $this->get_field_id( 'link-color' ); ?>">
+				<?php _e( 'Link Color (hex):', 'jetpack' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo $this->get_field_id( 'link-color' ); ?>"
+				name="<?php echo $this->get_field_name( 'link-color' ); ?>"
+				type="text"
+				value="<?php echo esc_attr( $instance['link-color'] ); ?>"
+			/>
+		</p>
+
+		<p>
+			<label for="<?php echo $this->get_field_id( 'border-color' ); ?>">
+				<?php _e( 'Border Color (hex):', 'jetpack' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo $this->get_field_id( 'border-color' ); ?>"
+				name="<?php echo $this->get_field_name( 'border-color' ); ?>"
+				type="text"
+				value="<?php echo esc_attr( $instance['border-color'] ); ?>"
+			/>
+		</p>
+
+		<p>
+			<label for="<?php echo $this->get_field_id( 'theme' ); ?>">
+				<?php _e( 'Timeline Theme:', 'jetpack' ); ?>
+			</label>
+			<select
+				name="<?php echo $this->get_field_name( 'theme' ); ?>"
+				id="<?php echo $this->get_field_id( 'theme' ); ?>"
+				class="widefat"
+			>
+				<option value="light"<?php selected( $instance['theme'], 'light' ); ?>>
+					<?php esc_html_e( 'Light', 'jetpack' ); ?>
+				</option>
+				<option value="dark"<?php selected( $instance['theme'], 'dark' ); ?>>
+					<?php esc_html_e( 'Dark', 'jetpack' ); ?>
+				</option>
 			</select>
 		</p>
 	<?php


### PR DESCRIPTION
This PR updates the Twitter Timeline widget and shortcode to no loner require a Twitter widget ID, per #3993.

Also contains lots of miscellaneous cleanup to this code, including:

- Added validation and documentation of width and height constraints (determined from playing around with the interface at publish.twitter.com)
- Tried to clean up long lines of HTML/PHP soup
- Removed "No Scrollbar" option which is not working for me

Closes #3993; also closes #3283 by moving the `width` and `height` attributes as follows:

```diff
- <a width="..." height="...">
+ <a data-width="..." data-height="...">
```

### To test - Widget

**Before** applying this patch, add a Twitter timeline widget to your site. Here is a widget ID you can use to show tweets about corgis - `741284449141334020`

Apply the patch and test the following:

- Existing timeline widgets display correctly on the site and in the admin settings (type should be set to "Widget ID")
- New timeline widgets are added with type set to "Profile", and display correctly on the site when a Twitter username is entered
- Changing the type of the widget changes the label of the next field to either "Twitter Username" or "Widget ID" (and this label loads correctly for existing widgets)

Test configuring the widget in both `wp-admin/widgets.php` and the Customizer.  Ensure that all settings still work, and that the new validation for `width` and `height` works correctly.

### To test - Shortcode

To test the `[twitter-timeline]` shortcode, specify either the `username` parameter (now supported without a widget ID) or the `id` parameter with an existing Twitter widget ID (now supported without a username, because the widget ID overrides the username anyway).

### More info

The new features of the Twitter widget and shortcode are documented at https://en.support.wordpress.com/widgets/twitter-timeline-widget/ .  Note that there are 3 places where the widget settings will link to the Jetpack documentation page:

- https://jetpack.com/support/extra-sidebar-widgets/twitter-timeline-widget/#widget-type
- https://jetpack.com/support/extra-sidebar-widgets/twitter-timeline-widget/#twitter-username
- https://jetpack.com/support/extra-sidebar-widgets/twitter-timeline-widget/#widget-id

The Jetpack documentation page should be updated to be similar to the WordPress.com page when these changes go live.

The changes introduced here have been deployed on WordPress.com, but this PR does not quite bring the Twitter Timeline widget into sync with WP.com because of #3543.  Per https://github.com/Automattic/jetpack/pull/3543#issuecomment-200037364 there is still some work left to do by the Jetpack team to merge these changes back.

cc @westonruter - I don't understand the selective refresh changes in #3543 very well and would like to make sure I didn't break anything introduced there.