### PR TITLE
Made static generation task clean up after itself.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,7 +105,7 @@ function doRTL( files, done ) {
 		.pipe( gulp.dest( './_inc/build' ) )
 		.on( 'end', function() {
 			console.log( 'main' === files ? 'Dashboard RTL CSS finished.' : 'DOPS Components RTL CSS finished.' );
-			if ( done ) {
+			if ( done && 'function' === typeof done ) {
 				done();
 			}
 		} );
@@ -171,12 +171,11 @@ function doStatic( done ) {
 
 		try {
 			path = __dirname + '/_inc/build/static.js';
-			static_files = [];
 
 			delete require.cache[ path ]; // Making sure NodeJS requires this file every time this is called
 			require( path );
 
-			gulp.src( [ '_inc/build/static*', '!*html' ] )
+			gulp.src( [ '_inc/build/static*' ] )
 				.pipe( tap( function( file ) {
 					fs.unlinkSync( file.path );
 				} ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Makes the static file generation job run after dops-components styles and RTL styles have finished running.
- Removes intermediate files that were used to generate static HTML on each build/watch.

#### Testing instructions:
- Build the plugin or make changes in watch mode.
- Only files that start with `static` in the `_inc/build` folder should be HTML files: no CSS, JS or MAP files.
- Make sure that the static loading screen works as usual, plus the notices on the fallback page.

cc @eliorivero because you have worked on the RTL task recently