### PR TITLE
Performance: Remove `perform_security_reporting` from `init`

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -312,8 +312,6 @@ class Jetpack {
 
 			self::$instance->plugin_upgrade();
 
-			add_action( 'init', array( __CLASS__, 'perform_security_reporting' ) );
-
 		}
 
 		return self::$instance;


### PR DESCRIPTION
Apply #4274 to `master` as well.