### PR TITLE
Jetpack Sync: Call spawn_cron after scheduling full sync

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -10,6 +10,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 		Jetpack::init();
 		/** This action is documented in class.jetpack-sync-client.php */
 		Jetpack_Sync_Actions::schedule_full_sync();
+		spawn_cron();
 
 		return array( 'scheduled' => true );
 	}


### PR DESCRIPTION
In order to not block the API, we schedule a cron event to start a full sync. While this makes sense so that we are not slowing down the API request, it has the side effect of the UI not being as responsive.

To get around this, we can call spawn_cron() immediately after scheduling our full sync which will fire off an HTTP request and get our full sync started.

Note: spawn_cron is throttled to only run once per minute.

To test:

- Checkout `update/sync-status-endpoint` branch
- Go to API console: https://developer.wordpress.com/docs/api/console/
- Make a `POST` request to `/sites/$site/sync`
- Make a `GET` request to `/sites/$site/sync/status` and observe the sync has started

