### PR TITLE
Remove compatibility code for unsupported WP version < 4.1

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -166,14 +166,7 @@ class Jetpack_Options {
 		 */
 		do_action( 'pre_update_jetpack_option_' . $name, $name, $value );
 		if ( self::is_valid( $name, 'non_compact' ) ) {
-			/**
-			 * Allowing update_option to change autoload status only shipped in WordPress v4.2
-			 * @link https://github.com/WordPress/WordPress/commit/305cf8b95
-			 */
-			if ( version_compare( $GLOBALS['wp_version'], '4.2', '>=' ) ) {
-				return update_option( "jetpack_$name", $value, $autoload );
-			}
-			return update_option( "jetpack_$name", $value );
+			return update_option( "jetpack_$name", $value, $autoload );
 		}
 
 		foreach ( array_keys( self::$grouped_options ) as $group ) {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -178,14 +178,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	private function update_status_option( $name, $value ) {
 		$prefix = self::STATUS_OPTION_PREFIX;
-		/**
-		 * Allowing update_option to change autoload status only shipped in WordPress v4.2
-		 * @link https://github.com/WordPress/WordPress/commit/305cf8b95
-		 */
-		if ( version_compare( $GLOBALS['wp_version'], '4.2', '>=' ) ) {
-			update_option( "{$prefix}_{$name}", $value, false );
-		} else {
-			update_option( "{$prefix}_{$name}", $value );
-		}
+		update_option( "{$prefix}_{$name}", $value, false );
 	}
 }


### PR DESCRIPTION
@jeherve [commented in a separate PR](https://github.com/Automattic/jetpack/pull/4546/files/be66b7cd30f100026b208520f7361f192ac27d8e#r72601611) that we don't need to support the legacy options syntax since those versions of WP are no longer supported by Jetpack. This PR removes them.