### PR TITLE
Fixes the production build script.

### DIFF
--- a/_inc/jetpack-strings.php
+++ b/_inc/jetpack-strings.php
@@ -1,338 +1,421 @@
 <?php
 /* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
-$undefined_i18n_strings = array(
-__( 'Need Help?' ),
-
-__( 'Need Help?' ),
-
-__( 'Send us Feedback' ),
-
-__( 'Send us Feedback' ),
-
-_x( 'At a Glance', 'Navigation item.' ),
-
-_x( 'Engagement', 'Navigation item.' ),
-
-_x( 'Security', 'Navigation item.' ),
-
-_x( 'Health', 'Navigation item.' ),
-
-_x( 'More', 'Navigation item.' ),
-
-_x( 'General', 'Navigation item.' ),
-
-__( 'Please Connect Jetpack' ),
-
-__( 'Please connect to or create a WordPress.com account to enable Jetpack, including powerful security, traffic, and customization services.' ),
-
-__( 'No WordPress.com account? Create one for free.' ),
-
-__( 'Drive more traffic to your site' ),
-
-__( 'Jetpack has many traffic and engagement tools to help you get more viewers to your site and keep them there.' ),
-
-_x( 'Publicize', 'Header. Noun: Publicize is a module of Jetpack' ),
-
-__( 'Automated social marketing.' ),
-
-__( 'Use Publicize to automatically share your posts with friends, followers, and the world.' ),
-
-__( 'Sharing & Like Buttons' ),
-
-__( 'Build a community.' ),
-
-__( 'Give visitors the tools to share and subscribe to your content.' ),
-
-_x( 'Related Posts', 'Header. Noun: Related posts is a module of Jetpack.' ),
-
-__( 'Increase page views.' ),
-
-__( 'Keep visitors engaged by giving them more to share and read with Related Posts.' ),
-
-__( 'Track your growth' ),
-
-__( 'Jetpack harnesses the power of WordPress.com to show you detailed insights about your visitors, what they’re reading, and where they’re coming from.' ),
-
-__( 'Site security and peace of mind' ),
-
-__( 'Jetpack blocks malicious log in attempts, lets you know if your site goes down, and can automatically update your plugins, so you don’t have to worry.' ),
-
-_x( 'Protect', 'Header. Noun: Protect is a module of Jetpack.' ),
-
-__( 'Block site attacks.' ),
-
-__( 'Gain peace of mind with Protect, the tool that has blocked billions of login attacks across millions of sites.' ),
-
-_x( 'Monitor', 'Header. Noun: Monitor is a module of Jetpack.' ),
-
-__( 'Live site monitoring.' ),
-
-__( 'Stress less. Monitor will send you real-time alerts if your site ever goes down.' ),
-
-_x( 'Manage', 'Header. Noun: Manage is a module of Jetpack.' ),
-
-__( 'Automatic site updates.' ),
-
-__( 'Never fall behind on a security release or waste time updating multiple sites.' ),
-
-__( 'Lightning fast, optimized images' ),
-
-__( 'Jetpack utilizes the state-of-the-art WordPress.com content delivery network to load your gorgeous imagery super fast. Optimized for any device, and its completely free.' ),
-
-__( 'Did we mention free, professional support?' ),
-
-__( 'Jetpack is supported by some of the most technical and passionate people in the community. They\'re located around the globe and ready to help you.' ),
-
-__( 'Join the millions of users who rely on Jetpack to enhance and secure their sites. We’re passionate about WordPress and here to make your life easier.' ),
-
-__( 'Unlink me from WordPress.com' ),
-
-__( 'Link to WordPress.com' ),
-
-__( 'Disconnect site from WordPress.com ' ),
-
-__( 'Connect to WordPress.com' ),
-
-__( 'Jump Start your Website' ),
-
-__( 'Quickly enhance your site by activating Jetpack\'s recommended features.' ),
-
-__( 'Activate Recommended Features' ),
-
-__( 'Jetpack\'s recommended features include:' ),
-
-__( 'Social Sharing Tools' ),
-
-__( 'Image Performance (Photon)' ),
-
-__( 'Single Sign On' ),
-
-__( 'Contact Form' ),
-
-__( 'Related Posts' ),
-
-__( 'Automatic Updates (Site Manangement)' ),
-
-__( 'Image Carousel' ),
-
-__( 'Gravatar Hovercards' ),
-
-__( 'Visitor Subscriptions' ),
-
-__( 'Features can be activated or deactivated at any time.' ),
-
-__( 'Skip the Jetpack Jumpstart process' ),
-
-__( 'Skip this step' ),
-
-__( 'Site Security' ),
-
-__( 'Manage Security on WordPress.com' ),
-
-__( 'Site Health' ),
-
-__( 'Traffic Tools' ),
-
-_x( 'Settings', 'Noun. Displayed to screen readers.' ),
-
-__( 'Week of %(date)s' ),
-
-__( 'Views: %(numberOfViews)s' ),
-
-__( 'Click to view detailed stats.' ),
-
-__( 'Error loading stats. See JavaScript console for logs.' ),
-
-__( 'Something happened while loading stats. Please try again later or {{a}}view your stats now on WordPress.com{{/a}}' ),
-
-__( '{{a}}Activate Site Statistics{{/a}} to see detailed stats, likes, followers, subscribers, and more!' ),
-
-__( 'Days' ),
-
-__( 'Weeks' ),
-
-__( 'Months' ),
-
-/* translators: Referring to a number of page views */
-__( 'Views today' ),
-
-/* translators: Referring to a number of page views */
-__( 'Best overall day' ),
-
-_n( '%(number)s View', '%(number)s Views', 1 ),
-
-/* translators: Referring to a number of page views */
-__( 'All-time views' ),
-
+$jetpack_strings = array(
+_x( "Writing", "Navigation item.", "jetpack" ), // _inc/client/admin.js:65
+_x( "Appearance", "Navigation item.", "jetpack" ), // _inc/client/admin.js:64
+_x( "Security", "Navigation item.", "jetpack" ), // _inc/client/admin.js:63
+_x( "Engagement", "Navigation item.", "jetpack" ), // _inc/client/admin.js:62
+_x( "General", "Navigation item.", "jetpack" ), // _inc/client/admin.js:61
+_x( "General", "Navigation item.", "jetpack" ), // _inc/client/admin.js:60
+_x( "Plans", "Navigation item.", "jetpack" ), // _inc/client/admin.js:59
+_x( "Apps", "Navigation item.", "jetpack" ), // _inc/client/admin.js:58
+__( "At A Glance", "jetpack" ), // _inc/client/admin.js:57
+_x( "At A Glance", "Navigation item.", "jetpack" ), // _inc/client/admin.js:55
+__( "Error unlinking from WordPress.com. %(error)s", "jetpack" ), // _inc/client/state/connection/actions.js:128
+__( "Unlinked from WordPress.com.", "jetpack" ), // _inc/client/state/connection/actions.js:119
+__( "Unlinking from WordPress.com", "jetpack" ), // _inc/client/state/connection/actions.js:112
+__( "There was an error disconnecting Jetpack. Error: %(error)s", "jetpack" ), // _inc/client/state/connection/actions.js:96
+__( "Disconnecting Jetpack", "jetpack" ), // _inc/client/state/connection/actions.js:81
+__( "Options failed to reset.", "jetpack" ), // _inc/client/state/dev-version/actions.js:35
+__( "Options reset.", "jetpack" ), // _inc/client/state/dev-version/actions.js:28
+__( "Resetting Jetpack options…", "jetpack" ), // _inc/client/state/dev-version/actions.js:22
+__( "Error regenerating %(slug) address. %(error)d", "jetpack" ), // _inc/client/state/modules/actions.js:290
+__( "Regenerated %(slug)s address .", "jetpack" ), // _inc/client/state/modules/actions.js:272
+__( "Updating %(slug)s address…", "jetpack" ), // _inc/client/state/modules/actions.js:252
+__( "Error updating %(slug)s settings. %(error)s", "jetpack" ), // _inc/client/state/modules/actions.js:225
+__( "Updated %(slug)s settings.", "jetpack" ), // _inc/client/state/modules/actions.js:207
+__( "Updating %(slug)s settings…", "jetpack" ), // _inc/client/state/modules/actions.js:189
+__( "%(slug)s failed to deactivate. %(error)d", "jetpack" ), // _inc/client/state/modules/actions.js:167
+__( "%(slug)s has been deactivated.", "jetpack" ), // _inc/client/state/modules/actions.js:150
+__( "Deactivating %(slug)s…", "jetpack" ), // _inc/client/state/modules/actions.js:134
+__( "%(slug)s failed to activate. %(error)s", "jetpack" ), // _inc/client/state/modules/actions.js:113
+__( "%(slug)s has been activated.", "jetpack" ), // _inc/client/state/modules/actions.js:96
+__( "Activating %(slug)s…", "jetpack" ), // _inc/client/state/modules/actions.js:80
+__( "Recommended features failed to activate. %(error)d", "jetpack" ), // _inc/client/state/jumpstart/actions.js:45
+__( "Recommended features active.", "jetpack" ), // _inc/client/state/jumpstart/actions.js:36
+__( "Activating recommended features…", "jetpack" ), // _inc/client/state/jumpstart/actions.js:28
+__( "Show falling snow on my blog from Dec 1st until Jan 4th.", "jetpack" ), // _inc/client/appearance/index.jsx:105
+__( "Show falling snow in the holiday period.", "jetpack" ), // _inc/client/appearance/index.jsx:92
+__( "Holiday Snow", "jetpack" ), // _inc/client/appearance/index.jsx:91
+__( "Learn More", "jetpack" ), // _inc/client/appearance/index.jsx:80
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/appearance/index.jsx:50
+_x( "Spam comments blocked.", "Example: \"412 Spam comments blocked\"", "jetpack" ), // _inc/client/at-a-glance/akismet.jsx:129
+__( "Whoops! Your Akismet key is missing or invalid. {{akismetSettings}}Go to Akismet settings to fix{{/akismetSettings}}.", "jetpack" ), // _inc/client/at-a-glance/akismet.jsx:108
+__( "Invalid Key", "jetpack" ), // _inc/client/at-a-glance/akismet.jsx:103
+__( "For state-of-the-art spam defense, please {{a}}activate Akismet{{/a}}.", "jetpack" ), // _inc/client/at-a-glance/akismet.jsx:85
+__( "For state-of-the-art spam defense, please {{a}}install Akismet{{/a}}.", "jetpack" ), // _inc/client/at-a-glance/akismet.jsx:63
+__( "Loading…", "jetpack" ), // _inc/client/at-a-glance/akismet.jsx:46
+__( "Spam Protection", "jetpack" ), // _inc/client/at-a-glance/akismet.jsx:35
+__( "Unavailable in Dev Mode.", "jetpack" ), // _inc/client/at-a-glance/backups.jsx:96
+__( "To automatically back up your entire site, please {{a}}upgrade!{{/a}}.", "jetpack" ), // _inc/client/at-a-glance/backups.jsx:77
+__( "To automatically back up your entire site, please {{a}}install and activate{{/a}} VaultPress.", "jetpack" ), // _inc/client/at-a-glance/backups.jsx:69
+__( "{{a}}View backup details{{/a}}.", "jetpack" ), // _inc/client/at-a-glance/backups.jsx:55
+__( "Loading…", "jetpack" ), // _inc/client/at-a-glance/backups.jsx:37
+__( "Backups", "jetpack" ), // _inc/client/at-a-glance/backups.jsx:27
+__( "Performance", "jetpack" ), // _inc/client/at-a-glance/index.jsx:42
+__( "Manage security on WordPress.com", "jetpack" ), // _inc/client/at-a-glance/index.jsx:36
+__( "Security", "jetpack" ), // _inc/client/at-a-glance/index.jsx:34
+__( "{{a}}Activate Monitor{{/a}} to receive notifications if your site goes down.", "jetpack" ), // _inc/client/at-a-glance/monitor.jsx:61
+__( "Unavailable in Dev Mode.", "jetpack" ), // _inc/client/at-a-glance/monitor.jsx:60
+__( "Jetpack is monitoring your site. If we think your site is down you will receive an email.", "jetpack" ), // _inc/client/at-a-glance/monitor.jsx:47
+__( "Loading…", "jetpack" ), // _inc/client/at-a-glance/monitor.jsx:36
+__( "Downtime Monitoring", "jetpack" ), // _inc/client/at-a-glance/monitor.jsx:23
+__( "{{a}}Activate Photon{{/a}} to enhance the performance and speed of your images.", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:43
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:42
+__( "Jetpack is improving and optimising your image speed.", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:29
+__( "Image Performance %(photon)s", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:20
+__( "{{a}}Activate Manage{{/a}} to turn on auto updates and manage your plugins from WordPress.com.", "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:99
+__( "All plugins are up-to-date. Awesome work!", "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:98
+__( "{{a}}Activate Manage and turn on auto updates{{/a}}", "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:82
+__( "{{a}}Turn on plugin auto updates{{/a}}", "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:81
+_n( "Needs updating. ", "Need updating. ", 1, "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:71
+_n( "%(number)s plugin", "%(number)s plugins", 1, "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:61
+__( "Loading…", "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:47
+__( "Plugin Updates", "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:32
+__( "{{a}}Activate Protect{{/a}} to keep your site protected from malicious login attempts.", "jetpack" ), // _inc/client/at-a-glance/protect.jsx:64
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/at-a-glance/protect.jsx:63
+__( "Total malicious attacks blocked on your site.", "jetpack" ), // _inc/client/at-a-glance/protect.jsx:51
+__( "Jetpack is actively blocking malicious login attempts. Data will display here soon!", "jetpack" ), // _inc/client/at-a-glance/protect.jsx:39
+__( "Unavailable in Dev Mode.", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:119
+__( "For automated, comprehensive scanning of security threats, please {{a}}upgrade your account{{/a}}.", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:100
+__( "For automated, comprehensive scanning of security threats, please {{a}}install and activate{{/a}} VaultPress.", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:92
+__( "No threats found, you're good to go!", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:82
+__( "{{a}}Contact Support{{/a}}", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:66
+__( "{{a}}View details at VaultPress.com{{/a}}", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:64
+_n( "Uh oh, %(number)s threat found.", "Uh oh, %(number)s threats found.", 1, "jetpack" ), // _inc/client/at-a-glance/scan.jsx:54
+__( "Threats found", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:50
+__( "Loading…", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:37
+__( "Malware Scanning", "jetpack" ), // _inc/client/at-a-glance/scan.jsx:28
+__( "{{a}}Activate Site Verification{{/a}} to verify your site and increase ranking with Google, Bing, and Pinterest.", "jetpack" ), // _inc/client/at-a-glance/site-verification.jsx:41
+__( "Site Verification Tools are active. Ensure your site is verified with Google, Bing, and Pinterest for more accurate indexing and ranking. {{a}}Verify now{{/a}}", "jetpack" ), // _inc/client/at-a-glance/site-verification.jsx:25
+__( "Site Verification Tools", "jetpack" ), // _inc/client/at-a-glance/site-verification.jsx:19
+__( "WordPress.com for Linux", "jetpack" ), // _inc/client/apps/index.jsx:173
+__( "WordPress.com for Windows", "jetpack" ), // _inc/client/apps/index.jsx:169
+__( "WordPress.com for Mac OS X", "jetpack" ), // _inc/client/apps/index.jsx:164
+__( "A desktop app that gives WordPress a permanent home on your computer. Not to mention the distraction free environment you get writing outside of a web browser.", "jetpack" ), // _inc/client/apps/index.jsx:161
+__( "On your Desktop", "jetpack" ), // _inc/client/apps/index.jsx:160
+__( "WordPress.com in Google Play", "jetpack" ), // _inc/client/apps/index.jsx:148
+__( "WordPress.com in the App Store", "jetpack" ), // _inc/client/apps/index.jsx:139
+__( "Publish content, track stats, moderate comments and so much more from anywhere in the world. Our mobile apps are open source, free and available to you on Apple or Android devices.", "jetpack" ), // _inc/client/apps/index.jsx:136
+__( "In your Pocket", "jetpack" ), // _inc/client/apps/index.jsx:135
+__( "Get WordPress apps for any screen.", "jetpack" ), // _inc/client/apps/index.jsx:128
+__( "Inspiration strikes any time, anywhere.", "jetpack" ), // _inc/client/apps/index.jsx:124
+__( "Launch Reader", "jetpack" ), // _inc/client/apps/index.jsx:102
+__( "The WordPress apps all have impressively fast and full featured readers so you can catch up with your favorite sites and join the conversation anywhere, any time.", "jetpack" ), // _inc/client/apps/index.jsx:100
+__( "Connect with the Community", "jetpack" ), // _inc/client/apps/index.jsx:99
+__( "View Your Stats", "jetpack" ), // _inc/client/apps/index.jsx:79
+__( "Monitor your visitors with advanced stats. Watch for trends, learn what content performs the best and understand your visitors from anywhere in the world.", "jetpack" ), // _inc/client/apps/index.jsx:77
+__( "Connect with your Visitors", "jetpack" ), // _inc/client/apps/index.jsx:76
+__( "Try the New Editor", "jetpack" ), // _inc/client/apps/index.jsx:61
+__( "Our new editor is lightning fast, optimized for writers and eliminates distractions, giving you the ability to focus on your work.", "jetpack" ), // _inc/client/apps/index.jsx:59
+__( "Focus on your Writing", "jetpack" ), // _inc/client/apps/index.jsx:58
+__( "Manage Plugins", "jetpack" ), // _inc/client/apps/index.jsx:51
+__( "Most security flaws are found in outdated plugins. Use our Web and Desktop apps to turn on auto-updates or update plugins manually for all your websites in one convenient place.", "jetpack" ), // _inc/client/apps/index.jsx:49
+__( "Bulk and automatic updates", "jetpack" ), // _inc/client/apps/index.jsx:48
+__( "All the WordPress apps are built for speed. You'll notice the difference in performance immediately, with near-instant page-loads and less waiting around.", "jetpack" ), // _inc/client/apps/index.jsx:31
+__( "Feel the performance", "jetpack" ), // _inc/client/apps/index.jsx:30
+__( "Manage all your sites from a single dashboard.", "jetpack" ), // _inc/client/apps/index.jsx:25
+__( "Powerful WordPress.com features on every device.", "jetpack" ), // _inc/client/apps/index.jsx:21
+__( "View your {{a}}Email Followers{{/a}}", "jetpack" ), // _inc/client/engagement/index.jsx:143
+__( "View {{a}}All Stats{{/a}}", "jetpack" ), // _inc/client/engagement/index.jsx:129
+__( "Learn More", "jetpack" ), // _inc/client/engagement/index.jsx:123
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/engagement/index.jsx:92
+__( "Your site must be accessible by search engines for this feature to work properly. You can change this in {{a}}Reading Settings{{/a}}.", "jetpack" ), // _inc/client/engagement/index.jsx:48
+__( "Link your account to WordPress.com to get the most out of Jetpack.", "jetpack" ), // _inc/client/general-settings/connection-settings.jsx:57
+__( "You are connected as ", "jetpack" ), // _inc/client/general-settings/connection-settings.jsx:47
+__( "The site is in Development Mode, so you can not connect to WordPress.com.", "jetpack" ), // _inc/client/general-settings/connection-settings.jsx:37
+__( "Manage your Jetpack connection.", "jetpack" ), // _inc/client/general-settings/index.jsx:81
+__( "Connection Settings", "jetpack" ), // _inc/client/general-settings/index.jsx:80
+__( "Learn More", "jetpack" ), // _inc/client/general-settings/index.jsx:71
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/general-settings/index.jsx:43
+__( "Need help? A Happiness Engineer can answer questions about your site, your account or how to do about anything.", "jetpack" ), // _inc/client/plans/plan-body.jsx:120
+__( "Enjoy priority support", "jetpack" ), // _inc/client/plans/plan-body.jsx:119
+__( "Bulletproof spam filtering protects your brand, your readers, and improves SEO. Brute force login protection helps maintain peace of mind and keeps your backend safe from intruders.", "jetpack" ), // _inc/client/plans/plan-body.jsx:115
+__( "Lock out the bad guys", "jetpack" ), // _inc/client/plans/plan-body.jsx:114
+__( "Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense and brute-force login protection - all in one place and optimized for WordPress.", "jetpack" ), // _inc/client/plans/plan-body.jsx:111
+__( "Maximum grade security", "jetpack" ), // _inc/client/plans/plan-body.jsx:110
+__( "Compare Plans", "jetpack" ), // _inc/client/plans/plan-body.jsx:95
+__( "Advanced polls and ratings", "jetpack" ), // _inc/client/plans/plan-body.jsx:92
+__( "One-click threat resolution", "jetpack" ), // _inc/client/plans/plan-body.jsx:91
+__( "Real-time backups", "jetpack" ), // _inc/client/plans/plan-body.jsx:90
+__( "Unlimited backup archive", "jetpack" ), // _inc/client/plans/plan-body.jsx:89
+__( "Includes on-demand malware scanning", "jetpack" ), // _inc/client/plans/plan-body.jsx:88
+__( "Supports 1-3 sites", "jetpack" ), // _inc/client/plans/plan-body.jsx:87
+__( "Jetpack Professional offers advanced features including:", "jetpack" ), // _inc/client/plans/plan-body.jsx:86
+__( "Need more?", "jetpack" ), // _inc/client/plans/plan-body.jsx:85
+__( "Create a new poll", "jetpack" ), // _inc/client/plans/plan-body.jsx:76
+__( "Unlimited surveys, unlimited responses. Use the survey editor to create surveys quickly and easily. Collect responses via your website, e-mail or on your iPad or iPhone.", "jetpack" ), // _inc/client/plans/plan-body.jsx:74
+__( "Surveys & Polls", "jetpack" ), // _inc/client/plans/plan-body.jsx:73
+__( "Configure VaultPress", "jetpack" ), // _inc/client/plans/plan-body.jsx:64
+__( "View your security dashboard", "jetpack" ), // _inc/client/plans/plan-body.jsx:59
+__( "Realtime backup with unlimited space, one-click restores, bulletproof spam monitoring, malware defense, and brute-force login protection - all in one place.", "jetpack" ), // _inc/client/plans/plan-body.jsx:53
+__( "Security Scanning & Backups", "jetpack" ), // _inc/client/plans/plan-body.jsx:52
+__( "Configure Akismet", "jetpack" ), // _inc/client/plans/plan-body.jsx:45
+__( "View your spam stats", "jetpack" ), // _inc/client/plans/plan-body.jsx:40
+__( "State-of-the-art spam defense powered by Akismet.", "jetpack" ), // _inc/client/plans/plan-body.jsx:34
+__( "Spam Protection", "jetpack" ), // _inc/client/plans/plan-body.jsx:33
+__( "Once you connect, you can upgrade to Premium or Pro in order to unlock worldclass security, spam protection tools, and priority support.", "jetpack" ), // _inc/client/plans/plan-header.jsx:97
+__( "Your site is on Development Mode", "jetpack" ), // _inc/client/plans/plan-header.jsx:96
+__( "Unlock the full potential of your site with the features included in your plan.", "jetpack" ), // _inc/client/plans/plan-header.jsx:83
+__( "Your site is on the Jetpack Professional plan", "jetpack" ), // _inc/client/plans/plan-header.jsx:82
+__( "Unlock the full potential of your site with the features included in your plan.", "jetpack" ), // _inc/client/plans/plan-header.jsx:68
+__( "Your site is on the Jetpack Premium plan", "jetpack" ), // _inc/client/plans/plan-header.jsx:67
+__( "Upgrade to Premium or Pro in order to unlock world class security, spam protection tools, and priority support.", "jetpack" ), // _inc/client/plans/plan-header.jsx:53
+__( "Your site is on the Free Jetpack Plan", "jetpack" ), // _inc/client/plans/plan-header.jsx:52
+__( "Compare Plans", "jetpack" ), // _inc/client/plans/plan-header.jsx:33
+__( "Hackers, botnets and spammers attack websites indiscriminately. Their goal is to attack everywhere and often. Our goal is to help you prepare by blocking these threats, and in worst-case-scenarios we'll be here to help you restore your site to its former glory.", "jetpack" ), // _inc/client/plans/plan-header.jsx:30
+__( "Threats don't discriminate", "jetpack" ), // _inc/client/plans/plan-header.jsx:29
+__( "Backup, protect, repair and build a better website.", "jetpack" ), // _inc/client/plans/plan-header.jsx:25
+__( "Powerful security tools for ultimate peace of mind", "jetpack" ), // _inc/client/plans/plan-header.jsx:22
+__( "ACTIVE", "jetpack" ), // _inc/client/pro-status/index.jsx:115
+__( "ACTIVE", "jetpack" ), // _inc/client/pro-status/index.jsx:100
+__( "Upgrade", "jetpack" ), // _inc/client/pro-status/index.jsx:95
+__( "Set up", "jetpack" ), // _inc/client/pro-status/index.jsx:90
+__( "Invalid Key", "jetpack" ), // _inc/client/pro-status/index.jsx:79
+__( "Threats found!", "jetpack" ), // _inc/client/pro-status/index.jsx:65
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/pro-status/index.jsx:55
+__( "No Results Found.", "jetpack" ), // _inc/client/search/index.jsx:174
+__( "Learn More", "jetpack" ), // _inc/client/search/index.jsx:163
+__( "Pro", "jetpack" ), // _inc/client/search/index.jsx:120
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/search/index.jsx:96
+__( "Keep your site backed up!", "jetpack" ), // _inc/client/search/index.jsx:71
+__( "Site Backups", "jetpack" ), // _inc/client/search/index.jsx:70
+__( "Keep those spammers away!", "jetpack" ), // _inc/client/search/index.jsx:64
+__( "Automatically scan your site for common threats and attacks.", "jetpack" ), // _inc/client/search/index.jsx:57
+__( "Security Scanning", "jetpack" ), // _inc/client/search/index.jsx:56
+__( "Learn More", "jetpack" ), // _inc/client/security/index.jsx:111
+__( "Pro", "jetpack" ), // _inc/client/security/index.jsx:74
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/security/index.jsx:51
+__( "Automatically backup your entire site.", "jetpack" ), // _inc/client/security/index.jsx:46
+__( "Site Backups", "jetpack" ), // _inc/client/security/index.jsx:46
+__( "State-of-the-art spam defense.", "jetpack" ), // _inc/client/security/index.jsx:45
+__( "Automated, comprehensive protection from threats and attacks.", "jetpack" ), // _inc/client/security/index.jsx:42
+__( "Security Scanning", "jetpack" ), // _inc/client/security/index.jsx:42
+__( "Learn More", "jetpack" ), // _inc/client/writing/index.jsx:105
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/writing/index.jsx:70
+__( "{{button}}View More Stats{{/button}}", "jetpack" ), // _inc/client/at-a-glance/stats/dash-stats-bottom.jsx:95
 /* translators: Referring to a number of comments */
-__( 'All-time comments' ),
-
-__( 'Need to see more stats, likes, followers, subscribers, and more?' ),
-
-__( '{{button}}View old stats{{/button}}' ),
-
-__( '{{button}}View enhanced stats on WordPress.com{{/button}}' ),
-
-__( 'Downtime Monitoring' ),
-
-__( 'Loading…' ),
-
-__( 'Monitor is on and is watching your site.' ),
-
-__( 'Last downtime was %(time)s ago.' ),
-
-__( '{{a}}Activate Monitor{{/a}} to receive notifications if your site goes down.' ),
-
-__( 'Security Scan %(vaultpress)s' ),
-
-__( 'Loading…' ),
-
-_n( 'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.', 1 ),
-
-__( '{{a}}View details at VaultPress.com{{/a}}' ),
-
-__( '{{a}}Contact Support{{/a}}' ),
-
-__( 'No threats found, you\'re good to go!' ),
-
-__( 'To automatically scan your site for malicious threats, please {{a}}upgrade your account{{/a}}' ),
-
-__( 'Anti-spam %(akismet)s' ),
-
-__( 'Loading…' ),
-
-__( '{{a}}Activate Akismet{{/a}} to automatically block spam comments and more.' ),
-
-__( '{{a}}Install Akismet{{/a}} to automatically block spam comments and more.' ),
-
-__( '{{a}}Activate Manage and Akismet{{/a}} to automatically block spam comments and more.' ),
-
-__( '{{a}}Activate Manage and Install Akismet{{/a}} to automatically block spam comments and more.' ),
-
-__( 'Whoops! It appears your Akismet key is missing or invalid. {{akismetSettings}}Go to Akismet settings to fix{{/akismetSettings}}.' ),
-
-_x( 'Spam comments blocked.', 'Example: "412 Spam comments blocked"' ),
-
-__( 'Site Backups %(vaultpress)s' ),
-
-__( 'Loading…' ),
-
-__( 'Your site is completely backed up!' ),
-
-__( 'Full Backup Status:' ),
-
-__( 'Last Backup:' ),
-
-__( 'Currently backing up your site.' ),
-
-__( 'Full Backup Status:' ),
-
-__( 'Last Backup:' ),
-
-__( 'To automatically back up your site, please {{a}}upgrade your account{{/a}}' ),
-
-__( 'Plugin Updates' ),
-
-__( 'Loading…' ),
-
-_n( '%(number)s plugin needs updating.', '%(number)s plugins need updating.', 1 ),
-
-__( '{{a}}Turn on plugin auto updates{{/a}}' ),
-
-__( '{{a}}Activate Manage and turn on auto updates{{/a}}' ),
-
-__( 'All plugins are up-to-date. Keep up the good work!' ),
-
-__( 'Image Performance %(photon)s' ),
-
-__( 'Photon is active and currently improving image performance.' ),
-
-__( '{{a}}Activate Photon{{/a}} to enhance the performance of your images.' ),
-
-__( 'Site Verification Tools' ),
-
-__( 'Site Verification Tools are active. Ensure your site is verified with Google, Bing, and Pinterest for more accurate indexing and ranking. {{a}}Verify now{{/a}}' ),
-
-__( '{{a}}Activate Site Verification{{/a}} to verify your site and increase ranking with Google, Bing, and Pinterest.' ),
-
-__( 'What would you like to see on your Jetpack Dashboard? {{a}}Send us some feedback and let us know!{{/a}}' ),
-
-__( 'Learn More' ),
-
-__( 'Link to old settings' ),
-
-__( 'Link to old settings' ),
-
-__( 'No plan available since site runs in development mode.' ),
-
-__( 'Loading plan data...' ),
-
-__( 'Your current plan is: %s' ),
-
-__( 'No plan information available.' ),
-
-_x( 'Reset Options (dev versions only)', 'Navigation item.' ),
-
-__( 'Test your site’s compatibility with Jetpack.' ),
-
-_x( 'Debug', 'Navigation item. Noun. Links to a debugger tool for Jetpack.' ),
-
-__( 'WordPress.com Terms of Service' ),
-
-_x( 'Terms', 'Shorthand for Terms of Service.' ),
-
-__( 'Automattic\'s Privacy Policy' ),
-
-_x( 'Privacy', 'Shorthand for Privacy Policy.' ),
-
-__( 'Jetpack Happiness Engineer' ),
-
-__( 'Need help? The Jetpack team is here for you.' ),
-
-__( 'We offer free, full support to all of our Jetpack users. Our support team is always around to help you.' ),
-
-__( 'Go to Jetpack.com/support' ),
-
-__( 'Go to the WordPress.org support forums' ),
-
-__( 'Contact Jetpack support staff directly' ),
-
-__( '{{supportLink}}View our support page{{/supportLink}}{{hideOnMobile}},{{/hideOnMobile}} {{forumLink}}check the forums for answers{{/forumLink}}{{hideOnMobile}}, or{{/hideOnMobile}} {{contactLink}}contact us directly{{/contactLink}}{{hideOnMobile}}.{{/hideOnMobile}}' ),
-
-__( 'Leave a Jetpack review' ),
-
-__( 'Follow Jetpack on Twitter' ),
-
-__( 'Like us on facebook' ),
-
-__( '{{hideOnMobile}}Enjoying Jetpack or have feedback?{{/hideOnMobile}} {{reviewLink}}Leave us a review{{/reviewLink}}{{hideOnMobile}},{{/hideOnMobile}} {{twitterLink}}follow us on twitter{{/twitterLink}} {{hideOnMobile}}, or{{/hideOnMobile}} {{facebookLink}}like us on facebook{{/facebookLink}}{{hideOnMobile}}.{{/hideOnMobile}}' ),
-
-__( 'Write posts via email, get notifications about your site activity, and log in with a single click.' ),
-
-__( 'Get notifications about your site activity and log in with a single click.' ),
-
-__( 'Sign in to your WordPress.com account to unlock these features.' ),
-
-__( 'No WordPress.com account? Create one for free.' ),
-
-__( 'Connected as user %(userLogin)s / %(userEmail)s' ),
-
-__( 'You are currently running a development version of Jetpack. {{a}} Submit your feedback {{/a}}' ),
-
-__( 'You are running Jetpack on a {{a}}staging server{{/a}}.' ),
-
-__( 'the jetpack_development_mode filter. ' ),
-
-__( 'the JETPACK_DEV_DEBUG constant. ' ),
-
-__( 'your site URL lacking a dot (e.g. http://localhost).' ),
-
-__( 'Currently in {{a}}Development Mode{{/a}} VIA false' ),
-
-__( 'You have successfully disconnected Jetpack' ),
-
-__( 'Would you tell us why? Just {{a}}answering two simple questions{{/a}} would help us improve Jetpack.' ),
-
-__( 'Dismiss' ),
+__( "All-time comments", "jetpack" ), // _inc/client/at-a-glance/stats/dash-stats-bottom.jsx:82
+/* translators: Referring to a number of page views */
+__( "All-time views", "jetpack" ), // _inc/client/at-a-glance/stats/dash-stats-bottom.jsx:74
+_n( "%(number)s View", "%(number)s Views", 1, "jetpack" ), // _inc/client/at-a-glance/stats/dash-stats-bottom.jsx:56
+/* translators: Referring to a number of page views */
+__( "Best overall day", "jetpack" ), // _inc/client/at-a-glance/stats/dash-stats-bottom.jsx:52
+/* translators: Referring to a number of page views */
+__( "Views today", "jetpack" ), // _inc/client/at-a-glance/stats/dash-stats-bottom.jsx:48
+__( "Site Stats", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:209
+__( "Months", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:185
+__( "Weeks", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:180
+__( "Days", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:175
+__( "Activate Site Stats", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:158
+__( "{{a}}Activate Site Stats{{/a}} to see detailed stats, likes, followers, subscribers, and more! {{a1}}Learn More{{/a1}}", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:143
+__( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:142
+__( "Jetpack Stats Icon", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:138
+__( "Something happened while loading stats. Please try again later or {{a}}view your stats now on WordPress.com{{/a}}", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:111
+__( "Click to view detailed stats.", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:86
+__( "Views: %(numberOfViews)s", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:84
+__( "Week of %(date)s", "jetpack" ), // _inc/client/at-a-glance/stats/index.jsx:68
+__( "Connect Jetpack", "jetpack" ), // _inc/client/components/connect-button/index.jsx:93
+__( "Disconnect Jetpack", "jetpack" ), // _inc/client/components/connect-button/index.jsx:83
+__( "Do you really want to disconnect your site from WordPress.com?", "jetpack" ), // _inc/client/components/connect-button/index.jsx:65
+__( "Link to WordPress.com", "jetpack" ), // _inc/client/components/connect-button/index.jsx:59
+__( "Unlink me from WordPress.com", "jetpack" ), // _inc/client/components/connect-button/index.jsx:48
+__( "Pro", "jetpack" ), // _inc/client/components/dash-item/index.jsx:94
+__( "Active", "jetpack" ), // _inc/client/components/dash-item/index.jsx:83
+__( "Updates Needed", "jetpack" ), // _inc/client/components/dash-item/index.jsx:78
+_x( "Settings", "Noun. Displayed to screen readers.", "jetpack" ), // _inc/client/components/dash-section-header/index.jsx:43
+__( "Save Settings", "jetpack" ), // _inc/client/components/forms/index.jsx:146
+__( "Saving…", "jetpack" ), // _inc/client/components/forms/index.jsx:146
+_x( "Privacy", "Shorthand for Privacy Policy.", "jetpack" ), // _inc/client/components/footer/index.jsx:115
+__( "Automattic's Privacy Policy", "jetpack" ), // _inc/client/components/footer/index.jsx:113
+_x( "Terms", "Shorthand for Terms of Service.", "jetpack" ), // _inc/client/components/footer/index.jsx:106
+__( "WordPress.com Terms of Service", "jetpack" ), // _inc/client/components/footer/index.jsx:104
+__( "Disconnect Jetpack", "jetpack" ), // _inc/client/components/footer/index.jsx:77
+__( "Disconnect from WordPress.com", "jetpack" ), // _inc/client/components/footer/index.jsx:75
+_x( "Debug", "Navigation item. Noun. Links to a debugger tool for Jetpack.", "jetpack" ), // _inc/client/components/footer/index.jsx:62
+__( "Test your site’s compatibility with Jetpack.", "jetpack" ), // _inc/client/components/footer/index.jsx:60
+_x( "Reset Options (dev versions only)", "Navigation item.", "jetpack" ), // _inc/client/components/footer/index.jsx:46
+__( "Do you really want to disconnect your site from WordPress.com?", "jetpack" ), // _inc/client/components/footer/index.jsx:27
+__( "No account? Create one for free…", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:220
+__( "Join the millions of users who rely on Jetpack to enhance and secure their sites. We're passionate about WordPress and here to make your life easier.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:212
+__( "Jetpack is supported by some of the most technical and passionate people in the community. They're located around the globe and ready to help you.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:197
+__( "Did we mention free, professional support?", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:194
+__( "Jetpack utilizes the state-of-the-art WordPress.com content delivery network to load your gorgeous imagery super fast. Optimized for any device, and its completely free.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:178
+__( "Lightning fast, optimized images", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:175
+__( "Never fall behind on a security release or waste time updating multiple sites.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:165
+__( "Automatic site updates.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:162
+_x( "Manage", "Header. Noun: Manage is a module of Jetpack.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:158
+__( "Stress less. Monitor will send you real-time alerts if your site ever goes down.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:152
+__( "Live site monitoring.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:149
+_x( "Monitor", "Header. Noun: Monitor is a module of Jetpack.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:145
+__( "Gain peace of mind with Protect, the tool that has blocked billions of login attacks across millions of sites.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:136
+__( "Block site attacks.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:133
+_x( "Protect", "Header. Noun: Protect is a module of Jetpack.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:129
+__( "Jetpack blocks malicious log in attempts, lets you know if your site goes down, and can automatically update your plugins, so you don’t have to worry.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:118
+__( "Site security and peace of mind", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:115
+__( "Jetpack harnesses the power of WordPress.com to show you detailed insights about your visitors, what they’re reading, and where they’re coming from.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:100
+__( "Track your growth", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:97
+__( "Keep visitors engaged by giving them more to share and read with Related Posts.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:90
+__( "Increase page views.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:87
+_x( "Related Posts", "Header. Noun: Related posts is a module of Jetpack.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:83
+__( "Give visitors the tools to share and subscribe to your content.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:77
+__( "Build a community.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:74
+__( "Sharing & Like Buttons", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:70
+__( "Use Publicize to automatically share your posts with friends, followers, and the world.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:64
+__( "Automated social marketing.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:61
+_x( "Publicize", "Header. Noun: Publicize is a module of Jetpack", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:57
+__( "Jetpack has many traffic and engagement tools to help you get more viewers to your site and keep them there.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:45
+__( "Drive more traffic to your site", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:42
+__( "No account? Create one for free…", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:33
+__( "Please connect to or create a WordPress.com account to start using Jetpack. This will enable powerful security, traffic, and customization services.", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:28
+__( "Welcome to Jetpack", "jetpack" ), // _inc/client/components/jetpack-connect/index.jsx:23
+__( "Would you tell us why? Just {{a}}answering two simple questions{{/a}} would help us improve Jetpack.", "jetpack" ), // _inc/client/components/jetpack-notices/dismissable.jsx:40
+__( "You have successfully disconnected Jetpack", "jetpack" ), // _inc/client/components/jetpack-notices/dismissable.jsx:37
+__( "Let us know!", "jetpack" ), // _inc/client/components/jetpack-notices/feedback-dash-request.jsx:36
+__( "What would you like to see on your Jetpack Dashboard?", "jetpack" ), // _inc/client/components/jetpack-notices/feedback-dash-request.jsx:31
+__( "Link to WordPress.com", "jetpack" ), // _inc/client/components/jetpack-notices/index.jsx:151
+__( "You, %(userName)s, are not connected to WordPress.com.", "jetpack" ), // _inc/client/components/jetpack-notices/index.jsx:136
+__( "Currently in {{a}}Development Mode{{/a}} because your site URL lacks a dot (e.g. http://localhost).{{br/}}Some features are disabled.", "jetpack" ), // _inc/client/components/jetpack-notices/index.jsx:100
+__( "Currently in {{a}}Development Mode{{/a}} via the JETPACK_DEV_DEBUG constant.{{br/}}Some features are disabled.", "jetpack" ), // _inc/client/components/jetpack-notices/index.jsx:91
+__( "Currently in {{a}}Development Mode{{/a}} via the jetpack_development_mode filter.{{br/}}Some features are disabled.", "jetpack" ), // _inc/client/components/jetpack-notices/index.jsx:82
+__( "You are running Jetpack on a {{a}}staging server{{/a}}.", "jetpack" ), // _inc/client/components/jetpack-notices/index.jsx:51
+__( "Submit your feedback", "jetpack" ), // _inc/client/components/jetpack-notices/index.jsx:35
+__( "You are currently running a development version of Jetpack.", "jetpack" ), // _inc/client/components/jetpack-notices/index.jsx:30
+__( "You're fueled up and ready to go.", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:188
+__( "You're fueled up and ready to go, Jetpack is now active.", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:184
+__( "Your Jetpack is already connected.", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:180
+__( "Welcome to {{s}}Jetpack %(jetpack_version)s{{/s}}!", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:168
+__( "{{s}}Your Jetpack has a glitch.{{/s}}  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %(error_key)s", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:128
+__( "Jetpack could not contact WordPress.com: %(error_key)s.  This usually means something is incorrectly configured on your web host.", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:89
+__( "WordPress.com is currently having problems and is unable to fuel up your Jetpack.  Please try again later.", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:85
+__( "{{s}}Your Jetpack has a glitch.{{/s}} Connecting this site with WordPress.com is not possible. This usually means your site is not publicly accessible (localhost).", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:72
+__( "Your website needs to be publicly accessible to use Jetpack: %(error_key)s", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:63
+__( "There was an issue connecting your Jetpack. Please click \"Connect to WordPress.com\" again.", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:59
+__( "We had an issue connecting Jetpack; deactivate then reactivate the Jetpack plugin, then connect again.", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:56
+__( "You need to stay logged in to your WordPress blog while you authorize Jetpack.", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:53
+__( "{{p}}Would you mind telling us why you did not complete the Jetpack connection in this {{a}}2 question survey{{/a}}?{{/p}}{{p}}A Jetpack connection is required for our free security and traffic features to work.{{/p}}", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:42
+__( "Cheatin' uh?", "jetpack" ), // _inc/client/components/jetpack-notices/state-notices.jsx:39
+__( "Skip this step", "jetpack" ), // _inc/client/components/jumpstart/index.jsx:84
+__( "Skip the Jetpack Jumpstart process", "jetpack" ), // _inc/client/components/jumpstart/index.jsx:83
+__( "Features can be activated or deactivated at any time.", "jetpack" ), // _inc/client/components/jumpstart/index.jsx:76
+__( "Jetpack's recommended features include:", "jetpack" ), // _inc/client/components/jumpstart/index.jsx:68
+__( "Activate Recommended Features", "jetpack" ), // _inc/client/components/jumpstart/index.jsx:58
+__( "Quickly enhance your site by activating Jetpack's recommended features.", "jetpack" ), // _inc/client/components/jumpstart/index.jsx:55
+__( "Jump Start your Site", "jetpack" ), // _inc/client/components/jumpstart/index.jsx:49
+__( "Send us Feedback", "jetpack" ), // _inc/client/components/masthead/index.jsx:43
+__( "Send us Feedback", "jetpack" ), // _inc/client/components/masthead/index.jsx:41
+__( "Need Help?", "jetpack" ), // _inc/client/components/masthead/index.jsx:35
+__( "Need Help?", "jetpack" ), // _inc/client/components/masthead/index.jsx:33
+__( "News Sitemap: {{a}}%(url)s{{/a}}", "jetpack" ), // _inc/client/components/module-settings/index.jsx:760
+__( "Sitemap: {{a}}%(url)s{{/a}}", "jetpack" ), // _inc/client/components/module-settings/index.jsx:750
+__( "Search engines will find the sitemaps at these locations:", "jetpack" ), // _inc/client/components/module-settings/index.jsx:748
+__( "Use Markdown for comments", "jetpack" ), // _inc/client/components/module-settings/index.jsx:729
+__( "Add a phrase", "jetpack" ), // _inc/client/components/module-settings/index.jsx:701
+__( "Ignored Phrases", "jetpack" ), // _inc/client/components/module-settings/index.jsx:697
+__( "Redundant Phrases", "jetpack" ), // _inc/client/components/module-settings/index.jsx:693
+__( "Phrases to Avoid", "jetpack" ), // _inc/client/components/module-settings/index.jsx:689
+__( "Passive Voice", "jetpack" ), // _inc/client/components/module-settings/index.jsx:685
+__( "Jargon", "jetpack" ), // _inc/client/components/module-settings/index.jsx:681
+__( "Hidden Verbs", "jetpack" ), // _inc/client/components/module-settings/index.jsx:677
+__( "Double Negatives", "jetpack" ), // _inc/client/components/module-settings/index.jsx:673
+__( "Diacritical Marks", "jetpack" ), // _inc/client/components/module-settings/index.jsx:669
+__( "Complex Phrases", "jetpack" ), // _inc/client/components/module-settings/index.jsx:665
+__( "Clichés", "jetpack" ), // _inc/client/components/module-settings/index.jsx:661
+__( "Bias Language", "jetpack" ), // _inc/client/components/module-settings/index.jsx:657
+__( "Enable proofreading for the following grammar and style rules: ", "jetpack" ), // _inc/client/components/module-settings/index.jsx:653
+__( "English Options", "jetpack" ), // _inc/client/components/module-settings/index.jsx:652
+__( "Use automatically detected language to proofread posts and pages", "jetpack" ), // _inc/client/components/module-settings/index.jsx:649
+__( "The proofreader supports English, French, German, Portuguese and Spanish.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:644
+__( "Automatic Language Detection", "jetpack" ), // _inc/client/components/module-settings/index.jsx:642
+__( "A post or page is updated", "jetpack" ), // _inc/client/components/module-settings/index.jsx:639
+__( "A post or page is first published", "jetpack" ), // _inc/client/components/module-settings/index.jsx:635
+__( "Automatically proofread content when: ", "jetpack" ), // _inc/client/components/module-settings/index.jsx:631
+__( "Proofreading", "jetpack" ), // _inc/client/components/module-settings/index.jsx:630
+__( "Enable Testimonials for this site.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:608
+__( "Enable Portfolio Projects for this site.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:603
+__( "Configure Testimonials", "jetpack" ), // _inc/client/components/module-settings/index.jsx:594
+__( "Configure Portfolios", "jetpack" ), // _inc/client/components/module-settings/index.jsx:584
+__( "Regenerate address", "jetpack" ), // _inc/client/components/module-settings/index.jsx:564
+__( "Highlight and copy the following text to your clipboard:", "jetpack" ), // _inc/client/components/module-settings/index.jsx:560
+__( "Copied!", "jetpack" ), // _inc/client/components/module-settings/index.jsx:559
+_x( "Copy", "verb", "jetpack" ), // _inc/client/components/module-settings/index.jsx:558
+__( "Email Address", "jetpack" ), // _inc/client/components/module-settings/index.jsx:555
+__( "Display all your gallery pictures in a cool mosaic", "jetpack" ), // _inc/client/components/module-settings/index.jsx:523
+__( "Excerpts", "jetpack" ), // _inc/client/components/module-settings/index.jsx:519
+__( "Meta key example: ", "jetpack" ), // _inc/client/components/module-settings/index.jsx:497
+__( "Meta key example: ", "jetpack" ), // _inc/client/components/module-settings/index.jsx:480
+__( "Meta key example: ", "jetpack" ), // _inc/client/components/module-settings/index.jsx:463
+__( "Enter your meta key \"content\" value to verify your blog with {{a}}Google Search Console{{/a}}, {{a}}Bing Webmaster Center{{/a}} and {{a}}Pinterest Site Verification{{/a}}.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:441
+__( "View people's profiles when you mouse over their Gravatars", "jetpack" ), // _inc/client/components/module-settings/index.jsx:417
+__( "Show a promo for the WordPress mobile apps in the footer of the mobile theme", "jetpack" ), // _inc/client/components/module-settings/index.jsx:399
+__( "Mobile Promos", "jetpack" ), // _inc/client/components/module-settings/index.jsx:395
+__( "Featured Images", "jetpack" ), // _inc/client/components/module-settings/index.jsx:388
+__( "Excerpts", "jetpack" ), // _inc/client/components/module-settings/index.jsx:381
+__( "Track each infinite Scroll post load as a page view in Google Analytics", "jetpack" ), // _inc/client/components/module-settings/index.jsx:363
+__( "Scroll infinitely (Shows 7 posts on each load)", "jetpack" ), // _inc/client/components/module-settings/index.jsx:359
+__( "Background Color", "jetpack" ), // _inc/client/components/module-settings/index.jsx:334
+__( "Show photo metadata (Exif) in carousel, when available", "jetpack" ), // _inc/client/components/module-settings/index.jsx:331
+__( "Mobile Promos", "jetpack" ), // _inc/client/components/module-settings/index.jsx:327
+__( "Require Two-Step Authentication", "jetpack" ), // _inc/client/components/module-settings/index.jsx:309
+__( "Match By Email", "jetpack" ), // _inc/client/components/module-settings/index.jsx:305
+__( "{{a}}Edit{{/a}}", "jetpack" ), // _inc/client/components/module-settings/index.jsx:278
+__( "Emails will be sent to ", "jetpack" ), // _inc/client/components/module-settings/index.jsx:275
+__( "Receive Monitor Email Notifications", "jetpack" ), // _inc/client/components/module-settings/index.jsx:274
+__( "List the IP addresses or IP address ranges.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:253
+__( "Whitelisted IP addresses", "jetpack" ), // _inc/client/components/module-settings/index.jsx:245
+__( "Report Visibility: Select the roles that will be able to view stats reports", "jetpack" ), // _inc/client/components/module-settings/index.jsx:222
+__( "Registered Users: Count the page views of registered users who are logged in", "jetpack" ), // _inc/client/components/module-settings/index.jsx:215
+__( "Hide the stats smiley face image", "jetpack" ), // _inc/client/components/module-settings/index.jsx:212
+__( "Smiley", "jetpack" ), // _inc/client/components/module-settings/index.jsx:208
+__( "Put a chart showing 48 hours of views in the admin bar", "jetpack" ), // _inc/client/components/module-settings/index.jsx:205
+__( "Admin Bar", "jetpack" ), // _inc/client/components/module-settings/index.jsx:201
+__( "Show a \"follow comments\" option in the comment form.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:182
+__( "Show a \"follow blog\" options in the comment form", "jetpack" ), // _inc/client/components/module-settings/index.jsx:178
+__( "Can readers subscribe to your posts, comments or both?", "jetpack" ), // _inc/client/components/module-settings/index.jsx:173
+__( "Color Scheme", "jetpack" ), // _inc/client/components/module-settings/index.jsx:152
+__( "A few catchy words to motivate your readers to comment.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:149
+__( "Comments headline", "jetpack" ), // _inc/client/components/module-settings/index.jsx:141
+__( "WordPress.com Likes are:", "jetpack" ), // _inc/client/components/module-settings/index.jsx:119
+__( "Preview", "jetpack" ), // _inc/client/components/module-settings/index.jsx:98
+__( "Use a large and visually striking layout", "jetpack" ), // _inc/client/components/module-settings/index.jsx:96
+__( "Show a \"Related\" header to more clearly separate the related section from posts", "jetpack" ), // _inc/client/components/module-settings/index.jsx:92
+__( "Related", "jetpack" ), // _inc/client/components/module-settings/index.jsx:70
+__( "Upgrade Focus: VideoPress For Weddings", "jetpack" ), // _inc/client/components/module-settings/index.jsx:63
+__( "The WordPress for Android App Gets a Big Facelift", "jetpack" ), // _inc/client/components/module-settings/index.jsx:60
+__( "Big iPhone/iPad Update Now Available", "jetpack" ), // _inc/client/components/module-settings/index.jsx:57
+__( "Subscriber", "jetpack" ), // _inc/client/components/module-settings/index.jsx:38
+__( "{{link}}Configure your %(module_slug)s Settings {{/link}}", "jetpack" ), // _inc/client/components/module-settings/modules-per-tab-page.jsx:134
+__( "{{link}}Configure your %(module_slug)s Settings {{/link}}", "jetpack" ), // _inc/client/components/module-settings/modules-per-tab-page.jsx:115
+__( "Real-time offsite backups with automated restores deliver peace-of-mind, so you can focus on writing great content and increasing traffic while we protect every aspect of your investment. Upgrade today.", "jetpack" ), // _inc/client/components/module-settings/modules-per-tab-page.jsx:108
+__( "Let search engines and visitors know that you are serious about your websites integrity by upgrading Jetpack. Our anti-spam tools will eliminate comment spam, protect your SEO, and make it easier for visitors to stay in touch.", "jetpack" ), // _inc/client/components/module-settings/modules-per-tab-page.jsx:106
+__( "This module has no configuration options", "jetpack" ), // _inc/client/components/module-settings/modules-per-tab-page.jsx:99
+__( "Configure your Security Scans", "jetpack" ), // _inc/client/components/module-settings/modules-per-tab-page.jsx:70
+__( "You can see the information about security scanning in the \"At a Glance\" section.", "jetpack" ), // _inc/client/components/module-settings/modules-per-tab-page.jsx:67
+__( "Upgrade Jetpack and our state-of-the-art security scanner will hunt out malicious files and report them immediately so that you're never unaware of what is happening on your website.", "jetpack" ), // _inc/client/components/module-settings/modules-per-tab-page.jsx:61
+_x( "Writing", "Navigation item.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:112
+_x( "Engagement", "Navigation item.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:107
+_x( "General", "Navigation item.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:102
+_x( "Writing", "Navigation item.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:92
+_x( "Appearance", "Navigation item.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:87
+_x( "Security", "Navigation item.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:82
+_x( "Engagement", "Navigation item.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:77
+_x( "General", "Navigation item.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:72
+__( "Search for a Jetpack feature.", "jetpack" ), // _inc/client/components/navigation-settings/index.jsx:51
+_x( "Apps", "Navigation item.", "jetpack" ), // _inc/client/components/navigation/index.jsx:60
+_x( "At a Glance", "Navigation item.", "jetpack" ), // _inc/client/components/navigation/index.jsx:50
+_x( "Plans", "Navigation item.", "jetpack" ), // _inc/client/components/navigation/index.jsx:39
+_x( "Apps", "Navigation item.", "jetpack" ), // _inc/client/components/navigation/index.jsx:34
+_x( "At a Glance", "Navigation item.", "jetpack" ), // _inc/client/components/navigation/index.jsx:29
+__( "{{hideOnMobile}}Enjoying Jetpack or have feedback?{{/hideOnMobile}} {{reviewLink}}Leave us a review{{/reviewLink}}{{hideOnMobile}},{{/hideOnMobile}} {{twitterLink}}follow us on Twitter{{/twitterLink}}{{hideOnMobile}}, and{{/hideOnMobile}} {{facebookLink}}like us on Facebook{{/facebookLink}}{{hideOnMobile}}.{{/hideOnMobile}}", "jetpack" ), // _inc/client/components/support-card/index.jsx:79
+__( "Like us on Facebook", "jetpack" ), // _inc/client/components/support-card/index.jsx:106
+__( "Follow Jetpack on Twitter", "jetpack" ), // _inc/client/components/support-card/index.jsx:98
+__( "Leave a Jetpack review", "jetpack" ), // _inc/client/components/support-card/index.jsx:90
+__( "{{supportLink}}View our support page{{/supportLink}}{{hideOnMobile}},{{/hideOnMobile}} {{forumLink}}check the forums for answers{{/forumLink}}{{hideOnMobile}}, or{{/hideOnMobile}} {{contactLink}}contact us directly{{/contactLink}}{{hideOnMobile}}.{{/hideOnMobile}}", "jetpack" ), // _inc/client/components/support-card/index.jsx:44
+__( "Contact Jetpack support staff directly", "jetpack" ), // _inc/client/components/support-card/index.jsx:68
+__( "Go to the WordPress.org support forums", "jetpack" ), // _inc/client/components/support-card/index.jsx:61
+__( "Go to Jetpack.com/support", "jetpack" ), // _inc/client/components/support-card/index.jsx:54
+__( "We offer free, full support to all of our Jetpack users. Our support team is always around to help you.", "jetpack" ), // _inc/client/components/support-card/index.jsx:41
+__( "Need help? The Jetpack team is here for you.", "jetpack" ), // _inc/client/components/support-card/index.jsx:38
+__( "Jetpack Happiness Engineer", "jetpack" ), // _inc/client/components/support-card/index.jsx:32
 );
 /* THIS IS THE END OF THE GENERATED FILE */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var autoprefixer = require( 'gulp-autoprefixer' ),
 	fs = require( 'fs' ),
 	gulp = require( 'gulp' ),
 	gutil = require( 'gulp-util' ),
-	glotpress = require( 'glotpress-js' ),
+	i18n_calypso = require( 'i18n-calypso/cli' ),
 	jshint = require( 'gulp-jshint' ),
 	phplint = require( 'gulp-phplint' ),
 	phpunit = require( 'gulp-phpunit' ),
@@ -18,6 +18,7 @@ var autoprefixer = require( 'gulp-autoprefixer' ),
 	sass = require( 'gulp-sass' ),
 	spawn = require( 'child_process' ).spawn,
 	sourcemaps = require( 'gulp-sourcemaps' ),
+	tap = require( 'gulp-tap' ),
 	util = require( 'gulp-util' ),
 	webpack = require( 'webpack' );
 
@@ -454,14 +455,26 @@ gulp.task( 'languages:cleanup', [ 'languages:build' ], function() {
 	);
 } );
 
-gulp.task( 'languages:extract', [ 'react:build' ], function( callback ) {
-	glotpress( {
-		inputPaths: [ '_inc/build/admin.js' ],
-		output: '_inc/jetpack-strings.php',
-		format: 'php'
-	} );
+gulp.task( 'languages:extract', function( done ) {
+	var paths = [];
 
-	callback();
+	gulp.src( [ '_inc/client/**/*.js', '_inc/client/**/*.jsx' ] )
+		.pipe( tap( function( file ) {
+			paths.push( file.path );
+		} ) )
+		.on( 'end', function() {
+			i18n_calypso( {
+				projectName: 'Jetpack',
+				inputPaths: paths,
+				output: '_inc/jetpack-strings.php',
+				phpArrayName: 'jetpack_strings',
+				format: 'PHP',
+				textdomain: 'jetpack',
+				keywords: [ 'translate', '__' ]
+			} );
+
+			done();
+		} );
 } );
 
 // Default task

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "distclean": "rm -rf node_modules",
     "build": "npm install && npm run build-client",
     "build-client": "gulp",
-    "build-production": "npm run build-languages && NODE_ENV=production npm run build",
+    "build-production": "npm run clean && npm run build && npm run build-languages && gulp languages:extract && NODE_ENV=production npm run build",
     "build-languages": "gulp languages",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "lint": "eslint _inc/client -c .eslintrc"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "gulp-sass": "^2.0.4",
     "gulp-sftp": "^0.1.5",
     "gulp-sourcemaps": "^1.6.0",
+    "gulp-tap": "^0.1.3",
     "gulp-util": "^3.0.6",
     "history": "2.0.0",
     "i18n-calypso": "github:automattic/i18n-calypso",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Makes sure that `npm run build-production` works well even without previous npm installations.
- Changes the way we use i18n: actually using `i18n-calypso` now, giving us the opportunity to add the textdomain string.
- Gathering translatable strings from uncompiled JavaScript code to have references to files and line numbers.

#### Testing instructions:
- Run `npm run build-script`, note that it would take a lot of time and generate lots of new language files. The main thing that we're currently interested in is the `_inc/jetpack-strings.php` file, it should contain all the translatable strings from `_inc/client/**/*.js*` files.
