### PR TITLE
Publicize: Fixes an issue where PressThis posts were not publicized

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -289,6 +289,8 @@ abstract class Publicize_Base {
 			!did_action( 'wp_ajax_instapost_publish' )
 		&&
 			!did_action( 'wp_ajax_post_reblog' )
+		&&
+			!did_action( 'wp_ajax_press-this-save-post' )
 		) {
 			$submit_post = false;
 		}


### PR DESCRIPTION
In #4906, it was reported that publicize was no longer working when publishing via PressThis. 

After quite a bit of debugging, I was able to narrow it down to the fact that we only allow publicizing posts via AJAX under certain conditions. This was easily fixed by changing the conditional in this PR. Previously, when we saved a post via AJAX, we initially add the post flag for publicize a post, but then remove it

But, the bigger question that remains is, should we not allow publicize for posts via AJAX by default? Or, should we at least add a filter to allow plugins the ability to control this?

To test:

- Checkout `fix/publicize-from-press-this` branch
- Ensure you have publicize enabled and have at least one connection
- Publish post via PressThis
- Verify that the post was publicized

cc @gravityrail @kraftbj @lezama for code review.


