### PR TITLE
Don’t delay before next sync if no items were sent this time

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -72,7 +72,8 @@ class Jetpack_Sync_Sender {
 			$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );
 			$full_sync_result = false;
 			$sync_result      = false;
-		} else {
+		} elseif ( $full_sync_result || $sync_result ) {
+			// if we actually sent data, wait before sending again
 			$this->set_next_sync_time( time() + $this->get_sync_wait_time() );
 		}
 


### PR DESCRIPTION
Sync tries to go easy on our servers by rate limiting how often we send batches to once every 10 seconds (by default). Every time we finish a sync, we save the time of the next sync attempt, and every time we start trying to send synced items, we check if that next sync time has passed.

HOWEVER!

We were setting the next sync time even if we **didn't send anything**, which both adds DB load from saving that option AND means we often don't send data as early as we can, because we're rate limiting writes that never happened.

This change only sets the next sync time if data was actually sent.