### PR TITLE
Fix/only send publicize even if connected to service

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -426,15 +426,17 @@ class Publicize extends Publicize_Base {
 	function save_publicized( $post_ID, $post, $update ) {
 		// Only do this when a post transitions to being published
 		if ( get_post_meta( $post->ID, $this->PENDING ) ) {
-
-			/**
-			 * Fires when a post is saved that has is marked as pending publicizing
-			 *
-			 * @since 4.1.0
-			 *
-			 * @param int The post ID
-			 */
-			do_action( 'jetpack_publicize_post', $post->ID );
+			$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
+			if ( ! empty( $connected_services ) ) {
+				/**
+				 * Fires when a post is saved that has is marked as pending publicizing
+				 *
+				 * @since 4.1.0
+				 *
+				 * @param int The post ID
+				 */
+				do_action( 'jetpack_publicize_post', $post->ID );
+			}
 			delete_post_meta( $post->ID, $this->PENDING );
 			update_post_meta( $post->ID, $this->POST_DONE . 'all', true );
 		}

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -17,6 +17,8 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
 		$this->post = get_post( $post_id );
 
+		Jetpack_Options::update_options( array( 'publicize_connections' => array( 'not_empty' ) ) );
+
 		add_action( 'jetpack_publicize_post', array( $this, 'publicized_post' ), 10, 1 );
 	}
 
@@ -26,6 +28,15 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		wp_insert_post( $this->post->to_array() );
 
 		$this->assertPublicized( true, $this->post );
+	}
+
+	public function test_does_not_fire_jetpack_publicize_post_on_save_as_published() {
+		$this->post->post_status = 'publish';
+
+		Jetpack_Options::delete_option( array( 'publicize_connections' ) );
+		wp_insert_post( $this->post->to_array() );
+
+		$this->assertPublicized( false, $this->post );
 	}
 
 	public function test_does_not_fire_jetpack_publicize_post_on_other_status_transitions() {


### PR DESCRIPTION
We shouldn't send a publicize event to .com if we don't have any connections.

#### Testing instructions:
`phpunit --filter=WP_Test_Publicize`
