### PR TITLE
Fix display connection error notices during `try_registration()`

### DIFF
--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -178,15 +178,6 @@ const JetpackStateNotices = React.createClass( {
 				status = 'is-success';
 				break;
 
-			// @todo: These notices should be handled in-app
-			//case 'module_activated' :
-			//case 'module_deactivated' :
-			//case 'module_configured' :
-			//case 'unlinked' : // unlinked user
-			//case 'switch_master' :
-			//	return key;
-
-
 			default:
 				message = key;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3413,8 +3413,8 @@ p {
 				$registered = Jetpack::try_registration();
 				if ( is_wp_error( $registered ) ) {
 					$error = $registered->get_error_code();
-					Jetpack::state( 'error_description', $error );
-					Jetpack::state( 'error_description', $registered->get_error_message() );
+					Jetpack::state( 'error', $error );
+					Jetpack::state( 'error', $registered->get_error_message() );
 					break;
 				}
 


### PR DESCRIPTION
Fixes #4494

This displays the error messages received during `try_registration()`. The state() key was wrong, and updating this allows us to display error notices like this one: 

![screen shot 2016-08-09 at 3 23 06 pm](https://cloud.githubusercontent.com/assets/7129409/17530373/34b77f40-5e45-11e6-902a-7e103a1819ba.png)

**To Test:** 
- Disconnect your site
- Hack [`is_usable_domain()`](https://github.com/Automattic/jetpack/blob/master/class.jetpack-data.php#L51) by adding this as the first line in the function: `return new WP_Error( 'fail_domain_bad_ip_range', sprintf( __( 'Domain `%1$s` just failed is_usable_domain check as its IP `%2$s` is either invalid, or in a reserved or private range.', 'jetpack' ), $domain, '123123' ) );`
- Try to connect
- You should see a dismissable error message