### PR TITLE
Sync: Stop syncing blacklist_keys

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -70,7 +70,6 @@ class Jetpack_Sync_Defaults {
 		'comment_whitelist',
 		'comment_max_links',
 		'moderation_keys',
-		'blacklist_keys',
 		'lang_id',
 		'wga',
 		'disabled_likes',

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -127,7 +127,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'comment_whitelist'                    => 'pineapple',
 			'comment_max_links'                    => 99,
 			'moderation_keys'                      => 'pineapple',
-			'blacklist_keys'                       => 'pineapple',
 			'lang_id'                              => 'pineapple',
 			'wga'                                  => 'pineapple',
 			'disabled_likes'                       => 'pineapple',


### PR DESCRIPTION
Some Jetpack sites have enormous lists of words that are blacklisted in comments. For now, let's stop syncing those. In the future, we can look into syncing them again. We'll likely need to truncate the list and then somehow set a flag that the list is truncated.