### PR TITLE
Sync: Filter out callbacks from post types and taxonomies callables

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -17,10 +17,15 @@ class Jetpack_Sync_Functions {
 		$cloned_taxonomies = array();
 
 		foreach ( (array) $wp_taxonomies as $key => $taxonomy ) {
-			$clone = clone( $taxonomy );
-			unset( $clone->update_count_callback );
-			unset( $clone->meta_box_cb );
-			$cloned_taxonomies[ $key ] = $clone;
+			$cloned_taxonomy = new stdClass();
+			foreach( (array) get_object_vars( $taxonomy ) as $var_key => $value ) {
+				if ( in_array( $var_key, array( 'update_count_callback', 'meta_box_cb' ) ) ) {
+					continue;
+				}
+				$cloned_taxonomy->$var_key = $value;
+			}
+
+			$cloned_taxonomies[ $key ] = $cloned_taxonomy;
 		}
 
 		return $cloned_taxonomies;
@@ -31,9 +36,15 @@ class Jetpack_Sync_Functions {
 		$cloned_post_types = array();
 
 		foreach ( (array) $wp_post_types as $key => $post_type ) {
-			$clone = clone( $post_type );
-			unset( $clone->register_meta_box_cb );
-			$cloned_post_types[ $key ] = $clone;
+			$cloned_post_type = new stdClass();
+			foreach ( (array) get_object_vars( $post_type ) as $var_key => $value ) {
+				if ( 'register_meta_box_cb' == $var_key ) {
+					continue;
+				}
+				$cloned_post_type->$var_key = $value;
+			}
+
+			$cloned_post_types[ $key ] = $cloned_post_type;
 		}
 
 		return $cloned_post_types;

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -20,8 +20,15 @@ class Jetpack_Sync_Functions {
 
 	public static function get_post_types() {
 		global $wp_post_types;
+		$cloned_post_types = array();
 
-		return $wp_post_types;
+		foreach ( (array) $wp_post_types as $key => $post_type ) {
+			$clone = clone( $post_type );
+			unset( $clone->register_meta_box_cb );
+			$cloned_post_types[ $key ] = $clone;
+		}
+
+		return $cloned_post_types;
 	}
 
 	public static function get_post_type_features() {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -14,8 +14,16 @@ class Jetpack_Sync_Functions {
 
 	public static function get_taxonomies() {
 		global $wp_taxonomies;
+		$cloned_taxonomies = array();
 
-		return $wp_taxonomies;
+		foreach ( (array) $wp_taxonomies as $key => $taxonomy ) {
+			$clone = clone( $taxonomy );
+			unset( $clone->update_count_callback );
+			unset( $clone->meta_box_cb );
+			$cloned_taxonomies[ $key ] = $clone;
+		}
+
+		return $cloned_taxonomies;
 	}
 
 	public static function get_post_types() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -305,4 +305,13 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			$this->assertObjectNotHasAttribute( 'register_meta_box_cb', $post_type, "{$key} has the register_meta_box_cb attribute, which should be removed since it is a callback" );
 		}
 	}
+
+	function test_taxonomies_objects_do_not_have_meta_box_callback() {
+		$taxonomies = Jetpack_Sync_Functions::get_taxonomies();
+		foreach ( $taxonomies as $key => $taxonomy ) {
+			$this->assertInternalType( 'object', $taxonomy );
+			$this->assertObjectNotHasAttribute( 'update_count_callback', $taxonomy, "{$key} has the update_count_callback attribute, which should be removed since it is a callback" );
+			$this->assertObjectNotHasAttribute( 'meta_box_cb', $taxonomy, "{$key} has the meta_box_cb attribute, which should be removed since it is a callback" );
+		}
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -297,4 +297,13 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		return "{$parsed_url['scheme']}://www.{$parsed_url['host']}";
 	}
+
+	function test_post_types_objects_do_not_have_meta_box_callback() {
+		$post_types = Jetpack_Sync_Functions::get_post_types();
+		foreach ( $post_types as $key => $post_type ) {
+			$this->assertInternalType( 'object', $post_type );
+			$this->assertObjectNotHasAttribute( 'register_meta_box_cb', $post_type, "{$key} has the register_meta_box_cb attribute, which should be removed since it is a callback" );
+		}
+		
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -304,6 +304,5 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			$this->assertInternalType( 'object', $post_type );
 			$this->assertObjectNotHasAttribute( 'register_meta_box_cb', $post_type, "{$key} has the register_meta_box_cb attribute, which should be removed since it is a callback" );
 		}
-		
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -302,7 +302,37 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$post_types = Jetpack_Sync_Functions::get_post_types();
 		foreach ( $post_types as $key => $post_type ) {
 			$this->assertInternalType( 'object', $post_type );
+
+			// Did we get rid of the expected attribute?
 			$this->assertObjectNotHasAttribute( 'register_meta_box_cb', $post_type, "{$key} has the register_meta_box_cb attribute, which should be removed since it is a callback" );
+
+			// Did we preserve expected attributes?
+			$check_object_vars = array(
+				'labels',
+				'description',
+				'public',
+				'hierarchical',
+				'exclude_from_search',
+				'publicly_queryable',
+				'show_ui',
+				'show_in_menu',
+				'show_in_nav_menus',
+				'show_in_admin_bar',
+				'menu_position',
+				'menu_icon',
+				'capability_type',
+				'map_meta_cap',
+				'rewrite',
+				'query_var',
+				'can_export',
+				'delete_with_user',
+				'cap',
+				'label',
+			);
+
+			foreach ( $check_object_vars as $test ) {
+				$this->assertObjectHasAttribute( $test, $post_type, "Post type does not have expected {$test} attribute." );
+			}
 		}
 	}
 
@@ -310,8 +340,29 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$taxonomies = Jetpack_Sync_Functions::get_taxonomies();
 		foreach ( $taxonomies as $key => $taxonomy ) {
 			$this->assertInternalType( 'object', $taxonomy );
+
+			// Did we get rid of the expected attributes?
 			$this->assertObjectNotHasAttribute( 'update_count_callback', $taxonomy, "{$key} has the update_count_callback attribute, which should be removed since it is a callback" );
 			$this->assertObjectNotHasAttribute( 'meta_box_cb', $taxonomy, "{$key} has the meta_box_cb attribute, which should be removed since it is a callback" );
+
+			// Did we preserve the expected attributes?
+			$check_object_vars = array(
+				'labels',
+				'description',
+				'public',
+				'publicly_queryable',
+				'hierarchical',
+				'show_ui',
+				'show_in_menu',
+				'show_in_nav_menus',
+				'show_tagcloud',
+				'show_in_quick_edit',
+				'show_admin_column',
+				'rewrite',
+			);
+			foreach ( $check_object_vars as $test ) {
+				$this->assertObjectHasAttribute( $test, $taxonomy, "Taxonomy does not have expected {$test} attribute." );
+			}
 		}
 	}
 }


### PR DESCRIPTION
We had a report of the following warnings and error:

```
[21-Aug-2016 15:53:14 UTC] PHP Fatal error: Allowed memory size of 134217728
bytes exhausted (tried to allocate 130968 bytes) in
/wp-content/plugins/jetpack/sync/class.jetpack-sync-json-deflate-codec.php on
line 39

[21-Aug-2016 15:58:25 UTC] PHP Warning: unserialize(): Function
spl_autoload_call() hasn't defined the class it was called for in
/wp-content/plugins/jetpack/sync/class.jetpack-sync-json-deflate-codec.php on
line 17

[21-Aug-2016 20:11:59 UTC] PHP Fatal error: Maximum execution time of 300
seconds exceeded in
/wp-content/plugins/jetpack/sync/class.jetpack-sync-json-deflate-codec.php on
line 38
```

The user did some debugging and was able to narrow the issue down to the fact that they have plugins that use the `meta_box_cb` argument when registering taxonomies. When the user turned off taxonomies, errors went away.

Further, the user reported that the infinite loops were likely due to circular references where the callback pointed back to the post type or taxonomy and around and around it went.

Since we are likely not interested in these callbacks, let's not sync them.

To test:

- Run tests locally


cc @lezama for review