### PR TITLE
Sharedaddy: Use new object structure for Facebook share count

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -72,7 +72,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 			}
 
 			for ( url in data ) {
-				if ( ! data.hasOwnProperty( url ) || ! data[ url ].shares ) {
+				if ( ! data.hasOwnProperty( url ) || ! data[ url ].share.share_count ) {
 					continue;
 				}
 
@@ -82,7 +82,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 					continue;
 				}
 
-				WPCOMSharing.inject_share_count( 'sharing-facebook-' + WPCOM_sharing_counts[ permalink ], data[ url ].shares );
+				WPCOMSharing.inject_share_count( 'sharing-facebook-' + WPCOM_sharing_counts[ permalink ], data[ url ].share.share_count );
 			}
 		},
 		update_linkedin_count : function( data ) {


### PR DESCRIPTION
This pull request resolves an issue where Facebook share counts are no longer shown, due to changes in the response object structure of the unversioned Facebook Graph share counts API endpoint.