### PR TITLE
Gulp: Fix frontend css paths to images

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-download-stream": "0.0.13",
     "gulp-jshint": "2.0.0",
     "gulp-live-server": "0.0.28",
+    "gulp-modify": "0.1.1",
     "gulp-open": "^1.0.0",
     "gulp-phplint": "^0.0.6",
     "gulp-phpunit": "^0.14.0",


### PR DESCRIPTION
Fixes #4972

This adds the missing `transformRelativePath` function that was used in Grunt [#](https://github.com/Automattic/jetpack/blob/branch-4.2/Gruntfile.js#L4-L33) that would transform the relative image paths to absolute during the `frontendcss` task.  

**To Test:** 
- `npm install` for new dependencies  
- run `gulp frontendcss`
- Make sure that the images have the correct paths.  you can check this by inserting a Carousel and checking for the arrow images, as described in the issue linked.   