### PR TITLE
Gulpfile: remove duplicate sass:build call

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -467,7 +467,7 @@ gulp.task( 'languages:extract', [ 'react:build' ], function( callback ) {
 // Default task
 gulp.task(
 	'default',
-	['react:build', 'sass:build', 'old-styles', 'checkstrings', 'php:lint', 'js:hint']
+	['react:build', 'old-styles', 'checkstrings', 'php:lint', 'js:hint']
 );
 gulp.task(
 	'watch',


### PR DESCRIPTION
Fixes #4908

This removes the `sass:build` task from running during `npm run build`.  It's already triggered by the `doSass()` call at the end of the `react:build` task anyway, so there's no reason to duplicate it.  

To test: 
- run `npm run build` and make sure these are only building once: 
![screen shot 2016-08-23 at 9 32 03 am](https://cloud.githubusercontent.com/assets/7129409/17893654/7b46dbf2-6914-11e6-9967-6f1441265562.png)