### PR TITLE
Sync: Update /sites/$site/sync/object to return array of objects

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -196,13 +196,13 @@ class Jetpack_JSON_API_Sync_Object extends Jetpack_JSON_API_Sync_Endpoint {
 		}
 
 		$object_type = $args['object_type'];
-		$object_id   = $args['object_id'];
+		$object_ids  = $args['object_ids'];
 
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 		$codec = Jetpack_Sync_Sender::get_instance()->get_codec();
 
 		return array(
-			'object' => $codec->encode( $sync_module->get_object_by_id( $object_type, $object_id ) )
+			'objects' => $codec->encode( $sync_module->get_objects_by_id( $object_type, $object_ids ) )
 		);
 	}
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -708,14 +708,14 @@ new Jetpack_JSON_API_Sync_Object( array(
 		'$site'        => '(int|string) The site ID, The site domain'
 	),
 	'query_parameters' => array(
-		'module_name'      => '(string) The sync module ID, e.g. "posts"',
-		'object_type' => '(string) An identified for the object type, e.g. "post"',
-		'object_id'   => '(int|string) The ID of the object',
+		'module_name'    => '(string) The sync module ID, e.g. "posts"',
+		'object_type'    => '(string) An identified for the object type, e.g. "post"',
+		'object_ids'     => '(array) The IDs of the objects',
 	),
 	'response_format' => array(
-		'object' => '(string) The encoded object'
+		'objects' => '(string) The encoded objects'
 	),
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/object/posts/post/5'
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/object?module_name=posts&object_type=post&object_ids[]=1&object_ids[]=2&object_ids[]=3'
 ) );
 
 // POST /sites/%s/sync/now

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -108,4 +108,22 @@ abstract class Jetpack_Sync_Module {
 		$meta->meta_value = maybe_unserialize( $meta->meta_value );
 		return $meta;
 	}
+
+	public function get_objects_by_id( $object_type, $ids ) {
+		if ( empty( $ids ) || empty( $object_type ) ) {
+			return array();
+		}
+
+		$objects = array();
+		foreach( (array) $ids as $id ) {
+			$object = $this->get_object_by_id( $object_type, $id );
+
+			// Only add object if we have the object.
+			if ( $object ) {
+				$objects[ $id ] = $object;
+			}
+		}
+
+		return $objects;
+	}
 }


### PR DESCRIPTION
Alternative to #5055.

In this PR, we udpate the the `/sites/$site/sync/object` endpoint to accept an array of object IDs which will be useful for us to bulk backfill objects where we are missing data on WPCOM.
