### PR TITLE
Removed duplicate line that made IE break.

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -471,7 +471,6 @@ export let VerificationToolsSettings = React.createClass( {
 								value={ this.props.getOptionValue( 'bing' ) }
 								placeholder={ 'Example: 12C1203B5086AECE94EB3A3D9830B2E' }
 								className="widefat code"
-								className="widefat code"
 								disabled={ this.props.isUpdating( 'bing' ) }
 								onChange={ this.props.onOptionChange} />
 						</FormLabel>


### PR DESCRIPTION
Fixes #4849.

#### Changes proposed in this Pull Request:
Removes a duplicate line that caused `class` attribute to appear twice in one element, which in turn broke Internet Explorer's fragile standards mode.