### PR TITLE
Sync: Remove maybe call constants when syncing callables and constants

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -77,6 +77,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		 * @param boolean Whether to expand callables (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_callables', true );
+		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
 		remove_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_callables' ) );
 
 		return 1; // The number of actions enqueued

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -41,6 +41,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	public function reset_data() {
 		delete_option( self::CALLABLES_CHECKSUM_OPTION_NAME );
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
+		remove_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_callables' ) );
 	}
 
 	function set_callable_whitelist( $callables ) {

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -77,6 +77,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		 * @param boolean Whether to expand callables (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_callables', true );
+		remove_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_callables' ) );
 
 		return 1; // The number of actions enqueued
 	}

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -104,10 +104,11 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 
-		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
-
 		$callable_checksums = (array) get_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
-
+		if ( empty( $callable_checksums ) ) {
+			$this->enqueue_full_sync_actions();
+			return;
+		}
 		// only send the callables that have changed
 		foreach ( $callables as $name => $value ) {
 			$checksum = $this->get_check_sum( $value );
@@ -128,11 +129,20 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			}
 		}
 		update_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
+		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
 	}
 
 	public function expand_callables( $args ) {
 		if ( $args[0] ) {
-			return $this->get_all_callables();
+			$callables = $this->get_all_callables();
+			// Update the callable checksums on full sync.
+			$callable_checksums = array();
+			foreach ( $callables as $name => $value ) {
+				$callable_checksums[ $name ] = $this->get_check_sum( $value );
+			}
+			update_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
+
+			return $callables;
 		}
 
 		return $args;

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -31,6 +31,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 	public function reset_data() {
 		delete_option( self::CONSTANTS_CHECKSUM_OPTION_NAME );
 		delete_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME );
+		remove_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_constants' ) );
 	}
 
 	function set_constants_whitelist( $constants ) {

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -57,6 +57,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_full_sync_constants', true );
 		remove_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_constants' ) );
+		set_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_constants_wait_time );
 		return 1;
 	}
 

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -56,7 +56,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		 * @param boolean Whether to expand constants (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_constants', true );
-
+		remove_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_constants' ) );
 		return 1;
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -18,7 +18,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	public function setUp() {
 		parent::setUp();
 
-		$this->callable_module = Jetpack_Sync_Modules::get_module( "functions" );
+		$this->callable_module = Jetpack_Sync_Modules::get_module( 'functions' );
 	}
 
 	function test_white_listed_function_is_synced() {
@@ -29,6 +29,22 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
 		$this->assertEquals( jetpack_foo_is_callable(), $synced_value );
+	}
+
+	function test_use_full_sync_instead_of_individual_sync_if_we_send_all_data() {
+		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+
+		$this->callable_module->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable' ) );
+		$this->sender->do_sync();
+
+		$this->assertFalse( empty( get_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME ) ) );
+		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
+		$this->assertEquals( jetpack_foo_is_callable(), $synced_value );
+		$jetpack_sync_full_sync_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_callables' );
+		$jetpack_sync_callable_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_callable' );
+
+		$this->assertFalse( empty( $jetpack_sync_full_sync_event ) );
+		$this->assertFalse( $jetpack_sync_callable_event );
 	}
 
 	public function test_sync_jetpack_updates() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -37,7 +37,9 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->callable_module->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable' ) );
 		$this->sender->do_sync();
 
-		$this->assertFalse( empty( get_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME ) ) );
+		$checksum_option = get_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+		$this->assertFalse( empty( $checksum_option ) );
+
 		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
 		$this->assertEquals( jetpack_foo_is_callable(), $synced_value );
 		$jetpack_sync_full_sync_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_callables' );

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -39,7 +39,8 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$this->assertFalse( empty( get_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME ) ) );
+		$checksum_option = get_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+		$this->assertFalse( empty( $checksum_option ) );
 
 		$synced_bar_value = $this->server_replica_storage->get_constant( 'TEST_BAR_2' );
 

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -32,6 +32,25 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 		$this->assertNotEquals( TEST_BAR, $synced_bar_value );
 	}
 
