### PR TITLE
SSO: Fixes incorrect logic for SSO checkboxes

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -271,16 +271,17 @@ class Jetpack_SSO {
 	 * @since 2.7
 	 **/
 	public function render_require_two_step() {
-		/** This filter is documented in modules/sso.php */
-		$require_two_step = Jetpack_SSO_Helpers::is_two_step_required();
-		$disabled = Jetpack_SSO_Helpers::is_require_two_step_checkbox_disabled()
-			? ' disabled="disabled"'
-			: '';
-
-		echo '<label>';
-			echo '<input type="checkbox" name="jetpack_sso_require_two_step" ' . checked( $require_two_step, true, false ) . "$disabled>";
-			esc_html_e( 'Require Two-Step Authentication' , 'jetpack' );
-		echo '</label>';
+		?>
+		<label>
+			<input
+				type="checkbox"
+				name="jetpack_sso_require_two_step"
+				<?php checked( Jetpack_SSO_Helpers::is_two_step_required() ); ?>
+				<?php disabled( Jetpack_SSO_Helpers::is_require_two_step_checkbox_disabled() ); ?>
+			>
+			<?php esc_html_e( 'Require Two-Step Authentication' , 'jetpack' ); ?>
+		</label>
+		<?php
 	}
 
 	/**
@@ -300,15 +301,17 @@ class Jetpack_SSO {
 	 * @since 2.9
 	 **/
 	public function render_match_by_email() {
-		$match_by_email = 1 == Jetpack_SSO_Helpers::match_by_email();
-		$disabled = Jetpack_SSO_Helpers::is_match_by_email_checkbox_disabled()
-			? ' disabled="disabled"'
-			: '';
-
-		echo '<label>';
-			echo '<input type="checkbox" name="jetpack_sso_match_by_email"' . checked( $match_by_email, true, false ) . "$disabled>";
-			esc_html_e( 'Match by Email', 'jetpack' );
-		echo '</label>';
+		?>
+			<label>
+				<input
+					type="checkbox"
+					name="jetpack_sso_match_by_email"
+					<?php checked( Jetpack_SSO_Helpers::match_by_email() ); ?>
+					<?php disabled( Jetpack_SSO_Helpers::is_match_by_email_checkbox_disabled() ); ?>
+				>
+				<?php esc_html_e( 'Match by Email', 'jetpack' ); ?>
+			</label>
+		<?php
 	}
 
 	/**

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -273,7 +273,9 @@ class Jetpack_SSO {
 	public function render_require_two_step() {
 		/** This filter is documented in modules/sso.php */
 		$require_two_step = Jetpack_SSO_Helpers::is_two_step_required();
-		$disabled = has_filter( 'jetpack_sso_require_two_step' ) ? ' disabled="disabled"' : '';
+		$disabled = Jetpack_SSO_Helpers::is_require_two_step_checkbox_disabled()
+			? ' disabled="disabled"'
+			: '';
 
 		echo '<label>';
 			echo '<input type="checkbox" name="jetpack_sso_require_two_step" ' . checked( $require_two_step, true, false ) . "$disabled>";
@@ -299,7 +301,7 @@ class Jetpack_SSO {
 	 **/
 	public function render_match_by_email() {
 		$match_by_email = 1 == Jetpack_SSO_Helpers::match_by_email();
-		$disabled = defined( 'WPCC_MATCH_BY_EMAIL' ) || has_filter( 'jetpack_sso_match_by_email' )
+		$disabled = Jetpack_SSO_Helpers::is_match_by_email_checkbox_disabled()
 			? ' disabled="disabled"'
 			: '';
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -273,10 +273,11 @@ class Jetpack_SSO {
 	public function render_require_two_step() {
 		/** This filter is documented in modules/sso.php */
 		$require_two_step = Jetpack_SSO_Helpers::is_two_step_required();
-		$disabled = $require_two_step ? ' disabled="disabled"' : '';
+		$disabled = has_filter( 'jetpack_sso_require_two_step' ) ? ' disabled="disabled"' : '';
+
 		echo '<label>';
-		echo '<input type="checkbox" name="jetpack_sso_require_two_step" ' . checked( $require_two_step, true, false ) . "$disabled>";
-		esc_html_e( 'Require Two-Step Authentication' , 'jetpack' );
+			echo '<input type="checkbox" name="jetpack_sso_require_two_step" ' . checked( $require_two_step, true, false ) . "$disabled>";
+			esc_html_e( 'Require Two-Step Authentication' , 'jetpack' );
 		echo '</label>';
 	}
 
@@ -298,10 +299,13 @@ class Jetpack_SSO {
 	 **/
 	public function render_match_by_email() {
 		$match_by_email = 1 == Jetpack_SSO_Helpers::match_by_email();
-		$disabled = $match_by_email ? ' disabled="disabled"' : '';
+		$disabled = defined( 'WPCC_MATCH_BY_EMAIL' ) || has_filter( 'jetpack_sso_match_by_email' )
+			? ' disabled="disabled"'
+			: '';
+
 		echo '<label>';
-		echo '<input type="checkbox" name="jetpack_sso_match_by_email"' . checked( $match_by_email, true, false ) . "$disabled>";
-		esc_html_e( 'Match by Email', 'jetpack' );
+			echo '<input type="checkbox" name="jetpack_sso_match_by_email"' . checked( $match_by_email, true, false ) . "$disabled>";
+			esc_html_e( 'Match by Email', 'jetpack' );
 		echo '</label>';
 	}
 

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -132,6 +132,28 @@ class Jetpack_SSO_Helpers {
 		 */
 		return (bool) apply_filters( 'jetpack_sso_default_to_sso_login', true );
 	}
+
+	/**
+	 * Returns a boolean for whether the two step required checkbox, displayed on the Jetpack admin page, should be disabled.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return bool
+	 */
+	static function is_require_two_step_checkbox_disabled() {
+		return (bool) has_filter( 'jetpack_sso_require_two_step' );
+	}
+
+	/**
+	 * Returns a boolean for whether the match by email checkbox, displayed on the Jetpack admin page, should be disabled.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return bool
+	 */
+	static function is_match_by_email_checkbox_disabled() {
+		return defined( 'WPCC_MATCH_BY_EMAIL' ) || has_filter( 'jetpack_sso_match_by_email' );
+	}
 }
 
 endif;

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -78,4 +78,24 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_SSO_Helpers::bypass_login_forward_wpcom() );
 		remove_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_false' );
 	}
+	
+	function test_sso_helpers_require_two_step_disabled() {
+		add_filter( 'jetpack_sso_require_two_step', '__return_true' );
+		$this->assertTrue( Jetpack_SSO_Helpers::is_require_two_step_checkbox_disabled() );
+		remove_filter( 'jetpack_sso_require_two_step', '__return_true' );
+	}
+	
+	function test_sso_helpers_require_two_step_enabled() {
+		$this->assertFalse( Jetpack_SSO_Helpers::is_require_two_step_checkbox_disabled() );
+	}
+	
+	function test_sso_helpers_match_by_email_disabled() {
+		add_filter( 'jetpack_sso_match_by_email', '__return_true' );
+		$this->assertTrue( Jetpack_SSO_Helpers::is_match_by_email_checkbox_disabled() );
+		remove_filter( 'jetpack_sso_match_by_email', '__return_true' );
+	}
+
+	function test_sso_helpers_match_by_email_enabled() {
+		$this->assertFalse( Jetpack_SSO_Helpers::is_match_by_email_checkbox_disabled() );
+	}
 }


### PR DESCRIPTION
@Viper007Bond pointed out an issue where the SSO checkboxes  seemed to act like radios. In my testing, this seemed to happen due to some incorrect logic that handled the disabled state for the checkboxes.

cc @lezama for code review

To test:

- Checkout `update/sso-fix-sso-checkboxes` branch
- Go to `$site/wp-admin/admin.php?page=jetpack&configure=sso`
- Try checking each checkbox
- Make sure that you can change each setting individually
- The checkboxes should become disabled when you use the corresponding filter or constant. See the code to get the filter/constant names