### PR TITLE
Settings: Change styling of Learn More links

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -60,7 +62,9 @@ export const Page = ( props ) => {
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
-				<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
+				<div className="jp-module-settings__read-more">
+					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+				</div>
 			</FoldableCard>
 		);
 	} );

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -8,7 +8,6 @@ import Button from 'components/button';
 /**
  * Internal dependencies
  */
-import './style.scss';
 
 import {
 	FormFieldset,

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -1,6 +1,21 @@
 .jp-module-settings__read-more {
 	clear: both;
 	margin-top: rem( 16px );
+
+	.dops-button.is-compact.is-borderless,
+	.jp-module-settings__more-sep,
+	.jp-module-settings__more-text {
+		vertical-align: middle;
+	}
+
+	.jp-module-settings__more-sep {
+		background: #ddd;
+		width: rem( 2px );
+		height: rem( 14px );
+		margin-left: rem( 10px );
+		margin-right: rem( 10px );
+		display: inline-block;
+	}
 }
 
 /**

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -1,5 +1,6 @@
 .jp-module-settings__read-more {
-	margin-top: 16px;
+	clear: both;
+	margin-top: rem( 16px );
 }
 
 /**

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -1,3 +1,7 @@
+.jp-module-settings__read-more {
+	margin-top: 16px;
+}
+
 /**
  * Related Posts Preview styles
  */

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -87,20 +89,21 @@ export const Page = ( props ) => {
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
-				<p>
-					<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
-					{
-						'subscriptions' === element[0] && isModuleActive ? (
-							<span> | {
-								__( 'View your {{a}}Email Followers{{/a}}', {
-									components: {
-										a: <a href={ 'https://wordpress.com/people/email-followers/' + window.Initial_State.rawUrl } />
-									}
-								} )
-							}</span>
-						) : ''
-					}
-				</p>
+				<div className="jp-module-settings__read-more">
+					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+				</div>
+				{
+					'subscriptions' === element[0] && isModuleActive ? (
+						<p>
+							{
+							__( 'View your {{a}}Email Followers{{/a}}', {
+								components: {
+									a: <a href={ 'https://wordpress.com/people/email-followers/' + window.Initial_State.rawUrl } />
+								}
+							} )
+						}</p>
+					) : ''
+				}
 			</FoldableCard>
 		);
 	} );

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -91,19 +91,21 @@ export const Page = ( props ) => {
 				}
 				<div className="jp-module-settings__read-more">
 					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+					{
+						'subscriptions' === element[0] && isModuleActive ? (
+							<span>
+								<span className="jp-module-settings__more-sep" />
+								<span className="jp-module-settings__more-text">{
+									__( 'View your {{a}}Email Followers{{/a}}', {
+										components: {
+											a: <a href={ 'https://wordpress.com/people/email-followers/' + window.Initial_State.rawUrl } />
+										}
+									} )
+								}</span>
+							</span>
+						) : ''
+					}
 				</div>
-				{
-					'subscriptions' === element[0] && isModuleActive ? (
-						<p>
-							{
-							__( 'View your {{a}}Email Followers{{/a}}', {
-								components: {
-									a: <a href={ 'https://wordpress.com/people/email-followers/' + window.Initial_State.rawUrl } />
-								}
-							} )
-						}</p>
-					) : ''
-				}
 			</FoldableCard>
 		);
 	} );

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import FoldableCard from 'components/foldable-card';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 import Settings from 'components/settings';
 import { translate as __ } from 'i18n-calypso';
 
@@ -45,7 +47,9 @@ const GeneralSettings = React.createClass( {
 				expandedSummary={ nonAdmin ? '' : toggle( module_slug ) }
 			>
 				<div dangerouslySetInnerHTML={ renderLongDescription( this.props.getModule( module_slug ) ) } />
-				<a href={ this.props.getModule( module_slug ).learn_more_button } target="_blank">{ __( 'Learn More' ) }</a>
+				<div className="jp-module-settings__read-more">
+					<Button borderless compact href={ this.props.getModule( module_slug ).learn_more_button }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+				</div>
 			</FoldableCard>;
 
 		const maybeShowManage = this.props.isModuleActivated( 'manage' ) ? '' : moduleCard( 'manage' );

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -32,6 +32,7 @@
 @import '../components/jetpack-connect/style';
 @import '../components/jumpstart/style';
 @import '../components/masthead/style';
+@import '../components/module-settings/style';
 @import '../components/support-card/style';
 @import '../components/forms/styles';
 

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -79,8 +81,9 @@ export const Page = ( props ) => {
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
-				<br/>
-				<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
+				<div className="jp-module-settings__read-more">
+					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+				</div>
 			</FoldableCard>
 		);
 	} );

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -90,8 +92,9 @@ export const Page = ( props ) => {
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
-				<br/>
-				<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
+				<div className="jp-module-settings__read-more">
+					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+				</div>
 			</FoldableCard>
 		);
 	} );


### PR DESCRIPTION
Changes styling from a link to a compact borderless button with a gridicon.

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17150182/71f0f58a-533c-11e6-89fe-e43cb4e66137.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17150171/657b505c-533c-11e6-8614-40bb61c8a594.png)
