### PR TITLE
Admin - Sitemaps: add links to sitemap and news sitemap in feature card.

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -8,6 +8,7 @@ import TextInput from 'components/text-input';
 import Textarea from 'components/textarea';
 import TagsInput from 'components/tags-input';
 import ClipboardButtonInput from 'components/clipboard-button-input';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -712,3 +713,37 @@ export let MarkdownSettings = React.createClass( {
 } );
 
 MarkdownSettings = ModuleSettingsForm( MarkdownSettings );
+
+export let SitemapsSettings = React.createClass( {
+	render() {
+		let sitemap_url = get( this.props, [ 'module', 'extra', 'sitemap_url' ], '' ),
+			news_sitemap_url = get( this.props, [ 'module', 'extra', 'news_sitemap_url' ], '' );
+		return (
+			<div>
+				<p>{ __( 'Search engines will find the sitemaps at these locations:' ) }</p>
+				<p>{
+					__( 'Sitemap: {{a}}%(url)s{{/a}}', {
+						components: {
+							a: <a href={ sitemap_url } target="_blank" />
+						},
+						args: {
+							url: sitemap_url
+						}
+					} )
+				}</p>
+				<p>{
+					__( 'News Sitemap: {{a}}%(url)s{{/a}}', {
+						components: {
+							a: <a href={ news_sitemap_url } target="_blank" />
+						},
+						args: {
+							url: news_sitemap_url
+						}
+					} )
+				}</p>
+			</div>
+		)
+	}
+} );
+
+SitemapsSettings = ModuleSettingsForm( SitemapsSettings );

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -27,6 +27,7 @@ import {
 	AfterTheDeadlineSettings,
 	MarkdownSettings,
 	VerificationToolsSettings,
+	SitemapsSettings
 } from 'components/module-settings/';
 import Button from 'components/button';
 
@@ -77,6 +78,8 @@ export const AllModuleSettings = React.createClass( {
 				return ( <LikesSettings module={ module } { ...this.props } /> );
 			case 'verification-tools':
 				return ( <VerificationToolsSettings module={ module } { ...this.props } /> );
+			case 'sitemaps':
+				return ( <SitemapsSettings module={ module } { ...this.props } /> );
 			case 'contact-form':
 			case 'latex':
 			case 'shortlinks':
@@ -85,7 +88,6 @@ export const AllModuleSettings = React.createClass( {
 			case 'widget-visibility':
 			case 'notifications':
 			case 'enhanced-distribution':
-			case 'sitemaps':
 				return <span className="jp-form-setting-explanation">{ __( 'This module has no configuration options' ) } </span>;
 			case 'custom-css':
 			case 'widgets':


### PR DESCRIPTION
Fixes #4841

#### Changes proposed in this Pull Request:
- add, to the Sitemaps card, links pointing to the sitemap and news sitemap location

#### Testing instructions:
- go to Jetpack > Settings > Engagement
- activate Sitemaps
- expand the card. It should display correct clickable links to each sitemap location.
