### PR TITLE
SSO: Allow SSO during identity crisis

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -411,21 +411,13 @@ class Jetpack_SSO {
 				$this->handle_login();
 				$this->display_sso_login_form();
 			} else {
-				if ( Jetpack::check_identity_crisis() ) {
-					JetpackTracking::record_user_event( 'sso_login_redirect_failed', array(
-						'error_message' => 'identity_crisis'
-					) );
-					wp_die( __( "Error: This site's Jetpack connection is currently experiencing problems.", 'jetpack' ) );
-				} else {
-					$this->maybe_save_cookie_redirect();
-					// Is it wiser to just use wp_redirect than do this runaround to wp_safe_redirect?
-					add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
-					$reauth = ! empty( $_GET['force_reauth'] );
-					$sso_url = $this->get_sso_url_or_die( $reauth );
-					JetpackTracking::record_user_event( 'sso_login_redirect_success' );
-					wp_safe_redirect( $sso_url );
-					exit;
-				}
+				$this->maybe_save_cookie_redirect();
+				add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+				$reauth = ! empty( $_GET['force_reauth'] );
+				$sso_url = $this->get_sso_url_or_die( $reauth );
+				JetpackTracking::record_user_event( 'sso_login_redirect_success' );
+				wp_safe_redirect( $sso_url );
+				exit;
 			}
 		}
 	}


### PR DESCRIPTION
Occasionally I run into an issue where I can't log in to my site with SSO. And since I remove the default login form, this is especially irritating because then I can't get into my site without opening up SFTP and allowing the default login form. 😱 

I'm not 100% sure why we don't allow SSO during an identity crisis. After removing the check, it seems like we are still able to set an SSO nonce and then retrieve the WP.com profile.

To test:

- Checkout `update/sso-work-with-idc` branch
- Ensure you are able to SSO during an identity crisis
- I was lucky enough to have an active IDC. 😄 

cc @samhotchkiss in case this can go in earlier than 4.4
cc @lezama for code review