### PR TITLE
Likes: move settings below other notification settings

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -299,7 +299,7 @@ class Jetpack_Likes {
 	<script type="text/javascript">
 	jQuery( function( $ )  {
 		var table = $( '#social_notifications_like' ).parents( 'table:first' ),
-			header = table.prevAll( 'h3:first' ),
+			header = table.prevAll( 'h2:first' ),
 			newParent = $( '#moderation_notify' ).parent( 'label' ).parent();
 
 		if ( !table.length || !header.length || !newParent.length ) {


### PR DESCRIPTION
WordPress used h3 for its settings section headings before. Since it switched to h2,
the JavaScript that we used to move our Like notification inside the core Notifications settings was broken.

Before patch:
<img width="595" alt="likes-notification" src="https://cloud.githubusercontent.com/assets/426388/18468860/1d3d4d96-79a6-11e6-9528-8b4fdcc93ae2.png">

After patch:

<img width="558" alt="likes-fixed" src="https://cloud.githubusercontent.com/assets/426388/18468940/72386416-79a6-11e6-9787-1b9263b536ec.png">
