### PR TITLE
Related Posts: solve minor styling issues in compatibility stylesheets

### DIFF
--- a/modules/related-posts/related-posts.css
+++ b/modules/related-posts/related-posts.css
@@ -105,6 +105,7 @@
 	left:0;
 	right:0;
 	display:block;
+	border-bottom: 0;
 }
 
 #jp-relatedposts .jp-relatedposts-items p {

--- a/modules/theme-tools/compat/twentysixteen-rtl.css
+++ b/modules/theme-tools/compat/twentysixteen-rtl.css
@@ -474,6 +474,7 @@ iframe[src^="http://api.mixcloud.com/"] {
 	opacity: 0.2;
 	position: absolute;
 	top: 0;
+	right: 0;
 	width: 100%;
 }
 

--- a/modules/theme-tools/compat/twentysixteen.css
+++ b/modules/theme-tools/compat/twentysixteen.css
@@ -474,6 +474,7 @@ iframe[src^="http://api.mixcloud.com/"] {
 	opacity: 0.2;
 	position: absolute;
 	top: 0;
+	left: 0;
 	width: 100%;
 }
 


### PR DESCRIPTION
Fixes #4291
Also fixes #3434 and #3724 in Firefox.

#### Changes proposed in this Pull Request:
- for TwentySixteen, align the top/bottom borders towards left (or right in RTL) in Settings > Reading preview.
- for TwentyFifteen, remove the bottom border from an entry without a featured image.