### PR TITLE
Modules: if Manage is active, remove the Centralized Management filter

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -150,6 +150,9 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 				continue;
 			}
 			$key           = sanitize_title( $title );
+			if ( 'centralized-management' === $key && Jetpack::is_module_active( 'manage' ) ) {
+				continue;
+			}
 			$display_title = esc_html( wptexturize( $title ) );
 			$url           = esc_url( add_query_arg( 'module_tag', urlencode( $title ) ) );
 			$current       = '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- check if Manage module is active. If it is, remove Centralized Management filter from list of views.

If Manage is not active
<img width="274" alt="views-before" src="https://cloud.githubusercontent.com/assets/1041600/16672521/02218bb6-447d-11e6-92c8-3ec5cdcd9554.png">

If Manage is active
<img width="262" alt="views" src="https://cloud.githubusercontent.com/assets/1041600/16672510/edf4d47c-447c-11e6-912a-567154a51a95.png">

cc @Viper007Bond since he spotted the issue