### PR TITLE
Ensure that if comments or posts are deleted, sync doesn’t fail

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -91,7 +91,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	public function expand_post_ids( $args ) {
 		$post_ids = $args[0];
 
-		$posts = array_map( array( 'WP_Post', 'get_instance' ), $post_ids );
+		$posts = array_filter( array_map( array( 'WP_Post', 'get_instance' ), $post_ids ) );
 		$posts = array_map( array( $this, 'filter_post_content_and_add_links' ), $posts );
 
 		return array(

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -640,6 +640,44 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'jetpack_sync_blocked', $blocked_post->post_status );
 	}
 
+	function test_full_sync_doesnt_send_deleted_posts() {
+		// previously, the behaviour was to send false or throw errors - we
+		// should actively detect false values and remove them
+		$keep_post_id = $this->factory->post->create();
+		$delete_post_id = $this->factory->post->create();
+
+		$this->full_sync->start();
+
+		wp_delete_post( $delete_post_id, true );
+
+		$this->sender->do_sync();
+
+		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
+
+		$posts = $synced_posts_event->args[0];
+		$this->assertEquals( 1, count( $posts ) );
+		$this->assertEquals( $keep_post_id, $posts[0]->ID );
+	}
+
+	function test_full_sync_doesnt_send_deleted_comments() {
+		// previously, the behaviour was to send false or throw errors - we
+		// should actively detect false values and remove them
+		$post_id     = $this->factory->post->create();
+		list( $keep_comment_id, $delete_comment_id ) = $this->factory->comment->create_post_comments( $post_id, 2 );
+
+		$this->full_sync->start();
+
+		wp_delete_comment( $delete_comment_id, true );
+
+		$this->sender->do_sync();
+
+		$synced_comments_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
+
+		$comments = $synced_comments_event->args[0];
+		$this->assertEquals( 1, count( $comments ) );
+		$this->assertEquals( $keep_comment_id, $comments[0]->comment_ID );
+	}
+
 	function test_full_sync_status_with_a_small_queue() {
 
 		$this->sender->set_dequeue_max_bytes( 1500 ); // process 0.0015MB of items at a time\


### PR DESCRIPTION
Fixes an issue we noticed with syncing large sites, if some objects get deleted before the sync packets are sent, the send fails.