### PR TITLE
Add sync of login logout

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -109,7 +109,7 @@ class Jetpack_Sync_Sender {
 			 *
 			 * @param array The action parameters
 			 */
-			$item[1] = apply_filters( "jetpack_sync_before_send_" . $item[0], $item[1] );
+			$item[1] = apply_filters( "jetpack_sync_before_send_" . $item[0], $item[1], $item[2] );
 
 			$encoded_item = $this->codec->encode( $item );
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -173,9 +173,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Comments
-	 *
-	 * @dataProvider store_provider
-	 * @requires PHP 5.3
 	 */
 
 	/**


### PR DESCRIPTION
Synchronize login, login-failed and logout actions. We append username to the logout action for convenience on the server side.