### PR TITLE
Perform a full sync on Jetpack site authorization

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -28,6 +28,15 @@ class Jetpack_Client_Server {
 			$this->wp_safe_redirect( Jetpack::admin_url() );
 		}
 
+		/**
+		 * Fires after the Jetpack client is authorized to communicate with WordPress.com.
+		 *
+		 * @since 4.2.0
+		 *
+		 * @param int Jetpack Blog ID.
+		 */
+		do_action( 'jetpack_client_authorized', Jetpack_Options::get_option( 'id' ) );
+
 		$this->do_exit();
 	}
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -1,37 +1,58 @@
 <?php
 
-function jetpack_send_db_checksum() {
-	$sync_sender = Jetpack_Sync_Sender::getInstance();
-	$sync_sender->send_checksum();
-}
-
+/**
+ * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
+ * when to send, when to perform a full sync, etc.
+ *
+ * It also binds the action to send data to WPCOM to Jetpack's XMLRPC client object.
+ */
 class Jetpack_Sync_Actions {
 	static $sender = null;
 	static $listener = null;
 
 	static function init() {
+		
+		// On jetpack authorization, schedule a full sync
+		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ) );
+
+		// cron hooks
+		add_action( 'jetpack_sync_send_db_checksum', array( __CLASS__, 'send_db_checksum' ) );
+		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ) );
+
+		$prevent_sync_loading = 
+				( !Jetpack::is_active() || Jetpack::is_development_mode() || Jetpack::is_staging_site() ) 
+			&& 
+				!defined( 'PHPUNIT_JETPACK_TESTSUITE' );
+
+		if ( ! $prevent_sync_loading && ! wp_next_scheduled ( 'jetpack_sync_send_db_checksum' ) ) {
+			// Schedule a job to send DB checksums once an hour
+			wp_schedule_event( time(), 'hourly', 'jetpack_sync_send_db_checksum' );
+		}
+
 		/**
 		 * Fires on every request before default loading sync listener code.
 		 * Return false to not load sync listener code that monitors common
-		 * WP actions to be serialized
+		 * WP actions to be serialized.
+		 * 
+		 * By default this returns true for non-GET-requests, or requests where the 
+		 * user is logged-in.
 		 *
 		 * @since 4.2.0
 		 *
 		 * @param bool should we load sync listener code for this request
 		 */
-		if ( apply_filters( 'jetpack_sync_listener_should_load',
+		if ( !$prevent_sync_loading && apply_filters( 'jetpack_sync_listener_should_load',
 				(
 					$_SERVER['REQUEST_METHOD'] !== 'GET'
 				||
-					defined( 'DOING_AJAX' ) && DOING_AJAX
+					is_user_logged_in()
 				||
 					defined( 'PHPUNIT_JETPACK_TESTSUITE' )
 				||
 					is_admin()
 				)
-		) ) {
-			require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
-			self::$listener = Jetpack_Sync_Listener::getInstance();
+			) ) {
+			self::initialize_listener();
 		}
 
 		// Sync connected user role changes to .com
@@ -42,11 +63,14 @@ class Jetpack_Sync_Actions {
 		 * Return false to not load sync sender code that serializes pending
 		 * data and sends it to WPCOM for processing.
 		 *
+		 * By default this returns true for POST requests, admin requests, or requests
+		 * by users who can manage_options.
+		 *
 		 * @since 4.2.0
 		 *
 		 * @param bool should we load sync sender code for this request
 		 */
-		if ( ! apply_filters( 'jetpack_sync_sender_should_load',
+		if ( !$prevent_sync_loading && apply_filters( 'jetpack_sync_sender_should_load',
 			(
 				$_SERVER['REQUEST_METHOD'] === 'POST'
 			||
@@ -56,30 +80,9 @@ class Jetpack_Sync_Actions {
 			||
 				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
 			)
-		&&
-			( Jetpack::is_active() || defined( 'PHPUNIT_JETPACK_TESTSUITE' ) )
-		&&
-			!( Jetpack::is_development_mode() || Jetpack::is_staging_site() )
-
-		) ) {
-			return;
-		}
-
-		require_once dirname( __FILE__ ) . '/class.jetpack-sync-sender.php';
-		self::$sender = Jetpack_Sync_Sender::getInstance();
-
-		// bind the do_sync process to shutdown
-		add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
-
-		// bind the sending process
-		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 3 );
-
-		// On jetpack registration
-		add_action( 'jetpack_site_registered', array( __CLASS__, 'schedule_full_sync' ) );
-
-		// Schedule a job to send DB checksums once an hour
-		if ( ! wp_next_scheduled ( 'jetpack_send_db_checksum' ) ) {
-			wp_schedule_event( time(), 'hourly', 'jetpack_send_db_checksum' );
+			) ) {
+			self::initialize_sender();
+			add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
 		}
 
 	}
@@ -112,6 +115,29 @@ class Jetpack_Sync_Actions {
 		wp_schedule_single_event( time() + 1, 'jetpack_sync_full' );
 	}
 
+	static function do_full_sync() {
+		self::initialize_listener();
+		Jetpack_Sync_Modules::get_module( 'full-sync' )->start();
+	}
+
+	static function send_db_checksum() {
+		self::initialize_sender();
+		self::$sender->send_checksum();
+	}
+
+	static function initialize_listener() {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
+		self::$listener = Jetpack_Sync_Listener::getInstance();
+	}
+
+	static function initialize_sender() {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-sender.php';
+		self::$sender = Jetpack_Sync_Sender::getInstance();
+		
+		// bind the sending process
+		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 3 );
+	}
 }
+
 // Allow other plugins to add filters before we initalize the actions.
 add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 11, 0 );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -49,8 +49,6 @@ class Jetpack_Sync_Actions {
 					is_user_logged_in()
 				||
 					defined( 'PHPUNIT_JETPACK_TESTSUITE' )
-				||
-					is_admin()
 				)
 			) ) {
 			self::initialize_listener();

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -18,6 +18,7 @@ class Jetpack_Sync_Actions {
 		// cron hooks
 		add_action( 'jetpack_sync_send_db_checksum', array( __CLASS__, 'send_db_checksum' ) );
 		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ) );
+		add_action( 'jetpack_sync_send_pending_data', array( __CLASS__, 'do_send_pending_data' ) );
 
 		$prevent_sync_loading = 
 				( !Jetpack::is_active() || Jetpack::is_development_mode() || Jetpack::is_staging_site() ) 
@@ -118,11 +119,19 @@ class Jetpack_Sync_Actions {
 	static function do_full_sync() {
 		self::initialize_listener();
 		Jetpack_Sync_Modules::get_module( 'full-sync' )->start();
+		self::do_send_pending_data(); // try to send at least some of the data
+	}
+
+	static function do_send_pending_data() {
+		self::initialize_sender();
+		self::$sender->do_sync();
 	}
 
 	static function send_db_checksum() {
+		self::initialize_listener();
 		self::initialize_sender();
 		self::$sender->send_checksum();
+		self::$sender->do_sync();
 	}
 
 	static function initialize_listener() {


### PR DESCRIPTION
This change tries to perform a full sync when a Jetpack site is connected.

It also refactors and fixes several problems with how the sync listener and sender are initialized.

- nothing was listening for the full sync action required by the cron job
- sending the checksum didn't initialise the listener object

This builds on the work from #4347