### PR TITLE
Admin Page: Remove direct access to window.Initial_State from Settings component

### DIFF
--- a/_inc/client/components/settings/index.jsx
+++ b/_inc/client/components/settings/index.jsx
@@ -13,7 +13,8 @@ import {
 	fetchSettings,
 	isSettingActivated,
 	updateSetting,
-	isFetchingSettingsList
+	isFetchingSettingsList,
+	getSettingName
 } from 'state/settings';
 
 export const Settings = React.createClass( {
@@ -25,8 +26,8 @@ export const Settings = React.createClass( {
 		return (
 			<div>
 				<SettingToggle
-					slug={ window.Initial_State.settingNames.jetpack_holiday_snow_enabled }
-					activated={ this.props.isSettingActivated( window.Initial_State.settingNames.jetpack_holiday_snow_enabled ) }
+					slug={ this.props.snowSlug }
+					activated={ this.props.isSettingActivated( this.props.snowSlug ) }
 					toggleSetting={ this.props.toggleSetting }
 					disabled={ this.props.isFetchingSettingsList }
 				>{ __( 'Show falling snow on my blog from Dec 1st until Jan 4th.' ) }</SettingToggle>
@@ -38,9 +39,8 @@ export const Settings = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			isSettingActivated: ( setting_name ) => {
-				return isSettingActivated( state, setting_name );
-			},
+			snowSlug: getSettingName( state, 'jetpack_holiday_snow_enabled' ),
+			isSettingActivated: ( setting_name ) => isSettingActivated( state, setting_name ),
 			isFetchingSettingsList: isFetchingSettingsList( state ),
 			settings: fetchSettings( state )
 		};

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -25,7 +25,7 @@ import {
 } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 
-export const Page = ( props ) => {
+export const GeneralSettings = ( props ) => {
 	let {
 		toggleModule,
 		isModuleActivated,
@@ -138,4 +138,4 @@ export default connect(
 			disconnectSite: () => dispatch( disconnectSite )
 		};
 	}
-)( Page );
+)( GeneralSettings );

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -116,3 +116,13 @@ export function isSettingActivated( state, name ) {
 export function toggleSetting( state, name ) {
 	return get( state.jetpack.settings.items, [ name ], false ) ? true : false;
 }
+
+/**
+ * Returns the slug of a general setting.
+ * @param  {Object}  state Global state tree
+ * @param  {String}  name  A setting's name
+ * @return {String}       The setting name
+ */
+export function getSettingName( state, name ) {
+	return get( state.jetpack.initialState.settingNames, [ name ] );
+}


### PR DESCRIPTION
#### Testing instructions

As an Admin user and with the React Dev tools open, expand the Snow Settings card and check that the `Settings` component is receiving at least this prop and that it has a value of `"jetpack_holiday_snow_enabled"`

* snowSlug