### PR TITLE
Admin Page: define fallback path when no route matches

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -59,6 +59,7 @@ function render() {
 					<Route path='/security' name={ i18n.translate( 'Security', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/appearance' name={ i18n.translate( 'Appearance', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/writing' name={ i18n.translate( 'Writing', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path="*" />
 				</Router>
 			</Provider>
 		</div>,


### PR DESCRIPTION
Fixes #4436

#### Changes proposed in this Pull Request:

- if there are hashes that make the page scroll/jump, allow them to do so without throwing a warning by defining a fallback path when no route matches.

#### Testing

Can be tested for example with the Query Monitor plugin. Before this PR, clicking its buttons in Admin Bar scrolls the page down but throws warnings in JS console. After applying this PR, the page scrolls as usual but no warnings are issued.