### PR TITLE
Admin Page: Related Posts Settings - Implement thumbnails and text previews

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -61,7 +61,7 @@ export let RelatedPostsSettings = React.createClass( {
 			<div className="related-posts-settings_preview_container">
 				{
 					show_headline ?
-						<h3>Related</h3> :
+						<h3>{ __( 'Related' ) }</h3> :
 						''
 				}
 				{
@@ -89,7 +89,7 @@ export let RelatedPostsSettings = React.createClass( {
 						name={ 'show_thumbnails' }
 						label={ __( 'Use a large and visually striking layout' ) }
 						{ ...this.props } />
-					<h3>Preview</h3>
+					<h3>{ __( 'Preview' ) }</h3>
 					<Card>
 						{ this.renderPreviews() }
 					</Card>

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -59,16 +59,18 @@ export let RelatedPostsSettings = React.createClass( {
 
 		return (
 			<div className="related-posts-settings_preview_container">
-				<h3>Related</h3>
+				{
+					show_headline ?
+						<h3>Related</h3> :
+						''
+				}
 				{
 					previews.map( ( preview, i ) => (
 						<span key={ `preview_${ i }` } className="related-posts-settings_preview_image_container" >
 							{
 								show_thumbnails ? <img src={ preview.url } /> : ''
 							}
-							{
-								show_headline ? <span><a href="#/engagement"> { preview.text } </a></span> : ''
-							}
+							<span><a href="#/engagement"> { preview.text } </a></span>
 						</span>
 					) )
 				}

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -59,6 +59,7 @@ export let RelatedPostsSettings = React.createClass( {
 
 		return (
 			<div className="related-posts-settings_preview_container">
+				<h3>Related</h3>
 				{
 					previews.map( ( preview, i ) => (
 						<span key={ `preview_${ i }` } className="related-posts-settings_preview_image_container" >

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -4,10 +4,13 @@
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
  */
+import './style.scss';
+
 import {
 	FormFieldset,
 	FormLegend,
@@ -40,6 +43,37 @@ export let SharedaddySettings = React.createClass( {
 SharedaddySettings = ModuleSettingsForm( SharedaddySettings );
 
 export let RelatedPostsSettings = React.createClass( {
+	renderPreviews() {
+		const show_headline = this.props.getOptionValue( 'show_headline' );
+		const show_thumbnails = this.props.getOptionValue( 'show_thumbnails' );
+		const previews = [ {
+			url: 'https://jetpackme.files.wordpress.com/2014/08/1-wpios-ipad-3-1-viewsite.png?w=350&h=200&crop=1',
+			text: __( 'Big iPhone/iPad Update Now Available' )
+		}, {
+			url: 'https://jetpackme.files.wordpress.com/2014/08/wordpress-com-news-wordpress-for-android-ui-update2.jpg?w=350&h=200&crop=1',
+			text: __( 'The WordPress for Android App Gets a Big Facelift' )
+		}, {
+			url: 'https://jetpackme.files.wordpress.com/2014/08/videopresswedding.jpg?w=350&h=200&crop=1',
+			text: __( 'Upgrade Focus: VideoPress For Weddings' )
+		} ];
+
+		return (
+			<div className="related-posts-settings_preview_container">
+				{
+					previews.map( ( preview, i ) => (
+						<span key={ `preview_${ i }` } className="related-posts-settings_preview_image_container" >
+							{
+								show_thumbnails ? <img src={ preview.url } /> : ''
+							}
+							{
+								show_headline ? <span><a href="#/engagement"> { preview.text } </a></span> : ''
+							}
+						</span>
+					) )
+				}
+			</div>
+		);
+	},
 	render() {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
@@ -52,6 +86,10 @@ export let RelatedPostsSettings = React.createClass( {
 						name={ 'show_thumbnails' }
 						label={ __( 'Use a large and visually striking layout' ) }
 						{ ...this.props } />
+					<h3>Preview</h3>
+					<Card>
+						{ this.renderPreviews() }
+					</Card>
 					<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
 				</FormFieldset>
 			</form>

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -1,0 +1,15 @@
+/**
+ * Related Posts Preview styles
+ */
+.related-posts-settings_preview_container {
+	text-align: center;
+}
+
+.related-posts-settings_preview_image_container {
+	display: inline-block;
+	width: 29%;
+}
+
+.related-posts-settings_preview_image_container img {
+	max-width: 100%;
+}

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -5,6 +5,10 @@
 	text-align: center;
 }
 
+.related-posts-settings_preview_container h3 {
+	text-align: left;
+}
+
 .related-posts-settings_preview_image_container {
 	display: inline-block;
 	width: 29%;


### PR DESCRIPTION
Fixes #4388 .

#### Changes proposed in this Pull Request:
- Implements Related Posts Previews. 

#### Currently looking like this

![related-posts-preview](https://cloud.githubusercontent.com/assets/746152/16924045/b2f42740-4cf3-11e6-8743-9598a2b06fe4.gif)


#### Testing instructions

1. Get to the **Related Posts** settings under the **Engagement** tab.
1. Check and uncheck both available options
1. Watch the thumbnails and the texts disappear / appear
1. Save the settings
1. Refresh the page to confirm that the changes persisted and the previews/text are shown or hidden appropriately 