### PR TITLE
Sync post, comment, user by ID

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -9,8 +9,16 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		$modules = null;
 
+		// convert list of modules in comma-delimited format into an array
+		// of "$modulename => true"
 		if ( isset( $args['modules'] ) && !empty( $args['modules'] ) ) {
-			$modules = array_map('trim', explode( ',', $args['modules'] ) );
+			$modules = array_map( '__return_true', array_flip( array_map('trim', explode( ',', $args['modules'] ) ) ) );
+		}
+
+		foreach ( array( 'posts', 'comments', 'users' ) as $module_name ) {
+			if ( isset( $args[ $module_name ] ) ) {
+				$modules[ $module_name ] = explode( ',', $args[ $module_name ] );
+			}
 		}
 
 		if ( empty( $modules ) ) {
@@ -29,21 +37,21 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	protected function result() {
 		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-modules.php';
-		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-
 		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
-		$sender = Jetpack_Sync_Sender::get_instance();
-		$queue = $sender->get_sync_queue();
-		$full_queue = $sender->get_full_sync_queue();
+
+		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$sender      = Jetpack_Sync_Sender::get_instance();
+		$queue       = $sender->get_sync_queue();
+		$full_queue  = $sender->get_full_sync_queue();
 
 		return array_merge(
 			$sync_module->get_status(),
 			array(
-				'is_scheduled' => (bool) wp_next_scheduled( 'jetpack_sync_full' ),
-				'queue_size' => $queue->size(),
-				'queue_lag' => $queue->lag(),
+				'is_scheduled'    => (bool) wp_next_scheduled( 'jetpack_sync_full' ),
+				'queue_size'      => $queue->size(),
+				'queue_lag'       => $queue->lag(),
 				'full_queue_size' => $full_queue->size(),
-				'full_queue_lag' => $full_queue->lag()
+				'full_queue_lag'  => $full_queue->lag()
 			)
 		);
 	}

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -17,7 +17,10 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		foreach ( array( 'posts', 'comments', 'users' ) as $module_name ) {
 			if ( isset( $args[ $module_name ] ) ) {
-				$modules[ $module_name ] = explode( ',', $args[ $module_name ] );
+				$ids = explode( ',', $args[ $module_name ] );
+				if ( count( $ids ) > 0 ) {
+					$modules[ $module_name ] = $ids;
+				}
 			}
 		}
 

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -575,7 +575,10 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 		'$site' => '(int|string) The site ID, The site domain'
 	),
 	'request_format' => array(
-		'modules' => '(string) Comma-delimited set of sync modules to use (default: all of them)'
+		'modules'  => '(string) Comma-delimited set of sync modules to use (default: all of them)',
+		'posts'    => '(string) Comma-delimited list of post IDs to sync',
+		'comments' => '(string) Comma-delimited list of comment IDs to sync',
+		'users'    => '(string) Comma-delimited list of user IDs to sync',
 	),
 	'response_format' => array(
 		'scheduled' => '(bool) Whether or not the synchronisation was scheduled'

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -72,7 +72,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		return call_user_func( $callable );
 	}
 
