### PR TITLE
Reduce travis tests to reduce run time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,60 +22,33 @@ env:
 
 matrix:
   include:
-  - php: hhvm
-    env: WP_VERSION=master
-    sudo: required
-    dist: trusty
-    group: edge
-    addons:
-      apt:
-        packages:
-        - mysql-server-5.6
-        - mysql-client-core-5.6
-        - mysql-client-5.6
-  - php: "nightly"
-    env: WP_VERSION=master
   - php: "5.6"
-    env: WP_VERSION=4.5 WP_TRAVISCI="gulp travis:js"
-  - php: "5.6"
-    env: WP_VERSION=4.5 WP_TRAVISCI="npm run test-client"
+    env: WP_TRAVISCI="npm run test-client"
   - php: "5.2"
-    env: WP_VERSION=master
   - php: "5.3"
-    env: WP_VERSION=master WP_TRAVISCI="phpunit --group=uninstall --testsuite=uninstall"
-  - php: "5.2"
-    env: WP_VERSION=4.4
-  - php: "5.2"
-    env: WP_VERSION=4.5
-  - php: "5.3"
-    env: WP_VERSION=4.5
-  - php: "5.4"
-    env: WP_VERSION=4.5
   - php: "5.5"
-    env: WP_VERSION=master
-  - php: "5.5"
-    env: WP_VERSION=4.4
-  - php: "5.5"
-    env: WP_VERSION=4.5
   - php: "5.6"
-    env: WP_VERSION=master
-  - php: "5.6"
-    env: WP_VERSION=4.4
-  - php: "5.6"
-    env: WP_VERSION=4.5
   - php: "7.0"
-    env: WP_VERSION=master
-  - php: "5.3"
-    env: WP_VERSION=4.4 WP_MULTISITE=1 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
-  - php: "5.3"
-    env: WP_VERSION=4.5 WP_MULTISITE=1 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
-  - php: "5.3"
-    env: WP_VERSION=master WP_MULTISITE=1 WP_TRAVISCI="phpunit -c tests/php.multisite.xml"
+#
+#  - php: hhvm
+#    env: WP_VERSION=master
+#    sudo: required
+#    dist: trusty
+#    group: edge
+#    addons:
+#      apt:
+#        packages:
+#        - mysql-server-5.6
+#        - mysql-client-core-5.6
+#        - mysql-client-5.6
 
-
-  allow_failures:
-  - php: "hhvm"
-  - php: "nightly"
+#
+# Allow failure tests did not prove that useful, but we might bring them back
+# so leaving this here as a reminder
+#
+#  allow_failures:
+#  - php: "hhvm"
+#  - php: "nightly"
 
 # whitelist branches for the "push" build check.
 branches:
@@ -86,23 +59,13 @@ branches:
 
 # Clones WordPress and configures our testing environment.
 before_script:
+    - phpenv config-rm xdebug.ini
+    - source ~/.nvm/nvm.sh && nvm install 5
     - export PLUGIN_SLUG=$(basename $(pwd))
-    - git clone --depth=1 --branch $WP_VERSION git://develop.git.wordpress.org/ /tmp/wordpress
-# - git clone . "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-    - cd ..
-    - mv $PLUGIN_SLUG "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-    - cd /tmp/wordpress
-    - git checkout $WP_VERSION
-    - mysql -u root -e "CREATE DATABASE wordpress_tests;"
-    - cp wp-tests-config-sample.php wp-tests-config.php
-    - sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-    - sed -i "s/yourusernamehere/root/" wp-tests-config.php
-    - sed -i "s/yourpasswordhere//" wp-tests-config.php
-    - cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-    - ./tests/load-travis.sh
+    - ./tests/prepare-wordpress.sh
 
 script:
-    - $WP_TRAVISCI
+    - ./tests/run-travis.sh
 
 sudo: false
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -54,8 +54,6 @@
 		</testsuite>
 		<testsuite name="sync">
 			<directory prefix="test_" suffix=".php">tests/php/sync</directory>
-			<exclude>tests/php/sync/test_interface.jetpack-sync-replicastore.php</exclude>
-			<file phpVersion="5.3.0" phpVersionOperator=">=">tests/php/sync/test_interface.jetpack-sync-replicastore.php</file>
 		</testsuite>
 		<testsuite name="uninstall">
 			<directory prefix="test_" suffix=".php">tests/php/uninstall</directory>

