### PR TITLE
Admin: replace file_get_contents with wp_remote_get

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -136,11 +136,17 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		/** This action is already documented in views/admin/admin-page.php */
 		do_action( 'jetpack_notices' );
 
-		echo file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' );
+		$static_html = wp_remote_get( esc_url( JETPACK__PLUGIN_URL . '/_inc/build/static.html' ), array( 'sslverify' => false ) );
+		echo 200 == wp_remote_retrieve_response_code( $static_html )
+			? wp_remote_retrieve_body( $static_html )
+			: esc_html__( 'Error fetching page.', 'jetpack' );
 	}
 
 	function get_i18n_data() {
-		$locale_data = @file_get_contents( JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . get_locale() . '.json' );
+		$locale_data = wp_remote_get( esc_url( JETPACK__PLUGIN_URL . '/languages/json/jetpack-' . get_locale() . '.json' ), array( 'sslverify' => false ) );
+		$locale_data = 200 == wp_remote_retrieve_response_code( $locale_data )
+			? wp_remote_retrieve_body( $locale_data )
+			: false;
 		if ( $locale_data ) {
 			return $locale_data;
 		} else {

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -19,10 +19,27 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	// actions to activate/deactivate and configure modules
 	function page_render() {
 		$list_table = new Jetpack_Modules_List_Table;
-		$static_html = file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' );
-		$noscript_notice = file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' );
-		$version_notice = file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
-		$ie_notice = file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-ie-notice.html' );
+		$build_url = JETPACK__PLUGIN_URL . '/_inc/build/';
+
+		$static_html = wp_remote_get( esc_url( $build_url . 'static.html' ), array( 'sslverify' => false ) );
+		$static_html = 200 == wp_remote_retrieve_response_code( $static_html )
+			? wp_remote_retrieve_body( $static_html )
+			: '';
+
+		$noscript_notice = wp_remote_get( esc_url( $build_url . 'static-noscript-notice.html' ), array( 'sslverify' => false ) );
+		$noscript_notice = 200 == wp_remote_retrieve_response_code( $noscript_notice )
+			? wp_remote_retrieve_body( $noscript_notice )
+			: '';
+
+		$version_notice = wp_remote_get( esc_url( $build_url . 'static-version-notice.html' ), array( 'sslverify' => false ) );
+		$version_notice = 200 == wp_remote_retrieve_response_code( $version_notice )
+			? wp_remote_retrieve_body( $version_notice )
+			: '';
+
+		$ie_notice = wp_remote_get( esc_url( $build_url . 'static-ie-notice.html' ), array( 'sslverify' => false ) );
+		$ie_notice = 200 == wp_remote_retrieve_response_code( $ie_notice )
+			? wp_remote_retrieve_body( $ie_notice )
+			: '';
 
 		$noscript_notice = str_replace(
 			'#HEADER_TEXT#',

--- a/jetpack.php
+++ b/jetpack.php
@@ -18,6 +18,7 @@ define( 'JETPACK__VERSION',            '4.3-beta3' );
 define( 'JETPACK_MASTER_USER',         true );
 define( 'JETPACK__API_VERSION',        1 );
 define( 'JETPACK__PLUGIN_DIR',         plugin_dir_path( __FILE__ ) );
+define( 'JETPACK__PLUGIN_URL',         plugins_url( '', __FILE__ ) );
 define( 'JETPACK__PLUGIN_FILE',        __FILE__ );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' )   or define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );


### PR DESCRIPTION
Fixes #4974

#### Changes proposed in this Pull Request:
- introduces a new constant JETPACK__PLUGIN_URL
- replace file_get_contents with wp_remote_get, checking the response code and retrieving the body.

#### Testing instructions:
- go to Jetpack > Dashboard and admin.php?page=jetpack_modules, they should look fine
