### PR TITLE
Add blacklist settings api for meta and post types

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -156,6 +156,12 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sy
 				if ( is_numeric( $value ) ) {
 					$value = (int) $value;
 				}
+				
+				// special case for sending empty arrays - a string with value 'empty'
+				if ( $value === 'empty' ) {
+					$value = array();
+				}
+
 				$sync_settings[ $key ] = $value;
 			}
 		}

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -655,13 +655,16 @@ new Jetpack_JSON_API_Sync_Histogram_Endpoint( array(
 ) );
 
 $sync_settings_response = array(
-	'dequeue_max_bytes'   => '(int|bool=false) Maximum bytes to read from queue in a single request',
-	'sync_wait_time'      => '(int|bool=false) Wait time between requests in seconds if sync threshold exceeded',
-	'sync_wait_threshold' => '(int|bool=false) If a request to WPCOM exceeds this duration, wait sync_wait_time seconds before sending again',
-	'upload_max_bytes'    => '(int|bool=false) Maximum bytes to send in a single request',
-	'upload_max_rows'     => '(int|bool=false) Maximum rows to send in a single request',
-	'max_queue_size'      => '(int|bool=false) Maximum queue size that that the queue is allowed to expand to in DB rows to prevent the DB from filling up. Needs to also meet the max_queue_lag limit.',
-	'max_queue_lag'       => '(int|bool=false) Maximum queue lag in seconds used to prevent the DB from filling up. Needs to also meet the max_queue_size limit.',
+	'dequeue_max_bytes'    => '(int|bool=false) Maximum bytes to read from queue in a single request',
+	'sync_wait_time'       => '(int|bool=false) Wait time between requests in seconds if sync threshold exceeded',
+	'sync_wait_threshold'  => '(int|bool=false) If a request to WPCOM exceeds this duration, wait sync_wait_time seconds before sending again',
+	'upload_max_bytes'     => '(int|bool=false) Maximum bytes to send in a single request',
+	'upload_max_rows'      => '(int|bool=false) Maximum rows to send in a single request',
+	'max_queue_size'       => '(int|bool=false) Maximum queue size that that the queue is allowed to expand to in DB rows to prevent the DB from filling up. Needs to also meet the max_queue_lag limit.',
+	'max_queue_lag'        => '(int|bool=false) Maximum queue lag in seconds used to prevent the DB from filling up. Needs to also meet the max_queue_size limit.',
+	'queue_max_writes_sec' => '(int|bool=false) Maximum writes per second to allow to the queue during full sync.',
+	'post_types_blacklist' => '(array|string|bool=false) List of post types to exclude from sync. Send "empty" to unset.',
+	'meta_blacklist'       => '(array|string|bool=false) List of meta keys to exclude from sync. Send "empty" to unset.',
 );
 
 // GET /sites/%s/sync/settings

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -172,11 +172,6 @@ class Jetpack_Sync_Defaults {
 		'option_value',
 	);
 
-	// returns escapted SQL that can be injected into a WHERE clause
-	static function get_blacklisted_post_types_sql() {
-		return 'post_type NOT IN (\'' . join( '\', \'', array_map( 'esc_sql', self::$blacklisted_post_types ) ) . '\')';
-	}
-
 	static $default_multisite_callable_whitelist = array(
 		'network_name'                        => array( 'Jetpack', 'network_name' ),
 		'network_allow_new_registrations'     => array( 'Jetpack', 'network_allow_new_registrations' ),
@@ -261,6 +256,7 @@ class Jetpack_Sync_Defaults {
 	static $default_max_queue_size = 1000;
 	static $default_max_queue_lag = 900; // 15 minutes
 	static $default_queue_max_writes_sec = 100; // 100 rows a second
+	static $default_post_types_blacklist = array();
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 }

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -257,6 +257,7 @@ class Jetpack_Sync_Defaults {
 	static $default_max_queue_lag = 900; // 15 minutes
 	static $default_queue_max_writes_sec = 100; // 100 rows a second
 	static $default_post_types_blacklist = array();
+	static $default_meta_blacklist = array();
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 }

--- a/sync/class.jetpack-sync-module-meta.php
+++ b/sync/class.jetpack-sync-module-meta.php
@@ -29,7 +29,7 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 			return false;
 		}
 
