### PR TITLE
[Shortcodes] Enhance jetpack_shortcodes_to_include usability by including filename as array key

### DIFF
--- a/modules/shortcodes.php
+++ b/modules/shortcodes.php
@@ -40,12 +40,12 @@ function shortcode_new_to_old_params( $params, $old_format_support = false ) {
 }
 
 function jetpack_load_shortcodes() {
-	global $wp_version;
-
 	$shortcode_includes = array();
 
 	foreach ( Jetpack::glob_php( dirname( __FILE__ ) . '/shortcodes' ) as $file ) {
-		$shortcode_includes[] = $file;
+		$filename = substr( basename( $file ), 0, -4 );
+
+		$shortcode_includes[ $filename ] = $file;
 	}
 
 /**
@@ -54,6 +54,7 @@ function jetpack_load_shortcodes() {
  * @module shortcodes
  *
  * @since 2.2.1
+ * @since 4.2.0 Added filename without extension as array key.
  *
  * @param array $shortcode_includes An array of which shortcodes to include.
  */


### PR DESCRIPTION
The `jetpack_shortcodes_to_include` filter is passed an array of absolute paths. As a plugin author trying to get Jetpack to not take over some of my plugin's shortcodes, that's a pretty difficult to use because I have to work my way through the array and parse the paths.

I'd like to suggest that we add the filename as the key in the array. This _should_ be backwards compatible (no one is going to be messing with keys in a numeric array) while adding the ability to do this:

```php
add_filter( 'jetpack_shortcodes_to_include', function( $shortcodes ) {
	unset( $shortcodes['youtube'] );

	return $shortcodes;
} );
```