### PR TITLE
Dashboard: fixed background of sidebar item at tablet widths

### DIFF
--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -17,7 +17,7 @@
 	padding-left: 0;
 }
 
-.toplevel_page_jetpack {
+.wp-admin.toplevel_page_jetpack {
 	background-color: $gray-light;
 	line-height: 1.4; // fixes core bug that sets an em unit on body
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* increased specificity of background target since the class is reused on the sidebar item and `body` for some reason

#### Testing instructions:
-resize window until the sidebar collapses

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/16993094/9a7fb38a-4e67-11e6-8e10-e406e48c7491.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/16993078/87174560-4e67-11e6-8755-73dcbd62c861.png)


CC @jeffgolenski for quick review