### PR TITLE
Add a test to make sure that we sync modules alway right away.

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -23,9 +23,15 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
 
+		// full sync
+		add_action( 'jetpack_full_sync_callables', $callable );
+
+		// always send change to active modules right away
+		add_action( 'update_option_jetpack_active_modules', array( $this, 'unlock_sync_callable' ) );
+
 		// get_plugins and wp_version
 		// gets fired when new code gets installed, updates etc.
-		add_action( 'upgrader_process_complete', array( $this, 'force_sync_callables' ) );
+		add_action( 'upgrader_process_complete', array( $this, 'unlock_sync_callable' ) );
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -92,6 +98,10 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		$this->maybe_sync_callables();
 	}
 
+	public function unlock_sync_callable() {
+		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
+	}
+	
 	public function maybe_sync_callables() {
 		if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
 			return;

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -92,12 +92,6 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		return array( 'jetpack_full_sync_callables' );
 	}
 
-	public function force_sync_callables() {
-		delete_option( self::CALLABLES_CHECKSUM_OPTION_NAME );
-		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
-		$this->maybe_sync_callables();
-	}
-
 	public function unlock_sync_callable() {
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
 	}

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -44,12 +44,6 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		return $this->constants_whitelist;
 	}
 
-	function force_sync_constants() {
-		delete_option( self::CONSTANTS_CHECKSUM_OPTION_NAME );
-		delete_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME );
-		$this->maybe_sync_constants();
-	}
-
 	function enqueue_full_sync_actions() {
 		/**
 		 * Tells the client to sync all constants to the server

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -128,6 +128,26 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
 	}
 
+	function test_sync_always_sync_changes_to_modules_right_away() {
+		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
+		$this->setSyncClientDefaults();
+		Jetpack::update_active_modules( array( 'stats' ) );
+
+		$this->sender->do_sync();
+		
+		$synced_value = $this->server_replica_storage->get_callable( 'active_modules' );
+		$this->assertEquals(  array( 'stats' ), $synced_value  );
+
+		$this->server_replica_storage->reset();
+
+		Jetpack::update_active_modules( array( 'json-api' ) );
+		$this->sender->do_sync();
+
+		$synced_value = $this->server_replica_storage->get_callable( 'active_modules' );
+		$this->assertEquals( array( 'json-api' ), $synced_value );
+	}
+
 	function test_scheme_switching_does_not_cause_sync() {
 		$this->setSyncClientDefaults();
 		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );


### PR DESCRIPTION
Lets make sure that we always sync active modules

#### Changes proposed in this Pull Request:
- delete the lock that would prevent the change from happening right away.
- Added a test that shows that this corrent thing happens.

#### Testing instructions:
- run the test suite. 
- toggle modules and see that changes right away.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

This would solve any issues where the module syncing is delayed when a
toggle happens!