### PR TITLE
Admin: patch WC notices and move into Jetpack notice area, fixes #4964

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -21,13 +21,15 @@ const AdminNotices = React.createClass( {
 			$wcNotice.each( function () {
 				let $notice = jQuery( this ).addClass( 'dops-notice is-basic' ).removeClass( 'updated wc-connect' );
 				$notice.find( '.button-primary' ).addClass( 'dops-notice__action' ).removeClass( 'button-primary' ).detach().appendTo( $notice );
-				$notice.find( 'p' ).first().replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML, class: 'dops-notice__text' } ); } );
+				$notice.find( 'p' ).not( '.submit' ).wrapAll( '<div class="dops-notice__text"/>' );
 				let $dopsNotice = $notice.find( '.dops-notice__text' );
-				$dopsNotice.append( '<br/>' );
+				$dopsNotice.find( 'p' ).replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML, class: 'dops-notice__moved_text' } ); } );
+				$dopsNotice.find( 'br' ).remove();
 				$notice.find( '.button-secondary' ).removeClass( 'button-secondary' ).detach().appendTo( $dopsNotice );
 				$notice.find( '.submit' ).remove();
 				$notice.find( '.woocommerce-message-close' ).removeClass( 'woocommerce-message-close' ).addClass( 'dops-notice__action' );
 				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
+				$notice.find( '.dops-notice__action' ).not( ':first' ).removeClass( 'dops-notice__action' ).detach().appendTo( $notice.find( '.dops-notice__text' ) );
 			} );
 		}
 	},

--- a/_inc/client/components/admin-notices/style.scss
+++ b/_inc/client/components/admin-notices/style.scss
@@ -1,0 +1,43 @@
+.jetpack-pagestyles {
+	// Initially hide VaultPress and WooCommerce notices until they're displayed in Jetpack notices area
+	.vp-notice, .woocommerce-message, .wc-connect {
+		display: none;
+	}
+
+	.woocommerce-message.dops-notice {
+		display: block;
+
+		.submit {
+			padding: 0;
+		}
+
+		.skip {
+			color: $gray;
+			opacity: 0.85;
+		}
+
+		.skip:hover {
+			opacity: 1;
+		}
+
+		.notice-dismiss::before {
+			display: none;
+		}
+
+		.dops-notice__text > div {
+			max-width: 620px;
+		}
+
+		.dops-notice__text > a {
+			margin-right: 15px;
+		}
+
+		.dops-notice__moved_text {
+			margin-bottom: 5px;
+		}
+	}
+
+	.dops-notice__action.notice-dismiss {
+		height: 100%;
+	}
+}

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -70,31 +70,3 @@
 @keyframes pulse-light {
 	50% { background-color: lighten( $gray, 30% ); }
 }
-
-.jetpack-pagestyles {
-	// Initially hide VaultPress and WooCommerce notices until they're displayed in Jetpack notices area
-	.vp-notice, .woocommerce-message, .wc-connect {
-		display: none;
-	}
-
-	.woocommerce-message.dops-notice {
-		display: block;
-
-		.submit {
-			padding: 0;
-		}
-
-		.skip {
-			color: $gray;
-			opacity: 0.85;
-		}
-
-		.skip:hover {
-			opacity: 1;
-		}
-
-		.notice-dismiss::before {
-			display: none;
-		}
-	}
-}

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -37,6 +37,7 @@
 @import '../components/support-card/style';
 @import '../components/forms/styles';
 @import '../components/tags-input/style';
+@import '../components/admin-notices/style';
 
 
 // Page Templates


### PR DESCRIPTION
Fixes #4964

#### Changes proposed in this Pull Request:
- Patch the additional different notice from WC
- Move styles into its own scss file so it's easier to find

#### Testing instructions:
- activate VaultPress
- activate WooCommerce, hack the file `woocommerce/includes/admin/class-wc-admin-notices.php` and add this at the beginning
```php
add_action( 'admin_notices', function(){
	include( 'views/html-notice-install.php' );
	include( 'views/html-notice-update.php' );
	include( 'views/html-notice-updated.php' );
	include( 'views/html-notice-template-check.php' );
	include( 'views/html-notice-theme-support.php' );
	include( 'views/html-notice-tracking.php' );
	include( 'views/html-notice-simplify-commerce.php' );
	include( 'views/html-notice-legacy-shipping.php' );
	include( 'views/html-notice-updating.php' );
	include( 'views/html-notice-no-shipping-methods.php' );
	$notice_html = 'Testing this custom notice';
	include( 'views/html-notice-custom.php' );
} );
```
- make sure notices look ok

<img width="759" alt="captura de pantalla 2016-08-29 a las 19 39 33" src="https://cloud.githubusercontent.com/assets/1041600/18069886/63707e46-6e20-11e6-99b8-61203fce2123.png">
<img width="740" alt="captura de pantalla 2016-08-29 a las 19 43 56" src="https://cloud.githubusercontent.com/assets/1041600/18069961/f83db32c-6e20-11e6-8cb0-a6c801777f36.png">
<img width="746" alt="captura de pantalla 2016-08-29 a las 19 44 03" src="https://cloud.githubusercontent.com/assets/1041600/18069962/f8410e0a-6e20-11e6-8f8d-d752ac615131.png">
