### PR TITLE
Sync: Remove unused private variable $sender

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -18,8 +18,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	const STATUS_OPTION = 'jetpack_full_sync_status';
 	const FULL_SYNC_TIMEOUT = 3600;
 
-	private $sender;
-
 	public function name() {
 		return 'full-sync';
 	}


### PR DESCRIPTION
When looking through the full sync code, I noticed that the private member `$sender` is unused. This PR removes it.

To test:

- Checkout `update/full-sync-unused-sender` branch
- Go to `$site/wp-admin/admin.php?page=jetpack-sync`
- Verify that you can trigger a full sync and there are no errors

cc @gravityrail for review.