### PR TITLE
SSO: Fix clearfloat for default login form submit

### DIFF
--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -177,3 +177,9 @@
 .jetpack-sso-form-display #backtoblog {
 	margin: 24px 0 0;
 }
+
+.jetpack-sso-clear:after {
+	content: "";
+	display: table;
+	clear: both;
+}

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -6,7 +6,7 @@ jQuery( document ).ready( function( $ ) {
 		userLogin = $( '#user_login' ),
 		ssoWrap   = $( '#jetpack-sso-wrap' ),
 		loginForm = $( '#loginform' ),
-		overflow  = $( '<div style="overflow: auto;"></div>' );
+		overflow  = $( '<div class="jetpack-sso-clear"></div>' );
 
 	// The overflow div is a poor man's clearfloat. We reposition the remember me
 	// checkbox and the submit button within that to clear the float on the


### PR DESCRIPTION
Today I noticed a minor issue where the "Log In" button for the default login form could cause a scroll bar. 😞 

This seems to be because I made the decision to use a lazy clearfloat (`overflow: auto`) instead of a better clearfix solution. I updated the clearfix and tested back to IE8.

![screen shot 2016-07-09 at 10 28 40 pm](https://cloud.githubusercontent.com/assets/1126811/16711515/630d4eac-4625-11e6-8354-bb4fa3ddc50e.png)

To test existence of bug:

- Checkout `4.1` of Jetpack or higher
- Go to `$site/wp-admin`
- Click "Log in with username and password"
- Inspect "Log in" button, and set `active` state
- You should see a scrollbar

To test fix:

- Checkout `update/sso-login-button-overflow` branch
- Follow steps above
- Ensure there is no scrollbar

cc @lezama for code review.