### PR TITLE
svnignore: remove mapped files from the build

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -20,5 +20,10 @@ to-test.md
 .editorconfig
 _inc/client
 _inc/build/admin.js.map
+_inc/build/static.js.map
 _inc/build/dops-style.css.map
+_inc/build/admin.dops-style.rtl.css.map
+_inc/build/static.dops-style.css.map
+_inc/build/static.dops-style.rtl.css.map
+_inc/build/style.min.rtl.css.map
 .codeclimate.yml


### PR DESCRIPTION
Save us over 5M (unzipped) in size.  This will also affect the builds to master-stable.  