### PR TITLE
dailymotion shortcode: add support for dailymotion widget http://www.dailymotion.com/widgets

### DIFF
--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -344,7 +344,7 @@ function jetpack_dailymotion_widget_shortcode( $atts ) {
 		return '<!--Dailymotion error: bad or missing ID-->';
 	}
 
-	$output="<div class='dailymotion-widget' data-placement='" . $id . "'></div>";
+	$output = "<div class='dailymotion-widget' data-placement='$id'></div>";
 	$output .= '<script>(function(w,d,s,u,n,e,c){w.PXLObject = n; w[n] = w[n] || function(){(w[n].q = w[n].q || []).push(arguments);};w[n].l = 1 * new Date();e = d.createElement(s); e.async = 1; e.src = u;c = d.getElementsByTagName(s)[0]; c.parentNode.insertBefore(e,c);})(window, document, "script", "//api.dmcdn.net/pxl/client.js", "pxl");</script>';
 
 	return $output;

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -365,20 +365,19 @@ function jetpack_dailymotion_widget_reversal( $content ) {
 		<div class="dailymotion-widget" data-placement="XXXXXXXXX"></div><script>(function(w,d,s,u,n,e,c){w.PXLObject = n; w[n] = w[n] || function(){(w[n].q = w[n].q || []).push(arguments);};w[n].l = 1 * new Date();e = d.createElement(s); e.async = 1; e.src = u;c = d.getElementsByTagName(s)[0]; c.parentNode.insertBefore(e,c);})(window, document, "script", "//api.dmcdn.net/pxl/client.js", "pxl");</script>
 	*/
 
-	$regexes = array();
-	$ifr_regexp = '<div class="dailymotion-widget" data-placement="([^"]+)"><\/div><script>.+?<\/script>';
+	$ifr_regexp = '#<div class="dailymotion-widget" data-placement="([A-Za-z0-9]+)"><\/div><script>.+?<\/script>#';
 	$ifr_regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $ifr_regexp, ENT_NOQUOTES ) );
 
