### PR TITLE
Immediately begin sending data after queuing it

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -149,8 +149,6 @@ class Jetpack_Sync_Actions {
 			wp_schedule_single_event( time() + 1, 'jetpack_sync_full' );
 		}
 
-		wp_schedule_single_event( time() + 2, 'jetpack_sync_cron' );
-
 		spawn_cron();
 	}
 


### PR DESCRIPTION
Often sites don't get their cron triggered often enough. This PR begins sending queued-up full sync actions as soon as they're enqueued, hopefully syncing the entire site within the scope of a single request.