### PR TITLE
Endpoints: restore the preparation of module/s for response

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -177,7 +177,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 			}
 		}
 
-		return $modules;
+		return Jetpack_Core_Json_Api_Endpoints::prepare_modules_for_response( $modules );
 	}
 
 	/**
@@ -310,7 +310,7 @@ class Jetpack_Core_API_Module_Endpoint
 				$module['activated'] = false;
 			}
 
-			return $module;
+			return Jetpack_Core_Json_Api_Endpoints::prepare_modules_for_response( $module );
 		}
 
 		return new WP_Error(


### PR DESCRIPTION
Fixes #4927 

Fixes the empty URLs in Sitemaps card once it's activated.

#### Changes proposed in this Pull Request:
- restore functionality passed removed in bd4f825d1f0ce3432fc55951bf128599fc6b487d

#### Testing instructions:
- go to Jetpack > Settings > Engagement > Sitemaps. Activate it. The card body should display the URLs.
