### PR TITLE
Admin Page: Remove direct access to window.Initial_State from Search component

### DIFF
--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -33,7 +33,7 @@ import {
 } from 'state/site';
 import ProStatus from 'pro-status';
 
-export const Page = ( {
+export const SearchResults = ( {
 	siteAdminUrl,
 	toggleModule,
 	isModuleActivated,
@@ -191,4 +191,4 @@ export default connect(
 			}
 		};
 	}
-)( Page );
+)( SearchResults );

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -34,6 +34,7 @@ import {
 import ProStatus from 'pro-status';
 
 export const Page = ( {
+	siteAdminUrl,
 	toggleModule,
 	isModuleActivated,
 	isTogglingModule,
@@ -99,7 +100,7 @@ export const Page = ( {
 				module: element[0],
 				configure_url: 'backups' === element[0] || 'scan' === element[0] ?
 					'https://dashboard.vaultpress.com' :
-					Initial_State.adminUrl + 'admin.php?page=akismet-key-config'
+					siteAdminUrl + 'admin.php?page=akismet-key-config'
 			};
 			toggle = <ProStatus proFeature={ element[0] } />;
 


### PR DESCRIPTION
#### Testing instructions

As an Admin user and with the React Dev tools open,  check that the `Search` component (shown as search results after you enter a query) is receiving at least this prop and that it has the site's Admin url

* siteAdminUrl