### PR TITLE
Sync allowed post types for API

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -140,6 +140,7 @@ class Jetpack_Sync_Defaults {
 		'is_version_controlled'           => array( 'Jetpack_Sync_Functions', 'is_version_controlled' ),
 		'taxonomies'                      => array( 'Jetpack_Sync_Functions', 'get_taxonomies' ),
 		'post_types'                      => array( 'Jetpack_Sync_Functions', 'get_post_types' ),
+		'rest_api_allowed_post_types'     => array( 'Jetpack_Sync_Functions', 'rest_api_allowed_post_types' ),
 		'sso_is_two_step_required'        => array( 'Jetpack_SSO_Helpers', 'is_two_step_required' ),
 		'sso_should_hide_login_form'      => array( 'Jetpack_SSO_Helpers', 'should_hide_login_form' ),
 		'sso_match_by_email'              => array( 'Jetpack_SSO_Helpers', 'match_by_email' ),

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -23,6 +23,10 @@ class Jetpack_Sync_Functions {
 		return $wp_post_types;
 	}
 
+	public static function rest_api_allowed_post_types() {
+		return apply_filters( 'rest_api_allowed_post_types', array( 'post', 'page', 'revision' ) );
+	}
+
 	/**
 	 * Finds out if a site is using a version control system.
 	 * @return bool

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -24,6 +24,7 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function rest_api_allowed_post_types() {
+		/** This filter is already documented in class.json-api-endpoints.php */
 		return apply_filters( 'rest_api_allowed_post_types', array( 'post', 'page', 'revision' ) );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -61,6 +61,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'is_version_controlled'           => Jetpack_Sync_Functions::is_version_controlled(),
 			'taxonomies'                      => Jetpack_Sync_Functions::get_taxonomies(),
 			'post_types'                      => Jetpack_Sync_Functions::get_post_types(),
+			'rest_api_allowed_post_types'     => Jetpack_Sync_Functions::rest_api_allowed_post_types(),
 			'sso_is_two_step_required'        => Jetpack_SSO_Helpers::is_two_step_required(),
 			'sso_should_hide_login_form'      => Jetpack_SSO_Helpers::should_hide_login_form(),
 			'sso_match_by_email'              => Jetpack_SSO_Helpers::match_by_email(),


### PR DESCRIPTION
This change allows us to apply filtering for which post types are permitted for the get-posts REST API endpoint on WPCOM.

cc @lezama @nylen 