### PR TITLE
Admin: move VaultPress and WooCommerce notices into the Jetpack notices area

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const AdminNotices = React.createClass( {
+	componentDidMount() {
+		const $adminNotices = jQuery( this.refs.adminNotices );
+
+		let $vpNotice = jQuery( '.vp-notice' );
+		if ( $vpNotice.length > 0 ) {
+			$vpNotice.each( function () {
+				let $notice = jQuery( this ).addClass( 'dops-notice is-warning' ).removeClass( 'wrap vp-notice' );
+				$notice.find( 'a' ).addClass( 'dops-notice__action' ).appendTo( $notice );
+				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );
+				$notice.find( 'h3' ).replaceWith( function () { return jQuery( '<strong />', { html: this.innerHTML } ); } );
+				$notice.find( 'p' ).replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML } ); } );
+				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
+			} );
+		}
+
+		let $wcNotice = jQuery( '.woocommerce-message' );
+		if ( $wcNotice.length > 0 ) {
+			$wcNotice.each( function () {
+				let $notice = jQuery( this ).addClass( 'dops-notice is-basic' ).removeClass( 'updated wc-connect' );
+				$notice.find( '.button-primary' ).addClass( 'dops-notice__action' ).removeClass( 'button-primary' ).detach().appendTo( $notice );
+				$notice.find( 'p' ).first().replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML, class: 'dops-notice__text' } ); } );
+				let $dopsNotice = $notice.find( '.dops-notice__text' );
+				$dopsNotice.append( '<br/>' );
+				$notice.find( '.button-secondary' ).removeClass( 'button-secondary' ).detach().appendTo( $dopsNotice );
+				$notice.find( '.submit' ).remove();
+				$notice.find( '.woocommerce-message-close' ).removeClass( 'woocommerce-message-close' ).addClass( 'dops-notice__action' );
+				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
+			} );
+		}
+	},
+
+	render() {
+		return ( <div ref="adminNotices"></div> )
+	}
+} );
+
+export default AdminNotices;

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -57,6 +57,21 @@ const AdminNotices = React.createClass( {
 				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
 			} );
 		}