-	public function enqueue_full_sync_actions() {
+	public function enqueue_full_sync_actions( $config ) {
 		/**
 		 * Tells the client to sync all callables to the server
 		 *

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -44,7 +44,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'expand_comment_ids' ) );
 	}
 
-	public function enqueue_full_sync_actions() {
+	public function enqueue_full_sync_actions( $config ) {
 		global $wpdb;
 
 		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', null );

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -49,7 +49,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 
 		// config is a list of comment IDs to sync
 		if ( is_array( $config ) ) {
-			$where_sql = 'comment_ID IN (' . implode( array_map( 'intval', $config ) ) . ')';
+			$where_sql = 'comment_ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		} else {
 			$where_sql = null;
 		}

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -47,7 +47,14 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 	public function enqueue_full_sync_actions( $config ) {
 		global $wpdb;
 
-		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', null );
+		// config is a list of comment IDs to sync
+		if ( is_array( $config ) ) {
+			$where_sql = 'comment_ID IN (' . implode( array_map( 'intval', $config ) ) . ')';
+		} else {
+			$where_sql = null;
+		}
+
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', $where_sql );
 	}
 
 	public function get_full_sync_actions() {

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -44,7 +44,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		return $this->constants_whitelist;
 	}
 
-	function enqueue_full_sync_actions() {
+	function enqueue_full_sync_actions( $config ) {
 		/**
 		 * Tells the client to sync all constants to the server
 		 *

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -41,6 +41,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$this->reset_data();
 
 		if ( $was_already_running ) {
+			/**
+			 * Fires when a full sync is cancelled.
+			 *
+			 * @since 4.2.0
+			 */
 			do_action( 'jetpack_full_sync_cancelled' );
 		}
 
@@ -51,7 +56,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * @since 4.2.0
 		 */
 		do_action( 'jetpack_full_sync_start' );
-		$this->update_status_option( "started", time() );
+		$this->update_status_option( 'started', time() );
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();
@@ -66,7 +71,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			}
 		}
 
-		$this->update_status_option( "queue_finished", time() );
+		$this->update_status_option( 'queue_finished', time() );
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 
@@ -92,7 +97,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		if ( isset( $actions_with_counts['jetpack_full_sync_start'] ) ) {
-			$this->update_status_option( "sent_started", time() );
+			$this->update_status_option( 'sent_started', time() );
 		}
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
@@ -112,16 +117,16 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		if ( isset( $actions_with_counts['jetpack_full_sync_end'] ) ) {
-			$this->update_status_option( "finished", time() );
+			$this->update_status_option( 'finished', time() );
 		}
 	}
 
 	public function is_started() {
-		return !! $this->get_status_option( "started" );
+		return !! $this->get_status_option( 'started' );
 	}
 
 	public function is_finished() {
-		return !! $this->get_status_option( "finished" );
+		return !! $this->get_status_option( 'finished' );
 	}
 
 	public function get_status() {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -200,7 +200,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			return $default;
 		}
 
-		return intval( $value );
+		return is_numeric( $value ) ? intval( $value ) : $value;
 	}
 
 	private function update_status_option( $name, $value ) {

--- a/sync/class.jetpack-sync-module-network-options.php
+++ b/sync/class.jetpack-sync-module-network-options.php
@@ -43,7 +43,7 @@ class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
 		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
 	}
 
