### PR TITLE
Admin Page: Split admin.js into two chunks. admin.js with the app code and vendor.js containing some common dependencies

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -184,6 +184,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		$rtl = is_rtl() ? '.rtl' : '';
 
 		// Enqueue jp.js and localize it
+		wp_enqueue_script( 'react-plugin-dependencies', plugins_url( '_inc/build/vendor.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
 		wp_enqueue_script( 'react-plugin', plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
 		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/admin.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,8 @@ var webpackConfig = {
 	// The key is used as the name of the script.
 	entry: {
 		admin: './_inc/client/admin.js',
-		static: './_inc/client/static.jsx'
+		static: './_inc/client/static.jsx',
+		vendor: [ 'react', 'react-dom', 'redux', 'react-redux', 'moment', 'moment-timezone', 'i18n-calypso' ]
 	},
 	output: {
 		path: path.join( __dirname, '_inc/build' ),
@@ -94,7 +95,8 @@ var webpackConfig = {
 				NODE_ENV: JSON.stringify( NODE_ENV )
 			}
 		}),
-		new ExtractTextPlugin( '[name].dops-style.css' )
+		new ExtractTextPlugin( '[name].dops-style.css' ),
+		new webpack.optimize.CommonsChunkPlugin( 'vendor', 'vendor.js', [ 'admin', 'vendor' ] )
 	]
 };
 


### PR DESCRIPTION
This is currently an experiment
1. I don't think this is gonna stay like it is now with  one `vendor` chunk listing explicitly a few dependencies
2. Ideally we could split `at-a-glance` on one side and everything else on two different chunks

![image](https://cloud.githubusercontent.com/assets/746152/17791282/c83a85fa-6570-11e6-920a-dccadd150356.png)
#### Testing instructions
1. With the Dev tools open, in the network panel, filtering the JS request, load the admin page
2. On the dev tools, disable javascript.
3. Reload the page, and get to see the old settings page 
