### PR TITLE
SSO: Use the SSO Helper class to call function

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -313,7 +313,7 @@ class Jetpack_SSO {
 	 * @since 2.9
 	 **/
 	public function render_match_by_email() {
-		$match_by_email = 1 == $this->match_by_email();
+		$match_by_email = 1 == Jetpack_SSO_Helpers::match_by_email();
 		$disabled = $match_by_email ? ' disabled="disabled"' : '';
 		echo '<label>';
 		echo '<input type="checkbox" name="jetpack_sso_match_by_email"' . checked( $match_by_email, true, false ) . "$disabled>";


### PR DESCRIPTION
`match_by_email` was moved into the `Jetpack_SSO_Helpers` class in 8cf63fb3e666db76e47c23131e4c0ff9deae1bd8

Fixes #4213

cc @ebinnion 