### PR TITLE
At a Glance: fixes alignment of remaining left dashitem in the grid

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -258,6 +258,10 @@
 
 	@include breakpoint( ">660px" ) {
 		margin-right: rem( 16px );
+
+		&:last-child {
+			flex-basis: calc( 50% - .5rem ); // rem function doesn't work in calc()
+		}
 	}
 }
 // end flexbox nesting


### PR DESCRIPTION
Fixes [alignment issue](https://github.com/Automattic/jetpack/pull/4489#issuecomment-234322546) brought up by @jeffgolenski .

#### Changes proposed in this Pull Request:
- use calc to make left item in grid slightly smaller when it's the last child in a group
- `rem()` function doesn't work within `calc()` for some reason so did math the old fashioned way
- tested in IE11 and Chrome so far

#### Testing instructions:
- look at alignment

Before:
![image](https://cloud.githubusercontent.com/assets/214813/17032185/eef949c4-4f45-11e6-8244-8f480b89b47f.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17060939/c75c0530-4ff1-11e6-97b2-fa57480779cd.png)

CC @jeffgolenski 