### PR TITLE
Admin Page: add site data cache

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -168,15 +168,23 @@ const restApi = {
 		}
 	} )
 		.then( checkStatus ).then( response => response.json() ),
-	fetchSiteData: () => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/site`, {
-		method: 'get',
-		credentials: 'same-origin',
-		headers: {
-			'X-WP-Nonce': window.Initial_State.WP_API_nonce,
-			'Content-type': 'application/json'
+	fetchSiteData: () => {
+		if ( Promise.resolve( window.Initial_State.siteData ) === window.Initial_State.siteData ) {
+			return window.Initial_State.siteData;
 		}
-	} )
-		.then( checkStatus ).then( response => response.json() ),
+		return fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/site`, {
+			method: 'get',
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': window.Initial_State.WP_API_nonce,
+				'Content-type': 'application/json'
+			}
+		} )
+			.then( checkStatus ).then( response => {
+				window.Initial_State.siteData = response.json();
+				return window.Initial_State.siteData;
+			} );
+	},
 	dismissJetpackNotice: ( notice ) => fetch( `${ window.Initial_State.WP_API_root }jetpack/v4/notice/${ notice }/dismiss`, {
 		method: 'put',
 		credentials: 'same-origin',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- implement a site data temporary cache that is recreated on each page load so it always has fresh values. It will be used by any card or landing page that fires `fetchSiteData()`.

If user starts in At a Glance, when he switches to Professional tab, the load will be instantaneous since the data is cached. The same happens if user starts in Professional tab and switches to At a Glance.
There were previously 2 requests in AAG and 1 in Professional tab, they are now unified as 1, thus reducing requests, improving loading times and UX.

#### Testing instructions:
- go to Jetpack Admin. Make sure that AAG card values are ok. Switch to Professional tab, it should load instantly with the correct plan.
- reload while you're in the Professional tab, it should show the skeleton loading before displaying the data. Switch to AAG tab, the data in cards should load instantly since the data is cached.