### PR TITLE
Jetpack Sync: Don't sync users with user_level 0 on "initial_sync"

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -136,8 +136,8 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function get_user_ids_for_initial_sync() {
-		global $wpdb;
-		return $wpdb->get_col( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '{$wpdb->base_prefix}user_level' AND meta_value > 0" );
+		$user_query = new WP_User_Query( array( 'who' => 'authors', 'fields' => 'ID' ) );
+		return $user_query->get_results();
 	}
 
 	static function schedule_initial_sync() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -137,7 +137,11 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function get_initial_sync_user_config() {
-		$user_query = new WP_User_Query( array( 'who' => 'authors', 'fields' => 'ID' ) );
+		$user_query = new WP_User_Query( array(
+			'who' => 'authors',
+			'fields' => 'ID',
+			'number' => self::MAX_INITIAL_SYNC_USERS + 1,
+			) );
 		if ( $user_query->get_total() >= self::MAX_INITIAL_SYNC_USERS ) {
 			return false;
  		}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -138,13 +138,14 @@ class Jetpack_Sync_Actions {
 
 	static function get_initial_sync_user_config() {
 		$user_query = new WP_User_Query( array(
-			'who' => 'authors',
+			'who'    => 'authors',
 			'fields' => 'ID',
 			'number' => self::MAX_INITIAL_SYNC_USERS + 1,
-			) );
+		) );
 		if ( $user_query->get_total() >= self::MAX_INITIAL_SYNC_USERS ) {
 			return false;
- 		}
+		}
+
 		return $user_query->get_results();
 	}
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -135,11 +135,16 @@ class Jetpack_Sync_Actions {
 		return $rpc->getResponse();
 	}
 
+	static function get_user_ids_for_initial_sync() {
+		global $wpdb;
+		return $wpdb->get_col( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '{$wpdb->base_prefix}user_level' AND meta_value > 0" );
+	}
+
 	static function schedule_initial_sync() {
-		// we need this function call here because we have to run this function 
+		// we need this function call here because we have to run this function
 		// reeeeally early in init, before WP_CRON_LOCK_TIMEOUT is defined.
 		wp_functionality_constants();
-		self::schedule_full_sync( array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => true ) );
+		self::schedule_full_sync( array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => self::get_user_ids_for_initial_sync() ) );
 	}
 
 	static function schedule_full_sync( $modules = null ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -10,6 +10,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 class Jetpack_Sync_Actions {
 	static $sender = null;
 	static $listener = null;
+	const MAX_INITIAL_SYNC_USERS = 500;
 
 	static function init() {
 
@@ -135,8 +136,11 @@ class Jetpack_Sync_Actions {
 		return $rpc->getResponse();
 	}
 
-	static function get_user_ids_for_initial_sync() {
+	static function get_initial_sync_user_config() {
 		$user_query = new WP_User_Query( array( 'who' => 'authors', 'fields' => 'ID' ) );
+		if ( $user_query->get_total() >= self::MAX_INITIAL_SYNC_USERS ) {
+			return false;
+ 		}
 		return $user_query->get_results();
 	}
 
@@ -144,7 +148,7 @@ class Jetpack_Sync_Actions {
 		// we need this function call here because we have to run this function
 		// reeeeally early in init, before WP_CRON_LOCK_TIMEOUT is defined.
 		wp_functionality_constants();
-		self::schedule_full_sync( array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => self::get_user_ids_for_initial_sync() ) );
+		self::schedule_full_sync( array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => self::get_initial_sync_user_config() ) );
 	}
 
 	static function schedule_full_sync( $modules = null ) {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -119,7 +119,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		/** This action is documented in class.jetpack.php */
 		do_action( 'updating_jetpack_version', '4.1', '4.2' );
 
-		$modules = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => true );
+		$modules = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => Jetpack_Sync_Actions::get_initial_sync_user_config() );
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( $modules ) ) > time()-5 );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -984,6 +984,23 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( is_array( $wp_taxonomies['category']->rewrite ) );
 	}
 
+	public function test_initial_sync_doesnt_sync_subscribers() {
+		$this->factory->user->create( array( 'user_login' => 'theauthor', 'role' => 'author' ) );
+		$this->factory->user->create( array( 'user_login' => 'thesubscriber', 'role' => 'subscriber' ) );
+
+		$this->full_sync->start();
+		$this->sender->do_sync();
+		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
+
+		$this->server_replica_storage->reset();
+		$this->assertEquals( 0, $this->server_replica_storage->user_count() );
+
+		$this->full_sync->start( array( 'users' => Jetpack_Sync_Actions::get_user_ids_for_initial_sync() ) );
+		$this->sender->do_sync();
+
+		$this->assertEquals( 2, $this->server_replica_storage->user_count() );
+	}
+
 	function upgrade_terms_to_pass_test( $term ) {
 		global $wp_version;
 		if ( version_compare( $wp_version, '4.4', '<' ) ) {


### PR DESCRIPTION
We sync users on plugin upgrade so we have the information to populate subscription and notification posts. We don't need users with user_level 0 at this point. 

cc @gravityrail @enejb 