### PR TITLE
Admin: added CSS class to stylize explanation text in card header

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -31,28 +31,11 @@ export const Page = ( props ) => {
 		isModuleActivated,
 		isTogglingModule,
 		getModule
-	} = props,
-		photonDesc = getModule( 'photon' ).description;
-
-	if ( ! props.isSitePublic() ) {
-		let makePublic = (
-			<p className="jp-form-setting-explanation">
-				{ __( 'Your site must be publicly accessible for this feature to work properly. You can make your site public in {{a}}Reading Settings{{/a}}.', {
-					components: {
-						a: <a href={ props.getSiteAdminUrl() + 'options-reading.php#blog_public' } className="jetpack-js-stop-propagation" />
-					}
-				} ) }
-			</p>
-		);
-		photonDesc = <span>
-			{ photonDesc }
-			{ makePublic }
-		</span>;
-	}
+	} = props;
 
 	var cards = [
 		[ 'tiled-gallery', getModule( 'tiled-gallery' ).name, getModule( 'tiled-gallery' ).description, getModule( 'tiled-gallery' ).learn_more_button ],
-		[ 'photon', getModule( 'photon' ).name, photonDesc, getModule( 'photon' ).learn_more_button ],
+		[ 'photon', getModule( 'photon' ).name, getModule( 'photon' ).description, getModule( 'photon' ).learn_more_button ],
 		[ 'carousel', getModule( 'carousel' ).name, getModule( 'carousel' ).description, getModule( 'carousel' ).learn_more_button ],
 		[ 'widgets', getModule( 'widgets' ).name, getModule( 'widgets' ).description, getModule( 'widgets' ).learn_more_button ],
 		[ 'widget-visibility', getModule( 'widget-visibility' ).name, getModule( 'widget-visibility' ).description, getModule( 'widget-visibility' ).learn_more_button ],

--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -36,7 +36,7 @@ export const Page = ( props ) => {
 
 	if ( ! props.isSitePublic() ) {
 		let makePublic = (
-			<p className="howto small">
+			<p className="jp-form-setting-explanation">
 				{ __( 'Your site must be publicly accessible for this feature to work properly. You can make your site public in {{a}}Reading Settings{{/a}}.', {
 					components: {
 						a: <a href={ props.getSiteAdminUrl() + 'options-reading.php#blog_public' } className="jetpack-js-stop-propagation" />

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -44,7 +44,7 @@ export const Engagement = ( props ) => {
 
 	if ( ! props.isSitePublic() ) {
 		let makePublic = (
-			<p className="howto small">
+			<p className="jp-form-setting-explanation">
 				{ __( 'Your site must be publicly accessible for this feature to work properly. You can make your site public in {{a}}Reading Settings{{/a}}.', {
 					components: {
 						a: <a href={ props.getSiteAdminUrl() + 'options-reading.php#blog_public' } className="jetpack-js-stop-propagation" />

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -39,26 +39,18 @@ export const Engagement = ( props ) => {
 		getModule
 	} = props,
 		isAdmin = props.userCanManageModules,
-		sitemapsDesc = getModule( 'sitemaps' ).description,
-		enhaDistDesc = getModule( 'enhanced-distribution' ).description;
+		sitemapsDesc = getModule( 'sitemaps' ).description;
 
 	if ( ! props.isSitePublic() ) {
-		let makePublic = (
-			<p className="jp-form-setting-explanation">
-				{ __( 'Your site must be publicly accessible for this feature to work properly. You can make your site public in {{a}}Reading Settings{{/a}}.', {
+		sitemapsDesc = <span>
+			{ sitemapsDesc }
+			{ <p className="jp-form-setting-explanation">
+				{ __( 'Your site must be accessible by search engines for this feature to work properly. You can change this in {{a}}Reading Settings{{/a}}.', {
 					components: {
 						a: <a href={ props.getSiteAdminUrl() + 'options-reading.php#blog_public' } className="jetpack-js-stop-propagation" />
 					}
 				} ) }
-			</p>
-		);
-		sitemapsDesc = <span>
-			{ sitemapsDesc }
-			{ makePublic }
-		</span>;
-		enhaDistDesc = <span>
-			{ enhaDistDesc }
-			{ makePublic }
+			</p> }
 		</span>;
 	}
 
@@ -76,7 +68,7 @@ export const Engagement = ( props ) => {
 		[ 'subscriptions', getModule( 'subscriptions' ).name, getModule( 'subscriptions' ).description, getModule( 'subscriptions' ).learn_more_button ],
 		[ 'gravatar-hovercards', getModule( 'gravatar-hovercards' ).name, getModule( 'gravatar-hovercards' ).description, getModule( 'gravatar-hovercards' ).learn_more_button ],
 		[ 'sitemaps', getModule( 'sitemaps' ).name, sitemapsDesc, getModule( 'sitemaps' ).learn_more_button ],
-		[ 'enhanced-distribution', getModule( 'enhanced-distribution' ).name, enhaDistDesc, getModule( 'enhanced-distribution' ).learn_more_button ],
+		[ 'enhanced-distribution', getModule( 'enhanced-distribution' ).name, getModule( 'enhanced-distribution' ).description, getModule( 'enhanced-distribution' ).learn_more_button ],
 		[ 'verification-tools', getModule( 'verification-tools' ).name, getModule( 'verification-tools' ).description, getModule( 'verification-tools' ).learn_more_button ],
 	],
 		nonAdminAvailable = [ 'publicize' ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- add CSS class to stylize the message shown when a feature requires the site to be publicly accessible. This makes it consistent with the change in #4854 
- update texts of Sitemaps to explain in which way the site must be publicly accessible by search engines.
- remove text for Enhanced Distribution and Photon since they need to be connected to wpcom and the new endpoint that checks with wpcom using the endpoint jetpack.isPubliclyAccessible takes care of this.

#### Testing instructions:
- go to Settings > Reading and discourage search engines
- go to Jetpack > Settings > Engagement. The Sitemaps card should have a message stating that the site has to be publicly accessible by search engines typed in light blue text.