### PR TITLE
VideoPress: Fix for an error in PHP 5.2.17 when uploading a video

### DIFF
--- a/modules/videopress/class.videopress-video.php
+++ b/modules/videopress/class.videopress-video.php
@@ -254,7 +254,7 @@ class VideoPress_Video {
 		if ( empty( $expires_header ) || ! is_string( $expires_header ) )
 			return false;
 
-		if ( class_exists( 'DateTime' ) && class_exists( 'DateTimeZone' ) ) {
+		if ( version_compare( PHP_VERSION, '5.3.0' ) >= 0 && class_exists( 'DateTime' ) && class_exists( 'DateTimeZone' ) ) {
 			$expires_date = DateTime::createFromFormat( 'D, d M Y H:i:s T', $expires_header, new DateTimeZone( 'UTC' ) );
 			if ( $expires_date instanceOf DateTime )
 				return date_format( $expires_date, 'U' );

--- a/modules/videopress/class.videopress-video.php
+++ b/modules/videopress/class.videopress-video.php
@@ -255,8 +255,7 @@ class VideoPress_Video {
 			return false;
 
 		if (
-			class_exists( 'DateTime' )
-			&& class_exists( 'DateTimeZone' )
+			class_exists( 'DateTimeZone' )
 			&& method_exists( 'DateTime', 'createFromFormat' )
 		) {
 			$expires_date = DateTime::createFromFormat( 'D, d M Y H:i:s T', $expires_header, new DateTimeZone( 'UTC' ) );

--- a/modules/videopress/class.videopress-video.php
+++ b/modules/videopress/class.videopress-video.php
@@ -254,7 +254,11 @@ class VideoPress_Video {
 		if ( empty( $expires_header ) || ! is_string( $expires_header ) )
 			return false;
 
-		if ( version_compare( PHP_VERSION, '5.3.0' ) >= 0 && class_exists( 'DateTime' ) && class_exists( 'DateTimeZone' ) ) {
+		if (
+			class_exists( 'DateTime' )
+			&& class_exists( 'DateTimeZone' )
+			&& method_exists( 'DateTime', 'createFromFormat' )
+		) {
 			$expires_date = DateTime::createFromFormat( 'D, d M Y H:i:s T', $expires_header, new DateTimeZone( 'UTC' ) );
 			if ( $expires_date instanceOf DateTime )
 				return date_format( $expires_date, 'U' );


### PR DESCRIPTION
It seems like VideoPress is using the `DateTime::createFromFormat()` function, which was introduced in PHP 5.3. There is already a check before this code runs that checks that the `DateTime` exists, however since that class does exist, but is missing the required method, this code is still running.

In order to fix this, I'm adding an explicit version check to verify that PHP 5.3 is being used before this runs. Otherwise, it will use the existing non-DateTime fallback.