### PR TITLE
Make the test runner parse as ES6 the dops-component module

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build-client": "gulp",
     "build-production": "npm run build-languages && NODE_ENV=production npm run build",
     "build-languages": "gulp languages",
-    "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client tests/runner.js"
+    "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js"
   },
   "devDependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-require( 'babel-core/register' );
+require( 'babel-core/register' )( {
+	ignore: /\/node_modules\/(?!(@automattic|dops-components)\/)/
+} );
 
 const program = require( 'commander' ),
 	Mocha = require( 'mocha' ),

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 require( 'babel-core/register' )( {
-	ignore: /\/node_modules\/(?!(@automattic|dops-components)\/)/
+	ignore: /\/node_modules\/(?!@automattic\/dops-components\/)/
 } );
 
 const program = require( 'commander' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Makes the test runner parse as ES6 the dops-component module by adding the dops-components directory to NODE_PATH and making `babel-core/register` not ignore it for parsing ES^

#### Testing instructions:
1. Checkout to  the `add/global-notices` branch for cherry picking this commit
1. `git cherry-pick 36fdaf1906f5d39ab850676aa83c8cf9d0e5e05f` 
1.  Run `npm run test-client`.
1. Tests should pass
1. remove that commit from the `add/global-notices` branch (`git reset HEAD~1`)
