### PR TITLE
Fix/47 years

### DIFF
--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -38,6 +38,22 @@ const DashMonitor = React.createClass( {
 				);
 			}
 
+			const lastDowntimeMessage = () => {
+				if ( null !== lastDowntime.date ) {
+					return (
+						<p className="jp-dash-item__description">
+							{
+								__( 'Last downtime was %(time)s ago.', {
+									args: {
+										time: lastDowntime.date
+									}
+								} )
+							}
+						</p>
+					);
+				}
+			};
+
 			return(
 				<DashItem
 					label={ labelName }
@@ -45,15 +61,7 @@ const DashMonitor = React.createClass( {
 					status="is-working"
 				>
 					<p className="jp-dash-item__description">{ __( 'Monitor is on and is watching your site.' ) }</p>
-					<p className="jp-dash-item__description">
-						{
-							__( 'Last downtime was %(time)s ago.', {
-								args: {
-									time: lastDowntime.date
-								}
-							} )
-						}
-					</p>
+					{ lastDowntimeMessage() }
 				</DashItem>
 			);
 		}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2728,6 +2728,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
 			if ( is_wp_error( $data ) ) {
 				return $data;
+			} else if ( ! $data->backups->last_backup ) {
+				return rest_ensure_response( array(
+					'code'    => 'success',
+					'message' => esc_html__( 'VaultPress is active and will back up your site soon.', 'jetpack' ),
+					'data'    => $data,
+				) );
 			} else {
 				return rest_ensure_response( array(
 					'code'    => 'success',

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2613,6 +2613,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$last_downtime = $monitor->monitor_get_last_downtime();
 			if ( is_wp_error( $last_downtime ) ) {
 				return $last_downtime;
+			} else if ( false === strtotime( $last_downtime ) ) {
+				return rest_ensure_response( array(
+					'code' => 'success',
+					'date' => null,
+				) );
 			} else {
 				return rest_ensure_response( array(
 					'code' => 'success',


### PR DESCRIPTION
Fixes #4501 

To Test: 
- Activate VaultPress on a site that has not been backed up yet
- The text in the AAG card should read "VaultPress is active and will back up your site soon." (Text up for review as well)
- Any time you activate monitor you should never see a message about 47 years.  You will either see a `last downtime at... ` with a correct time, or see ONLY "monitor is on and watching your site"