### PR TITLE
Pro Features: Point to https://wordpress.com/plugins/setup/your-site.com to set up pro plugins

### DIFF
--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -71,7 +71,7 @@ const DashItem = React.createClass( {
 				status = <Button
 					compact={ true }
 					primary={ true }
-					href={ 'https://wordpress.com/plugins/' + this.props.module + '/' + window.Initial_State.rawUrl }
+					href={ 'https://wordpress.com/plugins/setup/' + window.Initial_State.rawUrl }
 				>
 					{ __( 'Install' ) }
 				</Button>;
@@ -80,7 +80,7 @@ const DashItem = React.createClass( {
 				status = <Button
 					compact={ true }
 					primary={ true }
-					href={ 'https://wordpress.com/plugins/' + this.props.module + '/' + window.Initial_State.rawUrl }
+					href={ 'https://wordpress.com/plugins/setup/' + window.Initial_State.rawUrl }
 				>
 					{ __( 'Activate' ) }
 				</Button>;

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -119,7 +119,7 @@ export const Page = ( props ) => {
 						<Button
 							compact={ true }
 							primary={ true }
-							href={ 'https://wordpress.com/plugins/' + pluginSlug + '/' + window.Initial_State.rawUrl }
+							href={ 'https://wordpress.com/plugins/setup/' + window.Initial_State.rawUrl }
 						>
 							{ ! installed ? __( 'Install' ) : __( 'Activate' ) }
 						</Button>


### PR DESCRIPTION
Fixes #4538

When the site is on a plan, but the pro plugin is not installed, update the links to point to `wp.com/setup` rather than `wp.com/plugins/slug`, which provides a much better experience.  

To Test: 
- On a site that has a plan, uninstall/deactivate any or all of the Pro plugins.  
- Click on the CTA in the dashboard.  It should redirect you to /setup and the plugins should be installed/activated. 
- Repeat for the CTA's in the settings/security Pro cards.  