### PR TITLE
Build Script: npm install before production build

### DIFF
--- a/tools/deploy-to-master-stable-branch.sh
+++ b/tools/deploy-to-master-stable-branch.sh
@@ -41,7 +41,8 @@ echo ""
 
 echo "Building Jetpack"
 npm run distclean
-NODE_ENV=production npm run build
+npm install
+NODE_ENV=production npm run build-client
 echo "Done"
 
 # Prep a home to drop our new files in. Just make it in /tmp so we can start fresh each time.


### PR DESCRIPTION
Building the production plugin requires gulp, so let's install everything before we run production.  