### PR TITLE
Stats settings: add link to view all stats data in WP Admin

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -92,6 +92,20 @@ export const Page = ( props ) => {
 				<div className="jp-module-settings__read-more">
 					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
 					{
+						'stats' === element[0] && isModuleActive ? (
+							<span>
+								<span className="jp-module-settings__more-sep" />
+								<span className="jp-module-settings__more-text">{
+									__( 'View {{a}}All Stats{{/a}}', {
+										components: {
+											a: <a href={ window.Initial_State.adminUrl + 'admin.php?page=stats' } />
+										}
+									} )
+								}</span>
+							</span>
+						) : ''
+					}
+					{
 						'subscriptions' === element[0] && isModuleActive ? (
 							<span>
 								<span className="jp-module-settings__more-sep" />


### PR DESCRIPTION
Fixes #4613

#### Changes proposed in this Pull Request:
- Add link to view all stats in WP Admin.

#### Testing instructions:
- go to Jetpack admin > Settings > Engagement and expand the Stats module. It should display the link at the bottom of the foldable card

<img width="738" alt="all-stats" src="https://cloud.githubusercontent.com/assets/1041600/17307167/12241aba-580a-11e6-9750-95eaffac1758.png">
