### PR TITLE
Mobile theme: remove unused option that prevented it from loading

### DIFF
--- a/modules/minileven.php
+++ b/modules/minileven.php
@@ -129,6 +129,8 @@ function minileven_enabled( $wp_mobile_disable_option ) {
 	return true;
 }
 
-add_filter( 'option_wp_mobile_disable', 'minileven_enabled' );
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	add_filter( 'option_wp_mobile_disable', 'minileven_enabled' );
+}
 
 jetpack_load_minileven();


### PR DESCRIPTION
Fixes p1HpG7-3s1-p2

#### Changes proposed in this Pull Request:
- Removes the option `wp_mobile_disable` and an associated filter `option_wp_mobile_disable` that prevented it from loading.

#### Testing instructions:
- Activate mobile theme
- Visit the site in desktop, it should use the regular theme
- Visit the site in mobile, it should use the Minileven mobile theme
