### PR TITLE
Remove REST_API_REQUEST from some filters

### DIFF
--- a/class.jetpack-bbpress-json-api-compat.php
+++ b/class.jetpack-bbpress-json-api-compat.php
@@ -21,11 +21,6 @@ class bbPress_Jetpack_REST_API {
 	}
 
 	function allow_bbpress_post_types( $allowed_post_types ) {
-
-		// only run for REST API requests
-		if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST )
-			return $allowed_post_types;
-
 		$allowed_post_types[] = 'forum';
 		$allowed_post_types[] = 'topic';
 		$allowed_post_types[] = 'reply';
@@ -33,11 +28,6 @@ class bbPress_Jetpack_REST_API {
 	}
 
 	function allow_bbpress_public_metadata( $allowed_meta_keys ) {
-
-		// only run for REST API requests
-		if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST )
-			return $allowed_meta_keys;
-
 		$allowed_meta_keys[] = '_bbp_forum_id';
 		$allowed_meta_keys[] = '_bbp_topic_id';
 		$allowed_meta_keys[] = '_bbp_status';

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -141,6 +141,7 @@ class Jetpack_Sync_Defaults {
 		'taxonomies'                      => array( 'Jetpack_Sync_Functions', 'get_taxonomies' ),
 		'post_types'                      => array( 'Jetpack_Sync_Functions', 'get_post_types' ),
 		'rest_api_allowed_post_types'     => array( 'Jetpack_Sync_Functions', 'rest_api_allowed_post_types' ),
+		'rest_api_allowed_public_metadata'=> array( 'Jetpack_Sync_Functions', 'rest_api_allowed_public_metadata' ),
 		'sso_is_two_step_required'        => array( 'Jetpack_SSO_Helpers', 'is_two_step_required' ),
 		'sso_should_hide_login_form'      => array( 'Jetpack_SSO_Helpers', 'should_hide_login_form' ),
 		'sso_match_by_email'              => array( 'Jetpack_SSO_Helpers', 'match_by_email' ),

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -28,6 +28,11 @@ class Jetpack_Sync_Functions {
 		return apply_filters( 'rest_api_allowed_post_types', array( 'post', 'page', 'revision' ) );
 	}
 
+	public static function rest_api_allowed_public_metadata() {
+		/** This filter is documented in json-endpoints/class.wpcom-json-api-post-endpoint.php */
+		return apply_filters( 'rest_api_allowed_public_metadata', array() );
+	}
+
 	/**
 	 * Finds out if a site is using a version control system.
 	 * @return bool

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -86,6 +86,11 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
 			return;
 		}
+
+		if ( ! defined( 'REST_API_REQUEST' ) ) {
+			define( 'REST_API_REQUEST', true );
+		}
+
 		$callables = $this->get_all_callables();
 
 		if ( empty( $callables ) ) {

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -87,10 +87,6 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( ! defined( 'REST_API_REQUEST' ) ) {
-			define( 'REST_API_REQUEST', true );
-		}
-
 		$callables = $this->get_all_callables();
 
 		if ( empty( $callables ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -62,6 +62,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'taxonomies'                      => Jetpack_Sync_Functions::get_taxonomies(),
 			'post_types'                      => Jetpack_Sync_Functions::get_post_types(),
 			'rest_api_allowed_post_types'     => Jetpack_Sync_Functions::rest_api_allowed_post_types(),
+			'rest_api_allowed_public_metadata'=> Jetpack_Sync_Functions::rest_api_allowed_public_metadata(),
 			'sso_is_two_step_required'        => Jetpack_SSO_Helpers::is_two_step_required(),
 			'sso_should_hide_login_form'      => Jetpack_SSO_Helpers::should_hide_login_form(),
 			'sso_match_by_email'              => Jetpack_SSO_Helpers::match_by_email(),

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -110,35 +110,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEqualsObject( $value, $this->server_replica_storage->get_callable( $name ), 'Function '. $name .' didn\'t have the expected value of ' . json_encode( $value ) );
 	}
 
-	function test_white_listed_callables_have_REST_API_REQUEST_true() {
-		// this hack is necessary because so many filters we want to sync return early if
-		// REST_API_REQUEST is false or not defined.
-
-		// sync existing constants
-		$this->sender->do_sync();
-		$this->server_event_storage->reset();
-
-		add_filter( 'rest_api_allowed_post_types', array( $this, 'conditionally_add_post_type' ) );
-
-		// force re-sync of callables despite wait time not having passed
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_callable' );
-		$synced_post_types = $event->args[1];
-
-		$this->assertTrue( in_array( 'my_new_post_type', $synced_post_types ) );
-	}
-
-	// designed to work much the same as other allowed-post-type filters
-	function conditionally_add_post_type( $allowed_post_types ) {
-		if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST )
-			return $allowed_post_types;
-
-		$allowed_post_types[] = 'my_new_post_type';
-		return $allowed_post_types;
-	} 
-
 	function test_white_listed_callables_doesnt_get_synced_twice() {
 		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
 		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );


### PR DESCRIPTION
Fixes the issue where `rest_api_allowed_post_types` wouldn't return correct results because filters often exit early if `REST_API_REQUEST` is not defined or false. 

Originally this PR fixed the issue by setting the `REST_API_REQUEST` constant, but instead I decided to remove the check from the places where it was present, since it didn't seem to be necessary and just added complexity for no discernable benefit.

Also adds callable for `rest_api_allowed_public_metadata`