### PR TITLE
Admin Page: Post By Email Settings - Don't show `false` on the input text if the address value is `false`

### DIFF
--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -28,7 +28,7 @@ export function connectModuleOptions( Component ) {
 		( state, ownProps ) => {
 			return {
 				validValues: ( option_name ) => getModuleOptionValidValues( state, ownProps.module.module, option_name ),
-				getOptionCurrentValue: ( module_name, option_name ) => getModuleOption( state, module_name, option_name ),
+				getOptionCurrentValue: ( module_slug, option_name ) => getModuleOption( state, module_slug, option_name ),
 				enabled: getModuleOption( state, ownProps.module.module, ownProps.option_name ),
 				getSiteRoles: () => getSiteRoles( state ),
 				isToggling: false,

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -34,9 +34,6 @@ export function connectModuleOptions( Component ) {
 			}
 		},
 		( dispatch, ownProps ) => ( {
-			toggleOption: ( option_name, currentValue ) => {
-				return dispatch( updateModuleOption( ownProps.module.module, option_name, ! currentValue ) );
-			},
 			updateOptions: ( newOptions ) => {
 				return dispatch( updateModuleOptions( ownProps.module.module, newOptions ) );
 			},

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -29,9 +29,7 @@ export function connectModuleOptions( Component ) {
 			return {
 				validValues: ( option_name ) => getModuleOptionValidValues( state, ownProps.module.module, option_name ),
 				getOptionCurrentValue: ( module_slug, option_name ) => getModuleOption( state, module_slug, option_name ),
-				enabled: getModuleOption( state, ownProps.module.module, ownProps.option_name ),
 				getSiteRoles: () => getSiteRoles( state ),
-				isToggling: false,
 				isUpdating: ( option_name ) => isUpdatingModuleOption( state, ownProps.module.module, option_name )
 			}
 		},

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -28,7 +28,6 @@ export function connectModuleOptions( Component ) {
 		( state, ownProps ) => {
 			return {
 				validValues: ( option_name ) => getModuleOptionValidValues( state, ownProps.module.module, option_name ),
-				currentValue: getModuleOption( state, ownProps.module.module, ownProps.option_name ),
 				getOptionCurrentValue: ( module_name, option_name ) => getModuleOption( state, module_name, option_name ),
 				enabled: getModuleOption( state, ownProps.module.module, ownProps.option_name ),
 				getModuleOption: ( module_slug ) => getModuleOption( state, module_slug, module_name ),

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -30,7 +30,6 @@ export function connectModuleOptions( Component ) {
 				validValues: ( option_name ) => getModuleOptionValidValues( state, ownProps.module.module, option_name ),
 				getOptionCurrentValue: ( module_name, option_name ) => getModuleOption( state, module_name, option_name ),
 				enabled: getModuleOption( state, ownProps.module.module, ownProps.option_name ),
-				getModuleOption: ( module_slug ) => getModuleOption( state, module_slug, module_name ),
 				getSiteRoles: () => getSiteRoles( state ),
 				isToggling: false,
 				isUpdating: ( option_name ) => isUpdatingModuleOption( state, ownProps.module.module, option_name )

--- a/_inc/client/components/module-settings/form-components.jsx
+++ b/_inc/client/components/module-settings/form-components.jsx
@@ -20,8 +20,8 @@ export const ModuleSettingCheckbox = React.createClass( {
 			<FormLabel>
 				<FormCheckbox
 					name={ props.name }
-					checked={ props.getOptionValue( props.name ) }
-					value={ props.getOptionValue( props.name ) }
+					checked={ !! props.getOptionValue( props.name ) }
+					value={ !! props.getOptionValue( props.name ) }
 					disabled={ props.isUpdating( props.name ) }
 					onChange= { props.onOptionChange } />
 				<span>{ ( props.label ) }</span>
@@ -41,7 +41,7 @@ export const ModuleSettingRadios = React.createClass( {
 					<FormLabel key={ `option-${ props.option_name }-${key}` } >
 						<FormRadio
 							name={ props.name }
-							checked= { key === props.getOptionValue( props.name ) }
+							checked={ key === props.getOptionValue( props.name ) }
 							value={ key }
 							disabled={ props.isUpdating( props.name ) }
 							onChange= { props.onOptionChange } />

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -383,6 +383,15 @@ export let PostByEmailSettings = React.createClass( {
 	regeneratePostByEmailAddress() {
 		this.props.regeneratePostByEmailAddress();
 	},
+	address() {
+		const currentValue = this.props.getOptionValue( 'post_by_email_address' )
+		// If the module Post-by-email is enabled BUT it's configured as disabled
+		// Its value is set to false
+		if ( currentValue === false ) {
+			return '';
+		}
+		return currentValue;
+	},
 	render() {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
@@ -390,7 +399,7 @@ export let PostByEmailSettings = React.createClass( {
 					<FormLabel>
 						<span> { __( 'Email Address' ) } </span>
 						<FormTextInput
-							value={ this.props.getOptionValue( 'post_by_email_address' ) }
+							value={ this.address() }
 							readOnly="readonly" />
 						<Button
 							onClick={ this.regeneratePostByEmailAddress } >

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -32,6 +32,10 @@ export function ModuleSettingsForm( InnerComponent ) {
 				optionValue = event.target.value;
 			}
 
+			if ( event.target.type === 'textarea' ) {
+				optionValue = event.target.value;
+			}
+
 			this.updateFormStateOptionValue( optionName, optionValue );
 		},
 		updateFormStateOptionValue( optionName, optionValue ) {

--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -166,7 +166,7 @@ export function isUpdatingModuleOption( state, module_slug, option_name ) {
 }
 
 export function getModuleOption( state, module_slug, option_name ) {
-	return get( state.jetpack.modules.items, [ module_slug, 'options', option_name, 'current_value' ], false );
+	return get( state.jetpack.modules.items, [ module_slug, 'options', option_name, 'current_value' ] );
 }
 
 export function getModuleOptionValidValues( state, module_slug, option_name ) {


### PR DESCRIPTION
Fixes #4483.
Fixes #4507.  

#### Changes proposed in this Pull Request:

* Avoids showing false in the text input for the Post By Email Address setitng.
* Fixes textarea input behaviour for the **Protect** module's settings.
* Includes a few code-cleaning commits.

#### Testing instructions:

1. Delete the Post By Email Address option using wp-cli.

    ```
     $ wp option delete post_by_email_address 
    ```
1. check **The Post By Email** setting under the **Writing** tab. Expect to see an empty text input instead of it reading `false.`
1. Toggle any radio option for the **Mobile Theme** feature under the **Appearance** tab, save, refresh the browser. See if the change persisted.
1. toggle any checkbox option, save, refresh the browser. See if the change persisted.
1. toggle one of the Roles checkbox in **Stats** module settings under the **Engagement** tab, save, refresh the browser. See if the change persisted.
