### PR TITLE
Rate limit writing of options when queuing sync

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -251,6 +251,7 @@ class Jetpack_Sync_Defaults {
 	static $default_sync_wait_threshold = 5; // only wait before next send if the current send took more than X seconds
 	static $default_max_queue_size = 1000;
 	static $default_max_queue_lag = 900; // 15 minutes
+	static $default_queue_max_writes_sec = 100; // 100 rows a second
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 }

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -268,7 +268,9 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			if ( $sleep_duration > 0.0 ) {
 				error_log("sleeping for $sleep_duration");
 				sleep( $sleep_duration );
+				$this->last_pause_time = microtime( true );
 			}
+			$this->items_added_since_last_pause = 0;
 		}
 	}
 }

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -54,6 +54,8 @@ class Jetpack_Sync_Queue {
 			) );
 			$added      = ( 0 !== $rows_added );
 		}
+
+		do_action( 'jpsq_item_added' );
 	}
 
 	// Attempts to insert all the items in a single SQL query. May be subject to query size limits!
@@ -76,6 +78,8 @@ class Jetpack_Sync_Queue {
 		if ( count( $items ) === $rows_added ) {
 			return new WP_Error( 'row_count_mismatch', "The number of rows inserted didn't match the size of the input array" );
 		}
+
+		do_action( 'jpsq_items_added', $rows_added );
 	}
 
 	// Peek at the front-most item on the queue without checking it out

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -6,13 +6,14 @@ class Jetpack_Sync_Settings {
 	const SETTINGS_OPTION_PREFIX = 'jetpack_sync_settings_';
 
 	static $valid_settings = array(
-		'dequeue_max_bytes'   => true,
-		'upload_max_bytes'    => true,
-		'upload_max_rows'     => true,
-		'sync_wait_time'      => true,
-		'sync_wait_threshold' => true,
-		'max_queue_size'      => true,
-		'max_queue_lag'       => true,
+		'dequeue_max_bytes'    => true,
+		'upload_max_bytes'     => true,
+		'upload_max_rows'      => true,
+		'sync_wait_time'       => true,
+		'sync_wait_threshold'  => true,
+		'max_queue_size'       => true,
+		'max_queue_lag'        => true,
+		'queue_max_writes_sec' => true,
 	);
 
 	static $is_importing;

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -825,6 +825,18 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $keep_user_id, $users[ $existing_user_count ]->ID );
 	}
 
+	function test_full_sync_doesnt_exceed_options_write_rate_limit() {
+		foreach( range( 1, 2100 ) as $i ) { // 200 items+
+			$this->factory->user->create();	
+		}
+
+		$start_time = microtime( true );
+
+		$this->full_sync->start();
+
+		$this->assertTrue( microtime( true ) > ( $start_time + 2.0 ) );
+	}
+
 	function test_full_sync_has_correct_sent_count_even_if_some_actions_unsent() {
 		// if actions get filtered out after dequeue, this can lead to the sent count 
 		// not matching the queued count - we should make sure the count is incremented even for late-deleted items


### PR DESCRIPTION
Fixes an issue where writing options too quickly can introduce issues like replication lag on some sites.