### PR TITLE
Travis: Add Multisite tests to the automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,13 @@ matrix:
     env: WP_VERSION=4.5
   - php: "7.0"
     env: WP_VERSION=master
+  - php: "5.2"
+    env: WP_VERSION=4.4 WP_TRAVIS="phpunit -c tests/php.multisite.xml"
+  - php: "5.2"
+    env: WP_VERSION=4.5 WP_TRAVIS="phpunit -c tests/php.multisite.xml"
+  - php: "5.2"
+    env: WP_VERSION=master WP_TRAVIS="phpunit -c tests/php.multisite.xml"
+
 
   allow_failures:
   - php: "hhvm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ matrix:
     env: WP_VERSION=4.5 WP_TRAVISCI="npm run test-client"
   - php: "5.2"
     env: WP_VERSION=master
-  - php: "5.2"
-    env: WP_VERSION=master WP_TRAVIS="phpunit --group=uninstall --testsuite=uninstall"
+  - php: "5.3"
+    env: WP_VERSION=master WP_TRAVISCI="phpunit --group=uninstall --testsuite=uninstall"
   - php: "5.2"
     env: WP_VERSION=4.4
   - php: "5.2"
@@ -65,12 +65,12 @@ matrix:
     env: WP_VERSION=4.5
   - php: "7.0"
     env: WP_VERSION=master
-  - php: "5.2"
-    env: WP_VERSION=4.4 WP_TRAVIS="phpunit -c tests/php.multisite.xml"
-  - php: "5.2"
-    env: WP_VERSION=4.5 WP_TRAVIS="phpunit -c tests/php.multisite.xml"
-  - php: "5.2"
-    env: WP_VERSION=master WP_TRAVIS="phpunit -c tests/php.multisite.xml"
+  - php: "5.3"
+    env: WP_VERSION=4.4 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
+  - php: "5.3"
+    env: WP_VERSION=4.5 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
+  - php: "5.3"
+    env: WP_VERSION=master WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
 
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,11 +66,11 @@ matrix:
   - php: "7.0"
     env: WP_VERSION=master
   - php: "5.3"
-    env: WP_VERSION=4.4 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
+    env: WP_VERSION=4.4 WP_MULTISITE=1 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
   - php: "5.3"
-    env: WP_VERSION=4.5 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
+    env: WP_VERSION=4.5 WP_MULTISITE=1 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
   - php: "5.3"
-    env: WP_VERSION=master WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
+    env: WP_VERSION=master WP_MULTISITE=1 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
 
 
   allow_failures:

--- a/tests/php.multisite.xml
+++ b/tests/php.multisite.xml
@@ -4,12 +4,59 @@
         <const name="PHPUNIT_JETPACK_TESTSUITE" value="true"/>
     </php>
     <testsuites>
-        <!-- Default test suite to run all tests -->
-        <testsuite>
-            <directory prefix="test_" suffix=".php">php</directory>
+        <testsuite name="general">
+            <file>php/test_class.jetpack.php</file>
+            <file>php/test_class.functions.compat.php</file>
+            <file>php/test_class.jetpack-network.php</file>
+            <file>php/test_class.jetpack-client-server.php</file>
+            <file>php/test_class.jetpack-xmlrpc-server.php</file>
+            <file>php/test_class.jetpack-heartbeat.php</file>
+        </testsuite>
+        <testsuite name="media">
+            <file>php/test_class.jetpack-media-extractor.php</file>
+            <file>php/test_class.jetpack-media-summary.php</file>
+            <file>php/test_class.jetpack-post-images.php</file>
+        </testsuite>
+        <testsuite name="photon">
+            <file>php/test_class.jetpack_photon.php</file>
+            <file>php/test_functions.photon.php</file>
+            <directory prefix="test_" suffix=".php">tests/php/modules/photon</directory>
+            <file>php/test_class.functions.opengraph.php</file>
+        </testsuite>
+        <testsuite name="json-api">
+            <file>php/test_class.json-api-jetpack-endpoints.php</file>
+        </testsuite>
+        <testsuite name="contact-form">
+            <directory prefix="test_" suffix=".php">php/modules/contact-form</directory>
+        </testsuite>
+        <testsuite name="infinite-scroll">
+            <directory prefix="test_" suffix=".php">php/modules/infinite-scroll</directory>
+        </testsuite>
+        <testsuite name="publicize">
+            <directory prefix="test_" suffix=".php">php/modules/publicize</directory>
+        </testsuite>
+        <testsuite name="sharedaddy">
+            <directory prefix="test_" suffix=".php">php/modules/sharedaddy</directory>
+        </testsuite>
+        <testsuite name="shortcodes">
+            <directory prefix="test_" suffix=".php">php/modules/shortcodes</directory>
+        </testsuite>
+        <testsuite name="after-the-deadline">
+            <file>php/modules/test_class.after_the_deadline.php</file>
+        </testsuite>
+        <testsuite name="widgets">
+            <directory prefix="test_" suffix=".php">php/modules/widgets</directory>
+        </testsuite>
+        <testsuite name="sso">
+            <directory prefix="test_" suffix=".php">php/modules/sso</directory>
         </testsuite>
         <testsuite name="sync">
             <directory prefix="test_" suffix=".php">php/sync</directory>
