### PR TITLE
require 'class.jetpack-sync-sender.php'

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2618,6 +2618,7 @@ p {
 		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
 		
 		// Delete all the sync related data. Since it could be taking up space.
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 		Jetpack_Sync_Sender::getInstance()->uninstall();
 
 		// Disable the Heartbeat cron


### PR DESCRIPTION
Fixes #4329

__How to test__

run `wp plugin deactivate jetpack` and check that it doesn't fatal :)

