### PR TITLE
Fix: select nav dropdown for smaller widths

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -49,16 +49,16 @@ function render() {
 		<div>
 			<Provider store={ store }>
 				<Router history={ history }>
-					<Route path='/' component={ Main } />
-					<Route path='/dashboard' component={ Main } />
-					<Route path='/apps' component={ Main } />
-					<Route path='/professional' component={ Main } />
-					<Route path='/settings' component={ Main } />
-					<Route path='/general' component={ Main } />
-					<Route path='/engagement' component={ Main } />
-					<Route path='/security' component={ Main } />
-					<Route path='/appearance' component={ Main } />
-					<Route path='/writing' component={ Main } />
+					<Route path='/' name={ i18n.translate( 'At A Glance', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/dashboard' name={ i18n.translate( 'At A Glance' ) } component={ Main } />
+					<Route path='/apps' name={ i18n.translate( 'Apps', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/professional' name={ i18n.translate( 'Professional', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/settings' name={ i18n.translate( 'General', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/general' name={ i18n.translate( 'General', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/engagement' name={ i18n.translate( 'Engagement', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/security' name={ i18n.translate( 'Security', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/appearance' name={ i18n.translate( 'Appearance', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/writing' name={ i18n.translate( 'Writing', { context: 'Navigation item.' } ) } component={ Main } />
 				</Router>
 			</Provider>
 		</div>,

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -18,8 +18,8 @@ const NavigationSettings = React.createClass( {
 	render: function() {
 		return (
 			<div className='dops-navigation'>
-				<SectionNav>
-					<NavTabs>
+				<SectionNav selectedText={ this.props.route.name }>
+					<NavTabs selectedText={ this.props.route.name }>
 						<NavItem
 							path="#general"
 							selected={ ( this.props.route.path === '/general' || this.props.route.path === '/settings' ) }>


### PR DESCRIPTION
Fixes #3874 
Replaces #4339 as a much less intrusive (and more logical) fix.

![section-nav-demo](https://cloud.githubusercontent.com/assets/7129409/16672650/6f160c18-4475-11e6-8632-99c8de996672.gif)

To Test: 
- Make sure navigation/dropdown/routing works correctly when navigating from the dashboard AND settings.  
- Make sure to test above 480px (500ish is fine)
- Make sure to test below 480px

This change includes adding the `name` prop to each route, so that we can use it in the section nav dropdown to determine what text to show.