### PR TITLE
SSO: Use retina gravatar on login form

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1167,7 +1167,7 @@ class Jetpack_SSO {
 			'jetpack_sso_wpcom_gravatar_' . COOKIEHASH,
 			get_avatar_url(
 				$user_data->email,
-				array( 'size' => 72, 'default' => 'mystery' )
+				array( 'size' => 144, 'default' => 'mystery' )
 			),
 			time() + WEEK_IN_SECONDS,
 			COOKIEPATH,


### PR DESCRIPTION
A user reported that we are not using a retina friendly image for the gravatar that is displayed on the SSO login form. This PR fixes that.

To test:
- Checkout `fix/sso-retina-gravatar` branch
- Go to `$site/wp-admin`
- Log in, and then log back out (when you log out, we set a cookie with your gravatar)
- Confirm that your gravatar is `144` pixels and isn't blurry on a retina screen
