### PR TITLE
Make unreliable sync tests work consistently

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -55,11 +55,11 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 
 	function test_white_listed_constant_doesnt_get_synced_twice() {
 		$this->constant_module->set_constants_whitelist( array( 'TEST_ABC' ) );
-		define( 'TEST_ABC', microtime( true ) );
+		define( 'TEST_ABC', 'FOO' );
 		$this->sender->do_sync();
 
 		$synced_value = $this->server_replica_storage->get_constant( 'TEST_ABC' );
-		$this->assertEquals( sprintf( "%.2f", TEST_ABC ), sprintf( "%.2f", $synced_value ) );
+		$this->assertEquals( 'FOO', $synced_value );
 
 		$this->server_replica_storage->reset();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -781,8 +781,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$comments = $synced_comments_event->args[0];
 
 		$this->assertEquals( 2, count( $comments ) );
-		$this->assertEquals( $sync_comment_id, $comments[0]->comment_ID );
-		$this->assertEquals( $sync_comment_id_2, $comments[1]->comment_ID );
+		$comment_IDs = array( $comments[0]->comment_ID, $comments[1]->comment_ID );
+
+		$this->assertTrue( in_array( $sync_comment_id, $comment_IDs ) );
+		$this->assertTrue( in_array( $sync_comment_id_2, $comment_IDs ) );
 
 		$sync_status = $this->full_sync->get_status();
 		$this->assertEquals( array( $sync_comment_id, $sync_comment_id_2 ), $sync_status['config']['comments'] );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -783,8 +783,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 2, count( $comments ) );
 		$comment_IDs = array( $comments[0]->comment_ID, $comments[1]->comment_ID );
 
-		$this->assertTrue( in_array( $sync_comment_id, $comment_IDs ) );
-		$this->assertTrue( in_array( $sync_comment_id_2, $comment_IDs ) );
+		$this->assertContains( $sync_comment_id, $comment_IDs );
+		$this->assertContains( $sync_comment_id_2, $comment_IDs );
 
 		$sync_status = $this->full_sync->get_status();
 		$this->assertEquals( array( $sync_comment_id, $sync_comment_id_2 ), $sync_status['config']['comments'] );


### PR DESCRIPTION
Don't use time, just use a string.

Don't rely on comment IDs syncing in a particular order.