### PR TITLE
Sync: Remove require for the protect module to resolve a PHP fatal

### DIFF
--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -1,13 +1,11 @@
 <?php
 
-require dirname( __FILE__ ) . '/../modules/protect.php';
-
-/** 
+/**
  * logs bruteprotect failed logins via sync
  */
 class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
 	private $taxonomy_whitelist;
-	
+
 	function name() {
 		return "protect";
 	}

--- a/tests/php/sync/test_class.jetpack-sync-modules-protect.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-protect.php
@@ -3,6 +3,9 @@
 /**
  * Test pluggable functionality for bruteprotect
  */
+
+require_once dirname( __FILE__ ) . '/../../../modules/protect.php';
+
 class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_New_Sync_Base {
 	function test_sends_failed_login_message() {
 


### PR DESCRIPTION
Before, led to 
`[30-Jun-2016 22:28:09 UTC] PHP Fatal error:  Cannot declare class Jetpack_Protect_Module, because the name is already in use in /html/wp-content/plugins/jetpack/modules/protect.php on line 17`