### PR TITLE
Just exclude users from initial sync if upgrading from 4.2+

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -142,13 +142,16 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function schedule_initial_sync( $new_version = null, $old_version = null ) {
-		if ( $old_version && ( version_compare( $old_version, '4.2', '>=' ) ) ) {
-			error_log( "$old_version: " . version_compare( $old_version, '4.2', '>=' ) );
-			return;
+		$initial_sync_config = array( 
+			'options' => true, 
+			'network_options' => true, 
+			'functions' => true, 
+			'constants' => true, 
+		);
+
+		if ( $old_version && ( version_compare( $old_version, '4.2', '<' ) ) ) {
+			$initial_sync_config['users'] = 'initial';
 		}
-
-		error_log("scheduling initial sync for old version $old_version and new version $new_version");
-
 
 		// we need this function call here because we have to run this function
 		// reeeeally early in init, before WP_CRON_LOCK_TIMEOUT is defined.
@@ -162,13 +165,7 @@ class Jetpack_Sync_Actions {
 		}
 
 		self::schedule_full_sync( 
-			array( 
-				'options' => true, 
-				'network_options' => true, 
-				'functions' => true, 
-				'constants' => true, 
-				'users' => 'initial' 
-			),
+			$initial_sync_config,
 			$time_offset
 		);
 	}
@@ -217,7 +214,7 @@ class Jetpack_Sync_Actions {
 			return false;
 		}
 
-		return wp_next_scheduled( 'jetpack_sync_full', array( $modules ) );
+		return !! wp_next_scheduled( 'jetpack_sync_full', array( $modules ) );
 	}
 
 	static function do_full_sync( $modules = null ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -141,7 +141,15 @@ class Jetpack_Sync_Actions {
 		return $rpc->getResponse();
 	}
 
-	static function schedule_initial_sync() {
+	static function schedule_initial_sync( $new_version = null, $old_version = null ) {
+		if ( $old_version && ( version_compare( $old_version, '4.2', '>=' ) ) ) {
+			error_log( "$old_version: " . version_compare( $old_version, '4.2', '>=' ) );
+			return;
+		}
+
+		error_log("scheduling initial sync for old version $old_version and new version $new_version");
+
+
 		// we need this function call here because we have to run this function
 		// reeeeally early in init, before WP_CRON_LOCK_TIMEOUT is defined.
 		wp_functionality_constants();
@@ -282,4 +290,4 @@ class Jetpack_Sync_Actions {
 add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
-add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'schedule_initial_sync' ), 10 );
+add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'schedule_initial_sync' ), 10, 2 );

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -123,12 +123,17 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( $modules ) ) > time()-5 );
 	}
 
-	function test_upgrading_from_42_plus_does_not_schedule_initial_sync() {
+	function test_upgrading_from_42_plus_does_not_includes_users_in_initial_sync() {
+
+		$initial_sync_without_users_config = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true );
+		$initial_sync_with_users_config = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => 'initial' );
+
 		do_action( 'updating_jetpack_version', '4.3', '4.2' );
-		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync() );
+		$this->assertTrue( Jetpack_Sync_Actions::is_scheduled_full_sync( $initial_sync_without_users_config ) );
+		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync( $initial_sync_with_users_config ) );
 
 		do_action( 'updating_jetpack_version', '4.2', '4.1' );
-		$this->assertTrue( Jetpack_Sync_Actions::is_scheduled_full_sync() );
+		$this->assertTrue( Jetpack_Sync_Actions::is_scheduled_full_sync( $initial_sync_with_users_config ) );
 	}
 
 	function test_schedules_regular_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -117,10 +117,18 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_upgrading_sends_options_constants_and_callables() {
 		/** This action is documented in class.jetpack.php */
-		do_action( 'updating_jetpack_version', '4.1', '4.2' );
+		do_action( 'updating_jetpack_version', '4.2', '4.1' );
 
 		$modules = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => 'initial' );
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( $modules ) ) > time()-5 );
+	}
+
+	function test_upgrading_from_42_plus_does_not_schedule_initial_sync() {
+		do_action( 'updating_jetpack_version', '4.3', '4.2' );
+		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync() );
+
+		do_action( 'updating_jetpack_version', '4.2', '4.1' );
+		$this->assertTrue( Jetpack_Sync_Actions::is_scheduled_full_sync() );
 	}
 
 	function test_schedules_regular_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1030,7 +1030,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
-		Jetpack_Sync_Actions::schedule_initial_sync();
+		Jetpack_Sync_Actions::schedule_initial_sync( '4.2', '4.1' );
 		$this->assertTrue(
 			!! Jetpack_Sync_Actions::is_scheduled_full_sync(
 				array(


### PR DESCRIPTION
This PR only syncs authors on the initial upgrade to 4.2+. All upgrades sync constants, callables, and options since those are more likely to have changed between releases.