### PR TITLE
Refactor full sync code into modules

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -79,6 +79,10 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		return 1; // The number of actions enqueued
 	}
 
+	public function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_callables' );
+	}
+
 	public function force_sync_callables() {
 		delete_option( self::CALLABLES_CHECKSUM_OPTION_NAME );
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -9,7 +9,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	private $callable_whitelist;
 
 	public function name() {
-		return "callables";
+		return 'functions';
 	}
 
 	public function set_defaults() {
@@ -33,6 +33,9 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function init_before_send() {
 		add_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_callables' ) );
+
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_callables', array( $this, 'expand_callables' ) );
 	}
 
 	public function reset_data() {
@@ -64,7 +67,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		return call_user_func( $callable );
 	}
 
-	public function full_sync() {
+	public function enqueue_full_sync_actions() {
 		/**
 		 * Tells the client to sync all callables to the server
 		 *
@@ -117,5 +120,12 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			}
 		}
 		update_option( self::CALLABLES_CHECKSUM_OPTION_NAME , $callable_checksums );
+	}
+
+	public function expand_callables( $args ) {
+		if ( $args[0] ) {
+			return $this->get_all_callables();
+		}
+		return $args;
 	}
 }

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -3,7 +3,7 @@
 class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 
 	public function name() {
-		return "comments";
+		return 'comments';
 	}
 
 	public function init_listeners( $callable ) {
@@ -35,6 +35,14 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 				add_filter( 'jetpack_sync_before_send_' . $comment_action_name, array( $this, 'expand_wp_insert_comment' ) );
 			}
 		}
+
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'expand_comment_ids' ) );
+	}
+
+	public function enqueue_full_sync_actions() {
+		global $wpdb;
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', null );
 	}
 
 	function expand_wp_comment_status_change( $args ) {
@@ -69,5 +77,18 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		}
 
 		return $comment;
+	}
+
+	public function expand_comment_ids( $args ) {
+		$comment_ids = $args[0];
+		$comments    = get_comments( array(
+			'include_unapproved' => true,
+			'comment__in'        => $comment_ids,
+		) );
+
+		return array(
+			$comments,
+			$this->get_metadata( $comment_ids, 'comment' ),
+		);
 	}
 }

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -45,6 +45,14 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', null );
 	}
 
+	public function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_comments' );
+	}
+
+	public function count_full_sync_actions( $action_names ) {
+		return $this->count_actions( $action_names, array( 'jetpack_full_sync_comments' ) );
+	}
+
 	function expand_wp_comment_status_change( $args ) {
 		return array( $args[0], $this->filter_comment( $args[1] ) );
 	}

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -59,6 +59,10 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		return 1;
 	}
 
+	function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_constants' );
+	}
+
 	function maybe_sync_constants() {
 		if ( get_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME ) ) {
 			return;

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -5,7 +5,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 	const CONSTANTS_AWAIT_TRANSIENT_NAME = 'jetpack_sync_constants_await';
 
 	public function name() {
-		return "constants";
+		return 'constants';
 	}
 
 	private $constants_whitelist;
@@ -23,6 +23,9 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 
 	public function init_before_send() {
 		add_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_constants' ) );
+
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_constants', array( $this, 'expand_constants' ) );
 	}
 
 	public function reset_data() {
@@ -44,7 +47,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		$this->maybe_sync_constants();
 	}
 
-	function full_sync() {
+	function enqueue_full_sync_actions() {
 		/**
 		 * Tells the client to sync all constants to the server
 		 *
@@ -53,7 +56,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		 * @param boolean Whether to expand constants (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_constants', true );
-		return 1; // The number of actions enqueued
+		return 1;
 	}
 
 	function maybe_sync_constants() {
@@ -102,5 +105,12 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		return ( defined( $constant ) ) ?
 			constant( $constant )
 			: null;
+	}
+
+	public function expand_constants( $args ) {
+		if ( $args[0] ) {
+			return $this->get_all_constants();
+		}
+		return $args;
 	}
 }

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -41,8 +41,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 		/**
 		 * Fires when a full sync begins. This action is serialized
-		 * and sent to the server so that it can clear the replica storage,
-		 * and/or reset other data.
+		 * and sent to the server so that it knows a full sync is coming.
 		 *
 		 * @since 4.2.0
 		 */
@@ -56,6 +55,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->set_status_queuing_finished();
 
 		$store = new Jetpack_Sync_WP_Replicastore();
+
+		/**
+		 * Fires when a full sync ends. This action is serialized
+		 * and sent to the server with checksums so that we can confirm the
+		 * sync was successful.
+		 *
+		 * @since 4.2.0
+		 */
 		do_action( 'jetpack_full_sync_end', $store->checksum_all() );
 		return true;
 	}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -52,9 +52,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		foreach( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module->full_sync();
 		}
-		if ( is_multisite() ) {
-			$this->enqueue_all_network_options();
-		}
 
 		$this->set_status_queuing_finished();
 
@@ -78,11 +75,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		return $this->sender;
-	}
-
-	private function enqueue_all_network_options() {
-		$total = Jetpack_Sync_Modules::get_module( "options" )->full_sync_network();
-		$this->update_queue_progress( 'network_options', $total );
 	}
 
 	function update_sent_progress_action( $actions ) {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -69,14 +69,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return false;
 	}
 
-	private function get_sender() {
-		if ( ! $this->sender ) {
-			$this->sender = Jetpack_Sync_Sender::getInstance();
-		}
-
-		return $this->sender;
-	}
-
 	function update_sent_progress_action( $actions ) {
 		// quick way to map to first items with an array of arrays
 		$actions_with_counts = array_count_values( array_map( 'reset', $actions ) );
@@ -87,7 +79,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		if ( isset( $actions_with_counts[ 'jetpack_full_sync_start' ] ) ) {
-			$this->set_status_sending_started();
 			$status['sent_started'] = time();
 		}
 
@@ -105,7 +96,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		if ( isset( $actions_with_counts[ 'jetpack_full_sync_end' ] ) ) {
-			$this->set_status_sending_finished();
 			$status['finished'] = time();
 		}
 
@@ -122,29 +112,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->update_status( array( 'queue_finished' => time() ) );
 	}
 
-	// these are called by the Sync Client when it sees that the full sync start/end actions have actually been transmitted
-	public function set_status_sending_started() {
-		/**
-		 * Fires when the full_sync_start action is actually transmitted.
-		 * This is useful for telling the user the status of full synchronization.
-		 *
-		 * @since 4.2.0
-		 */
-
-		do_action( 'jetpack_full_sync_start_sent' );
-
-	}
-
-	public function set_status_sending_finished() {
-		/**
-		 * Fires when the full_sync_end action is actually transmitted.
-		 * This is useful for telling the user the status of full synchronization.
-		 *
-		 * @since 4.2.0
-		 */
-		do_action( 'jetpack_full_sync_end_sent' );
-	}
-
 	private $initial_status = array(
 		'started' => null,
 		'queue_finished' => null,
@@ -158,7 +125,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return get_option( self::$status_option, $this->initial_status );
 	}
 
-
 	public function update_status( $status ) {
 		return update_option(
 			self::$status_option,
@@ -169,14 +135,4 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	private function clear_status() {
 		delete_option( self::$status_option );
 	}
-
-	public function update_sent_progress( $module, $data ) {
-		$status = $this->get_status();
-		if ( isset( $status['sent'][ $module ] ) )  {
-			return $data + $status['sent'][ $module ];
-		} else {
-			return $data;
-		}
-	}
-
 }

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -15,8 +15,7 @@
 require_once 'class.jetpack-sync-wp-replicastore.php';
 
 class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
-	static $status_option = 'jetpack_full_sync_status';
-	static $transient_timeout = 3600; // an hour
+	const STATUS_OPTION = 'jetpack_full_sync_status';
 
 	private $sender;
 
@@ -129,17 +128,17 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	);
 
 	public function get_status() {
-		return get_option( self::$status_option, $this->initial_status );
+		return get_option( self::STATUS_OPTION, $this->initial_status );
 	}
 
 	public function update_status( $status ) {
 		return update_option(
-			self::$status_option,
+			self::STATUS_OPTION,
 			array_merge( $this->get_status(), $status )
 		);
 	}
 
 	private function clear_status() {
-		delete_option( self::$status_option );
+		delete_option( self::STATUS_OPTION );
 	}
 }

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -98,19 +98,21 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->update_queue_progress( 'network_options', $total );
 	}
 
