### PR TITLE
Notices: update propname for dismissing notices

### DIFF
--- a/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
+++ b/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
@@ -27,7 +27,7 @@ const FeedbackDashRequest = React.createClass( {
 				<SimpleNotice
 					className="jp-dash-item__feedback-request"
 					status="is-basic"
-					onClick={ this.props.dismissNotice }
+					onDismissClick={ this.props.dismissNotice }
 				>
 				{
 					__( 'What would you like to see on your Jetpack Dashboard? {{a}}Let us know!{{/a}}', {

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -71,7 +71,7 @@ export const WelcomeNotice = React.createClass( {
 			<div>
 				<SimpleNotice
 					status="is-info"
-					onClick={ this.dismissWelcomeNotice }
+					onDismissClick={ this.dismissWelcomeNotice }
 				>
 					{ this.getWelcomeMessageText() }
 				</SimpleNotice>

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -220,7 +220,7 @@ const JetpackStateNotices = React.createClass( {
 		return (
 			<SimpleNotice
 				status={ status }
-				onClick={ this.dismissJetpackStateNotice }
+				onDismissClick={ this.dismissJetpackStateNotice }
 			>
 				{ noticeText }
 			</SimpleNotice>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Changes the propname for dismissing notices function 

Propname was changed in https://github.com/Automattic/dops-components/pull/32

You should be able to dismiss the feedback request in the Dashboard as well as the "connected" notice you get immediately after connecting.  