### PR TITLE
Jetpack Sync: Add is_scheduled to GET /sites/$site/sync/status endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -22,7 +22,10 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	protected function result() {
 		$client = Jetpack_Sync_Client::getInstance();
-		return $client->get_full_sync_client()->get_status();
+		return array_merge(
+			$client->get_full_sync_client()->get_status(),
+			array( 'is_scheduled' => (bool) wp_next_scheduled( 'jetpack_sync_full' ) )
+		);
 	}
 }
 


### PR DESCRIPTION
When we trigger a full sync through the API, we do this via cron so that we do not block the API while enqueuing items.

While scheduling a cron event handles the issue of blocking the API gracefully, it can take several minutes for a scheduled event to run. This means that a user could trigger a sync via the API, and not begin seeing any progress from that sync until several minutes later.

To address this, we can add an is_schedule property to the response so that the UI can respond accordingly. This can be as simple as showing "Sync is scheduled text, check back soon" text, or can be handled in another way.

To test:

- Checkout `update/sync-status-scheduled` branch
- Go to API console: https://developer.wordpress.com/docs/api/console/
- Make a `POST` request to `/sites/$site/sync`
- Make a `GET` request to `/sites/$site/sync/status` 
- You should see an `is_scheduled` property in the response
- Further, once the sync starts, `is_scheduled` should update to false
