### PR TITLE
ProStatus: Don't show wrong status if still fetching plugin data

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -82,7 +82,7 @@ const ProStatus = React.createClass( {
 				}
 			}
 
-			if ( false !== sitePlan ) {
+			if ( sitePlan.product_slug ) {
 				let btnVals = {};
 				if ( 'jetpack_free' !== sitePlan.product_slug ) {
 					btnVals = {


### PR DESCRIPTION
Fixes a bug where the pro card status would show the `Set Up` button while the plugin data was still fetching, then would change to `Active` (if on a pro plan)

**To Test:** 
- On a site that's on a Pro plan, and has akismet and VP set up and active, load the `/security` tab.  
- You should only see the `ACTIVE` status at any time.  
- Navigating away (another tab) and then back, the status should not change or disappear. 
- Repeat steps for the dashboard card 
- Repeat the steps for /search pro cards