### PR TITLE
Admin: build RTL versions for the main styles and for dops components

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -172,10 +172,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return; // No need for scripts on a fallback page
 		}
 
+		$rtl = is_rtl() ? '.rtl' : '';
+
 		// Enqueue jp.js and localize it
 		wp_enqueue_script( 'react-plugin', plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
-		wp_enqueue_style( 'dops-css', plugins_url( '_inc/build/admin.dops-style.css', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
-		wp_enqueue_style( 'components-css', plugins_url( '_inc/build/style.min.css', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/admin.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 
 		$localeSlug = explode( '_', get_locale() );
 		$localeSlug = $localeSlug[0];

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -127,8 +127,10 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 	// Javascript logic specific to the list table
 	function page_admin_scripts() {
-		wp_enqueue_script( 'jetpack-admin-js', plugins_url( '_inc/jetpack-admin.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION . '-20121111' );
-		wp_enqueue_style( 'dops-css', plugins_url( '_inc/build/static.dops-style.css', JETPACK__PLUGIN_FILE ), array(), time() );
-		wp_enqueue_style( 'components-css', plugins_url( '_inc/build/style.min.css', JETPACK__PLUGIN_FILE ), array(), time() );
+		$rtl = is_rtl() ? '.rtl' : '';
+
+		wp_enqueue_script( 'jetpack-admin-js', plugins_url( '_inc/jetpack-admin.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION );
+		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/static.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 	}
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,6 +53,9 @@ function onBuild( done ) {
 
 		if ( done ) {
 			doStatic( done );
+
+			// After CSS files are built, create RTL versions
+			doRTL();
 		} else {
 			doStatic();
 		}
@@ -84,13 +87,30 @@ function doSass() {
 		} );
 }
 
-gulp.task( 'sass:build', function() {
+function doRTL( files ) {
+	gulp.src( 'main' === files ? './_inc/build/style.min.css' : './_inc/build/*style!(.rtl)*.css' )
+		.pipe( banner( '/* Do not modify this file directly.  It is compiled SASS code. */\n' ) )
+		.pipe( autoprefixer( { browsers: [ 'last 2 versions', 'ie >= 8' ] } ) )
+		.pipe( rtlcss() )
+		.pipe( rename( { suffix: '.rtl' } ) )
+		.pipe( sourcemaps.init() )
+		.pipe( sourcemaps.write( './' ) )
+		.pipe( gulp.dest( './_inc/build' ) )
+		.on( 'end', function() {
+			console.log( 'main' === files ? 'Dashboard RTL CSS finished.' : 'DOPS Components RTL CSS finished.' );
+		} );
+}
+
+function doSassAndRTL() {
 	doSass();
-} );
+	doRTL( 'main' );
+}
+
+gulp.task( 'sass:build', doSassAndRTL );
 
 gulp.task( 'sass:watch', function() {
-	doSass();
-	gulp.watch( [ './**/*.scss' ], doSass );
+	doSassAndRTL();
+	gulp.watch( [ './**/*.scss' ], doSassAndRTL );
 } );
 
 gulp.task( 'react:build', function( done ) {


### PR DESCRIPTION
Fixes #4529

#### Changes proposed in this Pull Request:
- on `npm run build`, build RTL versions for the main Jetpack React stylesheet and DOPS styles
- on `npm run watch`, the RTL version for the main Jetpack style will be also built
- load .rtl version in WP Admin if it's a RTL installation
- in fallback settings page, replace time() with version constant to allow caching

#### Testing instructions:
- use a RTL language in your WP Admin
- do `npm run build`, the Admin should look ok