### PR TITLE
Masthead: Positioning hello dolly within jetpack

### DIFF
--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -23,6 +23,26 @@
 	height: auto;
 }
 
+// Hello Dolly positioning overwrite
+.jetpack-pagestyles #dolly {
+	float: none;
+	position: relative;
+	right: 0;
+	left: 0;
+	top: 0;
+	padding: rem( 10px );
+	text-align: right;
+	background: $white;
+	font-size: rem( 12px );
+	font-style: italic;
+	color: $gray;
+	border-bottom: 1px lighten( $gray, 30% ) solid;
+
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
 // restyled the arrow to match our gray
 .toplevel_page_jetpack ul#adminmenu a.wp-has-current-submenu:after {
 	border-right-color: $gray-light;


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/3986

When Holly Dolly is active, on wide screens it shifts the Jetpack masthead over to the left due to its positioning. And on medium screens it sits on top of the masthead and looks very odd.

This PR adds some slight style mods to make hello dolly visually integrate with the Jetpack UI. It only effects Dolly within the Jetpack area. Due to the varying length of each random phrase from dolly, I just stacked it so we don't have to spend a bunch of time hassling with positioning.

**Before:**
<img width="1151" alt="dolly1" src="https://cloud.githubusercontent.com/assets/1041600/17182332/7fdb223e-53f9-11e6-9474-e32bc148ad6c.png">
<img width="673" alt="dolly2" src="https://cloud.githubusercontent.com/assets/1041600/17182333/7fde7646-53f9-11e6-8062-811d95e5d9d8.png">


**After:**
**Wide screens:**
<img width="834" alt="screen shot 2016-07-27 at 12 38 04 pm" src="https://cloud.githubusercontent.com/assets/214813/17183907/a46b28b2-53f7-11e6-9b95-1171de74c68c.png">

**Medium screens:**
<img width="380" alt="screen shot 2016-07-27 at 12 38 25 pm" src="https://cloud.githubusercontent.com/assets/214813/17183953/cdd2ebae-53f7-11e6-8279-a799175bead2.png">

**Small screens:** 
_not displayed._