### PR TITLE
Add setting to remotely (and entirely) disable sync

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -32,9 +32,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 			$modules = null;
 		}
 
-		Jetpack_Sync_Actions::schedule_full_sync( $modules );
-
-		return array( 'scheduled' => true );
+		return array( 'scheduled' => Jetpack_Sync_Actions::schedule_full_sync( $modules ) );
 	}
 }
 

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -665,6 +665,7 @@ $sync_settings_response = array(
 	'queue_max_writes_sec' => '(int|bool=false) Maximum writes per second to allow to the queue during full sync.',
 	'post_types_blacklist' => '(array|string|bool=false) List of post types to exclude from sync. Send "empty" to unset.',
 	'meta_blacklist'       => '(array|string|bool=false) List of meta keys to exclude from sync. Send "empty" to unset.',
+	'disable'              => '(int|bool=false) Set to 1 or true to disable sync entirely.',
 );
 
 // GET /sites/%s/sync/settings

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -13,6 +13,9 @@ class Jetpack_Sync_Actions {
 	const MAX_INITIAL_SYNC_USERS = 500;
 
 	static function init() {
+		if ( Jetpack_Sync_Settings::get_setting( 'disable' ) ) {
+			return false;
+		}
 
 		// Add a custom "every minute" cron schedule
 		add_filter( 'cron_schedules', array( __CLASS__, 'minute_cron_schedule' ) );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -13,10 +13,7 @@ class Jetpack_Sync_Actions {
 	const MAX_INITIAL_SYNC_USERS = 500;
 
 	static function init() {
-		if ( Jetpack_Sync_Settings::get_setting( 'disable' ) ) {
-			return false;
-		}
-
+		
 		// Add a custom "every minute" cron schedule
 		add_filter( 'cron_schedules', array( __CLASS__, 'minute_cron_schedule' ) );
 
@@ -106,7 +103,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function sync_allowed() {
-		return ( Jetpack::is_active() && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
+		return ( ! Jetpack_Sync_Settings::get_setting( 'disable' ) && Jetpack::is_active() && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
 			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
 	}
 
@@ -160,6 +157,10 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function schedule_full_sync( $modules = null ) {
+		if ( ! self::sync_allowed() ) {
+			return false;
+		}
+
 		if ( $modules ) {
 			wp_schedule_single_event( time() + 1, 'jetpack_sync_full', array( $modules ) );
 		} else {
@@ -167,6 +168,8 @@ class Jetpack_Sync_Actions {
 		}
 
 		spawn_cron();
+
+		return true;
 	}
 
 	static function is_scheduled_full_sync( $modules = null ) {

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -259,6 +259,7 @@ class Jetpack_Sync_Defaults {
 	static $default_queue_max_writes_sec = 100; // 100 rows a second
 	static $default_post_types_blacklist = array();
 	static $default_meta_blacklist = array();
+	static $default_disable = 0; // completely disable sending data to wpcom
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 }

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -34,9 +34,6 @@ class Jetpack_Sync_Listener {
 	}
 
 	private function init() {
-		if ( Jetpack_Sync_Settings::get_setting( 'disable' ) ) {
-			return;
-		}
 
 		$handler = array( $this, 'action_handler' );
 		$full_sync_handler = array( $this, 'full_sync_action_handler' );

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -34,6 +34,9 @@ class Jetpack_Sync_Listener {
 	}
 
 	private function init() {
+		if ( Jetpack_Sync_Settings::get_setting( 'disable' ) ) {
+			return;
+		}
 
 		$handler = array( $this, 'action_handler' );
 		$full_sync_handler = array( $this, 'full_sync_action_handler' );
@@ -83,6 +86,10 @@ class Jetpack_Sync_Listener {
 	// prevent adding items to the queue if it hasn't sent an item for 15 mins
 	// AND the queue is over 1000 items long (by default)
 	function can_add_to_queue( $queue ) {
+		if ( Jetpack_Sync_Settings::get_setting( 'disable' ) ) {
+			return false;
+		}
+
 		$state_transient_name = self::QUEUE_STATE_CHECK_TRANSIENT . '_' . $queue->id;
 
 		$queue_state = get_transient( $state_transient_name );

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -16,6 +16,7 @@ class Jetpack_Sync_Settings {
 		'queue_max_writes_sec' => true,
 		'post_types_blacklist' => true,
 		'meta_blacklist'       => true,
+		'disable'              => true,
 	);
 
 	static $is_importing;
@@ -74,6 +75,13 @@ class Jetpack_Sync_Settings {
 		foreach ( $validated_settings as $setting => $value ) {
 			update_option( self::SETTINGS_OPTION_PREFIX . $setting, $value, true );
 			unset( self::$settings_cache[ $setting ] );
+
+			// if we set the disabled option to true, clear the queues
+			if ( 'disable' === $setting && !! $value ) {
+				$listener = Jetpack_Sync_Listener::get_instance();
+				$listener->get_sync_queue()->reset();
+				$listener->get_full_sync_queue()->reset();
+			}
 		}
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -11,7 +11,8 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 				'upload_max_bytes',
 				'upload_max_rows',
 				'max_queue_size',
-				'max_queue_lag'
+				'max_queue_lag',
+				'disable',
 			) as $key
 		) {
 			$this->assertTrue( isset( $settings[ $key ] ) );
@@ -23,5 +24,26 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 		$updated_settings = Jetpack_Sync_Settings::get_settings();
 
 		$this->assertSame( 50, $updated_settings['dequeue_max_bytes'] );
+	}
+
+	function test_settings_disable_enqueue_and_clears_queue() {
+		$event = $this->server_event_storage->reset();
+
+		// create a post - this will end up in the queue before data is sent
+		$post_id = $this->factory->post->create();
+		$this->assertTrue( $this->listener->get_sync_queue()->size() > 0 );
+
+		Jetpack_Sync_Settings::update_settings( array( 'disable' => 1 ) );
+
+		// generating posts should no longer affect queue size
+		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
+		$post_id = $this->factory->post->create();
+		$this->assertEquals( 0, $this->listener->get_sync_queue()->size() );
+
+		// syncing sends no data
+		$this->sender->do_sync();
+		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'wp_insert_post' ) );
+
+		Jetpack_Sync_Settings::update_settings( array( 'disable' => 0 ) );
 	}
 }


### PR DESCRIPTION
Sometimes sites behave in erratic and strange ways, and as a failsafe it's important to be able to disable sync until we can remedy the problem.