### PR TITLE
Admin Stats Chart: Fix breaking chart with bar values over 1,000

### DIFF
--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -73,7 +73,7 @@ const DashStats = React.createClass( {
 
 			s.push( {
 				label: chartLabel,
-				value: numberFormat( views ),
+				value: views,
 				nestedValue: null,
 				className: 'statsChartbar',
 				data: {


### PR DESCRIPTION
The chart is broken when there are bar values over 1,000:

<img width="758" alt="bar-broken" src="https://cloud.githubusercontent.com/assets/7129409/17907963/4917f516-694c-11e6-8df0-f356707e1cc7.png">

**To reproduce the problem before applying the patch:** 
- Replace `v[1]` with the integer `2000` [in this line](https://github.com/Automattic/jetpack/blob/master/_inc/client/at-a-glance/stats/index.jsx#L60)
- You should see the stats chart but the y-axis values will read `NaN` and no bars or data will be displayed

**To test the fix:**
- Checkout to this branch and repeat the steps above. 
- You should now see a beautiful chart with the values all listed appropriately. 
- Make sure that the number is still formatted in the y-axis of the chart
- Make sure that the number is still formatted in the tooltip.  

