### PR TITLE
Fix/non admin permissions

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -17,7 +17,10 @@ injectTapEventPlugin();
  * Internal dependencies
  */
 import { filterSearch } from 'state/search';
-import { userCanManageModules as _userCanManageModules } from 'state/initial-state';
+import {
+	userCanManageModules as _userCanManageModules,
+	userIsSubscriber as _userIsSubscriber
+} from 'state/initial-state';
 
 const NavigationSettings = React.createClass( {
 	openSearch: function() {
@@ -93,6 +96,16 @@ const NavigationSettings = React.createClass( {
 					</NavItem>
 				</NavTabs>
 			);
+		} else if ( this.props.isSubscriber ) {
+			navItems = (
+				<NavTabs selectedText={ this.props.route.name }>
+					<NavItem
+						path="#general"
+						selected={ ( this.props.route.path === '/general' || this.props.route.path === '/settings' ) }>
+						{ __( 'General', { context: 'Navigation item.' } ) }
+					</NavItem>
+				</NavTabs>
+			);
 		} else {
 			navItems = (
 				<NavTabs selectedText={ this.props.route.name }>
@@ -133,7 +146,8 @@ NavigationSettings.contextTypes = {
 export default connect(
 	( state ) => {
 		return {
-			userCanManageModules: _userCanManageModules( state )
+			userCanManageModules: _userCanManageModules( state ),
+			isSubscriber: _userIsSubscriber( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -7,7 +7,10 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { userCanViewStats as _userCanViewStats } from 'state/initial-state';
+import {
+	userCanViewStats as _userCanViewStats,
+	userIsSubscriber as _userIsSubscriber
+} from 'state/initial-state';
 import { isModuleActivated as _isModuleActivated } from 'state/modules';
 import Navigation from 'components/navigation';
 import NavigationSettings from 'components/navigation-settings';
@@ -47,12 +50,16 @@ const NonAdminView = React.createClass( {
 				pageComponent = <GeneralSettings { ...this.props } />;
 				break;
 			case '/engagement':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <Engagement { ...this.props } />;
+				if ( ! this.props.isSubscriber ) {
+					navComponent = <NavigationSettings { ...this.props } />;
+					pageComponent = <Engagement { ...this.props } />;
+				}
 				break;
 			case '/writing':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <Writing { ...this.props } />;
+				if ( ! this.props.isSubscriber ) {
+					navComponent = <NavigationSettings { ...this.props } />;
+					pageComponent = <Writing { ...this.props } />;
+				}
 				break;
 
 			default:
@@ -81,6 +88,7 @@ export default connect(
 	( state ) => {
 		return {
 			userCanViewStats: _userCanViewStats( state ),
+			isSubscriber: _userIsSubscriber( state ),
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
 		};
 	}

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -90,7 +90,7 @@ export const Engagement = ( props ) => {
 			isModuleActive = isModuleActivated( element[0] );
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );
-		} else if ( adminAndNonAdmin ) {
+		} else if ( isAdmin ) {
 			toggle = <ModuleToggle slug={ element[0] }
 						activated={ isModuleActivated( element[0] ) }
 						toggling={ isTogglingModule( element[0] ) }

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -75,6 +75,10 @@ export function isSitePublic( state ) {
 	return get( state.jetpack.initialState, [ 'connectionStatus', 'isPublic' ] );
 }
 
+export function userIsSubscriber( state ) {
+	return ! get( state.jetpack.initialState.userData.currentUser.permissions, 'edit_posts', false );
+}
+
 export function userCanManageModules( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'manage_modules', false );
 }

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -68,7 +68,7 @@ export const Writing = ( props ) => {
 			adminAndNonAdmin = isAdmin || includes( nonAdminAvailable, element[0] );
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );
-		} else if ( adminAndNonAdmin ) {
+		} else if ( isAdmin ) {
 			toggle = <ModuleToggle slug={ element[0] }
 				activated={ isModuleActivated( element[0] ) }
 				toggling={ isTogglingModule( element[0] ) }


### PR DESCRIPTION
Fixes #4948

- New state selector `userIsSubscriber()`
- Subscribers will only be able to view the `/general` settings tab
- Settings card toggles will be hidden from ALL non-admins

**To Test:** 
- Create a subscriber user 
- Log in and verify that you only see the `general` tab in settings 
- Verify that you can't sneak your way into it by manually inputting `/writing` as the url path
- Verify that other non-admin roles no longer can see the settings toggles 
- Verify that you can still link/unlink as a subscriber and other non-admin roles
- Verify that things still look normal as an admin. 