### PR TITLE
Maximum sync queue size

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -210,6 +210,7 @@ class Jetpack_Sync_Defaults {
 	static $default_upload_max_bytes = 600000; // a little bigger than the upload limit to account for serialization
 	static $default_upload_max_rows = 500;
 	static $default_sync_wait_time = 10; // seconds, between syncs
+	static $default_max_queue_size = 1000;
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 }

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -9,7 +9,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-modules.php';
  */
 class Jetpack_Sync_Listener {
 	const QUEUE_SIZE_CHECK_TRANSIENT = "jetpack_sync_last_checked_queue_size";
-	const QUEUE_SIZE_CHECK_TIMEOUT = 60*5; // 5 minutes
+	const QUEUE_SIZE_CHECK_TIMEOUT = 300; // 5 minutes
 
 	private $sync_queue;
 	private $sync_queue_limit;

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -1,17 +1,18 @@
 <?php
 
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-queue.php';
-require_once dirname( __FILE__ ) . '/class.jetpack-sync-functions.php';
-require_once dirname( __FILE__ ) . '/class.jetpack-sync-defaults.php';
-
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-modules.php';
 
 /** 
  * This class monitors actions and logs them to the queue to be sent
  */
 class Jetpack_Sync_Listener {
+	const QUEUE_SIZE_CHECK_TRANSIENT = "jetpack_sync_last_checked_queue_size";
+	const QUEUE_SIZE_CHECK_TIMEOUT = 60*5; // 5 minutes
 
 	private $sync_queue;
+	private $sync_queue_limit;
 
 	// singleton functions
 	private static $instance;
@@ -50,6 +51,25 @@ class Jetpack_Sync_Listener {
 		add_action( 'jetpack_sync_checksum', $handler );
 	}
 
+	function set_queue_limit( $limit ) {
+		$this->sync_queue_limit = $limit;
+	}
+
+	function get_queue_limit() {
+		return $this->sync_queue_limit;
+	}
+
+	function is_over_queue_limit() {
+		$queue_size = get_transient( self::QUEUE_SIZE_CHECK_TRANSIENT );
+
+		if ( $queue_size === false ) {
+			$queue_size = $this->sync_queue->size();
+			set_transient( self::QUEUE_SIZE_CHECK_TRANSIENT, $queue_size, self::QUEUE_SIZE_CHECK_TIMEOUT );
+		}
+
+		return false;
+	}
+
 	function action_handler() {
 		$current_filter = current_filter();
 		$args           = func_get_args();
@@ -72,6 +92,13 @@ class Jetpack_Sync_Listener {
 			return;
 		}
 
+		// periodically check the size of the queue, and disable adding to it if 
+		// it exceeds some limit
+		if ( $this->is_over_queue_limit() ) {
+			// 
+			return;
+		}
+
 		// if we add any items to the queue, we should 
 		// try to ensure that our script can't be killed before
 		// they are sent
@@ -89,5 +116,6 @@ class Jetpack_Sync_Listener {
 
 	function set_defaults() {
 		$this->sync_queue = new Jetpack_Sync_Queue( 'sync' );
+		$this->set_queue_limit( Jetpack_Sync_Settings::get_setting( 'max_queue_size' ) );
 	}
 }

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -51,12 +51,20 @@ class Jetpack_Sync_Listener {
 		add_action( 'jetpack_sync_checksum', $handler );
 	}
 
+	function get_sync_queue() {
+		return $this->sync_queue;
+	}
+
 	function set_queue_limit( $limit ) {
 		$this->sync_queue_limit = $limit;
 	}
 
 	function get_queue_limit() {
 		return $this->sync_queue_limit;
+	}
+
+	function force_recheck_queue_limit() {
+		delete_transient( self::QUEUE_SIZE_CHECK_TRANSIENT );
 	}
 
 	function is_over_queue_limit() {
@@ -67,7 +75,7 @@ class Jetpack_Sync_Listener {
 			set_transient( self::QUEUE_SIZE_CHECK_TRANSIENT, $queue_size, self::QUEUE_SIZE_CHECK_TIMEOUT );
 		}
 
-		return false;
+		return ( $queue_size + 1 ) > $this->sync_queue_limit;
 	}
 
 	function action_handler() {
@@ -95,7 +103,6 @@ class Jetpack_Sync_Listener {
 		// periodically check the size of the queue, and disable adding to it if 
 		// it exceeds some limit
 		if ( $this->is_over_queue_limit() ) {
-			// 
 			return;
 		}
 

--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -4,7 +4,6 @@
  * logs bruteprotect failed logins via sync
  */
 class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
-	private $taxonomy_whitelist;
 
 	function name() {
 		return "protect";

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -213,7 +213,7 @@ class Jetpack_Sync_Sender {
 	}
 
 	function get_sync_wait_time() {
-		return get_option( self::SYNC_THROTTLE_OPTION_NAME );
+		return (int) get_option( self::SYNC_THROTTLE_OPTION_NAME );
 	}
 
 	private function get_last_sync_time() {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -1,0 +1,47 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-defaults.php';
+
+class Jetpack_Sync_Settings {
+	const SETTINGS_OPTION_PREFIX = 'jetpack_sync_settings_';
+
+	static $valid_settings = array( 
+		'dequeue_max_bytes' => true, 
+		'upload_max_bytes' => true, 
+		'upload_max_rows' => true, 
+		'sync_wait_time' => true,
+		'max_queue_size' => true
+	);
+
+	static function get_settings() {
+		$settings = array();
+		foreach( array_keys( self::$valid_settings ) as $setting ) {
+			$settings[ $setting ] = self::get_setting( $setting );
+		}
+		return $settings;
+	}
+
+	static function get_setting( $setting ) {
+		if ( ! isset( self::$valid_settings[ $setting ] ) ) {
+			return false;
+		}
+
+		$default_name = "default_$setting"; // e.g. default_dequeue_max_bytes
+		return (int) get_option( self::SETTINGS_OPTION_PREFIX.$setting, Jetpack_Sync_Defaults::$$default_name );
+	}
+
+	static function update_settings( $new_settings ) {
+		$validated_settings = array_intersect_key( $new_settings, self::$valid_settings );
+		foreach( $validated_settings as $setting => $value ) {
+			update_option( self::SETTINGS_OPTION_PREFIX.$setting, $value, true );
+		}
+	}
+
+	static function reset_data() {
+		$valid_settings  = self::$valid_settings;
+		$settings_prefix =  self::SETTINGS_OPTION_PREFIX;
+		foreach ( $valid_settings as $option => $value ) {
+			delete_option( $settings_prefix . $option );
+		}
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -59,6 +59,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		$this->sender->set_dequeue_max_bytes( 5000000 ); // process 5MB of items at a time
 		$this->sender->set_sync_wait_time(0); // disable rate limiting
 	}
+	
 	public function test_pass() {
 		// so that we don't have a failing test
 		$this->assertTrue( true );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -11,7 +11,7 @@ function jetpack_foo_is_callable() {
 /**
  * Testing Functions
  */
-class WP_Test_Jetpack_New_Sync_Functions extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	protected $post;
 	protected $callable_module;
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -2,7 +2,7 @@
 
 require_once dirname( __FILE__ ) . '/../../../sync/class.jetpack-sync-functions.php';
 
-require_once 'test_class.jetpack-sync-client.php';
+require_once 'test_class.jetpack-sync-base.php';
 
 function jetpack_foo_is_callable() {
 	return 'bar';

--- a/tests/php/sync/test_class.jetpack-sync-client.php
+++ b/tests/php/sync/test_class.jetpack-sync-client.php
@@ -19,7 +19,7 @@ require_once $sync_server_dir . 'class.jetpack-sync-server-eventstore.php';
  * process events.
  */
 
-class WP_Test_Jetpack_New_Sync_Base extends WP_UnitTestCase {
+class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 	protected $listener;
 	protected $sender;
 
@@ -51,19 +51,6 @@ class WP_Test_Jetpack_New_Sync_Base extends WP_UnitTestCase {
 		$this->server_event_storage->init();
 	}
 
-	// public function tearDown() {
-	// 	parent::tearDown();
-	// 	$this->sender->set_defaults();
-	// 	foreach( Jetpack_Sync_Modules::get_modules() as $module ) {
-	// 		$module->set_defaults();
-	// 	}
-	// }
-
-	public function test_pass() {
-		// so that we don't have a failing test
-		$this->assertTrue( true );
-	}
-
 	public function setSyncClientDefaults() {
 		$this->sender->set_defaults();
 		foreach( Jetpack_Sync_Modules::get_modules() as $module ) {
@@ -71,6 +58,10 @@ class WP_Test_Jetpack_New_Sync_Base extends WP_UnitTestCase {
 		}
 		$this->sender->set_dequeue_max_bytes( 5000000 ); // process 5MB of items at a time
 		$this->sender->set_sync_wait_time(0); // disable rate limiting
+	}
+	public function test_pass() {
+		// so that we don't have a failing test
+		$this->assertTrue( true );
 	}
 
 	protected function assertDataIsSynced() {
@@ -101,12 +92,9 @@ class WP_Test_Jetpack_New_Sync_Base extends WP_UnitTestCase {
 	function serverReceive( $data ) {
 		return $this->server->receive( $data );
 	}
-
-	// TODO:
-	// limit overall rate of sending
 }
 
-class WP_Test_Jetpack_New_Sync_Integration extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	
 	function test_sending_empties_queue() {
 		$this->factory->post->create();
@@ -122,302 +110,5 @@ class WP_Test_Jetpack_New_Sync_Integration extends WP_Test_Jetpack_New_Sync_Base
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_publicize_post' );
 		$this->assertEquals( $post_id, $event->args[0] );
-	}
-}
-
-class WP_Test_Jetpack_New_Sync_Listener extends WP_Test_Jetpack_New_Sync_Base {
-	function test_never_queues_if_development() {
-		$this->markTestIncomplete( "We now check this during 'init', so testing is pretty hard" );
-		
-		add_filter( 'jetpack_development_mode', '__return_true' );
-
-		$queue = $this->listener->get_sync_queue();
-		$queue->reset(); // remove any actions that already got queued
-
-		$this->factory->post->create();
-
-		$this->assertEquals( 0, $queue->size() );
-	}
-
-	function test_never_queues_if_staging() {
-		$this->markTestIncomplete( "We now check this during 'init', so testing is pretty hard" );
-
-		add_filter( 'jetpack_is_staging_site', '__return_true' );
-
-		$queue = $this->listener->get_sync_queue();
-		$queue->reset(); // remove any actions that already got queued
-
-		$this->factory->post->create();
-
-		$this->assertEquals( 0, $queue->size() );
-	}
-}
-
-class WP_Test_Jetpack_New_Sync_Sender extends WP_Test_Jetpack_New_Sync_Base {
-	protected $action_ran;
-	protected $encoded_data;
-
-	function test_add_post_fires_sync_data_action_with_codec_on_do_sync() {
-		$this->action_ran = false;
-		$this->action_codec = null;
-
-		add_filter( 'jetpack_sync_send_data', array( $this, 'action_ran' ), 10, 2 );
-
-		$this->sender->do_sync();
-
-		$this->assertEquals( true, $this->action_ran );
-		$this->assertEquals( 'deflate-json', $this->action_codec );
-	}
-
-	function test_queues_cron_job_if_queue_exceeds_max_buffer() {
-		$this->sender->set_dequeue_max_bytes( 500 ); // bytes
-
-		for ( $i = 0; $i < 20; $i+= 1) {
-			$this->factory->post->create();
-		}
-
-		$this->sender->do_sync();
-
-		$events = $this->server_event_storage->get_all_events();
-		$this->assertTrue( count( $events ) < 20 );
-
-		$timestamp = wp_next_scheduled( 'jetpack_sync_actions' );
-		
-		// we're making some assumptions here about how fast the test will run...
-		$this->assertTrue( $timestamp >= time()+59 );
-		$this->assertTrue( $timestamp <= time()+61 );
-	}
-
-	function test_can_write_settings() {
-		$settings = $this->sender->get_settings();
-
-		foreach( array( 'dequeue_max_bytes', 'sync_wait_time', 'upload_max_bytes', 'upload_max_rows' ) as $key ) {
-			$this->assertTrue( isset( $settings[ $key ] ) );	
-		}
-
-		$settings[ 'dequeue_max_bytes' ] = 50;
-		$this->sender->update_settings( $settings );
-
-		$updated_settings = $this->sender->get_settings();
-
-		$this->assertSame( 50, $updated_settings[ 'dequeue_max_bytes' ] );
-	}
-
-	function test_queue_limits_upload_bytes() {
-		// flush previous stuff in queue
-		$this->sender->do_sync();
-
-		$this->sender->set_upload_max_bytes( 5000 ); // 5k
-
-		// make the sync listener listen for a new action
-		add_action( 'my_expanding_action', array( $this->listener, 'action_handler' ) );
-
-		// expand these events to a much larger size
-		add_filter( "jetpack_sync_before_send_my_expanding_action", array( $this, 'expand_small_action_to_large_size' ) );
-
-		// now let's trigger our action a few times
-		do_action( 'my_expanding_action', 'x' );
-		do_action( 'my_expanding_action', 'x' );
-		do_action( 'my_expanding_action', 'x' );
-
-		// trigger the sync
-		$this->sender->do_sync();
-
-		// evenstore should only have the first two items
-		$events = $this->server_event_storage->get_all_events( 'my_expanding_action' );
-		$this->assertEquals( 2, count( $events ) );
-
-		// now let's sync again - our remaining action should be pushed
-		$this->sender->do_sync();
-
-		$events = $this->server_event_storage->get_all_events( 'my_expanding_action' );
-		$this->assertEquals( 3, count( $events ) );
-	}
-
-	function test_queue_limits_upload_rows() {
-		// flush previous stuff in queue
-		$this->sender->do_sync();
-
-		$this->sender->set_upload_max_rows( 2 ); // 5k
-
-		// make the sync sender listen for a new action
-		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
-
-		// now let's trigger our action a few times
-		do_action( 'my_action' );
-		do_action( 'my_action' );
-		do_action( 'my_action' );
-
-		// trigger the sync
-		$this->sender->do_sync();
-
-		// evenstore should only have the first two items
-		$events = $this->server_event_storage->get_all_events( 'my_action' );
-		$this->assertEquals( 2, count( $events ) );
-
-		// now let's sync again - our remaining action should be pushed
-		$this->sender->do_sync();
-
-		$events = $this->server_event_storage->get_all_events( 'my_action' );
-		$this->assertEquals( 3, count( $events ) );
-
-		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
-	}
-
-	function test_queue_limits_very_large_object_doesnt_stall_upload() {
-		// basically, if an object's serialized size is bigger than the max upload
-		// size, we should still upload it, just by itself rather than with others.
-
-		// flush previous stuff in queue
-		$this->sender->do_sync();
-
-		$this->sender->set_upload_max_bytes( 1000 ); // 1k, tiny
-
-		// make the sync sender listen for a new action
-		add_action( 'my_expanding_action', array( $this->listener, 'action_handler' ) );
-
-		// expand these events to a much larger size
-		add_filter( "jetpack_sync_before_send_my_expanding_action", array( $this, 'expand_small_action_to_large_size' ) );
-
-		// now let's trigger our action a few times
-		do_action( 'my_expanding_action', 'x' );
-		do_action( 'my_expanding_action', 'x' );
-		do_action( 'my_expanding_action', 'x' );
-
-		// trigger the sync
-		$this->sender->do_sync();
-
-		// evenstore should have the first item
-		$this->assertEquals( 1, count( $this->server_event_storage->get_all_events( 'my_expanding_action' ) ) );
-
-		// ... then the second
-		$this->sender->do_sync();
-		$this->assertEquals( 2, count( $this->server_event_storage->get_all_events( 'my_expanding_action' ) ) );
-
-		remove_action( 'my_expanding_action', array( $this->listener, 'action_handler' ) );
-	}
-
-	// expand the input to 2000 random chars
-	function expand_small_action_to_large_size( $args ) {
-		// we generate a random string so it's hard to compress (i.e. doesn't shrink when gzencoded)
-		$characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-		$charactersLength = strlen($characters);
-		$randomString = '';
-		for ($i = 0; $i < 2000; $i++) {
-			$randomString .= $characters[rand(0, $charactersLength - 1)];
-		}
-		return $randomString;
-	}
-
-	/**
-	 * We have to run this in a separate process so we can set the constant without
-	 * it interfering with other tests. That's also why we have to reconnect the DB
-	 */
-	function test_queues_cron_job_if_is_importing() {
-		$this->markTestIncomplete("This works but I haven't found a way to undefine the WP_IMPORTING constant when I'm done :(");
-
-		$queue = $this->sender->get_sync_queue();
-
-		$this->factory->post->create();
-
-		$pre_sync_queue_size = $queue->size();
-		$this->assertTrue( $pre_sync_queue_size > 0 ); // just to be sure stuff got queued
-
-		define( 'WP_IMPORTING', true );
-
-		$this->sender->do_sync();
-
-		// assert that queue hasn't budged
-		$this->assertEquals( $pre_sync_queue_size, $queue->size() );
-
-		$timestamp = wp_next_scheduled( 'jetpack_sync_actions' );
-		
-		// we're making some assumptions here about how fast the test will run...
-		$this->assertTrue( $timestamp >= time()+59 );
-		$this->assertTrue( $timestamp <= time()+61 );
-	}
-
-	function test_rate_limit_how_often_sync_runs_with_option() {
-		$this->sender->do_sync();
-
-		// so we take multiple syncs to upload
-		$this->sender->set_upload_max_rows( 2 ); 
-
-		// make the sync listener listen for a new action
-		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
-
-		// now let's trigger our action a few times
-		do_action( 'my_action' );
-		do_action( 'my_action' );
-		do_action( 'my_action' );
-		do_action( 'my_action' );
-		do_action( 'my_action' );
-
-		// now let's try to sync and observe the rate limit
-		$this->sender->do_sync();
-
-		$this->sender->set_sync_wait_time( 2 );
-		$this->assertSame( 2, $this->sender->get_sync_wait_time() );
-
-		$this->assertEquals( 2, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
-
-		sleep( 3 );
-
-		$this->sender->do_sync();
-		$this->assertEquals( 4, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
-
-		$this->sender->do_sync();
-		$this->assertEquals( 4, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
-
-		sleep( 3 );
-
-		$this->sender->do_sync();
-		$this->assertEquals( 5, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
-
-		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
-	}
-
-	function test_enqueue_db_checksum() {
-		$this->sender->send_checksum();
-		$this->sender->do_sync();
-
-		$checksum_event = $this->server_event_storage->get_most_recent_event( 'sync_checksum' );
-
-		$this->assertNotNull( $checksum_event );
-	}
-
-	function test_adds_timestamp_to_action() {
-		$beginning_of_test = microtime(true);
-
-		$this->factory->post->create();
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
-
-		$this->assertTrue( $event->timestamp > $beginning_of_test );
-		$this->assertTrue( $event->timestamp < microtime(true) );
-	}
-
-	function test_adds_user_id_to_action() {
-		$user_id = $this->factory->user->create();
-
-		wp_set_current_user( $user_id );
-		$this->factory->post->create();
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
-
-		$this->assertEquals( $user_id, $event->user_id );
-	}
-
-	function action_ran( $data, $codec ) {
-		$this->action_ran = true;
-		$this->action_codec = $codec;
-		return $data;
-	}
-
-	function set_encoded_data( $data ) {
-		$this->encoded_data = $data;
-		return $data;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -3,7 +3,7 @@
 /**
  * Testing CRUD on Comments
  */
-class WP_Test_Jetpack_New_Sync_Comments extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 
 	protected $comment;
 

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -3,7 +3,7 @@
 /**
  * Testing CRUD on Constants
  */
-class WP_Test_Jetpack_New_Sync_Constants extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
 	protected $constants_module;
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -7,7 +7,7 @@ function jetpack_foo_full_sync_callable() {
 	return 'the value';
 }
 
-class WP_Test_Jetpack_New_Sync_Full extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	private $transients;
 	private $full_sync;
 	private $start_sent;

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -1,0 +1,34 @@
+<?php
+
+class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
+	function test_never_queues_if_development() {
+		$this->markTestIncomplete( "We now check this during 'init', so testing is pretty hard" );
+		
+		add_filter( 'jetpack_development_mode', '__return_true' );
+
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset(); // remove any actions that already got queued
+
+		$this->factory->post->create();
+
+		$this->assertEquals( 0, $queue->size() );
+	}
+
+	function test_never_queues_if_staging() {
+		$this->markTestIncomplete( "We now check this during 'init', so testing is pretty hard" );
+
+		add_filter( 'jetpack_is_staging_site', '__return_true' );
+
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset(); // remove any actions that already got queued
+
+		$this->factory->post->create();
+
+		$this->assertEquals( 0, $queue->size() );
+	}
+
+	// function test_detects_if_exceeded_queue_size_limit() {
+	// 	$queue = $this->sender->get_sync_queue();
+	// 	$queue->set_size_limit( 2 );
+	// }
+}

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -27,8 +27,36 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 0, $queue->size() );
 	}
 
-	// function test_detects_if_exceeded_queue_size_limit() {
-	// 	$queue = $this->sender->get_sync_queue();
-	// 	$queue->set_size_limit( 2 );
-	// }
+	// this is trickier than you would expect because we only check against 
+	// maximum queue size periodically (to avoid a counts on every request), and then
+	// we cache the "blocked on queue size" status
+	function test_detects_if_exceeded_queue_size_limit() {
+		$this->listener->get_sync_queue()->reset();
+
+		// first, let's try overriding the default queue limit
+		$this->assertEquals( Jetpack_Sync_Defaults::$default_max_queue_size, $this->listener->get_queue_limit() );
+
+		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size' => 2 ) );
+		$this->listener->set_defaults(); // should pick up new queue size limit
+
+		$this->assertEquals( 2, $this->listener->get_queue_limit() );
+		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
+		
+		// now let's try exceeding the new limit
+		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
+
+		$this->listener->force_recheck_queue_limit();
+		do_action( 'my_action' );
+		$this->assertEquals( 1, $this->listener->get_sync_queue()->size() );
+
+		$this->listener->force_recheck_queue_limit();
+		do_action( 'my_action' );
+		$this->assertEquals( 2, $this->listener->get_sync_queue()->size() );
+
+		$this->listener->force_recheck_queue_limit();
+		do_action( 'my_action' );
+		$this->assertEquals( 2, $this->listener->get_sync_queue()->size() );
+
+		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -3,7 +3,7 @@
 /**
  * Testing CRUD on Meta
  */
-class WP_Test_Jetpack_New_Sync_Meta extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
 
 	public function setUp() {

--- a/tests/php/sync/test_class.jetpack-sync-modules-protect.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-protect.php
@@ -6,7 +6,8 @@
 
 require_once dirname( __FILE__ ) . '/../../../modules/protect.php';
 
-class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
+
 	function test_sends_failed_login_message() {
 
 		Jetpack_Protect_Module::instance()->log_failed_attempt();

--- a/tests/php/sync/test_class.jetpack-sync-modules.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules.php
@@ -3,7 +3,7 @@
 /**
  * Testing Activation and Deactivation of Modules
  */
-class WP_Test_Jetpack_Sync_Modules extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Modules extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sync_activate_module_event() {
 		// Calling the activate_module in tests is difficult.

--- a/tests/php/sync/test_class.jetpack-sync-network-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-network-options.php
@@ -2,9 +2,9 @@
 
 /**
  * Testing CRUD on Network Options
- * use phpunit --testsuite sync  -c tests/php.multisite.xml --filter WP_Test_Jetpack_New_Sync_Network_Options
+ * use phpunit --testsuite sync  -c tests/php.multisite.xml --filter WP_Test_Jetpack_Sync_Network_Options
  */
-class WP_Test_Jetpack_New_Sync_Network_Options extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Network_Options extends WP_Test_Jetpack_Sync_Base {
 	protected $post;
 	protected $options_module;
 

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -3,7 +3,7 @@
 /**
  * Testing CRUD on Options
  */
-class WP_Test_Jetpack_New_Sync_Options extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 	protected $post;
 	protected $options_module;
 

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -3,7 +3,7 @@
 /**
  * Testing CRUD on Plugins
  */
-class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 	protected $theme;
 
 	public function setUp() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -3,7 +3,7 @@
 /**
  * Testing CRUD on Posts
  */
-class WP_Test_Jetpack_New_Sync_Post extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	protected $post;
 

--- a/tests/php/sync/test_class.jetpack-sync-queue.php
+++ b/tests/php/sync/test_class.jetpack-sync-queue.php
@@ -4,7 +4,7 @@ $sync_dir = dirname( __FILE__ ) . '/../../../sync/';
 
 require_once $sync_dir . 'class.jetpack-sync-queue.php';
 
-class WP_Test_Jetpack_New_Sync_Queue extends WP_UnitTestCase {
+class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 
 	private $queue;
 

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -1,0 +1,255 @@
+<?php
+
+class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
+	protected $action_ran;
+	protected $encoded_data;
+
+	function test_add_post_fires_sync_data_action_with_codec_on_do_sync() {
+		$this->action_ran = false;
+		$this->action_codec = null;
+
+		add_filter( 'jetpack_sync_send_data', array( $this, 'action_ran' ), 10, 2 );
+
+		$this->sender->do_sync();
+
+		$this->assertEquals( true, $this->action_ran );
+		$this->assertEquals( 'deflate-json', $this->action_codec );
+	}
+
+	function test_queues_cron_job_if_queue_exceeds_max_buffer() {
+		$this->sender->set_dequeue_max_bytes( 500 ); // bytes
+
+		for ( $i = 0; $i < 20; $i+= 1) {
+			$this->factory->post->create();
+		}
+
+		$this->sender->do_sync();
+
+		$events = $this->server_event_storage->get_all_events();
+		$this->assertTrue( count( $events ) < 20 );
+
+		$timestamp = wp_next_scheduled( 'jetpack_sync_actions' );
+		
+		// we're making some assumptions here about how fast the test will run...
+		$this->assertTrue( $timestamp >= time()+59 );
+		$this->assertTrue( $timestamp <= time()+61 );
+	}
+
+	function test_queue_limits_upload_bytes() {
+		// flush previous stuff in queue
+		$this->sender->do_sync();
+
+		$this->sender->set_upload_max_bytes( 5000 ); // 5k
+
+		// make the sync listener listen for a new action
+		add_action( 'my_expanding_action', array( $this->listener, 'action_handler' ) );
+
+		// expand these events to a much larger size
+		add_filter( "jetpack_sync_before_send_my_expanding_action", array( $this, 'expand_small_action_to_large_size' ) );
+
+		// now let's trigger our action a few times
+		do_action( 'my_expanding_action', 'x' );
+		do_action( 'my_expanding_action', 'x' );
+		do_action( 'my_expanding_action', 'x' );
+
+		// trigger the sync
+		$this->sender->do_sync();
+
+		// evenstore should only have the first two items
+		$events = $this->server_event_storage->get_all_events( 'my_expanding_action' );
+		$this->assertEquals( 2, count( $events ) );
+
+		// now let's sync again - our remaining action should be pushed
+		$this->sender->do_sync();
+
+		$events = $this->server_event_storage->get_all_events( 'my_expanding_action' );
+		$this->assertEquals( 3, count( $events ) );
+	}
+
+	function test_queue_limits_upload_rows() {
+		// flush previous stuff in queue
+		$this->sender->do_sync();
+
+		$this->sender->set_upload_max_rows( 2 ); // 5k
+
+		// make the sync sender listen for a new action
+		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
+
+		// now let's trigger our action a few times
+		do_action( 'my_action' );
+		do_action( 'my_action' );
+		do_action( 'my_action' );
+
+		// trigger the sync
+		$this->sender->do_sync();
+
+		// evenstore should only have the first two items
+		$events = $this->server_event_storage->get_all_events( 'my_action' );
+		$this->assertEquals( 2, count( $events ) );
+
+		// now let's sync again - our remaining action should be pushed
+		$this->sender->do_sync();
+
+		$events = $this->server_event_storage->get_all_events( 'my_action' );
+		$this->assertEquals( 3, count( $events ) );
+
+		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
+	}
+
+	function test_queue_limits_very_large_object_doesnt_stall_upload() {
+		// basically, if an object's serialized size is bigger than the max upload
+		// size, we should still upload it, just by itself rather than with others.
+
+		// flush previous stuff in queue
+		$this->sender->do_sync();
+
+		$this->sender->set_upload_max_bytes( 1000 ); // 1k, tiny
+
+		// make the sync sender listen for a new action
+		add_action( 'my_expanding_action', array( $this->listener, 'action_handler' ) );
+
+		// expand these events to a much larger size
+		add_filter( "jetpack_sync_before_send_my_expanding_action", array( $this, 'expand_small_action_to_large_size' ) );
+
+		// now let's trigger our action a few times
+		do_action( 'my_expanding_action', 'x' );
+		do_action( 'my_expanding_action', 'x' );
+		do_action( 'my_expanding_action', 'x' );
+
+		// trigger the sync
+		$this->sender->do_sync();
+
+		// evenstore should have the first item
+		$this->assertEquals( 1, count( $this->server_event_storage->get_all_events( 'my_expanding_action' ) ) );
+
+		// ... then the second
+		$this->sender->do_sync();
+		$this->assertEquals( 2, count( $this->server_event_storage->get_all_events( 'my_expanding_action' ) ) );
+
+		remove_action( 'my_expanding_action', array( $this->listener, 'action_handler' ) );
+	}
+
+	// expand the input to 2000 random chars
+	function expand_small_action_to_large_size( $args ) {
+		// we generate a random string so it's hard to compress (i.e. doesn't shrink when gzencoded)
+		$characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$charactersLength = strlen($characters);
+		$randomString = '';
+		for ($i = 0; $i < 2000; $i++) {
+			$randomString .= $characters[rand(0, $charactersLength - 1)];
+		}
+		return $randomString;
+	}
+
+	/**
+	 * We have to run this in a separate process so we can set the constant without
+	 * it interfering with other tests. That's also why we have to reconnect the DB
+	 */
+	function test_queues_cron_job_if_is_importing() {
+		$this->markTestIncomplete("This works but I haven't found a way to undefine the WP_IMPORTING constant when I'm done :(");
+
+		$queue = $this->sender->get_sync_queue();
+
+		$this->factory->post->create();
+
+		$pre_sync_queue_size = $queue->size();
+		$this->assertTrue( $pre_sync_queue_size > 0 ); // just to be sure stuff got queued
+
+		define( 'WP_IMPORTING', true );
+
+		$this->sender->do_sync();
+
+		// assert that queue hasn't budged
+		$this->assertEquals( $pre_sync_queue_size, $queue->size() );
+
+		$timestamp = wp_next_scheduled( 'jetpack_sync_actions' );
+		
+		// we're making some assumptions here about how fast the test will run...
+		$this->assertTrue( $timestamp >= time()+59 );
+		$this->assertTrue( $timestamp <= time()+61 );
+	}
+
+	function test_rate_limit_how_often_sync_runs_with_option() {
+		$this->sender->do_sync();
+
+		// so we take multiple syncs to upload
+		$this->sender->set_upload_max_rows( 2 ); 
+
+		// make the sync listener listen for a new action
+		add_action( 'my_action', array( $this->listener, 'action_handler' ) );
+
+		// now let's trigger our action a few times
+		do_action( 'my_action' );
+		do_action( 'my_action' );
+		do_action( 'my_action' );
+		do_action( 'my_action' );
+		do_action( 'my_action' );
+
+		// now let's try to sync and observe the rate limit
+		$this->sender->do_sync();
+
+		$this->sender->set_sync_wait_time( 2 );
+		$this->assertSame( 2, $this->sender->get_sync_wait_time() );
+
+		$this->assertEquals( 2, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
+
+		sleep( 3 );
+
+		$this->sender->do_sync();
+		$this->assertEquals( 4, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
+
+		$this->sender->do_sync();
+		$this->assertEquals( 4, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
+
+		sleep( 3 );
+
+		$this->sender->do_sync();
+		$this->assertEquals( 5, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
+
+		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
+	}
+
+	function test_enqueue_db_checksum() {
+		$this->sender->send_checksum();
+		$this->sender->do_sync();
+
+		$checksum_event = $this->server_event_storage->get_most_recent_event( 'sync_checksum' );
+
+		$this->assertNotNull( $checksum_event );
+	}
+
+	function test_adds_timestamp_to_action() {
+		$beginning_of_test = microtime(true);
+
+		$this->factory->post->create();
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+
+		$this->assertTrue( $event->timestamp > $beginning_of_test );
+		$this->assertTrue( $event->timestamp < microtime(true) );
+	}
+
+	function test_adds_user_id_to_action() {
+		$user_id = $this->factory->user->create();
+
+		wp_set_current_user( $user_id );
+		$this->factory->post->create();
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+
+		$this->assertEquals( $user_id, $event->user_id );
+	}
+
+	function action_ran( $data, $codec ) {
+		$this->action_ran = true;
+		$this->action_codec = $codec;
+		return $data;
+	}
+
+	function set_encoded_data( $data ) {
+		$this->encoded_data = $data;
+		return $data;
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -1,0 +1,18 @@
+<?php
+
+class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
+	function test_can_write_settings() {
+		$settings = Jetpack_Sync_Settings::get_settings();
+
+		foreach( array( 'dequeue_max_bytes', 'sync_wait_time', 'upload_max_bytes', 'upload_max_rows', 'max_queue_size' ) as $key ) {
+			$this->assertTrue( isset( $settings[ $key ] ) );	
+		}
+
+		$settings[ 'dequeue_max_bytes' ] = 50;
+		Jetpack_Sync_Settings::update_settings( $settings );
+
+		$updated_settings = Jetpack_Sync_Settings::get_settings();
+
+		$this->assertSame( 50, $updated_settings[ 'dequeue_max_bytes' ] );
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-site-icon-url.php
+++ b/tests/php/sync/test_class.jetpack-sync-site-icon-url.php
@@ -3,7 +3,7 @@
 /**
  * Testing Crud Site icon
  */
-class WP_Test_Jetpack_Sync_Site_Icon_Url extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Site_Icon_Url extends WP_Test_Jetpack_Sync_Base {
 	protected $post;
 
 	public function setUp() {

--- a/tests/php/sync/test_class.jetpack-sync-sso.php
+++ b/tests/php/sync/test_class.jetpack-sync-sso.php
@@ -3,7 +3,7 @@
 /**
  * Testing sync of values for SSO.
  */
-class WP_Test_Jetpack_Sync_SSO extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_SSO extends WP_Test_Jetpack_Sync_Base {
 	function test_sync_sso_is_two_step_required_filter_true() {
 		add_filter( 'jetpack_sso_require_two_step', '__return_true' );
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -4,7 +4,7 @@
 /**
  * Testing CRUD on Terms
  */
-class WP_Test_Jetpack_New_Sync_Terms extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
 	protected $term_object;
 	protected $taxonomy;

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -3,7 +3,7 @@
 /**
  * Testing CRUD on Options
  */
-class WP_Test_Jetpack_New_Sync_Themes extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	protected $theme;
 
 	public function setUp() {

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -3,7 +3,7 @@
 /**
  * Testing Updates Sync
  */
-class WP_Test_Jetpack_New_Sync_Updates extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
 
 	public function setUp() {

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -4,7 +4,7 @@
 /**
  * Testing CRUD on Users
  */
-class WP_Test_Jetpack_New_Sync_Users extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	protected $user_id;
 
 	public function setUp() {

--- a/tests/php/sync/test_class.jetpack_sync_backward_compatibility.php
+++ b/tests/php/sync/test_class.jetpack_sync_backward_compatibility.php
@@ -3,7 +3,7 @@
 /**
  * Testing Backward Compatibility with Olter plugins.
  */
-class WP_Test_Jetpack_Sync_Backward_Compatibility extends WP_Test_Jetpack_New_Sync_Base {
+class WP_Test_Jetpack_Sync_Backward_Compatibility extends WP_Test_Jetpack_Sync_Base {
 
 	public function setUp() {
 		parent::setUp();


### PR DESCRIPTION
This PR implements a maximum size of 1000 items for the sync queue. The main reason for implementing this is that if sites have sync enabled but they can't post to WPCOM to flush the queue, then their database would eventually fill up with queued items.

It also tries hard not to place too much strain on the system when checking the queue size - it caches the count so that it re-checks once every 5 minutes at the most.

*Controversy:*

This basically imposes a hard limit on the size of DB's that we can sync, since a full sync will add one item to the queue for every 10 posts and 10 comments, in addition to items for options, users etc. So, more or less this means if you've got more than 10,000 posts in your DB, you need to change this limit.

Definitely looking for feedback on what a more appropriate limit might be, or whether we should (for example) temporarily lift the limit during full sync. Or maybe no limit at all, but just periodically sending WPCOM the queue size. What do you think?
