### PR TITLE
Sync Settings:Update the endpoint so that we can update additional settings

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -627,6 +627,8 @@ $sync_settings_response = array(
 	'sync_wait_time'    => '(int|bool=false) Minimum time between requests in seconds',
 	'upload_max_bytes'  => '(int|bool=false) Maximum bytes to send in a single request',
 	'upload_max_rows'   => '(int|bool=false) Maximum rows to send in a single request',
+	'max_queue_size'    => '(int|bool=false) Maximum queue size that that the queue is allowed to expand to in DB rows to prevent the DB from filling up. Needs to also meet the max_queue_lag limit.',
+	'max_queue_lag'     => '(int|bool=false) Maximum queue lag in seconds used to prevent the DB from filling up. Needs to also meet the max_queue_size limit.',
 );
 
 // GET /sites/%s/sync/settings


### PR DESCRIPTION
We were not able to update some of the settings via the api. 
This PR fixed it by adding the settings to the endpoint.

Adds max_queue_size and max_queue_lab to the list of settings that we
can update.

cc: @gravityrail and @lezama 
