### PR TITLE
Sync: Email subscribers action.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,6 +34,9 @@
 		<testsuite name="publicize">
 			<directory prefix="test_" suffix=".php">tests/php/modules/publicize</directory>
 		</testsuite>
+		<testsuite name="subscriptions">
+			<directory prefix="test_" suffix=".php">tests/php/modules/subscriptions</directory>
+		</testsuite>
 		<testsuite name="sharedaddy">
 			<directory prefix="test_" suffix=".php">tests/php/modules/sharedaddy</directory>
 		</testsuite>

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -12,6 +12,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'wp_insert_post', $callable, 10, 3 );
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
+		add_action( 'jetpack_email_subscribers', $callable );
 
 		// full sync
 		add_action( 'jetpack_full_sync_posts', $callable ); // also sends post meta

--- a/tests/php.multisite.xml
+++ b/tests/php.multisite.xml
@@ -38,6 +38,9 @@
         <testsuite name="publicize">
             <directory prefix="test_" suffix=".php">php/modules/publicize</directory>
         </testsuite>
+        <testsuite name="subscriptions">
+            <directory prefix="test_" suffix=".php">tests/php/modules/subscriptions</directory>
+        </testsuite>
         <testsuite name="sharedaddy">
             <directory prefix="test_" suffix=".php">php/modules/sharedaddy</directory>
         </testsuite>

--- a/tests/php/modules/subscriptions/test_class.subscriptions.php
+++ b/tests/php/modules/subscriptions/test_class.subscriptions.php
@@ -1,0 +1,123 @@
+<?php
+
+require dirname( __FILE__ ) . '/../../../../modules/subscriptions.php';
+
+class WP_Test_Subscriptions extends WP_UnitTestCase {
+
+	private $fired_email_subscribers = false;
+	private $emailed_post_id = null;
+	private $post;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->subscriptions  = Jetpack_Subscriptions::init();
+		$this->fired_email_subscribers = false;
+		$this->emailed_post_id = null;
+
+		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
+		$this->post = get_post( $post_id );
+
+		add_action( 'jetpack_email_subscribers', array( $this, 'email_subscribers' ), 10, 1 );
+	}
+
+	public function test_fires_jetpack_email_subscribers_on_save_as_published() {
+		$this->post->post_status = 'publish';
+		$post_id = wp_insert_post( $this->post->to_array() );
+		$this->assertSendEmail( true, $post_id );
+	}
+
+	public function test_does_not_fire_jetpack_email_subscribers_on_other_status_transitions() {
+		$this->post->post_status = 'pending';
+		wp_insert_post( $this->post->to_array() );
+
+		$this->assertSendEmail( false, $this->post->ID );
+	}
+	public function test_does_not_fire_jetpack_email_subscribers_on_other_post_types() {
+		$this->post->post_status = 'publish';
+		$this->post->post_status = 'page';
+		wp_insert_post( $this->post->to_array() );
+
+		$this->assertSendEmail( false, $this->post->ID );
+	}
+
+	public function test_does_not_fire_jetpack_email_subscribers_post_with_passwords() {
+		$this->post->post_status = 'publish';
+		$this->post->post_password = 'password';
+		wp_insert_post( $this->post->to_array() );
+
+		$this->assertSendEmail( false, $this->post->ID );
+	}
+
+	public function test_does_not_fire_jetpack_email_subscribers_with_filters_set() {
+		$this->post->post_status = 'publish';
+		
+		add_filter( 'jetpack_is_post_mailable', '__return_false' );
+		wp_insert_post( $this->post->to_array() );
+		
+		$this->assertSendEmail( false, $this->post->ID );
+
+		remove_filter( 'jetpack_is_post_mailable', '__return_false' );
+
+		$this->fired_email_subscribers = false;
+		$this->emailed_post_id = null;
+
+		add_filter( 'jetpack_subscriptions_exclude_these_categories', array( __CLASS__, 'exclude_category_from_subscribers' ) );
+		wp_insert_post( $this->post->to_array() );
+		$this->assertSendEmail( false, $this->post->ID );
+		remove_filter( 'jetpack_subscriptions_exclude_these_categories', array( __CLASS__, 'exclude_category_from_subscribers' ) );
+
+
+		// Don't send the email because the category is not included...
+		add_filter( 'jetpack_subscriptions_exclude_all_categories_except', array( __CLASS__, 'include_category_from_subscribers' ) );
+		wp_insert_post( $this->post->to_array() );
+		$this->assertSendEmail( false, $this->post->ID );
+		remove_filter( 'jetpack_subscriptions_exclude_all_categories_except', array( __CLASS__, 'include_category_from_subscribers' ) );
+
+
+		// Should send the email if the filters are not there any more..
+		wp_insert_post( $this->post->to_array() );
+		$this->assertSendEmail( true, $this->post->ID );
+	}
+
+	public function test_does_not_fire_jetpack_email_subscribers_with_checkbox_to_not_send_email() {
+		global $_POST;
+		$nonce = wp_create_nonce( 'disable_subscribe' );
+		$_POST['disable_subscribe_nonce'] = $nonce;
+		$_POST['_jetpack_dont_email_post_to_subs'] = true;
+		$this->post->post_status = 'publish';
+
+		// Should send the email if the filters are not there any more..
+		wp_insert_post( $this->post->to_array() );
+		$this->assertSendEmail( false, $this->post->ID );
+	}
+
+
+	function assertSendEmail( $should_have_sent_email, $post_id ) {
+		if ( $should_have_sent_email ) {
+			$this->assertTrue( $this->fired_email_subscribers );
+			$this->assertEquals( $post_id, $this->emailed_post_id );
+		} else {
+			$this->assertFalse( $this->fired_email_subscribers );
+			$this->assertNull( $this->emailed_post_id );
+		}
+
+	}
+
+	static function exclude_category_from_subscribers() {
+		return array( 1 );
+	}
+
+	static function include_category_from_subscribers() {
+		return array( 2 );
+	}
+
+	function email_subscribers( $post_id ) {
+		$this->fired_email_subscribers = true;
+		$this->emailed_post_id = $post_id;
+	}
+
+	function prevent_publicize_post( $should_publicize, $post ) {
+		return false;
+	}
+}


### PR DESCRIPTION
Lets us send an action when a user is suppose to email the subscribers. 
- Added test to show that we only send the action when absolutely we are
going to sent the emails to subscribers.