### PR TITLE
Sync Stats: Name space the action

### DIFF
--- a/sync/class.jetpack-sync-module-stats.php
+++ b/sync/class.jetpack-sync-module-stats.php
@@ -7,11 +7,19 @@ class Jetpack_Sync_Module_Stats extends Jetpack_Sync_Module {
 	}
 
 	function init_listeners( $callback ) {
-		add_action( 'jetpack_heartbeat', $callback );
+		add_action( 'jetpack_heartbeat', array( $this, 'sync_site_stats' ), 20 );
+		add_action( 'jetpack_sync_heartbeat_stats', $callback );
+	}
+	/*
+	 * This namespaces the action that we sync.
+	 * So that we can differentiate it from future actions.
+	 */
+	public function sync_site_stats() {
+		do_action( 'jetpack_sync_heartbeat_stats' );
 	}
 
 	public function init_before_send() {
-		add_filter( 'jetpack_sync_before_send_jetpack_heartbeat', array( $this, 'add_stats' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_sync_heartbeat_stats', array( $this, 'add_stats' ) );
 	}
 
 	public function add_stats() {

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -8,7 +8,7 @@ class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 		$heartbeat->cron_exec();
 		$this->sender->do_sync();
 
-		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_heartbeat' );
+		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
 		$this->assertEquals( JETPACK__VERSION, $action->args[0]['version'] );
 	}
 }


### PR DESCRIPTION
This renames the action from jetpack_heartbeat to jetpack_sync_heartbeat_stats in case we add more actions to be synced on heartbeat and we want to be able to differentiate them on the .com
side.