-		if ( in_array( $args[2], Jetpack_Sync_Defaults::$default_blacklist_meta_keys ) ) {
+		if ( in_array( $args[2], Jetpack_Sync_Settings::get_setting( 'meta_blacklist' ) ) ) {
 			return false;
 		}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -43,7 +43,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	private function get_where_sql( $config ) {
-		$where_sql = Jetpack_Sync_Defaults::get_blacklisted_post_types_sql();
+		$where_sql = Jetpack_Sync_Settings::get_blacklisted_post_types_sql();
 
 		// config is a list of post IDs to sync
 		if ( is_array( $config ) ) {
@@ -67,7 +67,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	function filter_blacklisted_post_types( $args ) {
 		$post = $args[1];
-		if ( in_array( $post->post_type, Jetpack_Sync_Defaults::$blacklisted_post_types ) ) {
+
+		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
 		}
 

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -15,10 +15,7 @@ class Jetpack_Sync_Settings {
 		'max_queue_lag'        => true,
 		'queue_max_writes_sec' => true,
 		'post_types_blacklist' => true,
-	);
-
-	static $array_settings = array(
-		'post_types_blacklist',
+		'meta_blacklist'       => true,
 	);
 
 	static $is_importing;
@@ -60,6 +57,11 @@ class Jetpack_Sync_Settings {
 		// specifically for the post_types blacklist, we want to include the hardcoded settings
 		if ( $setting === 'post_types_blacklist' ) {
 			$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$blacklisted_post_types ) );
+		}
+
+		// ditto for meta blacklist
+		if ( $setting === 'meta_blacklist' ) {
+			$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$default_blacklist_meta_keys ) );
 		}
 
 		self::$settings_cache[ $setting ] = $value;

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -145,7 +145,7 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 
 	public function posts_checksum( $min_id = null, $max_id = null ) {
 		global $wpdb;
-		return $this->table_checksum( $wpdb->posts, Jetpack_Sync_Defaults::$default_post_checksum_columns , 'ID', Jetpack_Sync_Defaults::get_blacklisted_post_types_sql(), $min_id, $max_id );
+		return $this->table_checksum( $wpdb->posts, Jetpack_Sync_Defaults::$default_post_checksum_columns , 'ID', Jetpack_Sync_Settings::get_blacklisted_post_types_sql(), $min_id, $max_id );
 	}
 
 	public function comment_count( $status = null, $min_id = null, $max_id = null ) {

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -100,6 +100,27 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( '200', $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'not_post_views_count', true ) );
 	}
 
+	public function test_meta_blacklist_can_be_appended_in_settings() {
+		Jetpack_Sync_Settings::update_settings( array( 'meta_blacklist' => array( 'a_blacklisted_meta_key' ) ) );
+
+		add_post_meta( $this->post_id, 'a_blacklisted_meta_key', 'foo' );
+		add_post_meta( $this->post_id, 'not_a_blacklisted_meta_key', 'bar' );
+
+		$this->sender->do_sync();
+
+		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'a_blacklisted_meta_key', true ) );
+		$this->assertEquals( 'bar', $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'not_a_blacklisted_meta_key', true ) );
+
+		$setting = Jetpack_Sync_Settings::get_setting( 'meta_blacklist' );
+
+		$this->assertTrue( in_array( 'a_blacklisted_meta_key', $setting ) );
+
+		// default blacklist should still be there
+		foreach( Jetpack_Sync_Defaults::$default_blacklist_meta_keys as $hardcoded_blacklist_meta ) {
+			$this->assertTrue( in_array( $hardcoded_blacklist_meta, $setting ) );
+		}
+	}
+
 
 	// TODO:
 	// Add tests for other post meta

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -4,7 +4,6 @@
 class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sends_stats_data_on_heartbeat() {
-		$this->markTestIncomplete( 'Stalls' );
 		$heartbeat = Jetpack_Heartbeat::init();
 		$heartbeat->cron_exec();
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -4,6 +4,7 @@
 class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sends_stats_data_on_heartbeat() {
+		$this->markTestIncomplete( 'Stalls' );
 		$heartbeat = Jetpack_Heartbeat::init();
 		$heartbeat->cron_exec();
 		$this->sender->do_sync();


### PR DESCRIPTION
Allows remotely adding (but not removing) blacklisted meta and post types.

These lists have been the most actively updated to deal with rapid over-synchronization.

Note that post type blacklisting does not pay any attention to the object type - it blacklists the same meta across posts, comments and users. This hasn't been a problem so far but perhaps later we should address it.