### PR TITLE
Add sync config to full sync start action

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -55,7 +55,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 *
 		 * @since 4.2.0
 		 */
-		do_action( 'jetpack_full_sync_start' );
+		do_action( 'jetpack_full_sync_start', $modules );
 		$this->update_status_option( 'started', time() );
 
 		// configure modules

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -32,7 +32,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 		$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key NOT LIKE '\_%'" );
 	}
 
-	function full_sync_start() {
+	function full_sync_start( $config ) {
 		$this->reset();
 	}
 

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -15,7 +15,7 @@ interface iJetpack_Sync_Replicastore {
 	public function reset();
 
 	// trigger setup for sync start/end
-	public function full_sync_start();
+	public function full_sync_start( $config );
 
 	public function full_sync_end( $checksum );
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -136,7 +136,8 @@ class Jetpack_Sync_Server_Replicator {
 
 			// full sync
 			case 'jetpack_full_sync_start':
-				$this->store->full_sync_start();
+				list( $config ) = $args;
+				$this->store->full_sync_start( $config );
 				break;
 
 			case 'jetpack_full_sync_end':

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -43,7 +43,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		$this->users           = array();
 	}
 
-	function full_sync_start() {
+	function full_sync_start( $config ) {
 		$this->reset();
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -8,6 +8,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	private $full_sync;
 
 	private $full_sync_end_checksum;
+	private $full_sync_start_config;
 
 	function setUp() {
 		parent::setUp();
@@ -511,6 +512,21 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $updates->last_checked > strtotime( "-10 seconds" ) );
 	}
 
+	function test_full_sync_start_sends_configuration() {
+		// this is so that on WPCOM we can tell what has been synchronized in the past
+		add_action( 'jetpack_full_sync_start', array( $this, 'record_full_sync_start_config' ), 10, 1 );
+
+		$this->full_sync->start();
+
+		$this->assertEquals( null, $this->full_sync_start_config );
+
+		$custom_config = array( 'posts' => array( 1, 2, 3, ) );
+
+		$this->full_sync->start( $custom_config );
+
+		$this->assertEquals( $custom_config, $this->full_sync_start_config );
+	}
+
 	function test_full_sync_end_sends_checksums() {
 		add_action( 'jetpack_full_sync_end', array( $this, 'record_full_sync_end_checksum' ), 10, 1 );
 
@@ -526,6 +542,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function record_full_sync_end_checksum( $checksum ) {
 		$this->full_sync_end_checksum = $checksum;
+	}
+
+	function record_full_sync_start_config( $modules ) {
+		$this->full_sync_start_config = $modules;
 	}
 
 	function create_dummy_data_and_empty_the_queue() {


### PR DESCRIPTION
This allows us to record what is _supposed_ to have been synced on WPCOM, so that in future if we detect config changes that require a full sync, we can decide to initiate one.