### PR TITLE
Widgets: use Photon to display image in Image Widget.

### DIFF
--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -91,11 +91,11 @@ class Jetpack_Image_Widget extends WP_Widget {
 				$output .= 'height="' . esc_attr( $instance['img_height'] ) .'" ';
 			}
 			$output .= '/>';
-			if ( '' != $instance['link'] && ! empty( $instance['link_target_blank'] ) ) {
-				$output = '<a target="_blank" href="' . esc_url( $instance['link'] ) . '">' . $output . '</a>';
-			}
-			if ( '' != $instance['link'] && empty( $instance['link_target_blank'] ) ) {
-				$output = '<a href="' . esc_url( $instance['link'] ) . '">' . $output . '</a>';
+			if ( '' != $instance['link'] ) {
+				$target = ! empty( $instance['link_target_blank'] )
+					? 'target="_blank"'
+					: '';
+				$output = '<a ' . $target . ' href="' . esc_url( $instance['link'] ) . '">' . $output . '</a>';
 			}
 			if ( '' != $instance['caption'] ) {
 				/** This filter is documented in core/src/wp-includes/default-widgets.php */

--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -70,10 +70,14 @@ class Jetpack_Image_Widget extends WP_Widget {
 
 		if ( '' != $instance['img_url'] ) {
 
-			$output = '<img src="' . esc_url( jetpack_photon_url( $instance['img_url'], array(
-					'w' => $instance['img_width'],
-					'h' => $instance['img_height'],
-				) ) ) . '" ';
+			$image_url = Jetpack::is_module_active( 'photon' )
+				? jetpack_photon_url( $instance['img_url'], array(
+                                        'w' => $instance['img_width'],
+                                        'h' => $instance['img_height'],
+                                  ) )
+				: $instance['img_url'];
+
+			$output = '<img src="' . esc_url( $image_url ) . '" ';
 
 			if ( '' != $instance['alt_text'] ) {
 				$output .= 'alt="' . esc_attr( $instance['alt_text'] ) .'" ';

--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -70,7 +70,10 @@ class Jetpack_Image_Widget extends WP_Widget {
 
 		if ( '' != $instance['img_url'] ) {
 
-			$output = '<img src="' . esc_attr( $instance['img_url'] ) .'" ';
+			$output = '<img src="' . esc_url( jetpack_photon_url( $instance['img_url'], array(
+					'w' => $instance['img_width'],
+					'h' => $instance['img_height'],
+				) ) ) . '" ';
 
 			if ( '' != $instance['alt_text'] ) {
 				$output .= 'alt="' . esc_attr( $instance['alt_text'] ) .'" ';
@@ -89,10 +92,10 @@ class Jetpack_Image_Widget extends WP_Widget {
 			}
 			$output .= '/>';
 			if ( '' != $instance['link'] && ! empty( $instance['link_target_blank'] ) ) {
-				$output = '<a target="_blank" href="' . esc_attr( $instance['link'] ) . '">' . $output . '</a>';
+				$output = '<a target="_blank" href="' . esc_url( $instance['link'] ) . '">' . $output . '</a>';
 			}
 			if ( '' != $instance['link'] && empty( $instance['link_target_blank'] ) ) {
-				$output = '<a href="' . esc_attr( $instance['link'] ) . '">' . $output . '</a>';
+				$output = '<a href="' . esc_url( $instance['link'] ) . '">' . $output . '</a>';
 			}
 			if ( '' != $instance['caption'] ) {
 				/** This filter is documented in core/src/wp-includes/default-widgets.php */


### PR DESCRIPTION
Fixes #4141
#### Changes proposed in this Pull Request:
- image is loaded through Photon
#### Changelog

Extra Widgets: if Photon is available, use it to serve the image in the Image widget.
