### PR TITLE
Remove duplicate key in Initial_State object used for static HTML generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,6 @@ gulp.task( 'react:static', [ 'react:build' ], function() {
 		global.navigator = window.navigator;
 
 		window.Initial_State = {
-			userData: {},
 			dismissedNotices: [],
 			connectionStatus: {
 				devMode: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- in gulpfile, in Initial_Status object used for static HTML generation, remove empty duplicated `userData` property

cc @zinigor for review