### PR TITLE
Normalize URLs containing www subdomain

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -73,29 +73,54 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function home_url() {
-		return self::preserve_scheme( 'home', home_url() );
+		return self::preserve_scheme( 'home', home_url(), true );
 	}
 
 	public static function site_url() {
-		return self::preserve_scheme( 'siteurl', site_url() );
+		return self::preserve_scheme( 'siteurl', site_url(), true );
 	}
 
 	public static function main_network_site_url() {
-		return self::preserve_scheme( 'siteurl', network_site_url() );
+		return self::preserve_scheme( 'siteurl', network_site_url(), false );
 	}
 
-	public static function preserve_scheme( $option, $current_url ) {
+	public static function preserve_scheme( $option, $url, $normalize_www = false ) {
 		$option_url = get_option( $option );
-		if ( $option_url === $current_url ) {
-			return $current_url;
-		}
-		$parsed_option_url = parse_url( $option_url );
-		$parsed_current_url = parse_url( $current_url );
-		if ( $parsed_current_url[ 'host' ] === $parsed_option_url[ 'host' ] ) {
-			return set_url_scheme( $current_url,  $parsed_option_url['scheme'] );
+		if ( $option_url === $url ) {
+			return $url;
 		}
 
-		return $current_url;
+		// turn them both into parsed format
+		$option_url = parse_url( $option_url );
+		$url = parse_url( $url );
+
+		if ( $normalize_www ) {
+			if ( $url[ 'host' ] === "www.{$option_url[ 'host' ]}" ) {
+				// remove www if not present in option URL
+				$url[ 'host' ] = $option_url[ 'host' ];
+			}
+			if ( $option_url[ 'host' ] === "www.{$url[ 'host' ]}" ) {
+				// add www if present in option URL
+				$option_url[ 'host' ] = $url[ 'host' ];	
+			}
+		}
+
+		if ( $url[ 'host' ] === $option_url[ 'host' ] ) {
+			$url['scheme'] = $option_url['scheme'];
+			// return set_url_scheme( $current_url,  $option_url['scheme'] );
+		} 
+
+		$normalized_url = "{$url['scheme']}://{$url['host']}";
+
+		if ( isset( $url['path'] ) ) {
+			$normalized_url .= "{$url['path']}";
+		}
+
+		if ( isset( $url['query'] ) ) {
+			$normalized_url .= "?{$url['query']}";
+		}
+
+		return $normalized_url;
 	}
 
 	public static function get_plugins() {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -101,7 +101,7 @@ class Jetpack_Sync_Functions {
 			}
 			if ( $option_url[ 'host' ] === "www.{$url[ 'host' ]}" ) {
 				// add www if present in option URL
-				$option_url[ 'host' ] = $url[ 'host' ];	
+				$url[ 'host' ] = $option_url[ 'host' ];	
 			}
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -169,6 +169,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Jetpack_Sync_Functions::preserve_scheme( 'banana', 'https://www.example.com', true ), 'https://example.com' );
 		// other subdomains are preserved
 		$this->assertEquals( Jetpack_Sync_Functions::preserve_scheme( 'banana', 'https://foo.example.com', true ), 'https://foo.example.com' );
+
+		// if original domain is www, prefer that
+		update_option( 'banana', 'https://www.example.com' );
+		$this->assertEquals( Jetpack_Sync_Functions::preserve_scheme( 'banana', 'https://example.com', true ), 'https://www.example.com' );
 	}
 
 	function test_subdomain_switching_to_www_does_not_cause_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -164,5 +164,38 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Jetpack_Sync_Functions::preserve_scheme( 'banana', 'https://site.com' ), 'https://site.com' );
 		$this->assertEquals( Jetpack_Sync_Functions::preserve_scheme( 'banana', 'https://site.com/blog' ), 'https://site.com/blog' );
 		$this->assertEquals( Jetpack_Sync_Functions::preserve_scheme( 'banana', 'https://example.org' ), 'https://example.org' );
+
+		// adding www subdomain reverts to original domain
+		$this->assertEquals( Jetpack_Sync_Functions::preserve_scheme( 'banana', 'https://www.example.com', true ), 'https://example.com' );
+		// other subdomains are preserved
+		$this->assertEquals( Jetpack_Sync_Functions::preserve_scheme( 'banana', 'https://foo.example.com', true ), 'https://foo.example.com' );
+	}
+
+	function test_subdomain_switching_to_www_does_not_cause_sync() {
+		// a lot of sites accept www.domain.com or just domain.com, and we want to prevent lots of 
+		// switching back and forth, so we force the domain to be the one in the siteurl option
+		$this->setSyncClientDefaults();
+		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+
+		$original_site_url = site_url();
+
+		// sync original value
+		$this->sender->do_sync();
+
+		$this->assertEquals( $original_site_url, $this->server_replica_storage->get_callable( 'site_url' ) );
+
+		add_filter( 'site_url', array( $this, 'add_www_subdomain_to_siteurl' ) );
+
+		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+		$this->sender->do_sync();
+
+		$this->assertEquals( $original_site_url, $this->server_replica_storage->get_callable( 'site_url' ) );
+	}
+
+	function add_www_subdomain_to_siteurl( $url ) {
+		$parsed_url = parse_url( $url );
+		return "{$parsed_url['scheme']}://www.{$parsed_url['host']}";
 	}
 }


### PR DESCRIPTION
Fixes issue where the output of the `site_url` and `home_url` filters could change depending on the context in which a sync was initialised.

In particular, sites might alternate between www.example.com and example.com.

This change _only_ targets the specific case of the www subdomain, as I think it's pretty universal that it's the same site as the naked domain. A case where the URL switches to, say, blog.example.com is harder to make assumptions about. Did they just permanently reconfigure their web server, or is this a temporary change specific to this request?