### PR TITLE
General: Fix failed login logging for Jetpack XML-RPC auth

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -746,13 +746,7 @@ class Jetpack {
 		// Don't let anyone authenticate
 		$_COOKIE = array();
 		remove_all_filters( 'authenticate' );
-
-		/**
-		 * For the moment, remove Limit Login Attempts if its xmlrpc for Jetpack.
-		 * If Limit Login Attempts is installed as a mu-plugin, it can occasionally
-		 * generate false-positives.
-		 */
-		remove_filter( 'wp_login_failed', 'limit_login_failed' );
+		remove_all_actions( 'wp_login_failed' );
 
 		if ( Jetpack::is_active() ) {
 			// Allow Jetpack authentication


### PR DESCRIPTION
In 2740068-t, a user reported that the [Sucuri Scanner](https://wordpress.org/plugins/sucuri-scanner/) plugin was reporting failed logins that came from our IPs. After adding some debugging code, I was able to narrow down the issue to here:

https://github.com/Automattic/jetpack/blob/d8541615ac1c89fe20d1d8145d6b57d0ed74107a/class.jetpack-xmlrpc-server.php#L206-L227

Previously, we fixed a similar issue with Limit Login Attempts here:

https://github.com/Automattic/jetpack/commit/5eeb3113776ef80ac9b9f33a398c6484c89197d5

This PR suggests that we remove all `wp_login_failed` hooks, instead of just the one for Limit Login Attempts. An alternative here would be to just remove Sucuri's hook, but that feels a bit like playing Whack-a-mole since we'll surely run into similar issues in the future.

But, is that a good idea?

By the time we've hit `Jetpack_XMLRPC_Server::login()` we've already determined that the user is specifically making a Jetpack XML-RPC request. And because of that, we prevent any other authentication by removing all `authenticate` filters in `Jetpack::require_jetpack_authentication()`. So, if we've made that decision, I don't think it's far off to decide to remove all `wp_login_failed` hooks either. 

Further, by the time we have called `wp_authenticate()`, we have already verified the XML-RPC signature. When we authenticate the user, we're simply deciding which methods to expose. Because of that, I think it also makes sense to remove the `wp_login_failed` action.

To test existence of bug:

- Install/activate Sucuri Scanner plugin
- Ensure failed logins logging is on
- Log out of WP.com
- Go to API console: https://developer.wordpress.com/docs/api/console/
- Make a request to `/sites/$site/posts`
- Verify that failed login is logged

To test bug fix:

- Checkout `update/xmlrpc-jetpack-failed-login` branch
- Go to API console: https://developer.wordpress.com/docs/api/console/
- Make a request to `/sites/$site/posts`
- Verify that nothing is logged