### PR TITLE
Fix singleton syntax in json-api-links for PHP 5.2.17

### DIFF
--- a/sal/class.json-api-links.php
+++ b/sal/class.json-api-links.php
@@ -7,11 +7,11 @@ class WPCOM_JSON_API_Links {
 	private static $instance;
 
 	public static function getInstance() {
-		if (null === static::$instance) {
-			static::$instance = new static();
+		if ( null === self::$instance ) {
+			self::$instance = new self();
 		}
-		
-		return static::$instance;
+
+		return self::$instance;
 	}
 
 	// protect these methods for singleton


### PR DESCRIPTION
Fixes #4361 
cc @jeherve 