### PR TITLE
Cancel previous sync when starting a new one

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -9,26 +9,9 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		$modules = null;
 
-		if ( isset( $args['clear'] ) && $args['clear'] ) {
-			// clear sync queue
-			require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
-
-			$sender = Jetpack_Sync_Sender::get_instance();
-			$sender->reset_sync_queue();
-		}
-
-		if ( isset( $args['force'] ) && $args['force'] ) {
-			// reset full sync lock
-			require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-modules.php';
-
-			$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-			$sync_module->clear_status();
-		}
-
 		if ( isset( $args['modules'] ) && !empty( $args['modules'] ) ) {
 			$modules = array_map('trim', explode( ',', $args['modules'] ) );
 		}
-
 
 		if ( empty( $modules ) ) {
 			$modules = null;

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -575,8 +575,6 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 		'$site' => '(int|string) The site ID, The site domain'
 	),
 	'request_format' => array(
-		'force'   => '(bool=false) Force a full sync by clearing the full sync lock',
-		'clear'   => '(bool=false) Clear the sync queue before full-syncing',
 		'modules' => '(string) Comma-delimited set of sync modules to use (default: all of them)'
 	),
 	'response_format' => array(

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -35,10 +35,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	function start( $modules = null ) {
-		// ensure listener is loaded so we can guarantee full sync actions are enqueued
-		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
-		Jetpack_Sync_Listener::get_instance();
-
 		$was_already_running = $this->is_started() && ! $this->is_finished();
 
 		// remove all evidence of previous full sync items and status
@@ -167,6 +163,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	public function reset_data() {
 		$this->clear_status();
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 		$listener = Jetpack_Sync_Listener::get_instance();
 		$listener->get_full_sync_queue()->reset();
 	}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -26,6 +26,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		// synthetic actions for full sync
 		add_action( 'jetpack_full_sync_start', $callable );
 		add_action( 'jetpack_full_sync_end', $callable );
+		add_action( 'jetpack_full_sync_cancelled', $callable );
 	}
 
 	function init_before_send() {
@@ -38,6 +39,15 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 		Jetpack_Sync_Listener::get_instance();
 
+		$was_already_running = $this->is_started() && ! $this->is_finished();
+
+		// remove all evidence of previous full sync items and status
+		$this->reset_data();
+
+		if ( $was_already_running ) {
+			do_action( 'jetpack_full_sync_cancelled' );
+		}
+
 		/**
 		 * Fires when a full sync begins. This action is serialized
 		 * and sent to the server so that it knows a full sync is coming.
@@ -45,7 +55,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * @since 4.2.0
 		 */
 		do_action( 'jetpack_full_sync_start' );
-		$this->set_status_queuing_started();
+		$this->update_status_option( "started", time() );
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();
@@ -60,7 +70,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			}
 		}
 
-		$this->set_status_queuing_finished();
+		$this->update_status_option( "queue_finished", time() );
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 
@@ -108,15 +118,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 	}
 
-	private function set_status_queuing_started() {
-		$this->clear_status();
-		$this->update_status_option( "started", time() );
-	}
-
-	private function set_status_queuing_finished() {
-		$this->update_status_option( "queue_finished", time() );
-	}
-
 	public function is_started() {
 		return !! $this->get_status_option( "started" );
 	}
@@ -162,6 +163,12 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			delete_option( "{$prefix}_{$module->name()}_queued" );
 			delete_option( "{$prefix}_{$module->name()}_sent" );
 		}
+	}
+
+	public function reset_data() {
+		$this->clear_status();
+		$listener = Jetpack_Sync_Listener::get_instance();
+		$listener->get_full_sync_queue()->reset();
 	}
 
 	private function get_status_option( $option ) {

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -217,9 +217,7 @@ class Jetpack_Sync_Sender {
 	}
 
 	function reset_sync_queue() {
-		Jetpack_Sync_Modules::get_module( 'full-sync' )->clear_status();
 		$this->sync_queue->reset();
-		$this->full_sync_queue->reset();
 	}
 
 	function set_dequeue_max_bytes( $size ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -40,6 +40,23 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 	}
 
+	function test_sync_start_resets_previous_sync_and_sends_full_sync_cancelled() {
+		$this->factory->post->create();
+		$this->full_sync->start();
+
+		$initial_full_sync_queue_size = $this->sender->get_full_sync_queue()->size();
+
+		// if we start again, it should reset the queue back to its original state,
+		// plus a "full_sync_cancelled" action
+		$this->full_sync->start();
+
+		$this->assertEquals( $initial_full_sync_queue_size + 1, $this->sender->get_full_sync_queue()->size() );
+
+		$cancelled_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_cancelled' );
+
+		$this->assertTrue( $cancelled_event !== false );
+	}
+
 	function test_full_sync_lock_has_one_hour_timeout() {
 		$this->started_sync_count = 0;
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -51,7 +51,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start();
 
 		$this->assertEquals( $initial_full_sync_queue_size + 1, $this->sender->get_full_sync_queue()->size() );
-
+		$this->sender->do_sync();
+		
 		$cancelled_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_cancelled' );
 
 		$this->assertTrue( $cancelled_event !== false );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -256,14 +256,14 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $event->sent_timestamp < microtime( true ) );
 	}
 
-	function test_reset_queue_also_resets_full_sync_lock() {
+	function test_reset_module_also_resets_full_sync_lock() {
 		$full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
 		$full_sync->start();
 		$status = $full_sync->get_status();
 		$this->assertTrue( $full_sync->is_started() );
 
-		$this->sender->reset_sync_queue();
-
+		$full_sync->reset_data();
+		
 		$status = $full_sync->get_status();
 		$this->assertFalse( $full_sync->is_started() );
 	}


### PR DESCRIPTION
Previous we used locks to prevent a full sync from starting if one was already running.

We removed the lock but we still have an issue where we can potentially have two syncs enqueued/sending, but we send back only one status and that can get corrupted. 

Taking advantage of the fact that full syncs now send from their own queue, this PR erases that queue and sends a "full sync cancelled" event if a previous sync was running. This fails much safer and behaves (perhaps) closer to a user's expectations. If the client detects a full sync is already running, it can warn the user that that will be cancelled before enqueuing the new one.