### PR TITLE
Don't sync incrementally during WP import

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -17,6 +17,9 @@ class Jetpack_Sync_Actions {
 
 		// On jetpack authorization, schedule a full sync
 		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ) );
+		
+		// When imports are finished, schedule a full sync
+		add_action( 'import_end', array( __CLASS__, 'schedule_full_sync' ) );
 
 		// Sync connected user role changes to .com
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -133,7 +133,12 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function schedule_full_sync( $modules = null ) {
-		wp_schedule_single_event( time() + 1, 'jetpack_sync_full', array( $modules ) );
+		if ( $modules ) {
+			wp_schedule_single_event( time() + 1, 'jetpack_sync_full', array( $modules ) );
+		} else {
+			wp_schedule_single_event( time() + 1, 'jetpack_sync_full' );
+		}
+
 		spawn_cron();
 	}
 

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -100,19 +100,18 @@ class Jetpack_Sync_Listener {
 	}
 
 	function full_sync_action_handler() {
-		$args           = func_get_args();
-		$this->enqueue_action( current_filter(), $args, $this->full_sync_queue );
+		$args = func_get_args();
+		$this->enqueue_action( current_filter(), $args, $this->full_sync_queue, true );
 	}
 
 	function action_handler() {
-		$args           = func_get_args();
+		$args = func_get_args();
 		$this->enqueue_action( current_filter(), $args, $this->sync_queue );
 	}
 
