### PR TITLE
Reset full sync lock when queue is reset

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -14,8 +14,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 			require_once dirname(__FILE__).'/../../sync/class.jetpack-sync-sender.php';
 
 			$sender = Jetpack_Sync_Sender::getInstance();
-			$sync_queue = $sender->get_sync_queue();
-			$sync_queue->reset();
+			$sender->reset_sync_queue();
 		}
 
 		if ( isset( $args['force'] ) && $args['force'] ) {

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -184,6 +184,7 @@ class Jetpack_Sync_Sender {
 	}
 
 	function reset_sync_queue() {
+		Jetpack_Sync_Modules::get_module( 'full-sync' )->clear_status();
 		$this->sync_queue->reset();
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -266,7 +266,18 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $event->sent_timestamp > $before_sync );
 		$this->assertTrue( $event->sent_timestamp < $after_sync );
 		$this->assertTrue( $event->sent_timestamp < microtime(true) );
+	}
 
+	function test_reset_queue_also_resets_full_sync_lock() {
+		$full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$full_sync->start();
+		$status = $full_sync->get_status();
+		$this->assertNotNull( $status['started'] );
+
+		$this->sender->reset_sync_queue();
+
+		$status = $full_sync->get_status();
+		$this->assertNull( $status['started'] );
 	}
 
 	function action_ran( $data, $codec, $sent_timestamp ) {


### PR DESCRIPTION
Fixes an issue where resetting the queue via API or dashboard while full syncing would result in the full sync lock not being cleared, preventing another full sync for up to an hour.

cc @ebinnion 