### PR TITLE
Only delay next sync to WPCOM if request duration was > 5 seconds

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -645,12 +645,13 @@ new Jetpack_JSON_API_Sync_Histogram_Endpoint( array(
 ) );
 
 $sync_settings_response = array(
-	'dequeue_max_bytes' => '(int|bool=false) Maximum bytes to read from queue in a single request',
-	'sync_wait_time'    => '(int|bool=false) Minimum time between requests in seconds',
-	'upload_max_bytes'  => '(int|bool=false) Maximum bytes to send in a single request',
-	'upload_max_rows'   => '(int|bool=false) Maximum rows to send in a single request',
-	'max_queue_size'    => '(int|bool=false) Maximum queue size that that the queue is allowed to expand to in DB rows to prevent the DB from filling up. Needs to also meet the max_queue_lag limit.',
-	'max_queue_lag'     => '(int|bool=false) Maximum queue lag in seconds used to prevent the DB from filling up. Needs to also meet the max_queue_size limit.',
+	'dequeue_max_bytes'   => '(int|bool=false) Maximum bytes to read from queue in a single request',
+	'sync_wait_time'      => '(int|bool=false) Wait time between requests in seconds if sync threshold exceeded',
+	'sync_wait_threshold' => '(int|bool=false) If a request to WPCOM exceeds this duration, wait sync_wait_time seconds before sending again',
+	'upload_max_bytes'    => '(int|bool=false) Maximum bytes to send in a single request',
+	'upload_max_rows'     => '(int|bool=false) Maximum rows to send in a single request',
+	'max_queue_size'      => '(int|bool=false) Maximum queue size that that the queue is allowed to expand to in DB rows to prevent the DB from filling up. Needs to also meet the max_queue_lag limit.',
+	'max_queue_lag'       => '(int|bool=false) Maximum queue lag in seconds used to prevent the DB from filling up. Needs to also meet the max_queue_size limit.',
 );
 
 // GET /sites/%s/sync/settings

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -245,6 +245,7 @@ class Jetpack_Sync_Defaults {
 	static $default_upload_max_bytes = 600000; // a little bigger than the upload limit to account for serialization
 	static $default_upload_max_rows = 500;
 	static $default_sync_wait_time = 10; // seconds, between syncs
+	static $default_sync_wait_threshold = 5; // only wait before next send if the current send took more than X seconds
 	static $default_max_queue_size = 1000;
 	static $default_max_queue_lag = 900; // 15 minutes
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -77,7 +77,7 @@ class Jetpack_Sync_Sender {
 			$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );
 			$full_sync_result = false;
 			$sync_result      = false;
-		} elseif ( ( $full_sync_result || $sync_result ) && $exceeded_sync_wait_threshold ) {
+		} elseif ( $exceeded_sync_wait_threshold ) {
 			// if we actually sent data and it took a while, wait before sending again
 			$this->set_next_sync_time( time() + $this->get_sync_wait_time() );
 		}