-	function enqueue_action( $current_filter, $args, $queue ) {
-
-		if ( Jetpack_Sync_Settings::is_importing() ) {
-			return false;
+	function enqueue_action( $current_filter, $args, $queue, $override_import = false ) {
+		if ( Jetpack_Sync_Settings::is_importing() && ! $override_import ) {
+			return;
 		}
 
 		/**
@@ -135,9 +134,8 @@ class Jetpack_Sync_Listener {
 			return;
 		}
 
-		// if we add any items to the queue, we should
-		// try to ensure that our script can't be killed before
-		// they are sent
+		// if we add any items to the queue, we should try to ensure that our script 
+		// can't be killed before they are sent
 		if ( function_exists( 'ignore_user_abort' ) ) {
 			ignore_user_abort( true );
 		}

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -111,6 +111,9 @@ class Jetpack_Sync_Listener {
 
 	function enqueue_action( $current_filter, $args, $queue, $override_import = false ) {
 		if ( Jetpack_Sync_Settings::is_importing() && ! $override_import ) {
+			if ( ! wp_next_scheduled( 'jetpack_sync_full' ) ) {
+				Jetpack_Sync_Actions::schedule_full_sync();
+			}
 			return;
 		}
 

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -111,6 +111,10 @@ class Jetpack_Sync_Listener {
 
 	function enqueue_action( $current_filter, $args, $queue ) {
 
+		if ( Jetpack_Sync_Settings::is_importing() ) {
+			return false;
+		}
+
 		/**
 		 * Modify or reject the data within an action before it is enqueued locally.
 		 *

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -111,9 +111,6 @@ class Jetpack_Sync_Listener {
 
 	function enqueue_action( $current_filter, $args, $queue, $override_import = false ) {
 		if ( Jetpack_Sync_Settings::is_importing() && ! $override_import ) {
-			if ( ! wp_next_scheduled( 'jetpack_sync_full' ) ) {
-				Jetpack_Sync_Actions::schedule_full_sync();
-			}
 			return;
 		}
 

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -268,6 +268,7 @@ class Jetpack_Sync_Sender {
 		$this->codec      = new Jetpack_Sync_JSON_Deflate_Codec();
 
 		// saved settings
+		Jetpack_Sync_Settings::set_importing( null );
 		$settings = Jetpack_Sync_Settings::get_settings();
 		$this->set_dequeue_max_bytes( $settings['dequeue_max_bytes'] );
 		$this->set_upload_max_bytes( $settings['upload_max_bytes'] );

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -15,6 +15,8 @@ class Jetpack_Sync_Settings {
 		'max_queue_lag'       => true,
 	);
 
+	static $is_importing;
+
 	static function get_settings() {
 		$settings = array();
 		foreach ( array_keys( self::$valid_settings ) as $setting ) {
@@ -55,5 +57,19 @@ class Jetpack_Sync_Settings {
 		foreach ( $valid_settings as $option => $value ) {
 			delete_option( $settings_prefix . $option );
 		}
+		self::set_importing( null );
+	}
+
+	static function set_importing( $is_importing ) {
+		// set to NULL to revert to WP_IMPORTING, the standard behaviour
+		self::$is_importing = $is_importing;
+	}
+
+	static function is_importing() {
+		if ( ! is_null( self::$is_importing ) ) {
+			return self::$is_importing;
+		}
+
+		return defined( 'WP_IMPORTING' ) && WP_IMPORTING;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -131,4 +131,9 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		// the beginning of the entire test run, not at the beginning of this test :)
 		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );
 	}
+
+	function test_enqueues_full_sync_after_import() {
+		do_action( 'import_end' );
+		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -36,8 +36,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 		$this->setSyncClientDefaults();
 
-		$server       = new Jetpack_Sync_Server();
-		$this->server = $server;
+		$this->server = new Jetpack_Sync_Server();
 
 		// bind the sender to the server
 		remove_all_filters( 'jetpack_sync_send_data' );

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -76,4 +76,16 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 
 		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
 	}
+
+	function test_doesnt_enqueue_if_is_importing() {
+		Jetpack_Sync_Settings::set_importing( true );
+
+		$post_id = $this->factory->post->create();
+
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+
+		$this->assertFalse( $event );
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -105,11 +105,4 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( is_object ( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' ) ) );
 		
 	}
-
-	function test_enqueues_full_sync_after_import() {
-		Jetpack_Sync_Settings::set_importing( true );
-		$post_id = $this->factory->post->create();
-		$this->sender->do_sync();
-		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );
-	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -77,7 +77,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
 	}
 
-	function test_doesnt_enqueue_incremental_actions_if_is_importing() {
+	function test_doesnt_enqueue_incremental_actions_while_importing() {
 		Jetpack_Sync_Settings::set_importing( true );
 
 		$post_id = $this->factory->post->create();
@@ -104,5 +104,12 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
 		$this->assertTrue( is_object ( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' ) ) );
 		
+	}
+
+	function test_enqueues_full_sync_after_import() {
+		Jetpack_Sync_Settings::set_importing( true );
+		$post_id = $this->factory->post->create();
+		$this->sender->do_sync();
+		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -136,34 +136,6 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		return $randomString;
 	}
 
-	/**
-	 * We have to run this in a separate process so we can set the constant without
-	 * it interfering with other tests. That's also why we have to reconnect the DB
-	 */
-	function test_queues_cron_job_if_is_importing() {
-		$this->markTestIncomplete( "This works but I haven't found a way to undefine the WP_IMPORTING constant when I'm done :(" );
-
-		$queue = $this->sender->get_sync_queue();
-
-		$this->factory->post->create();
-
-		$pre_sync_queue_size = $queue->size();
-		$this->assertTrue( $pre_sync_queue_size > 0 ); // just to be sure stuff got queued
-
-		define( 'WP_IMPORTING', true );
-
-		$this->sender->do_sync();
-
-		// assert that queue hasn't budged
-		$this->assertEquals( $pre_sync_queue_size, $queue->size() );
-
-		$timestamp = wp_next_scheduled( 'jetpack_sync_actions' );
-
-		// we're making some assumptions here about how fast the test will run...
-		$this->assertTrue( $timestamp >= time() + 59 );
-		$this->assertTrue( $timestamp <= time() + 61 );
-	}
-
 	function test_rate_limit_how_often_sync_runs_with_option() {
 		$this->sender->do_sync();
 


### PR DESCRIPTION
Fixes an issue found by @jessefriedman where importing would trigger non-silent events inside WPCOM that resulted in things like publishing to subscribers.

This change:

- prevents incremental sync actions from being enqueued if `WP_IMPORTING` is true
- schedules a full sync after an import, using the `import_end` action from [wordpress-importer](https://wordpress.org/plugins/wordpress-importer/other_notes/)