### PR TITLE
Settings: add connection settings card for non-admin views.

### DIFF
--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -76,22 +76,19 @@ export const Page = ( props ) => {
 
 	return (
 		<div>
-			{
-				isAdmin ? <FoldableCard
-					header={ __( 'Connection Settings' ) }
-					subheader={ __( 'Manage your connection or disconnect Jetpack.' ) }
-					clickableHeaderText={ true }
-					disabled={ ! isAdmin }
-					onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-						{
-							card: 'connection_settings',
-							path: props.route.path
-						}
-					) }
-				>
-					<ConnectionSettings { ...props } />
-				</FoldableCard> : ''
-			}
+			<FoldableCard
+				header={ __( 'Connection Settings' ) }
+				subheader={ __( 'Manage your Jetpack connection.' ) }
+				clickableHeaderText={ true }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: 'connection_settings',
+						path: props.route.path
+					}
+				) }
+			>
+				<ConnectionSettings { ...props } />
+			</FoldableCard>
 			{ isModuleActivated( 'manage' ) ? '' : moduleCard( 'manage' ) }
 			{ moduleCard( 'notes' ) }
 			{ moduleCard( 'json-api' ) }


### PR DESCRIPTION
This fixes a bug where the Connection Settings card was not showing for non-admins.  

To Test: 
- Link any non-admin user to wp.com
- Verify that the Connection card is showing in General tab
- Verify that you are able to unlink
- Verify that you don't see any option to disconnect the SITE 
- Verify that nothing has changed in the view for an admin

cc @eliorivero for review