### PR TITLE
Set HTTPS to off when rendering site_url, home_url and network url

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -81,18 +81,27 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function home_url() {
-		return self::preserve_scheme( 'home', home_url(), true );
+		return self::preserve_scheme( 'home', 'home_url', true );
 	}
 
 	public static function site_url() {
-		return self::preserve_scheme( 'siteurl', site_url(), true );
+		return self::preserve_scheme( 'siteurl', 'site_url', true );
 	}
 
 	public static function main_network_site_url() {
-		return self::preserve_scheme( 'siteurl', network_site_url(), false );
+		return self::preserve_scheme( 'siteurl', 'network_site_url', false );
 	}
 
-	public static function preserve_scheme( $option, $url, $normalize_www = false ) {
+	public static function preserve_scheme( $option, $url_function, $normalize_www = false ) {
+		$previous_https_value = isset( $_SERVER['HTTPS'] ) ? $_SERVER['HTTPS'] : null;
+		$_SERVER['HTTPS'] = 'off';
+		$url = call_user_func( $url_function );
+		if ( $previous_https_value ) {
+			$_SERVER['HTTPS'] = $previous_https_value;	
+		} else {
+			unset( $_SERVER['HTTPS'] );
+		}
+
 		$option_url = get_option( $option );
 		if ( $option_url === $url ) {
 			return $url;

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -96,13 +96,13 @@ class Jetpack_Sync_Functions {
 		$previous_https_value = isset( $_SERVER['HTTPS'] ) ? $_SERVER['HTTPS'] : null;
 		$_SERVER['HTTPS'] = 'off';
 		$url = call_user_func( $url_function );
+		$option_url = get_option( $option );
 		if ( $previous_https_value ) {
 			$_SERVER['HTTPS'] = $previous_https_value;	
 		} else {
 			unset( $_SERVER['HTTPS'] );
 		}
 
-		$option_url = get_option( $option );
 		if ( $option_url === $url ) {
 			return $url;
 		}

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -245,6 +245,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $non_https_site_url, Jetpack_Sync_Functions::preserve_scheme( 'siteurl', 'site_url') );
 
 		$this->assertEquals( $_SERVER['HTTPS'], 'on' );
+
+		unset( $_SERVER['HTTPS'] );
 	}
 
 	function test_subdomain_switching_to_www_does_not_cause_sync() {


### PR DESCRIPTION
Fixes an issue where option and function values for site, home and network URL were getting intercepted and modified by plugins depending on the request scheme at the time that sync is triggered.

So, if sync was triggered at the end of a HTTP request, then BOTH `site_url()` and the `siteurl` option would be HTTP, and if it was a HTTPS request they'd both be HTTPS. This made it impossible for us to create a "stable" value that wouldn't keep flipping (causing, amongst other things, headaches like frequent identity crises).

This PR attempts to fix the problem by forcing the `$_SERVER['HTTPS']` value to be `off` just while we invoke the URL generating and option-fetching functions. That way, if the site is "always SSL", it should still render the HTTPS scheme, but if it's ok either way it should write the HTTP scheme.