### PR TITLE
SSO: Show default login form if we can not log user in with SSO

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -217,15 +217,22 @@ class Jetpack_SSO {
 			return $classes;
 		}
 
-		//Always add the jetpack-sso class so that we can add SSO specific styling even when the SSO form isn't being displayed.
+		// Always add the jetpack-sso class so that we can add SSO specific styling even when the SSO form isn't being displayed.
 		$classes[] = 'jetpack-sso';
 
-		// If jetpack-sso-default-form, show the default login form.
-		if ( isset( $_GET['jetpack-sso-default-form'] ) && 1 == $_GET['jetpack-sso-default-form'] ) {
-			return $classes;
+		/**
+		 * Should we show the SSO login form?
+		 *
+		 * $_GET['jetpack-sso-default-form'] is used to provide a fallback in case JavaScript is not enabled.
+		 *
+		 * The default_to_sso_login() method allows us to dynamically decide whether we show the SSO login form or not.
+		 * The SSO module uses the method to display the default login form if we can not find a user to log in via SSO.
+		 * But, the method could be filtered by a site admin to always show the default login form if that is preferred.
+		 */
+		if ( empty( $_GET['jetpack-sso-show-default-form'] ) && Jetpack_SSO_Helpers::show_sso_login() ) {
+			$classes[] = 'jetpack-sso-form-display';
 		}
 
-		$classes[] = 'jetpack-sso-form-display';
 		return $classes;
 	}
 
@@ -516,13 +523,13 @@ class Jetpack_SSO {
 					<span><?php esc_html_e( 'Or', 'jetpack' ); ?></span>
 				</div>
 
-				<a href="<?php echo add_query_arg( 'jetpack-sso-default-form', '1' ); ?>" class="jetpack-sso-toggle wpcom">
+				<a href="<?php echo add_query_arg( 'jetpack-sso-show-default-form', '1' ); ?>" class="jetpack-sso-toggle wpcom">
 					<?php
 						esc_html_e( 'Log in with username and password', 'jetpack' )
 					?>
 				</a>
 
-				<a href="<?php echo add_query_arg( 'jetpack-sso-default-form', '0' ); ?>" class="jetpack-sso-toggle default">
+				<a href="<?php echo add_query_arg( 'jetpack-sso-show-default-form', '0' ); ?>" class="jetpack-sso-toggle default">
 					<?php
 						esc_html_e( 'Log in with WordPress.com', 'jetpack' )
 					?>
@@ -808,6 +815,8 @@ class Jetpack_SSO {
 			exit;
 		}
 
+		add_filter( 'jetpack_sso_default_to_sso_login', '__return_false' );
+
 		JetpackTracking::record_user_event( 'sso_login_failed', array(
 			'error_message' => 'cant_find_user'
 		) );
@@ -1023,7 +1032,7 @@ class Jetpack_SSO {
 				),
 				array(  'a' => array( 'href' => array() ) )
 			),
-			esc_url_raw( add_query_arg( 'jetpack-sso-default-form', '1', wp_login_url() ) )
+			esc_url_raw( add_query_arg( 'jetpack-sso-show-default-form', '1', wp_login_url() ) )
 		);
 
 		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -107,6 +107,31 @@ class Jetpack_SSO_Helpers {
 		 */
 		return (bool) apply_filters( 'jetpack_sso_bypass_login_forward_wpcom', false );
 	}
+
+	/**
+	 * Returns a boolean for whether the SSO login form should be displayed as the default
+	 * when both the default and SSO login form allowed.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return bool
+	 */
+	static function show_sso_login() {
+		if ( self::should_hide_login_form() ) {
+			return true;
+		}
+
+		/**
+		 * Display the SSO login form as the default when both the default and SSO login forms are enabled.
+		 *
+		 * @module sso
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param bool true Should the SSO login form be displayed by default when the default login form is also enabled?
+		 */
+		return (bool) apply_filters( 'jetpack_sso_default_to_sso_login', true );
+	}
 }
 
 endif;


### PR DESCRIPTION
Currently, if a user attempts to log in via SSO, and for some reason we can't find a user to login, we simply show a notice and the SSO login form again.

@rickybanister recently suggested that we show the default login form and then prompt the user (after logging in with Jetpack site credentials) to connect to WP.com. This is the first part of that flow.

To test:

- Checkout `update/sso-show-default-cant-find-user` branch
- Pick, or create, a test user on the remote site that is not connected to WP.com.
- And then either:
    - Make sure the test user has an email that doesn't match the WP.com user's email
    - In a compatibility plugin: `add_filter( 'jetpack_sso_match_by_email', '__return_false') ;`
- Go to `/wp-admin`
- Click "Log in with WordPress.com" button
- Approve the SSO process on WP.com
- When you land back on your site, you should see the username and password fields (aka default login form)


If you'd like to test more:

- In a compatibility plugin:
    - `add_filter( 'jetpack_remove_login_form', '__return_true' );`
- Follow same steps above to log in with WP.com
- When you land back on your Jetpack site, you should see the SSO login form
    - This is because we have disabled the default login form

cc @rickybanister for a design/flow review. @lezama and @enejb for code review.