-	foreach ( array( 'regexp', 'regexp_ent' ) as $regex ) {
-		if ( ! preg_match_all( $regex, $content, $matches, PREG_SET_ORDER ) ) {
+	foreach ( array( 'ifr_regexp', 'ifr_regexp_ent' ) as $regex ) {
+		if ( ! preg_match_all( $$regex, $content, $matches, PREG_SET_ORDER ) ) {
 			continue;
 		}
 
 		foreach ( $matches as $match ) {
 			$id = $match[1];
-
 			$shortcode = '[dailymotion-widget id=' . $id . ']';
 			$content = str_replace( $match[0], $shortcode, $content );
+
 		}
 	}
 

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -19,6 +19,8 @@
  *
  * Scroll down for the new <iframe> embed code handler.
  *
+ * @module shortcodes
+ *
  * @param string $content
  * @return string shortcode
  */
@@ -84,6 +86,8 @@ add_filter( 'pre_kses', 'dailymotion_embed_to_shortcode' );
  * ui-highlight, ui-logo, ui-start-screen-info, ui-theme
  * see https://developer.dailymotion.com/player#player-parameters
  * @todo: Update code to sniff for iframe embeds and convert those to shortcodes.
+ *
+ * @module shortcodes
  *
  * @param array $atts
  * @return string html
@@ -221,6 +225,8 @@ add_shortcode( 'dailymotion', 'dailymotion_shortcode' );
  * [dailymotion-channel user=MatthewDominick]
  * [dailymotion-channel user=MatthewDominick type=grid] (supports grid, carousel, badge/default)
  *
+ * @module shortcodes
+ *
  * @param array $atts
  * @return string html
  */
@@ -243,6 +249,8 @@ add_shortcode( 'dailymotion-channel', 'dailymotion_channel_shortcode' );
 
 /**
  * Embed Reversal for Badge/Channel
+ *
+ * @module shortcodes
  *
  * @param string $content
  * @return string shortcode
@@ -296,6 +304,8 @@ add_filter( 'pre_kses', 'dailymotion_channel_reversal' );
  * Converts a generic HTML embed code from Dailymotion into an
  * oEmbeddable URL.
  *
+ * @module shortcodes
+ *
  * @param string $content
  * @return string oEmbeddable URL
  */
@@ -346,6 +356,8 @@ add_filter( 'pre_kses', 'jetpack_dailymotion_embed_reversal' );
  * Example:
  * [dailymotion-widget id=XYZ]
  *
+ * @module shortcodes
+ *
  * @param array $atts
  * @return string html
  */
@@ -366,6 +378,8 @@ add_shortcode( 'dailymotion-widget', 'jetpack_dailymotion_widget_shortcode' );
 
 /**
  * Embed Reversal for Dailymotion widget
+ *
+ * @module shortcodes
  *
  * @param string $content
  * @return string shortcode

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -337,7 +337,7 @@ add_filter( 'pre_kses', 'jetpack_dailymotion_embed_reversal' );
  * @param array $atts
  * @return string html
  */
-function dailymotion_widget_shortcode( $atts ) {
+function jetpack_dailymotion_widget_shortcode( $atts ) {
 	if ( isset( $atts['id'] ) ) {
 		$id = $atts['id'];
 	} else {
@@ -350,12 +350,12 @@ function dailymotion_widget_shortcode( $atts ) {
 	return $output;
 }
 
-add_shortcode( 'dailymotion-widget', 'dailymotion_widget_shortcode' );
+add_shortcode( 'dailymotion-widget', 'jetpack_dailymotion_widget_shortcode' );
 
 /**
  * Embed Reversal for Dailymotion widget
  */
-function dailymotion_widget_reversal( $content ) {
+function jetpack_dailymotion_widget_reversal( $content ) {
 
 	if ( false === stripos( $content, 'dailymotion-widget' ) ) {
 		return $content;
@@ -385,4 +385,4 @@ function dailymotion_widget_reversal( $content ) {
 	return $content;
 }
 
-add_filter( 'pre_kses', 'dailymotion_widget_reversal' );
+add_filter( 'pre_kses', 'jetpack_dailymotion_widget_reversal' );

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -327,3 +327,27 @@ function jetpack_dailymotion_embed_reversal( $content ) {
 }
 
 add_filter( 'pre_kses', 'jetpack_dailymotion_embed_reversal' );
+
+/**
+ * DailyMotion Widget Shortcode
+ *
+ * Example:
+ * [dailymotion-widget id=XYZ]
+ *
+ * @param array $atts
+ * @return string html
+ */
+function dailymotion_widget_shortcode( $atts ) {
+	if ( isset( $atts['id'] ) ) {
+		$id = $atts['id'];
+	} else {
+		return '<!--Dailymotion error: bad or missing ID-->';
+	}
+
+	$output="<div class='dailymotion-widget' data-placement='" . $id . "'></div>";
+	$output .= '<script>(function(w,d,s,u,n,e,c){w.PXLObject = n; w[n] = w[n] || function(){(w[n].q = w[n].q || []).push(arguments);};w[n].l = 1 * new Date();e = d.createElement(s); e.async = 1; e.src = u;c = d.getElementsByTagName(s)[0]; c.parentNode.insertBefore(e,c);})(window, document, "script", "//api.dmcdn.net/pxl/client.js", "pxl");</script>';
+
+	return $output;
+}
+
+add_shortcode( 'dailymotion-widget', 'dailymotion_widget_shortcode' );

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -18,6 +18,9 @@
  * movie param enforces anti-xss protection
  *
  * Scroll down for the new <iframe> embed code handler.
+ *
+ * @param string $content
+ * @return string shortcode
  */
 
 function dailymotion_embed_to_shortcode( $content ) {
@@ -217,6 +220,9 @@ add_shortcode( 'dailymotion', 'dailymotion_shortcode' );
  * Examples:
  * [dailymotion-channel user=MatthewDominick]
  * [dailymotion-channel user=MatthewDominick type=grid] (supports grid, carousel, badge/default)
+ *
+ * @param array $atts
+ * @return string html
  */
 function dailymotion_channel_shortcode( $atts ) {
 	$username = $atts['user'];
@@ -237,6 +243,9 @@ add_shortcode( 'dailymotion-channel', 'dailymotion_channel_shortcode' );
 
 /**
  * Embed Reversal for Badge/Channel
+ *
+ * @param string $content
+ * @return string shortcode
  */
 function dailymotion_channel_reversal( $content ) {
 	if ( false === stripos( $content, 'dailymotion.com/badge/' ) ) {
@@ -286,6 +295,9 @@ add_filter( 'pre_kses', 'dailymotion_channel_reversal' );
  *
  * Converts a generic HTML embed code from Dailymotion into an
  * oEmbeddable URL.
+ *
+ * @param string $content
+ * @return string oEmbeddable URL
  */
 
 function jetpack_dailymotion_embed_reversal( $content ) {
@@ -354,6 +366,9 @@ add_shortcode( 'dailymotion-widget', 'jetpack_dailymotion_widget_shortcode' );
 
 /**
  * Embed Reversal for Dailymotion widget
+ *
+ * @param string $content
+ * @return string shortcode
  */
 function jetpack_dailymotion_widget_reversal( $content ) {
 

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -351,3 +351,38 @@ function dailymotion_widget_shortcode( $atts ) {
 }
 
 add_shortcode( 'dailymotion-widget', 'dailymotion_widget_shortcode' );
+
+/**
+ * Embed Reversal for Dailymotion widget
+ */
+function dailymotion_widget_reversal( $content ) {
+
+	if ( false === stripos( $content, 'dailymotion-widget' ) ) {
+		return $content;
+	}
+
+	/* Sample embed code:
+		<div class="dailymotion-widget" data-placement="XXXXXXXXX"></div><script>(function(w,d,s,u,n,e,c){w.PXLObject = n; w[n] = w[n] || function(){(w[n].q = w[n].q || []).push(arguments);};w[n].l = 1 * new Date();e = d.createElement(s); e.async = 1; e.src = u;c = d.getElementsByTagName(s)[0]; c.parentNode.insertBefore(e,c);})(window, document, "script", "//api.dmcdn.net/pxl/client.js", "pxl");</script>
+	*/
+
+	$regexes = array();
+	$ifr_regexp = '<div class="dailymotion-widget" data-placement="([^"]+)"><\/div><script>.+?<\/script>';
+	$ifr_regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $ifr_regexp, ENT_NOQUOTES ) );
+
+	foreach ( array( 'regexp', 'regexp_ent' ) as $regex ) {
+		if ( ! preg_match_all( $regex, $content, $matches, PREG_SET_ORDER ) ) {
+			continue;
+		}
+
+		foreach ( $matches as $match ) {
+			$id = $match[1];
+
+			$shortcode = '[dailymotion-widget id=' . $id . ']';
+			$content = str_replace( $match[0], $shortcode, $content );
+		}
+	}
+
+	return $content;
+}
+
+add_filter( 'pre_kses', 'dailymotion_widget_reversal' );

--- a/tests/php/modules/shortcodes/test_class.dailymotion.php
+++ b/tests/php/modules/shortcodes/test_class.dailymotion.php
@@ -141,4 +141,52 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 		$this->assertContains( 'ui-theme=dark', $shortcode_content );
 	}
 
+	/**
+	 * @author mathildes
+	 * @covers ::dailymotion_shortcode
+	 * @since 4.2.0
+	 */
+	public function test_shortcodes_dailymotion_widget_exists() {
+		$this->assertEquals( shortcode_exists( 'dailymotion-widget' ), true );
+	}
+
+	/**
+	 * @author mathildes
+	 * @covers ::dailymotion_shortcode
+	 * @since 4.2.0
+	 */
+	public function test_shortcodes_dailymotion_widget() {
+		$content = '[dailymotion-widget]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+	}
+
+	/**
+	 * @author mathildes
+	 * @covers ::dailymotion_shortcode
+	 * @since 4.2.0
+	 */
+	public function test_shortcodes_dailymotion_widget_id() {
+		$id = 'xyz';
+		$content = '[dailymotion-widget id=' . $id . ']';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( $id, $shortcode_content );
+	}
+
+	/**
+	 * @author mathildes
+	 * @covers ::dailymotion_shortcode
+	 * @since 4.2.0
+	 */
+	public function test_shortcodes_dailymotion_widget_missing_id() {
+		$content = '[dailymotion-widget]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals( '<!--Dailymotion error: bad or missing ID-->', $shortcode_content );
+	}
 }


### PR DESCRIPTION
adding support for dailymotion widget which is available for dailymotion partners at http://www.dailymotion.com/widgets
#### Changes proposed in this Pull Request:
- Shortcode [dailymotion-widget id=ID]
- Widget embed reversal
- Corresponding unit tests 
#### Testing instructions:
- you can test by passing this widget id: 574dadf2a94fba04f31ec1de 
- for the embed reversal, the code is as follow: 
  `<div class="dailymotion-widget" data-placement="574dadf2a94fba04f31ec1de"></div><script>(function(w,d,s,u,n,e,c){w.PXLObject = n; w[n] = w[n] || function(){(w[n].q = w[n].q || []).push(arguments);};w[n].l = 1 * new Date();e = d.createElement(s); e.async = 1; e.src = u;c = d.getElementsByTagName(s)[0]; c.parentNode.insertBefore(e,c);})(window, document, "script", "//api.dmcdn.net/pxl/client.js", "pxl");</script>`
