### PR TITLE
Performance: Remove security report method from `init` hook

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -317,8 +317,6 @@ class Jetpack {
 
 			self::$instance->plugin_upgrade();
 
-			add_action( 'init', array( __CLASS__, 'perform_security_reporting' ) );
-
 		}
 
 		return self::$instance;


### PR DESCRIPTION
We don't need to run this on every request.
@dereksmart  says that's ok to remove it :)

How to test:

Run branch-4.1, use https://wordpress.org/plugins/query-monitor/ to observe that we hit twice the database in order to get:
`_site_transient_security_report_performed_recently` and `_site_transient_timeout_security_report_performed_recently`

Run this branch and observe that we don't do those anymore

cc @samhotchkiss @jeherve 