### PR TITLE
Sync: Run callables always as the master user.

### DIFF
--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -854,12 +854,8 @@ class Jetpack_Sync_Client {
 		if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
 			return;
 		}
-		// get_all_callables should run as the master user always.
-		$current_user_id = get_current_user_id();
-		wp_set_current_user( Jetpack_Options::get_option( 'master_user' ) );
 		$callables = $this->get_all_callables();
-		wp_set_current_user( $current_user_id );
-
+		
 		if ( empty( $callables ) ) {
 			return;
 		}
@@ -896,10 +892,15 @@ class Jetpack_Sync_Client {
 	}
 
 	public function get_all_callables() {
-		return array_combine(
+		// get_all_callables should run as the master user always.
+		$current_user_id = get_current_user_id();
+		wp_set_current_user( Jetpack_Options::get_option( 'master_user' ) );
+		$callables = array_combine(
 			array_keys( $this->callable_whitelist ),
 			array_map( array( $this, 'get_callable' ), array_values( $this->callable_whitelist ) )
 		);
+		wp_set_current_user( $current_user_id );
+		return $callables;
 	}
 
 	private function get_callable( $callable ) {

--- a/sync/class.jetpack-sync-client.php
+++ b/sync/class.jetpack-sync-client.php
@@ -854,8 +854,12 @@ class Jetpack_Sync_Client {
 		if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
 			return;
 		}
-
+		// get_all_callables should run as the master user always.
+		$current_user_id = get_current_user_id();
+		wp_set_current_user( Jetpack_Options::get_option( 'master_user' ) );
 		$callables = $this->get_all_callables();
+		wp_set_current_user( $current_user_id );
+
 		if ( empty( $callables ) ) {
 			return;
 		}

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -34,6 +34,14 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 		$admin_id = $this->factory->user->create( array(
 			'role' => 'administrator',
 		) );
+		
+		if ( is_multisite() ) {
+			$admin_user = get_user_by( 'id', $admin_id );
+			$site_admins = get_site_option( 'site_admins' );
+			
+			// Make the new admin_user super admin to that the test passes
+			update_site_option( 'site_admins', array( $admin_user->user_login ) );
+		}
 
 		$current_master_user = Jetpack_Options::get_option( 'master_user' );
 		Jetpack_Options::update_option( 'master_user', $admin_id );
@@ -62,6 +70,10 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 		wp_set_current_user( $current_user->ID );
 		delete_transient( 'update_plugins' );
 		Jetpack_Options::update_option( 'master_user', $current_master_user );
+
+		if ( is_multisite() ) {
+			update_site_option( 'site_admins', $site_admins );
+		}
 
 		$this->assertEqualsObject( $updates, $server_updates );
 		$this->assertEquals( 2, $server_updates['total'] );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -29,11 +29,43 @@ class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
 	}
 
 	public function test_sync_jetpack_updates() {
-		$this->client->do_sync();
-		$updates = $this->server_replica_storage->get_callable( 'updates' );
-		$this->assertEqualsObject( Jetpack::get_updates(), $updates );
-	}
+		$current_user = wp_get_current_user();
 
+		$admin_id = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+
+		$current_master_user = Jetpack_Options::get_option( 'master_user' );
+		Jetpack_Options::update_option( 'master_user', $admin_id );
+		wp_set_current_user( $admin_id );
+		
+		// fake updates
+		$plugin_option = new stdClass;
+		$plugin_option->last_checked = time();
+		$plugin_option->response = array( 'apple', 'shoe' ); // this should set the total to 2
+		$plugin_option->translations = array();
+		$plugin_option->no_update = array();
+
+		set_site_transient( 'update_plugins', $plugin_option );
+		$updates = Jetpack::get_updates();
+
+		// set a role that doesn't have the privlages
+		$subscriber_id = $this->factory->user->create( array(
+			'role' => 'subscriber',
+		) );
+		wp_set_current_user( $subscriber_id );
+
+		$this->client->do_sync();
+		$server_updates = $this->server_replica_storage->get_callable( 'updates' );
+
+		// reset things
+		wp_set_current_user( $current_user->ID );
+		delete_transient( 'update_plugins' );
+		Jetpack_Options::update_option( 'master_user', $current_master_user );
+
+		$this->assertEqualsObject( $updates, $server_updates );
+		$this->assertEquals( 2, $server_updates['total'] );
+	}
 
 	function test_wp_version_is_synced() {
 		global $wp_version;


### PR DESCRIPTION
Sometimes updates would return null because the data was being sent as a user that didn't have permission to retrieve the data and didn't have all the privileges. 

This PR fixes this callables are always called by the permissions of the master user. Which should be match the admin of the site. 

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

