### PR TITLE
Sharing / Likes: add new filter to customize the heading HTML.

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -787,8 +787,14 @@ class Jetpack_Likes {
 		$src = sprintf( '//widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s', $blog_id, $post->ID, $domain, $uniqid );
 		$name = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post->ID, $uniqid );
 		$wrapper = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post->ID, $uniqid );
+		$headline = sprintf(
+			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
+			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>',esc_html__( 'Like this:', 'jetpack' ), 'likes' ),
+			esc_html__( 'Like this:', 'jetpack' )
+		);
 
-		$html  = "<div class='sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded' id='$wrapper' data-src='$src' data-name='$name'><h3 class='sd-title'>" . esc_html__( 'Like this:', 'jetpack' ) . '</h3>';
+		$html  = "<div class='sharedaddy sd-block sd-like jetpack-likes-widget-wrapper jetpack-likes-widget-unloaded' id='$wrapper' data-src='$src' data-name='$name'>";
+		$html .= $headline;
 		$html .= "<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'><span class='button'><span>" . esc_html__( 'Like', 'jetpack' ) . '</span></span> <span class="loading">' . esc_html__( 'Loading...', 'jetpack' ) . '</span></div>';
 		$html .= "<span class='sd-text-color'></span><a class='sd-link-color'></a>";
 		$html .= '</div>';

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -789,7 +789,7 @@ class Jetpack_Likes {
 		$wrapper = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post->ID, $uniqid );
 		$headline = sprintf(
 			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
-			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>',esc_html__( 'Like this:', 'jetpack' ), 'likes' ),
+			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', esc_html__( 'Like this:', 'jetpack' ), 'likes' ),
 			esc_html__( 'Like this:', 'jetpack' )
 		);
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -681,8 +681,23 @@ function sharing_display( $text = '', $echo = false ) {
 
 			// Wrapper
 			$sharing_content .= '<div class="sharedaddy sd-sharing-enabled"><div class="robots-nocontent sd-block sd-social sd-social-' . $global['button_style'] . ' sd-sharing">';
-			if ( $global['sharing_label'] != '' )
-				$sharing_content .= '<h3 class="sd-title">' . $global['sharing_label'] . '</h3>';
+			if ( $global['sharing_label'] != '' ) {
+				$sharing_content .= sprintf(
+					/**
+					 * Filter the sharing buttons' headline structure.
+					 *
+					 * @module sharing
+					 *
+					 * @since 4.4.0
+					 *
+					 * @param string $sharing_headline Sharing headline structure.
+					 * @param string $global['sharing_label'] Sharing title.
+					 * @param string $sharing Module name.
+					 */
+					apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', $global['sharing_label'], 'sharing' ),
+					esc_html( $global['sharing_label'] )
+				);
+			}
 			$sharing_content .= '<div class="sd-content"><ul>';
 
 			// Visible items


### PR DESCRIPTION
@see https://wordpress.org/support/topic/remove-sharedaddy-h3?replies=1

Once that filter is available, one could use it like this:

```php
/**
 * Customize the HTML structure of the Sharing buttons headline.
 */
function jeherve_custom_heading( $headline, $label, $module ) {
        if ( 'sharing' == $module ) {
                $headline = sprintf(
                        '<h1>%s</h1>',
                        $label
                );
        }
        return $headline;
}
add_filter( 'jetpack_sharing_headline_html', 'jeherve_custom_heading', 10, 3 );
```