### PR TITLE
Admin: fix privacy check notice

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -22,6 +22,7 @@ import {
 import { ModuleToggle } from 'components/module-toggle';
 import { AppearanceModulesSettings } from 'components/module-settings/modules-per-tab-page';
 import { isUnavailableInDevMode } from 'state/connection';
+import { getSiteAdminUrl, isSitePublic } from 'state/initial-state';
 
 export const Page = ( props ) => {
 	let {
@@ -29,10 +30,28 @@ export const Page = ( props ) => {
 		isModuleActivated,
 		isTogglingModule,
 		getModule
-	} = props;
+	} = props,
+		photonDesc = getModule( 'photon' ).description;
+
+	if ( ! props.isSitePublic() ) {
+		let makePublic = (
+			<p className="howto small">
+				{ __( 'Your site must be publicly accesible for this feature to work properly. You can make your site public in {{a}}Reading Settings{{/a}}.', {
+					components: {
+						a: <a href={ props.getSiteAdminUrl() + 'options-reading.php#blog_public' } className="jetpack-js-stop-propagation" />
+					}
+				} ) }
+			</p>
+		);
+		photonDesc = <span>
+			{ photonDesc }
+			{ makePublic }
+		</span>;
+	}
+
 	var cards = [
 		[ 'tiled-gallery', getModule( 'tiled-gallery' ).name, getModule( 'tiled-gallery' ).description, getModule( 'tiled-gallery' ).learn_more_button ],
-		[ 'photon', getModule( 'photon' ).name, getModule( 'photon' ).description, getModule( 'photon' ).learn_more_button ],
+		[ 'photon', getModule( 'photon' ).name, photonDesc, getModule( 'photon' ).learn_more_button ],
 		[ 'carousel', getModule( 'carousel' ).name, getModule( 'carousel' ).description, getModule( 'carousel' ).learn_more_button ],
 		[ 'widgets', getModule( 'widgets' ).name, getModule( 'widgets' ).description, getModule( 'widgets' ).learn_more_button ],
 		[ 'widget-visibility', getModule( 'widget-visibility' ).name, getModule( 'widget-visibility' ).description, getModule( 'widget-visibility' ).learn_more_button ],
@@ -89,7 +108,9 @@ export default connect(
 			isTogglingModule: ( module_name ) =>
 				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
-			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name )
+			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
+			getSiteAdminUrl: () => getSiteAdminUrl( state ),
+			isSitePublic: () => isSitePublic( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -22,6 +22,7 @@ import {
 import { ModuleToggle } from 'components/module-toggle';
 import { EngagementModulesSettings } from 'components/module-settings/modules-per-tab-page';
 import { isUnavailableInDevMode } from 'state/connection';
+import { getSiteAdminUrl, getSiteRawUrl, isSitePublic } from 'state/initial-state';
 
 export const Page = ( props ) => {
 	let {
@@ -29,8 +30,31 @@ export const Page = ( props ) => {
 		isModuleActivated,
 		isTogglingModule,
 		getModule
-	} = props;
-	let isAdmin = window.Initial_State.userData.currentUser.permissions.manage_modules;
+	} = props,
+		isAdmin = window.Initial_State.userData.currentUser.permissions.manage_modules,
+		sitemapsDesc = getModule( 'sitemaps' ).description,
+		enhaDistDesc = getModule( 'enhanced-distribution' ).description;
+
+	if ( ! props.isSitePublic() ) {
+		let makePublic = (
+			<p className="howto small">
+				{ __( 'Your site must be publicly accesible for this feature to work properly. You can make your site public in {{a}}Reading Settings{{/a}}.', {
+					components: {
+						a: <a href={ props.getSiteAdminUrl() + 'options-reading.php#blog_public' } className="jetpack-js-stop-propagation" />
+					}
+				} ) }
+			</p>
+		);
+		sitemapsDesc = <span>
+			{ sitemapsDesc }
+			{ makePublic }
+		</span>;
+		enhaDistDesc = <span>
+			{ enhaDistDesc }
+			{ makePublic }
+		</span>;
+	}
+
 	/**
 	 * Array of modules that directly map to a card for rendering
 	 * @type {Array}
@@ -44,8 +68,8 @@ export const Page = ( props ) => {
 		[ 'likes', getModule( 'likes' ).name, getModule( 'likes' ).description, getModule( 'likes' ).learn_more_button ],
 		[ 'subscriptions', getModule( 'subscriptions' ).name, getModule( 'subscriptions' ).description, getModule( 'subscriptions' ).learn_more_button ],
 		[ 'gravatar-hovercards', getModule( 'gravatar-hovercards' ).name, getModule( 'gravatar-hovercards' ).description, getModule( 'gravatar-hovercards' ).learn_more_button ],
-		[ 'sitemaps', getModule( 'sitemaps' ).name, getModule( 'sitemaps' ).description, getModule( 'sitemaps' ).learn_more_button ],
-		[ 'enhanced-distribution', getModule( 'enhanced-distribution' ).name, getModule( 'enhanced-distribution' ).description, getModule( 'enhanced-distribution' ).learn_more_button ],
+		[ 'sitemaps', getModule( 'sitemaps' ).name, sitemapsDesc, getModule( 'sitemaps' ).learn_more_button ],
+		[ 'enhanced-distribution', getModule( 'enhanced-distribution' ).name, enhaDistDesc, getModule( 'enhanced-distribution' ).learn_more_button ],
 		[ 'verification-tools', getModule( 'verification-tools' ).name, getModule( 'verification-tools' ).description, getModule( 'verification-tools' ).learn_more_button ],
 	],
 		nonAdminAvailable = [ 'publicize' ];
@@ -98,7 +122,7 @@ export const Page = ( props ) => {
 								<span className="jp-module-settings__more-text">{
 									__( 'View {{a}}All Stats{{/a}}', {
 										components: {
-											a: <a href={ window.Initial_State.adminUrl + 'admin.php?page=stats' } />
+											a: <a href={ props.getSiteAdminUrl() + 'admin.php?page=stats' } />
 										}
 									} )
 								}</span>
@@ -112,7 +136,7 @@ export const Page = ( props ) => {
 								<span className="jp-module-settings__more-text">{
 									__( 'View your {{a}}Email Followers{{/a}}', {
 										components: {
-											a: <a href={ 'https://wordpress.com/people/email-followers/' + window.Initial_State.rawUrl } />
+											a: <a href={ 'https://wordpress.com/people/email-followers/' + props.getSiteRawUrl() } />
 										}
 									} )
 								}</span>
@@ -142,7 +166,10 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) => isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
-			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name )
+			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
+			getSiteRawUrl: () => getSiteRawUrl( state ),
+			getSiteAdminUrl: () => getSiteAdminUrl( state ),
+			isSitePublic: () => isSitePublic( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -186,4 +186,8 @@ window.wpNavMenuClassChange = function() {
 		} );
 		subNavItem[0].classList.add( 'current' );
 	}
+
+	jQuery( 'body' ).on( 'click', '.jetpack-js-stop-propagation', function( e ) {
+		e.stopPropagation();
+	} );
 };

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -34,3 +34,7 @@ export function getSiteRawUrl( state ) {
 export function getSiteAdminUrl( state ) {
 	return get( state.jetpack.initialState, 'adminUrl', {} );
 }
+
+export function isSitePublic( state ) {
+	return get( state.jetpack.initialState, [ 'connectionStatus', 'isPublic' ] );
+}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -204,6 +204,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 					'url'      => site_url() && false === strpos( site_url(), '.' ),
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),
 				),
+				'isPublic'	=> '1' == get_option( 'blog_public' ),
 			),
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),
 			'isDevVersion' => Jetpack::is_development_version(),

--- a/class.photon.php
+++ b/class.photon.php
@@ -45,9 +45,6 @@ class Jetpack_Photon {
 	 * @return null
 	 */
 	private function setup() {
-		// Display warning if site is private
-		add_action( 'jetpack_activate_module_photon', array( $this, 'action_jetpack_activate_module_photon' ) );
-
 		if ( ! function_exists( 'jetpack_photon_url' ) )
 			return;
 
@@ -64,17 +61,6 @@ class Jetpack_Photon {
 
 		// Helpers for maniuplated images
 		add_action( 'wp_enqueue_scripts', array( $this, 'action_wp_enqueue_scripts' ), 9 );
-	}
-
-	/**
-	 * Check if site is private and warn user if it is
-	 *
-	 * @uses Jetpack::check_privacy
-	 * @action jetpack_activate_module_photon
-	 * @return null
-	 */
-	public function action_jetpack_activate_module_photon() {
-		Jetpack::check_privacy( __FILE__ );
 	}
 
 	/**

--- a/modules/enhanced-distribution.php
+++ b/modules/enhanced-distribution.php
@@ -11,11 +11,6 @@
  * Additional Search Queries: google, seo, firehose, search, broadcast, broadcasting
  */
 
-function jetpack_enhanced_distribution_activate() {
-	Jetpack::check_privacy( __FILE__ );
-}
-
-
 // In case it's active prior to upgrading to 1.9
 function jetpack_enhanced_distribution_before_activate_default_modules() {
 	$old_version = Jetpack_Options::get_option( 'old_version' );
@@ -28,7 +23,6 @@ function jetpack_enhanced_distribution_before_activate_default_modules() {
 	Jetpack::check_privacy( __FILE__ );
 }
 
-add_action( 'jetpack_activate_module_enhanced-distribution', 'jetpack_enhanced_distribution_activate' );
 add_action( 'jetpack_before_activate_default_modules', 'jetpack_enhanced_distribution_before_activate_default_modules' );
 
 /**

--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -10,17 +10,6 @@
  * Additional Search Queries: sitemap, traffic, search, site map, seo
  */
 
-/**
- * Check site privacy before activating sitemaps.
- *
- * @module sitemaps
- */
-function jetpack_sitemaps_activate() {
-	Jetpack::check_privacy( __FILE__ );
-}
-
-add_action( 'jetpack_activate_module_sitemaps', 'jetpack_sitemaps_activate' );
-
 if ( '1' == get_option( 'blog_public' ) ) {
 	include_once 'sitemaps/sitemaps.php';
 }


### PR DESCRIPTION
Fixes #4651

#### Changes proposed in this Pull Request:
- remove `Jetpack::privacy_check` so a notice in PHP isn't displayed after activating Sitemaps, Enhanced Distribution, Photon since it will be done differently in JS
- display a message in Photon, Sitemaps and Enhanced Distribution modules if the site isn't publicly accesible
- Introduce Initial_State.connectionStatus.isPublic, a boolean stating whether the site is public, that is, accesible by search engines.
- Introduce isSitePublic() that returns true if the site is public
- Propagation of click event is prevented on elements with CSS class .jetpack-js-stop-propagation

#### Testing instructions:
- set site to discourage indexing
- go to Jetpack react > Settings > Engagement. The Sitemaps module should display a message stating that the site isn't publicly accesible.
- activate Sitemaps and reload the page. No notice like pushing the masthead down should be visible.

<img width="743" alt="captura de pantalla 2016-08-10 a las 16 20 56" src="https://cloud.githubusercontent.com/assets/1041600/17567311/2d99dade-5f15-11e6-88ac-de1f26001913.png">
