### PR TITLE
Only sync callables in admin

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -98,10 +98,10 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	}
 	
 	public function maybe_sync_callables() {
-		if ( ! is_admin() ) {
+		if ( ! is_admin() || Jetpack_Sync_Settings::is_doing_cron() ) {
 			return;
 		}
-		
+
 		if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
 			return;
 		}

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -98,6 +98,10 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	}
 	
 	public function maybe_sync_callables() {
+		if ( ! is_admin() ) {
+			return;
+		}
+		
 		if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
 			return;
 		}

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -20,6 +20,7 @@ class Jetpack_Sync_Settings {
 	);
 
 	static $is_importing;
+	static $is_doing_cron;
 
 	static $settings_cache = array(); // some settings can be expensive to compute - let's cache them
 
@@ -110,5 +111,18 @@ class Jetpack_Sync_Settings {
 		}
 
 		return defined( 'WP_IMPORTING' ) && WP_IMPORTING;
+	}
+
+	static function set_doing_cron( $is_doing_cron ) {
+		// set to NULL to revert to WP_IMPORTING, the standard behaviour
+		self::$is_doing_cron = $is_doing_cron;
+	}
+
+	static function is_doing_cron() {
+		if ( ! is_null( self::$is_doing_cron ) ) {
+			return self::$is_doing_cron;
+		}
+
+		return defined( 'DOING_CRON' ) && DOING_CRON;
 	}
 }

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -98,6 +98,7 @@ class Jetpack_Sync_Settings {
 			delete_option( self::SETTINGS_OPTION_PREFIX . $option );
 		}
 		self::set_importing( null );
+		self::set_doing_cron( null );
 	}
 
 	static function set_importing( $is_importing ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -272,6 +272,25 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $original_site_url, $this->server_replica_storage->get_callable( 'site_url' ) );
 	}
 
+	function test_only_syncs_if_is_admin_and_not_cron() {
+		// non-admin
+		set_current_screen( 'front' );
+		$this->sender->do_sync();
+		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'site_url' ) );
+
+		set_current_screen( 'post-user' );
+
+		// admin but in cron (for some reason)
+		Jetpack_Sync_Settings::set_doing_cron( true );
+
+		$this->sender->do_sync();
+		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'site_url' ) );
+		
+		Jetpack_Sync_Settings::set_doing_cron( false );		
+		$this->sender->do_sync();
+		$this->assertEquals( site_url(), $this->server_replica_storage->get_callable( 'site_url' ) );
+	}
+
 	function add_www_subdomain_to_siteurl( $url ) {
 		$parsed_url = parse_url( $url );
 


### PR DESCRIPTION
We currently have an issue with the post_types and post_type_features callables changing values a lot. It appears to be due to differences in which plugins are loaded in cron and non-cron environments.

This change only syncs callables during is_admin(), when they're most likely to have their "true" values.