### PR TITLE
Admin Page: revamp non admin view when user is not linked and when it…

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -91,17 +91,31 @@ export default ( props ) => {
 			</div>
 		);
 	} else {
-		return (
-			<div>
-				<DashStats { ...props } />
+		let stats = '';
+		if ( window.Initial_State.userData.currentUser.permissions.view_stats ) {
+			stats = <DashStats { ...props } />;
+		}
 
-				{
-					// Site Security
+		let protect = '';
+		protect = <DashProtect { ...props } />;
 
-					securityHeader
-				}
-				<DashProtect { ...props } />
-			</div>
-		);
+		let nonAdminAAG = '';
+		if ( '' !== stats || '' !== protect ) {
+			nonAdminAAG = (
+				<div>
+					{
+						stats +
+
+						// Site Security
+
+						securityHeader +
+
+						protect
+					}
+				</div>
+			);
+		}
+
+		return nonAdminAAG;
 	}
 };

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import Card from 'components/card';
 import DashSectionHeader from 'components/dash-section-header';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,104 +20,118 @@ import DashPluginUpdates from './plugins';
 import DashPhoton from './photon';
 import DashSiteVerify from './site-verification';
 import FeedbackDashRequest from 'components/jetpack-notices/feedback-dash-request';
-import { translate as __ } from 'i18n-calypso';
+import { isModuleActivated as _isModuleActivated } from 'state/modules';
 
-export default ( props ) => {
+const AtAGlance = React.createClass( {
+	render() {
+		let props = this.props;
+		let securityHeader =
+				<DashSectionHeader
+				label={ __( 'Site Security' ) }
+				settingsPath="#security"
+				externalLink={ __( 'Manage Security on WordPress.com' ) }
+				externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } />,
+			healthHeader =
+				<DashSectionHeader
+					label={ __( 'Site Health' ) }
+					settingsPath="#health" />,
+			trafficHeader =
+				<DashSectionHeader
+					label={ __( 'Traffic Tools' ) }
+					settingsPath="#engagement" />;
 
-	let securityHeader =
-			<DashSectionHeader
-			label={ __( 'Site Security' ) }
-			settingsPath="#security"
-			externalLink={ __( 'Manage Security on WordPress.com' ) }
-			externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } />,
-		healthHeader =
-			<DashSectionHeader
-				label={ __( 'Site Health' ) }
-				settingsPath="#health" />,
-		trafficHeader =
-			<DashSectionHeader
-				label={ __( 'Traffic Tools' ) }
-				settingsPath="#engagement" />;
-
-	// If user can manage modules, we're in an admin view, otherwise it's a non-admin view.
-	if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
-		return (
-			<div>
-				<DashStats { ...props } />
-
-				{
-					// Site Security
-
-					securityHeader
-				}
-				<div className="jp-at-a-glance__item-grid">
-					<div className="jp-at-a-glance__left">
-						<DashProtect { ...props } />
-					</div>
-					<div className="jp-at-a-glance__right">
-						<DashScan { ...props } />
-						<DashMonitor { ...props } />
-					</div>
-				</div>
-
-				{
-					// Site Health
-
-					healthHeader
-				}
-				<div className="jp-at-a-glance__item-grid">
-						<div className="jp-at-a-glance__left">
-							<DashAkismet { ...props } />
-						</div>
-						<div className="jp-at-a-glance__right">
-							<DashBackups { ...props } />
-							<DashPluginUpdates { ...props } />
-						</div>
-				</div>
-
-				{
-					// Traffic Tools
-
-					trafficHeader
-				}
-				<div className="jp-at-a-glance__item-grid">
-						<div className="jp-at-a-glance__left">
-							<DashPhoton { ...props } />
-						</div>
-						<div className="jp-at-a-glance__right">
-							<DashSiteVerify { ...props } />
-						</div>
-				</div>
-
-				<FeedbackDashRequest { ...props } />
-			</div>
-		);
-	} else {
-		let stats = '';
-		if ( window.Initial_State.userData.currentUser.permissions.view_stats ) {
-			stats = <DashStats { ...props } />;
-		}
-
-		let protect = '';
-		protect = <DashProtect { ...props } />;
-
-		let nonAdminAAG = '';
-		if ( '' !== stats || '' !== protect ) {
-			nonAdminAAG = (
+		// If user can manage modules, we're in an admin view, otherwise it's a non-admin view.
+		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
+			return (
 				<div>
-					{
-						stats +
+					<DashStats { ...props } />
 
+					{
 						// Site Security
 
-						securityHeader +
-
-						protect
+						securityHeader
 					}
+					<div className="jp-at-a-glance__item-grid">
+						<div className="jp-at-a-glance__left">
+							<DashProtect { ...props } />
+						</div>
+						<div className="jp-at-a-glance__right">
+							<DashScan { ...props } />
+							<DashMonitor { ...props } />
+						</div>
+					</div>
+
+					{
+						// Site Health
+
+						healthHeader
+					}
+					<div className="jp-at-a-glance__item-grid">
+							<div className="jp-at-a-glance__left">
+								<DashAkismet { ...props } />
+							</div>
+							<div className="jp-at-a-glance__right">
+								<DashBackups { ...props } />
+								<DashPluginUpdates { ...props } />
+							</div>
+					</div>
+
+					{
+						// Traffic Tools
+
+						trafficHeader
+					}
+					<div className="jp-at-a-glance__item-grid">
+							<div className="jp-at-a-glance__left">
+								<DashPhoton { ...props } />
+							</div>
+							<div className="jp-at-a-glance__right">
+								<DashSiteVerify { ...props } />
+							</div>
+					</div>
+
+					<FeedbackDashRequest { ...props } />
 				</div>
 			);
-		}
+		} else {
+			let stats = '';
+			if ( window.Initial_State.userData.currentUser.permissions.view_stats ) {
+				stats = <DashStats { ...props } />;
+			}
 
-		return nonAdminAAG;
+			let protect = '';
+			if ( this.props.isModuleActivated( 'protect' ) ) {
+				protect = <DashProtect { ...props } />;
+			}
+
+			let nonAdminAAG = '';
+			if ( '' !== stats || '' !== protect ) {
+				nonAdminAAG = (
+					<div>
+						{
+							stats
+						}
+						{
+							// Site Security
+
+							securityHeader
+						}
+						{
+							protect
+						}
+					</div>
+				);
+			}
+
+			return nonAdminAAG;
+		}
+	} // render
+} );
+
+export default connect(
+	( state ) => {
+		return {
+			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
+		};
 	}
-};
+)( AtAGlance );

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -20,63 +20,88 @@ import DashSiteVerify from './site-verification';
 import FeedbackDashRequest from 'components/jetpack-notices/feedback-dash-request';
 import { translate as __ } from 'i18n-calypso';
 