+
+		let $wcNotice = jQuery( '.woocommerce-message' );
+		if ( $wcNotice.length > 0 ) {
+			$wcNotice.each( function () {
+				let $notice = jQuery( this ).addClass( 'dops-notice is-basic' ).removeClass( 'updated wc-connect' );
+				$notice.find( '.button-primary' ).addClass( 'dops-notice__action' ).removeClass( 'button-primary' ).detach().appendTo( $notice );
+				$notice.find( 'p' ).first().replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML, class: 'dops-notice__text' } ); } );
+				let $dopsNotice = $notice.find( '.dops-notice__text' );
+				$dopsNotice.append( '<br/>' );
+				$notice.find( '.button-secondary' ).removeClass( 'button-secondary' ).detach().appendTo( $dopsNotice );
+				$notice.find( '.submit' ).remove();
+				$notice.find( '.woocommerce-message-close' ).removeClass( 'woocommerce-message-close' ).addClass( 'dops-notice__action' );
+				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
+			} );
+		}
 	},
 
 	render() {

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -42,6 +42,28 @@ import SearchPage from 'search/index.jsx';
 import analytics from 'lib/analytics';
 import restApi from 'rest-api';
 
+const AdminNotices = React.createClass( {
+	componentDidMount() {
+		const $adminNotices = jQuery( this.refs.adminNotices );
+
+		let $vpNotice = jQuery( '.vp-notice' );
+		if ( $vpNotice.length > 0 ) {
+			$vpNotice.each( function () {
+				let $notice = jQuery( this ).addClass( 'dops-notice is-warning' ).removeClass( 'wrap vp-notice' );
+				$notice.find( 'a' ).addClass( 'dops-notice__action' ).appendTo( $notice );
+				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );
+				$notice.find( 'h3' ).replaceWith( function () { return jQuery( '<strong />', { html: this.innerHTML } ); } );
+				$notice.find( 'p' ).replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML } ); } );
+				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
+			} );
+		}
+	},
+
+	render() {
+		return ( <div ref="adminNotices"></div> )
+	}
+} );
+
 const Main = React.createClass( {
 	componentWillMount: function() {
 		this.props.setInitialState();
@@ -170,6 +192,7 @@ const Main = React.createClass( {
 			<div>
 				<Masthead { ...this.props } />
 					<div className="jp-lower">
+						<AdminNotices { ...this.props } />
 						<JetpackNotices { ...this.props } />
 						{ this.renderMainContent( this.props.route.path ) }
 						{

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -38,46 +38,10 @@ import Footer from 'components/footer';
 import SupportCard from 'components/support-card';
 import NonAdminView from 'components/non-admin-view';
 import JetpackNotices from 'components/jetpack-notices';
+import AdminNotices from 'components/admin-notices';
 import SearchPage from 'search/index.jsx';
 import analytics from 'lib/analytics';
 import restApi from 'rest-api';
-
-const AdminNotices = React.createClass( {
-	componentDidMount() {
-		const $adminNotices = jQuery( this.refs.adminNotices );
-
-		let $vpNotice = jQuery( '.vp-notice' );
-		if ( $vpNotice.length > 0 ) {
-			$vpNotice.each( function () {
-				let $notice = jQuery( this ).addClass( 'dops-notice is-warning' ).removeClass( 'wrap vp-notice' );
-				$notice.find( 'a' ).addClass( 'dops-notice__action' ).appendTo( $notice );
-				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );
-				$notice.find( 'h3' ).replaceWith( function () { return jQuery( '<strong />', { html: this.innerHTML } ); } );
-				$notice.find( 'p' ).replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML } ); } );
-				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
-			} );
-		}
-
-		let $wcNotice = jQuery( '.woocommerce-message' );
-		if ( $wcNotice.length > 0 ) {
-			$wcNotice.each( function () {
-				let $notice = jQuery( this ).addClass( 'dops-notice is-basic' ).removeClass( 'updated wc-connect' );
-				$notice.find( '.button-primary' ).addClass( 'dops-notice__action' ).removeClass( 'button-primary' ).detach().appendTo( $notice );
-				$notice.find( 'p' ).first().replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML, class: 'dops-notice__text' } ); } );
-				let $dopsNotice = $notice.find( '.dops-notice__text' );
-				$dopsNotice.append( '<br/>' );
-				$notice.find( '.button-secondary' ).removeClass( 'button-secondary' ).detach().appendTo( $dopsNotice );
-				$notice.find( '.submit' ).remove();
-				$notice.find( '.woocommerce-message-close' ).removeClass( 'woocommerce-message-close' ).addClass( 'dops-notice__action' );
-				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
-			} );
-		}
-	},
-
-	render() {
-		return ( <div ref="adminNotices"></div> )
-	}
-} );
 
 const Main = React.createClass( {
 	componentWillMount: function() {

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -66,3 +66,10 @@
 @keyframes pulse-light {
 	50% { background-color: lighten( $gray, 30% ); }
 }
+
+.jetpack-pagestyles {
+	// Initially hide VaultPress notices until they're displayed in Jetpack notices area
+	.vp-notice {
+		display: none;
+	}
+}

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -68,8 +68,29 @@
 }
 
 .jetpack-pagestyles {
-	// Initially hide VaultPress notices until they're displayed in Jetpack notices area
-	.vp-notice {
+	// Initially hide VaultPress and WooCommerce notices until they're displayed in Jetpack notices area
+	.vp-notice, .woocommerce-message, .wc-connect {
 		display: none;
+	}
+
+	.woocommerce-message.dops-notice {
+		display: block;
+
+		.submit {
+			padding: 0;
+		}
+
+		.skip {
+			color: $gray;
+			opacity: 0.85;
+		}
+
+		.skip:hover {
+			opacity: 1;
+		}
+
+		.notice-dismiss::before {
+			display: none;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #4693

#### Changes proposed in this Pull Request:
- moves VP and WC notices

Before running database update
<img width="769" alt="captura de pantalla 2016-08-18 a las 16 50 13" src="https://cloud.githubusercontent.com/assets/1041600/17789821/3372af52-656a-11e6-8dc4-0614fdd8a3f6.png">

After running database update
<img width="746" alt="captura de pantalla 2016-08-18 a las 17 44 39" src="https://cloud.githubusercontent.com/assets/1041600/17789824/38443442-656a-11e6-8e0a-585df3513aea.png">

#### Testing instructions:
- activate WooCommerce and VaultPress and check that the dashboard displays these notices