### PR TITLE
SSO: Fixes a broken link which results in invalid response data error

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1010,7 +1010,7 @@ class Jetpack_SSO {
 		$error = sprintf(
 			wp_kses(
 				__(
-					'Two-Step Authentication is required to access this site. Please visit your <a href="%1$s" target="_blank">Security Settings</a> to configure <a href="%2$S" target="_blank">Two-step Authentication</a> for your account.',
+					'Two-Step Authentication is required to access this site. Please visit your <a href="%1$s" target="_blank">Security Settings</a> to configure <a href="%2$s" target="_blank">Two-step Authentication</a> for your account.',
 					'jetpack'
 				),
 				array(  'a' => array( 'href' => array() ) )


### PR DESCRIPTION
@designsimply reported an issue where the link to the two-step authentication support documentation was broken. Because the link was broken, it could cause an "Error: Invalid response data" error when clicked.

This PR fixes that by fixing a typo the `sprintf` placeholder.

![screen shot 2016-07-22 at 9 37 07 am](https://cloud.githubusercontent.com/assets/1126811/17058814/18ccb952-4ff0-11e6-8d7e-1e2b9d53674d.png)

To test:

- Checkout `fix/sso-two-step-support-link`
- In a plugin, add `add_filter( 'jetpack_sso_require_two_step', '__return_true' );`
- Log in with SSO, using a WP.com user that does not have 2fa
- You should receive an error like the above
- Make sure both links work

cc @lezama for code review