### PR TITLE
Admin Page: Add link in Likes Settings to Sharing Settings for managing visibility of Likes

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -113,6 +113,7 @@ RelatedPostsSettings = moduleSettingsForm( RelatedPostsSettings );
 
 export let LikesSettings = React.createClass( {
 	render() {
+		const old_sharing_settings_url = this.props.module.configure_url;
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
@@ -126,6 +127,15 @@ export let LikesSettings = React.createClass( {
 						isSubmitting={ this.props.isSavingAnyOption() }
 						disabled={ this.props.shouldSaveButtonBeDisabled() } />
 				</FormFieldset>
+				<p>
+					{
+						__( '{{a}}Manage Likes visibility from the Sharing Module Settings{{/a}}', {
+							components: {
+								a: <a href={ old_sharing_settings_url } />
+							}
+						} )
+					}
+				</p>
 			</form>
 		)
 	}


### PR DESCRIPTION
Fixes #4988 .

#### Changes proposed in this Pull Request:

-Adds a link pointing to the old **Sharing** settings page stating that's where Likes visibility is handled.

#### Testing instructions:
- Reach the **Likes** module settings under the **Engagement** tab
- Expand the card
- Click the link that states "Manage Likes visibility from the Sharing Module Settings".
- Expected to be redirected to the Sharing Setting in wp-admin.

![likes-sharing](https://cloud.githubusercontent.com/assets/746152/18068733/41622e00-6e19-11e6-865c-f3d9e091caa1.gif)
