### PR TITLE
Sync post type features constant

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -139,6 +139,7 @@ class Jetpack_Sync_Defaults {
 		'is_version_controlled'            => array( 'Jetpack_Sync_Functions', 'is_version_controlled' ),
 		'taxonomies'                       => array( 'Jetpack_Sync_Functions', 'get_taxonomies' ),
 		'post_types'                       => array( 'Jetpack_Sync_Functions', 'get_post_types' ),
+		'post_type_features'               => array( 'Jetpack_Sync_Functions', 'get_post_type_features' ),
 		'rest_api_allowed_post_types'      => array( 'Jetpack_Sync_Functions', 'rest_api_allowed_post_types' ),
 		'rest_api_allowed_public_metadata' => array( 'Jetpack_Sync_Functions', 'rest_api_allowed_public_metadata' ),
 		'sso_is_two_step_required'         => array( 'Jetpack_SSO_Helpers', 'is_two_step_required' ),

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -24,6 +24,12 @@ class Jetpack_Sync_Functions {
 		return $wp_post_types;
 	}
 
+	public static function get_post_type_features() {
+		global $_wp_post_type_features;
+
+		return $_wp_post_type_features;
+	}
+
 	public static function rest_api_allowed_post_types() {
 		/** This filter is already documented in class.json-api-endpoints.php */
 		return apply_filters( 'rest_api_allowed_post_types', array( 'post', 'page', 'revision' ) );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -61,6 +61,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'is_version_controlled'            => Jetpack_Sync_Functions::is_version_controlled(),
 			'taxonomies'                       => Jetpack_Sync_Functions::get_taxonomies(),
 			'post_types'                       => Jetpack_Sync_Functions::get_post_types(),
+			'post_type_features'               => Jetpack_Sync_Functions::get_post_type_features(),
 			'rest_api_allowed_post_types'      => Jetpack_Sync_Functions::rest_api_allowed_post_types(),
 			'rest_api_allowed_public_metadata' => Jetpack_Sync_Functions::rest_api_allowed_public_metadata(),
 			'sso_is_two_step_required'         => Jetpack_SSO_Helpers::is_two_step_required(),


### PR DESCRIPTION
In order to know whether a post should be publicised on WPCOM, we must check if `post_type_supports( $post_type, 'publicize' );`. This information is actually stored in the `$_wp_post_type_features` global, which we weren't syncing. This PR syncs that global.