### PR TITLE
Tiled Gallery Settings: Switch from h3 to FormLegend

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -518,8 +518,8 @@ export let TiledGallerySettings = React.createClass( {
 	render() {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
-				<h3>{ __( 'Excerpts' ) }</h3>
 				<FormFieldset>
+					<FormLegend>{ __( 'Excerpts' ) }</FormLegend>
 					<ModuleSettingCheckbox
 						name={ 'tiled_galleries' }
 						{ ...this.props }


### PR DESCRIPTION
Fixes #4722 .

#### Changes proposed in this Pull Request:
* switched label from h3 to FormLegend

#### Testing instructions:
-Go to Appearance > Tiled Galleries

Before:
![image](https://cloud.githubusercontent.com/assets/437258/17563099/bcde5432-5efb-11e6-892b-4c722559aa44.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17623393/cf1c30ba-606d-11e6-9a4b-5829c7acc3f5.png)
