### PR TITLE
Admin - AAG: fix Protect card in non admin views. Remove clouds background

### DIFF
--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -109,49 +109,7 @@
 	}
 }
 
-.jp-dash-item__recently-activated {
-	.dops-card:last-of-type {
-		padding: 0;
-	}
-	.jp-dash-item__content {
-		flex: none;
-		flex-basis: 100%;
-	}
-}
-
-.jp-dash-item__recently-activated-lower {
-	background: $white;
-
-	@include breakpoint( ">660px" ) {
-		position: relative;
-		margin-top: 63px;
-		background: $gray-light;
-
-		&:before {
-			position: absolute;
-			top: rem( -24px );
-			left: 0;
-			width: 100%;
-			display: block;
-			content: "";
-			background: $white url('../../images/jp-4/long-clouds.svg') no-repeat;
-			background-size: 150%;
-			background-position: 0;
-			padding: 0;
-			height: rem( 24px );
-
-
-			@include breakpoint( "<660px" ) {
-				display: none;
-			}
-		}
-	}
-	.jp-dash-item__description {
-		box-sizing: border-box;
-	}
-}
-
 .jp-dash-item__recently-activated .jp-dash-item__description {
-	padding: rem( 16px );
 	font-style: italic;
+	box-sizing: border-box;
 }


### PR DESCRIPTION
Fixes #4774

#### Changes proposed in this Pull Request:

- Fixes layout of Protect card for non-admin views
- Removes clouds background in Protect card
- Removes top padding so it's consistent with other cards

Before: 
<img width="741" alt="editor-no-access" src="https://cloud.githubusercontent.com/assets/1041600/17635073/e804c1b2-60ab-11e6-8092-6b0baef4d8e7.png">

After:
<img width="743" alt="captura de pantalla 2016-08-15 a las 15 49 38" src="https://cloud.githubusercontent.com/assets/1041600/17675120/ad9af9c4-62fe-11e6-9516-b6a504e5588d.png">

<img width="372" alt="captura de pantalla 2016-08-15 a las 15 49 23" src="https://cloud.githubusercontent.com/assets/1041600/17675122/b0b3ace6-62fe-11e6-8bec-56c6da98ba66.png">


#### Testing instructions:
- Use an admin user to activate Protect feature.
- Log in as an non-admin user and check that Protect card in AAG displays correctly.