### PR TITLE
Wait a full minute before requesting again if there was an error

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -167,7 +167,7 @@ class Jetpack_Sync_Actions {
 		self::initialize_sender();
 		
 		do {
-			$next_sync_time = self::$sender->next_sync_time();
+			$next_sync_time = self::$sender->get_next_sync_time();
 			
 			if ( $next_sync_time ) {
 				$delay = $next_sync_time - time() + 1;


### PR DESCRIPTION
Currently if there's an error processing items on WPCOM, one of two things occurs:

- The client keeps trying to send the items at the maximum rate (by default once every 15s), and/or
- WPCOM ends up stuck with the concurrent request lock closed until it times out (one minute)

Since there's almost no point requesting from WPCOM again until the lock times out, AND in order to reduce the load from sites retrying requests when we have a bug on WPCOM, we detect WP_Error responses and wait at least one minute before retrying.

This PR also eliminates a couple of DB queries per sync by autoloading the next sync time.