### PR TITLE
My Jetpack: fix notice when user_options is not set.

### DIFF
--- a/views/admin/my-jetpack-page.php
+++ b/views/admin/my-jetpack-page.php
@@ -106,6 +106,7 @@
 									<?php
 									$all_users = get_users();
 
+									$user_options = '';
 									foreach ( $all_users as $user ) {
 										if ( Jetpack::is_user_connected( $user->ID ) && $user->caps['administrator'] ) {
 											if ( $user->ID == Jetpack_Options::get_option( 'master_user' ) ) {


### PR DESCRIPTION
A notice would appear when visiting the My Jetpack page:
`PHP Notice:  Undefined variable: user_options in /wp-content/plugins/jetpack/views/admin/my-jetpack-page.php on line 114`