### PR TITLE
Set Jetpack Version after running upgrade routine.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -346,6 +346,8 @@ class Jetpack {
 				 * @since 3.3.0
 				 */
 				do_action( 'jetpack_sync_all_registered_options' );
+
+				Jetpack::maybe_set_version_option();
 			}
 		}
 	}


### PR DESCRIPTION
We were not setting the new version into the database after running the upgrade routine, this was causing multiple hits to the database on every single request 😱 

How to test:

- Run branch-4.1 and observe the number of queries thanks to https://wordpress.org/plugins/query-monitor/
- Run this branch and observe the number of queries to go down by a half :) (after a second page load)

- check that the option `'jetpack_version'` has the correct value.

cc @dereksmart 
cc @jeherve this should go into master too

#### Changes proposed in this Pull Request:
-

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

