### PR TITLE
Admin Page - AAG: don't show button to activate Stats in Dev mode

### DIFF
--- a/_inc/client/at-a-glance/stats.jsx
+++ b/_inc/client/at-a-glance/stats.jsx
@@ -146,14 +146,18 @@ const DashStats = React.createClass( {
 							} )
 						}
 					</div>
-					<div className="jp-at-a-glance__stats-inactive-button">
-						<Button
-							onClick={ this.props.activateStats }
-							primary={ true }
-						>
-							{ __( 'Activate Site Statistics' ) }
-						</Button>
-					</div>
+						{
+							isDevMode( this.props ) ? '' : (
+								<div className="jp-at-a-glance__stats-inactive-button">
+									<Button
+										onClick={ this.props.activateStats }
+										primary={ true }
+									>
+										{ __( 'Activate Site Statistics' ) }
+									</Button>
+								</div>
+							)
+						}
 				</div>
 			);
 		}


### PR DESCRIPTION
Fixes #4462 

Previously, even if site was in Dev mode, the Activate Site Statistics button was visible and clicking it had no effect:
<img width="741" alt="stats1" src="https://cloud.githubusercontent.com/assets/1041600/16996928/b5ef6544-4e89-11e6-8a56-4b45716f5d13.png">

#### Changes proposed in this Pull Request:
This PR solves this so If site is in Dev mode, the Activate Site Statistics button is not displayed:
<img width="737" alt="stats2" src="https://cloud.githubusercontent.com/assets/1041600/16996912/a3faebd8-4e89-11e6-830a-4fd37b9b1ff5.png">

#### Testing instructions:
1. put your site is in Dev Mode
2. go to Jetpack screen
The button shouldn't be visible.