-	function enqueue_full_sync_actions() {
+	function enqueue_full_sync_actions( $config ) {
 		if ( ! is_multisite() ) {
 			return 0;
 		}

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -37,7 +37,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		$this->update_options_whitelist();
 	}
 
-	function enqueue_full_sync_actions() {
+	function enqueue_full_sync_actions( $config ) {
 		/**
 		 * Tells the client to sync all options to the server
 		 *

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -31,6 +31,12 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		$post_type_sql = Jetpack_Sync_Defaults::get_blacklisted_post_types_sql();
 
+		// config is a list of post IDs to sync
+		if ( is_array( $config ) ) {
+			$post_ids_sql   = implode( array_map( 'intval', $config ) );
+			$post_type_sql .= " AND ID IN ({$post_ids_sql})";
+		}
+
 		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $post_type_sql );
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -33,7 +33,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		// config is a list of post IDs to sync
 		if ( is_array( $config ) ) {
-			$where_sql   .= ' AND ID IN (' . implode( array_map( 'intval', $config ) ) . ')';
+			$where_sql   .= ' AND ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 
 		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $where_sql );

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -29,15 +29,14 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	public function enqueue_full_sync_actions( $config ) {
 		global $wpdb;
 
-		$post_type_sql = Jetpack_Sync_Defaults::get_blacklisted_post_types_sql();
+		$where_sql = Jetpack_Sync_Defaults::get_blacklisted_post_types_sql();
 
 		// config is a list of post IDs to sync
 		if ( is_array( $config ) ) {
-			$post_ids_sql   = implode( array_map( 'intval', $config ) );
-			$post_type_sql .= " AND ID IN ({$post_ids_sql})";
+			$where_sql   .= ' AND ID IN (' . implode( array_map( 'intval', $config ) ) . ')';
 		}
 
-		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $post_type_sql );
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $where_sql );
 	}
 
 	function get_full_sync_actions() {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -26,7 +26,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
 	}
 
-	public function enqueue_full_sync_actions() {
+	public function enqueue_full_sync_actions( $config ) {
 		global $wpdb;
 
 		$post_type_sql = Jetpack_Sync_Defaults::get_blacklisted_post_types_sql();

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -25,7 +25,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_terms', array( $this, 'expand_term_ids' ) );
 	}
 
-	function enqueue_full_sync_actions() {
+	function enqueue_full_sync_actions( $config ) {
 		global $wpdb;
 
 		$taxonomies           = get_taxonomies();

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -26,7 +26,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		do_action( 'jetpack_sync_current_theme_support' , $this->get_theme_support_info() );
 	}
 
-	public function enqueue_full_sync_actions() {
+	public function enqueue_full_sync_actions( $config ) {
 		/**
 		 * Tells the client to sync all theme data to the server
 		 *

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -29,7 +29,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
 	}
 
-	public function enqueue_full_sync_actions() {
+	public function enqueue_full_sync_actions( $config ) {
 		/**
 		 * Tells the client to sync all updates to the server
 		 *

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -158,7 +158,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 		// config is a list of post IDs to sync
 		if ( is_array( $config ) ) {
-			$where_sql = 'ID IN (' . implode( array_map( 'intval', $config ) ) . ')';
+			$where_sql = 'ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		} else {
 			$where_sql = null;
 		}

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -153,7 +153,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		}
 	}
 
-	public function enqueue_full_sync_actions() {
+	public function enqueue_full_sync_actions( $config ) {
 		global $wpdb;
 
 		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->users, 'ID', null );

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -156,7 +156,14 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function enqueue_full_sync_actions( $config ) {
 		global $wpdb;
 
-		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->users, 'ID', null );
+		// config is a list of post IDs to sync
+		if ( is_array( $config ) ) {
+			$where_sql = 'ID IN (' . implode( array_map( 'intval', $config ) ) . ')';
+		} else {
+			$where_sql = null;
+		}
+
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->users, 'ID', $where_sql );
 	}
 
 	function get_full_sync_actions() {

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -13,7 +13,6 @@ abstract class Jetpack_Sync_Module {
 	}
 
 	public function init_full_sync_listeners( $callable ) {
-		
 	}
 
 	public function init_before_send() {
@@ -25,7 +24,7 @@ abstract class Jetpack_Sync_Module {
 	public function reset_data() {
 	}
 
-	public function enqueue_full_sync_actions() {
+	public function enqueue_full_sync_actions( $config ) {
 		// in subclasses, return the number of items enqueued
 		return 0;
 	}
@@ -61,7 +60,7 @@ abstract class Jetpack_Sync_Module {
 		$page           = 1;
 		$chunk_count    = 0;
 		$previous_id    = 0;
-		while ( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} AND {$id_field} > $previous_id ORDER BY {$id_field} ASC LIMIT {$items_per_page}" ) ) {
+		while ( $ids = $wpdb->get_col( "SELECT {$id_field} FROM {$table_name} WHERE {$where_sql} AND {$id_field} > {$previous_id} ORDER BY {$id_field} ASC LIMIT {$items_per_page}" ) ) {
 			// Request posts in groups of N for efficiency
 			$chunked_ids = array_chunk( $ids, self::ARRAY_CHUNK_SIZE );
 

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -23,16 +23,17 @@ class Jetpack_Sync_Server {
 
 	function attempt_request_lock( $blog_id, $expiry = self::BLOG_LOCK_TRANSIENT_EXPIRY ) {
 		$transient_name = $this->get_concurrent_request_transient_name( $blog_id );
-		$locked_time = get_site_transient( $transient_name );
+		$locked_time    = get_site_transient( $transient_name );
 		if ( $locked_time ) {
 			return false;
 		}
-		set_site_transient( $transient_name, microtime(true), $expiry );
+		set_site_transient( $transient_name, microtime( true ), $expiry );
+
 		return true;
 	}
 
 	private function get_concurrent_request_transient_name( $blog_id ) {
-		return self::BLOG_LOCK_TRANSIENT_PREFIX.$blog_id;
+		return self::BLOG_LOCK_TRANSIENT_PREFIX . $blog_id;
 	}
 
 	function remove_request_lock( $blog_id ) {
@@ -53,11 +54,12 @@ class Jetpack_Sync_Server {
 			 *
 			 * @param token The token object of the misbehaving site
 			 */
-			do_action( "jetpack_sync_multi_request_fail", $token );
+			do_action( 'jetpack_sync_multi_request_fail', $token );
+
 			return new WP_Error( 'concurrent_request_error', 'There is another request running for the same blog ID' );
 		}
 
-		$events = wp_unslash( array_map( array( $this->codec, 'decode' ), $data ) );
+		$events           = wp_unslash( array_map( array( $this->codec, 'decode' ), $data ) );
 		$events_processed = array();
 
 		/**
@@ -67,7 +69,7 @@ class Jetpack_Sync_Server {
 		 *
 		 * @param array Array of actions received from the remote site
 		 */
-		do_action( "jetpack_sync_remote_actions", $events, $token );
+		do_action( 'jetpack_sync_remote_actions', $events, $token );
 
 		foreach ( $events as $key => $event ) {
 			list( $action_name, $args, $user_id, $timestamp ) = $event;

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -23,17 +23,16 @@ class Jetpack_Sync_Server {
 
 	function attempt_request_lock( $blog_id, $expiry = self::BLOG_LOCK_TRANSIENT_EXPIRY ) {
 		$transient_name = $this->get_concurrent_request_transient_name( $blog_id );
-		$locked_time    = get_site_transient( $transient_name );
+		$locked_time = get_site_transient( $transient_name );
 		if ( $locked_time ) {
 			return false;
 		}
-		set_site_transient( $transient_name, microtime( true ), $expiry );
-
+		set_site_transient( $transient_name, microtime(true), $expiry );
 		return true;
 	}
 
 	private function get_concurrent_request_transient_name( $blog_id ) {
-		return self::BLOG_LOCK_TRANSIENT_PREFIX . $blog_id;
+		return self::BLOG_LOCK_TRANSIENT_PREFIX.$blog_id;
 	}
 
 	function remove_request_lock( $blog_id ) {
@@ -54,12 +53,11 @@ class Jetpack_Sync_Server {
 			 *
 			 * @param token The token object of the misbehaving site
 			 */
-			do_action( 'jetpack_sync_multi_request_fail', $token );
-
+			do_action( "jetpack_sync_multi_request_fail", $token );
 			return new WP_Error( 'concurrent_request_error', 'There is another request running for the same blog ID' );
 		}
 
-		$events           = wp_unslash( array_map( array( $this->codec, 'decode' ), $data ) );
+		$events = wp_unslash( array_map( array( $this->codec, 'decode' ), $data ) );
 		$events_processed = array();
 
 		/**
@@ -69,7 +67,7 @@ class Jetpack_Sync_Server {
 		 *
 		 * @param array Array of actions received from the remote site
 		 */
-		do_action( 'jetpack_sync_remote_actions', $events, $token );
+		do_action( "jetpack_sync_remote_actions", $events, $token );
 
 		foreach ( $events as $key => $event ) {
 			list( $action_name, $args, $user_id, $timestamp ) = $event;

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -664,10 +664,14 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_do_not_sync_events_if_no_data_to_sync() {
-		$non_existent_id = 123123123123123213;
-		$this->assertTrue( empty( get_post( $non_existent_id ) ) );
-		$this->assertTrue( empty( get_comment( $non_existent_id ) ) );
-		$this->assertTrue( empty( get_user_by( 'id', $non_existent_id ) ) );
+		$non_existent_id      = 123123123123123213;
+		$non_existent_post    = get_post( $non_existent_id );
+		$non_existent_comment = get_comment( $non_existent_id );
+		$non_existent_user    = get_user_by( 'id', $non_existent_id );
+
+		$this->assertTrue( empty( $non_existent_post ) );
+		$this->assertTrue( empty( $non_existent_comment ) );
+		$this->assertTrue( empty( $non_existent_user ) );
 
 		$this->full_sync->start( array( 'posts' => array( $non_existent_id ), 'comments' => array( $non_existent_id ), 'users' => array( $non_existent_id ) )  );
 		$this->sender->do_sync();
@@ -678,8 +682,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_can_sync_individual_posts() {
-		$sync_post_id = $this->factory->post->create();
-		$sync_post_id_2 = $this->factory->post->create();
+		$sync_post_id    = $this->factory->post->create();
+		$sync_post_id_2  = $this->factory->post->create();
 		$no_sync_post_id = $this->factory->post->create();
 
 		$this->full_sync->start( array( 'posts' => array( $sync_post_id, $sync_post_id_2 ) ) );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -85,7 +85,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 		$this->factory->post->create();
 
-		$this->full_sync->start( array( 'options' ) );
+		$this->full_sync->start( array( 'options' => true ) );
 
 		$this->sender->do_sync();
 
@@ -550,6 +550,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 				'finished'       => null,
 				'sent'           => array(),
 				'queue'          => array(),
+				'config'         => array(),
 			)
 		);
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -663,6 +663,25 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'jetpack_sync_blocked', $blocked_post->post_status );
 	}
 
+	function test_full_sync_do_not_sync_events_if_no_data_to_sync() {
+		$non_existent_id = 123123123123123213;
+		$this->assertTrue( empty( get_post( $non_existent_id ) ) );
+		$this->assertTrue( empty( get_comment( $non_existent_id ) ) );
+		$this->assertTrue( empty( get_user_by( 'id', $non_existent_id ) ) );
+
+		$this->full_sync->start( array( 'posts' => array( $non_existent_id ), 'comments' => array( $non_existent_id ), 'users' => array( $non_existent_id ) )  );
+		$this->sender->do_sync();
+
+		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
+		$this->assertFalse( $synced_posts_event );
+
+		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
+		$this->assertFalse( $synced_posts_event );
+
+		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
+		$this->assertFalse( $synced_posts_event );
+	}
+
 	function test_full_sync_can_sync_individual_posts() {
 		$sync_post_id = $this->factory->post->create();
 		$sync_post_id2 = $this->factory->post->create();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -697,6 +697,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 2, count( $posts ) );
 		$this->assertEquals( $sync_post_id, $posts[0]->ID );
 		$this->assertEquals( $sync_post_id2, $posts[1]->ID );
+
+		$sync_status = $this->full_sync->get_status();
+		$this->assertEquals( array( $sync_user_id ), $sync_status['config']['users'] );
 	}
 
 	function test_full_sync_can_sync_individual_comments() {
@@ -713,8 +716,11 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 2, count( $comments ) );
 		$this->assertEquals( $sync_comment_id, $comments[0]->comment_ID );
 		$this->assertEquals( $sync_comment_id2, $comments[1]->comment_ID );
+
+		$sync_status = $this->full_sync->get_status();
+		$this->assertEquals( array( $sync_user_id ), $sync_status['config']['users'] );
 	}
-	
+
 	function test_full_sync_can_sync_individual_users() {
 		$sync_user_id = $this->factory->user->create();
 		$sync_user_id2 = $this->factory->user->create();
@@ -730,6 +736,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 2, count( $users ) );
 		$this->assertEquals( $sync_user_id, $users[0]->ID );
 		$this->assertEquals( $sync_user_id2, $users[1]->ID );
+
+		$sync_status = $this->full_sync->get_status();
+		$this->assertEquals( array( $sync_user_id ), $sync_status['config']['users'] );
 	}
 
 	function test_full_sync_doesnt_send_deleted_posts() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -665,53 +665,52 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_full_sync_can_sync_individual_posts() {
 		$sync_post_id = $this->factory->post->create();
+		$sync_post_id2 = $this->factory->post->create();
 		$no_sync_post_id = $this->factory->post->create();
 
-		$this->full_sync->start( array( 'posts' => array( $sync_post_id ) ) );
+		$this->full_sync->start( array( 'posts' => array( $sync_post_id, $sync_post_id2 ) ) );
 		$this->sender->do_sync();
 
 		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
 
 		$posts = $synced_posts_event->args[0];
 
-		$this->assertEquals( 1, count( $posts ) );
+		$this->assertEquals( 2, count( $posts ) );
 		$this->assertEquals( $sync_post_id, $posts[0]->ID );
-		$sync_status = $this->full_sync->get_status();
-		$this->assertEquals( array( $sync_post_id ), $sync_status['config']['posts'] );
+		$this->assertEquals( $sync_post_id2, $posts[1]->ID );
 	}
 
 	function test_full_sync_can_sync_individual_comments() {
 		$post_id = $this->factory->post->create();
-		list( $sync_comment_id, $no_sync_comment_id ) = $this->factory->comment->create_post_comments( $post_id, 2 );
+		list( $sync_comment_id, $no_sync_comment_id, $sync_comment_id2 ) = $this->factory->comment->create_post_comments( $post_id, 3 );
 
-		$this->full_sync->start( array( 'comments' => array( $sync_comment_id ) ) );
+		$this->full_sync->start( array( 'comments' => array( $sync_comment_id, $sync_comment_id2 ) ) );
 		$this->sender->do_sync();
 
 		$synced_comments_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
 
 		$comments = $synced_comments_event->args[0];
 
-		$this->assertEquals( 1, count( $comments ) );
+		$this->assertEquals( 2, count( $comments ) );
 		$this->assertEquals( $sync_comment_id, $comments[0]->comment_ID );
-		$sync_status = $this->full_sync->get_status();
-		$this->assertEquals( array( $sync_comment_id ), $sync_status['config']['comments'] );
+		$this->assertEquals( $sync_comment_id2, $comments[1]->comment_ID );
 	}
-
+	
 	function test_full_sync_can_sync_individual_users() {
 		$sync_user_id = $this->factory->user->create();
+		$sync_user_id2 = $this->factory->user->create();
 		$no_sync_user_id = $this->factory->user->create();
 
-		$this->full_sync->start( array( 'users' => array( $sync_user_id ) ) );
+		$this->full_sync->start( array( 'users' => array( $sync_user_id, $sync_user_id2) ) );
 		$this->sender->do_sync();
 
 		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
 
 		$users = $synced_users_event->args;
 
-		$this->assertEquals( 1, count( $users ) );
+		$this->assertEquals( 2, count( $users ) );
 		$this->assertEquals( $sync_user_id, $users[0]->ID );
-		$sync_status = $this->full_sync->get_status();
-		$this->assertEquals( array( $sync_user_id ), $sync_status['config']['users'] );
+		$this->assertEquals( $sync_user_id2, $users[1]->ID );
 	}
 
 	function test_full_sync_doesnt_send_deleted_posts() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -650,6 +650,21 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'jetpack_sync_blocked', $blocked_post->post_status );
 	}
 
