### PR TITLE
Admin Page: Avoid watch task to crash on runtime errors when server-rendering

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,18 +169,27 @@ function doStatic( done ) {
 			}
 		};
 
-		path = __dirname + '/_inc/build/static.js';
+		try {
+			path = __dirname + '/_inc/build/static.js';
 
-		delete require.cache[ path ]; // Making sure NodeJS requires this file every time this is called
-		require( path );
+			delete require.cache[ path ]; // Making sure NodeJS requires this file every time this is called
+			require( path );
 
-		fs.writeFile( __dirname + '/_inc/build/static.html', window.staticHtml );
-		fs.writeFile( __dirname + '/_inc/build/static-noscript-notice.html', window.noscriptNotice );
-		fs.writeFile( __dirname + '/_inc/build/static-version-notice.html', window.versionNotice );
-		fs.writeFile( __dirname + '/_inc/build/static-ie-notice.html', window.ieNotice );
+			fs.writeFile( __dirname + '/_inc/build/static.html', window.staticHtml );
+			fs.writeFile( __dirname + '/_inc/build/static-noscript-notice.html', window.noscriptNotice );
+			fs.writeFile( __dirname + '/_inc/build/static-version-notice.html', window.versionNotice );
+			fs.writeFile( __dirname + '/_inc/build/static-ie-notice.html', window.ieNotice );
 
-		if ( done ) {
-			done();
+			if ( done ) {
+				done();
+			}
+		} catch ( err ) {
+			util.log( util.colors.red( "doStatic errored" ) );
+			util.log( util.colors.red( err.stack ) );
+			if ( done ) {
+				done( err );
+
+			}
 		}
 
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Wraps static generation with a try/catch. Any runtime error  stopped the watch process

This had the side effect of leaving a pseudo-zombie gulp process which eventually consumed lots of CPU time

#### Testing instructions

1. Create a runtime error in `static.jsx`. For example:
  ```
  import Server from 'react-dom/server';
  import React from 'react';
  import { Provider } from 'react-redux';

  foo=2;
  ```
1. Run `npm run watch`
1. See a red message stating `static.js` errored
1. See the error stack
1. Without stopping the watch task, fix the error you previously wrote
1. See the watch process rebuild without errors
1. For contrast, you can checkout to master keeping the error and running `npm run watch` again for seeing it crash.