### PR TITLE
Check if current screen base exists before using it

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6238,7 +6238,7 @@ p {
 	 */
 	function jetpack_user_col_style() {
 		global $current_screen;
-		if ( 'users' == $current_screen->base ) { ?>
+		if ( ! empty( $current_screen->base ) && 'users' == $current_screen->base ) { ?>
 			<style>
 				.fixed .column-user_jetpack {
 					width: 21px;


### PR DESCRIPTION
This is a simple check of the `$current_screen->base` property since sometimes `$current_screen` may be `null` on some pages like WooCommerce Setup Wizard and triggers a PHP notice like this:
![screen shot 2016-07-21 at 11 44 02 am](https://cloud.githubusercontent.com/assets/1893980/17017284/68db117e-4f3b-11e6-8552-39468931b9e7.png)


