### PR TITLE
If sync values are 0 return as null to match Calypso’s expectations

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -89,7 +89,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		// allow enqueuing if last full sync was started more than FULL_SYNC_TIMEOUT seconds ago
 		$started_at = $this->get_status_option( "started" );
-		if ( $started_at > 0 && $started_at + self::FULL_SYNC_TIMEOUT < time() ) {
+		if ( $started_at && $started_at + self::FULL_SYNC_TIMEOUT < time() ) {
 			return true;
 		}
 
@@ -159,11 +159,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$queued = $this->get_status_option( "{$module->name()}_queued" );
 			$sent   = $this->get_status_option( "{$module->name()}_sent" );
 
-			if ( $queued > 0 ) {
+			if ( $queued ) {
 				$status[ 'queue' ][ $module->name() ] = $queued;
 			}
 			
-			if ( $sent > 0 ) {
+			if ( $sent ) {
 				$status[ 'sent' ][ $module->name() ] = $sent;
 			}
 		}
@@ -186,7 +186,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	private function get_status_option( $option ) {
 		$prefix = self::STATUS_OPTION_PREFIX;
-		return intval( get_option( "{$prefix}_{$option}", 0 ) );
+
+		$value = get_option( "{$prefix}_{$option}", null );
+		
+		if ( ! $value ) {
+			return null;
+		}
+
+		return intval( $value );
 	}
 
 	private function update_status_option( $name, $value ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -572,8 +572,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $full_sync_status['queue'], $should_be_status['queue'] );
 		$this->assertInternalType( 'int', $full_sync_status['started'] );
 		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
-		$this->assertEquals( 0, $full_sync_status['sent_started'] );
-		$this->assertEquals( 0, $full_sync_status['finished'] );
+		$this->assertNull( $full_sync_status['sent_started'] );
+		$this->assertNull( $full_sync_status['finished'] );
 		$this->assertInternalType( 'array', $full_sync_status['sent'] );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -620,7 +620,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
 		$this->assertInternalType( 'int', $full_sync_status['sent_started'] );
 		$this->assertInternalType( 'int', $full_sync_status['finished'] );
-
 	}
 
 	function test_full_sync_respects_post_and_comment_filters() {


### PR DESCRIPTION
Fixes an issue where full sync was reported as occurring 47 years ago.

<img width="734" alt="sync-47-years-ago" src="https://cloud.githubusercontent.com/assets/51896/17155807/8b85d62e-533b-11e6-80f0-85a2acb1e3ab.png">
