### PR TITLE
Fix/pro (security) settings cards

### DIFF
--- a/_inc/client/components/foldable-card/style.scss
+++ b/_inc/client/components/foldable-card/style.scss
@@ -1,23 +1,64 @@
+// Jetpack specific foldable card mods
+
 .dops-foldable-card.dops-card {
-
-	.dops-foldable-card__header-text {
-
-		@include breakpoint( "<480px" ) {
-			font-size: rem( 14px );
-		}
-	}
-
-	.dops-foldable-card__subheader {
-
-		@include breakpoint( "<480px" ) {
-			display: none;
-		}
-	}
 
 	&.devmode-disabled {
 		.dops-foldable-card__summary,
 		.dops-foldable-card__summary_expanded {
 			width: 100px;
+		}
+	}
+}
+
+.dops-foldable-card__main {
+
+	@include breakpoint( ">660px" ) {
+		max-width: 85%;
+	}
+
+	@include breakpoint( ">480px" ) {
+		max-width: 60%;
+	}
+
+	@include breakpoint( "<480px" ) {
+		flex-basis: 100%;
+	}
+}
+
+.dops-foldable-card__header {
+
+	@include breakpoint( "<480px" ) {
+		flex-wrap: wrap;
+	}
+}
+
+.dops-foldable-card__header-text {
+
+	@include breakpoint( "<480px" ) {
+		font-size: rem( 14px );
+		line-height: 1.8;
+	}
+
+	.dops-button {
+		margin-left: rem( 8px );
+	}
+}
+
+.dops-foldable-card__subheader {
+
+	@include breakpoint( "<480px" ) {
+		display: none;
+	}
+}
+
+.dops-foldable-card.has-expanded-summary {
+
+	.dops-foldable-card__summary,
+	.dops-foldable-card__summary_expanded {
+
+		@include breakpoint( "<480px" ) {
+			text-align: left;
+			margin-top: rem( 8px );
 		}
 	}
 }

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -155,6 +155,17 @@ export const Page = ( props ) => {
 					props.isPluginActive( 'akismet/akismet.php' )
 			};
 			toggle = ! isFetchingSiteData ? getProToggle( proProps.isProPluginActive, proProps.isProPluginInstalled ) : '';
+
+			// Add a "pro" button next to the header title
+			element[1] = <span>
+				{ element[1] }
+				<Button
+					compact={ true }
+				    href="#professional"
+				>
+					{ __( 'Pro' ) }
+				</Button>
+			</span>
 		}
 
 		return (

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -28,7 +28,10 @@ import {
 } from 'state/site/plugins';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import QuerySite from 'components/data/query-site';
-import { getSitePlan } from 'state/site';
+import {
+	getSitePlan,
+	isFetchingSiteData
+} from 'state/site';
 import { isUnavailableInDevMode } from 'state/connection';
 
 export const Page = ( props ) => {
@@ -37,7 +40,8 @@ export const Page = ( props ) => {
 		isModuleActivated,
 		isTogglingModule,
 		getModule,
-		getSitePlan
+		getSitePlan,
+		isFetchingSiteData
 		} = props;
 	var cards = [
 		[ 'scan', __( 'Security Scanning' ), __( 'Automatically scan your site for common threats and attacks.' ) ],
@@ -66,16 +70,32 @@ export const Page = ( props ) => {
 			if ( false !== getSitePlan() ) {
 				if ( active && installed ) {
 					return (
-						__('ACTIVE')
+						__( 'ACTIVE' )
 					);
 				} else {
 					return (
 						<Button
 							compact={ true }
 							primary={ true }
-							href={ 'https://wordpress.com/plugins/' + pluginSlug }
+							href={ 'https://wordpress.com/plugins/' + pluginSlug + '/' + window.Initial_State.rawUrl }
 						>
 							{ ! installed ? __( 'Install' ) : __( 'Activate' ) }
+						</Button>
+					);
+				}
+			} else {
+				if ( active && installed ) {
+					return (
+						__( 'ACTIVE' )
+					);
+				} else {
+					return (
+						<Button
+							compact={ true }
+							primary={ true }
+							href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl }
+						>
+							{ __( 'Upgrade' ) }
 						</Button>
 					);
 				}
@@ -93,7 +113,7 @@ export const Page = ( props ) => {
 					props.isPluginActive( 'vaultpress/vaultpress.php' ) :
 					props.isPluginActive( 'akismet/akismet.php' )
 			};
-			toggle = getProToggle( proProps.isProPluginActive, proProps.isProPluginInstalled );
+			toggle = ! isFetchingSiteData ? getProToggle( proProps.isProPluginActive, proProps.isProPluginInstalled ) : '';
 		}
 
 		return (
@@ -142,7 +162,8 @@ export default connect(
 			isFetchingPluginsData: isFetchingPluginsData( state ),
 			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
 			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug ),
-			getSitePlan: () => getSitePlan( state )
+			getSitePlan: () => getSitePlan( state ),
+			isFetchingSiteData: isFetchingSiteData( state )
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
Fixes #4495 && #3989 && #4481

This replaces the Pro settings toggles with buttons/notices mocked in p6TEKc-xF-p2.

**Note that this does not do anything to the content within the card itself.  That will be done in a following PR**

To test: 

**Akismet:**
- Active and installed
- Active and installed with no API key
- Inactive and installed
- Uninstalled

**Scan:**
- VaultPress Active and installed
- VaultPress Active and installed with spoofing a threat. You can change the `0` to any number in [this line](https://github.com/Automattic/jetpack/pull/4500/files#diff-5d91be5e15745cca6f9fc3fdb7b0483bR83)
- VP inactive but installed
- VP uninstalled

**Backups:**
- VaultPress Active and installed
- VP inactive but installed
- VP uninstalled

cc @jeffgolenski or @MichaelArestad for help with fixing the width of the notices with too much text, like 
![screen shot 2016-07-21 at 5 28 01 pm](https://cloud.githubusercontent.com/assets/7129409/17039431/82c16f5c-4f68-11e6-87b5-c9be30b959aa.png)
