### PR TITLE
Blacklist some meta keys that see a lot of churn

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -204,6 +204,16 @@ class Jetpack_Sync_Defaults {
 		'_publicize_twitter_user',
 	);
 
+	static $default_blacklist_meta_keys = array(
+		'post_views_count',
+		'Views',
+		'tve_leads_impressions',
+		'views',
+		'scc_share_count_crawldate',
+		'wprss_last_update',
+		'wprss_feed_is_updating',
+	);
+
 	// TODO: move this to server? - these are theme support values
 	// that should be synced as jetpack_current_theme_supports_foo option values
 	static $default_theme_support_whitelist = array(

--- a/sync/class.jetpack-sync-module-meta.php
+++ b/sync/class.jetpack-sync-module-meta.php
@@ -29,6 +29,10 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 			return false;
 		}
 
+		if ( in_array( $args[2], Jetpack_Sync_Defaults::$default_blacklist_meta_keys ) ) {
+			return false;
+		}
+
 		return $args;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -90,6 +90,16 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $this->post_id, '_private_meta', true ) );
 	}
 
+	public function test_doesnt_sync_blacklisted_meta() {
+		add_post_meta( $this->post_id, 'post_views_count', '100' );
+		add_post_meta( $this->post_id, 'not_post_views_count', '200' );
+
+		$this->sender->do_sync();
+
+		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'post_views_count', true ) );
+		$this->assertEquals( '200', $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'not_post_views_count', true ) );
+	}
+
 
 	// TODO:
 	// Add tests for other post meta


### PR DESCRIPTION
Some meta keys update a lot - particularly those which record views of content.

This PR filters out most of the top 20 keys.