### PR TITLE
Admin Page: Fix the updating of Gravatar Hovercards Settings

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -313,7 +313,6 @@ export let GravatarHovercardsSettings = React.createClass( {
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
 					<FormLegend>{ __( 'View people\'s profiles when you mouse over their Gravatars' ) }</FormLegend>
-					<span> { '(Currently does not work)' } </span>
 					<ModuleSettingRadios
 						name={ 'gravatar_disable_hovercards' }
 						{ ...this.props }

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1467,7 +1467,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 						'type'               => 'string',
 						'default'            => 'enabled',
 						// Not visible. This is used as the checkbox value.
-						'enum'				 => array( 'enabled', 'disabled' ),
+						'enum'				 => array(
+							'enabled' => esc_html__( 'Enabled', 'jetpack' ),
+							'disabled' => esc_html__( 'Disabled', 'jetpack' ),
+						),
 						'validate_callback'  => __CLASS__ . '::validate_list_item',
 					),
 				);


### PR DESCRIPTION
Fixes #4381  .

#### Changes proposed in this Pull Request:

- Changes the Gravatar Hovercards enum array (for the `gravatar_disable_hovercard` option) from an indexed array to an associative array for consistency with other module options.


#### Testing instructions

1. On the **Settings** Page, look for the **Gravatar Hovercards** settings under the **Engagement** tab
2. Update the **View people's profiles when you mouse over their Gravatars** option.
3. Refresh the page and check the value you chose remains set for that option.