### PR TITLE
Admin Page: Add connected user gravatar to the data returned by jetpack_current_user_data() in class.jetpack-react-page.php

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -388,6 +388,9 @@ function jetpack_current_user_data() {
 	global $current_user;
 	$is_master_user = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
 	$dotcom_data    = Jetpack::get_connected_user_data();
+	// Add connected user gravatar to the returned dotcom_data
+	$avatar_data = Jetpack::get_avatar_url( $dotcom_data[ 'email' ] );
+	$dotcom_data[ 'avatar'] = $avatar_data[ 0 ];
 
 	$current_user_data = array(
 		'isConnected' => Jetpack::is_user_connected( $current_user->ID ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds an `avatar` key to the `Initial_State.userData.wpcomUser` object generated by the `jetpack_current_user_data()` PHP function in `_inc/lib/class.jetpack-react-page.php`

#### Testing instructions:
1. Check out this branch
2. Load the admin Page.
3. In the browser console, check that `Initial_State.userData.currentUser.wpcomUser` has the Gravatar url matching the email you used for the WordPress.com connected-user

### Observation

* This code is only getting the default size for the gravatar which is `96` and it's not stating that anywhere.

cc @eliorivero @dereksmart , your magic is needed in room #4823