-	function update_sent_progress_action( $actions_sent ) {
+	function update_sent_progress_action( $actions ) {
+		$action_names = array_map( 'reset', $actions );
+
 		$modules_count = array();
 		$status = $this->get_status();
 		if ( is_null( $status['started'] ) || $status['finished'] ) {
 			return;
 		}
 
-		if ( in_array( 'jetpack_full_sync_start', $actions_sent ) ) {
+		if ( in_array( 'jetpack_full_sync_start', $action_names ) ) {
 			$this->set_status_sending_started();
 			$status['sent_started'] = time();
 		}
 
-		foreach( $actions_sent as $action ) {
+		foreach( $action_names as $action ) {
 			$module_key = $this->action_to_modules( $action );
 			if ( $module_key ) {
 				$modules_count[ $module_key ] = isset( $modules_count[ $module_key ] ) ?  $modules_count[ $module_key ] + 1 : 1;
@@ -121,7 +123,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$status[ 'sent' ][ $module ] = $this->update_sent_progress( $module, $count );
 		}
 
-		if ( in_array( 'jetpack_full_sync_end', $actions_sent ) ) {
+		if ( in_array( 'jetpack_full_sync_end', $action_names ) ) {
 			$this->set_status_sending_finished();
 			$status['finished'] = time();
 		}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -15,7 +15,6 @@
 require_once 'class.jetpack-sync-wp-replicastore.php';
 
 class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
-	const ARRAY_CHUNK_SIZE = 10;
 	static $status_option = 'jetpack_full_sync_status';
 	static $transient_timeout = 3600; // an hour
 	static $modules = array(
@@ -45,19 +44,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	function init_before_send() {
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'expand_comment_ids' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_options', array( $this, 'expand_options' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_constants', array( $this, 'expand_constants' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_callables', array( $this, 'expand_callables' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_users', array( $this, 'expand_users' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_network_options', array(
-			$this,
-			'expand_network_options'
-		) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_terms', array( $this, 'expand_term_ids' ) );
-
 		// this is triggered after actions have been processed on the server
 		add_action( 'jetpack_sync_processed_actions', array( $this, 'update_sent_progress_action' ) );
 	}
@@ -76,18 +62,12 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		do_action( 'jetpack_full_sync_start' );
 		$this->set_status_queuing_started();
 
-		$this->enqueue_all_constants();
-		$this->enqueue_all_functions();
-		$this->enqueue_all_options();
+		foreach( Jetpack_Sync_Modules::get_modules() as $module ) {
+			$module->full_sync();
+		}
 		if ( is_multisite() ) {
 			$this->enqueue_all_network_options();
 		}
-		$this->enqueue_all_terms();
-		$this->enqueue_all_theme_info();
-		$this->enqueue_all_users();
-		$this->enqueue_all_posts();
-		$this->enqueue_all_comments();
-		$this->enqueue_all_updates();
 
 		$this->set_status_queuing_finished();
 
@@ -113,221 +93,9 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return $this->sender;
 	}
 
-	private function enqueue_all_constants() {
-		$total = Jetpack_Sync_Modules::get_module( "constants" )->full_sync();
-		$this->update_queue_progress( 'constants', $total );
-	}
-
-	private function enqueue_all_functions() {
-		$total = Jetpack_Sync_Modules::get_module( "callables" )->full_sync();
-		$this->update_queue_progress( 'functions', $total );
-	}
-
-	private function enqueue_all_options() {
-		$total = Jetpack_Sync_Modules::get_module( "options" )->full_sync();
-		$this->update_queue_progress( 'options', $total );
-	}
-
 	private function enqueue_all_network_options() {
 		$total = Jetpack_Sync_Modules::get_module( "options" )->full_sync_network();
 		$this->update_queue_progress( 'network_options', $total );
-	}
-
-	private function enqueue_all_terms() {
-		global $wpdb;
-
-		$taxonomies = get_taxonomies();
-		$total_chunks_counter = 0;
-		foreach ( $taxonomies as $taxonomy ) {
-			// I hope this is never bigger than RAM...
-			$term_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s", $taxonomy ) ); // Should we set a limit here?
-			// Request posts in groups of N for efficiency
-			$chunked_term_ids = array_chunk( $term_ids, self::ARRAY_CHUNK_SIZE );
-
-			// Send each chunk as an array of objects
-			foreach ( $chunked_term_ids as $chunk ) {
-				do_action( 'jetpack_full_sync_terms', $chunk, $taxonomy );
-				$total_chunks_counter++;
-			}
-		}
-
-		$this->update_queue_progress( 'terms', $total_chunks_counter );
-
-	}
-
-	private function enqueue_all_posts() {
-		global $wpdb;
-
-		$post_type_sql = Jetpack_Sync_Defaults::get_blacklisted_post_types_sql();
-		$total = $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $post_type_sql );
-		$this->update_queue_progress( 'posts', $total );
-
-	}
-
-	private function enqueue_all_ids_as_action( $action_name, $table_name, $id_field, $where_sql ) {
-		global $wpdb;
-
-		if ( ! $where_sql ) {
-			$where_sql = "1 = 1";
-		}
-
-		$items_per_page = 500;
-		$page = 1;
-		$offset = ( $page * $items_per_page ) - $items_per_page;
-		$chunk_count = 0;
-		while( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} ORDER BY {$id_field} asc LIMIT {$offset}, {$items_per_page}" ) ) {
-			// Request posts in groups of N for efficiency
-			$chunked_ids = array_chunk( $ids, self::ARRAY_CHUNK_SIZE );
-
-			// Send each chunk as an array of objects
-			foreach ( $chunked_ids as $chunk ) {
-				/**
-			 	 * Fires with a chunk of object IDs during full sync.
-			 	 * These are expanded to full objects before upload
-			 	 *
-			 	 * @since 4.2.0
-			 	 */
-				do_action( $action_name, $chunk );
-				$chunk_count++;
-			}
-
-			$page += 1;
-			$offset = ( $page * $items_per_page ) - $items_per_page;
-		}
-		return $chunk_count;
-	}
-
-	public function expand_post_ids( $args ) {
-		$post_ids = $args[0];
-
-		$posts = array_map( array( 'WP_Post', 'get_instance' ), $post_ids );
-		$posts = array_map( array( Jetpack_Sync_Modules::get_module( "posts" ), 'filter_post_content_and_add_links' ), $posts );
-
-		return array(
-			$posts,
-			$this->get_metadata( $post_ids, 'post' ),
-			$this->get_term_relationships( $post_ids )
-		);
-	}
-
-	private function enqueue_all_comments() {
-		global $wpdb;
-
-		$total = $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', null );
-		$this->update_queue_progress( 'comments', $total );
-	}
-
-	public function expand_comment_ids( $args ) {
-		$comment_ids = $args[0];
-		$comments    = get_comments( array(
-			'include_unapproved' => true,
-			'comment__in'        => $comment_ids,
-		) );
-
-		return array(
-			$comments,
-			$this->get_metadata( $comment_ids, 'comment' ),
-		);
-	}
-
-	public function expand_term_ids( $args ) {
-		global $wp_version;
-		$term_ids = $args[0];
-		$taxonomy = $args[1];
-		// version 4.5 or higher
-		if ( version_compare( $wp_version, 4.5, '>=' ) ) {
-			$terms = get_terms( array(
-				'taxonomy'   => $taxonomy,
-				'hide_empty' => false,
-				'include'    => $term_ids
-			) );
-		} else {
-			$terms = get_terms( $taxonomy, array(
-				'hide_empty' => false,
-				'include'    => $term_ids
-			) );
-		}
-
-		return $terms;
-	}
-
-	public function expand_options( $args ) {
-		if ( $args[0] ) {
-			return Jetpack_Sync_Modules::get_module( "options" )->get_all_options();
-		}
-
-		return $args;
-	}
-
-	public function expand_constants( $args ) {
-		if ( $args[0] ) {
-			return Jetpack_Sync_Modules::get_module( "constants" )->get_all_constants();
-		}
-		return $args;
-	}
-
-	public function expand_callables( $args ) {
-		if ( $args[0] ) {
-			return Jetpack_Sync_Modules::get_module( "callables" )->get_all_callables();
-		}
-		return $args;
-	}
-
-	private function enqueue_all_users() {
-		global $wpdb;
-		$total = $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->users, 'ID', null );
-		$this->update_queue_progress( 'users', $total );
-	}
-
-	public function expand_users( $args ) {
-		$user_ids = $args[0];
-		return array_map( array( Jetpack_Sync_Modules::get_module( "users" ), 'sanitize_user_and_expand' ), get_users( array( 'include' => $user_ids ) ) );
-	}
-
-	public function expand_network_options( $args ) {
-		if ( $args[0] ) {
-			return Jetpack_Sync_Modules::get_module( "options" )->get_all_network_options();
-		}
-
-		return $args;
-	}
-
-	private function get_metadata( $ids, $meta_type ) {
-		global $wpdb;
-		$table = _get_meta_table( $meta_type );
-		$id    = $meta_type . '_id';
-		if ( ! $table ) {
-			return array();
-		}
-
-		return $wpdb->get_results( "SELECT $id, meta_key, meta_value, meta_id FROM $table WHERE $id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . " )", OBJECT );
-	}
-
-	private function get_term_relationships( $ids ) {
-		global $wpdb;
-
-		return $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . " )", OBJECT );
-	}
-
-	// TODO:
-	private function enqueue_all_theme_info() {
-		$total = Jetpack_Sync_Modules::get_module( "themes" )->send_theme_info();
-		$this->update_queue_progress( 'themes', $total );
-	}
-
-	private function enqueue_all_updates() {
-
-		// check for updates
-		$total = Jetpack_Sync_Modules::get_module( "updates" )->full_sync();
-		$this->update_queue_progress( 'updates', $total );
-	}
-
-	public function expand_updates( $args ) {
-		if ( $args[0] ) {
-			return Jetpack_Sync_Modules::get_module( "updates" )->get_all_updates();
-		}
-
-		return $args;
 	}
 
 	function update_sent_progress_action( $actions_sent ) {
@@ -347,8 +115,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			if ( $module_key ) {
 				$modules_count[ $module_key ] = isset( $modules_count[ $module_key ] ) ?  $modules_count[ $module_key ] + 1 : 1;
 			}
-
 		}
+
 		foreach( $modules_count as $module => $count ) {
 			$status[ 'sent' ][ $module ] = $this->update_sent_progress( $module, $count );
 		}
@@ -463,17 +231,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	private function clear_status() {
 		delete_option( self::$status_option );
-	}
-
-	public function update_queue_progress( $module, $data ) {
-		$status = $this->get_status();
-		if ( isset( $status['queue'][ $module ] ) )  {
-			$status['queue'][ $module ] = $data + $status['queue'][ $module ];
-		} else {
-			$status['queue'][ $module ] = $data;
-		}
-
-		return $this->update_status( $status );
 	}
 
 	public function update_sent_progress( $module, $data ) {

--- a/sync/class.jetpack-sync-module-meta.php
+++ b/sync/class.jetpack-sync-module-meta.php
@@ -4,7 +4,7 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 	private $meta_types = array( 'post', 'comment' );
 
 	public function name() {
-		return "meta";
+		return 'meta';
 	}
 
 	public function init_listeners( $callable ) {

--- a/sync/class.jetpack-sync-module-network-options.php
+++ b/sync/class.jetpack-sync-module-network-options.php
@@ -1,0 +1,102 @@
+<?php
+
+class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
+	private $network_options_whitelist;
+
+	public function name() {
+		return 'network_options';
+	}
+
+	public function init_listeners( $callable ) {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		// multi site network options
+		add_action( 'add_site_option', $callable, 10, 2 );
+		add_action( 'update_site_option', $callable, 10, 3 );
+		add_action( 'delete_site_option', $callable, 10, 1 );
+
+		// full sync
+		add_action( 'jetpack_full_sync_network_options', $callable );
+
+		$whitelist_network_option_handler = array( $this, 'whitelist_network_options' );
+		add_filter( 'jetpack_sync_before_enqueue_delete_site_option', $whitelist_network_option_handler );
+		add_filter( 'jetpack_sync_before_enqueue_add_site_option', $whitelist_network_option_handler );
+		add_filter( 'jetpack_sync_before_enqueue_update_site_option', $whitelist_network_option_handler );
+	}
+
+	public function init_before_send() {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_network_options', array(
+			$this,
+			'expand_network_options'
+		) );
+	}
+
+	public function set_defaults() {
+		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
+	}
+
+	function enqueue_full_sync_actions() {
+		if ( ! is_multisite() ) {
+			return 0;
+		}
+
+		/**
+		 * Tells the client to sync all options to the server
+		 *
+		 * @since 4.2.0
+		 *
+		 * @param boolean Whether to expand options (should always be true)
+		 */
+		do_action( 'jetpack_full_sync_network_options', true );
+		return 1; // The number of actions enqueued
+	}
+
+	function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_network_options' );
+	}
+
+	function get_all_network_options() {
+		$options = array();
+		foreach ( $this->network_options_whitelist as $option ) {
+			$options[ $option ] = get_site_option( $option );
+		}
+
+		return $options;
+	}
+
+	function set_network_options_whitelist( $options ) {
+		$this->network_options_whitelist = $options;
+	}
+
+	function get_network_options_whitelist() {
+		return $this->network_options_whitelist;
+	}
+
+	// reject non-whitelisted network options
+	function whitelist_network_options( $args ) {
+		if ( ! $this->is_whitelisted_network_option( $args[0] ) ) {
+			return false;
+		}
+
+		return $args;
+	}
+
+	function is_whitelisted_network_option( $option ) {
+		return is_multisite() && in_array( $option, $this->network_options_whitelist );
+	}
+
+	public function expand_network_options( $args ) {
+		if ( $args[0] ) {
+			return $this->get_all_network_options();
+		}
+
+		return $args;
+	}
+}

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -2,7 +2,6 @@
 
 class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 	private $options_whitelist;
-	private $network_options_whitelist;
 
 	public function name() {
 		return 'options';
@@ -22,39 +21,19 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		// full sync
 		add_action( 'jetpack_full_sync_options', $callable );
 
-		// multi site network options
-		if ( is_multisite() ) {
-			add_action( 'add_site_option', $callable, 10, 2 );
-			add_action( 'update_site_option', $callable, 10, 3 );
-			add_action( 'delete_site_option', $callable, 10, 1 );
-
-			// full sync
-			add_action( 'jetpack_full_sync_network_options', $callable );
-		}
-
 		$whitelist_option_handler = array( $this, 'whitelist_options' );
 		add_filter( 'jetpack_sync_before_enqueue_deleted_option', $whitelist_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_added_option', $whitelist_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_updated_option', $whitelist_option_handler );
-
-		$whitelist_network_option_handler = array( $this, 'whitelist_network_options' );
-		add_filter( 'jetpack_sync_before_enqueue_delete_site_option', $whitelist_network_option_handler );
-		add_filter( 'jetpack_sync_before_enqueue_add_site_option', $whitelist_network_option_handler );
-		add_filter( 'jetpack_sync_before_enqueue_update_site_option', $whitelist_network_option_handler );
 	}
 
 	public function init_before_send() {
 		// full sync
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_options', array( $this, 'expand_options' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_network_options', array(
-			$this,
-			'expand_network_options'
-		) );
 	}
 
 	public function set_defaults() {
 		$this->update_options_whitelist();
-		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
 		// theme mod varies from theme to theme.
 		$this->options_whitelist[] = 'theme_mods_' . get_option( 'stylesheet' );
 	}
