### PR TITLE
Fix site endpoint bug that was using wrong user function

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -171,7 +171,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			array_intersect( $default_fields, $this->fields_to_include ) :
 			$default_fields;
 
-		if ( ! is_user_member_of_blog( get_current_user(), $blog_id ) ) {
+		if ( ! is_user_member_of_blog( get_current_user_id(), $blog_id ) ) {
 			$response_keys = array_intersect( $response_keys, self::$no_member_fields );
 		}
 
@@ -459,7 +459,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			$response->{ $key } = $value;
 		}
 
-		if ( is_user_member_of_blog( get_current_user(), $response->ID ) ) {
+		$token_details = (object) $this->api->token_details;
+
+		if ( is_user_member_of_blog( get_current_user_id(), $response->ID ) || 'blog' === $token_details->access ) {
 			$wpcom_member_response = $this->render_response_keys( self::$jetpack_response_field_member_additions );
 
 			foreach( $wpcom_member_response as $key => $value ) {


### PR DESCRIPTION
Fixes use of incorrect `get_current_user()` function in Sites endpoint.

cc @enejb 
cc @lezama - were there other places we needed to fix this?