### PR TITLE
Set subs email blocking meta as an int, not a string

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -81,7 +81,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
 		$post->permalink               = get_permalink( $post->ID );
 		$post->shortlink               = wp_get_shortlink( $post->ID );
-		$post->dont_email_post_to_subs = get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true );
+		$post->dont_email_post_to_subs = intval( get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) );
 
 		return $post;
 	}


### PR DESCRIPTION
Fixes an issue where jetpack filters weren't blocking emails to certain categories.