### PR TITLE
Connect Url: Photonize site_icon property in connection URL

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4048,7 +4048,7 @@ p {
 			@list( $secret ) = explode( ':', $secrets );
 			
 			$site_icon = ( function_exists( 'has_site_icon') && has_site_icon() )
-				? get_site_icon_url()
+				? jetpack_photon_url( get_site_icon_url(), array(), 'https' )
 				: false;
 
 			$args = urlencode_deep(


### PR DESCRIPTION
In #4011, we began passing `site_icon` in the the connection URL. We then displayed this in WordPress.com. And since WP.com is `https`, displaying the site icon from the remote site could cause issues if the site was `http` 😱 

This PR will run the site icon through `jetpack_photon_url()` before adding to the connection URL. This should ensure that we get an `https` site icon that is served from WordPress.com's Photon CDN.

cc @johnHackworth for testing and review.

To test:

- Checkout `update/photonize-site-icon-connection-url` branch
- Disconnect site from WP.com by going to Jetpack admin page
- Go to `wordpress.com/jetpack/connect`
- Enter in URL and attempt to connect site
- After a page refresh, you should see something like this (no mixed content warnings):
![screen shot 2016-06-29 at 10 40 30 am](https://cloud.githubusercontent.com/assets/1126811/16459026/0862be6a-3de7-11e6-8097-916effe92eec.png)
