### PR TITLE
deploy-to-master-stable: Remove deleted files when building 

### DIFF
--- a/tools/deploy-to-master-stable-branch.sh
+++ b/tools/deploy-to-master-stable-branch.sh
@@ -65,7 +65,7 @@ git clone --depth 1 -b $TARGET --single-branch git@github.com:Automattic/jetpack
 echo "Done!"
 
 echo "Rsync'ing everything over remote version"
-rsync -r $JETPACK_TMP_DIR_2/* $JETPACK_TMP_DIR
+rsync -r --delete $JETPACK_TMP_DIR_2/* $JETPACK_TMP_DIR
 echo "Done!"
 
 cd $JETPACK_TMP_DIR


### PR DESCRIPTION
This script now will remove files from master-stable (or whatever target branch) that have also been removed from master.  Before it was only updating with changes and new files.

See how much unnecessary stuff we were still packaging c03e0d6f4d7b0926e4035b3ba44d0afc7f4e6790