### PR TITLE
Admin Page: don't collapse the height until it's necessary

### DIFF
--- a/scss/jetpack-icons.scss
+++ b/scss/jetpack-icons.scss
@@ -35,7 +35,7 @@ li.toplevel_page_jetpack .wp-menu-image:before {
 	background: none !important;
 	background-repeat: no-repeat;
 }
-@media (max-width:900px) {
+@media (max-width:782px) {
 	.auto-fold #adminmenu a.toplevel_page_jetpack {
 		height: auto ;
 	}


### PR DESCRIPTION
Fixes #4458

In this way the WP menu item background is visible and arrow is aligned

Before
![image](https://cloud.githubusercontent.com/assets/1041600/16996367/6aac102a-4e87-11e6-86f6-3b2589367d59.png)

After
<img width="54" alt="menu" src="https://cloud.githubusercontent.com/assets/1041600/16996378/7b642ac4-4e87-11e6-9809-1a8b6a79c0c4.png">
