### PR TITLE
Admin Page: Monitor Settings - Add link to WordPress.com email address edit screen

### DIFF
--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -14,7 +14,10 @@ import {
 	regeneratePostByEmailAddress
 } from 'state/modules';
 
-import { getSiteRoles } from 'state/initial-state';
+import {
+	getSiteRoles,
+	getAdminEmailAddress
+} from 'state/initial-state';
 
 /**
  * High order component that connects to Jetpack modules'options
@@ -30,7 +33,8 @@ export function connectModuleOptions( Component ) {
 				validValues: ( option_name ) => getModuleOptionValidValues( state, ownProps.module.module, option_name ),
 				getOptionCurrentValue: ( module_slug, option_name ) => getModuleOption( state, module_slug, option_name ),
 				getSiteRoles: () => getSiteRoles( state ),
-				isUpdating: ( option_name ) => isUpdatingModuleOption( state, ownProps.module.module, option_name )
+				isUpdating: ( option_name ) => isUpdatingModuleOption( state, ownProps.module.module, option_name ),
+				adminEmailAddress: getAdminEmailAddress( state )
 			}
 		},
 		( dispatch, ownProps ) => ( {

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -268,6 +268,19 @@ export let MonitorSettings = React.createClass( {
 						name={ 'monitor_receive_notifications' }
 						{ ...this.props }
 						label={ __( 'Receive Monitor Email Notifications' ) } />
+					<p>
+						<em>{ __( 'Emails will be sent to ' ) + this.props.adminEmailAddress }.</em>
+						<span>
+							&nbsp;
+							{
+								__( '{{a}}Edit{{/a}}', {
+									components: {
+										a: <a href={ 'https://wordpress.com/settings/account/' } />
+									}
+								} )
+							}
+						</span>
+					</p>
 					<FormButton
 						className="is-primary"
 						isSubmitting={ this.props.isSavingAnyOption() }

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -23,3 +23,7 @@ export function getSiteRoles( state ) {
 	const roles = get( state.jetpack.initialState.stats, 'roles', {} );
 	return roles;
 }
+
+export function getAdminEmailAddress( state ) {
+	return get( state.jetpack.initialState, [ 'userData', 'currentUser', 'wpcomUser', 'email' ] );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Adds link for editing email address in Monitor Settings

#### Testing instructions:
- Get to the **Monitor** module Settings under the **Security** tab. 
- You should read  "Emails will be sent to <your-wpcom-email-address>" and an `Edit` right after that pointing to https://wordpress.com/settings/account/
