### PR TITLE
Redirects old IE versions to the fallback page.

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -7,6 +7,7 @@ import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -53,7 +54,7 @@ export const Page = ( props ) => {
 	if ( ! isAdmin ) {
 		let cardsCopy = cards.slice();
 		cardsCopy.reverse().forEach( ( element ) => {
-			if ( nonAdminAvailable.includes( element[0] ) ) {
+			if ( includes( nonAdminAvailable, element[0] ) ) {
 				cards.unshift( element );
 			}
 		} );
@@ -63,7 +64,7 @@ export const Page = ( props ) => {
 		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			toggle = '',
-			adminAndNonAdmin = isAdmin || nonAdminAvailable.includes( element[0] ),
+			adminAndNonAdmin = isAdmin || includes( nonAdminAvailable, element[0] ),
 			isModuleActive = isModuleActivated( element[0] );
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -56,7 +57,7 @@ const PlanBody = React.createClass( {
 						</div>
 
 						{
-							[ 'jetpack_business', 'jetpack_business_monthly' ].includes( this.props.plan ) ?
+							includes( [ 'jetpack_business', 'jetpack_business_monthly' ], this.props.plan ) ?
 								<div className="jp-landing__plan-features-card">
 									<h3 className="jp-landing__plan-features-title">{ __( 'Surveys & Polls' ) }</h3>
 									<p>{ __( 'Unlimited surveys, unlimited responses. Use the survey editor to create surveys quickly and easily. Collect responses via your website, e-mail or on your iPad or iPhone.' ) }</p>
@@ -68,7 +69,7 @@ const PlanBody = React.createClass( {
 						}
 
 						{
-							[ 'jetpack_premium', 'jetpack_premium_monthly' ].includes( this.props.plan ) ?
+							includes( [ 'jetpack_premium', 'jetpack_premium_monthly' ], this.props.plan ) ?
 								<div className="jp-landing__plan-features-card">
 									<h3 className="jp-landing__plan-features-title">{ __( 'Need more?' ) }</h3>
 									<p>{ __( 'Jetpack Professional offers more features.' ) }</p>

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -4,6 +4,7 @@
 import { combineReducers } from 'redux';
 import assign from 'lodash/assign';
 import get from 'lodash/get';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -224,10 +225,10 @@ export function isStaging( state ) {
  * @return {boolean} True if module requires connection.
  */
 export function requiresConnection( state, slug ) {
-	return getModulesThatRequireConnection( state ).concat( [
+	return includes( getModulesThatRequireConnection( state ).concat( [
 		'backups',
 		'scan'
-	] ).includes( slug );
+	] ), slug );
 }
 
 /**

--- a/_inc/client/static.jsx
+++ b/_inc/client/static.jsx
@@ -33,3 +33,5 @@ window.versionNotice = Server.renderToStaticMarkup(
 			<StaticWarning />
 		</Provider>
 	);
+
+window.ieNotice = "<!--[if lte IE 10]>" + window.versionNotice + "<![endif]-->";

--- a/_inc/client/static.jsx
+++ b/_inc/client/static.jsx
@@ -34,4 +34,19 @@ window.versionNotice = Server.renderToStaticMarkup(
 		</Provider>
 	);
 
-window.ieNotice = "<!--[if lte IE 10]>" + window.versionNotice + "<![endif]-->";
+window.ieNotice = Server.renderToStaticMarkup(
+		<Provider store={ store }>
+			<div id="ie-legacy-notice" style={{ display: 'none' }}>
+				<StaticWarning  />
+			</div>
+		</Provider>
+	);
+
+window.ieNotice = window.ieNotice +
+	"<script type=\"text/javascript\">\n" +
+	"/*@cc_on\n" +
+	"if ( @_jscript_version <= 10) {\n" +
+	"jQuery( '#ie-legacy-notice' ).show();\n" +
+	"}\n" +
+	"@*/\n" +
+	"</script>";

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -7,6 +7,7 @@ import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -51,7 +52,7 @@ export const Page = ( props ) => {
 	if ( ! isAdmin ) {
 		let cardsCopy = cards.slice();
 		cardsCopy.reverse().forEach( ( element ) => {
-			if ( nonAdminAvailable.includes( element[0] ) ) {
+			if ( includes( nonAdminAvailable, element[0] ) ) {
 				cards.unshift( element );
 			}
 		} );
@@ -61,7 +62,7 @@ export const Page = ( props ) => {
 		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			toggle = '',
-			adminAndNonAdmin = isAdmin || nonAdminAvailable.includes( element[0] );
+			adminAndNonAdmin = isAdmin || includes( nonAdminAvailable, element[0] );
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );
 		} else {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -51,6 +51,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		// Adding a redirect meta tag wrapped in noscript tags for all browsers in case they have
 		// JavaScript disabled
 		add_action( 'admin_head', array( $this, 'add_noscript_head_meta' ) );
+
+		// Adding a redirect tag wrapped in browser conditional comments
+		add_action( 'admin_head', array( $this, 'add_legacy_browsers_head_meta' ) );
 	}
 
 	/**
@@ -92,6 +95,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		echo '<noscript>';
 		$this->add_fallback_head_meta();
 		echo '</noscript>';
+	}
+
+	function add_legacy_browsers_head_meta() {
+		echo '<!--[if lte IE 10]>';
+		$this->add_fallback_head_meta();
+		echo '<![endif]-->';
 	}
 
 	function jetpack_menu_order( $menu_order ) {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -53,7 +53,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		add_action( 'admin_head', array( $this, 'add_noscript_head_meta' ) );
 
 		// Adding a redirect tag wrapped in browser conditional comments
-		add_action( 'admin_head', array( $this, 'add_legacy_browsers_head_meta' ) );
+		add_action( 'admin_head', array( $this, 'add_legacy_browsers_head_script' ) );
 	}
 
 	/**
@@ -97,10 +97,15 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		echo '</noscript>';
 	}
 
-	function add_legacy_browsers_head_meta() {
-		echo '<!--[if lte IE 10]>';
-		$this->add_fallback_head_meta();
-		echo '<![endif]-->';
+	function add_legacy_browsers_head_script() {
+		echo
+			"<script type=\"text/javascript\">\n"
+			. "/*@cc_on\n"
+			. "if ( @_jscript_version <= 10) {\n"
+			. "window.location.href = '?page=jetpack_modules';\n"
+			. "}\n"
+			. "@*/\n"
+			. "</script>";
 	}
 
 	function jetpack_menu_order( $menu_order ) {

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -22,6 +22,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 		$static_html = file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' );
 		$noscript_notice = file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' );
 		$version_notice = file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
+		$ie_notice = file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-ie-notice.html' );
 
 		$noscript_notice = str_replace(
 			'#HEADER_TEXT#',
@@ -45,6 +46,17 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			$version_notice
 		);
 
+		$ie_notice = str_replace(
+			'#HEADER_TEXT#',
+			esc_html( __( 'You are using an unsupported browser version.', 'jetpack' ) ),
+			$ie_notice
+		);
+		$ie_notice = str_replace(
+			'#TEXT#',
+			esc_html( __( "Update your browser to unlock Jetpack's full potential!", 'jetpack' ) ),
+			$ie_notice
+		);
+
 		ob_start();
 
 		$this->admin_page_top();
@@ -53,6 +65,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			echo $version_notice;
 		}
 		echo $noscript_notice;
+		echo $ie_notice;
 		?>
 
 		<div class="page-content configure">

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -132,9 +132,9 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 		ob_end_clean();
 
 		echo str_replace(
-		     '<div id="jetpack-static-container"></div>',
-		     $page_content,
-		     $static_html
+			'<div class="jp-loading-placeholder"><span class="dashicons dashicons-wordpress-alt"></span></div>',
+			$page_content,
+			$static_html
 		);
 	}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,10 +156,12 @@ function doStatic( done ) {
 		fs.writeFile( __dirname + '/_inc/build/static.html', window.staticHtml );
 		fs.writeFile( __dirname + '/_inc/build/static-noscript-notice.html', window.noscriptNotice );
 		fs.writeFile( __dirname + '/_inc/build/static-version-notice.html', window.versionNotice );
+		fs.writeFile( __dirname + '/_inc/build/static-ie-notice.html', window.ieNotice );
 
 		if ( done ) {
 			done();
 		}
+
 	} );
 }
 


### PR DESCRIPTION
Fixes #4112.

#### Changes proposed in this Pull Request:
- Adds a new redirection header inside a conditional comment that will make older IE versions redirect to the fallback page.
- Adds a notice on the fallback page for older IE versions.

#### Testing instructions:
- Get a device that has Internet Explorer on it.
- Make IE work in IE9 mode.
- Visit the Jetpack settings page, you should be redirected to the fallback page with `page=jetpack_modules` in the URL.
- You should also see a notice saying that your browser is not supported.

#### Problems with this PR:
- ~~The issue that this PR aims to fix says that we need a fallback view for all old IE versions including IE10. But IE10 does not support conditional comments, on which this PR is based. We can probably let IE10 handle the React page - it works pretty well based on my cursory glance.~~ IE10 is now handled similarly to previous IE versions. No React for you, IE!

#### Awesome preview
![img_20160803_174641980](https://cloud.githubusercontent.com/assets/374293/17369933/51d73870-59ab-11e6-8da5-14442be4802c.jpg)
