### PR TITLE
Fix/dev mode modules

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -40,7 +40,7 @@ export const Page = ( props ) => {
 		[ 'infinite-scroll', getModule( 'infinite-scroll' ).name, getModule( 'infinite-scroll' ).description, getModule( 'infinite-scroll' ).learn_more_button ],
 		[ 'minileven', getModule( 'minileven' ).name, getModule( 'minileven' ).description, getModule( 'minileven' ).learn_more_button ]
 	].map( ( element ) => {
-		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			toggle = (
 				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
 					<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
@@ -88,7 +88,8 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) =>
 				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
-			getModule: ( module_name ) => _getModule( state, module_name )
+			getModule: ( module_name ) => _getModule( state, module_name ),
+			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -60,7 +60,7 @@ export const Page = ( props ) => {
 		cards = cards.filter( ( element, index ) => cards.indexOf( element ) === index );
 	}
 	cards = cards.map( ( element ) => {
-		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			toggle = '',
 			adminAndNonAdmin = isAdmin || nonAdminAvailable.includes( element[0] ),
@@ -141,7 +141,8 @@ export default connect(
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) => isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
-			getModule: ( module_name ) => _getModule( state, module_name )
+			getModule: ( module_name ) => _getModule( state, module_name ),
+			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/general-settings/connection-settings.jsx
+++ b/_inc/client/general-settings/connection-settings.jsx
@@ -3,18 +3,18 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { isCurrentUserLinked as _isCurrentUserLinked } from 'state/connection';
+import { isCurrentUserLinked, isDevMode } from 'state/connection';
 import QueryUserConnectionData from 'components/data/query-user-connection';
 import ConnectButton from 'components/connect-button';
 
 const ConnectionSettings = React.createClass( {
 	renderContent: function() {
 		const userData = window.Initial_State.userData;
-		const isLinked = this.props.isLinked( this.props );
 
 		const maybeShowDisconnectBtn = userData.currentUser.permissions.disconnect
 			? <ConnectButton />
@@ -24,17 +24,33 @@ const ConnectionSettings = React.createClass( {
 			? null
 			: <ConnectButton connectUser={ true } />;
 
-		return(
+		return isDevMode( this.props ) ?
 			<div>
 				{
-					isLinked
-						? `You are linked to WordPress.com account ${ userData.currentUser.wpcomUser.login } / ${ userData.currentUser.wpcomUser.email }`
-						: `You, ${ userData.currentUser.username }, are not connected to WordPress.com`
+					__( 'The site is in Development Mode, so you can not connect to WordPress.com.' )
+				}
+			</div>
+			:
+			<div>
+				{
+					this.props.isLinked( this.props ) ?
+						__( 'You are linked to WordPress.com account {{userLogin}} / {{userEmail}}.', {
+							components: {
+								userLogin: userData.currentUser.wpcomUser.login,
+								userEmail: userData.currentUser.wpcomUser.email
+							}
+						} )
+						:
+						__( 'You, {{userName}}, are not connected to WordPress.com.', {
+							components: {
+								userName: userData.currentUser.username
+							}
+						} )
 				}
 				{ maybeShowDisconnectBtn }
 				{ maybeShowLinkUnlinkBtn }
 			</div>
-		)
+			;
 	},
 
 	render() {
@@ -50,7 +66,7 @@ const ConnectionSettings = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			isLinked: () => _isCurrentUserLinked( state )
+			isLinked: () => isCurrentUserLinked( state )
 		}
 	}
 )( ConnectionSettings );

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -62,7 +62,7 @@ export const Page = ( props ) => {
 		[ 'backups', __( 'Site Backups' ), __( 'Keep your site backed up!' ), 'https://vaultpress.com/jetpack/' ],
 		[ 'sso', getModule( 'sso' ).name, getModule( 'sso' ).description, getModule( 'sso' ).learn_more_button ]
 	].map( ( element ) => {
-		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			toggle = (
 				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
 				<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
@@ -223,6 +223,7 @@ export default connect(
 			getScanThreats: () => _getVaultPressScanThreatCount( state ),
 			getVaultPressData: () => _getVaultPressData( state ),
 			getAkismetData: () => _getAkismetData( state ),
+			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -131,7 +131,7 @@ export const Page = ( props ) => {
 						__( 'ACTIVE' )
 					);
 				} else {
-					return (
+					return unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) : (
 						<Button
 							compact={ true }
 							primary={ true }

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -58,7 +58,7 @@ export const Page = ( props ) => {
 		cards = cards.filter( ( element, index ) => cards.indexOf( element ) === index );
 	}
 	cards = cards.map( ( element, i ) => {
-		var unavailableInDevMode = isUnavailableInDevMode( props, element[0] ),
+		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			toggle = '',
 			adminAndNonAdmin = isAdmin || nonAdminAvailable.includes( element[0] );
@@ -118,7 +118,8 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) =>
 				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
-			getModule: ( module_name ) => _getModule( state, module_name )
+			getModule: ( module_name ) => _getModule( state, module_name ),
+			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -689,6 +689,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$modules = Jetpack_Admin::init()->get_modules();
 		foreach ( $modules as $slug => $properties ) {
 			$modules[ $slug ]['options'] = self::prepare_options_for_response( $slug );
+			if ( isset( $modules[ $slug ]['requires_connection'] ) && $modules[ $slug ]['requires_connection'] && Jetpack::is_development_mode() ) {
+				$modules[ $slug ]['activated'] = false;
+			}
 		}
 
 		return $modules;
@@ -713,6 +716,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$module = Jetpack::get_module( $data['slug'] );
 
 			$module['options'] = self::prepare_options_for_response( $data['slug'] );
+
+			if ( isset( $module['requires_connection'] ) && $module['requires_connection'] && Jetpack::is_development_mode() ) {
+				$module['activated'] = false;
+			}
 
 			return $module;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- General tab: if site is in dev mode, don't show buttons to connect to wpcom in Connection Settings card. Make strings translatable.

- General tab: show Manage, Notifications, and JSON API unavailable in dev mode.

Shows functional Connection card with its now fixed content.
Toggle is now hidden on load for modules unavailable in dev mode. Previously this wasn't working when the page first loaded.
Refactor to match component approach used in Engagement and other tabs.
Removed unused isDevMode import.

- fix issue where module toggle was visible on page load even for modules unavailable in dev mode.

- don't show Upgrade button in modules that are unavailable in dev mode: Scan and Backups

- if a module requires connection and site is in dev mode, set its activated property in the response to false. This solves an issue where the Stats and other cards in AAG were displayed while in Dev Mode, which was incorrect. That's because if these modules are activated before the site enters Dev Mode, they are still active when the site is in Dev Mode.

#### Testing instructions:
- load the page in Dev Mode, and make sure the modules that are unavailable in dev mode have their toggle replaced by "Unavailable in Dev Mode" *on* page load. Previously this wasn't properly connected and only after a tab switch they were ok.

- Scan and Backups should not display the blue Upgrade button.

- in General tab, the Connection Settings should no longer display buttons for wpcom connection but only a message stating that it will be possible to connect once the site is out of dev mode.