### PR TITLE
Fix for CSSTidy crashing because of missing old-style constructor

### DIFF
--- a/modules/custom-css/custom-css.php
+++ b/modules/custom-css/custom-css.php
@@ -1812,9 +1812,6 @@ function safecss_class() {
 	require_once( dirname( __FILE__ ) . '/csstidy/class.csstidy.php' );
 
 	class safecss extends csstidy_optimise {
-		function __construct( &$css ) {
-			return $this->csstidy_optimise( $css );
-		}
 
 		function postparse() {
 


### PR DESCRIPTION
Fixes issue with crash when saving CSS due to removal of old-style PHP object constructors.