### PR TITLE
Use separate checksums if running in a cron environment

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -43,8 +43,8 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	}
 
 	public function reset_data() {
-		delete_option( self::CALLABLES_CHECKSUM_OPTION_NAME );
-		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_option( $this->get_checksum_option_name() );
+		delete_transient( $this->get_await_transient_name() );
 	}
 
 	function set_callable_whitelist( $callables ) {
@@ -94,11 +94,11 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	}
 
 	public function unlock_sync_callable() {
-		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_transient( $this->get_await_transient_name() );
 	}
 	
 	public function maybe_sync_callables() {
-		if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
+		if ( get_transient( $this->get_await_transient_name() ) ) {
 			return;
 		}
 
@@ -108,9 +108,9 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 
-		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
+		set_transient( $this->get_await_transient_name(), microtime( true ), Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
 
-		$callable_checksums = (array) get_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
+		$callable_checksums = (array) get_option( $this->get_checksum_option_name(), array() );
 
 		// only send the callables that have changed
 		foreach ( $callables as $name => $value ) {
@@ -131,7 +131,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 				$callable_checksums[ $name ] = $checksum;
 			}
 		}
-		update_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
+		update_option( $this->get_checksum_option_name(), $callable_checksums );
 	}
 
 	public function expand_callables( $args ) {
@@ -140,5 +140,15 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		}
 
 		return $args;
+	}
+
+	private function get_await_transient_name() {
+		$suffix = Jetpack_Sync_Settings::is_doing_cron() ? '_cron' : '';
+		return self::CALLABLES_AWAIT_TRANSIENT_NAME . $suffix;
+	}
+
+	private function get_checksum_option_name() {
+		$suffix = Jetpack_Sync_Settings::is_doing_cron() ? '_cron' : '';
+		return self::CALLABLES_CHECKSUM_OPTION_NAME . $suffix;
 	}
 }

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -16,6 +16,7 @@ class Jetpack_Sync_Settings {
 	);
 
 	static $is_importing;
+	static $is_doing_cron;
 
 	static function get_settings() {
 		$settings = array();
@@ -71,5 +72,17 @@ class Jetpack_Sync_Settings {
 		}
 
 		return defined( 'WP_IMPORTING' ) && WP_IMPORTING;
+	}
+
+	static function set_doing_cron( $is_doing_cron ) {
+		self::$is_doing_cron = $is_doing_cron;
+	}
+
+	static function is_doing_cron() {
+		if ( ! is_null( self::$is_doing_cron ) ) {
+			return self::$is_doing_cron;
+		}
+
+		defined( 'DOING_CRON' ) && DOING_CRON;
 	}
 }


### PR DESCRIPTION
In some environments, things like post types aren't fully loaded. This presents a problem that's hard to solve, in terms of resolving the truth, but ALSO it can result in the same value being synced over and over, as on different requests (particularly cron vs. non-cron) the output of the function can change.

This PR implements separate checksums for cron vs non-cron.