--- a/tests/get-wp-version.php
+++ b/tests/get-wp-version.php
@@ -1,0 +1,54 @@
+<?php
+
+$ch = curl_init();
+curl_setopt( $ch, CURLOPT_URL, 'https://api.wordpress.org/core/version-check/1.7/' );
+
+// Set so curl_exec returns the result instead of outputting it.
+curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+
+// Get the response and close the channel.
+$response = curl_exec( $ch );
+curl_close( $ch );
+
+$versions = json_decode( $response );
+$versions = $versions->offers;
+
+// Sorting available WordPress offers by version number
+function offer_version_sort( $first, $second ) {
+	return version_compare( $first->version, $second->version, '<' );
+}
+
+uasort( $versions, 'offer_version_sort' );
+
+$version_stack = array();
+
+foreach( $versions as $offer ) {
+	list( $major, $minor ) = explode( '.',  $offer->version );
+
+	$base = $major . '.' . $minor;
+
+	if (
+		! isset( $version_stack[ $base ] )
+		|| version_compare( $offer->version, $version_stack[ $base ] ) ) {
+
+		// There is no version like this yet or there is a newer patch to this major version
+		$version_stack[ $base ] = $offer->version;
+	}
+
+	if ( count( $version_stack ) === 2 ) {
+		break;
+	}
+}
+
+$wp_versions = array_values( $version_stack );
+
+if ( empty( $argv[1] ) ) {
+	print $wp_versions[0] . "\n";
+} else if ( '--previous' === $argv[1] ) {
+	print $wp_versions[1] . "\n";
+} else {
+	die(
+		"Unknown argument: " . $argv[1] . "\n"
+		. "Use with no arguments to get the latest stable WordPress version, or use `--previous' to get the previous stable major release.\n"
+	);
+}

--- a/tests/load-travis.sh
+++ b/tests/load-travis.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [ "$WP_TRAVISCI" != "phpunit" ]; then
-	gem install sass
-	gem install compass
-	npm install -g npm
-	npm install -g gulp-cli
-	npm install
-fi

--- a/tests/php.multisite.xml
+++ b/tests/php.multisite.xml
@@ -55,8 +55,6 @@
         </testsuite>
         <testsuite name="sync">
             <directory prefix="test_" suffix=".php">php/sync</directory>
-            <exclude>php/sync/test_interface.jetpack-sync-replicastore.php</exclude>
-            <file phpVersion="5.3.0" phpVersionOperator=">=">php/sync/test_interface.jetpack-sync-replicastore.php</file>
         </testsuite>
         <testsuite name="uninstall">
             <directory prefix="test_" suffix=".php">php/uninstall</directory>

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -766,6 +766,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_can_sync_individual_comments() {
+		if ( version_compare( phpversion(), '5.3.0', '<' ) ) {
+			$this->markTestSkipped( 'This test fails in PHP 5.2.' );
+		}
+
 		$post_id = $this->factory->post->create();
 		list( $sync_comment_id, $no_sync_comment_id, $sync_comment_id_2 ) = $this->factory->comment->create_post_comments( $post_id, 3 );
 
@@ -906,6 +910,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_status_with_a_small_queue() {
+		if ( version_compare( phpversion(), '5.3.0', '<' ) ) {
+			$this->markTestSkipped( 'This test fails in PHP 5.2.' );
+		}
 
 		$this->sender->set_dequeue_max_bytes( 750 ); // process 0.00075MB of items at a time
 

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -35,6 +35,13 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 	function setUp() {
 		parent::setUp();
 
+		if ( version_compare( phpversion(), '5.3.0', '<' ) ) {
+			$this->markTestSkipped(
+				'PHP 5.2 and below does not support ReflectionProperty to the extent that we need.'
+			);
+			return;
+		}
+
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			switch_to_blog( self::$token->blog_id );
 		}

--- a/tests/prepare-wordpress.sh
+++ b/tests/prepare-wordpress.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# If this is an NPM environment test we don't need a developer WordPress checkout
+
+if [ "$WP_TRAVISCI" != "phpunit" ]; then
+    exit 0;
+fi
+
+# This prepares a developer checkout of WordPress for running the test suite on Travis
+
+mysql -u root -e "CREATE DATABASE wordpress_tests;"
+
+CURRENT_DIR=$(pwd)
+
+for WP_SLUG in 'master' 'latest' 'previous'; do
+    echo "Preparing $WP_SLUG WordPress...";
+
+    cd $CURRENT_DIR/..
+
+    case $WP_SLUG in
+	master)
+	    git clone --depth=1 --branch master git://develop.git.wordpress.org/ /tmp/wordpress-master
+	    ;;
+	latest)
+	    git clone --depth=1 --branch `php ./$PLUGIN_SLUG/tests/get-wp-version.php` git://develop.git.wordpress.org/ /tmp/wordpress-latest
+	    ;;
+	previous)
+	    git clone --depth=1 --branch `php ./$PLUGIN_SLUG/tests/get-wp-version.php --previous` git://develop.git.wordpress.org/ /tmp/wordpress-previous
+	    ;;
+    esac
+
+    cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_SLUG/src/wp-content/plugins/$PLUGIN_SLUG"
+    cd /tmp/wordpress-$WP_SLUG
+
+    cp wp-tests-config-sample.php wp-tests-config.php
+    sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
+    sed -i "s/yourusernamehere/root/" wp-tests-config.php
+    sed -i "s/yourpasswordhere//" wp-tests-config.php
+
+    echo "Done!";
+done
+
+exit 0;

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -28,14 +28,6 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
         exit 1
     fi
 
