### PR TITLE
Add data-histograms endpoint and checksum_histogram replicastore method

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -44,11 +44,18 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	protected function result() {
 		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-modules.php';
-
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+
+		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
+		$queue = Jetpack_Sync_Sender::getInstance()->get_sync_queue();
+
 		return array_merge(
 			$sync_module->get_status(),
-			array( 'is_scheduled' => (bool) wp_next_scheduled( 'jetpack_sync_full' ) )
+			array( 
+				'is_scheduled' => (bool) wp_next_scheduled( 'jetpack_sync_full' ), 
+				'queue_size' => $queue->size(),
+				'queue_lag' => $queue->lag()
+			)
 		);
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -1,7 +1,7 @@
 <?php
 
+// POST /sites/%s/sync
 class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// POST /sites/%s/sync
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
@@ -11,7 +11,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		if ( isset( $args['clear'] ) && $args['clear'] ) {
 			// clear sync queue
-			require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-sender.php';
+			require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
 
 			$sender = Jetpack_Sync_Sender::getInstance();
 			$sync_queue = $sender->get_sync_queue();
@@ -20,7 +20,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		if ( isset( $args['force'] ) && $args['force'] ) {
 			// reset full sync lock
-			require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-modules.php';
+			require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-modules.php';
 
 			$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
 			$sync_module->clear_status();
@@ -38,12 +38,12 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 	}
 }
 
+// GET /sites/%s/sync/status
 class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// GET /sites/%s/sync/status
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-modules.php';
+		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-modules.php';
 
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
 		return array_merge(
@@ -53,12 +53,12 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 	}
 }
 
+// GET /sites/%s/data-check
 class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// GET /sites/%s/cached-data-check
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-sender.php';
+		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
 
 		$sender = Jetpack_Sync_Sender::getInstance();
 		$sync_queue = $sender->get_sync_queue();
@@ -76,7 +76,7 @@ class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
 			return $result;
 		}
 
-		require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-wp-replicastore.php';
+		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-wp-replicastore.php';
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 
@@ -91,11 +91,10 @@ class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 // GET /sites/%s/data-histogram
 class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// GET /sites/%s/cached-data-check
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-sender.php';
+		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
 
 		$sender = Jetpack_Sync_Sender::getInstance();
 		$sync_queue = $sender->get_sync_queue();
@@ -115,7 +114,7 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Endpoint
 
 		$args = $this->query_args();
 
-		require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-wp-replicastore.php';
+		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-wp-replicastore.php';
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 
@@ -128,14 +127,14 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Endpoint
 	}
 }
 
+// POST /sites/%s/sync/settings
 class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// POST /sites/%s/sync/settings
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
 		$args = $this->input();
 
-		require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-settings.php';
+		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-settings.php';
 
 		$sync_settings = Jetpack_Sync_Settings::get_settings();
 
@@ -155,12 +154,12 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_En
 	}
 }
 
