### PR TITLE
Omnisearch Settings: When active, display better/correct info

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -34,6 +34,14 @@ export const AllModuleSettings = React.createClass( {
 	render() {
 		let { module } = this.props;
 		switch ( module.module ) {
+			case 'omnisearch':
+				return (
+					<div>
+						<span className="jp-form-setting-explanation">{ this.props.module.long_description }</span>
+						<br/>
+						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href='/wp-admin/admin.php?page=omnisearch'>{ __( 'Search your content.' ) }</ExternalLink>
+					</div>
+				);
 			case 'post-by-email':
 				return ( <PostByEmailSettings module={ module } { ...this.props } /> );
 			case 'custom-content-types':


### PR DESCRIPTION
Fixes #5026

**To test:**
- Search for omnisearch
- Activate omnisearch 
- Make sure this all looks good and the link works 

![screen shot 2016-08-30 at 1 25 34 pm](https://cloud.githubusercontent.com/assets/7129409/18099665/97f7cbfc-6eb5-11e6-916b-fc8d9cb4c6f0.png)
