### PR TITLE
Static: replace usages of JETPACK__PLUGIN_URL with plugins_url

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -136,14 +136,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		/** This action is already documented in views/admin/admin-page.php */
 		do_action( 'jetpack_notices' );
 
-		$static_html = wp_remote_get( esc_url( JETPACK__PLUGIN_URL . '/_inc/build/static.html' ), array( 'sslverify' => false ) );
+		$static_html = wp_remote_get( esc_url( plugins_url( '/_inc/build/static.html', JETPACK__PLUGIN_FILE ) ), array( 'sslverify' => false ) );
 		echo 200 == wp_remote_retrieve_response_code( $static_html )
 			? wp_remote_retrieve_body( $static_html )
 			: esc_html__( 'Error fetching page.', 'jetpack' );
 	}
 
 	function get_i18n_data() {
-		$locale_data = wp_remote_get( esc_url( JETPACK__PLUGIN_URL . '/languages/json/jetpack-' . get_locale() . '.json' ), array( 'sslverify' => false ) );
+		$locale_data = wp_remote_get( esc_url( plugins_url( '/languages/json/jetpack-' . get_locale() . '.json', JETPACK__PLUGIN_FILE ) ), array( 'sslverify' => false ) );
 		$locale_data = 200 == wp_remote_retrieve_response_code( $locale_data )
 			? wp_remote_retrieve_body( $locale_data )
 			: false;

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -19,24 +19,24 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	// actions to activate/deactivate and configure modules
 	function page_render() {
 		$list_table = new Jetpack_Modules_List_Table;
-		$build_url = JETPACK__PLUGIN_URL . '/_inc/build/';
+		$build_url = esc_url( plugins_url( '/_inc/build/',  JETPACK__PLUGIN_FILE ) );
 
-		$static_html = wp_remote_get( esc_url( $build_url . 'static.html' ), array( 'sslverify' => false ) );
+		$static_html = wp_remote_get( $build_url . 'static.html', array( 'sslverify' => false ) );
 		$static_html = 200 == wp_remote_retrieve_response_code( $static_html )
 			? wp_remote_retrieve_body( $static_html )
 			: '';
 
-		$noscript_notice = wp_remote_get( esc_url( $build_url . 'static-noscript-notice.html' ), array( 'sslverify' => false ) );
+		$noscript_notice = wp_remote_get( $build_url . 'static-noscript-notice.html', array( 'sslverify' => false ) );
 		$noscript_notice = 200 == wp_remote_retrieve_response_code( $noscript_notice )
 			? wp_remote_retrieve_body( $noscript_notice )
 			: '';
 
-		$version_notice = wp_remote_get( esc_url( $build_url . 'static-version-notice.html' ), array( 'sslverify' => false ) );
+		$version_notice = wp_remote_get( $build_url . 'static-version-notice.html', array( 'sslverify' => false ) );
 		$version_notice = 200 == wp_remote_retrieve_response_code( $version_notice )
 			? wp_remote_retrieve_body( $version_notice )
 			: '';
 
-		$ie_notice = wp_remote_get( esc_url( $build_url . 'static-ie-notice.html' ), array( 'sslverify' => false ) );
+		$ie_notice = wp_remote_get( $build_url . 'static-ie-notice.html', array( 'sslverify' => false ) );
 		$ie_notice = 200 == wp_remote_retrieve_response_code( $ie_notice )
 			? wp_remote_retrieve_body( $ie_notice )
 			: '';

--- a/jetpack.php
+++ b/jetpack.php
@@ -18,7 +18,6 @@ define( 'JETPACK__VERSION',            '4.3-rc1' );
 define( 'JETPACK_MASTER_USER',         true );
 define( 'JETPACK__API_VERSION',        1 );
 define( 'JETPACK__PLUGIN_DIR',         plugin_dir_path( __FILE__ ) );
-define( 'JETPACK__PLUGIN_URL',         plugins_url( '', __FILE__ ) );
 define( 'JETPACK__PLUGIN_FILE',        __FILE__ );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' )   or define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- remove constant JETPACK_PLUGIN_URL
- replace usages with `plugins_url()`

#### Testing instructions:
- go to Jetpack > Dashboard and admin.php?page=jetpack_modules, they should look fine
- go to Jetpack admin, it should look fine too

Follow up to #5022