### PR TITLE
Sharing: fix inconsistent horizontal spacing for official buttons.

### DIFF
--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -77,7 +77,6 @@ body.highlander-dark h3.sd-title:before {
 .sd-social-official .sd-content>ul>li .digg_button >a {		/* official Digg button no longer works, needs cleaning */
 	text-decoration: none !important;
 	display: inline-block;
-	margin: 0 5px 5px 0;
 	font-size: 12px;
 	font-family: "Open Sans", sans-serif;
 	font-weight: normal;
@@ -182,7 +181,7 @@ body.highlander-dark h3.sd-title:before {
 }
 
 .sd-content ul li {
-	margin: 0 !important;
+	margin: 0 5px 5px 0;
 	padding: 0;
 }
 


### PR DESCRIPTION
This fixes the inconsistent spacing by moving the css margin to the same selector. The change only affects Official button mode. Icon & Text modes continues to look the same as they did before.

Before (note odd increase spacing after Print, Telegram, Whatsapp):
<img width="549" alt="screen shot 2016-06-11 at 11 11 51" src="https://cloud.githubusercontent.com/assets/611339/16626728/7729a220-4367-11e6-9aea-cccbe8be551f.png">

After (consistent spacing after all buttons):
<img width="533" alt="screen shot 2016-06-11 at 11 12 30" src="https://cloud.githubusercontent.com/assets/611339/16626743/8417791c-4367-11e6-8d9b-edc3022e5687.png">
