### PR TITLE
Properly unserialize post meta values for full sync

### DIFF
--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -96,12 +96,20 @@ abstract class Jetpack_Sync_Module {
 			return array();
 		}
 
-		return $wpdb->get_results( "SELECT $id, meta_key, meta_value, meta_id FROM $table WHERE $id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . ' )', OBJECT );
+		return array_map( 
+			array( $this, 'unserialize_meta' ), 
+			$wpdb->get_results( "SELECT $id, meta_key, meta_value, meta_id FROM $table WHERE $id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . ' )', OBJECT ) 
+		);
 	}
 
 	protected function get_term_relationships( $ids ) {
 		global $wpdb;
 
 		return $wpdb->get_results( "SELECT object_id, term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . ' )', OBJECT );
+	}
+
+	public function unserialize_meta( $meta ) {
+		$meta->meta_value = maybe_unserialize( $meta->meta_value );
+		return $meta;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -327,20 +327,24 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_sends_all_post_meta() {
 		$post_id = $this->factory->post->create();
 		add_post_meta( $post_id, 'test_meta_key', 'foo' );
+		add_post_meta( $post_id, 'test_meta_array', array( 'foo', 'bar' ) );
 
 		$this->sender->do_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
+		$this->assertEquals( array( 'foo', 'bar' ), $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
+		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
 
 		$this->full_sync->start();
 		$this->sender->do_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
+		$this->assertEquals( array( 'foo', 'bar' ), $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
 	}
 
 	function test_full_sync_sends_all_post_terms() {


### PR DESCRIPTION
Fixes an issue where non-scalar values were being sent as strings, so at the other end they would be double-serialized, resulting in subtle bugs.