+	function test_use_full_sync_instead_of_individual_sync_if_we_send_all_data() {
+		delete_option( Jetpack_Sync_Module_Constants::CONSTANTS_CHECKSUM_OPTION_NAME );
+		define( 'TEST_BAR_2', sprintf( "%.8f", microtime( true ) ) );
+		$this->constant_module->set_constants_whitelist( array( 'TEST_BAR_2' ) );
+
+		$this->sender->do_sync();
+
+		$this->assertFalse( empty( get_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME ) ) );
+
+		$synced_bar_value = $this->server_replica_storage->get_constant( 'TEST_BAR_2' );
+
+		$this->assertEquals( TEST_BAR_2, $synced_bar_value );
+		$jetpack_sync_full_sync_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_constants' );
+		$jetpack_sync_constant_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_constant' );
+
+		$this->assertFalse( empty( $jetpack_sync_full_sync_event ) );
+		$this->assertFalse( $jetpack_sync_constant_event );
+	}
+
 	function test_does_not_fire_if_constants_havent_changed() {
 		$this->constant_module->set_defaults(); // use the default constants
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -229,7 +229,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_sends_all_constants() {
 		define( 'TEST_SYNC_ALL_CONSTANTS', 'foo' );
 
-		Jetpack_Sync_Modules::get_module( "constants" )->set_constants_whitelist( array( 'TEST_SYNC_ALL_CONSTANTS' ) );
+		Jetpack_Sync_Modules::get_module( 'constants' )->set_constants_whitelist( array( 'TEST_SYNC_ALL_CONSTANTS' ) );
 		$this->sender->do_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!
@@ -244,7 +244,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_functions() {
-		Jetpack_Sync_Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
+		Jetpack_Sync_Modules::get_module( 'functions' )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
 		$this->sender->do_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!
@@ -260,8 +260,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_full_sync_does_not_set_callables_and_constants() {
 		define( 'TEST_SYNC_ALL_CONSTANTS_BAR', 'foo' );
-		Jetpack_Sync_Modules::get_module( "constants" )->set_constants_whitelist( array( 'TEST_SYNC_ALL_CONSTANTS_BAR' ) );
-		Jetpack_Sync_Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
+		Jetpack_Sync_Modules::get_module( 'constants' )->set_constants_whitelist( array( 'TEST_SYNC_ALL_CONSTANTS_BAR' ) );
+		Jetpack_Sync_Modules::get_module( 'functions' )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
 		$this->sender->do_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!
@@ -281,7 +281,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_options() {
-		Jetpack_Sync_Modules::get_module( "options" )->set_options_whitelist( array( 'my_option', 'my_prefix_value' ) );
+		Jetpack_Sync_Modules::get_module( 'options' )->set_options_whitelist( array( 'my_option', 'my_prefix_value' ) );
 		update_option( 'my_option', 'foo' );
 		update_option( 'my_prefix_value', 'bar' );
 		update_option( 'my_non_synced_option', 'baz' );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -258,6 +258,28 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'the value', $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
 	}
 
+	function test_full_sync_does_not_set_callables_and_constants() {
+		define( 'TEST_SYNC_ALL_CONSTANTS_BAR', 'foo' );
+		Jetpack_Sync_Modules::get_module( "constants" )->set_constants_whitelist( array( 'TEST_SYNC_ALL_CONSTANTS_BAR' ) );
+		Jetpack_Sync_Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
+		$this->sender->do_sync();
+
+		// reset the storage, check value, and do full sync - storage should be set!
+		$this->server_replica_storage->reset();
+		$this->server_event_storage->reset();
+		$this->full_sync->start();
+		$this->sender->do_sync();
+
+		$jetpack_sync_constant_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_constant' );
+		$jetpack_sync_callable_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_callable' );
+
+		$this->assertFalse( $jetpack_sync_constant_event );
+		$this->assertFalse( $jetpack_sync_callable_event );
+
+		$this->assertEquals( 'the value', $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
+		$this->assertEquals( 'foo', $this->server_replica_storage->get_constant( 'TEST_SYNC_ALL_CONSTANTS_BAR' ) );
+	}
+
 	function test_full_sync_sends_all_options() {
 		Jetpack_Sync_Modules::get_module( "options" )->set_options_whitelist( array( 'my_option', 'my_prefix_value' ) );
 		update_option( 'my_option', 'foo' );

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -8,7 +8,6 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 	public function setUp() {
 		parent::setUp();
-		$this->sender->reset_data();
 		wp_set_current_user( 1 );
 		$this->sender->do_sync();
 	}


### PR DESCRIPTION
This was effecting sites when they first upgraded or reconnected to
.com Since the data was sent twice. This is not necessary since we are
planing to send the data already during the full sync.

#### Changes proposed in this Pull Request:
- Remove the maybe calls when doing the full sync.

#### Testing instructions:
Disconnect and reconnect jetpack watch the actions that are being sent to .com. 
Do they send duplicate data? 

-------------------

- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

