### PR TITLE
Fix/inacurate pro dashboard card buttons

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -13,6 +13,7 @@ import QueryAkismetData from 'components/data/query-akismet-data';
 import {
 	getAkismetData as _getAkismetData
 } from 'state/at-a-glance';
+import { getSitePlan } from 'state/site';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule
@@ -28,9 +29,10 @@ const DashAkismet = React.createClass( {
 	},
 
 	getContent: function() {
-		const akismetData = this.props.getAkismetData();
-		const akismetSettingsUrl = window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config';
-		const labelName = __( 'Anti-spam', { args: { akismet: '(Akismet)' } } );
+		const akismetData = this.props.getAkismetData(),
+			akismetSettingsUrl = window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config',
+			labelName = __( 'Anti-spam', { args: { akismet: '(Akismet)' } }),
+			hasSitePlan = false !== this.props.getSitePlan();
 
 		if ( akismetData === 'N/A' ) {
 			return(
@@ -52,7 +54,7 @@ const DashAkismet = React.createClass( {
 					label={ labelName }
 					module="akismet"
 					className="jp-dash-item__is-inactive"
-					status="pro-uninstalled"
+					status={ hasSitePlan ? 'pro-uninstalled' : 'no-pro-uninstalled-or-inactive' }
 					pro={ true }
 				>
 					<p className="jp-dash-item__description">
@@ -69,7 +71,7 @@ const DashAkismet = React.createClass( {
 				<DashItem
 					label={ labelName }
 					module="akismet"
-					status="pro-inactive"
+					status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
 					className="jp-dash-item__is-inactive"
 					pro={ true }
 				>
@@ -149,7 +151,8 @@ export default connect(
 	( state ) => {
 		return {
 			getAkismetData: () => _getAkismetData( state ),
-			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
+			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
+			getSitePlan: () => getSitePlan( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -31,7 +31,7 @@ const DashAkismet = React.createClass( {
 	getContent: function() {
 		const akismetData = this.props.getAkismetData(),
 			akismetSettingsUrl = window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config',
-			labelName = __( 'Anti-spam', { args: { akismet: '(Akismet)' } }),
+			labelName = __( 'Anti-spam' ),
 			hasSitePlan = false !== this.props.getSitePlan();
 
 		if ( akismetData === 'N/A' ) {

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -16,6 +16,7 @@ import {
 	isFetchingModulesList as _isFetchingModulesList
 } from 'state/modules';
 import { getSitePlan } from 'state/site';
+import { isPluginInstalled } from 'state/site/plugins';
 import {
 	getVaultPressData as _getVaultPressData
 } from 'state/at-a-glance';
@@ -24,7 +25,8 @@ import { isDevMode } from 'state/connection';
 const DashBackups = React.createClass( {
 	getContent: function() {
 		const labelName = __( 'Backups' ),
-			hasSitePlan = false !== this.props.getSitePlan();
+			hasSitePlan = false !== this.props.getSitePlan(),
+			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			const vpData = this.props.getVaultPressData();
@@ -85,7 +87,7 @@ const DashBackups = React.createClass( {
 				label={ labelName }
 				module="vaultpress"
 				className="jp-dash-item__is-inactive"
-				status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
+				status={ hasSitePlan ? inactiveOrUninstalled : 'no-pro-uninstalled-or-inactive' }
 				pro={ true }
 			>
 				<p className="jp-dash-item__description">
@@ -114,7 +116,8 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isFetchingModulesList: () => _isFetchingModulesList( state ),
 			getVaultPressData: () => _getVaultPressData( state ),
-			getSitePlan: () => getSitePlan( state )
+			getSitePlan: () => getSitePlan( state ),
+			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -85,7 +85,7 @@ const DashBackups = React.createClass( {
 				label={ labelName }
 				module="vaultpress"
 				className="jp-dash-item__is-inactive"
-				status="pro-inactive"
+				status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
 				pro={ true }
 			>
 				<p className="jp-dash-item__description">

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -16,6 +16,8 @@ import {
 	isFetchingModulesList as _isFetchingModulesList
 } from 'state/modules';
 import { getSitePlan } from 'state/site';
+import { SecurityModulesSettings } from 'components/module-settings/modules-per-tab-page';
+import { isPluginInstalled } from 'state/site/plugins';
 import {
 	getVaultPressScanThreatCount as _getVaultPressScanThreatCount,
 	getVaultPressData as _getVaultPressData
@@ -26,13 +28,8 @@ const DashScan = React.createClass( {
 	getContent: function() {
 		const labelName = __( 'Malware Scan' ),
 			hasSitePlan = false !== this.props.getSitePlan(),
-			vpData = this.props.getVaultPressData();
-
-		let vpActive = typeof vpData.data !== 'undefined' && vpData.data.active;
-
-		const ctaLink = vpActive ?
-			'https://dashboard.vaultpress.com/' :
-			'https://wordpress.com/plans/' + window.Initial_State.rawUrl;
+			vpData = this.props.getVaultPressData(),
+			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {
@@ -64,7 +61,7 @@ const DashScan = React.createClass( {
 								} )
 						}</h3>
 						<p className="jp-dash-item__description">
-							{ __( '{{a}}View details at VaultPress.com{{/a}}', { components: { a: <a href={ ctaLink } /> } } ) }
+							{ __( '{{a}}View details at VaultPress.com{{/a}}', { components: { a: <a href="https://dashboard.vaultpress.com/" /> } } ) }
 							<br/>
 							{ __( '{{a}}Contact Support{{/a}}', { components: { a: <a href='https://jetpack.com/support' /> } } ) }
 						</p>
@@ -113,7 +110,7 @@ const DashScan = React.createClass( {
 				label={ labelName }
 				module="vaultpress"
 				className="jp-dash-item__is-inactive"
-				status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
+				status={ hasSitePlan ? inactiveOrUninstalled : 'no-pro-uninstalled-or-inactive' }
 				pro={ true }
 			>
 				<p className="jp-dash-item__description">
@@ -143,7 +140,8 @@ export default connect(
 			isFetchingModulesList: () => _isFetchingModulesList( state ),
 			getVaultPressData: () => _getVaultPressData( state ),
 			getScanThreats: () => _getVaultPressScanThreatCount( state ),
-			getSitePlan: () => getSitePlan( state )
+			getSitePlan: () => getSitePlan( state ),
+			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -16,7 +16,6 @@ import {
 	isFetchingModulesList as _isFetchingModulesList
 } from 'state/modules';
 import { getSitePlan } from 'state/site';
-import { SecurityModulesSettings } from 'components/module-settings/modules-per-tab-page';
 import { isPluginInstalled } from 'state/site/plugins';
 import {
 	getVaultPressScanThreatCount as _getVaultPressScanThreatCount,

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -113,7 +113,7 @@ const DashScan = React.createClass( {
 				label={ labelName }
 				module="vaultpress"
 				className="jp-dash-item__is-inactive"
-				status="pro-inactive"
+				status={ hasSitePlan ? 'pro-inactive' : 'no-pro-uninstalled-or-inactive' }
 				pro={ true }
 			>
 				<p className="jp-dash-item__description">

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -15,6 +15,7 @@ import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import SectionHeader from 'components/section-header';
 import { ModuleToggle } from 'components/module-toggle';
+import { isFetchingSiteData } from 'state/site';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
@@ -47,14 +48,27 @@ const DashItem = React.createClass( {
 	proCardStatus() {
 		let status;
 
+		if ( this.props.isFetchingSiteData ) {
+			return '';
+		}
+
 		switch ( this.props.status ) {
-			case 'pro-uninstalled':
+			case 'no-pro-uninstalled-or-inactive':
 				status = <Button
 					compact={ true }
 					primary={ true }
 					href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl }
 				>
 					{ __( 'Upgrade' ) }
+				</Button>;
+				break;
+			case 'pro-uninstalled':
+				status = <Button
+					compact={ true }
+					primary={ true }
+					href={ 'https://wordpress.com/plugins/' + this.props.module }
+				>
+					{ __( 'Install' ) }
 				</Button>;
 				break;
 			case 'pro-inactive':
@@ -170,7 +184,8 @@ export default connect(
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) => isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
-			getModule: ( module_name ) => _getModule( state, module_name )
+			getModule: ( module_name ) => _getModule( state, module_name ),
+			isFetchingSiteData: isFetchingSiteData( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -67,7 +67,7 @@ const DashItem = React.createClass( {
 				status = <Button
 					compact={ true }
 					primary={ true }
-					href={ 'https://wordpress.com/plugins/' + this.props.module }
+					href={ 'https://wordpress.com/plugins/' + this.props.module + '/' + window.Initial_State.rawUrl }
 				>
 					{ __( 'Install' ) }
 				</Button>;
@@ -76,7 +76,7 @@ const DashItem = React.createClass( {
 				status = <Button
 					compact={ true }
 				    primary={ true }
-					href={ 'https://wordpress.com/plugins/' + this.props.module }
+					href={ 'https://wordpress.com/plugins/' + this.props.module + '/' + window.Initial_State.rawUrl }
 				>
 					{ __( 'Activate' ) }
 				</Button>;

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import SimpleNotice from 'components/notice';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
+import Spinner from 'components/spinner';
 
 /**
  * Internal dependencies
@@ -49,7 +50,7 @@ const DashItem = React.createClass( {
 		let status;
 
 		if ( this.props.isFetchingSiteData ) {
-			return '';
+			return <Spinner />;
 		}
 
 		switch ( this.props.status ) {

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -13,10 +13,10 @@ import Spinner from 'components/spinner';
  * Internal dependencies
  */
 import Card from 'components/card';
-import Gridicon from 'components/gridicon';
 import SectionHeader from 'components/section-header';
 import { ModuleToggle } from 'components/module-toggle';
 import { isFetchingSiteData } from 'state/site';
+import { isDevMode } from 'state/connection';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
@@ -49,6 +49,10 @@ const DashItem = React.createClass( {
 	proCardStatus() {
 		let status;
 
+		if ( this.props.isDevMode ) {
+			return '';
+		}
+
 		if ( this.props.isFetchingSiteData ) {
 			return <Spinner />;
 		}
@@ -75,7 +79,7 @@ const DashItem = React.createClass( {
 			case 'pro-inactive':
 				status = <Button
 					compact={ true }
-				    primary={ true }
+					primary={ true }
 					href={ 'https://wordpress.com/plugins/' + this.props.module + '/' + window.Initial_State.rawUrl }
 				>
 					{ __( 'Activate' ) }
@@ -126,7 +130,7 @@ const DashItem = React.createClass( {
 					activated={ this.props.isModuleActivated( this.props.module ) }
 					toggling={ this.props.isTogglingModule( this.props.module ) }
 					toggleModule={ this.props.toggleModule }
-				    compact={ true }
+					compact={ true }
 				/>
 			);
 
@@ -152,7 +156,7 @@ const DashItem = React.createClass( {
 			proButton =
 				<Button
 					compact={ true }
-				    href="#professional"
+					href="#professional"
 				>
 					{ __( 'Pro' ) }
 				</Button>
@@ -186,7 +190,8 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) => isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
-			isFetchingSiteData: isFetchingSiteData( state )
+			isFetchingSiteData: isFetchingSiteData( state ),
+			isDevMode: isDevMode( state )
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
Fixes #4540

This fixes the remaining inconsistencies in the DashItem CTA buttons for the pro cards (akismet/vaultpress). 

Changes made: 
- More accurate links (now points directly to the Calypso plugin page _for your site_)
- New DashItem status `no-pro-inactive-or-uninstalled`, which will show `upgrade` button with link to plans.  
- Now correctly identifying whether pro plugins are installed or just inactive. 

To test: 
- Have an active plan for the site
- Uninstall VaultPress & Akismet.  You should see the button as `Install`, and it should link directly to the plugin for your site with the ability to install.  
- Deactivate VaultPress & Akismet (but leave it installed).  The button should read `activate`, and it should take you to the same calypso plugin page for your site.  
- On a site with no plan, the buttons should read `upgrade` if the plugins are either uninstalled or inactive.  