### PR TITLE
Fix undefined array indices while updating comments via API

### DIFF
--- a/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -81,6 +81,8 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 				&&
 					isset( $this->api->token_details['user'] )
 				&&
+					isset( $this->api->token_details['user']['user_email'] )
+				&&
 					$this->api->token_details['user']['user_email'] === $comment->comment_author_email
 				&&
 					$this->api->token_details['user']['display_name'] === $comment->comment_author

--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -168,7 +168,7 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 		}
 
 		$comment_status = wp_get_comment_status( $comment->comment_ID );
-		if ( $comment_status !== $update['status'] && !current_user_can( 'moderate_comments' ) ) {
+		if ( $comment_status !== $update['comment_status'] && !current_user_can( 'moderate_comments' ) ) {
 			return new WP_Error( 'unauthorized', 'User cannot moderate comments', 403 );
 		}
 


### PR DESCRIPTION
Fixes #3687

Fixes a bug checking for comment privileges, and ensures an array index exists when checking if an authenticated user can read a comment.