### PR TITLE
Fix issue where is_scheduled_full_sync didn’t return the right values…

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -148,18 +148,17 @@ class Jetpack_Sync_Actions {
 	static function is_scheduled_full_sync( $modules = null ) {
 		if ( is_null( $modules ) ) {
 			$crons = _get_cron_array();
-			if ( empty( $crons ) ) {
-				return false;
-			}
-			$result = array();
+			
 			foreach ( $crons as $timestamp => $cron ) {
 				if ( ! empty( $cron['jetpack_sync_full'] ) ) {
-					$result[ $timestamp ] = $cron['jetpack_sync_full'];
+					return true;
 				}
 			}
-			return $result;
+
+			return false;
 		}
-		return wp_next_scheduled( 'jetpack_sync_full', $modules );
+
+		return wp_next_scheduled( 'jetpack_sync_full', array( $modules ) );
 	}
 
 	static function do_full_sync( $modules = null ) {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -138,7 +138,12 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_is_scheduled_full_sync_works_with_different_args() {
+		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync() );
+
 		Jetpack_Sync_Actions::schedule_full_sync( array( 'posts' => true ) );
+
 		$this->assertTrue( (bool) Jetpack_Sync_Actions::is_scheduled_full_sync() );
+		$this->assertTrue( (bool) Jetpack_Sync_Actions::is_scheduled_full_sync( array( 'posts' => true ) ) );
+		$this->assertFalse( (bool) Jetpack_Sync_Actions::is_scheduled_full_sync( array( 'comments' => true ) ) );
 	}
 }


### PR DESCRIPTION
Fixes a couple of bugs introduced in #4625.

When you checked if a full sync was scheduled:

- if no sync was scheduled and no modules passed, it would return an empty array instead of fals
- if a sync was scheduled and no modules passed, it would return the actual scheduling data instead of true
- if a sync was scheduled with module configs and you tried to check against a supplied module config, it would fail because wp_next_scheduled expects an array of arguments.

cc @lezama 