### PR TITLE
Don’t sync snitch post type, it accumulates very rapidly

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -154,7 +154,7 @@ class Jetpack_Sync_Defaults {
 	);
 
 	static $blacklisted_post_types = array(
-		'ai1ec_event'
+		'ai1ec_event', 'snitch'
 	);
 
 	static $default_post_checksum_columns = array(

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -13,6 +13,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'wp_insert_post', $callable, 10, 3 );
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
+		add_filter( "jetpack_sync_before_enqueue_wp_insert_post", array( $this, 'filter_blacklisted_post_types' ) );
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -62,6 +63,15 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	function expand_wp_insert_post( $args ) {
 		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2] );
+	}
+
+	function filter_blacklisted_post_types( $args ) {
+		$post = $args[1];
+		if ( in_array( $post->post_type, Jetpack_Sync_Defaults::$blacklisted_post_types ) ) {
+			return false;
+		}
+
+		return $args;
 	}
 
 	// Expands wp_insert_post to include filtered content

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -361,7 +361,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Options::update_option( 'active_modules', $active_modules );
 	}
 
-
 	function test_sync_post_jetpack_sync_prevent_sending_post_data_filter() {
 
 		add_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
@@ -395,6 +394,20 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$synced_post = $this->server_replica_storage->get_post( $this->post->ID );
 		// no we sync the content and it looks like what we expect to be.
 		$this->assertEquals( $this->post->post_content, $synced_post->post_content );
+	}
+
+	function test_filters_out_blacklisted_post_types() {
+		$args = array(
+			'public' => true,
+			'label'  => 'Snitch'
+		);
+		register_post_type( 'snitch', $args );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'snitch' ) );
+
+		$this->sender->do_sync();
+
+		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 	}
 
 	function assertAttachmentSynced( $attachment_id ) {


### PR DESCRIPTION
Snitch is a plugin that creates a new post for every outbound request.

Jetpack Sync is a feature which creates a new outbound request for every post.

I think you can see where this is going.