### PR TITLE
Add/update master user on role change

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -47,7 +47,7 @@ class Jetpack_Client_Server {
 			update_option( 'jetpack_unique_connection', $jetpack_unique_connection );
 
 			//track unique connection
-			$jetpack = Jetpack::init();
+			$jetpack = $this->get_jetpack();;
 
 			$jetpack->stat( 'connections', 'unique-connection' );
 			$jetpack->do_stats( 'server_side' );

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -12,8 +12,7 @@ class Jetpack_Client_Server {
 	function client_authorize() {
 		$data              = stripslashes_deep( $_GET );
 		$data['auth_type'] = 'client';
-		$jetpack           = $this->get_jetpack();
-		$role              = $jetpack->translate_current_user_to_role();
+		$role              = Jetpack::translate_current_user_to_role();
 		$redirect          = isset( $data['redirect'] ) ? esc_url_raw( (string) $data['redirect'] ) : '';
 
 		$this->check_admin_referer( "jetpack-authorize_{$role}_{$redirect}" );
@@ -58,14 +57,13 @@ class Jetpack_Client_Server {
 		$jetpack_unique_connection['connected'] += 1;
 		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
 
-		$jetpack = $this->get_jetpack();
-		$role = $jetpack->translate_current_user_to_role();
+		$role = Jetpack::translate_current_user_to_role();
 
 		if ( ! $role ) {
 			return new Jetpack_Error( 'no_role', 'Invalid request.', 400 );
 		}
 
-		$cap = $jetpack->translate_role_to_cap( $role );
+		$cap = Jetpack::translate_role_to_cap( $role );
 		if ( ! $cap ) {
 			return new Jetpack_Error( 'no_cap', 'Invalid request.', 400 );
 		}
@@ -156,8 +154,7 @@ class Jetpack_Client_Server {
 	 * @return object|WP_Error
 	 */
 	function get_token( $data ) {
-		$jetpack = $this->get_jetpack();
-		$role = $jetpack->translate_current_user_to_role();
+		$role = Jetpack::translate_current_user_to_role();
 
 		if ( ! $role ) {
 			return new Jetpack_Error( 'role', __( 'An administrator for this blog must set up the Jetpack connection.', 'jetpack' ) );
@@ -234,11 +231,11 @@ class Jetpack_Client_Server {
 			return new Jetpack_Error( 'scope', 'Malformed Scope', $code );
 		}
 
-		if ( $jetpack->sign_role( $role ) !== $json->scope ) {
+		if ( Jetpack::sign_role( $role ) !== $json->scope ) {
 			return new Jetpack_Error( 'scope', 'Invalid Scope', $code );
 		}
 
-		if ( ! $cap = $jetpack->translate_role_to_cap( $role ) ) {
+		if ( ! $cap = Jetpack::translate_role_to_cap( $role ) ) {
 			return new Jetpack_Error( 'scope', 'No Cap', $code );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3733,7 +3733,7 @@ p {
 	}
 
 	static function translate_current_user_to_role() {
-		foreach ( static::$capability_translations as $role => $cap ) {
+		foreach ( self::$capability_translations as $role => $cap ) {
 			if ( current_user_can( $role ) || current_user_can( $cap ) ) {
 				return $role;
 			}
@@ -3743,11 +3743,11 @@ p {
 	}
 
 	static function translate_role_to_cap( $role ) {
-		if ( ! isset( static::$capability_translations[$role] ) ) {
+		if ( ! isset( self::$capability_translations[$role] ) ) {
 			return false;
 		}
 
-		return static::$capability_translations[$role];
+		return self::$capability_translations[$role];
 	}
 
 	static function sign_role( $role ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -71,7 +71,7 @@ class Jetpack {
 		'latex'               => array( 'wp-latex/wp-latex.php', 'WP LaTeX' )
 	);
 
-	public $capability_translations = array(
+	static $capability_translations = array(
 		'administrator' => 'manage_options',
 		'editor'        => 'edit_others_posts',
 		'author'        => 'publish_posts',
@@ -3773,8 +3773,8 @@ p {
 		return $url;
 	}
 
-	function translate_current_user_to_role() {
-		foreach ( $this->capability_translations as $role => $cap ) {
+	static function translate_current_user_to_role() {
+		foreach ( static::$capability_translations as $role => $cap ) {
 			if ( current_user_can( $role ) || current_user_can( $cap ) ) {
 				return $role;
 			}
@@ -3783,15 +3783,15 @@ p {
 		return false;
 	}
 
-	function translate_role_to_cap( $role ) {
-		if ( ! isset( $this->capability_translations[$role] ) ) {
+	static function translate_role_to_cap( $role ) {
+		if ( ! isset( static::$capability_translations[$role] ) ) {
 			return false;
 		}
 
-		return $this->capability_translations[$role];
+		return static::$capability_translations[$role];
 	}
 
-	function sign_role( $role ) {
+	static function sign_role( $role ) {
 		if ( ! $user_id = (int) get_current_user_id() ) {
 			return false;
 		}
@@ -3829,8 +3829,8 @@ p {
 				$gp_locale = GP_Locales::by_field( 'wp_locale', get_locale() );
 			}
 
-			$role = $this->translate_current_user_to_role();
-			$signed_role = $this->sign_role( $role );
+			$role = self::translate_current_user_to_role();
+			$signed_role = self::sign_role( $role );
 
 			$user = wp_get_current_user();
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -795,7 +795,7 @@ class Jetpack_SSO {
 			JetpackTracking::record_user_event( 'sso_user_logged_in', array(
 				'user_found_with' => $user_found_with,
 				'user_connected'  => (bool) $is_user_connected,
-				'user_role'       => Jetpack::init()->translate_current_user_to_role()
+				'user_role'       => Jetpack::translate_current_user_to_role()
 			) );
 
 			if ( ! $is_user_connected ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -74,6 +74,10 @@ class Jetpack_Sync_Actions {
 		if ( ! wp_next_scheduled ( 'jetpack_send_db_checksum' ) ) {
 			wp_schedule_event( time(), 'hourly', 'jetpack_send_db_checksum' );
 		}
+
+		// Sync Master User Role Changes
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
+
 	}
 
 	static function send_data( $data, $codec_name ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -30,6 +30,9 @@ class Jetpack_Sync_Actions {
 			self::$listener = Jetpack_Sync_Listener::getInstance();
 		}
 
+		// Sync connected user role changes to .com
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
+
 		/**
 		 * Fires on every request before default loading sync sender code.
 		 * Return false to not load sync sender code that serializes pending
@@ -74,9 +77,6 @@ class Jetpack_Sync_Actions {
 		if ( ! wp_next_scheduled ( 'jetpack_send_db_checksum' ) ) {
 			wp_schedule_event( time(), 'hourly', 'jetpack_send_db_checksum' );
 		}
-
-		// Sync Master User Role Changes
-		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
 
 	}
 

--- a/sync/class.jetpack-sync-users.php
+++ b/sync/class.jetpack-sync-users.php
@@ -6,59 +6,76 @@
  * Responsible for syncing user data changes.
  */
 class Jetpack_Sync_Users {
-
-	static $check_sum_id = 'user_check_sum';
+	static $user_roles = array();
 
 	static function init() {
-		// Kick off synchronization of user role when it changes
-		add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
+		if ( Jetpack::is_active() || Jetpack::is_development_mode() ) {
+			// Kick off synchronization of user role when it changes
+			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
+		}
 	}
 
 	/**
 	 * Synchronize connected user role changes
 	 */
 	static function user_role_change( $user_id ) {
-		if ( Jetpack::is_active() && Jetpack::is_user_connected( $user_id ) ) {
-			$current_user_id = get_current_user_id();
-			wp_set_current_user( $user_id );
-			$role        = Jetpack::translate_current_user_to_role();
-			$signed_role = Jetpack::sign_role( $role );
-			wp_set_current_user( $current_user_id );
+		if ( Jetpack::is_user_connected( $user_id ) ) {
+			self::update_role_on_com( $user_id );
+			//try to choose a new master if we're demoting the current one
+			self::maybe_demote_master_user( $user_id );
+		}
+	}
 
-			$master_token   = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-			$master_user_id = absint( $master_token->external_user_id );
+	static function get_role( $user_id ) {
+		if ( isset( $user_roles[ $user_id ] ) ) {
+			return $user_roles[ $user_id ];
+		}
 
-			if ( ! $master_user_id ) {
-				return;
-			} // this shouldn't happen
+		$current_user_id = get_current_user_id();
+		wp_set_current_user( $user_id );
+		$role        = Jetpack::translate_current_user_to_role();
+		wp_set_current_user( $current_user_id );
+		$user_roles[ $user_id ] = $role;
 
-			Jetpack::xmlrpc_async_call( 'jetpack.updateRole', $user_id, $signed_role );
-//@todo retry on failure
+		return $role;
+	}
 
-//try to choose a new master if we're demoting the current one
-			if ( $user_id == $master_user_id && 'administrator' != $role ) {
-				$query      = new WP_User_Query(
-					array(
-						'fields'  => array( 'id' ),
-						'role'    => 'administrator',
-						'orderby' => 'id',
-						'exclude' => array( $master_user_id ),
-					)
-				);
-				$new_master = false;
-				foreach ( $query->results as $result ) {
-					$uid = absint( $result->id );
-					if ( $uid && Jetpack::is_user_connected( $uid ) ) {
-						$new_master = $uid;
-						break;
-					}
+	static function get_signed_role( $user_id ) {
+		return Jetpack::sign_role( self::get_role( $user_id ) );
+	}
+
+	static function update_role_on_com( $user_id ) {
+		$signed_role = self::get_signed_role( $user_id );
+		Jetpack::xmlrpc_async_call( 'jetpack.updateRole', $user_id, $signed_role );
+	}
+
+	static function maybe_demote_master_user( $user_id ) {
+		$master_user_id = Jetpack_Options::get_option( 'master_user' );
+		$role = self::get_role( $user_id );
+		if ( $user_id == $master_user_id && 'administrator' != $role ) {
+			$query      = new WP_User_Query(
+				array(
+					'fields'  => array( 'id' ),
+					'role'    => 'administrator',
+					'orderby' => 'id',
+					'exclude' => array( $master_user_id ),
+				)
+			);
+			$new_master = false;
+			foreach ( $query->results as $result ) {
+				$found_user_id = absint( $result->id );
+				if ( $found_user_id && Jetpack::is_user_connected( $found_user_id ) ) {
+					$new_master = $found_user_id;
+					break;
 				}
-
-				if ( $new_master ) {
-					Jetpack_Options::update_option( 'master_user', $new_master );
-				}
-// else disconnect..?
 			}
+
+			if ( $new_master ) {
+				Jetpack_Options::update_option( 'master_user', $new_master );
+			}
+			// else disconnect..?
 		}
 	}
 }
+
+add_action( 'admin_init', array( 'Jetpack_Sync_Users', 'init' ) );

--- a/sync/class.jetpack-sync-users.php
+++ b/sync/class.jetpack-sync-users.php
@@ -9,7 +9,7 @@ class Jetpack_Sync_Users {
 	static $user_roles = array();
 
 	static function init() {
-		if ( Jetpack::is_active() || Jetpack::is_development_mode() ) {
+		if ( Jetpack::is_active() ) {
 			// Kick off synchronization of user role when it changes
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}
@@ -77,5 +77,4 @@ class Jetpack_Sync_Users {
 		}
 	}
 }
-
-add_action( 'admin_init', array( 'Jetpack_Sync_Users', 'init' ) );
+Jetpack_Sync_Users::init();

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -4,6 +4,7 @@ $sync_dir = dirname( __FILE__ ) . '/../../../sync/';
 $sync_server_dir = dirname( __FILE__ ) . '/server/';
 
 require_once $sync_dir . 'class.jetpack-sync-server.php';
+require_once $sync_dir . 'class.jetpack-sync-users.php';
 require_once $sync_dir . 'class.jetpack-sync-listener.php';
 require_once $sync_dir . 'class.jetpack-sync-sender.php';
 require_once $sync_dir . 'class.jetpack-sync-wp-replicastore.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Move the role changes to the Jetpack_Sync_Users and we make sure that the class is actually used. 
- Added tests for what happend when the master user isn't an admin any more. 
- Deprecates user_role_change method. 
- And turns some methods static. 
