### PR TITLE
Admin - Modules: fix issues with Settings button

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -53,6 +53,7 @@ export const EngagementModulesSettings = React.createClass( {
 				return ( <VerificationToolsSettings module={ module } { ...this.props } /> );
 			case 'notifications':
 			case 'enhanced-distribution':
+			case 'sitemaps':
 				return <span>{ __( 'This module has no configuration options' ) } </span>;
 			case 'publicize':
 			default:
@@ -80,7 +81,7 @@ export const SecurityModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<a href={ module.configure_url }>{ __( 'Settings' ) }</a>
+						<Button compact href={ module.configure_url }>{ __( 'Settings' ) }</Button>
 					</div>
 				);
 		}
@@ -107,7 +108,7 @@ export const AppearanceModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<a href={ module.configure_url }>{ __( 'Settings' ) }</a>
+						<Button compact href={ module.configure_url }>{ __( 'Settings' ) }</Button>
 					</div>
 				);
 		}
@@ -134,7 +135,7 @@ export const WritingModulesSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<a href={ module.configure_url }>{ __( 'Settings' ) }</a>
+						<Button compact href={ module.configure_url }>{ __( 'Settings' ) }</Button>
 					</div>
 				);
 		}


### PR DESCRIPTION
Fixes #4652

#### Changes proposed in this Pull Request:
- fixes issue where Settings is showing a link instead of button in some modules
- fixes Settings showing in Sitemaps but it has no settings.

#### Testing instructions:
go to Jetpack admin

 Settings > Appearance, expand Extra Sidebar Widgets: Settings should be a button
 Settings > Engagement, expand Sitemaps: there should not be a button