### PR TITLE
Sync: Begin syncing _wp_attached_file meta

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -198,6 +198,7 @@ class Jetpack_Sync_Defaults {
 		'_wp_page_template',
 		'_publicize_twitter_user',
 		'_wp_trash_meta_comments_status',
+		'_wp_attached_file',
 	);
 
 	static $default_blacklist_meta_keys = array(


### PR DESCRIPTION
Previously, we were not syncing `_wp_attached_file` meta which is needed to use core functions such as `wp_get_attachment_image_src()`.

This, along with a WPCOM patch, will fix an issue we're seeing with featured posts not being properly synced over. Awaiting WPCOM patch.