### PR TITLE
Shortcodes: Update Carto (formerly CartoDB) main domain from cartodb.com to carto.com

### DIFF
--- a/modules/shortcodes/cartodb.php
+++ b/modules/shortcodes/cartodb.php
@@ -2,17 +2,20 @@
 
 
 /*
- * CartoDB
+ * Carto (formerly CartoDB)
  *
- * example URL: http://osm2.cartodb.com/viz/08aef918-94da-11e4-ad83-0e0c41326911/public_map
+ * example URL: http://osm2.carto.com/viz/08aef918-94da-11e4-ad83-0e0c41326911/public_map
  *
  * possible patterns:
- * [username].cartodb.com/viz/[map-id]/public_map
- * [username].cartodb.com/viz/[map-id]/embed_map
- * [username].cartodb.com/viz/[map-id]/map
- * [organization].cartodb.com/u/[username]/viz/[map-id]/public_map
- * [organization].cartodb.com/u/[username]/viz/[map-id]/embed_map
- * [organization].cartodb.com/u/[username]/viz/[map-id]/map
+ * [username].carto.com/viz/[map-id]/public_map
+ * [username].carto.com/viz/[map-id]/embed_map
+ * [username].carto.com/viz/[map-id]/map
+ * [organization].carto.com/u/[username]/viz/[map-id]/public_map
+ * [organization].carto.com/u/[username]/viz/[map-id]/embed_map
+ * [organization].carto.com/u/[username]/viz/[map-id]/map
+ *
+ * On July 8th, 2016 CartoDB changed its primary domain from cartodb.com to carto.com
+ * So this shortcode still supports the cartodb.com domain for oembeds.
 */
 
-wp_oembed_add_provider( '#https?://(?:www\.)?[^/^\.]+\.cartodb\.com/\S+#i', 'https://services.cartodb.com/oembed', true );
+wp_oembed_add_provider( '#https?://(?:www\.)?[^/^\.]+\.carto(db)?\.com/\S+#i', 'https://services.carto.com/oembed', true );


### PR DESCRIPTION
Carto switched its main domain from cartodb.com to carto.com

Fixes #4348 

#### Changes proposed in this Pull Request:

- Updates the format string used in call to `wp_oembed_add_provider()` for registering the Carto.com oembed provider. 

