### PR TITLE
Only enforce queue size if sending has been delayed by 15 mins

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -213,6 +213,7 @@ class Jetpack_Sync_Defaults {
 	static $default_upload_max_rows = 500;
 	static $default_sync_wait_time = 10; // seconds, between syncs
 	static $default_max_queue_size = 1000;
+	static $default_max_queue_lag = 900; // 15 minutes
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 }

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -8,7 +8,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-modules.php';
  * This class monitors actions and logs them to the queue to be sent
  */
 class Jetpack_Sync_Listener {
-	const QUEUE_STATE_CHECK_TRANSIENT = "jetpack_sync_last_checked_queue_state";
+	const QUEUE_STATE_CHECK_TRANSIENT = 'jetpack_sync_last_checked_queue_state';
 	const QUEUE_STATE_CHECK_TIMEOUT = 300; // 5 minutes
 
 	private $sync_queue;
@@ -69,24 +69,24 @@ class Jetpack_Sync_Listener {
 	}
 
 	function force_recheck_queue_limit() {
-		error_log("deleting transient ".self::QUEUE_STATE_CHECK_TRANSIENT);
 		delete_transient( self::QUEUE_STATE_CHECK_TRANSIENT );
 	}
 
+	// prevent adding items to the queue if it hasn't sent an item for 15 mins
+	// AND the queue is over 1000 items long (by default)
 	function can_add_to_queue() {
 		$queue_state = get_transient( self::QUEUE_STATE_CHECK_TRANSIENT );
 
 		if ( $queue_state === false ) {
-			$queue_size = $this->sync_queue->size();
-			$queue_age = $this->sync_queue->lag();
-			set_transient( self::QUEUE_STATE_CHECK_TRANSIENT, array( $queue_size, $queue_age ), self::QUEUE_STATE_CHECK_TIMEOUT );
-		} else {
-			list( $queue_size, $queue_age ) = $queue_state;
+			$queue_state = array( $this->sync_queue->size(), $this->sync_queue->lag() );
+			set_transient( self::QUEUE_STATE_CHECK_TRANSIENT, $queue_state, self::QUEUE_STATE_CHECK_TIMEOUT );
 		}
 
-		return ( $queue_age > $this->sync_queue_lag_limit ) 
-			&& 
-				( ( $queue_size + 1 ) > $this->sync_queue_size_limit );
+		list( $queue_size, $queue_age ) = $queue_state;
+
+		return 	( $queue_age < $this->sync_queue_lag_limit ) 
+			|| 
+				( ( $queue_size + 1 ) < $this->sync_queue_size_limit );
 	}
 
 	function action_handler() {
@@ -113,7 +113,7 @@ class Jetpack_Sync_Listener {
 
 		// periodically check the size of the queue, and disable adding to it if
 		// it exceeds some limit AND the oldest item exceeds the age limit (i.e. sending has stopped)
-		if ( $this->can_add_to_queue() ) {
+		if ( ! $this->can_add_to_queue() ) {
 			return;
 		}
 

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -8,11 +8,12 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-modules.php';
  * This class monitors actions and logs them to the queue to be sent
  */
 class Jetpack_Sync_Listener {
-	const QUEUE_SIZE_CHECK_TRANSIENT = "jetpack_sync_last_checked_queue_size";
-	const QUEUE_SIZE_CHECK_TIMEOUT = 300; // 5 minutes
+	const QUEUE_STATE_CHECK_TRANSIENT = "jetpack_sync_last_checked_queue_state";
+	const QUEUE_STATE_CHECK_TIMEOUT = 300; // 5 minutes
 
 	private $sync_queue;
-	private $sync_queue_limit;
+	private $sync_queue_size_limit;
+	private $sync_queue_lag_limit;
 
 	// singleton functions
 	private static $instance;
@@ -51,27 +52,41 @@ class Jetpack_Sync_Listener {
 		return $this->sync_queue;
 	}
 
-	function set_queue_limit( $limit ) {
-		$this->sync_queue_limit = $limit;
+	function set_queue_size_limit( $limit ) {
+		$this->sync_queue_size_limit = $limit;
 	}
 
-	function get_queue_limit() {
-		return $this->sync_queue_limit;
+	function get_queue_size_limit() {
+		return $this->sync_queue_size_limit;
+	}
+
+	function set_queue_lag_limit( $age ) {
+		$this->sync_queue_lag_limit = $age;
+	}
+
+	function get_queue_lag_limit() {
+		return $this->sync_queue_lag_limit;
 	}
 
 	function force_recheck_queue_limit() {
-		delete_transient( self::QUEUE_SIZE_CHECK_TRANSIENT );
+		error_log("deleting transient ".self::QUEUE_STATE_CHECK_TRANSIENT);
+		delete_transient( self::QUEUE_STATE_CHECK_TRANSIENT );
 	}
 
-	function is_over_queue_limit() {
-		$queue_size = get_transient( self::QUEUE_SIZE_CHECK_TRANSIENT );
+	function can_add_to_queue() {
+		$queue_state = get_transient( self::QUEUE_STATE_CHECK_TRANSIENT );
 
-		if ( $queue_size === false ) {
+		if ( $queue_state === false ) {
 			$queue_size = $this->sync_queue->size();
-			set_transient( self::QUEUE_SIZE_CHECK_TRANSIENT, $queue_size, self::QUEUE_SIZE_CHECK_TIMEOUT );
+			$queue_age = $this->sync_queue->lag();
+			set_transient( self::QUEUE_STATE_CHECK_TRANSIENT, array( $queue_size, $queue_age ), self::QUEUE_STATE_CHECK_TIMEOUT );
+		} else {
+			list( $queue_size, $queue_age ) = $queue_state;
 		}
 
-		return ( $queue_size + 1 ) > $this->sync_queue_limit;
+		return ( $queue_age > $this->sync_queue_lag_limit ) 
+			&& 
+				( ( $queue_size + 1 ) > $this->sync_queue_size_limit );
 	}
 
 	function action_handler() {
@@ -97,8 +112,8 @@ class Jetpack_Sync_Listener {
 		}
 
 		// periodically check the size of the queue, and disable adding to it if
-		// it exceeds some limit
-		if ( $this->is_over_queue_limit() ) {
+		// it exceeds some limit AND the oldest item exceeds the age limit (i.e. sending has stopped)
+		if ( $this->can_add_to_queue() ) {
 			return;
 		}
 
@@ -119,6 +134,7 @@ class Jetpack_Sync_Listener {
 
 	function set_defaults() {
 		$this->sync_queue = new Jetpack_Sync_Queue( 'sync' );
-		$this->set_queue_limit( Jetpack_Sync_Settings::get_setting( 'max_queue_size' ) );
+		$this->set_queue_size_limit( Jetpack_Sync_Settings::get_setting( 'max_queue_size' ) );
+		$this->set_queue_lag_limit( Jetpack_Sync_Settings::get_setting( 'max_queue_lag' ) );
 	}
 }

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -88,25 +88,26 @@ class Jetpack_Sync_Queue {
 		return array();
 	}
 
-	// lag is the difference in time between the age of the oldest item and the current time
+	// lag is the difference in time between the age of the oldest item 
+	// (aka first or frontmost item) and the current time
 	function lag() {
 		global $wpdb;
 
-		$last_item_name = $wpdb->get_var( $wpdb->prepare(
+		$first_item_name = $wpdb->get_var( $wpdb->prepare(
 			"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT 1",
 			"jpsq_{$this->id}-%"
 		) );
 
-		if ( ! $last_item_name ) {
-			return null;
+		if ( ! $first_item_name ) {
+			return 0;
 		}
 
 		// break apart the item name to get the timestamp
 		$matches = null;
-		if ( preg_match( '/^jpsq_' . $this->id . '-(\d+\.\d+)-/', $last_item_name, $matches ) ) {
+		if ( preg_match( '/^jpsq_' . $this->id . '-(\d+\.\d+)-/', $first_item_name, $matches ) ) {
 			return microtime( true ) - floatval( $matches[1] );
 		} else {
-			return null;
+			return 0;
 		}
 	}
 

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -10,7 +10,8 @@ class Jetpack_Sync_Settings {
 		'upload_max_bytes' => true,
 		'upload_max_rows' => true,
 		'sync_wait_time' => true,
-		'max_queue_size' => true
+		'max_queue_size' => true,
+		'max_queue_lag' => true,
 	);
 
 	static function get_settings() {

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -27,19 +27,28 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 0, $queue->size() );
 	}
 
-	// this is trickier than you would expect because we only check against
+	// This is trickier than you would expect because we only check against
 	// maximum queue size periodically (to avoid a counts on every request), and then
-	// we cache the "blocked on queue size" status
-	function test_detects_if_exceeded_queue_size_limit() {
+	// we cache the "blocked on queue size" status.
+	// In addition, we should only enforce the queue size limit if the oldest (aka frontmost) 
+	// item in the queue is gt 15 minutes old.
+	function test_detects_if_exceeded_queue_size_limit_and_oldest_item_gt_15_mins() {
 		$this->listener->get_sync_queue()->reset();
 
 		// first, let's try overriding the default queue limit
-		$this->assertEquals( Jetpack_Sync_Defaults::$default_max_queue_size, $this->listener->get_queue_limit() );
+		$this->assertEquals( Jetpack_Sync_Defaults::$default_max_queue_size, $this->listener->get_queue_size_limit() );
+		$this->assertEquals( Jetpack_Sync_Defaults::$default_max_queue_lag, $this->listener->get_queue_lag_limit() );
 
+		// set max queue size to 2 items
 		Jetpack_Sync_Settings::update_settings( array( 'max_queue_size' => 2 ) );
+
+		// set max queue age to 3 seconds
+		Jetpack_Sync_Settings::update_settings( array( 'max_queue_lag' => 3 ) );
+
 		$this->listener->set_defaults(); // should pick up new queue size limit
 
-		$this->assertEquals( 2, $this->listener->get_queue_limit() );
+		$this->assertEquals( 2, $this->listener->get_queue_size_limit() );
+		$this->assertEquals( 3, $this->listener->get_queue_lag_limit() );
 		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
 
 		// now let's try exceeding the new limit
@@ -55,7 +64,15 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 
 		$this->listener->force_recheck_queue_limit();
 		do_action( 'my_action' );
-		$this->assertEquals( 2, $this->listener->get_sync_queue()->size() );
+		$this->assertEquals( 3, $this->listener->get_sync_queue()->size() );
+
+		// sleep for 3 seconds, so the oldest item in the queue is at least 3 seconds old -
+		// now our queue limit should kick in
+		sleep( 3 );
+
+		$this->listener->force_recheck_queue_limit();
+		do_action( 'my_action' );
+		$this->assertEquals( 3, $this->listener->get_sync_queue()->size() );
 
 		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 	function test_can_write_settings() {
 		$settings = Jetpack_Sync_Settings::get_settings();
 
-		foreach( array( 'dequeue_max_bytes', 'sync_wait_time', 'upload_max_bytes', 'upload_max_rows', 'max_queue_size' ) as $key ) {
+		foreach( array( 'dequeue_max_bytes', 'sync_wait_time', 'upload_max_bytes', 'upload_max_rows', 'max_queue_size', 'max_queue_lag' ) as $key ) {
 			$this->assertTrue( isset( $settings[ $key ] ) );
 		}
 


### PR DESCRIPTION
Previously we enforced a strict queue size, but often sites need to burst to large queue sizes when full syncing.

This patch only enforces the queue size limit if the age of the oldest item is 15 mins (adjustable via sync settings)