### PR TITLE
Staging: Remove the whitelist

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -129,7 +129,7 @@ class Jetpack_Options {
 	 */
 	public static function get_option_and_ensure_autoload( $name, $default ) {
 		$value = get_option( $name );
-		
+
 		if ( $value === false && $default !== false ) {
 			update_option( $name, $default );
 			$value = $default;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -325,6 +325,12 @@ class Jetpack {
 				}
 
 				add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
+
+				// Upgrade to 4.3.0
+				if ( Jetpack_Options::get_option( 'identity_crisis_whitelist' ) ) {
+					Jetpack_Options::delete_option( 'identity_crisis_whitelist' );
+				}
+
 				Jetpack::maybe_set_version_option();
 			}
 		}
@@ -2736,7 +2742,7 @@ p {
 		if ( $encode ) {
 			return json_encode( $merged_data );
 		}
-		
+
 		return $merged_data;
 	}
 
@@ -5176,25 +5182,12 @@ p {
 	 * Written so that we don't have re-check $key and $value params every time
 	 * we want to check if this site is whitelisted, for example in footer.php
 	 *
+	 * @since  3.8.0
 	 * @return bool True = already whitelisted False = not whitelisted
 	 */
 	public static function is_staging_site() {
 		$is_staging = false;
 
-		$current_whitelist = Jetpack_Options::get_option( 'identity_crisis_whitelist' );
-		if ( $current_whitelist && ! get_transient( 'jetpack_checked_is_staging' ) ) {
-			$options_to_check  = Jetpack::identity_crisis_options_to_check();
-			$cloud_options     = Jetpack::init()->get_cloud_site_options( $options_to_check );
-
-			foreach ( $cloud_options as $cloud_key => $cloud_value ) {
-				if ( self::is_identity_crisis_value_whitelisted( $cloud_key, $cloud_value ) ) {
-					$is_staging = true;
-					break;
-				}
-			}
-			// set a flag so we don't check again for an hour
-			set_transient( 'jetpack_checked_is_staging', 1, HOUR_IN_SECONDS );
-		}
 		$known_staging = array(
 			'urls' => array(
 				'#\.staging\.wpengine\.com$#i', // WP Engine


### PR DESCRIPTION
The whitelist was added in 3.8.0, which was populated via a UI option. We removed the UI from stable releases in 3.8.1 to go back to the drawing board.

The drawing board told us to nuke it and so we did, finally removing the UI completely in #4272.

For those few sites that actually did use the whitelist, we still respected it. Since we're dropping this approach, we should also remove the option.

This PR:
1. Removes consideration for the staging whitelist in `is_staging_site`.
2. Delete the option on upgrade to clean up after ourselves.

cc: @dereksmart 