### PR TITLE
Admin Page: Update eslint version to 2.13.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,7 @@
 		"no-mixed-spaces-and-tabs": 1,
 		"no-multiple-empty-lines": [ 1, { "max": 1 } ],
 		"no-multi-spaces": 1,
-		"no-nested-ternary": 1,
+		"no-nested-ternary": 0,
 		"no-new": 1,
 		"no-process-exit": 1,
 		"no-shadow": 1,
@@ -56,7 +56,7 @@
 		// We split external, internal, module variables
 		"one-var": 0,
 		"operator-linebreak": [ 1, "after", { "overrides": { "?": "ignore", ":": "ignore" } } ],
-		"padded-blocks": [ 1, "never" ],
+		"padded-blocks": 0,
 		"quote-props": [ 1, "as-needed" ],
 		"quotes": [ 1, "single", "avoid-escape" ],
 		"semi-spacing": 1,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "commander": "2.3.0",
     "css-loader": "0.23.1",
     "es6-promise": "3.0.2",
-    "eslint": "1.7.3",
+    "eslint": "2.13.1",
     "eslint-loader": "^1.1.0",
     "eslint-plugin-react": "3.6.3",
     "extract-text-webpack-plugin": "0.9.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates the eslint dependency to a newer version for being able to use the `keyword-spacing` rule.

eslint rule `space-after-keyword` was replaced by `keyword-spacing` in recent eslint version, thus editors mark that as a warning for Jetpack's .estlintrc 
#### Testing instructions:
1. Checkout this branch
2. Run `npm run lint` 
3. Remove current eslint module: `rm -rf node_modules/eslint`.
4. Install the new verison: `npm install eslint`
5. Expect to no longer see `warning  Definition for rule 'keyword-spacing' was not found  keyword-spacing` in the output

This branch is currently erroring on `npm run build-client`:

![image](https://cloud.githubusercontent.com/assets/746152/17819315/b78206cc-661d-11e6-8a39-925adf2df800.png)
#### Why

This allows compatibility with **eslint** integration on some editors. These editors, tend to rely on the global `estlint` command and not the one we're declaring for Jetpack, in this case. So, if the global version is newer than the one we use in Jetpack, the editor will complain while parsing linting rules that are deprecated in newer eslint versions.
