### PR TITLE
Admin Page: After The Deadline Settings - Add ignored phrases option

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import Button from 'components/button';
+import TagsInput from 'components/tags-input';
+
 /**
  * Internal dependencies
  */
@@ -661,6 +663,18 @@ export let AfterTheDeadlineSettings = React.createClass( {
 						name={ 'guess_lang' }
 						{ ...this.props }
 						label={ __( 'Use automatically detected language to proofread posts and pages' ) } />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLegend>
+						{ __( 'Ignored Phrases' ) }
+					</FormLegend>
+					<TagsInput
+						name="ignored_phrases"
+						placeholder={ __( 'Add a phrase' ) }
+						value={ this.props.getOptionValue( 'ignored_phrases' ).split( ',' ) }
+						onChange={ this.props.onOptionChange } />
+				</FormFieldset>
+				<FormFieldset>
 					<FormButton
 						className="is-primary"
 						isSubmitting={ this.props.isSavingAnyOption() }

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -620,11 +620,11 @@ export let AfterTheDeadlineSettings = React.createClass( {
 					<ModuleSettingCheckbox
 						name={ 'Cliches' }
 						{ ...this.props }
-						label={ __( 'Cliches' ) } />
+						label={ __( 'Clichés' ) } />
 					<ModuleSettingCheckbox
 						name={ 'Complex Expression' }
 						{ ...this.props }
-						label={ __( 'Complex Expression' ) } />
+						label={ __( 'Complex Phrases' ) } />
 					<ModuleSettingCheckbox
 						name={ 'Diacritical Marks' }
 						{ ...this.props }
@@ -632,7 +632,7 @@ export let AfterTheDeadlineSettings = React.createClass( {
 					<ModuleSettingCheckbox
 						name={ 'Double Negative' }
 						{ ...this.props }
-						label={ __( 'Double Negative' ) } />
+						label={ __( 'Double Negatives' ) } />
 					<ModuleSettingCheckbox
 						name={ 'Hidden Verbs' }
 						{ ...this.props }
@@ -640,11 +640,11 @@ export let AfterTheDeadlineSettings = React.createClass( {
 					<ModuleSettingCheckbox
 						name={ 'Jargon Language' }
 						{ ...this.props }
-						label={ __( 'Jargon Language' ) } />
+						label={ __( 'Jargon' ) } />
 					<ModuleSettingCheckbox
 						name={ 'Passive voice' }
 						{ ...this.props }
-						label={ __( 'Passive voice' ) } />
+						label={ __( 'Passive Voice' ) } />
 					<ModuleSettingCheckbox
 						name={ 'Phrases to Avoid' }
 						{ ...this.props }
@@ -652,7 +652,7 @@ export let AfterTheDeadlineSettings = React.createClass( {
 					<ModuleSettingCheckbox
 						name={ 'Redundant Expression' }
 						{ ...this.props }
-						label={ __( 'Redundant Expression' ) } />
+						label={ __( 'Redundant Phrases' ) } />
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend> { __( 'Language: The proofreader supports English, French, ' +

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -671,7 +671,10 @@ export let AfterTheDeadlineSettings = React.createClass( {
 					<TagsInput
 						name="ignored_phrases"
 						placeholder={ __( 'Add a phrase' ) }
-						value={ this.props.getOptionValue( 'ignored_phrases' ).split( ',' ) }
+						value={ this.props.getOptionValue( 'ignored_phrases' ) !== '' ?
+							this.props.getOptionValue( 'ignored_phrases' ).split( ',' ) :
+							[]
+						}
 						onChange={ this.props.onOptionChange } />
 				</FormFieldset>
 				<FormFieldset>

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -23,16 +23,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 				optionValue = typeof event.target.checked !== 'undefined'
 					? event.target.checked
 					: event.target.value;
-			}
-			if ( event.target.type === 'radio' ) {
-				optionValue = event.target.value;
-			}
-
-			if ( event.target.type === 'text' ) {
-				optionValue = event.target.value;
-			}
-
-			if ( event.target.type === 'textarea' ) {
+			} else {
 				optionValue = event.target.value;
 			}
 

--- a/_inc/client/components/tags-input/index.jsx
+++ b/_inc/client/components/tags-input/index.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import TagsInput from 'react-tagsinput';
+
+const JetpackTagsInput = React.createClass( {
+	getInitialState() {
+		return {
+			tags: this.props.value || []
+		};
+	},
+
+	handleChange( tags ) {
+		this.setState( { tags } )
+		if ( this.props.onChange ) {
+			this.props.onChange( {
+				target: {
+					name: this.props.name,
+					value: tags.join( ',' )
+				}
+			} );
+		}
+	},
+
+	render() {
+		const props = this.props;
+		return (
+			<TagsInput
+				inputProps={ { placeholder: props.placeholder } }
+				onChange={ this.handleChange }
+				value={ this.state.tags } />
+		);
+	}
+} );
+
+export default JetpackTagsInput;

--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -1,0 +1,48 @@
+.react-tagsinput {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  overflow: hidden;
+  padding-left: 5px;
+  padding-top: 5px;
+}
+
+.react-tagsinput--focused {
+  border-color: #a5d24a;
+}
+
+.react-tagsinput-tag {
+  background-color: #00aadc;
+  border-radius: 2px;
+  border: 1px solid #0087be;
+  color: white;
+  display: inline-block;
+  font-family: sans-serif;
+  font-size: 13px;
+  font-weight: 400;
+  margin-bottom: 5px;
+  margin-right: 5px;
+  padding: 5px;
+}
+
+.react-tagsinput-remove {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.react-tagsinput-tag a::before {
+  content: " ×";
+}
+
+.react-tagsinput-input {
+  background: transparent;
+  border: 0;
+  color: #777;
+  font-family: sans-serif;
+  font-size: 13px;
+  font-weight: 400;
+  margin-bottom: 6px;
+  margin-top: 1px;
+  outline: none;
+  padding: 5px;
+  width: 80px;
+}

--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -44,5 +44,5 @@
   margin-top: 1px;
   outline: none;
   padding: 5px;
-  width: 80px;
+  width: 150px;
 }

--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -1,48 +1,47 @@
 .react-tagsinput {
-  background-color: #fff;
-  border: 1px solid #ccc;
-  overflow: hidden;
-  padding-left: 5px;
-  padding-top: 5px;
+	border: 1px solid #e9eff3;
+	padding: rem( 5px );
 }
 
 .react-tagsinput--focused {
-  border-color: #a5d24a;
+	border-color: #a5d24a;
 }
 
 .react-tagsinput-tag {
-  background-color: #00aadc;
-  border-radius: 2px;
-  border: 1px solid #0087be;
-  color: white;
-  display: inline-block;
-  font-family: sans-serif;
-  font-size: 13px;
-  font-weight: 400;
-  margin-bottom: 5px;
-  margin-right: 5px;
-  padding: 5px;
+	background-color: #00aadc;
+	border-radius: 2px;
+	border: 1px solid #0087be;
+	color: #fff;
+	display: inline-block;
+	font-size: 13px;
+	padding: rem( 5px );
+	margin-right: rem( 5px );
+	transition: background-color .2s ease-out;
+
+	&:hover {
+		background-color: #26b7e2;
+	}
 }
 
 .react-tagsinput-remove {
-  cursor: pointer;
-  font-weight: bold;
+	cursor: pointer;
+	font-weight: bold;
+	transition: color .2s ease-out;
+
+	&:hover {
+		color: #caf3ff;
+	}
 }
 
 .react-tagsinput-tag a::before {
-  content: " ×";
+	content: " \00d7";
 }
 
 .react-tagsinput-input {
-  background: transparent;
-  border: 0;
-  color: #777;
-  font-family: sans-serif;
-  font-size: 13px;
-  font-weight: 400;
-  margin-bottom: 6px;
-  margin-top: 1px;
-  outline: none;
-  padding: 5px;
-  width: 150px;
+	font-size: 13px;
+	padding: rem( 5px );
+	width: rem( 150px );
+	margin: 0;
+	height: rem( 30px );
+	vertical-align: top;
 }

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -35,6 +35,8 @@
 @import '../components/module-settings/style';
 @import '../components/support-card/style';
 @import '../components/forms/styles';
+@import '../components/tags-input/style';
+
 
 // Page Templates
 @import '../at-a-glance/style';

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1233,7 +1233,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					$atd_option = 'AtD_ignored_phrases';
 					$grouped_options = $grouped_options_current = explode( ',', AtD_get_setting( $user_id, $atd_option ) );
 					if ( 'ignored_phrases' == $option ) {
-						$grouped_options[] = $value;
+						$grouped_options = explode( ',', $value );
 					} else {
 						$index = array_search( $value, $grouped_options );
 						if ( false !== $index ) {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-redux": "^4.4.1",
     "react-router": "^2.0.1",
     "react-router-redux": "^4.0.1",
+    "react-tagsinput": "^3.13.1",
     "react-tap-event-plugin": "0.2.1",
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1",


### PR DESCRIPTION
Fixes #4382

#### Changes proposed in this Pull Request:

* Adds a react-tagsinput component as dependency from npm
* Adds a tag input for ignored phrases on **Spelling and Grammar** settings under the **Writing** tab .
* Updates handling of the `ignored_phrases` option value to override current value. Prior to this PR, the handling code either added or removed the passed value.

![ignored-phrases](https://cloud.githubusercontent.com/assets/746152/17332519/6c8d38b0-58a5-11e6-9d61-6baa7bb70a02.gif)


#### Testing instructions:

1. Get to the **Spelling and Grammaer** settings card under the **Writing** tab.
1. Add  two new ignored phrases on the tag-like input (You need to press enter for the save button to be enabled and allows you to save the changes.
1. Save Settings
1. Refresh the page and check that the change persisted
1. Do the same, but deleting one of the new options by click the `x`, save refresh the page and check again if the change persisted 