### PR TITLE
Admin Page: Make the QuerySitePlugins component fetch data earlier in its lifecycle

### DIFF
--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -15,7 +15,6 @@ import includes from 'lodash/includes';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import { ModuleToggle } from 'components/module-toggle';
-import { isFetchingSiteData } from 'state/site';
 import { isDevMode } from 'state/connection';
 import {
 	isModuleActivated as _isModuleActivated,
@@ -123,7 +122,6 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) => isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
-			isFetchingSiteData: isFetchingSiteData( state ),
 			isDevMode: isDevMode( state ),
 			userCanToggle: userCanManageModules( state )
 		};

--- a/_inc/client/components/data/query-site-plugins/index.jsx
+++ b/_inc/client/components/data/query-site-plugins/index.jsx
@@ -10,12 +10,11 @@ import { connect } from 'react-redux';
  */
 import {
 	fetchPluginsData,
-	isFetchingPluginsData,
-	isPluginActive
+	isFetchingPluginsData
 } from 'state/site/plugins';
 
 export const QuerySitePlugins = React.createClass( {
-	componentDidMount() {
+	componentWillMount() {
 		if ( ! this.props.isFetchingPluginsData ) {
 			this.props.fetchPluginsData();
 		}
@@ -29,8 +28,7 @@ export const QuerySitePlugins = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			isFetchingPluginsData: isFetchingPluginsData( state ),
-			pluginsData: fetchPluginsData( state )
+			isFetchingPluginsData: isFetchingPluginsData( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -10,7 +10,6 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import {
-	isFetchingSiteData,
 	getSitePlan
 } from 'state/site';
 import QuerySite from 'components/data/query-site';
@@ -42,7 +41,6 @@ export default connect(
 	( state ) => {
 		return {
 			getSiteConnectionStatus: () => getSiteConnectionStatus( state ),
-			isFetchingSiteData: isFetchingSiteData( state ),
 			sitePlan: getSitePlan( state )
 		};
 	}

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
 import SimpleNotice from 'components/notice';
-import Spinner from 'components/spinner';
 
 /**
  * Internal dependencies
@@ -27,7 +26,6 @@ import {
 } from 'state/at-a-glance';
 import {
 	getSitePlan,
-	isFetchingSiteData
 } from 'state/site';
 
 const ProStatus = React.createClass( {

--- a/_inc/client/state/site/plugins/reducer.js
+++ b/_inc/client/state/site/plugins/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import get from 'lodash/get';
 import assign from 'lodash/assign';
 
 /**


### PR DESCRIPTION
Make the `<QuerySitePlugins />` component call the `fetchSitePlugins()` action on `willComponentMount` instead of doing it in `didComponentUpdate`. 

Previous behaviour didn't set the `isFetchingSitePluginsData` at the right moment, thus, several request to the API were being made at the same time

* Also removes some unused variables on three files
  * `plans/index.jsx`
  * `components/dash-item/index.jsx`
  * `pro-status/index.jsx`

#### Testing instructions

1. Ignore the branch name. It started being something different but it does what the branch name states
1. Visiting the Plans page should work as expected. 
1. Visit the card for Akismet and Site backup under *Security* in the settings page. The settings button/link should work as expected if plugins are active