### PR TITLE
SSO: Add JETPACK__API_BASE host to allowed redirect hosts

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1157,7 +1157,19 @@ class Jetpack {
 	 * Whether Jetpack's version maps to a public release, or a development version.
 	 */
 	public static function is_development_version() {
-		return ! preg_match( '/^\d+(\.\d+)+$/', JETPACK__VERSION );
+		/**
+		 * Allows filtering whether this is a development version of Jetpack.
+		 *
+		 * This filter is especially useful for tests.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param bool $development_version Is this a develoment version of Jetpack?
+		 */
+		return (bool) apply_filters(
+			'jetpack_development_version',
+			! preg_match( '/^\d+(\.\d+)+$/', JETPACK__VERSION )
+		);
 	}
 
 	/**
@@ -2736,7 +2748,7 @@ p {
 		if ( $encode ) {
 			return json_encode( $merged_data );
 		}
-		
+
 		return $merged_data;
 	}
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -847,6 +847,16 @@ class Jetpack_SSO {
 		$hosts[] = 'wordpress.com';
 		$hosts[] = 'jetpack.wordpress.com';
 
+		if (
+			Jetpack::is_development_mode() || Jetpack::is_development_version() &&
+			( false === strpos( JETPACK__API_BASE, 'jetpack.wordpress.com/jetpack' ) )
+		) {
+			$base_url_parts = parse_url( esc_url_raw( JETPACK__API_BASE ) );
+			if ( $base_url_parts && ! empty( $base_url_parts['host'] ) ) {
+				$hosts[] = $base_url_parts['host'];
+			}
+		}
+
 		return array_unique( $hosts );
 	}
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -395,7 +395,7 @@ class Jetpack_SSO {
 			$this->wants_to_login()
 			&& Jetpack_SSO_Helpers::bypass_login_forward_wpcom()
 		) {
-			add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+			add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );
 			$this->maybe_save_cookie_redirect();
 			$reauth = ! empty( $_GET['force_reauth'] );
 			$sso_url = $this->get_sso_url_or_die( $reauth );
@@ -419,7 +419,7 @@ class Jetpack_SSO {
 				} else {
 					$this->maybe_save_cookie_redirect();
 					// Is it wiser to just use wp_redirect than do this runaround to wp_safe_redirect?
-					add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+					add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );
 					$reauth = ! empty( $_GET['force_reauth'] );
 					$sso_url = $this->get_sso_url_or_die( $reauth );
 					JetpackTracking::record_user_event( 'sso_login_redirect_success' );
@@ -840,26 +840,6 @@ class Jetpack_SSO {
 		return admin_url( 'profile.php' );
 	}
 
-	function allowed_redirect_hosts( $hosts ) {
-		if ( empty( $hosts ) ) {
-			$hosts = array();
-		}
-		$hosts[] = 'wordpress.com';
-		$hosts[] = 'jetpack.wordpress.com';
-
-		if (
-			Jetpack::is_development_mode() || Jetpack::is_development_version() &&
-			( false === strpos( JETPACK__API_BASE, 'jetpack.wordpress.com/jetpack' ) )
-		) {
-			$base_url_parts = parse_url( esc_url_raw( JETPACK__API_BASE ) );
-			if ( $base_url_parts && ! empty( $base_url_parts['host'] ) ) {
-				$hosts[] = $base_url_parts['host'];
-			}
-		}
-
-		return array_unique( $hosts );
-	}
-
 	/**
 	 * Builds the "Login to WordPress.com" button that is displayed on the login page as well as user profile page.
 	 *
@@ -1146,7 +1126,7 @@ class Jetpack_SSO {
 		 */
 		$connect_url = Jetpack::init()->build_connect_url( true, $redirect_after_auth, 'sso' );
 
-		add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+		add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );
 		wp_safe_redirect( $connect_url );
 		exit;
 	}

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -154,6 +154,37 @@ class Jetpack_SSO_Helpers {
 	static function is_match_by_email_checkbox_disabled() {
 		return defined( 'WPCC_MATCH_BY_EMAIL' ) || has_filter( 'jetpack_sso_match_by_email' );
 	}
+
+	/**
+	 * Returns an array of hosts that SSO will redirect to.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param array $hosts
+	 * @param string $api_base
+	 *
+	 * @return array
+	 */
+	static function allowed_redirect_hosts( $hosts, $api_base = JETPACK__API_BASE ) {
+		if ( empty( $hosts ) ) {
+			$hosts = array();
+		}
+
+		$hosts[] = 'wordpress.com';
+		$hosts[] = 'jetpack.wordpress.com';
+
+		if (
+			( Jetpack::is_development_mode() || Jetpack::is_development_version() ) &&
+			( false === strpos( $api_base, 'jetpack.wordpress.com/jetpack' ) )
+		) {
+			$base_url_parts = parse_url( esc_url_raw( $api_base ) );
+			if ( $base_url_parts && ! empty( $base_url_parts[ 'host' ] ) ) {
+				$hosts[] = $base_url_parts[ 'host' ];
+			}
+		}
+
+		return array_unique( $hosts );
+	}
 }
 
 endif;

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -158,6 +158,9 @@ class Jetpack_SSO_Helpers {
 	/**
 	 * Returns an array of hosts that SSO will redirect to.
 	 *
+	 * Instead of accessing JETPACK__API_BASE within the method directly, we set it as the
+	 * default for $api_base due to restrictions with testing constants in our tests.
+	 *
 	 * @since 4.4.0
 	 *
 	 * @param array $hosts

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -98,4 +98,37 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 	function test_sso_helpers_match_by_email_enabled() {
 		$this->assertFalse( Jetpack_SSO_Helpers::is_match_by_email_checkbox_disabled() );
 	}
+	
+	function test_allow_redirect_hosts_adds_default_hosts() {
+		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts( array( 'test.com' ) );
+		$this->assertInternalType( 'array', $hosts );
+		$this->assertContains( 'test.com', $hosts );
+		$this->assertContains( 'wordpress.com', $hosts );
+		$this->assertContains( 'jetpack.wordpress.com', $hosts );
+	}
+
+	function test_allow_redirect_host_api_base_not_added_when_not_in_dev() {
+		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts(
+			array( 'test.com' ),
+			'http://fakesite.com/jetpack.'
+		);
+		$this->assertInternalType( 'array', $hosts );
+		$this->assertCount( 3, $hosts );
+		$this->assertContains( 'test.com', $hosts );
+		$this->assertContains( 'wordpress.com', $hosts );
+		$this->assertContains( 'jetpack.wordpress.com', $hosts );
+		$this->assertNotContains( 'fakesite.com', $hosts );
+	}
+
+	function test_allowed_redirect_hosts_api_base_added_in_dev() {
+		add_filter( 'jetpack_development_mode', '__return_true' );
+		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts(
+			array( 'test.com' ),
+			'http://fakesite.com/jetpack.'
+		);
+		$this->assertInternalType( 'array', $hosts );
+		$this->assertCount( 4, $hosts );
+		$this->assertContains( 'fakesite.com', $hosts );
+		remove_filter( 'jetpack_development_mode', '__return_true' );
+	}
 }

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -108,6 +108,7 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 	}
 
 	function test_allow_redirect_host_api_base_not_added_when_not_in_dev() {
+		add_filter( 'jetpack_development_version', '__return_false' );
 		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts(
 			array( 'test.com' ),
 			'http://fakesite.com/jetpack.'
@@ -118,9 +119,10 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertContains( 'wordpress.com', $hosts );
 		$this->assertContains( 'jetpack.wordpress.com', $hosts );
 		$this->assertNotContains( 'fakesite.com', $hosts );
+		remove_filter( 'jetpack_development_version', '__return_false' );
 	}
 
-	function test_allowed_redirect_hosts_api_base_added_in_dev() {
+	function test_allowed_redirect_hosts_api_base_added_in_dev_mode() {
 		add_filter( 'jetpack_development_mode', '__return_true' );
 		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts(
 			array( 'test.com' ),
@@ -130,5 +132,17 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertCount( 4, $hosts );
 		$this->assertContains( 'fakesite.com', $hosts );
 		remove_filter( 'jetpack_development_mode', '__return_true' );
+	}
+
+	function test_allowed_redirect_hosts_api_base_added_on_dev_version() {
+		add_filter( 'jetpack_development_version', '__return_true' );
+		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts(
+			array( 'test.com' ),
+			'http://fakesite.com/jetpack.'
+		);
+		$this->assertInternalType( 'array', $hosts );
+		$this->assertCount( 4, $hosts );
+		$this->assertContains( 'fakesite.com', $hosts );
+		remove_filter( 'jetpack_development_version', '__return_true' );
 	}
 }


### PR DESCRIPTION
Testing SSO is a bit of pain. 😄 

[Here's an example](https://github.com/Automattic/wp-calypso/pull/7324#issuecomment-238351461) of the steps needed to test SSO when making a change on WPCOM:

> - Checkout WPCOM diff
> - Checkout this PR branch
> - On my Jetpack site, update API base to point to my sandbox
> - On my remote site, on Jetpack, update the `allowed_redirect_hosts` method so that the API base domain is in the array.
> - Ensure test user is not already connected to WP.com
> - Go to `$site/wp-admin`
> - Click "Log in with WordPress.com"
> - Click "Log in" on WordPress.com (which approves the connection)
> - Then I landed on the legacy connection screen

The biggest pain here is updating the `allowed_redirect_hosts` to match the sandbox that the user set for `JETPACK_API_BASE`. What if we're not testing a Jetpack change, but a WPCOM change? What if we're testing a Jetpack change and accidentally commit our change to allowed redirect hosts?

We can do that automagically, and this PR is an attempt at doing that.

To test issue:

- Update `JETPAK__API_BASE` to point to your sandbox
- Ensure your site is connected
- Use another WordPress.com (other than master user) with an email that matches on the Jetpack site. Ensure Jetpack user is not connected to WP.com user
- Go to `$site/wp-admin`
- Click "Log in with WordPress.com" button
- You should land on wp-admin
- If you go to the Jetpack admin page in your site, you should not be connected. You'll see a button that says "Link to WordPress.com"

To test fix:

- Checkout `update/sso-safe-redirect-to-base-api` branch
- Follow steps above
- Before going to wp-admin, you should have gone to WordPress.com and been auto-authorized
- Go to Jetpack admin page. You should be connected.

cc @lezama for code review