### PR TITLE
Endpoints: cast value of string type options. Fixes 'false' in Site Verification.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1990,6 +1990,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 				case 'float':
 					return (float) $value;
 					break;
+
+				case 'string':
+					return (string) $value;
+					break;
 			}
 		}
 		return $value;


### PR DESCRIPTION
Fixes #4928

#### Changes proposed in this Pull Request:
- This solves issue where a boolean value like false was displayed as a string 'false', instead of an empty string.

#### Testing instructions:
- you can forcefully update `verification_services_codes` to hold different values using:
```php
update_option( 'verification_services_codes', array (
		'google'    => 's0m3t3xt',
		'bing'      => false,
		'pinterest' => 'true',
	)
);
```
after that, go to Jetpack > Settings > Engagement, expand Site Verification and verify that what is shown in the text fields are only strings, with `false` converted to an empty string.