### PR TITLE
Add npm run lint script

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,7 +60,7 @@
 		"quote-props": [ 1, "as-needed" ],
 		"quotes": [ 1, "single", "avoid-escape" ],
 		"semi-spacing": 1,
-		"space-after-keywords": [ 1, "always" ],
+		"keyword-spacing": 1,
 		"space-before-blocks": [ 1, "always" ],
 		"space-before-function-paren": [ 1, "never" ],
 		// Our array literal index exception violates this rule

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build-client": "gulp",
     "build-production": "npm run build-languages && NODE_ENV=production npm run build",
     "build-languages": "gulp languages",
-    "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js"
+    "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
+    "lint": "eslint _inc/client -c .eslintrc"
   },
   "devDependencies": {
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:


* Adds `npm run lint` command.
* Replaces usage of deprecated `space-after-keyword` rule for `keyword-spacing` in `.eslintrc`.

#### Testing instructions

1. clone this branch
2. On the command line, run `npm run script`
3. Expect to see a lot of warnings. 