### PR TITLE
Sync: Add more sync status info to the debugger.

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -95,12 +95,19 @@ class Jetpack_Debugger {
 		}
 
 		require_once JETPACK__PLUGIN_DIR. 'sync/class.jetpack-sync-sender.php';
+
 		$queue = Jetpack_Sync_Sender::get_instance()->get_sync_queue();
 
 		$debug_info .= "\r\n". sprintf( esc_html__( 'Sync Queue size: `%1$s`', 'jetpack' ), $queue->size() );
 		$debug_info .= "\r\n". sprintf( esc_html__( 'Sync Queue lag: `%1$s`', 'jetpack' ), self::seconds_to_time( $queue->lag() ) );
+
+		$full_sync_queue = Jetpack_Sync_Sender::get_instance()->get_full_sync_queue();
+
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Full Sync Queue size: `%1$s`', 'jetpack' ), $full_sync_queue->size() );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Full Sync Queue lag: `%1$s`', 'jetpack' ), self::seconds_to_time( $full_sync_queue->lag() ) );
+
 		$debug_info .= "\r\n";
-		
+
 		foreach ( array (
 					  'HTTP_HOST',
 					  'SERVER_PORT',

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -105,13 +105,13 @@ class Jetpack_Debugger {
 
 		$queue = Jetpack_Sync_Sender::get_instance()->get_sync_queue();
 
-		$debug_info .= "\r\n". sprintf( esc_html__( 'Sync Queue size: `%1$s`', 'jetpack' ), $queue->size() );
-		$debug_info .= "\r\n". sprintf( esc_html__( 'Sync Queue lag: `%1$s`', 'jetpack' ), self::seconds_to_time( $queue->lag() ) );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Sync Queue size: %1$s', 'jetpack' ), $queue->size() );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Sync Queue lag: %1$s', 'jetpack' ), self::seconds_to_time( $queue->lag() ) );
 
 		$full_sync_queue = Jetpack_Sync_Sender::get_instance()->get_full_sync_queue();
 
-		$debug_info .= "\r\n". sprintf( esc_html__( 'Full Sync Queue size: `%1$s`', 'jetpack' ), $full_sync_queue->size() );
-		$debug_info .= "\r\n". sprintf( esc_html__( 'Full Sync Queue lag: `%1$s`', 'jetpack' ), self::seconds_to_time( $full_sync_queue->lag() ) );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Full Sync Queue size: %1$s', 'jetpack' ), $full_sync_queue->size() );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Full Sync Queue lag: %1$s', 'jetpack' ), self::seconds_to_time( $full_sync_queue->lag() ) );
 
 		$debug_info .= "\r\n";
 

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -85,20 +85,20 @@ class Jetpack_Debugger {
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
 
-		$debug_info .= "\r\n". esc_html( "Jetpack Sync Full Status: " . print_r( $sync_module->get_status(), 1 ) );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Jetpack Sync Full Status: `%1$s`', 'jetpack' ), print_r( $sync_module->get_status(), 1 ) );
 
 		$next_schedules = wp_next_scheduled( 'jetpack_sync_full' );
 		if( $next_schedules ) {
-			$debug_info .= "\r\n". esc_html( "Next Jetpack Full Sync Schedule: " . date( 'r', $next_schedules ) );
+			$debug_info .= "\r\n". sprintf( esc_html__( 'Next Jetpack Full Sync Schedule: `%1$s`', 'jetpack' ), date( 'r', $next_schedules ) );
 		} else {
-			$debug_info .= "\r\n". esc_html( "Next Jetpack Full Sync Schedule: Not Schedules" );
+			$debug_info .= "\r\n". esc_html__( "Next Jetpack Full Sync Schedule: Not Schedules", 'jetpack' );
 		}
 
 		require_once JETPACK__PLUGIN_DIR. 'sync/class.jetpack-sync-sender.php';
 		$queue = Jetpack_Sync_Sender::get_instance()->get_sync_queue();
 
-		$debug_info .= "\r\n". esc_html( "Sync Queue size: " . $queue->size() );
-		$debug_info .= "\r\n". esc_html( "Sync Queue lag: " . self::seconds_to_time( $queue->lag() ) );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Sync Queue size: `%1$s`', 'jetpack' ), $queue->size() );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Sync Queue lag: `%1$s`', 'jetpack' ), self::seconds_to_time( $queue->lag() ) );
 		$debug_info .= "\r\n";
 		
 		foreach ( array (

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -84,8 +84,15 @@ class Jetpack_Debugger {
 		$debug_info .= "\r\n";
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$sync_statuses = $sync_module->get_status();
+		$human_readable_sync_status = array();
+		foreach( $sync_statuses  as $sync_status => $sync_status_value ) {
+			$human_readable_sync_status[ $sync_status ] =
+				in_array( $sync_status, array( 'started', 'queue_finished', 'sent_started', 'finished' ) )
+				? date( 'r', $sync_status_value ) : $sync_status_value ;
+		}
 
-		$debug_info .= "\r\n". sprintf( esc_html__( 'Jetpack Sync Full Status: `%1$s`', 'jetpack' ), print_r( $sync_module->get_status(), 1 ) );
+		$debug_info .= "\r\n". sprintf( esc_html__( 'Jetpack Sync Full Status: `%1$s`', 'jetpack' ), print_r( $human_readable_sync_status, 1 ) );
 
 		$next_schedules = wp_next_scheduled( 'jetpack_sync_full' );
 		if( $next_schedules ) {
@@ -317,7 +324,7 @@ class Jetpack_Debugger {
 		<div id="toggle_debug_info"><a href="#"><?php _e( 'View Advanced Debug Results', 'jetpack' ); ?></a></div>
 			<div id="debug_info_div" style="display:none">
 			<h4><?php esc_html_e( 'Debug Info', 'jetpack' ); ?></h4>
-			<div id="debug_info"><?php echo wpautop( esc_html( $debug_info ) ); ?></div>
+			<div id="debug_info"><pre><?php echo esc_html( $debug_info ) ; ?></pre></div>
 		</div>
 		</div>
 	<?php
@@ -398,6 +405,12 @@ class Jetpack_Debugger {
 				padding: 10px;
 				width: 97%;
 			}
+			#debug_info_div {
+				border-radius: 0;
+				margin-top: 16px;
+				background: #FFF;
+				padding: 16px;
+			}
 			.formbox .contact-support input[type="submit"] {
 				float: right;
 				margin: 0 !important;
@@ -439,7 +452,7 @@ class Jetpack_Debugger {
 			}
 
 			#debug_info_div, #toggle_debug_info, #debug_info_div p {
-				font-size: smaller;
+				font-size: 12px;
 			}
 
 		</style>


### PR DESCRIPTION
Add sync status to the debugger. This info is hopefully useful to the happiness engineers. 

#### Changes proposed in this Pull Request:
Adds data regaridng the sync status to the debug info that users find on the 
http://example.com/wp-admin/admin.php?page=jetpack-debugger

#### Testing instructions:
- Go to the jetpack debugger expand the debug info.

cc: @jeherve 
<img width="484" alt="screen shot 2016-07-27 at 20 54 31" src="https://cloud.githubusercontent.com/assets/115071/17200693/5a490674-543c-11e6-89e8-19dde2121fba.png">
