### PR TITLE
Admin Page: Move enqueuing of admin page stylesheets to <head>

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -36,6 +36,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		// Adding a redirect meta tag wrapped in noscript tags for all browsers in case they have JavaScript disabled
 		add_action( 'admin_head', array( $this, 'add_noscript_head_meta' ) );
 
+		// Enqueue admin page styles in head
+		add_action( 'admin_head', array( $this, 'page_admin_styles' ) );
+
 		// Adding a redirect tag wrapped in browser conditional comments
 		add_action( 'admin_head', array( $this, 'add_legacy_browsers_head_script' ) );
 	}
@@ -175,18 +178,22 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		);
 	}
 
+	function page_admin_styles() {
+		$rtl = is_rtl() ? '.rtl' : '';
+		
+		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/admin.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+	}
+
 	function page_admin_scripts() {
 		if ( $this->is_redirecting ) {
 			return; // No need for scripts on a fallback page
 		}
 
 		$is_dev_mode = Jetpack::is_development_mode();
-		$rtl = is_rtl() ? '.rtl' : '';
 
 		// Enqueue jp.js and localize it
 		wp_enqueue_script( 'react-plugin', plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION, true );
-		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/admin.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
-		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 
 		if ( ! $is_dev_mode ) {
 			// Required for Analytics


### PR DESCRIPTION
Fixes #4946 .

#### Changes proposed in this Pull Request:

-Creates a new method `page_admin_styles()` on the Jetpack React Admin page class to be called on `admin_head` action.

#### Testing instructions:
1. Clone this branch
1. Using Chrome dev tools, switch **Network conditions** to `Regular 3G`
1. Try loading the admin page 
1. You should not see what's shown in #4946 screenshot. You should see the gray-ish background with the WordPress.com logo

