### PR TITLE
Read jetpack stats data

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2727,9 +2727,9 @@ p {
 	/**
 	 * Return stat data for WPCOM sync
 	 */
-	function get_stat_data() {
+	public static function get_stat_data() {
 		$heartbeat_data = Jetpack_Heartbeat::generate_stats_array();
-		$additional_data = $this->get_additional_stat_data();
+		$additional_data = self::get_additional_stat_data();
 
 		return json_encode( array_merge( $heartbeat_data, $additional_data ) );
 	}
@@ -2737,7 +2737,7 @@ p {
 	/**
 	 * Get additional stat data to sync to WPCOM
 	 */
-	function get_additional_stat_data( $prefix = '' ) {
+	public static function get_additional_stat_data( $prefix = '' ) {
 		$return["{$prefix}themes"]         = Jetpack::get_parsed_theme_data();
 		$return["{$prefix}plugins-extra"]  = Jetpack::get_parsed_plugin_data();
 		$return["{$prefix}users"]          = count_users();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2727,11 +2727,17 @@ p {
 	/**
 	 * Return stat data for WPCOM sync
 	 */
-	public static function get_stat_data() {
+	public static function get_stat_data( $encode = true ) {
 		$heartbeat_data = Jetpack_Heartbeat::generate_stats_array();
 		$additional_data = self::get_additional_stat_data();
 
-		return json_encode( array_merge( $heartbeat_data, $additional_data ) );
+		$merged_data = array_merge( $heartbeat_data, $additional_data );
+
+		if ( $encode ) {
+			return json_encode( $merged_data );
+		}
+		
+		return $merged_data;
 	}
 
 	/**

--- a/sync/class.jetpack-sync-module-stats.php
+++ b/sync/class.jetpack-sync-module-stats.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * 
+ */
+class Jetpack_Sync_Module_Stats extends Jetpack_Sync_Module {
+
+	function name() {
+		return 'stats';
+	}
+
+	function init_listeners( $callback ) {
+		add_action( 'jetpack_heartbeat', array( $this, 'run_action' ) );
+		add_action( 'jetpack_sync_site_stats', $callback );
+	}
+
+	function run_action() {
+		do_action( 'jetpack_sync_site_stats' );
+	}
+
+	public function init_before_send() {
+		add_filter( 'jetpack_sync_before_send_jetpack_sync_add_stats', array( $this, 'add_stats' ) );
+	}
+
+	public function add_stats() {
+		return Jetpack::get_stat_data();
+	}
+}
+
+

--- a/sync/class.jetpack-sync-module-stats.php
+++ b/sync/class.jetpack-sync-module-stats.php
@@ -7,19 +7,14 @@ class Jetpack_Sync_Module_Stats extends Jetpack_Sync_Module {
 	}
 
 	function init_listeners( $callback ) {
-		add_action( 'jetpack_heartbeat', array( $this, 'run_action' ) );
-		add_action( 'jetpack_sync_site_stats', $callback );
-	}
-
-	function run_action() {
-		do_action( 'jetpack_sync_site_stats' );
+		add_action( 'jetpack_heartbeat', $callback );
 	}
 
 	public function init_before_send() {
-		add_filter( 'jetpack_sync_before_send_jetpack_sync_add_stats', array( $this, 'add_stats' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_heartbeat', array( $this, 'add_stats' ) );
 	}
 
 	public function add_stats() {
-		return Jetpack::get_stat_data();
+		return array( Jetpack::get_stat_data( false ) );
 	}
 }

--- a/sync/class.jetpack-sync-module-stats.php
+++ b/sync/class.jetpack-sync-module-stats.php
@@ -1,8 +1,5 @@
 <?php
 
-/**
- * 
- */
 class Jetpack_Sync_Module_Stats extends Jetpack_Sync_Module {
 
 	function name() {
@@ -26,5 +23,3 @@ class Jetpack_Sync_Module_Stats extends Jetpack_Sync_Module {
 		return Jetpack::get_stat_data();
 	}
 }
-
-

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -21,6 +21,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-terms.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-plugins.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-protect.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-full-sync.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-stats.php';
 
 class Jetpack_Sync_Modules {
 
@@ -40,6 +41,7 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Plugins',
 		'Jetpack_Sync_Module_Protect',
 		'Jetpack_Sync_Module_Full_Sync',
+		'Jetpack_Sync_Module_Stats',
 	);
 
 	private static $initialized_modules = null;

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -1,0 +1,15 @@
+<?php
+
+
+class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
+
+	function test_sends_stats_data_on_heartbeat() {
+
+		$heartbeat = Jetpack_Heartbeat::init();
+		$heartbeat->cron_exec();
+		$this->sender->do_sync();
+
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_site_stats' );
+		$this->assertTrue( ! empty( $action->args ) );
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -8,7 +8,7 @@ class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 		$heartbeat->cron_exec();
 		$this->sender->do_sync();
 
-		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_site_stats' );
-		$this->assertTrue( ! empty( $action->args ) );
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_heartbeat' );
+		$this->assertEquals( JETPACK__VERSION, $action->args[0]['version'] );
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -4,7 +4,6 @@
 class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sends_stats_data_on_heartbeat() {
-
 		$heartbeat = Jetpack_Heartbeat::init();
 		$heartbeat->cron_exec();
 		$this->sender->do_sync();


### PR DESCRIPTION
Previously we were sending the data daily in the mock option jetpack_stat_data.
In the new sync we still send the data on heartbeat once a day. And attach it to jetpack_sync_site_stats action.

This PR add the stats that we over looked in the new sync. 
cc: @samhotchkiss, @lezama 