+// GET /sites/%s/sync/settings
 class Jetpack_JSON_API_Sync_Get_Settings_Endpoint extends Jetpack_JSON_API_Endpoint {
-	// GET /sites/%s/sync/settings
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-settings.php';
+		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-settings.php';
 		return Jetpack_Sync_Settings::get_settings();
 	}
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -606,13 +606,13 @@ new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 ) );
 
 
-// GET /sites/%s/cached-data-check
+// GET /sites/%s/data-checksums
 new Jetpack_JSON_API_Sync_Check_Endpoint( array(
 	'description'     => 'Check that cacheable data on the site is in sync with wordpress.com',
 	'group'           => '__do_not_document',
 	'method'          => 'GET',
-	'path'            => '/sites/%s/cached-data-check',
-	'stat'            => 'cached-data-check',
+	'path'            => '/sites/%s/data-checksums',
+	'stat'            => 'data-checksums',
 	'path_labels' => array(
 		'$site' => '(int|string) The site ID, The site domain'
 	),
@@ -620,7 +620,29 @@ new Jetpack_JSON_API_Sync_Check_Endpoint( array(
 		'posts' => '(string) Posts checksum',
 		'comments' => '(string) Comments checksum',
 	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/cached-data-check'
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/data-checksums'
+) );
+
+// GET /sites/%s/data-histogram
+new Jetpack_JSON_API_Sync_Histogram_Endpoint( array(
+	'description'     => 'Get a histogram of checksums for certain synced data',
+	'group'           => '__do_not_document',
+	'method'          => 'GET',
+	'path'            => '/sites/%s/data-histogram',
+	'stat'            => 'data-histogram',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'query_parameters' => array(
+		'object_type' => '(string=posts) The type of object to checksum - posts, comments or options',
+		'buckets' => '(int=10) The number of buckets for the checksums',
+		'start_id' => '(int=0) Starting ID for the range',
+		'end_id' => '(int=null) Ending ID for the range'
+	),
+	'response_format' => array(
+		'histogram' => '(array) Associative array of histograms by ID range, e.g. "500-999" => "abcd1234"'
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/data-histogram'
 ) );
 
 $sync_settings_response = array(

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -61,7 +61,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 		return $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE $where" );
 	}
 
-	public function get_posts( $status = null ) {
+	public function get_posts( $status = null, $min_id = null, $max_id = null ) {
 		$args = array( 'orderby' => 'ID', 'posts_per_page' => -1 );
 
 		if ( $status ) {
@@ -206,7 +206,7 @@ ENDSQL;
 		}
 	}
 
-	public function get_comments( $status = null ) {
+	public function get_comments( $status = null, $min_id = null, $max_id = null ) {
 		$args = array( 'orderby' => 'ID', 'status' => 'all' );
 
 		if ( $status ) {
@@ -283,7 +283,7 @@ ENDSQL;
 		wp_spam_comment( $comment_id );
 	}
 
-	public function comments_checksum() {
+	public function comments_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
 
 		$query = <<<ENDSQL

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -40,7 +40,12 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	public function post_count( $status = null ) {
-		return count( $this->get_posts( $status ) );
+		$count = wp_count_posts();
+		if ( $status != null ) {
+			return $count->{$status};
+		} else {
+			return array_sum( array_values( get_object_vars( $count ) ) );
+		}
 	}
 
 	public function get_posts( $status = null ) {

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -286,8 +286,22 @@ ENDSQL;
 	public function comments_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
 
+		$where_sql = "1=1";
+
+		if ( $min_id !== null ) {
+			$min_id = intval( $min_id );
+			$where_sql .= " AND comment_ID >= $min_id";
+		}
+
+		if ( $max_id !== null ) {
+			$max_id = intval( $max_id );
+			$where_sql .= " AND comment_ID <= $max_id";
+		}
+
 		$query = <<<ENDSQL
-			SELECT CONV(BIT_XOR(CRC32(CONCAT(comment_ID,comment_content))), 10, 16) FROM $wpdb->comments
+			SELECT CONV(BIT_XOR(CRC32(CONCAT(comment_ID,comment_content))), 10, 16) 
+			  FROM $wpdb->comments
+			  WHERE $where_sql
 ENDSQL;
 
 		return $wpdb->get_var( $query );

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -40,11 +40,15 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	public function post_count( $status = null ) {
-		$count = wp_count_posts();
-		if ( $status != null ) {
-			return $count->{$status};
+		global $wpdb;
+
+		if ( $status ) {
+			return $wpdb->get_var( $wpdb->prepare(
+				"SELECT COUNT(*) FROM $wpdb->posts WHERE post_status = %s",
+				$status
+			) );
 		} else {
-			return array_sum( array_values( get_object_vars( $count ) ) );
+			return $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts" );
 		}
 	}
 

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -566,6 +566,10 @@ ENDSQL;
 		);
 	}
 
+	function checksum_histogram( $object_type, $buckets, $start_id, $end_id ) {
+		return null;
+	}
+
 	private function invalid_call() {
 		$backtrace = debug_backtrace();
 		$caller    = $backtrace[1]['function'];

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -20,9 +20,9 @@ interface iJetpack_Sync_Replicastore {
 	public function full_sync_end( $checksum );
 
 	// posts
-	public function post_count( $status = null );
+	public function post_count( $status = null, $min_id = null, $max_id = null );
 
-	public function get_posts( $status = null );
+	public function get_posts( $status = null, $min_id = null, $max_id = null );
 
 	public function get_post( $id );
 
@@ -30,12 +30,12 @@ interface iJetpack_Sync_Replicastore {
 
 	public function delete_post( $post_id );
 
-	public function posts_checksum();
+	public function posts_checksum( $min_id = null, $max_id = null );
 
 	// comments
-	public function comment_count( $status = null );
+	public function comment_count( $status = null, $min_id = null, $max_id = null );
 
-	public function get_comments( $status = null );
+	public function get_comments( $status = null, $min_id = null, $max_id = null );
 
 	public function get_comment( $id );
 
@@ -47,7 +47,7 @@ interface iJetpack_Sync_Replicastore {
 
 	public function delete_comment( $comment_id );
 
-	public function comments_checksum();
+	public function comments_checksum( $min_id = null, $max_id = null );
 
 	// options
 	public function update_option( $option, $value );

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -121,5 +121,5 @@ interface iJetpack_Sync_Replicastore {
 	public function checksum_all();
 
 	// histogram
-	public function checksum_histogram( $object_type, $buckets, $start_id, $end_id );
+	public function checksum_histogram( $object_type, $buckets, $start_id = null, $end_id = null );
 }

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -119,4 +119,7 @@ interface iJetpack_Sync_Replicastore {
 
 	// full checksum
 	public function checksum_all();
+
+	// histogram
+	public function checksum_histogram( $object_type, $buckets, $start_id, $end_id );
 }

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -54,7 +54,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		return count( $this->get_posts( $status, $min_id, $max_id ) );
 	}
 
-	function get_posts( $status = null, $min_id = null, $max_id = null  ) {
+	function get_posts( $status = null, $min_id = null, $max_id = null ) {
 		$this->post_status = $status;
 
 		$posts = array_filter( array_values( $this->posts ), array( $this, 'filter_post_status' ) );
@@ -68,7 +68,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		return array_values($posts);
 	}
 
-	function posts_checksum() {
+	function posts_checksum( $min_id = null, $max_id = null ) {
 		return $this->calculate_checksum( $this->posts, 'post_checksum' );
 	}
 
@@ -114,7 +114,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		return array_values($comments);
 	}
 
-	function comments_checksum() {
+	function comments_checksum( $min_id = null, $max_id = null ) {
 		return $this->calculate_checksum( $this->comments, 'comment_checksum' );
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -475,6 +475,10 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		);
 	}
 
+	function checksum_histogram( $object_type, $buckets, $start_id, $end_id ) {
+		return null;
+	}
+
 	function cast_to_post( $object ) {
 		if ( isset( $object->extra ) ) {
 			$object->extra = (array) $object->extra;

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -129,7 +129,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		for ( $i = 1; $i <= 20; $i += 1 ) {
 			do {
 				$post_id = rand(1, 1000000);
-			} while( ! in_array( $post_id, $generated_post_ids ) );
+			} while ( in_array( $post_id, $generated_post_ids ) );
 
 			$generated_post_ids[] = $post_id;
 
@@ -145,7 +145,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 			do {
 				$comment_id = rand(1, 1000000);
-			} while( ! in_array( $post_id, $generated_comment_ids ) );
+			} while ( in_array( $post_id, $generated_comment_ids ) );
 
 			$generated_comment_ids[] = $comment_id;
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -162,9 +162,20 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		}
 
-		$histogram = $store->checksum_histogram( 'posts', 10, 0, 0 );
+		foreach( array( 'posts', 'comments' ) as $object_type ) {
+			$histogram = $store->checksum_histogram( $object_type, 10, 0, 0 );
+			$this->assertEquals( 10, count( $histogram ) );
 
-		$this->assertEquals( 10, count( $histogram ) );
+			// histogram bucket should equal entire histogram of just the ID range for that bucket
+			foreach( $histogram as $range => $checksum ) {
+				list( $min_id, $max_id ) = explode( '-', $range );
+
+				$range_histogram = $store->checksum_histogram( $object_type, 1, intval( $min_id ), intval( $max_id ) );
+				$range_checksum = array_pop( $range_histogram );
+				
+				$this->assertEquals( $checksum, $range_checksum );
+			}
+		}
 
 		// histogram with one bucket should equal checksum of corresponding object type
 		$histogram = $store->checksum_histogram( 'posts', 1, 0, 0 );

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -110,6 +110,23 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Histograms
+	 **/
+
+	/**
+	 * @dataProvider store_provider
+	 * @requires PHP 5.3
+	 */
+	function test_checksum_histogram( $store ) {
+
+		$post = self::$factory->post( 5 );
+
+		$histogram = $store->checksum_histogram( 'posts', 10, 0, 0 );
+
+		error_log(print_r($histogram, 1));
+	}
+
+	/**
 	 * Posts
 	 */
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -63,11 +63,11 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 */
 	function test_all_checksums_match() {
 		$post = self::$factory->post( 5 );
+		$second_post = self::$factory->post( 10 );
 		$comment = self::$factory->comment( 3, $post->ID );
+		$second_comment = self::$factory->comment( 6, $second_post->ID );
 		$option_name  = 'blogdescription';
 		$option_value = rand();
-
-		update_option( $option_name, $option_value );
 
 		// create an instance of each type of replicastore
 		$all_replicastores = array();
@@ -84,7 +84,9 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// insert the same data into all of them
 		foreach( $all_replicastores as $replicastore ) {
 			$replicastore->upsert_post( $post );
+			$replicastore->upsert_post( $second_post );
 			$replicastore->upsert_comment( $comment );
+			$replicastore->upsert_comment( $second_comment );
 			$replicastore->update_option( $option_name, $option_value );
 		}
 
@@ -97,6 +99,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		// set the class property back to the original value;
 		Jetpack_Sync_Defaults::$default_options_whitelist = $default_options_whitelist_original;
 
+		// for helpful debug output in case they don't match
 		$labelled_checksums = array_combine( array_map( 'get_class', $all_replicastores ), $checksums );
 
 		// find unique checksums - if all checksums are the same, there should be only one element


### PR DESCRIPTION
Create an endpoint which can be used to compare buckets of checksums across replicastores, as a way of drilling down into disrepancies and ultimately performing selective sync

On WPCOM, invoking this API looks like this:

```
wp> $validator->get_site_histogram( 'posts', 5 );
array(15) {
  '1-51' =>
  string(8) "2ADAE1EC"
  '52-90' =>
  string(8) "5B073436"
  '91-129' =>
  string(8) "B8AD19B7"
  '130-168' =>
  string(8) "A927F6CB"
  '169-207' =>
  string(7) "60028C6"
  '208-246' =>
  string(8) "6FDB19B8"
  '247-285' =>
  string(8) "99A33198"
  '286-324' =>
  string(8) "85329053"
  '325-363' =>
  string(8) "2C9A485F"
  '364-402' =>
  string(8) "C69DEE10"
  '403-441' =>
  string(8) "CD9C1A9F"
  '442-480' =>
  string(8) "105F977E"
  '481-519' =>
  string(8) "59B764F4"
  '520-558' =>
  string(8) "97AD1E3A"
  '559-600' =>
  string(8) "A8C759DA"
}
```

This PR also adds some unrelated functionality: sync queue size and lag for the sync status API

cc @lezama 