### PR TITLE
At a Glance: fixing SectionHeader clashing on small screens

### DIFF
--- a/_inc/client/components/dash-section-header/style.scss
+++ b/_inc/client/components/dash-section-header/style.scss
@@ -6,6 +6,10 @@
 	@include breakpoint( "<660px" ) {
 		margin-bottom: rem( 24px );
 	}
+
+	@include breakpoint( "<480px" ) {
+		display: block;
+	}
 }
 
 .jp-dash-section-header__label {
@@ -59,7 +63,7 @@
 	@include breakpoint( "<480px" ) {
 		display: block;
 		width: 100%;
-		margin-top: rem( 32px );
+		// margin-top: rem( 32px );
 	}
 }
 

--- a/_inc/client/components/dash-section-header/style.scss
+++ b/_inc/client/components/dash-section-header/style.scss
@@ -9,13 +9,23 @@
 }
 
 .jp-dash-section-header__label {
-	display: inline-block;
 	flex: 1;
 	margin-top: 0;
 	margin-bottom: 0;
 	font-size: rem( 20px );
 	font-weight: 400;
 	white-space: nowrap;
+
+	@include breakpoint( ">480px" ) {
+		display: inline-block;
+	}
+
+	// need to clean up ClassName nesting
+	.jp-dash-section-header__label {
+		@include breakpoint( "<480px" ) {
+			display: inline-block;
+		}
+	}
 }
 
 .jp-dash-section-header__settings {
@@ -44,6 +54,12 @@
 
 	@include breakpoint( "<660px" ) {
 		margin-top: rem( 4px );
+	}
+
+	@include breakpoint( "<480px" ) {
+		display: block;
+		width: 100%;
+		margin-top: rem( 32px );
 	}
 }
 


### PR DESCRIPTION
On small screens the SectionHeader has an overlap of nested elements.

Before:
![slack for ios upload-1 png](https://cloud.githubusercontent.com/assets/214813/17716669/aef1948e-63d7-11e6-9c1e-99e6bd0f56ad.jpeg)


After:
![slack for ios upload png](https://cloud.githubusercontent.com/assets/214813/17716675/b36bb558-63d7-11e6-9f62-6a34d84a6cc6.jpeg)

