### PR TITLE
Add full sync queue and lag to the sync status api endpint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -32,14 +32,18 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
 
 		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
-		$queue = Jetpack_Sync_Sender::get_instance()->get_sync_queue();
+		$sender = Jetpack_Sync_Sender::get_instance()
+		$queue = $sender->get_sync_queue();
+		$full_queue = $sender->get_full_sync_queue();
 
 		return array_merge(
 			$sync_module->get_status(),
 			array( 
 				'is_scheduled' => (bool) wp_next_scheduled( 'jetpack_sync_full' ), 
 				'queue_size' => $queue->size(),
-				'queue_lag' => $queue->lag()
+				'queue_lag' => $queue->lag(),
+				'full_queue_size' => $full_queue->size(),
+				'full_queue_lag' => $full_queue->lag()
 			)
 		);
 	}

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -599,6 +599,10 @@ new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 		'finished' => '(int|null) The unix timestamp when the last sync finished',
 		'queue'  => '(array) Count of actions that have been added to the queue',
 		'sent'  => '(array) Count of actions that have been sent',
+		'queue_size' => '(int) Number of items in the  sync queue',
+		'queue_lag' => '(float) Time delay of the oldest item in the sync queue',
+		'full_queue_size' => '(int) Number of items in the full sync queue',
+		'full_queue_lag' => '(float) Time delay of the oldest item in the full sync queue'
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status'
 ) );


### PR DESCRIPTION
Would be great to know how the full sync status is doing in more detail. This PR show us that by providing the info in the endpoint.