### PR TITLE
Allow bulk enqueuing of full sync actions to reduce DB queries

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -266,7 +266,9 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	public function queue_items_added( $item_count ) {
-		$this->items_added_since_last_pause += $item_count;
+		// jpsq_item_added and jpsq_items_added both exec 1 db query, 
+		// so we ignore $item_count and treat it as always 1
+		$this->items_added_since_last_pause += 1; 
 
 		if ( $this->items_added_since_last_pause > $this->queue_rate_limit ) {
 			// sleep for the rest of the second

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -223,7 +223,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->get_sync_queue()->reset();
 
 		// let's register a listener that asserts that only our intended users get enqueued
-		add_action( 'jetpack_full_sync_users', array( $this, 'record_full_synced_users' ) );
+		add_filter( 'jetpack_sync_before_enqueue_jetpack_full_sync_users', array( $this, 'record_full_synced_users' ) );
 
 		$this->full_sync->start();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -841,6 +841,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_doesnt_exceed_options_write_rate_limit() {
+		Jetpack_Sync_Settings::update_settings( array( 'queue_max_writes_sec' => 2 ) );
+		
 		foreach( range( 1, 2100 ) as $i ) { // 200 items+
 			$this->factory->user->create();	
 		}


### PR DESCRIPTION
This reduces the number of writes to the queue by sending a batch of 100 writes at the same time when enqueuing IDs.

This should reduce database contention and it is now much less likely to hit the 100 rows/sec write limit - a blessing and possibly a curse, as each write generates 100x as much I/O to disk. It's possible that we should benchmark this to see if it's worth lowering the max writes/sec for full syncs to 20ish.

It's also worth noting that because of the way this enqueues all these actions at once, it doesn't fire the full sync actions as actions - it just enqueues them directly.