### PR TITLE
Admin - Plans: change Akismet link to go to Calypso auto-config when site has a Plan but Akismet is not installed or activated

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -17,7 +17,7 @@ import JetpackConnect from 'components/jetpack-connect';
 import JumpStart from 'components/jumpstart';
 import { getJumpStartStatus } from 'state/jumpstart';
 import { getSiteConnectionStatus } from 'state/connection';
-import { setInitialState } from 'state/initial-state';
+import { setInitialState, getSiteRawUrl, getSiteAdminUrl } from 'state/initial-state';
 import AtAGlance from 'at-a-glance/index.jsx';
 import Engagement from 'engagement/index.jsx';
 import Security from 'security/index.jsx';
@@ -71,7 +71,7 @@ const Main = React.createClass( {
 				pageComponent = <Apps { ...this.props } />;
 				break;
 			case '/professional':
-				pageComponent = <Plans { ...this.props } />;
+				pageComponent = <Plans siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } { ...this.props } />;
 				break;
 			case '/settings':
 				navComponent = <NavigationSettings { ...this.props } />;
@@ -135,7 +135,9 @@ const Main = React.createClass( {
 export default connect(
 	state => {
 		return assign( {}, state, {
-			getJumpStartStatus: getJumpStartStatus( state )
+			getJumpStartStatus: getJumpStartStatus( state ),
+			siteRawUrl: getSiteRawUrl( state ),
+			siteAdminUrl: getSiteAdminUrl( state )
 		} );
 	},
 	dispatch => bindActionCreators( { setInitialState }, dispatch )

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -30,15 +30,14 @@ export const Plans = React.createClass( {
 			// do nothing
 		} else {
 			// Plan is jetpack_free, jetpack_premium, jetpack_premium_monthly, jetpack_business, jetpack_business_monthly
-			sitePlan = this.props.getSitePlan();
-			sitePlan = sitePlan.product_slug;
+			sitePlan = this.props.getSitePlan().product_slug;
 		}
 		return (
 			<div>
 				<QuerySite />
 				<div className="jp-landing__plans dops-card">
 					<PlanHeader plan={ sitePlan } />
-					<PlanBody plan={ sitePlan } />
+					<PlanBody plan={ sitePlan } siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />
 				</div>
 			</div>
 		);

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import Button from 'components/button';
 import { translate as __ } from 'i18n-calypso';
 
@@ -9,6 +10,13 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import { imagePath } from 'constants';
+import {
+	fetchPluginsData,
+	isFetchingPluginsData,
+	isPluginActive,
+	isPluginInstalled
+} from 'state/site/plugins';
+import QuerySitePlugins from 'components/data/query-site-plugins';
 
 const PlanBody = React.createClass( {
 	render() {
@@ -25,10 +33,10 @@ const PlanBody = React.createClass( {
 							<h3 className="jp-landing__plan-features-title">{ __( 'Need more?' ) }</h3>
 							<p>{ __( 'Jetpack Professional offers more features.' ) }</p>
 							<p>
-								<Button href={ 'https://wordpress.com/plans/compare/' + window.Initial_State.rawUrl }>
+								<Button href={ 'https://wordpress.com/plans/compare/' + this.props.siteRawUrl }>
 									{ __( 'Compare Plans' ) }
 								</Button>
-								<Button href={ 'https://wordpress.com/plans/' + window.Initial_State.rawUrl } className="is-primary">
+								<Button href={ 'https://wordpress.com/plans/' + this.props.siteRawUrl } className="is-primary">
 									{ __( 'Upgrade to Professional' ) }
 								</Button>
 							</p>
@@ -40,9 +48,20 @@ const PlanBody = React.createClass( {
 						<div className="jp-landing__plan-features-card">
 							<h3 className="jp-landing__plan-features-title">{ __( 'Jetpack Anti-spam' ) }</h3>
 							<p>{ __( 'Bulletproof spam filtering help maintain peace of mind while you build and grow your site.' ) }</p>
-							<Button href={ window.Initial_State.adminUrl + 'admin.php?page=akismet-key-config' } className="is-primary">
-								{ __( 'View your spam stats' ) }
-							</Button>
+							{
+								this.props.isFetchingPluginsData ? '' :
+									this.props.isPluginInstalled( 'akismet/akismet.php' )
+									&& this.props.isPluginActive( 'akismet/akismet.php' ) ? (
+										<Button href={ this.props.siteAdminUrl + 'admin.php?page=akismet-key-config' } className="is-primary">
+											{ __( 'View your spam stats' ) }
+										</Button>
+									)
+									: (
+										<Button href={ 'https://wordpress.com/plugins/setup/' + this.props.siteRawUrl } className="is-primary">
+											{ __( 'Configure Akismet' ) }
+										</Button>
+									)
+							}
 						</div>
 
 						<div className="jp-landing__plan-features-card">
@@ -100,10 +119,24 @@ const PlanBody = React.createClass( {
 		}
 		return (
 			<div>
+				<QuerySitePlugins />
 				{ planCard	}
 			</div>
 		);
 	}
 } );
 
-export default PlanBody;
+export default connect(
+	( state ) => {
+		return {
+			isFetchingPluginsData: isFetchingPluginsData( state ),
+			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
+			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
+		};
+	},
+	( dispatch ) => {
+		return {
+			fetchPluginsData: () => dispatch( fetchPluginsData() )
+		};
+	}
+)( PlanBody );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -20,10 +20,17 @@ export const initialState = ( state = window.Initial_State, action ) => {
 };
 
 export function getSiteRoles( state ) {
-	const roles = get( state.jetpack.initialState.stats, 'roles', {} );
-	return roles;
+	return get( state.jetpack.initialState.stats, 'roles', {} );
 }
 
 export function getAdminEmailAddress( state ) {
 	return get( state.jetpack.initialState, [ 'userData', 'currentUser', 'wpcomUser', 'email' ] );
+}
+
+export function getSiteRawUrl( state ) {
+	return get( state.jetpack.initialState, 'rawUrl', {} );
+}
+
+export function getSiteAdminUrl( state ) {
+	return get( state.jetpack.initialState, 'adminUrl', {} );
 }


### PR DESCRIPTION
Fixes #4539

#### Changes proposed in this Pull Request:
- check if Akismet is installed or active and if it's not, change the button "View your spam stats" into "Configure Akismet" pointing to Calypso auto config.

#### Testing instructions:
- disable Akismet and go to Jetpac admin > Dashboard > Professional
