### PR TITLE
Update: Always fire jetpack_activate_module after update of module.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -833,7 +833,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 					// Reset to default modules
 					$default_modules = Jetpack::get_default_modules();
-					Jetpack_Options::update_option( 'active_modules', $default_modules );
+					Jetpack::update_active_modules( $default_modules );
 
 					// Jumpstart option is special
 					Jetpack_Options::update_option( 'jumpstart', 'new_connection' );
@@ -845,8 +845,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 				case 'modules':
 					$default_modules = Jetpack::get_default_modules();
-					Jetpack_Options::update_option( 'active_modules', $default_modules );
-
+					Jetpack::update_active_modules( $default_modules );
 					return rest_ensure_response( array(
 						'code' 	  => 'success',
 						'message' => esc_html__( 'Modules reset to default.', 'jetpack' ),

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -215,7 +215,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				_e( "Resetting default modules...\n", "jetpack" );
 				usleep( 500000 ); // Take a breath
 				$default_modules = Jetpack::get_default_modules();
-				Jetpack_Options::update_option( 'active_modules', $default_modules );
+				Jetpack::update_active_modules( $default_modules );
 				WP_CLI::success( __( 'Modules reset to default.', 'jetpack' ) );
 
 				// Jumpstart option is special
@@ -224,7 +224,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				break;
 			case 'modules':
 				$default_modules = Jetpack::get_default_modules();
-				Jetpack_Options::update_option( 'active_modules', $default_modules );
+				Jetpack::update_active_modules( $default_modules );
 				WP_CLI::success( __( 'Modules reset to default.', 'jetpack' ) );
 				break;
 			case 'prompt':
@@ -306,7 +306,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				break;
 			case 'activate_all':
 				$modules = Jetpack::get_available_modules();
-				Jetpack_Options::update_option( 'active_modules', $modules );
+				Jetpack::update_active_modules( $modules );
 				WP_CLI::success( __( 'All modules activated!', 'jetpack' ) );
 				break;
 			case 'deactivate':
@@ -316,7 +316,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				WP_CLI::success( sprintf( __( '%s has been deactivated.', 'jetpack' ), $module['name'] ) );
 				break;
 			case 'deactivate_all':
-				Jetpack_Options::update_option( 'active_modules', '' );
+				Jetpack::delete_active_modules();
 				WP_CLI::success( __( 'All modules deactivated!', 'jetpack' ) );
 				break;
 			case 'toggle':

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -124,7 +124,7 @@ class Jetpack_Client_Server {
 
 		$redirect_on_activation_error = ( 'client' === $data['auth_type'] ) ? true : false;
 		if ( $active_modules = Jetpack_Options::get_option( 'active_modules' ) ) {
-			Jetpack_Options::delete_option( 'active_modules' );
+			Jetpack::delete_active_modules();
 
 			Jetpack::activate_default_modules( 999, 1, $active_modules, $redirect_on_activation_error );
 		} else {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -321,7 +321,7 @@ class Jetpack {
 				$unfiltered_modules = Jetpack::get_active_modules();
 				$modules = array_filter( $unfiltered_modules, array( 'Jetpack', 'is_module' ) );
 				if ( array_diff( $unfiltered_modules, $modules ) ) {
-					Jetpack_Options::update_option( 'active_modules', $modules );
+					Jetpack::update_active_modules( $modules );
 				}
 
 				add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
@@ -331,13 +331,51 @@ class Jetpack {
 	}
 
 	static function activate_manage( ) {
-
 		if ( did_action( 'init' ) || current_filter() == 'init' ) {
 			self::activate_module( 'manage', false, false );
 		} else if ( !  has_action( 'init' , array( __CLASS__, 'activate_manage' ) ) ) {
 			add_action( 'init', array( __CLASS__, 'activate_manage' ) );
 		}
+	}
 
+	static function update_active_modules( $modules ) {
+		$current_modules = Jetpack_Options::get_option( 'active_modules', array() );
+		
+		$success = Jetpack_Options::update_option( 'active_modules', array_unique( $modules ) );
+		
+		if ( is_array( $modules ) && is_array( $current_modules ) ) {
+			$new_active_modules = array_diff( $modules, $current_modules );
+			foreach( $new_active_modules as $module ) {
+				/**
+				 * Fires when a specific module is activated.
+				 *
+				 * @since 1.9.0
+				 *
+				 * @param string $module Module slug.
+				 * @param boolean $success whether the module was activated. @since 4.2
+				 */
+				do_action( 'jetpack_activate_module', $module, $success );
+			}
+
+			$new_deactive_modules = array_diff( $current_modules, $modules );
+			foreach( $new_deactive_modules as $module ) {
+				/**
+				 * Fired after a module has been deactivated.
+				 *
+				 * @since 4.2.0
+				 *
+				 * @param string $module Module slug.
+				 * @param boolean $success whether the module was deactivated.
+				 */
+				do_action( 'jetpack_deactivate_module', $module, $success );
+			}
+		}
+
+		return $success;
+	}
+
+	static function delete_active_modules() {
+		self::update_active_modules( array() );
 	}
 
 	/**
@@ -1312,7 +1350,7 @@ class Jetpack {
 
 			if ( ! @include( Jetpack::get_module_path( $module ) ) ) {
 				unset( $modules[ $index ] );
-				Jetpack_Options::update_option( 'active_modules', array_values( $modules ) );
+				self::update_active_modules( array_values( $modules ) );
 				continue;
 			}
 
@@ -2181,7 +2219,7 @@ class Jetpack {
 		foreach ( $modules as $module ) {
 			if ( did_action( "jetpack_module_loaded_$module" ) ) {
 				$active[] = $module;
-				Jetpack_Options::update_option( 'active_modules', array_unique( $active ) );
+				self::update_active_modules( $active );
 				continue;
 			}
 
@@ -2213,14 +2251,7 @@ class Jetpack {
 			Jetpack::state( 'module', $module );
 			ob_start();
 			require $file;
-			/**
-			 * Fires when a specific module is activated.
-			 *
-			 * @since 1.9.0
-			 *
-			 * @param string $module Module slug.
-			 */
-			do_action( 'jetpack_activate_module', $module );
+
 			$active[] = $module;
 			$state    = in_array( $module, $other_modules ) ? 'reactivated_modules' : 'activated_modules';
 			if ( $active_state = Jetpack::state( $state ) ) {
@@ -2230,7 +2261,8 @@ class Jetpack {
 			}
 			$active_state[] = $module;
 			Jetpack::state( $state, implode( ',', $active_state ) );
-			Jetpack_Options::update_option( 'active_modules', array_unique( $active ) );
+			Jetpack::update_active_modules( $active );
+
 			ob_end_clean();
 		}
 		Jetpack::state( 'error', false );
@@ -2308,7 +2340,8 @@ class Jetpack {
 		/** This action is documented in class.jetpack.php */
 		do_action( 'jetpack_activate_module', $module );
 		$active[] = $module;
-		Jetpack_Options::update_option( 'active_modules', array_unique( $active ) );
+
+		Jetpack::update_active_modules( $active );
 		Jetpack::state( 'error', false ); // the override
 		ob_end_clean();
 		Jetpack::catch_errors( false );
@@ -2379,18 +2412,7 @@ class Jetpack {
 			$jetpack->do_stats( 'server_side' );
 		}
 
-		$success = Jetpack_Options::update_option( 'active_modules', array_unique( $new ) );
-		/**
-		 * Fired after a module has been deactivated.
-		 *
-		 * @since 4.2.0
-		 *
-		 * @param string $module Module slug.
-		 * @param boolean $success whether the module was deactivated.
-		 */
-		do_action( 'jetpack_deactivate_module', $module, $success );
-
-		return $success;
+		return self::update_active_modules( $new );
 	}
 
 	public static function enable_module_configurable( $module ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -355,6 +355,16 @@ class Jetpack {
 				 * @param boolean $success whether the module was activated. @since 4.2
 				 */
 				do_action( 'jetpack_activate_module', $module, $success );
+
+				/**
+				 * Fires when a module is activated.
+				 * The dynamic part of the filter, $module, is the module slug.
+				 *
+				 * @since 1.9.0
+				 *
+				 * @param string $module Module slug.
+				 */
+				do_action( "jetpack_activate_module_$module", $module );
 			}
 
 			$new_deactive_modules = array_diff( $current_modules, $modules );
@@ -368,6 +378,15 @@ class Jetpack {
 				 * @param boolean $success whether the module was deactivated.
 				 */
 				do_action( 'jetpack_deactivate_module', $module, $success );
+				/**
+				 * Fires when a module is deactivated.
+				 * The dynamic part of the filter, $module, is the module slug.
+				 *
+				 * @since 1.9.0
+				 *
+				 * @param string $module Module slug.
+				 */
+				do_action( "jetpack_deactivate_module_$module", $module );
 			}
 		}
 
@@ -483,8 +502,6 @@ class Jetpack {
 		add_action( 'wp_enqueue_scripts', array( $this, 'devicepx' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'devicepx' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'devicepx' ) );
-
-		add_action( 'jetpack_activate_module', array( $this, 'activate_module_actions' ) );
 
 		add_action( 'plugins_loaded', array( $this, 'extra_oembed_providers' ), 100 );
 
@@ -2337,11 +2354,10 @@ class Jetpack {
 		Jetpack::catch_errors( true );
 		ob_start();
 		require Jetpack::get_module_path( $module );
-		/** This action is documented in class.jetpack.php */
-		do_action( 'jetpack_activate_module', $module );
-		$active[] = $module;
 
+		$active[] = $module;
 		Jetpack::update_active_modules( $active );
+
 		Jetpack::state( 'error', false ); // the override
 		ob_end_clean();
 		Jetpack::catch_errors( false );
@@ -2366,15 +2382,7 @@ class Jetpack {
 	}
 
 	function activate_module_actions( $module ) {
-		/**
-		 * Fires when a module is activated.
-		 * The dynamic part of the filter, $module, is the module slug.
-		 *
-		 * @since 1.9.0
-		 *
-		 * @param string $module Module slug.
-		 */
-		do_action( "jetpack_activate_module_$module", $module );
+		_deprecated_function( __METHOD__, 'jeptack-4.2' );
 	}
 
 	public static function deactivate_module( $module ) {
@@ -2391,16 +2399,6 @@ class Jetpack {
 
 		$active = Jetpack::get_active_modules();
 		$new    = array_filter( array_diff( $active, (array) $module ) );
-
-		/**
-		 * Fires when a module is deactivated.
-		 * The dynamic part of the filter, $module, is the module slug.
-		 *
-		 * @since 1.9.0
-		 *
-		 * @param string $module Module slug.
-		 */
-		do_action( "jetpack_deactivate_module_$module", $module );
 
 		// A flag for Jump Start so it's not shown again.
 		if ( 'new_connection' === Jetpack_Options::get_option( 'jumpstart' ) ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -164,6 +164,8 @@ class Jetpack_Sync_Actions {
 }
 
 // Allow other plugins to add filters before we initialize the actions.
-add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 11, 0 );
+// Load the listeners if before modules get loaded so that we can capture version changes etc.
+add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
+
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'schedule_initial_sync' ), 10 );

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -81,7 +81,6 @@ class Jetpack_Sync_Defaults {
 		'wpcom_publish_posts_with_markdown',
 		'wpcom_publish_comments_with_markdown',
 		'jetpack_activated',
-		'jetpack_active_modules',
 		'jetpack_available_modules',
 		'jetpack_autoupdate_plugins',
 		'jetpack_autoupdate_themes',
@@ -149,6 +148,7 @@ class Jetpack_Sync_Defaults {
 		'sso_bypass_default_login_form'    => array( 'Jetpack_SSO_Helpers', 'bypass_login_forward_wpcom' ),
 		'wp_version'                       => array( 'Jetpack_Sync_Functions', 'wp_version' ),
 		'get_plugins'                      => array( 'Jetpack_Sync_Functions', 'get_plugins' ),
+		'active_modules'                   => array( 'Jetpack', 'get_active_modules' ),
 	);
 
 	static $blacklisted_post_types = array(

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -70,6 +70,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'sso_bypass_default_login_form'    => Jetpack_SSO_Helpers::bypass_login_forward_wpcom(),
 			'wp_version'                       => Jetpack_Sync_Functions::wp_version(),
 			'get_plugins'                      => Jetpack_Sync_Functions::get_plugins(),
+			'active_modules'                   => Jetpack::get_active_modules(),
 		);
 
 		if ( is_multisite() ) {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -56,7 +56,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_sync_initalize_Jetpack_Sync_Action_on_init() {
 		// prioroty should be set to 11 so that Plugins by default (10) initialize the whitelist_filter before.
-		$this->assertEquals( 11, has_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ) ) );
+		$this->assertEquals( 90, has_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ) ) );
 	}
 
 	public function test_sync_default_options() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -138,7 +138,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_publish_posts_with_markdown'    => 'pineapple',
 			'wpcom_publish_comments_with_markdown' => 'pineapple',
 			'jetpack_activated'                    => 'pineapple',
-			'jetpack_active_modules'               => 'pineapple',
 			'jetpack_available_modules'            => 'pineapple',
 			'jetpack_autoupdate_plugins'           => 'pineapple',
 			'jetpack_autoupdate_themes'            => 'pineapple',

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -8,6 +8,9 @@ class MockJetpack extends Jetpack {
 
 class WP_Test_Jetpack extends WP_UnitTestCase {
 
+	static $activated_modules = array();
+	static $deactivated_modules = array();
+
 	/**
 	 * @author blobaugh
 	 * @covers Jetpack::init
@@ -324,5 +327,49 @@ EXPECTED;
 		            "<link rel='dns-prefetch' href='//example3.com'>\r\n";
 
 		$this->assertEquals( $expected, str_replace( $remove_this, "\r\n", get_echo( array( 'Jetpack', 'dns_prefetch' ) ) ) );
+	}
+
+	public function test_activating_deactivating_modules_fires_actions() {
+		self::reset_tracking_of_module_activation();
+
+		add_action( 'jetpack_activate_module', array( __CLASS__, 'track_activated_modules' ) );
+		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivated_modules' ) );
+
+		Jetpack::update_active_modules( array( 'stats', 'json-api' ) );
+		Jetpack::update_active_modules( array( 'stats' ) );
+
+		$this->assertEquals( self::$activated_modules, array( 'stats', 'json-api' ) );
+		$this->assertEquals(  self::$deactivated_modules, array( 'stats' ) );
+
+		remove_action( 'jetpack_activate_module', array( __CLASS__, 'track_activated_modules' ) );
+		remove_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivated_modules' ) );
+	}
+
+	public function test_activating_deactivating_modules_fires_specific_actions() {
+		self::reset_tracking_of_module_activation();
+		add_action( 'jetpack_activate_module_stats', array( __CLASS__, 'track_activated_modules' ) );
+		add_action( 'jetpack_deactivate_module_stats', array( __CLASS__, 'track_deactivated_modules' ) );
+
+		Jetpack::update_active_modules( array( 'stats' ) );
+		Jetpack::update_active_modules( array( 'stats' ) );
+
+		$this->assertEquals( self::$activated_modules, array( 'stats', 'json-api' ) );
+		$this->assertEquals(  self::$deactivated_modules, array( 'stats' ) );
+
+		remove_action( 'jetpack_activate_module_stats', array( __CLASS__, 'track_activated_modules' ) );
+		remove_action( 'jetpack_deactivate_module_stats', array( __CLASS__, 'track_deactivated_modules' ) );
+	}
+
+	static function reset_tracking_of_module_activation() {
+		self::$activated_modules = array();
+		self::$deactivated_modules = array();
+	}
+
+	static function track_activated_modules( $module ) {
+		self::$activated_modules[] = $module;
+	}
+
+	static function track_deactivated_modules( $module ) {
+		self::$deactivated_modules[] = $module;
 	}
 } // end class

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -335,8 +335,10 @@ EXPECTED;
 		add_action( 'jetpack_activate_module', array( __CLASS__, 'track_activated_modules' ) );
 		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivated_modules' ) );
 
-		Jetpack::update_active_modules( array( 'stats', 'json-api' ) );
 		Jetpack::update_active_modules( array( 'stats' ) );
+		Jetpack::update_active_modules( array( 'stats' ) );
+		Jetpack::update_active_modules( array( 'json-api' ) );
+		Jetpack::update_active_modules( array( 'json-api' ) );
 
 		$this->assertEquals( self::$activated_modules, array( 'stats', 'json-api' ) );
 		$this->assertEquals(  self::$deactivated_modules, array( 'stats' ) );
@@ -352,8 +354,10 @@ EXPECTED;
 
 		Jetpack::update_active_modules( array( 'stats' ) );
 		Jetpack::update_active_modules( array( 'stats' ) );
+		Jetpack::update_active_modules( array( 'json-api' ) );
+		Jetpack::update_active_modules( array( 'json-api' ) );
 
-		$this->assertEquals( self::$activated_modules, array( 'stats', 'json-api' ) );
+		$this->assertEquals( self::$activated_modules, array( 'stats' ) );
 		$this->assertEquals(  self::$deactivated_modules, array( 'stats' ) );
 
 		remove_action( 'jetpack_activate_module_stats', array( __CLASS__, 'track_activated_modules' ) );


### PR DESCRIPTION
Fixes issue that were created becasue we didn't always call the activate_module action. 

#### Changes proposed in this Pull Request:
- Remove any calls to update_ modules. 

#### Testing instructions:
- Activate, deactivate different modules. 
Does it work as expected? 

