### PR TITLE
Fixes #4309 - flickr shortcode: size parameter not used anywhere

### DIFF
--- a/modules/shortcodes/flickr.php
+++ b/modules/shortcodes/flickr.php
@@ -102,7 +102,6 @@ function flickr_shortcode_handler( $atts ) {
 			'w'         => 400,
 			'h'         => 300,
 			'secret'    => 0,
-			'size'      => 0,
 		), $atts, 'flickr'
 	);
 


### PR DESCRIPTION
Fixes #4309 .

#### Changes proposed in this Pull Request:
Delete the line containing the only instance of 'size'

I don't see the need to change any test cases.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

