### PR TITLE
Related Posts: fixed preview styles

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -93,7 +93,7 @@ export let RelatedPostsSettings = React.createClass( {
 						name={ 'show_thumbnails' }
 						label={ __( 'Use a large and visually striking layout' ) }
 						{ ...this.props } />
-					<div className="jp-related-posts__preview-label">{ __( 'Preview' ) }</div>
+					<div className="jp-related-posts-settings__preview-label">{ __( 'Preview' ) }</div>
 					<Card>
 						{ this.renderPreviews() }
 					</Card>

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -61,7 +61,7 @@
 // Related Posts Preview styles
 .jp-related-posts-settings__preview-label {
 	margin-bottom: rem( 8px );
-	margin-top: rem( 16px );
+	margin-top: rem( 24px );
 	font-size: rem( 14px );
 	font-weight: 600;
 }

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -58,10 +58,15 @@
 }
 
 
-/**
- * Related Posts Preview styles
- */
-.related-posts-settings_preview_container {
+// Related Posts Preview styles
+.jp-related-posts-settings__preview-label {
+	margin-bottom: rem( 8px );
+	margin-top: rem( 16px );
+	font-size: rem( 14px );
+	font-weight: 600;
+}
+
+.jp-related-posts-preview {
 	text-align: center;
 }
 
@@ -79,6 +84,7 @@
 	display: inline-block;
 	width: 33.33%;
 	padding: rem( 8px );
+	text-align: left;
 
 	@include breakpoint( "<480px" ) {
 		width: 100%;


### PR DESCRIPTION
I noticed that some of my styles got borked somewhere along the way for the related posts preview. No worries. Fixed!

#### Changes proposed in this Pull Request:
* fixed styles

#### Testing instructions:
* go to settings > engagement > related posts

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17739070/d547b37c-6461-11e6-99ae-80e3d0531298.png)

After:
![image](https://cloud.githubusercontent.com/assets/1123119/17739025/a95776f8-6461-11e6-8178-5a7d1f99e03c.png)
