### PR TITLE
Sharing: Resolve JS error on Facebook share counts

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -72,7 +72,7 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 			}
 
 			for ( url in data ) {
-				if ( ! data.hasOwnProperty( url ) || ! data[ url ].share.share_count ) {
+				if ( ! data.hasOwnProperty( url ) || ! data[ url ].share || ! data[ url ].share.share_count ) {
 					continue;
 				}
 


### PR DESCRIPTION
On URLs not previously scraped by Facebook, a JS error returned in the console due to FB's API response differing than our expected.

Merges r141509-wpcom to Jetpack. cc: @aduth 