### PR TITLE
Implement usage of `.form-setting-explanation` in settings

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -39,6 +39,10 @@
 	font-style: italic;
 	font-weight: 400;
 	margin: rem( 5px ) 0 0 0;
+
+	+ .dops-card {
+		margin-top: rem( 16px );
+	}
 }
 
 // ==========================================================================

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -271,19 +271,16 @@ export let MonitorSettings = React.createClass( {
 						name={ 'monitor_receive_notifications' }
 						{ ...this.props }
 						label={ __( 'Receive Monitor Email Notifications' ) } />
-					<p>
-						<em>{ __( 'Emails will be sent to ' ) + this.props.adminEmailAddress }.</em>
-						<span>
-							&nbsp;
-							{
-								__( '{{a}}Edit{{/a}}', {
-									components: {
-										a: <a href={ 'https://wordpress.com/settings/account/' } />
-									}
-								} )
-							}
-						</span>
-					</p>
+					<span className="form-setting-explanation">{ __( 'Emails will be sent to ' ) + this.props.adminEmailAddress }. <span>
+						&nbsp;
+						{
+							__( '{{a}}Edit{{/a}}', {
+								components: {
+									a: <a href={ 'https://wordpress.com/settings/account/' } />
+								}
+							} )
+						}
+					</span></span>
 					<FormButton
 						className="is-primary"
 						isSubmitting={ this.props.isSavingAnyOption() }
@@ -438,7 +435,7 @@ export let VerificationToolsSettings = React.createClass( {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
-					<p>
+					<p className="form-setting-explanation">
 						{
 							__( 'Enter your meta key "content" value to verify your blog with {{a}}Google Search Console{{/a}}, {{a}}Bing Webmaster Center{{/a}} and {{a}}Pinterest Site Verification{{/a}}.', {
 								components: {

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -86,7 +86,7 @@ export const AllModuleSettings = React.createClass( {
 			case 'notifications':
 			case 'enhanced-distribution':
 			case 'sitemaps':
-				return <span>{ __( 'This module has no configuration options' ) } </span>;
+				return <span className="form-setting-explanation">{ __( 'This module has no configuration options' ) } </span>;
 			case 'custom-css':
 			case 'widgets':
 			case 'publicize':


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Implements `.form-setting-explanation` usage in the settings sections.

#### Testing instructions:
Go to settings and look at:
- any setting without configuration options (Writing > Shortlinks)
- Engagement > Site Verification

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17626356/f2a40262-607a-11e6-98c0-1a96702d7094.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/17626335/e0d092b2-607a-11e6-9a79-cb62b583a0d7.png)


