### PR TITLE
Add sent time to synced actions so we know action age and site-local time

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -76,12 +76,13 @@ class Jetpack_Sync_Actions {
 		}
 	}
 
-	static function send_data( $data, $codec_name ) {
+	static function send_data( $data, $codec_name, $sent_timestamp ) {
 		Jetpack::load_xml_rpc_client();
 
 		$url = add_query_arg( array(
 			'sync' => '1', // add an extra parameter to the URL so we can tell it's a sync action
 			'codec' => $codec_name, // send the name of the codec used to encode the data
+			'timestamp' => $sent_timestamp, // send current server time so we can compensate for clock differences
 		), Jetpack::xmlrpc_api_url() );
 
 		$rpc = new Jetpack_IXR_Client( array(

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -65,7 +65,7 @@ class Jetpack_Sync_Actions {
 		add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
 
 		// bind the sending process
-		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 2 );
+		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 3 );
 
 		// On jetpack registration
 		add_action( 'jetpack_site_registered', array( __CLASS__, 'schedule_full_sync' ) );

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -98,7 +98,6 @@ class Jetpack_Sync_Sender {
 		$upload_size   = 0;
 		$items_to_send = array();
 		$actions_to_send = array();
-		$sent_time = microtime( true );
 		
 		// we estimate the total encoded size as we go by encoding each item individually
 		// this is expensive, but the only way to really know :/
@@ -113,9 +112,6 @@ class Jetpack_Sync_Sender {
 			 * @param array The action parameters
 			 */
 			$item[1] = apply_filters( "jetpack_sync_before_send_" . $item[0], $item[1], $item[2] );
-
-			// add "sent time" to outgoing action
-			$item[] = $sent_time;
 
 			$encoded_item = $this->codec->encode( $item );
 
@@ -138,7 +134,7 @@ class Jetpack_Sync_Sender {
 		 *
 		 * @param array $data The action buffer
 		 */
-		$result = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name() );
+		$result = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ) );
 
 		if ( ! $result || is_wp_error( $result ) ) {
 			$result = $this->sync_queue->checkin( $buffer );

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -98,6 +98,8 @@ class Jetpack_Sync_Sender {
 		$upload_size   = 0;
 		$items_to_send = array();
 		$actions_to_send = array();
+		$sent_time = microtime( true );
+		
 		// we estimate the total encoded size as we go by encoding each item individually
 		// this is expensive, but the only way to really know :/
 		foreach ( $buffer->get_items() as $key => $item ) {
@@ -111,6 +113,9 @@ class Jetpack_Sync_Sender {
 			 * @param array The action parameters
 			 */
 			$item[1] = apply_filters( "jetpack_sync_before_send_" . $item[0], $item[1], $item[2] );
+
+			// add "sent time" to outgoing action
+			$item[] = $sent_time;
 
 			$encoded_item = $this->codec->encode( $item );
 

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -81,9 +81,10 @@ class Jetpack_Sync_Server {
 			 * @param array $args The arguments passed to the action
 			 * @param int $user_id The external_user_id who did the action
 			 * @param double $timestamp Timestamp (in seconds) when the action occurred
+			 * @param double $sent_timestamp Timestamp (in seconds) when the action was transmitted
 			 * @param array $token The auth token used to invoke the API
 			 */
-			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $timestamp, $token, $sent_timestamp );
+			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $timestamp, $sent_timestamp, $token );
 
 			/**
 			 * Fires when an action is received from a remote Jetpack site
@@ -93,9 +94,10 @@ class Jetpack_Sync_Server {
 			 * @param array $args The arguments passed to the action
 			 * @param int $user_id The external_user_id who did the action
 			 * @param double $timestamp Timestamp (in seconds) when the action occurred
+			 * @param double $sent_timestamp Timestamp (in seconds) when the action was transmitted
 			 * @param array $token The auth token used to invoke the API
 			 */
-			do_action( 'jetpack_sync_' . $action_name, $args, $user_id, $timestamp, $token, $sent_timestamp );
+			do_action( 'jetpack_sync_' . $action_name, $args, $user_id, $timestamp, $sent_timestamp, $token );
 
 			$events_processed[] = $key;
 

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -70,7 +70,7 @@ class Jetpack_Sync_Server {
 		do_action( "jetpack_sync_remote_actions", $events, $token );
 
 		foreach ( $events as $key => $event ) {
-			list( $action_name, $args, $user_id, $timestamp ) = $event;
+			list( $action_name, $args, $user_id, $timestamp, $sent_timestamp ) = $event;
 
 			/**
 			 * Fires when an action is received from a remote Jetpack site
@@ -83,7 +83,7 @@ class Jetpack_Sync_Server {
 			 * @param double $timestamp Timestamp (in seconds) when the action occurred
 			 * @param array $token The auth token used to invoke the API
 			 */
-			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $timestamp, $token );
+			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $timestamp, $token, $sent_timestamp );
 
 			/**
 			 * Fires when an action is received from a remote Jetpack site
@@ -95,7 +95,7 @@ class Jetpack_Sync_Server {
 			 * @param double $timestamp Timestamp (in seconds) when the action occurred
 			 * @param array $token The auth token used to invoke the API
 			 */
-			do_action( 'jetpack_sync_' . $action_name, $args, $user_id, $timestamp, $token );
+			do_action( 'jetpack_sync_' . $action_name, $args, $user_id, $timestamp, $token, $sent_timestamp );
 
 			$events_processed[] = $key;
 

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -39,7 +39,7 @@ class Jetpack_Sync_Server {
 		delete_site_transient( $this->get_concurrent_request_transient_name( $blog_id ) );
 	}
 
-	function receive( $data, $token = null ) {
+	function receive( $data, $token = null, $sent_timestamp = null ) {
 		$start_time = microtime( true );
 		if ( ! is_array( $data ) ) {
 			return new WP_Error( 'action_decoder_error', 'Events must be an array' );
@@ -70,7 +70,7 @@ class Jetpack_Sync_Server {
 		do_action( "jetpack_sync_remote_actions", $events, $token );
 
 		foreach ( $events as $key => $event ) {
-			list( $action_name, $args, $user_id, $timestamp, $sent_timestamp ) = $event;
+			list( $action_name, $args, $user_id, $timestamp ) = $event;
 
 			/**
 			 * Fires when an action is received from a remote Jetpack site

--- a/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -8,11 +8,11 @@ class Jetpack_Sync_Server_Eventstore {
 	private $action_name = null;
 
 	function init() {
-		add_action( "jetpack_sync_remote_action", array( $this, 'handle_remote_action' ), 10, 5 );
+		add_action( "jetpack_sync_remote_action", array( $this, 'handle_remote_action' ), 10, 6 );
 	}
 
-	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $token ) {
-		$this->events[] = (object) array( 'action' => $action_name, 'args' => $args, 'user_id' => $user_id, 'timestamp' => $timestamp );
+	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $token, $sent_timestamp ) {
+		$this->events[] = (object) array( 'action' => $action_name, 'args' => $args, 'user_id' => $user_id, 'timestamp' => $timestamp, 'sent_timestamp' => $sent_timestamp );
 	}
 
 	function get_all_events( $action_name = null ) {

--- a/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -11,7 +11,7 @@ class Jetpack_Sync_Server_Eventstore {
 		add_action( "jetpack_sync_remote_action", array( $this, 'handle_remote_action' ), 10, 6 );
 	}
 
-	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $token, $sent_timestamp ) {
+	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $sent_timestamp, $token ) {
 		$this->events[] = (object) array( 'action' => $action_name, 'args' => $args, 'user_id' => $user_id, 'timestamp' => $timestamp, 'sent_timestamp' => $sent_timestamp );
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -12,10 +12,10 @@ class Jetpack_Sync_Server_Replicator {
 	}
 
 	function init() {
-		add_action( "jetpack_sync_remote_action", array( $this, 'handle_remote_action' ), 5, 5 );
+		add_action( "jetpack_sync_remote_action", array( $this, 'handle_remote_action' ), 5, 6 );
 	}
 
-	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $token ) {
+	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $sent_timestamp, $token ) {
 
 		switch ( $action_name ) {
 			// posts

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -40,7 +40,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 		// bind the sender to the server
 		remove_all_filters( 'jetpack_sync_send_data' );
-		add_filter( 'jetpack_sync_send_data', array( $this, 'serverReceive' ) );
+		add_filter( 'jetpack_sync_send_data', array( $this, 'serverReceive' ), 10 , 3 );
 
 		// bind the two storage systems to the server events
 		$this->server_replica_storage = new Jetpack_Sync_Test_Replicastore();
@@ -90,8 +90,8 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		return $codec->decode( $codec->encode( $instance ) );
 	}
 
-	function serverReceive( $data ) {
-		return $this->server->receive( $data );
+	function serverReceive( $data, $codec, $sent_timestamp ) {
+		return $this->server->receive( $data, null, $sent_timestamp );
 	}
 }
 

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -242,6 +242,26 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $user_id, $event->user_id );
 	}
 
+	function test_adds_sent_time_to_action() {
+		$beginning_of_test = microtime(true);
+
+		$this->factory->post->create();
+
+		$before_sync = microtime(true);
+
+		$this->sender->do_sync();
+
+		$after_sync = microtime(true);
+
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+
+		$this->assertTrue( $event->sent_timestamp > $beginning_of_test );
+		$this->assertTrue( $event->sent_timestamp > $before_sync );
+		$this->assertTrue( $event->sent_timestamp < $after_sync );
+		$this->assertTrue( $event->sent_timestamp < microtime(true) );
+
+	}
+
 	function action_ran( $data, $codec ) {
 		$this->action_ran = true;
 		$this->action_codec = $codec;

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -2,18 +2,25 @@
 
 class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	protected $action_ran;
+	protected $action_codec;
+	protected $action_timestamp;
 	protected $encoded_data;
 
-	function test_add_post_fires_sync_data_action_with_codec_on_do_sync() {
+	function test_add_post_fires_sync_data_action_with_codec_and_timestamp_on_do_sync() {
+		$start_test_timestamp = microtime( true );
 		$this->action_ran = false;
 		$this->action_codec = null;
+		$this->action_timestamp = null;
 
-		add_filter( 'jetpack_sync_send_data', array( $this, 'action_ran' ), 10, 2 );
+		add_filter( 'jetpack_sync_send_data', array( $this, 'action_ran' ), 10, 3 );
 
 		$this->sender->do_sync();
 
 		$this->assertEquals( true, $this->action_ran );
 		$this->assertEquals( 'deflate-json', $this->action_codec );
+		$this->assertNotNull( $this->action_timestamp );
+		$this->assertTrue( $this->action_timestamp > $start_test_timestamp );
+		$this->assertTrue( $this->action_timestamp < microtime( true ) );
 	}
 
 	function test_queues_cron_job_if_queue_exceeds_max_buffer() {
@@ -262,9 +269,10 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 	}
 
-	function action_ran( $data, $codec ) {
+	function action_ran( $data, $codec, $sent_timestamp ) {
 		$this->action_ran = true;
 		$this->action_codec = $codec;
+		$this->action_timestamp = $sent_timestamp;
 		return $data;
 	}
 


### PR DESCRIPTION
We had a couple of requirements for sync that have been rolled into sync here:

- tracking the latency of sync at a fairly tight granularity, so we can tell if any sites are getting way behind and tune things accordingly.
- tracking the clock skew of Jetpack sites relative to WPCOM. Within reason, this helps us do that (it's not a real "clock sync" protocol, but tracking event times and relative clocks within 10 seconds is probably OK).

Pros:
- don't need additional endpoint or protocol for figuring out what time a Jetpack site thinks it is

Cons:
- duplication - this adds the local time to every outbound action, even though it's the same for all of them. This was done in the name of simplicity at the other end, not having to grab some header value etc.

Alternative approach: We could add local time since epoch (`microtime(true)`) as a header parameter to the XMLRPC call. This feels brittle and weird though, and it's harder to test in our suite.