### PR TITLE
Admin Page Add stats module settings handling in Admin Page

### DIFF
--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -14,6 +14,8 @@ import {
 	regeneratePostByEmailAddress
 } from 'state/modules';
 
+import { getSiteRoles } from 'state/initial-state';
+
 /**
  * High order component that connects to Jetpack modules'options
  * redux state selectors and action creators.
@@ -30,6 +32,7 @@ export function connectModuleOptions( Component ) {
 				getOptionCurrentValue: ( module_name, option_name ) => getModuleOption( state, module_name, option_name ),
 				enabled: getModuleOption( state, ownProps.module.module, ownProps.option_name ),
 				getModuleOption: ( module_slug ) => getModuleOption( state, module_slug, module_name ),
+				getSiteRoles: () => getSiteRoles( state ),
 				isToggling: false,
 				isUpdating: ( option_name ) => isUpdatingModuleOption( state, ownProps.module.module, option_name )
 			}

--- a/_inc/client/components/module-settings/form-components.jsx
+++ b/_inc/client/components/module-settings/form-components.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-
+import concat from 'lodash/concat';
+import without from 'lodash/without';
 /**
  * Internal dependencies
  */
@@ -54,3 +55,34 @@ export const ModuleSettingRadios = React.createClass( {
 	}
 } );
 
+export const ModuleSettingMultipleSelectCheckboxes = React.createClass( {
+	onOptionChange( event ) {
+		const justUpdated = event.target.value;
+		const currentValue = this.props.getOptionValue( this.props.name );
+		const newValue = currentValue.indexOf( justUpdated ) === -1 ?
+			concat( currentValue, justUpdated ) :
+			without( currentValue, justUpdated );
+		this.props.updateFormStateOptionValue( this.props.name, newValue );
+	},
+	render() {
+		let props = this.props;
+		let validValues = this.props.validValues;
+		return (
+			<div>
+				{
+				Object.keys( validValues ).map( ( key ) => (
+					<FormLabel key={ `option-${ props.option_name }-${key}` } >
+						<FormCheckbox
+							name={ props.name }
+							checked= { props.getOptionValue( props.name ).indexOf( key ) !== -1 }
+							value={ key }
+							disabled={ props.isUpdating( props.name ) }
+							onChange= { this.onOptionChange } />
+						<span>{ ( validValues[ key ].name ) }</span>
+					</FormLabel>
+				) )
+				}
+			</div>
+		);
+	}
+} );

