### PR TITLE
Admin Page: remove duplicate import Button statement that was breaking build

### DIFF
--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -7,7 +7,6 @@ import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
 import SimpleNotice from 'components/notice';
 
 /**


### PR DESCRIPTION
The duplicate line was throwing this error on build
```
Module build failed: TypeError: /wp-content/plugins/jetpack/node_modules/eslint-loader/index.js!/wp-content/plugins/jetpack/_inc/client/security/index.jsx: Line 10: Duplicate declaration "Button"
   8 | import Gridicon from 'components/gridicon';
   9 | import { translate as __ } from 'i18n-calypso';
> 10 | import Button from 'components/button';
     |        ^
  11 | import SimpleNotice from 'components/notice';
  12 | 
  13 | /**
    at File.errorWithNode (/wp-content/plugins/jetpack/node_modules/babel-core/lib/transformation/file/index.js:489:13)
```
and failing to complete build.

#### Changes proposed in this Pull Request:
- removes a duplicate import Button statement.

#### Testing instructions:
- run `npm run build`, it should work