@@ -75,19 +54,6 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		return array( 'jetpack_full_sync_options' );
 	}
 
-	// TODO
-	function full_sync_network() {
-		/**
-		 * Tells the client to sync all network options to the server
-		 *
-		 * @since 4.2.0
-		 *
-		 * @param boolean Whether to expand options (should always be true)
-		 */
-		do_action( 'jetpack_full_sync_network_options', true );
-		return 1; // The number of actions enqueued
-	}
-
 	// Is public so that we don't have to store so much data all the options twice.
 	function get_all_options() {
 		$options = array();
@@ -96,23 +62,6 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		}
 
 		return $options;
-	}
-
-	function get_all_network_options() {
-		$options = array();
-		foreach ( $this->network_options_whitelist as $option ) {
-			$options[ $option ] = get_site_option( $option );
-		}
-
-		return $options;
-	}
-
-	function set_network_options_whitelist( $options ) {
-		$this->network_options_whitelist = $options;
-	}
-
-	function get_network_options_whitelist() {
-		return $this->network_options_whitelist;
 	}
 
 	function update_options_whitelist() {
@@ -141,19 +90,6 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		return in_array( $option, $this->options_whitelist );
 	}
 
-	// reject non-whitelisted network options
-	function whitelist_network_options( $args ) {
-		if ( ! $this->is_whitelisted_network_option( $args[0] ) ) {
-			return false;
-		}
-
-		return $args;
-	}
-
-	function is_whitelisted_network_option( $option ) {
-		return is_multisite() && in_array( $option, $this->network_options_whitelist );
-	}
-
 	function jetpack_sync_core_icon() {
 		if ( function_exists( 'get_site_icon_url' ) ) {
 			$url = get_site_icon_url();
@@ -174,14 +110,6 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 	public function expand_options( $args ) {
 		if ( $args[0] ) {
 			return $this->get_all_options();
-		}
-
-		return $args;
-	}
-
-	public function expand_network_options( $args ) {
-		if ( $args[0] ) {
-			return $this->get_all_network_options();
 		}
 
 		return $args;

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -5,7 +5,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 	private $network_options_whitelist;
 
 	public function name() {
-		return "options";
+		return 'options';
 	}
 
 	public function init_listeners( $callable ) {
@@ -43,6 +43,15 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_enqueue_update_site_option', $whitelist_network_option_handler );
 	}
 
+	public function init_before_send() {
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_options', array( $this, 'expand_options' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_network_options', array(
+			$this,
+			'expand_network_options'
+		) );
+	}
+
 	public function set_defaults() {
 		$this->update_options_whitelist();
 		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
@@ -50,10 +59,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		$this->options_whitelist[] = 'theme_mods_' . get_option( 'stylesheet' );
 	}
 
-	// TODO: force sync for whole module as interface method?
-	function full_sync() {
-
-
+	function enqueue_full_sync_actions() {
 		/**
 		 * Tells the client to sync all options to the server
 		 *
@@ -62,10 +68,10 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		 * @param boolean Whether to expand options (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_options', true );
-
 		return 1; // The number of actions enqueued
 	}
 
+	// TODO
 	function full_sync_network() {
 		/**
 		 * Tells the client to sync all network options to the server
@@ -159,5 +165,21 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		} else if ( empty( $url ) ) {
 			Jetpack_Options::delete_option( 'site_icon_url' );
 		}
+	}
+
+	public function expand_options( $args ) {
+		if ( $args[0] ) {
+			return $this->get_all_options();
+		}
+
+		return $args;
+	}
+
+	public function expand_network_options( $args ) {
+		if ( $args[0] ) {
+			return $this->get_all_network_options();
+		}
+
+		return $args;
 	}
 }

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -71,6 +71,10 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		return 1; // The number of actions enqueued
 	}
 
+	function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_options' );
+	}
+
 	// TODO
 	function full_sync_network() {
 		/**

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -3,7 +3,7 @@
 class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 
 	public function name() {
-		return "plugins";
+		return 'plugins';
 	}
 
 	public function init_listeners( $callable ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -3,7 +3,7 @@
 class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function name() {
-		return "posts";
+		return 'posts';
 	}
 
 	public function set_defaults() {}
@@ -19,6 +19,16 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_wp_insert_post', array( $this, 'expand_wp_insert_post' ) );
+
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
+	}
+
+	public function enqueue_full_sync_actions() {
+		global $wpdb;
+
+		$post_type_sql = Jetpack_Sync_Defaults::get_blacklisted_post_types_sql();
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $post_type_sql );
 	}
 
 	/**
@@ -66,5 +76,18 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$post->dont_email_post_to_subs = get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true );
 
 		return $post;
+	}
+
+	public function expand_post_ids( $args ) {
+		$post_ids = $args[0];
+
+		$posts = array_map( array( 'WP_Post', 'get_instance' ), $post_ids );
+		$posts = array_map( array( $this, 'filter_post_content_and_add_links' ), $posts );
+
+		return array(
+			$posts,
+			$this->get_metadata( $post_ids, 'post' ),
+			$this->get_term_relationships( $post_ids )
+		);
 	}
 }

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -31,6 +31,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $post_type_sql );
 	}
 
+	function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_posts' );
+	}
+
 	/**
 	 * Process content before send
 	 */

--- a/sync/class.jetpack-sync-module-protect.php
+++ b/sync/class.jetpack-sync-module-protect.php
@@ -6,7 +6,7 @@
 class Jetpack_Sync_Module_Protect extends Jetpack_Sync_Module {
 
 	function name() {
-		return "protect";
+		return 'protect';
 	}
 
 	function init_listeners( $callback ) {

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -4,7 +4,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 	private $taxonomy_whitelist;
 
 	function name() {
-		return "terms";
+		return 'terms';
 	}
 
 	function init_listeners( $callable ) {
@@ -17,6 +17,32 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 
 		//full sync
 		add_action( 'jetpack_full_sync_terms', $callable, 10, 2 );
+	}
+
+	function init_before_send() {
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_terms', array( $this, 'expand_term_ids' ) );
+	}
+
+	function enqueue_full_sync_actions() {
+		global $wpdb;
+
+		$taxonomies = get_taxonomies();
+		$total_chunks_counter = 0;
+		foreach ( $taxonomies as $taxonomy ) {
+			// I hope this is never bigger than RAM...
+			$term_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s", $taxonomy ) ); // Should we set a limit here?
+			// Request posts in groups of N for efficiency
+			$chunked_term_ids = array_chunk( $term_ids, self::ARRAY_CHUNK_SIZE );
+
+			// Send each chunk as an array of objects
+			foreach ( $chunked_term_ids as $chunk ) {
+				do_action( 'jetpack_full_sync_terms', $chunk, $taxonomy );
+				$total_chunks_counter++;
+			}
+		}
+
+		return $total_chunks_counter;
 	}
 
 	function save_term_handler( $term_id, $tt_id, $taxonomy ) {
@@ -42,5 +68,26 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 
 	function set_defaults() {
 		$this->taxonomy_whitelist = Jetpack_Sync_Defaults::$default_taxonomy_whitelist;
+	}
+
+	public function expand_term_ids( $args ) {
+		global $wp_version;
+		$term_ids = $args[0];
+		$taxonomy = $args[1];
+		// version 4.5 or higher
+		if ( version_compare( $wp_version, 4.5, '>=' ) ) {
+			$terms = get_terms( array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => false,
+				'include'    => $term_ids
+			) );
+		} else {
+			$terms = get_terms( $taxonomy, array(
+				'hide_empty' => false,
+				'include'    => $term_ids
+			) );
+		}
+
+		return $terms;
 	}
 }

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -45,6 +45,10 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 		return $total_chunks_counter;
 	}
 
+	function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_terms' );
+	}
+
 	function save_term_handler( $term_id, $tt_id, $taxonomy ) {
 		if ( class_exists( 'WP_Term' ) ) {
 			$term_object = WP_Term::get_instance( $term_id, $taxonomy );

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -2,15 +2,15 @@
 
 class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	function name() {
-		return "themes";
+		return 'themes';
 	}
 
 	public function init_listeners( $handler ) {
-		add_action( 'switch_theme', array( $this, 'send_theme_info' ) );
+		add_action( 'switch_theme', array( $this, 'enqueue_full_sync_actions' ) );
 		add_action( 'jetpack_sync_current_theme_support', $handler, 10 );
 	}
 
-	function send_theme_info() {
+	function enqueue_full_sync_actions() {
 		global $_wp_theme_features;
 
 		$theme_support = array();

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -34,4 +34,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		do_action( 'jetpack_sync_current_theme_support', $theme_support );
 		return 1; // The number of actions enqueued
 	}
+
+	function get_full_sync_actions() {
+		return array( 'jetpack_sync_current_theme_support' );
+	}
 }

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -2,7 +2,7 @@
 
 class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	function name() {
-		return "updates";
+		return 'updates';
 	}
 
 	public function init_listeners( $callable ) {
@@ -16,7 +16,12 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_enqueue_set_site_transient_update_plugins', array( $this, 'filter_update_keys' ), 10, 2 );
 	}
 
-	public function full_sync() {
+	public function init_before_send() {
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
+	}
+
+	public function enqueue_full_sync_actions() {
 		/**
 		 * Tells the client to sync all updates to the server
 		 *
@@ -42,6 +47,14 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 		if ( isset( $updates->no_update ) ) {
 			unset( $updates->no_update );
+		}
+
+		return $args;
+	}
+
+	public function expand_updates( $args ) {
+		if ( $args[0] ) {
+			return $this->get_all_updates();
 		}
 
 		return $args;

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -33,6 +33,10 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		return 1; // The number of actions enqueued
 	}
 
+	function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_updates' );
+	}
+
 	public function get_all_updates() {
 		return array(
 			'core' => get_site_transient( 'update_core' ),

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -142,6 +142,10 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->users, 'ID', null );
 	}
 
+	function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_users' );
+	}
+
 	public function expand_users( $args ) {
 		$user_ids = $args[0];
 		return array_map( array( $this, 'sanitize_user_and_expand' ), get_users( array( 'include' => $user_ids ) ) );

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -2,7 +2,7 @@
 
 class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	function name() {
-		return "users";
+		return 'users';
 	}
 
 	public function init_listeners( $callable ) {
@@ -37,6 +37,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_wp_logout', array( $this, 'expand_logout_username' ), 10, 2 );
+
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_users', array( $this, 'expand_users' ) );
 	}
 
 	public function sanitize_user_and_expand( $user ) {
@@ -132,5 +135,15 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			 */
 			do_action( 'jetpack_sync_save_user', $user );
 		}
+	}
+
+	public function enqueue_full_sync_actions() {
+		global $wpdb;
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->users, 'ID', null );
+	}
+
+	public function expand_users( $args ) {
+		$user_ids = $args[0];
+		return array_map( array( $this, 'sanitize_user_and_expand' ), get_users( array( 'include' => $user_ids ) ) );
 	}
 }

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -18,6 +18,14 @@ abstract class Jetpack_Sync_Module {
 		// in subclasses, return the number of items enqueued
 		return 0;
 	}
+	
+	public function get_full_sync_actions() {
+		return array();
+	}
+
+	protected function count_actions( $action_names, $actions_to_count ) {
+		return count( array_intersect( $action_names, $actions_to_count ) );
+	}
 
 	final public function full_sync() {
 		$items_enqueued = $this->enqueue_full_sync_actions();

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -5,6 +5,8 @@
  */
 
 abstract class Jetpack_Sync_Module {
+	const ARRAY_CHUNK_SIZE = 10;
+
 	abstract public function name();
 
 	// override these to set up listeners and set/reset data/defaults
@@ -12,6 +14,17 @@ abstract class Jetpack_Sync_Module {
 	public function init_before_send() {}
 	public function set_defaults() {}
 	public function reset_data() {}
+	public function enqueue_full_sync_actions() {
+		// in subclasses, return the number of items enqueued
+		return 0;
+	}
+
+	final public function full_sync() {
+		$items_enqueued = $this->enqueue_full_sync_actions();
+		if ( $items_enqueued !== 0 ) {
+			$this->update_queue_progress( $this->name(), $items_enqueued );	
+		}
+	}
 
 	protected function get_check_sum( $values ) {
 		return crc32( json_encode( $values ) );
@@ -22,5 +35,67 @@ abstract class Jetpack_Sync_Module {
 			return true;
 		}
 		return false;
+	}
+
+	public function update_queue_progress( $module, $data ) {
+		$full_sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$status = $full_sync_module->get_status();
+		if ( isset( $status['queue'][ $module ] ) )  {
+			$status['queue'][ $module ] = $data + $status['queue'][ $module ];
+		} else {
+			$status['queue'][ $module ] = $data;
+		}
+
+		return $full_sync_module->update_status( $status );
+	}
+
+	protected function enqueue_all_ids_as_action( $action_name, $table_name, $id_field, $where_sql ) {
+		global $wpdb;
+
+		if ( ! $where_sql ) {
+			$where_sql = "1 = 1";
+		}
+
+		$items_per_page = 500;
+		$page = 1;
+		$offset = ( $page * $items_per_page ) - $items_per_page;
+		$chunk_count = 0;
+		while( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} ORDER BY {$id_field} asc LIMIT {$offset}, {$items_per_page}" ) ) {
+			// Request posts in groups of N for efficiency
+			$chunked_ids = array_chunk( $ids, self::ARRAY_CHUNK_SIZE );
+
+			// Send each chunk as an array of objects
+			foreach ( $chunked_ids as $chunk ) {
+				/**
+			 	 * Fires with a chunk of object IDs during full sync.
+			 	 * These are expanded to full objects before upload
+			 	 *
+			 	 * @since 4.2.0
+			 	 */
+				do_action( $action_name, $chunk );
+				$chunk_count++;
+			}
+
+			$page += 1;
+			$offset = ( $page * $items_per_page ) - $items_per_page;
+		}
+		return $chunk_count;
+	}
+
+	protected function get_metadata( $ids, $meta_type ) {
+		global $wpdb;
+		$table = _get_meta_table( $meta_type );
+		$id    = $meta_type . '_id';
+		if ( ! $table ) {
+			return array();
+		}
+
+		return $wpdb->get_results( "SELECT $id, meta_key, meta_value, meta_id FROM $table WHERE $id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . " )", OBJECT );
+	}
+
+	protected function get_term_relationships( $ids ) {
+		global $wpdb;
+
+		return $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . " )", OBJECT );
 	}
 }

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -24,17 +24,19 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-full-sync.php';
 class Jetpack_Sync_Modules {
 
 	private static $default_sync_modules = array(
-		'Jetpack_Sync_Module_Posts',
-		'Jetpack_Sync_Module_Comments',
 		'Jetpack_Sync_Module_Constants',
 		'Jetpack_Sync_Module_Callables',
 		'Jetpack_Sync_Module_Options',
-		'Jetpack_Sync_Module_Updates',
-		'Jetpack_Sync_Module_Users',
+		'Jetpack_Sync_Module_Terms',
 		'Jetpack_Sync_Module_Themes',
+		'Jetpack_Sync_Module_Users',
+		'Jetpack_Sync_Module_Posts',
+		'Jetpack_Sync_Module_Comments',
+		'Jetpack_Sync_Module_Updates',
+		
+		// not in full sync?
 		'Jetpack_Sync_Module_Attachments',
 		'Jetpack_Sync_Module_Meta',
-		'Jetpack_Sync_Module_Terms',
 		'Jetpack_Sync_Module_Plugins',
 		'Jetpack_Sync_Module_Protect',
 		'Jetpack_Sync_Module_Full_Sync'

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -11,6 +11,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-comments.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-constants.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-callables.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-options.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-network-options.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-updates.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-users.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-themes.php';
@@ -27,14 +28,13 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Constants',
 		'Jetpack_Sync_Module_Callables',
 		'Jetpack_Sync_Module_Options',
+		'Jetpack_Sync_Module_Network_Options',
 		'Jetpack_Sync_Module_Terms',
 		'Jetpack_Sync_Module_Themes',
 		'Jetpack_Sync_Module_Users',
 		'Jetpack_Sync_Module_Posts',
 		'Jetpack_Sync_Module_Comments',
 		'Jetpack_Sync_Module_Updates',
-		
-		// not in full sync?
 		'Jetpack_Sync_Module_Attachments',
 		'Jetpack_Sync_Module_Meta',
 		'Jetpack_Sync_Module_Plugins',

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -18,7 +18,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	public function setUp() {
 		parent::setUp();
 
-		$this->callable_module = Jetpack_Sync_Modules::get_module( "callables" );
+		$this->callable_module = Jetpack_Sync_Modules::get_module( "functions" );
 	}
 
 	function test_white_listed_function_is_synced() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -187,7 +187,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_functions() {
-		Jetpack_Sync_Modules::get_module( "callables" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
+		Jetpack_Sync_Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
 		$this->sender->do_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -24,6 +24,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $start_event !== false );
 	}
 
+	// this only applies to the test replicastore - in production we overlay data
 	function test_sync_start_resets_storage() {
 		$this->factory->post->create();
 		$this->sender->do_sync();
@@ -39,6 +40,25 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
+	}
+
+	function test_sync_wont_start_twice() {
+		$this->started_sync_count = 0;
+
+		add_action( 'jetpack_full_sync_start', array( $this, 'count_full_sync_start' ) );
+
+		$this->full_sync->start();
+
+		$this->assertEquals( 1, $this->started_sync_count );
+
+		// trying to start again shouldn't enqueue twice
+		$this->full_sync->start();
+
+		$this->assertEquals( 1, $this->started_sync_count );
+	}
+
+	function count_full_sync_start() {
+		$this->started_sync_count += 1;
 	}
 
 	function test_full_sync_sends_wp_version() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -233,7 +233,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 			$this->markTestSkipped( 'Run it in multi site mode' );
 		}
 
-		Jetpack_Sync_Modules::get_module( "options" )->set_network_options_whitelist( array( 'my_option', 'my_prefix_value' ) );
+		Jetpack_Sync_Modules::get_module( "network_options" )->set_network_options_whitelist( array( 'my_option', 'my_prefix_value' ) );
 		update_site_option( 'my_option', 'foo' );
 		update_site_option( 'my_prefix_value', 'bar' );
 		update_site_option( 'my_non_synced_option', 'baz');

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -424,31 +424,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $updates->last_checked > strtotime("-10 seconds") );
 	}
 
-	function test_full_sync_fires_events_on_send_start_and_end() {
-		$this->start_sent = false;
-		add_action( 'jetpack_full_sync_start_sent', array( $this, 'set_start_sent_true' ) );
-
-		$this->end_sent = false;
-		add_action( 'jetpack_full_sync_end_sent', array( $this, 'set_end_sent_false' ) );
-
-		$this->full_sync->start();
-
-		$this->assertFalse( $this->start_sent );
-		$this->assertFalse( $this->end_sent );
-
-		$this->sender->do_sync();
-
-		$this->assertTrue( $this->start_sent );
-		$this->assertTrue( $this->end_sent );
-	}
-
-	function set_start_sent_true() {
-		$this->start_sent  = true;
-	}
-	function set_end_sent_false() {
-		$this->end_sent  = true;
-	}
-
 	function test_full_sync_end_sends_checksums() {
 		add_action( 'jetpack_full_sync_end', array( $this, 'record_full_sync_end_checksum' ), 10, 1 );
 

--- a/tests/php/sync/test_class.jetpack-sync-network-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-network-options.php
@@ -6,15 +6,15 @@
  */
 class WP_Test_Jetpack_Sync_Network_Options extends WP_Test_Jetpack_Sync_Base {
 	protected $post;
-	protected $options_module;
+	protected $network_options_module;
 
 	public function setUp() {
 
 		parent::setUp();
 
-		$this->options_module = Jetpack_Sync_Modules::get_module( "options" );
+		$this->network_options_module = Jetpack_Sync_Modules::get_module( "network_options" );
 
-		$this->options_module->set_network_options_whitelist( array( 'test_network_option' ) );
+		$this->network_options_module->set_network_options_whitelist( array( 'test_network_option' ) );
 		add_site_option( 'test_network_option', 'foo' );
 		$this->sender->do_sync();
 	}


### PR DESCRIPTION
And also refactors full sync functionality into the existing modules, which hopefully adds readability and maintainability. It also means that any third-party modules hooking into sync can also implement the `enqueue_full_sync_actions()` method and return the number of actions enqueued, in order to participate in full sync.