### PR TITLE
Sync: Hook sync listener if `is_admin()`

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -26,6 +26,8 @@ class Jetpack_Sync_Actions {
 					defined( 'DOING_AJAX' ) && DOING_AJAX
 				||
 					defined( 'PHPUNIT_JETPACK_TESTSUITE' )
+				||
+				    is_admin()
 				)
 			) ) {
 			require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -27,9 +27,9 @@ class Jetpack_Sync_Actions {
 				||
 					defined( 'PHPUNIT_JETPACK_TESTSUITE' )
 				||
-				    is_admin()
+					is_admin()
 				)
-			) ) {
+		) ) {
 			require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 			self::$listener = Jetpack_Sync_Listener::getInstance();
 		}


### PR DESCRIPTION
Activating modules id done via non ajax get requests 😱 

Probably some other plugins could be doing the same, I think we have no option than to hook the listener on every request.

cc @gravityrail @enejb 