### PR TITLE
Markdown: Set class for footnote links

### DIFF
--- a/_inc/lib/markdown/extra.php
+++ b/_inc/lib/markdown/extra.php
@@ -32,7 +32,7 @@ define( 'MARKDOWNEXTRA_VERSION',  "1.2.8" ); # 29 Nov 2013
 @define( 'MARKDOWN_FN_BACKLINK_TITLE',     "" );
 
 # Optional class attribute for footnote links and backlinks.
-@define( 'MARKDOWN_FN_LINK_CLASS',         "" );
+@define( 'MARKDOWN_FN_LINK_CLASS',         "jetpack-footnote" );
 @define( 'MARKDOWN_FN_BACKLINK_CLASS',     "" );
 
 # Optional class prefix for fenced code block.


### PR DESCRIPTION
In #3440, we removed an outdated attribute. The attribute was helpful for isolating footnote links via JS.

We can add a class to restore similar functionality.

See https://github.com/Automattic/jetpack/pull/3440#issuecomment-225946022