### PR TITLE
Fix/infinite scroll wpml

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -768,7 +768,7 @@ class The_Neverending_Home_Page {
 			'google_analytics' => false,
 			'offset'           => self::wp_query()->get( 'paged' ),
 			'history'          => array(
-				'host'                 => preg_replace( '#^http(s)?://#i', '', untrailingslashit( get_option( 'home' ) ) ),
+				'host'                 => preg_replace( '#^http(s)?://#i', '', untrailingslashit( esc_url( get_home_url() ) ) ),
 				'path'                 => self::get_request_path(),
 				'use_trailing_slashes' => $wp_rewrite->use_trailing_slashes,
 				'parameters'           => self::get_request_parameters(),


### PR DESCRIPTION
Fixes # .
#### Changes proposed in this Pull Request:

Paged URL while using infinite scroll wasn't translating properly with WPML. 
Changed to get_home_url() so filters can be used. Also escaped URL.
#### Testing instructions:
1. Install WP, WPML & Jetpack
2. Finish WPML configuration, enable Jetpack IS module.
3. Add dummy content (20 posts) and translate with WPML.
4. Go to Blog page and scroll down and observe URL.

URLs are now seen properly, for example:
ENGLISH: http://jetpack.local/blog/page/2/
SPANISH: http://jetpack.local/es/spanish-blog/page/2/

There is also a problem when blog page permalinks are same across languages, than infinite scroll is not working at all. But that is another topic, I'm just mentioning it here.
## 
---
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
