### PR TITLE
Add VaultPress and Jetpack 4.1 compatibility

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -10,3 +10,4 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/wpml.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/vaultpress.php' );

--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * For backward compatibility with VaultPress 1.8.3 to play nicely with Jetpack 4.1
+ */
+add_action( 'init', 'jetpack_vaultpress_sync_options' );
+function jetpack_vaultpress_sync_options() {
+	if ( !class_exists( 'VaultPress' ) ) {
+		return;
+	}
+	$vaultpress = VaultPress::init();
+	Jetpack_Sync::sync_options( __FILE__, $vaultpress->auto_register_option, $vaultpress->option_name );
+}

--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -5,7 +5,7 @@
  */
 add_action( 'init', 'jetpack_vaultpress_sync_options' );
 function jetpack_vaultpress_sync_options() {
-	if ( !class_exists( 'VaultPress' ) ) {
+	if ( ! class_exists( 'VaultPress' ) ) {
 		return;
 	}
 	$vaultpress = VaultPress::init();


### PR DESCRIPTION
Since we though that we would ship Jetpack 4.1 with the new sync we
added code to VaultPress to turn off the old syncing in version 1.8.3.
This code adds VaultPress compatibility. Which is VaultPress is
installed sends same data as before.

This code doesn't exist in new Version of Jetpack. But is there for
version 4.1 to make sure that sync continuous to work as expected.
Without replying on a specific version of VaultPress.

#### Changes proposed in this Pull Request:
- Adds syncing for VaultPress options. 
If an older version of VaultPress is used syncing worked as expected.
Sync doesn't send the data twice or causes any conflicts. 

This code is only suppose to live in Jetpack 4.1, 
Jetpack 4.2 (fingers crossed) will sync data differently. 

@jeherve, @Viper007Bond, @lezama 

