### PR TITLE
Subscription Settings: changed from h3 to FormLegend

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -169,7 +169,7 @@ export let SubscriptionsSettings = React.createClass( {
 	render() {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
-				<h3>{ __( 'Can readers subscribe to your posts, comments or both?' ) }</h3>
+				<FormLegend>{ __( 'Can readers subscribe to your posts, comments or both?' ) }</FormLegend>
 				<FormFieldset>
 					<ModuleSettingCheckbox
 						name={ "stb_enabled" }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* switched from h3 to FormLegend

#### Testing instructions:
-Go to Settings > Engagement > Subscriptions

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17677995/4d673a54-6303-11e6-90ee-465dbbd864ff.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17677983/3d9d02ca-6303-11e6-9409-8fab45c8132c.png)
