### PR TITLE
Sync: Swap lang_id for locale

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -70,7 +70,6 @@ class Jetpack_Sync_Defaults {
 		'comment_whitelist',
 		'comment_max_links',
 		'moderation_keys',
-		'lang_id',
 		'wga',
 		'disabled_likes',
 		'disabled_reblogs',
@@ -150,6 +149,7 @@ class Jetpack_Sync_Defaults {
 		'wp_version'                       => array( 'Jetpack_Sync_Functions', 'wp_version' ),
 		'get_plugins'                      => array( 'Jetpack_Sync_Functions', 'get_plugins' ),
 		'active_modules'                   => array( 'Jetpack', 'get_active_modules' ),
+		'locale'                           => 'get_locale',
 	);
 
 	static $blacklisted_post_types = array(

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -72,6 +72,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'wp_version'                       => Jetpack_Sync_Functions::wp_version(),
 			'get_plugins'                      => Jetpack_Sync_Functions::get_plugins(),
 			'active_modules'                   => Jetpack::get_active_modules(),
+			'locale'                           => get_locale(),
 		);
 
 		if ( is_multisite() ) {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -127,7 +127,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'comment_whitelist'                    => 'pineapple',
 			'comment_max_links'                    => 99,
 			'moderation_keys'                      => 'pineapple',
-			'lang_id'                              => 'pineapple',
 			'wga'                                  => 'pineapple',
 			'disabled_likes'                       => 'pineapple',
 			'disabled_reblogs'                     => 'pineapple',


### PR DESCRIPTION
Previously, we were syncing `lang_id` and improperly overwriting that option on WPCOM. But, WP.org doesn't use `lang_id`, it uses `WPLANG` and `get_locale()`.

This PR stops syncing `lang_id` and begins syncing `locale`. Then, on the WPCOM side, with D2582 we sanitize and map the locale to a proper language ID.

To test:

- Checkout D2582 patch
- Checkout `update/lang_id_site` branch
- Update Jetpack API base to point to your sandbox
-Go to Settings > General
- Change language to Hebrew
- Go to API console and make post request to `/sites/$site/sync`
-After site syncs, go to WPCOM network admin for `$site`, and verify that language id is 29
- Go to Settings > General on `$site`
- Change to English
- Full sync again
- Go to WP.com network admin and verify language ID is 1
