### PR TITLE
Admin - AAG: don't show toggle in cards that are unavailable in Dev Mode

### DIFF
--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import SimpleNotice from 'components/notice';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -57,7 +58,7 @@ const DashItem = React.createClass( {
 		);
 
 		if ( '' !== this.props.module ) {
-			toggle = (
+			toggle = ( includes( [ 'protect', 'monitor', 'photon' ], this.props.module ) && this.props.isDevMode ) ? '' : (
 				<ModuleToggle
 					slug={ this.props.module }
 					activated={ this.props.isModuleActivated( this.props.module ) }


### PR DESCRIPTION
The cards Protect, Monitor and Photon are unavailable in Dev Mode, but they were displaying the mini toggle.

<img width="364" alt="captura de pantalla 2016-08-16 a las 13 17 22" src="https://cloud.githubusercontent.com/assets/1041600/17706501/ab1ca8dc-63b2-11e6-8947-4077aafb04d1.png">

#### Changes proposed in this Pull Request:
- Don't display the mini toggle in those cards in Dev Mode

<img width="373" alt="captura de pantalla 2016-08-16 a las 13 15 15" src="https://cloud.githubusercontent.com/assets/1041600/17706502/ab4392da-63b2-11e6-87df-e11f8de4cb3a.png">


#### Testing instructions:
- Put your site in Dev mode. Go to Dashboard, make sure toggles are not there
- Put your site in normal mode back, go to Dashboard, make sure toggles are there.
