### PR TITLE
Hardening.  Use hash_equals() to avoid theoretical timing attacks.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5213,11 +5213,11 @@ p {
 			wp_die( $die_error );
 		} else if ( is_wp_error( $signature ) ) {
 			wp_die( $die_error );
-		} else if ( $signature !== $_GET['signature'] ) {
+		} else if ( ! hash_equals( $signature, $_GET['signature'] ) ) {
 			if ( is_ssl() ) {
 				// If we signed an HTTP request on the Jetpack Servers, but got redirected to HTTPS by the local blog, check the HTTP signature as well
 				$signature = $jetpack_signature->sign_current_request( array( 'scheme' => 'http', 'body' => null, 'method' => 'GET' ) );
-				if ( ! $signature || is_wp_error( $signature ) || $signature !== $_GET['signature'] ) {
+				if ( ! $signature || is_wp_error( $signature ) || ! hash_equals( $signature, $_GET['signature'] ) ) {
 					wp_die( $die_error );
 				}
 			} else {


### PR DESCRIPTION
hash_equals (and it's core polyfill for older versions of PHP) will compare two strings in the same amount of time, without taking short circuits, so as to not tip off potential attackers to partial matches based on evaluation time.