### PR TITLE
Admin Page: Redistribute dependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "lint": "eslint _inc/client -c .eslintrc"
   },
-  "devDependencies": {
+  "dependencies": {
+    "del": "^2.2.0",
     "@automattic/custom-colors-loader": "automattic/custom-colors-loader",
     "@automattic/dops-components": "automattic/dops-components",
     "babel-core": "6.8.0",
@@ -35,11 +36,8 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
-    "babel-register": "^6.8.0",
     "babel-runtime": "^6.6.1",
-    "chai": "^3.5.0",
     "classnames": "2.2.1",
-    "commander": "2.3.0",
     "css-loader": "0.23.1",
     "es6-promise": "3.0.2",
     "eslint": "1.7.3",
@@ -71,16 +69,12 @@
     "gulp-tap": "^0.1.3",
     "gulp-util": "^3.0.6",
     "history": "2.0.0",
-    "i18n-calypso": "github:automattic/i18n-calypso",
     "jsdom": "^9.2.1",
+    "i18n-calypso": "github:automattic/i18n-calypso",
     "jshint": "2.9.1",
     "jshint-stylish": "~2.1.0",
     "lodash": "^4.9.0",
-    "mocha": "^2.4.5",
-    "mockery": "^1.4.1",
-    "nock": "^7.2.2",
     "node-sass": "3.4.2",
-    "qunitjs": "~1.20.0",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
     "react-dom": "0.14.3",
@@ -93,18 +87,24 @@
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1",
     "sass-loader": "3.1.2",
+    "style-loader": "0.13",
+    "webpack": "1.12.9",
+    "whatwg-fetch": "^1.0.0"
+  },
+  "devDependencies": {
+    "babel-register": "^6.8.0",
+    "chai": "^3.5.0",
+    "commander": "2.3.0",
+    "mocha": "^2.4.5",
+    "mockery": "^1.4.1",
+    "nock": "^7.2.2",
+    "qunitjs": "~1.20.0",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "sinon-qunit": "~2.0.0",
-    "style-loader": "0.13",
-    "webpack": "1.12.9",
-    "webpack-dev-server": "1.14.0",
-    "whatwg-fetch": "^1.0.0"
+    "webpack-dev-server": "1.14.0"
   },
   "engines": {
     "node": ">=0.8"
-  },
-  "dependencies": {
-    "del": "^2.2.0"
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Redistributes `dependencies` and `devDependencies` in `package.json `for a minimum viable set of dependencies to be available for running `NODE_ENV=production npm run build`

#### Testing instructions

1. clone this branch
1. Run `npm run distclean`
1. Run
  ```
  $ NODE_ENV=production npm run build
1. Expect to see no errors, build working and files generated in `_inc/builld`.
  ```