### PR TITLE
Added a new list of roles that can view stats to the initial state.

### DIFF
--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -37,7 +37,7 @@ const DashStats = React.createClass( {
 
 	statsChart: function( unit ) {
 		let s = [];
-		forEach( window.Initial_State.statsData[unit].data, function( v ) {
+		forEach( window.Initial_State.stats.data[unit].data, function( v ) {
 			let date = v[0];
 			let chartLabel = '';
 			let tooltipLabel = '';
@@ -79,7 +79,7 @@ const DashStats = React.createClass( {
 	 * @returns {object|bool}
 	 */
 	statsErrors() {
-		let checkStats = window.Initial_State.statsData.general;
+		let checkStats = window.Initial_State.stats.data.general;
 		if ( 'object' === typeof checkStats.errors ) {
 			return checkStats.errors;
 		}
@@ -197,7 +197,7 @@ const DashStats = React.createClass( {
 
 const DashStatsBottom = React.createClass( {
 	statsBottom: function() {
-		const generalStats = ( getSiteConnectionStatus( this.props ) === 'dev' ) ? demoStatsBottom : window.Initial_State.statsData.general.stats;
+		const generalStats = ( getSiteConnectionStatus( this.props ) === 'dev' ) ? demoStatsBottom : window.Initial_State.stats.data.general.stats;
 		return [
 			{
 				viewsToday: generalStats.views_today,

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -166,6 +166,13 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		$localeSlug = explode( '_', get_locale() );
 		$localeSlug = $localeSlug[0];
 
+		// Collecting roles that can view site stats
+		$can_view_stats = array();
+		$roles = get_editable_roles();
+		foreach( stats_get_option( 'roles' ) as $role ) {
+			$can_view_stats[ $role ] = translate_user_role( $roles[ $role ]['name'] );
+		}
+
 		// Add objects to be passed to the initial state of the app
 		wp_localize_script( 'react-plugin', 'Initial_State', array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
@@ -189,7 +196,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'showJumpstart' => jetpack_show_jumpstart(),
 			'rawUrl' => Jetpack::build_raw_urls( get_home_url() ),
 			'adminUrl' => esc_url( admin_url() ),
-			'statsData' => build_initial_stats_shape(),
+			'stats' => array(
+				'data' => build_initial_stats_shape(),
+				'canView' => $can_view_stats,
+			),
 			'settingNames' => array(
 				'jetpack_holiday_snow_enabled' => function_exists( 'jetpack_holiday_snow_option_name' ) ? jetpack_holiday_snow_option_name() : false,
 			),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -167,10 +167,13 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		$localeSlug = $localeSlug[0];
 
 		// Collecting roles that can view site stats
-		$can_view_stats = array();
-		$roles = get_editable_roles();
-		foreach( stats_get_option( 'roles' ) as $role ) {
-			$can_view_stats[ $role ] = translate_user_role( $roles[ $role ]['name'] );
+		$stats_roles = array();
+		$enabled_roles = stats_get_option( 'roles' );
+		foreach( get_editable_roles() as $slug => $role ) {
+			$stats_roles[ $slug ] = array(
+				'name' => translate_user_role( $role['name'] ),
+				'canView' => in_array( $slug, $enabled_roles, true ),
+			);
 		}
 
 		// Add objects to be passed to the initial state of the app
@@ -198,7 +201,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'adminUrl' => esc_url( admin_url() ),
 			'stats' => array(
 				'data' => build_initial_stats_shape(),
-				'canView' => $can_view_stats,
+				'roles' => $stats_roles,
 			),
 			'settingNames' => array(
 				'jetpack_holiday_snow_enabled' => function_exists( 'jetpack_holiday_snow_option_name' ) ? jetpack_holiday_snow_option_name() : false,


### PR DESCRIPTION
Fixes #4385  .

#### Changes proposed in this Pull Request:
- Changes the way the stats object looks in the initial state to include a `canView` key.
- Adds an object that has role slugs for keys and translated names as values to the `canView' key.
- Modified the code that accesses stats data to use the new object structure.
 
cc @oskosk