### PR TITLE
Add test to ensure we only sync users of the current blog in multisite

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -287,6 +287,10 @@ class Jetpack_Sync_Client {
 		$this->codec = $codec;
 	}
 
+	function get_codec() {
+		return $this->codec;
+	}
+
 	function set_full_sync_client( $full_sync_client ) {
 		if ( $this->full_sync_client ) {
 			remove_action( 'jetpack_sync_full', array( $this->full_sync_client, 'start' ) );

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -133,10 +133,12 @@ class Jetpack_Sync_Client {
 		// users
 		add_action( 'user_register', array( $this, 'save_user_handler' ) );
 		add_action( 'profile_update', array( $this, 'save_user_handler' ), 10, 2 );
+		add_action( 'add_user_to_blog', array( $this, 'save_user_handler' ) );
 		add_action( 'jetpack_sync_save_user', $handler, 10, 2 );
+
 		add_action( 'deleted_user', $handler, 10, 2 );
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ), 10, 2 );
-
+		add_action( 'remove_user_from_blog', $handler, 10, 2 );
 
 		// user roles
 		add_action( 'add_user_role', array( $this, 'save_user_role_handler' ), 10, 2 );
@@ -418,6 +420,12 @@ class Jetpack_Sync_Client {
 	}
 
 	function save_user_handler( $user_id, $old_user_data = null ) {
+
+		// ensure we only sync users who are members of the current blog
+		if ( ! is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
+			return;
+		}
+
 		$user = $this->sanitize_user( get_user_by( 'id', $user_id ) );
 
 		// Older versions of WP don't pass the old_user_data in ->data
@@ -457,6 +465,16 @@ class Jetpack_Sync_Client {
 	}
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
+
+		// if a user is currently being removed as a member of this blog, we don't fire the event
+		if ( current_filter() === 'deleted_user_meta' 
+		&&
+			preg_match( '/capabilities|user_level/', $meta_key )
+		&& 
+			! is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
+			return;
+		}
+
 		$user = $this->sanitize_user( get_user_by( 'id', $user_id ) );
 		if ( $meta_key === $user->cap_key ) {
 			/**

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -238,6 +238,10 @@ class Jetpack_Sync_Server_Replicator {
 				list( $user_id, $reassign ) = $args;
 				$this->store->delete_user( $user_id );
 				break;
+			case 'remove_user_from_blog':
+				list( $user_id, $blog_id ) = $args;
+				$this->store->delete_user( $user_id );
+				break;
 
 			// plugins
 			case 'upgrader_process_complete':

--- a/tests/php/sync/test_class.jetpack-sync-client.php
+++ b/tests/php/sync/test_class.jetpack-sync-client.php
@@ -83,7 +83,8 @@ class WP_Test_Jetpack_New_Sync_Base extends WP_UnitTestCase {
 	}
 
 	protected function objectify( $instance ) {
-		return json_decode( json_encode( $instance ) );
+		$codec = $this->client->get_codec();
+		return $codec->decode( $codec->encode( $instance ) );
 	}
 
 	function serverReceive( $data ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -344,6 +344,10 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 
 	function test_full_sync_sends_plugin_updates() {
 
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Not compatible with multisite mode' );
+		}
+
 		wp_update_plugins();
 
 		$this->client->do_sync();
@@ -366,6 +370,10 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	function test_full_sync_sends_theme_updates() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Not compatible with multisite mode' );
+		}
 
 		wp_update_themes();
 
@@ -391,6 +399,10 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	function test_full_sync_sends_core_updates() {
+
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Not compatible with multisite mode' );
+		}
 
 		_maybe_update_core();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -131,6 +131,47 @@ class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
 		$this->assertFalse( isset( $user->data->user_pass ) );
 	}
 
+	// phpunit -c tests/php.multisite.xml --filter test_full_sync_sends_only_current_blog_users_in_multisite
+	function test_full_sync_sends_only_current_blog_users_in_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Run it in multi site mode' );
+		}
+
+		$original_blog_id = get_current_blog_id();
+
+		$user_id = $this->factory->user->create();
+
+		// NOTE this is necessary because WPMU causes certain assumptions about transients
+		// to be wrong, and tests to explode. @see: https://github.com/sheabunge/WordPress/commit/ff4f1bb17095c6af8a0f35ac304f79074f3c3ff6
+		global $wpdb;
+
+		$suppress = $wpdb->suppress_errors();
+		$other_blog_id = wpmu_create_blog( 'foo.com', '', "My Blog", $this->user_id );
+		$wpdb->suppress_errors( $suppress );
+
+		// let's create some users on the other blog
+		switch_to_blog( $other_blog_id );
+		$mu_blog_user_id = $this->factory->user->create();
+		$added_mu_blog_user_id = $this->factory->user->create();
+		restore_current_blog();
+
+		// add one of the users to our current blog
+		add_user_to_blog( $original_blog_id, $added_mu_blog_user_id, 'administrator' );
+
+		// reset the storage, check value, and do full sync - storage should be set!
+		$this->server_replica_storage->reset();
+
+		$this->full_sync->start();
+		$this->client->do_sync();
+
+		// admin user, our current-blog-created user and our "added" user
+		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
+
+		$this->assertNotNull( $this->server_replica_storage->get_user( $user_id ) );
+		$this->assertNotNull( $this->server_replica_storage->get_user( $added_mu_blog_user_id ) );
+		$this->assertNull( $this->server_replica_storage->get_user( $mu_blog_user_id ) );
+	}
+
 	function test_full_sync_sends_all_constants() {
 		define( 'TEST_SYNC_ALL_CONSTANTS', 'foo' );
 		

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -14,6 +14,10 @@ class WP_Test_Jetpack_New_Sync_Updates extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	public function test_update_plugins_is_synced() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Not compatible with multisite mode' );
+		}
+		
 		wp_update_plugins();
 		$this->client->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
@@ -25,6 +29,10 @@ class WP_Test_Jetpack_New_Sync_Updates extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	public function test_sync_update_themes() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Not compatible with multisite mode' );
+		}
+
 		wp_update_themes();
 		$this->client->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
@@ -32,6 +40,10 @@ class WP_Test_Jetpack_New_Sync_Updates extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	public function test_sync_maybe_update_core() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Not compatible with multisite mode' );
+		}
+
 		_maybe_update_core();
 		$this->client->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'core' );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -267,13 +267,13 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 
 		$this->client->do_sync();
 
-		$this->assertNull( $this->server_replica_storage->get_user( (int) $mu_blog_user_id ) );
+		$this->assertNull( $this->server_replica_storage->get_user( $mu_blog_user_id ) );
 
 		add_user_to_blog( $original_blog_id, $mu_blog_user_id, 'administrator' );
 
 		$this->client->do_sync();
 
-		$this->assertNotNull( $this->server_replica_storage->get_user( (int) $mu_blog_user_id ) );
+		$this->assertNotNull( $this->server_replica_storage->get_user( $mu_blog_user_id ) );
 	}
 
 	protected function assertUsersEqual( $user1, $user2 ) {

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -251,6 +251,10 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 	public function test_syncs_users_added_to_multisite() {
 		global $wpdb;
 
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Run it in multi site mode' );
+		}
+
 		$original_blog_id = get_current_blog_id();
 
 		// create a different blog

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -212,11 +212,10 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 		$this->client->do_sync();
 
 		$server_user = $this->server_replica_storage->get_user( $this->user_id );
-
 		$client_user = get_user_by( 'id', $this->user_id );
 		unset( $client_user->data->user_pass );
 
-		$this->assertEqualsObject( $client_user, $server_user );
+		$this->assertUsersEqual( $client_user, $server_user );
 	}
 	public function test_sync_allowed_file_type() {
 		$server_user_file_mime_types = $this->server_replica_storage->get_allowed_mime_types( $this->user_id );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -224,29 +224,56 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	// to test run phpunit -c tests/php.multisite.xml --filter test_does_not_sync_non_site_users_in_multisite
-	public function test_does_not_sync_non_site_users_in_multisite() {
+	public function test_deletes_users_removed_from_multisite() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Run it in multi site mode' );
 		}
 		
-		$other_blog_admin_id = $this->factory->user->create();
+		// $other_blog_admin_id = $this->factory->user->create();
+
+		$original_blog_id = get_current_blog_id();
 
 		// NOTE this is necessary because WPMU causes certain assumptions about transients
 		// to be wrong, and tests to explode. @see: https://github.com/sheabunge/WordPress/commit/ff4f1bb17095c6af8a0f35ac304f79074f3c3ff6
 		global $wpdb;
 
 		$suppress = $wpdb->suppress_errors();
-		$other_blog_id = wpmu_create_blog( 'foo.com', '', "My Blog", $other_blog_admin_id );
+		$other_blog_id = wpmu_create_blog( 'foo.com', '', "My Blog", $this->user_id );
 		$wpdb->suppress_errors( $suppress );
 
-		switch_to_blog( $other_blog_id );
 		$other_blog_user_id = $this->factory->user->create();
 		add_user_to_blog( $other_blog_id, $other_blog_user_id, 'administrator' );
-		restore_current_blog();
+		remove_user_from_blog( $other_blog_user_id, $original_blog_id );
 
 		$this->client->do_sync();
 
 		$this->assertNull( $this->server_replica_storage->get_user( $other_blog_user_id ) );
+	}
+
+	public function test_syncs_users_added_to_multisite() {
+		global $wpdb;
+
+		$original_blog_id = get_current_blog_id();
+
+		// create a different blog
+		$suppress = $wpdb->suppress_errors();
+		$other_blog_id = wpmu_create_blog( 'foo.com', '', "My Blog", $this->user_id );
+		$wpdb->suppress_errors( $suppress );
+
+		// create a user from within that blog (won't be synced)
+		switch_to_blog( $other_blog_id );
+		$mu_blog_user_id = $this->factory->user->create();
+		restore_current_blog();
+
+		$this->client->do_sync();
+
+		$this->assertNull( $this->server_replica_storage->get_user( (int) $mu_blog_user_id ) );
+
+		add_user_to_blog( $original_blog_id, $mu_blog_user_id, 'administrator' );
+
+		$this->client->do_sync();
+
+		$this->assertNotNull( $this->server_replica_storage->get_user( (int) $mu_blog_user_id ) );
 	}
 
 	protected function assertUsersEqual( $user1, $user2 ) {

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -228,8 +228,6 @@ class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Run it in multi site mode' );
 		}
-		
-		// $other_blog_admin_id = $this->factory->user->create();
 
 		$original_blog_id = get_current_blog_id();
 


### PR DESCRIPTION
Ensure that we sync all users who are members of the current site, and that we delete synced users when they stop being members of the current site.

cc @lezama 