### PR TITLE
Admin Page: Remove direct access to window.Initial_State from footer component

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -10,14 +10,15 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import {
+	isDevVersion as _isDevVersion,
 	getCurrentVersion,
-	isDevVersion,
 	userCanManageOptions,
 	userCanDisconnectSite
 } from 'state/initial-state';
 import { resetOptions } from 'state/dev-version';
 import { disconnectSite } from 'state/connection';
 import { getSiteConnectionStatus } from 'state/connection';
+import { isDevMode as _isDevMode } from 'state/connection';
 
 export const Footer = React.createClass( {
 	displayName: 'Footer',
@@ -66,7 +67,7 @@ export const Footer = React.createClass( {
 		};
 
 		const maybeShowDisconnect = () => {
-			if ( this.props.userCanDisconnectSite && this.props.siteConnectionStatus ) {
+			if ( this.props.userCanDisconnectSite && this.props.siteConnectionStatus && ! this.props.isDevMode ) {
 				return (
 					<li className="jp-footer__link-item">
 						<a
@@ -129,7 +130,8 @@ export default connect(
 			currentVersion: getCurrentVersion( state ),
 			userCanManageOptions: userCanManageOptions( state ),
 			userCanDisconnectSite: userCanDisconnectSite( state ),
-			isDevVersion: isDevVersion( state ),
+			isDevVersion: _isDevVersion( state ),
+			isDevMode: _isDevMode( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state )
 		}
 	},

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -9,7 +9,12 @@ import { translate as __ } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getCurrentVersion, isDevVersion } from 'state/initial-state';
+import {
+	getCurrentVersion,
+	isDevVersion,
+	userCanManageOptions,
+	userCanDisconnectSite
+} from 'state/initial-state';
 import { resetOptions } from 'state/dev-version';
 import { disconnectSite } from 'state/connection';
 import { getSiteConnectionStatus } from 'state/connection';
@@ -29,9 +34,9 @@ export const Footer = React.createClass( {
 			'jp-footer'
 		);
 
-		const version = getCurrentVersion( this.props );
+		const version = this.props.currentVersion;
 		const maybeShowReset = () => {
-			if ( isDevVersion( this.props ) ) {
+			if ( this.props.isDevVersion ) {
 				return(
 					<li className="jp-footer__link-item">
 						<a
@@ -45,13 +50,13 @@ export const Footer = React.createClass( {
 			return '';
 		};
 
-		const maybeShowDebug = () =>  {
-			if ( window.Initial_State.userData.currentUser.permissions.manage_options ) {
+		const maybeShowDebug = () => {
+			if ( this.props.userCanManageOptions ) {
 				return (
 					<li className="jp-footer__link-item">
 						<a
-							href={ window.Initial_State.adminUrl + 'admin.php?page=jetpack-debugger' }
-							title={ __( "Test your site’s compatibility with Jetpack." ) }
+							href={ this.props.adminUrl + 'admin.php?page=jetpack-debugger' }
+							title={ __( 'Test your site’s compatibility with Jetpack.' ) }
 							className="jp-footer__link">
 							{ __( 'Debug', { context: 'Navigation item. Noun. Links to a debugger tool for Jetpack.' } ) }
 						</a>
@@ -60,13 +65,13 @@ export const Footer = React.createClass( {
 			}
 		};
 
-		const maybeShowDisconnect = () =>  {
-			if ( window.Initial_State.userData.currentUser.permissions.disconnect && getSiteConnectionStatus( this.props ) ) {
+		const maybeShowDisconnect = () => {
+			if ( this.props.userCanDisconnectSite && this.props.siteConnectionStatus ) {
 				return (
 					<li className="jp-footer__link-item">
 						<a
 							onClick={ this.disconnectSite }
-							title={ __( "Disconnect from WordPress.com" ) }
+							title={ __( 'Disconnect from WordPress.com' ) }
 							className="jp-footer__link">
 							{ __( 'Disconnect Jetpack' ) }
 						</a>
@@ -120,7 +125,13 @@ export const Footer = React.createClass( {
 
 export default connect(
 	state => {
-		return state;
+		return {
+			currentVersion: getCurrentVersion( state ),
+			userCanManageOptions: userCanManageOptions( state ),
+			userCanDisconnectSite: userCanDisconnectSite( state ),
+			isDevVersion: isDevVersion( state ),
+			siteConnectionStatus: getSiteConnectionStatus( state )
+		}
 	},
 	( dispatch ) => {
 		return {

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -43,6 +43,14 @@ export function userCanManageModules( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'manage_modules', false );
 }
 
+export function userCanManageOptions( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'manage_options', false );
+}
+
+export function userCanDisconnectSite( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'disconnect', false );
+}
+
 export function userCanViewStats( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'view_stats', false );
 }


### PR DESCRIPTION
#### Testing instructions

As an Admin and with the React Dev tools open, check that the Footer coomponent is receiving at least these props and that they all have truthy values. 

* currentVersion
* userCanManageOptions
* userCanDisconnectSite
* isDevVersion
* siteConnectionStatus

In dev mode, check that you don't see the disconnect button on the footer