### PR TITLE
Enhanced Distribution: Add site/post ID to feed

### DIFF
--- a/modules/enhanced-distribution.php
+++ b/modules/enhanced-distribution.php
@@ -50,3 +50,24 @@ if ( isset( $_GET['get_freshly_pressed_data'] ) ) {
 		}
 	}
 }
+
+add_action( 'rss_head',  'jetpack_enhanced_distribution_feed_id' );
+add_action( 'rss_item',  'jetpack_enhanced_distribution_post_id' );
+add_action( 'rss2_head', 'jetpack_enhanced_distribution_feed_id' );
+add_action( 'rss2_item', 'jetpack_enhanced_distribution_post_id' );
+
+function jetpack_enhanced_distribution_feed_id(){
+	(int) $id = Jetpack_Options::get_option( 'id' );
+	if ( $id > 0 ) {
+		$output = sprintf( '<site xmlns="com-wordpress:feed-additions:1">%d</site>', $id );
+		echo $output;
+	}
+}
+
+function jetpack_enhanced_distribution_post_id(){
+	$id = get_the_ID();
+	if ( $id ) {
+		$output = sprintf( '<post-id xmlns="com-wordpress:feed-additions:1">%d</post-id>', $id );
+		echo $output;
+	}
+}


### PR DESCRIPTION
Fixes #996 

When the Enhanced Distribution module is active (is there a better place for this?), it adds the site ID and the post ID to the RSS feed to help the WP.com Reader make magic happen (correctly associate a feed ID to a synced data object).

cc: @blowery 
@jeherve Still time for 4.2 or should this be for 4.3?