--- a/_inc/client/components/module-settings/form-components.jsx
+++ b/_inc/client/components/module-settings/form-components.jsx
@@ -10,8 +10,7 @@ import without from 'lodash/without';
  import {
 	FormLabel,
 	FormCheckbox,
-	FormRadio,
-	FormTextInput
+	FormRadio
  } from 'components/forms';
 
 export const ModuleSettingCheckbox = React.createClass( {
@@ -56,6 +55,11 @@ export const ModuleSettingRadios = React.createClass( {
 } );
 
 export const ModuleSettingMultipleSelectCheckboxes = React.createClass( {
+	getDefaultProps() {
+		return {
+			always_checked: []
+		}
+	},
 	onOptionChange( event ) {
 		const justUpdated = event.target.value;
 		const currentValue = this.props.getOptionValue( this.props.name );
@@ -63,6 +67,17 @@ export const ModuleSettingMultipleSelectCheckboxes = React.createClass( {
 			concat( currentValue, justUpdated ) :
 			without( currentValue, justUpdated );
 		this.props.updateFormStateOptionValue( this.props.name, newValue );
+	},
+	isAlwaysChecked( key ) {
+		return this.props.always_checked.indexOf( key ) !== -1;
+	},
+	shouldBeChecked( key ) {
+		return this.isAlwaysChecked( key ) ||
+			this.props.getOptionValue( this.props.name ).indexOf( key ) !== -1;
+	},
+	shouldBeDisabled( key ) {
+		return this.isAlwaysChecked( key ) ||
+			this.props.isUpdating( this.props.name );
 	},
 	render() {
 		let props = this.props;
@@ -74,9 +89,9 @@ export const ModuleSettingMultipleSelectCheckboxes = React.createClass( {
 					<FormLabel key={ `option-${ props.option_name }-${key}` } >
 						<FormCheckbox
 							name={ props.name }
-							checked= { props.getOptionValue( props.name ).indexOf( key ) !== -1 }
+							checked= { this.shouldBeChecked( key ) }
 							value={ key }
-							disabled={ props.isUpdating( props.name ) }
+							disabled={ this.shouldBeDisabled( key ) }
 							onChange= { this.onOptionChange } />
 						<span>{ ( validValues[ key ].name ) }</span>
 					</FormLabel>

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -22,7 +22,8 @@ import {
 
 import {
 	ModuleSettingRadios,
-	ModuleSettingCheckbox
+	ModuleSettingCheckbox,
+	ModuleSettingMultipleSelectCheckboxes
 } from 'components/module-settings/form-components';
 
 import { ModuleSettingsForm } from 'components/module-settings/module-settings-form';
@@ -133,62 +134,30 @@ export let StatsSettings = React.createClass( {
 				<FormFieldset>
 					<FormLegend>{ __( 'Admin Bar' ) }</FormLegend>
 					<ModuleSettingCheckbox
-						name={ 'option_name' }
+						name={ 'admin_bar' }
 						{ ...this.props }
 						label={ __( 'Put a chart showing 48 hours of views in the admin bar' ) } />
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ __( 'Smiley' ) }</FormLegend>
 					<ModuleSettingCheckbox
-						name={ 'option_name' }
+						name={ 'hide_smile' }
 						{ ...this.props }
 						label={ __( 'Hide the stats smiley face image' ) } />
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
+					<ModuleSettingMultipleSelectCheckboxes
+						name={ 'count_roles' }
 						{ ...this.props }
-						label={ __( 'Administrator' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Editor' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Author' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Contributor' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Subscriber' ) } />
+						validValues={ this.props.getSiteRoles() } />
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Administrator' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Editor' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Author' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Contributor' ) } />
-					<ModuleSettingCheckbox
-						name={ 'option_name' }
-						{ ...this.props }
-						label={ __( 'Subscriber' ) } />
+						<ModuleSettingMultipleSelectCheckboxes
+							name={ 'roles' }
+							{ ...this.props }
+							validValues={ this.props.getSiteRoles() } />
 				</FormFieldset>
 				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -155,6 +155,7 @@ export let StatsSettings = React.createClass( {
 				<FormFieldset>
 					<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
 						<ModuleSettingMultipleSelectCheckboxes
+							always_checked={ [ 'administrator' ] }
 							name={ 'roles' }
 							{ ...this.props }
 							validValues={ this.props.getSiteRoles() } />

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -28,6 +28,9 @@ export function ModuleSettingsForm( InnerComponent ) {
 				optionValue = event.target.value;
 			}
 
+			this.updateFormStateOptionValue( optionName, optionValue );
+		},
+		updateFormStateOptionValue( optionName, optionValue ) {
 			const newOptions = {
 				...this.state.options,
 				[ optionName ]: optionValue
@@ -54,6 +57,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 					getOptionValue={ this.getOptionValue }
 					onSubmit={ this.onSubmit }
 					onOptionChange={ this.onOptionChange }
+					updateFormStateOptionValue={ this.updateFormStateOptionValue }
 					isDirty={ this.isDirty }
 					{ ...this.props } />
 			);

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import assign from 'lodash/assign';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -17,3 +18,8 @@ export const initialState = ( state = window.Initial_State, action ) => {
 			return state;
 	}
 };
+
+export function getSiteRoles( state ) {
+	const roles = get( state.jetpack.initialState.stats, 'roles', {} );
+	return roles;
+}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1908,6 +1908,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 						'type'              => 'array',
 						'default'           => array( 'administrator' ),
 						'validate_callback' => __CLASS__ . '::validate_stats_roles',
+						'sanitize_callback' => __CLASS__ . '::sanitize_stats_allowed_roles',
 					),
 					'count_roles' => array(
 						'description'       => esc_html__( 'Count the page views of registered users who are logged in.', 'jetpack' ),
@@ -2223,6 +2224,23 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be a string.', 'jetpack' ), $param ) );
 		}
 		return true;
+	}
+
+	/**
+	 * If for some reason the roles allowed to see Stats are empty (for example, user tampering with checkboxes),
+	 * return an array with only 'administrator' as the allowed role and save it for 'roles' option.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string|bool $value Value to check.
+	 *
+	 * @return bool
+	 */
+	public static function sanitize_stats_allowed_roles( $value ) {
+		if ( empty( $value ) ) {
+			return array( 'administrator' );
+		}
+		return $value;
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2065,7 +2065,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool
 	 */
 	public static function validate_stats_roles( $value, $request, $param ) {
-		if ( ! array_intersect( self::$stats_roles, $value ) ) {
+		if ( ! empty( $value ) && ! array_intersect( self::$stats_roles, $value ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be %s.', 'jetpack' ), $param, join( ', ', self::$stats_roles ) ) );
 		}
 		return true;


### PR DESCRIPTION
Fixes #featureset .

#### Changes proposed in this Pull Request:

Adds correct Settings handling for the **Site Stats** module under the **Engagement** tab

#### Testing instructions:

1. Get to the **Site Stats** setings under the **Engagement** tab. 
1. Toggle the **Put a chart showing 48 hours of views in the admin bar** option
1. Save and reload the page
1. Check that the change persisted
1. Toggle the **Editor** Role on both role-related options
1. Save and reload the page
1. Check that the change persisted

