### PR TITLE
Updating csstidy constructors to prevent PHP7 deprecation warnings

### DIFF
--- a/modules/custom-css/csstidy/class.csstidy.php
+++ b/modules/custom-css/csstidy/class.csstidy.php
@@ -246,7 +246,7 @@ class csstidy {
 	 * @access private
 	 * @version 1.3
 	 */
-	function csstidy() {
+	function __construct() {
 		$this->settings['remove_bslash'] = true;
 		$this->settings['compress_colors'] = true;
 		$this->settings['compress_font-weight'] = true;

--- a/modules/custom-css/csstidy/class.csstidy_optimise.php
+++ b/modules/custom-css/csstidy/class.csstidy_optimise.php
@@ -47,7 +47,7 @@ class csstidy_optimise {
 	 * @access private
 	 * @version 1.0
 	 */
-	function csstidy_optimise(&$css) {
+	function __construct(&$css) {
 		$this->parser = & $css;
 		$this->css = & $css->css;
 		$this->sub_value = & $css->sub_value;

--- a/modules/custom-css/csstidy/class.csstidy_print.php
+++ b/modules/custom-css/csstidy/class.csstidy_print.php
@@ -66,7 +66,7 @@ class csstidy_print {
 	 * @access private
 	 * @version 1.0
 	 */
-	function csstidy_print(&$css) {
+	function __construct(&$css) {
 		$this->parser = & $css;
 		$this->css = & $css->css;
 		$this->template = & $css->template;


### PR DESCRIPTION
On nginx 1.9.5 + HTTP2 and PHP7, I received the following deprecation warnings intermittently when clicking the Save Stylesheet button while editing custom CSS:

```
PHP message: PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; csstidy has a deprecated constructor in /home/jetpack.rcollier.me/wp-content/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php on line 73
PHP message: PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; csstidy_print has a deprecated constructor in /home/jetpack.rcollier.me/wp-content/plugins/jetpack/modules/custom-css/csstidy/class.csstidy_print.php on line 42
PHP message: PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; csstidy_optimise has a deprecated constructor in /home/jetpack.rcollier.me/wp-content/plugins/jetpack/modules/custom-css/csstidy/class.csstidy_optimise.php on line 42
```

This PR fixes those warnings while maintaining acceptable backwards compatibility. 