### PR TITLE
Sometimes listener isn’t included when setting `disabled` from API

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
+
 class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function name() {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -79,6 +79,7 @@ class Jetpack_Sync_Settings {
 
 			// if we set the disabled option to true, clear the queues
 			if ( 'disable' === $setting && !! $value ) {
+				require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 				$listener = Jetpack_Sync_Listener::get_instance();
 				$listener->get_sync_queue()->reset();
 				$listener->get_full_sync_queue()->reset();


### PR DESCRIPTION
Fixes an issue where sometimes the sync listener wasn't loaded when we were updating settings.

```
[17-Aug-2016 04:50:43 UTC] PHP Fatal error:  Uncaught Error: Class 'Jetpack_Sync_Listener' not found in /path/to/wp/wp-content/plugins/jetpack/sync/class.jetpack-sync-settings.php:82
```

cc @ebinnion 