### PR TITLE
Update sync status in separate options so that writes and reads don't collide

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -138,23 +138,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		update_option( "{$prefix}_started", time() );
 	}
 
-	private function get_status_queuing_started() {
-		$prefix = self::STATUS_OPTION_PREFIX;
-		$status = get_option( "{$prefix}_started", null );
-		if ( is_null( $status ) ) {
-			return $status;
-		}
-		return intval( $status );
-	}
-
 	private function set_status_queuing_finished() {
 		$prefix = self::STATUS_OPTION_PREFIX;
 		update_option( "{$prefix}_queue_finished", time() );
 	}
 
-	private function get_status_queuing_finished() {
+	private function get_status_option( $option ) {
 		$prefix = self::STATUS_OPTION_PREFIX;
-		$status = get_option( "{$prefix}_queue_finished", null );
+		$status = get_option( "{$prefix}_{$option}", null );
 		if ( is_null( $status ) ) {
 			return $status;
 		}
@@ -174,10 +165,10 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	public function get_status() {
 		$prefix = self::STATUS_OPTION_PREFIX;
 		$status = array(
-			'started'        => $this->get_status_queuing_started(),
-			'queue_finished' => $this->get_status_queuing_finished(),
-			'sent_started'   => get_option( "{$prefix}_sent_started", null ),
-			'finished'       => get_option( "{$prefix}_finished", null ),
+			'started'        => $this->get_status_option( 'started' ),
+			'queue_finished' => $this->get_status_option( 'queue_finished' ),
+			'sent_started'   => $this->get_status_option( 'sent_started' ),
+			'finished'       => $this->get_status_option( 'finished' ),
 			'sent'           => array(),
 			'queue'          => array(),
 		);

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -105,7 +105,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		// quick way to map to first items with an array of arrays
 		$actions_with_counts = array_count_values( array_map( 'reset', $actions ) );
 
-		$status = $this->get_status();
 		if ( ! $this->is_started() || $this->is_finished() ) {
 			return;
 		}
@@ -115,7 +114,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
-			$module_name    = $module->name();
 			$module_actions = $module->get_full_sync_actions();
 			$items_sent     = 0;
 			foreach ( $module_actions as $module_action ) {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -137,11 +137,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->update_status_option( "queue_finished", time() );
 	}
 
-	private function is_started() {
+	public function is_started() {
 		return !! $this->get_status_option( "started" );
 	}
 
-	private function is_finished() {
+	public function is_finished() {
 		return !! $this->get_status_option( "finished" );
 	}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -51,8 +51,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		do_action( 'jetpack_full_sync_start' );
 		$this->set_status_queuing_started();
 
-		$prefix = self::STATUS_OPTION_PREFIX;
-
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();
 			if ( is_array( $modules ) && ! in_array( $module_name, $modules ) ) {
@@ -62,7 +60,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$items_enqueued = $module->enqueue_full_sync_actions();
 			if ( ! is_null( $items_enqueued ) && $items_enqueued > 0 ) {
 				// TODO: only update this once every N items, then at end - why cause all that DB churn?
-				update_option( "{$prefix}_{$module->name()}_queued", $items_enqueued );
+				$this->update_status_option( "{$module->name()}_queued", $items_enqueued );
 			}
 		}
 
@@ -110,7 +108,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		if ( isset( $actions_with_counts['jetpack_full_sync_start'] ) ) {
-			update_option( "{$prefix}_sent_started", time() );
+			$this->update_status_option( "sent_started", time() );
 		}
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
@@ -123,24 +121,24 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			}
 
 			if ( $items_sent > 0 ) {
-				update_option( "{$prefix}_{$module->name()}_sent", $items_sent );
+				$this->update_status_option( "{$module->name()}_sent", $items_sent );
 			}	
 		}
 
 		if ( isset( $actions_with_counts['jetpack_full_sync_end'] ) ) {
-			update_option( "{$prefix}_finished", time() );
+			$this->update_status_option( "finished", time() );
 		}
 	}
 
 	private function set_status_queuing_started() {
 		$this->clear_status();
 		$prefix = self::STATUS_OPTION_PREFIX;
-		update_option( "{$prefix}_started", time() );
+		$this->update_status_option( "started", time() );
 	}
 
 	private function set_status_queuing_finished() {
 		$prefix = self::STATUS_OPTION_PREFIX;
-		update_option( "{$prefix}_queue_finished", time() );
+		$this->update_status_option( "queue_finished", time() );
 	}
 
 	private function get_status_option( $option ) {
@@ -200,5 +198,10 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			delete_option( "{$prefix}_{$module->name()}_queued" );
 			delete_option( "{$prefix}_{$module->name()}_sent" );
 		}
+	}
+
+	private function update_status_option( $name, $value ) {
+		$prefix = self::STATUS_OPTION_PREFIX;
+		update_option( "{$prefix}_{$name}", $value, false );
 	}
 }

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -138,9 +138,27 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		update_option( "{$prefix}_started", time() );
 	}
 
