### PR TITLE
Global Notices: Show maximum one notice for any module toggle event

### DIFF
--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -98,7 +98,7 @@ export const activateModule = ( slug ) => {
 						slug: getModule( getState(), slug ).name
 					}
 				} ),
-				{ id: 'module-toggle' }
+				{ id: 'module-toggle', duration: 6000 }
 			) );
 		} ).catch( error => {
 			dispatch( {
@@ -152,7 +152,7 @@ export const deactivateModule = ( slug ) => {
 						slug: getModule( getState(), slug ).name
 					}
 				} ),
-				{ id: 'module-toggle' }
+				{ id: 'module-toggle', duration: 6000 }
 			) );
 		} ).catch( error => {
 			dispatch( {

--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -74,7 +74,7 @@ export const activateModule = ( slug ) => {
 			type: JETPACK_MODULE_ACTIVATE,
 			module: slug
 		} );
-		dispatch( removeNotice( `module-${ slug }` ) );
+		dispatch( removeNotice( 'module-toggle' ) );
 		dispatch( createNotice(
 			'is-info',
 			__( 'Activating %(slug)s…', {
@@ -82,7 +82,7 @@ export const activateModule = ( slug ) => {
 					slug: getModule( getState(), slug ).name
 				}
 			} ),
-			{ id: `module-${ slug }` }
+			{ id: 'module-toggle' }
 		) );
 		return restApi.activateModule( slug ).then( () => {
 			dispatch( {
@@ -90,7 +90,7 @@ export const activateModule = ( slug ) => {
 				module: slug,
 				success: true
 			} );
-			dispatch( removeNotice( `module-${ slug }` ) );
+			dispatch( removeNotice( 'module-toggle' ) );
 			dispatch( createNotice(
 				'is-success',
 				__( '%(slug)s has been activated.', {
@@ -98,7 +98,7 @@ export const activateModule = ( slug ) => {
 						slug: getModule( getState(), slug ).name
 					}
 				} ),
-				{ id: `module-${ slug }` }
+				{ id: 'module-toggle' }
 			) );
 		} ).catch( error => {
 			dispatch( {
@@ -107,7 +107,7 @@ export const activateModule = ( slug ) => {
 				success: false,
 				error: error
 			} );
-			dispatch( removeNotice( `module-${ slug }` ) );
+			dispatch( removeNotice( 'module-toggle' ) );
 			dispatch( createNotice(
 				'is-error',
 				__( '%(slug)s failed to activate. %(error)s', {
@@ -116,7 +116,7 @@ export const activateModule = ( slug ) => {
 						error: error
 					}
 				} ),
-				{ id: `module-${ slug }` }
+				{ id: 'module-toggle' }
 			) );
 		} );
 	}
@@ -128,7 +128,7 @@ export const deactivateModule = ( slug ) => {
 			type: JETPACK_MODULE_DEACTIVATE,
 			module: slug
 		} );
-		dispatch( removeNotice( `module-${ slug }` ) );
+		dispatch( removeNotice( 'module-toggle' ) );
 		dispatch( createNotice(
 			'is-info',
 			__( 'Deactivating %(slug)s…', {
@@ -136,7 +136,7 @@ export const deactivateModule = ( slug ) => {
 					slug: getModule( getState(), slug ).name
 				}
 			} ),
-			{ id: `module-${ slug }` }
+			{ id: 'module-toggle' }
 		) );
 		return restApi.deactivateModule( slug ).then( () => {
 			dispatch( {
@@ -144,7 +144,7 @@ export const deactivateModule = ( slug ) => {
 				module: slug,
 				success: true
 			} );
-			dispatch( removeNotice( `module-${ slug }` ) );
+			dispatch( removeNotice( 'module-toggle' ) );
 			dispatch( createNotice(
 				'is-success',
 				__( '%(slug)s has been deactivated.', {
@@ -152,7 +152,7 @@ export const deactivateModule = ( slug ) => {
 						slug: getModule( getState(), slug ).name
 					}
 				} ),
-				{ id: `module-${ slug }` }
+				{ id: 'module-toggle' }
 			) );
 		} ).catch( error => {
 			dispatch( {
@@ -161,7 +161,7 @@ export const deactivateModule = ( slug ) => {
 				success: false,
 				error: error
 			} );
-			dispatch( removeNotice( `module-${ slug }` ) );
+			dispatch( removeNotice( 'module-toggle' ) );
 			dispatch( createNotice(
 				'is-error',
 				__( '%(slug)s failed to deactivate. %(error)d', {
@@ -170,7 +170,7 @@ export const deactivateModule = ( slug ) => {
 						error: error
 					}
 				} ),
-				{ id: `module-${ slug }` }
+				{ id: 'module-toggle' }
 			) );
 		} );
 	}


### PR DESCRIPTION
Fixes #4921

Only shows one `module toggle` action notice at a time. 
Auto-dismisses the success notice only after 6 seconds.  

**To Test:**
- Make sure that when toggling any and all modules, that there is a maximum of ONE notice shown.  
- Updating the settings should (for now) still throw a separate notice. 

![modue-toggle-notice](https://cloud.githubusercontent.com/assets/7129409/17910696/083cbe9e-6958-11e6-8d28-c972bded8223.gif)
