### PR TITLE
Jetpack Options: ensure autoload is set for the specified option

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -124,12 +124,14 @@ class Jetpack_Options {
 	 *
 	 * @param string $name Option name
 	 * @param mixed $default (optional)
+	 *
+	 * @return mixed|void
 	 */
 	public static function get_option_and_ensure_autoload( $name, $default ) {
 		$value = get_option( $name );
 		
 		if ( $value === false && $default !== false ) {
-			update_option( $name, $default, null, true );
+			update_option( $name, $default );
 			$value = $default;
 		}
 


### PR DESCRIPTION
Follow up to #4281.

The function `update_option` only accepts 3 parameters at most.

The method `get_option_and_ensure_autoload` will only attempt to set autoload if the option didn't exist before.

#### Changes proposed in this Pull Request:
So, since the option doesn't have to exist for `update_option` to be called in `get_option_and_ensure_autoload` then we can pass only the first two params. Since it's a new option, leaving `autoload` parameter to its `null` default is [enough to make them autoload](https://github.com/WordPress/WordPress/blob/master/wp-includes/option.php#L299).


