### PR TITLE
Sync: Add silent/importing flag when syncing content during import

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -1,4 +1,5 @@
 <?php
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -20,6 +21,9 @@ class Jetpack_Sync_Actions {
 		
 		// When imports are finished, schedule a full sync
 		add_action( 'import_end', array( __CLASS__, 'schedule_full_sync' ) );
+
+		// When importing via cron, do not sync
+		add_action( 'wp_cron_importer_hook', array( __CLASS__, 'set_is_importing_true' ), 1 );
 
 		// Sync connected user role changes to .com
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
@@ -101,6 +105,10 @@ class Jetpack_Sync_Actions {
 	static function sync_allowed() {
 		return ( Jetpack::is_active() && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
 			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
+	}
+
+	static function set_is_importing_true() {
+		Jetpack_Sync_Settings::set_importing( true );
 	}
 
 	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id ) {

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -110,10 +110,6 @@ class Jetpack_Sync_Listener {
 	}
 
 	function enqueue_action( $current_filter, $args, $queue, $override_import = false ) {
-		if ( Jetpack_Sync_Settings::is_importing() && ! $override_import ) {
-			return;
-		}
-
 		/**
 		 * Modify or reject the data within an action before it is enqueued locally.
 		 *
@@ -145,6 +141,7 @@ class Jetpack_Sync_Listener {
 			$args,
 			get_current_user_id(),
 			microtime( true ),
+			Jetpack_Sync_Settings::is_importing()
 		) );
 	}
 

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -101,7 +101,7 @@ class Jetpack_Sync_Listener {
 
 	function full_sync_action_handler() {
 		$args = func_get_args();
-		$this->enqueue_action( current_filter(), $args, $this->full_sync_queue, true );
+		$this->enqueue_action( current_filter(), $args, $this->full_sync_queue );
 	}
 
 	function action_handler() {
@@ -109,7 +109,7 @@ class Jetpack_Sync_Listener {
 		$this->enqueue_action( current_filter(), $args, $this->sync_queue );
 	}
 
-	function enqueue_action( $current_filter, $args, $queue, $override_import = false ) {
+	function enqueue_action( $current_filter, $args, $queue ) {
 		/**
 		 * Modify or reject the data within an action before it is enqueued locally.
 		 *

--- a/sync/class.jetpack-sync-server.php
+++ b/sync/class.jetpack-sync-server.php
@@ -72,7 +72,7 @@ class Jetpack_Sync_Server {
 		do_action( 'jetpack_sync_remote_actions', $events, $token );
 
 		foreach ( $events as $key => $event ) {
-			list( $action_name, $args, $user_id, $timestamp ) = $event;
+			list( $action_name, $args, $user_id, $timestamp, $silent ) = $event;
 
 			/**
 			 * Fires when an action is received from a remote Jetpack site
@@ -82,12 +82,13 @@ class Jetpack_Sync_Server {
 			 * @param string $action_name The name of the action executed on the remote site
 			 * @param array $args The arguments passed to the action
 			 * @param int $user_id The external_user_id who did the action
+			 * @param bool $silent Whether the item was created via import
 			 * @param double $timestamp Timestamp (in seconds) when the action occurred
 			 * @param double $sent_timestamp Timestamp (in seconds) when the action was transmitted
 			 * @param string $queue_id ID of the queue from which the event was sent (sync or full_sync)
 			 * @param array $token The auth token used to invoke the API
 			 */
-			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $timestamp, $sent_timestamp, $queue_id, $token );
+			do_action( 'jetpack_sync_remote_action', $action_name, $args, $user_id, $silent, $timestamp, $sent_timestamp, $queue_id, $token );
 
 			$events_processed[] = $key;
 

--- a/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -8,14 +8,15 @@ class Jetpack_Sync_Server_Eventstore {
 	private $action_name = null;
 
 	function init() {
-		add_action( 'jetpack_sync_remote_action', array( $this, 'handle_remote_action' ), 10, 7 );
+		add_action( 'jetpack_sync_remote_action', array( $this, 'handle_remote_action' ), 10, 8 );
 	}
 
-	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $sent_timestamp, $queue_id ) {
+	function handle_remote_action( $action_name, $args, $user_id, $silent, $timestamp, $sent_timestamp, $queue_id ) {
 		$this->events[] = (object) array(
 			'action'         => $action_name,
 			'args'           => $args,
 			'user_id'        => $user_id,
+			'silent'         => $silent,
 			'timestamp'      => $timestamp,
 			'sent_timestamp' => $sent_timestamp,
 			'queue'          => $queue_id,

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -12,16 +12,16 @@ class Jetpack_Sync_Server_Replicator {
 	}
 
 	function init() {
-		add_action( 'jetpack_sync_remote_action', array( $this, 'handle_remote_action' ), 5, 7 );
+		add_action( 'jetpack_sync_remote_action', array( $this, 'handle_remote_action' ), 5, 8 );
 	}
 
-	function handle_remote_action( $action_name, $args, $user_id, $timestamp, $sent_timestamp, $queue_id, $token ) {
+	function handle_remote_action( $action_name, $args, $user_id, $silent, $timestamp, $sent_timestamp, $queue_id, $token ) {
 
 		switch ( $action_name ) {
 			// posts
 			case 'wp_insert_post':
 				list( $post_id, $post ) = $args;
-				$this->store->upsert_post( $post );
+				$this->store->upsert_post( $post, $silent );
 				break;
 			case 'deleted_post':
 				list( $post_id ) = $args;
@@ -31,18 +31,18 @@ class Jetpack_Sync_Server_Replicator {
 			// attachments
 			case 'attachment_updated':
 				list( $post_id, $post, $post_before ) = $args;
-				$this->store->upsert_post( $post );
+				$this->store->upsert_post( $post, $silent );
 				break;
 			case 'jetpack_sync_save_add_attachment':
 				list( $attachment_id, $attachment ) = $args;
-				$this->store->upsert_post( $attachment );
+				$this->store->upsert_post( $attachment, $silent );
 				break;
 
 			// comments
 			case 'wp_insert_comment':
 			case ( preg_match( '/^comment_[^_]*_[^_]*$/', $action_name ) ? true : false ):
 				list( $comment_id, $comment ) = $args;
-				$this->store->upsert_comment( $comment );
+				$this->store->upsert_comment( $comment, $silent );
 				break;
 			case 'deleted_comment':
 				list( $comment_id ) = $args;

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -827,7 +827,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_full_sync_status_with_a_small_queue() {
 
-		$this->sender->set_dequeue_max_bytes( 700 ); // process 0.0007MB of items at a time
+		$this->sender->set_dequeue_max_bytes( 750 ); // process 0.00075MB of items at a time
 
 		$this->create_dummy_data_and_empty_the_queue();
 

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -77,32 +77,14 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
 	}
 
-	function test_doesnt_enqueue_incremental_actions_while_importing() {
+	function test_does_set_silent_flag_true_while_importing() {
 		Jetpack_Sync_Settings::set_importing( true );
 
-		$post_id = $this->factory->post->create();
+		$this->factory->post->create();
 
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
-
-		$this->assertFalse( $event );
-	}
-
-	function test_does_enqueue_full_sync_actions_while_importing() {
-		// since full sync actions are "silent" on the other end, we can (and should) allow
-		// them to be enqueued
-
-		Jetpack_Sync_Settings::set_importing( true );
-
-		$post_id = $this->factory->post->create();
-
-		Jetpack_Sync_Modules::get_module( 'posts' )->enqueue_full_sync_actions( true );
-
-		$this->sender->do_sync();
-
-		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
-		$this->assertTrue( is_object ( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' ) ) );
-		
+		$this->assertObjectHasAttribute( 'silent', $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
+		$this->assertTrue( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->silent );
 	}
 }


### PR DESCRIPTION
If you import from a Tumblr blog while Jetpack and sync is enabled, you could end up sending out unexpected subscription emails and notifications for all of your posts.

We'd previously [solved this issue for the regular WP importer](https://github.com/Automattic/jetpack/pull/4617), but Tumblr uses cron to do importing, so the `WP_IMPORTING` constant doesn't seem to be set since the user has not loaded the importer page in the process that is importing.

This PR solves the issue for the Tumblr importer, and should fix the issue for any other importers that use the `WP_Importer_Cron` class.

To test:

- Checkout `update/sync-set-is-importing-cron-importer` 
- Subscribe to your blog with a test email
- In dashboard, go to `Tools > Import` and do a Tumblr import
- Ensure you don't get email subscriptions

I still haven't worked out how to start a full sync after the cron job is done. @gravityrail suggested that instead of not sending items that are added during import, we could instead add something like an `{ imported: true }` flag and then handle that on the WPCOM side. Which should be more performant.