### PR TITLE
Admin Page: Remove non-functional setting from Sharedaddy settings

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -43,8 +43,6 @@ export const EngagementModulesSettings = React.createClass( {
 				return ( <CommentsSettings module={ module } { ...this.props } /> );
 			case 'subscriptions':
 				return ( <SubscriptionsSettings module={ module } { ...this.props } /> );
-			case 'sharedaddy':
-				return ( <SharedaddySettings module={ module } { ...this.props } /> );
 			case 'gravatar-hovercards':
 				return ( <GravatarHovercardsSettings module={ module } { ...this.props } /> );
 			case 'likes':
@@ -55,6 +53,7 @@ export const EngagementModulesSettings = React.createClass( {
 			case 'enhanced-distribution':
 				return <span>{ __( 'This module has no configuration options' ) } </span>;
 			case 'publicize':
+			case 'sharedaddy':
 			default:
 				return (
 					<div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Removes a rogue checkbox which was present on **Sharing** settings. 

#### Testing instructions:

1. Get to the settings for **Sharing** under the **Engagement** tab. 
2. Check that you only see the **Settings** button and the "Learn more" icon/link

![image](https://cloud.githubusercontent.com/assets/746152/17406523/1c22cef8-5a3a-11e6-8997-39ca91bf665c.png)