+	private function get_status_queuing_started() {
+		$prefix = self::STATUS_OPTION_PREFIX;
+		$status = get_option( "{$prefix}_started", null );
+		if ( is_null( $status ) ) {
+			return $status;
+		}
+		return intval( $status );
+	}
+
 	private function set_status_queuing_finished() {
 		$prefix = self::STATUS_OPTION_PREFIX;
 		update_option( "{$prefix}_queue_finished", time() );
+	}
+
+	private function get_status_queuing_finished() {
+		$prefix = self::STATUS_OPTION_PREFIX;
+		$status = get_option( "{$prefix}_queue_finished", null );
+		if ( is_null( $status ) ) {
+			return $status;
+		}
+		return intval( $status );
 	}
 
 	private function is_started() {
@@ -156,8 +174,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	public function get_status() {
 		$prefix = self::STATUS_OPTION_PREFIX;
 		$status = array(
-			'started'        => get_option( "{$prefix}_started", null ),
-			'queue_finished' => get_option( "{$prefix}_queue_finished", null ),
+			'started'        => $this->get_status_queuing_started(),
+			'queue_finished' => $this->get_status_queuing_finished(),
 			'sent_started'   => get_option( "{$prefix}_sent_started", null ),
 			'finished'       => get_option( "{$prefix}_finished", null ),
 			'sent'           => array(),

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -202,6 +202,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	private function update_status_option( $name, $value ) {
 		$prefix = self::STATUS_OPTION_PREFIX;
-		update_option( "{$prefix}_{$name}", $value, false );
+		/**
+		 * Allowing update_option to change autoload status only shipped in WordPress v4.2
+		 * @link https://github.com/WordPress/WordPress/commit/305cf8b95
+		 */
+		if ( version_compare( $GLOBALS['wp_version'], '4.2', '>=' ) ) {
+			update_option( "{$prefix}_{$name}", $value, false );
+		} else {
+			update_option( "{$prefix}_{$name}", $value );
+		}
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -65,7 +65,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 1, $this->started_sync_count );
 
 		// fake the last sync being over an hour ago
-		$this->full_sync->update_status( array( 'started' => ( time() - 3700 ) ) );
+		$prefix = Jetpack_Sync_Module_Full_Sync::STATUS_OPTION_PREFIX;
+		update_option( "{$prefix}_started", time() - 3700 );
 
 		$this->full_sync->start();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -572,8 +572,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $full_sync_status['queue'], $should_be_status['queue'] );
 		$this->assertInternalType( 'int', $full_sync_status['started'] );
 		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
-		$this->assertNull( $full_sync_status['sent_started'] );
-		$this->assertNull( $full_sync_status['finished'] );
+		$this->assertEquals( 0, $full_sync_status['sent_started'] );
+		$this->assertEquals( 0, $full_sync_status['finished'] );
 		$this->assertInternalType( 'array', $full_sync_status['sent'] );
 	}
 
@@ -711,11 +711,11 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 		$full_sync_status = $this->full_sync->get_status();
-		$this->assertNull( $full_sync_status['finished'] );
+		$this->assertEquals( 0, $full_sync_status['finished'] );
 
 		$this->sender->do_sync();
 		$full_sync_status = $this->full_sync->get_status();
-		$this->assertNull( $full_sync_status['finished'] );
+		$this->assertEquals( 0, $full_sync_status['finished'] );
 
 		$this->sender->do_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -260,12 +260,12 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
 		$full_sync->start();
 		$status = $full_sync->get_status();
-		$this->assertNotNull( $status['started'] );
+		$this->assertTrue( $full_sync->is_started() );
 
 		$this->sender->reset_sync_queue();
 
 		$status = $full_sync->get_status();
-		$this->assertNull( $status['started'] );
+		$this->assertFalse( $full_sync->is_started() );
 	}
 
 	function test_waits_one_minute_on_server_error_with_last_item() {


### PR DESCRIPTION
Previously, we were storing full sync status in one option that included both sent values and queued values.

The problem is that typically this status was read and/or written from two processes - one doing the queuing, and one doing the sending. This would result in values saved by one process being overwritten with values from the other, and the status would be wrong.

This PR splits the sync status into one option per value, fixing that issue (though it's now a bit more expensive to read - something that could be solved fairly easily by a custom query).