### PR TITLE
Admin Page: Add Comments module settings to Admin Page

### DIFF
--- a/_inc/client/components/module-settings/form-components.jsx
+++ b/_inc/client/components/module-settings/form-components.jsx
@@ -23,7 +23,7 @@ export const ModuleSettingCheckbox = React.createClass( {
 					checked={ props.getOptionValue( props.name ) }
 					value={ props.getOptionValue( props.name ) }
 					disabled={ props.isUpdating( props.name ) }
-					onChange= { props.onOptionChange} />
+					onChange= { props.onOptionChange } />
 				<span>{ ( props.label ) }</span>
 			</FormLabel>
 		);

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -103,6 +103,35 @@ export let RelatedPostsSettings = React.createClass( {
 
 RelatedPostsSettings = ModuleSettingsForm( RelatedPostsSettings );
 
+export let CommentsSettings = React.createClass( {
+	render() {
+		return (
+			<form onSubmit={ this.props.onSubmit } >
+				<FormFieldset>
+					<FormLegend>{ __( 'Comments headline: A few catchy words to motivate your readers to comment' ) }</FormLegend>
+					<FormLabel>
+						<FormTextInput
+							name={ 'highlander_comment_form_prompt' }
+							value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
+							disabled={ this.props.isUpdating( 'highlander_comment_form_prompt' ) }
+							onChange={ this.props.onOptionChange} />
+					</FormLabel>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLegend>{ __( 'Color Scheme' ) }</FormLegend>
+					<ModuleSettingRadios
+						name={ 'jetpack_comment_form_color_scheme' }
+						{ ...this.props }
+						validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme' ) } />
+					<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				</FormFieldset>
+			</form>
+		)
+	}
+} );
+
+CommentsSettings = ModuleSettingsForm( CommentsSettings );
+
 export let SubscriptionsSettings = React.createClass( {
 	render() {
 		return (

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -28,6 +28,10 @@ export function ModuleSettingsForm( InnerComponent ) {
 				optionValue = event.target.value;
 			}
 
+			if ( event.target.type === 'text' ) {
+				optionValue = event.target.value;
+			}
+
 			this.updateFormStateOptionValue( optionName, optionValue );
 		},
 		updateFormStateOptionValue( optionName, optionValue ) {

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -10,6 +10,7 @@ import { translate as __ } from 'i18n-calypso';
 import {
 	StatsSettings,
 	RelatedPostsSettings,
+	CommentsSettings,
 	SubscriptionsSettings,
 	SharedaddySettings,
 	ProtectSettings,
@@ -34,6 +35,8 @@ export const EngagementModulesSettings = React.createClass( {
 				return( <StatsSettings module={ module } { ...this.props } /> );
 			case 'related-posts':
 				return ( <RelatedPostsSettings module={ module } { ...this.props } /> );
+			case 'comments':
+				return ( <CommentsSettings module={ module } { ...this.props } /> );
 			case 'subscriptions':
 				return ( <SubscriptionsSettings module={ module } { ...this.props } /> );
 			case 'sharedaddy':


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds settings for the **Comments** module under the **Engagement** tab.

#### Testing instructions:
1. Get to the **Comments** Card under the **Engagement** tab, change any of the values
1. Save
1. Refresh the page and check the change was persisted
