### PR TITLE
Jetpack Start URL

### DIFF
--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -10,6 +10,7 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import ConnectButton from 'components/connect-button';
+import { getConnectUrl as _getConnectUrl } from 'state/connection';
 import { imagePath } from 'constants';
 
 const JetpackConnect = React.createClass( {
@@ -28,7 +29,7 @@ const JetpackConnect = React.createClass( {
 					</p>
 					<ConnectButton />
 					<p>
-						<a href="https://wordpress.com/start/jetpack/" className="jp-jetpack-connect__link">
+						<a href={ this.props.connectUrl( this.props ) } className="jp-jetpack-connect__link">
 							{ __( 'No WordPress.com account? Create one for free.' ) }
 						</a>
 					</p>
@@ -222,6 +223,8 @@ const JetpackConnect = React.createClass( {
 
 export default connect(
 	state => {
-		return state;
+		return {
+			connectUrl: () => _getConnectUrl( state )
+		}
 	}
 )( JetpackConnect );


### PR DESCRIPTION
<img width="807" alt="screen shot 2016-08-05 at 3 25 58 pm" src="https://cloud.githubusercontent.com/assets/2694219/17448181/fbb36e56-5b20-11e6-81ca-198d70aade3e.png">

The "No WordPress.com account..." button is currently linking to wordpress.com/start/jetpack, which is no longer in use. This PR replaces that link with the standard `connectUrl`.

To test:
- Disconnect your site
- Click on "No WordPress.com account..." button
- Ensure you are sent through the standard connection flow

cc: @dereksmart @oskosk 