### PR TITLE
Publicize Settings: point directly to the sharing page for publicize settings

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -128,6 +128,9 @@ export const AllModuleSettings = React.createClass( {
 			case 'publicize':
 			case 'sharedaddy':
 			default:
+				if ( 'publicize' === module.module ) {
+					module.configure_url = '/wp-admin/options-general.php?page=sharing';
+				}
 				return (
 					<div>
 						{


### PR DESCRIPTION
Fixes #4952

**To Test:**
- Make sure this link takes you to the correct settings area for both non-admins and admins: 
![screen shot 2016-08-29 at 3 35 45 pm](https://cloud.githubusercontent.com/assets/7129409/18064711/a1ddd95c-6dfe-11e6-8aac-75bf78e152b4.png)