### PR TITLE
Remove queries and HTTP requests on each page load

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -120,6 +120,24 @@ class Jetpack_Options {
 		return $default;
 	}
 
+	/**
+	 * Returns the requested option, and ensures it's autoloaded in the future.
+	 * This does _not_ adjust the prefix in any way (does not prefix jetpack_%)
+	 *
+	 * @param string $name Option name
+	 * @param mixed $default (optional)
+	 */
+	public static function get_option_and_ensure_autoload( $name, $default ) {
+		$value = get_option( $name );
+		
+		if ( $value === false ) {
+			update_option( $name, $default, null, true );
+			$value = $default;
+		}
+
+		return $value;
+	}
+
 	private static function update_grouped_option( $group, $name, $value ) {
 		$options = get_option( self::$grouped_options[ $group ] );
 		if ( ! is_array( $options ) ) {

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -128,7 +128,7 @@ class Jetpack_Options {
 	public static function get_option_and_ensure_autoload( $name, $default ) {
 		$value = get_option( $name );
 		
-		if ( $value === false ) {
+		if ( $value === false && $default !== false ) {
 			update_option( $name, $default, null, true );
 			$value = $default;
 		}

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -23,7 +23,6 @@ class Jetpack_Options {
 				'wpcc_options',
 				'relatedposts',
 				'file_data',
-				'security_report',
 				'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
 				'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
 				'autoupdate_core',             // (bool)   Whether or not to autoupdate core
@@ -63,7 +62,6 @@ class Jetpack_Options {
 			'identity_crisis_whitelist',    // (array)  An array of options, each having an array of the values whitelisted for it.
 			'gplus_authors',                // (array)  The Google+ authorship information for connected users.
 			'last_heartbeat',               // (int)    The timestamp of the last heartbeat that fired.
-			'last_security_report',         // (int)    The timestamp of the last security report that was run.
 			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
 			'hide_jitm'                     // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 		);

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -178,7 +178,7 @@ class Jetpack_Twitter_Cards {
 	}
 
 	static function site_tag() {
-		$site_tag = get_option( 'jetpack-twitter-cards-site-tag' );
+		$site_tag = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack-twitter-cards-site-tag', '' );
 		if ( empty( $site_tag ) ) {
 			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 				return 'wordpressdotcom';

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -279,13 +279,6 @@ class Jetpack {
 	public $stats = array();
 
 	/**
-	 * Allows us to build a temporary security report
-	 *
-	 * @var array
-	 */
-	static $security_report = array();
-
-	/**
 	 * Jetpack_Sync object
 	 */
 	public $sync;
@@ -311,7 +304,6 @@ class Jetpack {
 			self::$instance = new Jetpack;
 
 			self::$instance->plugin_upgrade();
-
 		}
 
 		return self::$instance;
@@ -1637,53 +1629,6 @@ class Jetpack {
 		}
 	}
 
-
-
-
-	/*
-	 *
-	 * Jetpack Security Reports
-	 *
-	 * Allowed types: login_form, backup, file_scanning, spam
-	 *
-	 * Args for login_form and spam: 'blocked'=>(int)(optional), 'status'=>(string)(ok, warning, error), 'message'=>(optional, disregarded if status is ok, allowed tags: a, em, strong)
-	 *
-	 * Args for backup and file_scanning: 'last'=>(timestamp)(optional), 'next'=>(timestamp)(optional), 'status'=>(string)(ok, warning, error), 'message'=>(optional, disregarded if status is ok, allowed tags: a, em, strong)
-	 *
-	 *
-	 * Example code to submit a security report:
-	 *
-	 *  function akismet_submit_jetpack_security_report() {
-	 *  	Jetpack::submit_security_report( 'spam', __FILE__, $args = array( 'blocked' => 138284, status => 'ok' ) );
-	 *  }
-	 *  add_action( 'jetpack_security_report', 'akismet_submit_jetpack_security_report' );
-	 *
-	 */
-
-
-	/**
-	 * Calls for security report submissions.
-	 *
-	 * @return null
-	 */
-	public static function perform_security_reporting() {
-		$no_check_needed = get_site_transient( 'security_report_performed_recently' );
-
-		if ( $no_check_needed ) {
-			return;
-		}
-
-		/**
-		 * Fires before a security report is created.
-		 *
-		 * @since 3.4.0
-		 */
-		do_action( 'jetpack_security_report' );
-
-		Jetpack_Options::update_option( 'security_report', self::$security_report );
-		set_site_transient( 'security_report_performed_recently', 1, 15 * MINUTE_IN_SECONDS );
-	}
-
 	/**
 	 * Allows plugins to submit security reports.
  	 *
@@ -1692,78 +1637,8 @@ class Jetpack {
 	 * @param array   $args         See definitions above
 	 */
 	public static function submit_security_report( $type = '', $plugin_file = '', $args = array() ) {
-
-		if( !doing_action( 'jetpack_security_report' ) ) {
-			return new WP_Error( 'not_collecting_report', 'Not currently collecting security reports.  Please use the jetpack_security_report hook.' );
-		}
-
-		if( !is_string( $type ) || !is_string( $plugin_file ) ) {
-			return new WP_Error( 'invalid_security_report', 'Invalid Security Report' );
-		}
-
-		if( !function_exists( 'get_plugin_data' ) ) {
-			include( ABSPATH . 'wp-admin/includes/plugin.php' );
-		}
-
-		//Get rid of any non-allowed args
-		$args = array_intersect_key( $args, array_flip( array( 'blocked', 'last', 'next', 'status', 'message' ) ) );
-
-		$plugin = get_plugin_data( $plugin_file );
-
-		if ( !$plugin['Name'] ) {
-			return new WP_Error( 'security_report_missing_plugin_name', 'Invalid Plugin File Provided' );
-		}
-
-		// Sanitize everything to make sure we're not syncing something wonky
-		$type = sanitize_key( $type );
-
-		$args['plugin'] = $plugin;
-
-		// Cast blocked, last and next as integers.
-		// Last and next should be in unix timestamp format
-		if ( isset( $args['blocked'] ) ) {
-			$args['blocked'] = (int) $args['blocked'];
-		}
-		if ( isset( $args['last'] ) ) {
-			$args['last'] = (int) $args['last'];
-		}
-		if ( isset( $args['next'] ) ) {
-			$args['next'] = (int) $args['next'];
-		}
-		if ( !in_array( $args['status'], array( 'ok', 'warning', 'error' ) ) ) {
-			$args['status'] = 'ok';
-		}
-		if ( isset( $args['message'] ) ) {
-
-			if( $args['status'] == 'ok' ) {
-				unset( $args['message'] );
-			}
-
-			$allowed_html = array(
-			    'a' => array(
-			        'href' => array(),
-			        'title' => array()
-			    ),
-			    'em' => array(),
-			    'strong' => array(),
-			);
-
-			$args['message'] = wp_kses( $args['message'], $allowed_html );
-		}
-
-		$plugin_name = $plugin[ 'Name' ];
-
-		self::$security_report[ $type ][ $plugin_name ] = $args;
+		_deprecated_function( __FUNCTION__, 'always', 'Security reports feature has been removed' );
 	}
-
-	/**
-	 * Collects a new report if needed, then returns it.
-	 */
-	public function get_security_report() {
-		self::perform_security_reporting();
-		return Jetpack_Options::get_option( 'security_report' );
-	}
-
 
 /* Jetpack Options API */
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2891,7 +2891,7 @@ p {
 		// If the plugin is not connected, display a connect message.
 		if (
 			// the plugin was auto-activated and needs its candy
-			Jetpack_Options::get_option( 'do_activate' )
+			Jetpack_Options::get_option_and_ensure_autoload( 'do_activate', '0' )
 		||
 			// the plugin is active, but was never activated.  Probably came from a site-wide network activation
 			! Jetpack_Options::get_option( 'activated' )

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5435,13 +5435,13 @@ p {
 	 * Written so that we don't have re-check $key and $value params every time
 	 * we want to check if this site is whitelisted, for example in footer.php
 	 *
-	 * @return bool True = already whitelsisted False = not whitelisted
+	 * @return bool True = already whitelisted False = not whitelisted
 	 */
 	public static function is_staging_site() {
 		$is_staging = false;
 
 		$current_whitelist = Jetpack_Options::get_option( 'identity_crisis_whitelist' );
-		if ( $current_whitelist ) {
+		if ( $current_whitelist && ! get_transient( 'jetpack_checked_is_staging' ) ) {
 			$options_to_check  = Jetpack::identity_crisis_options_to_check();
 			$cloud_options     = Jetpack::init()->get_cloud_site_options( $options_to_check );
 
@@ -5451,6 +5451,8 @@ p {
 					break;
 				}
 			}
+			// set a flag so we don't check again for an hour
+			set_transient( 'jetpack_checked_is_staging', 1, HOUR_IN_SECONDS );
 		}
 		$known_staging = array(
 			'urls' => array(

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -67,7 +67,7 @@ function jetpack_og_tags() {
 			$tags['og:url'] = home_url( '/' );
 
 		// Associate a blog's root path with one or more Facebook accounts
-		$facebook_admins = get_option( 'facebook_admins' );
+		$facebook_admins = Jetpack_Options::get_option_and_ensure_autoload( 'facebook_admins', array() );
 		if ( ! empty( $facebook_admins ) )
 			$tags['fb:admins'] = $facebook_admins;
 

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -55,7 +55,7 @@ function jetpack_og_tags() {
 	$description_length = 197;
 
 	if ( is_home() || is_front_page() ) {
-		$site_type              = get_option( 'open_graph_protocol_site_type' );
+		$site_type              = Jetpack_Options::get_option_and_ensure_autoload( 'open_graph_protocol_site_type', '' );
 		$tags['og:type']        = ! empty( $site_type ) ? $site_type : 'website';
 		$tags['og:title']       = get_bloginfo( 'name' );
 		$tags['og:description'] = get_bloginfo( 'description' );

--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -721,7 +721,7 @@ class Jetpack_Custom_CSS {
 		$option = Jetpack_Custom_CSS::is_preview() ? 'safecss_preview' : 'safecss';
 
 		if ( 'safecss' == $option ) {
-			if ( get_option( 'safecss_revision_migrated' ) ) {
+			if ( Jetpack_Options::get_option_and_ensure_autoload( 'safecss_revision_migrated', '0' ) ) {
 				$safecss_post = Jetpack_Custom_CSS::get_post();
 
 				if ( ! empty( $safecss_post['post_content'] ) ) {
@@ -737,7 +737,7 @@ class Jetpack_Custom_CSS {
 
 			// Fix for un-migrated Custom CSS
 			if ( empty( $safecss_post ) ) {
-				$_css = get_option( 'safecss' );
+				$_css = Jetpack_Options::get_option_and_ensure_autoload( 'safecss', '' );
 				if ( !empty( $_css ) ) {
 					$css = $_css;
 				}

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -35,7 +35,7 @@ class Jetpack_Portfolio {
 		// Make sure the post types are loaded for imports
 		add_action( 'import_start',                                                    array( $this, 'register_post_types' ) );
 
-		$setting = get_option( self::OPTION_NAME, '0' );
+		$setting = Jetpack_Options::get_option_and_ensure_autoload( self::OPTION_NAME, '0' );
 
 		// Bail early if Portfolio option is not set and the theme doesn't declare support
 		if ( empty( $setting ) && ! $this->site_supports_custom_post_type() ) {

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -47,7 +47,7 @@ class Jetpack_Testimonial {
 		// Check on theme switch if theme supports CPT and setting is disabled
 		add_action( 'after_switch_theme', array( $this, 'activation_post_type_support' ) );
 
-		$setting = get_option( self::OPTION_NAME, '0' );
+		$setting = Jetpack_Options::get_option_and_ensure_autoload( self::OPTION_NAME, '0' );
 
 		// Bail early if Testimonial option is not set and the theme doesn't declare support
 		if ( empty( $setting ) && ! $this->site_supports_custom_post_type() ) {

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -181,7 +181,7 @@ function grofiles_attach_cards() {
 	}
 
 	// Is the display of Gravatar Hovercards disabled?
-	if ( 'disabled' == get_option( 'gravatar_disable_hovercards' ) ) {
+	if ( 'disabled' == Jetpack_Options::get_option_and_ensure_autoload( 'gravatar_disable_hovercards', '0' ) ) {
 		return;
 	}
 

--- a/modules/minileven.php
+++ b/modules/minileven.php
@@ -16,7 +16,7 @@
 function jetpack_load_minileven() {
 	include dirname( __FILE__ ) . "/minileven/minileven.php";
 
-	if ( get_option( 'wp_mobile_app_promos' ) != '1' )
+	if ( Jetpack_Options::get_option_and_ensure_autoload( 'wp_mobile_app_promos', '0' ) != '1' )
 		remove_action( 'wp_mobile_theme_footer', 'jetpack_mobile_app_promo' );
 }
 

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -34,7 +34,7 @@ function jetpack_check_mobile() {
 		return false;
 	if ( jetpack_mobile_exclude() )
 		return false;
-	if ( 1 == get_option('wp_mobile_disable') )
+	if ( 1 == Jetpack_Options::get_option_and_ensure_autoload( 'wp_mobile_disable', '0' ) )
 		return false;
 	if ( isset($_COOKIE['akm_mobile']) && $_COOKIE['akm_mobile'] == 'true' )
 		return true;

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -538,10 +538,13 @@ class Jetpack_Protect_Module {
 	 * Checks if the protect API call has failed, and if so initiates the math captcha fallback.
 	 */
 	public function check_use_math() {
-		$use_math = $this->get_transient( 'brute_use_math' );
-		if ( $use_math ) {
-			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
-			new Jetpack_Protect_Math_Authenticate;
+		global $pagenow;
+		if ( isset( $pagenow ) && 'wp-login.php' == $pagenow ) {
+			$use_math = $this->get_transient( 'brute_use_math' );
+			if ( $use_math ) {
+				include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
+				new Jetpack_Protect_Math_Authenticate;
+			}
 		}
 	}
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -540,13 +540,10 @@ class Jetpack_Protect_Module {
 	 * Checks if the protect API call has failed, and if so initiates the math captcha fallback.
 	 */
 	public function check_use_math() {
-		global $pagenow;
-		if ( isset( $pagenow ) && 'wp-login.php' == $pagenow ) {
-			$use_math = $this->get_transient( 'brute_use_math' );
-			if ( $use_math ) {
-				include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
-				new Jetpack_Protect_Math_Authenticate;
-			}
+		$use_math = $this->get_transient( 'brute_use_math' );
+		if ( $use_math ) {
+			include_once dirname( __FILE__ ) . '/protect/math-fallback.php';
+			new Jetpack_Protect_Math_Authenticate;
 		}
 	}
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -49,7 +49,6 @@ class Jetpack_Protect_Module {
 	private function __construct() {
 		add_action( 'jetpack_activate_module_protect', array ( $this, 'on_activation' ) );
 		add_action( 'jetpack_deactivate_module_protect', array ( $this, 'on_deactivation' ) );
-		add_action( 'init', array ( $this, 'maybe_get_protect_key' ) );
 		add_action( 'jetpack_modules_loaded', array ( $this, 'modules_loaded' ) );
 		add_action( 'init', array ( $this, 'check_use_math' ) );
 		add_filter( 'authenticate', array ( $this, 'check_preauth' ), 10, 3 );
@@ -91,9 +90,12 @@ class Jetpack_Protect_Module {
 
 	public function maybe_get_protect_key() {
 		if ( get_site_option( 'jetpack_protect_activating', false ) && ! get_site_option( 'jetpack_protect_key', false ) ) {
-			$this->get_protect_key();
+			$key = $this->get_protect_key();
 			delete_site_option( 'jetpack_protect_activating' );
+			return $key;
 		}
+
+		return get_site_option( 'jetpack_protect_key' );
 	}
 
 	/**
@@ -652,7 +654,7 @@ class Jetpack_Protect_Module {
 	function protect_call( $action = 'check_ip', $request = array () ) {
 		global $wp_version, $wpdb, $current_user;
 
-		$api_key = get_site_option( 'jetpack_protect_key' );
+		$api_key = $this->maybe_get_protect_key();
 
 		$user_agent = "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' );
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -231,7 +231,7 @@ EOT;
 	 */
 	public function get_options() {
 		if ( null === $this->_options ) {
-			$this->_options = Jetpack_Options::get_option( 'relatedposts' );
+			$this->_options = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack_relatedposts', array() );
 			if ( ! is_array( $this->_options ) )
 				$this->_options = array();
 			if ( ! isset( $this->_options['enabled'] ) )

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -200,7 +200,7 @@ function sharing_restrict_to_single( $services ) {
 }
 
 function sharing_init() {
-	if ( get_option( 'sharedaddy_disable_resources' ) ) {
+	if ( Jetpack_Options::get_option_and_ensure_autoload( 'sharedaddy_disable_resources', '0' ) ) {
 		add_filter( 'sharing_js', 'sharing_disable_js' );
 		remove_action( 'wp_head', 'sharing_add_header', 1 );
 	}

--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -293,7 +293,7 @@ function vimeo_link_callback( $matches ) {
 }
 
 /** This filter is documented in modules/shortcodes/youtube.php */
-if ( apply_filters( 'jetpack_comments_allow_oembed', get_option('embed_autourls') ) ) {
+if ( apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
 	// We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway, so the iframe gets filtered out.
 	if ( ! is_admin() ) {
 		// Higher priority because we need it before auto-link and autop get to it

--- a/modules/shortcodes/vimeo.php
+++ b/modules/shortcodes/vimeo.php
@@ -293,10 +293,8 @@ function vimeo_link_callback( $matches ) {
 }
 
 /** This filter is documented in modules/shortcodes/youtube.php */
-if ( apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
+if ( ! is_admin() && apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
 	// We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway, so the iframe gets filtered out.
-	if ( ! is_admin() ) {
-		// Higher priority because we need it before auto-link and autop get to it
-		add_filter( 'comment_text', 'vimeo_link', 1 );
-	}
+	// Higher priority because we need it before auto-link and autop get to it
+	add_filter( 'comment_text', 'vimeo_link', 1 );
 }

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -363,7 +363,7 @@ add_action( 'init', 'wpcom_youtube_embed_crazy_url_init' );
  *
  * @param int get_option('embed_autourls') Option to automatically embed all plain text URLs.
  */
-if ( apply_filters( 'jetpack_comments_allow_oembed', get_option('embed_autourls') ) ) {
+if ( apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
 	// We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway, so the iframe gets filtered out.
 	if ( ! is_admin() ) {
 		// Higher priority because we need it before auto-link and autop get to it

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -363,12 +363,10 @@ add_action( 'init', 'wpcom_youtube_embed_crazy_url_init' );
  *
  * @param int get_option('embed_autourls') Option to automatically embed all plain text URLs.
  */
-if ( apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
+if ( ! is_admin() && apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
 	// We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway, so the iframe gets filtered out.
-	if ( ! is_admin() ) {
-		// Higher priority because we need it before auto-link and autop get to it
-		add_filter( 'comment_text', 'youtube_link', 1 );
-	}
+	// Higher priority because we need it before auto-link and autop get to it
+	add_filter( 'comment_text', 'youtube_link', 1 );
 }
 
 /**

--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -31,7 +31,7 @@ function jetpack_verification_options_init() {
 add_action( 'admin_init', 'jetpack_verification_options_init' );
 
 function jetpack_verification_print_meta() {
-	$verification_services_codes = get_option( 'verification_services_codes' );
+	$verification_services_codes =  Jetpack_Options::get_option_and_ensure_autoload( 'verification_services_codes', '0' );
 	if ( is_array( $verification_services_codes ) ) {
 		$ver_output = "<!-- Jetpack Site Verification Tags -->\n";
 		foreach ( jetpack_verification_services() as $name => $service ) {

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -18,6 +18,7 @@ class Jetpack_Sync_Sender {
 	private $dequeue_max_bytes;
 	private $upload_max_bytes;
 	private $upload_max_rows;
+	private $sync_wait_time;
 	private $sync_queue;
 	private $full_sync_client;
 	private $codec;
@@ -209,11 +210,11 @@ class Jetpack_Sync_Sender {
 
 	// in seconds
 	function set_sync_wait_time( $seconds ) {
-		update_option( self::SYNC_THROTTLE_OPTION_NAME, $seconds, true );
+		$this->sync_wait_time = $seconds;
 	}
 
 	function get_sync_wait_time() {
-		return (int) get_option( self::SYNC_THROTTLE_OPTION_NAME );
+		return $this->sync_wait_time;
 	}
 
 	private function get_last_sync_time() {


### PR DESCRIPTION
A bunch of fixes to reduce the number of queries that Jetpack adds to typical front-end and admin page loads, and some to improve overall performance.

- Remove use of `embed_autourls` option which was [removed in WP 3.5](https://core.trac.wordpress.org/ticket/23715) (2 queries)
- Small logic changes to reduce filter calls where there are nested if's.
- Ensure portfolio, testimonial, sharedaddy_disable_resources, gravatar_disable_hovercards, verification_services_codes, open_graph_protocol_site_type, safecss ( x 2 ), facebook_admins, jetpack-twitter-cards-site-tag options are set and autoloaded after first page load (10 queries)
- Fix bug which set sync_wait_time on every page load
- Remove unused "security_reports" feature (2 queries)
- Refactor Jetpack Protect's key initialization to avoid activation check on every page load (1 query)
- Autoload mobile theme queries if enabled (2 queries)

Total queries removed: 19

In admin:
- When the jetpack option `identity_crisis_whitelist` was set, then every check for `is_staging()` would result in a call to WPCOM to retrieve cloud site options - which basically meant an additional second added to the load time of every wp-admin page. Set a transient to reduce this to once per hour.
- Autoload `do_activate` (1 query)

cc @lezama @bazza @josephscott 
