### PR TITLE
Added .form-setting-explanation class and fixed comment setting layout

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -35,10 +35,10 @@
 .form-setting-explanation {
 	color: $gray;
 	display: block;
-	font-size: 13px;
+	font-size: rem( 13px );
 	font-style: italic;
 	font-weight: 400;
-	margin: 5px 0 0 0;
+	margin: rem( 5px ) 0 0 0;
 }
 
 // ==========================================================================

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -32,6 +32,15 @@
 	margin-left: 10px;
 }
 
+.form-setting-explanation {
+	color: $gray;
+	display: block;
+	font-size: 13px;
+	font-style: italic;
+	font-weight: 400;
+	margin: 5px 0 0 0;
+}
+
 // ==========================================================================
 // Buttons
 // ==========================================================================

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -136,7 +136,8 @@ export let CommentsSettings = React.createClass( {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
-					<FormLegend>{ __( 'Comments headline: A few catchy words to motivate your readers to comment' ) }</FormLegend>
+					<FormLegend>{ __( 'Comments headline' ) }</FormLegend>
+					<span className="form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
 					<FormLabel>
 						<FormTextInput
 							name={ 'highlander_comment_form_prompt' }


### PR DESCRIPTION
Fixes #4723 .

NOTE: The text input will be fancy and updated once we get https://github.com/Automattic/dops-components/pull/42#issuecomment-238980182 merged.

#### Changes proposed in this Pull Request:
* adds `.form-setting-explanation` class as used in Calypso for notes about settings

#### Testing instructions:
-Look at Engagement > Comments

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17623278/3078f416-606d-11e6-87dc-f08d0d8dcc4c.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17623241/073460ea-606d-11e6-98fb-de7ad3e0eb4b.png)