+	function test_full_sync_can_sync_individual_posts() {
+		$sync_post_id = $this->factory->post->create();
+		$no_sync_post_id = $this->factory->post->create();
+
+		$this->full_sync->start( array( 'posts' => array( $sync_post_id ) ) );
+		$this->sender->do_sync();
+
+		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
+
+		$posts = $synced_posts_event->args[0];
+
+		$this->assertEquals( 1, count( $posts ) );
+		$this->assertEquals( $sync_post_id, $posts[0]->ID );
+	}
+
 	function test_full_sync_doesnt_send_deleted_posts() {
 		// previously, the behaviour was to send false or throw errors - we
 		// should actively detect false values and remove them

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -572,14 +572,27 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 				'themes'    => 1,
 				'updates'   => 1,
 				'users'     => 1,
-				'terms'     => 1
+				'terms'     => 1,
 			),
+			'config' => array(
+				'constants' => true,
+				'functions' => true,
+				'options'   => true,
+				'posts'     => true,
+				'comments'  => true,
+				'themes'    => true,
+				'updates'   => true,
+				'users'     => true,
+				'terms'     => true,
+			)
 		);
 		if ( is_multisite() ) {
 			$should_be_status['queue']['network_options'] = 1;
+			$should_be_status['config']['network_options'] = 1;
 		}
 
 		$this->assertEquals( $full_sync_status['queue'], $should_be_status['queue'] );
