### PR TITLE
Admin - AAG: while in Dev mode, don't display message to check security in wpcom

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -26,6 +26,7 @@ import {
 	userCanManageModules,
 	userCanViewStats
 } from 'state/initial-state';
+import { isDevMode } from 'state/connection';
 
 const AtAGlance = React.createClass( {
 	render() {
@@ -33,8 +34,15 @@ const AtAGlance = React.createClass( {
 				<DashSectionHeader
 					label={ __( 'Security' ) }
 					settingsPath="#security"
-					externalLink={ __( 'Manage security on WordPress.com' ) }
-					externalLinkPath={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
+					externalLink={
+						this.props.isDevMode
+						? ''
+						: __( 'Manage security on WordPress.com' )
+					}
+					externalLinkPath={ this.props.isDevMode
+						? ''
+						: 'https://wordpress.com/settings/security/' + this.props.siteRawUrl
+					}
 					externalLinkClick={ () => analytics.tracks.recordEvent( 'jetpack_wpa_aag_security_wpcom_click', {} ) }
 				/>,
 			performanceHeader =
@@ -126,7 +134,8 @@ export default connect(
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			userCanManageModules: userCanManageModules( state ),
-			userCanViewStats: userCanViewStats( state )
+			userCanViewStats: userCanViewStats( state ),
+			isDevMode: isDevMode( state )
 		};
 	}
 )( AtAGlance );


### PR DESCRIPTION
Before this PR, the `Manage security on WordPress.com` message shows up but it's an invalid link in Dev mode and shouldn't be displayed
<img width="764" alt="secudev" src="https://cloud.githubusercontent.com/assets/1041600/18138390/d412d974-6f82-11e6-9623-46621f9b8b56.png">

After the PR, message won't be displayed in dev mode
<img width="747" alt="after" src="https://cloud.githubusercontent.com/assets/1041600/18138493/40a4dbc8-6f83-11e6-8b83-e45a79473e47.png">

#### Changes proposed in this Pull Request:
- check that the site is in Dev mode, and if it is, the message `Manage security on WordPress.com` will not be displayed

#### Testing instructions:
- verify that everything works normally in dev mode and also normal mode.