### PR TITLE
JSON API: Ensure term is a string.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -192,6 +192,10 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				 * Note: A category named "0" will not work right.
 				 * https://core.trac.wordpress.org/ticket/9059
 				 */
+				if ( ! is_string( $term ) ) {
+					continue;
+				}
+
 				$term_info = get_term_by( 'name', $term, $taxonomy, ARRAY_A );
 
 				if ( ! $term_info ) {


### PR DESCRIPTION
Update the post v1.2 endpoint to match a WPCOM bug fix.

D2607-code

#### Changes proposed in this Pull Request:

- Add string check to prevent errors on post edits where `terms` is sending an array of objects.