### PR TITLE
Update documentation for sync-related filters

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -37,7 +37,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ) );
-		add_filter( 'jetpack_sync_before_send_wp_login', array( $this, 'expand_login_username' ), 10, 2 );
+		add_filter( 'jetpack_sync_before_send_wp_login', array( $this, 'expand_login_username' ), 10, 1 );
 		add_filter( 'jetpack_sync_before_send_wp_logout', array( $this, 'expand_logout_username' ), 10, 2 );
 
 		// full sync

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -134,6 +134,7 @@ class Jetpack_Sync_Sender {
 			 * @since 4.2.0
 			 *
 			 * @param array The action parameters
+			 * @param int The ID of the user who triggered the action
 			 */
 			$item[1] = apply_filters( 'jetpack_sync_before_send_' . $item[0], $item[1], $item[2] );
 
@@ -156,6 +157,9 @@ class Jetpack_Sync_Sender {
 		 * @since 4.2.0
 		 *
 		 * @param array $data The action buffer
+		 * @param string $codec The codec name used to encode the data
+		 * @param double $time The current time
+		 * @param string $queue The queue used to send ('sync' or 'full_sync')
 		 */
 		$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id );
 


### PR DESCRIPTION
Some filters had outdated documentation. This adds missing docs for newly added params.

cc @ebinnion 