### PR TITLE
User Agent: avoid PHP notice when an invalid kind is passed in

### DIFF
--- a/class.jetpack-user-agent.php
+++ b/class.jetpack-user-agent.php
@@ -15,6 +15,11 @@ function jetpack_is_mobile( $kind = 'any', $return_matched_agent = false ) {
 	static $first_run     = true;
 	static $matched_agent = '';
 
+	// If an invalid kind is passed in, reset it to default.
+	if ( ! isset( $kinds[ $kind ] ) ) {
+			$kind = 'any';
+	}
+
 	if ( function_exists( 'apply_filters' ) ) {
 		/**
 		 * Filter the value of jetpack_is_mobile before it is calculated.


### PR DESCRIPTION
This avoids errors like

Notice: Undefined index: in /var/www/wp-content/plugins/jetpack/class.jetpack-user-agent.php on line 97

because some code calls it with an empty string in the first argument.

Also, general sanitization.