### PR TITLE
Admin Page: Translate strings in some features' settings

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -65,7 +65,7 @@ export let SubscriptionsSettings = React.createClass( {
 	render() {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
-				<h3>Can readers subscribe to your posts, comments or both?</h3>
+				<h3>{ __( 'Can readers subscribe to your posts, comments or both?' ) }</h3>
 				<FormFieldset>
 					<ModuleSettingCheckbox
 						name={ "stb_enabled" }
@@ -324,7 +324,7 @@ export let TiledGallerySettings = React.createClass( {
 	render() {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
-				<h3>Excerpts</h3>
+				<h3>{ __( 'Excerpts' ) }</h3>
 				<FormFieldset>
 					<ModuleSettingCheckbox
 						name={ 'tiled_galleries' }

--- a/_inc/client/components/settings/index.jsx
+++ b/_inc/client/components/settings/index.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { SettingToggle } from 'components/setting-toggle';
-
+import { translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
@@ -29,7 +29,7 @@ export const Settings = React.createClass( {
 					activated={ this.props.isSettingActivated( window.Initial_State.settingNames.jetpack_holiday_snow_enabled ) }
 					toggleSetting={ this.props.toggleSetting }
 					disabled={ this.props.isFetchingSettingsList }
-				>Show falling snow on my blog until January 4<sup>th</sup>.</SettingToggle>
+				>{ __( 'Show falling snow on my blog from Dec 1st until Jan 4th.' ) }</SettingToggle>
 			</div>
 		);
 	}

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -91,7 +91,7 @@ export const Page = ( props ) => {
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
 				<br/>
-				<a href={ element[3] } target="_blank">Learn More</a>
+				<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
 			</FoldableCard>
 		);
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Translates a few strings in the following settings or section:
* Subscriptions
* Tiled Galleries
* Snow
* Writing Tab page (Text: _Learn More_)

#### Testing instructions:

1. In the Admin Page's Settings,
2. Expand the card for **Subscriptions** under the Engagement tab. Check that the card expands correctly.
2. Expand the card for **Tiled galleries** under the Appearance tab. Check that the card expands correctly.
2. Expand the card for **Miscellaneous** under the General tab. Check that the card expands correctly.
3. Expand the card for **WP.me Shortlinks** under the Writing tab. Check that the card expands correctly.




