### PR TITLE
Stats: Added proper verbiage to primary CTA

### DIFF
--- a/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -101,7 +101,7 @@ const DashStatsBottom = React.createClass( {
 								/>
 						}
 					} ) }
-					{ __( '{{button}}View More Stats{{/button}}', {
+					{ __( '{{button}}View More Stats on WordPress.com {{/button}}', {
 						components: {
 							button:
 								<Button


### PR DESCRIPTION
Letting the user know that the CTA will take them to WordPress.com

<img width="720" alt="screen shot 2016-08-29 at 9 44 40 pm" src="https://cloud.githubusercontent.com/assets/214813/18073166/d66a1162-6e31-11e6-9d59-89471ee3573a.png">
