### PR TITLE
Admin Page: Use lodash/get in isStaging() state selector for obtaining the isStaging flag from the state

### DIFF
--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -3,6 +3,7 @@
  */
 import { combineReducers } from 'redux';
 import assign from 'lodash/assign';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -212,7 +213,7 @@ export function isDevMode( state ) {
  * @return {boolean} True if site is in staging. False otherwise.
  */
 export function isStaging( state ) {
-	return state.jetpack.connection.status.siteConnected.isStaging;
+	return get( state.jetpack.connection.status, [ 'siteConnected', 'isStaging' ], false );
 }
 
 /**


### PR DESCRIPTION
Fixes #4582  .

#### Changes proposed in this Pull Request:

- Replace literal traversing on state object for an alternative using lodash.get.

#### Testing instructions:

- Get to Jetpack Settings Admin Page.
- Disconnect your site from the **Connection Settings** card under the **General tab**
- Expect to see no error in the console


