### PR TITLE
Move spawn_cron to full sync, sync full on plugin upgrade

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4406,6 +4406,10 @@ p {
 	public static function maybe_set_version_option() {
 		list( $version ) = explode( ':', Jetpack_Options::get_option( 'version' ) );
 		if ( JETPACK__VERSION != $version ) {
+			if ( version_compare( JETPACK__VERSION, $version, '>' ) ) {
+				do_action( 'updating_jetpack_version', JETPACK__VERSION, $version );
+			}
+
 			Jetpack_Options::update_option( 'version', JETPACK__VERSION . ':' . time() );
 			return true;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4406,11 +4406,12 @@ p {
 	public static function maybe_set_version_option() {
 		list( $version ) = explode( ':', Jetpack_Options::get_option( 'version' ) );
 		if ( JETPACK__VERSION != $version ) {
+			Jetpack_Options::update_option( 'version', JETPACK__VERSION . ':' . time() );
+
 			if ( version_compare( JETPACK__VERSION, $version, '>' ) ) {
 				do_action( 'updating_jetpack_version', JETPACK__VERSION, $version );
 			}
-
-			Jetpack_Options::update_option( 'version', JETPACK__VERSION . ':' . time() );
+			
 			return true;
 		}
 		return false;

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -30,7 +30,6 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 		}
 
 		Jetpack_Sync_Actions::schedule_full_sync( $modules );
-		spawn_cron();
 
 		return array( 'scheduled' => true );
 	}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -14,7 +14,7 @@ class Jetpack_Sync_Actions {
 
 		// On jetpack authorization, schedule a full sync
 		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ) );
-		add_action( 'updating_jetpack_version', array( __CLASS__, 'schedule_full_sync' ) );
+		add_action( 'updating_jetpack_version', array( __CLASS__, 'schedule_initial_sync' ) );
 		
 		// Sync connected user role changes to .com
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
@@ -114,6 +114,10 @@ class Jetpack_Sync_Actions {
 		}
 
 		return $rpc->getResponse();
+	}
+
+	static function schedule_initial_sync() {
+		self::schedule_full_sync( array( 'options', 'network_options', 'functions', 'constants' ) );
 	}
 
 	static function schedule_full_sync( $modules = null ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -164,6 +164,6 @@ class Jetpack_Sync_Actions {
 }
 
 // Allow other plugins to add filters before we initialize the actions.
-add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 1, 0 );
+add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 11, 0 );
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'schedule_initial_sync' ), 10 );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -14,7 +14,8 @@ class Jetpack_Sync_Actions {
 
 		// On jetpack authorization, schedule a full sync
 		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ) );
-
+		add_action( 'updating_jetpack_version', array( __CLASS__, 'schedule_full_sync' ) );
+		
 		// Sync connected user role changes to .com
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
 
@@ -117,6 +118,7 @@ class Jetpack_Sync_Actions {
 
 	static function schedule_full_sync( $modules = null ) {
 		wp_schedule_single_event( time() + 1, 'jetpack_sync_full', array( $modules ) );
+		spawn_cron();
 	}
 
 	static function do_full_sync( $modules = null ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -14,7 +14,6 @@ class Jetpack_Sync_Actions {
 
 		// On jetpack authorization, schedule a full sync
 		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ) );
-		add_action( 'updating_jetpack_version', array( __CLASS__, 'schedule_initial_sync' ) );
 		
 		// Sync connected user role changes to .com
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
@@ -117,6 +116,9 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function schedule_initial_sync() {
+		// we need this function call here because we have to run this function 
+		// reeeeally early in init, before WP_CRON_LOCK_TIMEOUT is defined.
+		wp_functionality_constants();
 		self::schedule_full_sync( array( 'options', 'network_options', 'functions', 'constants' ) );
 	}
 
@@ -162,4 +164,6 @@ class Jetpack_Sync_Actions {
 }
 
 // Allow other plugins to add filters before we initialize the actions.
-add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 11, 0 );
+add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 1, 0 );
+// We need to define this here so that it's hooked before `updating_jetpack_version` is called
+add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'schedule_initial_sync' ), 10 );

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -117,4 +117,11 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_publicize_post' );
 		$this->assertEquals( $post_id, $event->args[0] );
 	}
+
+	function test_upgrading_sends_options_constants_and_callables() {
+		do_action( 'updating_jetpack_version', '4.1', '4.2' );
+
+		$modules = array( 'options', 'network_options', 'functions', 'constants' );
+		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( $modules ) ) > time()-5 );
+	}
 }


### PR DESCRIPTION
Fixes issues with jetpack version not getting synced before user hits Calypso sync UI.

We sync options, callables and constants on version upgrade.

This PR also, out of necessity, fires the `updating_jetpack_version` hook in at least one additional place, because it wasn't firing consistently before. This may affect other aspects of Jetpack's initialization behaviour and should be tested carefully.

cc @lezama @ebinnion 