### PR TITLE
Admin: don't always scroll to the top when clicking on a tab

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -103,9 +103,6 @@ const Main = React.createClass( {
 		// Track page views
 		analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: route } );
 
-		// On any route change/re-render, jump back to the top of the page
-		window.scrollTo( 0, 0 );
-
 		if ( ! canManageModules ) {
 			return <NonAdminView { ...this.props } />
 		}
@@ -253,7 +250,13 @@ window.wpNavMenuClassChange = function() {
 		subNavItem[0].classList.add( 'current' );
 	}
 
-	jQuery( 'body' ).on( 'click', '.jetpack-js-stop-propagation', function( e ) {
+	const $body = jQuery( 'body' );
+
+	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#security"], .dops-button[href="#professional"]', function() {
+		window.scrollTo( 0, 0 );
+	} );
+
+	$body.on( 'click', '.jetpack-js-stop-propagation', function( e ) {
 		e.stopPropagation();
 	} );
 };


### PR DESCRIPTION
Currently, whenever you click a tab, the scroll jumps to the top. This is annoying if the user scrolled down past the header and notices to leave only the tabs visible.

#### Changes proposed in this Pull Request:
- do not jump when switching tabs
- do jump when changing from Dashboard to Settings or viceversa

#### Testing instructions:
- go to Jetpack > Dashboard
- scroll down leaving only the tabs visible at the top
- click on each tab, the body shouldn't scroll back to the top
- click on Settings in the WP menu, now it should scroll back to the top
- scroll down
- click on Dashboard, it should scroll back to the top