### PR TITLE
Fixed broken side nav arrow location at certain widths

### DIFF
--- a/scss/jetpack-icons.scss
+++ b/scss/jetpack-icons.scss
@@ -20,9 +20,6 @@
 	}
 }
 
-// .jetpack-icon-20:before { content: "\f102"; }
-
-
 li.toplevel_page_jetpack .wp-menu-image:before {
 	font-family: 'jetpack' !important;
 	content: '\f102';
@@ -35,12 +32,3 @@ li.toplevel_page_jetpack .wp-menu-image:before {
 	background: none !important;
 	background-repeat: no-repeat;
 }
-@media (max-width:900px) {
-	.auto-fold #adminmenu a.toplevel_page_jetpack {
-		height: auto ;
-	}
-}
-
-// ==========================================================================
-// Protect Widget Icons
-// ==========================================================================


### PR DESCRIPTION
Fixes #4458

#### Changes proposed in this Pull Request:
Removed old CSS that was causing the box to collapse and the arrow to look funky.

#### Testing instructions:
-resize window to various sizes

After:
![image](https://cloud.githubusercontent.com/assets/1123119/16998416/f1511ff2-4e7e-11e6-8689-01eca519fc99.png)

CC @jeffgolenski for quick review


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

