### PR TITLE
Add test that show we sync allowed_mime_types.

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -472,7 +472,7 @@ class Jetpack_Sync_Client {
 
 	public function sanitize_user( $user ) {
 		unset( $user->data->user_pass );
-
+		$user->allowed_mime_types = get_allowed_mime_types( $user );
 		return $user;
 	}
 

--- a/sync/class.jetpack-sync-full.php
+++ b/sync/class.jetpack-sync-full.php
@@ -286,7 +286,7 @@ class Jetpack_Sync_Full {
 
 	public function expand_users( $args ) {
 		$user_ids = $args[0];
-		return array_map( array( $this->get_client(), 'sanitize_user' ), get_users( array( 'include' => $user_ids ) ) );
+		return array_map( array( $this->get_client(), 'sanitize_user_and_expand' ), get_users( array( 'include' => $user_ids ) ) );
 	}
 
 	public function expand_network_options( $args ) {

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -551,6 +551,10 @@ ENDSQL;
 		// TODO: Implement upsert_plugins() method.
 	}
 
+	public function get_allowed_mime_types( $user_id ) {
+		
+	}
+
 	public function checksum_all() {
 		return array(
 			'posts'    => $this->posts_checksum(),

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -114,9 +114,13 @@ interface iJetpack_Sync_Replicastore {
 
 	public function delete_user( $user_id );
 
+	public function get_allowed_mime_types( $user_id );
+
+
 	// plugins
 	public function get_plugins();
 	public function upsert_plugins( $plugins );
+
 
 	// full checksum
 	public function checksum_all();

--- a/tests/php/sync/server/class.jetpack-sync-test-object-factory.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-object-factory.php
@@ -105,6 +105,7 @@ class JetpackSyncTestObjectFactory {
 				'user_email'      => "$username@example.com",
 				'user_registered' => $now,
 				'display_name'    => $username,
+				'allowed_mime_types' => array( 'jpg|jpeg|jpe' => 'image/jpeg', 'gif' => 'image/gif' )
 			)
 		);
 

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -445,8 +445,15 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 	
 	function upsert_user( $user ) {
-		$this->allowed_mime_types[ $user->ID ] = $user->allowed_mime_types;
-		unset( $user->allowed_mime_types );
+		if ( isset( $user->allowed_mime_types ) ) {
+			$this->allowed_mime_types[ $user->ID ] = $user->allowed_mime_types;
+			unset( $user->allowed_mime_types );
+		}
+		// when doing a full sync
+		if ( isset( $user->data->allowed_mime_types ) ) {
+			$this->allowed_mime_types[ $user->ID ] = $user->data->allowed_mime_types;
+			unset( $user->data->allowed_mime_types );
+		}
 		$this->users[ $user->ID ] = $user;
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -22,6 +22,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	private $object_terms;
 	private $users;
 	private $plugins;
+	private $allowed_mime_types;
 
 	function __construct() {
 		$this->reset();
@@ -439,7 +440,13 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		return isset( $this->users[ $user_id ] ) ? $this->users[ $user_id ] : null;
 	}
 
+	function get_allowed_mime_types( $user_id ) {
+		return isset( $this->allowed_mime_types[ $user_id ] ) ? $this->allowed_mime_types[ $user_id ] : null;
+	}
+	
 	function upsert_user( $user ) {
+		$this->allowed_mime_types[ $user->ID ] = $user->allowed_mime_types;
+		unset( $user->allowed_mime_types );
 		$this->users[ $user->ID ] = $user;
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -126,6 +126,7 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 
 		$this->assertEquals( 11, $this->server_replica_storage->user_count() );
 		$user = $this->server_replica_storage->get_user( $user_id );
+		$this->assertEquals( get_allowed_mime_types( $user_id ), $this->server_replica_storage->get_allowed_mime_types( $user_id ) );
 		// Lets make sure that we don't send users passwords around.
 		$this->assertFalse( isset( $user->data->user_pass ) );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -211,8 +211,14 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 
 		$client_user = get_user_by( 'id', $this->user_id );
 		unset( $client_user->data->user_pass );
-		$this->assertEqualsObject( $client_user, $server_user );
 
+		$this->assertEqualsObject( $client_user, $server_user );
+	}
+
+	public function test_sync_allowed_file_type() {
+		$user_file_mine_types = get_allowed_mime_types( $this->user_id );
+		$server_user_file_mime_types = $this->server_replica_storage->get_allowed_mime_types( $this->user_id );
+		$this->assertEquals( $user_file_mine_types, $server_user_file_mime_types );
 	}
 
 	protected function assertUsersEqual( $user1, $user2 ) {

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -21,6 +21,10 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 		// make sure that we don't have a password
 		unset( $user->data->user_pass );
 		$this->assertFalse(  isset( $server_user->data->user_pass ) );
+
+		// The regular user object doesn't have allowed_mime_types
+		unset( $server_user->data->allowed_mime_types );
+
 		$this->assertEqualsObject( $user, $server_user );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -216,9 +216,8 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	public function test_sync_allowed_file_type() {
-		$user_file_mine_types = get_allowed_mime_types( $this->user_id );
 		$server_user_file_mime_types = $this->server_replica_storage->get_allowed_mime_types( $this->user_id );
-		$this->assertEquals( $user_file_mine_types, $server_user_file_mime_types );
+		$this->assertEquals( get_allowed_mime_types( $this->user_id ), $server_user_file_mime_types );
 	}
 
 	protected function assertUsersEqual( $user1, $user2 ) {

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -590,6 +590,23 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @dataProvider store_provider
+	 * @requires PHP 5.3
+	 */
+	function test_replica_get_allowed_mime_types( $store ) {
+		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
+			$this->markTestIncomplete("The WP replicastore doesn't support setting users");
+		}
+
+		$this->assertNull( $store->get_user( 12 ) );
+
+		$user = self::$factory->user( 12, 'example_user' );
+		$user_allowed_mime_types = $user->data->allowed_mime_types;
+		$store->upsert_user( $user );
+		$this->assertEquals( $user_allowed_mime_types, $store->get_allowed_mime_types( 12 ) );
+	}
+
+	/**
 	 * Terms
 	 */
 


### PR DESCRIPTION
Currently in calypso we don't have the information regarding what files a user is allowed to upload to a site. file_mime_types are user specific so we need to send the data as attached by attaching it to the user object.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

