### PR TITLE
Fix issue where users wasn't able to login.

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -51,6 +51,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function sanitize_user( $user ) {
+		// this create a new user object and stops the passing of the object by reference.
+		$user = unserialize( serialize( $user ) );
 		unset( $user->data->user_pass );
 
 		return $user;
@@ -144,16 +146,16 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$user = $this->sanitize_user( get_user_by( 'id', $user_id ) );
+		$user =  get_user_by( 'id', $user_id );
 		if ( $meta_key === $user->cap_key ) {
 			/**
 			 * Fires when the client needs to sync an updated user
 			 *
 			 * @since 4.2.0
 			 *
-			 * @param object The WP_User object
+			 * @param object The Sanitized WP_User object
 			 */
-			do_action( 'jetpack_sync_save_user', $user );
+			do_action( 'jetpack_sync_save_user', $this->sanitize_user( $user ) );
 		}
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -84,6 +84,27 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $this->user_id, $event->args[0] );
 		$this->assertEquals( $reassign, $event->args[1] );
 	}
+	
+	// User meta not syncing 
+	public function test_do_not_sync_user_data_on_user_meta_change() {
+		$this->server_event_storage->reset();
+		
+		add_user_meta( $this->user_id, 'session_tokens', 'world', 1 );
+		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event( );
+		$this->assertFalse( $event );
+
+		update_user_meta( $this->user_id, 'session_tokens', 'moon' );
+		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event( );
+		$this->assertFalse( $event );
+
+		delete_user_meta( $this->user_id, 'session_tokens', 'moon' );
+		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event( );
+		$this->assertFalse( $event );
+
+	}
 
 	// Roles syncing
 


### PR DESCRIPTION
#This fixed an issue reported by users where they were not able to login
if they had W3TC installed and all the caching enabled.

The issue was that we seem to be overwriting the user object with a
user object that doesn't contain the password has.

This PR fixes it in 2 ways. It delays the sanitisation of users when
meta data capabilities sync might happen. And it clones a new user
object before modifying it so that the user object stored in cache
doesn't get modified.

- We added a test that shows that we don't sync random user meta.
- We were not able to write a good tests showing the modification of
the user object in cache.

cc: @ebinnion and @kraftbj 
to test the fix. 

To test
- install activate and enable all the caching in W3TC plugging. 
- login in still works. 
