### PR TITLE
Admin Page - AAG: load stats data on demand according to a specified time range

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -55,6 +55,13 @@
 
 .jp-at-a-glance__stats-chart {
 	padding: rem( 16px );
+	position: relative;
+}
+
+.jp-at-a-glance__stats-chart .dops-spinner {
+	position: absolute;
+	top: 50%;
+	left: 50%;
 }
 
 .jp-at-a-glance__stats-bottom {

--- a/_inc/client/components/data/query-stats-data/index.jsx
+++ b/_inc/client/components/data/query-stats-data/index.jsx
@@ -3,7 +3,6 @@
  */
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -13,7 +12,7 @@ import { isFetchingStatsData, fetchStatsData } from 'state/at-a-glance';
 class QueryStatsData extends Component {
 	componentWillMount() {
 		if ( ! this.props.fetchingStatsData ) {
-			this.props.fetchStatsData();
+			this.props.fetchStatsData( this.props.range );
 		}
 	}
 
@@ -28,12 +27,14 @@ QueryStatsData.defaultProps = {
 
 export default connect( ( state ) => {
 	return {
-		fetchStatsData: fetchStatsData(),
+		fetchStatsData: ( range ) => fetchStatsData( state, range ),
 		fetchingStatsData: isFetchingStatsData( state )
 	};
 }, ( dispatch ) => {
-	return bindActionCreators( {
-		fetchStatsData
-	}, dispatch );
+	return {
+		fetchStatsData: ( range ) => {
+			return dispatch( fetchStatsData( range ) );
+		}
+	};
 }
 )( QueryStatsData );

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -122,12 +122,16 @@ const restApi = {
 		}
 	} )
 		.then( checkStatus ).then( response => response.json() ),
-	getStatsData: () => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/module/stats/get`, {
+	getStatsData: ( range ) => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/module/stats/get`, {
+		method: 'put',
 		credentials: 'same-origin',
 		headers: {
 			'X-WP-Nonce': window.Initial_State.WP_API_nonce,
 			'Content-type': 'application/json'
-		}
+		},
+		body: JSON.stringify( {
+			'range': range
+		} )
 	} )
 		.then( checkStatus ).then( response => response.json() ),
 	getPluginUpdates: () => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/updates/plugins`, {

--- a/_inc/client/state/at-a-glance/actions.js
+++ b/_inc/client/state/at-a-glance/actions.js
@@ -33,12 +33,12 @@ export const statsSwitchTab = ( tab ) => {
 	}
 };
 
-export const fetchStatsData = () => {
+export const fetchStatsData = ( range ) => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: STATS_DATA_FETCH
 		} );
-		return restApi.getStatsData().then( statsData => {
+		return restApi.getStatsData( range ).then( statsData => {
 			dispatch( {
 				type: STATS_DATA_FETCH_SUCCESS,
 				statsData: statsData

--- a/_inc/client/state/at-a-glance/reducer.js
+++ b/_inc/client/state/at-a-glance/reducer.js
@@ -172,7 +172,7 @@ export function isFetchingStatsData( state ) {
  * Returns object with Stats data.
  *
  * @param  {Object}  state  Global state tree
- * @return {Object} 		Stats data.
+ * @return {Object}			Stats data.
  */
 export function getStatsData( state ) {
 	return state.jetpack.dashboard.statsData;

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -201,7 +201,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'adminUrl' => esc_url( admin_url() ),
 			'stats' => array(
 				// data is populated asynchronously on page load
-				'data'  => false,
+				'data'  => array(
+					'general' => false,
+					'day'     => false,
+					'week'    => false,
+					'month'   => false,
+				),
 				'roles' => $stats_roles,
 			),
 			'settingNames' => array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Improves page loading time by loading specific data for day, week or month only when user requests it.
This reduces the load of the initial stats data fetch, since now only days are fetch, while previously, days, weeks and months were fetch even if user never looked at them.

![stats](https://cloud.githubusercontent.com/assets/1041600/17070748/1b72f650-5034-11e6-896b-075c885535ec.gif)

#### Testing instructions:
- go to Dashboard and make sure Stats are loading fine.
- click on Week and Month selectors: they should load as well.
- click on selectors you've clicked previously: they should load instantly now that data for them is cached.
