### PR TITLE
Add a full sync queue to the sync listener

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -12,6 +12,7 @@ class Jetpack_Sync_Listener {
 	const QUEUE_STATE_CHECK_TIMEOUT = 300; // 5 minutes
 
 	private $sync_queue;
+	private $full_sync_queue;
 	private $sync_queue_size_limit;
 	private $sync_queue_lag_limit;
 
@@ -35,9 +36,11 @@ class Jetpack_Sync_Listener {
 	private function init() {
 
 		$handler = array( $this, 'action_handler' );
+		$full_sync_handler = array( $this, 'full_sync_action_handler' );
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module->init_listeners( $handler );
+			$module->init_full_sync_listeners( $full_sync_handler );
 		}
 
 		// Module Activation
@@ -50,6 +53,10 @@ class Jetpack_Sync_Listener {
 
 	function get_sync_queue() {
 		return $this->sync_queue;
+	}
+
+	function get_full_sync_queue() {
+		return $this->full_sync_queue;
 	}
 
 	function set_queue_size_limit( $limit ) {
@@ -69,17 +76,20 @@ class Jetpack_Sync_Listener {
 	}
 
 	function force_recheck_queue_limit() {
-		delete_transient( self::QUEUE_STATE_CHECK_TRANSIENT );
+		delete_transient( self::QUEUE_STATE_CHECK_TRANSIENT . '_' . $this->sync_queue->id );
+		delete_transient( self::QUEUE_STATE_CHECK_TRANSIENT . '_' . $this->full_sync_queue->id );
 	}
 
 	// prevent adding items to the queue if it hasn't sent an item for 15 mins
 	// AND the queue is over 1000 items long (by default)
-	function can_add_to_queue() {
-		$queue_state = get_transient( self::QUEUE_STATE_CHECK_TRANSIENT );
+	function can_add_to_queue( $queue ) {
+		$state_transient_name = self::QUEUE_STATE_CHECK_TRANSIENT . '_' . $queue->id;
+
+		$queue_state = get_transient( $state_transient_name );
 
 		if ( false === $queue_state ) {
-			$queue_state = array( $this->sync_queue->size(), $this->sync_queue->lag() );
-			set_transient( self::QUEUE_STATE_CHECK_TRANSIENT, $queue_state, self::QUEUE_STATE_CHECK_TIMEOUT );
+			$queue_state = array( $queue->size(), $queue->lag() );
+			set_transient( $state_transient_name, $queue_state, self::QUEUE_STATE_CHECK_TIMEOUT );
 		}
 
 		list( $queue_size, $queue_age ) = $queue_state;
@@ -89,9 +99,15 @@ class Jetpack_Sync_Listener {
 		       ( ( $queue_size + 1 ) < $this->sync_queue_size_limit );
 	}
 
+	function full_sync_action_handler() {
+		$this->enqueue_action( current_filter(), func_get_args(), $this->full_sync_queue );
+	}
+
 	function action_handler() {
-		$current_filter = current_filter();
-		$args           = func_get_args();
+		$this->enqueue_action( current_filter(), func_get_args(), $this->sync_queue );
+	}
+
+	function enqueue_action( $current_filter, $args, $queue ) {
 
 		/**
 		 * Modify or reject the data within an action before it is enqueued locally.
@@ -109,7 +125,7 @@ class Jetpack_Sync_Listener {
 
 		// periodically check the size of the queue, and disable adding to it if
 		// it exceeds some limit AND the oldest item exceeds the age limit (i.e. sending has stopped)
-		if ( ! $this->can_add_to_queue() ) {
+		if ( ! $this->can_add_to_queue( $queue ) ) {
 			return;
 		}
 
@@ -120,7 +136,7 @@ class Jetpack_Sync_Listener {
 			ignore_user_abort( true );
 		}
 
-		$this->sync_queue->add( array(
+		$queue->add( array(
 			$current_filter,
 			$args,
 			get_current_user_id(),
@@ -130,6 +146,7 @@ class Jetpack_Sync_Listener {
 
 	function set_defaults() {
 		$this->sync_queue = new Jetpack_Sync_Queue( 'sync' );
+		$this->full_sync_queue = new Jetpack_Sync_Queue( 'full_sync' );
 		$this->set_queue_size_limit( Jetpack_Sync_Settings::get_setting( 'max_queue_size' ) );
 		$this->set_queue_lag_limit( Jetpack_Sync_Settings::get_setting( 'max_queue_lag' ) );
 	}

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -100,11 +100,13 @@ class Jetpack_Sync_Listener {
 	}
 
 	function full_sync_action_handler() {
-		$this->enqueue_action( current_filter(), func_get_args(), $this->full_sync_queue );
+		$args           = func_get_args();
+		$this->enqueue_action( current_filter(), $args, $this->full_sync_queue );
 	}
 
 	function action_handler() {
-		$this->enqueue_action( current_filter(), func_get_args(), $this->sync_queue );
+		$args           = func_get_args();
+		$this->enqueue_action( current_filter(), $args, $this->sync_queue );
 	}
 
 	function enqueue_action( $current_filter, $args, $queue ) {

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -23,16 +23,17 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
 
-		// full sync
-		add_action( 'jetpack_full_sync_callables', $callable );
-
 		// get_plugins and wp_version
 		// gets fired when new code gets installed, updates etc.
 		add_action( 'upgrader_process_complete', array( $this, 'force_sync_callables' ) );
 	}
 
+	public function init_full_sync_listeners( $callable ) {
+		add_action( 'jetpack_full_sync_callables', $callable );
+	}
+
 	public function init_before_send() {
-		add_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_callables' ) );
+		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_sync_callables' ) );
 
 		// full sync
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_callables', array( $this, 'expand_callables' ) );

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -21,8 +21,9 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 				add_action( $comment_action_name, $callable, 10, 2 );
 			}
 		}
+	}
 
-		// full sync
+	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_comments', $callable ); // also send comments meta
 	}
 

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -18,13 +18,14 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_constant', $callable, 10, 2 );
+	}
 
-		// full sync
+	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_constants', $callable );
 	}
 
 	public function init_before_send() {
-		add_action( 'jetpack_sync_before_send', array( $this, 'maybe_sync_constants' ) );
+		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_sync_constants' ) );
 
 		// full sync
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_constants', array( $this, 'expand_constants' ) );

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -22,7 +22,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return 'full-sync';
 	}
 
-	function init_listeners( $callable ) {
+	function init_full_sync_listeners( $callable ) {
 		// synthetic actions for full sync
 		add_action( 'jetpack_full_sync_start', $callable );
 		add_action( 'jetpack_full_sync_end', $callable );

--- a/sync/class.jetpack-sync-module-network-options.php
+++ b/sync/class.jetpack-sync-module-network-options.php
@@ -17,13 +17,14 @@ class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
 		add_action( 'update_site_option', $callable, 10, 3 );
 		add_action( 'delete_site_option', $callable, 10, 1 );
 
-		// full sync
-		add_action( 'jetpack_full_sync_network_options', $callable );
-
 		$whitelist_network_option_handler = array( $this, 'whitelist_network_options' );
 		add_filter( 'jetpack_sync_before_enqueue_delete_site_option', $whitelist_network_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_add_site_option', $whitelist_network_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_update_site_option', $whitelist_network_option_handler );
+	}
+
+	public function init_full_sync_listeners( $callable ) {
+		add_action( 'jetpack_full_sync_network_options', $callable );
 	}
 
 	public function init_before_send() {

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -18,13 +18,14 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		add_action( 'update_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
 		add_action( 'delete_option_site_icon', array( $this, 'jetpack_sync_core_icon' ) );
 
-		// full sync
-		add_action( 'jetpack_full_sync_options', $callable );
-
 		$whitelist_option_handler = array( $this, 'whitelist_options' );
 		add_filter( 'jetpack_sync_before_enqueue_deleted_option', $whitelist_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_added_option', $whitelist_option_handler );
 		add_filter( 'jetpack_sync_before_enqueue_updated_option', $whitelist_option_handler );
+	}
+
+	public function init_full_sync_listeners( $callable ) {
+		add_action( 'jetpack_full_sync_options', $callable );
 	}
 
 	public function init_before_send() {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -13,8 +13,9 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'wp_insert_post', $callable, 10, 3 );
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
+	}
 
-		// full sync
+	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_posts', $callable ); // also sends post meta
 	}
 

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -14,8 +14,9 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 		add_action( 'delete_term', $callable, 10, 4 );
 		add_action( 'set_object_terms', $callable, 10, 6 );
 		add_action( 'deleted_term_relationships', $callable, 10, 2 );
+	}
 
-		//full sync
+	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_terms', $callable, 10, 2 );
 	}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -5,12 +5,25 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		return 'themes';
 	}
 
-	public function init_listeners( $handler ) {
-		add_action( 'switch_theme', array( $this, 'enqueue_full_sync_actions' ) );
-		add_action( 'jetpack_sync_current_theme_support', $handler, 10 );
+	public function init_listeners( $callable ) {
+		add_action( 'switch_theme', array( $this, 'sync_theme_support' ) );
+		add_action( 'jetpack_sync_current_theme_support', $callable );
 	}
 
-	function enqueue_full_sync_actions() {
+	// TODO: distinct action for full sync
+	public function init_full_sync_listeners( $callable ) {
+		add_action( 'jetpack_full_sync_themes', $callable );
+	}
+
+	public function sync_theme_support() {
+		$this->enqueue_theme_support_as_action( 'jetpack_sync_current_theme_support' );		
+	}
+
+	public function enqueue_full_sync_actions() {
+		return $this->enqueue_theme_support_as_action( 'jetpack_full_sync_themes' );
+	}
+
+	function enqueue_theme_support_as_action( $action_name ) {
 		global $_wp_theme_features;
 
 		$theme_support = array();
@@ -30,12 +43,12 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		 *
 		 * @param object the theme support hash
 		 */
-		do_action( 'jetpack_sync_current_theme_support', $theme_support );
+		do_action( $action_name, $theme_support );
 
 		return 1; // The number of actions enqueued
 	}
 
 	function get_full_sync_actions() {
-		return array( 'jetpack_sync_current_theme_support' );
+		return array( 'jetpack_full_sync_themes' );
 	}
 }

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -10,9 +10,6 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_action( 'set_site_transient_update_themes', $callable, 10, 1 );
 		add_action( 'set_site_transient_update_core', $callable, 10, 1 );
 
-		// full sync
-		add_action( 'jetpack_full_sync_updates', $callable );
-
 		add_filter( 'jetpack_sync_before_enqueue_set_site_transient_update_plugins', array(
 			$this,
 			'filter_update_keys',
@@ -21,6 +18,10 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			$this,
 			'filter_upgrader_process_complete',
 		), 10, 2 );
+	}
+
+	public function init_full_sync_listeners( $callable ) {
+		add_action( 'jetpack_full_sync_updates', $callable );
 	}
 
 	public function init_before_send() {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -29,8 +29,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'wp_login', $callable, 10, 2 );
 		add_action( 'wp_login_failed', $callable, 10, 2 );
 		add_action( 'wp_logout', $callable, 10, 0 );
+	}
 
-		// full sync
+	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_users', $callable );
 	}
 

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -12,6 +12,10 @@ abstract class Jetpack_Sync_Module {
 	public function init_listeners( $callable ) {
 	}
 
+	public function init_full_sync_listeners( $callable ) {
+		
+	}
+
 	public function init_before_send() {
 	}
 

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -20,6 +20,7 @@ class Jetpack_Sync_Sender {
 	private $upload_max_rows;
 	private $sync_wait_time;
 	private $sync_queue;
+	private $full_sync_queue;
 	private $codec;
 
 	// singleton functions
@@ -63,10 +64,28 @@ class Jetpack_Sync_Sender {
 		if ( $this->get_next_sync_time() > microtime( true ) ) {
 			return false;
 		}
+		
+		$full_sync_result = $this->do_sync_for_queue( $this->full_sync_queue );
+		$sync_result      = $this->do_sync_for_queue( $this->sync_queue );
 
-		do_action( 'jetpack_sync_before_send' );
+		if ( is_wp_error( $full_sync_result ) || is_wp_error( $sync_result ) ) {
+			$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );
+			$full_sync_result = false;
+			$sync_result      = false;
+		} else {
+			$this->set_next_sync_time( time() + $this->get_sync_wait_time() );
+		}
 
-		if ( $this->sync_queue->size() === 0 ) {
+		// we use OR here because if either one returns true then the caller should
+		// be allowed to call do_sync again, as there may be more items
+		return $full_sync_result || $sync_result;
+	}
+
+	public function do_sync_for_queue( $queue ) {
+
+		do_action( 'jetpack_sync_before_send_queue_' . $queue->id );
+
+		if ( $queue->size() === 0 ) {
 			return false;
 		}
 
@@ -77,7 +96,7 @@ class Jetpack_Sync_Sender {
 			ignore_user_abort( true );
 		}
 
-		$buffer = $this->sync_queue->checkout_with_memory_limit( $this->dequeue_max_bytes, $this->upload_max_rows );
+		$buffer = $queue->checkout_with_memory_limit( $this->dequeue_max_bytes, $this->upload_max_rows );
 
 		if ( ! $buffer ) {
 			// buffer has no items
@@ -135,14 +154,16 @@ class Jetpack_Sync_Sender {
 		$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ) );
 
 		if ( ! $processed_item_ids || is_wp_error( $processed_item_ids ) ) {
-			$processed_item_ids = $this->sync_queue->checkin( $buffer );
+			$checked_in_item_ids = $queue->checkin( $buffer );
 
-			if ( is_wp_error( $processed_item_ids ) ) {
-				error_log( 'Error checking in buffer: ' . $processed_item_ids->get_error_message() );
-				$this->sync_queue->force_checkin();
+			if ( is_wp_error( $checked_in_item_ids ) ) {
+				error_log( 'Error checking in buffer: ' . $checked_in_item_ids->get_error_message() );
+				$queue->force_checkin();
 			}
 
-			$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );
+			// returning a WP_Error is a sign to the caller that we should wait a while
+			// before syncing again
+			return new WP_Error( 'server_error' );
 			
 		} else {
 
@@ -165,14 +186,13 @@ class Jetpack_Sync_Sender {
 			 */
 			do_action( 'jetpack_sync_processed_actions', $processed_items );
 
-			$this->sync_queue->close( $buffer, $processed_item_ids );
+			$queue->close( $buffer, $processed_item_ids );
 
-			// detect if the last item ID was an error
+			// returning a WP_Error is a sign to the caller that we should wait a while
+			// before syncing again
 			if ( $had_wp_error ) {
-				$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );
-			} else {
-				$this->set_next_sync_time( time() + $this->get_sync_wait_time() );
-			}
+				return $wp_error;
+			} 
 		}
 		
 		return true;
@@ -180,6 +200,10 @@ class Jetpack_Sync_Sender {
 
 	function get_sync_queue() {
 		return $this->sync_queue;
+	}
+
+	function get_full_sync_queue() {
+		return $this->full_sync_queue;
 	}
 
 	function get_codec() {
@@ -195,6 +219,7 @@ class Jetpack_Sync_Sender {
 	function reset_sync_queue() {
 		Jetpack_Sync_Modules::get_module( 'full-sync' )->clear_status();
 		$this->sync_queue->reset();
+		$this->full_sync_queue->reset();
 	}
 
 	function set_dequeue_max_bytes( $size ) {
@@ -222,6 +247,7 @@ class Jetpack_Sync_Sender {
 
 	function set_defaults() {
 		$this->sync_queue = new Jetpack_Sync_Queue( 'sync' );
+		$this->full_sync_queue = new Jetpack_Sync_Queue( 'full_sync' );
 		$this->codec      = new Jetpack_Sync_JSON_Deflate_Codec();
 
 		// saved settings

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -15,6 +15,9 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_installing_and_removing_plugin_is_synced() {
+		if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50300 ) {
+			$this->markTestIncomplete("Right now this doesn't work on PHP 5.2");	
+		}
 		$this->remove_plugin(); // make sure that we start with no plugin.
 		$this->install_wp_super_cache();
 		$this->sender->do_sync();


### PR DESCRIPTION
In order to allow regular data to flow unimpeded into WPCOM, without full sync stalling audit updates etc while it runs, this PR puts full sync into a separate queue.