### PR TITLE
Admin Page: Monitor settings - Remove checkbox for 'Emails will be sent to admin address'

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -189,11 +189,6 @@ export let MonitorSettings = React.createClass( {
 						name={ 'monitor_receive_notifications' }
 						{ ...this.props }
 						label={ __( 'Receive Monitor Email Notifications' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Emails will be sent to admin address' ) +
-						' (Currently does not work)' } />
 				</FormFieldset>
 				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Removes the option **Emails will be sent to admin address** from the **Monitor** module Settings until it's implemented on the backend. 