### PR TITLE
Only activate sync after the site is connected

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2814,6 +2814,9 @@ p {
 		}
 
 		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
+		
+		// Delete all the sync related data. Since it could be taking up space.
+		Jetpack_Sync_Client::getInstance()->uninstall();
 
 		// Disable the Heartbeat cron
 		Jetpack_Heartbeat::init()->deactivate();

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -23,6 +23,8 @@ class Jetpack_Sync_Actions {
 				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
 			)
 		&&
+			( Jetpack::is_active() || defined( 'PHPUNIT_JETPACK_TESTSUITE' ) )
+		&&
 			!( Jetpack::is_development_mode() || Jetpack::is_staging_site() )
 		
 		) ) {


### PR DESCRIPTION
Before we would start enquiring data setting the cron job and before
the site was even connected.
Only enable sync when the site is connected solves this issue.

-------------------
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

cc: @lezama, @gravityrail 
