### PR TITLE
Fixes php notice by setting the global $post variable.

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -44,8 +44,9 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	// Expands wp_insert_post to include filtered content
-	function filter_post_content_and_add_links( $post ) {
-
+	function filter_post_content_and_add_links( $post_object ) {
+		global $post;
+		$post = $post_object;
 		/**
 		 * Filters whether to prevent sending post data to .com
 		 *


### PR DESCRIPTION
Fixes a php notice in modules/shortcodes/slideshow.php line 125
`global $post` should be set so that it is available in shortcodes and the filter if necessary.

To test: Add the [slideshow] shortcode to one of your posts notice that there are no php errors.