### PR TITLE
Admin: adding query var in URL so it's ready when the endpoint admits it

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -40,7 +40,7 @@ const PlanBody = React.createClass( {
 										</Button>
 									)
 									: (
-										<Button href={ 'https://wordpress.com/plugins/setup/' + this.props.siteRawUrl } className="is-primary">
+										<Button href={ 'https://wordpress.com/plugins/setup/' + this.props.siteRawUrl + '?only=akismet' } className="is-primary">
 											{ __( 'Configure Akismet' ) }
 										</Button>
 									)


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- adds '?only=akismet' to link that performs plugin setup so it only configures Akismet when the endpoint allows to do so in the near future
