### PR TITLE
Admin - Legacy: show error message in fallback page when static.html is missing

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -136,14 +136,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		/** This action is already documented in views/admin/admin-page.php */
 		do_action( 'jetpack_notices' );
 
-		$static_html = wp_remote_get( esc_url( plugins_url( '/_inc/build/static.html', JETPACK__PLUGIN_FILE ) ), array( 'sslverify' => false ) );
+		$static_html = wp_remote_get( esc_url( plugins_url( '/_inc/build/static.html', JETPACK__PLUGIN_FILE ) ) );
 		echo 200 == wp_remote_retrieve_response_code( $static_html )
 			? wp_remote_retrieve_body( $static_html )
-			: esc_html__( 'Error fetching page.', 'jetpack' );
+			: esc_html__( 'Error fetching static.html.', 'jetpack' );
 	}
 
 	function get_i18n_data() {
-		$locale_data = wp_remote_get( esc_url( plugins_url( '/languages/json/jetpack-' . get_locale() . '.json', JETPACK__PLUGIN_FILE ) ), array( 'sslverify' => false ) );
+		$locale_data = wp_remote_get( esc_url( plugins_url( '/languages/json/jetpack-' . get_locale() . '.json', JETPACK__PLUGIN_FILE ) ) );
 		$locale_data = 200 == wp_remote_retrieve_response_code( $locale_data )
 			? wp_remote_retrieve_body( $locale_data )
 			: false;

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -21,22 +21,27 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 		$list_table = new Jetpack_Modules_List_Table;
 		$build_url = esc_url( plugins_url( '/_inc/build/',  JETPACK__PLUGIN_FILE ) );
 
-		$static_html = wp_remote_get( $build_url . 'static.html', array( 'sslverify' => false ) );
-		$static_html = 200 == wp_remote_retrieve_response_code( $static_html )
-			? wp_remote_retrieve_body( $static_html )
-			: '';
+		$static_html = wp_remote_get( $build_url . 'static.html' );
+		if ( 200 == wp_remote_retrieve_response_code( $static_html ) ) {
+			$static_html = wp_remote_retrieve_body( $static_html );
+		} else {
+			esc_html_e( 'Error fetching static.html.', 'jetpack' );
 
-		$noscript_notice = wp_remote_get( $build_url . 'static-noscript-notice.html', array( 'sslverify' => false ) );
+			// If static.html isn't there, there's nothing else we can do.
+			return;
+		}
+
+		$noscript_notice = wp_remote_get( $build_url . 'static-noscript-notice.html' );
 		$noscript_notice = 200 == wp_remote_retrieve_response_code( $noscript_notice )
 			? wp_remote_retrieve_body( $noscript_notice )
 			: '';
 
-		$version_notice = wp_remote_get( $build_url . 'static-version-notice.html', array( 'sslverify' => false ) );
+		$version_notice = wp_remote_get( $build_url . 'static-version-notice.html' );
 		$version_notice = 200 == wp_remote_retrieve_response_code( $version_notice )
 			? wp_remote_retrieve_body( $version_notice )
 			: '';
 
-		$ie_notice = wp_remote_get( $build_url . 'static-ie-notice.html', array( 'sslverify' => false ) );
+		$ie_notice = wp_remote_get( $build_url . 'static-ie-notice.html' );
 		$ie_notice = 200 == wp_remote_retrieve_response_code( $ie_notice )
 			? wp_remote_retrieve_body( $ie_notice )
 			: '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- show error message in ?page=jetpack_modules
- reword error to point it's specifically `static.html` the missing file
- remove `sslverify => false`.

#### Testing instructions:
- go to `admin.php?page=jetpack` and `admin.php?page=jetpack_modules` and verify everything loads fine.
- rename static.html and check that there's a message in both pages.