### PR TITLE
Settings: Spelling & Grammar form enhancements

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -8,7 +8,7 @@
 
 .jp-form-legend {
 	padding: 0;
-	margin-bottom: 5px;
+	margin-bottom: rem( 5px );
 	font-size: rem( 14px );
 	font-weight: 600;
 }
@@ -17,7 +17,7 @@
 	display: block;
 	font-size: rem( 14px );
 	line-height: 1.5;
-	margin-bottom: 5px;
+	margin-bottom: rem( 5px );
 }
 
 .jp-form-label input[type="radio"] + span {
@@ -45,6 +45,17 @@
 	margin: rem( 5px ) 0 0 0;
 
 	+ .dops-card {
+		margin-top: rem( 16px );
+	}
+}
+
+.jp-form-fieldset {
+
+	.jp-form-legend + .jp-form-setting-explanation {
+		margin-top: rem( 8px );
+	}
+
+	.jp-form-setting-explanation + .jp-form-label {
 		margin-top: rem( 16px );
 	}
 }

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -604,7 +604,8 @@ export let AfterTheDeadlineSettings = React.createClass( {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
-					<FormLegend> { __( 'Automatic proofread content when ' ) } </FormLegend>
+					<FormLegend> { __( 'Proofreading' ) } </FormLegend>
+					<span className="jp-form-setting-explanation">{ __( 'Automatically proofread content when: ' ) }</span>
 					<ModuleSettingCheckbox
 						name={ 'onpublish' }
 						{ ...this.props }
@@ -615,7 +616,18 @@ export let AfterTheDeadlineSettings = React.createClass( {
 						label={ __( 'A post or page is updated' ) } />
 				</FormFieldset>
 				<FormFieldset>
-					<FormLegend> { __( 'English Options: Enable proofreading for the following grammar and style rules' ) } </FormLegend>
+					<FormLegend> { __( 'Automatic Language Detection' ) }
+					</FormLegend>
+					<span className="jp-form-setting-explanation">{ __( 'The proofreader supports English, French, ' +
+						'German, Portuguese and Spanish.' ) }</span>
+					<ModuleSettingCheckbox
+						name={ 'guess_lang' }
+						{ ...this.props }
+						label={ __( 'Use automatically detected language to proofread posts and pages' ) } />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLegend> { __( 'English Options' ) } </FormLegend>
+					<span className="jp-form-setting-explanation">{ __( 'Enable proofreading for the following grammar and style rules: ' ) }</span>
 					<ModuleSettingCheckbox
 						name={ 'Bias Language' }
 						{ ...this.props }
@@ -656,16 +668,6 @@ export let AfterTheDeadlineSettings = React.createClass( {
 						name={ 'Redundant Expression' }
 						{ ...this.props }
 						label={ __( 'Redundant Phrases' ) } />
-				</FormFieldset>
-				<FormFieldset>
-					<FormLegend> { __( 'Language: The proofreader supports English, French, ' +
-						'German, Portuguese and Spanish. Your user interface language (see above) ' +
-						'is the default proofreading language.' ) }
-					</FormLegend>
-					<ModuleSettingCheckbox
-						name={ 'guess_lang' }
-						{ ...this.props }
-						label={ __( 'Use automatically detected language to proofread posts and pages' ) } />
 				</FormFieldset>
 				<FormFieldset>
 					<FormLegend>


### PR DESCRIPTION
Updated spelling and grammar verbiage, broke apart options and title descriptions, and adjusted the spacing a bit.

to test: look at spelling and grammar settings area.

**Before:**
![screen shot 2016-08-15 at 5 22 46 pm](https://cloud.githubusercontent.com/assets/214813/17682198/fdb24566-6317-11e6-86dd-a6baf0f43239.png)

**After:**
![screen shot 2016-08-15 at 6 38 15 pm](https://cloud.githubusercontent.com/assets/214813/17682176/e3ce28b8-6317-11e6-9e0f-1b1b686a3fa5.png)
