### PR TITLE
Manage: Support directing to the plugins/setup page after activation

### DIFF
--- a/modules/manage/confirm-admin.php
+++ b/modules/manage/confirm-admin.php
@@ -42,6 +42,11 @@ switch( $section ) {
 		$link_title = __( 'Manage Your Site', 'jetpack' );
 		break;
 }
+
+if ( isset( $_GET['return_url'] ) && isset( $_GET['return_title'] ) ) {
+	$link = $_GET['return_url'];
+	$link_title = $_GET['return_title'];
+}
 ?>
 <div class="page-content landing manage-page">
 	<div class="manage__icon">

--- a/modules/manage/confirm-admin.php
+++ b/modules/manage/confirm-admin.php
@@ -22,6 +22,11 @@ switch( $section ) {
 		$link_title = __( 'Manage Your Plugins', 'jetpack' );
 		break;
 
+	case 'plugins-setup':
+		$link = 'https://wordpress.com/plugins/setup/' . $normalized_site_url;
+		$link_title = __( 'Back to Plan Setup', 'jetpack' );
+		break;
+
 	case 'themes':
 		$link = 'https://wordpress.com/design/' . $normalized_site_url;
 		$link_title = __( 'Manage Your Themes', 'jetpack' );
@@ -41,11 +46,6 @@ switch( $section ) {
 		$link = 'https://wordpress.com/stats/day/' . $normalized_site_url;
 		$link_title = __( 'Manage Your Site', 'jetpack' );
 		break;
-}
-
-if ( isset( $_GET['return_url'] ) && isset( $_GET['return_title'] ) ) {
-	$link = $_GET['return_url'];
-	$link_title = $_GET['return_title'];
 }
 ?>
 <div class="page-content landing manage-page">


### PR DESCRIPTION
#### Background

Related issue: https://github.com/Automattic/wp-calypso/issues/6006
Related PR: https://github.com/Automattic/wp-calypso/pull/7297

#### Changes proposed in this Pull Request:
In the Manage module, add a new possible value for the `section` parameter: `plugins-setup`. This will be used to direct the user back to where they come from (the Plan Setup page in WordPress.com) after the user has enabled Jetpack Manage. 

#### Preview

The updated link (**"Back to Plan Setup"**) that leads back to the plan setup process after activating Jetpack Manage:
![](https://cldup.com/cnPiE62qIS.png)

#### Testing instructions:
* Perform the testing instructions from this PR: https://github.com/Automattic/wp-calypso/pull/7297
* Click on the **"Enable Jetpack Manage Now"** button
* After Jetpack Manage is activated, verify that the link at the bottom says **"Back to Plan Setup"**
* Click the **"Back to Plan Setup"** link, and verify it leads you back to the plan setup page, continuing the setup of the plan.