### PR TITLE
Fix: Make sure that _jetpack_dont_email_post_to_subs is always set correctly

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -81,7 +81,9 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
 		$post->permalink               = get_permalink( $post->ID );
 		$post->shortlink               = wp_get_shortlink( $post->ID );
-		$post->dont_email_post_to_subs = get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true );
+		$post->dont_email_post_to_subs = Jetpack::is_module_active( 'subscriptions' ) ?
+				get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) :
+				true; // Don't email subscription if the subscription module is not active.
 
 		return $post;
 	}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -345,6 +345,23 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( true, $post_on_server->dont_email_post_to_subs );
 	}
 
+	function test_sync_post_includes_dont_email_post_to_subs_when_subscription_is_not_active() {
+		$active_modules = Jetpack::get_active_modules();
+		Jetpack_Options::update_option( 'active_modules', array() );
+		// Subscription is not an active module
+		$this->assertTrue( ! in_array( 'subscriptions', Jetpack::get_active_modules() ) );
+		$post_id = $this->factory->post->create();
+
+		$this->sender->do_sync();
+
+		$post_on_server = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->args[1];
+
+		$this->assertEquals( true, $post_on_server->dont_email_post_to_subs );
+
+		Jetpack_Options::update_option( 'active_modules', $active_modules );
+	}
+
+
 	function test_sync_post_jetpack_sync_prevent_sending_post_data_filter() {
 
 		add_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );


### PR DESCRIPTION
Send the `_jetpack_dont_email_post_to_subs` as true if we don't have the module enabled.
This makes sure that the correct data is sent to .com