### PR TITLE
Add sync checksum to heartbeat and cron

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -139,6 +139,10 @@ class Jetpack_Heartbeat {
 			$return["{$prefix}module-{$slug}"] = Jetpack::is_module_active( $slug ) ? 'on' : 'off';
 		}
 
+		require_once dirname(__FILE__).'/sync/class.jetpack-sync-wp-replicastore.php';
+		$store = new Jetpack_Sync_WP_Replicastore();
+		$return["{$prefix}sync-checksum"] = $store->checksum_all();
+
 		return $return;
 	}
 

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -141,7 +141,7 @@ class Jetpack_Heartbeat {
 
 		require_once dirname(__FILE__).'/sync/class.jetpack-sync-wp-replicastore.php';
 		$store = new Jetpack_Sync_WP_Replicastore();
-		$return["{$prefix}sync-checksum"] = $store->checksum_all();
+		$return["{$prefix}sync-checksum"] = json_encode( $store->checksum_all() );
 
 		return $return;
 	}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -1,5 +1,10 @@
 <?php
 
+function jetpack_send_db_checksum() {
+	$sync_client = Jetpack_Sync_Client::getInstance();
+	$sync_client->send_checksum();
+}
+
 class Jetpack_Sync_Actions {
 	static $client = null;
 
@@ -41,6 +46,11 @@ class Jetpack_Sync_Actions {
 
 		// On jetpack registration
 		add_action( 'jetpack_site_registered', array( __CLASS__, 'schedule_full_sync' ) );
+
+		// Schedule a job to send DB checksums once an hour
+		if (! wp_next_scheduled ( 'jetpack_send_db_checksum' )) {
+			wp_schedule_event( time(), 'hourly', 'jetpack_send_db_checksum' );
+		}
 	}
 
 	static function send_data( $data, $codec_name ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -48,7 +48,7 @@ class Jetpack_Sync_Actions {
 		add_action( 'jetpack_site_registered', array( __CLASS__, 'schedule_full_sync' ) );
 
 		// Schedule a job to send DB checksums once an hour
-		if (! wp_next_scheduled ( 'jetpack_send_db_checksum' )) {
+		if ( ! wp_next_scheduled ( 'jetpack_send_db_checksum' ) ) {
 			wp_schedule_event( time(), 'hourly', 'jetpack_send_db_checksum' );
 		}
 	}

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -1014,5 +1014,8 @@ class Jetpack_Sync_Client {
 
 		// clear the sync cron.
 		wp_clear_scheduled_hook( 'jetpack_sync_actions' );
+
+		// clear the checksum cron
+		wp_clear_scheduled_hook( 'jetpack_send_db_checksum' );
 	}
 }

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -189,6 +189,9 @@ class Jetpack_Sync_Client {
 		add_action( 'jetpack_activate_module', $handler );
 		add_action( 'jetpack_deactivate_module', $handler );
 
+		// Send periodic checksum
+		add_action( 'jetpack_sync_checksum', $handler );
+
 		/**
 		 * Sync all pending actions with server
 		 */
@@ -698,6 +701,12 @@ class Jetpack_Sync_Client {
 
 	private function schedule_sync( $when ) {
 		wp_schedule_single_event( strtotime( $when ), 'jetpack_sync_actions' );
+	}
+
+	function send_checksum() {
+		require_once 'class.jetpack-sync-wp-replicastore.php';
+		$store = new Jetpack_Sync_WP_Replicastore();
+		do_action( 'jetpack_sync_checksum', $store->checksum_all() );
 	}
 
 	function force_sync_constants() {

--- a/tests/php/sync/test_class.jetpack-sync-client.php
+++ b/tests/php/sync/test_class.jetpack-sync-client.php
@@ -321,6 +321,15 @@ class WP_Test_Jetpack_New_Sync_Client extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertEquals( 5, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
 	}
 
+	function test_enqueue_db_checksum() {
+		$this->client->send_checksum();
+		$this->client->do_sync();
+
+		$checksum_event = $this->server_event_storage->get_most_recent_event( 'sync_checksum' );
+
+		$this->assertNotNull( $checksum_event );
+	}
+
 	function test_never_queues_if_development() {
 		$this->markTestIncomplete( "We now check this during 'init', so testing is pretty hard" );
 		

--- a/tests/php/test_class.jetpack-heartbeat.php
+++ b/tests/php/test_class.jetpack-heartbeat.php
@@ -45,7 +45,7 @@ class WP_Test_Jetpack_Heartbeat extends WP_UnitTestCase {
 		// checksum from our database
 		$store = new Jetpack_Sync_WP_Replicastore();
 		$this->assertArrayHasKey( $prefix . 'sync-checksum', $result );
-		$this->assertEquals( $result["{$prefix}sync-checksum"], $store->checksum_all() );
+		$this->assertEquals( $result["{$prefix}sync-checksum"], json_encode( $store->checksum_all() ) );
 	}
 
 	/**

--- a/tests/php/test_class.jetpack-heartbeat.php
+++ b/tests/php/test_class.jetpack-heartbeat.php
@@ -41,7 +41,6 @@ class WP_Test_Jetpack_Heartbeat extends WP_UnitTestCase {
 		$this->assertNotEmpty( $result );
 		$this->assertArrayHasKey( $prefix . 'version', $result );
 
-
 		// checksum from our database
 		$store = new Jetpack_Sync_WP_Replicastore();
 		$this->assertArrayHasKey( $prefix . 'sync-checksum', $result );

--- a/tests/php/test_class.jetpack-heartbeat.php
+++ b/tests/php/test_class.jetpack-heartbeat.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-wp-replicastore.php';
+
 class WP_Test_Jetpack_Heartbeat extends WP_UnitTestCase {
 
 	/**
@@ -38,6 +40,12 @@ class WP_Test_Jetpack_Heartbeat extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $result );
 		$this->assertArrayHasKey( $prefix . 'version', $result );
+
+
+		// checksum from our database
+		$store = new Jetpack_Sync_WP_Replicastore();
+		$this->assertArrayHasKey( $prefix . 'sync-checksum', $result );
+		$this->assertEquals( $result["{$prefix}sync-checksum"], $store->checksum_all() );
 	}
 
 	/**


### PR DESCRIPTION
This makes database synchronization checking part of the WPCOM heartbeat data.

It also schedules an hourly cron job to send the checksum as an action.
