### PR TITLE
Search: Make sure pro cards render settings

### DIFF
--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -138,7 +138,7 @@ export const SearchResults = ( {
 				) }
 			>
 				{
-					isModuleActivated( element[0] ) ?
+					isModuleActivated( element[0] ) || isPro ?
 						<AllModuleSettings module={ isPro ? proProps : getModule( element[0] ) } /> :
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />


### PR DESCRIPTION
Fixes #4829

To Test: 
- navigate to `/search`
- open the pro cards.  You should at the very least see a `settings` button.  (note, these buttons might not be working and is a known issue)