### PR TITLE
Sync: Add comment handling for post trashing

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -202,6 +202,7 @@ class Jetpack_Sync_Defaults {
 		'_wp_attachment_metadata',
 		'_wp_page_template',
 		'_publicize_twitter_user',
+		'_wp_trash_meta_comments_status',
 	);
 
 	static $default_blacklist_meta_keys = array(

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -8,9 +8,11 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 
 	public function init_listeners( $callable ) {
 		add_action( 'wp_insert_comment', $callable, 10, 2 );
-		add_action( 'deleted_comment', $callable, 10 );
-		add_action( 'trashed_comment', $callable, 10 );
-		add_action( 'spammed_comment', $callable, 10 );
+		add_action( 'deleted_comment', $callable );
+		add_action( 'trashed_comment', $callable );
+		add_action( 'spammed_comment', $callable );
+		add_action( 'trashed_post_comments', $callable, 10, 2 );
+		add_action( 'untrash_post_comments', $callable );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -267,6 +267,14 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 		wp_spam_comment( $comment_id );
 	}
 
+	public function trashed_post_comments( $post_id, $statuses ) {
+		wp_trash_post_comments( $post_id );
+	}
+
+	public function untrashed_post_comments( $post_id ) {
+		wp_untrash_post_comments( $post_id );
+	}
+
 	public function comments_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
 		return $this->table_checksum( $wpdb->comments, Jetpack_Sync_Defaults::$default_comment_checksum_columns, 'comment_ID', "comment_approved <> 'spam'", $min_id, $max_id );

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -47,6 +47,10 @@ interface iJetpack_Sync_Replicastore {
 
 	public function delete_comment( $comment_id );
 
+	public function trashed_post_comments( $post_id, $statuses );
+
+	public function untrashed_post_comments( $post_id );
+
 	public function comments_checksum( $min_id = null, $max_id = null );
 
 	// options

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -56,6 +56,15 @@ class Jetpack_Sync_Server_Replicator {
 				list( $comment_id ) = $args;
 				$this->store->spam_comment( $comment_id );
 				break;
+			case 'trashed_post_comments':
+				list( $post_id, $statuses ) = $args;
+				$statuses = (array) $statuses;
+				$this->store->trashed_post_comments( $post_id, $statuses );
+				break;
+			case 'untrash_post_comments':
+				list( $post_id ) = $args;
+				$this->store->untrashed_post_comments( $post_id );
+				break;
 
 			// options
 			case 'added_option':

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -108,7 +108,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	function get_comments( $status = null, $min_id = null, $max_id = null ) {
 		$this->comment_status = $status;
 
-		// valid statuses: 'hold', 'approve', 'spam', or 'trash'.
+		// valid statuses: 'hold', 'approve', 'spam', 'trash', or 'post-trashed.
 		$comments = array_filter( array_values( $this->comments ), array( $this, 'filter_comment_status' ) );
 
 		foreach ( $comments as $i => $comment ) {
@@ -138,6 +138,8 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 				return 'spam' === $comment->comment_approved;
 			case 'trash':
 				return 'trash' === $comment->comment_approved;
+			case 'post-trashed':
+				return 'post-trashed' === $comment->comment_approved;
 			case 'any':
 				return true;
 			case 'all':
@@ -165,6 +167,21 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function spam_comment( $comment_id ) {
 		$this->comments[ $comment_id ]->comment_approved = 'spam';
+	}
+
+	function trashed_post_comments( $post_id, $statuses ) {
+		$statuses = (array) $statuses;
+		foreach( $statuses as $comment_id => $status ) {
+			$this->comments[ $comment_id ]->comment_approved = 'post-trashed';
+		}
+	}
+
+	function untrashed_post_comments( $post_id ) {
+		$statuses = (array) $this->get_metadata( 'post', $post_id, '_wp_trash_meta_comments_status', true );
+
+		foreach( $statuses as $comment_id => $status ) {
+			$this->comments[ $comment_id ]->comment_approved = $status;
+		}
 	}
 
 	function delete_comment( $comment_id ) {


### PR DESCRIPTION
Previously, we weren't handling the `post-trashed` status for comments, which occurs when a post is trashed with `wp_trash_post`. Also, when running `wp_untrash_post` the comment status should be restored.

This PR handles the Jetpack side of syncing that status.
