### PR TITLE
Settings Comments: replaced old input with TextInput and more!

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -2,7 +2,7 @@
 	clear: both;
 
 	+ .jp-form-fieldset {
-		margin-top: rem( 16px );
+		margin-top: rem( 24px );
 	}
 }
 

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -138,14 +138,14 @@ export let CommentsSettings = React.createClass( {
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
 					<FormLegend>{ __( 'Comments headline' ) }</FormLegend>
-					<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
 					<FormLabel>
-						<FormTextInput
+						<TextInput
 							name={ 'highlander_comment_form_prompt' }
 							value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
 							disabled={ this.props.isUpdating( 'highlander_comment_form_prompt' ) }
 							onChange={ this.props.onOptionChange} />
 					</FormLabel>
+					<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>{ __( 'Color Scheme' ) }</FormLegend>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* replaced old form input with new TextInput (needs testing, but seems to work)
* repositioned explanation text to be after the input as per calypso patterns
* made `jp-form-fieldset` styles match Calypso's

#### Testing instructions:
* Go to Writing > Comments in the settings

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17670891/10e5a050-62e2-11e6-8497-236f7b69c7f5.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/17670874/f579fd02-62e1-11e6-93ce-f7bd862a9217.png)
