### PR TITLE
Photon: Return original sizes array for images outside of the_content

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -733,12 +733,16 @@ class Jetpack_Photon {
 	 * Filters an array of image `sizes` values, using $content_width instead of image's full size.
 	 *
 	 * @since 4.0.4
+	 * @since 4.1.0 Returns early for images not within the_content.
 	 * @param array $sizes An array of media query breakpoints.
 	 * @param array $size  Width and height of the image
 	 * @uses Jetpack::get_content_width
 	 * @return array An array of media query breakpoints.
 	 */
 	public function filter_sizes( $sizes, $size ) {
+		if ( ! doing_filter( 'the_content' ) ){
+			return $sizes;
+		}
 		$content_width = Jetpack::get_content_width();
 		if ( ! $content_width ) {
 			$content_width = 1000;


### PR DESCRIPTION
See #4175 

In 4.1.0, we modify the `sizes` array anytime the Core filter is invoked. This resulted in undesired results when the Core filter was invoked on a thumbnail or other image used outside of the_content and expected to be larger.

This PR would return early if `the_content` is not in the current filter stack.