### PR TITLE
Schedule cron job once a minute to send pending updates

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -150,7 +150,8 @@ class Jetpack_Sync_Actions {
 		if( ! isset( $schedules["1min"] ) ) {
 			$schedules["1min"] = array(
 				'interval' => 60,
-				'display' => __( 'Every minute' ) );
+				'display' => __( 'Every minute' ) 
+			);
 		}
 		return $schedules;
 	}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -172,7 +172,9 @@ class Jetpack_Sync_Actions {
 			// sleep for up to 10s
 			if ( $next_sync_time ) {
 				$delay = $next_sync_time - time() + 1;
-				if ( 0 < $delay && $delay < 10 ) {
+				if ( $delay > 15 ) {
+					break;
+				} elseif ( $delay > 0 ) {
 					sleep( $delay );
 				}
 			}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -12,9 +12,12 @@ class Jetpack_Sync_Actions {
 
 	static function init() {
 
+		// Add a custom "every minute" cron schedule
+		add_filter( 'cron_schedules', array( __CLASS__, 'minute_cron_schedule' ) );
+
 		// On jetpack authorization, schedule a full sync
 		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ) );
-		
+
 		// Sync connected user role changes to .com
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
 
@@ -26,11 +29,17 @@ class Jetpack_Sync_Actions {
 		// cron hooks
 		add_action( 'jetpack_sync_send_db_checksum', array( __CLASS__, 'send_db_checksum' ) );
 		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ), 10, 1 );
+		add_action( 'jetpack_sync_cron', array( __CLASS__, 'do_cron_sync' ) );
 		add_action( 'jetpack_sync_send_pending_data', array( __CLASS__, 'do_send_pending_data' ) );
 
 		if ( ! wp_next_scheduled( 'jetpack_sync_send_db_checksum' ) ) {
 			// Schedule a job to send DB checksums once an hour
 			wp_schedule_event( time(), 'hourly', 'jetpack_sync_send_db_checksum' );
+		}
+
+		if ( ! wp_next_scheduled( 'jetpack_sync_cron' ) ) {
+			// Schedule a job to send pending queue items once a minute
+			wp_schedule_event( time(), '1min', 'jetpack_sync_cron' );
 		}
 
 		/**
@@ -88,7 +97,7 @@ class Jetpack_Sync_Actions {
 
 	static function sync_allowed() {
 		return ( Jetpack::is_active() && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
-		       || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
+			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
 	}
 
 	static function send_data( $data, $codec_name, $sent_timestamp ) {
@@ -135,6 +144,34 @@ class Jetpack_Sync_Actions {
 		self::initialize_listener();
 		Jetpack_Sync_Modules::get_module( 'full-sync' )->start( $modules );
 		self::do_send_pending_data(); // try to send at least some of the data
+	}
+
+	static function minute_cron_schedule( $schedules ) {
+		if( ! isset( $schedules["1min"] ) ) {
+			$schedules["1min"] = array(
+				'interval' => 60,
+				'display' => __( 'Every minute' ) );
+		}
+		return $schedules;
+	}
+
+	// try to send actions for up to a minute
+	static function do_cron_sync() {
+		if ( ! self::sync_allowed() ) {
+			return;
+		}
+
+		self::initialize_sender();
+
+		$start_time = microtime( true );
+
+		do {
+			self::$sender->do_sync();
+		} while ( 
+			self::$sender->get_sync_queue()->size() > 0 
+			&& 
+			microtime( true ) - $start_time < 60 
+		);
 	}
 
 	static function do_send_pending_data() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -164,11 +164,20 @@ class Jetpack_Sync_Actions {
 		self::initialize_sender();
 
 		$start_time = microtime( true );
-
+		
 		do {
-			self::$sender->do_sync();
+			$next_sync_time = self::$sender->next_sync_time();
+			
+			// sleep for up to 10s
+			if ( $next_sync_time ) {
+				$delay = $next_sync_time - time() + 1;
+				if ( 0 < $delay && $delay < 10 ) {
+					sleep( $delay );
+				}
+			}
+			$result = self::$sender->do_sync();
 		} while ( 
-			self::$sender->get_sync_queue()->size() > 0 
+			$result 
 			&& 
 			microtime( true ) - $start_time < 60 
 		);

--- a/sync/class.jetpack-sync-dashboard.php
+++ b/sync/class.jetpack-sync-dashboard.php
@@ -82,7 +82,7 @@ class Jetpack_Sync_Dashboard extends Jetpack_Admin_Page {
 
 	function ajax_reset_queue() {
 		Jetpack_Sync_Sender::get_instance()->reset_sync_queue();
-		delete_option( Jetpack_Sync_Full::$status_option );
+		delete_option( Jetpack_Sync_Module_Full_Sync::STATUS_OPTION );
 		echo json_encode( array( 'success' => true ) );
 
 		exit;

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -26,7 +26,9 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_enqueue_added_option', $whitelist_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_updated_option', $whitelist_option_handler );
 
-		add_action( 'switch_theme', array( $this, 'set_defaults' ) );
+		// set this early so that other theme switching actions 
+		// enqueue the correct options
+		add_action( 'switch_theme', array( $this, 'set_defaults' ), 1 ); 
 	}
 
 	public function init_before_send() {

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -25,6 +25,8 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_enqueue_deleted_option', $whitelist_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_added_option', $whitelist_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_updated_option', $whitelist_option_handler );
+
+		add_action( 'switch_theme', array( $this, 'set_defaults' ) );
 	}
 
 	public function init_before_send() {

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -53,11 +53,11 @@ abstract class Jetpack_Sync_Module {
 			$where_sql = '1 = 1';
 		}
 
-		$items_per_page = 500;
+		$items_per_page = 1000;
 		$page           = 1;
-		$offset         = ( $page * $items_per_page ) - $items_per_page;
 		$chunk_count    = 0;
-		while ( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} ORDER BY {$id_field} asc LIMIT {$offset}, {$items_per_page}" ) ) {
+		$previous_id    = 0;
+		while ( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} AND {$id_field} > $previous_id ORDER BY {$id_field} ASC LIMIT {$items_per_page}" ) ) {
 			// Request posts in groups of N for efficiency
 			$chunked_ids = array_chunk( $ids, self::ARRAY_CHUNK_SIZE );
 
@@ -74,7 +74,7 @@ abstract class Jetpack_Sync_Module {
 			}
 
 			$page += 1;
-			$offset = ( $page * $items_per_page ) - $items_per_page;
+			$previous_id = end( $ids );
 		}
 
 		return $chunk_count;

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -53,7 +53,7 @@ class Jetpack_Sync_Modules {
 	}
 
 	public static function set_defaults() {
-		foreach( self::get_modules() as $module ) {
+		foreach ( self::get_modules() as $module ) {
 			$module->set_defaults();
 		}
 	}

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -52,6 +52,12 @@ class Jetpack_Sync_Modules {
 		return self::$initialized_modules;
 	}
 
+	public static function set_defaults() {
+		foreach( self::get_modules() as $module ) {
+			$module->set_defaults();
+		}
+	}
+
 	public static function get_module( $module_name ) {
 		foreach ( self::get_modules() as $module ) {
 			if ( $module->name() === $module_name ) {

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -44,6 +44,13 @@ class Jetpack_Sync_Sender {
 		}
 	}
 
+	public function next_sync_time() {
+		$sync_wait = $this->get_sync_wait_time();
+                $last_sync = $this->get_last_sync_time();
+		$next_sync_time = ( $last_sync && $sync_wait ) ? $last_sync + $sync_wait : 0;
+		return $next_sync_time;
+	}
+
 	public function do_sync() {
 		// don't sync if importing
 		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
@@ -51,10 +58,7 @@ class Jetpack_Sync_Sender {
 		}
 
 		// don't sync if we are throttled
-		$sync_wait = $this->get_sync_wait_time();
-		$last_sync = $this->get_last_sync_time();
-
-		if ( $last_sync && $sync_wait && $last_sync + $sync_wait > microtime( true ) ) {
+		if ( $this->next_sync_time() > microtime( true ) ) {
 			return false;
 		}
 
@@ -88,6 +92,9 @@ class Jetpack_Sync_Sender {
 		$upload_size   = 0;
 		$items_to_send = array();
 		$items         = $buffer->get_items();
+
+		// set up current screen to avoid errors rendering content
+		set_current_screen( 'sync' );
 
 		// we estimate the total encoded size as we go by encoding each item individually
 		// this is expensive, but the only way to really know :/

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -46,7 +46,7 @@ class Jetpack_Sync_Sender {
 
 	public function next_sync_time() {
 		$sync_wait = $this->get_sync_wait_time();
-                $last_sync = $this->get_last_sync_time();
+		$last_sync = $this->get_last_sync_time();
 		$next_sync_time = ( $last_sync && $sync_wait ) ? $last_sync + $sync_wait : 0;
 		return $next_sync_time;
 	}

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -94,6 +94,8 @@ class Jetpack_Sync_Sender {
 		$items         = $buffer->get_items();
 
 		// set up current screen to avoid errors rendering content
+		require_once(ABSPATH . 'wp-admin/includes/class-wp-screen.php');
+		require_once(ABSPATH . 'wp-admin/includes/screen.php');
 		set_current_screen( 'sync' );
 
 		// we estimate the total encoded size as we go by encoding each item individually

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -126,6 +126,8 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_schedules_regular_sync() {
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
+		error_log("next cron: ".$timestamp);
+		error_log("current time: ".time());
 		// we need to check a while in the past because the task got scheduled at 
 		// the beginning of the entire test run, not at the beginning of this test :)
 		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -128,8 +128,6 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		// we need to run this again because cron is cleared between tests
 		Jetpack_Sync_Actions::init(); 
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
-		error_log("next cron: ".$timestamp);
-		error_log("current time: ".time());
 		// we need to check a while in the past because the task got scheduled at 
 		// the beginning of the entire test run, not at the beginning of this test :)
 		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -128,6 +128,8 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_schedules_regular_sync() {
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
+		error_log( '$timestamp:' );
+		error_log( $timestamp );
 		$this->assertTrue( $timestamp > time()-5 );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -54,9 +54,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 	public function setSyncClientDefaults() {
 		$this->sender->set_defaults();
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
-			$module->set_defaults();
-		}
+		Jetpack_Sync_Modules::set_defaults();
 		$this->sender->set_dequeue_max_bytes( 5000000 ); // process 5MB of items at a time
 		$this->sender->set_sync_wait_time( 0 ); // disable rate limiting
 	}

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -125,4 +125,13 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$modules = array( 'options', 'network_options', 'functions', 'constants' );
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( $modules ) ) > time()-5 );
 	}
+
+	function test_schedules_regular_sync() {
+		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
+		$this->assertTrue( $timestamp > time()-5 );
+	}
+
+	function test_do_cron_sync_sends_until_buffer_empty_or_one_min() {
+		// TODO
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -128,6 +128,8 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_schedules_regular_sync() {
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
-		$this->assertTrue( $timestamp > time()-5 );
+		// we need to check a while in the past because the task got scheduled at 
+		// the beginning of the entire test run, not at the beginning of this test :)
+		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -128,12 +128,6 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_schedules_regular_sync() {
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
-		error_log( '$timestamp:' );
-		error_log( $timestamp );
 		$this->assertTrue( $timestamp > time()-5 );
-	}
-
-	function test_do_cron_sync_sends_until_buffer_empty_or_one_min() {
-		// TODO
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -125,6 +125,8 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_schedules_regular_sync() {
+		// we need to run this again because cron is cleared between tests
+		Jetpack_Sync_Actions::init(); 
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
 		error_log("next cron: ".$timestamp);
 		error_log("current time: ".time());

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -384,6 +384,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertNotEquals( 'twentyfourteen', get_option( 'stylesheet' ) );
 
 		switch_theme( 'twentyfourteen' );
+		set_theme_mod( 'foo', 'bar' );
 		$this->sender->do_sync();
 
 		$this->assertEquals( 'twentyfourteen', $this->server_replica_storage->get_option( 'stylesheet' ) );
@@ -397,7 +398,17 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$this->assertEquals( 'twentyfourteen', $this->server_replica_storage->get_option( 'stylesheet' ) );
-		$this->assertEquals( get_option( 'theme_mods_twentyfourteen' ), $this->server_replica_storage->get_option( 'theme_mods_twentyfourteen' ) );
+		$local_option = get_option( 'theme_mods_twentyfourteen' );
+		$remote_option = $this->server_replica_storage->get_option( 'theme_mods_twentyfourteen' );
+		
+		if ( isset( $local_option[0] ) ) {
+			// this is a spurious value that sometimes gets set during tests, and is
+			// actively removed before sending to WPCOM
+			// it appears to be due to a bug which sets array( false ) as the default value for theme_mods
+			unset( $local_option[0] );
+		}
+		
+		$this->assertEquals( $local_option, $remote_option );
 	}
 
 	function test_full_sync_sends_plugin_updates() {

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -23,25 +23,6 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $this->action_timestamp < microtime( true ) );
 	}
 
-	function test_queues_cron_job_if_queue_exceeds_max_buffer() {
-		$this->sender->set_dequeue_max_bytes( 500 ); // bytes
-
-		for ( $i = 0; $i < 20; $i += 1 ) {
-			$this->factory->post->create();
-		}
-
-		$this->sender->do_sync();
-
-		$events = $this->server_event_storage->get_all_events();
-		$this->assertTrue( count( $events ) < 20 );
-
-		$timestamp = wp_next_scheduled( 'jetpack_sync_actions' );
-
-		// we're making some assumptions here about how fast the test will run...
-		$this->assertTrue( $timestamp >= time() + 59 );
-		$this->assertTrue( $timestamp <= time() + 61 );
-	}
-
 	function test_queue_limits_upload_bytes() {
 		// flush previous stuff in queue
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -35,6 +35,10 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			'site-logo'
 		);
 
+		// this forces theme mods to be saved as an option so that this test is valid
+		set_theme_mod( 'foo', 'bar' );
+		$this->sender->do_sync();
+
 		foreach ( $theme_features as $theme_feature ) {
 			$synced_theme_support_value = $this->server_replica_storage->current_theme_supports( $theme_feature );
 			$this->assertEquals( current_theme_supports( $theme_feature ), $synced_theme_support_value, 'Feature(s) not synced' . $theme_feature );

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -8,7 +8,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 	public function setUp() {
 		parent::setUp();
-		$themes      = array( 'twentyten', 'twentyeleven', 'twentytwelve', 'thwentythirteen', 'twentyfourteen' );
+		$themes      = array( 'twentyten', 'twentyeleven', 'twentytwelve', 'twentythirteen', 'twentyfourteen' );
 		$this->theme = $themes[ rand( 0, 4 ) ];
 
 		switch_theme( $this->theme );

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -52,6 +52,17 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		// theme name and options should be whitelisted as a synced option
 		$this->assertEquals( $this->theme, $this->server_replica_storage->get_option( 'stylesheet' ) );
-		$this->assertEquals( get_option( 'theme_mods_' . $this->theme ), $this->server_replica_storage->get_option( 'theme_mods_' . $this->theme ) );
+
+		$local_value = get_option( 'theme_mods_' . $this->theme );
+		$remote_value = $this->server_replica_storage->get_option( 'theme_mods_' . $this->theme );
+		
+		if ( isset( $local_value[0] ) ) {
+			// this is a spurious value that sometimes gets set during tests, and is
+			// actively removed before sending to WPCOM
+			// it appears to be due to a bug which sets array( false ) as the default value for theme_mods
+			unset( $local_value[0] );
+		}
+
+		$this->assertEquals( $local_value, $this->server_replica_storage->get_option( 'theme_mods_' . $this->theme ) );
 	}
 }


### PR DESCRIPTION
Currently we try to send when there's certain kinds of traffic. This PR not only schedules a once-a-minute cron job to send updates to WPCOM, it also continues sending as long as there is data in the queue.

This branch also contains some additional fixes:
- big performance improvement for enqueuing IDs during full sync by avoiding OFFSET
- fix error when clearing queue from dashboard
- fix broken theme sync tests

cc @lezama 