### PR TITLE
Disable stats sync

### DIFF
--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -21,7 +21,6 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-terms.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-plugins.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-protect.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-full-sync.php';
-require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-stats.php';
 
 class Jetpack_Sync_Modules {
 
@@ -41,7 +40,6 @@ class Jetpack_Sync_Modules {
 		'Jetpack_Sync_Module_Plugins',
 		'Jetpack_Sync_Module_Protect',
 		'Jetpack_Sync_Module_Full_Sync',
-		'Jetpack_Sync_Module_Stats',
 	);
 
 	private static $initialized_modules = null;

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -4,6 +4,7 @@
 class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sends_stats_data_on_heartbeat() {
+		$this->markTestIncomplete( "Doesn't scale for large multisites" );
 		$heartbeat = Jetpack_Heartbeat::init();
 		$heartbeat->cron_exec();
 		$this->sender->do_sync();


### PR DESCRIPTION
It looks like wpcom automatically sends a heartbeat request when sites register, and this can cause a lot of additional load when large multisites register for the first time. There is, in particular, a really slow query in the stats which counts all of the users of each type on a site - this can take several minutes to complete with a few million users.