### PR TITLE
Upgraded node-sass in order to make Jetpack run under Node 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jshint": "2.9.1",
     "jshint-stylish": "~2.1.0",
     "lodash": "^4.9.0",
-    "node-sass": "3.4.2",
+    "node-sass": "^3.7.0",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
     "react-dom": "0.14.3",

--- a/readme.md
+++ b/readme.md
@@ -40,16 +40,13 @@ Developers of all levels can help — whether you can barely recognize a filter 
 
 The javascript and CSS components of this plugin's admin interface need to be built in order to get the runtime bundle (`_inc/build/admin.js`)
 
-**Recommended Dependencies and Known Issues**
+**Recommended Dependencies**
 
 Recommended environment:
-- Node 5.x (preferably 5.11 or 5.10)
+- Node 6.x
 - npm 3.8.x
 
-If you're having trouble installing 5.x, [nvm](https://www.npmjs.com/package/nvm) is a nice tool for node version management :)
-
-Known Issues:
-- Does not work with Node 6.x nor 4.x.
+If you're having trouble installing 6.x, [nvm](https://www.npmjs.com/package/nvm) is a nice tool for node version management :)
 
 **Start Development**
 

--- a/scss/molecules/_nav-horizontal.scss
+++ b/scss/molecules/_nav-horizontal.scss
@@ -3,7 +3,13 @@
 // ==========================================================================
 
 .nav-horizontal {
-	@extend %clearfix;
+	&:after {
+		content: ".";
+		display: block;
+		height: 0;
+		clear: both;
+		visibility: hidden;
+	}
 
 	a {
 		display: inline-block;


### PR DESCRIPTION
This PR should be used together with [the related dops-components PR](https://github.com/Automattic/dops-components/pull/26) that would enable us to use Node 6. 