### PR TITLE
Correct spelling mistake of "the"

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -906,7 +906,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	}
 
 	/**
-	 * Get VaultPress site data including, among other things, the date of tge last backup if it was completed.
+	 * Get VaultPress site data including, among other things, the date of the last backup if it was completed.
 	 *
 	 * @since 4.3.0
 	 *


### PR DESCRIPTION
`the` is accidentally misspelled as `tge` in a PHPDoc.