### PR TITLE
Fix: twitter cards site tag

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -77,7 +77,7 @@ class Jetpack_Sync_Defaults {
 		'disabled_reblogs',
 		'jetpack_comment_likes_enabled',
 		'twitter_via',
-		'twitter-cards-site-tag',
+		'jetpack-twitter-cards-site-tag',
 		'wpcom_publish_posts_with_markdown',
 		'wpcom_publish_comments_with_markdown',
 		'jetpack_activated',

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -134,7 +134,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'disabled_reblogs'                     => 'pineapple',
 			'jetpack_comment_likes_enabled'        => 'pineapple',
 			'twitter_via'                          => 'pineapple',
-			'twitter-cards-site-tag'               => 'pineapple',
+			'jetpack-twitter-cards-site-tag'       => 'pineapple',
 			'wpcom_publish_posts_with_markdown'    => 'pineapple',
 			'wpcom_publish_comments_with_markdown' => 'pineapple',
 			'jetpack_activated'                    => 'pineapple',


### PR DESCRIPTION
Type fix, option name is actually `jetpack-twitter-cards-site-tag` and not `twitter-cards-site-tag`

#### Testing instructions:
To test: 
Go to `wp-admin/options-general.php?page=sharing` 
and click update the setting make sure that this data is synced to .com
