### PR TITLE
Publicize: revert PENDING flag added to all published posts.

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -359,25 +359,7 @@ class Publicize extends Publicize_Base {
 	}
 
 	function flag_post_for_publicize( $new_status, $old_status, $post ) {
-		if ( 'publish' == $new_status && 'publish' != $old_status ) {
-			/**
-			 * Determines whether a post being published gets publicized.
-			 *
-			 * Side-note: Possibly our most alliterative filter name.
-			 *
-			 * @module publicize
-			 *
-			 * @since 4.1.0
-			 *
-			 * @param bool $should_publicize Should the post be publicized? Default to true.
-			 * @param WP_POST $post Current Post object.
-			 */
-			$should_publicize = apply_filters( 'publicize_should_publicize_published_post', true, $post );
-
-			if ( $should_publicize ) {
-				update_post_meta( $post->ID, $this->PENDING, true );
-			}
-		}
+		// Stub only. Doesn't need to do anything on Jetpack Client
 	}
 
 	function test_connection( $service_name, $connection ) {


### PR DESCRIPTION
Flag added in 4bb5e896b34a14c278c066e437d00946f59cf501

This commit should not have been part of 4.1, since it's part of the new sync added in #3729, slated for 4.2.