### PR TITLE
Stats Options: Fix infinite loop

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -181,8 +181,9 @@ function stats_footer() {
 function stats_get_options() {
 	$options = get_option( 'stats_options' );
 
-	if ( !isset( $options['version'] ) || $options['version'] < STATS_VERSION )
+	if ( ! isset( $options['version'] ) || $options['version'] < STATS_VERSION ) {
 		$options = stats_upgrade_options( $options );
+	}
 
 	return $options;
 }
@@ -204,11 +205,11 @@ function stats_set_option( $option, $value ) {
 
 	$options[$option] = $value;
 
-	stats_set_options($options);
+	return stats_set_options($options);
 }
 
 function stats_set_options($options) {
-	update_option( 'stats_options', $options );
+	return update_option( 'stats_options', $options );
 }
 
 function stats_upgrade_options( $options ) {
@@ -236,7 +237,9 @@ function stats_upgrade_options( $options ) {
 
 	$new_options['version'] = STATS_VERSION;
 
-	stats_set_options( $new_options );
+	if ( !  stats_set_options( $new_options ) ) {
+		return false;
+	}
 
 	stats_update_blog();
 


### PR DESCRIPTION
It has been reported that Jetpack can get into an infinite loop and cause the server to run out of memory when using memcache.

While this issue seems intermittent, I was able to reproduce once. Here is some example output from my slow script logs:

```
[23-Aug-2016 14:21:34]  [pool oomtest] pid 25781
script_filename = $root_wp_path/wp-admin/admin.php
[9178] mysqli_query() $root_wp_path/wp-includes/wp-db.php:1858
[9000] _do_query() $root_wp_path/wp-includes/wp-db.php:1746
[8e38] query() $root_wp_path/wp-includes/option.php:435
[8c68] add_option() $root_wp_path/wp-includes/option.php:304
[8b58] update_option() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:211
[8a50] stats_set_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:239
[8948] stats_upgrade_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:185
[87f8] stats_get_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:698
[86e0] stats_get_blog() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:678
[85e0] stats_update_blog() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:241
[84d8] stats_upgrade_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:185
[8388] stats_get_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:698
[8270] stats_get_blog() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:678
[8170] stats_update_blog() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:241
[8068] stats_upgrade_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:185
[7f18] stats_get_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:698
[7e00] stats_get_blog() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:678
[7d00] stats_update_blog() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:241
[7bf8] stats_upgrade_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:185
[7aa8] stats_get_options() $root_wp_path/wp-content/plugins/jetpack/modules/stats.php:698
```

When tracing this code, it became apparent that there was an infinite loop. Here's what that looks like.

- We start in [stats_get_options()](https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L181-L188)
- Which calls [stats_upgrade_options()](https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L214-L244)
     - Within that function we call [stats_set_options()](https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L239), but we don't do any validation on where the options successfully saved
    - Then we call [stats_update_blog()](https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L241)
- In [stats_update_blog()](https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L679-L681) we call [stats_get_blog()](https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L680)
- Which then calls [stats_get_options()](https://github.com/Automattic/jetpack/blob/master/modules/stats.php#L700) again
- Now that we're in `stats_get_options()`, all is well as long as our stats option successfully saved
- But, if the cache is polluted, we do the whole dance again

This isn't the right fix. We need to figure out why the cache becomes polluted in the first place and the option never updates. But, this does prevent the infinite loop from happening.

To test:

- Here are some steps you can follow to test, although they may or may not work for you
- Create a fresh installation of WordPress
- Ensure you have memcached installed and the memcache drop-in
- Download the `update/stats-upgrade-infinite-loop` branch and upload to site
- Activate Jetpack
- Connect to WP.com
- After connecting, immediately click `Jetpack > Settings`