+            <exclude>php/sync/test_interface.jetpack-sync-replicastore.php</exclude>
+            <file phpVersion="5.3.0" phpVersionOperator=">=">php/sync/test_interface.jetpack-sync-replicastore.php</file>
+        </testsuite>
+        <testsuite name="uninstall">
+            <directory prefix="test_" suffix=".php">php/uninstall</directory>
         </testsuite>
     </testsuites>
     <groups>

--- a/tests/php.multisite.xml
+++ b/tests/php.multisite.xml
@@ -1,4 +1,7 @@
-<phpunit bootstrap="php/bootstrap.php" backupGlobals="false" colors="true">
+<phpunit bootstrap="php/bootstrap.php" backupGlobals="false" colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true" >
     <php>
         <const name="WP_TESTS_MULTISITE" value="1" />
         <const name="PHPUNIT_JETPACK_TESTSUITE" value="true"/>
@@ -69,7 +72,7 @@
         <whitelist processUncoveredFilesFromWhitelist="false">
             <directory suffix=".php">.</directory>
             <exclude>
-                <directory suffix=".php">tests</directory>
+                <directory suffix=".php">php</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/tests/php.multisite.xml
+++ b/tests/php.multisite.xml
@@ -1,6 +1,7 @@
 <phpunit bootstrap="php/bootstrap.php" backupGlobals="false" colors="true">
     <php>
-      <const name="WP_TESTS_MULTISITE" value="1" />
+        <const name="WP_TESTS_MULTISITE" value="1" />
+        <const name="PHPUNIT_JETPACK_TESTSUITE" value="true"/>
     </php>
     <testsuites>
         <!-- Default test suite to run all tests -->
@@ -14,6 +15,7 @@
     <groups>
         <exclude>
             <group>external-http</group>
+            <group>uninstall</group>
         </exclude>
     </groups>
     <filter>

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -25,7 +25,7 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 
 		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
-		$this->assertEquals( jetpack_foo_is_callable(), 'bar' );
+		$this->assertEquals( jetpack_foo_is_callable(), $synced_value );
 	}
 
 	public function test_sync_jetpack_updates() {
@@ -65,6 +65,15 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 			'sso_bypass_default_login_form'   => Jetpack_SSO_Helpers::bypass_login_forward_wpcom(),
 			'wp_version'                      => Jetpack_Sync_Functions::wp_version(),
 		);
+
+		if ( is_multisite() ) {
+			$callables[ 'network_name' ] = Jetpack::network_name();
+			$callables[ 'network_allow_new_registrations' ] = Jetpack::network_allow_new_registrations();
+			$callables[ 'network_add_new_users' ] = Jetpack::network_add_new_users();
+			$callables[ 'network_site_upload_space' ] = Jetpack::network_site_upload_space();
+			$callables[ 'network_upload_file_types' ] = Jetpack::network_upload_file_types();
+			$callables[ 'network_enable_administration_menus' ] = Jetpack::network_enable_administration_menus();
+		}
 
 		$this->client->do_sync();
 

--- a/tests/php/test_class.jetpack-network.php
+++ b/tests/php/test_class.jetpack-network.php
@@ -19,11 +19,10 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 		$jpms = Jetpack_Network::init();
 
 		$url = $jpms->get_url( 'network_admin_page' );
-
-		$expected_url = 'http://example.org/wp-admin/network/admin.php?page=jetpack';
+		$expected_url = '/wp-admin/network/admin.php?page=jetpack';
 
 		$this->assertInternalType( 'string', $url );
-		$this->assertEquals( $expected_url, $url );
+		$this->assertStringEndsWith( $expected_url, $url );
 	}
 
 	/**
@@ -46,11 +45,11 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 		$jpms = Jetpack_Network::init();
 
 		$url = $jpms->get_url(  array( 'name' => 'subsiteregister', 'site_id' => 123 ) );
-
-		$expected_url = 'http://example.org/wp-admin/network/admin.php?page=jetpack&action=subsiteregister&site_id=123';
+		$expected_url = '/wp-admin/network/admin.php?page=jetpack&action=subsiteregister&site_id=123';
 
 		$this->assertInternalType( 'string', $url );
-		$this->assertEquals( $expected_url, $url );
+		$this->assertStringEndsWith( $expected_url, $url );
+
 	}
 
 	/**
@@ -73,11 +72,10 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 		$jpms = Jetpack_Network::init();
 
 		$url = $jpms->get_url(  array( 'name' => 'subsitedisconnect', 'site_id' => 123 ) );
-
-		$expected_url = 'http://example.org/wp-admin/network/admin.php?page=jetpack&action=subsitedisconnect&site_id=123';
+		$expected_url = '/wp-admin/network/admin.php?page=jetpack&action=subsitedisconnect&site_id=123';
 
 		$this->assertInternalType( 'string', $url );
-		$this->assertEquals( $expected_url, $url );
+		$this->assertStringEndsWith( $expected_url, $url );
 	}
 
 	/**
@@ -111,7 +109,6 @@ class WP_Test_Jetpack_Network extends WP_UnitTestCase {
 		$this->assertInternalType( 'string', $classes );
 		$this->assertContains( 'network-admin', $classes );
 	}
-
 
 } // end class
 endif;


### PR DESCRIPTION
Lets start testing multisite test in travis as well. 

- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

