### PR TITLE
Jump Start: update module state after jumpstarting

### DIFF
--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -18,6 +18,7 @@ import {
 	JUMPSTART_SKIP_FAIL
 } from 'state/action-types';
 import restApi from 'rest-api';
+import { fetchModules } from 'state/modules';
 
 export const jumpStartActivate = () => {
 	return ( dispatch ) => {
@@ -34,6 +35,7 @@ export const jumpStartActivate = () => {
 			analytics.tracks.recordEvent( 'jetpack_wpa_jumpstart_submit', {} );
 			dispatch( removeNotice( 'jumpstart-activate' ) );
 			dispatch( createNotice( 'is-success', __( 'Recommended features active.' ), { id: 'jumpstart-activate' } ) );
+			dispatch( fetchModules() );
 		} ).catch( error => {
 			dispatch( {
 				type: JUMPSTART_ACTIVATE_FAIL,


### PR DESCRIPTION
Fixes a bug in which the module state tree was not being updated after activating Jump Start, so the Jump Started modules did not appear as active after jumpstarting.  

**To Test:**
- Click `reset options` and then refresh the page. 
- Click to `jump start`
- Verify that the "recommended features" (example, Photon) appear as active on the dashboard and in their respective tabs.  