### PR TITLE
Manage: in landing page, make sure the Activate features button doesn't overlap Inactive toggle.

### DIFF
--- a/_inc/jp.js
+++ b/_inc/jp.js
@@ -391,7 +391,7 @@
 					// Manual element alteration for Manage, since it's not part of the template
 					if ( 'manage' === data.thisModuleSlug ) {
 						if ( response.activated ) {
-							thisLabel.show().html( 'ACTIVE' );
+							$( '#manage-row .module-action' ).hide();
 							$( '#manage-row' ).addClass( 'activated' );
 						} else {
 							thisLabel.show().html( 'INACTIVE' );

--- a/scss/templates/_connection-landing.scss
+++ b/scss/templates/_connection-landing.scss
@@ -375,15 +375,6 @@ So I moved to stack the svgs as actual imgs instead. IE also had a hard time dea
 		transform: translate(0,-50%);
 }
 
-@mixin verthorzalign { // center this div in both axis
-	position: absolute;
-	top: 50%;
-	right: 50%;
-	-ms-transform: translate(50%,-50%);
-	-webkit-transform: translate(50%,-50%);
-	transform: translate(50%,-50%);
-}
-
 .nux-intro {
 
 	h3 {
@@ -582,7 +573,14 @@ So I moved to stack the svgs as actual imgs instead. IE also had a hard time dea
 				padding-bottom: 5px;
 			}
 			.feat {
-				@include verthorzalign;
+				@include vertalign;
+			}
+
+			&.activated .feat {
+				right: 50%;
+				-ms-transform: translate(50%,-50%);
+				-webkit-transform: translate(50%,-50%);
+				transform: translate(50%,-50%);
 			}
 		} // go-to
 	}


### PR DESCRIPTION
Fixes #4243

Once Manage is activated, center the button since Inactive toggle won't be there anymore.

Run `grunt sass` before testing.

cc @samhotchkiss since he found the issue