### PR TITLE
Sync: Make Sync endpoints available when Manage is off

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -4,6 +4,10 @@
 class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
+	protected function validate_call( $_blog_id, $capability, $check_manage_active = true ) {
+		parent::validate_call( $_blog_id, $capability, false );
+	}
+
 	protected function result() {
 		$args = $this->input();
 
@@ -35,7 +39,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 }
 
 // GET /sites/%s/sync/status
-class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
+class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
@@ -61,7 +65,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Endpoint {
 }
 
 // GET /sites/%s/data-check
-class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
+class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
@@ -99,7 +103,7 @@ class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Endpoint {
 }
 
 // GET /sites/%s/data-histogram
-class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Endpoint {
+class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
@@ -145,7 +149,7 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Endpoint
 }
 
 // POST /sites/%s/sync/settings
-class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Endpoint {
+class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {
@@ -172,7 +176,7 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_En
 }
 
 // GET /sites/%s/sync/settings
-class Jetpack_JSON_API_Sync_Get_Settings_Endpoint extends Jetpack_JSON_API_Endpoint {
+class Jetpack_JSON_API_Sync_Get_Settings_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function result() {

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -40,8 +40,6 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 // GET /sites/%s/sync/status
 class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
-	protected $needed_capabilities = 'manage_options';
-
 	protected function result() {
 		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-modules.php';
 		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
@@ -66,8 +64,6 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 
 // GET /sites/%s/data-check
 class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
-	protected $needed_capabilities = 'manage_options';
-
 	protected function result() {
 		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
 
@@ -104,8 +100,6 @@ class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 
 // GET /sites/%s/data-histogram
 class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
-	protected $needed_capabilities = 'manage_options';
-
 	protected function result() {
 		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
 
@@ -150,8 +144,6 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 
 // POST /sites/%s/sync/settings
 class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
-	protected $needed_capabilities = 'manage_options';
-
 	protected function result() {
 		$args = $this->input();
 
@@ -177,8 +169,6 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sy
 
 // GET /sites/%s/sync/settings
 class Jetpack_JSON_API_Sync_Get_Settings_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
-	protected $needed_capabilities = 'manage_options';
-
 	protected function result() {
 		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-settings.php';
 


### PR DESCRIPTION
How to test:

* Turn off manage module
* POST to `sites/%site%/sync/`
* Check that a Full Sync is actually scheduled