### PR TITLE
Support updated CartoDB URL format.

### DIFF
--- a/modules/shortcodes/cartodb.php
+++ b/modules/shortcodes/cartodb.php
@@ -13,6 +13,12 @@
  * [organization].cartodb.com/u/[username]/viz/[map-id]/public_map
  * [organization].cartodb.com/u/[username]/viz/[map-id]/embed_map
  * [organization].cartodb.com/u/[username]/viz/[map-id]/map
+ * [username].carto.com/viz/[map-id]/public_map
+ * [username].carto.com/viz/[map-id]/embed_map
+ * [username].carto.com/viz/[map-id]/map
+ * [organization].carto.com/u/[username]/viz/[map-id]/public_map
+ * [organization].carto.com/u/[username]/viz/[map-id]/embed_map
+ * [organization].carto.com/u/[username]/viz/[map-id]/map
 */
 
-wp_oembed_add_provider( '#https?://(?:www\.)?[^/^\.]+\.cartodb\.com/\S+#i', 'https://services.cartodb.com/oembed', true );
+wp_oembed_add_provider( '#https?://(?:www\.)?[^/^\.]+\.carto(db)?\.com/\S+#i', 'https://services.cartodb.com/oembed', true );


### PR DESCRIPTION
Fixes #4348 .

#### Changes proposed in this Pull Request:
- Fix regular expression so that both cartodb.com and carto.com URLs can be embedded.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

CartoDB recently changed their primary domain from cartodb.com to
carto.com. This changeset modifies the oEmbed regex to match both kinds
of URL.