### PR TITLE
Settings: switched to using Checkbox component

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -12,11 +12,10 @@
 .form-label {
 	display: block;
 	font-size: 14px;
-	font-weight: 600;
+	line-height: 1.5;
 	margin-bottom: 5px;
 }
 
-.form-label input[type="checkbox"] + span,
 .form-label input[type="radio"] + span {
 	font-weight: normal;
 }

--- a/_inc/client/components/module-settings/form-components.jsx
+++ b/_inc/client/components/module-settings/form-components.jsx
@@ -4,21 +4,23 @@
 import React from 'react';
 import concat from 'lodash/concat';
 import without from 'lodash/without';
+
 /**
  * Internal dependencies
  */
- import {
+import {
 	FormLabel,
-	FormCheckbox,
 	FormRadio
- } from 'components/forms';
+} from 'components/forms';
+import Checkbox from 'components/checkbox';
+
 
 export const ModuleSettingCheckbox = React.createClass( {
 	render() {
 		const props = this.props;
 		return (
 			<FormLabel>
-				<FormCheckbox
+				<Checkbox
 					name={ props.name }
 					checked={ !! props.getOptionValue( props.name ) }
 					value={ !! props.getOptionValue( props.name ) }
@@ -87,7 +89,7 @@ export const ModuleSettingMultipleSelectCheckboxes = React.createClass( {
 				{
 				Object.keys( validValues ).map( ( key ) => (
 					<FormLabel key={ `option-${ props.option_name }-${key}` } >
-						<FormCheckbox
+						<Checkbox
 							name={ props.name }
 							checked= { this.shouldBeChecked( key ) }
 							value={ key }


### PR DESCRIPTION
Fixes some spacing issues in settings and matches Calypso styles.

#### Changes proposed in this Pull Request:
Switched to using new Checkbox component introduced in dops-components.

#### Testing instructions:
-Switch to the `add/checkbox-component` branch on `dops-components` and go to settings

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17148217/2e985cb8-5334-11e6-8478-915d02d938c6.png)
![image](https://cloud.githubusercontent.com/assets/1123119/17148221/365fa1e0-5334-11e6-9d66-a361824d4981.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/17148165/f6fb67e6-5333-11e6-80a2-4ddce187431f.png)