### PR TITLE
Sharing: add inline script for js_dialog only after sharing-js has been enqueued

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -327,18 +327,19 @@ abstract class Sharing_Source {
 			$opts[] = "$key=$val";
 		}
 		$opts = implode( ',', $opts );
-		?>
-		<script type="text/javascript">
-		var windowOpen;
-		jQuery(document.body).on('click', 'a.share-<?php echo $name; ?>', function() {
-			if ( 'undefined' !== typeof windowOpen ){ // If there's another sharing window open, close it.
-				windowOpen.close();
-			}
-			windowOpen = window.open( jQuery(this).attr( 'href' ), 'wpcom<?php echo $name; ?>', '<?php echo $opts; ?>' );
-			return false;
-		});
-		</script>
-		<?php
+
+		// Add JS after sharing-js has been enqueued.
+		wp_add_inline_script( 'sharing-js',
+			"var windowOpen;
+			jQuery( document.body ).on( 'click', 'a.share-$name', function() {
+				// If there's another sharing window open, close it.
+				if ( 'undefined' !== typeof windowOpen ) {
+					windowOpen.close();
+				}
+				windowOpen = window.open( jQuery( this ).attr( 'href' ), 'wpcom$name', '$opts' );
+				return false;
+			});"
+		);
 	}
 }
 


### PR DESCRIPTION
Fixes #4661

#### Changes proposed in this Pull Request:
- Use the new `wp_add_inline_script()` to enqueue the inline script in method `Sharing_Source::js_dialog` only after `sharing-js` has been enqueued in `sharing_add_footer()`.

#### Testing instructions:
To test, use a theme that doesn't load jQuery at all. Make sure you don't have a plugin that does it on its own.

1. before testing this branch, add some buttons to Sharing and go to to the front end _without being logged in_ (WP adds jQuery with the Admin Bar) and verify the JS errors in Console.

2. test the branch, go to front end again and verify that it works fine now.