### PR TITLE
API to sync immediately and return response

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -223,7 +223,7 @@ class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint 
 		$response = $sender->do_sync_for_queue( $queue_name );
 
 		return array(
-			'response' => $response;
+			'response' => $response
 		)
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -224,6 +224,6 @@ class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint 
 
 		return array(
 			'response' => $response
-		)
+		);
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -206,3 +206,24 @@ class Jetpack_JSON_API_Sync_Object extends Jetpack_JSON_API_Sync_Endpoint {
 		);
 	}
 }
+
+class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
+	protected function result() {
+		$args = $this->input();
+
+		if ( ! isset( $args['queue'] ) ) {
+			return new WP_Error( 'invalid_queue', 'Queue name is required' );
+		}
+
+		$queue_name = $args['queue'];
+
+		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
+
+		$sender = Jetpack_Sync_Sender::get_instance();
+		$response = $sender->do_sync_for_queue( $queue_name );
+
+		return array(
+			'response' => $response;
+		)
+	}
+}

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -220,7 +220,7 @@ class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint 
 		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
 
 		$sender = Jetpack_Sync_Sender::get_instance();
-		$response = $sender->do_sync_for_queue( $queue_name );
+		$response = $sender->do_sync_for_queue( new Jetpack_Sync_Queue( $queue_name ) );
 
 		return array(
 			'response' => $response

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -41,8 +41,8 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 // GET /sites/%s/sync/status
 class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-modules.php';
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
 		$sender      = Jetpack_Sync_Sender::get_instance();
@@ -65,7 +65,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 // GET /sites/%s/data-check
 class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 
 		$sender     = Jetpack_Sync_Sender::get_instance();
 		$sync_queue = $sender->get_sync_queue();
@@ -85,7 +85,7 @@ class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 			return $result;
 		}
 
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-wp-replicastore.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-wp-replicastore.php';
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 
@@ -101,7 +101,7 @@ class Jetpack_JSON_API_Sync_Check_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 // GET /sites/%s/data-histogram
 class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 
 		$sender     = Jetpack_Sync_Sender::get_instance();
 		$sync_queue = $sender->get_sync_queue();
@@ -129,7 +129,7 @@ class Jetpack_JSON_API_Sync_Histogram_Endpoint extends Jetpack_JSON_API_Sync_End
 			$columns = null; // go with defaults
 		}
 
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-wp-replicastore.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-wp-replicastore.php';
 
 		$store = new Jetpack_Sync_WP_Replicastore();
 
@@ -147,7 +147,7 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sy
 	protected function result() {
 		$args = $this->input();
 
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-settings.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-settings.php';
 
 		$sync_settings = Jetpack_Sync_Settings::get_settings();
 
@@ -176,7 +176,7 @@ class Jetpack_JSON_API_Sync_Modify_Settings_Endpoint extends Jetpack_JSON_API_Sy
 // GET /sites/%s/sync/settings
 class Jetpack_JSON_API_Sync_Get_Settings_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-settings.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-settings.php';
 
 		return Jetpack_Sync_Settings::get_settings();
 	}
@@ -189,7 +189,7 @@ class Jetpack_JSON_API_Sync_Object extends Jetpack_JSON_API_Sync_Endpoint {
 
 		$module_name = $args['module_name'];
 
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-modules.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
 
 		if ( ! $sync_module = Jetpack_Sync_Modules::get_module( $module_name ) ) {
 			return new WP_Error( 'invalid_module', 'You specified an invalid sync module' );
@@ -198,7 +198,7 @@ class Jetpack_JSON_API_Sync_Object extends Jetpack_JSON_API_Sync_Endpoint {
 		$object_type = $args['object_type'];
 		$object_id   = $args['object_id'];
 
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 		$codec = Jetpack_Sync_Sender::get_instance()->get_codec();
 
 		return array(
@@ -212,12 +212,16 @@ class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint 
 		$args = $this->input();
 
 		if ( ! isset( $args['queue'] ) ) {
-			return new WP_Error( 'invalid_queue', 'Queue name is required' );
+			return new WP_Error( 'invalid_queue', 'Queue name is required', 400 );
+		}
+
+		if ( ! in_array( $args['queue'], array( 'sync', 'full_sync' ) ) ) {
+			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', 400 );
 		}
 
 		$queue_name = $args['queue'];
 
-		require_once dirname( __FILE__ ) . '/../../sync/class.jetpack-sync-sender.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 
 		$sender = Jetpack_Sync_Sender::get_instance();
 		$response = $sender->do_sync_for_queue( new Jetpack_Sync_Queue( $queue_name ) );

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -718,6 +718,24 @@ new Jetpack_JSON_API_Sync_Object( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/object/posts/post/5'
 ) );
 
+// POST /sites/%s/sync/now
+new Jetpack_JSON_API_Sync_Now_Endpoint( array(
+	'description'     => 'Force immediate sync of top items on a queue',
+	'method'          => 'POST',
+	'path'            => '/sites/%s/sync/now',
+	'stat'            => 'sync-now',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'request_format' => array(
+		'queue'  => '(string) sync or full_sync',
+	),
+	'response_format' => array(
+		'response' => '(array) The response from the server'
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/now?queue=full_sync'
+) );
+
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-log-endpoint.php' );
 
 new Jetpack_JSON_API_Jetpack_Log_Endpoint( array(


### PR DESCRIPTION
When sync is failing, it can be hard to diagnose the issue from afar. This PR adds an API which can help narrow down the possibilities, essentially acting as a remote WP-Cron by forcing the sync sender to send data to WPCOM and returning the response.

To test:

```
> $m = new Jetpack_Sync_Manager( $blog_id );
> $m->sync_now();
```

This will return true if data was synced, false if no data was synced (usually because it's being rate limited) or a WP_Error if there was an issue talking to WPCOM.