### PR TITLE
Admin Page: Feature Settings - Replace 'Link to Old Settings' 'text' for just 'Settings' in admin pa…

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -49,7 +49,7 @@ export const EngagementModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<a href={ module.configure_url }>{ __( 'Link to old settings' ) }</a>
+						<a href={ module.configure_url }>{ __( 'Settings' ) }</a>
 					</div>
 				);
 		}
@@ -71,7 +71,7 @@ export const SecurityModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<a href={ module.configure_url }>{ __( 'Link to old settings' ) }</a>
+						<a href={ module.configure_url }>{ __( 'Settings' ) }</a>
 					</div>
 				);
 		}
@@ -98,7 +98,7 @@ export const AppearanceModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<a href={ module.configure_url }>{ __( 'Link to old settings' ) }</a>
+						<a href={ module.configure_url }>{ __( 'Settings' ) }</a>
 					</div>
 				);
 		}
@@ -124,7 +124,7 @@ export const WritingModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<a href={ module.configure_url }>{ __( 'Link to old settings' ) }</a>
+						<a href={ module.configure_url }>{ __( 'Settings' ) }</a>
 					</div>
 				);
 		}


### PR DESCRIPTION
Fixes #4498  .

#### Changes proposed in this Pull Request:

* Updates text `Link to Old Settings` for just `Settings`. 

#### Testing instructions:

- Get to **Publicize** settings under the **Engagement** tab and check the old settings link reads just **Settings**.
