### PR TITLE
Admin Page - Dashboard: show the current section in the dropdown displayed in small screens

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -20,7 +20,7 @@ const Navigation = React.createClass( {
 		let navTabs;
 		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
 			navTabs = (
-				<NavTabs>
+				<NavTabs selectedText={ this.props.route.name }>
 					<NavItem
 						path="#dashboard"
 						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
@@ -50,7 +50,7 @@ const Navigation = React.createClass( {
 				);
 			}
 			navTabs = (
-				<NavTabs>
+				<NavTabs selectedText={ this.props.route.name }>
 					{ dashboard }
 					<NavItem
 						path="#apps"
@@ -62,7 +62,7 @@ const Navigation = React.createClass( {
 		}
 		return (
 			<div className='dops-navigation'>
-				<SectionNav>
+				<SectionNav selectedText={ this.props.route.name }>
 					{ navTabs }
 				</SectionNav>
 			</div>


### PR DESCRIPTION
Fixes #4447

#### Changes proposed in this Pull Request:
- Add the selected text to the section navigation component label

#### Testing instructions:
1. go to Dashboard
2. make your screen smaller, down to mobile size.

The dropdown should display the current section

<img width="362" alt="nav" src="https://cloud.githubusercontent.com/assets/1041600/17025868/3a909f70-4f34-11e6-84f0-3442860c957b.png">
