### PR TITLE
Ensure we always call `Jetpack::init();`

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -103,3 +103,5 @@ if ( is_admin() && ! Jetpack::check_identity_crisis() ) {
 */
 
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php' );
+
+Jetpack::init();


### PR DESCRIPTION
Closes #4895

Calls `Jetpack::init()` early enough to ensure that hooks on the constructor are "hooked"

To test:

* Check that you have a  `meta name="twitter:card"` in the source code of a post

