### PR TITLE
Admin Page: introduce localforage to cache site data

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -27,7 +27,10 @@ const restApi = {
 			'X-WP-Nonce': window.Initial_State.WP_API_nonce
 		}
 	} )
-		.then( checkStatus ).then( response => response.json() ),
+		.then( checkStatus ).then( response => {
+			localforage.removeItem( 'siteData' );
+			return response.json();
+		} ),
 	fetchConnectUrl: () => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/connect-url`, {
 		credentials: 'same-origin',
 		headers: {

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -3,6 +3,7 @@
  */
 require( 'es6-promise' ).polyfill();
 import 'whatwg-fetch';
+import localforage from 'localforage';
 
 const restApi = {
 	fetchSiteConnectionStatus: () => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/connection-status`, {
@@ -168,15 +169,30 @@ const restApi = {
 		}
 	} )
 		.then( checkStatus ).then( response => response.json() ),
-	fetchSiteData: () => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/site`, {
-		method: 'get',
-		credentials: 'same-origin',
-		headers: {
-			'X-WP-Nonce': window.Initial_State.WP_API_nonce,
-			'Content-type': 'application/json'
-		}
-	} )
-		.then( checkStatus ).then( response => response.json() ),
+	fetchSiteData: () => {
+		return localforage.getItem( 'siteData' ).then( siteData => {
+			if ( 'object' === typeof siteData && 0 < Object.keys( siteData ).length ) {
+				return siteData;
+			}
+			return fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/site`, {
+				method: 'get',
+				credentials: 'same-origin',
+				headers: {
+					'X-WP-Nonce': window.Initial_State.WP_API_nonce,
+					'Content-type': 'application/json'
+				}
+			} )
+				.then( checkStatus ).then( response => {
+					response = response.json();
+					localforage.setItem( 'siteData', response );
+					return response;
+				}
+			);
+		} ).catch( () => {
+			localforage.setItem( 'siteData', {} );
+			return {};
+		} );
+	},
 	dismissJetpackNotice: ( notice ) => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/notice/${ notice }/dismiss`, {
 		method: 'put',
 		credentials: 'same-origin',

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "jsdom": "^9.2.1",
     "jshint": "2.9.1",
     "jshint-stylish": "~2.1.0",
+    "localforage": "1.4.2",
     "lodash": "^4.9.0",
     "mocha": "^2.4.5",
     "mockery": "^1.4.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,8 @@ var webpackConfig = {
 				test: /\.scss$/,
 				loader: ExtractTextPlugin.extract( 'style-loader', 'css!sass' )
 			}
-		]
+		],
+		noParse: /node_modules\/localforage\/dist\/localforage.js/
 	},
 	resolve: {
 		extensions: [ '', '.js', '.jsx' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
With localforage, we'll cache some data that doesn't need to be fetch from WordPress.com every time.

Right now this is implemented for site data, which is used in the Plans tab and in the Connection Settings card.

- [x] cache site data when user loads Plan and keep it for subsequent page loads or when user switches tabs
- [x] clear persistent data when site is disconnected
- [ ] clear persistent data when user upgrades Plan

Notes:
- I'm filing this under 4.3-public-beta because it would be nice to have this for a better UX but it's not a blocker and can be moved to a later milestone. If this is moved I'd still like to implement a basic cache for the session like what I did for the Stats data so once the data is fetch, it's saved.
- I've added this file to the list of files to not be parsed by Webpack because it was throwing a warning and Travis was failing. See [this for info about the warning](https://github.com/localForage/localForage/issues/577)