### PR TITLE
Fix AtD plugin URL

### DIFF
--- a/modules/after-the-deadline.php
+++ b/modules/after-the-deadline.php
@@ -131,7 +131,7 @@ function register_AtD_button( $buttons ) {
 function add_AtD_tinymce_plugin( $plugin_array ) {
 	$plugin = ATD_TINYMCE_4 ? 'plugin' : 'editor_plugin';
 
-	$plugin_array['AtD'] = plugins_url( 'after-the-deadline/tinymce/' . $plugin . '.js?v=' . ATD_VERSION, __FILE__ );
+	$plugin_array['AtD'] = plugins_url( 'after-the-deadline/tinymce/' . $plugin . '.js', __FILE__ ) . '?v=' . ATD_VERSION;
 	return $plugin_array;
 }
 

--- a/modules/after-the-deadline.php
+++ b/modules/after-the-deadline.php
@@ -131,7 +131,7 @@ function register_AtD_button( $buttons ) {
 function add_AtD_tinymce_plugin( $plugin_array ) {
 	$plugin = ATD_TINYMCE_4 ? 'plugin' : 'editor_plugin';
 
-	$plugin_array['AtD'] = plugins_url( 'after-the-deadline/tinymce/' . $plugin . '.js', __FILE__ ) . '?v=' . ATD_VERSION;
+	$plugin_array['AtD'] = add_query_arg('v', ATD_VERSION, plugins_url( 'after-the-deadline/tinymce/' . $plugin . '.js', __FILE__));
 	return $plugin_array;
 }
 


### PR DESCRIPTION
Fixes #4406 .

The `plugin_url($path, $plugin)` function [accepts a path as the first argument](https://developer.wordpress.org/reference/functions/plugins_url/), not a URL, so the query string that was being passed in was not handled correctly and the `?` was being stripped out causing the incorrect URL to be returned.

#### Changes proposed in this Pull Request:
- Moves the query string outside of the `plugin_url` function, so that the `?` is not removed from the end result.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

