### PR TITLE
Sync: Don't call items on do_sync on shutdown

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -82,6 +82,15 @@ class Jetpack_Sync_Sender {
 			$this->set_next_sync_time( time() + $this->get_sync_wait_time() );
 		}
 
+		// This insures that do_sync doesn't get called on shutdown again.
+		if ( has_action( 'shutdown', array( __CLASS__, 'do_sync' ) ) ) {
+			remove_action( 'shutdown', array( __CLASS__, 'do_sync' ) );
+
+			// Remove any action that are attached to _sync_before_send_queue since they should only be called once.
+			remove_action( 'jetpack_sync_before_send_queue_' . $this->full_sync_queue );
+			remove_action( 'jetpack_sync_before_send_queue_' . $this->sync_queue );
+		}
+
 		// we use OR here because if either one returns true then the caller should
 		// be allowed to call do_sync again, as there may be more items
 		return $full_sync_result || $sync_result;

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -83,12 +83,12 @@ class Jetpack_Sync_Sender {
 		}
 
 		// This insures that do_sync doesn't get called on shutdown again.
-		if ( has_action( 'shutdown', array( __CLASS__, 'do_sync' ) ) ) {
-			remove_action( 'shutdown', array( __CLASS__, 'do_sync' ) );
+		if ( has_action( 'shutdown', array( $this, 'do_sync' ) ) ) {
+			remove_action( 'shutdown', array( $this, 'do_sync' ) );
 
-			// Remove any action that are attached to _sync_before_send_queue since they should only be called once.
-			remove_action( 'jetpack_sync_before_send_queue_' . $this->full_sync_queue );
-			remove_action( 'jetpack_sync_before_send_queue_' . $this->sync_queue );
+			// Remove maybe sync callables and constants from being synced more then they should.
+			remove_action( 'jetpack_sync_before_send_queue_' . $this->sync_queue->id, array( Jetpack_Sync_Modules::get_module( 'functions' ), 'maybe_sync_callables' ) );
+			remove_action( 'jetpack_sync_before_send_queue_' . $this->sync_queue->id, array( Jetpack_Sync_Modules::get_module( 'constants' ), 'maybe_sync_constants' ) );
 		}
 
 		// we use OR here because if either one returns true then the caller should

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -311,7 +311,15 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $this->sender->get_next_sync_time() > time() + 9 );	
 	}
 
-	function serverReceiveWithThreeSecondDelay( $data, $codec, $sent_timestamp ) {
+	function test_do_sync_removes_shutdown_action() {
+
+		$this->assertTrue( is_int( has_action( 'shutdown', array( $this->sender, 'do_sync' ) ) ) );
+		$this->sender->do_sync();
+		$this->assertFalse( has_action( 'shutdown', array( $this->sender, 'do_sync' ) ) );
+	}
+
+
+function serverReceiveWithThreeSecondDelay( $data, $codec, $sent_timestamp ) {
 		sleep( 3 );
 		return array_keys( $data );
 	}


### PR DESCRIPTION
Also make sure that `jetpack_sync_before_send_queue_sync` and `jetpack_sync_before_send_queue_full_sync` only gets called once by removing any actions attached.

This make sure that callables and constants only get set once. 

Removing the shutdown function means that we don't do do_sync on cron more then once. 
