### PR TITLE
Widgets: Add Google Maps API key field to Contact Info widget settings

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -231,10 +231,6 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		function form( $instance ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
 			wp_enqueue_script( 'contact-info-admin', plugins_url( 'contact-info/contact-info-admin.js', __FILE__ ), array( 'jquery' ), 20160727 );
-			wp_localize_script( 'contact-info-admin', 'jetpackContactInfoFieldIds', array(
-				'showmap' => $this->get_field_id( 'showmap' ),
-				'apikey' => $this->get_field_id( 'apikey' )
-			) );
 
 			?>
 			<p>
@@ -248,7 +244,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				<?php
 				if ( $this->has_good_map( $instance ) ) {
 					?>
-					<input class="" id="<?php echo esc_attr( $this->get_field_id( 'showmap' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'showmap' ) ); ?>" value="1" type="checkbox" <?php checked( $instance['showmap'], 1 ); ?> />
+					<input class="jp-contact-info-showmap" id="<?php echo esc_attr( $this->get_field_id( 'showmap' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'showmap' ) ); ?>" value="1" type="checkbox" <?php checked( $instance['showmap'], 1 ); ?> />
 					<label for="<?php echo esc_attr( $this->get_field_id( 'showmap' ) ); ?>"><?php esc_html_e( 'Show map', 'jetpack' ); ?></label>
 					<?php
 				}
@@ -261,7 +257,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				?>
 			</p>
 
-			<p style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
+			<p class="jp-contact-info-apikey" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<label for="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>">
 					<?php _e( 'Google Maps API Key', 'jetpack' ); ?>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'apikey' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['apikey'] ); ?>" />

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				$showmap = $instance['showmap'];
 
 				/** This action is documented in modules/widgets/contact-info.php */
-				if ( $showmap && $this->has_good_map( $instance ) && apply_filters( 'jetpack_google_maps_api_key', null ) ) {
+				if ( $showmap && $this->has_good_map( $instance ) ) {
 					echo $this->build_map( $instance['address'] );
 				}
 

--- a/modules/widgets/contact-info/contact-info-admin.js
+++ b/modules/widgets/contact-info/contact-info-admin.js
@@ -1,13 +1,8 @@
 (function( $ ) {
-	var fieldIds = window.jetpackContactInfoFieldIds,
-		$apiKeyField = $( document.getElementById( fieldIds.apikey ) ).closest( 'p' ),
-		$showMapInput = $( document.getElementById( fieldIds.showmap ) );
+	$( document ).on( 'change', '.jp-contact-info-showmap', function() {
+		var $checkbox = $( this ),
+			isChecked = $checkbox.is( ':checked' );
 
-	function toggleVisibility() {
-		$apiKeyField.toggle( $showMapInput.is( ':checked' ) );
-	}
-
-	$( document ).ready(function() {
-		$showMapInput.on( 'change', toggleVisibility );
+		$checkbox.closest( '.widget' ).find( '.jp-contact-info-apikey' ).toggle( isChecked );
 	});
 })( window.jQuery );

--- a/modules/widgets/contact-info/contact-info-admin.js
+++ b/modules/widgets/contact-info/contact-info-admin.js
@@ -1,0 +1,13 @@
+(function( $ ) {
+	var fieldIds = window.jetpackContactInfoFieldIds,
+		$apiKeyField = $( document.getElementById( fieldIds.apikey ) ).closest( 'p' ),
+		$showMapInput = $( document.getElementById( fieldIds.showmap ) );
+
+	function toggleVisibility() {
+		$apiKeyField.toggle( $showMapInput.is( ':checked' ) );
+	}
+
+	$( document ).ready(function() {
+		$showMapInput.on( 'change', toggleVisibility );
+	});
+})( window.jQuery );


### PR DESCRIPTION
Closes #4240

This pull request seeks to add a new "Google Maps API Key" field to the widget settings for Contact Info Widget. See #4240 for more context; specifically that [Google now requires a key to be included in all maps products API requests](https://developers.google.com/maps/pricing-and-plans/standard-plan-2016-update).

![API Key](https://cloud.githubusercontent.com/assets/1779930/17178104/1f633836-53e2-11e6-9940-310eefe516c7.png)

It also changes the existing behavior of map output to always try to display a map, even if an API key is not configured. The hope here is that sites with grandfathered usage can continue to show a map without an API key (see https://github.com/Automattic/jetpack/pull/4242#issuecomment-235581837).

__Testing instructions:__

Verify that when configuring a Contact Info Widget, a "Google Maps API Key" field is shown if the "Show Map" option is checked. Save an API key and observe both that the key setting is persisted, and that the key is included in the `src` of the `iframe` that is displayed on the front-end of the site.

__Follow-up Tasks:__

The linked documentation article in the help text does not currently include any instructions on obtaining an API key and should be updated.

/cc @jeherve , @kraftbj 