### PR TITLE
Admin Page: Remove direct access to window.Initial_State from DashAkismet component

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -62,7 +62,7 @@ const DashAkismet = React.createClass( {
 						{
 							__( 'For state-of-the-art spam defense, please {{a}}install Akismet{{/a}}.', {
 								components: {
-									a: <a href={ 'https://wordpress.com/plugins/akismet/' + window.Initial_State.rawUrl } target="_blank" />
+									a: <a href={ 'https://wordpress.com/plugins/akismet/' + this.props.siteRawUrl } target="_blank" />
 								}
 							} )
 						}


### PR DESCRIPTION
#### Testing instructions

As an Admin and with the React Dev tools open, check that the `DashAkismet` component is receiving at least this prop and that it has a truthy value

* siteRawUrl