### PR TITLE
Theme Tools: do not load compat files in the dashboard.

### DIFF
--- a/modules/theme-tools/compat/twentyfifteen.php
+++ b/modules/theme-tools/compat/twentyfifteen.php
@@ -18,11 +18,13 @@ function twentyfifteen_init_jetpack() {
 	 * Set the version equal to filemtime for development builds, and the JETPACK__VERSION for production
 	 * or skip it entirely for wpcom.
 	 */
-	$version = false;
-	if ( method_exists( 'Jetpack', 'is_development_version' ) ) {
-		$version = Jetpack::is_development_version() ? filemtime( plugin_dir_path( __FILE__ ) . 'twentyfifteen.css' ) : JETPACK__VERSION;
+	if ( ! is_admin() ) {
+		$version = false;
+		if ( method_exists( 'Jetpack', 'is_development_version' ) ) {
+			$version = Jetpack::is_development_version() ? filemtime( plugin_dir_path( __FILE__ ) . 'twentyfifteen.css' ) : JETPACK__VERSION;
+		}
+		wp_enqueue_style( 'twentyfifteen-jetpack', plugins_url( 'twentyfifteen.css', __FILE__ ), array(), $version );
+		wp_style_add_data( 'twentyfifteen-jetpack', 'rtl', 'replace' );
 	}
-	wp_enqueue_style( 'twentyfifteen-jetpack', plugins_url( 'twentyfifteen.css', __FILE__ ), array(), $version );
-	wp_style_add_data( 'twentyfifteen-jetpack', 'rtl', 'replace' );
 }
 add_action( 'init', 'twentyfifteen_init_jetpack' );

--- a/modules/theme-tools/compat/twentyfourteen.php
+++ b/modules/theme-tools/compat/twentyfourteen.php
@@ -61,11 +61,13 @@ function twentyfourteen_init_jetpack() {
 	 * Add our compat CSS file for custom widget stylings and such.
 	 * Set the version equal to filemtime for development builds, and the JETPACK__VERSION for production.
 	 */
-	$version = false;
-	if ( method_exists( 'Jetpack', 'is_development_version' ) ) {
-		$version = Jetpack::is_development_version() ? filemtime( plugin_dir_path( __FILE__ ) . 'twentyfourteen.css' ) : JETPACK__VERSION;
+	if ( ! is_admin() ) {
+		$version = false;
+		if ( method_exists( 'Jetpack', 'is_development_version' ) ) {
+			$version = Jetpack::is_development_version() ? filemtime( plugin_dir_path( __FILE__ ) . 'twentyfourteen.css' ) : JETPACK__VERSION;
+		}
+		wp_enqueue_style( 'twentyfourteen-jetpack', plugins_url( 'twentyfourteen.css', __FILE__ ), array(), $version );
+		wp_style_add_data( 'twentyfourteen-jetpack', 'rtl', 'replace' );
 	}
-	wp_enqueue_style( 'twentyfourteen-jetpack', plugins_url( 'twentyfourteen.css', __FILE__ ), array(), $version );
-	wp_style_add_data( 'twentyfourteen-jetpack', 'rtl', 'replace' );
 }
 add_action( 'init', 'twentyfourteen_init_jetpack' );

--- a/modules/theme-tools/compat/twentysixteen.php
+++ b/modules/theme-tools/compat/twentysixteen.php
@@ -18,12 +18,14 @@ function twentysixteen_init_jetpack() {
 	 * Set the version equal to filemtime for development builds, and the JETPACK__VERSION for production
 	 * or skip it entirely for wpcom.
 	 */
-	$version = false;
-	if ( method_exists( 'Jetpack', 'is_development_version' ) ) {
-		$version = Jetpack::is_development_version() ? filemtime( plugin_dir_path( __FILE__ ) . 'twentysixteen.css' ) : JETPACK__VERSION;
+	if ( ! is_admin() ) {
+		$version = false;
+		if ( method_exists( 'Jetpack', 'is_development_version' ) ) {
+			$version = Jetpack::is_development_version() ? filemtime( plugin_dir_path( __FILE__ ) . 'twentysixteen.css' ) : JETPACK__VERSION;
+		}
+		wp_enqueue_style( 'twentysixteen-jetpack', plugins_url( 'twentysixteen.css', __FILE__ ), array(), $version );
+		wp_style_add_data( 'twentysixteen-jetpack', 'rtl', 'replace' );
 	}
-	wp_enqueue_style( 'twentysixteen-jetpack', plugins_url( 'twentysixteen.css', __FILE__ ), array(), $version );
-	wp_style_add_data( 'twentysixteen-jetpack', 'rtl', 'replace' );
 }
 add_action( 'init', 'twentysixteen_init_jetpack' );
 


### PR DESCRIPTION
Fixes # 3679
#### Changes proposed in this Pull Request:

twentysixteen.css loads in the WordPress admin, but I can't find any page admin page where it is used. Added an if statement to test for this.
#### Testing instructions:
## 
---
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

css file loads in the WordPress admin, but I can't find any page admin
page where it is used. Added if statement to test
