### PR TITLE
Admin Page: Remove direct access to window.Initial_State from Apps, Akismet widget, and Backups widget components

### DIFF
--- a/_inc/client/apps/index.jsx
+++ b/_inc/client/apps/index.jsx
@@ -46,7 +46,7 @@ const Apps = ( props ) => {
 					<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
 						<h3 className="jp-landing__apps-feature-title">{ __( 'Bulk and automatic updates' ) }</h3>
 						<p className="jp-landing__apps-feature-text">{ __( 'Most security flaws are found in outdated plugins. Use our Web and Desktop apps to turn on auto-updates or update plugins manually for all your websites in one convenient place.' ) }</p>
-						<Button href={ 'https://wordpress.com/plugins/' + window.Initial_State.rawUrl }	className="is-primary">
+						<Button href={ 'https://wordpress.com/plugins/' + props.siteRawUrl }	className="is-primary">
 							{ __( 'Manage Plugins' ) }
 						</Button>
 					</div>
@@ -56,7 +56,7 @@ const Apps = ( props ) => {
 					<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
 						<h3 className="jp-landing__apps-feature-title">{ __( 'Focus on your Writing' ) }</h3>
 						<p className="jp-landing__apps-feature-text">{ __( 'Our new editor is lightning fast, optimized for writers and eliminates distractions, giving you the ability to focus on your work.' ) }</p>
-						<Button href={ 'https://wordpress.com/post/' + window.Initial_State.rawUrl }	className="is-primary">
+						<Button href={ 'https://wordpress.com/post/' + props.siteRawUrl }	className="is-primary">
 							{ __( 'Try the New Editor' ) }
 						</Button>
 					</div>
@@ -74,7 +74,7 @@ const Apps = ( props ) => {
 							<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
 								<h2>{ __( 'Connect with your Visitors' ) }</h2>
 								<p>{ __( 'Monitor your visitors with advanced stats. Watch for trends, learn what content performs the best and understand your visitors from anywhere in the world.' ) }</p>
-								<Button href={ 'https://wordpress.com/stats/' + window.Initial_State.rawUrl }	className="is-primary">
+								<Button href={ 'https://wordpress.com/stats/' + props.siteRawUrl }	className="is-primary">
 									{ __( 'View Your Stats' ) }
 								</Button>
 							</div>

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -21,16 +21,17 @@ import {
 
 const DashAkismet = React.createClass( {
 	activateManageAndRedirect: function( e ) {
+		const props = this.props;
 		e.preventDefault();
 
 		this.props.activateModule( 'manage' )
-			.then( window.location = 'https://wordpress.com/plugins/akismet/' + window.Initial_State.rawUrl )
+			.then( window.location = 'https://wordpress.com/plugins/akismet/' + props.siteRawUrl )
 			.catch( console.log( 'Error: unable to activate Manage' ) );
 	},
 
 	getContent: function() {
 		const akismetData = this.props.getAkismetData(),
-			akismetSettingsUrl = window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config',
+			akismetSettingsUrl = this.props.siteAdminUrl + 'admin.php?page=akismet-key-config',
 			labelName = __( 'Spam Protection' ),
 			hasSitePlan = false !== this.props.getSitePlan();
 
@@ -83,7 +84,7 @@ const DashAkismet = React.createClass( {
 						{
 							__( 'For state-of-the-art spam defense, please {{a}}activate Akismet{{/a}}.', {
 								components: {
-									a: <a href={ 'https://wordpress.com/plugins/akismet/' + window.Initial_State.rawUrl } target="_blank" />
+									a: <a href={ 'https://wordpress.com/plugins/akismet/' + this.props.siteRawUrl } target="_blank" />
 								}
 							} )
 						}

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -76,7 +76,7 @@ const DashBackups = React.createClass( {
 				return(
 					__( 'To automatically back up your entire site, please {{a}}upgrade!{{/a}}.', {
 						components: {
-							a: <a href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl } target="_blank" />
+							a: <a href={ 'https://wordpress.com/plans/' + this.props.siteRawUrl } target="_blank" />
 						}
 					} )
 				);

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -24,6 +24,10 @@ import FeedbackDashRequest from 'components/jetpack-notices/feedback-dash-reques
 import { isModuleActivated as _isModuleActivated } from 'state/modules';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import QuerySite from 'components/data/query-site';
+import {
+	userCanManageModules,
+	userCanViewStats
+} from 'state/initial-state';
 
 const AtAGlance = React.createClass( {
 	render() {
@@ -32,7 +36,7 @@ const AtAGlance = React.createClass( {
 					label={ __( 'Security' ) }
 					settingsPath="#security"
 					externalLink={ __( 'Manage security on WordPress.com' ) }
-					externalLinkPath={ 'https://wordpress.com/settings/security/' + window.Initial_State.rawUrl }
+					externalLinkPath={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
 					externalLinkClick={ () => analytics.tracks.recordEvent( 'jetpack_wpa_aag_security_wpcom_click', {} ) }
 				/>,
 			performanceHeader =
@@ -41,7 +45,7 @@ const AtAGlance = React.createClass( {
 				/>;
 
 		// If user can manage modules, we're in an admin view, otherwise it's a non-admin view.
-		if ( window.Initial_State.userData.currentUser.permissions.manage_modules ) {
+		if ( this.props.userCanManageModules ) {
 			return (
 				<div className="jp-at-a-glance">
 					<QuerySitePlugins />
@@ -91,7 +95,7 @@ const AtAGlance = React.createClass( {
 			);
 		} else {
 			let stats = '';
-			if ( window.Initial_State.userData.currentUser.permissions.view_stats ) {
+			if ( this.props.userCanViewStats ) {
 				stats = <DashStats { ...this.props } />;
 			}
 
@@ -122,7 +126,9 @@ const AtAGlance = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
+			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
+			userCanManageModules: userCanManageModules( state ),
+			userCanViewStats: userCanViewStats( state )
 		};
 	}
 )( AtAGlance );

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -21,9 +21,10 @@ import { isDevMode } from 'state/connection';
 
 const DashPluginUpdates = React.createClass( {
 	activateAndRedirect: function( e ) {
+		const props = this.props;
 		e.preventDefault();
 		this.props.activateManage()
-			.then( window.location = 'https://wordpress.com/plugins/' + window.Initial_State.rawUrl )
+			.then( window.location = 'https://wordpress.com/plugins/' + props.siteRawUrl )
 			.catch( console.log( 'Error activating Manage' ) );
 	},
 
@@ -32,8 +33,8 @@ const DashPluginUpdates = React.createClass( {
 		const pluginUpdates = this.props.getPluginUpdates();
 		const manageActive = this.props.isModuleActivated( 'manage' );
 		const ctaLink = manageActive ?
-			'https://wordpress.com/plugins/' + window.Initial_State.rawUrl :
-			window.Initial_State.adminUrl + 'plugins.php';
+			'https://wordpress.com/plugins/' + this.props.siteRawUrl :
+			this.props.siteAdminUrl + 'plugins.php';
 
 		if ( 'N/A' === pluginUpdates ) {
 			return(

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -99,7 +99,7 @@ const DashScan = React.createClass( {
 				return(
 					__( 'For automated, comprehensive scanning of security threats, please {{a}}upgrade your account{{/a}}.', {
 						components: {
-							a: <a href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl } target="_blank" />
+							a: <a href={ 'https://wordpress.com/plans/' + this.props.siteRawUrl } target="_blank" />
 						}
 					} )
 				);

--- a/_inc/client/at-a-glance/site-verification.jsx
+++ b/_inc/client/at-a-glance/site-verification.jsx
@@ -24,10 +24,10 @@ const DashSiteVerify = React.createClass( {
 						{
 							__( 'Site Verification Tools are active. Ensure your site is verified with Google, ' +
 								'Bing, and Pinterest for more accurate indexing and ranking. {{a}}Verify now{{/a}}', {
-								components: {
-									a: <a href={ window.Initial_State.adminUrl + 'tools.php' } />
-								}
-							} )
+									components: {
+										a: <a href={ this.props.siteAdminUrl + 'tools.php' } />
+									}
+								} )
 						}
 					</p>
 				</DashItem>

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -107,7 +107,7 @@ const Main = React.createClass( {
 				pageComponent = <AtAGlance { ...this.props } />;
 				break;
 			case '/apps':
-				pageComponent = <Apps { ...this.props } />;
+				pageComponent = <Apps siteRawUrl={ this.props.siteRawUrl } { ...this.props } />;
 				break;
 			case '/professional':
 				pageComponent = <Plans siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } { ...this.props } />;

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -43,3 +43,6 @@ export function userCanManageModules( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'manage_modules', false );
 }
 
+export function userCanViewStats( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'view_stats', false );
+}

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -38,3 +38,8 @@ export function getSiteAdminUrl( state ) {
 export function isSitePublic( state ) {
 	return get( state.jetpack.initialState, [ 'connectionStatus', 'isPublic' ] );
 }
+
+export function userCanManageModules( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'manage_modules', false );
+}
+


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Updates some code to use data that we're getting from `window.Initial_state` to now use the data relying on it being provided on the components `.props`. 

For this, a few new state selectors were introduced. 

#### Testing instructions:

1. Got to the Apps Page. check that the first button link has your Site’s URL on it
2. With a Pro Plan check that the URLs in the activate button of the Dashboard’s Akismet widget are correct
3. With a Pro Plan check that the URLs in the activate button of the Dashboard’s Backups widget are correct
4. With a non-admin user check that you see module cards grayed out 
5. With a non-admin user who’s not allowed to see stats, check that you’re unable to view stats on the dashboard
