### PR TITLE
Settings: fix FormLabel padding

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -4,9 +4,10 @@
 }
 
 .form-legend {
+	padding: 0;
+	margin-bottom: 5px;
 	font-size: 14px;
 	font-weight: 600;
-	margin-bottom: 5px;
 }
 
 .form-label {


### PR DESCRIPTION
Fixes padding on formlabel.

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17148386/fb9beb8a-5334-11e6-9182-b7f75f0b4ba5.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17148378/f0deac96-5334-11e6-85f3-48c13532f41b.png)