-export default ( props ) =>
-	<div>
-		<DashStats { ...props } />
+export default ( props ) => {
 
-		{
-			// Site Security
-		}
-
-		<DashSectionHeader
+	let securityHeader =
+			<DashSectionHeader
 			label={ __( 'Site Security' ) }
 			settingsPath="#security"
 			externalLink={ __( 'Manage Security on WordPress.com' ) }
-			externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } />
-		<div className="jp-at-a-glance__item-grid">
-			<div className="jp-at-a-glance__left">
+			externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } />,
+		healthHeader =
+			<DashSectionHeader
+				label={ __( 'Site Health' ) }
+				settingsPath="#health" />,
+		trafficHeader =
+			<DashSectionHeader
+				label={ __( 'Traffic Tools' ) }
+				settingsPath="#engagement" />;
+
+	// If user can manage modules, we're in an admin view, otherwise it's a non-admin view.
+	if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
+		return (
+			<div>
+				<DashStats { ...props } />
+
+				{
+					// Site Security
+
+					securityHeader
+				}
+				<div className="jp-at-a-glance__item-grid">
+					<div className="jp-at-a-glance__left">
+						<DashProtect { ...props } />
+					</div>
+					<div className="jp-at-a-glance__right">
+						<DashScan { ...props } />
+						<DashMonitor { ...props } />
+					</div>
+				</div>
+
+				{
+					// Site Health
+
+					healthHeader
+				}
+				<div className="jp-at-a-glance__item-grid">
+						<div className="jp-at-a-glance__left">
+							<DashAkismet { ...props } />
+						</div>
+						<div className="jp-at-a-glance__right">
+							<DashBackups { ...props } />
+							<DashPluginUpdates { ...props } />
+						</div>
+				</div>
+
+				{
+					// Traffic Tools
+
+					trafficHeader
+				}
+				<div className="jp-at-a-glance__item-grid">
+						<div className="jp-at-a-glance__left">
+							<DashPhoton { ...props } />
+						</div>
+						<div className="jp-at-a-glance__right">
+							<DashSiteVerify { ...props } />
+						</div>
+				</div>
+
+				<FeedbackDashRequest { ...props } />
+			</div>
+		);
+	} else {
+		return (
+			<div>
+				<DashStats { ...props } />
+
+				{
+					// Site Security
+
+					securityHeader
+				}
 				<DashProtect { ...props } />
 			</div>
-			<div className="jp-at-a-glance__right">
-				<DashScan { ...props } />
-				<DashMonitor { ...props } />
-			</div>
-		</div>
-
-		{
-			// Site Health
-		}
-
-		<DashSectionHeader
-			label={ __( 'Site Health' ) }
-			settingsPath="#health" />
-
-		<div className="jp-at-a-glance__item-grid">
-				<div className="jp-at-a-glance__left">
-					<DashAkismet { ...props } />
-				</div>
-				<div className="jp-at-a-glance__right">
-					<DashBackups { ...props } />
-					<DashPluginUpdates { ...props } />
-				</div>
-		</div>
-
-		{
-			// Traffic Tools
-		}
-
-		<DashSectionHeader
-			label={ __( 'Traffic Tools' ) }
-			settingsPath="#engagement" />
-
-		<div className="jp-at-a-glance__item-grid">
-				<div className="jp-at-a-glance__left">
-					<DashPhoton { ...props } />
-				</div>
-				<div className="jp-at-a-glance__right">
-					<DashSiteVerify { ...props } />
-				</div>
-		</div>
-
-		<FeedbackDashRequest { ...props } />
-	</div>
+		);
+	}
+};

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -24,7 +24,6 @@ import { isModuleActivated as _isModuleActivated } from 'state/modules';
 
 const AtAGlance = React.createClass( {
 	render() {
-		let props = this.props;
 		let securityHeader =
 				<DashSectionHeader
 				label={ __( 'Site Security' ) }
@@ -44,7 +43,7 @@ const AtAGlance = React.createClass( {
 		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
 			return (
 				<div>
-					<DashStats { ...props } />
+					<DashStats { ...this.props } />
 
 					{
 						// Site Security
@@ -53,11 +52,11 @@ const AtAGlance = React.createClass( {
 					}
 					<div className="jp-at-a-glance__item-grid">
 						<div className="jp-at-a-glance__left">
-							<DashProtect { ...props } />
+							<DashProtect { ...this.props } />
 						</div>
 						<div className="jp-at-a-glance__right">
-							<DashScan { ...props } />
-							<DashMonitor { ...props } />
+							<DashScan { ...this.props } />
+							<DashMonitor { ...this.props } />
 						</div>
 					</div>
 
@@ -68,11 +67,11 @@ const AtAGlance = React.createClass( {
 					}
 					<div className="jp-at-a-glance__item-grid">
 							<div className="jp-at-a-glance__left">
-								<DashAkismet { ...props } />
+								<DashAkismet { ...this.props } />
 							</div>
 							<div className="jp-at-a-glance__right">
-								<DashBackups { ...props } />
-								<DashPluginUpdates { ...props } />
+								<DashBackups { ...this.props } />
+								<DashPluginUpdates { ...this.props } />
 							</div>
 					</div>
 
@@ -83,42 +82,38 @@ const AtAGlance = React.createClass( {
 					}
 					<div className="jp-at-a-glance__item-grid">
 							<div className="jp-at-a-glance__left">
-								<DashPhoton { ...props } />
+								<DashPhoton { ...this.props } />
 							</div>
 							<div className="jp-at-a-glance__right">
-								<DashSiteVerify { ...props } />
+								<DashSiteVerify { ...this.props } />
 							</div>
 					</div>
 
-					<FeedbackDashRequest { ...props } />
+					<FeedbackDashRequest { ...this.props } />
 				</div>
 			);
 		} else {
 			let stats = '';
 			if ( window.Initial_State.userData.currentUser.permissions.view_stats ) {
-				stats = <DashStats { ...props } />;
+				stats = <DashStats { ...this.props } />;
 			}
 
 			let protect = '';
 			if ( this.props.isModuleActivated( 'protect' ) ) {
-				protect = <DashProtect { ...props } />;
+				protect = <DashProtect { ...this.props } />;
 			}
 
 			let nonAdminAAG = '';
 			if ( '' !== stats || '' !== protect ) {
 				nonAdminAAG = (
 					<div>
-						{
-							stats
-						}
+						{ stats	}
 						{
 							// Site Security
 
 							securityHeader
 						}
-						{
-							protect
-						}
+						{ protect }
 					</div>
 				);
 			}

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -26,18 +26,21 @@ const AtAGlance = React.createClass( {
 	render() {
 		let securityHeader =
 				<DashSectionHeader
-				label={ __( 'Site Security' ) }
-				settingsPath="#security"
-				externalLink={ __( 'Manage Security on WordPress.com' ) }
-				externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } />,
+					label={ __( 'Site Security' ) }
+					settingsPath="#security"
+					externalLink={ __( 'Manage Security on WordPress.com' ) }
+					externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl }
+				/>,
 			healthHeader =
 				<DashSectionHeader
 					label={ __( 'Site Health' ) }
-					settingsPath="#health" />,
+					settingsPath="#health"
+				/>,
 			trafficHeader =
 				<DashSectionHeader
 					label={ __( 'Traffic Tools' ) }
-					settingsPath="#engagement" />;
+					settingsPath="#engagement"
+				/>;
 
 		// If user can manage modules, we're in an admin view, otherwise it's a non-admin view.
 		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
@@ -47,7 +50,6 @@ const AtAGlance = React.createClass( {
 
 					{
 						// Site Security
-
 						securityHeader
 					}
 					<div className="jp-at-a-glance__item-grid">
@@ -62,17 +64,16 @@ const AtAGlance = React.createClass( {
 
 					{
 						// Site Health
-
 						healthHeader
 					}
 					<div className="jp-at-a-glance__item-grid">
-							<div className="jp-at-a-glance__left">
-								<DashAkismet { ...this.props } />
-							</div>
-							<div className="jp-at-a-glance__right">
-								<DashBackups { ...this.props } />
-								<DashPluginUpdates { ...this.props } />
-							</div>
+						<div className="jp-at-a-glance__left">
+							<DashAkismet { ...this.props } />
+						</div>
+						<div className="jp-at-a-glance__right">
+							<DashBackups { ...this.props } />
+							<DashPluginUpdates { ...this.props } />
+						</div>
 					</div>
 
 					{
@@ -81,12 +82,12 @@ const AtAGlance = React.createClass( {
 						trafficHeader
 					}
 					<div className="jp-at-a-glance__item-grid">
-							<div className="jp-at-a-glance__left">
-								<DashPhoton { ...this.props } />
-							</div>
-							<div className="jp-at-a-glance__right">
-								<DashSiteVerify { ...this.props } />
-							</div>
+						<div className="jp-at-a-glance__left">
+							<DashPhoton { ...this.props } />
+						</div>
+						<div className="jp-at-a-glance__right">
+							<DashSiteVerify { ...this.props } />
+						</div>
 					</div>
 
 					<FeedbackDashRequest { ...this.props } />
@@ -110,7 +111,6 @@ const AtAGlance = React.createClass( {
 						{ stats	}
 						{
 							// Site Security
-
 							securityHeader
 						}
 						{ protect }

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -16,36 +16,62 @@ const NavigationSettings = React.createClass( {
 	},
 
 	render: function() {
+		let navItems;
+		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
+			navItems = (
+				<NavTabs selectedText={ this.props.route.name }>
+					<NavItem
+						path="#general"
+						selected={ ( this.props.route.path === '/general' || this.props.route.path === '/settings' ) }>
+						{ __( 'General', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#engagement"
+						selected={ this.props.route.path === '/engagement' }>
+						{ __( 'Engagement', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#security"
+						selected={ this.props.route.path === '/security' }>
+						{ __( 'Security', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#appearance"
+						selected={ this.props.route.path === '/appearance' }>
+						{ __( 'Appearance', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#writing"
+						selected={ this.props.route.path === '/writing' }>
+						{ __( 'Writing', { context: 'Navigation item.' } ) }
+					</NavItem>
+				</NavTabs>
+			);
+		} else {
+			navItems = (
+				<NavTabs selectedText={ this.props.route.name }>
+					<NavItem
+						path="#general"
+						selected={ ( this.props.route.path === '/general' || this.props.route.path === '/settings' ) }>
+						{ __( 'General', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#engagement"
+						selected={ this.props.route.path === '/engagement' }>
+						{ __( 'Engagement', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#writing"
+						selected={ this.props.route.path === '/writing' }>
+						{ __( 'Writing', { context: 'Navigation item.' } ) }
+					</NavItem>
+				</NavTabs>
+			);
+		}
 		return (
 			<div className='dops-navigation'>
 				<SectionNav selectedText={ this.props.route.name }>
-					<NavTabs selectedText={ this.props.route.name }>
-						<NavItem
-							path="#general"
-							selected={ ( this.props.route.path === '/general' || this.props.route.path === '/settings' ) }>
-							{ __( 'General', { context: 'Navigation item.' } ) }
-						</NavItem>
-						<NavItem
-							path="#engagement"
-							selected={ this.props.route.path === '/engagement' }>
-							{ __( 'Engagement', { context: 'Navigation item.' } ) }
-						</NavItem>
-						<NavItem
-							path="#security"
-							selected={ this.props.route.path === '/security' }>
-							{ __( 'Security', { context: 'Navigation item.' } ) }
-						</NavItem>
-						<NavItem
-							path="#appearance"
-							selected={ this.props.route.path === '/appearance' }>
-							{ __( 'Appearance', { context: 'Navigation item.' } ) }
-						</NavItem>
-						<NavItem
-							path="#writing"
-							selected={ this.props.route.path === '/writing' }>
-							{ __( 'Writing', { context: 'Navigation item.' } ) }
-						</NavItem>
-					</NavTabs>
+					{ navItems }
 
 					<Search
 						pinned={ true }

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -11,29 +11,45 @@ injectTapEventPlugin();
 
 const Navigation = React.createClass( {
 	render: function() {
+		let navTabs;
+		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
+			navTabs = (
+				<NavTabs>
+					<NavItem
+						path="#dashboard"
+						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
+						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#apps"
+						selected={ this.props.route.path === '/apps' }>
+						{ __( 'Apps', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
+						path="#professional"
+						selected={ this.props.route.path === '/professional' }>
+						{ __( 'Professional', { context: 'Navigation item.' } ) }
+					</NavItem>
+				</NavTabs>
+			);
+		} else {
+			navTabs = (
+				<NavTabs>
+					<NavItem
+						path="#dashboard"
+						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
+						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
+					</NavItem>
+				</NavTabs>
+			);
+		}
 		return (
 			<div className='dops-navigation'>
 				<SectionNav>
-					<NavTabs>
-						<NavItem
-							path="#dashboard"
-							selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
-							{ __( 'At a Glance', { context: 'Navigation item.' } ) }
-						</NavItem>
-						<NavItem
-							path="#apps"
-							selected={ this.props.route.path === '/apps' }>
-							{ __( 'Apps', { context: 'Navigation item.' } ) }
-						</NavItem>
-						<NavItem
-							path="#professional"
-							selected={ this.props.route.path === '/professional' }>
-							{ __( 'Professional', { context: 'Navigation item.' } ) }
-						</NavItem>
-					</NavTabs>
+					{ navTabs }
 				</SectionNav>
 			</div>
-		)
+		);
 	}
 } );
 

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -40,6 +40,11 @@ const Navigation = React.createClass( {
 						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
+					<NavItem
+						path="#apps"
+						selected={ this.props.route.path === '/apps' }>
+						{ __( 'Apps', { context: 'Navigation item.' } ) }
+					</NavItem>
 				</NavTabs>
 			);
 		}

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -2,12 +2,18 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import { translate as __ } from 'i18n-calypso';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
+
+/**
+ * Internal dependencies
+ */
+import { isModuleActivated as _isModuleActivated } from 'state/modules';
 
 const Navigation = React.createClass( {
 	render: function() {
@@ -33,13 +39,19 @@ const Navigation = React.createClass( {
 				</NavTabs>
 			);
 		} else {
-			navTabs = (
-				<NavTabs>
+			let dashboard = '';
+			if ( window.Initial_State.userData.currentUser.permissions.view_stats || this.props.isModuleActivated( 'protect' ) ) {
+				dashboard = (
 					<NavItem
 						path="#dashboard"
 						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
+				);
+			}
+			navTabs = (
+				<NavTabs>
+					{ dashboard }
 					<NavItem
 						path="#apps"
 						selected={ this.props.route.path === '/apps' }>
@@ -58,4 +70,10 @@ const Navigation = React.createClass( {
 	}
 } );
 
-export default Navigation;
+export default connect(
+	( state ) => {
+		return {
+			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
+		};
+	}
+)( Navigation );

--- a/_inc/client/components/non-admin-view/connected.jsx
+++ b/_inc/client/components/non-admin-view/connected.jsx
@@ -15,9 +15,11 @@ import QueryUserConnectionData from 'components/data/query-user-connection';
 import { setInitialState } from 'state/initial-state';
 
 import Navigation from 'components/navigation';
+import NavigationSettings from 'components/navigation-settings';
 import AtAGlance from 'at-a-glance/index.jsx';
 import Engagement from 'engagement/index.jsx';
 import GeneralSettings from 'general-settings/index.jsx';
+import Writing from 'writing/index.jsx';
 
 const NonAdminViewConnected = React.createClass( {
 	componentWillMount: function() {
@@ -29,25 +31,38 @@ const NonAdminViewConnected = React.createClass( {
 	},
 
 	renderMainContent: function( route ) {
-		let pageComponent;
+		let pageComponent,
+			navComponent = <Navigation { ...this.props } />;
 		switch ( route ) {
 			case '/dashboard':
 				pageComponent = <AtAGlance { ...this.props } />;
 				break;
-			case '/engagement':
-				pageComponent = <Engagement { ...this.props } />;
+			case '/settings':
+				navComponent = <NavigationSettings { ...this.props } />;
+				pageComponent = <GeneralSettings { ...this.props } />;
 				break;
 			case '/general':
+				navComponent = <NavigationSettings { ...this.props } />;
 				pageComponent = <GeneralSettings { ...this.props } />;
+				break;
+			case '/engagement':
+				navComponent = <NavigationSettings { ...this.props } />;
+				pageComponent = <Engagement { ...this.props } />;
+				break;
+			case '/writing':
+				navComponent = <NavigationSettings { ...this.props } />;
+				pageComponent = <Writing { ...this.props } />;
 				break;
 
 			default:
 				pageComponent = <AtAGlance { ...this.props } />;
 		}
 
+		window.wpNavMenuClassChange();
+
 		return (
 			<div>
-				<Navigation { ...this.props } />
+				{ navComponent }
 				{ pageComponent }
 			</div>
 		);

--- a/_inc/client/components/non-admin-view/connected.jsx
+++ b/_inc/client/components/non-admin-view/connected.jsx
@@ -37,6 +37,9 @@ const NonAdminViewConnected = React.createClass( {
 			case '/dashboard':
 				pageComponent = <AtAGlance { ...this.props } />;
 				break;
+			case '/apps':
+				pageComponent = 'this will be the APPS page';
+				break;
 			case '/settings':
 				navComponent = <NavigationSettings { ...this.props } />;
 				pageComponent = <GeneralSettings { ...this.props } />;

--- a/_inc/client/components/non-admin-view/connected.jsx
+++ b/_inc/client/components/non-admin-view/connected.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import Card from 'components/card';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ConnectButton from 'components/connect-button';
+import { isCurrentUserLinked as _isCurrentUserLinked } from 'state/connection';
+import QueryUserConnectionData from 'components/data/query-user-connection';
+import { setInitialState } from 'state/initial-state';
+
+import Navigation from 'components/navigation';
+import AtAGlance from 'at-a-glance/index.jsx';
+import Engagement from 'engagement/index.jsx';
+import GeneralSettings from 'general-settings/index.jsx';
+
+const NonAdminViewConnected = React.createClass( {
+	componentWillMount: function() {
+		this.props.setInitialState();
+	},
+
+	shouldComponentUpdate: function( nextProps ) {
+		return nextProps.jetpack.connection.status !== this.props.jetpack.connection.status || nextProps.route.path !== this.props.route.path;
+	},
+
+	renderMainContent: function( route ) {
+		let pageComponent;
+		switch ( route ) {
+			case '/dashboard':
+				pageComponent = <AtAGlance { ...this.props } />;
+				break;
+			case '/engagement':
+				pageComponent = <Engagement { ...this.props } />;
+				break;
+			case '/general':
+				pageComponent = <GeneralSettings { ...this.props } />;
+				break;
+
+			default:
+				pageComponent = <AtAGlance { ...this.props } />;
+		}
+
+		return (
+			<div>
+				<Navigation { ...this.props } />
+				{ pageComponent }
+			</div>
+		);
+	},
+
+	render: function() {
+		return (
+			this.renderMainContent( this.props.route.path )
+		);
+	}
+
+} );
+
+export default NonAdminViewConnected;

--- a/_inc/client/components/non-admin-view/connected.jsx
+++ b/_inc/client/components/non-admin-view/connected.jsx
@@ -13,7 +13,7 @@ import ConnectButton from 'components/connect-button';
 import { isCurrentUserLinked as _isCurrentUserLinked } from 'state/connection';
 import QueryUserConnectionData from 'components/data/query-user-connection';
 import { setInitialState } from 'state/initial-state';
-
+import { isModuleActivated as _isModuleActivated } from 'state/modules';
 import Navigation from 'components/navigation';
 import NavigationSettings from 'components/navigation-settings';
 import AtAGlance from 'at-a-glance/index.jsx';
@@ -35,7 +35,9 @@ const NonAdminViewConnected = React.createClass( {
 			navComponent = <Navigation { ...this.props } />;
 		switch ( route ) {
 			case '/dashboard':
-				pageComponent = <AtAGlance { ...this.props } />;
+				if ( window.Initial_State.userData.currentUser.permissions.view_stats || this.props.isModuleActivated( 'protect' ) ) {
+					pageComponent = <AtAGlance { ...this.props } />;
+				}
 				break;
 			case '/apps':
 				pageComponent = 'this will be the APPS page';
@@ -79,4 +81,10 @@ const NonAdminViewConnected = React.createClass( {
 
 } );
 
-export default NonAdminViewConnected;
+export default connect(
+	( state ) => {
+		return {
+			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
+		};
+	}
+)( NonAdminViewConnected );

--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -12,38 +12,24 @@ import { translate as __ } from 'i18n-calypso';
 import ConnectButton from 'components/connect-button';
 import { isCurrentUserLinked as _isCurrentUserLinked } from 'state/connection';
 import QueryUserConnectionData from 'components/data/query-user-connection';
+import NonAdminViewConnected from './connected';
+import NonAdminViewNotConnected from './not-connected';
 
 const NonAdminView = React.createClass( {
 	displayName: 'JetpackConnect',
 
 	renderContent: function() {
-		const userData = window.Initial_State.userData.currentUser;
-		const isLinked = this.props.isLinked( this.props );
-		const headerText = userData.permissions.edit_posts
-			? __( 'Write posts via email, get notifications about your site activity, and log in with a single click.' )
-			: __( 'Get notifications about your site activity and log in with a single click.' );
-		let descriptionText = __( 'Sign in to your WordPress.com account to unlock these features.' );
-		let belowText = __( 'No WordPress.com account? Create one for free.' );
-
-		if ( isLinked ) {
-			descriptionText = __( 'Connected as user %(userLogin)s / %(userEmail)s', {
-				args: {
-					userLogin: userData.wpcomUser.login,
-					userEmail: userData.wpcomUser.email
-				}
-			} );
-			belowText = '';
+		if ( this.props.isLinked( this.props ) ) {
+			return (
+				<div>
+					<NonAdminViewConnected { ...this.props } />
+				</div>
+			);
 		}
 
 		return (
-			<div className="jp-jetpack-connect__container">
-				<h3 className="jp-jetpack-connect__container-title" title={ headerText }>{ headerText }</h3>
-
-				<Card className="jp-jetpack-connect__cta">
-					<p className="jp-jetpack-connect__description">{ descriptionText }</p>
-					<ConnectButton connectUser={ true } />
-					<p><a href="https://wordpress.com/start/jetpack/" className="jp-jetpack-connect__link">{ belowText }</a></p>
-				</Card>
+			<div>
+				<NonAdminViewNotConnected />
 			</div>
 		);
 	},

--- a/_inc/client/components/non-admin-view/not-connected.jsx
+++ b/_inc/client/components/non-admin-view/not-connected.jsx
@@ -1,0 +1,165 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import Card from 'components/card';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ConnectButton from 'components/connect-button';
+import { isCurrentUserLinked as _isCurrentUserLinked } from 'state/connection';
+import QueryUserConnectionData from 'components/data/query-user-connection';
+import { imagePath } from 'constants';
+
+const NonAdminViewNotConnected = React.createClass( {
+
+	renderContent() {
+		return (
+			<div className="jp-jetpack-connect__container">
+				<h1 className="jp-jetpack-connect__container-title" title="Please connect Jetpack to WordPress.com">
+					{ __( 'Please Connect Jetpack' ) }
+				</h1>
+
+				<Card className="jp-jetpack-connect__cta">
+					<p className="jp-jetpack-connect__description">
+						{ __( 'Please connect to or create a WordPress.com account to get access to powerful WordPress.com features including the new editor, enhanced stats, and an overall faster WordPress experience.' ) }
+					</p>
+					<ConnectButton connectUser={ true } />
+					<p><a href="https://wordpress.com/start/jetpack/" className="jp-jetpack-connect__link">{ __( 'No WordPress.com account? Create one for free.' ) }</a></p>
+				</Card>
+
+				<Card className="jp-jetpack-connect__feature jp-jetpack-connect__traffic">
+
+					<header className="jp-jetpack-connect__header">
+						<h2 className="jp-jetpack-connect__container-subtitle" title="Drive more traffic to your site with Jetpack">
+							{ __( 'Drive more traffic to your site' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __( 'Jetpack has many traffic and engagement tools to help you get more viewers to your site and keep them there.' ) }
+						</p>
+						<div className="jp-jetpack-connect__header-img-container">
+							<img src={ imagePath + 'long-clouds.svg' } width="1160" height="63" alt="Decoration: Jetpack clouds" className="jp-jetpack-connect__header-img" /> {/* defining width and height for IE here */}
+							<img src={ imagePath + 'stat-bars.svg' } width="400" alt="Decoration: Jetpack bar graph" className="jp-jetpack-connect__header-img" />
+						</div>
+					</header>
+
+					<div className="jp-jetpack-connect__interior-container">
+
+						<h2 className="jp-jetpack-connect__container-subtitle" title="Track your growth">
+							{ __( 'Track your growth' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __(
+								'Jetpack harnesses the power of WordPress.com to show you detailed insights about your visitors, what they’re reading, and where they’re coming from.'
+							) }
+						</p>
+
+						<img src={ imagePath + 'stats-example-med.png' }
+							 srcSet={ `${imagePath}stats-example-sm.png 445w, ${imagePath}stats-example-med.png 770w, ${imagePath}stats-example-lrg.png 1200w` }
+							 className="jp-jetpack-connect__feature-image" alt="Jetpack statistics and traffic insights graph" />
+					</div>
+				</Card>
+				<Card className="jp-jetpack-connect__feature">
+
+					<header className="jp-jetpack-connect__header">
+						<h2 className="jp-jetpack-connect__container-subtitle" title="Site security and peace of mind with Jetpack">
+							{ __( 'Site security and peace of mind' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __(
+								'Jetpack blocks malicious log in attempts, lets you know if your site goes down, and can automatically update your plugins, so you don’t have to worry.'
+							) }
+						</p>
+					</header>
+
+					<div className="jp-jetpack-connect__interior-container">
+						<div className="jp-jetpack-connect__feature-list">
+							<div className="jp-jetpack-connect__feature-list-column">
+								<h3 title="Jetpack's Protect feature" className="dops-section-header__label">
+									{ __( 'Protect', { context: 'Header. Noun: Protect is a module of Jetpack.' } ) }
+								</h3>
+								<div className="jp-jetpack-connect__feature-content">
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Block site attacks">
+										{ __( 'Block site attacks.' ) }
+									</h4>
+									<p>
+										{ __(
+											'Gain peace of mind with Protect, the tool that has blocked billions of login attacks across millions of sites.'
+										) }
+									</p>
+								</div>
+							</div>
+							<div className="jp-jetpack-connect__feature-list-column">
+								<h3 title="Jetpack's Single Sign On feature" className="dops-section-header__label">
+									{ __( 'Single Sign On', { context: 'Header. Noun: Single Sign On is a module of Jetpack.' } ) }
+								</h3>
+								<div className="jp-jetpack-connect__feature-content">
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Live site monitoring">
+										{ __( 'Sign in once, everywhere.' ) }
+									</h4>
+									<p>
+										{ __( 'Once you connect, you can use your WordPress.com log in to sign into any of your Jetpack sites with ease.' ) }
+									</p>
+								</div>
+							</div>
+							<div className="jp-jetpack-connect__feature-list-column">
+								<h3 title="Jetpack's Two Factor Auth feature" className="dops-section-header__label">
+									{ __( 'Manage', { context: 'Header. Noun: Two Factor Auth is a module of Jetpack.' } ) }
+								</h3>
+								<div className="jp-jetpack-connect__feature-content">
+									<h4 className="jp-jetpack-connect__feature-content-title" title="Automatic site updates">
+										{ __( 'An extra layer of security.' ) }
+									</h4>
+									<p>
+										{ __( 'Two factor authentication enables you to use your phone or an app as an extra layer of login security.' ) }
+									</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</Card>
+
+				<Card className="jp-jetpack-connect__feature">
+					<header className="jp-jetpack-connect__header">
+						<h2 className="jp-jetpack-connect__container-subtitle" title="Jetpack offers free, professional support">
+							{ __( 'Did we mention free, professional support?' ) }
+						</h2>
+						<p className="jp-jetpack-connect__description">
+							{ __(
+								"Jetpack is supported by some of the most technical and passionate people in the community. They're located around the globe and ready to help you."
+							) }
+						</p>
+					</header>
+
+					<div className="jp-jetpack-connect__interior-container">
+						<img src={ imagePath + 'aurora-med.jpg' }
+							 srcSet={ `${imagePath}aurora-sm.jpg 600w, ${imagePath}aurora-med.jpg 770w, ${imagePath}aurora-lrg.jpg 1200w` }
+							 className="jp-jetpack-connect__feature-image" alt="Jetpack's free support team" />
+					</div>
+				</Card>
+				<Card className="jp-jetpack-connect__cta">
+					<p className="jp-jetpack-connect__description">
+						{ __(
+							"Join the millions of users who rely on Jetpack to enhance and secure their sites. We’re passionate about WordPress and here to make your life easier."
+						) }
+					</p>
+					<ConnectButton />
+				</Card>
+			</div>
+		);
+	},
+
+	render() {
+		return (
+			<div>
+				<QueryUserConnectionData />
+				{ this.renderContent() }
+			</div>
+		);
+	}
+} );
+
+export default NonAdminViewNotConnected;

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -32,19 +32,27 @@ export const Page = ( props ) => {
 	 * Array of modules that directly map to a card for rendering
 	 * @type {Array}
 	 */
-	let cards = [
-		[ 'stats', getModule( 'stats' ).name, getModule( 'stats' ).description, getModule( 'stats' ).learn_more_button ],
-		[ 'sharedaddy', getModule( 'sharedaddy' ).name, getModule( 'sharedaddy' ).description, getModule( 'sharedaddy' ).learn_more_button ],
-		[ 'publicize', getModule( 'publicize' ).name, getModule( 'publicize' ).description, getModule( 'publicize' ).learn_more_button ],
-		[ 'related-posts', getModule( 'related-posts' ).name, getModule( 'related-posts' ).description, getModule( 'related-posts' ).learn_more_button ],
-		[ 'comments', getModule( 'comments' ).name, getModule( 'comments' ).description, getModule( 'comments' ).learn_more_button ],
-		[ 'likes', getModule( 'likes' ).name, getModule( 'likes' ).description, getModule( 'likes' ).learn_more_button ],
-		[ 'subscriptions', getModule( 'subscriptions' ).name, getModule( 'subscriptions' ).description, getModule( 'subscriptions' ).learn_more_button ],
-		[ 'gravatar-hovercards', getModule( 'gravatar-hovercards' ).name, getModule( 'gravatar-hovercards' ).description, getModule( 'gravatar-hovercards' ).learn_more_button ],
-		[ 'sitemaps', getModule( 'sitemaps' ).name, getModule( 'sitemaps' ).description, getModule( 'sitemaps' ).learn_more_button ],
-		[ 'enhanced-distribution', getModule( 'enhanced-distribution' ).name, getModule( 'enhanced-distribution' ).description, getModule( 'enhanced-distribution' ).learn_more_button ],
-		[ 'verification-tools', getModule( 'verification-tools' ).name, getModule( 'verification-tools' ).description, getModule( 'verification-tools' ).learn_more_button ],
-	].map( ( element ) => {
+	let cards;
+	if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
+		cards = [
+			[ 'stats', getModule( 'stats' ).name, getModule( 'stats' ).description, getModule( 'stats' ).learn_more_button ],
+			[ 'sharedaddy', getModule( 'sharedaddy' ).name, getModule( 'sharedaddy' ).description, getModule( 'sharedaddy' ).learn_more_button ],
+			[ 'publicize', getModule( 'publicize' ).name, getModule( 'publicize' ).description, getModule( 'publicize' ).learn_more_button ],
+			[ 'related-posts', getModule( 'related-posts' ).name, getModule( 'related-posts' ).description, getModule( 'related-posts' ).learn_more_button ],
+			[ 'comments', getModule( 'comments' ).name, getModule( 'comments' ).description, getModule( 'comments' ).learn_more_button ],
+			[ 'likes', getModule( 'likes' ).name, getModule( 'likes' ).description, getModule( 'likes' ).learn_more_button ],
+			[ 'subscriptions', getModule( 'subscriptions' ).name, getModule( 'subscriptions' ).description, getModule( 'subscriptions' ).learn_more_button ],
+			[ 'gravatar-hovercards', getModule( 'gravatar-hovercards' ).name, getModule( 'gravatar-hovercards' ).description, getModule( 'gravatar-hovercards' ).learn_more_button ],
+			[ 'sitemaps', getModule( 'sitemaps' ).name, getModule( 'sitemaps' ).description, getModule( 'sitemaps' ).learn_more_button ],
+			[ 'enhanced-distribution', getModule( 'enhanced-distribution' ).name, getModule( 'enhanced-distribution' ).description, getModule( 'enhanced-distribution' ).learn_more_button ],
+			[ 'verification-tools', getModule( 'verification-tools' ).name, getModule( 'verification-tools' ).description, getModule( 'verification-tools' ).learn_more_button ],
+		];
+	} else {
+		cards = [
+			[ 'publicize', getModule( 'publicize' ).name, getModule( 'publicize' ).description, getModule( 'publicize' ).learn_more_button ],
+		];
+	}
+	cards = cards .map( ( element ) => {
 		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
 			toggle = (
 				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
@@ -56,11 +64,11 @@ export const Page = ( props ) => {
 
 		return (
 			<FoldableCard className={ customClasses } key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
-				header={ element[1] }
-				subheader={ element[2] }
-				summary={ toggle }
-				expandedSummary={ toggle }
-				clickableHeaderText={ true }
+						  header={ element[1] }
+						  subheader={ element[2] }
+						  summary={ toggle }
+						  expandedSummary={ toggle }
+						  clickableHeaderText={ true }
 			>
 				{ isModuleActivated( element[0] ) ?
 					<EngagementModulesSettings module={ getModule( element[0] ) } /> :
@@ -78,7 +86,7 @@ export const Page = ( props ) => {
 			{ cards }
 		</div>
 	);
-}
+};
 
 function renderLongDescription( module ) {
 	// Rationale behind returning an object and not just the string
@@ -91,7 +99,7 @@ export default connect(
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) =>
-				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
+			isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name )
 		};
 	},

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -28,37 +28,32 @@ export const Page = ( props ) => {
 		isTogglingModule,
 		getModule
 	} = props;
+	let nonAdmin = ! window.Initial_State.userData.currentUser.permissions.manage_modules;
 	/**
 	 * Array of modules that directly map to a card for rendering
 	 * @type {Array}
 	 */
-	let cards;
-	if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
-		cards = [
-			[ 'stats', getModule( 'stats' ).name, getModule( 'stats' ).description, getModule( 'stats' ).learn_more_button ],
-			[ 'sharedaddy', getModule( 'sharedaddy' ).name, getModule( 'sharedaddy' ).description, getModule( 'sharedaddy' ).learn_more_button ],
-			[ 'publicize', getModule( 'publicize' ).name, getModule( 'publicize' ).description, getModule( 'publicize' ).learn_more_button ],
-			[ 'related-posts', getModule( 'related-posts' ).name, getModule( 'related-posts' ).description, getModule( 'related-posts' ).learn_more_button ],
-			[ 'comments', getModule( 'comments' ).name, getModule( 'comments' ).description, getModule( 'comments' ).learn_more_button ],
-			[ 'likes', getModule( 'likes' ).name, getModule( 'likes' ).description, getModule( 'likes' ).learn_more_button ],
-			[ 'subscriptions', getModule( 'subscriptions' ).name, getModule( 'subscriptions' ).description, getModule( 'subscriptions' ).learn_more_button ],
-			[ 'gravatar-hovercards', getModule( 'gravatar-hovercards' ).name, getModule( 'gravatar-hovercards' ).description, getModule( 'gravatar-hovercards' ).learn_more_button ],
-			[ 'sitemaps', getModule( 'sitemaps' ).name, getModule( 'sitemaps' ).description, getModule( 'sitemaps' ).learn_more_button ],
-			[ 'enhanced-distribution', getModule( 'enhanced-distribution' ).name, getModule( 'enhanced-distribution' ).description, getModule( 'enhanced-distribution' ).learn_more_button ],
-			[ 'verification-tools', getModule( 'verification-tools' ).name, getModule( 'verification-tools' ).description, getModule( 'verification-tools' ).learn_more_button ],
-		];
-	} else {
-		cards = [
-			[ 'publicize', getModule( 'publicize' ).name, getModule( 'publicize' ).description, getModule( 'publicize' ).learn_more_button ],
-		];
-	}
-	cards = cards .map( ( element ) => {
+	let cards = [
+		[ 'stats', getModule( 'stats' ).name, getModule( 'stats' ).description, getModule( 'stats' ).learn_more_button ],
+		[ 'sharedaddy', getModule( 'sharedaddy' ).name, getModule( 'sharedaddy' ).description, getModule( 'sharedaddy' ).learn_more_button ],
+		[ 'publicize', getModule( 'publicize' ).name, getModule( 'publicize' ).description, getModule( 'publicize' ).learn_more_button ],
+		[ 'related-posts', getModule( 'related-posts' ).name, getModule( 'related-posts' ).description, getModule( 'related-posts' ).learn_more_button ],
+		[ 'comments', getModule( 'comments' ).name, getModule( 'comments' ).description, getModule( 'comments' ).learn_more_button ],
+		[ 'likes', getModule( 'likes' ).name, getModule( 'likes' ).description, getModule( 'likes' ).learn_more_button ],
+		[ 'subscriptions', getModule( 'subscriptions' ).name, getModule( 'subscriptions' ).description, getModule( 'subscriptions' ).learn_more_button ],
+		[ 'gravatar-hovercards', getModule( 'gravatar-hovercards' ).name, getModule( 'gravatar-hovercards' ).description, getModule( 'gravatar-hovercards' ).learn_more_button ],
+		[ 'sitemaps', getModule( 'sitemaps' ).name, getModule( 'sitemaps' ).description, getModule( 'sitemaps' ).learn_more_button ],
+		[ 'enhanced-distribution', getModule( 'enhanced-distribution' ).name, getModule( 'enhanced-distribution' ).description, getModule( 'enhanced-distribution' ).learn_more_button ],
+		[ 'verification-tools', getModule( 'verification-tools' ).name, getModule( 'verification-tools' ).description, getModule( 'verification-tools' ).learn_more_button ],
+	].map( ( element ) => {
 		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+			notInNonAdmin = ! ( nonAdmin && ( 'publicize' === element[0] ) ),
 			toggle = (
-				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
-					<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-								  toggling={ isTogglingModule( element[0] ) }
-								  toggleModule={ toggleModule } />
+				notInNonAdmin ? '' :
+					unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
+						<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
+									  toggling={ isTogglingModule( element[0] ) }
+									  toggleModule={ toggleModule } />
 			),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
 
@@ -69,6 +64,7 @@ export const Page = ( props ) => {
 						  summary={ toggle }
 						  expandedSummary={ toggle }
 						  clickableHeaderText={ true }
+						  disabled={ notInNonAdmin }
 			>
 				{ isModuleActivated( element[0] ) ?
 					<EngagementModulesSettings module={ getModule( element[0] ) } /> :

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -67,20 +67,22 @@ export const Page = ( props ) => {
 		} else {
 			if ( adminAndNonAdmin ) {
 				toggle = <ModuleToggle slug={ element[0] }
-									   activated={ isModuleActivated( element[0] ) }
-									   toggling={ isTogglingModule( element[0] ) }
-									   toggleModule={ toggleModule } />;
+							activated={ isModuleActivated( element[0] ) }
+							toggling={ isTogglingModule( element[0] ) }
+							toggleModule={ toggleModule } />;
 			}
 		}
 
 		return (
-			<FoldableCard className={ customClasses } key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
-						  header={ element[1] }
-						  subheader={ element[2] }
-						  summary={ toggle }
-						  expandedSummary={ toggle }
-						  clickableHeaderText={ true }
-						  disabled={ ! adminAndNonAdmin }
+			<FoldableCard
+				className={ customClasses }
+				key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
+				header={ element[1] }
+				subheader={ element[2] }
+				summary={ toggle }
+				expandedSummary={ toggle }
+				clickableHeaderText={ true }
+				disabled={ ! adminAndNonAdmin }
 			>
 				{ isModuleActivated( element[0] ) ?
 					<EngagementModulesSettings module={ getModule( element[0] ) } /> :
@@ -110,8 +112,7 @@ export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
-			isTogglingModule: ( module_name ) =>
-			isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
+			isTogglingModule: ( module_name ) => isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name )
 		};
 	},

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -26,6 +26,7 @@ import { ModuleToggle } from 'components/module-toggle';
 
 const GeneralSettings = React.createClass( {
 	render() {
+		let nonAdmin = ! window.Initial_State.userData.currentUser.permissions.manage_modules;
 		const toggle = ( module_name ) =>
 			<ModuleToggle
 				slug={ module_name }
@@ -39,9 +40,9 @@ const GeneralSettings = React.createClass( {
 				header={ this.props.getModule( module_slug ).name }
 				subheader={ this.props.getModule( module_slug ).description }
 				clickableHeaderText={ true }
-				disabled={ ( isDevMode( this.props ) && requires_connection ) }
-				summary={ toggle( module_slug ) }
-				expandedSummary={ toggle( module_slug ) }
+				disabled={ ( isDevMode( this.props ) && requires_connection ) || nonAdmin }
+				summary={ nonAdmin ? '' : toggle( module_slug ) }
+				expandedSummary={ nonAdmin ? '' : toggle( module_slug ) }
 			>
 				<div dangerouslySetInnerHTML={ renderLongDescription( this.props.getModule( module_slug ) ) } />
 				<a href={ this.props.getModule( module_slug ).learn_more_button } target="_blank">{ __( 'Learn More' ) }</a>
@@ -49,43 +50,29 @@ const GeneralSettings = React.createClass( {
 
 		const maybeShowManage = this.props.isModuleActivated( 'manage' ) ? '' : moduleCard( 'manage' );
 
-		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
-			return(
-				<div>
-					<FoldableCard
-						header={ __( 'Connection Settings' ) }
-						subheader={ __( 'Manage your connected user accounts or disconnect.' ) }
-						clickableHeaderText={ true }
-						disabled={ isDevMode( this.props ) }
-					>
-						<ConnectionSettings { ...this.props } />
-					</FoldableCard>
-					{ maybeShowManage }
-					{ moduleCard( 'notes' ) }
-					{ moduleCard( 'json-api' ) }
-					<FoldableCard
-						header={ __( 'Miscellaneous Settings' ) }
-						subheader={ __( 'Manage Snow and other fun things for your site.' ) }
-						clickableHeaderText={ true }
-					>
-						<Settings />
-					</FoldableCard>
-				</div>
-			);
-		} else {
-			return(
-				<div>
-					<FoldableCard
-						header={ __( 'Connection Settings' ) }
-						subheader={ __( 'Manage your connected user accounts or disconnect.' ) }
-						clickableHeaderText={ true }
-						disabled={ isDevMode( this.props ) }
-					>
-						<ConnectionSettings { ...this.props } />
-					</FoldableCard>
-				</div>
-			);
-		}
+		return(
+			<div>
+				<FoldableCard
+					header={ __( 'Connection Settings' ) }
+					subheader={ __( 'Manage your connected user accounts or disconnect.' ) }
+					clickableHeaderText={ true }
+					disabled={ isDevMode( this.props ) }
+				>
+					<ConnectionSettings { ...this.props } />
+				</FoldableCard>
+				{ maybeShowManage }
+				{ moduleCard( 'notes' ) }
+				{ moduleCard( 'json-api' ) }
+				<FoldableCard
+					header={ __( 'Miscellaneous Settings' ) }
+					subheader={ __( 'Manage Snow and other fun things for your site.' ) }
+					clickableHeaderText={ true }
+					disabled={ nonAdmin }
+				>
+					<Settings />
+				</FoldableCard>
+			</div>
+		);
 	}
 } );
 

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -49,28 +49,43 @@ const GeneralSettings = React.createClass( {
 
 		const maybeShowManage = this.props.isModuleActivated( 'manage' ) ? '' : moduleCard( 'manage' );
 
-		return(
-			<div>
-				<FoldableCard
-					header={ __( 'Connection Settings' ) }
-					subheader={ __( 'Manage your connected user accounts or disconnect.' ) }
-					clickableHeaderText={ true }
-					disabled={ isDevMode( this.props ) }
-				>
-					<ConnectionSettings { ...this.props } />
-				</FoldableCard>
-				{ maybeShowManage }
-				{ moduleCard( 'notes' ) }
-				{ moduleCard( 'json-api' ) }
-				<FoldableCard
-					header={ __( 'Miscellaneous Settings' ) }
-					subheader={ __( 'Manage Snow and other fun things for your site.' ) }
-					clickableHeaderText={ true }
-				>
-					<Settings />
-				</FoldableCard>
-			</div>
-		)
+		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
+			return(
+				<div>
+					<FoldableCard
+						header={ __( 'Connection Settings' ) }
+						subheader={ __( 'Manage your connected user accounts or disconnect.' ) }
+						clickableHeaderText={ true }
+						disabled={ isDevMode( this.props ) }
+					>
+						<ConnectionSettings { ...this.props } />
+					</FoldableCard>
+					{ maybeShowManage }
+					{ moduleCard( 'notes' ) }
+					{ moduleCard( 'json-api' ) }
+					<FoldableCard
+						header={ __( 'Miscellaneous Settings' ) }
+						subheader={ __( 'Manage Snow and other fun things for your site.' ) }
+						clickableHeaderText={ true }
+					>
+						<Settings />
+					</FoldableCard>
+				</div>
+			);
+		} else {
+			return(
+				<div>
+					<FoldableCard
+						header={ __( 'Connection Settings' ) }
+						subheader={ __( 'Manage your connected user accounts or disconnect.' ) }
+						clickableHeaderText={ true }
+						disabled={ isDevMode( this.props ) }
+					>
+						<ConnectionSettings { ...this.props } />
+					</FoldableCard>
+				</div>
+			);
+		}
 	}
 } );
 
@@ -86,7 +101,7 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			isTogglingModule: ( module_name ) =>
-				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name )
+			isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -100,7 +100,7 @@ const Main = React.createClass( {
 				pageComponent = <AtAGlance { ...this.props } />;
 		}
 
-		wpNavMenuClassChange();
+		window.wpNavMenuClassChange();
 
 		return (
 			<div>
@@ -142,7 +142,7 @@ export default connect(
 /**
  * Hack for changing the sub-nav menu core classes for 'settings' and 'dashboard'
  */
-function wpNavMenuClassChange() {
+window.wpNavMenuClassChange = function() {
 	let hash = window.location.hash;
 	const settingRoutes = [
 		'#/settings',
@@ -176,4 +176,4 @@ function wpNavMenuClassChange() {
 		} );
 		subNavItem[0].classList.add( 'current' );
 	}
-}
+};

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -28,17 +28,30 @@ export const Page = ( props ) => {
 		isTogglingModule,
 		getModule
 	} = props;
-	var cards = [
-		[ 'shortlinks', getModule( 'shortlinks' ).name, getModule( 'shortlinks' ).description, getModule( 'shortlinks' ).learn_more_button ],
-		[ 'shortcodes', getModule( 'shortcodes' ).name, getModule( 'shortcodes' ).description, getModule( 'shortcodes' ).learn_more_button ],
-		[ 'videopress', getModule( 'videopress' ).name, getModule( 'videopress' ).description, getModule( 'videopress' ).learn_more_button ],
-		[ 'contact-form', getModule( 'contact-form' ).name, getModule( 'contact-form' ).description, getModule( 'contact-form' ).learn_more_button ],
-		[ 'after-the-deadline', getModule( 'after-the-deadline' ).name, getModule( 'after-the-deadline' ).description, getModule( 'after-the-deadline' ).learn_more_button ],
-		[ 'markdown', getModule( 'markdown' ).name, getModule( 'markdown' ).description, getModule( 'markdown' ).learn_more_button ],
-		[ 'post-by-email', getModule( 'post-by-email' ).name, getModule( 'post-by-email' ).description, getModule( 'post-by-email' ).learn_more_button ],
-		[ 'latex', getModule( 'latex' ).name, getModule( 'latex' ).description, getModule( 'latex' ).learn_more_button ],
-		[ 'custom-content-types', getModule( 'custom-content-types' ).name, getModule( 'custom-content-types' ).description, getModule( 'custom-content-types' ).learn_more_button ]
-	].map( ( element, i ) => {
+	/**
+	 * Array of modules that directly map to a card for rendering
+	 * @type {Array}
+	 */
+	let cards;
+	if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
+		cards = [
+			[ 'shortlinks', getModule( 'shortlinks' ).name, getModule( 'shortlinks' ).description, getModule( 'shortlinks' ).learn_more_button ],
+			[ 'shortcodes', getModule( 'shortcodes' ).name, getModule( 'shortcodes' ).description, getModule( 'shortcodes' ).learn_more_button ],
+			[ 'videopress', getModule( 'videopress' ).name, getModule( 'videopress' ).description, getModule( 'videopress' ).learn_more_button ],
+			[ 'contact-form', getModule( 'contact-form' ).name, getModule( 'contact-form' ).description, getModule( 'contact-form' ).learn_more_button ],
+			[ 'after-the-deadline', getModule( 'after-the-deadline' ).name, getModule( 'after-the-deadline' ).description, getModule( 'after-the-deadline' ).learn_more_button ],
+			[ 'markdown', getModule( 'markdown' ).name, getModule( 'markdown' ).description, getModule( 'markdown' ).learn_more_button ],
+			[ 'post-by-email', getModule( 'post-by-email' ).name, getModule( 'post-by-email' ).description, getModule( 'post-by-email' ).learn_more_button ],
+			[ 'latex', getModule( 'latex' ).name, getModule( 'latex' ).description, getModule( 'latex' ).learn_more_button ],
+			[ 'custom-content-types', getModule( 'custom-content-types' ).name, getModule( 'custom-content-types' ).description, getModule( 'custom-content-types' ).learn_more_button ]
+		];
+	} else {
+		cards = [
+			[ 'after-the-deadline', getModule( 'after-the-deadline' ).name, getModule( 'after-the-deadline' ).description, getModule( 'after-the-deadline' ).learn_more_button ],
+			[ 'post-by-email', getModule( 'post-by-email' ).name, getModule( 'post-by-email' ).description, getModule( 'post-by-email' ).learn_more_button ],
+		];
+	}
+	cards = cards.map( ( element, i ) => {
 		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
 			toggle = (
 				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -28,36 +28,31 @@ export const Page = ( props ) => {
 		isTogglingModule,
 		getModule
 	} = props;
+	let nonAdmin = ! window.Initial_State.userData.currentUser.permissions.manage_modules;
 	/**
 	 * Array of modules that directly map to a card for rendering
 	 * @type {Array}
 	 */
-	let cards;
-	if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
-		cards = [
-			[ 'shortlinks', getModule( 'shortlinks' ).name, getModule( 'shortlinks' ).description, getModule( 'shortlinks' ).learn_more_button ],
-			[ 'shortcodes', getModule( 'shortcodes' ).name, getModule( 'shortcodes' ).description, getModule( 'shortcodes' ).learn_more_button ],
-			[ 'videopress', getModule( 'videopress' ).name, getModule( 'videopress' ).description, getModule( 'videopress' ).learn_more_button ],
-			[ 'contact-form', getModule( 'contact-form' ).name, getModule( 'contact-form' ).description, getModule( 'contact-form' ).learn_more_button ],
-			[ 'after-the-deadline', getModule( 'after-the-deadline' ).name, getModule( 'after-the-deadline' ).description, getModule( 'after-the-deadline' ).learn_more_button ],
-			[ 'markdown', getModule( 'markdown' ).name, getModule( 'markdown' ).description, getModule( 'markdown' ).learn_more_button ],
-			[ 'post-by-email', getModule( 'post-by-email' ).name, getModule( 'post-by-email' ).description, getModule( 'post-by-email' ).learn_more_button ],
-			[ 'latex', getModule( 'latex' ).name, getModule( 'latex' ).description, getModule( 'latex' ).learn_more_button ],
-			[ 'custom-content-types', getModule( 'custom-content-types' ).name, getModule( 'custom-content-types' ).description, getModule( 'custom-content-types' ).learn_more_button ]
-		];
-	} else {
-		cards = [
-			[ 'after-the-deadline', getModule( 'after-the-deadline' ).name, getModule( 'after-the-deadline' ).description, getModule( 'after-the-deadline' ).learn_more_button ],
-			[ 'post-by-email', getModule( 'post-by-email' ).name, getModule( 'post-by-email' ).description, getModule( 'post-by-email' ).learn_more_button ],
-		];
-	}
-	cards = cards.map( ( element, i ) => {
+	let cards = [
+		[ 'shortlinks', getModule( 'shortlinks' ).name, getModule( 'shortlinks' ).description, getModule( 'shortlinks' ).learn_more_button ],
+		[ 'shortcodes', getModule( 'shortcodes' ).name, getModule( 'shortcodes' ).description, getModule( 'shortcodes' ).learn_more_button ],
+		[ 'videopress', getModule( 'videopress' ).name, getModule( 'videopress' ).description, getModule( 'videopress' ).learn_more_button ],
+		[ 'contact-form', getModule( 'contact-form' ).name, getModule( 'contact-form' ).description, getModule( 'contact-form' ).learn_more_button ],
+		[ 'after-the-deadline', getModule( 'after-the-deadline' ).name, getModule( 'after-the-deadline' ).description, getModule( 'after-the-deadline' ).learn_more_button ],
+		[ 'markdown', getModule( 'markdown' ).name, getModule( 'markdown' ).description, getModule( 'markdown' ).learn_more_button ],
+		[ 'post-by-email', getModule( 'post-by-email' ).name, getModule( 'post-by-email' ).description, getModule( 'post-by-email' ).learn_more_button ],
+		[ 'latex', getModule( 'latex' ).name, getModule( 'latex' ).description, getModule( 'latex' ).learn_more_button ],
+		[ 'custom-content-types', getModule( 'custom-content-types' ).name, getModule( 'custom-content-types' ).description, getModule( 'custom-content-types' ).learn_more_button ]
+	].map( ( element, i ) => {
 		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+			notInNonAdmin = ! ( nonAdmin && ( 'after-the-deadline' === element[0] || 'post-by-email' === element[0] ) ),
 			toggle = (
-				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
-					<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-								  toggling={ isTogglingModule( element[0] ) }
-								  toggleModule={ toggleModule } />
+				notInNonAdmin ? '' :
+					unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
+						<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
+									  toggling={ isTogglingModule( element[0] ) }
+									  toggleModule={ toggleModule }
+						/>
 			),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
 
@@ -72,6 +67,7 @@ export const Page = ( props ) => {
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
+				disabled={ notInNonAdmin }
 			>
 				{ isModuleActivated( element[0] ) || 'scan' === element[0] ?
 					<MoreModulesSettings module={ getModule( element[0] ) } /> :

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -333,6 +333,7 @@ function jetpack_current_user_data() {
 			'network_sites_page' => current_user_can( 'jetpack_network_sites_page' ),
 			'edit_posts'         => current_user_can( 'edit_posts' ),
 			'manage_options'     => current_user_can( 'manage_options' ),
+			'view_stats'		 => current_user_can( 'view_stats' ),
 		),
 	);
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -38,7 +38,11 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 	function jetpack_add_dashboard_sub_nav_item() {
 		global $submenu;
-		$permalink = Jetpack::admin_url( 'page=jetpack#/dashboard' );
+		if ( current_user_can( 'jetpack_manage_modules' ) || ( Jetpack::is_module_active( 'protect' ) || current_user_can( 'view_stats' ) ) ) {
+			$permalink = Jetpack::admin_url( 'page=jetpack#/dashboard' );
+		} else {
+			$permalink = Jetpack::admin_url( 'page=jetpack#/apps' );
+		}
 		$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', $permalink );
 	}
 


### PR DESCRIPTION
Closes #3915

#### Changes proposed in this Pull Request:

- [x] When user is not linked, page will be displayed like this https://github.com/Automattic/jetpack/issues/3915#issuecomment-230569070

- When user is linked, some elements are displayed in At a Glance and the setting tabs:

Dashboard
  - [x] At a Glance: Stats and Protect count
  - [x] Apps

Settings:
  - [x] General tab: Connection (link) setting
  - [x] Engagement tab: Publicize (not in React UI for v1)
  - [x] Writing tab: Post By Email
  - [x] Writing tab: After the Deadline

- [x] If user can't view Stats and Protect is not active, don't show At a Glance, only Apps

