### PR TITLE
Admin: removes _k hash from address bar

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -4,8 +4,9 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { Route, Router, hashHistory } from 'react-router';
+import { Route, Router, useRouterHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
+import { createHashHistory } from 'history'
 
 /**
  * Internal dependencies
@@ -33,6 +34,8 @@ if ( 'undefined' !== typeof Initial_State.locale[ '' ] ) {
 }
 
 i18n.setLocale( Initial_State.locale );
+
+const hashHistory = useRouterHistory( createHashHistory )( { queryKey: false } );
 
 const history = syncHistoryWithStore( hashHistory, store );
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "gulp-sftp": "^0.1.5",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.6",
+    "history": "2.0.0",
     "i18n-calypso": "github:automattic/i18n-calypso",
     "jsdom": "^9.2.1",
     "jshint": "2.9.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- removes `_k` hash in address bar

#### Testing instructions:
- do `npm run distclean` and `npm run build`
- go to Jetpack admin. You shouldn't see a hash in the url (if you're reloading a URL that had a hash remove it first).


