### PR TITLE
Admin Page: Remove references to calypso in webpack config file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,8 +43,7 @@ var webpackConfig = {
 					path.join( __dirname, 'test' ),
 					path.join( __dirname, '_inc/client' ),
 					fs.realpathSync( path.join( __dirname, './node_modules/@automattic/dops-components/client' ) ),
-					path.join( __dirname, './node_modules/@automattic/dops-components/client' ),
-					path.resolve( __dirname, 'node_modules', 'wp-calypso', 'client' )
+					path.join( __dirname, './node_modules/@automattic/dops-components/client' )
 				]
 			},
 			{
@@ -72,8 +71,7 @@ var webpackConfig = {
 		},
 		root: [
 			path.resolve( __dirname, '_inc/client' ),
-			fs.realpathSync( path.join(__dirname, 'node_modules/@automattic/dops-components/client') ),
-			path.resolve( __dirname, 'node_modules', 'wp-calypso', 'client' )
+			fs.realpathSync( path.join(__dirname, 'node_modules/@automattic/dops-components/client') )
 		]
 	},
 	resolveLoader: {


### PR DESCRIPTION
Fixes #4672 

#### Changes proposed in this Pull Request:

1. Removes references to `wp-calypso` in webpack's `modules.loaders.include` config key

#### Testing instructions:
1. Take a look at webpack.config.js and check no reference to calypso is present
2. Run `npm run build` and check that nothing failes
