### PR TITLE
Admin: add text for Scan, Akismet and Backups cards.

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -55,7 +55,13 @@ export const AllModuleSettings = React.createClass( {
 			case 'monitor':
 				return ( <MonitorSettings module={ module } { ...this.props } /> );
 			case 'scan':
-				return '' === module.configure_url ? null : (
+				return '' === module.configure_url ? (
+					<div>
+						{
+							__( 'Upgrade Jetpack and our state-of-the-art security scanner will hunt out malicious files and report them immediately so that you’re never unaware of what is happening on your website.' )
+						}
+					</div>
+				) : (
 					<div>
 						<div className="jp-form-setting-explanation">
 							{ __( 'You can see the information about security scanning in the "At a Glance" section.' ) }
@@ -93,7 +99,16 @@ export const AllModuleSettings = React.createClass( {
 				return <span className="jp-form-setting-explanation">{ __( 'This module has no configuration options' ) } </span>;
 			case 'akismet':
 			case 'backups':
-				return '' === module.configure_url ? null : (
+				return '' === module.configure_url ? (
+					<div>
+						{
+							module.module === 'akismet' ?
+								__( 'Let search engines and visitors know that you are serious about your websites integrity by upgrading Jetpack. Our anti-spam tools will eliminate comment spam, protect your SEO, and make it easier for visitors to stay in touch..' )
+								:
+								__( 'Real-time offsite backups with automated restores deliver peace-of-mind, so you can focus on writing great content and increasing traffic while we protect every aspect of your investment. Upgrade today.' )
+						}
+					</div>
+				) : (
 					<div>
 						{
 

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -58,7 +58,7 @@ export const AllModuleSettings = React.createClass( {
 				return '' === module.configure_url ? (
 					<div>
 						{
-							__( 'Upgrade Jetpack and our state-of-the-art security scanner will hunt out malicious files and report them immediately so that you’re never unaware of what is happening on your website.' )
+							__( 'Upgrade Jetpack and our state-of-the-art security scanner will hunt out malicious files and report them immediately so that you\'re never unaware of what is happening on your website.' )
 						}
 					</div>
 				) : (
@@ -103,7 +103,7 @@ export const AllModuleSettings = React.createClass( {
 					<div>
 						{
 							module.module === 'akismet' ?
-								__( 'Let search engines and visitors know that you are serious about your websites integrity by upgrading Jetpack. Our anti-spam tools will eliminate comment spam, protect your SEO, and make it easier for visitors to stay in touch..' )
+								__( 'Let search engines and visitors know that you are serious about your websites integrity by upgrading Jetpack. Our anti-spam tools will eliminate comment spam, protect your SEO, and make it easier for visitors to stay in touch.' )
 								:
 								__( 'Real-time offsite backups with automated restores deliver peace-of-mind, so you can focus on writing great content and increasing traffic while we protect every aspect of your investment. Upgrade today.' )
 						}


### PR DESCRIPTION
Fixes #4885

#### Testing instructions:
- go to Jetpack > Settings > Security and expand the cards. If Akismet, Scan and Backups aren't active, they should display the text given by Jesse in the issue.
- when they're active, it should display a link to configure the settings.