### PR TITLE
Travis: Increase MySQL's default wait timeout on open connection to 360.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ before_script:
     - source ~/.nvm/nvm.sh && nvm install 5
     - export PLUGIN_SLUG=$(basename $(pwd))
     - ./tests/prepare-wordpress.sh
+    - mysql -e "set global wait_timeout = 360;"
 
 script:
     - ./tests/run-travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_script:
     - source ~/.nvm/nvm.sh && nvm install 5
     - export PLUGIN_SLUG=$(basename $(pwd))
     - ./tests/prepare-wordpress.sh
-    - mysql -e "set global wait_timeout = 360;"
+    - mysql -e "set global wait_timeout = 3600;"
 
 script:
     - ./tests/run-travis.sh


### PR DESCRIPTION
Travis CI has a small timeout of 180 seconds while the default is 28800.
This is why tests are passing locally and why we are seeing travis randomly failing on new PRs.

This PR increases the value to a cautious 360.

We have too many tests 🎉! 

props @gravityrail for contacting Travis!