### PR TITLE
Admin Page: Move some Admin Page's initial-state selectors from actions file to reducer file

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -21,7 +21,6 @@ import {
 } from 'state/connection';
 import QueryConnectUrl from 'components/data/query-connect-url';
 
-
 const ConnectButton = React.createClass( {
 	displayName: 'ConnectButton',
 
@@ -81,7 +80,7 @@ const ConnectButton = React.createClass( {
 				<Button
 					onClick={ this.disconnectSite }
 					disabled={ disconnecting }>
-					{ __( 'Disconnect Jetpack') }
+					{ __( 'Disconnect Jetpack' ) }
 				</Button>
 			);
 		}

--- a/_inc/client/state/initial-state/actions.js
+++ b/_inc/client/state/initial-state/actions.js
@@ -11,15 +11,3 @@ export const setInitialState = () => {
 		} );
 	}
 }
-
-/**
- * Returns a string of the Connect URL used to connect or link an account
- * to WordPress.com
- *
- * @param  {Object}  state  Global state tree
- * @return {string}         Connect URL
- */
-export function getConnectUrl( state ) {
-	return state.jetpack.initialState.connectUrl;
-}
-

--- a/_inc/client/state/initial-state/actions.js
+++ b/_inc/client/state/initial-state/actions.js
@@ -23,34 +23,3 @@ export function getConnectUrl( state ) {
 	return state.jetpack.initialState.connectUrl;
 }
 
-/**
- * Returns a string of the current Jetpack version defined
- * by JETPACK__VERSION
- *
- * @param  {Object}  state  Global state tree
- * @return {string}         Version number
- */
-export function getCurrentVersion( state ) {
-	return state.jetpack.initialState.currentVersion;
-}
-
-/**
- * Returns an array of HE gravatar ID's
- *
- * @param  {Object}  state  Global state tree
- * @return {array}          array of IDs
- */
-export function getHappinessGravatarIds( state ) {
-	return state.jetpack.initialState.happinessGravIds;
-}
-
-/**
- * Returns bool if current version is Dev version
- * Which means -alpha, -beta, etc...
- *
- * @param  {Object}  state  Global state tree
- * @return {bool} true if dev version
- */
-export function isDevVersion( state ) {
-	return state.jetpack.initialState.isDevVersion;
-}

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -19,6 +19,40 @@ export const initialState = ( state = window.Initial_State, action ) => {
 	}
 };
 
+/**
+ * Returns an array of HE gravatar ID's
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {array}          array of IDs
+ */
+export function getHappinessGravatarIds( state ) {
+	return state.jetpack.initialState.happinessGravIds;
+}
+
+
+/**
+ * Returns bool if current version is Dev version
+ * Which means -alpha, -beta, etc...
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {bool} true if dev version
+ */
+export function isDevVersion( state ) {
+	return state.jetpack.initialState.isDevVersion;
+}
+
+/**
+ * Returns a string of the current Jetpack version defined
+ * by JETPACK__VERSION
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {string}         Version number
+ */
+export function getCurrentVersion( state ) {
+	return state.jetpack.initialState.currentVersion;
+}
+
+
 export function getSiteRoles( state ) {
 	return get( state.jetpack.initialState.stats, 'roles', {} );
 }

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -29,7 +29,6 @@ export function getHappinessGravatarIds( state ) {
 	return state.jetpack.initialState.happinessGravIds;
 }
 
-
 /**
  * Returns bool if current version is Dev version
  * Which means -alpha, -beta, etc...


### PR DESCRIPTION
Fixes #4786 

#### 

Moves some functions from `initial-state/actions.js` to `initial-state/reducer.js`

#### Testing instructions 

1. Disconnect your site from Jetpack's Admin Page
2. Connect your site
3. Expect to see no errors

*This PR affected the connect-button functionality. If this still works, the changes here are ok*.