### PR TITLE
Admin Page: Remove direct access to window.Initial_State from connection-settings component

### DIFF
--- a/_inc/client/general-settings/connection-settings.jsx
+++ b/_inc/client/general-settings/connection-settings.jsx
@@ -9,40 +9,46 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import { isCurrentUserLinked, isDevMode } from 'state/connection';
+import {
+	userCanDisconnectSite as _userCanDisconnectSite,
+	userIsMaster as _userIsMaster,
+	getUserWpComLogin as _getUserWpComLogin,
+	getUserWpComEmail as _getUserWpComEmail,
+	getUsername as _getUsername
+} from 'state/initial-state';
 import QueryUserConnectionData from 'components/data/query-user-connection';
 import ConnectButton from 'components/connect-button';
 
 const ConnectionSettings = React.createClass( {
 	renderContent: function() {
-		const userData = window.Initial_State.userData;
-
-		const maybeShowDisconnectBtn = userData.currentUser.permissions.disconnect
+		const maybeShowDisconnectBtn = this.props.userCanDisconnectSite
 			? <ConnectButton />
 			: null;
 
-		const maybeShowLinkUnlinkBtn = userData.currentUser.isMaster
+		const maybeShowLinkUnlinkBtn = this.props.userIsMaster
 			? null
 			: <ConnectButton connectUser={ true } />;
 
 		return isDevMode( this.props ) ?
-			<div>
-				{
-					__( 'The site is in Development Mode, so you can not connect to WordPress.com.' )
-				}
-			</div>
-			:
+			(
+				<div>
+					{
+						__( 'The site is in Development Mode, so you can not connect to WordPress.com.' )
+					}
+				</div>
+			)	:
 			<div>
 				{
 					this.props.isLinked( this.props ) ?
 						__( 'You are linked to WordPress.com account %(userLogin)s / %(userEmail)s.', {
 							args: {
-								userLogin: userData.currentUser.wpcomUser.login,
-								userEmail: userData.currentUser.wpcomUser.email
+								userLogin: this.props.userWpComLogin,
+								userEmail: this.props.userWpComEmail
 							}
 						} ) :
 						__( 'You, %(userName)s, are not connected to WordPress.com.', {
 							args: {
-								userName: userData.currentUser.username
+								userName: this.props.username
 							}
 						} )
 				}
@@ -65,6 +71,11 @@ const ConnectionSettings = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
+			userCanDisconnectSite: _userCanDisconnectSite( state ),
+			userIsMaster: _userIsMaster( state ),
+			userWpComLogin: _getUserWpComLogin( state ),
+			userWpComEmail: _getUserWpComEmail( state ),
+			username: _getUsername( state ),
 			isLinked: () => isCurrentUserLinked( state )
 		}
 	}

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -51,6 +51,22 @@ export function userCanDisconnectSite( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'disconnect', false );
 }
 
+export function userIsMaster( state ) {
+	return get( state.jetpack.initialState.userData.currentUser, 'isMaster', false );
+}
+
+export function getUserWpComLogin( state ) {
+	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'login' ] );
+}
+
+export function getUserWpComEmail( state ) {
+	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'email' ] );
+}
+
+export function getUsername( state ) {
+	return get( state.jetpack.initialState.userData.currentUser, [ 'username' ] );
+}
+
 export function userCanViewStats( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'view_stats', false );
 }


### PR DESCRIPTION
#### Testing instructions

As an Admin and with the React Dev tools open, check that the `ConnectionSettings` component is receiving at least these props and that they have truthy values. 

* userCanDisconnectSite
* userIsMaster

And these other three should have values according to your  WordPress.com user and your local username

* userWpComLogin
* userWpComEmail
* username