### PR TITLE
ProStatus (VaultPress): fix pro status notices for scan/backups

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -43,7 +43,7 @@ const DashBackups = React.createClass( {
 				return (
 					<DashItem
 						label={ labelName }
-						module="vaultpress"
+						module="backups"
 						status="is-working"
 						className="jp-dash-item__is-active"
 						pro={ true }
@@ -86,7 +86,7 @@ const DashBackups = React.createClass( {
 		return (
 			<DashItem
 				label={ labelName }
-				module="vaultpress"
+				module="backups"
 				className="jp-dash-item__is-inactive"
 				status={ hasSitePlan ? inactiveOrUninstalled : 'no-pro-uninstalled-or-inactive' }
 				pro={ true }

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -45,7 +45,7 @@ const DashScan = React.createClass( {
 				return (
 					<DashItem
 						label={ labelName }
-						module="vaultpress"
+						module="scan"
 						status="is-error"
 						statusText={ __( 'Threats found' ) }
 						pro={ true }
@@ -74,7 +74,7 @@ const DashScan = React.createClass( {
 				return (
 					<DashItem
 						label={ labelName }
-						module="vaultpress"
+						module="scan"
 						status="is-working"
 						pro={ true }
 					>
@@ -109,7 +109,7 @@ const DashScan = React.createClass( {
 		return (
 			<DashItem
 				label={ labelName }
-				module="vaultpress"
+				module="scan"
 				className="jp-dash-item__is-inactive"
 				status={ hasSitePlan ? inactiveOrUninstalled : 'no-pro-uninstalled-or-inactive' }
 				pro={ true }

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -57,7 +57,7 @@ const DashItem = React.createClass( {
 		);
 
 		if ( '' !== this.props.module ) {
-			toggle = ( includes( [ 'protect', 'monitor', 'photon', 'vaultpress', 'akismet' ], this.props.module ) && this.props.isDevMode ) ? '' : (
+			toggle = ( includes( [ 'protect', 'monitor', 'photon', 'vaultpress', 'scan', 'backups', 'akismet' ], this.props.module ) && this.props.isDevMode ) ? '' : (
 				<ModuleToggle
 					slug={ this.props.module }
 					activated={ this.props.isModuleActivated( this.props.module ) }

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -55,7 +55,7 @@ const ProStatus = React.createClass( {
 				return __( 'Unavailable in Dev Mode' );
 			}
 
-			if ( 'N/A' !== vpData && 'vaultpress' === feature && 0 !== this.props.getScanThreats() ) {
+			if ( 'N/A' !== vpData && 'scan' === feature && 0 !== this.props.getScanThreats() ) {
 				return(
 					<SimpleNotice
 						showDismiss={ false }


### PR DESCRIPTION
Fixes #4926

Ensure that we're passing unique slugs for backups and scan, as well as displaying the correct status for each in all places.

**To Test:**
- Hack the `getVaultPressScanThreatCount()` state selector to `return 4;` [in the first line of the function](https://github.com/Automattic/jetpack/blob/master/_inc/client/state/at-a-glance/reducer.js#L271)
- Make sure you see a threat alert only in the `scan` card on the Dashboard 
- Make sure you see a threat alert only in the `scan` card in the `/security` tab
- Make sure you see a threat alert only in the `scan` card in the `/search` route
- Make sure everything else looks normal when there is no threats found.  