### PR TITLE
Use prefix (multisite-aware) not base prefix when fetching user IDs for site

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -182,7 +182,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		global $wpdb;
 
 		if ( is_multisite() ) {
-			$query = "ID IN ( SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '{$wpdb->base_prefix}capabilities' )";
+			$query = "ID IN ( SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '{$wpdb->prefix}capabilities' )";
 		} else {
 			$query = '1=1';
 		}


### PR DESCRIPTION
`$wpdb->base_prefix` doesn't (according to the documentation) include the site ID. This PR changes usage of this variable to `$wpdb->prefix`.

From the WP docs:

> *$base_prefix*
> The original prefix as defined in wp-config.php. For multi-site: Use if you want to get the prefix without the blog number appended.
