### PR TITLE
Stats: fixed up how menu items align on small screens

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -198,6 +198,11 @@
 	&:focus {
 		outline: 0;
 	}
+
+	@include breakpoint( "<480px" ) {
+		margin-left: 0;
+		margin-right: rem( 16px );
+	}
 }
 
 .jp-at-a-glance__stats-view-link,

--- a/_inc/client/components/dash-section-header/style.scss
+++ b/_inc/client/components/dash-section-header/style.scss
@@ -49,4 +49,8 @@
 
 .jp-dash-section-header__children {
 	align-self: center;
+
+	@include breakpoint( "<480px" ) {
+		width: 100%;
+	}
 }


### PR DESCRIPTION
Currently, on small screens, the mobile nav looks fine in English, but with longer strings, I suspect it will be pushed down and the margins will line up poorly.

#### Changes proposed in this Pull Request:
* added breakpoint that moves the margin from the left to the right side on small screens

#### Testing instructions:
* go to At a Glance and resize the browser

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17738411/285b65fc-645f-11e6-9e18-93c7a0771969.png)


After:
![image](https://cloud.githubusercontent.com/assets/1123119/17738312/b8a77d18-645e-11e6-9723-1e81426fa2ed.png)