### PR TITLE
Jetpack Sync: Update jetpack debugger code to check for all scheduled full syncs

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -11,8 +11,8 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		// convert list of modules in comma-delimited format into an array
 		// of "$modulename => true"
-		if ( isset( $args['modules'] ) && !empty( $args['modules'] ) ) {
-			$modules = array_map( '__return_true', array_flip( array_map('trim', explode( ',', $args['modules'] ) ) ) );
+		if ( isset( $args['modules'] ) && ! empty( $args['modules'] ) ) {
+			$modules = array_map( '__return_true', array_flip( array_map( 'trim', explode( ',', $args['modules'] ) ) ) );
 		}
 
 		foreach ( array( 'posts', 'comments', 'users' ) as $module_name ) {
@@ -39,8 +39,8 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-modules.php';
-		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-modules.php';
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
 
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
 		$sender      = Jetpack_Sync_Sender::get_instance();
@@ -50,7 +50,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 		return array_merge(
 			$sync_module->get_status(),
 			array(
-				'is_scheduled'    => (bool) wp_next_scheduled( 'jetpack_sync_full' ),
+				'is_scheduled'    => Jetpack_Sync_Actions::is_scheduled_full_sync(),
 				'queue_size'      => $queue->size(),
 				'queue_lag'       => $queue->lag(),
 				'full_queue_size' => $full_queue->size(),
@@ -65,25 +65,27 @@ class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
 
-		$sender = Jetpack_Sync_Sender::get_instance();
+		$sender     = Jetpack_Sync_Sender::get_instance();
 		$sync_queue = $sender->get_sync_queue();
 
 		// lock sending from the queue while we compare checksums with the server
 		$result = $sync_queue->lock( 30 ); // tries to acquire the lock for up to 30 seconds
 
-		if ( !$result ) {
+		if ( ! $result ) {
 			$sync_queue->unlock();
+
 			return new WP_Error( 'unknown_error', 'Unknown error trying to lock the sync queue' );
 		}
 
 		if ( is_wp_error( $result ) ) {
 			$sync_queue->unlock();
+
 			return $result;
 		}
 
-		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-wp-replicastore.php';
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-wp-replicastore.php';
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 
@@ -101,33 +103,35 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Endpoint
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-sender.php';
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
 
-		$sender = Jetpack_Sync_Sender::get_instance();
+		$sender     = Jetpack_Sync_Sender::get_instance();
 		$sync_queue = $sender->get_sync_queue();
 
 		// lock sending from the queue while we compare checksums with the server
 		$result = $sync_queue->lock( 30 ); // tries to acquire the lock for up to 30 seconds
 
-		if ( !$result ) {
+		if ( ! $result ) {
 			$sync_queue->unlock();
+
 			return new WP_Error( 'unknown_error', 'Unknown error trying to lock the sync queue' );
 		}
 
 		if ( is_wp_error( $result ) ) {
 			$sync_queue->unlock();
+
 			return $result;
 		}
 
 		$args = $this->query_args();
 
 		if ( isset( $args['columns'] ) ) {
-			$columns = array_map('trim', explode( ',', $args['columns'] ) );
+			$columns = array_map( 'trim', explode( ',', $args['columns'] ) );
 		} else {
 			$columns = null; // go with defaults
 		}
 
-		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-wp-replicastore.php';
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-wp-replicastore.php';
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 
@@ -147,11 +151,11 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_En
 	protected function result() {
 		$args = $this->input();
 
-		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-settings.php';
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-settings.php';
 
 		$sync_settings = Jetpack_Sync_Settings::get_settings();
 
-		foreach( $args as $key => $value ) {
+		foreach ( $args as $key => $value ) {
 			if ( $value !== false ) {
 				if ( is_numeric( $value ) ) {
 					$value = (int) $value;
@@ -172,7 +176,8 @@ class Jetpack_JSON_API_Sync_Get_Settings_Endpoint extends Jetpack_JSON_API_Endpo
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
-		require_once dirname(__FILE__) . '/../../sync/class.jetpack-sync-settings.php';
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-settings.php';
+
 		return Jetpack_Sync_Settings::get_settings();
 	}
 }

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -145,6 +145,23 @@ class Jetpack_Sync_Actions {
 		spawn_cron();
 	}
 
+	static function is_scheduled_full_sync( $modules = null ) {
+		if ( is_null( $modules ) ) {
+			$crons = _get_cron_array();
+			if ( empty( $crons ) ) {
+				return false;
+			}
+			$result = array();
+			foreach ( $crons as $timestamp => $cron ) {
+				if ( ! empty( $cron['jetpack_sync_full'] ) ) {
+					$result[ $timestamp ] = $cron['jetpack_sync_full'];
+				}
+			}
+			return $result;
+		}
+		return wp_next_scheduled( 'jetpack_sync_full', $modules );
+	}
+
 	static function do_full_sync( $modules = null ) {
 		if ( ! self::sync_allowed() ) {
 			return;

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -136,4 +136,9 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		do_action( 'import_end' );
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );
 	}
+
+	function test_is_scheduled_full_sync_works_with_different_args() {
+		Jetpack_Sync_Actions::schedule_full_sync( array( 'posts' => true ) );
+		$this->assertTrue( (bool) Jetpack_Sync_Actions::is_scheduled_full_sync() );
+	}
 }


### PR DESCRIPTION
> I found a disturbing behaviour of wp_next_scheduled
>
> if you have a job scheduled, say jetpack_sync_full, with an argument like array( 'posts' ), then wp_next_scheduled( 'jetpack_sync_full' ) will return false - you have to provide all the arguments
>
> This means that some of our code which checks if a full sync is enabled is wrong, including the debugger page (the internal one, in the plugin)