### PR TITLE
Sync: Only sync capabilities related user meta changes in save_user_c…

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -133,14 +133,16 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
+		$is_capability_meta_key =  preg_match( '/capabilities|user_level/', $meta_key );
 
 		// if a user is currently being removed as a member of this blog, we don't fire the event
-		if ( current_filter() === 'deleted_user_meta'
-		     &&
-		     preg_match( '/capabilities|user_level/', $meta_key )
-		     &&
-		     ! is_user_member_of_blog( $user_id, get_current_blog_id() )
+		if (
+			current_filter() === 'deleted_user_meta' &&
+			$is_capability_meta_key &&
+			! is_user_member_of_blog( $user_id, get_current_blog_id() )
 		) {
+			return;
+		} else if ( ! $is_capability_meta_key ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR solves two issues.

First - After launching 4.2, some users reported that they could no longer log in to their sites. They were constantly being redirected back to the login page. As of now, this seems to only affect users with W3TC. While I am still finding the root cause, the issue seems to be that the auth cookie was invalid after (my guess is because there was some output before setting the cookie), which then led to the user being redirected back to the login page. I'm still tracking down this issue.

Second - We were syncing users way too often. `save_user_cap_handler` is specifically meant to sync a user when the capabilities for that user had changed, but we were causing sync actions to be fired each time the user meta was updated.

To test:

- Checkout `update/sync-user-meta-filter` branch
- Install W3TC
- Turn on all default caches
- Log in tosite
- Can you log in?

cc @kraftbj for confirmation