### PR TITLE
Admin Page: ask for confirmation before disconnecting

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -62,6 +62,12 @@ const ConnectButton = React.createClass( {
 		);
 	},
 
+	disconnectSite() {
+		if ( window.confirm( __( 'Do you really want to disconnect your site from WordPress.com?' ) ) ) {
+			this.props.disconnectSite();
+		}
+	},
+
 	renderContent: function() {
 		const fetchingUrl = this.props.fetchingConnectUrl( this.props );
 		const disconnecting = this.props.isDisconnecting( this.props );
@@ -73,7 +79,7 @@ const ConnectButton = React.createClass( {
 		if ( this.props.isSiteConnected( this.props ) ) {
 			return(
 				<Button
-					onClick={ this.props.disconnectSite }
+					onClick={ this.disconnectSite }
 					disabled={ disconnecting }>
 					{ __( 'Disconnect site from WordPress.com ') }
 				</Button>


### PR DESCRIPTION
Fixes #4334

#### Changes proposed in this Pull Request:
- when user clicks Disconnect button, show a modal dialog asking for confirmation.
<img width="782" alt="confirm" src="https://cloud.githubusercontent.com/assets/1041600/17179264/f237f376-53ee-11e6-8a12-890a2641980c.png">

#### Testing instructions:
- go to Jetpack Admin, click the Disconnect site from WordPress.com button
a modal dialog should show up and ask you for confirmation.
