### PR TITLE
Endpoints: allow to activate Sitemaps and Sharing even if site isn't public or connected to WPCOM

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -7,10 +7,8 @@ class Jetpack_Core_API_Module_Activate_Endpoint
 	extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 	private $modules_requiring_public = array(
-		'sitemaps',
 		'photon',
 		'enhanced-distribution',
-		'sharedaddy',
 		'json-api',
 	);
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -6,12 +6,29 @@
 class Jetpack_Core_API_Module_Activate_Endpoint
 	extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
+	/**
+	 * List of modules that require WPCOM public access.
+	 *
+	 * @since 4.3
+	 *
+	 * @var array
+	 */
 	private $modules_requiring_public = array(
 		'photon',
 		'enhanced-distribution',
 		'json-api',
 	);
 
+	/**
+	 * Check if the module requires the site to be publicly accessible from WPCOM.
+	 * If the site meets this requirement, the module is activated. Otherwise an error is returned.
+	 *
+	 * @since 4.3
+	 *
+	 * @param array $data
+	 *
+	 * @return bool|WP_Error
+	 */
 	public function process( $data ) {
 		if (
 			! in_array( $data['slug'], $this->modules_requiring_public )
@@ -25,6 +42,13 @@ class Jetpack_Core_API_Module_Activate_Endpoint
 			array( 'status' => 404 ) );
 	}
 
+	/**
+	 * Check that the current user has permissions to manage Jetpack modules.
+	 *
+	 * @since 4.3
+	 *
+	 * @return bool
+	 */
 	public function can_write() {
 		return current_user_can( 'jetpack_manage_modules' );
 	}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -38,8 +38,8 @@ class Jetpack_Core_API_Module_Activate_Endpoint
 		}
 		return new WP_Error(
 			'rest_cannot_publish',
-			__( 'This module requires your site to be set to publicly accessible.', 'jetpack' ),
-			array( 'status' => 404 ) );
+			esc_html__( 'This module requires your site to be set to publicly accessible.', 'jetpack' ),
+			array( 'status' => 424 ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4856

#### Changes proposed in this Pull Request:
- allow Sitemaps and Sharing to be activated when there's no connection to WPCOM
- return the `424 - Failed dependency` HTTP error code, more suitable for this case
- replace `__` with the safer `esc_html__`
- add inline documentation

#### Testing instructions:
- Sitemaps and Sharing features must be able to be activated even when site is not connected to WPCOM, even if search engines are discouraged.

