### PR TITLE
Stop related posts title from displaying when there's no posts to show.

### DIFF
--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -189,6 +189,10 @@
 			} else {
 				html = jprp.generateVisualHtml( response.items );
 			}
+			
+			if ( 0 === html.length ) {
+				return;
+			}
 
 			$( '#jp-relatedposts' ).append( html );
 			jprp.setVisualExcerptHeights();


### PR DESCRIPTION
Stop related posts from displaying if there's no related posts to display.

Sometimes the related posts title displays on a page when there's no related posts returned from the json request. This seems to happen all the time on post types that aren't blog posts (such as Jetpack projects), but it also happens when there's no data for the current post.

I've attached a screenshot showing what happens on a portfolio project on my site (using jetpack portfolios) when there's no related content returned.

The live url is here: https://www.binarymoon.co.uk/portfolio/chronicle/

![screen shot 2016-07-14 at 11 37 34](https://cloud.githubusercontent.com/assets/1004130/16836836/b0370994-49b7-11e6-8bbe-5e54e14c4706.png)
