### PR TITLE
Implement Calypso Style text inputs

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import Button from 'components/button';
-import InputText from 'components/input-text';
+import TextInput from 'components/text-input';
 import TagsInput from 'components/tags-input';
 
 /**
@@ -556,7 +556,7 @@ export let PostByEmailSettings = React.createClass( {
 				<FormFieldset>
 					<FormLabel>
 						<span> { __( 'Email Address' ) } </span>
-						<InputText
+						<TextInput
 							value={ this.address() }
 							readOnly="readonly" />
 						<Button

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import Button from 'components/button';
+import InputText from 'components/input-text';
 import TagsInput from 'components/tags-input';
 
 /**
@@ -555,7 +556,7 @@ export let PostByEmailSettings = React.createClass( {
 				<FormFieldset>
 					<FormLabel>
 						<span> { __( 'Email Address' ) } </span>
-						<FormTextInput
+						<InputText
 							value={ this.address() }
 							readOnly="readonly" />
 						<Button


### PR DESCRIPTION
Adds Calypso style text inputs. Currently, there is only one implemented for testing here:

![image](https://cloud.githubusercontent.com/assets/1123119/17560401/eed6811e-5eef-11e6-90ab-514726394bb5.png)

Requires switching to `dops-components` branch, `add/input-text`