### PR TITLE
Admin Page: make body full height so background covers the entire height

### DIFF
--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -20,6 +20,7 @@
 .wp-admin.toplevel_page_jetpack {
 	background-color: $gray-light;
 	line-height: 1.4; // fixes core bug that sets an em unit on body
+	height: auto;
 }
 
 // restyled the arrow to match our gray


### PR DESCRIPTION
Fixes #4497

#### Changes proposed in this Pull Request:
Let body height flow freely so the height isn't clipped and the light blue background is visible in the entire page.

#### Testing instructions:
- go to `wp-admin/profile.php` and select Coffee as the admin color theme.
- go to Jetpack admin and make sure the light blue background covers the entire page height
