### PR TITLE
AAG Plugins: Conditionally show toggle/active text

### DIFF
--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -78,7 +78,7 @@ const DashPluginUpdates = React.createClass( {
 							isDevMode( this.props ) ? '' :
 							manageActive ?
 								__( '{{a}}Turn on plugin auto updates{{/a}}', { components: { a: <a href={ ctaLink } /> } } ):
-								__( '{{a}}Activate Manage and turn on auto updates{{/a}}', { components: { a: <a onClick={ this.activateAndRedirect } href="#" /> } } )
+								__( '{{a}}Activate Manage and turn on auto updates{{/a}}', { components: { a: <a onClick={ this.activateAndRedirect } href="javascript:void(0)" /> } } )
 						}
 					</p>
 				</DashItem>
@@ -89,10 +89,14 @@ const DashPluginUpdates = React.createClass( {
 			<DashItem
 				label={ labelName }
 				module="manage"
-				status="is-working"
+				status={ manageActive ? 'is-working' : 'is-inactive' }
 			>
 				<p className="jp-dash-item__description">
-					{ __( 'All plugins are up-to-date. Keep up the good work!' ) }
+					{
+						manageActive ?
+							__( 'All plugins are up-to-date. Keep up the good work!' ) :
+							__( '{{a}}Activate Manage{{/a}} to turn on auto updates and manage your plugins from WordPress.com.', { components: { a: <a onClick={ this.props.activateManage } href="javascript:void(0)" /> } } )
+					}
 				</p>
 			</DashItem>
 		);

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -115,16 +115,21 @@ const DashItem = React.createClass( {
 				/>
 			);
 
-			if ( 'manage' === this.props.module && 'is-warning' === this.props.status ) {
-				toggle = (
-					<SimpleNotice
-						showDismiss={ false }
-						status={ this.props.status }
-					    isCompact={ true }
-					>
-						{ __( 'Updates Needed' ) }
-					</SimpleNotice>
-				);
+			if ( 'manage' === this.props.module ) {
+				if ( 'is-warning' === this.props.status ) {
+					toggle = (
+						<SimpleNotice
+							showDismiss={ false }
+							status={ this.props.status }
+							isCompact={ true }
+						>
+							{ __( 'Updates Needed' ) }
+						</SimpleNotice>
+					);
+				}
+				if ( 'is-working' === this.props.status ) {
+					toggle = <span className="jp-dash-item__active-label">{ __( 'Active' ) }</span>
+				}
 			}
 		}
 


### PR DESCRIPTION
Before, when there are no plugins that need updating, the toggle would show regardless of status.  This change will replace the toggle with `ACTIVE` text if manage is active, and also change the text within the card.  

cc @jeffgolenski 

![plugincardmange](https://cloud.githubusercontent.com/assets/7129409/16995269/6a632724-4e79-11e6-934d-b89a44a651d9.gif)
