### PR TITLE
Don’t publicize post types that are blacklisted from sync - it won’t work

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -34,6 +34,9 @@ class Jetpack_Sync_Actions {
 			return;
 		}
 
+		// publicize filter to prevent publicizing blacklisted post types
+		add_filter( 'publicize_should_publicize_published_post', array( __CLASS__, 'prevent_publicize_blacklisted_posts' ), 10, 2 );
+
 		// cron hooks
 		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ), 10, 1 );
 		add_action( 'jetpack_sync_cron', array( __CLASS__, 'do_cron_sync' ) );
@@ -99,6 +102,14 @@ class Jetpack_Sync_Actions {
 	static function sync_allowed() {
 		return ( ! Jetpack_Sync_Settings::get_setting( 'disable' ) && Jetpack::is_active() && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
 			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
+	}
+
+	static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {
+		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
+			return false;
+		}
+
+		return $should_publicize;
 	}
 
 	static function set_is_importing_true() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -439,12 +439,12 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_does_not_publicize_blacklisted_post_types() {
-		register_post_type( 'filter_me', array( 'public' => true, 'label' => 'Filter Me' ) );
-		$post_id = $this->factory->post->create( array( 'post_type' => 'filter_me' ) );
+		register_post_type( 'dont_publicize_me', array( 'public' => true, 'label' => 'Filter Me' ) );
+		$post_id = $this->factory->post->create( array( 'post_type' => 'dont_publicize_me' ) );
 
 		$this->assertTrue( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $post_id ) ) );
 
-		Jetpack_Sync_Settings::update_settings( array( 'post_types_blacklist' => array( 'filter_me' ) ) );
+		Jetpack_Sync_Settings::update_settings( array( 'post_types_blacklist' => array( 'dont_publicize_me' ) ) );
 
 		$this->assertFalse( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $post_id ) ) );
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -438,6 +438,21 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		}
 	}
 
+	function test_does_not_publicize_blacklisted_post_types() {
+		register_post_type( 'filter_me', array( 'public' => true, 'label' => 'Filter Me' ) );
+		$post_id = $this->factory->post->create( array( 'post_type' => 'filter_me' ) );
+
+		$this->assertTrue( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $post_id ) ) );
+
+		Jetpack_Sync_Settings::update_settings( array( 'post_types_blacklist' => array( 'filter_me' ) ) );
+
+		$this->assertFalse( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $post_id ) ) );
+
+		$good_post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+
+		$this->assertTrue( apply_filters( 'publicize_should_publicize_published_post', true, get_post( $good_post_id ) ) );
+	}
+
 	function assertAttachmentSynced( $attachment_id ) {
 		$remote_attachment = $this->server_replica_storage->get_post( $attachment_id );
 		$attachment        = get_post( $attachment_id );


### PR DESCRIPTION
We blacklist certain post types either because they're created in huge volume and/or created by sync itself (resulting in an infinite loop of post creation).

There is no point publicizing such post types either, as it won't work - there will be an error on the WPCOM side.