### PR TITLE
Site Verification settings: updated to use TextInput, improved styles, fixed autoprefixer

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -459,7 +459,7 @@ export let VerificationToolsSettings = React.createClass( {
 								onChange={ this.props.onOptionChange} />
 						</FormLabel>
 						<span className="jp-form-setting-explanation">
-							{ __( 'Meta key example:' ) }
+							{ __( 'Meta key example: ' ) }
 							&lt;meta name='google-site-verification' content='<strong className="code">dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8</strong>'&gt;
 						</span>
 					</div>
@@ -477,7 +477,7 @@ export let VerificationToolsSettings = React.createClass( {
 								onChange={ this.props.onOptionChange} />
 						</FormLabel>
 						<span className="jp-form-setting-explanation">
-							{ __( 'Meta key example:' ) }
+							{ __( 'Meta key example: ' ) }
 							&lt;meta name='msvalidate.01' content='<strong>12C1203B5086AECE94EB3A3D9830B2E</strong>'&gt;
 						</span>
 					</div>
@@ -494,7 +494,7 @@ export let VerificationToolsSettings = React.createClass( {
 								onChange={ this.props.onOptionChange} />
 						</FormLabel>
 						<span className="jp-form-setting-explanation">
-							{ __( 'Meta key example:' ) }
+							{ __( 'Meta key example: ' ) }
 							&lt;meta name='p:domain_verify' content='<strong>f100679e6048d45e4a0b0b92dce1efce</strong>'&gt;
 						</span>
 					</div>

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -449,56 +449,54 @@ export let VerificationToolsSettings = React.createClass( {
 
 					<div className="dops-card">
 						<FormLabel>
-							<span>Google</span>
-							<FormTextInput
+							<FormLegend>Google</FormLegend>
+							<TextInput
 								name={ 'google' }
 								value={ this.props.getOptionValue( 'google' ) }
+								placeholder={ 'Example: dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8' }
 								className="widefat code"
 								disabled={ this.props.isUpdating( 'google' ) }
 								onChange={ this.props.onOptionChange} />
 						</FormLabel>
-						<p>
-							{ __( 'Example:' ) }
-						</p>
-						<p className="small">
+						<span className="jp-form-setting-explanation">
+							{ __( 'Meta key example:' ) }
 							&lt;meta name='google-site-verification' content='<strong className="code">dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8</strong>'&gt;
-						</p>
+						</span>
 					</div>
 
 					<div className="dops-card">
 						<FormLabel>
-							<span>Bing</span>
-							<FormTextInput
+							<FormLegend>Bing</FormLegend>
+							<TextInput
 								name={ 'bing' }
 								value={ this.props.getOptionValue( 'bing' ) }
+								placeholder={ 'Example: 12C1203B5086AECE94EB3A3D9830B2E' }
+								className="widefat code"
 								className="widefat code"
 								disabled={ this.props.isUpdating( 'bing' ) }
 								onChange={ this.props.onOptionChange} />
 						</FormLabel>
-						<p>
-							{ __( 'Example:' ) }
-						</p>
-						<p className="small">
+						<span className="jp-form-setting-explanation">
+							{ __( 'Meta key example:' ) }
 							&lt;meta name='msvalidate.01' content='<strong>12C1203B5086AECE94EB3A3D9830B2E</strong>'&gt;
-						</p>
+						</span>
 					</div>
 
 					<div className="dops-card">
 						<FormLabel>
-							<span>Pinterest</span>
-							<FormTextInput
+							<FormLegend>Pinterest</FormLegend>
+							<TextInput
 								name={ 'pinterest' }
 								value={ this.props.getOptionValue( 'pinterest' ) }
+								placeholder={ 'Example: f100679e6048d45e4a0b0b92dce1efce' }
 								className="widefat code"
 								disabled={ this.props.isUpdating( 'pinterest' ) }
 								onChange={ this.props.onOptionChange} />
 						</FormLabel>
-						<p>
-							{ __( 'Example:' ) }
-						</p>
-						<p className="small">
+						<span className="jp-form-setting-explanation">
+							{ __( 'Meta key example:' ) }
 							&lt;meta name='p:domain_verify' content='<strong>f100679e6048d45e4a0b0b92dce1efce</strong>'&gt;
-						</p>
+						</span>
 					</div>
 
 					<FormButton

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,6 +56,8 @@ function onBuild( done ) {
 		} else {
 			doStatic();
 		}
+
+		doSass();
 	};
 }
 
@@ -83,14 +85,14 @@ function doSass() {
 			console.log( 'Dashboard CSS finished.' );
 			doRTL( 'main' );
 		} );
-		console.log( 'Building dops-components CSS bundle...' );
-		gulp.src( './_inc/build/*dops-style.css' )
-			.pipe( autoprefixer( 'last 2 versions', 'ie >= 8' ) )
-			.pipe( gulp.dest( './_inc/build' ) )
-			.on( 'end', function() {
-				console.log( 'dops-components CSS finished.' );
-				doRTL( 'dops' );
-			} );
+	console.log( 'Building dops-components CSS bundle...' );
+	gulp.src( './_inc/build/*dops-style.css' )
+		.pipe( autoprefixer( 'last 2 versions', 'ie >= 8' ) )
+		.pipe( gulp.dest( './_inc/build' ) )
+		.on( 'end', function() {
+			console.log( 'dops-components CSS finished.' );
+			doRTL( 'dops' );
+		} );
 }
 
 function doRTL( files ) {
@@ -105,7 +107,7 @@ function doRTL( files ) {
 		} );
 }
 
-gulp.task( 'sass:build', doSass );
+gulp.task( 'sass:build', ['react:build'], doSass );
 
 gulp.task( 'sass:watch', function() {
 	doSass();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,9 +53,6 @@ function onBuild( done ) {
 
 		if ( done ) {
 			doStatic( done );
-
-			// After CSS files are built, create RTL versions
-			doRTL( 'dops' );
 		} else {
 			doStatic();
 		}
@@ -86,6 +83,14 @@ function doSass() {
 			console.log( 'Dashboard CSS finished.' );
 			doRTL( 'main' );
 		} );
+		console.log( 'Building dops-components CSS bundle...' );
+		gulp.src( './_inc/build/*dops-style.css' )
+			.pipe( autoprefixer( 'last 2 versions', 'ie >= 8' ) )
+			.pipe( gulp.dest( './_inc/build' ) )
+			.on( 'end', function() {
+				console.log( 'dops-components CSS finished.' );
+				doRTL( 'dops' );
+			} );
 }
 
 function doRTL( files ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Switched to use new TextInput component
* Changed styles and verbiage of meta key examples
* Used placeholder text
* It turns out the `dops-components` styles weren't being autoprefixed, so now they are thanks to some painful detective work (hat tip @dereksmart )

#### Testing instructions:
* Go to Settings > Engagement > Site verification
* try adding to the fields
* try removing stuff
* try to break it
