### PR TITLE
Remove options from sync checksum

### DIFF
--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -573,8 +573,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	public function checksum_all() {
 		return array(
 			'posts'    => $this->posts_checksum(),
-			'comments' => $this->comments_checksum(),
-			'options'  => $this->options_checksum(),
+			'comments' => $this->comments_checksum()
 		);
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -489,8 +489,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	function checksum_all() {
 		return array(
 			'posts'    => $this->posts_checksum(),
-			'comments' => $this->comments_checksum(),
-			'options'  => $this->options_checksum(),
+			'comments' => $this->comments_checksum()
 		);
 	}
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -67,8 +67,6 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$second_post    = self::$factory->post( 10 );
 		$comment        = self::$factory->comment( 3, $post->ID );
 		$second_comment = self::$factory->comment( 6, $second_post->ID );
-		$option_name    = 'blogdescription';
-		$option_value   = rand();
 
 		// create an instance of each type of replicastore
 		$all_replicastores = array();
@@ -88,17 +86,10 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 			$replicastore->upsert_post( $second_post );
 			$replicastore->upsert_comment( $comment );
 			$replicastore->upsert_comment( $second_comment );
-			$replicastore->update_option( $option_name, $option_value );
 		}
-
-		// just check the option we updated in the replicastores
-		$default_options_whitelist_original               = Jetpack_Sync_Defaults::$default_options_whitelist;
-		Jetpack_Sync_Defaults::$default_options_whitelist = array( 'blogdescription' );
 
 		// ensure the checksums are the same
 		$checksums = array_map( array( $this, 'get_all_checksums' ), $all_replicastores );
-		// set the class property back to the original value;
-		Jetpack_Sync_Defaults::$default_options_whitelist = $default_options_whitelist_original;
 
 		// for helpful debug output in case they don't match
 		$labelled_checksums = array_combine( array_map( 'get_class', $all_replicastores ), $checksums );


### PR DESCRIPTION
Fixes an issue where options checksums were not reliable enough due to differing whitelists between jetpack and wpcom.