### PR TITLE
Admin Page: ensure that stats_get_option exists before calling it.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -168,7 +168,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 		// Collecting roles that can view site stats
 		$stats_roles = array();
-		$enabled_roles = stats_get_option( 'roles' );
+		$enabled_roles = function_exists( 'stats_get_option' ) ? stats_get_option( 'roles' ) : array( 'administrator' );
 		foreach( get_editable_roles() as $slug => $role ) {
 			$stats_roles[ $slug ] = array(
 				'name' => translate_user_role( $role['name'] ),


### PR DESCRIPTION
This solves a fatal error when the Stats module isn't activated.
It was introduced by the commit 7a924523c8e1c1aff6f64c97f9b5e32a73296381.

#### Testing instructions:
- First check master and see if it throws the fatal error when you try to access the Jetpack Admin page
```
PHP Fatal error:  Call to undefined function stats_get_option() in /wp-content/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php on line 171
```
Now test this PR and it should work fine.