@@ -165,6 +165,10 @@ class Jetpack_Sync_Sender {
 			if ( is_wp_error( $checked_in_item_ids ) ) {
 				error_log( 'Error checking in buffer: ' . $checked_in_item_ids->get_error_message() );
 				$queue->force_checkin();
+			}
+
+			if ( is_wp_error( $processed_item_ids ) ) {
+				return $processed_item_ids;
 			}
 
 			// returning a WP_Error is a sign to the caller that we should wait a while

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -19,6 +19,7 @@ class Jetpack_Sync_Sender {
 	private $upload_max_bytes;
 	private $upload_max_rows;
 	private $sync_wait_time;
+	private $sync_wait_threshold;
 	private $sync_queue;
 	private $full_sync_queue;
 	private $codec;
@@ -64,16 +65,20 @@ class Jetpack_Sync_Sender {
 		if ( $this->get_next_sync_time() > microtime( true ) ) {
 			return false;
 		}
+
+		$start_time = time();
 		
 		$full_sync_result = $this->do_sync_for_queue( $this->full_sync_queue );
 		$sync_result      = $this->do_sync_for_queue( $this->sync_queue );
+
+		$exceeded_sync_wait_threshold = ( time() - $start_time ) > $this->get_sync_wait_threshold();
 
 		if ( is_wp_error( $full_sync_result ) || is_wp_error( $sync_result ) ) {
 			$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );
 			$full_sync_result = false;
 			$sync_result      = false;
-		} elseif ( $full_sync_result || $sync_result ) {
-			// if we actually sent data, wait before sending again
+		} elseif ( ( $full_sync_result || $sync_result ) && $exceeded_sync_wait_threshold ) {
+			// if we actually sent data and it took a while, wait before sending again
 			$this->set_next_sync_time( time() + $this->get_sync_wait_time() );
 		}
 
@@ -244,6 +249,15 @@ class Jetpack_Sync_Sender {
 		return $this->sync_wait_time;
 	}
 
+	// in seconds
+	function set_sync_wait_threshold( $seconds ) {
+		$this->sync_wait_threshold = $seconds;
+	}
+
+	function get_sync_wait_threshold() {
+		return $this->sync_wait_threshold;
+	}
+
 	function set_defaults() {
 		$this->sync_queue = new Jetpack_Sync_Queue( 'sync' );
 		$this->full_sync_queue = new Jetpack_Sync_Queue( 'full_sync' );
@@ -255,6 +269,7 @@ class Jetpack_Sync_Sender {
 		$this->set_upload_max_bytes( $settings['upload_max_bytes'] );
 		$this->set_upload_max_rows( $settings['upload_max_rows'] );
 		$this->set_sync_wait_time( $settings['sync_wait_time'] );
+		$this->set_sync_wait_threshold( $settings['sync_wait_threshold'] );
 	}
 
 	function reset_data() {

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -66,12 +66,12 @@ class Jetpack_Sync_Sender {
 			return false;
 		}
 
-		$start_time = time();
+		$start_time = microtime( true );
 		
 		$full_sync_result = $this->do_sync_for_queue( $this->full_sync_queue );
 		$sync_result      = $this->do_sync_for_queue( $this->sync_queue );
 
-		$exceeded_sync_wait_threshold = ( time() - $start_time ) > $this->get_sync_wait_threshold();
+		$exceeded_sync_wait_threshold = ( microtime( true ) - $start_time ) > (double) $this->get_sync_wait_threshold();
 
 		if ( is_wp_error( $full_sync_result ) || is_wp_error( $sync_result ) ) {
 			$this->set_next_sync_time( time() + self::WPCOM_ERROR_SYNC_DELAY );

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -6,12 +6,13 @@ class Jetpack_Sync_Settings {
 	const SETTINGS_OPTION_PREFIX = 'jetpack_sync_settings_';
 
 	static $valid_settings = array(
-		'dequeue_max_bytes' => true,
-		'upload_max_bytes'  => true,
-		'upload_max_rows'   => true,
-		'sync_wait_time'    => true,
-		'max_queue_size'    => true,
-		'max_queue_lag'     => true,
+		'dequeue_max_bytes'   => true,
+		'upload_max_bytes'    => true,
+		'upload_max_rows'     => true,
+		'sync_wait_time'      => true,
+		'sync_wait_threshold' => true,
+		'max_queue_size'      => true,
+		'max_queue_lag'       => true,
 	);
 
 	static function get_settings() {

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -185,6 +185,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$this->sender->set_sync_wait_time( 2 );
+		$this->sender->set_sync_wait_threshold( -1 ); // wait no matter what
 		$this->assertSame( 2, $this->sender->get_sync_wait_time() );
 
 		$this->assertEquals( 2, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -185,7 +185,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$this->sender->set_sync_wait_time( 2 );
-		$this->sender->set_sync_wait_threshold( -1 ); // wait no matter what
+		$this->sender->set_sync_wait_threshold( 0 ); // wait no matter what
 		$this->assertSame( 2, $this->sender->get_sync_wait_time() );
 
 		$this->assertEquals( 2, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
@@ -207,15 +207,6 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertTrue( $this->sender->do_sync() );
 		$this->assertEquals( 6, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
-
-		// now that we're fully synced and not sending data each time, 
-		// the sync wait time shouldn't change between invocations
-		$next_sync_time = $this->sender->get_next_sync_time();
-		
-		sleep( 3 );
-
-		$this->sender->do_sync();
-		$this->assertEquals( $next_sync_time, $this->sender->get_next_sync_time() );
 
 		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
 	}


### PR DESCRIPTION
The Jetpack settings UI allows the user to toggle modules quickly, each one of which syncs its status in a separate request. Often this can result in the requests being delayed by the sync wait time, which is designed to prevent WPCOM from being overwhelmed by requests.

Depending on subsequent user activity, how cron is run, etc. this can result in long delays before changes are synced to WPCOM.

This PR sets a threshold, where if a request to WPCOM finishes quickly (well, more correctly, if the combined time of full sync and incremental sync queue flushing is <= 5s) then we don't set the next sync date, and data can flush to WPCOM the next time the do_sync is called.

The _hope_ here is that lots of small requests are ok, but as requests get longer they should be spaced further apart (to avoid contention for PHP processes on the server).