### PR TITLE
Add: Notice to Jetpack Page when the regular sync lag is more then 24 hours.

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -286,7 +286,7 @@ class Jetpack_Debugger {
 					?>
 					<div class="formbox">
 						<label for="message" class="h"><?php esc_html_e( 'Please describe the problem you are having.', 'jetpack' ); ?></label>
-						<textarea name="message" cols="40" rows="7" id="did"></textarea>
+						<textarea name="message" cols="40" rows="7" id="did"><?php echo ( isset( $_GET['note'] ) ? esc_textarea( $_GET['note'] ) : '' ); ?></textarea>
 					</div>
 
 					<div id="name_div" class="formbox">
@@ -314,7 +314,7 @@ class Jetpack_Debugger {
 
 					<div id="blog_div" class="formbox">
 						<div id="submit_div" class="contact-support">
-						<input type="submit" name="submit" value="<?php esc_html_e( 'Submit &#187;', 'jetpack' ); ?>">
+						<input type="submit" name="submit" class="button button-primary button-large" value="<?php esc_html_e( 'Submit &#187;', 'jetpack' ); ?>">
 						</div>
 					</div>
 					<div style="clear: both;"></div>
@@ -376,13 +376,11 @@ class Jetpack_Debugger {
 
 			form#contactme {
 				border: 1px solid #dfdfdf;
-				background: #eaf3fa;
+				background: #FFF;
 				padding: 20px;
 				margin: 10px;
-				background-color: #eaf3fa;
-				border-radius: 5px;
+				background-color: #F3F6F8;
 				font-size: 15px;
-				font-family: "Open Sans", "Helvetica Neue", sans-serif;
 			}
 
 			form#contactme label.h {
@@ -399,7 +397,6 @@ class Jetpack_Debugger {
 
 			.formbox input[type="text"], .formbox input[type="email"], .formbox input[type="url"], .formbox textarea, #debug_info_div {
 				border: 1px solid #e5e5e5;
-				border-radius: 11px;
 				box-shadow: inset 0 1px 1px rgba(0,0,0,0.1);
 				color: #666;
 				font-size: 14px;
@@ -411,25 +408,6 @@ class Jetpack_Debugger {
 				margin-top: 16px;
 				background: #FFF;
 				padding: 16px;
-			}
-			.formbox .contact-support input[type="submit"] {
-				float: right;
-				margin: 0 !important;
-				border-radius: 20px !important;
-				cursor: pointer;
-				font-size: 13pt !important;
-				height: auto !important;
-				margin: 0 0 2em 10px !important;
-				padding: 8px 16px !important;
-				background-color: #ddd;
-				border: 1px solid rgba(0,0,0,0.05);
-				border-top-color: rgba(255,255,255,0.1);
-				border-bottom-color: rgba(0,0,0,0.15);
-				color: #333;
-				font-weight: 400;
-				display: inline-block;
-				text-align: center;
-				text-decoration: none;
 			}
 
 			.formbox span.errormsg {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -518,6 +518,8 @@ class Jetpack {
 
 		add_action( 'jetpack_notices', array( $this, 'show_development_mode_notice' ) );
 
+		add_action( 'jetpack_notices', array( $this, 'show_sync_lag_notice' ) );
+
 		/**
 		 * These actions run checks to load additional files.
 		 * They check for external files or plugins, so they need to run as late as possible.
@@ -1316,6 +1318,20 @@ class Jetpack {
 			$notice = sprintf( __( 'You are running Jetpack on a <a href="%s" target="_blank">staging server</a>.', 'jetpack' ), 'https://jetpack.com/support/staging-sites/' );
 
 			echo '<div class="updated" style="border-color: #f0821e;"><p>' . $notice . '</p></div>';
+		}
+	}
+
+	public static function show_sync_lag_notice() {
+		if ( ! class_exists( 'Jetpack_Sync_Queue' ) ) {
+			require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-queue.php';
+		}
+
+		if ( Jetpack::is_active() &&
+		     ! Jetpack::is_staging_site() &&
+		     Jetpack_Sync_Queue::get_lag( 'sync' )  > DAY_IN_SECONDS * 1000000 ) { // Display notice if the lag is large then 24 hours.
+			$contact_url = admin_url( "admin.php?page=jetpack-debugger&contact=1&note=Jetpack is not able to talk to WordPress.com." );
+			$notice = sprintf( __( 'Oh no, Jetpack is not able to communicate properly with WordPress.com. Please check your error logs for errors or <a href="%s">contact support</a>.', 'jetpack' ), $contact_url );
+			echo '<div class="error" style="border-color: #dc3232;"><p>' . $notice . '</p></div>';
 		}
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1330,7 +1330,10 @@ class Jetpack {
 		     ! Jetpack::is_staging_site() &&
 		     Jetpack_Sync_Queue::get_lag( 'sync' )  > DAY_IN_SECONDS * 1000000 ) { // Display notice if the lag is large then 24 hours.
 			$contact_url = admin_url( "admin.php?page=jetpack-debugger&contact=1&note=Jetpack is not able to talk to WordPress.com." );
-			$notice = sprintf( __( 'Oh no, Jetpack is not able to communicate with WordPress.com. Please check your error logs for errors or <a href="%s">contact support</a>.', 'jetpack' ), $contact_url );
+			$notice = sprintf(
+				__( 'Oh no! Jetpack is unable to communicate with WordPress.com. This affects a number of features you may be using. Please check your server logs for errors and <a href="%s">contact Jetpack support</a>.', 'jetpack' ),
+				esc_url( $contact_url )
+			);
 			echo '<div class="error" style="border-color: #dc3232;"><p>' . $notice . '</p></div>';
 		}
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1330,7 +1330,7 @@ class Jetpack {
 		     ! Jetpack::is_staging_site() &&
 		     Jetpack_Sync_Queue::get_lag( 'sync' )  > DAY_IN_SECONDS * 1000000 ) { // Display notice if the lag is large then 24 hours.
 			$contact_url = admin_url( "admin.php?page=jetpack-debugger&contact=1&note=Jetpack is not able to talk to WordPress.com." );
-			$notice = sprintf( __( 'Oh no, Jetpack is not able to communicate properly with WordPress.com. Please check your error logs for errors or <a href="%s">contact support</a>.', 'jetpack' ), $contact_url );
+			$notice = sprintf( __( 'Oh no, Jetpack is not able to communicate with WordPress.com. Please check your error logs for errors or <a href="%s">contact support</a>.', 'jetpack' ), $contact_url );
 			echo '<div class="error" style="border-color: #dc3232;"><p>' . $notice . '</p></div>';
 		}
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1322,13 +1322,15 @@ class Jetpack {
 	}
 
 	public static function show_sync_lag_notice() {
-		if ( ! class_exists( 'Jetpack_Sync_Queue' ) ) {
-			require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-queue.php';
+		if ( ! Jetpack::is_active() && Jetpack::is_staging_site() && Jetpack::is_development_mode() ) {
+			return;
 		}
 
-		if ( Jetpack::is_active() &&
-		     ! Jetpack::is_staging_site() &&
-		     Jetpack_Sync_Queue::get_lag( 'sync' )  > DAY_IN_SECONDS * 1000000 ) { // Display notice if the lag is large then 24 hours.
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-listener.php';
+		$listener = Jetpack_Sync_Listener::get_instance();
+		$queue = $listener->get_sync_queue();
+
+		if ( ! $listener->can_add_to_queue( $queue ) ) { // Display notice if the lag is large then 24 hours.
 			$contact_url = admin_url( "admin.php?page=jetpack-debugger&contact=1&note=Jetpack is not able to talk to WordPress.com." );
 			$notice = sprintf(
 				__( 'Oh no! Jetpack is unable to communicate with WordPress.com. This affects a number of features you may be using. Please check your server logs for errors and <a href="%s">contact Jetpack support</a>.', 'jetpack' ),

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -91,11 +91,15 @@ class Jetpack_Sync_Queue {
 	// lag is the difference in time between the age of the oldest item
 	// (aka first or frontmost item) and the current time
 	function lag() {
+		return self::get_lag( $this->id );
+	}
+
+	static function get_lag( $id ) {
 		global $wpdb;
 
 		$first_item_name = $wpdb->get_var( $wpdb->prepare(
 			"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT 1",
-			"jpsq_{$this->id}-%"
+			"jpsq_{$id}-%"
 		) );
 
 		if ( ! $first_item_name ) {
@@ -104,7 +108,7 @@ class Jetpack_Sync_Queue {
 
 		// break apart the item name to get the timestamp
 		$matches = null;
-		if ( preg_match( '/^jpsq_' . $this->id . '-(\d+\.\d+)-/', $first_item_name, $matches ) ) {
+		if ( preg_match( '/^jpsq_' . $id . '-(\d+\.\d+)-/', $first_item_name, $matches ) ) {
 			return microtime( true ) - floatval( $matches[1] );
 		} else {
 			return 0;


### PR DESCRIPTION
Adds a notice to sites that have a lag that is larger then 24 hours. 

Since a lag of more then 24 hours indicated that something is probably
wrong with the Jetpack site.

![screen shot 2016-08-03 at 11 31 40](https://cloud.githubusercontent.com/assets/115071/17377274/e73bd9c2-596d-11e6-8d33-f06419d8f697.png)


The link will take you to this page. Already expanded to show the contact form.
![screen shot 2016-08-03 at 11 21 44](https://cloud.githubusercontent.com/assets/115071/17377104/412f2e9e-596d-11e6-8574-7ba07945eee7.png)


This PR is only for Jetpack 4.2 Since Jetpack master implements notices a bit differently ( I am guessing )
