### PR TITLE
Only sync users who can edit posts and pages on initial sync

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -119,7 +119,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		/** This action is documented in class.jetpack.php */
 		do_action( 'updating_jetpack_version', '4.1', '4.2' );
 
-		$modules = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => true );
+		$modules = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => Jetpack_Sync_Actions::get_initial_sync_user_config() );
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( $modules ) ) > time()-5 );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -982,6 +982,50 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( is_array( $wp_taxonomies['category']->rewrite ) );
 	}
 
+	public function test_initial_sync_doesnt_sync_subscribers() {
+		$this->factory->user->create( array( 'user_login' => 'theauthor', 'role' => 'author' ) );
+		$this->factory->user->create( array( 'user_login' => 'theadmin', 'role' => 'administrator' ) );
+
+		foreach( range( 1, 10 ) as $i ) {
+			$this->factory->user->create( array( 'role' => 'subscriber' ) );
+		}
+
+		$this->full_sync->start();
+		$this->sender->do_sync();
+		$this->assertEquals( 13, $this->server_replica_storage->user_count() );
+
+		$this->server_replica_storage->reset();
+		$this->assertEquals( 0, $this->server_replica_storage->user_count() );
+
+		$user_ids = Jetpack_Sync_Actions::get_initial_sync_user_config();
+		$this->assertEquals( 3, count( $user_ids ) );		
+
+		$this->full_sync->start( array( 'users' => Jetpack_Sync_Actions::get_initial_sync_user_config() ) );
+		$this->sender->do_sync();
+
+		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
+
+		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
+
+		Jetpack_Sync_Actions::schedule_initial_sync();
+		$this->assertTrue( 
+			!! Jetpack_Sync_Actions::is_scheduled_full_sync( 
+				array( 
+					'options' => true, 
+					'network_options' => true, 
+					'functions' => true, 
+					'constants' => true, 
+					'users' => Jetpack_Sync_Actions::get_initial_sync_user_config(),
+				) 
+			) 
+		);
+	}
+
+	function _do_cron() {
+		$_GET['check'] = wp_hash( '187425' );
+		require( ABSPATH . '/wp-cron.php' );
+	}
+
 	function upgrade_terms_to_pass_test( $term ) {
 		global $wp_version;
 		if ( version_compare( $wp_version, '4.4', '<' ) ) {


### PR DESCRIPTION
A variation of #4740, this tries to limit initial sync just to users who might create or publish posts, so that publicize and related functionality works out of the box.

Previously we were syncing all users, and this could create a lot of DB load.

This PR tries to use the more modern capabilities based system instead of the old user levels system that was deprecated in WP 3.x

cc @lezama 