### PR TITLE
Ensure full sync lock can be broken

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -5,6 +5,25 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
+		$args = $this->input();
+
+		if ( isset( $args['clear'] ) && $args['clear'] ) {
+			// clear sync queue
+			require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-sender.php';
+
+			$sender = Jetpack_Sync_Sender::getInstance();
+			$sync_queue = $sender->get_sync_queue();
+			$sync_queue->reset();
+		}
+
+		if ( isset( $args['force'] ) && $args['force'] ) {
+			// reset full sync lock
+			require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-modules.php';
+
+			$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+			$sync_module->clear_status();
+		}
+
 		/** This action is documented in class.jetpack-sync-sender.php */
 		Jetpack_Sync_Actions::schedule_full_sync();
 		spawn_cron();

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -574,6 +574,10 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 	'path_labels' => array(
 		'$site' => '(int|string) The site ID, The site domain'
 	),
+	'request_format' => array(
+		'force'   => '(bool=false) Force a full sync by clearing the full sync lock',
+		'clear'   => '(bool=false) Clear the sync queue before full-syncing'
+	),
 	'response_format' => array(
 		'scheduled' => '(bool) Whether or not the synchronisation was scheduled'
 	),

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -78,10 +78,6 @@ class Jetpack_Sync_Listener {
 		$current_filter = current_filter();
 		$args           = func_get_args();
 
-		if ( $current_filter === 'upgrader_process_complete' ) {
-			array_shift( $args );
-		}
-
 		/**
 		 * Modify or reject the data within an action before it is enqueued locally.
 		 *

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -162,7 +162,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		);
 	}
 
-	private function clear_status() {
+	public function clear_status() {
 		delete_option( self::STATUS_OPTION );
 	}
 }

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -38,6 +38,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		if( ! $this->should_start_full_sync() ) {
 			return false;
 		}
+
+		// ensure listener is loaded so we can guarantee full sync actions are enqueued
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
+		Jetpack_Sync_Listener::getInstance();
+
 		/**
 		 * Fires when a full sync begins. This action is serialized
 		 * and sent to the server so that it knows a full sync is coming.

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -16,6 +16,7 @@ require_once 'class.jetpack-sync-wp-replicastore.php';
 
 class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	const STATUS_OPTION = 'jetpack_full_sync_status';
+	const FULL_SYNC_TIMEOUT = 3600;
 
 	private $sender;
 
@@ -84,10 +85,17 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	private function should_start_full_sync() {
 		$status = $this->get_status();
+		
 		// We should try sync if we haven't started it yet or if we have finished it.
 		if( is_null( $status['started'] ) || is_integer( $status['finished'] ) ) {
 			return true;
 		}
+
+		// allow enqueing if last full sync was started more than FULL_SYNC_TIMEOUT seconds ago
+		if ( intval( $status['started'] ) + self::FULL_SYNC_TIMEOUT < time() ) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -48,7 +48,18 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->set_status_queuing_started();
 
 		foreach( Jetpack_Sync_Modules::get_modules() as $module ) {
-			$module->full_sync();
+			$items_enqueued = $module->enqueue_full_sync_actions();
+			$module_name = $module->name();
+			if ( $items_enqueued !== 0 ) {
+				$status = $this->get_status();
+
+				if ( ! isset( $status['queue'][ $module_name ] ) ) {
+					$status['queue'][ $module_name ] = 0;	
+				}
+
+				$status['queue'][ $module_name ] += $items_enqueued;
+			}
+			$this->update_status( $status );
 		}
 
 		$this->set_status_queuing_finished();

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -14,6 +14,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_action( 'jetpack_full_sync_updates', $callable );
 
 		add_filter( 'jetpack_sync_before_enqueue_set_site_transient_update_plugins', array( $this, 'filter_update_keys' ), 10, 2 );
+		add_filter( 'jetpack_sync_before_enqueue_upgrader_process_complete', array( $this, 'filter_upgrader_process_complete' ), 10, 2 );
 	}
 
 	public function init_before_send() {
@@ -53,6 +54,11 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			unset( $updates->no_update );
 		}
 
+		return $args;
+	}
+
+	function filter_upgrader_process_complete( $args ) {
+		array_shift( $args );
 		return $args;
 	}
 

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -27,13 +27,6 @@ abstract class Jetpack_Sync_Module {
 		return count( array_intersect( $action_names, $actions_to_count ) );
 	}
 
-	final public function full_sync() {
-		$items_enqueued = $this->enqueue_full_sync_actions();
-		if ( $items_enqueued !== 0 ) {
-			$this->update_queue_progress( $this->name(), $items_enqueued );	
-		}
-	}
-
 	protected function get_check_sum( $values ) {
 		return crc32( json_encode( $values ) );
 	}
@@ -43,18 +36,6 @@ abstract class Jetpack_Sync_Module {
 			return true;
 		}
 		return false;
-	}
-
-	public function update_queue_progress( $module, $data ) {
-		$full_sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-		$status = $full_sync_module->get_status();
-		if ( isset( $status['queue'][ $module ] ) )  {
-			$status['queue'][ $module ] = $data + $status['queue'][ $module ];
-		} else {
-			$status['queue'][ $module ] = $data;
-		}
-
-		return $full_sync_module->update_status( $status );
 	}
 
 	protected function enqueue_all_ids_as_action( $action_name, $table_name, $id_field, $where_sql ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -42,7 +42,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 	}
 
-	function test_sync_wont_start_twice() {
+	function test_full_sync_wont_start_twice() {
 		$this->started_sync_count = 0;
 
 		add_action( 'jetpack_full_sync_start', array( $this, 'count_full_sync_start' ) );
@@ -55,6 +55,23 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start();
 
 		$this->assertEquals( 1, $this->started_sync_count );
+	}
+
+	function test_full_sync_lock_has_one_hour_timeout() {
+		$this->started_sync_count = 0;
+
+		add_action( 'jetpack_full_sync_start', array( $this, 'count_full_sync_start' ) );
+
+		$this->full_sync->start();
+
+		$this->assertEquals( 1, $this->started_sync_count );
+
+		// fake the last sync being over an hour ago
+		$this->full_sync->update_status( array( 'started' => ( time() - 3700 ) ) );
+		
+		$this->full_sync->start();
+
+		$this->assertEquals( 2, $this->started_sync_count );
 	}
 
 	function count_full_sync_start() {


### PR DESCRIPTION
Some small refactors for full sync, and a fix that ensures that full sync can't be permanently blocked by a crash during the enqueuing phase.

This also includes a couple of minor, unrelated cleanups that I discovered while working on it.