### PR TITLE
Protect Settings: Add missing information in settings card

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -242,7 +242,10 @@ export let ProtectSettings = React.createClass( {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
-					<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
+					<FormLegend>{ __( 'Whitelist Management' ) }</FormLegend>
+					<p>{ __( 'Whitelisting an IP address prevents it from ever being blocked by Jetpack.' ) }</p>
+					<small>{ __( 'Make sure to add your most frequently used IP addresses as they can change between your home, office or other locations. Removing an IP address from the list below will remove it from your whitelist.' ) }</small>
+					<p>{ __( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } ) }</p>
 					<FormLabel>
 						<Textarea
 							name={ 'jetpack_protect_global_whitelist' }
@@ -250,7 +253,11 @@ export let ProtectSettings = React.createClass( {
 							onChange={ this.props.onOptionChange }
 							value={ this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local } />
 					</FormLabel>
-					<span className="jp-form-setting-explanation">{ __( 'List the IP addresses or IP address ranges.' ) }</span>
+					<span className="jp-form-setting-explanation">{ __( 'IPv4 and IPv6 are acceptable. {{br/}} To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
+						components: {
+							br: <br/>
+						}
+					} ) }</span>
 					<FormButton
 						className="is-primary"
 						isSubmitting={ this.props.isSavingAnyOption() }

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -239,13 +239,17 @@ StatsSettings = moduleSettingsForm( StatsSettings );
 
 export let ProtectSettings = React.createClass( {
 	render() {
+		const maybeShowIp = this.props.currentIp ?
+			<p>{ __( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } ) }</p> :
+			'';
+
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
 					<FormLegend>{ __( 'Whitelist Management' ) }</FormLegend>
 					<p>{ __( 'Whitelisting an IP address prevents it from ever being blocked by Jetpack.' ) }</p>
 					<small>{ __( 'Make sure to add your most frequently used IP addresses as they can change between your home, office or other locations. Removing an IP address from the list below will remove it from your whitelist.' ) }</small>
-					<p>{ __( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } ) }</p>
+					{ maybeShowIp }
 					<FormLabel>
 						<Textarea
 							name={ 'jetpack_protect_global_whitelist' }

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -30,13 +30,15 @@ import {
 	isFetchingPluginsData,
 	isPluginActive
 } from 'state/site/plugins';
+import { getCurrentIp } from 'state/initial-state';
 
 export const Page = ( props ) => {
 	let {
 		toggleModule,
 		isModuleActivated,
 		isTogglingModule,
-		getModule
+		getModule,
+		currentIp
 		} = props;
 	var cards = [
 		[ 'scan', __( 'Security Scanning' ), __( 'Automated, comprehensive protection from threats and attacks.' ), 'https://vaultpress.com/jetpack/' ],
@@ -103,7 +105,7 @@ export const Page = ( props ) => {
 			>
 				{
 					isModuleActivated( element[0] ) || isPro ?
-						<AllModuleSettings module={ isPro ? proProps : getModule( element[ 0 ] ) } /> :
+						<AllModuleSettings module={ isPro ? proProps : getModule( element[ 0 ] ) } currentIp={ currentIp } /> :
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
@@ -137,7 +139,8 @@ export default connect(
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
 			isFetchingPluginsData: isFetchingPluginsData( state ),
-			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug )
+			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
+			currentIp: getCurrentIp( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -126,3 +126,7 @@ export function getApiRootUrl( state ) {
 export function getTracksUserData( state ) {
 	return get( state.jetpack.initialState, 'tracksUserData' );
 }
+
+export function getCurrentIp( state ) {
+	return get( state.jetpack.initialState, 'currentIp' );
+}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -265,6 +265,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'errorDescription' => Jetpack::state( 'error_description' ),
 			),
 			'tracksUserData' => $this->jetpack_get_tracks_user_data(),
+			'currentIp' => jetpack_protect_get_ip()
 		) );
 	}
 }


### PR DESCRIPTION
Fixes #4983

Protect Settings: Add missing information in settings card
- Adds the users current IP in the protect settings
- New getCurrentIp() state selector from initial-state passed via wp_localize_script
- Added missing descriptive text from the protect settings area

**To Test:** 
- Open the Protect card and make sure you see your IP as well as the extra text
- Toggle the module and make sure it looks ok active and inactive 

Before: 
![protect-before](https://cloud.githubusercontent.com/assets/7129409/18068562/ec0f547c-6e0f-11e6-907e-39d6cee5fad4.png)

After: 
![screen shot 2016-08-29 at 5 42 21 pm](https://cloud.githubusercontent.com/assets/7129409/18068575/fe5b9bae-6e0f-11e6-8b5f-ef1c072c51bb.png)
