### PR TITLE
Footer: add a confirm() before resetting options

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -29,6 +29,12 @@ export const Footer = React.createClass( {
 		}
 	},
 
+	resetOnClick() {
+		if ( window.confirm( __( 'This will reset all Jetpack options, are you sure?' ) ) ) {
+			this.props.resetOptions()
+		}
+	},
+
 	render() {
 		const classes = classNames(
 			this.props.className,
@@ -41,7 +47,7 @@ export const Footer = React.createClass( {
 				return (
 					<li className="jp-footer__link-item">
 						<a
-							onClick={ this.props.resetOptions }
+							onClick={ this.resetOnClick }
 							className="jp-footer__link">
 							{ __( 'Reset Options (dev versions only)', { context: 'Navigation item.' } ) }
 						</a>

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -43,7 +43,7 @@ export const Footer = React.createClass( {
 
 		const version = this.props.currentVersion;
 		const maybeShowReset = () => {
-			if ( this.props.isDevVersion ) {
+			if ( this.props.isDevVersion && this.props.userCanManageOptions ) {
 				return (
 					<li className="jp-footer__link-item">
 						<a


### PR DESCRIPTION
This adds a confirmation before resetting options (dev mode only)

![screen shot 2016-08-24 at 8 22 09 am](https://cloud.githubusercontent.com/assets/7129409/17930378/dfeeab06-69d3-11e6-8c33-359a7e1069c0.png)

To Test: 
- Click `Reset Options`
- Verify you see the confirmation, and that confirming and denying works as expected. 