### PR TITLE
Sync: Fix issue where we sync callabled before init is even called

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -243,7 +243,7 @@ class Jetpack_Sync_Actions {
 
 // Allow other plugins to add filters before we initialize the actions.
 // Load the listeners if before modules get loaded so that we can capture version changes etc.
-add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
+add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'schedule_initial_sync' ), 10 );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -56,7 +56,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_sync_initalize_Jetpack_Sync_Action_on_init() {
 		// prioroty should be set to 11 so that Plugins by default (10) initialize the whitelist_filter before.
-		$this->assertEquals( 90, has_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ) ) );
+		$this->assertEquals( 90, has_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ) ) );
 	}
 
 	public function test_sync_default_options() {


### PR DESCRIPTION
Trying to sync callables before init is even called produced a case
where post types might not even be registered. Which in turn doesn't
all allow produce the correct callables list that gets synced.