### PR TITLE
Don’t prevent multiple full syncs running at once

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -34,10 +34,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	function start( $modules = null ) {
-		if ( ! $this->should_start_full_sync() ) {
-			return false;
-		}
-
 		// ensure listener is loaded so we can guarantee full sync actions are enqueued
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 		Jetpack_Sync_Listener::get_instance();
@@ -78,22 +74,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		do_action( 'jetpack_full_sync_end', $store->checksum_all() );
 
 		return true;
-	}
-
-	private function should_start_full_sync() {
-
-		// We should try sync if we haven't started it yet or if we have finished it.
-		if ( ! $this->is_started() || $this->is_finished() ) {
-			return true;
-		}
-
-		// allow enqueuing if last full sync was started more than FULL_SYNC_TIMEOUT seconds ago
-		$started_at = $this->get_status_option( "started" );
-		if ( $started_at && $started_at + self::FULL_SYNC_TIMEOUT < time() ) {
-			return true;
-		}
-
-		return false;
 	}
 
 	function update_sent_progress_action( $actions ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -500,7 +500,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function create_dummy_data_and_empty_the_queue() {
-
 		// lets create a bunch of posts
 		for ( $i = 0; $i < 20; $i += 1 ) {
 			$post = $this->factory->post->create();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -40,21 +40,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 	}
 
-	function test_full_sync_wont_start_twice() {
-		$this->started_sync_count = 0;
-
-		add_action( 'jetpack_full_sync_start', array( $this, 'count_full_sync_start' ) );
-
-		$this->full_sync->start();
-
-		$this->assertEquals( 1, $this->started_sync_count );
-
-		// trying to start again shouldn't enqueue twice
-		$this->full_sync->start();
-
-		$this->assertEquals( 1, $this->started_sync_count );
-	}
-
 	function test_full_sync_lock_has_one_hour_timeout() {
 		$this->started_sync_count = 0;
 


### PR DESCRIPTION
Reasoning:

- blocking full sync has been the source of several bugs where full sync crashes before it’s done but you can’t kick off a new one for an hour even if you fixed the problem
- sometimes you’ve only triggered a partial sync, which is usually very small, and blocking a full sync from running seems like less of a win (e.g. on initial connection)
- now that we trigger sync via an API call, the client can implement their own blocking logic by reading from the sync status API and making its own decision about whether to perform the sync when there’s one in progress. For example, it might prompt the user to confirm: “it looks like there’s a sync in progress, are you sure?"