### PR TITLE
Jetpack Sync: Fix users not being sent on Jetpack Upgrade

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -129,7 +129,7 @@ class Jetpack_Sync_Actions {
 		// we need this function call here because we have to run this function 
 		// reeeeally early in init, before WP_CRON_LOCK_TIMEOUT is defined.
 		wp_functionality_constants();
-		self::schedule_full_sync( array( 'options', 'network_options', 'functions', 'constants', 'users' ) );
+		self::schedule_full_sync( array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => true ) );
 	}
 
 	static function schedule_full_sync( $modules = null ) {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -120,7 +120,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		/** This action is documented in class.jetpack.php */
 		do_action( 'updating_jetpack_version', '4.1', '4.2' );
 
-		$modules = array( 'options', 'network_options', 'functions', 'constants', 'users' );
+		$modules = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => true );
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( $modules ) ) > time()-5 );
 	}
 


### PR DESCRIPTION
How to test:

* bump `JETPACK__VERSION`;
* check that modules hooked to `schedule_initial_sync` get called;

cc @gravityrail, @enejb 
