### PR TITLE
Jetpack Sync: Use random_int() instead of getmypid()

### DIFF
--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -38,6 +38,7 @@ class Jetpack_Sync_Queue {
 	function __construct( $id ) {
 		$this->id           = str_replace( '-', '_', $id ); // necessary to ensure we don't have ID collisions in the SQL
 		$this->row_iterator = 0;
+		$this->random_int = random_int( 1, 1000000 );
 	}
 
 	function add( $item ) {
@@ -339,7 +340,7 @@ class Jetpack_Sync_Queue {
 			$this->row_iterator += 1;
 		}
 
-		return 'jpsq_' . $this->id . '-' . $timestamp . '-' . getmypid() . '-' . $this->row_iterator;
+		return 'jpsq_' . $this->id . '-' . $timestamp . '-' . $this->random_int . '-' . $this->row_iterator;
 	}
 
 	private function fetch_items( $limit = null ) {


### PR DESCRIPTION
Fixes #4877

In #4877, it was reported that users would see a "security" warning if `getmypid()` had been disabled. To prevent those warnings, we can just stop using `getmypid()`.

To test:

- Checkout `update/jetpack-sync-queue-getmypid` branch
- Run a full sync
- Ensure full sync still works