### PR TITLE
Admin - Post by Email: make each user have a different email address

### DIFF
--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -19,6 +19,8 @@ import {
 	getAdminEmailAddress
 } from 'state/initial-state';
 
+import { isCurrentUserLinked } from 'state/connection';
+
 /**
  * High order component that connects to Jetpack modules'options
  * redux state selectors and action creators.
@@ -34,7 +36,8 @@ export function connectModuleOptions( Component ) {
 				getOptionCurrentValue: ( module_slug, option_name ) => getModuleOption( state, module_slug, option_name ),
 				getSiteRoles: () => getSiteRoles( state ),
 				isUpdating: ( option_name ) => isUpdatingModuleOption( state, ownProps.module.module, option_name ),
-				adminEmailAddress: getAdminEmailAddress( state )
+				adminEmailAddress: getAdminEmailAddress( state ),
+				isCurrentUserLinked: isCurrentUserLinked( state )
 			}
 		},
 		( dispatch, ownProps ) => ( {

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -8,6 +8,7 @@ import TextInput from 'components/text-input';
 import Textarea from 'components/textarea';
 import TagsInput from 'components/tags-input';
 import ClipboardButtonInput from 'components/clipboard-button-input';
+import ConnectButton from 'components/connect-button';
 import get from 'lodash/get';
 import Button from 'components/button';
 
@@ -535,11 +536,11 @@ TiledGallerySettings = moduleSettingsForm( TiledGallerySettings );
 
 export let PostByEmailSettings = React.createClass( {
 	regeneratePostByEmailAddress( event ) {
-		event.preventDefault()
+		event.preventDefault();
 		this.props.regeneratePostByEmailAddress();
 	},
 	address() {
-		const currentValue = this.props.getOptionValue( 'post_by_email_address' )
+		const currentValue = this.props.getOptionValue( 'post_by_email_address' );
 		// If the module Post-by-email is enabled BUT it's configured as disabled
 		// Its value is set to false
 		if ( currentValue === false ) {
@@ -549,23 +550,35 @@ export let PostByEmailSettings = React.createClass( {
 	},
 	render() {
 		return (
-			<form>
-				<FormFieldset>
-					<FormLabel>
-						<FormLegend>{ __( 'Email Address' ) }</FormLegend>
-						<ClipboardButtonInput
-							value={ this.address() }
-							copy={ __( 'Copy', { context: 'verb' } ) }
-							copied={ __( 'Copied!' ) }
-							prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
-						/>
-						<FormButton
-							onClick={ this.regeneratePostByEmailAddress } >
-							{ __( 'Regenerate address' ) }
-						</FormButton>
-					</FormLabel>
-				</FormFieldset>
-			</form>
+			this.props.isCurrentUserLinked ?
+				<form>
+					<FormFieldset>
+						<FormLabel>
+							<FormLegend>{ __( 'Email Address' ) }</FormLegend>
+							<ClipboardButtonInput
+								value={ this.address() }
+								copy={ __( 'Copy', { context: 'verb' } ) }
+								copied={ __( 'Copied!' ) }
+								prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+							/>
+							<FormButton
+								onClick={ this.regeneratePostByEmailAddress } >
+								{ __( 'Regenerate address' ) }
+							</FormButton>
+						</FormLabel>
+					</FormFieldset>
+				</form>
+				:
+				<div>
+					{
+						<div className="jp-connection-settings">
+							<div className="jp-connection-settings__headline">{ __( 'Link your account to WordPress.com to start using this feature.' ) }</div>
+							<div className="jp-connection-settings__actions">
+								<ConnectButton connectUser={ true } />
+							</div>
+						</div>
+					}
+				</div>
 		)
 	}
 } );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -892,7 +892,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		if ( empty( $module ) ) {
-			$module = self::get_module_requested( '/module/(?P<slug>[a-z\-]+)/update' );
+			$module = self::get_module_requested();
 			if ( empty( $module ) ) {
 				return array();
 			}
@@ -1766,7 +1766,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return array
 	 */
-	public static function get_module_requested( $route ) {
+	public static function get_module_requested( $route = '/module/(?P<slug>[a-z\-]+)' ) {
 
 		if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
 			return '';
@@ -2010,6 +2010,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool Whether user is receiving notifications or not.
 	 */
 	public static function get_remote_value( $module, $option ) {
+
+		if ( in_array( $module, array( 'post-by-email' ), true ) ) {
+			$option .= get_current_user_id();
+		}
 
 		// If option doesn't exist, 'does_not_exist' will be returned.
 		$value = get_option( $option, 'does_not_exist' );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -880,22 +880,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return array
 	 */
-	public static function get_module_available_options( $module = '', $cache = true ) {
-		if ( $cache ) {
-			static $options;
-		} else {
-			$options = null;
-		}
-
-		if ( isset( $options ) ) {
-			return $options;
-		}
+	public static function get_module_available_options( $module = '' ) {
+		$options = array();
 
 		if ( empty( $module ) ) {
 			$module = self::get_module_requested();
-			if ( empty( $module ) ) {
-				return array();
-			}
 		}
 
 		switch ( $module ) {
@@ -1827,7 +1816,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return array
 	 */
 	public static function prepare_options_for_response( $module = '' ) {
-		$options = self::get_module_available_options( $module, false );
+		$options = self::get_module_available_options( $module );
 
 		if ( ! is_array( $options ) || empty( $options ) ) {
 			return $options;

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -646,15 +646,28 @@ class Jetpack_Core_API_Module_Endpoint
 		}
 
 		// Used only in Jetpack_Core_Json_Api_Endpoints::get_remote_value.
-		update_option( 'post_by_email_address', $response );
+		update_option( 'post_by_email_address' . get_current_user_id(), $response );
 
 		return $response;
 	}
 
+	/**
+	 * Check if user is allowed to perform the update.
+	 *
+	 * @since 4.3
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return bool
+	 */
 	public function can_request( $request ) {
 		if ( 'GET' === $request->get_method() ) {
 			return current_user_can( 'jetpack_admin_page' );
 		} else {
+			// User is trying to create, regenerate or delete its PbE address.
+			if ( 'post-by-email' === Jetpack_Core_Json_Api_Endpoints::get_module_requested() ) {
+				return current_user_can( 'edit_posts' ) && current_user_can( 'jetpack_admin_page' );
+			}
 			return current_user_can( 'jetpack_configure_modules' );
 		}
 	}

--- a/modules/post-by-email.php
+++ b/modules/post-by-email.php
@@ -200,9 +200,9 @@ class Jetpack_Post_By_Email {
 			wp_send_json_error( $error_message );
 		}
 
-		wp_send_json_success( $response );
-
 		// Will be used only in Jetpack_Core_Json_Api_Endpoints::get_remote_value.
-		update_option( 'post_by_email_address', $response );
+		update_option( 'post_by_email_address' . get_current_user_id(), $response );
+
+		wp_send_json_success( $response );
 	}
 }


### PR DESCRIPTION
Fixes #4949

#### Changes proposed in this Pull Request:
- use have a different email address for each user
- allow users with edit_posts permissions to generate their address.

#### Testing instructions:
- make sure the email address of a user with edit_posts permissions, like an editor, is different than the one from another user with similar rights
- regenerate the email address of an editor, make sure it works