### PR TITLE
Selective sync api

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -7,6 +7,8 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 	protected function result() {
 		$args = $this->input();
 
+		$modules = null;
+
 		if ( isset( $args['clear'] ) && $args['clear'] ) {
 			// clear sync queue
 			require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-sender.php';
@@ -24,8 +26,12 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 			$sync_module->clear_status();
 		}
 
+		if ( isset( $args['modules'] ) && !empty( $args['modules'] ) ) {
+			$modules = array_map('trim', explode( ',', $args['modules'] ) );
+		}
+
 		/** This action is documented in class.jetpack-sync-sender.php */
-		Jetpack_Sync_Actions::schedule_full_sync();
+		Jetpack_Sync_Actions::schedule_full_sync( $modules );
 		spawn_cron();
 
 		return array( 'scheduled' => true );

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -576,7 +576,8 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 	),
 	'request_format' => array(
 		'force'   => '(bool=false) Force a full sync by clearing the full sync lock',
-		'clear'   => '(bool=false) Clear the sync queue before full-syncing'
+		'clear'   => '(bool=false) Clear the sync queue before full-syncing',
+		'modules' => '(string) Comma-delimited set of sync modules to use (default: all of them)'
 	),
 	'response_format' => array(
 		'scheduled' => '(bool) Whether or not the synchronisation was scheduled'

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -25,7 +25,7 @@ class Jetpack_Sync_Actions {
 
 		// cron hooks
 		add_action( 'jetpack_sync_send_db_checksum', array( __CLASS__, 'send_db_checksum' ) );
-		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ) );
+		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ), 10, 1 );
 		add_action( 'jetpack_sync_send_pending_data', array( __CLASS__, 'do_send_pending_data' ) );
 
 		if ( ! wp_next_scheduled ( 'jetpack_sync_send_db_checksum' ) ) {
@@ -115,17 +115,17 @@ class Jetpack_Sync_Actions {
 		return $rpc->getResponse();
 	}
 
-	static function schedule_full_sync() {
-		wp_schedule_single_event( time() + 1, 'jetpack_sync_full' );
+	static function schedule_full_sync( $modules = null ) {
+		wp_schedule_single_event( time() + 1, 'jetpack_sync_full', array( $modules ) );
 	}
 
-	static function do_full_sync() {
+	static function do_full_sync( $modules = null ) {
 		if ( ! self::sync_allowed() ) {
 			return;
 		}
 
 		self::initialize_listener();
-		Jetpack_Sync_Modules::get_module( 'full-sync' )->start();
+		Jetpack_Sync_Modules::get_module( 'full-sync' )->start( $modules );
 		self::do_send_pending_data(); // try to send at least some of the data
 	}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -55,7 +55,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		foreach( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();
-			if ( is_array( $modules ) && ! isset( $modules[ $module_name ] ) ) {
+			if ( is_array( $modules ) && ! in_array( $module_name, $modules ) ) {
 				continue;
 			}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -35,7 +35,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		add_action( 'jetpack_sync_processed_actions', array( $this, 'update_sent_progress_action' ) );
 	}
 
-	function start() {
+	function start( $modules = null ) {
 		if( ! $this->should_start_full_sync() ) {
 			return false;
 		}
@@ -54,8 +54,12 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->set_status_queuing_started();
 
 		foreach( Jetpack_Sync_Modules::get_modules() as $module ) {
-			$items_enqueued = $module->enqueue_full_sync_actions();
 			$module_name = $module->name();
+			if ( is_array( $modules ) && ! isset( $modules[ $module_name ] ) ) {
+				continue;
+			}
+
+			$items_enqueued = $module->enqueue_full_sync_actions();
 			if ( $items_enqueued !== 0 ) {
 				$status = $this->get_status();
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -5,11 +5,11 @@
  * enqueuing an outbound action for every single object
  * that we care about.
  *
- * This class contains a few non-obvious optimisations that should be explained:
+ * This class, and its related class Jetpack_Sync_Module, contain a few non-obvious optimisations that should be explained:
  * - we fire an action called jetpack_full_sync_start so that WPCOM can erase the contents of the cached database
- * - for each object type, we obtain a full list of object IDs to sync via a single API call (hoping that since they're ints, they can all fit in RAM)
- * - we load the full objects for those IDs in chunks of Jetpack_Sync_Full::ARRAY_CHUNK_SIZE (to reduce the number of MySQL calls)
- * - we fire a trigger for the entire array which the Jetpack_Sync_Sender then serializes and queues.
+ * - for each object type, we page through the object IDs and enqueue them by firing some monitored actions
+ * - we load the full objects for those IDs in chunks of Jetpack_Sync_Module::ARRAY_CHUNK_SIZE (to reduce the number of MySQL calls)
+ * - we fire a trigger for the entire array which the Jetpack_Sync_Listener then serializes and queues.
  */
 
 require_once 'class.jetpack-sync-wp-replicastore.php';

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -95,9 +95,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$posts_full_sync_actions = Jetpack_Sync_Modules::get_module( 'posts' )->get_full_sync_actions();
 		$posts_event = $this->server_event_storage->get_most_recent_event( $posts_full_sync_actions[0] );
 
-		$this->assertNotNull( $start_event );
-		$this->assertNotNull( $options_event );
-		$this->assertFalse( $posts_event );
+		$this->assertTrue( $start_event !== false );
+		$this->assertTrue( $options_event !== false );
+		$this->assertTrue( $posts_event === false );
 	}
 
 	function test_full_sync_sends_wp_version() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -78,6 +78,28 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->started_sync_count += 1;
 	}
 
+	function test_full_sync_can_select_modules() {
+		$this->server_replica_storage->reset();
+		$this->sender->reset_data();
+		$this->factory->post->create();
+
+		$this->full_sync->start( array( 'options' ) );
+
+		$this->sender->do_sync();
+
+		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
+
+		$options_full_sync_actions = Jetpack_Sync_Modules::get_module( 'options' )->get_full_sync_actions();
+		$options_event = $this->server_event_storage->get_most_recent_event( $options_full_sync_actions[0] );
+
+		$posts_full_sync_actions = Jetpack_Sync_Modules::get_module( 'posts' )->get_full_sync_actions();
+		$posts_event = $this->server_event_storage->get_most_recent_event( $posts_full_sync_actions[0] );
+
+		$this->assertNotNull( $start_event );
+		$this->assertNotNull( $options_event );
+		$this->assertFalse( $posts_event );
+	}
+
 	function test_full_sync_sends_wp_version() {
 		$this->server_replica_storage->reset();
 		$this->sender->reset_data();


### PR DESCRIPTION
Allows specifying specific "sync modules" to run a full sync, for example "options".

This gives us the flexibility to force updates from WPCOM if we detect issues, without having to sync everything. It seems likely that this will most often be necessary for options, constants and functions.