### PR TITLE
ProStatus: hide pro status if in dev mode

### DIFF
--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -57,7 +57,7 @@ const DashItem = React.createClass( {
 		);
 
 		if ( '' !== this.props.module ) {
-			toggle = ( includes( [ 'protect', 'monitor', 'photon' ], this.props.module ) && this.props.isDevMode ) ? '' : (
+			toggle = ( includes( [ 'protect', 'monitor', 'photon', 'vaultpress', 'akismet' ], this.props.module ) && this.props.isDevMode ) ? '' : (
 				<ModuleToggle
 					slug={ this.props.module }
 					activated={ this.props.isModuleActivated( this.props.module ) }
@@ -85,7 +85,7 @@ const DashItem = React.createClass( {
 			}
 		}
 
-		if ( this.props.pro ) {
+		if ( this.props.pro && ! this.props.isDevMode ) {
 			proButton =
 				<Button
 					compact={ true }

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -14,6 +14,7 @@ import { getSiteRawUrl } from 'state/initial-state';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import QueryAkismetData from 'components/data/query-akismet-data';
+import { isDevMode } from 'state/connection';
 import {
 	isFetchingPluginsData,
 	isPluginActive,
@@ -49,6 +50,10 @@ const ProStatus = React.createClass( {
 
 		let getStatus = ( feature, active, installed ) => {
 			let vpData = this.props.getVaultPressData();
+
+			if ( this.props.isDevMode ) {
+				return __( 'Unavailable in Dev Mode' );
+			}
 
 			if ( 'N/A' !== vpData && 'vaultpress' === feature && 0 !== this.props.getScanThreats() ) {
 				return(
@@ -136,7 +141,8 @@ export default connect(
 			sitePlan: () => getSitePlan( state ),
 			fetchingPluginsData: isFetchingPluginsData( state ),
 			pluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
-			pluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
+			pluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug ),
+			isDevMode: isDevMode( state )
 		};
 	}
 )( ProStatus );


### PR DESCRIPTION
This hides the pro status CTA's in the Dashboard area, and shows an `Unavailable in Dev Mode` message in the foldable cards.  

To Test: 
- Turn on development mode
- Make sure you see no CTA in the DashItem header
![screen shot 2016-08-22 at 12 16 16 pm](https://cloud.githubusercontent.com/assets/7129409/17862217/4aa94528-6862-11e6-8f0f-27c60b978e10.png)

- Make sure you see the `unavailable` message in the security tab and search route. 
![screen shot 2016-08-22 at 12 16 28 pm](https://cloud.githubusercontent.com/assets/7129409/17862220/4df842ec-6862-11e6-8ac4-ba8c7a944684.png)
