### PR TITLE
Add placeholder on the Admin Page until if finishes rendering

### DIFF
--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -21,6 +21,7 @@
 	background-color: $gray-light;
 	line-height: 1.4; // fixes core bug that sets an em unit on body
 	height: auto;
+	min-height: 100%;
 }
 
 // Hello Dolly positioning overwrite
@@ -65,4 +66,17 @@
 
 @keyframes pulse-light {
 	50% { background-color: lighten( $gray, 30% ); }
+}
+
+.jp-admin-page--placeholder {
+	font-size: 12vw;
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	-webkit-transform: translate(-50%, -50%);
+	transform: translate(-50%, -50%);
+}
+
+.jp-admin-page--placeholder img {
+	height: 50px;
 }

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -137,7 +137,11 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			/** This action is already documented in views/admin/admin-page.php */
 			do_action( 'jetpack_notices' );
 		?>
-		<div id="jp-plugin-container"></div>
+		<div id="jp-plugin-container">
+			<div class="jp-admin-page--placeholder">
+				<img src="<?php echo plugins_url( '', JETPACK__PLUGIN_FILE ) . '/images/jetpack-logo.svg' ?>"/>
+			</div>
+		</div>
 	<?php }
 
 	function get_i18n_data() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Adds a new div inside the #jp-plugin-container container with an svg image of the jetpack logo inside. 

## TODO

* [ ] Make the image color be  `#c8d7e1` (@light-gray)
* [ ] Make the background be full height somehow.

Currently looking like:

![backlogo](https://cloud.githubusercontent.com/assets/746152/17444659/8cd7e93e-5b17-11e6-888b-74886c13e25b.gif)

#### Testing instructions:
-
