### PR TITLE
Admin - Plans: if VaultPress isn't installed or active, show button to configure it

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -51,9 +51,20 @@ const PlanBody = React.createClass( {
 						<div className="jp-landing__plan-features-card">
 							<h3 className="jp-landing__plan-features-title">{ __( 'Security Scanning & Backups' ) }</h3>
 							<p>{ __( 'Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense, and brute-force login protection - all in one place.' ) }</p>
-							<Button href="https://dashboard.vaultpress.com/" className="is-primary">
-								{ __( 'View your security dashboard' ) }
-							</Button>
+							{
+								this.props.isFetchingPluginsData ? '' :
+									this.props.isPluginInstalled( 'vaultpress/vaultpress.php' )
+									&& this.props.isPluginActive( 'vaultpress/vaultpress.php' ) ? (
+										<Button href="https://dashboard.vaultpress.com/" className="is-primary">
+											{ __( 'View your security dashboard' ) }
+										</Button>
+									)
+									: (
+										<Button href={ 'https://wordpress.com/plugins/setup/' + this.props.siteRawUrl + '?only=vaultpress' } className="is-primary">
+											{ __( 'Configure VaultPress' ) }
+										</Button>
+									)
+							}
 						</div>
 
 						{


### PR DESCRIPTION
Fixes #4917

#### Changes proposed in this Pull Request:
- when user has Business or Premium plan, if VP plugin isn't installed or activated, a button Configure VaultPress (like the Akismet equivalent "Configure Akismet") is displayed pointing to Calypso auto setup.
- once it's installed and active the button points to the VP dashboard.

#### Testing instructions:
- make sure you're in a Business or Premium plan and deactivate and/or uninstall VaultPress.
- go to Jetpack > Dashboard > Plans. The button in the section Security Scanning & Backups should read "Configure VaultPress", pointing to Calypso auto setup.
- once VP is configured, the button should read "View your security dashboard" and point to VP dashboard.