### PR TITLE
Removed Open Sans from admin CSS and from admin page.

### DIFF
--- a/_inc/client/dashboard-widget/style.scss
+++ b/_inc/client/dashboard-widget/style.scss
@@ -6,7 +6,7 @@
 	.inside {
 		margin: 0;
 		padding: 0;
-		font-family: "proxima-nova", "Open Sans", Helvetica, Arial, sans-serif;
+		font-family: "proxima-nova", Helvetica, Arial, sans-serif;
 	}
 
 	.stats,

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -19,6 +19,7 @@
 
 .jetpack-pagestyles #wpbody-content {
 	background-color: $gray-light;
+	line-height: 1.4; // fixes core bug that sets an em unit on body
 }
 
 .jp-lower {

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -100,8 +100,6 @@ abstract class Jetpack_Admin_Page {
 	function admin_styles() {
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-		wp_enqueue_style( 'jetpack-google-fonts', '//fonts.googleapis.com/css?family=Open+Sans:400italic,400,700,600,800' );
-
 		wp_enqueue_style( 'jetpack-admin', plugins_url( "css/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons' ), JETPACK__VERSION . '-20121016' );
 		wp_style_add_data( 'jetpack-admin', 'rtl', 'replace' );
 		wp_style_add_data( 'jetpack-admin', 'suffix', $min );

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -328,7 +328,6 @@ class Jetpack_Debugger {
 				background-color: #eaf3fa;
 				border-radius: 5px;
 				font-size: 15px;
-				font-family: "Open Sans", "Helvetica Neue", sans-serif;
 			}
 
 			form#contactme label.h {

--- a/modules/protect/protect-dashboard-widget.css
+++ b/modules/protect/protect-dashboard-widget.css
@@ -88,7 +88,7 @@
 .blocked-attacks h2,
 .blocked-attacks h3 {
 	color: #7BAC48;
-	font-family: "proxima-nova", "Open Sans", Helvetica, Arial, sans-serif;
+	font-family: "proxima-nova", Helvetica, Arial, sans-serif;
 	font-weight: 300;
 }
 

--- a/scss/atoms/_buttons.scss
+++ b/scss/atoms/_buttons.scss
@@ -11,7 +11,9 @@
 	position: relative;
 	padding: em(10px, 13px) em(19px, 13px);
 	color: #efefef;
-	font: 800 0.9285714286em/1 'Open Sans', Helvetica, sans-serif; // 13/14
+	font-weight: bold;
+	font-size: 0.9285714286em; // 13/14
+	line-height: 1;
 	text-shadow: 0 1px 1px rgba(0,0,0,.2);
 	background: #6f7476;
 	border-radius: 3px;
@@ -55,7 +57,7 @@
 	position: relative;
 	padding: em(18px, 28px) em(50px, 46px) em(15px, 28px);
 	color: #fff;
-	font: 400 20px/1 "proxima-nova", 'Open Sans', Helvetica, sans-serif; // 28/14
+	font: 400 20px/1 "proxima-nova", Helvetica, sans-serif; // 28/14
 	background: #518d2a;
 	z-index: 3;
 	border-radius: 6px;

--- a/scss/atoms/typography/_typography.scss
+++ b/scss/atoms/typography/_typography.scss
@@ -6,34 +6,6 @@
 	"variables",
 	"functions";
 
-body,
-button,
-input,
-select,
-textarea {
-	color: map-get($root-font, color);
-	font-family: $sans;
-	font-size: map-get($root-font, font-size);
-	line-height: map-get($root-font, line-height);
-	-webkit-font-smoothing: antialiased;
-}
-
-
-// ==========================================================================
-// Headings
-// ==========================================================================
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	color: #222;
-	clear: both;
-}
-
-
 // ==========================================================================
 // Links
 // ==========================================================================

--- a/scss/atoms/typography/_variables.scss
+++ b/scss/atoms/typography/_variables.scss
@@ -2,8 +2,8 @@
 // Typography variables
 // ==========================================================================
 
-$normal: 400; // Change these values when using custom fonts
-$bold: 700; // For example, bold could change to 400;
+$normal: normal; // Change these values when using custom fonts
+$bold: bold; // For example, bold could change to 400;
 
 $root-font:(
 	color: #222,
@@ -20,7 +20,7 @@ $mark__background: #fff9c0;
 
 $monospace: 'courier new', monospace;
 $serif: Georgia, "Times New Roman", Times, serif;
-$sans: 'Open Sans', Helvetica, Arial, sans-serif; // 400i,400,600,700,800
+$sans: Helvetica, Arial, sans-serif; // 400i,400,600,700,800
 $calluna: 'calluna', $sans; // 400
 $gill: "Gill Sans", "Gill Sans MT", $sans;
 $proxima: "proxima-nova", $sans; // 300,400,600

--- a/scss/templates/_connection-landing.scss
+++ b/scss/templates/_connection-landing.scss
@@ -223,7 +223,7 @@ So I moved to stack the svgs as actual imgs instead. IE also had a hard time dea
 		position: relative;
 	}
 	h1 {
-		font: 400 1.75em "proxima-nova","Open Sans",Helvetica,Arial,sans-serif;
+		font: 400 1.75em "proxima-nova",Helvetica,Arial,sans-serif;
 		position: relative;
 		z-index: 3;
 		width: 100%;


### PR DESCRIPTION
Fixes #4124 .

#### Changes proposed in this Pull Request:
- Removed Open Sans from various files. Would remove Proxima, but it's not enqueued and isn't used on any current UI.

Looks pretty dang good: 

![image](https://cloud.githubusercontent.com/assets/1123119/16634445/f59a9240-438a-11e6-95a6-82f521c702cf.png)

CC @jeffgolenski for review
