### PR TITLE
Omnisearch: Remove splashes from search query

### DIFF
--- a/modules/omnisearch/omnisearch-core.php
+++ b/modules/omnisearch/omnisearch-core.php
@@ -189,7 +189,7 @@ class Jetpack_Omnisearch {
 			'form_class'         => null,
 			'search_class'       => null,
 			'search_id'          => null,
-			'search_value'       => isset( $_REQUEST['s'] ) ? $_REQUEST['s'] : null,
+			'search_value'       => isset( $_REQUEST['s'] ) ? wp_unslash( $_REQUEST['s'] ) : null,
 			'search_placeholder' => __( 'Search Everything', 'jetpack' ),
 			'submit_class'       => 'button',
 			'submit_value'       => __( 'Search', 'jetpack' ),


### PR DESCRIPTION
Fixes #4628

#### Changes proposed in this Pull Request:
- Unslash the Request before presenting it to the user.  

#### Testing instructions:
- go to example.com/wp-admin/admin.php?page=omnisearch&s=wo%27w+
and see that the value in the search box looks like wo'w. 
