### PR TITLE
Don’t include spam comments in checksum

### DIFF
--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -269,7 +269,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 
 	public function comments_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->comments, Jetpack_Sync_Defaults::$default_comment_checksum_columns, 'comment_ID', '1=1', $min_id, $max_id );
+		return $this->table_checksum( $wpdb->comments, Jetpack_Sync_Defaults::$default_comment_checksum_columns, 'comment_ID', "comment_approved <> 'spam'", $min_id, $max_id );
 	}
 
 	public function options_checksum() {

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -121,7 +121,11 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	}
 
 	function comments_checksum( $min_id = null, $max_id = null ) {
-		return $this->calculate_checksum( $this->comments, 'comment_ID', $min_id, $max_id, Jetpack_Sync_Defaults::$default_comment_checksum_columns );
+		return $this->calculate_checksum( array_filter( $this->comments, array( $this, 'is_not_spam' ) ), 'comment_ID', $min_id, $max_id, Jetpack_Sync_Defaults::$default_comment_checksum_columns );
+	}
+
+	function is_not_spam( $comment ) {
+		return $comment->comment_approved !== 'spam';
 	}
 
 	function filter_comment_status( $comment ) {

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -430,7 +430,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 */
 	function test_replica_update_option( $store ) {
 		$option_name  = 'blogdescription';
-		$option_value = rand();
+		$option_value = (string) rand();
 		$store->update_option( $option_name, $option_value );
 		$replica_option_value = $store->get_option( $option_name );
 
@@ -443,7 +443,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	 */
 	function test_replica_delete_option( $store ) {
 		$option_name  = 'test_replicastore_' . rand();
-		$option_value = rand();
+		$option_value = (string) rand();
 		$store->update_option( $option_name, $option_value );
 		$store->delete_option( $option_name );
 		$replica_option_value = $store->get_option( $option_name );

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -150,6 +150,26 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		$this->assertEquals( $store->comments_checksum( 6, 10 ), $histogram['6'] );
 	}
 
+	/**
+	 * @dataProvider store_provider
+	 * @requires PHP 5.3
+	 */
+	function test_does_not_checksum_spam_comments( $store ) {
+		$comment        = self::$factory->comment( 3, 1 );
+		$spam_comment = self::$factory->comment( 6, 1, array( 'comment_approved' => 'spam' ) );
+		$trash_comment = self::$factory->comment( 9, 1, array( 'comment_approved' => 'trash' )  );
+
+		$store->upsert_comment( $comment );
+		$store->upsert_comment( $trash_comment );
+
+		$checksum = $store->comments_checksum();
+
+		// add a spam comment and assert that checksum didn't change
+		$store->upsert_comment( $spam_comment );
+
+		$this->assertEquals( $checksum, $store->comments_checksum() );
+	}
+
 
 	/**
 	 * Histograms


### PR DESCRIPTION
Spam comments are bulky and not generally useful, so we sometimes flush them from WPCOM.

This change excludes spam comments from the checksum so that this doesn't affect our full sync validity checking.