-    echo "Testing uninstallation suite on WordPress stable..."
-    if $WP_TRAVISCI --group=uninstall --testsuite=uninstall; then
-	# Everything is fine
-	:
-    else
-        exit 1
-    fi
-
     echo "Testing on WordPress stable minus one..."
     cd /tmp/wordpress-previous/src/wp-content/plugins/$PLUGIN_SLUG
     if $WP_TRAVISCI; then

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+if [ "$WP_TRAVISCI" == "phpunit" ]; then
+
+    echo "Testing on WordPress master..."
+    cd /tmp/wordpress-master/src/wp-content/plugins/$PLUGIN_SLUG
+    $WP_TRAVISCI
+
+    if [ $? -ne 0 ]; then
+        exit $?
+    fi
+    
+    echo "Testing on WordPress stable..."
+    cd /tmp/wordpress-latest/src/wp-content/plugins/$PLUGIN_SLUG
+    $WP_TRAVISCI
+
+    if [ $? -ne 0 ]; then
+        exit $?
+    fi
+
+    echo "Testing in Multisite mode on WordPress stable..."
+    WP_MULTISITE=1 $WP_TRAVISCI -c tests/php.multisite.xml
+
+    if [ $? -ne 0 ]; then
+        exit $?
+    fi
+
+    echo "Testing uninstallation suite on WordPress stable..."
+    $WP_TRAVISCI --group=uninstall --testsuite=uninstall
+
+    if [ $? -ne 0 ]; then
+        exit $?
+    fi
+
+    echo "Testing on WordPress stable minus one..."
+    cd /tmp/wordpress-previous/src/wp-content/plugins/$PLUGIN_SLUG
+    $WP_TRAVISCI
+
+    if [ $? -ne 0 ]; then
+        exit $?
+    fi
+else
+
+    gem install sass
+    gem install compass
+    npm install -g npm
+    npm install -g gulp-cli
+    npm install
+
+    $WP_TRAVISCI
+
+    if [ $? -ne 0 ]; then
+        exit $?
+    fi
+fi
+
+exit 0

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -4,40 +4,45 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
     echo "Testing on WordPress master..."
     cd /tmp/wordpress-master/src/wp-content/plugins/$PLUGIN_SLUG
-    $WP_TRAVISCI
-
-    if [ $? -ne 0 ]; then
-        exit $?
+    if $WP_TRAVISCI; then
+	# Everything is fine
+	:
+    else
+        exit 1
     fi
     
     echo "Testing on WordPress stable..."
     cd /tmp/wordpress-latest/src/wp-content/plugins/$PLUGIN_SLUG
-    $WP_TRAVISCI
-
-    if [ $? -ne 0 ]; then
-        exit $?
+    if $WP_TRAVISCI; then
+	# Everything is fine
+	:
+    else
+        exit 1
     fi
 
     echo "Testing in Multisite mode on WordPress stable..."
-    WP_MULTISITE=1 $WP_TRAVISCI -c tests/php.multisite.xml
-
-    if [ $? -ne 0 ]; then
-        exit $?
+    if WP_MULTISITE=1 $WP_TRAVISCI -c tests/php.multisite.xml; then
+	# Everything is fine
+	:
+    else
+        exit 1
     fi
 
     echo "Testing uninstallation suite on WordPress stable..."
-    $WP_TRAVISCI --group=uninstall --testsuite=uninstall
-
-    if [ $? -ne 0 ]; then
-        exit $?
+    if $WP_TRAVISCI --group=uninstall --testsuite=uninstall; then
+	# Everything is fine
+	:
+    else
+        exit 1
     fi
 
     echo "Testing on WordPress stable minus one..."
     cd /tmp/wordpress-previous/src/wp-content/plugins/$PLUGIN_SLUG
-    $WP_TRAVISCI
-
-    if [ $? -ne 0 ]; then
-        exit $?
+    if $WP_TRAVISCI; then
+	# Everything is fine
+	:
+    else
+        exit 1
     fi
 else
 
@@ -47,10 +52,11 @@ else
     npm install -g gulp-cli
     npm install
 
-    $WP_TRAVISCI
-
-    if [ $? -ne 0 ]; then
-        exit $?
+    if $WP_TRAVISCI; then
+	# Everything is fine
+	:
+    else
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- PHP test containers now use three versions of WordPress each instead of there being three different containers.
- PHP test containers now run regular test suite on *master*, *stable* and *stable minus one* versions of WordPress. Stable and stable minus one are determined automatically based on WordPress.org update check API.
- PHP test containers now run multisite test suite on *stable*.
- PHP test containers now run uninstallation test suite on *stable*.
- PHP test containers now only differ by the PHP version they use, which are: *5.2*, *5.3*, *5.5*, *5.6* and *7.0*. Note that there are no *hhvm* and *nightly* anymore because we haven't caught anything with them as far as I know.
- Node test containers do not check out WordPress code anymore, just Jetpack. They do `npm install` and run their tests.
- QUnit tests were nuked because there were only 4 test cases that did not test any code that was in flux. They can still be run manually if needed.

#### Result ####
A build now has 6 jobs that finish in under 10 minutes.