### PR TITLE
Sync integration fixes

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -29,6 +29,11 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 			$modules = array_map('trim', explode( ',', $args['modules'] ) );
 		}
 
+
+		if ( empty( $modules ) ) {
+			$modules = null;
+		}
+
 		Jetpack_Sync_Actions::schedule_full_sync( $modules );
 
 		return array( 'scheduled' => true );

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-defaults.php';
+
 class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 	const CONSTANTS_CHECKSUM_OPTION_NAME = 'jetpack_constants_sync_checksum';
 	const CONSTANTS_AWAIT_TRANSIENT_NAME = 'jetpack_sync_constants_await';

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -1,6 +1,7 @@
 <?php
 
-require_once 'interface.jetpack-sync-replicastore.php';
+require_once dirname( __FILE__ ) . '/interface.jetpack-sync-replicastore.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-defaults.php';
 
 /**
  * An implementation of iJetpack_Sync_Replicastore which returns data stored in a WordPress.org DB.

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -680,9 +680,9 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 
 		$this->assertNull( $store->get_callable( 'is_main_network' ) );
 
-		$store->set_callable( 'is_main_network', 'yes' );
+		$store->set_callable( 'is_main_network', '1' );
 
-		$this->assertEquals( 'yes', $store->get_callable( 'is_main_network' ) );
+		$this->assertEquals( '1', $store->get_callable( 'is_main_network' ) );
 	}
 
 	/**


### PR DESCRIPTION
A handful of fixes for errors I saw coming up when triggering full sync from wordpress.com

- full sync modules is a zero length list instead of null, leading to nothing getting synced when triggered via API
- some files were missing Jetpack_Sync_Defaults if required in a certain order
- sync some tests with those from WPCOM