### PR TITLE
Forms: prefixed classes with `.jp-` and added margin to bottom of fie…

### DIFF
--- a/_inc/client/components/forms/index.jsx
+++ b/_inc/client/components/forms/index.jsx
@@ -15,7 +15,7 @@ export const FormFieldset = React.createClass( {
 
 	render: function() {
 		return (
-			<fieldset { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-fieldset' ) } >
+			<fieldset { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'jp-form-fieldset' ) } >
 				{ this.props.children }
 			</fieldset>
 		);
@@ -28,7 +28,7 @@ export const FormLabel = React.createClass( {
 
 	render: function() {
 		return (
-			<label { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-label' ) } >
+			<label { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'jp-form-label' ) } >
 				{ this.props.children }
 			</label>
 		);
@@ -41,7 +41,7 @@ export const FormLegend = React.createClass( {
 
 	render: function() {
 		return (
-			<legend { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-legend' ) } >
+			<legend { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'jp-form-legend' ) } >
 				{ this.props.children }
 			</legend>
 		);
@@ -56,7 +56,7 @@ export const FormCheckbox = React.createClass( {
 		var otherProps = omit( this.props, [ 'className', 'type' ] );
 
 		return (
-			<input { ...otherProps } type="checkbox" className={ classnames( this.props.className, 'form-checkbox' ) } />
+			<input { ...otherProps } type="checkbox" className={ classnames( this.props.className, 'jp-form-checkbox' ) } />
 		);
 	}
 } );
@@ -81,7 +81,7 @@ export const FormTextInput = React.createClass( {
 	render() {
 		const { className, selectOnFocus } = this.props;
 		const classes = classNames( className, {
-			'form-text-input': true,
+			'jp-form-text-input': true,
 			'is-error': this.props.isError,
 			'is-valid': this.props.isValid
 		} );
@@ -107,7 +107,7 @@ export const FormTextarea = React.createClass( {
 
 	render: function() {
 		return (
-			<textarea { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-textarea' ) } >
+			<textarea { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'jp-form-textarea' ) } >
 				{ this.props.children }
 			</textarea>
 		);
@@ -125,7 +125,7 @@ export const FormRadio = React.createClass( {
 			<input
 				{ ...otherProps }
 				type="radio"
-				className={ classnames( this.props.className, 'form-radio' ) } />
+				className={ classnames( this.props.className, 'jp-form-radio' ) } />
 		);
 	}
 } );
@@ -148,7 +148,7 @@ export const FormButton = React.createClass( {
 
 	render: function() {
 		var buttonClasses = classNames( {
-			'form-button': true
+			'jp-form-button': true
 		} );
 
 		return (

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -1,38 +1,42 @@
-.form-fieldset {
+.jp-form-fieldset {
 	clear: both;
+
+	+ .jp-form-fieldset {
+		margin-top: rem( 16px );
+	}
 }
 
-.form-legend {
+.jp-form-legend {
 	padding: 0;
 	margin-bottom: 5px;
 	font-size: rem( 14px );
 	font-weight: 600;
 }
 
-.form-label {
+.jp-form-label {
 	display: block;
 	font-size: rem( 14px );
 	line-height: 1.5;
 	margin-bottom: 5px;
 }
 
-.form-label input[type="radio"] + span {
+.jp-form-label input[type="radio"] + span {
 	font-weight: normal;
 }
 
-.form-textarea {
+.jp-form-textarea {
 	display: block;
 	width: 100%;
 	min-height: rem( 250px );
 }
 
-.form-button {
+.jp-form-button {
 	float: right;
 	margin-top: rem( 16px );
 	margin-left: rem( 8px );
 }
 
-.form-setting-explanation {
+.jp-form-setting-explanation {
 	color: $gray;
 	display: block;
 	font-size: rem( 13px );

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -137,7 +137,7 @@ export let CommentsSettings = React.createClass( {
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
 					<FormLegend>{ __( 'Comments headline' ) }</FormLegend>
-					<span className="form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
+					<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
 					<FormLabel>
 						<FormTextInput
 							name={ 'highlander_comment_form_prompt' }
@@ -270,7 +270,7 @@ export let MonitorSettings = React.createClass( {
 						name={ 'monitor_receive_notifications' }
 						{ ...this.props }
 						label={ __( 'Receive Monitor Email Notifications' ) } />
-					<span className="form-setting-explanation">{ __( 'Emails will be sent to ' ) + this.props.adminEmailAddress }. <span>
+					<span className="jp-form-setting-explanation">{ __( 'Emails will be sent to ' ) + this.props.adminEmailAddress }. <span>
 						&nbsp;
 						{
 							__( '{{a}}Edit{{/a}}', {
@@ -434,7 +434,7 @@ export let VerificationToolsSettings = React.createClass( {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
-					<p className="form-setting-explanation">
+					<p className="jp-form-setting-explanation">
 						{
 							__( 'Enter your meta key "content" value to verify your blog with {{a}}Google Search Console{{/a}}, {{a}}Bing Webmaster Center{{/a}} and {{a}}Pinterest Site Verification{{/a}}.', {
 								components: {

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -86,7 +86,7 @@ export const AllModuleSettings = React.createClass( {
 			case 'notifications':
 			case 'enhanced-distribution':
 			case 'sitemaps':
-				return <span className="form-setting-explanation">{ __( 'This module has no configuration options' ) } </span>;
+				return <span className="jp-form-setting-explanation">{ __( 'This module has no configuration options' ) } </span>;
 			case 'custom-css':
 			case 'widgets':
 			case 'publicize':


### PR DESCRIPTION
Fixes #4759 .

#### Changes proposed in this Pull Request:
* prefixes classes with `jp-`
* adds spacing between form fieldsets

#### Testing instructions:
-Go to settings and look at Engagement > Site Stats