### PR TITLE
Fix PHP warnings when user subscribes to comments

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -576,11 +576,13 @@ class Jetpack_Subscriptions {
 		$blog_checked     = '';
 
 		// Check for a comment / blog submission and set a cookie to retain the setting and check the boxes.
-		if ( isset( $_COOKIE[ 'jetpack_comments_subscribe_' . self::$hash . '_' . $post->ID ] ) )
+		if ( isset( $_COOKIE[ 'jetpack_comments_subscribe_' . self::$hash . '_' . $post->ID ] ) ) {
 			$comments_checked = ' checked="checked"';
+		}
 
-		if ( isset( $_COOKIE[ 'jetpack_blog_subscribe_' . self::$hash ] ) )
+		if ( isset( $_COOKIE[ 'jetpack_blog_subscribe_' . self::$hash ] ) ) {
 			$blog_checked = ' checked="checked"';
+		}
 
 		// Some themes call this function, don't show the checkbox again
 		remove_action( 'comment_form', 'subscription_comment_form' );
@@ -715,15 +717,17 @@ class Jetpack_Subscriptions {
 		 */
 		$cookie_domain   = apply_filters( 'jetpack_comment_cookie_domain', COOKIE_DOMAIN );
 
-		if ( $subscribe_to_post && $post_id >= 0 )
+		if ( $subscribe_to_post && $post_id >= 0 ) {
 			setcookie( 'jetpack_comments_subscribe_' . self::$hash . '_' . $post_id, 1, time() + $cookie_lifetime, $cookie_path, $cookie_domain );
-		else
+		} else {
 			setcookie( 'jetpack_comments_subscribe_' . self::$hash . '_' . $post_id, '', time() - 3600, $cookie_path, $cookie_domain );
+		}
 
-		if ( $subscribe_to_blog )
+		if ( $subscribe_to_blog ) {
 			setcookie( 'jetpack_blog_subscribe_' . self::$hash, 1, time() + $cookie_lifetime, $cookie_path, $cookie_domain );
-		else
+		} else {
 			setcookie( 'jetpack_blog_subscribe_' . self::$hash, '', time() - 3600, $cookie_path, $cookie_domain );
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #3339. 

#### Changes proposed in this Pull Request:

Reported in #3339, PHP warnings are generated when a user subscribes to comments, and the cookie is set with a null value instead of the expected post ID, making the cookie useless since the check in `comment_subscribe_init()` will never pass.

This patch fixes the reference to the post ID, and it saves the "Subscribe to all comments" value for each post separately. Previously, if a user subscribed to comments on post 1, then commented on post 2 and did not subscribe to comments on it, the checkbox on post 1 would remain unchecked. Now, both checkboxes will have the appropriate state.

This will increase the number of cookies set for users that subscribe to comments on many individual posts. We may wish to revisit the ~1-year cookie expiration limit.

#### Testing instructions:
1. Comment on a post. Leave both subscription checkboxes unchecked. Observe no PHP warnings, and both boxes remain unchecked.
1. Comment on a post. Check only the comments subscription checkbox. Observe no PHP warnings, and only the comment checkbox is checked. Visit another post. Observe that the comment checkbox is not checked.
1. Comment on a different post. Check both subscription checkboxes. Observe no PHP warnings, and both checkboxes should remain checked. Visit the post commented on in the previous step. Observe both checkboxes are now checked.
1. Re-comment on the first post, and uncheck both subscription checkboxes. Observe no PHP warnings, and both checkboxes should now be unchecked. Visit the second post commented on above, and observe that the comment subscription box is checked.