### PR TITLE
Subscriptions Module: add link to the Email Followers list in Calypso

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -61,18 +61,16 @@ export const Page = ( props ) => {
 		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			toggle = '',
-			adminAndNonAdmin = isAdmin || nonAdminAvailable.includes( element[0] );
+			adminAndNonAdmin = isAdmin || nonAdminAvailable.includes( element[0] ),
+			isModuleActive = isModuleActivated( element[0] );
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );
-		} else {
-			if ( adminAndNonAdmin ) {
-				toggle = <ModuleToggle slug={ element[0] }
-							activated={ isModuleActivated( element[0] ) }
-							toggling={ isTogglingModule( element[0] ) }
-							toggleModule={ toggleModule } />;
-			}
+		} else if ( adminAndNonAdmin ) {
+			toggle = <ModuleToggle slug={ element[0] }
+						activated={ isModuleActivated( element[0] ) }
+						toggling={ isTogglingModule( element[0] ) }
+						toggleModule={ toggleModule } />;
 		}
-
 		return (
 			<FoldableCard
 				className={ customClasses }
@@ -84,13 +82,24 @@ export const Page = ( props ) => {
 				clickableHeaderText={ true }
 				disabled={ ! adminAndNonAdmin } >
 				{
-					isModuleActivated( element[0] ) ?
+					isModuleActive ?
 						<EngagementModulesSettings module={ getModule( element[0] ) } /> :
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
 				<p>
 					<a href={ element[3] } target="_blank">{ __( 'Learn More' ) }</a>
+					{
+						'subscriptions' === element[0] && isModuleActive ? (
+							<span> | {
+								__( 'View your {{a}}Email Followers{{/a}}', {
+									components: {
+										a: <a href={ 'https://wordpress.com/people/email-followers/' + window.Initial_State.rawUrl } />
+									}
+								} )
+							}</span>
+						) : ''
+					}
 				</p>
 			</FoldableCard>
 		);


### PR DESCRIPTION
Fixes #4496

#### Changes proposed in this Pull Request:
Adds a link to the Subscriptions module, only visible when it's active, to the Email Followers list in WordPress.com

<img width="740" alt="captura de pantalla 2016-07-29 a las 18 21 26" src="https://cloud.githubusercontent.com/assets/1041600/17263674/a9837c10-55b8-11e6-827a-f56381da1262.png">

When module is inactive, nothing is shown

<img width="749" alt="captura de pantalla 2016-07-29 a las 18 21 34" src="https://cloud.githubusercontent.com/assets/1041600/17263680/b978d17e-55b8-11e6-99dc-488f7a2d87dd.png">

#### Testing instructions:
- go to Jetpack admin > Settings > Engagement and expand the Subscriptions module. If it's active, it should display a link to Email Followers in WordPress.com
- nothing should be displayed in Dev Mode since the module isn't available
