### PR TITLE
Admin Page: fix issues related to non-admin like menu/sub menu, Apps tab content, and Stats block in Apps tab

### DIFF
--- a/_inc/client/apps/index.jsx
+++ b/_inc/client/apps/index.jsx
@@ -12,6 +12,7 @@ import { translate as __ } from 'i18n-calypso';
 import { imagePath } from 'constants';
 
 const Apps = ( props ) => {
+	let canViewStats = 'object' === typeof window.Initial_State.userData && window.Initial_State.userData.currentUser && window.Initial_State.userData.currentUser.permissions && window.Initial_State.userData.currentUser.permissions.view_stats;
 	return (
 		<div>
 			<div className="jp-landing__apps dops-card">
@@ -65,49 +66,52 @@ const Apps = ( props ) => {
 						</div>
 					</div>
 
-					<div className="jp-landing-apps__feature">
-						<div className="jp-landing-apps__feature-col jp-landing-apps__feature-img">
-							<img src={ imagePath + '/apps/stats2x.png' } />
+				{
+					canViewStats ? (
+						<div className="jp-jetpack-landing__img-text">
+							<div className="jp-jetpack-landing__column">
+								<img src={ imagePath + '/apps/stats2x.png' } />
+							</div>
+							<div className="jp-jetpack-landing__column">
+								<h2>{ __( 'Connect with your Visitors' ) }</h2>
+								<p>{ __( 'Monitor your visitors with advanced stats. Watch for trends, learn what content performs the best and understand your visitors from anywhere in the world.' ) }</p>
+								<Button href={ 'https://wordpress.com/stats/' + window.Initial_State.rawUrl }	className="is-primary">
+									{ __( 'View Stats on WordPress.com' ) }
+								</Button>
+							</div>
 						</div>
-						<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
-							<h3 className="jp-landing__apps-feature-title">{ __( 'Connect with your Visitors' ) }</h3>
-							<p className="jp-landing__apps-feature-text">{ __( 'Monitor your visitors with advanced stats. Watch for trends, learn what content performs the best and understand your visitors from anywhere in the world.' ) }</p>
-							<Button href={ 'https://wordpress.com/stats/' + window.Initial_State.rawUrl }	className="is-primary">
-								{ __( 'View Stats on WordPress.com' ) }
-							</Button>
-						</div>
-					</div>
+					) : (
+						''
+					)
+				}
 
-					<div className="jp-landing-apps__feature">
-						<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
-							<h3 className="jp-landing__apps-feature-title">{ __( 'Connect with the Community' ) }</h3>
-							<p className="jp-landing__apps-feature-text">{ __( 'The WordPress apps all have impressively fast and full featured readers so you can catch up with your favorite sites and join the conversation anywhere, any time.' ) }</p>
-							<Button href={ 'https://wordpress.com/reader' }	className="is-primary">
-								{ __( 'Browse WordPress.com' ) }
-							</Button>
-						</div>
-						<div className="jp-landing-apps__feature-col jp-landing-apps__feature-img">
-							<img src={ imagePath + '/apps/community2x.png' } />
-						</div>
+				<div className="jp-jetpack-landing__img-text">
+					{
+						canViewStats ? (
+							''
+						) : (
+							<div className="jp-jetpack-landing__column">
+								<img src={ imagePath + '/apps/community2x.png' } />
+							</div>
+						)
+					}
+					<div className="jp-jetpack-landing__column">
+						<h2>{ __( 'Connect with the Community' ) }</h2>
+						<p>{ __( 'The WordPress apps all have impressively fast and full featured readers so you can catch up with your favorite sites and join the conversation anywhere, any time.' ) }</p>
+						<Button href={ 'https://wordpress.com/reader' }	className="is-primary">
+							{ __( 'Browse WordPress.com' ) }
+						</Button>
 					</div>
+					{
+						canViewStats ? (
+							<div className="jp-jetpack-landing__column">
+								<img src={ imagePath + '/apps/community2x.png' } />
+							</div>
+						) : (
+							''
+						)
+					}
 				</div>
-
-				<div className="jp-landing-apps__footer">
-					<div className="jp-landing-apps__clouds jp-clouds-bottom">
-						<img src={ imagePath + '/white-clouds-reverse.svg' } />
-					</div>
-					<div className="jp-landing-apps__footer-top">
-						<h2 className="jp-landing-apps__title">
-							{ __( 'Inspiration strikes any time, anywhere.' ) }
-						</h2>
-
-						<p className="jp-landing-apps__description">
-							{ __( 'Get WordPress apps for any screen.' ) }
-						</p>
-
-						<img src={ imagePath + '/apps/triple-devices.svg' } className="jp-landing-apps__devices" />
-
-					</div>
 
 					<div className="jp-landing-apps__downloads">
 						<h3 className="jp-landing-apps__subtitle">{ __( 'In your Pocket' ) }</h3>

--- a/_inc/client/components/non-admin-view/connected.jsx
+++ b/_inc/client/components/non-admin-view/connected.jsx
@@ -20,6 +20,7 @@ import AtAGlance from 'at-a-glance/index.jsx';
 import Engagement from 'engagement/index.jsx';
 import GeneralSettings from 'general-settings/index.jsx';
 import Writing from 'writing/index.jsx';
+import Apps from 'apps/index.jsx';
 
 const NonAdminViewConnected = React.createClass( {
 	componentWillMount: function() {
@@ -40,7 +41,7 @@ const NonAdminViewConnected = React.createClass( {
 				}
 				break;
 			case '/apps':
-				pageComponent = 'this will be the APPS page';
+				pageComponent = <Apps { ...this.props } />;
 				break;
 			case '/settings':
 				navComponent = <NavigationSettings { ...this.props } />;

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -53,20 +53,35 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		add_action( 'admin_head', array( $this, 'add_noscript_head_meta' ) );
 	}
 
+	/**
+	 * Add Jetpack Dashboard sub-link and point it to AAG if the user can view stats, manage modules or if Protect is active.
+	 * Otherwise and only if user is allowed to see the Jetpack Admin, the Dashboard sub-link is added but pointed to Apps tab.
+	 *
+	 * Works in Dev Mode or when user is connected.
+	 *
+	 * @since 4.3
+	 */
 	function jetpack_add_dashboard_sub_nav_item() {
-		global $submenu;
-		if ( current_user_can( 'jetpack_manage_modules' ) || ( Jetpack::is_module_active( 'protect' ) || current_user_can( 'view_stats' ) ) ) {
-			$permalink = Jetpack::admin_url( 'page=jetpack#/dashboard' );
-		} else {
-			$permalink = Jetpack::admin_url( 'page=jetpack#/apps' );
+		if ( Jetpack::is_development_mode() || Jetpack::is_active() ) {
+			global $submenu;
+			if ( current_user_can( 'jetpack_manage_modules' ) || Jetpack::is_module_active( 'protect' ) || current_user_can( 'view_stats' ) ) {
+				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', Jetpack::admin_url( 'page=jetpack#/dashboard' ) );
+			} elseif ( current_user_can( 'jetpack_admin_page' ) ) {
+				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', Jetpack::admin_url( 'page=jetpack#/apps' ) );
+			}
 		}
-		$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', $permalink );
 	}
 
+	/**
+	 * If user is allowed to see the Jetpack Admin, add Settings sub-link.
+	 *
+	 * @since 4.3
+	 */
 	function jetpack_add_settings_sub_nav_item() {
-		global $submenu;
-		$permalink = Jetpack::admin_url( 'page=jetpack#/settings' );
-		$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', $permalink );
+		if ( ( Jetpack::is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) ) {
+			global $submenu;
+			$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', Jetpack::admin_url( 'page=jetpack#/settings' ) );
+		}
 	}
 
 	function add_fallback_head_meta() {


### PR DESCRIPTION
fixes #4492 fixes #4606 fixes #4614 

#### Changes proposed in this Pull Request:
- Jetpack Admin Menu: don't show sub menus for users that can't access them
- If user is not connected and we're not in Dev Mode, don't show Dashboard and Settings links since user must be connected.
- display Apps landing page when users are connected
- Plans Tab: hide Stats block including View Stats on WordPress.com so users don't think they can click it to view stats.

#### Testing instructions:
1. log in as a user that can't access the Jetpack Admin in general and Stats in particular. Make sure Protect isn't active.
    - the Jetpack menu shouldn't be visible.

2. log as a user that can access Stats:
    - if user is still not connected, the Dashboard and Settings sub-menus shouldn't be visible, since they useless without connection
    - after connection, the Apps tab should display correctly

3. log as a user that is connected and can't access Stats, but can access Jetpack Admin. Go to Jetpack Admin, to the Apps tab:
    - the block
    ```
Connect with your Visitors
...
View Stats on WordPress.com
    ```
    shouldn't be visible.
