### PR TITLE
Related Posts Preview: updated styles and classes

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -62,15 +62,15 @@ export let RelatedPostsSettings = React.createClass( {
 		} ];
 
 		return (
-			<div className="related-posts-settings_preview_container">
+			<div className="jp-related-posts-preview">
 				{
 					show_headline ?
-						<h3>{ __( 'Related' ) }</h3> :
+						<div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div> :
 						''
 				}
 				{
 					previews.map( ( preview, i ) => (
-						<span key={ `preview_${ i }` } className="related-posts-settings_preview_image_container" >
+						<span key={ `preview_${ i }` } className="jp-related-posts-preview__item" >
 							{
 								show_thumbnails ? <img src={ preview.url } /> : ''
 							}
@@ -93,7 +93,7 @@ export let RelatedPostsSettings = React.createClass( {
 						name={ 'show_thumbnails' }
 						label={ __( 'Use a large and visually striking layout' ) }
 						{ ...this.props } />
-					<h3>{ __( 'Preview' ) }</h3>
+					<div className="jp-related-posts__preview-label">{ __( 'Preview' ) }</div>
 					<Card>
 						{ this.renderPreviews() }
 					</Card>

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -18,22 +18,39 @@
 	}
 }
 
-/**
- * Related Posts Preview styles
- */
-.related-posts-settings_preview_container {
+// Related Posts Preview styles
+.jp-related-posts__preview-label {
+	margin-top: rem( 24px );
+	margin-bottom: rem( 8px );
+	font-size: rem( 14px );
+	font-weight: 600;
+}
+
+.jp-related-posts__preview {
 	text-align: center;
 }
 
-.related-posts-settings_preview_container h3 {
+.jp-related-posts-preview__title {
 	text-align: left;
+	color: $gray;
+	font-weight: 600;
+	margin-left: rem( 8px );
+	margin-bottom: rem( 16px );
+	text-transform: uppercase;
 }
 
-.related-posts-settings_preview_image_container {
+.jp-related-posts-preview__item {
+	box-sizing: border-box;
 	display: inline-block;
-	width: 29%;
-}
+	width: 33.33%;
+	padding: rem( 8px );
 
-.related-posts-settings_preview_image_container img {
-	max-width: 100%;
+	@include breakpoint( "<480px" ) {
+		width: 100%;
+	}
+
+	img {
+		max-width: 100%;
+		margin-bottom: rem( 8px );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* changed styles and classes in the Related Posts settings

#### Testing instructions:
Go to related posts setting in Engagement settings

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17715222/3031bdaa-63d1-11e6-991d-34bcd5b44ef1.png)
![image](https://cloud.githubusercontent.com/assets/1123119/17715228/371cb598-63d1-11e6-851d-259b31b2be74.png)
![image](https://cloud.githubusercontent.com/assets/1123119/17715234/3e3b96a0-63d1-11e6-8aea-496698bd7428.png)
![image](https://cloud.githubusercontent.com/assets/1123119/17715249/4882860a-63d1-11e6-9424-208ff085a86e.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17715186/0fb4bfaa-63d1-11e6-9940-523e79ae158e.png)

![image](https://cloud.githubusercontent.com/assets/1123119/17715200/19eb164a-63d1-11e6-820d-8b81c6b101eb.png)

![image](https://cloud.githubusercontent.com/assets/1123119/17715173/06a7e7ca-63d1-11e6-8484-c0de8c71903f.png)

![image](https://cloud.githubusercontent.com/assets/1123119/17715207/24733444-63d1-11e6-9de5-cf2816b45b8f.png)

