### PR TITLE
At a glance: fixes DashItem overflow in IE11

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -236,6 +236,9 @@
 		display: flex;
 		flex-direction: column;
 	}
+	> div {
+		flex-basis: 100%;
+	}
 	.jp-dash-item {
 		.dops-card {
 			flex-grow: 1;


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17030538/6c0f6e68-4f35-11e6-8cac-ef0f9d8df747.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/17030553/8df36a2a-4f35-11e6-8222-87e808913bec.png)

