### PR TITLE
Send queue ID with sync actions so we can track separately

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -100,13 +100,14 @@ class Jetpack_Sync_Actions {
 			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
 	}
 
-	static function send_data( $data, $codec_name, $sent_timestamp ) {
+	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id ) {
 		Jetpack::load_xml_rpc_client();
 
 		$url = add_query_arg( array(
 			'sync'      => '1', // add an extra parameter to the URL so we can tell it's a sync action
 			'codec'     => $codec_name, // send the name of the codec used to encode the data
 			'timestamp' => $sent_timestamp, // send current server time so we can compensate for clock differences
+			'queue'     => $queue_id, // sync or full_sync
 		), Jetpack::xmlrpc_api_url() );
 
 		$rpc = new Jetpack_IXR_Client( array(
@@ -204,7 +205,7 @@ class Jetpack_Sync_Actions {
 		self::$sender = Jetpack_Sync_Sender::get_instance();
 
 		// bind the sending process
-		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 3 );
+		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 4 );
 	}
 }
 

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -157,7 +157,7 @@ class Jetpack_Sync_Sender {
 		 *
 		 * @param array $data The action buffer
 		 */
-		$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ) );
+		$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id );
 
 		if ( ! $processed_item_ids || is_wp_error( $processed_item_ids ) ) {
 			$checked_in_item_ids = $queue->checkin( $buffer );

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -40,7 +40,7 @@ class Jetpack_Sync_Server {
 		delete_site_transient( $this->get_concurrent_request_transient_name( $blog_id ) );
 	}
 
-	function receive( $data, $token = null, $sent_timestamp = null ) {
+	function receive( $data, $token = null, $sent_timestamp = null, $queue_id = null ) {
 		$start_time = microtime( true );
 		if ( ! is_array( $data ) ) {
 			return new WP_Error( 'action_decoder_error', 'Events must be an array' );
@@ -84,22 +84,10 @@ class Jetpack_Sync_Server {
 			 * @param int $user_id The external_user_id who did the action
 			 * @param double $timestamp Timestamp (in seconds) when the action occurred
 			 * @param double $sent_timestamp Timestamp (in seconds) when the action was transmitted
+			 * @param string $queue_id ID of the queue from which the event was sent (sync or full_sync)
 			 * @param array $token The auth token used to invoke the API
 			 */
-			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $timestamp, $sent_timestamp, $token );
-
-			/**
-			 * Fires when an action is received from a remote Jetpack site
-			 *
-			 * @since 4.2.0
-			 *
-			 * @param array $args The arguments passed to the action
-			 * @param int $user_id The external_user_id who did the action
-			 * @param double $timestamp Timestamp (in seconds) when the action occurred
-			 * @param double $sent_timestamp Timestamp (in seconds) when the action was transmitted
-			 * @param array $token The auth token used to invoke the API
-			 */
-			do_action( 'jetpack_sync_' . $action_name, $args, $user_id, $timestamp, $sent_timestamp, $token );
+			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $timestamp, $sent_timestamp, $queue_id, $token );
 
 			$events_processed[] = $key;
 

--- a/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -8,16 +8,17 @@ class Jetpack_Sync_Server_Eventstore {
 	private $action_name = null;
 
 	function init() {
-		add_action( 'jetpack_sync_remote_action', array( $this, 'handle_remote_action' ), 10, 6 );
+		add_action( 'jetpack_sync_remote_action', array( $this, 'handle_remote_action' ), 10, 7 );
 	}
 
-	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $sent_timestamp ) {
+	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $sent_timestamp, $queue_id ) {
 		$this->events[] = (object) array(
 			'action'         => $action_name,
 			'args'           => $args,
 			'user_id'        => $user_id,
 			'timestamp'      => $timestamp,
 			'sent_timestamp' => $sent_timestamp,
+			'queue'          => $queue_id,
 		);
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -12,10 +12,10 @@ class Jetpack_Sync_Server_Replicator {
 	}
 
 	function init() {
-		add_action( 'jetpack_sync_remote_action', array( $this, 'handle_remote_action' ), 5, 6 );
+		add_action( 'jetpack_sync_remote_action', array( $this, 'handle_remote_action' ), 5, 7 );
 	}
 
-	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $sent_timestamp, $token ) {
+	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $sent_timestamp, $queue_id, $token ) {
 
 		switch ( $action_name ) {
 			// posts

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -41,7 +41,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 		// bind the sender to the server
 		remove_all_filters( 'jetpack_sync_send_data' );
-		add_filter( 'jetpack_sync_send_data', array( $this, 'serverReceive' ), 10, 3 );
+		add_filter( 'jetpack_sync_send_data', array( $this, 'serverReceive' ), 10, 4 );
 
 		// bind the two storage systems to the server events
 		$this->server_replica_storage = new Jetpack_Sync_Test_Replicastore();
@@ -93,8 +93,8 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		return $codec->decode( $codec->encode( $instance ) );
 	}
 
-	function serverReceive( $data, $codec, $sent_timestamp ) {
-		return $this->server->receive( $data, null, $sent_timestamp );
+	function serverReceive( $data, $codec, $sent_timestamp, $queue_id ) {
+		return $this->server->receive( $data, null, $sent_timestamp, $queue_id );
 	}
 }
 


### PR DESCRIPTION
Now that we have two queues, full sync and incremental sync, we have two different lags, sizes, etc.

This PR sends the queue ID with the request to WPCOM so we can accurately track values for each queue.