### PR TITLE
Using static HTML generated by React as placeholder.

### DIFF
--- a/_inc/client/components/loading-placeholder/index.jsx
+++ b/_inc/client/components/loading-placeholder/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+
+export const LoadingPlaceholder = React.createClass( {
+	displayName: 'LoadingPlaceholder',
+
+	render() {
+		const classes = classNames(
+			this.props.className,
+			'jp-loading-placeholder'
+		);
+
+		return (
+			<div className={ classes }>
+				<span className="dashicons dashicons-wordpress-alt"></span>
+			</div>
+		);
+	}
+} );
+
+export default connect(
+	state => {
+		return state;
+	},
+	( dispatch ) => {
+		return {};
+	}
+)( LoadingPlaceholder );

--- a/_inc/client/components/loading-placeholder/style.scss
+++ b/_inc/client/components/loading-placeholder/style.scss
@@ -1,0 +1,10 @@
+.jp-loading-placeholder {
+	margin: 0 auto;
+	width: 500px;
+	height: 500px;
+
+	.dashicons {
+		width: 500px;
+		font-size: 500px;
+	}
+}

--- a/_inc/client/components/loading-placeholder/style.scss
+++ b/_inc/client/components/loading-placeholder/style.scss
@@ -1,10 +1,19 @@
 .jp-loading-placeholder {
-	margin: 0 auto;
-	width: 500px;
-	height: 500px;
+	$size: 12vw;
+
+	margin-top: 30vh;
+	margin-bottom: 25vh;
+	color: lighten( $gray, 20% );
+	font-size: $size;
+	text-align: center;
+
+	@include breakpoint( ">960px" ) {
+		font-size: 120px;
+	}
 
 	.dashicons {
-		width: 500px;
-		font-size: 500px;
+		font-size: inherit;
+		width: auto;
+		height: auto;
 	}
 }

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -29,6 +29,7 @@
 @import '../components/expanded-card/style';
 @import '../components/foldable-card/style';
 @import '../components/footer/style';
+@import '../components/loading-placeholder/style';
 @import '../components/jetpack-connect/style';
 @import '../components/jumpstart/style';
 @import '../components/masthead/style';

--- a/_inc/client/static-main.jsx
+++ b/_inc/client/static-main.jsx
@@ -9,6 +9,7 @@ import { bindActionCreators } from 'redux';
  * Internal dependencies
  */
 import Masthead from 'components/masthead';
+import LoadingPlaceholder from 'components/loading-placeholder';
 import { setInitialState } from 'state/initial-state';
 import Footer from 'components/footer';
 
@@ -21,6 +22,7 @@ const StaticMain = React.createClass( {
 		return (
 			<div id="jp-plugin-container">
 				<Masthead { ...this.props } />
+				<LoadingPlaceholder { ...this.props } />
 				<Footer { ...this.props } />
 			</div>
 		);

--- a/_inc/client/static-main.jsx
+++ b/_inc/client/static-main.jsx
@@ -19,9 +19,8 @@ const StaticMain = React.createClass( {
 
 	render: function() {
 		return (
-			<div>
+			<div id="jp-plugin-container">
 				<Masthead { ...this.props } />
-				<div id="jetpack-static-container"></div>
 				<Footer { ...this.props } />
 			</div>
 		);

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -132,13 +132,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		if ( ! empty( $_GET['configure'] ) ) {
 			return $this->render_nojs_configurable( $_GET['configure'] );
 		}
-		?>
-		<?php
-			/** This action is already documented in views/admin/admin-page.php */
-			do_action( 'jetpack_notices' );
-		?>
-		<div id="jp-plugin-container"></div>
-	<?php }
+
+		/** This action is already documented in views/admin/admin-page.php */
+		do_action( 'jetpack_notices' );
+
+		echo file_get_contents( JETPACK__PLUGIN_DIR . '/_inc/build/static.html' );
+	}
 
 	function get_i18n_data() {
 		$locale_data = @file_get_contents( JETPACK__PLUGIN_DIR . '/languages/json/jetpack-' . get_locale() . '.json' );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "watch": "gulp watch",
-    "clean": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map",
+    "clean": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html",
     "distclean": "rm -rf node_modules",
     "build": "npm install && npm run build-client",
     "build-client": "gulp",


### PR DESCRIPTION
Will fix #4052 when done.

#### Changes proposed in this Pull Request:
- [x] Load static markup with real Masthead and Footer in it.
- [x] Fill the blank in the page with something so that the Footer doesn't stick to the Masthead.
- [ ] Possibly use some elements of the page in an intermediate state to show what the loaded page would look like. Although that would be tricky because we don't have the luxury of using Routes and i18n for static HTML.
- [x] Make sure that the `gulp watch` task includes regeneration of the static files.