### PR TITLE
Admin Page: Remove direct access to window.Initial_State from engagement component

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -31,7 +31,7 @@ import {
 	userCanManageModules as _userCanManageModules
 } from 'state/initial-state';
 
-export const Page = ( props ) => {
+export const Engagement = ( props ) => {
 	let {
 		toggleModule,
 		isModuleActivated,
@@ -196,4 +196,4 @@ export default connect(
 			}
 		};
 	}
-)( Page );
+)( Engagement );

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -24,7 +24,12 @@ import {
 import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
 import { isUnavailableInDevMode } from 'state/connection';
-import { getSiteAdminUrl, getSiteRawUrl, isSitePublic } from 'state/initial-state';
+import {
+	getSiteAdminUrl,
+	getSiteRawUrl,
+	isSitePublic,
+	userCanManageModules as _userCanManageModules
+} from 'state/initial-state';
 
 export const Page = ( props ) => {
 	let {
@@ -33,7 +38,7 @@ export const Page = ( props ) => {
 		isTogglingModule,
 		getModule
 	} = props,
-		isAdmin = window.Initial_State.userData.currentUser.permissions.manage_modules,
+		isAdmin = props.userCanManageModules,
 		sitemapsDesc = getModule( 'sitemaps' ).description,
 		enhaDistDesc = getModule( 'enhanced-distribution' ).description;
 
@@ -178,7 +183,8 @@ export default connect(
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
 			getSiteRawUrl: () => getSiteRawUrl( state ),
 			getSiteAdminUrl: () => getSiteAdminUrl( state ),
-			isSitePublic: () => isSitePublic( state )
+			isSitePublic: () => isSitePublic( state ),
+			userCanManageModules: _userCanManageModules( state )
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
#### Testing instructions

As an Admin user and with the React Dev tools open,  check that the `Engagement` component is receiving at least this prop and that it has a `true` value

* userCanManageModules