### PR TITLE
Publicize Settings: Fix config link on subdirectories 

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -137,7 +137,7 @@ export const AllModuleSettings = React.createClass( {
 			case 'sharedaddy':
 			default:
 				if ( 'publicize' === module.module ) {
-					module.configure_url = '/wp-admin/options-general.php?page=sharing';
+					module.configure_url = this.props.adminUrl + 'options-general.php?page=sharing';
 				}
 				return (
 					<div>

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -119,7 +119,7 @@ export const Engagement = ( props ) => {
 			>
 				{
 					isModuleActive ?
-						<AllModuleSettings module={ getModule( element[0] ) } /> :
+						<AllModuleSettings module={ getModule( element[0] ) } adminUrl={ props.getSiteAdminUrl() } /> :
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}


### PR DESCRIPTION
Fixes #5060

**To Test:** 
- Make sure the publicize configure link works in subdirectories

![screen shot 2016-09-02 at 11 13 05 am](https://cloud.githubusercontent.com/assets/7129409/18208640/457af80e-70fe-11e6-9f50-401c9cc4bfe6.png)
