### PR TITLE
Rename REST API endpoints to make the interface more RESTful.

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -27,9 +27,11 @@ const DashScan = React.createClass( {
 	getContent: function() {
 		const labelName = __( 'Malware Scanning' ),
 			hasSitePlan = false !== this.props.getSitePlan(),
-			vpData = this.props.getVaultPressData(),
+		vpData = this.props.getVaultPressData(),
+
 			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
 
+		console.log( vpData );
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {
 				return (

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -27,11 +27,9 @@ const DashScan = React.createClass( {
 	getContent: function() {
 		const labelName = __( 'Malware Scanning' ),
 			hasSitePlan = false !== this.props.getSitePlan(),
-		vpData = this.props.getVaultPressData(),
-
+			vpData = this.props.getVaultPressData(),
 			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
 
-		console.log( vpData );
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {
 				return (

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -200,8 +200,8 @@ function JetpackRestApiClient( root, nonce ) {
 				return JSON.parse( body.data );
 			} );
 		},
-		dismissJetpackNotice: ( notice ) => fetch( `${ apiRoot }jetpack/v4/notice/${ notice }/dismiss`, {
-			method: 'put',
+		dismissJetpackNotice: ( notice ) => fetch( `${ apiRoot }jetpack/v4/notice/${ notice }`, {
+			method: 'delete',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -58,14 +58,25 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		jumpStart: ( action ) => fetch( `${ apiRoot }jetpack/v4/jumpstart/${ action }`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
+		jumpStart: ( action ) => {
+			let active;
+			if ( action === 'activate' ) {
+				active = true
 			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
+			if ( action === 'deactivate' ) {
+				active = false
+			}
+			return fetch( `${ apiRoot }jetpack/v4/jumpstart`, {
+				method: 'post',
+				credentials: 'same-origin',
+				headers: {
+					'X-WP-Nonce': apiNonce,
+					'Content-type': 'application/json'
+				},
+				body: JSON.stringify( { active } )
+			} )
+			.then( checkStatus ).then( response => response.json() )
+		},
 		fetchModules: () => fetch( `${ apiRoot }jetpack/v4/module/all`, {
 			credentials: 'same-origin',
 			headers: {

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -27,7 +27,7 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( response => response.json() ),
-		fetchUserConnectionData: () => fetch( `${ apiRoot }jetpack/v4/user-connection-data`, {
+		fetchUserConnectionData: () => fetch( `${ apiRoot }jetpack/v4/connection/data`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -57,7 +57,7 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		fetchModules: () => fetch( `${ apiRoot }jetpack/v4/modules`, {
+		fetchModules: () => fetch( `${ apiRoot }jetpack/v4/module/all`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -90,7 +90,7 @@ function JetpackRestApiClient( root, nonce ) {
 			},
 			body: JSON.stringify( { active: false } )
 		} ),
-		updateModuleOptions: ( slug, newOptionValues ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/update`, {
+		updateModuleOptions: ( slug, newOptionValues ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }`, {
 			method: 'put',
 			credentials: 'same-origin',
 			headers: {

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -71,20 +71,24 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		activateModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/activate`, {
+		activateModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
 			method: 'put',
 			credentials: 'same-origin',
 			headers: {
-				'X-WP-Nonce': apiNonce
-			}
+				'X-WP-Nonce': apiNonce,
+				'Content-type': 'application/json'
+			},
+			body: JSON.stringify( { active: true } )
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		deactivateModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/deactivate`, {
+		deactivateModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
 			method: 'put',
 			credentials: 'same-origin',
 			headers: {
-				'X-WP-Nonce': apiNonce
-			}
+				'X-WP-Nonce': apiNonce,
+				'Content-type': 'application/json'
+			},
+			body: JSON.stringify( { active: false } )
 		} ),
 		updateModuleOptions: ( slug, newOptionValues ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/update`, {
 			method: 'put',

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -49,6 +49,15 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
+		unlinkUser: () => fetch( `${ apiRoot }jetpack/v4/connection/user`, {
+			method: 'delete',
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': apiNonce,
+				'Content-type': 'application/json'
+			}
+		} )
+		.then( checkStatus ).then( response => response.json() ),
 		jumpStart: ( action ) => fetch( `${ apiRoot }jetpack/v4/jumpstart/${ action }`, {
 			method: 'post',
 			credentials: 'same-origin',
@@ -175,15 +184,6 @@ function JetpackRestApiClient( root, nonce ) {
 				'Content-type': 'application/json'
 			},
 			body: JSON.stringify( updatedSetting )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		unlinkUser: () => fetch( `${ apiRoot }jetpack/v4/unlink`, {
-			method: 'put',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		fetchSiteData: () => {

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -108,8 +108,8 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		resetOptions: ( options ) => fetch( `${ apiRoot }jetpack/v4/reset/${ options }`, {
-			method: 'post',
+		resetOptions: ( options ) => fetch( `${ apiRoot }jetpack/v4/options/${ options }`, {
+			method: 'delete',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -167,8 +167,8 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		updateSetting: ( updatedSetting ) => fetch( `${ apiRoot }jetpack/v4/setting/update`, {
-			method: 'put',
+		updateSetting: ( updatedSetting ) => fetch( `${ apiRoot }jetpack/v4/settings`, {
+			method: 'post',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -34,8 +34,8 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( response => response.json() ),
-		disconnectSite: () => fetch( `${ apiRoot }jetpack/v4/disconnect/site`, {
-			method: 'post',
+		disconnectSite: () => fetch( `${ apiRoot }jetpack/v4/connection`, {
+			method: 'delete',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -20,7 +20,7 @@ function JetpackRestApiClient( root, nonce ) {
 		setApiNonce( newNonce ) {
 			apiNonce = newNonce;
 		},
-		fetchSiteConnectionStatus: () => fetch( `${ apiRoot }jetpack/v4/connection-status`, {
+		fetchSiteConnectionStatus: () => fetch( `${ apiRoot }jetpack/v4/connection`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -100,7 +100,7 @@ function JetpackRestApiClient( root, nonce ) {
 			body: JSON.stringify( newOptionValues )
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		getProtectCount: () => fetch( `${ apiRoot }jetpack/v4/module/protect/count/get`, {
+		getProtectCount: () => fetch( `${ apiRoot }jetpack/v4/module/protect/data`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,
@@ -125,7 +125,7 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		getLastDownTime: () => fetch( `${ apiRoot }jetpack/v4/module/monitor/downtime/last`, {
+		getLastDownTime: () => fetch( `${ apiRoot }jetpack/v4/module/monitor/data`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,
@@ -133,7 +133,7 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		getAkismetData: () => fetch( `${ apiRoot }jetpack/v4/akismet/stats/get`, {
+		getAkismetData: () => fetch( `${ apiRoot }jetpack/v4/module/akismet/data`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,
@@ -141,8 +141,7 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		fetchStatsData: ( range ) => fetch( `${ apiRoot }jetpack/v4/module/stats/get`, {
-			method: 'put',
+		fetchStatsData: ( range ) => fetch( `${ apiRoot }jetpack/v4/module/stats/data`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -42,7 +42,7 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		fetchConnectUrl: () => fetch( `${ apiRoot }jetpack/v4/connect-url`, {
+		fetchConnectUrl: () => fetch( `${ apiRoot }jetpack/v4/connection/url`, {
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -161,16 +161,15 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
-		fetchStatsData: ( range ) => fetch( `${ apiRoot }jetpack/v4/module/stats/data`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( {
-				range: range
-			} )
-		} )
+		fetchStatsData: ( range ) => fetch(
+			`${ apiRoot }jetpack/v4/module/stats/data?range=${ encodeURIComponent( range ) }`,
+			{
+				credentials: 'same-origin',
+				headers: {
+					'X-WP-Nonce': apiNonce
+				}
+			}
+		)
 		.then( checkStatus ).then( response => response.json() ),
 		getPluginUpdates: () => fetch( `${ apiRoot }jetpack/v4/updates/plugins`, {
 			credentials: 'same-origin',

--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -220,7 +220,7 @@ export const updateModuleOptions = ( slug, newOptionValues ) => {
 			dispatch( removeNotice( `module-setting-${ slug }` ) );
 			dispatch( createNotice(
 				'is-error',
-				__( 'Error updating %(slug) settings. %(error)d', {
+				__( 'Error updating %(slug)s settings. %(error)s', {
 					args: {
 						slug: getModule( getState(), slug ).name,
 						error: error

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -133,11 +133,11 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		/** This action is already documented in views/admin/admin-page.php */
 		do_action( 'jetpack_notices' );
 
-		echo file_get_contents( JETPACK__PLUGIN_DIR . '/_inc/build/static.html' );
+		echo file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' );
 	}
 
 	function get_i18n_data() {
-		$locale_data = @file_get_contents( JETPACK__PLUGIN_DIR . '/languages/json/jetpack-' . get_locale() . '.json' );
+		$locale_data = @file_get_contents( JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . get_locale() . '.json' );
 		if ( $locale_data ) {
 			return $locale_data;
 		} else {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -206,6 +206,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			);
 		}
 
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/jetpack/v4/module/all' ) );
+		$modules = $response->get_data();
+
 		// Add objects to be passed to the initial state of the app
 		wp_localize_script( 'react-plugin', 'Initial_State', array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
@@ -226,7 +229,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'isDevVersion' => Jetpack::is_development_version(),
 			'currentVersion' => JETPACK__VERSION,
 			'happinessGravIds' => jetpack_get_happiness_gravatar_ids(),
-			'getModules' => Jetpack_Core_Json_Api_Endpoints::get_modules(),
+			'getModules' => $modules,
 			'showJumpstart' => jetpack_show_jumpstart(),
 			'rawUrl' => Jetpack::build_raw_urls( get_home_url() ),
 			'adminUrl' => esc_url( admin_url() ),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -210,6 +210,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::jumpstart_toggle',
 			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
+			'args' => array(
+				'active' => array(
+					'required' => true,
+					'validate_callback' => __CLASS__  . '::validate_boolean',
+				),
+			),
 		) );
 
 		// Updates: get number of plugin updates available
@@ -725,18 +731,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function jumpstart_toggle( $data ) {
 		$param = $data->get_json_params();
-
-		// Exit if no parameters were passed.
-		if ( ! isset( $param[ 'active' ] ) ) {
-			return new WP_Error( 'missing_parameter_active', esc_html__( 'Missing parameter active.', 'jetpack' ), array( 'status' => 400 ) );
-		}
-
-		$validates = self::validate_boolean( $param[ 'active' ], null, 'active' );
-
-		// Exit if `activate` was passed as a non-boolean
-		if ( true !== $validates ) {
-			return $validates;
-		}
 
 		if ( $param[ 'active' ] ) {
 			return self::jumpstart_activate( $data );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -167,6 +167,23 @@ class Jetpack_Core_Json_Api_Endpoints {
 			self::get_module_updating_parameters()
 		);
 
+		// Get data for a specific module, i.e. Protect block count, WPCOM stats,
+		// Akismet spam count, etc.
+		self::route(
+			'/module/(?P<slug>[a-z\-]+)/data',
+			'Jetpack_Core_API_Module_Data_Endpoint',
+			WP_REST_Server::READABLE,
+			NULL,
+			array(
+				'range' => array(
+					'default'           => 'day',
+					'type'              => 'string',
+					'required'          => false,
+					'validate_callback' => __CLASS__ . '::validate_string',
+				),
+			)
+		);
+
 		// Reset all Jetpack options
 		register_rest_route( 'jetpack/v4', '/reset/(?P<options>[a-z\-]+)', array(
 			'methods' => WP_REST_Server::EDITABLE,
@@ -201,60 +218,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
 		) );
 
-		// Protect: get blocked count
-		register_rest_route( 'jetpack/v4', '/module/protect/count/get', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::protect_get_blocked_count',
-			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
-		) );
-
-		// Stats: get stats from WPCOM
-		register_rest_route( 'jetpack/v4', '/module/stats/get', array(
-			'methods'  => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::site_get_stats_data',
-			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
-			'args' => array(
-				'range' => array(
-					'default'           => 'day',
-					'type'              => 'string',
-					'required'          => true,
-					'validate_callback' => __CLASS__ . '::validate_string',
-				),
-			),
-		) );
-
-		// Akismet: get spam count
-		register_rest_route( 'jetpack/v4', '/akismet/stats/get', array(
-			'methods'  => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::akismet_get_stats_data',
-			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
-		) );
-
-		// Monitor: get last downtime
-		register_rest_route( 'jetpack/v4', '/module/monitor/downtime/last', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::monitor_get_last_downtime',
-			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
-		) );
 
 		// Updates: get number of plugin updates available
 		register_rest_route( 'jetpack/v4', '/updates/plugins', array(
 			'methods' => WP_REST_Server::READABLE,
 			'callback' => __CLASS__ . '::get_plugin_update_count',
-			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
-		) );
-
-		// Verification: get services that this site is verified with
-		register_rest_route( 'jetpack/v4', '/module/verification-tools/services', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::get_verified_services',
-			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
-		) );
-
-		// VaultPress: get date last backup or status and actions for user to take
-		register_rest_route( 'jetpack/v4', '/module/vaultpress/data', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::vaultpress_get_site_data',
 			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 		) );
 
@@ -689,34 +657,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return new WP_Error( 'site_id_missing', esc_html__( 'The ID of this site does not exist.', 'jetpack' ), array( 'status' => 404 ) );
-	}
-
-	/**
-	 * Is Akismet registered and active?
-	 *
-	 * @since 4.1.0
-	 *
-	 * @return bool|WP_Error True if Akismet is active and registered. Otherwise, a WP_Error instance with the corresponding error.
-	 */
-	public static function akismet_is_active_and_registered() {
-		if ( ! file_exists( WP_PLUGIN_DIR . '/akismet/class.akismet.php' ) ) {
-			return new WP_Error( 'not_installed', esc_html__( 'Please install Akismet.', 'jetpack' ), array( 'status' => 400 ) );
-		}
-
-		if ( ! class_exists( 'Akismet' ) ) {
-			return new WP_Error( 'not_active', esc_html__( 'Please activate Akismet.', 'jetpack' ), array( 'status' => 400 ) );
-		}
-
-		// What about if Akismet is put in a sub-directory or maybe in mu-plugins?
-		require_once WP_PLUGIN_DIR . '/akismet/class.akismet.php';
-		require_once WP_PLUGIN_DIR . '/akismet/class.akismet-admin.php';
-		$akismet_key = Akismet::verify_key( Akismet::get_api_key() );
-
-		if ( ! $akismet_key || 'invalid' === $akismet_key || 'failed' === $akismet_key ) {
-			return new WP_Error( 'invalid_key', esc_html__( 'Invalid Akismet key. Please contact support.', 'jetpack' ), array( 'status' => 400 ) );
-		}
-
-		return true;
 	}
 
 
@@ -2096,115 +2036,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * Get number of blocked intrusion attempts.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @return mixed|WP_Error Number of blocked attempts if protection is enabled. Otherwise, a WP_Error instance with the corresponding error.
-	 */
-	public static function protect_get_blocked_count() {
-		if ( Jetpack::is_module_active( 'protect' ) ) {
-			return get_site_option( 'jetpack_protect_blocked_attempts' );
-		}
-
-		return new WP_Error( 'not_active', esc_html__( 'The requested Jetpack module is not active.', 'jetpack' ), array( 'status' => 404 ) );
-	}
-
-	/**
-	 * Get number of spam messages blocked by Akismet.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @param WP_REST_Request $data {
-	 *     Array of parameters received by request.
-	 *
-	 *     @type string $date Date range to restrict results to.
-	 * }
-	 *
-	 * @return int|string Number of spam blocked by Akismet. Otherwise, an error message.
-	 */
-	public static function akismet_get_stats_data( WP_REST_Request $data ) {
-		if ( ! is_wp_error( $status = self::akismet_is_active_and_registered() ) ) {
-			return rest_ensure_response( Akismet_Admin::get_stats( Akismet::get_api_key() ) );
-		} else {
-			return $status->get_error_code();
-		}
-	}
-
-	/**
-	 * Get stats data for this site
-	 *
-	 * @since 4.1.0
-	 *
-	 * @param WP_REST_Request $data {
-	 *     Array of parameters received by request.
-	 *
-	 *     @type string $date Date range to restrict results to.
-	 * }
-	 *
-	 * @return int|string Number of spam blocked by Akismet. Otherwise, an error message.
-	 */
-	public static function site_get_stats_data( WP_REST_Request $data ) {
-		// Get parameters to fetch Stats data.
-		$params = $data->get_json_params();
-
-		// If no parameters were passed.
-		$range = is_array( $params ) && isset( $params['range'] )
-				 && in_array( $params['range'], array( 'day', 'week', 'month' ), true ) ? $params['range'] : 'day';
-
-		if ( ! function_exists( 'stats_get_from_restapi' ) ) {
-			require_once( JETPACK__PLUGIN_DIR . 'modules/stats.php' );
-		}
-
-		$response = array(
-			'general' => stats_get_from_restapi(),
-		);
-
-		switch ( $range ) {
-			case 'day':
-				$response['day'] = stats_get_from_restapi( array(), 'visits?unit=day&quantity=30' );
-				break;
-			case 'week':
-				$response['week'] = stats_get_from_restapi( array(), 'visits?unit=week&quantity=14' );
-				break;
-			case 'month':
-				$response['month'] = stats_get_from_restapi( array(), 'visits?unit=month&quantity=12&' );
-				break;
-		}
-
-		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Get date of last downtime.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @return mixed|WP_Error Number of days since last downtime. Otherwise, a WP_Error instance with the corresponding error.
-	 */
-	public static function monitor_get_last_downtime() {
-		if ( Jetpack::is_module_active( 'monitor' ) ) {
-			$monitor       = new Jetpack_Monitor();
-			$last_downtime = $monitor->monitor_get_last_downtime();
-			if ( is_wp_error( $last_downtime ) ) {
-				return $last_downtime;
-			} else if ( false === strtotime( $last_downtime ) ) {
-				return rest_ensure_response( array(
-					'code' => 'success',
-					'date' => null,
-				) );
-			} else {
-				return rest_ensure_response( array(
-					'code' => 'success',
-					'date' => human_time_diff( strtotime( $last_downtime ), strtotime( 'now' ) ),
-				) );
-			}
-		}
-
-		return new WP_Error( 'not_active', esc_html__( 'The requested Jetpack module is not active.', 'jetpack' ), array( 'status' => 404 ) );
-	}
-
-	/**
 	 * Get number of plugin updates available.
 	 *
 	 * @since 4.1.0
@@ -2234,92 +2065,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 		return new WP_Error( 'not_found', esc_html__( 'Could not check updates for plugins on this site.', 'jetpack' ), array( 'status' => 404 ) );
 	}
 
-	/**
-	 * Get services that this site is verified with.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @return mixed|WP_Error List of services that verified this site. Otherwise, a WP_Error instance with the corresponding error.
-	 */
-	public static function get_verified_services() {
-		if ( Jetpack::is_module_active( 'verification-tools' ) ) {
-			$verification_services_codes = get_option( 'verification_services_codes' );
-			if ( is_array( $verification_services_codes ) && ! empty( $verification_services_codes ) ) {
-				$services = array();
-				foreach ( jetpack_verification_services() as $name => $service ) {
-					if ( is_array( $service ) && ! empty( $verification_services_codes[ $name ] ) ) {
-						switch ( $name ) {
-							case 'google':
-								$services[] = 'Google';
-								break;
-							case 'bing':
-								$services[] = 'Bing';
-								break;
-							case 'pinterest':
-								$services[] = 'Pinterest';
-								break;
-						}
-					}
-				}
-				if ( ! empty( $services ) ) {
-					if ( 2 > count( $services ) ) {
-						$message = esc_html( sprintf( __( 'Your site is verified with %s.', 'jetpack' ), $services[0] ) );
-					} else {
-						$copy_services = $services;
-						$last = count( $copy_services ) - 1;
-						$last_service = $copy_services[ $last ];
-						unset( $copy_services[ $last ] );
-						$message = esc_html( sprintf( __( 'Your site is verified with %s and %s.', 'jetpack' ), join( ', ', $copy_services ), $last_service ) );
-					}
-					return rest_ensure_response( array(
-						'code'     => 'success',
-						'message'  => $message,
-						'services' => $services,
-					) );
-				}
-			}
-			return new WP_Error( 'empty', esc_html__( 'Site not verified with any service.', 'jetpack' ), array( 'status' => 404 ) );
-		}
-
-		return new WP_Error( 'not_active', esc_html__( 'The requested Jetpack module is not active.', 'jetpack' ), array( 'status' => 404 ) );
-	}
-
-	/**
-	 * Get VaultPress site data including, among other things, the date of tge last backup if it was completed.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @return mixed|WP_Error VaultPress site data. Otherwise, a WP_Error instance with the corresponding error.
-	 */
-	public static function vaultpress_get_site_data() {
-		if ( class_exists( 'VaultPress' ) ) {
-			$vaultpress = new VaultPress();
-			if ( ! $vaultpress->is_registered() ) {
-				return rest_ensure_response( array(
-					'code'    => 'not_registered',
-					'message' => esc_html( __( 'You need to register for VaultPress.', 'jetpack' ) )
-				) );
-			}
-			$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
-			if ( is_wp_error( $data ) ) {
-				return $data;
-			} else if ( ! $data->backups->last_backup ) {
-				return rest_ensure_response( array(
-					'code'    => 'success',
-					'message' => esc_html__( 'VaultPress is active and will back up your site soon.', 'jetpack' ),
-					'data'    => $data,
-				) );
-			} else {
-				return rest_ensure_response( array(
-					'code'    => 'success',
-					'message' => esc_html( sprintf( __( 'Your site was successfully backed-up %s ago.', 'jetpack' ), human_time_diff( $data->backups->last_backup, current_time( 'timestamp' ) ) ) ),
-					'data'    => $data,
-				) );
-			}
-		}
-
-		return new WP_Error( 'not_active', esc_html__( 'The requested Jetpack module is not active.', 'jetpack' ), array( 'status' => 404 ) );
-	}
 
 	/**
 	 * Returns a list of all plugins in the site.

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -43,10 +43,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function register_endpoints() {
 
 		// Load API endpoint base classes
-		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
 
 		// Load API endpoints
-		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
 
 		self::$user_permissions_error_msg = esc_html__(
 			'You do not have the correct user permissions to perform this action.

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -106,35 +106,36 @@ class Jetpack_Core_Json_Api_Endpoints {
 		// Return all modules
 		self::route(
 			'module/all',
-			'Jetpack_Core_API_Module_Endpoint',
-			WP_REST_Server::READABLE
-		);
-
-		// Return a single module
-		self::route(
-			'/module/(?P<slug>[a-z\-]+)',
-			'Jetpack_Core_API_Module_Get_Endpoint',
+			'Jetpack_Core_API_Module_List_Endpoint',
 			WP_REST_Server::READABLE
 		);
 
 		Jetpack::load_xml_rpc_client();
-		$xmlrpc = new Jetpack_IXR_Client();
+
+		// Return a single module and update it when needed
+		self::route(
+			'/module/(?P<slug>[a-z\-]+)',
+			'Jetpack_Core_API_Module_Endpoint',
+			WP_REST_Server::READABLE,
+			new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) )
+		);
 
 		// Activate and deactivate a module
 		self::route(
 			'/module/(?P<slug>[a-z\-]+)/active',
 			'Jetpack_Core_API_Module_Toggle_Endpoint',
 			WP_REST_Server::EDITABLE,
-			$xmlrpc
+			new Jetpack_IXR_Client()
 		);
 
 		// Update a module
-		register_rest_route( 'jetpack/v4', '/module/(?P<slug>[a-z\-]+)/update', array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::update_module',
-			'permission_callback' => __CLASS__ . '::configure_modules_permission_check',
-			'args' => self::get_module_updating_parameters(),
-		) );
+		self::route(
+			'/module/(?P<slug>[a-z\-]+)',
+			'Jetpack_Core_API_Module_Endpoint',
+			WP_REST_Server::EDITABLE,
+			new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) ),
+			self::get_module_updating_parameters()
+		);
 
 		// Activate many modules
 		register_rest_route( 'jetpack/v4', '/modules/activate', array(
@@ -264,26 +265,27 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 	}
 
-	public static function route( $path, $classname, $method, $arguments = NULL ) {
-		if ( ! empty( $arguments ) ) {
-			$endpoint = new $classname( $arguments );
+	public static function route( $path, $classname, $method,
+		$constructor_arguments = NULL,
+		$endpoint_arguments = NULL
+	) {
+		if ( ! empty( $constructor_arguments ) ) {
+			$endpoint = new $classname( $constructor_arguments );
 		} else {
 			$endpoint = new $classname();
 		}
 
-		register_rest_route(
-			'jetpack/v4',
-			$path,
-			array(
-				'methods' => $method,
-				'callback' => array( $endpoint, 'process' ),
-				'permission_callback' => array(
-					$endpoint,
-					WP_REST_Server::READABLE === $method ?
-						'can_read' : 'can_write'
-				)
-			)
+		$parameters = array(
+			'methods' => $method,
+			'callback' => array( $endpoint, 'process' ),
+			'permission_callback' => array( $endpoint, 'can_request' )
 		);
+
+		if ( ! empty( $endpoint_arguments ) ) {
+			$parameters['args'] = $endpoint_arguments;
+		}
+
+		register_rest_route( 'jetpack/v4', $path, $parameters );
 	}
 
 	/**
@@ -942,340 +944,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'code' 	  => 'success',
 			'message' => esc_html__( 'Nothing to dismiss. This was not a new connection.', 'jetpack' ),
 		) );
-	}
-
-	/**
-	 * If it's a valid Jetpack module and configuration parameters have been sent, update it.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @param WP_REST_Request $data {
-	 *     Array of parameters received by request.
-	 *
-	 *     @type string $slug Module slug.
-	 * }
-	 *
-	 * @return bool|WP_Error True if module was updated. Otherwise, a WP_Error instance with the corresponding error.
-	 */
-	public static function update_module( $data ) {
-		if ( ! Jetpack::is_module( $data['slug'] ) ) {
-			return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
-		}
-
-		if ( ! Jetpack::is_module_active( $data['slug'] ) ) {
-			return new WP_Error( 'inactive', esc_html__( 'The requested Jetpack module is inactive.', 'jetpack' ), array( 'status' => 409 ) );
-		}
-
-		// Get parameters to update the module.
-		$params = $data->get_json_params();
-
-		// Exit if no parameters were passed.
-		if ( ! is_array( $params ) ) {
-			return new WP_Error( 'missing_options', esc_html__( 'Missing options.', 'jetpack' ), array( 'status' => 404 ) );
-		}
-
-		// Get available module options.
-		$options = self::get_module_available_options( $data['slug'] );
-
-		// Options that are invalid or failed to update.
-		$invalid = array();
-		$not_updated = array();
-
-		// Used if response is successful. The message can be overwritten and additional data can be added here.
-		$response = array(
-			'code' 	  => 'success',
-			'message' => esc_html__( 'The requested Jetpack module was updated.', 'jetpack' ),
-		);
-
-		foreach ( $params as $option => $value ) {
-			// If option is invalid, don't go any further.
-			if ( ! in_array( $option, array_keys( $options ) ) ) {
-				$invalid[] = $option;
-				continue;
-			}
-
-			// Used if there was an error. Can be overwritten with specific error messages.
-			$error = '';
-
-			// Set to true if the option update was successful.
-			$updated = false;
-
-			// Properly cast value based on its type defined in endpoint accepted args.
-			$value = self::cast_value( $value, $options[ $option ] );
-
-			switch ( $option ) {
-				case 'monitor_receive_notifications':
-					$monitor = new Jetpack_Monitor();
-
-					// If we got true as response, consider it done.
-					$updated = true === $monitor->update_option_receive_jetpack_monitor_notification( $value );
-					break;
-
-				case 'post_by_email_address':
-					if ( 'create' == $value ) {
-						$result = self::_process_post_by_email(
-							'jetpack.createPostByEmailAddress',
-							esc_html__( 'Unable to create the Post by Email address. Please try again later.', 'jetpack' )
-						);
-					} elseif ( 'regenerate' == $value ) {
-						$result = self::_process_post_by_email(
-							'jetpack.regeneratePostByEmailAddress',
-							esc_html__( 'Unable to regenerate the Post by Email address. Please try again later.', 'jetpack' )
-						);
-					} elseif ( 'delete' == $value ) {
-						$result = self::_process_post_by_email(
-							'jetpack.deletePostByEmailAddress',
-							esc_html__( 'Unable to delete the Post by Email address. Please try again later.', 'jetpack' )
-						);
-					} else {
-						$result = false;
-					}
-
-					// If we got an email address (create or regenerate) or 1 (delete), consider it done.
-					if ( preg_match( '/[a-z0-9]+@post.wordpress.com/', $result ) ) {
-						$response[ $option ] = $result;
-						$updated = true;
-					} elseif ( 1 == $result ) {
-						$updated = true;
-					} elseif ( is_array( $result ) && isset( $result['message'] ) ) {
-						$error = $result['message'];
-					}
-					break;
-
-				case 'jetpack_protect_key':
-					$protect = Jetpack_Protect_Module::instance();
-					if ( 'create' == $value ) {
-						$result = $protect->get_protect_key();
-					} else {
-						$result = false;
-					}
-
-					// If we got one of Protect keys, consider it done.
-					if ( preg_match( '/[a-z0-9]{40,}/i', $result ) ) {
-						$response[ $option ] = $result;
-						$updated = true;
-					}
-					break;
-
-				case 'jetpack_protect_global_whitelist':
-					$updated = jetpack_protect_save_whitelist( explode( PHP_EOL, str_replace( array( ' ', ',' ), array( '', "\n" ), $value ) ) );
-					if ( is_wp_error( $updated ) ) {
-						$error = $updated->get_error_message();
-					}
-					break;
-
-				case 'show_headline':
-				case 'show_thumbnails':
-					$grouped_options = $grouped_options_current = (array) Jetpack_Options::get_option( 'relatedposts' );
-					$grouped_options[ $option ] = $value;
-
-					// If option value was the same, consider it done.
-					$updated = $grouped_options_current != $grouped_options ? Jetpack_Options::update_option( 'relatedposts', $grouped_options ) : true;
-					break;
-
-				case 'google':
-				case 'bing':
-				case 'pinterest':
-					$grouped_options = $grouped_options_current = (array) get_option( 'verification_services_codes' );
-					$grouped_options[ $option ] = $value;
-
-					// If option value was the same, consider it done.
-					$updated = $grouped_options_current != $grouped_options ? update_option( 'verification_services_codes', $grouped_options ) : true;
-					break;
-
-				case 'sharing_services':
-					$sharer = new Sharing_Service();
-
-					// If option value was the same, consider it done.
-					$updated = $value != $sharer->get_blog_services() ? $sharer->set_blog_services( $value['visible'], $value['hidden'] ) : true;
-					break;
-
-				case 'button_style':
-				case 'sharing_label':
-				case 'show':
-					$sharer = new Sharing_Service();
-					$grouped_options = $sharer->get_global_options();
-					$grouped_options[ $option ] = $value;
-					$updated = $sharer->set_global_options( $grouped_options );
-					break;
-
-				case 'custom':
-					$sharer = new Sharing_Service();
-					$updated = $sharer->new_service( stripslashes( $value['sharing_name'] ), stripslashes( $value['sharing_url'] ), stripslashes( $value['sharing_icon'] ) );
-
-					// Return new custom service
-					$response[ $option ] = $updated;
-					break;
-
-				case 'sharing_delete_service':
-					$sharer = new Sharing_Service();
-					$updated = $sharer->delete_service( $value );
-					break;
-
-				case 'jetpack-twitter-cards-site-tag':
-					$value = trim( ltrim( strip_tags( $value ), '@' ) );
-					$updated = get_option( $option ) !== $value ? update_option( $option, $value ) : true;
-					break;
-
-				case 'onpublish':
-				case 'onupdate':
-				case 'Bias Language':
-				case 'Cliches':
-				case 'Complex Expression':
-				case 'Diacritical Marks':
-				case 'Double Negative':
-				case 'Hidden Verbs':
-				case 'Jargon Language':
-				case 'Passive voice':
-				case 'Phrases to Avoid':
-				case 'Redundant Expression':
-				case 'guess_lang':
-					if ( in_array( $option, array( 'onpublish', 'onupdate' ) ) ) {
-						$atd_option = 'AtD_check_when';
-					} elseif ( 'guess_lang' == $option ) {
-						$atd_option = 'AtD_guess_lang';
-						$option = 'true';
-					} else {
-						$atd_option = 'AtD_options';
-					}
-					$user_id = get_current_user_id();
-					$grouped_options_current = AtD_get_options( $user_id, $atd_option );
-					unset( $grouped_options_current['name'] );
-					$grouped_options = $grouped_options_current;
-					if ( $value && ! isset( $grouped_options [ $option ] ) ) {
-						$grouped_options [ $option ] = $value;
-					} elseif ( ! $value && isset( $grouped_options [ $option ] ) ) {
-						unset( $grouped_options [ $option ] );
-					}
-					// If option value was the same, consider it done, otherwise try to update it.
-					$options_to_save = implode( ',', array_keys( $grouped_options ) );
-					$updated = $grouped_options != $grouped_options_current ? AtD_update_setting( $user_id, $atd_option, $options_to_save ) : true;
-					break;
-
-				case 'ignored_phrases':
-				case 'unignore_phrase':
-					$user_id = get_current_user_id();
-					$atd_option = 'AtD_ignored_phrases';
-					$grouped_options = $grouped_options_current = explode( ',', AtD_get_setting( $user_id, $atd_option ) );
-					if ( 'ignored_phrases' == $option ) {
-						$grouped_options = explode( ',', $value );
-					} else {
-						$index = array_search( $value, $grouped_options );
-						if ( false !== $index ) {
-							unset( $grouped_options[ $index ] );
-							$grouped_options = array_values( $grouped_options );
-						}
-					}
-					$ignored_phrases = implode( ',', array_filter( array_map( 'strip_tags', $grouped_options ) ) );
-					$updated = $grouped_options != $grouped_options_current ? AtD_update_setting( $user_id, $atd_option, $ignored_phrases ) : true;
-					break;
-
-				case 'admin_bar':
-				case 'roles':
-				case 'count_roles':
-				case 'blog_id':
-				case 'do_not_track':
-				case 'hide_smile':
-				case 'version':
-					$grouped_options = $grouped_options_current = (array) get_option( 'stats_options' );
-					$grouped_options[ $option ] = $value;
-
-					// If option value was the same, consider it done.
-					$updated = $grouped_options_current != $grouped_options ? update_option( 'stats_options', $grouped_options ) : true;
-					break;
-
-				case 'wp_mobile_featured_images':
-				case 'wp_mobile_excerpt':
-					$value = ( 'enabled' === $value ) ? '1' : '0';
-					// break intentionally omitted
-				default:
-					// If option value was the same, consider it done.
-					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;
-					break;
-			}
-
-			// The option was not updated.
-			if ( ! $updated ) {
-				$not_updated[ $option ] = $error;
-			}
-		}
-
-		if ( empty( $invalid ) && empty( $not_updated ) ) {
-			// The option was updated.
-			return rest_ensure_response( $response );
-		} else {
-			$invalid_count = count( $invalid );
-			$not_updated_count = count( $not_updated );
-			$error = '';
-			if ( $invalid_count > 0 ) {
-				$error = sprintf(
-					/* Translators: the plural variable is a comma-separated list. Example: dog, cat, bird. */
-					_n( 'Invalid option for this module: %s.', 'Invalid options for this module: %s.', $invalid_count, 'jetpack' ),
-					join( ', ', $invalid )
-				);
-			}
-			if ( $not_updated_count > 0 ) {
-				$not_updated_messages = array();
-				foreach ( $not_updated as $not_updated_option => $not_updated_message ) {
-					if ( ! empty( $not_updated_message ) ) {
-						$not_updated_messages[] = sprintf(
-							/* Translators: the first variable is a module option name. The second is the error message . */
-							__( 'Extra info for %1$s: %2$s', 'jetpack' ),
-							$not_updated_option, $not_updated_message );
-					}
-				}
-				if ( ! empty( $error ) ) {
-					$error .= ' ';
-				}
-				$error .= sprintf(
-					/* Translators: the plural variable is a comma-separated list. Example: dog, cat, bird. */
-					_n( 'Option not updated: %s.', 'Options not updated: %s.', $not_updated_count, 'jetpack' ),
-					join( ', ', array_keys( $not_updated ) ) );
-				if ( ! empty( $not_updated_messages ) ) {
-					$error .= ' ' . join( '. ', $not_updated_messages );
-				}
-
-			}
-			// There was an error because some options were updated but others were invalid or failed to update.
-			return new WP_Error( 'some_updated', esc_html( $error ), array( 'status' => 400 ) );
-		}
-
-	}
-
-	/**
-	 * Calls WPCOM through authenticated request to create, regenerate or delete the Post by Email address.
-	 * @todo: When all settings are updated to use endpoints, move this to the Post by Email module and replace __process_ajax_proxy_request.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @param string $endpoint Process to call on WPCOM to create, regenerate or delete the Post by Email address.
-	 * @param string $error	   Error message to return.
-	 *
-	 * @return array
-	 */
-	private static function _process_post_by_email( $endpoint, $error ) {
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return array( 'message' => $error );
-		}
-		Jetpack::load_xml_rpc_client();
-		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => get_current_user_id(),
-		) );
-		$xml->query( $endpoint );
-
-		if ( $xml->isError() ) {
-			return array( 'message' => $error );
-		}
-
-		$response = $xml->getResponse();
-		if ( empty( $response ) ) {
-			return array( 'message' => $error );
-		}
-
-		// Used only in Jetpack_Core_Json_Api_Endpoints::get_remote_value.
-		update_option( 'post_by_email_address', $response );
-
-		return $response;
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -227,8 +227,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Dismiss Jetpack Notices
-		register_rest_route( 'jetpack/v4', '/notice/(?P<notice>[a-z\-_]+)/dismiss', array(
-			'methods' => WP_REST_Server::EDITABLE,
+		register_rest_route( 'jetpack/v4', '/notice/(?P<notice>[a-z\-_]+)', array(
+			'methods' => WP_REST_Server::DELETABLE,
 			'callback' => __CLASS__ . '::dismiss_notice',
 			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 		) );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -63,7 +63,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Fetches a fresh connect URL
-		register_rest_route( 'jetpack/v4', '/connect-url', array(
+		register_rest_route( 'jetpack/v4', '/connection/url', array(
 			'methods' => WP_REST_Server::READABLE,
 			'callback' => __CLASS__ . '::build_connect_url',
 			'permission_callback' => __CLASS__ . '::connect_url_permission_callback',

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -77,8 +77,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Disconnect site from WordPress.com servers
-		register_rest_route( 'jetpack/v4', '/disconnect/site', array(
-			'methods' => WP_REST_Server::EDITABLE,
+		register_rest_route( 'jetpack/v4', '/connection', array(
+			'methods' => WP_REST_Server::DELETABLE,
 			'callback' => __CLASS__ . '::disconnect_site',
 			'permission_callback' => __CLASS__ . '::disconnect_site_permission_callback',
 		) );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -111,11 +111,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 		);
 
 		// Return a single module
-		register_rest_route( 'jetpack/v4', '/module/(?P<slug>[a-z\-]+)', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::get_module',
-			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
-		) );
+		self::route(
+			'/module/(?P<slug>[a-z\-]+)',
+			'Jetpack_Core_API_Module_Get_Endpoint',
+			WP_REST_Server::READABLE
+		);
 
 		Jetpack::load_xml_rpc_client();
 		$xmlrpc = new Jetpack_IXR_Client();
@@ -707,36 +707,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Get information about a specific and valid Jetpack module.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @param WP_REST_Request $data {
-	 *     Array of parameters received by request.
-	 *
-	 *     @type string $slug Module slug.
-	 * }
-	 *
-	 * @return mixed|void|WP_Error
-	 */
-	public static function get_module( $data ) {
-		if ( Jetpack::is_module( $data['slug'] ) ) {
-
-			$module = Jetpack::get_module( $data['slug'] );
-
-			$module['options'] = self::prepare_options_for_response( $data['slug'] );
-
-			if ( isset( $module['requires_connection'] ) && $module['requires_connection'] && Jetpack::is_development_mode() ) {
-				$module['activated'] = false;
-			}
-
-			return self::prepare_modules_for_response( $module, $data['slug'] );
-		}
-
-		return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -185,8 +185,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 		);
 
 		// Reset all Jetpack options
-		register_rest_route( 'jetpack/v4', '/reset/(?P<options>[a-z\-]+)', array(
-			'methods' => WP_REST_Server::EDITABLE,
+		register_rest_route( 'jetpack/v4', '/options/(?P<options>[a-z\-]+)', array(
+			'methods' => WP_REST_Server::DELETABLE,
 			'callback' => __CLASS__ . '::reset_jetpack_options',
 			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
 		) );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -21,7 +21,7 @@ add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register
 /**
  * Class Jetpack_Core_Json_Api_Endpoints
  *
- * @since 4.1.0
+ * @since 4.3.0
  */
 class Jetpack_Core_Json_Api_Endpoints {
 
@@ -38,7 +38,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Declare the Jetpack REST API endpoints.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 */
 	public static function register_endpoints() {
 
@@ -273,7 +273,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Handles dismissing of Jetpack Notices
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return array|wp-error
 	 */
@@ -299,7 +299,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that the user can disconnect the site.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool|WP_Error True if user is able to disconnect the site.
 	 */
@@ -315,7 +315,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that the user can get a connect/link URL
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool|WP_Error True if user is able to disconnect the site.
 	 */
@@ -331,7 +331,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that a user can use the link endpoint.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool|WP_Error True if user is able to link to WordPress.com
 	 */
@@ -347,7 +347,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Verify that a user can get the data about the current user.
 	 * Only those who can connect.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @uses Jetpack::is_user_connected();
 	 *
@@ -365,7 +365,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Verify that a user can use the unlink endpoint.
 	 * Either needs to be an admin of the site, or for them to be currently linked.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @uses Jetpack::is_user_connected();
 	 *
@@ -382,7 +382,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that user can manage Jetpack modules.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool Whether user has the capability 'jetpack_manage_modules'.
 	 */
@@ -397,7 +397,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that user can update Jetpack modules.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool Whether user has the capability 'jetpack_configure_modules'.
 	 */
@@ -412,7 +412,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that user can view Jetpack admin page.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool Whether user has the capability 'jetpack_admin_page'.
 	 */
@@ -427,7 +427,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that user can update Jetpack options.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool Whether user has the capability 'jetpack_admin_page'.
 	 */
@@ -442,7 +442,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that user can view Jetpack admin page and can activate plugins.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool Whether user has the capability 'jetpack_admin_page' and 'activate_plugins'.
 	 */
@@ -460,7 +460,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Taken from rest_authorization_required_code() in WP-API plugin until is added to core.
 	 * @see https://github.com/WP-API/WP-API/commit/7ba0ae6fe4f605d5ffe4ee85b1cd5f9fb46900a6
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return int
 	 */
@@ -471,7 +471,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Get connection status for this Jetpack site.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return bool True if site is connected
 	 */
@@ -493,7 +493,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Disconnects Jetpack from the WordPress.com Servers
 	 *
 	 * @uses Jetpack::disconnect();
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 * @return bool|WP_Error True if Jetpack successfully disconnected.
 	 */
 	public static function disconnect_site() {
@@ -509,7 +509,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Gets a new connect URL with fresh nonce
 	 *
 	 * @uses Jetpack::disconnect();
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 * @return bool|WP_Error True if Jetpack successfully disconnected.
 	 */
 	public static function build_connect_url() {
@@ -524,7 +524,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Get miscellaneous settings for this Jetpack installation, like Holiday Snow.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return object $response {
 	 *     Array of miscellaneous settings.
@@ -544,7 +544,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Information about the master/primary user.
 	 * Information about the current user.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return object
 	 */
@@ -563,7 +563,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Update a single miscellaneous setting for this Jetpack installation, like Holiday Snow.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data
 	 *
@@ -608,7 +608,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * Example: '/unlink?id=1234'
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 * @uses  Jetpack::unlink_user
 	 *
 	 * @param WP_REST_Request $data {
@@ -634,7 +634,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Get site data, including for example, the site's current plan.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return array Array of Jetpack modules.
 	 */
@@ -662,7 +662,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Reset Jetpack options
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data {
 	 *     Array of parameters received by request.
@@ -721,7 +721,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Toggles activation or deactivation of the JumpStart
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data {
 	 *     Array of parameters received by request.
@@ -742,7 +742,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Activates a series of valid Jetpack modules and initializes some options.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data {
 	 *     Array of parameters received by request.
@@ -824,7 +824,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Dismisses Jumpstart so user is not prompted to go through it again.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data {
 	 *     Array of parameters received by request.
@@ -856,7 +856,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Get the query parameters for module updating.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return array
 	 */
@@ -873,7 +873,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Returns a list of module options that can be updated.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $module Module slug. If empty, it's assumed we're updating a module and we'll try to get its slug.
 	 * @param bool $cache Whether to cache the options or return always fresh.
@@ -1464,7 +1464,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is either a pure boolean or a numeric string that can be mapped to a boolean.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1482,7 +1482,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is a positive integer.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param int $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1500,7 +1500,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter belongs to a list of admitted values.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1528,7 +1528,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter belongs to a list of admitted values.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1553,7 +1553,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is an alphanumeric or empty string (to be able to clear the field).
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1571,7 +1571,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is among the roles allowed for Stats.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1589,7 +1589,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is among the views where the Sharing can be displayed.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1608,7 +1608,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is among the views where the Sharing can be displayed.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1645,7 +1645,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter has enough information to build a custom sharing button.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1678,7 +1678,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is a custom sharing service ID like 'custom-1461976264'.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1707,7 +1707,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is a Twitter username or empty string (to be able to clear the field).
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1725,7 +1725,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Validates that the parameter is a string.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
 	 * @param WP_REST_Request $request
@@ -1744,7 +1744,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * If for some reason the roles allowed to see Stats are empty (for example, user tampering with checkboxes),
 	 * return an array with only 'administrator' as the allowed role and save it for 'roles' option.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
 	 *
@@ -1760,7 +1760,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Get the currently accessed route and return the module slug in it.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $route Regular expression for the endpoint with the module slug to return.
 	 *
@@ -1821,7 +1821,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Fetch current option value and add to array of module options.
 	 * Prepare values of module options that need special handling, like those saved in wpcom.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $module Module slug.
 	 * @return array
@@ -1937,7 +1937,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Splits module options saved as arrays like relatedposts or verification_services_codes into separate options to be returned in the response.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param array  $separate_options Array of options admitted by the module.
 	 * @param array  $grouped_options Option saved as array to be splitted.
@@ -1960,7 +1960,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Perform a casting to the value specified in the option definition.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param mixed $value Value to cast to the proper type.
 	 * @param array $definition Type to cast the value to.
@@ -1998,7 +1998,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Get a value not saved locally.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $module Module slug.
 	 * @param string $option Option name.
@@ -2058,7 +2058,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Get number of plugin updates available.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return mixed|WP_Error Number of plugin updates available. Otherwise, a WP_Error instance with the corresponding error.
 	 */

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -120,20 +120,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 		Jetpack::load_xml_rpc_client();
 		$xmlrpc = new Jetpack_IXR_Client();
 
-		// Activate a module
+		// Activate and deactivate a module
 		self::route(
-			'/module/(?P<slug>[a-z\-]+)/activate',
-			'Jetpack_Core_API_Module_Activate_Endpoint',
+			'/module/(?P<slug>[a-z\-]+)/active',
+			'Jetpack_Core_API_Module_Toggle_Endpoint',
 			WP_REST_Server::EDITABLE,
 			$xmlrpc
 		);
-
-		// Deactivate a module
-		register_rest_route( 'jetpack/v4', '/module/(?P<slug>[a-z\-]+)/deactivate', array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::deactivate_module',
-			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
-		) );
 
 		// Update a module
 		register_rest_route( 'jetpack/v4', '/module/(?P<slug>[a-z\-]+)/update', array(
@@ -710,33 +703,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * If it's a valid Jetpack module, activate it.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @param WP_REST_Request $data {
-	 *     Array of parameters received by request.
-	 *
-	 *     @type string $slug Module slug.
-	 * }
-	 *
-	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
-	 */
-	public static function activate_module( $data ) {
-		if ( Jetpack::is_module( $data['slug'] ) ) {
-			if ( Jetpack::activate_module( $data['slug'], false, false ) ) {
-				return rest_ensure_response( array(
-					'code' 	  => 'success',
-					'message' => esc_html__( 'The requested Jetpack module was activated.', 'jetpack' ),
-				) );
-			}
-			return new WP_Error( 'activation_failed', esc_html__( 'The requested Jetpack module could not be activated.', 'jetpack' ), array( 'status' => 424 ) );
-		}
-
-		return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
-	}
-
-	/**
 	 * Activate a list of valid Jetpack modules.
 	 *
 	 * @since 4.1.0
@@ -976,36 +942,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'code' 	  => 'success',
 			'message' => esc_html__( 'Nothing to dismiss. This was not a new connection.', 'jetpack' ),
 		) );
-	}
-
-	/**
-	 * If it's a valid Jetpack module, deactivate it.
-	 *
-	 * @since 4.1.0
-	 *
-	 * @param WP_REST_Request $data {
-	 *     Array of parameters received by request.
-	 *
-	 *     @type string $slug Module slug.
-	 * }
-	 *
-	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
-	 */
-	public static function deactivate_module( $data ) {
-		if ( Jetpack::is_module( $data['slug'] ) ) {
-			if ( ! Jetpack::is_module_active( $data['slug'] ) ) {
-				return new WP_Error( 'already_inactive', esc_html__( 'The requested Jetpack module was already inactive.', 'jetpack' ), array( 'status' => 409 ) );
-			}
-			if ( Jetpack::deactivate_module( $data['slug'] ) ) {
-				return rest_ensure_response( array(
-					'code' 	  => 'success',
-					'message' => esc_html__( 'The requested Jetpack module was deactivated.', 'jetpack' ),
-				) );
-			}
-			return new WP_Error( 'deactivation_failed', esc_html__( 'The requested Jetpack module could not be deactivated.', 'jetpack' ), array( 'status' => 400 ) );
-		}
-
-		return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -84,8 +84,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Disconnect/unlink user from WordPress.com servers
-		register_rest_route( 'jetpack/v4', '/unlink', array(
-			'methods' => WP_REST_Server::EDITABLE,
+		register_rest_route( 'jetpack/v4', '/connection/user', array(
+			'methods' => WP_REST_Server::DELETABLE,
 			'callback' => __CLASS__ . '::unlink_user',
 			'permission_callback' => __CLASS__ . '::link_user_permission_callback',
 			'args' => array(

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -199,7 +199,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Update miscellaneous setting
-		register_rest_route( 'jetpack/v4', '/setting/update', array(
+		register_rest_route( 'jetpack/v4', '/settings', array(
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::update_setting',
 			'permission_callback' => __CLASS__ . '::update_settings_permission_check',

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -57,7 +57,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		self::$stats_roles = array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' );
 
 		// Get current connection status of Jetpack
-		register_rest_route( 'jetpack/v4', '/connection-status', array(
+		register_rest_route( 'jetpack/v4', '/connection', array(
 			'methods' => WP_REST_Server::READABLE,
 			'callback' => __CLASS__ . '::jetpack_connection_status',
 		) );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -70,7 +70,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Get current user connection data
-		register_rest_route( 'jetpack/v4', '/user-connection-data', array(
+		register_rest_route( 'jetpack/v4', '/connection/data', array(
 			'methods' => WP_REST_Server::READABLE,
 			'callback' => __CLASS__ . '::get_user_connection_data',
 			'permission_callback' => __CLASS__ . '::get_user_connection_data_permission_callback',

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -206,18 +206,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Jumpstart
-		register_rest_route( 'jetpack/v4', '/jumpstart/activate', array(
+		register_rest_route( 'jetpack/v4', '/jumpstart', array(
 			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::jumpstart_activate',
+			'callback' => __CLASS__ . '::jumpstart_toggle',
 			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
 		) );
-
-		register_rest_route( 'jetpack/v4', '/jumpstart/deactivate', array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::jumpstart_deactivate',
-			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
-		) );
-
 
 		// Updates: get number of plugin updates available
 		register_rest_route( 'jetpack/v4', '/updates/plugins', array(
@@ -717,6 +710,39 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return new WP_Error( 'required_param', esc_html__( 'Missing parameter "type".', 'jetpack' ), array( 'status' => 404 ) );
+	}
+
+	/**
+	 * Toggles activation or deactivation of the JumpStart
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 * }
+	 *
+	 * @return bool|WP_Error True if toggling Jumpstart succeeded. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public static function jumpstart_toggle( $data ) {
+		$param = $data->get_json_params();
+
+		// Exit if no parameters were passed.
+		if ( ! isset( $param[ 'active' ] ) ) {
+			return new WP_Error( 'missing_parameter_active', esc_html__( 'Missing parameter active.', 'jetpack' ), array( 'status' => 400 ) );
+		}
+
+		$validates = self::validate_boolean( $param[ 'active' ], null, 'active' );
+
+		// Exit if `activate` was passed as a non-boolean
+		if ( true !== $validates ) {
+			return $validates;
+		}
+
+		if ( $param[ 'active' ] ) {
+			return self::jumpstart_activate( $data );
+		} else {
+			return self::jumpstart_deactivate( $data );
+		}
 	}
 
 	/**

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -86,3 +86,48 @@ class Jetpack_Core_API_Module_Endpoint {
 		return current_user_can( 'jetpack_admin_page' );
 	}
 }
+
+class Jetpack_Core_API_Module_Get_Endpoint {
+
+	/**
+	 * Get information about a specific and valid Jetpack module.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $slug Module slug.
+	 * }
+	 *
+	 * @return mixed|void|WP_Error
+	 */
+	public static function process( $data ) {
+		if ( Jetpack::is_module( $data['slug'] ) ) {
+
+			$module = Jetpack::get_module( $data['slug'] );
+
+			$module['options'] = Jetpack_Core_Json_Api_Endpoints::prepare_options_for_response( $data['slug'] );
+
+			if (
+				isset( $module['requires_connection'] )
+				&& $module['requires_connection']
+				&& Jetpack::is_development_mode()
+			) {
+				$module['activated'] = false;
+			}
+
+			return $module;
+		}
+
+		return new WP_Error(
+			'not_found',
+			esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	public function can_read() {
+		return current_user_can( 'jetpack_admin_page' );
+	}
+}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -3,7 +3,7 @@
  * This is the base class for every Core API endpoint Jetpack uses.
  *
  */
-class Jetpack_Core_API_Module_Activate_Endpoint
+class Jetpack_Core_API_Module_Toggle_Endpoint
 	extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 	/**
@@ -23,23 +23,113 @@ class Jetpack_Core_API_Module_Activate_Endpoint
 	 * Check if the module requires the site to be publicly accessible from WPCOM.
 	 * If the site meets this requirement, the module is activated. Otherwise an error is returned.
 	 *
-	 * @since 4.3
+	 * @since 4.3.0
 	 *
-	 * @param array $data
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
 	 *
-	 * @return bool|WP_Error
+	 *     @type string $slug Module slug.
+	 *     @type bool   $active should module be activated.
+	 * }
+	 *
+	 * @return WP_REST_Response|WP_Error A REST response if the request was served successfully, otherwise an error.
 	 */
 	public function process( $data ) {
+		if ( $data['active'] ) {
+			return $this->activate_module( $data );
+		} else {
+			return $this->deactivate_module( $data );
+		}
+	}
+
+	/**
+	 * If it's a valid Jetpack module, activate it.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $slug Module slug.
+	 * }
+	 *
+	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public function activate_module( $data ) {
+		if ( ! Jetpack::is_module( $data['slug'] ) ) {
+			return new WP_Error(
+				'not_found',
+				esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
 		if (
-			! in_array( $data['slug'], $this->modules_requiring_public )
-			|| $this->is_site_public()
+			in_array( $data['slug'], $this->modules_requiring_public )
+			&& ! $this->is_site_public()
 		) {
-			return Jetpack::activate_module( $data['slug'], false, false );
+			return new WP_Error(
+				'rest_cannot_publish',
+				__( 'This module requires your site to be set to publicly accessible.', 'jetpack' ),
+				array( 'status' => 424 )
+			);
+		}
+
+		if ( Jetpack::activate_module( $data['slug'], false, false ) ) {
+			return rest_ensure_response( array(
+				'code' 	  => 'success',
+				'message' => esc_html__( 'The requested Jetpack module was activated.', 'jetpack' ),
+			) );
+		}
+
+		return new WP_Error(
+			'activation_failed',
+			esc_html__( 'The requested Jetpack module could not be activated.', 'jetpack' ),
+			array( 'status' => 424 )
+		);
+	}
+
+	/**
+	 * If it's a valid Jetpack module, deactivate it.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $slug Module slug.
+	 * }
+	 *
+	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public function deactivate_module( $data ) {
+		if ( ! Jetpack::is_module( $data['slug'] ) ) {
+			return new WP_Error(
+				'not_found',
+				esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! Jetpack::is_module_active( $data['slug'] ) ) {
+			return new WP_Error(
+				'already_inactive',
+				esc_html__( 'The requested Jetpack module was already inactive.', 'jetpack' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( Jetpack::deactivate_module( $data['slug'] ) ) {
+			return rest_ensure_response( array(
+				'code' 	  => 'success',
+				'message' => esc_html__( 'The requested Jetpack module was deactivated.', 'jetpack' ),
+			) );
 		}
 		return new WP_Error(
-			'rest_cannot_publish',
-			esc_html__( 'This module requires your site to be set to publicly accessible.', 'jetpack' ),
-			array( 'status' => 424 ) );
+			'deactivation_failed',
+			esc_html__( 'The requested Jetpack module could not be deactivated.', 'jetpack' ),
+			array( 'status' => 400 )
+		);
 	}
 
 	/**
@@ -59,7 +149,7 @@ class Jetpack_Core_API_Module_Endpoint {
 	/**
 	 * Get a list of all Jetpack modules and their information.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return array Array of Jetpack modules.
 	 */
@@ -92,7 +182,7 @@ class Jetpack_Core_API_Module_Get_Endpoint {
 	/**
 	 * Get information about a specific and valid Jetpack module.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data {
 	 *     Array of parameters received by request.

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -333,7 +333,7 @@ class Jetpack_Core_API_Module_Endpoint
 	 *
 	 * @return bool|WP_Error True if module was updated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public static function update_module( $data ) {
+	public function update_module( $data ) {
 		if ( ! Jetpack::is_module( $data['slug'] ) ) {
 			return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
 		}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -139,12 +139,12 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @return bool
 	 */
-	public function can_write() {
+	public function can_request() {
 		return current_user_can( 'jetpack_manage_modules' );
 	}
 }
 
-class Jetpack_Core_API_Module_Endpoint {
+class Jetpack_Core_API_Module_List_Endpoint {
 
 	/**
 	 * Get a list of all Jetpack modules and their information.
@@ -172,12 +172,21 @@ class Jetpack_Core_API_Module_Endpoint {
 		return $modules;
 	}
 
-	public function can_read() {
+	public function can_request() {
 		return current_user_can( 'jetpack_admin_page' );
 	}
 }
 
-class Jetpack_Core_API_Module_Get_Endpoint {
+class Jetpack_Core_API_Module_Endpoint
+	extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
+
+	public function process( $data ) {
+		if ( 'GET' === $data->get_method() ) {
+			return $this->get_module( $data );
+		} else {
+			return $this->update_module( $data );
+		}
+	}
 
 	/**
 	 * Get information about a specific and valid Jetpack module.
@@ -192,7 +201,7 @@ class Jetpack_Core_API_Module_Get_Endpoint {
 	 *
 	 * @return mixed|void|WP_Error
 	 */
-	public static function process( $data ) {
+	public function get_module( $data ) {
 		if ( Jetpack::is_module( $data['slug'] ) ) {
 
 			$module = Jetpack::get_module( $data['slug'] );
@@ -217,7 +226,342 @@ class Jetpack_Core_API_Module_Get_Endpoint {
 		);
 	}
 
-	public function can_read() {
-		return current_user_can( 'jetpack_admin_page' );
+	/**
+	 * If it's a valid Jetpack module and configuration parameters have been sent, update it.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $slug Module slug.
+	 * }
+	 *
+	 * @return bool|WP_Error True if module was updated. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public static function update_module( $data ) {
+		if ( ! Jetpack::is_module( $data['slug'] ) ) {
+			return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
+		}
+
+		if ( ! Jetpack::is_module_active( $data['slug'] ) ) {
+			return new WP_Error( 'inactive', esc_html__( 'The requested Jetpack module is inactive.', 'jetpack' ), array( 'status' => 409 ) );
+		}
+
+		// Get parameters to update the module.
+		$params = $data->get_json_params();
+
+		// Exit if no parameters were passed.
+		if ( ! is_array( $params ) ) {
+			return new WP_Error( 'missing_options', esc_html__( 'Missing options.', 'jetpack' ), array( 'status' => 404 ) );
+		}
+
+		// Get available module options.
+		$options = Jetpack_Core_Json_Api_Endpoints::get_module_available_options( $data['slug'] );
+
+		// Options that are invalid or failed to update.
+		$invalid = array();
+		$not_updated = array();
+
+		// Used if response is successful. The message can be overwritten and additional data can be added here.
+		$response = array(
+			'code'	  => 'success',
+			'message' => esc_html__( 'The requested Jetpack module was updated.', 'jetpack' ),
+		);
+
+		foreach ( $params as $option => $value ) {
+			// If option is invalid, don't go any further.
+			if ( ! in_array( $option, array_keys( $options ) ) ) {
+				$invalid[] = $option;
+				continue;
+			}
+
+			// Used if there was an error. Can be overwritten with specific error messages.
+			$error = '';
+
+			// Set to true if the option update was successful.
+			$updated = false;
+
+			// Properly cast value based on its type defined in endpoint accepted args.
+			$value = Jetpack_Core_Json_Api_Endpoints::cast_value( $value, $options[ $option ] );
+
+			switch ( $option ) {
+				case 'monitor_receive_notifications':
+					$monitor = new Jetpack_Monitor();
+
+					// If we got true as response, consider it done.
+					$updated = true === $monitor->update_option_receive_jetpack_monitor_notification( $value );
+					break;
+
+				case 'post_by_email_address':
+					if ( 'create' == $value ) {
+						$result = $this->_process_post_by_email(
+							'jetpack.createPostByEmailAddress',
+							esc_html__( 'Unable to create the Post by Email address. Please try again later.', 'jetpack' )
+						);
+					} elseif ( 'regenerate' == $value ) {
+						$result = $this->_process_post_by_email(
+							'jetpack.regeneratePostByEmailAddress',
+							esc_html__( 'Unable to regenerate the Post by Email address. Please try again later.', 'jetpack' )
+						);
+					} elseif ( 'delete' == $value ) {
+						$result = $this->_process_post_by_email(
+							'jetpack.deletePostByEmailAddress',
+							esc_html__( 'Unable to delete the Post by Email address. Please try again later.', 'jetpack' )
+						);
+					} else {
+						$result = false;
+					}
+
+					// If we got an email address (create or regenerate) or 1 (delete), consider it done.
+					if ( preg_match( '/[a-z0-9]+@post.wordpress.com/', $result ) ) {
+						$response[ $option ] = $result;
+						$updated = true;
+					} elseif ( 1 == $result ) {
+						$updated = true;
+					} elseif ( is_array( $result ) && isset( $result['message'] ) ) {
+						$error = $result['message'];
+					}
+					break;
+
+				case 'jetpack_protect_key':
+					$protect = Jetpack_Protect_Module::instance();
+					if ( 'create' == $value ) {
+						$result = $protect->get_protect_key();
+					} else {
+						$result = false;
+					}
+
+					// If we got one of Protect keys, consider it done.
+					if ( preg_match( '/[a-z0-9]{40,}/i', $result ) ) {
+						$response[ $option ] = $result;
+						$updated = true;
+					}
+					break;
+
+				case 'jetpack_protect_global_whitelist':
+					$updated = jetpack_protect_save_whitelist( explode( PHP_EOL, str_replace( array( ' ', ',' ), array( '', "\n" ), $value ) ) );
+					if ( is_wp_error( $updated ) ) {
+						$error = $updated->get_error_message();
+					}
+					break;
+
+				case 'show_headline':
+				case 'show_thumbnails':
+					$grouped_options = $grouped_options_current = (array) Jetpack_Options::get_option( 'relatedposts' );
+					$grouped_options[ $option ] = $value;
+
+					// If option value was the same, consider it done.
+					$updated = $grouped_options_current != $grouped_options ? Jetpack_Options::update_option( 'relatedposts', $grouped_options ) : true;
+					break;
+
+				case 'google':
+				case 'bing':
+				case 'pinterest':
+					$grouped_options = $grouped_options_current = (array) get_option( 'verification_services_codes' );
+					$grouped_options[ $option ] = $value;
+
+					// If option value was the same, consider it done.
+					$updated = $grouped_options_current != $grouped_options ? update_option( 'verification_services_codes', $grouped_options ) : true;
+					break;
+
+				case 'sharing_services':
+					$sharer = new Sharing_Service();
+
+					// If option value was the same, consider it done.
+					$updated = $value != $sharer->get_blog_services() ? $sharer->set_blog_services( $value['visible'], $value['hidden'] ) : true;
+					break;
+
+				case 'button_style':
+				case 'sharing_label':
+				case 'show':
+					$sharer = new Sharing_Service();
+					$grouped_options = $sharer->get_global_options();
+					$grouped_options[ $option ] = $value;
+					$updated = $sharer->set_global_options( $grouped_options );
+					break;
+
+				case 'custom':
+					$sharer = new Sharing_Service();
+					$updated = $sharer->new_service( stripslashes( $value['sharing_name'] ), stripslashes( $value['sharing_url'] ), stripslashes( $value['sharing_icon'] ) );
+
+					// Return new custom service
+					$response[ $option ] = $updated;
+					break;
+
+				case 'sharing_delete_service':
+					$sharer = new Sharing_Service();
+					$updated = $sharer->delete_service( $value );
+					break;
+
+				case 'jetpack-twitter-cards-site-tag':
+					$value = trim( ltrim( strip_tags( $value ), '@' ) );
+					$updated = get_option( $option ) !== $value ? update_option( $option, $value ) : true;
+					break;
+
+				case 'onpublish':
+				case 'onupdate':
+				case 'Bias Language':
+				case 'Cliches':
+				case 'Complex Expression':
+				case 'Diacritical Marks':
+				case 'Double Negative':
+				case 'Hidden Verbs':
+				case 'Jargon Language':
+				case 'Passive voice':
+				case 'Phrases to Avoid':
+				case 'Redundant Expression':
+				case 'guess_lang':
+					if ( in_array( $option, array( 'onpublish', 'onupdate' ) ) ) {
+						$atd_option = 'AtD_check_when';
+					} elseif ( 'guess_lang' == $option ) {
+						$atd_option = 'AtD_guess_lang';
+						$option = 'true';
+					} else {
+						$atd_option = 'AtD_options';
+					}
+					$user_id = get_current_user_id();
+					$grouped_options_current = AtD_get_options( $user_id, $atd_option );
+					unset( $grouped_options_current['name'] );
+					$grouped_options = $grouped_options_current;
+					if ( $value && ! isset( $grouped_options [ $option ] ) ) {
+						$grouped_options [ $option ] = $value;
+					} elseif ( ! $value && isset( $grouped_options [ $option ] ) ) {
+						unset( $grouped_options [ $option ] );
+					}
+					// If option value was the same, consider it done, otherwise try to update it.
+					$options_to_save = implode( ',', array_keys( $grouped_options ) );
+					$updated = $grouped_options != $grouped_options_current ? AtD_update_setting( $user_id, $atd_option, $options_to_save ) : true;
+					break;
+
+				case 'ignored_phrases':
+				case 'unignore_phrase':
+					$user_id = get_current_user_id();
+					$atd_option = 'AtD_ignored_phrases';
+					$grouped_options = $grouped_options_current = explode( ',', AtD_get_setting( $user_id, $atd_option ) );
+					if ( 'ignored_phrases' == $option ) {
+						$grouped_options = explode( ',', $value );
+					} else {
+						$index = array_search( $value, $grouped_options );
+						if ( false !== $index ) {
+							unset( $grouped_options[ $index ] );
+							$grouped_options = array_values( $grouped_options );
+						}
+					}
+					$ignored_phrases = implode( ',', array_filter( array_map( 'strip_tags', $grouped_options ) ) );
+					$updated = $grouped_options != $grouped_options_current ? AtD_update_setting( $user_id, $atd_option, $ignored_phrases ) : true;
+					break;
+
+				case 'admin_bar':
+				case 'roles':
+				case 'count_roles':
+				case 'blog_id':
+				case 'do_not_track':
+				case 'hide_smile':
+				case 'version':
+					$grouped_options = $grouped_options_current = (array) get_option( 'stats_options' );
+					$grouped_options[ $option ] = $value;
+
+					// If option value was the same, consider it done.
+					$updated = $grouped_options_current != $grouped_options ? update_option( 'stats_options', $grouped_options ) : true;
+					break;
+
+				case 'wp_mobile_featured_images':
+				case 'wp_mobile_excerpt':
+					$value = ( 'enabled' === $value ) ? '1' : '0';
+					// break intentionally omitted
+				default:
+					// If option value was the same, consider it done.
+					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;
+					break;
+			}
+
+			// The option was not updated.
+			if ( ! $updated ) {
+				$not_updated[ $option ] = $error;
+			}
+		}
+
+		if ( empty( $invalid ) && empty( $not_updated ) ) {
+			// The option was updated.
+			return rest_ensure_response( $response );
+		} else {
+			$invalid_count = count( $invalid );
+			$not_updated_count = count( $not_updated );
+			$error = '';
+			if ( $invalid_count > 0 ) {
+				$error = sprintf(
+					/* Translators: the plural variable is a comma-separated list. Example: dog, cat, bird. */
+					_n( 'Invalid option for this module: %s.', 'Invalid options for this module: %s.', $invalid_count, 'jetpack' ),
+					join( ', ', $invalid )
+				);
+			}
+			if ( $not_updated_count > 0 ) {
+				$not_updated_messages = array();
+				foreach ( $not_updated as $not_updated_option => $not_updated_message ) {
+					if ( ! empty( $not_updated_message ) ) {
+						$not_updated_messages[] = sprintf(
+							/* Translators: the first variable is a module option name. The second is the error message . */
+							__( 'Extra info for %1$s: %2$s', 'jetpack' ),
+							$not_updated_option, $not_updated_message );
+					}
+				}
+				if ( ! empty( $error ) ) {
+					$error .= ' ';
+				}
+				$error .= sprintf(
+					/* Translators: the plural variable is a comma-separated list. Example: dog, cat, bird. */
+					_n( 'Option not updated: %s.', 'Options not updated: %s.', $not_updated_count, 'jetpack' ),
+					join( ', ', array_keys( $not_updated ) ) );
+				if ( ! empty( $not_updated_messages ) ) {
+					$error .= ' ' . join( '. ', $not_updated_messages );
+				}
+
+			}
+			// There was an error because some options were updated but others were invalid or failed to update.
+			return new WP_Error( 'some_updated', esc_html( $error ), array( 'status' => 400 ) );
+		}
+
+	}
+
+	/**
+	 * Calls WPCOM through authenticated request to create, regenerate or delete the Post by Email address.
+	 * @todo: When all settings are updated to use endpoints, move this to the Post by Email module and replace __process_ajax_proxy_request.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string $endpoint Process to call on WPCOM to create, regenerate or delete the Post by Email address.
+	 * @param string $error	   Error message to return.
+	 *
+	 * @return array
+	 */
+	private function _process_post_by_email( $endpoint, $error ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return array( 'message' => $error );
+		}
+
+		$this->xmlrpc->query( $endpoint );
+
+		if ( $this->xmlrpc->isError() ) {
+			return array( 'message' => $error );
+		}
+
+		$response = $this->xmlrpc->getResponse();
+		if ( empty( $response ) ) {
+			return array( 'message' => $error );
+		}
+
+		// Used only in Jetpack_Core_Json_Api_Endpoints::get_remote_value.
+		update_option( 'post_by_email_address', $response );
+
+		return $response;
+	}
+
+	public function can_request( $request ) {
+		if ( 'GET' === $request->get_method() ) {
+			return current_user_can( 'jetpack_admin_page' );
+		} else {
+			return current_user_can( 'jetpack_configure_modules' );
+		}
 	}
 }

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -924,7 +924,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 		if ( ! $vaultpress->is_registered() ) {
 			return rest_ensure_response( array(
 				'code'    => 'not_registered',
-				'message' => esc_html( __( 'You need to register for VaultPress.', 'jetpack' ) )
+				'message' => esc_html__( 'You need to register for VaultPress.', 'jetpack' )
 			) );
 		}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -9,7 +9,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	/**
 	 * List of modules that require WPCOM public access.
 	 *
-	 * @since 4.3
+	 * @since 4.3.0
 	 *
 	 * @var array
 	 */
@@ -45,7 +45,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	/**
 	 * If it's a valid Jetpack module, activate it.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data {
 	 *     Array of parameters received by request.
@@ -135,7 +135,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	/**
 	 * Check that the current user has permissions to manage Jetpack modules.
 	 *
-	 * @since 4.3
+	 * @since 4.3.0
 	 *
 	 * @return bool
 	 */
@@ -183,7 +183,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	/**
 	 * Activate a list of valid Jetpack modules.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data {
 	 *     Array of parameters received by request.
@@ -323,7 +323,7 @@ class Jetpack_Core_API_Module_Endpoint
 	/**
 	 * If it's a valid Jetpack module and configuration parameters have been sent, update it.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $data {
 	 *     Array of parameters received by request.
@@ -622,7 +622,7 @@ class Jetpack_Core_API_Module_Endpoint
 	 * Calls WPCOM through authenticated request to create, regenerate or delete the Post by Email address.
 	 * @todo: When all settings are updated to use endpoints, move this to the Post by Email module and replace __process_ajax_proxy_request.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @param string $endpoint Process to call on WPCOM to create, regenerate or delete the Post by Email address.
 	 * @param string $error	   Error message to return.
@@ -791,7 +791,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	/**
 	 * Get date of last downtime.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return mixed|WP_Error Number of days since last downtime. Otherwise, a WP_Error instance with the corresponding error.
 	 */
@@ -824,7 +824,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	/**
 	 * Get services that this site is verified with.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 *
 	 * @return mixed|WP_Error List of services that verified this site. Otherwise, a WP_Error instance with the corresponding error.
 	 */

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -161,7 +161,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	 *
 	 * @return array Array of Jetpack modules.
 	 */
-	public function get_modules( $data ) {
+	public function get_modules() {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php' );
 
 		$modules = Jetpack_Admin::init()->get_modules();
@@ -669,13 +669,13 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 			case 'stats':
 				return $this->get_stats_data( $request );
 			case 'akismet':
-				return $this->get_akismet_data( $request );
+				return $this->get_akismet_data();
 			case 'monitor':
-				return $this->get_monitor_data( $request );
+				return $this->get_monitor_data();
 			case 'verification-tools':
-				return $this->get_verification_tools_data( $request );
+				return $this->get_verification_tools_data();
 			case 'vaultpress':
-				return $this->get_vaultpress_data( $request );
+				return $this->get_vaultpress_data();
 		}
 	}
 
@@ -703,15 +703,9 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
-	 *     Array of parameters received by request.
-	 *
-	 *     @type string $date Date range to restrict results to.
-	 * }
-	 *
 	 * @return int|string Number of spam blocked by Akismet. Otherwise, an error message.
 	 */
-	public function get_akismet_data( WP_REST_Request $data ) {
+	public function get_akismet_data() {
 		if ( ! is_wp_error( $status = $this->akismet_is_active_and_registered() ) ) {
 			return rest_ensure_response( Akismet_Admin::get_stats( Akismet::get_api_key() ) );
 		} else {

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -53,3 +53,36 @@ class Jetpack_Core_API_Module_Activate_Endpoint
 		return current_user_can( 'jetpack_manage_modules' );
 	}
 }
+
+class Jetpack_Core_API_Module_Endpoint {
+
+	/**
+	 * Get a list of all Jetpack modules and their information.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return array Array of Jetpack modules.
+	 */
+	public function process( $data ) {
+		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php' );
+
+		$modules = Jetpack_Admin::init()->get_modules();
+		foreach ( $modules as $slug => $properties ) {
+			$modules[ $slug ]['options'] =
+				Jetpack_Core_Json_Api_Endpoints::prepare_options_for_response( $slug );
+			if (
+				isset( $modules[ $slug ]['requires_connection'] )
+				&& $modules[ $slug ]['requires_connection']
+				&& Jetpack::is_development_mode()
+			) {
+				$modules[ $slug ]['activated'] = false;
+			}
+		}
+
+		return $modules;
+	}
+
+	public function can_read() {
+		return current_user_can( 'jetpack_admin_page' );
+	}
+}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -150,7 +150,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 		if ( 'GET' === $request->get_method() ) {
 			return $this->get_modules( $request );
 		} else {
-			return $this->update_modules( $request );
+			return $this->activate_modules( $request );
 		}
 	}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -146,6 +146,14 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 
 class Jetpack_Core_API_Module_List_Endpoint {
 
+	public function process( $request ) {
+		if ( 'GET' === $request->get_method() ) {
+			return $this->get_modules( $request );
+		} else {
+			return $this->update_modules( $request );
+		}
+	}
+
 	/**
 	 * Get a list of all Jetpack modules and their information.
 	 *
@@ -153,7 +161,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	 *
 	 * @return array Array of Jetpack modules.
 	 */
-	public function process( $data ) {
+	public function get_modules( $data ) {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php' );
 
 		$modules = Jetpack_Admin::init()->get_modules();
@@ -172,8 +180,94 @@ class Jetpack_Core_API_Module_List_Endpoint {
 		return $modules;
 	}
 
-	public function can_request() {
-		return current_user_can( 'jetpack_admin_page' );
+	/**
+	 * Activate a list of valid Jetpack modules.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $slug Module slug.
+	 * }
+	 *
+	 * @return bool|WP_Error True if modules were activated. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public static function activate_modules( $data ) {
+		$params = $data->get_json_params();
+
+		if (
+			! isset( $params['modules'] )
+			|| is_array( $params['modules'] )
+		) {
+			return new WP_Error(
+				'not_found',
+				esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$activated = array();
+		$failed = array();
+
+		foreach ( $params['modules'] as $module ) {
+			if ( Jetpack::activate_module( $module, false, false ) ) {
+				$activated[] = $module;
+			} else {
+				$failed[] = $module;
+			}
+		}
+
+		if ( empty( $failed ) ) {
+			return rest_ensure_response( array(
+				'code' 	  => 'success',
+				'message' => esc_html__( 'All modules activated.', 'jetpack' ),
+			) );
+		}
+
+		$error = '';
+
+		$activated_count = count( $activated );
+		if ( $activated_count > 0 ) {
+			$activated_last = array_pop( $activated );
+			$activated_text = $activated_count > 1 ? sprintf(
+				/* Translators: first variable is a list followed by a last item. Example: dog, cat and bird. */
+				__( '%s and %s', 'jetpack' ),
+				join( ', ', $activated ), $activated_last ) : $activated_last;
+
+			$error = sprintf(
+				/* Translators: the plural variable is a list followed by a last item. Example: dog, cat and bird. */
+				_n( 'The module %s was activated.', 'The modules %s were activated.', $activated_count, 'jetpack' ),
+				$activated_text ) . ' ';
+		}
+
+		$failed_count = count( $failed );
+		if ( count( $failed ) > 0 ) {
+			$failed_last = array_pop( $failed );
+			$failed_text = $failed_count > 1 ? sprintf(
+				/* Translators: first variable is a list followed by a last item. Example: dog, cat and bird. */
+				__( '%s and %s', 'jetpack' ),
+				join( ', ', $failed ), $failed_last ) : $failed_last;
+
+			$error = sprintf(
+				/* Translators: the plural variable is a list followed by a last item. Example: dog, cat and bird. */
+				_n( 'The module %s failed to be activated.', 'The modules %s failed to be activated.', $failed_count, 'jetpack' ),
+				$failed_text ) . ' ';
+		}
+
+		return new WP_Error(
+			'activation_failed',
+			esc_html( $error ),
+			array( 'status' => 424 )
+		);
+	}
+
+	public function can_request( $request ) {
+		if ( 'GET' === $request->get_method() ) {
+			return current_user_can( 'jetpack_admin_page' );
+		} else {
+			return current_user_can( 'jetpack_manage_modules' );
+		}
 	}
 }
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -659,3 +659,308 @@ class Jetpack_Core_API_Module_Endpoint
 		}
 	}
 }
+
+class Jetpack_Core_API_Module_Data_Endpoint {
+
+	public function process( $request ) {
+		switch( $request['slug'] ) {
+			case 'protect':
+				return $this->get_protect_data();
+			case 'stats':
+				return $this->get_stats_data( $request );
+			case 'akismet':
+				return $this->get_akismet_data( $request );
+			case 'monitor':
+				return $this->get_monitor_data( $request );
+			case 'verification-tools':
+				return $this->get_verification_tools_data( $request );
+			case 'vaultpress':
+				return $this->get_vaultpress_data( $request );
+		}
+	}
+
+	/**
+	 * Get number of blocked intrusion attempts.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @return mixed|WP_Error Number of blocked attempts if protection is enabled. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public function get_protect_data() {
+		if ( Jetpack::is_module_active( 'protect' ) ) {
+			return get_site_option( 'jetpack_protect_blocked_attempts' );
+		}
+
+		return new WP_Error(
+			'not_active',
+			esc_html__( 'The requested Jetpack module is not active.', 'jetpack' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	/**
+	 * Get number of spam messages blocked by Akismet.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $date Date range to restrict results to.
+	 * }
+	 *
+	 * @return int|string Number of spam blocked by Akismet. Otherwise, an error message.
+	 */
+	public function get_akismet_data( WP_REST_Request $data ) {
+		if ( ! is_wp_error( $status = $this->akismet_is_active_and_registered() ) ) {
+			return rest_ensure_response( Akismet_Admin::get_stats( Akismet::get_api_key() ) );
+		} else {
+			return $status->get_error_code();
+		}
+	}
+
+	/**
+	 * Is Akismet registered and active?
+	 *
+	 * @since 4.3.0
+	 *
+	 * @return bool|WP_Error True if Akismet is active and registered. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	private function akismet_is_active_and_registered() {
+		if ( ! file_exists( WP_PLUGIN_DIR . '/akismet/class.akismet.php' ) ) {
+			return new WP_Error( 'not_installed', esc_html__( 'Please install Akismet.', 'jetpack' ), array( 'status' => 400 ) );
+		}
+
+		if ( ! class_exists( 'Akismet' ) ) {
+			return new WP_Error( 'not_active', esc_html__( 'Please activate Akismet.', 'jetpack' ), array( 'status' => 400 ) );
+		}
+
+		// What about if Akismet is put in a sub-directory or maybe in mu-plugins?
+		require_once WP_PLUGIN_DIR . '/akismet/class.akismet.php';
+		require_once WP_PLUGIN_DIR . '/akismet/class.akismet-admin.php';
+		$akismet_key = Akismet::verify_key( Akismet::get_api_key() );
+
+		if ( ! $akismet_key || 'invalid' === $akismet_key || 'failed' === $akismet_key ) {
+			return new WP_Error( 'invalid_key', esc_html__( 'Invalid Akismet key. Please contact support.', 'jetpack' ), array( 'status' => 400 ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get stats data for this site
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 *
+	 *     @type string $date Date range to restrict results to.
+	 * }
+	 *
+	 * @return int|string Number of spam blocked by Akismet. Otherwise, an error message.
+	 */
+	public function get_stats_data( WP_REST_Request $data ) {
+		// Get parameters to fetch Stats data.
+		$params = $data->get_json_params();
+
+		// If no parameters were passed.
+		$range =
+			is_array( $params )
+			&& isset( $params['range'] )
+			&& in_array( $params['range'], array( 'day', 'week', 'month' ), true ) ?
+				$params['range'] : 'day';
+
+		if ( ! function_exists( 'stats_get_from_restapi' ) ) {
+			require_once( JETPACK__PLUGIN_DIR . 'modules/stats.php' );
+		}
+
+		$response = array(
+			'general' => stats_get_from_restapi(),
+		);
+
+		switch ( $range ) {
+			case 'day':
+				$response['day'] = stats_get_from_restapi( array(), 'visits?unit=day&quantity=30' );
+				break;
+			case 'week':
+				$response['week'] = stats_get_from_restapi( array(), 'visits?unit=week&quantity=14' );
+				break;
+			case 'month':
+				$response['month'] = stats_get_from_restapi( array(), 'visits?unit=month&quantity=12&' );
+				break;
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Get date of last downtime.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return mixed|WP_Error Number of days since last downtime. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public function get_monitor_data() {
+		if ( ! Jetpack::is_module_active( 'monitor' ) ) {
+			return new WP_Error(
+				'not_active',
+				esc_html__( 'The requested Jetpack module is not active.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$monitor       = new Jetpack_Monitor();
+		$last_downtime = $monitor->monitor_get_last_downtime();
+		if ( is_wp_error( $last_downtime ) ) {
+			return $last_downtime;
+		} else if ( false === strtotime( $last_downtime ) ) {
+			return rest_ensure_response( array(
+				'code' => 'success',
+				'date' => null,
+			) );
+		} else {
+			return rest_ensure_response( array(
+				'code' => 'success',
+				'date' => human_time_diff( strtotime( $last_downtime ), strtotime( 'now' ) ),
+			) );
+		}
+	}
+
+	/**
+	 * Get services that this site is verified with.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @return mixed|WP_Error List of services that verified this site. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public function get_verification_tools_data() {
+		if ( ! Jetpack::is_module_active( 'verification-tools' ) ) {
+			return new WP_Error(
+				'not_active',
+				esc_html__( 'The requested Jetpack module is not active.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$verification_services_codes = get_option( 'verification_services_codes' );
+		if (
+			! is_array( $verification_services_codes )
+			|| empty( $verification_services_codes )
+		) {
+			return new WP_Error(
+				'empty',
+				esc_html__( 'Site not verified with any service.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$services = array();
+		foreach ( jetpack_verification_services() as $name => $service ) {
+			if ( is_array( $service ) && ! empty( $verification_services_codes[ $name ] ) ) {
+				switch ( $name ) {
+					case 'google':
+						$services[] = 'Google';
+						break;
+					case 'bing':
+						$services[] = 'Bing';
+						break;
+					case 'pinterest':
+						$services[] = 'Pinterest';
+						break;
+				}
+			}
+		}
+
+		if ( empty( $services ) ) {
+			return new WP_Error(
+				'empty',
+				esc_html__( 'Site not verified with any service.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 2 > count( $services ) ) {
+			$message = esc_html(
+				sprintf(
+					/* translators: %s is a service name like Google, Bing, Pinterest, etc. */
+					__( 'Your site is verified with %s.', 'jetpack' ),
+					$services[0]
+				)
+			);
+		} else {
+			$copy_services = $services;
+			$last = count( $copy_services ) - 1;
+			$last_service = $copy_services[ $last ];
+			unset( $copy_services[ $last ] );
+			$message = esc_html(
+				sprintf(
+					/* translators: %1$s is a comma separated list of services, and %2$s is a single service name like Google, Bing, Pinterest, etc. */
+					__( 'Your site is verified with %1$s and %2$s.', 'jetpack' ),
+					join( ', ', $copy_services ),
+					$last_service
+				)
+			);
+		}
+
+		return rest_ensure_response( array(
+			'code'     => 'success',
+			'message'  => $message,
+			'services' => $services,
+		) );
+	}
+
+	/**
+	 * Get VaultPress site data including, among other things, the date of tge last backup if it was completed.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @return mixed|WP_Error VaultPress site data. Otherwise, a WP_Error instance with the corresponding error.
+	 */
+	public function get_vaultpress_data() {
+		if ( ! class_exists( 'VaultPress' ) ) {
+			return new WP_Error(
+				'not_active',
+				esc_html__( 'The requested Jetpack module is not active.', 'jetpack' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$vaultpress = new VaultPress();
+		if ( ! $vaultpress->is_registered() ) {
+			return rest_ensure_response( array(
+				'code'    => 'not_registered',
+				'message' => esc_html( __( 'You need to register for VaultPress.', 'jetpack' ) )
+			) );
+		}
+
+		$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		} else if ( ! $data->backups->last_backup ) {
+			return rest_ensure_response( array(
+				'code'    => 'success',
+				'message' => esc_html__( 'VaultPress is active and will back up your site soon.', 'jetpack' ),
+				'data'    => $data,
+			) );
+		} else {
+			return rest_ensure_response( array(
+				'code'    => 'success',
+				'message' => esc_html(
+					sprintf(
+						__( 'Your site was successfully backed-up %s ago.', 'jetpack' ),
+						human_time_diff(
+							$data->backups->last_backup,
+							current_time( 'timestamp' )
+						)
+					)
+				),
+				'data'    => $data,
+			) );
+		}
+	}
+
+	public function can_request() {
+		return current_user_can( 'jetpack_admin_page' );
+	}
+}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -756,14 +756,15 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	 */
 	public function get_stats_data( WP_REST_Request $data ) {
 		// Get parameters to fetch Stats data.
-		$params = $data->get_json_params();
+		$range = $data->get_param( 'range' );
 
 		// If no parameters were passed.
-		$range =
-			is_array( $params )
-			&& isset( $params['range'] )
-			&& in_array( $params['range'], array( 'day', 'week', 'month' ), true ) ?
-				$params['range'] : 'day';
+		if (
+			empty ( $range )
+			|| ! in_array( $range, array( 'day', 'week', 'month' ), true )
+		) {
+			$range = 'day';
+		}
 
 		if ( ! function_exists( 'stats_get_from_restapi' ) ) {
 			require_once( JETPACK__PLUGIN_DIR . 'modules/stats.php' );

--- a/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -11,7 +11,7 @@ abstract class Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 * @private
 	 * @var Jetpack_IXR_Client
 	 */
-	private $xmlrpc;
+	protected $xmlrpc;
 
 	/**
 	 * @param Jetpack_IXR_Client $xmlrpc

--- a/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This is the base class for every Core API endpoint Jetpack uses.
+ * This is the base class for every Core API endpoint that needs an XMLRPC client.
  *
  */
 abstract class Jetpack_Core_API_XMLRPC_Consumer_Endpoint {

--- a/scss/jetpack-admin.scss
+++ b/scss/jetpack-admin.scss
@@ -1,4 +1,6 @@
 @import "atoms/colors/colors", // Color variables
+	"atoms/typography/functions",
+	"atoms/typography/variables",
 	"_utilities/mixins/breakpoint", // Mixins
 	"_utilities/grid",
 	"atoms/animations",

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -14,30 +14,35 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 	 * @author zinigor
 	 * @covers Jetpack_Core_API_Module_Activate_Endpoint
 	 * @requires PHP 5.2
+	 * @dataProvider api_routes
 	 */
-	public function test_register_routes() {
+	public function test_register_routes( $route = false, $method = false, $classname = false ) {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/activate', $routes );
+		$this->assertArrayHasKey( $route, $routes );
 
-		$route = $routes['/jetpack/v4/module/all'][0];
+		$route = $routes[ $route ][0];
 		$this->assertArrayHasKey(
-			'GET',
+			$method,
 			$route['methods'],
-			'should register a GET route'
+			"should register a $method route"
 		);
 		$this->assertInstanceOf(
-			'Jetpack_Core_API_Module_Endpoint',
-			$route['callback'][0]
+			$classname,
+			$route['callback'][0],
+			"process method object should be an instance of the $classname class"
 		);
+		$this->assertInstanceOf(
+			$classname,
+			$route['permission_callback'][0],
+			"permission method object should be an instance of the $classname class"
+		);
+	}
 
-		$route = $routes['/jetpack/v4/module/(?P<slug>[a-z\-]+)/activate'][0];
-		$this->assertInstanceOf(
-			'Jetpack_Core_API_Module_Activate_Endpoint',
-			$route['callback'][0]
-		);
-		$this->assertInstanceOf(
-			'Jetpack_Core_API_Module_Activate_Endpoint',
-			$route['permission_callback'][0]
+	public function api_routes() {
+		return array(
+			array( '/jetpack/v4/module/all', 'GET', 'Jetpack_Core_API_Module_Endpoint' ),
+			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'GET', 'Jetpack_Core_API_Module_Get_Endpoint' ),
+			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/activate', 'POST', 'Jetpack_Core_API_Module_Activate_Endpoint' ),
 		);
 	}
 

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -5,8 +5,6 @@ require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server
 class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Controller_Testcase {
 
 	public function setUp() {
-		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class.core-rest-api-endpoints.php';
-
 		parent::setUp();
 
 		Jetpack::load_xml_rpc_client();

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -16,16 +16,17 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 	 * @requires PHP 5.2
 	 * @dataProvider api_routes
 	 */
-	public function test_register_routes( $route = false, $method = false, $classname = false ) {
+	public function test_register_routes( $route_string = false, $method = false, $classname = false ) {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( $route, $routes );
+		$this->assertArrayHasKey( $route_string, $routes );
 
-		$route = $routes[ $route ][0];
-		$this->assertArrayHasKey(
-			$method,
-			$route['methods'],
-			"should register a $method route"
-		);
+		$route = array();
+		foreach ( $routes[ $route_string ] as $item ) {
+			if ( isset( $item['methods'][ $method ] ) ) {
+				$route = $item;
+			}
+		}
+
 		$this->assertInstanceOf(
 			$classname,
 			$route['callback'][0],
@@ -40,8 +41,9 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 
 	public function api_routes() {
 		return array(
-			array( '/jetpack/v4/module/all', 'GET', 'Jetpack_Core_API_Module_Endpoint' ),
-			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'GET', 'Jetpack_Core_API_Module_Get_Endpoint' ),
+			array( '/jetpack/v4/module/all', 'GET', 'Jetpack_Core_API_Module_List_Endpoint' ),
+			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'GET', 'Jetpack_Core_API_Module_Endpoint' ),
+			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'POST', 'Jetpack_Core_API_Module_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/active', 'POST', 'Jetpack_Core_API_Module_Toggle_Endpoint' ),
 		);
 	}

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -45,6 +45,7 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 			array( '/jetpack/v4/module/all/active', 'POST', 'Jetpack_Core_API_Module_List_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'GET', 'Jetpack_Core_API_Module_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'POST', 'Jetpack_Core_API_Module_Endpoint' ),
+			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/data', 'GET', 'Jetpack_Core_API_Module_Data_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/active', 'POST', 'Jetpack_Core_API_Module_Toggle_Endpoint' ),
 		);
 	}

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -42,7 +42,7 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 		return array(
 			array( '/jetpack/v4/module/all', 'GET', 'Jetpack_Core_API_Module_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'GET', 'Jetpack_Core_API_Module_Get_Endpoint' ),
-			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/activate', 'POST', 'Jetpack_Core_API_Module_Activate_Endpoint' ),
+			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/active', 'POST', 'Jetpack_Core_API_Module_Toggle_Endpoint' ),
 		);
 	}
 

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -19,6 +19,17 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 		$routes = $this->server->get_routes();
 		$this->assertArrayHasKey( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/activate', $routes );
 
+		$route = $routes['/jetpack/v4/module/all'][0];
+		$this->assertArrayHasKey(
+			'GET',
+			$route['methods'],
+			'should register a GET route'
+		);
+		$this->assertInstanceOf(
+			'Jetpack_Core_API_Module_Endpoint',
+			$route['callback'][0]
+		);
+
 		$route = $routes['/jetpack/v4/module/(?P<slug>[a-z\-]+)/activate'][0];
 		$this->assertInstanceOf(
 			'Jetpack_Core_API_Module_Activate_Endpoint',

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -42,6 +42,7 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 	public function api_routes() {
 		return array(
 			array( '/jetpack/v4/module/all', 'GET', 'Jetpack_Core_API_Module_List_Endpoint' ),
+			array( '/jetpack/v4/module/all/active', 'POST', 'Jetpack_Core_API_Module_List_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'GET', 'Jetpack_Core_API_Module_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'POST', 'Jetpack_Core_API_Module_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/active', 'POST', 'Jetpack_Core_API_Module_Toggle_Endpoint' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Moving the endpoints so that the interface looks like this:
### The module group:
- [x] GET `/module` returns all available modules and their status;
- [x] GET `/module/(?P[a-z\-]+)` returns a single module information;
- [x] GET `/module/(?P[a-z\-]+)/active` returns module’s activation status;
- [x] POST `/module/(?P[a-z\-]+)/active` sets module’s activation status;
- [x] POST `/module/(?P[a-z\-]+)/` updates module options;
- [x] POST `/module/activate` activates a bunch of modules – perhaps we should use a slug like all here?
- [x] GET `/modules/(?P[a-z\-]+)/data` retrieves special data that a module provides, like VaultPress data, Monitor stats, Protect count, verification tools keys, etc;

### The connection group:
- [x] GET `/connection` gives you connection status;
- [x] GET `/connection/url` gives you an URL you need to go to connect Jetpack;
- [x] GET `/connection/data` gives you connection data;
- [x] DELETE `/connection` disconnects Jetpack
- ~~GET `/connection/ssl` re-checks SSL status;~~
- [x] DELETE `/connection/user` disconnects a user from dotcom;

### The miscellaneous group:
- [x] DELETE `/options/` resets an option or options that are passed as an array;
- [x] POST `/jumpstart` activates or deactivates jumpstart depending on the passed boolean;
- [x] DELETE `/notice/` dismisses a certain notice;
- [x] GET `/settings/` retrieves miscellaneous settings;
- [x] POST `/settings` sets miscellaneous settings.
