### PR TITLE
Add `font-feature-settings` support for Custom CSS

### DIFF
--- a/modules/custom-css/csstidy/data-wp.inc.php
+++ b/modules/custom-css/csstidy/data-wp.inc.php
@@ -87,4 +87,5 @@ $GLOBALS['csstidy']['all_properties']['object-position'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['text-overflow'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['zoom'] = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['pointer-events'] = 'CSS3.0';
+$GLOBALS['csstidy']['all_properties']['font-feature-settings'] = 'CSS3.0';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- This should be useful for advanced typography control for fonts with OpenType features.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

