### PR TITLE
Admin - Plans: show Manage Plugins and Try Editor only to users that can do it in Calypso

### DIFF
--- a/_inc/client/apps/index.jsx
+++ b/_inc/client/apps/index.jsx
@@ -10,7 +10,7 @@ import { translate as __ } from 'i18n-calypso';
  * Internal dependencies
  */
 import { imagePath } from 'constants';
-import { userCanViewStats } from 'state/initial-state';
+import { userCanViewStats, userCanManagePlugins, userCanEditPosts } from 'state/initial-state';
 
 const Apps = ( props ) => {
 	let canViewStats = props.userCanViewStats;
@@ -40,33 +40,48 @@ const Apps = ( props ) => {
 			</div>
 
 			<div className="jp-landing-apps__feature-container">
-				<div className="jp-landing-apps__feature">
-					<div className="jp-landing-apps__feature-col jp-landing-apps__feature-img">
-						<img src={ imagePath + '/apps/manage2x.jpg' } />
-					</div>
-					<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
-						<h3 className="jp-landing__apps-feature-title">{ __( 'Bulk and automatic updates' ) }</h3>
-						<p className="jp-landing__apps-feature-text">{ __( 'Most security flaws are found in outdated plugins. Use our Web and Desktop apps to turn on auto-updates or update plugins manually for all your websites in one convenient place.' ) }</p>
-						<Button href={ 'https://wordpress.com/plugins/' + props.siteRawUrl }	className="is-primary">
-							{ __( 'Manage Plugins' ) }
-						</Button>
-					</div>
-				</div>
-
-				<div className="jp-landing-apps__feature">
-					<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
-						<h3 className="jp-landing__apps-feature-title">{ __( 'Focus on your Writing' ) }</h3>
-						<p className="jp-landing__apps-feature-text">{ __( 'Our new editor is lightning fast, optimized for writers and eliminates distractions, giving you the ability to focus on your work.' ) }</p>
-						<Button href={ 'https://wordpress.com/post/' + props.siteRawUrl }	className="is-primary">
-							{ __( 'Try the New Editor' ) }
-						</Button>
-					</div>
-					<div className="jp-landing-apps__feature-col jp-landing-apps__feature-img">
-						<img src={ imagePath + '/apps/editor2x.jpg' } />
-					</div>
-				</div>
 
 				{
+					// Manage Plugins
+
+					props.userCanManagePlugins
+					?	<div className="jp-landing-apps__feature">
+							<div className="jp-landing-apps__feature-col jp-landing-apps__feature-img">
+								<img src={ imagePath + '/apps/manage2x.jpg' } />
+							</div>
+							<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
+								<h3 className="jp-landing__apps-feature-title">{ __( 'Bulk and automatic updates' ) }</h3>
+								<p className="jp-landing__apps-feature-text">{ __( 'Most security flaws are found in outdated plugins. Use our Web and Desktop apps to turn on auto-updates or update plugins manually for all your websites in one convenient place.' ) }</p>
+								<Button href={ 'https://wordpress.com/plugins/' + props.siteRawUrl }	className="is-primary">
+									{ __( 'Manage Plugins' ) }
+								</Button>
+							</div>
+						</div>
+					: null
+				}
+
+				{
+					// Calypso Editor
+
+					props.userCanEditPosts
+					?	<div className="jp-landing-apps__feature">
+							<div className="jp-landing-apps__feature-col jp-landing-apps__feature-desc">
+								<h3 className="jp-landing__apps-feature-title">{ __( 'Focus on your Writing' ) }</h3>
+								<p className="jp-landing__apps-feature-text">{ __( 'Our new editor is lightning fast, optimized for writers and eliminates distractions, giving you the ability to focus on your work.' ) }</p>
+								<Button href={ 'https://wordpress.com/post/' + props.siteRawUrl }	className="is-primary">
+									{ __( 'Try the New Editor' ) }
+								</Button>
+							</div>
+							<div className="jp-landing-apps__feature-col jp-landing-apps__feature-img">
+								<img src={ imagePath + '/apps/editor2x.jpg' } />
+							</div>
+						</div>
+					: null
+				}
+
+				{
+					// Stats
+
 					canViewStats ? (
 						<div className="jp-landing-apps__feature">
 							<div className="jp-landing-apps__feature-col jp-landing-apps__feature-img">
@@ -87,6 +102,8 @@ const Apps = ( props ) => {
 
 				<div className="jp-landing-apps__feature">
 					{
+						// Community
+
 						canViewStats ? (
 							''
 						) : (
@@ -184,7 +201,9 @@ const Apps = ( props ) => {
 export default connect(
 	( state ) => {
 		return {
-			userCanViewStats: userCanViewStats( state )
+			userCanViewStats: userCanViewStats( state ),
+			userCanManagePlugins: userCanManagePlugins( state ),
+			userCanEditPosts: userCanEditPosts( state )
 		};
 	}
 )( Apps );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -87,6 +87,28 @@ export function userCanManageOptions( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'manage_options', false );
 }
 
+/**
+ * Return true if user can edit posts, usually admins, editors, authors and contributors.
+ *
+ * @param {Object} state Global state tree
+ *
+ * @return {bool} Whether user can edit posts.
+ */
+export function userCanEditPosts( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'edit_posts', false );
+}
+
+/**
+ * Return true if user can manage plugins, which means being able to install, activate, update and delete plugins.
+ *
+ * @param {Object} state Global state tree
+ *
+ * @return {bool} Whether user can manage plugins.
+ */
+export function userCanManagePlugins( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'manage_plugins', false );
+}
+
 export function userCanDisconnectSite( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'disconnect', false );
 }

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -397,7 +397,7 @@ function jetpack_master_user_data() {
 	return $master_user_data;
 }
 
-/*
+/**
  * Gather data about the current user.
  *
  * @since 4.1.0
@@ -428,6 +428,10 @@ function jetpack_current_user_data() {
 			'edit_posts'         => current_user_can( 'edit_posts' ),
 			'manage_options'     => current_user_can( 'manage_options' ),
 			'view_stats'		 => current_user_can( 'view_stats' ),
+			'manage_plugins'	 => current_user_can( 'install_plugins' )
+									&& current_user_can( 'activate_plugins' )
+									&& current_user_can( 'update_plugins' )
+									&& current_user_can( 'delete_plugins' ),
 		),
 	);
 


### PR DESCRIPTION
Fixes #5052

#### Changes proposed in this Pull Request:
- Initial State - User Data: add `manage_plugins` property that will be true if user can install, activate, update and delete plugins
- Introduce new reducers userCanManagePlugins and userCanEditPosts.

    The first one is true if user can install, activate, update and delete plugins.
    The second one is true if user can edit posts, usually admins, editors, authors and contributors.

- Show **Bulk and automatic updates** section only to users that can manage plugins.
    Show **Focus on your Writing** section only to users that can edit posts.

#### Testing instructions:
in all cases go to Jetpack > Dashboard > Apps:
- login as an editor, author or contributor, verify that you can see the Focus on your Writing section but not Bulk and automatic updates
- login as a subscriber, verify you can only see the Connect with the Community section
- login as an admin user, verify you have access to everything

