### PR TITLE
Fix for undefined index REQUEST_METHOD for some background jobs

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -326,7 +326,11 @@ abstract class Publicize_Base {
 		}
 
 		// Did this request happen via wp-admin?
-		$from_web = 'post' == strtolower( $_SERVER['REQUEST_METHOD'] ) && isset( $_POST[$this->ADMIN_PAGE] );
+		$from_web = isset( $_SERVER['REQUEST_METHOD'] )
+			&&
+			'post' == strtolower( $_SERVER['REQUEST_METHOD'] ) 
+			&& 
+			isset( $_POST[$this->ADMIN_PAGE] );
 
 		if ( ( $from_web || defined( 'POST_BY_EMAIL' ) ) && isset( $_POST['wpas_title'] ) ) {
 			if ( empty( $_POST['wpas_title'] ) ) {


### PR DESCRIPTION
Fixes #4286.

Just checks that REQUEST_METHOD isset on $_SERVER to avoid a PHP notice.