### PR TITLE
Added a default value for the threat count reducer.

### DIFF
--- a/_inc/client/state/at-a-glance/reducer.js
+++ b/_inc/client/state/at-a-glance/reducer.js
@@ -3,6 +3,7 @@
  */
 import { combineReducers } from 'redux';
 import assign from 'lodash/assign';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -267,7 +268,11 @@ export function getVaultPressData( state ) {
  * @return {int} The number of current security threats found by VaultPress
  */
 export function getVaultPressScanThreatCount( state ) {
-	return state.jetpack.dashboard.vaultPressData.data.security.notice_count;
+	return get(
+		state.jetpack.dashboard.vaultPressData,
+		'data.security.notice_count',
+		0
+	);
 }
 
 /**


### PR DESCRIPTION
This will make sure the reducer doesn't throw a fatal in case the state object does not have the structure it expects.

#### Testing instructions
On a site with an active Jetpack plan:
- Install VaultPress, but do not register it - you should see the yellow notice urging you to do it.
- Open the At a Glance page and scroll down.
- Both the Scan and Backup widgets should tell you that you should install and activate VaultPress.
- You should not see "Loading" on those widgets, nor should you see an error.