### PR TITLE
If both queues didn’t send data, wait 5 seconds before sending again

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -95,6 +95,9 @@ class Jetpack_Sync_Sender {
 		} elseif ( $exceeded_sync_wait_threshold ) {
 			// if we actually sent data and it took a while, wait before sending again
 			$this->set_next_sync_time( time() + $this->get_sync_wait_time(), $queue->id );
+		} elseif ( ! ( $full_sync_result || $sync_result ) ) {
+			// wait if both returned false
+			$this->set_next_sync_time( time() + self::WPCOM_REGULAR_SYNC_DELAY, $queue->id );
 		}
 
 		return $sync_result;

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -415,6 +415,23 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		return array_keys( $data );
 	}
 
+	function test_delays_next_send_by_5s_if_both_syncs_returned_false() {
+
+		// do this so that callables have been synced
+		$this->sender->do_sync();
+
+		$this->sender->set_sync_wait_time( 10 );     // 10 second delay
+		$this->sender->set_sync_wait_threshold( 2 ); // wait no matter what
+
+		// clear the queues - nothing to send
+		$this->sender->get_sync_queue()->reset();
+  		$this->sender->get_full_sync_queue()->reset();
+
+		$this->sender->do_sync();
+
+		$this->assertTrue( $this->sender->get_next_sync_time() > time() + 4 );	
+	}
+
 	function action_ran( $data, $codec, $sent_timestamp ) {
 		$this->action_ran       = true;
 		$this->action_codec     = $codec;

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -60,8 +60,6 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	public function test_delete_user_is_synced() {
 		$user = get_user_by( 'id', $this->user_id );
 
-		$this->sender->do_sync();
-
 		// make sure user exists in replica
 		$this->assertUsersEqual( $user, $this->server_replica_storage->get_user( $this->user_id ) );
 


### PR DESCRIPTION
Adds a 5 second delay before we next try to send data if both queues returned false, since this is a signal that there was no data to send.