### PR TITLE
Admin Page: Remove direct access to window.Initial_State from JetpackStateNotices component

### DIFF
--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -6,6 +6,17 @@ import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import SimpleNotice from 'components/notice';
 
+/**
+ * Internal dependencies
+ */
+
+import { getCurrentVersion } from 'state/initial-state';
+import {
+	getJetpackStateNoticesErrorCode,
+	getJetpackStateNoticesMessageCode,
+	getJetpackStateNoticesErrorDescription
+} from 'state/jetpack-notices';
+
 const JetpackStateNotices = React.createClass( {
 	displayName: 'JetpackStateNotices',
 	getInitialState: function() {
@@ -20,7 +31,7 @@ const JetpackStateNotices = React.createClass( {
 	},
 
 	getErrorFromKey: function( key ) {
-		const errorDesc = window.Initial_State.jetpackStateNotices.errorDescription || false;
+		const errorDesc = this.props.jetpackStateNoticesErrorDescription || false;
 		let message = '';
 
 		switch ( key ) {
@@ -157,7 +168,7 @@ const JetpackStateNotices = React.createClass( {
 				message = __( 'Welcome to {{s}}Jetpack %(jetpack_version)s{{/s}}!',
 					{
 						args: {
-							jetpack_version: window.Initial_State.currentVersion
+							jetpack_version: this.props.currentVersion
 						},
 						components: {
 							s: <strong />
@@ -188,8 +199,8 @@ const JetpackStateNotices = React.createClass( {
 	renderContent: function() {
 		let status = 'is-info';
 		let noticeText = '';
-		const error = window.Initial_State.jetpackStateNotices.errorCode,
-			message = window.Initial_State.jetpackStateNotices.messageCode;
+		const error = this.props.jetpackStateNoticesErrorCode,
+			message = this.props.jetpackStateNoticesMessageCode;
 
 		if ( ! error && ! message ) {
 			return;
@@ -227,4 +238,13 @@ const JetpackStateNotices = React.createClass( {
 	}
 } );
 
-export default JetpackStateNotices;
+export default connect(
+	( state ) => {
+		return {
+			currentVersion: getCurrentVersion( state ),
+			jetpackStateNoticesErrorCode: getJetpackStateNoticesErrorCode( state ),
+			jetpackStateNoticesMessageCode: getJetpackStateNoticesMessageCode( state ),
+			jetpackStateNoticesErrorDescription: getJetpackStateNoticesErrorDescription( state )
+		};
+	}
+)( JetpackStateNotices );

--- a/_inc/client/state/jetpack-notices/reducer.js
+++ b/_inc/client/state/jetpack-notices/reducer.js
@@ -20,7 +20,6 @@ import {
 	JUMPSTART_SKIP,
 
 } from 'state/action-types';
-import restApi from 'rest-api';
 
 const notice = ( state = false, action ) => {
 	switch ( action.type ) {
@@ -67,6 +66,36 @@ export const reducer = combineReducers( {
  */
 export function getJetpackNotices( state ) {
 	return state.jetpack.jetpackNotices.notice;
+}
+
+/**
+ * Returns any Jetpack notice error code hooked onto 'jetpack_notices' in PHP
+ *
+ * @param  {Object} state Global state tree
+ * @return {number}  An error code.
+ */
+export function getJetpackStateNoticesErrorCode( state ) {
+	return get( state.jetpack.initialState, ['jetpackStateNotices', 'errorCode' ] );
+}
+
+/**
+ * Returns any Jetpack notice message code hooked onto 'jetpack_notices' in PHP
+ *
+ * @param  {Object} state Global state tree
+ * @return {number}  A message code.
+ */
+export function getJetpackStateNoticesMessageCode( state ) {
+	return get( state.jetpack.initialState, ['jetpackStateNotices', 'messageCode' ] );
+}
+
+/**
+ * Returns any Jetpack notice error description hooked onto 'jetpack_notices' in PHP
+ *
+ * @param  {Object} state Global state tree
+ * @return {string}  An error description.
+ */
+export function getJetpackStateNoticesErrorDescription( state ) {
+	return get( state.jetpack.initialState, ['jetpackStateNotices', 'errorDescription' ] );
 }
 
 /**


### PR DESCRIPTION
#### Testing instructions

**I need to write a more accurate test instructions** because we need to error somehow for noticing this.

As an Admin and with the React Dev tools open...

1. Disconnect your site
2. Temporarily update, [this line](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L3338) in  `class.jetpack.php` to be 
```
// if ( Jetpack::is_active() && Jetpack::is_user_connected() ) {
if ( true ) {
```
3. Try to connect your site. 
4. You should see a red notice with an error message
4. Using the react dev tools check that the `JetpackStateNotices` component is receiving at least these props with non-undefined values

* `currentVersion`
* `jetpackNoticesErrorCode` (this one may have a null value and that's fine)
* `jetpackNoticesMessageCode` (this one may have a null vale and that's fine)
* `jetpackNoticesErrorDescription`