### PR TITLE
Fix/sync clone global objects before changing them.

### DIFF
--- a/sync/class.jetpack-sync-json-deflate-codec.php
+++ b/sync/class.jetpack-sync-json-deflate-codec.php
@@ -14,7 +14,7 @@ class Jetpack_Sync_JSON_Deflate_Codec implements iJetpack_Sync_Codec {
 	}
 
 	public function encode( $object ) {
-		return base64_encode( gzdeflate( $this->json_serialize( $object ) ) );
+		return base64_encode( gzdeflate( $this->json_serialize( unserialize( serialize( $object ) ) ) ) );
 	}
 
 	public function decode( $input ) {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -892,6 +892,16 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		}
 	}
 
+	function test_sync_call_ables_does_not_modify_globals() {
+		global $wp_taxonomies;
+		// assert that $wp_taxonomy object stays an array. 
+		$this->assertTrue( is_array( $wp_taxonomies['category']->rewrite ) );
+		$this->setSyncClientDefaults();
+		$this->full_sync->start();
+		$this->sender->do_sync();
+		$this->assertTrue( is_array( $wp_taxonomies['category']->rewrite ) );
+	}
+
 	function upgrade_terms_to_pass_test( $term ) {
 		global $wp_version;
 		if ( version_compare( $wp_version, '4.4', '<' ) ) {


### PR DESCRIPTION
Fixes an issue where we modified the global $wp_taxonomies array. And it was causing fatal error when it was expanding a post and generating the output of a shortcode. 

#### Changes proposed in this Pull Request:
- serealize and unseralized solves this problem because it generated a new object and does't create a new reference to the old array or object that is being modified before sending it. 

