### PR TITLE
Footer: Fixing link styles for mobile

### DIFF
--- a/_inc/client/components/footer/style.scss
+++ b/_inc/client/components/footer/style.scss
@@ -34,6 +34,15 @@
 .jp-footer__link-item {
 	display: inline-block;
 	margin-bottom: 0;
+
+	@include breakpoint( ">660px" ) {
+		display: inline-block;
+	}
+
+	@include breakpoint( "<660px" ) {
+		display: block;
+		border-bottom: 1px lighten( $gray, 25% ) solid;
+	}
 }
 
 .jp-footer__link {


### PR DESCRIPTION
Footer links were a jumbled mess on small screens. Fixed them!

Before:
<img width="412" alt="screen shot 2016-08-12 at 12 42 54 pm" src="https://cloud.githubusercontent.com/assets/214813/17632261/623d8070-6095-11e6-93f1-b74c67fc2b4b.png">

After:
<img width="502" alt="screen shot 2016-08-12 at 2 01 08 pm" src="https://cloud.githubusercontent.com/assets/214813/17632269/68743ae2-6095-11e6-801a-481e21a8b68a.png">

Fixes: https://github.com/Automattic/jetpack/issues/4769
