### PR TITLE
Reduce time after checking lock and setting lock for callables and constants

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -102,13 +102,13 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 
+		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
+
 		$callables = $this->get_all_callables();
 
 		if ( empty( $callables ) ) {
 			return;
 		}
-
-		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_callables_wait_time );
 
 		$callable_checksums = (array) get_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
 

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -70,12 +70,13 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 			return;
 		}
 
+		set_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_constants_wait_time );
+
 		$constants = $this->get_all_constants();
 		if ( empty( $constants ) ) {
 			return;
 		}
 
-		set_transient( self::CONSTANTS_AWAIT_TRANSIENT_NAME, microtime( true ), Jetpack_Sync_Defaults::$default_sync_constants_wait_time );
 		$constants_checksums = (array) get_option( self::CONSTANTS_CHECKSUM_OPTION_NAME, array() );
 
 		foreach ( $constants as $name => $value ) {


### PR DESCRIPTION
If callables or constants take a long time to fetch for some reason, multiple requests can pile up which all make the same request. This can result in potentially hundreds of enqueued items with the same information.

This PR reduces the time between checking the lock and setting it again.