### PR TITLE
Contact Form: do not include spam in the count bubble in WP Admin

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1987,9 +1987,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 
-		// Increase count of unread feedback.
-		$unread = get_option( 'feedback_unread_count', 0 ) + 1;
-		update_option( 'feedback_unread_count', $unread );
+		if ( 'publish' == $feedback_status ) {
+			// Increase count of unread feedback.
+			$unread = get_option( 'feedback_unread_count', 0 ) + 1;
+			update_option( 'feedback_unread_count', $unread );
+		}
 
 		if ( defined( 'AKISMET_VERSION' ) ) {
 			update_post_meta( $post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1983,7 +1983,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		) );
 
 		// once insert has finished we don't need this filter any more
-		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10, 2 );
+		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 
 		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 


### PR DESCRIPTION
Fixes #4288

#### Changes proposed in this Pull Request:
- The bubble in the Feedback menu in WP Admin now only counts valid submissions. Those flagged as `spam` (when the post is inserted with such state) are not counted.
- Removes unused third parameter passed to `remove_filter` which doesn't exist in the function signature.
