### PR TITLE
Sync: Backfill posts with _wp_attached_file meta key on upgrade from 4.2 - 4.2.2

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -158,7 +158,7 @@ class Jetpack_Sync_Actions {
 		}
 
 		if ( $old_version && version_compare( $old_version, '4.2.3', '<' ) && version_compare( $old_version, '4.2', '>=' ) ) {
-			$initial_sync_config['posts'] = true;
+			$initial_sync_config['posts'] = array( 'meta' => '_wp_attached_file' );
 		}
 
 		// we need this function call here because we have to run this function

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -157,6 +157,10 @@ class Jetpack_Sync_Actions {
 			$initial_sync_config['users'] = 'initial';
 		}
 
+		if ( $old_version && version_compare( $old_version, '4.2.3', '<' ) && version_compare( $old_version, '4.2', '>=' ) ) {
+			$initial_sync_config['posts'] = true;
+		}
+
 		// we need this function call here because we have to run this function
 		// reeeeally early in init, before WP_CRON_LOCK_TIMEOUT is defined.
 		wp_functionality_constants();

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -74,6 +74,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$modules['users'] = $user_module->get_initial_sync_user_config();
 		}
 
+		if( isset( $modules['posts'] ) && isset( $modules['posts']['meta'] ) ) {
+			$posts_module = Jetpack_Sync_Modules::get_module( 'posts' );
+			$modules['posts'] = $posts_module->backfill_posts_with_meta_key_config( $modules['posts']['meta'] );
+		}
+
 		// by default, all modules are fully enabled
 		if ( count( $modules ) === 0 ) {
 			$default_module_config = true;

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -140,4 +140,33 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$this->get_term_relationships( $post_ids ),
 		);
 	}
+
+	/**
+	 * Attempt to backfill up to the last 1,000 posts with $meta_key.
+	 *
+	 * Backfilling is necessary after adding meta keys to the whitelist.
+	 *
+	 * @param $meta_key
+	 *
+	 * @return array|bool
+	 */
+	public function backfill_posts_with_meta_key_config( $meta_key ) {
+		global $wpdb;
+		if ( ! $meta_key ) {
+			return false;
+		}
+
+		$post_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1000 ORDER BY post_id DESC",
+				$meta_key
+			)
+		);
+
+		if ( empty( $post_ids ) ){
+			return false;
+		}
+
+		return $post_ids;
+	}
 }


### PR DESCRIPTION
With previous versions of new sync, we weren't syncing `_wp_attached_file` meta, which meant that we couldn't use methods on WPCOM such as `wp_get_attachment_img_src()` to get featured images URLs.

In #5054, we began syncing that meta, but we now need to backfill the meta for posts that were published while a site was on `4.2 - 4.2.2` of Jetpack. This PR should handle that.
