### PR TITLE
Fix bug which was constantly resetting the sent counts for sync modules

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -23,9 +23,6 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
 
-		// full sync
-		add_action( 'jetpack_full_sync_callables', $callable );
-
 		// always send change to active modules right away
 		add_action( 'update_option_jetpack_active_modules', array( $this, 'unlock_sync_callable' ) );
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -96,8 +96,10 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
-			$module_actions = $module->get_full_sync_actions();
-			$items_sent     = 0;
+			$module_actions     = $module->get_full_sync_actions();
+			$status_option_name = "{$module->name()}_sent";
+			$items_sent         = $this->get_status_option( $status_option_name, 0 );
+
 			foreach ( $module_actions as $module_action ) {
 				if ( isset( $actions_with_counts[ $module_action ] ) ) {
 					$items_sent += $actions_with_counts[ $module_action ];
@@ -105,7 +107,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			}
 
 			if ( $items_sent > 0 ) {
-				$this->update_status_option( "{$module->name()}_sent", $items_sent );
+				$this->update_status_option( $status_option_name, $items_sent );
 			}	
 		}
 
@@ -168,13 +170,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$listener->get_full_sync_queue()->reset();
 	}
 
-	private function get_status_option( $option ) {
+	private function get_status_option( $option, $default = null ) {
 		$prefix = self::STATUS_OPTION_PREFIX;
 
-		$value = get_option( "{$prefix}_{$option}", null );
+		$value = get_option( "{$prefix}_{$option}", $default );
 		
 		if ( ! $value ) {
-			return null;
+			// don't cast to int if we didn't find a value - we want to preserve null or false as sentinals
+			return $default;
 		}
 
 		return intval( $value );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -732,7 +732,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$should_be_status = array(
 			'sent'  => array(
 				'constants' => 1,
-				'functions' => 2,
+				'functions' => 1,
 				'options'   => 1,
 				'posts'     => 2,
 				'comments'  => 2,

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -732,7 +732,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$should_be_status = array(
 			'sent'  => array(
 				'constants' => 1,
-				'functions' => 1,
+				'functions' => 2,
 				'options'   => 1,
 				'posts'     => 2,
 				'comments'  => 2,


### PR DESCRIPTION
Every time we processed another full sync batch we would start the sent-count again from zero if there were items in the full_sync_queue for a particular module.

This was causing erratic behaviour of the progress bar in Calypso, not to mention incorrect sync statuses in general.