### PR TITLE
Admin - Jumpstart: don't display after skipping, going somewhere and then back

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -53,6 +53,7 @@ function render() {
 			<Provider store={ store }>
 				<Router history={ history }>
 					<Route path='/' name={ i18n.translate( 'At A Glance', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/jumpstart' component={ Main } />
 					<Route path='/dashboard' name={ i18n.translate( 'At A Glance' ) } component={ Main } />
 					<Route path='/apps' name={ i18n.translate( 'Apps', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/professional' name={ i18n.translate( 'Professional', { context: 'Navigation item.' } ) } component={ Main } />

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import assign from 'lodash/assign';
 import includes from 'lodash/includes';
+import { createHistory } from 'history';
 
 /**
  * Internal dependencies
@@ -54,7 +55,12 @@ const Main = React.createClass( {
 		}
 
 		if ( showJumpStart ) {
-			return <JumpStart { ...this.props } />
+			if ( '/' === route ) {
+				const history = createHistory();
+				history.push( '/wp-admin/admin.php?page=jetpack#/jumpstart' );
+			} else if ( '/jumpstart' === route ) {
+				return <JumpStart { ...this.props } />
+			}
 		}
 
 		if ( ! getSiteConnectionStatus( this.props ) ) {

--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -3,6 +3,7 @@
  */
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import { translate as __ } from 'i18n-calypso';
+import { createHistory } from 'history';
 
 /**
  * Internal dependencies
@@ -50,11 +51,14 @@ export const jumpStartActivate = () => {
 	}
 }
 
+const history = createHistory();
+
 export const jumpStartSkip = () => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: JUMPSTART_SKIP
 		} );
+		history.push( '/wp-admin/admin.php?page=jetpack#/dashboard' );
 		return restApi.jumpStart( 'deactivate' ).then( () => {
 			dispatch( {
 				type: JUMPSTART_SKIP_SUCCESS,


### PR DESCRIPTION
Fixes #4637

#### Changes proposed in this Pull Request:
- set Jumpstart as a valid route, and push history state when it's visible
- when user skips Jumpstart and goes to Dashboard, push history state pointing to it

#### Testing instructions:
- disconnect Jetpack
- in wp-cli, do `wp jetpack options delete jumpstart`
- connect, approve
- Jumpstart must be visible. Click skip
- go to Calypso stats or a location in WP Admin
- click browser's back button
Jumpstart should not be visible

