### PR TITLE
Tests: Do not test on Trunk while waiting for https://core.trac.wordp…

### DIFF
--- a/tests/prepare-wordpress.sh
+++ b/tests/prepare-wordpress.sh
@@ -3,7 +3,7 @@
 # If this is an NPM environment test we don't need a developer WordPress checkout
 
 if [ "$WP_TRAVISCI" != "phpunit" ]; then
-    exit 0;
+	exit 0;
 fi
 
 # This prepares a developer checkout of WordPress for running the test suite on Travis
@@ -12,32 +12,32 @@ mysql -u root -e "CREATE DATABASE wordpress_tests;"
 
 CURRENT_DIR=$(pwd)
 
-for WP_SLUG in 'master' 'latest' 'previous'; do
-    echo "Preparing $WP_SLUG WordPress...";
+for WP_SLUG in 'latest' 'previous'; do
+	echo "Preparing $WP_SLUG WordPress...";
 
-    cd $CURRENT_DIR/..
+	cd $CURRENT_DIR/..
 
-    case $WP_SLUG in
+	case $WP_SLUG in
 	master)
-	    git clone --depth=1 --branch master git://develop.git.wordpress.org/ /tmp/wordpress-master
-	    ;;
+		git clone --depth=1 --branch master git://develop.git.wordpress.org/ /tmp/wordpress-master
+		;;
 	latest)
-	    git clone --depth=1 --branch `php ./$PLUGIN_SLUG/tests/get-wp-version.php` git://develop.git.wordpress.org/ /tmp/wordpress-latest
-	    ;;
+		git clone --depth=1 --branch `php ./$PLUGIN_SLUG/tests/get-wp-version.php` git://develop.git.wordpress.org/ /tmp/wordpress-latest
+		;;
 	previous)
-	    git clone --depth=1 --branch `php ./$PLUGIN_SLUG/tests/get-wp-version.php --previous` git://develop.git.wordpress.org/ /tmp/wordpress-previous
-	    ;;
-    esac
+		git clone --depth=1 --branch `php ./$PLUGIN_SLUG/tests/get-wp-version.php --previous` git://develop.git.wordpress.org/ /tmp/wordpress-previous
+		;;
+	esac
 
-    cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_SLUG/src/wp-content/plugins/$PLUGIN_SLUG"
-    cd /tmp/wordpress-$WP_SLUG
+	cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_SLUG/src/wp-content/plugins/$PLUGIN_SLUG"
+	cd /tmp/wordpress-$WP_SLUG
 
-    cp wp-tests-config-sample.php wp-tests-config.php
-    sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-    sed -i "s/yourusernamehere/root/" wp-tests-config.php
-    sed -i "s/yourpasswordhere//" wp-tests-config.php
+	cp wp-tests-config-sample.php wp-tests-config.php
+	sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
+	sed -i "s/yourusernamehere/root/" wp-tests-config.php
+	sed -i "s/yourpasswordhere//" wp-tests-config.php
 
-    echo "Done!";
+	echo "Done!";
 done
 
 exit 0;

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -2,15 +2,6 @@
 
 if [ "$WP_TRAVISCI" == "phpunit" ]; then
 
-    echo "Testing on WordPress master..."
-    cd /tmp/wordpress-master/src/wp-content/plugins/$PLUGIN_SLUG
-    if $WP_TRAVISCI; then
-	# Everything is fine
-	:
-    else
-        exit 1
-    fi
-    
     echo "Testing on WordPress stable..."
     cd /tmp/wordpress-latest/src/wp-content/plugins/$PLUGIN_SLUG
     if $WP_TRAVISCI; then


### PR DESCRIPTION
Tests are failing now, I think, because develop.git.wordpress.org requires building after https://core.trac.wordpress.org/changeset/38411

We can switch to the build repo, but at the moment, let's ignore trunk while we get 4.2.3 out.