### PR TITLE
Admin: remove modules filtered by jetpack_get_available_modules

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -19,14 +19,14 @@ import {
 	deactivateModule,
 	isActivatingModule,
 	isDeactivatingModule,
-	getModule as _getModule
+	getModule as _getModule,
+	getModules
 } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
 import { isUnavailableInDevMode } from 'state/connection';
 import { userCanManageModules } from 'state/initial-state';
 import Settings from 'components/settings';
-import { getModules } from 'state/modules';
 
 export const Page = ( props ) => {
 	let {
@@ -35,7 +35,8 @@ export const Page = ( props ) => {
 		isTogglingModule,
 		getModule
 	} = props,
-		isAdmin = props.userCanManageModules;
+		isAdmin = props.userCanManageModules,
+		moduleList = Object.keys( props.moduleList );
 
 	var cards = [
 		[ 'tiled-gallery', getModule( 'tiled-gallery' ).name, getModule( 'tiled-gallery' ).description, getModule( 'tiled-gallery' ).learn_more_button ],
@@ -47,7 +48,7 @@ export const Page = ( props ) => {
 		[ 'infinite-scroll', getModule( 'infinite-scroll' ).name, getModule( 'infinite-scroll' ).description, getModule( 'infinite-scroll' ).learn_more_button ],
 		[ 'minileven', getModule( 'minileven' ).name, getModule( 'minileven' ).description, getModule( 'minileven' ).learn_more_button ]
 	].map( ( element ) => {
-		if ( ! includes( Object.keys( props.moduleList ), element[0] ) ) {
+		if ( ! includes( moduleList, element[0] ) ) {
 			return null;
 		}
 		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),

--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -7,6 +7,7 @@ import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 import analytics from 'lib/analytics';
 
 /**
@@ -25,6 +26,7 @@ import { AllModuleSettings } from 'components/module-settings/modules-per-tab-pa
 import { isUnavailableInDevMode } from 'state/connection';
 import { userCanManageModules } from 'state/initial-state';
 import Settings from 'components/settings';
+import { getModules } from 'state/modules';
 
 export const Page = ( props ) => {
 	let {
@@ -45,6 +47,9 @@ export const Page = ( props ) => {
 		[ 'infinite-scroll', getModule( 'infinite-scroll' ).name, getModule( 'infinite-scroll' ).description, getModule( 'infinite-scroll' ).learn_more_button ],
 		[ 'minileven', getModule( 'minileven' ).name, getModule( 'minileven' ).description, getModule( 'minileven' ).learn_more_button ]
 	].map( ( element ) => {
+		if ( ! includes( Object.keys( props.moduleList ), element[0] ) ) {
+			return null;
+		}
 		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			toggle = (
 				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
@@ -123,7 +128,8 @@ export default connect(
 				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
-			userCanManageModules: userCanManageModules( state )
+			userCanManageModules: userCanManageModules( state ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -72,7 +72,8 @@ const DashMonitor = React.createClass( {
 	},
 
 	render: function() {
-		if ( ! includes( this.props.moduleList, 'monitor' ) ) {
+		const moduleList = Object.keys( this.props.moduleList );
+		if ( ! includes( moduleList, 'monitor' ) ) {
 			return null;
 		}
 

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -13,7 +14,8 @@ import QueryLastDownTime from 'components/data/query-last-downtime';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
-	isFetchingModulesList as _isFetchingModulesList
+	isFetchingModulesList as _isFetchingModulesList,
+	getModules
 } from 'state/modules';
 import { getLastDownTime as _getLastDownTime } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
@@ -70,6 +72,10 @@ const DashMonitor = React.createClass( {
 	},
 
 	render: function() {
+		if ( ! includes( this.props.moduleList, 'monitor' ) ) {
+			return null;
+		}
+
 		return (
 			<div>
 				<QueryLastDownTime />
@@ -84,7 +90,8 @@ export default connect(
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isFetchingModulesList: () => _isFetchingModulesList( state ),
-			getLastDownTime: () => _getLastDownTime( state )
+			getLastDownTime: () => _getLastDownTime( state ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -54,7 +54,8 @@ const DashPhoton = React.createClass( {
 	},
 
 	render: function() {
-		if ( ! includes( this.props.moduleList, 'photon' ) ) {
+		const moduleList = Object.keys( this.props.moduleList );
+		if ( ! includes( moduleList, 'photon' ) ) {
 			return null;
 		}
 

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -5,13 +5,15 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
  */
 import {
 	isModuleActivated as _isModuleActivated,
-	activateModule
+	activateModule,
+	getModules
 } from 'state/modules';
 import { isDevMode } from 'state/connection';
 
@@ -52,6 +54,10 @@ const DashPhoton = React.createClass( {
 	},
 
 	render: function() {
+		if ( ! includes( this.props.moduleList, 'photon' ) ) {
+			return null;
+		}
+
 		return (
 			<div className="jp-dash-item__interior">
 				{ this.getContent() }
@@ -63,7 +69,8 @@ const DashPhoton = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
+			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -106,7 +106,8 @@ const DashPluginUpdates = React.createClass( {
 	},
 
 	render: function() {
-		if ( ! includes( this.props.moduleList, 'manage' ) ) {
+		const moduleList = Object.keys( this.props.moduleList );
+		if ( ! includes( moduleList, 'manage' ) ) {
 			return null;
 		}
 

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -15,7 +16,8 @@ import {
 } from 'state/at-a-glance';
 import {
 	isModuleActivated as _isModuleActivated,
-	activateModule
+	activateModule,
+	getModules
 } from 'state/modules';
 import { isDevMode } from 'state/connection';
 
@@ -104,6 +106,10 @@ const DashPluginUpdates = React.createClass( {
 	},
 
 	render: function() {
+		if ( ! includes( this.props.moduleList, 'manage' ) ) {
+			return null;
+		}
+
 		return (
 			<div>
 				<QueryPluginUpdates />
@@ -117,7 +123,8 @@ export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
-			getPluginUpdates: () => _getPluginUpdates( state )
+			getPluginUpdates: () => _getPluginUpdates( state ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -74,7 +74,8 @@ const DashProtect = React.createClass( {
 	},
 
 	render: function() {
-		if ( ! includes( this.props.moduleList, 'protect' ) ) {
+		const moduleList = Object.keys( this.props.moduleList );
+		if ( ! includes( moduleList, 'protect' ) ) {
 			return null;
 		}
 

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { numberFormat, translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -13,7 +14,8 @@ import QueryProtectCount from 'components/data/query-dash-protect';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
-	isFetchingModulesList as _isFetchingModulesList
+	isFetchingModulesList as _isFetchingModulesList,
+	getModules
 } from 'state/modules';
 import {
 	fetchProtectCount,
@@ -72,6 +74,10 @@ const DashProtect = React.createClass( {
 	},
 
 	render: function() {
+		if ( ! includes( this.props.moduleList, 'protect' ) ) {
+			return null;
+		}
+
 		return (
 			<div className="jp-dash-item__interior">
 				<QueryProtectCount />
@@ -87,7 +93,7 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			getProtectCount: () => _getProtectCount( state ),
 			isFetchingModulesList: () => _isFetchingModulesList( state ),
-			getModule: ( module_name ) => _getModule( state, module_name )
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/site-verification.jsx
+++ b/_inc/client/at-a-glance/site-verification.jsx
@@ -5,13 +5,15 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
  */
 import {
 	isModuleActivated as _isModuleActivated,
-	activateModule
+	activateModule,
+	getModules
 } from 'state/modules';
 
 const DashSiteVerify = React.createClass( {
@@ -50,6 +52,10 @@ const DashSiteVerify = React.createClass( {
 	},
 
 	render: function() {
+		if ( ! includes( this.props.moduleList, 'site-verification' ) ) {
+			return null;
+		}
+
 		return (
 			<div>
 				{ this.getContent() }
@@ -61,7 +67,8 @@ const DashSiteVerify = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
+			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/site-verification.jsx
+++ b/_inc/client/at-a-glance/site-verification.jsx
@@ -52,7 +52,8 @@ const DashSiteVerify = React.createClass( {
 	},
 
 	render: function() {
-		if ( ! includes( this.props.moduleList, 'site-verification' ) ) {
+		const moduleList = Object.keys( this.props.moduleList );
+		if ( ! includes( moduleList, 'site-verification' ) ) {
 			return null;
 		}
 

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -12,6 +12,7 @@ import Button from 'components/button';
 import Spinner from 'components/spinner';
 import { numberFormat, moment, translate as __ } from 'i18n-calypso';
 import analytics from 'lib/analytics';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -34,7 +35,8 @@ import {
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
-	isFetchingModulesList as _isFetchingModulesList
+	isFetchingModulesList as _isFetchingModulesList,
+	getModules
 } from 'state/modules';
 
 const DashStats = React.createClass( {
@@ -211,6 +213,10 @@ const DashStats = React.createClass( {
 	},
 
 	render: function() {
+		if ( ! includes( this.props.moduleList, 'stats' ) ) {
+			return null;
+		}
+
 		let range = this.props.activeTab();
 		return (
 			<div>
@@ -230,7 +236,7 @@ export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
-			getModule: ( module_name ) => _getModule( state, module_name ),
+			moduleList: getModules( state ),
 			isFetchingModules: () => _isFetchingModulesList( state ),
 			activeTab: () => _getActiveStatsTab( state ),
 			statsData: getStatsData( state ) !== 'N/A' ? getStatsData( state ) : getInitialStateStatsData( state )

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -213,7 +213,8 @@ const DashStats = React.createClass( {
 	},
 
 	render: function() {
-		if ( ! includes( this.props.moduleList, 'stats' ) ) {
+		const moduleList = Object.keys( this.props.moduleList );
+		if ( ! includes( moduleList, 'stats' ) ) {
 			return null;
 		}
 

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -19,7 +19,8 @@ import {
 	deactivateModule,
 	isActivatingModule,
 	isDeactivatingModule,
-	getModule as _getModule
+	getModule as _getModule,
+	getModules
 } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
@@ -39,7 +40,8 @@ export const Engagement = ( props ) => {
 		getModule
 	} = props,
 		isAdmin = props.userCanManageModules,
-		sitemapsDesc = getModule( 'sitemaps' ).description;
+		sitemapsDesc = getModule( 'sitemaps' ).description,
+		moduleList = Object.keys( props.moduleList );
 
 	if ( ! props.isSitePublic() ) {
 		sitemapsDesc = <span>
@@ -83,6 +85,9 @@ export const Engagement = ( props ) => {
 		cards = cards.filter( ( element, index ) => cards.indexOf( element ) === index );
 	}
 	cards = cards.map( ( element ) => {
+		if ( ! includes( moduleList, element[0] ) ) {
+			return null;
+		}
 		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			toggle = '',
@@ -175,7 +180,8 @@ export default connect(
 			getSiteRawUrl: () => getSiteRawUrl( state ),
 			getSiteAdminUrl: () => getSiteAdminUrl( state ),
 			isSitePublic: () => isSitePublic( state ),
-			userCanManageModules: _userCanManageModules( state )
+			userCanManageModules: _userCanManageModules( state ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -7,6 +7,7 @@ import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
+import includes from 'lodash/includes';
 import analytics from 'lib/analytics';
 
 /**
@@ -20,7 +21,8 @@ import {
 	deactivateModule,
 	isActivatingModule,
 	isDeactivatingModule,
-	getModule as _getModule
+	getModule as _getModule,
+	getModules
 } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import { userCanManageModules } from 'state/initial-state';
@@ -31,8 +33,9 @@ export const GeneralSettings = ( props ) => {
 		isModuleActivated,
 		isTogglingModule,
 		getModule
-		} = props;
-	let isAdmin = props.userCanManageModules;
+	} = props,
+		isAdmin = props.userCanManageModules,
+		moduleList = Object.keys( props.moduleList );
 
 	const moduleCard = ( module_slug ) => {
 		var unavailableInDevMode = props.isUnavailableInDevMode( module_slug ),
@@ -50,28 +53,32 @@ export const GeneralSettings = ( props ) => {
 					toggleModule={ toggleModule }
 				/>;
 		}
-		return isAdmin ? (
-			<FoldableCard
-				className={ customClasses }
-				header={ getModule( module_slug ).name }
-				subheader={ getModule( module_slug ).description }
-				clickableHeaderText={ true }
-				disabled={ ! isAdmin }
-				summary={ isAdmin ? toggle( module_slug ) : '' }
-				expandedSummary={ isAdmin ? toggle( module_slug ) : '' }
-				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-					{
-						card: module_slug,
-						path: props.route.path
-					}
-				) }
-			>
-				<div className="jp-form-setting-explanation"><div dangerouslySetInnerHTML={ renderLongDescription( getModule( module_slug ) ) } /></div>
-				<div className="jp-module-settings__read-more">
-					<Button borderless compact href={ getModule( module_slug ).learn_more_button }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
-				</div>
-			</FoldableCard>
-		) : false;
+		return isAdmin
+			? includes( moduleList, module_slug )
+				? (
+					<FoldableCard
+						className={ customClasses }
+						header={ getModule( module_slug ).name }
+						subheader={ getModule( module_slug ).description }
+						clickableHeaderText={ true }
+						disabled={ ! isAdmin }
+						summary={ isAdmin ? toggle( module_slug ) : '' }
+						expandedSummary={ isAdmin ? toggle( module_slug ) : '' }
+						onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+							{
+								card: module_slug,
+								path: props.route.path
+							}
+						) }
+					>
+						<div className="jp-form-setting-explanation"><div dangerouslySetInnerHTML={ renderLongDescription( getModule( module_slug ) ) } /></div>
+						<div className="jp-module-settings__read-more">
+							<Button borderless compact href={ getModule( module_slug ).learn_more_button }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+						</div>
+				</FoldableCard>
+			)
+			: null
+		: false;
 	};
 
 	return (
@@ -109,7 +116,8 @@ export default connect(
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			isTogglingModule: ( module_name ) => isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
-			userCanManageModules: userCanManageModules( state )
+			userCanManageModules: userCanManageModules( state ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -53,32 +53,33 @@ export const GeneralSettings = ( props ) => {
 					toggleModule={ toggleModule }
 				/>;
 		}
-		return isAdmin
-			? includes( moduleList, module_slug )
-				? (
-					<FoldableCard
-						className={ customClasses }
-						header={ getModule( module_slug ).name }
-						subheader={ getModule( module_slug ).description }
-						clickableHeaderText={ true }
-						disabled={ ! isAdmin }
-						summary={ isAdmin ? toggle( module_slug ) : '' }
-						expandedSummary={ isAdmin ? toggle( module_slug ) : '' }
-						onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-							{
-								card: module_slug,
-								path: props.route.path
-							}
-						) }
-					>
-						<div className="jp-form-setting-explanation"><div dangerouslySetInnerHTML={ renderLongDescription( getModule( module_slug ) ) } /></div>
-						<div className="jp-module-settings__read-more">
-							<Button borderless compact href={ getModule( module_slug ).learn_more_button }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
-						</div>
-				</FoldableCard>
-			)
-			: null
-		: false;
+
+		if ( ! isAdmin || ! includes( moduleList, module_slug ) ) {
+			return null;
+		}
+
+		return (
+			<FoldableCard
+				className={ customClasses }
+				header={ getModule( module_slug ).name }
+				subheader={ getModule( module_slug ).description }
+				clickableHeaderText={ true }
+				disabled={ ! isAdmin }
+				summary={ isAdmin ? toggle( module_slug ) : '' }
+				expandedSummary={ isAdmin ? toggle( module_slug ) : '' }
+				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: module_slug,
+						path: props.route.path
+					}
+				) }
+			>
+				<div className="jp-form-setting-explanation"><div dangerouslySetInnerHTML={ renderLongDescription( getModule( module_slug ) ) } /></div>
+				<div className="jp-module-settings__read-more">
+					<Button borderless compact href={ getModule( module_slug ).learn_more_button }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+				</div>
+			</FoldableCard>
+		);
 	};
 
 	return (

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -8,6 +8,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
 import SimpleNotice from 'components/notice';
+import includes from 'lodash/includes';
 import analytics from 'lib/analytics';
 
 /**
@@ -21,7 +22,8 @@ import {
 	deactivateModule,
 	isActivatingModule,
 	isDeactivatingModule,
-	getModule as _getModule
+	getModule as _getModule,
+	getModules
 } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
@@ -39,7 +41,8 @@ export const Page = ( props ) => {
 		isTogglingModule,
 		getModule,
 		currentIp
-		} = props;
+	} = props,
+		moduleList = Object.keys( props.moduleList );
 	var cards = [
 		[ 'scan', __( 'Security Scanning' ), __( 'Automated, comprehensive protection from threats and attacks.' ), 'https://vaultpress.com/jetpack/' ],
 		[ 'protect', getModule( 'protect' ).name, getModule( 'protect' ).description, getModule( 'protect' ).learn_more_button ],
@@ -48,6 +51,9 @@ export const Page = ( props ) => {
 		[ 'backups', __( 'Site Backups' ), __( 'Automatically backup your entire site.' ), 'https://vaultpress.com/jetpack/' ],
 		[ 'sso', getModule( 'sso' ).name, getModule( 'sso' ).description, getModule( 'sso' ).learn_more_button ]
 	].map( ( element ) => {
+		if ( ! includes( moduleList, element[0] ) ) {
+			return null;
+		}
 		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			toggle = (
 				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
@@ -140,7 +146,8 @@ export default connect(
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
 			isFetchingPluginsData: isFetchingPluginsData( state ),
 			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
-			currentIp: getCurrentIp( state )
+			currentIp: getCurrentIp( state ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -19,7 +19,8 @@ import {
 	deactivateModule,
 	isActivatingModule,
 	isDeactivatingModule,
-	getModule as _getModule
+	getModule as _getModule,
+	getModules
 } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
@@ -33,8 +34,9 @@ export const Writing = ( props ) => {
 		isTogglingModule,
 		getModule,
 		userCanManageModules
-	} = props;
-	let isAdmin = userCanManageModules;
+	} = props,
+		isAdmin = userCanManageModules,
+		moduleList = Object.keys( props.moduleList );
 	/**
 	 * Array of modules that directly map to a card for rendering
 	 * @type {Array}
@@ -62,6 +64,9 @@ export const Writing = ( props ) => {
 		cards = cards.filter( ( element, index ) => cards.indexOf( element ) === index );
 	}
 	cards = cards.map( ( element, i ) => {
+		if ( ! includes( moduleList, element[0] ) ) {
+			return null;
+		}
 		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			toggle = '',
@@ -128,7 +133,8 @@ export default connect(
 			isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
-			userCanManageModules: _userCanManageModules( state )
+			userCanManageModules: _userCanManageModules( state ),
+			moduleList: getModules( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -271,7 +271,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'errorDescription' => Jetpack::state( 'error_description' ),
 			),
 			'tracksUserData' => $this->jetpack_get_tracks_user_data(),
-			'currentIp' => jetpack_protect_get_ip()
+			'currentIp' => function_exists( 'jetpack_protect_get_ip' ) ? jetpack_protect_get_ip() : false
 		) );
 	}
 }


### PR DESCRIPTION
Before this PR, filtering modules out could result in

<img width="743" alt="captura de pantalla 2016-08-31 a las 17 36 46" src="https://cloud.githubusercontent.com/assets/1041600/18145424/8bfa5832-6fa1-11e6-96a3-e7ae1c2772db.png">

#### Changes proposed in this Pull Request:
- checks that hardcoded modules are among those that are not filtered out by using the filter `jetpack_get_available_modules`
- removes card from At a Glance that belongs to a module removed through the filter

#### Testing instructions:
- paste this where it can be executed
```php
add_filter( 'jetpack_get_available_modules', function ( $modules ) {
	unset( $modules['protect'] );
	unset( $modules['carousel'] );
	unset( $modules['post-by-email'] );
	unset( $modules['sharedaddy'] );
	unset( $modules['json-api'] );
	unset( $modules['photon'] );
	return $modules;
} );
```
- go to Jetpack > Settings and make sure those cards don't look empty like before, but like

<img width="739" alt="captura de pantalla 2016-08-31 a las 17 38 19" src="https://cloud.githubusercontent.com/assets/1041600/18145474/c0b48a98-6fa1-11e6-8b88-e355b3e03b6f.png">

- in Jetpack > Dashboard > At a Glance, make sure that cards that belong to a filtered out module are not displayed.