### PR TITLE
Update pro setup links

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -43,6 +43,7 @@ const DashBackups = React.createClass( {
 				return(
 					<DashItem
 						label={ labelName }
+						module="vaultpress"
 						status="is-working"
 						className="jp-dash-item__is-active"
 						pro={ true }

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -45,6 +45,7 @@ const DashScan = React.createClass( {
 				return(
 					<DashItem
 						label={ labelName }
+						module="vaultpress"
 						status="is-error"
 						statusText={ __( 'Threats found' ) }
 						pro={ true }
@@ -73,6 +74,7 @@ const DashScan = React.createClass( {
 				return(
 					<DashItem
 						label={ labelName }
+						module="vaultpress"
 						status="is-working"
 						pro={ true }
 					>

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -98,7 +98,6 @@ const DashItem = React.createClass( {
 		}
 
 		return (
-
 			<div className={ classes }>
 				<SectionHeader
 					label={ this.props.label }

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -94,7 +94,7 @@ const ProStatus = React.createClass( {
 				}
 
 				if ( active && installed ) {
-					return __( 'ACTIVE' );
+					return <span className="jp-dash-item__active-label">{ __( 'ACTIVE' ) }</span>;
 				}
 
 				return (

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -11,6 +11,7 @@ import Spinner from 'components/spinner';
 /**
  * Internal dependencies
  */
+import { getSiteRawUrl } from 'state/initial-state';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import QueryAkismetData from 'components/data/query-akismet-data';
@@ -44,7 +45,7 @@ const ProStatus = React.createClass( {
 
 	render() {
 		let sitePlan = this.props.sitePlan(),
-			pluginSlug = 'scan' === this.props.proFeature || 'backups' === this.props.proFeature ?
+			pluginSlug = 'scan' === this.props.proFeature || 'backups' === this.props.proFeature || 'vaultpress' === this.props.proFeature ?
 			'vaultpress/vaultpress.php' :
 			'akismet/akismet.php';
 
@@ -82,12 +83,12 @@ const ProStatus = React.createClass( {
 				let btnVals = {};
 				if ( 'jetpack_free' !== sitePlan.product_slug ) {
 					btnVals = {
-						href: 'https://wordpress.com/plugins/' + pluginSlug + '/' + window.Initial_State.rawUrl,
-						text: ! installed ? __( 'Install' ) : __( 'Activate' )
+						href: 'https://wordpress.com/plugins/' + pluginSlug + '/' + this.props.siteRawUrl,
+						text: __( 'Set up' )
 					}
 				} else {
 					btnVals = {
-						href: 'https://wordpress.com/plans/' + window.Initial_State.rawUrl,
+						href: 'https://wordpress.com/plans/' + this.props.siteRawUrl,
 						text: __( 'Upgrade' )
 					}
 				}
@@ -130,6 +131,7 @@ const ProStatus = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
+			siteRawUrl: getSiteRawUrl( state ),
 			getScanThreats: () => _getVaultPressScanThreatCount( state ),
 			getVaultPressData: () => _getVaultPressData( state ),
 			getAkismetData: () => _getAkismetData( state ),

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -83,7 +83,7 @@ const ProStatus = React.createClass( {
 				let btnVals = {};
 				if ( 'jetpack_free' !== sitePlan.product_slug ) {
 					btnVals = {
-						href: 'https://wordpress.com/plugins/' + pluginSlug + '/' + this.props.siteRawUrl,
+						href: `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }`,
 						text: __( 'Set up' )
 					}
 				} else {

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -160,7 +160,7 @@ export const Page = ( props ) => {
 				{ element[1] }
 				<Button
 					compact={ true }
-				    href="#professional"
+					href="#professional"
 				>
 					{ __( 'Pro' ) }
 				</Button>


### PR DESCRIPTION
_**Will not work until https://github.com/Automattic/wp-calypso/pull/7340 is merged**_

Fixes #4538
Replaces #4680

When the site is on a plan, but the pro plugin is not installed, update the links to point to `wp.com/setup` rather than wp.com/plugins/slug, which provides a much better experience.

This PR also updates the `/security` cards to use the `ProStatus` component to keep it more DRY. 

**To Test:**
- On a site that has a plan, uninstall/deactivate any or all of the Pro plugins.
- Click on the CTA in the dashboard. It should redirect you to /setup and the plugins should be installed/activated.
- Repeat for the CTA's in the `/security` Pro cards, and in the `/search` route