### PR TITLE
Admin Page: Add Verification Tools module settings to Admin Page

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -101,6 +101,8 @@ export let RelatedPostsSettings = React.createClass( {
 	}
 } );
 
+RelatedPostsSettings = ModuleSettingsForm( RelatedPostsSettings );
+
 export let LikesSettings = React.createClass( {
 	render() {
 		return (
@@ -119,8 +121,6 @@ export let LikesSettings = React.createClass( {
 } );
 
 LikesSettings = ModuleSettingsForm( LikesSettings );
-
-RelatedPostsSettings = ModuleSettingsForm( RelatedPostsSettings );
 
 export let CommentsSettings = React.createClass( {
 	render() {
@@ -378,6 +378,47 @@ export let GravatarHovercardsSettings = React.createClass( {
 } );
 
 GravatarHovercardsSettings = ModuleSettingsForm( GravatarHovercardsSettings );
+
+export let VerificationToolsSettings = React.createClass( {
+	render() {
+		return (
+			<form onSubmit={ this.props.onSubmit } >
+				<FormFieldset>
+					<FormLabel>
+						<span>Google</span>
+						<FormTextInput
+							placeholder='<meta name="google-site-verification" content="1234" />'
+							name={ 'google' }
+							value={ this.props.getOptionValue( 'google' ) }
+							disabled={ this.props.isUpdating( 'google' ) }
+							onChange={ this.props.onOptionChange} />
+					</FormLabel>
+					<FormLabel>
+						<span>Bing</span>
+						<FormTextInput
+							placeholder='<meta name="msvalidate.01" content="1234" />'
+							name={ 'bing' }
+							value={ this.props.getOptionValue( 'bing' ) }
+							disabled={ this.props.isUpdating( 'bing' ) }
+							onChange={ this.props.onOptionChange} />
+					</FormLabel>
+					<FormLabel>
+						<span>Pinterest</span>
+						<FormTextInput
+							placeholder='<meta name="p:domain_verify" content="1234" />'
+							name={ 'pinterest' }
+							value={ this.props.getOptionValue( 'pinterest' ) }
+							disabled={ this.props.isUpdating( 'pinterest' ) }
+							onChange={ this.props.onOptionChange} />
+					</FormLabel>
+					<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				</FormFieldset>
+			</form>
+		)
+	}
+} );
+
+VerificationToolsSettings = ModuleSettingsForm( VerificationToolsSettings );
 
 export let TiledGallerySettings = React.createClass( {
 	render() {

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -384,30 +384,72 @@ export let VerificationToolsSettings = React.createClass( {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
-					<FormLabel>
-						<span>Google</span>
-						<FormTextInput
-							name={ 'google' }
-							value={ this.props.getOptionValue( 'google' ) }
-							disabled={ this.props.isUpdating( 'google' ) }
-							onChange={ this.props.onOptionChange} />
-					</FormLabel>
-					<FormLabel>
-						<span>Bing</span>
-						<FormTextInput
-							name={ 'bing' }
-							value={ this.props.getOptionValue( 'bing' ) }
-							disabled={ this.props.isUpdating( 'bing' ) }
-							onChange={ this.props.onOptionChange} />
-					</FormLabel>
-					<FormLabel>
-						<span>Pinterest</span>
-						<FormTextInput
-							name={ 'pinterest' }
-							value={ this.props.getOptionValue( 'pinterest' ) }
-							disabled={ this.props.isUpdating( 'pinterest' ) }
-							onChange={ this.props.onOptionChange} />
-					</FormLabel>
+					<p>
+						{
+							__( 'Enter your meta key "content" value to verify your blog with {{a}}Google Search Console{{/a}}, {{a}}Bing Webmaster Center{{/a}} and {{a}}Pinterest Site Verification{{/a}}.', {
+								components: {
+									a: <a href="https://www.google.com/webmasters/tools/" target="_blank" />,
+									a1: <a href="http://www.bing.com/webmaster/" target="_blank" />,
+									a2: <a href="https://pinterest.com/website/verify/" target="_blank" />
+								}
+							} )
+						}
+					</p>
+
+					<div className="dops-card">
+						<FormLabel>
+							<span>Google</span>
+							<FormTextInput
+								name={ 'google' }
+								value={ this.props.getOptionValue( 'google' ) }
+								className="widefat code"
+								disabled={ this.props.isUpdating( 'google' ) }
+								onChange={ this.props.onOptionChange} />
+						</FormLabel>
+						<p>
+							{ __( 'Example:' ) }
+						</p>
+						<p className="small">
+							&lt;meta name='google-site-verification' content='<strong className="code">dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8</strong>'&gt;
+						</p>
+					</div>
+
+					<div className="dops-card">
+						<FormLabel>
+							<span>Bing</span>
+							<FormTextInput
+								name={ 'bing' }
+								value={ this.props.getOptionValue( 'bing' ) }
+								className="widefat code"
+								disabled={ this.props.isUpdating( 'bing' ) }
+								onChange={ this.props.onOptionChange} />
+						</FormLabel>
+						<p>
+							{ __( 'Example:' ) }
+						</p>
+						<p className="small">
+							&lt;meta name='msvalidate.01' content='<strong>12C1203B5086AECE94EB3A3D9830B2E</strong>'&gt;
+						</p>
+					</div>
+
+					<div className="dops-card">
+						<FormLabel>
+							<span>Pinterest</span>
+							<FormTextInput
+								name={ 'pinterest' }
+								value={ this.props.getOptionValue( 'pinterest' ) }
+								className="widefat code"
+								disabled={ this.props.isUpdating( 'pinterest' ) }
+								onChange={ this.props.onOptionChange} />
+						</FormLabel>
+						<p>
+							{ __( 'Example:' ) }
+						</p>
+						<p className="small">
+							&lt;meta name='p:domain_verify' content='<strong>f100679e6048d45e4a0b0b92dce1efce</strong>'&gt;
+						</p>
+					</div>
+
 					<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
 				</FormFieldset>
 			</form>

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -387,7 +387,6 @@ export let VerificationToolsSettings = React.createClass( {
 					<FormLabel>
 						<span>Google</span>
 						<FormTextInput
-							placeholder='<meta name="google-site-verification" content="1234" />'
 							name={ 'google' }
 							value={ this.props.getOptionValue( 'google' ) }
 							disabled={ this.props.isUpdating( 'google' ) }
@@ -396,7 +395,6 @@ export let VerificationToolsSettings = React.createClass( {
 					<FormLabel>
 						<span>Bing</span>
 						<FormTextInput
-							placeholder='<meta name="msvalidate.01" content="1234" />'
 							name={ 'bing' }
 							value={ this.props.getOptionValue( 'bing' ) }
 							disabled={ this.props.isUpdating( 'bing' ) }
@@ -405,7 +403,6 @@ export let VerificationToolsSettings = React.createClass( {
 					<FormLabel>
 						<span>Pinterest</span>
 						<FormTextInput
-							placeholder='<meta name="p:domain_verify" content="1234" />'
 							name={ 'pinterest' }
 							value={ this.props.getOptionValue( 'pinterest' ) }
 							disabled={ this.props.isUpdating( 'pinterest' ) }

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -25,7 +25,8 @@ import {
 	PostByEmailSettings,
 	CustomContentTypesSettings,
 	AfterTheDeadlineSettings,
-	MarkdownSettings
+	MarkdownSettings,
+	VerificationToolsSettings,
 } from 'components/module-settings/';
 
 export const EngagementModulesSettings = React.createClass( {
@@ -44,13 +45,14 @@ export const EngagementModulesSettings = React.createClass( {
 			case 'sharedaddy':
 				return ( <SharedaddySettings module={ module } { ...this.props } /> );
 			case 'gravatar-hovercards':
-				return( <GravatarHovercardsSettings module={ module } { ...this.props } /> );
+				return ( <GravatarHovercardsSettings module={ module } { ...this.props } /> );
 			case 'likes':
-				return( <LikesSettings module={ module } { ...this.props } /> );
+				return ( <LikesSettings module={ module } { ...this.props } /> );
+			case 'verification-tools':
+				return ( <VerificationToolsSettings module={ module } { ...this.props } /> );
 			case 'notifications':
 			case 'enhanced-distribution':
 				return <span>{ __( 'This module has no configuration options' ) } </span>;
-			case 'verification-tools':
 			case 'publicize':
 			default:
 				return (

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1134,7 +1134,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 				case 'show_headline':
 				case 'show_thumbnails':
-					$grouped_options = $grouped_options_current = Jetpack_Options::get_option( 'relatedposts' );
+					$grouped_options = $grouped_options_current = (array) Jetpack_Options::get_option( 'relatedposts' );
 					$grouped_options[ $option ] = $value;
 
 					// If option value was the same, consider it done.
@@ -1144,7 +1144,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				case 'google':
 				case 'bing':
 				case 'pinterest':
-					$grouped_options = $grouped_options_current = get_option( 'verification_services_codes' );
+					$grouped_options = $grouped_options_current = (array) get_option( 'verification_services_codes' );
 					$grouped_options[ $option ] = $value;
 
 					// If option value was the same, consider it done.
@@ -1245,7 +1245,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				case 'do_not_track':
 				case 'hide_smile':
 				case 'version':
-					$grouped_options = $grouped_options_current = get_option( 'stats_options' );
+					$grouped_options = $grouped_options_current = (array) get_option( 'stats_options' );
 					$grouped_options[ $option ] = $value;
 
 					// If option value was the same, consider it done.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds settings for the **Verification Tools* module under the **Engagement** tab.

#### Testing instructions:
1. Get to the **Verification Tools** Card under the **Engagement** tab, update one of text inputs
1. Save
1. Refresh the page and check the change was persisted
