### PR TITLE
Admin Page - Protect: save IP list even if user separates them using commas instead of line breaks

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1133,7 +1133,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					break;
 
 				case 'jetpack_protect_global_whitelist':
-					$updated = jetpack_protect_save_whitelist( explode( PHP_EOL, str_replace( ' ', '', $value ) ) );
+					$updated = jetpack_protect_save_whitelist( explode( PHP_EOL, str_replace( array( ' ', ',' ), array( '', "\n" ), $value ) ) );
 					if ( is_wp_error( $updated ) ) {
 						$error = $updated->get_error_message();
 					}


### PR DESCRIPTION
Fixes #4532.

#### Changes proposed in this Pull Request:
- if list has commas, convert them to line breaks so they can be correctly exploded into separate IPs and properly saved.

#### Testing instructions:
- go to Admin Page, add a new IP like this: `1.2.3.4`
- save and reload
Make sure the IP is in the Protect text box.
- Now add one separated by a comma so it looks like: `1.2.3.4,5.6.7.8`
- save and reload
Make sure the two IPs are in the Protect text box.

cc @oskosk since he was able to reproduce the issue