+		$this->assertEquals( $full_sync_status['config'], $should_be_status['config'] );
 		$this->assertInternalType( 'int', $full_sync_status['started'] );
 		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
 		$this->assertNull( $full_sync_status['sent_started'] );
@@ -663,6 +676,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 1, count( $posts ) );
 		$this->assertEquals( $sync_post_id, $posts[0]->ID );
+		$sync_status = $this->full_sync->get_status();
+		$this->assertEquals( array( $sync_post_id ), $sync_status['config']['posts'] );
 	}
 
 	function test_full_sync_can_sync_individual_comments() {
@@ -678,6 +693,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 1, count( $comments ) );
 		$this->assertEquals( $sync_comment_id, $comments[0]->comment_ID );
+		$sync_status = $this->full_sync->get_status();
+		$this->assertEquals( array( $sync_comment_id ), $sync_status['config']['comments'] );
 	}
 
 	function test_full_sync_can_sync_individual_users() {
@@ -693,6 +710,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 1, count( $users ) );
 		$this->assertEquals( $sync_user_id, $users[0]->ID );
+		$sync_status = $this->full_sync->get_status();
+		$this->assertEquals( array( $sync_user_id ), $sync_status['config']['users'] );
 	}
 
 	function test_full_sync_doesnt_send_deleted_posts() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -665,6 +665,21 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $sync_post_id, $posts[0]->ID );
 	}
 
