### PR TITLE
Sharing: make sure css file paths are always correct.

### DIFF
--- a/_inc/social-logos.php
+++ b/_inc/social-logos.php
@@ -7,8 +7,8 @@
 add_action( 'init', 'jetpack_register_social_logos', 1 );
 function jetpack_register_social_logos() {
 	if ( ! wp_style_is( 'social-logos', 'registered' ) ) {
-		$post_fix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '.min' : '';
-		wp_register_style( 'social-logos', plugins_url( 'social-logos/social-logos.' . $post_fix . 'css', __FILE__ ), false, '1' );
+		$post_fix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+		wp_register_style( 'social-logos', plugins_url( 'social-logos/social-logos' . $post_fix . '.css', __FILE__ ), false, '1' );
 	}
 }
 

--- a/modules/sharedaddy/sharing.php
+++ b/modules/sharedaddy/sharing.php
@@ -24,7 +24,7 @@ class Sharing_Admin {
 
 	public function sharing_head() {
 		wp_enqueue_script( 'sharing-js', WP_SHARING_PLUGIN_URL . 'admin-sharing.js', array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable', 'jquery-form' ), 2 );
-		$postfix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+		$postfix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		if ( is_rtl() ) {
 			wp_enqueue_style( 'sharing-admin', WP_SHARING_PLUGIN_URL . 'admin-sharing-rtl' . $postfix . '.css', false, JETPACK__VERSION );
 		} else {


### PR DESCRIPTION
- `.min` should only be added when `SCRIPT_DEBUG` is false.
- no trailing dots should be left regardless of the debug status.

cc @enejb 