### PR TITLE
OG Tags: add the OG Tags plugin to the conflicting list.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -214,6 +214,7 @@ class Jetpack {
 		'nextgen-facebook/nextgen-facebook.php',                 // NextGEN Facebook OG
 		'social-networks-auto-poster-facebook-twitter-g/NextScripts_SNAP.php',
 		                                                         // NextScripts SNAP
+		'og-tags/og-tags.php',                                   // OG Tags
 		'opengraph/opengraph.php',                               // Open Graph
 		'open-graph-protocol-framework/open-graph-protocol-framework.php',
 		                                                         // Open Graph Protocol Framework


### PR DESCRIPTION
@see https://wordpress.org/support/topic/remove-jetpack-open-graph-tags-with-og-tags-plugin