+	function test_full_sync_can_sync_individual_comments() {
+		$post_id = $this->factory->post->create();
+		list( $sync_comment_id, $no_sync_comment_id ) = $this->factory->comment->create_post_comments( $post_id, 2 );
+
+		$this->full_sync->start( array( 'comments' => array( $sync_comment_id ) ) );
+		$this->sender->do_sync();
+
+		$synced_comments_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
+
+		$comments = $synced_comments_event->args[0];
+
+		$this->assertEquals( 1, count( $comments ) );
+		$this->assertEquals( $sync_comment_id, $comments[0]->comment_ID );
+	}
+
 	function test_full_sync_doesnt_send_deleted_posts() {
 		// previously, the behaviour was to send false or throw errors - we
 		// should actively detect false values and remove them

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -679,10 +679,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_full_sync_can_sync_individual_posts() {
 		$sync_post_id = $this->factory->post->create();
-		$sync_post_id2 = $this->factory->post->create();
+		$sync_post_id_2 = $this->factory->post->create();
 		$no_sync_post_id = $this->factory->post->create();
 
-		$this->full_sync->start( array( 'posts' => array( $sync_post_id, $sync_post_id2 ) ) );
+		$this->full_sync->start( array( 'posts' => array( $sync_post_id, $sync_post_id_2 ) ) );
 		$this->sender->do_sync();
 
 		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
@@ -691,17 +691,17 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 2, count( $posts ) );
 		$this->assertEquals( $sync_post_id, $posts[0]->ID );
-		$this->assertEquals( $sync_post_id2, $posts[1]->ID );
+		$this->assertEquals( $sync_post_id_2, $posts[1]->ID );
 
 		$sync_status = $this->full_sync->get_status();
-		$this->assertEquals( array( $sync_user_id ), $sync_status['config']['users'] );
+		$this->assertEquals( array( $sync_post_id, $sync_post_id_2 ), $sync_status['config']['posts'] );
 	}
 
 	function test_full_sync_can_sync_individual_comments() {
 		$post_id = $this->factory->post->create();
-		list( $sync_comment_id, $no_sync_comment_id, $sync_comment_id2 ) = $this->factory->comment->create_post_comments( $post_id, 3 );
+		list( $sync_comment_id, $no_sync_comment_id, $sync_comment_id_2 ) = $this->factory->comment->create_post_comments( $post_id, 3 );
 
-		$this->full_sync->start( array( 'comments' => array( $sync_comment_id, $sync_comment_id2 ) ) );
+		$this->full_sync->start( array( 'comments' => array( $sync_comment_id, $sync_comment_id_2 ) ) );
 		$this->sender->do_sync();
 
 		$synced_comments_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
@@ -710,18 +710,18 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 2, count( $comments ) );
 		$this->assertEquals( $sync_comment_id, $comments[0]->comment_ID );
