### PR TITLE
Fixes call-time pass-by-reference errors for PHP 5.4 compatibility

### DIFF
--- a/_inc/lib/markdown/extra.php
+++ b/_inc/lib/markdown/extra.php
@@ -1660,7 +1660,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	# Expression to use when parsing in a context when no capture is desired
 	public $id_class_attr_nocatch_re = '\{(?:[ ]*[#.][-_:a-zA-Z0-9]+){1,}[ ]*\}';
 
-	function doExtraAttributes($tag_name, $attr) {
+	function doExtraAttributes($tag_name, &$attr) {
 	#
 	# Parse attributes caught by the $this->id_class_attr_catch_re expression
 	# and return the HTML-formatted list of attributes.
@@ -1736,7 +1736,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 		$url = $matches[2] == '' ? $matches[3] : $matches[2];
 		$this->urls[$link_id] = $url;
 		$this->titles[$link_id] =& $matches[4];
-		$this->ref_attr[$link_id] = $this->doExtraAttributes("", $dummy =& $matches[5]);
+		$this->ref_attr[$link_id] = $this->doExtraAttributes("", $matches[5]);
 		return ''; # String that will replace the block
 	}
 
@@ -2326,7 +2326,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 		$link_text		=  $this->runSpanGamut($matches[2]);
 		$url			=  $matches[3] == '' ? $matches[4] : $matches[3];
 		$title			=& $matches[7];
-		$attr  = $this->doExtraAttributes("a", $dummy =& $matches[8]);
+		$attr  = $this->doExtraAttributes("a", $matches[8]);
 
 
 		$url = $this->encodeAttribute($url);
@@ -2436,7 +2436,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 		$alt_text		= $matches[2];
 		$url			= $matches[3] == '' ? $matches[4] : $matches[3];
 		$title			=& $matches[7];
-		$attr  = $this->doExtraAttributes("img", $dummy =& $matches[8]);
+		$attr  = $this->doExtraAttributes("img", $matches[8]);
 
 		$alt_text = $this->encodeAttribute($alt_text);
 		$url = $this->encodeAttribute($url);
@@ -2496,13 +2496,13 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 		if ($matches[3] == '-' && preg_match('{^- }', $matches[1]))
 			return $matches[0];
 		$level = $matches[3]{0} == '=' ? 1 : 2;
-		$attr  = $this->doExtraAttributes("h$level", $dummy =& $matches[2]);
+		$attr  = $this->doExtraAttributes("h$level", $matches[2]);
 		$block = "<h$level$attr>".$this->runSpanGamut($matches[1])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
 	function _doHeaders_callback_atx($matches) {
 		$level = strlen($matches[1]);
-		$attr  = $this->doExtraAttributes("h$level", $dummy =& $matches[3]);
+		$attr  = $this->doExtraAttributes("h$level", $matches[3]);
 		$block = "<h$level$attr>".$this->runSpanGamut($matches[2])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}


### PR DESCRIPTION
Fixes call-time-pass-by-reference errors for PHP 5.4 compatibility.
#### Changes proposed in this Pull Request:

When running `phpcs --standard=PHPCompatibility --extensions=php --runtime-set testVersion 5.5 wp-content/plugins/jetpack` on jetpack, I received the following report:

```
FILE: ...docs/mavs/wp-content/plugins/jetpack/_inc/lib/markdown/extra.php
----------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 5 LINES
----------------------------------------------------------------------
 1739 | ERROR | Using a call-time pass-by-reference is prohibited      |       | since php 5.4
 2329 | ERROR | Using a call-time pass-by-reference is prohibited      |       | since php 5.4
 2439 | ERROR | Using a call-time pass-by-reference is prohibited      |       | since php 5.4
 2499 | ERROR | Using a call-time pass-by-reference is prohibited      |       | since php 5.4
 2505 | ERROR | Using a call-time pass-by-reference is prohibited      |       | since php 5.4
---------------------------------------------------------------------- 
```

I've fixed the errors by defining the referenced variable in the function definition rather than at call time.
