### PR TITLE
Settings: changed settings link to a button with an icon

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -28,6 +28,8 @@ import {
 	MarkdownSettings,
 	VerificationToolsSettings,
 } from 'components/module-settings/';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 
 export const EngagementModulesSettings = React.createClass( {
 	render() {
@@ -57,7 +59,7 @@ export const EngagementModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<a href={ module.configure_url }>{ __( 'Settings' ) }</a>
+						<Button compact href={ module.configure_url }>{ __( 'Settings' ) } <Gridicon icon="external" /></Button>
 					</div>
 				);
 		}

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -29,7 +29,6 @@ import {
 	VerificationToolsSettings,
 } from 'components/module-settings/';
 import Button from 'components/button';
-import Gridicon from 'components/gridicon';
 
 export const EngagementModulesSettings = React.createClass( {
 	render() {
@@ -59,7 +58,7 @@ export const EngagementModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<Button compact href={ module.configure_url }>{ __( 'Settings' ) } <Gridicon icon="external" /></Button>
+						<Button compact href={ module.configure_url }>{ __( 'Settings' ) }</Button>
 					</div>
 				);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* changed Settings link to a button format with an icon

Questions:
* On the link itself, which currently just says “Settings”, does it make sense to add the External icon since it causes a page reload? (maybe not)
* Should we make it clear we haven’t moved over the settings yet in a comment?

Before: 
![image](https://cloud.githubusercontent.com/assets/1123119/17149436/43e83f16-5339-11e6-842b-c07cc752580f.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17149413/2e774adc-5339-11e6-9a1c-2be6205ca281.png)
