### PR TITLE
Add the all_plugins filter everytime we retrieve plugin

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2502,7 +2502,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugins = get_plugins();
+		$plugins = apply_filters( 'all_plugins', get_plugins() );
 
 		if ( is_array( $plugins ) && ! empty( $plugins ) ) {
 			foreach ( $plugins as $plugin_slug => $plugin_data ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1513,7 +1513,7 @@ class Jetpack {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 		}
-		$all_plugins    = get_plugins();
+		$all_plugins    = apply_filters( 'all_plugins', get_plugins() );
 		$active_plugins = Jetpack::get_active_plugins();
 
 		$plugins = array();

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -120,7 +120,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 
 	protected function get_plugins() {
 		$plugins = array();
-		$installed_plugins = get_plugins();
+		$installed_plugins = apply_filters( 'all_plugins', get_plugins() );
 		foreach( $this->plugins as $plugin ) {
 			if ( ! isset( $installed_plugins[ $plugin ] ) )
 				continue;

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -72,7 +72,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 	}
 
 	protected static function get_plugin_id_by_slug( $slug ) {
-		$plugins = get_plugins();
+		$plugins = apply_filters( 'all_plugins', get_plugins() );
 		if ( ! is_array( $plugins ) ) {
 			return false;
 		}

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -617,7 +617,7 @@ class Jetpack_Sync_Client {
 	function expand_upgrader_process_complete( $args ) {
 		list( $process ) = $args;
 		if ( isset( $process['type'] ) && $process['type'] === 'plugin' ) {
-			return array( $process, get_plugins() );
+			return array( $process, apply_filters( 'all_plugins', get_plugins() ) );
 		}
 		return $args;
 	}

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -107,9 +107,7 @@ class Jetpack_Sync_Client {
 		add_action( 'update_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
 		add_action( 'delete_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
 
-		// wordpress version
-		add_action( 'upgrader_process_complete', array( $this, 'send_wp_version' ), 10, 2 );
-		add_action( 'jetpack_sync_wp_version', $handler );
+
 
 		// themes
 		add_action( 'switch_theme', array( $this, 'send_theme_info' ) );
@@ -154,9 +152,10 @@ class Jetpack_Sync_Client {
 		add_action( 'set_site_transient_update_core', $handler, 10, 1 );
 		add_filter( 'jetpack_sync_before_enqueue_set_site_transient_update_plugins', array( $this, 'filter_update_keys' ), 10, 2 );
 
-		// plugins
-		add_action( 'upgrader_process_complete', $handler, 10, 2 );
-		add_filter( 'jetpack_sync_before_send_upgrader_process_complete', array( $this, 'expand_upgrader_process_complete' ) );
+		// get_plugins and wp_version
+		// gets fired when new code gets installed, updates etc.
+		add_action( 'upgrader_process_complete', array( $this, 'force_sync_callables' ) );
+
 		add_action( 'deleted_plugin', $handler, 10, 2 );
 		add_action( 'activated_plugin', $handler, 10, 2 );
 		add_action( 'deactivated_plugin', $handler, 10, 2 );
@@ -612,14 +611,6 @@ class Jetpack_Sync_Client {
 
 	function expand_wp_insert_post( $args ) {
 		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2] );
-	}
-
-	function expand_upgrader_process_complete( $args ) {
-		list( $process ) = $args;
-		if ( isset( $process['type'] ) && $process['type'] === 'plugin' ) {
-			return array( $process, apply_filters( 'all_plugins', get_plugins() ) );
-		}
-		return $args;
 	}
 
 	// Expands wp_insert_post to include filtered content

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -146,6 +146,7 @@ class Jetpack_Sync_Defaults {
 		'sso_new_user_override'           => array( 'Jetpack_SSO_Helpers', 'new_user_override' ),
 		'sso_bypass_default_login_form'   => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
 		'wp_version'                      => array( 'Jetpack_Sync_Functions', 'wp_version' ),
+		'get_plugins'                     => array( 'Jetpack_Sync_Functions', 'get_plugins' ),
 	);
 
 	static $blacklisted_post_types = array(

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -62,6 +62,10 @@ class Jetpack_Sync_Functions {
 		return false;
 	}
 
+	public static function get_plugins() {
+		return apply_filters( 'all_plugins', get_plugins() );
+	}
+
 	public static function wp_version() {
 		global $wp_version;
 		return $wp_version;

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -541,15 +541,6 @@ ENDSQL;
 	public function delete_user( $user_id ) {
 		$this->invalid_call();
 	}
-	
-	// plugins
-	public function get_plugins() {
-		// TODO: Implement get_plugins() method.
-	}
-
-	public function upsert_plugins( $plugins ) {
-		// TODO: Implement upsert_plugins() method.
-	}
 
 	public function get_allowed_mime_types( $user_id ) {
 		

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -115,12 +115,7 @@ interface iJetpack_Sync_Replicastore {
 	public function delete_user( $user_id );
 
 	public function get_allowed_mime_types( $user_id );
-
-
-	// plugins
-	public function get_plugins();
-	public function upsert_plugins( $plugins );
-
+	
 
 	// full checksum
 	public function checksum_all();

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -240,19 +240,12 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			// plugins
-			case 'upgrader_process_complete':
-				$process = $args[ 0 ];
-				if ( is_array( $process ) && $process['type'] == 'plugin' ) {
-					$plugin_data = $args[1];
-					$this->store->upsert_plugins( $plugin_data );
-				}
-				break;
 			case 'deleted_plugin':
 				list( $plugin_file, $deleted ) = $args;
 				if ( $deleted ) {
-					$plugins = $this->store->get_plugins();
+					$plugins = $this->store->get_callable( 'get_plugins' );
 					unset( $plugins[ $plugin_file ] );
-					$this->store->upsert_plugins( $plugins );
+					$this->store->set_callable( 'get_plugins',$plugins );
 				}
 		}
 	}

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -21,7 +21,6 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	private $terms;
 	private $object_terms;
 	private $users;
-	private $plugins;
 	private $allowed_mime_types;
 
 	function __construct() {
@@ -461,15 +460,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		unset( $this->users[ $user_id ] );
 	}
 
-	// plugins
-	function get_plugins() {
-		return $this->plugins;
-	}
-	
-	function upsert_plugins( $plugins ) {
-		$this->plugins = $plugins;
-	}
-	
+
 	function checksum_all() {
 		return array(
 			'posts'    => $this->posts_checksum(),

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -64,6 +64,7 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 			'sso_new_user_override'           => Jetpack_SSO_Helpers::new_user_override(),
 			'sso_bypass_default_login_form'   => Jetpack_SSO_Helpers::bypass_login_forward_wpcom(),
 			'wp_version'                      => Jetpack_Sync_Functions::wp_version(),
+			'get_plugins'                      => Jetpack_Sync_Functions::get_plugins(),
 		);
 
 		if ( is_multisite() ) {

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -741,26 +741,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( 0, $terms[0]->count );
 	}
 
-	/**
-	 * @dataProvider store_provider
-	 * @requires PHP 5.3
-	 */
-	function test_replica_update_plugins( $store ) {
-
-		if ( $store instanceof Jetpack_Sync_WP_Replicastore ) {
-			$this->markTestIncomplete( "The WP replicastore doesn't support setting plugins" );
-		}
-
-		$this->assertNull( $store->get_plugins() );
-
-		$plugins = self::$factory->plugins();
-
-		$store->upsert_plugins( $plugins );
-
-		$this->assertNotNull( $store->get_plugins() );
-		$this->assertEquals( $plugins, $store->get_plugins() );
-	}
-
 	public function store_provider( $name ) {
 		if ( !self::$all_replicastores ) {
 			// detect classes that implement iJetpack_Sync_Replicastore


### PR DESCRIPTION
Fixes #2739

#### Changes proposed in this Pull Request:
- Wrap any get_plugins requests to pass though the all_plugins filter this will let site admins determine what plugins end up showing in the wp-admin as well as calypso. 

-------------------
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

