### PR TITLE
Admin Page - AAG: hide the tooltip arrow in Stats chart

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -272,3 +272,7 @@
 	}
 }
 // end flexbox nesting
+
+.dops-chart__tooltip .tip-arrow {
+	display: none;
+}


### PR DESCRIPTION
Fixes #4486

#### Changes proposed in this Pull Request:
- Hide the arrow of the tooltip that is shown while rolling the mouse over a column in Stats chart.

This is a local fix for our JPR leaving dops-components untouched.

#### Testing instructions:
- go to Jetpack Admin and roll the mouse over the Stats chart. The tooltip must show up as usual but without the tip.