-		$this->assertEquals( $sync_comment_id2, $comments[1]->comment_ID );
+		$this->assertEquals( $sync_comment_id_2, $comments[1]->comment_ID );
 
 		$sync_status = $this->full_sync->get_status();
-		$this->assertEquals( array( $sync_user_id ), $sync_status['config']['users'] );
+		$this->assertEquals( array( $sync_comment_id, $sync_comment_id_2 ), $sync_status['config']['comments'] );
 	}
 
 	function test_full_sync_can_sync_individual_users() {
 		$sync_user_id = $this->factory->user->create();
-		$sync_user_id2 = $this->factory->user->create();
+		$sync_user_id_2 = $this->factory->user->create();
 		$no_sync_user_id = $this->factory->user->create();
 
-		$this->full_sync->start( array( 'users' => array( $sync_user_id, $sync_user_id2) ) );
+		$this->full_sync->start( array( 'users' => array( $sync_user_id, $sync_user_id_2) ) );
 		$this->sender->do_sync();
 
 		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
@@ -730,10 +730,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 2, count( $users ) );
 		$this->assertEquals( $sync_user_id, $users[0]->ID );
-		$this->assertEquals( $sync_user_id2, $users[1]->ID );
+		$this->assertEquals( $sync_user_id_2, $users[1]->ID );
 
 		$sync_status = $this->full_sync->get_status();
