### PR TITLE
Admin Page: Make the Module Settings save button be disabled while saving options

### DIFF
--- a/_inc/client/components/forms/index.jsx
+++ b/_inc/client/components/forms/index.jsx
@@ -8,6 +8,7 @@ import assign from 'lodash/assign';
 import noop from 'lodash/noop';
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
+import { translate as __ } from 'i18n-calypso';
 
 export const FormFieldset = React.createClass( {
 
@@ -143,7 +144,7 @@ export const FormButton = React.createClass( {
 	},
 
 	getDefaultButtonAction: function() {
-		return this.props.isSubmitting ? this.translate( 'Saving…' ) : this.translate( 'Save Settings' );
+		return this.props.isSubmitting ? __( 'Saving…' ) : __( 'Save Settings' );
 	},
 
 	render: function() {

--- a/_inc/client/components/forms/index.jsx
+++ b/_inc/client/components/forms/index.jsx
@@ -4,11 +4,10 @@
 var React = require( 'react' ),
 	classnames = require( 'classnames' );
 import classNames from 'classnames';
-import assign from 'lodash/assign';
-import noop from 'lodash/noop';
 import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import { translate as __ } from 'i18n-calypso';
+import Button from 'components/button';
 
 export const FormFieldset = React.createClass( {
 
@@ -160,47 +159,5 @@ export const FormButton = React.createClass( {
 				{ isEmpty( this.props.children ) ? this.getDefaultButtonAction() : this.props.children }
 			</Button>
 		);
-	}
-} );
-
-export const Button = React.createClass( {
-
-	displayName: 'Button',
-
-	propTypes: {
-		disabled: React.PropTypes.bool,
-		compact: React.PropTypes.bool,
-		primary: React.PropTypes.bool,
-		scary: React.PropTypes.bool,
-		type: React.PropTypes.string,
-		href: React.PropTypes.string,
-		onClick: React.PropTypes.func,
-		borderless: React.PropTypes.bool
-	},
-
-	getDefaultProps() {
-		return {
-			disabled: false,
-			type: 'button',
-			onClick: noop,
-			borderless: false
-		};
-	},
-
-	render() {
-		const element = this.props.href ? 'a' : 'button';
-		const buttonClasses = classNames( {
-			button: true,
-			'is-compact': this.props.compact,
-			'is-primary': this.props.primary,
-			'is-scary': this.props.scary,
-			'is-borderless': this.props.borderless
-		} );
-
-		const props = assign( {}, this.props, {
-			className: classNames( this.props.className, buttonClasses )
-		} );
-
-		return React.createElement( element, props, this.props.children );
 	}
 } );

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -35,7 +35,7 @@ export let SharedaddySettings = React.createClass( {
 				<FormFieldset>
 					<ModuleSettingCheckbox name={ 'option_name' } { ...this.props } label={ __( 'Subscriber' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="Submit">{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="Submit">{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -94,7 +94,7 @@ export let RelatedPostsSettings = React.createClass( {
 					<Card>
 						{ this.renderPreviews() }
 					</Card>
-					<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+					<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 				</FormFieldset>
 			</form>
 		);
@@ -114,7 +114,7 @@ export let LikesSettings = React.createClass( {
 						{ ...this.props }
 						validValues={ this.props.validValues( 'wpl_default' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -142,7 +142,7 @@ export let CommentsSettings = React.createClass( {
 						name={ 'jetpack_comment_form_color_scheme' }
 						{ ...this.props }
 						validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme' ) } />
-					<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+					<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 				</FormFieldset>
 			</form>
 		)
@@ -166,8 +166,8 @@ export let SubscriptionsSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Show a "follow comments" option in the comment form.' ) +
 							' (Currently does not work)' } />
-					<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
-					</FormFieldset>
+					<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
+				</FormFieldset>
 			</form>
 		)
 	}
@@ -208,7 +208,7 @@ export let StatsSettings = React.createClass( {
 							{ ...this.props }
 							validValues={ this.props.getSiteRoles() } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		);
 	}
@@ -231,7 +231,7 @@ export let ProtectSettings = React.createClass( {
 							value={ this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local } />
 					</FormLabel>
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -249,7 +249,7 @@ export let MonitorSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Receive Monitor Email Notifications' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -271,7 +271,7 @@ export let SingleSignOnSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Require Two-Step Authentication' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -297,7 +297,7 @@ export let CarouselSettings = React.createClass( {
 						{ ...this.props }
 						validValues={ this.props.validValues( 'carousel_background_color' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -319,7 +319,7 @@ export let InfiniteScrollSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Track each infinite Scroll post load as a page view in Google Analytics' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -352,7 +352,7 @@ export let MinilevenSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Show a promo for the WordPress mobile apps in the footer of the mobile theme' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -371,7 +371,7 @@ export let GravatarHovercardsSettings = React.createClass( {
 						{ ...this.props }
 						validValues={ this.props.validValues( 'gravatar_disable_hovercards' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -450,7 +450,7 @@ export let VerificationToolsSettings = React.createClass( {
 						</p>
 					</div>
 
-					<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+					<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 				</FormFieldset>
 			</form>
 		)
@@ -470,7 +470,7 @@ export let TiledGallerySettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Display all your gallery pictures in a cool mosaic' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -527,7 +527,7 @@ export let CustomContentTypesSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Enable Testimonials for this site' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -603,7 +603,7 @@ export let AfterTheDeadlineSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Use automatically detected language to proofread posts and pages' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -621,7 +621,7 @@ export let MarkdownSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Use Markdown for comments' ) } />
 				</FormFieldset>
-				<Button disabled={ ! this.props.isDirty() } type="submit" >{ __( 'Save' ) }</Button>
+				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -3,9 +3,8 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
 import Card from 'components/card';
-
+import Button from 'components/button';
 /**
  * Internal dependencies
  */
@@ -34,8 +33,11 @@ export let SharedaddySettings = React.createClass( {
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
 					<ModuleSettingCheckbox name={ 'option_name' } { ...this.props } label={ __( 'Subscriber' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="Submit">{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -94,7 +96,10 @@ export let RelatedPostsSettings = React.createClass( {
 					<Card>
 						{ this.renderPreviews() }
 					</Card>
-					<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
 			</form>
 		);
@@ -113,8 +118,11 @@ export let LikesSettings = React.createClass( {
 						name={ 'wpl_default' }
 						{ ...this.props }
 						validValues={ this.props.validValues( 'wpl_default' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -142,7 +150,10 @@ export let CommentsSettings = React.createClass( {
 						name={ 'jetpack_comment_form_color_scheme' }
 						{ ...this.props }
 						validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme' ) } />
-					<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
 			</form>
 		)
@@ -166,7 +177,10 @@ export let SubscriptionsSettings = React.createClass( {
 						{ ...this.props }
 						label={ __( 'Show a "follow comments" option in the comment form.' ) +
 							' (Currently does not work)' } />
-					<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
 			</form>
 		)
@@ -202,13 +216,16 @@ export let StatsSettings = React.createClass( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
-						<ModuleSettingMultipleSelectCheckboxes
-							always_checked={ [ 'administrator' ] }
-							name={ 'roles' }
-							{ ...this.props }
-							validValues={ this.props.getSiteRoles() } />
+					<ModuleSettingMultipleSelectCheckboxes
+						always_checked={ [ 'administrator' ] }
+						name={ 'roles' }
+						{ ...this.props }
+						validValues={ this.props.getSiteRoles() } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		);
 	}
@@ -230,8 +247,11 @@ export let ProtectSettings = React.createClass( {
 							onChange={ this.props.onOptionChange }
 							value={ this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local } />
 					</FormLabel>
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -248,8 +268,11 @@ export let MonitorSettings = React.createClass( {
 						name={ 'monitor_receive_notifications' }
 						{ ...this.props }
 						label={ __( 'Receive Monitor Email Notifications' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -270,8 +293,11 @@ export let SingleSignOnSettings = React.createClass( {
 						name={ 'jetpack_sso_require_two_step' }
 						{ ...this.props }
 						label={ __( 'Require Two-Step Authentication' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -296,8 +322,11 @@ export let CarouselSettings = React.createClass( {
 						name={ 'carousel_background_color' }
 						{ ...this.props }
 						validValues={ this.props.validValues( 'carousel_background_color' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -318,8 +347,11 @@ export let InfiniteScrollSettings = React.createClass( {
 						name={ 'infinite_scroll_google_analytics' }
 						{ ...this.props }
 						label={ __( 'Track each infinite Scroll post load as a page view in Google Analytics' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -351,8 +383,11 @@ export let MinilevenSettings = React.createClass( {
 						name={ 'wp_mobile_app_promos' }
 						{ ...this.props }
 						label={ __( 'Show a promo for the WordPress mobile apps in the footer of the mobile theme' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -370,8 +405,11 @@ export let GravatarHovercardsSettings = React.createClass( {
 						name={ 'gravatar_disable_hovercards' }
 						{ ...this.props }
 						validValues={ this.props.validValues( 'gravatar_disable_hovercards' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -450,7 +488,10 @@ export let VerificationToolsSettings = React.createClass( {
 						</p>
 					</div>
 
-					<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
 			</form>
 		)
@@ -469,8 +510,11 @@ export let TiledGallerySettings = React.createClass( {
 						name={ 'tiled_galleries' }
 						{ ...this.props }
 						label={ __( 'Display all your gallery pictures in a cool mosaic' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -526,8 +570,11 @@ export let CustomContentTypesSettings = React.createClass( {
 						name={ 'jetpack_testimonial' }
 						{ ...this.props }
 						label={ __( 'Enable Testimonials for this site' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -602,8 +649,11 @@ export let AfterTheDeadlineSettings = React.createClass( {
 						name={ 'guess_lang' }
 						{ ...this.props }
 						label={ __( 'Use automatically detected language to proofread posts and pages' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}
@@ -620,8 +670,11 @@ export let MarkdownSettings = React.createClass( {
 						name={ 'wpcom_publish_comments_with_markdown' }
 						{ ...this.props }
 						label={ __( 'Use Markdown for comments' ) } />
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
-				<Button disabled={ this.props.shouldSaveButtonBeDisabled() } type="submit" >{ __( 'Save' ) }</Button>
 			</form>
 		)
 	}

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -48,7 +48,10 @@ export function ModuleSettingsForm( InnerComponent ) {
 		},
 		onSubmit( event ) {
 			event.preventDefault();
-			this.props.updateOptions( this.state.options );
+			this.props.updateOptions( this.state.options )
+				.then( () => {
+					this.setState( { options: {} } )
+				} );
 		},
 		getOptionValue( optionName ) {
 			const currentValue = this.props.getOptionCurrentValue( this.props.module.module, optionName );
@@ -56,8 +59,18 @@ export function ModuleSettingsForm( InnerComponent ) {
 				? this.state.options[ optionName ]
 				: currentValue;
 		},
+		shouldSaveButtonBeDisabled() {
+			let shouldItBeEnabled = false;
+			// Check if the form is not currently dirty
+			shouldItBeEnabled = ! this.isSavingAnyOption() && this.isDirty();
+			return ! shouldItBeEnabled;
+		},
 		isDirty() {
 			return !! Object.keys( this.state.options ).length;
+		},
+		isSavingAnyOption() {
+			// Check if any of the updated options is still saving
+			return Object.keys( this.state.options ).some( option_name => this.props.isUpdating( option_name ) );
 		},
 		render() {
 			return(
@@ -67,6 +80,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 					onOptionChange={ this.onOptionChange }
 					updateFormStateOptionValue={ this.updateFormStateOptionValue }
 					isDirty={ this.isDirty }
+					shouldSaveButtonBeDisabled={ this.shouldSaveButtonBeDisabled }
 					{ ...this.props } />
 			);
 		}

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -79,8 +79,8 @@ export function ModuleSettingsForm( InnerComponent ) {
 					onSubmit={ this.onSubmit }
 					onOptionChange={ this.onOptionChange }
 					updateFormStateOptionValue={ this.updateFormStateOptionValue }
-					isDirty={ this.isDirty }
 					shouldSaveButtonBeDisabled={ this.shouldSaveButtonBeDisabled }
+					isSavingAnyOption={ this.isSavingAnyOption }
 					{ ...this.props } />
 			);
 		}


### PR DESCRIPTION
Fixes #4430  .

#### Changes proposed in this Pull Request:

- Makes the save button on feature settings forms disable when saving and re-enable when the API requests ends.
- Makes the save button read "Saving..." while the options are being saved.
- Moves every save button to be inside a `<FormFieldSet />` for appropriate positioning.
- Changes the save buttons to have the `.is-primary` class applied

#### Before

![beforesavebutton](https://cloud.githubusercontent.com/assets/746152/17221883/0cc05ea8-54cc-11e6-8379-3576cae01583.gif)


#### After

![savebutton](https://cloud.githubusercontent.com/assets/746152/17221837/ec7d8af8-54cb-11e6-8b37-db5dc5a00655.gif)


#### Testing instructions:
- Get to the **Stats** settings under the **Engagement** module
- Update one of the options for the Roles Permissions
- Save the change
- Watch the save button be disabled when the change is still being saved. It's label switched to "Saving..."
- Watch the save button remain disabled when the option has been saved. It's label switched to "Save settings".
- Watch the save button be re-enabled if you alter one of the options again