### PR TITLE
Admin - Post by Email: add button to text input so user can copy it to clipboard

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -6,6 +6,7 @@ import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import TextInput from 'components/text-input';
 import TagsInput from 'components/tags-input';
+import ClipboardButtonInput from 'components/clipboard-button-input';
 
 /**
  * Internal dependencies
@@ -554,9 +555,12 @@ export let PostByEmailSettings = React.createClass( {
 				<FormFieldset>
 					<FormLabel>
 						<FormLegend>{ __( 'Email Address' ) }</FormLegend>
-						<TextInput
+						<ClipboardButtonInput
 							value={ this.address() }
-							readOnly="readonly" />
+							copy={ __( 'Copy', { context: 'verb' } ) }
+							copied={ __( 'Copied!' ) }
+							prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+						/>
 						<FormButton
 							onClick={ this.regeneratePostByEmailAddress } >
 							{ __( 'Regenerate address' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- replaces the text input with the new DOPS component `ClipboardButtonInput`
<img width="731" alt="clipboardbuttoninput" src="https://cloud.githubusercontent.com/assets/1041600/17633385/68ae79ce-60a3-11e6-9ea9-5c5658e3986c.png">

#### Testing instructions:
❗ Requires https://github.com/Automattic/dops-components/pull/45 
- go to Jetpack admin > Settings > Writing, expand Post by Email, the field should display the email address and clicking the button should copy it to clipboard