### PR TITLE
Infinite Scroll: don't load the theme compatibility stylesheets if the main stylesheet isn't loaded

### DIFF
--- a/modules/infinite-scroll/themes/twentyeleven.php
+++ b/modules/infinite-scroll/themes/twentyeleven.php
@@ -20,8 +20,10 @@ add_action( 'init', 'twenty_eleven_infinite_scroll_init' );
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
 function twenty_eleven_infinite_scroll_enqueue_styles() {
-	// Add theme specific styles.
-	wp_enqueue_style( 'infinity-twentyeleven', plugins_url( 'twentyeleven.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
+	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+		// Add theme specific styles.
+		wp_enqueue_style( 'infinity-twentyeleven', plugins_url( 'twentyeleven.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twenty_eleven_infinite_scroll_enqueue_styles', 25 );
 

--- a/modules/infinite-scroll/themes/twentyfifteen.php
+++ b/modules/infinite-scroll/themes/twentyfifteen.php
@@ -20,7 +20,9 @@ add_action( 'after_setup_theme', 'twentyfifteen_infinite_scroll_init' );
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function twentyfifteen_infinite_scroll_enqueue_styles() {
-	wp_enqueue_style( 'infinity-twentyfifteen', plugins_url( 'twentyfifteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20141022' );
-	wp_style_add_data( 'infinity-twentyfifteen', 'rtl', 'replace' );
+	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+		wp_enqueue_style( 'infinity-twentyfifteen', plugins_url( 'twentyfifteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20141022' );
+		wp_style_add_data( 'infinity-twentyfifteen', 'rtl', 'replace' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twentyfifteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/infinite-scroll/themes/twentyfourteen.php
+++ b/modules/infinite-scroll/themes/twentyfourteen.php
@@ -42,6 +42,8 @@ if ( function_exists( 'jetpack_is_mobile' ) ) {
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function twentyfourteen_infinite_scroll_enqueue_styles() {
-	wp_enqueue_style( 'infinity-twentyfourteen', plugins_url( 'twentyfourteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20131118' );
+	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+		wp_enqueue_style( 'infinity-twentyfourteen', plugins_url( 'twentyfourteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20131118' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twentyfourteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/infinite-scroll/themes/twentysixteen.php
+++ b/modules/infinite-scroll/themes/twentysixteen.php
@@ -35,7 +35,9 @@ function twentysixteen_infinite_scroll_render() {
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function twentysixteen_infinite_scroll_enqueue_styles() {
-	wp_enqueue_style( 'infinity-twentysixteen', plugins_url( 'twentysixteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20151102' );
-	wp_style_add_data( 'infinity-twentysixteen', 'rtl', 'replace' );
+	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+		wp_enqueue_style( 'infinity-twentysixteen', plugins_url( 'twentysixteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20151102' );
+		wp_style_add_data( 'infinity-twentysixteen', 'rtl', 'replace' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twentysixteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/infinite-scroll/themes/twentyten.php
+++ b/modules/infinite-scroll/themes/twentyten.php
@@ -31,8 +31,10 @@ function twenty_ten_infinite_scroll_render() {
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
 function twenty_ten_infinite_scroll_enqueue_styles() {
-	// Add theme specific styles.
-	wp_enqueue_style( 'infinity-twentyten', plugins_url( 'twentyten.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
+	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+		// Add theme specific styles.
+		wp_enqueue_style( 'infinity-twentyten', plugins_url( 'twentyten.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twenty_ten_infinite_scroll_enqueue_styles', 25 );
 

--- a/modules/infinite-scroll/themes/twentythirteen.php
+++ b/modules/infinite-scroll/themes/twentythirteen.php
@@ -21,6 +21,8 @@ add_action( 'after_setup_theme', 'twentythirteen_infinite_scroll_init' );
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function twentythirteen_infinite_scroll_enqueue_styles() {
-	wp_enqueue_style( 'infinity-twentythirteen', plugins_url( 'twentythirteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20130409' );
+	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+		wp_enqueue_style( 'infinity-twentythirteen', plugins_url( 'twentythirteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20130409' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twentythirteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/infinite-scroll/themes/twentytwelve.php
+++ b/modules/infinite-scroll/themes/twentytwelve.php
@@ -20,8 +20,10 @@ add_action( 'after_setup_theme', 'twenty_twelve_infinite_scroll_init' );
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
 function twenty_twelve_infinite_scroll_enqueue_styles() {
-    // Add theme specific styles.
-    wp_enqueue_style( 'infinity-twentytwelve', plugins_url( 'twentytwelve.css', __FILE__ ), array( 'the-neverending-homepage' ), '20120817' );
+	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+		// Add theme specific styles.
+		wp_enqueue_style( 'infinity-twentytwelve', plugins_url( 'twentytwelve.css', __FILE__ ), array( 'the-neverending-homepage' ), '20120817' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twenty_twelve_infinite_scroll_enqueue_styles', 25 );
 


### PR DESCRIPTION
Fixes #4235

#### Changes proposed in this Pull Request:
- check if the main stylesheet `infinity.css` is loaded, and only then load the corresponding stylesheet for compatibility with Twenty* themes like TwentySixteen.



