### PR TITLE
Admin Page - Plans: add loading skeleton

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -77,6 +77,26 @@ const PlanBody = React.createClass( {
 					</div>
 				);
 				break;
+
+			default:
+				planCard = (
+					<div className="jp-landing__plan-features">
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title is-placeholder"> </h3>
+							<p className="jp-landing__plan-features-text is-placeholder"> </p>
+						</div>
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title is-placeholder"> </h3>
+							<p className="jp-landing__plan-features-text is-placeholder"> </p>
+						</div>
+
+						<div className="jp-landing__plan-features-card">
+							<h3 className="jp-landing__plan-features-title is-placeholder"> </h3>
+							<p className="jp-landing__plan-features-text is-placeholder"> </p>
+						</div>
+					</div>
+				);
+				break;
 		}
 		return (
 			<div>

--- a/_inc/client/plans/plan-header.jsx
+++ b/_inc/client/plans/plan-header.jsx
@@ -99,6 +99,19 @@ const PlanHeader = React.createClass( {
 					</div>
 				);
 				break;
+
+			default:
+				planCard = (
+					<div className="jp-landing__plan-card">
+						<div className="jp-landing__plan-card-img is-placeholder">
+						</div>
+						<div className="jp-landing__plan-card-current">
+							<h3 className="jp-landing__plan-features-title is-placeholder"> </h3>
+							<p className="jp-landing__plan-features-text is-placeholder"> </p>
+						</div>
+					</div>
+				);
+				break;
 		}
 		return (
 			<div>

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -166,7 +166,7 @@
 		padding: 0;
 
 		@include breakpoint( ">660px" ) {
-			padding-left: rem( 32px );
+			margin-left: rem( 32px );
 		}
 	}
 
@@ -193,4 +193,23 @@
 	@include breakpoint( "<660px" ) {
 		width: rem( 100px );
 	}
+}
+
+.jp-landing__plan-card-img.is-placeholder {
+	width: rem( 120px );
+	height: rem( 85px );
+
+	& + .jp-landing__plan-card-current {
+		width: 80%;
+	}
+}
+
+.jp-landing__plan-features-title.is-placeholder {
+	height: rem( 24px );
+	max-width: 50%;
+}
+
+.jp-landing__plan-features-text.is-placeholder {
+	height: rem( 44px );
+	max-width: 75%;
 }

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -145,3 +145,12 @@
 		}
 	}
 }
+
+.is-placeholder {
+	animation: pulse-light 0.8s ease-in-out infinite;
+	background: lighten( $gray, 20% );
+}
+
+@keyframes pulse-light {
+	50% { background-color: lighten( $gray, 30% ); }
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- introduces `.is-placeholder` CSS class to add it to the gray skeleton elements that pulsate.
- add skeleton loading to Plans landing page

![skeleton](https://cloud.githubusercontent.com/assets/1041600/17184646/c28cb7e6-5403-11e6-9ea6-3af294966671.gif)

#### Testing instructions:
- go to Jetpack Admin and check the Plans tab. Should display the skeleton while it's loading and then the real content.