### PR TITLE
Fix infinite loop caused by recursive callback to parse options

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -231,7 +231,7 @@ EOT;
 	 */
 	public function get_options() {
 		if ( null === $this->_options ) {
-			$this->_options = Jetpack_Options::get_option_and_ensure_autoload( 'jetpack_relatedposts', array() );
+			$this->_options = Jetpack_Options::get_option( 'relatedposts', array() );
 			if ( ! is_array( $this->_options ) )
 				$this->_options = array();
 			if ( ! isset( $this->_options['enabled'] ) )


### PR DESCRIPTION
Fixes an issue reported by @jeherve where if you have no related posts options, and you load the options-reading.php admin page, then you hit an infinite loop trying to parse the options.

cc @lezama 