### PR TITLE
Try: Try to send the sync queue right away if it is not that big.

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -62,6 +62,14 @@ class Jetpack_Sync_Sender {
 
 		// don't sync if we are throttled
 		if ( $this->get_next_sync_time() > microtime( true ) ) {
+			// even though we shouldn't be syncing untill next time if the queue is really small
+			// lets try any way.
+			if ( $this->sync_queue->size() < 12 ) {
+				$sync_result  = $this->do_sync_for_queue( $this->sync_queue );
+				if ( is_wp_error( $sync_result ) ) {
+					$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );
+				}
+			}
 			return false;
 		}
 		

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -13,7 +13,7 @@ class Jetpack_Sync_Sender {
 
 	const SYNC_THROTTLE_OPTION_NAME = 'jetpack_sync_min_wait';
 	const NEXT_SYNC_TIME_OPTION_NAME = 'jetpack_next_sync_time';
-	const WPCOM_ERROR_SYNC_DELAY = 60;
+	const WPCOM_ERROR_SYNC_DELAY = 300; // 5min
 
 	private $dequeue_max_bytes;
 	private $upload_max_bytes;
@@ -61,10 +61,11 @@ class Jetpack_Sync_Sender {
 		}
 
 		// don't sync if we are throttled
-		if ( $this->get_next_sync_time() > microtime( true ) ) {
-			// even though we shouldn't be syncing untill next time if the queue is really small
+		$next_sync_queue = $this->get_next_sync_time();
+		if ( $next_sync_queue > microtime( true ) ) {
+			// Even though we shouldn't be syncing untill next time if the queue is really small
 			// lets try any way.
-			if ( $this->sync_queue->size() < 12 ) {
+			if ( $this->sync_queue->size() < 12 && $next_sync_queue < $this->get_sync_wait_time() + time() ) {
 				$sync_result  = $this->do_sync_for_queue( $this->sync_queue );
 				if ( is_wp_error( $sync_result ) ) {
 					$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );


### PR DESCRIPTION
Fixes any delays that there might exists because actions want to be send right away but can not because we impose a delay on them. ( The delay is usually 1 minute ) 
If the queue is less then the 12 (a try to send it right away).


#### Changes proposed in this Pull Request:


#### Testing instructions:
- Toggle things modules on the .com side. ( Notice that you don't get error of this module is active since the delay between data being set and received is minimal. 

- [ ]  Write one another test that shows that if an error occurs the delay is respected. 

