### PR TITLE
Modifies external settings links

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -13,6 +13,7 @@ import {
 	CommentsSettings,
 	LikesSettings,
 	SubscriptionsSettings,
+	SharedaddySettings,
 	ProtectSettings,
 	MonitorSettings,
 	SingleSignOnSettings,
@@ -60,7 +61,8 @@ export const AllModuleSettings = React.createClass( {
 						<div className="jp-form-setting-explanation">
 							{ __( 'You can see the information about security scanning in the "At a Glance" section.' ) }
 						</div>
-						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url }> __( 'Configure your Security Scans' }</ExternalLink>
+						<br />
+						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url }>{ __( 'Configure your Security Scans' ) }</ExternalLink>
 					</div>
 				);
 			case 'sso':

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -30,6 +30,7 @@ import {
 	SitemapsSettings
 } from 'components/module-settings/';
 import Button from 'components/button';
+import ExternalLink from 'components/external-link';
 
 export const AllModuleSettings = React.createClass( {
 	render() {
@@ -103,7 +104,7 @@ export const AllModuleSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<Button compact href={ module.configure_url }>{ __( 'Settings' ) }</Button>
+						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ '16' } href={ module.configure_url }>{ __( 'Configure your NAME OF MODULE Settings' ) }</ExternalLink>
 					</div>
 				);
 		}

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -13,7 +13,6 @@ import {
 	CommentsSettings,
 	LikesSettings,
 	SubscriptionsSettings,
-	SharedaddySettings,
 	ProtectSettings,
 	MonitorSettings,
 	SingleSignOnSettings,
@@ -97,12 +96,13 @@ export const AllModuleSettings = React.createClass( {
 				return '' === module.configure_url ? null : (
 					<div>
 						{
+
 							__( '{{link}}Configure your %(module_slug)s Settings {{/link}}', {
 								components: {
 									link: <ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url } />,
 								},
 								args: {
-									module_slug: module.name
+									module_slug: module.module === 'akismet' ? 'Akismet' : 'Backups'
 								}
 							} )
 						}

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -28,7 +28,6 @@ import {
 	VerificationToolsSettings,
 	SitemapsSettings
 } from 'components/module-settings/';
-import Button from 'components/button';
 import ExternalLink from 'components/external-link';
 
 export const AllModuleSettings = React.createClass( {
@@ -58,15 +57,10 @@ export const AllModuleSettings = React.createClass( {
 			case 'scan':
 				return '' === module.configure_url ? null : (
 					<div>
-						{ __( 'You can see the information about security scanning in the "At a Glance" section.' ) }
-						<br/><Button compact href={ module.configure_url }>{ __( 'Settings' ) }</Button>
-					</div>
-				);
-			case 'akismet':
-			case 'backups':
-				return '' === module.configure_url ? null : (
-					<div>
-						<Button compact href={ module.configure_url }>{ __( 'Settings' ) }</Button>
+						<div className="jp-form-setting-explanation">
+							{ __( 'You can see the information about security scanning in the "At a Glance" section.' ) }
+						</div>
+						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url }> __( 'Configure your Security Scans' }</ExternalLink>
 					</div>
 				);
 			case 'sso':
@@ -96,6 +90,22 @@ export const AllModuleSettings = React.createClass( {
 			case 'notifications':
 			case 'enhanced-distribution':
 				return <span className="jp-form-setting-explanation">{ __( 'This module has no configuration options' ) } </span>;
+			case 'akismet':
+			case 'backups':
+				return '' === module.configure_url ? null : (
+					<div>
+						{
+							__( '{{link}}Configure your %(module_slug)s Settings {{/link}}', {
+								components: {
+									link: <ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url } />,
+								},
+								args: {
+									module_slug: module.name
+								}
+							} )
+						}
+					</div>
+				);
 			case 'custom-css':
 			case 'widgets':
 			case 'publicize':

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -13,7 +13,6 @@ import {
 	CommentsSettings,
 	LikesSettings,
 	SubscriptionsSettings,
-	SharedaddySettings,
 	ProtectSettings,
 	MonitorSettings,
 	SingleSignOnSettings,
@@ -104,7 +103,16 @@ export const AllModuleSettings = React.createClass( {
 			default:
 				return (
 					<div>
-						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ '16' } href={ module.configure_url }>{ __( 'Configure your NAME OF MODULE Settings' ) }</ExternalLink>
+						{
+							__( '{{link}}Configure your %(module_slug)s Settings {{/link}}', {
+								components: {
+									link: <ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url } />,
+								},
+								args: {
+									module_slug: module.name
+								}
+							} )
+						}
 					</div>
 				);
 		}

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -1,3 +1,7 @@
+.jp-module-settings__external-link {
+	font-size: rem( 14px );
+}
+
 .jp-module-settings__read-more {
 	clear: both;
 	margin-top: rem( 16px );


### PR DESCRIPTION
Fixes #4721 .

#### Changes proposed in this Pull Request:
* changes from Button to new ExternalLink

#### Testing instructions:
* requires `dops-components` branch `add/external-link` until https://github.com/Automattic/dops-components/pull/53 is merged
* then go to Settings > Security > Akismet

Before:
![image](https://cloud.githubusercontent.com/assets/1123119/17740922/617b41be-6468-11e6-813f-d5e3de30f877.png)

After (ish):
![image](https://cloud.githubusercontent.com/assets/1123119/17740896/497771aa-6468-11e6-8958-81b27ca03242.png)

I need help from someone to get the module name in each link. Maybe @oskosk or @dereksmart ?