### PR TITLE
Sync: Removes unneccessary action comment from POST /sites/$site/sync…

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -30,7 +30,6 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 			$modules = array_map('trim', explode( ',', $args['modules'] ) );
 		}
 
-		/** This action is documented in class.jetpack-sync-sender.php */
 		Jetpack_Sync_Actions::schedule_full_sync( $modules );
 		spawn_cron();
 


### PR DESCRIPTION
I noticed this action comment in the code for the `POST /sites/$site/sync` endpoint. The comment was initially added in https://github.com/Automattic/jetpack/commit/ce034939bdb86946bf48f8a04565955769fd8010#diff-7eba8bca1502098c08e8818da6353b18R9 when there was an action, but the action was removed in https://github.com/Automattic/jetpack/commit/3cad0ff77c0bfbf6869c1e8ebcbdd069e6fc39d3#diff-7eba8bca1502098c08e8818da6353b18R10.

cc @jeherve for review