### PR TITLE
Fix/stats error msg styling

### DIFF
--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -109,14 +109,14 @@ const DashStats = React.createClass( {
 					console.log( error );
 				} );
 				return (
-					<div className="jp-at-a-glance__stats-inactive-text">
-						{
-							__( 'Something happened while loading stats. Please try again later or {{a}}view your stats now on WordPress.com{{/a}}', {
-								components: {
-									a: <a href={ 'https://wordpress.com/stats/insights/' + this.props.siteRawUrl } />
-								}
-							} )
-						}
+					<div className="jp-at-a-glance__stats-inactive">
+							{
+								__( 'Something happened while loading stats. Please try again later or {{a}}view your stats now on WordPress.com{{/a}}', {
+									components: {
+										a: <a href={ 'https://wordpress.com/stats/insights/' + this.props.siteRawUrl } />
+									}
+								} )
+							}
 					</div>
 				);
 			}

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -109,7 +109,7 @@ const DashStats = React.createClass( {
 					console.log( error );
 				} );
 				return (
-					<p>
+					<div className="jp-at-a-glance__stats-inactive-text">
 						{
 							__( 'Something happened while loading stats. Please try again later or {{a}}view your stats now on WordPress.com{{/a}}', {
 								components: {
@@ -117,7 +117,7 @@ const DashStats = React.createClass( {
 								}
 							} )
 						}
-					</p>
+					</div>
 				);
 			}
 			let chartData = this.statsChart( this.props.activeTab() );

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -110,6 +110,7 @@ const DashStats = React.createClass( {
 				} );
 				return (
 					<div className="jp-at-a-glance__stats-inactive">
+						<span>
 							{
 								__( 'Something happened while loading stats. Please try again later or {{a}}view your stats now on WordPress.com{{/a}}', {
 									components: {
@@ -117,6 +118,7 @@ const DashStats = React.createClass( {
 									}
 								} )
 							}
+						</span>
 					</div>
 				);
 			}


### PR DESCRIPTION
Before:
![stats-error-formatting](https://cloud.githubusercontent.com/assets/214813/18095259/6545753a-6ea4-11e6-965c-ad6bd2aca656.png)


After:
<img width="747" alt="screen shot 2016-08-30 at 11 23 47 am" src="https://cloud.githubusercontent.com/assets/214813/18095265/6a3adf08-6ea4-11e6-8cd7-8e13339775e2.png">

To Test:
In: https://github.com/Automattic/jetpack/blob/master/_inc/client/at-a-glance/stats/index.jsx#L107
change `if ( statsErrors ) {` to `if ( true ) {`

Fixes: https://github.com/Automattic/jetpack/issues/5028
