### PR TITLE
Only enqueue full sync users belonging to the current site

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -177,12 +177,20 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	private function get_where_sql( $config ) {
-		// config is a list of user IDs to sync
-		if ( is_array( $config ) ) {
-			return 'ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
+		global $wpdb;
+
+		if ( is_multisite() ) {
+			$query = "ID IN ( SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '{$wpdb->base_prefix}capabilities' )";
+		} else {
+			$query = '1=1';
 		}
 
-		return null;
+		// config is a list of user IDs to sync
+		if ( is_array( $config ) ) {
+			$query .= ' AND ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
+		}
+
+		return $query;
 	}
 
 	function get_full_sync_actions() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -9,6 +9,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	private $full_sync_end_checksum;
 	private $full_sync_start_config;
+	private $synced_user_ids;
 
 	function setUp() {
 		parent::setUp();
@@ -219,8 +220,18 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
+		$this->sender->get_sync_queue()->reset();
+
+		// let's register a listener that asserts that only our intended users get enqueued
+		add_action( 'jetpack_full_sync_users', array( $this, 'record_full_synced_users' ) );
 
 		$this->full_sync->start();
+
+		// let's make sure we've only enqueued users from the current blog too
+		$this->assertTrue( in_array( $added_mu_blog_user_id, $this->synced_user_ids ) );
+		$this->assertTrue( in_array( $user_id, $this->synced_user_ids ) );
+		$this->assertFalse( in_array( $mu_blog_user_id, $this->synced_user_ids ) );
+
 		$this->sender->do_sync();
 
 		// admin user, our current-blog-created user and our "added" user
@@ -229,6 +240,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertNotNull( $this->server_replica_storage->get_user( $user_id ) );
 		$this->assertNotNull( $this->server_replica_storage->get_user( $added_mu_blog_user_id ) );
 		$this->assertNull( $this->server_replica_storage->get_user( $mu_blog_user_id ) );
+	}
+
+	function record_full_synced_users( $user_ids ) {
+		$this->synced_user_ids = $user_ids;
 	}
 
 	function test_full_sync_sends_all_constants() {
@@ -941,6 +956,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 			$this->assertSame( $estimate, $actual );
 		}
+	}
+
+	function test_only_sync_current_site_users_on_multisite() {
+
 	}
 
 	function test_sync_call_ables_does_not_modify_globals() {


### PR DESCRIPTION
We have been enqueuing all users by default, even on multisite, and this causes problems with large multisite installs where you end up syncing SITES x NUM_USERS to wpcom.

This change prevents users from other sites from being enqueued for the current site.