### PR TITLE
CSS Concatenating: update list of styles

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -46,10 +46,10 @@ class Jetpack {
 		'widget-conditions',
 		'jetpack_display_posts_widget',
 		'gravatar-profile-widget',
-		'widget-grid-and-list',
 		'jetpack-widgets',
 		'goodreads-widget',
 		'jetpack_social_media_icons_widget',
+		'jetpack-top-posts-widget',
 	);
 
 	public $plugins_to_deactivate = array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -42,14 +42,15 @@ class Jetpack {
 		'jetpack-slideshow',
 		'presentations',
 		'jetpack-subscriptions',
+		'jetpack-responsive-videos-style',
+		'jetpack-social-menu',
 		'tiled-gallery',
-		'widget-conditions',
 		'jetpack_display_posts_widget',
 		'gravatar-profile-widget',
-		'jetpack-widgets',
 		'goodreads-widget',
 		'jetpack_social_media_icons_widget',
 		'jetpack-top-posts-widget',
+		'jetpack_image_widget',
 	);
 
 	public $plugins_to_deactivate = array(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -241,7 +241,7 @@ frontendcss = [
 	'modules/widgets/goodreads/css/goodreads.css',
 	'modules/widgets/social-media-icons/style.css',
 	'modules/widgets/top-posts/style.css',
-	'modules/widgets/widgets.css' // TODO Moved to image-widget/style.css
+	'modules/widgets/image-widget/style.css'
 ];
 
 gulp.task( 'old-styles:watch', function() {

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -308,7 +308,6 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		switch ( $display ) {
 		case 'list' :
 		case 'grid' :
-			wp_enqueue_style( 'widget-grid-and-list' );
 			foreach ( $posts as &$post ) {
 				$image = Jetpack_PostImages::get_image( $post['post_id'], array( 'fallback_to_avatars' => true ) );
 				$post['image'] = $image['src'];


### PR DESCRIPTION
- Top Posts: update how the stylesheet is enqueued and concatenated

Before this commit, the stylesheet was enqueued on the page, and also added to jetpack.css.
I removed all references to the old stylesheet name (`widget-grid-and-list`), and made sure the stylesheet was concatenated, and dequeued when concatenated.

cc @jb510

- Updated the list to use all styles that should be concatenated.