### PR TITLE
Admin: make Holiday Snow setting look like another feature.

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -23,7 +23,8 @@ import {
 import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
 import { isUnavailableInDevMode } from 'state/connection';
-import { getSiteAdminUrl, isSitePublic } from 'state/initial-state';
+import { userCanManageModules } from 'state/initial-state';
+import Settings from 'components/settings';
 
 export const Page = ( props ) => {
 	let {
@@ -31,7 +32,8 @@ export const Page = ( props ) => {
 		isModuleActivated,
 		isTogglingModule,
 		getModule
-	} = props;
+	} = props,
+		isAdmin = props.userCanManageModules;
 
 	var cards = [
 		[ 'tiled-gallery', getModule( 'tiled-gallery' ).name, getModule( 'tiled-gallery' ).description, getModule( 'tiled-gallery' ).learn_more_button ],
@@ -84,6 +86,25 @@ export const Page = ( props ) => {
 	return (
 		<div>
 			{ cards }
+
+			<FoldableCard
+				header={ __( 'Holiday Snow' ) }
+				subheader={ __( 'Show falling snow in the holiday period.' ) }
+				clickableHeaderText={ true }
+				disabled={ ! isAdmin }
+				summary={ isAdmin ? <Settings slug="snow" /> : '' }
+				expandedSummary={ isAdmin ? <Settings slug="snow" /> : '' }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: 'holiday_snow',
+						path: props.route.path
+					}
+				) }
+			>
+				<span className="jp-form-setting-explanation">
+					{ __( 'Show falling snow on my blog from Dec 1st until Jan 4th.' ) }
+				</span>
+			</FoldableCard>
 		</div>
 	);
 };
@@ -102,8 +123,7 @@ export default connect(
 				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
-			getSiteAdminUrl: () => getSiteAdminUrl( state ),
-			isSitePublic: () => isSitePublic( state )
+			userCanManageModules: userCanManageModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/components/setting-toggle/index.jsx
+++ b/_inc/client/components/setting-toggle/index.jsx
@@ -1,8 +1,11 @@
-
 /**
  * External dependencies
  */
 import React from 'react';
+
+/**
+ * Internal dependencies
+ */
 import FormToggle from 'components/form/form-toggle';
 
 export const SettingToggle = React.createClass( {

--- a/_inc/client/components/settings/index.jsx
+++ b/_inc/client/components/settings/index.jsx
@@ -1,11 +1,10 @@
-
 /**
  * External dependencies
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { SettingToggle } from 'components/setting-toggle';
 import { translate as __ } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -16,21 +15,33 @@ import {
 	isFetchingSettingsList,
 	getSettingName
 } from 'state/settings';
+import { SettingToggle } from 'components/setting-toggle';
 
 export const Settings = React.createClass( {
+	propTypes: {
+		slug: React.PropTypes.string,
+		activated: React.PropTypes.bool,
+		toggleSetting: React.PropTypes.func,
+		disabled: React.PropTypes.bool
+	},
+
 	componentDidMount() {
-		this.props.fetchSettings();
+		if ( ! this.props.isFetchingSettingsList ) {
+			this.props.fetchSettings();
+		}
 	},
 
 	render() {
+		// The snow setting requires special care since the option name has a WP filter applied.
+		let settingSlug = 'snow' === this.props.slug ? this.props.snowSlug : this.props.slug;
 		return (
 			<div>
 				<SettingToggle
-					slug={ this.props.snowSlug }
-					activated={ this.props.isSettingActivated( this.props.snowSlug ) }
+					slug={ settingSlug }
+					activated={ this.props.isSettingActivated( settingSlug ) }
 					toggleSetting={ this.props.toggleSetting }
 					disabled={ this.props.isFetchingSettingsList }
-				>{ __( 'Show falling snow on my blog from Dec 1st until Jan 4th.' ) }</SettingToggle>
+				/>
 			</div>
 		);
 	}

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
-import Settings from 'components/settings';
 import { translate as __ } from 'i18n-calypso';
 import analytics from 'lib/analytics';
 
@@ -92,20 +91,6 @@ export const GeneralSettings = ( props ) => {
 			{ isModuleActivated( 'manage' ) ? '' : moduleCard( 'manage' ) }
 			{ moduleCard( 'notes' ) }
 			{ moduleCard( 'json-api' ) }
-			<FoldableCard
-				header={ __( 'Holiday Snow' ) }
-				subheader={ __( 'Show falling snow in the holiday period.' ) }
-				clickableHeaderText={ true }
-				disabled={ ! isAdmin }
-				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-					{
-						card: 'misc_settings',
-						path: props.route.path
-					}
-				) }
-			>
-				<Settings />
-			</FoldableCard>
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes #4847

#### Changes proposed in this Pull Request:
- Put toggle to activate Holiday Snow in the header of the foldable card.
- Move it to the bottom of Appearance tab.
- Make SettingToggle component accept a setting slug as prop.

#### Testing instructions:
- Go to Jetpack > Settings > Appearance. Activate Holiday Snow.
- Force holiday snow adding this somewhere where it's run
```php
add_filter( 'jetpack_is_holiday_snow_season', function() {
	$now = time();
	return mktime( 0, 0, 0, 8, 1 ) <= $now && $now < mktime( 0, 0, 0, 9, 1 );
} );
```
- Visit the front end and wait for the snow flakes to fall.
