### PR TITLE
Enhancing Plans Landing Pages

### DIFF
--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -36,7 +36,7 @@ export const Plans = React.createClass( {
 		return (
 			<div>
 				<QuerySite />
-				<div className="jp-jetpack-landing__plans jp-jetpack-landing__container">
+				<div className="jp-jetpack-landing__plans dops-card">
 					<PlanHeader plan={ sitePlan } />
 					<PlanBody plan={ sitePlan } />
 				</div>

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -36,7 +36,7 @@ export const Plans = React.createClass( {
 		return (
 			<div>
 				<QuerySite />
-				<div className="jp-jetpack-landing__plans dops-card">
+				<div className="jp-landing__plans dops-card">
 					<PlanHeader plan={ sitePlan } />
 					<PlanBody plan={ sitePlan } />
 				</div>

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -61,8 +61,8 @@ const PlanBody = React.createClass( {
 			case 'dev':
 				planCard = (
 					<div className="jp-jetpack-landing__plan-features">
-						<h3>{ __( 'Maximum grade security' ) }</h3>
-						<p>{ __( 'Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense, and brute-force login protection - all in one place and optimized for WordPress.' ) }</p>
+						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Maximum grade security' ) }</h3>
+						<p>{ __( 'Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense and brute-force login protection - all in one place and optimized for WordPress.' ) }</p>
 
 						<h3>{ __( 'Lock out the bad guys' ) }</h3>
 						<p>{ __( 'Bulletproof spam filtering protects your brand and your readers, and improves SEO. Brute force login protection helps maintain peace of mind and keeps your backend safe from intruders.' ) }</p>

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -21,8 +21,8 @@ const PlanBody = React.createClass( {
 				let needMore = '';
 				if ( [ 'jetpack_premium', 'jetpack_premium_monthly' ].includes( this.props.plan ) ) {
 					needMore = (
-						<div className="jp-jetpack-landing__plan-features-card">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Need more?' ) }</h3>
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Need more?' ) }</h3>
 							<p>{ __( 'Jetpack Professional offers more features.' ) }</p>
 							<p>
 								<Button href={ 'https://wordpress.com/plans/compare/' + window.Initial_State.rawUrl }>
@@ -36,17 +36,17 @@ const PlanBody = React.createClass( {
 					)
 				}
 				planCard = (
-					<div className="jp-jetpack-landing__plan-features">
-						<div className="jp-jetpack-landing__plan-features-card">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Jetpack Anti-spam' ) }</h3>
+					<div className="jp-landing__plan-features">
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Jetpack Anti-spam' ) }</h3>
 							<p>{ __( 'Bulletproof spam filtering help maintain peace of mind while you build and grow your site.' ) }</p>
 							<Button href={ window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config' } className="is-primary">
 								{ __( 'View your spam stats' ) }
 							</Button>
 						</div>
 
-						<div className="jp-jetpack-landing__plan-features-card">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Jetpack Security Scanning & Backups' ) }</h3>
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Jetpack Security Scanning & Backups' ) }</h3>
 							<p>{ __( 'Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense, and brute-force login protection - all in one place.' ) }</p>
 							<Button href={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } className="is-primary">
 								{ __( 'View your security dashboard' ) }
@@ -60,18 +60,18 @@ const PlanBody = React.createClass( {
 			case 'jetpack_free':
 			case 'dev':
 				planCard = (
-					<div className="jp-jetpack-landing__plan-features">
-						<div className="jp-jetpack-landing__plan-features-card">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Maximum grade security' ) }</h3>
+					<div className="jp-landing__plan-features">
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Maximum grade security' ) }</h3>
 							<p>{ __( 'Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense and brute-force login protection - all in one place and optimized for WordPress.' ) }</p>
 						</div>
-						<div className="jp-jetpack-landing__plan-features-card">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Lock out the bad guys' ) }</h3>
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Lock out the bad guys' ) }</h3>
 							<p>{ __( 'Bulletproof spam filtering protects your brand, your readers, and improves SEO. Brute force login protection helps maintain peace of mind and keeps your backend safe from intruders.' ) }</p>
 						</div>
 
-						<div className="jp-jetpack-landing__plan-features-card">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Enjoy priority support' ) }</h3>
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Enjoy priority support' ) }</h3>
 							<p>{ __( 'Need help? A Happiness Engineer can answer questions about your site, your account or how to do about anything.' ) }</p>
 						</div>
 					</div>

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -38,7 +38,7 @@ const PlanBody = React.createClass( {
 				planCard = (
 					<div className="jp-jetpack-landing__plan-features">
 						<div className="jp-jetpack-landing__plan-features-card">
-							<h3>{ __( 'Jetpack Anti-spam' ) }</h3>
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Jetpack Anti-spam' ) }</h3>
 							<p>{ __( 'Bulletproof spam filtering help maintain peace of mind while you build and grow your site.' ) }</p>
 							<Button href={ window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config' } className="is-primary">
 								{ __( 'View your spam stats' ) }
@@ -46,7 +46,7 @@ const PlanBody = React.createClass( {
 						</div>
 
 						<div className="jp-jetpack-landing__plan-features-card">
-							<h3>{ __( 'Jetpack Security Scanning & Backups' ) }</h3>
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Jetpack Security Scanning & Backups' ) }</h3>
 							<p>{ __( 'Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense, and brute-force login protection - all in one place.' ) }</p>
 							<Button href={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl } className="is-primary">
 								{ __( 'View your security dashboard' ) }

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -22,7 +22,7 @@ const PlanBody = React.createClass( {
 				if ( [ 'jetpack_premium', 'jetpack_premium_monthly' ].includes( this.props.plan ) ) {
 					needMore = (
 						<div className="jp-jetpack-landing__plan-features-card">
-							<h3>{ __( 'Need more?' ) }</h3>
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Need more?' ) }</h3>
 							<p>{ __( 'Jetpack Professional offers more features.' ) }</p>
 							<p>
 								<Button href={ 'https://wordpress.com/plans/compare/' + window.Initial_State.rawUrl }>
@@ -61,14 +61,19 @@ const PlanBody = React.createClass( {
 			case 'dev':
 				planCard = (
 					<div className="jp-jetpack-landing__plan-features">
-						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Maximum grade security' ) }</h3>
-						<p>{ __( 'Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense and brute-force login protection - all in one place and optimized for WordPress.' ) }</p>
+						<div className="jp-jetpack-landing__plan-features-card">
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Maximum grade security' ) }</h3>
+							<p>{ __( 'Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense and brute-force login protection - all in one place and optimized for WordPress.' ) }</p>
+						</div>
+						<div className="jp-jetpack-landing__plan-features-card">
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Lock out the bad guys' ) }</h3>
+							<p>{ __( 'Bulletproof spam filtering protects your brand, your readers, and improves SEO. Brute force login protection helps maintain peace of mind and keeps your backend safe from intruders.' ) }</p>
+						</div>
 
-						<h3>{ __( 'Lock out the bad guys' ) }</h3>
-						<p>{ __( 'Bulletproof spam filtering protects your brand and your readers, and improves SEO. Brute force login protection helps maintain peace of mind and keeps your backend safe from intruders.' ) }</p>
-
-						<h3>{ __( 'Enjoy priority support' ) }</h3>
-						<p>{ __( 'Need help? A Happiness Engineer can answer questions about your site, your account, or how to do about anything.' ) }</p>
+						<div className="jp-jetpack-landing__plan-features-card">
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Enjoy priority support' ) }</h3>
+							<p>{ __( 'Need help? A Happiness Engineer can answer questions about your site, your account or how to do about anything.' ) }</p>
+						</div>
 					</div>
 				);
 				break;

--- a/_inc/client/plans/plan-header.jsx
+++ b/_inc/client/plans/plan-header.jsx
@@ -47,9 +47,13 @@ const PlanHeader = React.createClass( {
 				);
 				planCard = (
 					<div className="jp-jetpack-landing__plan-card">
-						<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
-						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Free Jetpack Plan' ) }</h3>
-						<p className="jp-jetpack-landing__plan-features-text">{ __( 'Upgrade to Premium or Pro in order to unlock world class security, anti-spam tools, and priority support.' ) }</p>
+						<div className="jp-jetpack-landing__plan-card-img">
+							<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+						</div>
+						<div className="jp-jetpack-landing__plan-card-current">
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Free Jetpack Plan' ) }</h3>
+							<p className="jp-jetpack-landing__plan-features-text">{ __( 'Upgrade to Premium or Pro in order to unlock world class security, anti-spam tools, and priority support.' ) }</p>
+						</div>
 					</div>
 				);
 				break;
@@ -58,9 +62,13 @@ const PlanHeader = React.createClass( {
 			case 'jetpack_premium_monthly':
 				planCard = (
 					<div className="jp-jetpack-landing__plan-card">
-						<img src={ imagePath + '/plans/premium-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
-						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Premium Jetpack Plan' ) }</h3>
-						<p className="jp-jetpack-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the premium features included in your plan.' ) }</p>
+						<div className="jp-jetpack-landing__plan-card-img">
+							<img src={ imagePath + '/plans/premium-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+						</div>
+						<div className="jp-jetpack-landing__plan-card-current">
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Premium Jetpack Plan' ) }</h3>
+							<p className="jp-jetpack-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the premium features included in your plan.' ) }</p>
+						</div>
 					</div>
 				);
 				break;
@@ -69,9 +77,13 @@ const PlanHeader = React.createClass( {
 			case 'jetpack_business_monthly':
 				planCard = (
 					<div className="jp-jetpack-landing__plan-card">
-						<img src={ imagePath + '/plans/pro-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
-						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Professional Jetpack Plan' ) }</h3>
-						<p className="jp-jetpack-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the professional features included in your plan.' ) }</p>
+						<div className="jp-jetpack-landing__plan-card-img">
+							<img src={ imagePath + '/plans/pro-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+						</div>
+						<div className="jp-jetpack-landing__plan-card-current">
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Professional Jetpack Plan' ) }</h3>
+							<p className="jp-jetpack-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the professional features included in your plan.' ) }</p>
+						</div>
 					</div>
 				);
 				break;
@@ -79,9 +91,13 @@ const PlanHeader = React.createClass( {
 			case 'dev':
 				planCard = (
 					<div className="jp-jetpack-landing__plan-card">
-						<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
-						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on Development Mode' ) }</h3>
-						<p className="jp-jetpack-landing__plan-features-text">{ __( 'Once you connect, you can upgrade to Premium or Pro in order to unlock worldclass security, anti-spam tools, and priority support.' ) }</p>
+						<div className="jp-jetpack-landing__plan-card-img">
+							<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+						</div>
+						<div className="jp-jetpack-landing__plan-card-current">
+							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on Development Mode' ) }</h3>
+							<p className="jp-jetpack-landing__plan-features-text">{ __( 'Once you connect, you can upgrade to Premium or Pro in order to unlock worldclass security, anti-spam tools, and priority support.' ) }</p>
+						</div>
 					</div>
 				);
 				break;

--- a/_inc/client/plans/plan-header.jsx
+++ b/_inc/client/plans/plan-header.jsx
@@ -47,9 +47,9 @@ const PlanHeader = React.createClass( {
 				);
 				planCard = (
 					<div className="jp-jetpack-landing__plan-card">
-						<img src={ imagePath + '/plans/free-plan-icon.jpg' } />
-						<h3>{ __( 'Your site is on the Free Jetpack Plan' ) }</h3>
-						<p>{ __( 'Upgrade to Premium or Pro in order to unlock world class security, anti-spam tools, and priority support.' ) }</p>
+						<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Free Jetpack Plan' ) }</h3>
+						<p className="jp-jetpack-landing__plan-features-text">{ __( 'Upgrade to Premium or Pro in order to unlock world class security, anti-spam tools, and priority support.' ) }</p>
 					</div>
 				);
 				break;
@@ -58,9 +58,9 @@ const PlanHeader = React.createClass( {
 			case 'jetpack_premium_monthly':
 				planCard = (
 					<div className="jp-jetpack-landing__plan-card">
-						<img src={ imagePath + '/plans/premium-plan-icon.jpg' } />
-						<h3>{ __( 'Your site is on the Premium Jetpack Plan' ) }</h3>
-						<p>{ __( 'Unlock the full potential of your site with the premium features included in your plan.' ) }</p>
+						<img src={ imagePath + '/plans/premium-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Premium Jetpack Plan' ) }</h3>
+						<p className="jp-jetpack-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the premium features included in your plan.' ) }</p>
 					</div>
 				);
 				break;
@@ -69,9 +69,9 @@ const PlanHeader = React.createClass( {
 			case 'jetpack_business_monthly':
 				planCard = (
 					<div className="jp-jetpack-landing__plan-card">
-						<img src={ imagePath + '/plans/pro-plan-icon.jpg' } />
-						<h3>{ __( 'Your site is on the Professional Jetpack Plan' ) }</h3>
-						<p>{ __( 'Unlock the full potential of your site with the professional features included in your plan.' ) }</p>
+						<img src={ imagePath + '/plans/pro-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Professional Jetpack Plan' ) }</h3>
+						<p className="jp-jetpack-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the professional features included in your plan.' ) }</p>
 					</div>
 				);
 				break;
@@ -79,9 +79,9 @@ const PlanHeader = React.createClass( {
 			case 'dev':
 				planCard = (
 					<div className="jp-jetpack-landing__plan-card">
-						<img src={ imagePath + '/plans/free-plan-icon.jpg' } />
-						<h3>{ __( 'Your site is on Development Mode' ) }</h3>
-						<p>{ __( 'Once you connect, you can upgrade to Premium or Pro in order to unlock worldclass security, anti-spam tools, and priority support.' ) }</p>
+						<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+						<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on Development Mode' ) }</h3>
+						<p className="jp-jetpack-landing__plan-features-text">{ __( 'Once you connect, you can upgrade to Premium or Pro in order to unlock worldclass security, anti-spam tools, and priority support.' ) }</p>
 					</div>
 				);
 				break;

--- a/_inc/client/plans/plan-header.jsx
+++ b/_inc/client/plans/plan-header.jsx
@@ -17,20 +17,18 @@ const PlanHeader = React.createClass( {
 		switch ( this.props.plan ) {
 			case 'jetpack_free':
 				starrySky = (
-					<div className="jp-jetpack-landing__header">
-						<h2 className="jp-jetpack-landing__title">
+					<div className="jp-landing-plans__header">
+						<h2 className="jp-landing-plans__header-title">
 							{ __( 'World class security and publishing tools.' ) }
 						</h2>
-
-						<p className="jp-jetpack-landing__description">
-							{ __( 'Backup, protect, repair, and build a better website.' ) }
+						<p className="jp-landing-plans__header-description">
+							{ __( 'Backup, protect, repair and build a better website.' ) }
 						</p>
-
-						<div className="jp-jetpack-landing__img-text">
-							<div className="jp-jetpack-landing__column">
-								<h2>{ __( "Threats don't discriminate" ) }</h2>
-								<p>{ __( "Hackers, botnets, and spammers attack websites indiscriminately. Their goal is to attack everywhere and often. Our goal is to help you prepare by blocking these threats, and in worst-case-scenarios, we'll be here to help you restore your site to its former glory." ) }</p>
-								<p>
+						<div className="jp-landing-plans__header-img-container">
+							<div className="jp-landing-plans__header-col-left">
+								<h3 className="jp-landing-plans__header-subtitle">{ __( "Threats don't discriminate" ) }</h3>
+								<p className="jp-landing-plans__header-text">{ __( "Hackers, botnets and spammers attack websites indiscriminately. Their goal is to attack everywhere and often. Our goal is to help you prepare by blocking these threats, and in worst-case-scenarios we'll be here to help you restore your site to its former glory." ) }</p>
+								<p className="jp-landing-plans__header-btn-container">
 									<Button href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl }>
 										{ __( 'Compare Plans' ) }
 									</Button>
@@ -39,20 +37,20 @@ const PlanHeader = React.createClass( {
 									</Button>
 								</p>
 							</div>
-							<div className="jp-jetpack-landing__column">
-								<img src={ imagePath + '/plans/admin-lock2x.png' } />
+							<div className="jp-landing-plans__header-col-right">
+								<img src={ imagePath + '/plans/admin-lock2x.png' } className="jp-landing-plans__header-img" />
 							</div>
 						</div>
 					</div>
 				);
 				planCard = (
-					<div className="jp-jetpack-landing__plan-card">
-						<div className="jp-jetpack-landing__plan-card-img">
-							<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+					<div className="jp-landing__plan-card">
+						<div className="jp-landing__plan-card-img">
+							<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-landing__plan-icon" />
 						</div>
-						<div className="jp-jetpack-landing__plan-card-current">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Free Jetpack Plan' ) }</h3>
-							<p className="jp-jetpack-landing__plan-features-text">{ __( 'Upgrade to Premium or Pro in order to unlock world class security, anti-spam tools, and priority support.' ) }</p>
+						<div className="jp-landing__plan-card-current">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Your site is on the Free Jetpack Plan' ) }</h3>
+							<p className="jp-landing__plan-features-text">{ __( 'Upgrade to Premium or Pro in order to unlock world class security, anti-spam tools, and priority support.' ) }</p>
 						</div>
 					</div>
 				);
@@ -61,13 +59,13 @@ const PlanHeader = React.createClass( {
 			case 'jetpack_premium':
 			case 'jetpack_premium_monthly':
 				planCard = (
-					<div className="jp-jetpack-landing__plan-card">
-						<div className="jp-jetpack-landing__plan-card-img">
-							<img src={ imagePath + '/plans/premium-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+					<div className="jp-landing__plan-card">
+						<div className="jp-landing__plan-card-img">
+							<img src={ imagePath + '/plans/premium-plan-icon.jpg' } className="jp-landing__plan-icon" />
 						</div>
-						<div className="jp-jetpack-landing__plan-card-current">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Premium Jetpack Plan' ) }</h3>
-							<p className="jp-jetpack-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the premium features included in your plan.' ) }</p>
+						<div className="jp-landing__plan-card-current">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Your site is on the Premium Jetpack Plan' ) }</h3>
+							<p className="jp-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the premium features included in your plan.' ) }</p>
 						</div>
 					</div>
 				);
@@ -76,13 +74,13 @@ const PlanHeader = React.createClass( {
 			case 'jetpack_business':
 			case 'jetpack_business_monthly':
 				planCard = (
-					<div className="jp-jetpack-landing__plan-card">
-						<div className="jp-jetpack-landing__plan-card-img">
-							<img src={ imagePath + '/plans/pro-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+					<div className="jp-landing__plan-card">
+						<div className="jp-landing__plan-card-img">
+							<img src={ imagePath + '/plans/pro-plan-icon.jpg' } className="jp-landing__plan-icon" />
 						</div>
-						<div className="jp-jetpack-landing__plan-card-current">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on the Professional Jetpack Plan' ) }</h3>
-							<p className="jp-jetpack-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the professional features included in your plan.' ) }</p>
+						<div className="jp-landing__plan-card-current">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Your site is on the Professional Jetpack Plan' ) }</h3>
+							<p className="jp-landing__plan-features-text">{ __( 'Unlock the full potential of your site with the professional features included in your plan.' ) }</p>
 						</div>
 					</div>
 				);
@@ -90,13 +88,13 @@ const PlanHeader = React.createClass( {
 
 			case 'dev':
 				planCard = (
-					<div className="jp-jetpack-landing__plan-card">
-						<div className="jp-jetpack-landing__plan-card-img">
-							<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-jetpack-landing__plan-icon" />
+					<div className="jp-landing__plan-card">
+						<div className="jp-landing__plan-card-img">
+							<img src={ imagePath + '/plans/free-plan-icon.jpg' } className="jp-landing__plan-icon" />
 						</div>
-						<div className="jp-jetpack-landing__plan-card-current">
-							<h3 className="jp-jetpack-landing__plan-features-title">{ __( 'Your site is on Development Mode' ) }</h3>
-							<p className="jp-jetpack-landing__plan-features-text">{ __( 'Once you connect, you can upgrade to Premium or Pro in order to unlock worldclass security, anti-spam tools, and priority support.' ) }</p>
+						<div className="jp-landing__plan-card-current">
+							<h3 className="jp-landing__plan-features-title">{ __( 'Your site is on Development Mode' ) }</h3>
+							<p className="jp-landing__plan-features-text">{ __( 'Once you connect, you can upgrade to Premium or Pro in order to unlock worldclass security, anti-spam tools, and priority support.' ) }</p>
 						</div>
 					</div>
 				);

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -1,14 +1,117 @@
-.jp-jetpack-landing__plans {
+.jp-landing__plans.dops-card {
+	padding: 0;
+}
+
+.jp-landing-plans__header {
+	background: $gray-dark url( '../../images/jp-4/particles_bg-white.png' );
+
+	@include breakpoint( ">660px" ) {
+		padding: rem( 32px ) 0 0;
+	}
+
 	@include breakpoint( "<660px" ) {
-		padding: rem( 16px );
+		padding: rem( 32px );
+	}
+
+	.dops-button {
+		margin-right: 10px;
 	}
 }
 
-.jp-jetpack-landing__plan-features-card {
+.jp-landing-plans__header-img-container {
+	margin: rem( 32px ) 0 0;
+	overflow: hidden;
+
+	@include breakpoint( ">660px" ) {
+		display: flex;
+		flex-wrap: nowrap;
+		flex-direction: row;
+		align-items: center;
+		background: transparent url('../../images/jp-4/white-clouds.svg') 50% 100% no-repeat;
+		background-size: 110%; // safari bug
+		padding-bottom: rem( 64px );
+	}
+
+	@include breakpoint( "<660px" ) {
+		margin-bottom: 0;
+	}
+}
+
+.jp-landing-plans__header-img {
+	margin: 0 rem( -32px ) 0 rem( 32px );
+	max-width: 100%; // needs proper srcsets
+}
+
+.jp-landing-plans__header-col-left {
+	flex-basis: 60%;
+
+	@include breakpoint( ">660px" ) {
+		padding-left: rem( 32px );
+	}
+}
+
+.jp-landing-plans__header-col-right {
+	flex-basis: 40%;
+
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
+.jp-landing-plans__header-title, 
+.jp-landing-plans__header-description {
+	line-height: 1.5;
+
+	@include breakpoint( ">660px" ) {
+		text-align: center;
+	}
+}
+
+.jp-landing-plans__header-title,
+.jp-landing-plans__header-subtitle {
+	color: $white;
+	font-weight: 400;
+	margin: 0;
+}
+
+.jp-landing-plans__header-title {
+	font-size: rem( 20px );
+}
+
+.jp-landing-plans__header-description {
+	font-size: rem( 14px );
+	margin: 0;
+}
+
+.jp-landing-plans__header-subtitle {
+	font-size: rem( 16px );
+}
+
+.jp-landing-plans__header-description,
+.jp-landing-plans__header-text {
+	color: lighten($gray, 10%);
+}
+
+.jp-landing-plans__header-text {
+	font-size: rem( 14px );
+}
+
+.jp-landing-plans__header-btn-container {
+	margin: rem( 16px ) 0 0;
+}
+
+.jp-landing__plan-features-card {
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 	border-radius: 3px;
-	margin-bottom: rem( 32px );
+
+	@include breakpoint( ">660px" ) {
+		margin-bottom: rem( 32px );
+	}
+
+	@include breakpoint( "<660px" ) {
+		margin-bottom: rem( 16px );
+	}
 
 	@include breakpoint( ">480px" ) {
 		padding: rem( 32px );
@@ -23,44 +126,52 @@
 	}
 }
 
-.jp-jetpack-landing__plan-features-title {
+.jp-landing__plan-features-title {
 	margin: 0;
 }
 
-.jp-jetpack-landing__plan-features {
-	padding: rem( 16px );
+.jp-landing__plan-features {
+
+	@include breakpoint( ">660px" ) {
+		padding: rem( 32px );
+	}
+
+	@include breakpoint( "<660px" ) {
+		padding: rem( 16px );
+
+	}
 }
 
-.jp-jetpack-landing__plan-card {
+.jp-landing__plan-card {
 
 	@include breakpoint( ">660px" ) {
 		display: flex;
 		flex-wrap: nowrap;
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( ">660px" ) {
 		padding: rem( 32px );
 	}
 
-	@include breakpoint( "<480px" ) {
-		padding: rem( 16px );
+	@include breakpoint( "<660px" ) {
+		padding: rem( 32px ) rem( 32px ) rem( 16px );
 	}
 
-	.jp-jetpack-landing__plan-features-title,
-	.jp-jetpack-landing__plan-features-text {		
+	.jp-landing__plan-features-title,
+	.jp-landing__plan-features-text {		
 		padding: 0;
 
 		@include breakpoint( ">660px" ) {
-		padding-left: rem( 32px );
+			padding-left: rem( 32px );
 		}
 	}
 
-	.jp-jetpack-landing__plan-features-title {
+	.jp-landing__plan-features-title {
 		margin-bottom: rem( 16px );
 	}
 }
 
-.jp-jetpack-landing__plan-card-img {
+.jp-landing__plan-card-img {
 
 	@include breakpoint( "<660px" ) {
 		float: right;
@@ -72,7 +183,7 @@
 	}
 }
 
-.jp-jetpack-landing__plan-icon {
+.jp-landing__plan-icon {
 	width: rem( 120px ); // replace this png with svg
 
 	@include breakpoint( "<660px" ) {

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -1,9 +1,3 @@
-
-.jp-jetpack-landing__plans {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-			0 1px 2px lighten( $gray, 30% );
-}
-
 .jp-jetpack-landing__plan-features-card {
 	padding: rem( 16px );
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
@@ -22,12 +16,10 @@
 
 .jp-jetpack-landing__plan-features {
 	padding: rem( 32px );
-	background-color: #fff;
 }
 
 .jp-jetpack-landing__plan-card {
 	padding: 5% 4% 1%;
-	background-color: #fff;
 
 	img {
 		float: left;

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -1,9 +1,22 @@
+.jp-jetpack-landing__plans {
+	@include breakpoint( "<660px" ) {
+		padding: rem( 16px );
+	}
+}
+
 .jp-jetpack-landing__plan-features-card {
-	padding: rem( 32px );
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 	border-radius: 3px;
 	margin-bottom: rem( 32px );
+
+	@include breakpoint( ">480px" ) {
+		padding: rem( 32px );
+	}
+
+	@include breakpoint( "<480px" ) {
+		padding: rem( 16px );
+	}
 
 	&:last-of-type {
 		margin-bottom: 0;
@@ -19,11 +32,26 @@
 }
 
 .jp-jetpack-landing__plan-card {
-	padding: rem( 32px );
+
+	@include breakpoint( ">480px" ) {
+		padding: rem( 32px );
+	}
+
+	@include breakpoint( "<480px" ) {
+		padding: rem( 16px );
+	}
 
 	.jp-jetpack-landing__plan-features-title,
-	.jp-jetpack-landing__plan-features-text {
-		padding-left: rem( 160px );
+	.jp-jetpack-landing__plan-features-text {		
+		padding: 0;
+
+		@include breakpoint( ">480px" ) {
+			padding-left: rem( 100px );
+		}
+
+		@include breakpoint( ">660px" ) {
+			padding-left: rem( 160px );
+		}
 	}
 
 	.jp-jetpack-landing__plan-features-title {
@@ -34,4 +62,12 @@
 .jp-jetpack-landing__plan-icon {
 	float: left;
 	width: rem( 120px ); // replace this png with svg
+
+	@include breakpoint( "<660px" ) {
+		width: rem( 80px );
+	}
+
+	@include breakpoint( "<480px" ) {
+		display: none;
+	}
 }

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -1,0 +1,15 @@
+.jp-jetpack-landing__plan-features-card {
+	padding: rem( 16px );
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+	border-radius: 3px;
+	margin-bottom: rem( 16px );
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+}
+
+.jp-jetpack-landing__plan-features-title {
+	margin-top: 0;
+}

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -1,5 +1,9 @@
 .jp-landing__plans.dops-card {
 	padding: 0;
+
+	.dops-button {
+		margin-right: 10px;
+	}
 }
 
 .jp-landing-plans__header {
@@ -11,10 +15,6 @@
 
 	@include breakpoint( "<660px" ) {
 		padding: rem( 32px );
-	}
-
-	.dops-button {
-		margin-right: 10px;
 	}
 }
 

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -1,9 +1,9 @@
 .jp-jetpack-landing__plan-features-card {
-	padding: rem( 16px );
+	padding: rem( 32px );
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 	border-radius: 3px;
-	margin-bottom: rem( 16px );
+	margin-bottom: rem( 32px );
 
 	&:last-of-type {
 		margin-bottom: 0;
@@ -15,19 +15,23 @@
 }
 
 .jp-jetpack-landing__plan-features {
-	padding: rem( 32px );
+	padding: rem( 16px );
 }
 
 .jp-jetpack-landing__plan-card {
-	padding: 5% 4% 1%;
+	padding: rem( 32px );
 
-	img {
-		float: left;
-		width: 15%;
-		margin-right: 20px;
+	.jp-jetpack-landing__plan-features-title,
+	.jp-jetpack-landing__plan-features-text {
+		padding-left: rem( 160px );
 	}
 
-	img + h3 {
-		margin-top: 0;
+	.jp-jetpack-landing__plan-features-title {
+		margin-bottom: rem( 16px );
 	}
+}
+
+.jp-jetpack-landing__plan-icon {
+	float: left;
+	width: rem( 120px ); // replace this png with svg
 }

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -33,6 +33,11 @@
 
 .jp-jetpack-landing__plan-card {
 
+	@include breakpoint( ">660px" ) {
+		display: flex;
+		flex-wrap: nowrap;
+	}
+
 	@include breakpoint( ">480px" ) {
 		padding: rem( 32px );
 	}
@@ -45,12 +50,8 @@
 	.jp-jetpack-landing__plan-features-text {		
 		padding: 0;
 
-		@include breakpoint( ">480px" ) {
-			padding-left: rem( 100px );
-		}
-
 		@include breakpoint( ">660px" ) {
-			padding-left: rem( 160px );
+		padding-left: rem( 32px );
 		}
 	}
 
@@ -59,15 +60,22 @@
 	}
 }
 
-.jp-jetpack-landing__plan-icon {
-	float: left;
-	width: rem( 120px ); // replace this png with svg
+.jp-jetpack-landing__plan-card-img {
 
 	@include breakpoint( "<660px" ) {
-		width: rem( 80px );
+		float: right;
+		margin: 0 0 rem( 32px ) rem( 32px );
 	}
 
 	@include breakpoint( "<480px" ) {
 		display: none;
+	}
+}
+
+.jp-jetpack-landing__plan-icon {
+	width: rem( 120px ); // replace this png with svg
+
+	@include breakpoint( "<660px" ) {
+		width: rem( 100px );
 	}
 }

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -1,3 +1,9 @@
+
+.jp-jetpack-landing__plans {
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+			0 1px 2px lighten( $gray, 30% );
+}
+
 .jp-jetpack-landing__plan-features-card {
 	padding: rem( 16px );
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
@@ -11,5 +17,25 @@
 }
 
 .jp-jetpack-landing__plan-features-title {
-	margin-top: 0;
+	margin: 0;
+}
+
+.jp-jetpack-landing__plan-features {
+	padding: rem( 32px );
+	background-color: #fff;
+}
+
+.jp-jetpack-landing__plan-card {
+	padding: 5% 4% 1%;
+	background-color: #fff;
+
+	img {
+		float: left;
+		width: 15%;
+		margin-right: 20px;
+	}
+
+	img + h3 {
+		margin-top: 0;
+	}
 }

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -29,7 +29,7 @@
 		align-items: center;
 		background: transparent url('../../images/jp-4/white-clouds.svg') 50% 100% no-repeat;
 		background-size: 110%; // safari bug
-		padding-bottom: rem( 64px );
+		padding-bottom: rem( 80px );
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -81,10 +81,12 @@
 .jp-landing-plans__header-description {
 	font-size: rem( 14px );
 	margin: 0;
+	padding-bottom: rem( 16px );
 }
 
 .jp-landing-plans__header-subtitle {
 	font-size: rem( 16px );
+	line-height: 1.25;
 }
 
 .jp-landing-plans__header-description,
@@ -94,10 +96,12 @@
 
 .jp-landing-plans__header-text {
 	font-size: rem( 14px );
+	padding: rem( 24px ) 0;
+	margin: 0;
 }
 
 .jp-landing-plans__header-btn-container {
-	margin: rem( 16px ) 0 0;
+	margin: 0;
 }
 
 .jp-landing__plan-features-card {

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -145,29 +145,3 @@
 		}
 	}
 }
-
-.jp-jetpack-landing__plans {
-	.jp-jetpack-landing__plan-features {
-		padding: 1% 4% 5%;
-		background-color: #fff;
-
-		h3 {
-			margin-bottom: 0;
-		}
-	}
-
-	.jp-jetpack-landing__plan-card {
-		padding: 5% 4% 1%;
-		background-color: #fff;
-
-		img {
-			float: left;
-			width: 15%;
-			margin-right: 20px;
-		}
-
-		img + h3 {
-			margin-top: 0;
-		}
-	}
-}

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -37,3 +37,4 @@
 
 // Page Templates
 @import '../at-a-glance/style';
+@import '../plans/style';


### PR DESCRIPTION
I've gone in and cleaned up some of the styles, class names, and ensured the plans landing pages are usable on various screen sizes.

Paid plans before:
![screen shot 2016-07-20 at 1 18 34 pm](https://cloud.githubusercontent.com/assets/214813/16998677/7ece9626-4e88-11e6-9cf1-d6a135e36038.png)


Paid plans after:
![screen shot 2016-07-20 at 2 23 48 pm](https://cloud.githubusercontent.com/assets/214813/16998688/8a67b602-4e88-11e6-93a7-3529c571f63d.png)

Free plans after:
![screen shot 2016-07-22 at 4 15 50 pm](https://cloud.githubusercontent.com/assets/214813/17069992/a06cb6dc-5027-11e6-8c24-4885bce5c0a2.png)



Smaller screens:
![Uploading Screen Shot 2016-07-22 at 4.17.06 PM.png…]()


