### PR TITLE
Don’t accept default arguments for `jetpack_client_authorized` action

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -18,7 +18,7 @@ class Jetpack_Sync_Actions {
 		add_filter( 'cron_schedules', array( __CLASS__, 'minute_cron_schedule' ) );
 
 		// On jetpack authorization, schedule a full sync
-		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ) );
+		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ), 10, 0 );
 
 		// When imports are finished, schedule a full sync
 		add_action( 'import_end', array( __CLASS__, 'schedule_full_sync' ) );
@@ -65,6 +65,8 @@ class Jetpack_Sync_Actions {
 				is_user_logged_in()
 				||
 				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
+				||
+				defined( '')
 			)
 		) ) {
 			self::initialize_listener();

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -65,8 +65,6 @@ class Jetpack_Sync_Actions {
 				is_user_logged_in()
 				||
 				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
-				||
-				defined( '')
 			)
 		) ) {
 			self::initialize_listener();

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -145,6 +145,11 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );
 	}
 
+	function test_schedules_full_sync_on_client_authorized() {
+		do_action( 'jetpack_client_authorized', 'abcd1234' ); // Jetpack_Options::get_option( 'id' )
+		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );
+	}
+
 	function test_enqueues_full_sync_after_import() {
 		do_action( 'import_end' );
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );


### PR DESCRIPTION
Fixes an issue where initial sync was scheduled with the Jetpack ID instead of "real" configuration for the job.