### PR TITLE
Settings: Hide Custom Post Type nav menu items when disabled 

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -573,6 +573,20 @@ export let PostByEmailSettings = React.createClass( {
 PostByEmailSettings = moduleSettingsForm( PostByEmailSettings );
 
 export let CustomContentTypesSettings = React.createClass( {
+	componentWillReceiveProps: function() {
+		if ( ! this.props.getOptionValue( 'jetpack_portfolio' ) ) {
+			jQuery( '#menu-posts-jetpack-portfolio' ).hide();
+		} else {
+			jQuery( '#menu-posts-jetpack-portfolio' ).show();
+		}
+
+		if ( ! this.props.getOptionValue( 'jetpack_testimonial' ) ) {
+			jQuery( '#menu-posts-jetpack-testimonial' ).hide();
+		} else {
+			jQuery( '#menu-posts-jetpack-testimonial' ).show();
+		}
+	},
+
 	render() {
 		let portfolioConfigure = () => {
 			return ! this.props.getOptionValue( 'jetpack_portfolio' ) ?

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -573,20 +573,6 @@ export let PostByEmailSettings = React.createClass( {
 PostByEmailSettings = moduleSettingsForm( PostByEmailSettings );
 
 export let CustomContentTypesSettings = React.createClass( {
-	componentWillReceiveProps: function() {
-		if ( ! this.props.getOptionValue( 'jetpack_portfolio' ) ) {
-			jQuery( '#menu-posts-jetpack-portfolio' ).hide();
-		} else {
-			jQuery( '#menu-posts-jetpack-portfolio' ).show();
-		}
-
-		if ( ! this.props.getOptionValue( 'jetpack_testimonial' ) ) {
-			jQuery( '#menu-posts-jetpack-testimonial' ).hide();
-		} else {
-			jQuery( '#menu-posts-jetpack-testimonial' ).show();
-		}
-	},
-
 	render() {
 		let portfolioConfigure = () => {
 			return ! this.props.getOptionValue( 'jetpack_portfolio' ) ?

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -9,6 +9,7 @@ import Textarea from 'components/textarea';
 import TagsInput from 'components/tags-input';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import get from 'lodash/get';
+import Button from 'components/button';
 
 /**
  * Internal dependencies
@@ -573,17 +574,42 @@ PostByEmailSettings = moduleSettingsForm( PostByEmailSettings );
 
 export let CustomContentTypesSettings = React.createClass( {
 	render() {
+		let portfolioConfigure = () => {
+			return ! this.props.getOptionValue( 'jetpack_portfolio' ) ?
+				'' :
+				<Button
+					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
+					href="/wp-admin/edit.php?post_type=jetpack-portfolio"
+					compact={ true }
+				>{ __( 'Configure Portfolios' ) }</Button>;
+		};
+
+		let testimonialConfigure = () => {
+			return ! this.props.getOptionValue( 'jetpack_testimonial' ) ?
+				'' :
+				<Button
+					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
+					href="/wp-admin/edit.php?post_type=jetpack-testimonial"
+					compact={ true }
+				>{ __( 'Configure Testimonials' ) }</Button>;
+		};
+
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
 					<ModuleSettingCheckbox
 						name={ 'jetpack_portfolio' }
 						{ ...this.props }
-						label={ __( 'Enable Portfolio Projects for this site' ) } />
+						label={ __( 'Enable Portfolio Projects for this site.' ) }
+					/>
 					<ModuleSettingCheckbox
 						name={ 'jetpack_testimonial' }
 						{ ...this.props }
-						label={ __( 'Enable Testimonials for this site' ) } />
+						label={ __( 'Enable Testimonials for this site.' ) }
+					/>
+					<br/>
+					{ portfolioConfigure() }
+					{ testimonialConfigure() }
 					<FormButton
 						className="is-primary"
 						isSubmitting={ this.props.isSavingAnyOption() }

--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -3,6 +3,7 @@
  */
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import { translate as __ } from 'i18n-calypso';
+import forEach from 'lodash/forEach';
 
 /**
  * Internal dependencies
@@ -199,6 +200,7 @@ export const updateModuleOptions = ( slug, newOptionValues ) => {
 				newOptionValues,
 				success: success
 			} );
+			maybeHideNavMenuItem( slug, newOptionValues );
 			dispatch( removeNotice( `module-setting-${ slug }` ) );
 			dispatch( createNotice(
 				'is-success',
@@ -294,5 +296,27 @@ export const regeneratePostByEmailAddress = () => {
 				{ id: `module-setting-${ slug }` }
 			) );
 		} );
+	}
+}
+
+export function maybeHideNavMenuItem( module, values ) {
+	switch ( module ) {
+		case 'custom-content-types' :
+			if ( ! values ) { // Means the module was deactivated
+				jQuery( '#menu-posts-jetpack-portfolio, #menu-posts-jetpack-testimonial' ).toggle();
+			}
+
+			forEach( values, function( v, key ) {
+				if ( 'jetpack_portfolio' === key ) {
+					jQuery( '#menu-posts-jetpack-portfolio, .jp-toggle-portfolio' ).toggle();
+				}
+
+				if ( 'jetpack_testimonial' === key ) {
+					jQuery( '#menu-posts-jetpack-testimonial, .jp-toggle-testimonial' ).toggle();
+				}
+			} );
+			break;
+		default :
+			return false;
 	}
 }

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -54,6 +54,10 @@ class Jetpack_Testimonial {
 			return;
 		}
 
+		if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && ! Jetpack::is_module_active( 'custom-content-types' ) ) {
+			return;
+		}
+
 		// Enable Omnisearch for CPT.
 		if ( class_exists( 'Jetpack_Omnisearch_Posts' ) ) {
 			new Jetpack_Omnisearch_Posts( self::CUSTOM_POST_TYPE );


### PR DESCRIPTION
Mostly an enhancement, but also fixes #2809

Shows/hides nav menu items and CTA's for Custom Content Types as they are activated/deactivated.  

This gif will better explain what this PR does: 
![cpt-nav-items](https://cloud.githubusercontent.com/assets/7129409/17711171/5923b8ac-63be-11e6-8252-44e60d3614a2.gif)

**To Test:** 
- Load the page with the Custom Content Types deactivated.  You should not see any nav menu items. (except maybe testimonials see #2890)
- Activating one of the custom post types within the settings card should show you a button to configure.  
- The buttons in the settings card should show be `disabled` when they are in a transitional state
- The buttons in the card should not show if the CPT is disabled 
- If you reload the page with both CPT's active, you should see the buttons in the card, as well as the wp-admin nav menu items.  Toggling things should make them appear/disappear as you would expect.  