### PR TITLE
Don’t send save user action if user is empty

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -65,7 +65,11 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function expand_user( $args ) {
 		list( $user ) = $args;
 
-		return array( $this->add_to_user( $user ) );
+		if ( $user ) {
+			return array( $this->add_to_user( $user ) );	
+		}
+
+		return false;
 	}
 
 	public function expand_login_username( $args ) {

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -123,7 +123,7 @@ class Jetpack_Sync_Sender {
 		require_once(ABSPATH . 'wp-admin/includes/screen.php');
 		set_current_screen( 'sync' );
 
-		$skipped_items_ids = [];
+		$skipped_items_ids = array();
 
 		// we estimate the total encoded size as we go by encoding each item individually
 		// this is expensive, but the only way to really know :/

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -123,6 +123,8 @@ class Jetpack_Sync_Sender {
 		require_once(ABSPATH . 'wp-admin/includes/screen.php');
 		set_current_screen( 'sync' );
 
+		$skipped_items_ids = [];
+
 		// we estimate the total encoded size as we go by encoding each item individually
 		// this is expensive, but the only way to really know :/
 		foreach ( $items as $key => $item ) {
@@ -137,6 +139,11 @@ class Jetpack_Sync_Sender {
 			 * @param int The ID of the user who triggered the action
 			 */
 			$item[1] = apply_filters( 'jetpack_sync_before_send_' . $item[0], $item[1], $item[2] );
+
+			if ( $item[1] === false ) {
+				$skipped_items_ids[] = $key;
+				continue;
+			}
 
 			$encoded_item = $this->codec->encode( $item );
 
@@ -189,6 +196,11 @@ class Jetpack_Sync_Sender {
 			}
 
 			$processed_items = array_intersect_key( $items, array_flip( $processed_item_ids ) );
+
+			// also checkin any items that were skipped
+			if ( count( $skipped_items_ids ) > 0 ) {
+				$processed_item_ids = $processed_item_ids + $skipped_items_ids;				
+			}
 
 			/**
 			 * Allows us to keep track of all the actions that have been sent.

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -337,8 +337,6 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
 
-		error_log(print_r( $event, 1));
-
 		$this->assertFalse( $event );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -328,6 +328,20 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( isset( $user_data_sent_to_server->data->user_pass ) );
 	}
 
+	public function test_deleted_user_during_sync_doesnt_cause_error() {
+		$this->server_event_storage->reset();
+
+		do_action( 'jetpack_sync_save_user', null );
+
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_user' );
+
+		error_log(print_r( $event, 1));
+
+		$this->assertFalse( $event );
+	}
+
 	public function test_maybe_demote_master_user_method() {
 		// set up
 		$current_master_id = $this->factory->user->create( array( 'user_login' => 'current_master' ) );


### PR DESCRIPTION
Sometimes when processing the `jetpack_sync_save_user` action, we get an error because the user is empty.

This PR silently abandons those actions, and any actions that return `false` instead of an arg array, allowing any actions to be permanently skipped at the last minute.