### PR TITLE
Sync: Update the sync status to be seperate options and not autoloaded

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -47,7 +47,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 		$queue = Jetpack_Sync_Sender::get_instance()->get_sync_queue();
 
 		return array_merge(
-			$sync_module->get_status(),
+			$sync_module->get_full_status(),
 			array( 
 				'is_scheduled' => (bool) wp_next_scheduled( 'jetpack_sync_full' ), 
 				'queue_size' => $queue->size(),

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -65,7 +65,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 1, $this->started_sync_count );
 
 		// fake the last sync being over an hour ago
-		$this->full_sync->update_status( array( 'started' => ( time() - 3700 ) ) );
+		$this->full_sync->update_status( 'started', time() - 3700 );
 
 		$this->full_sync->start();
 
@@ -530,7 +530,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_status_should_be_not_started_after_reset() {
 		$this->create_dummy_data_and_empty_the_queue();
 
-		$full_sync_status = $this->full_sync->get_status();
+		$full_sync_status = $this->full_sync->get_full_status();
 		$this->assertEquals(
 			$full_sync_status,
 			array(
@@ -549,7 +549,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->full_sync->start();
 
-		$full_sync_status = $this->full_sync->get_status();
+		$full_sync_status = $this->full_sync->get_full_status();
 
 		$should_be_status = array(
 			'queue' => array(
@@ -582,7 +582,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start();
 		$this->sender->do_sync();
 
-		$full_sync_status = $this->full_sync->get_status();
+		$full_sync_status = $this->full_sync->get_full_status();
 
 		$should_be_status = array(
 			'sent'  => array(
@@ -709,16 +709,15 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start();
 
 		$this->sender->do_sync();
-		$full_sync_status = $this->full_sync->get_status();
+		$full_sync_status = $this->full_sync->get_full_status();
 		$this->assertNull( $full_sync_status['finished'] );
 
 		$this->sender->do_sync();
-		$full_sync_status = $this->full_sync->get_status();
+		$full_sync_status = $this->full_sync->get_full_status();
 		$this->assertNull( $full_sync_status['finished'] );
 
 		$this->sender->do_sync();
-
-		$full_sync_status = $this->full_sync->get_status();
+		$full_sync_status = $this->full_sync->get_full_status();
 
 		$should_be_status = array(
 			'sent'  => array(

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -259,12 +259,12 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	function test_reset_queue_also_resets_full_sync_lock() {
 		$full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
 		$full_sync->start();
-		$status = $full_sync->get_status();
+		$status = $full_sync->get_full_status();
 		$this->assertNotNull( $status['started'] );
 
 		$this->sender->reset_sync_queue();
 
-		$status = $full_sync->get_status();
+		$status = $full_sync->get_full_status();
 		$this->assertNull( $status['started'] );
 	}
 


### PR DESCRIPTION
Similar to #4546, but it also make sure that the data doesn't get autoloaded. 