-		$this->assertEquals( array( $sync_user_id ), $sync_status['config']['users'] );
+		$this->assertEquals( array( $sync_user_id, $sync_user_id_2 ), $sync_status['config']['users'] );
 	}
 
 	function test_full_sync_doesnt_send_deleted_posts() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -672,14 +672,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start( array( 'posts' => array( $non_existent_id ), 'comments' => array( $non_existent_id ), 'users' => array( $non_existent_id ) )  );
 		$this->sender->do_sync();
 
-		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
-		$this->assertFalse( $synced_posts_event );
-
-		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
-		$this->assertFalse( $synced_posts_event );
-
-		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
-		$this->assertFalse( $synced_posts_event );
+		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' ) );
+		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' ) );
+		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' ) );
 	}
 
 	function test_full_sync_can_sync_individual_posts() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -680,6 +680,21 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $sync_comment_id, $comments[0]->comment_ID );
 	}
 
+	function test_full_sync_can_sync_individual_users() {
+		$sync_user_id = $this->factory->user->create();
+		$no_sync_user_id = $this->factory->user->create();
+
+		$this->full_sync->start( array( 'users' => array( $sync_user_id ) ) );
+		$this->sender->do_sync();
+
+		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
+
+		$users = $synced_users_event->args;
+
+		$this->assertEquals( 1, count( $users ) );
+		$this->assertEquals( $sync_user_id, $users[0]->ID );
+	}
+
 	function test_full_sync_doesnt_send_deleted_posts() {
 		// previously, the behaviour was to send false or throw errors - we
 		// should actively detect false values and remove them


### PR DESCRIPTION
We currently have the ability to determine which content is out of sync with the server (at least, for posts and comments) using the "checksum histogram" protocol.

Ideally we would like to be able to correct this data without performing a full sync.

This PR lays the foundation for that feature by allowing a full sync to be requested just for particular IDs. A future PR will allow syncing by ID ranges, but I wanted to get this merged first, since we can work around a lack of ranges by just sending lots of IDs.

In addition, it returns configuration information for a sync when the sync status is requested, so that clients can display information about what was requested.

This PR also includes some unrelated code cleanups.