### PR TITLE
Fix loading of full sync listeners

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -21,9 +21,9 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		$sender = Jetpack_Sync_Sender::getInstance();
+		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
 		return array_merge(
-			$sender->get_full_sync_client()->get_status(),
+			$sync_module->get_status(),
 			array( 'is_scheduled' => (bool) wp_next_scheduled( 'jetpack_sync_full' ) )
 		);
 	}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -23,6 +23,8 @@ class Jetpack_Sync_Actions {
 				(
 					$_SERVER['REQUEST_METHOD'] !== 'GET'
 				||
+					defined( 'DOING_AJAX' ) && DOING_AJAX
+				||
 					defined( 'PHPUNIT_JETPACK_TESTSUITE' )
 				)
 			) ) {

--- a/sync/class.jetpack-sync-dashboard.php
+++ b/sync/class.jetpack-sync-dashboard.php
@@ -95,7 +95,7 @@ class Jetpack_Sync_Dashboard extends Jetpack_Admin_Page {
 	}
 
 	function ajax_begin_full_sync() {
-		Jetpack_Sync_Sender::getInstance()->get_full_sync_client()->start();
+		Jetpack_Sync_Modules::get_module( 'full-sync' )->start();
 		$this->ajax_full_sync_status();
 	}
 
@@ -119,7 +119,7 @@ class Jetpack_Sync_Dashboard extends Jetpack_Admin_Page {
 	}
 
 	function full_sync_status() {
-		return Jetpack_Sync_Sender::getInstance()->get_full_sync_client()->get_status();
+		return Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
 	}
 
 	function dashboard_ui() {

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -39,10 +39,6 @@ class Jetpack_Sync_Listener {
 			$module->init_listeners( $handler );
 		}
 
-		// synthetic actions for full sync
-		add_action( 'jetpack_full_sync_start', $handler );
-		add_action( 'jetpack_full_sync_end', $handler );
-
 		// Module Activation
 		add_action( 'jetpack_activate_module', $handler );
 		add_action( 'jetpack_deactivate_module', $handler );

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -64,7 +64,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	function start() {
 		if( ! $this->should_start_full_sync() ) {
-			return;
+			return false;
 		}
 		/**
 		 * Fires when a full sync begins. This action is serialized
@@ -93,6 +93,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 		do_action( 'jetpack_full_sync_end', $store->checksum_all() );
+		return true;
 	}
 
 	private function should_start_full_sync() {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -14,7 +14,7 @@
 
 require_once 'class.jetpack-sync-wp-replicastore.php';
 
-class Jetpack_Sync_Full {
+class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	const ARRAY_CHUNK_SIZE = 10;
 	static $status_option = 'jetpack_full_sync_status';
 	static $transient_timeout = 3600; // an hour
@@ -32,23 +32,19 @@ class Jetpack_Sync_Full {
 		'network_options',
 	);
 
-	// singleton functions
-	private static $instance;
 	private $sender;
 
-	public static function getInstance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
+	public function name() {
+		return 'full-sync';
 	}
 
-	protected function __construct() {
-		$this->init();
+	function init_listeners( $callable ) {
+		// synthetic actions for full sync
+		add_action( 'jetpack_full_sync_start', $callable );
+		add_action( 'jetpack_full_sync_end', $callable );
 	}
 
-	function init() {
+	function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'expand_comment_ids' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_options', array( $this, 'expand_options' ) );
@@ -60,9 +56,9 @@ class Jetpack_Sync_Full {
 			$this,
 			'expand_network_options'
 		) );
-
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_terms', array( $this, 'expand_term_ids' ) );
 
+		// this is triggered after actions have been processed on the server
 		add_action( 'jetpack_sync_processed_actions', array( $this, 'update_sent_progress_action' ) );
 	}
 

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -19,6 +19,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-meta.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-terms.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-plugins.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-protect.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-full-sync.php';
 
 class Jetpack_Sync_Modules {
 
@@ -35,7 +36,8 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Meta',
 		'Jetpack_Sync_Module_Terms',
 		'Jetpack_Sync_Module_Plugins',
-		'Jetpack_Sync_Module_Protect'
+		'Jetpack_Sync_Module_Protect',
+		'Jetpack_Sync_Module_Full_Sync'
 	);
 
 	private static $initialized_modules = null;

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -3,7 +3,6 @@
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-queue.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-defaults.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-json-deflate-codec.php';
-require_once dirname( __FILE__ ) . '/class.jetpack-sync-full.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-modules.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 
@@ -225,26 +224,8 @@ class Jetpack_Sync_Sender {
 		return update_option( self::LAST_SYNC_TIME_OPTION_NAME, microtime( true ), true );
 	}
 
-	function get_full_sync_client() {
-		return $this->full_sync_client;
-	}
-
-	function set_full_sync_client( $full_sync_client ) {
-		if ( $this->full_sync_client ) {
-			remove_action( 'jetpack_sync_full', array( $this->full_sync_client, 'start' ) );
-		}
-
-		$this->full_sync_client = $full_sync_client;
-
-		/**
-		 * Sync all objects in the database with the server
-		 */
-		add_action( 'jetpack_sync_full', array( $this->full_sync_client, 'start' ) );
-	}
-
 	function set_defaults() {
 		$this->sync_queue = new Jetpack_Sync_Queue( 'sync' );
-		$this->set_full_sync_client( Jetpack_Sync_Full::getInstance() );
 		$this->codec = new Jetpack_Sync_JSON_Deflate_Codec();
 
 		// saved settings

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1,8 +1,5 @@
 <?php
 
-$sync_dir = dirname( __FILE__ ) . '/../../../sync/';
-require_once $sync_dir . 'class.jetpack-sync-full.php';
-
 function jetpack_foo_full_sync_callable() {
 	return 'the value';
 }
@@ -16,7 +13,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function setUp() {
 		parent::setUp();
-		$this->full_sync = Jetpack_Sync_Full::getInstance();
+		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
 	}
 
 	function test_enqueues_sync_start_action() {


### PR DESCRIPTION
Fixes issue triggering full sync from the site's admin page.

The main issue that I assumed only POST requests result in data changes, but in WP-Admin that's not always true - in particular, AJAX requests are GETs by default.