### PR TITLE
Admin Page: Add Markdown module settings to Admin Page

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -473,3 +473,21 @@ export let AfterTheDeadlineSettings = React.createClass( {
 } );
 
 AfterTheDeadlineSettings = ModuleSettingsForm( AfterTheDeadlineSettings );
+
+export let MarkdownSettings = React.createClass( {
+	render() {
+		return (
+			<form onSubmit={ this.props.onSubmit } >
+				<FormFieldset>
+					<ModuleSettingCheckbox
+						name={ 'wpcom_publish_comments_with_markdown' }
+						{ ...this.props }
+						label={ __( 'Use Markdown for comments' ) } />
+				</FormFieldset>
+				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+			</form>
+		)
+	}
+} );
+
+MarkdownSettings = ModuleSettingsForm( MarkdownSettings );

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -22,7 +22,8 @@ import {
 	TiledGallerySettings,
 	PostByEmailSettings,
 	CustomContentTypesSettings,
-	AfterTheDeadlineSettings
+	AfterTheDeadlineSettings,
+	MarkdownSettings
 } from 'components/module-settings/';
 
 export const EngagementModulesSettings = React.createClass( {
@@ -115,9 +116,10 @@ export const WritingModulesSettings = React.createClass( {
 				return( <CustomContentTypesSettings module={ module } { ...this.props } /> );
 			case 'after-the-deadline':
 				return( <AfterTheDeadlineSettings module={ module } { ...this.props } /> );
+			case 'markdown':
+				return( <MarkdownSettings module={ module } { ...this.props } /> );
 			case 'contact-form':
 			case 'latex':
-			case 'markdown':
 			case 'shortlinks':
 			case 'shortcodes':
 				return <span>{ __( 'This module has no configuration options' ) } </span>;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds settings for the **Markdown** module under the **Writing** tab.

#### Testing instructions:
1. Get to the **Markdown** Card under the **Writing** tab, toggle the only option.
1. Save
1. Refresh the page and check the change was persisted
