### PR TITLE
Eliminate extra checks for publicize status if UI disabled

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -712,7 +712,9 @@ jQuery( function($) {
 					<input type="hidden" name="wpas[0]" value="1" />
 
 				</div>
-				<div id="pub-connection-tests"></div>
+				<?php if ( ! $all_done ) : ?>
+					<div id="pub-connection-tests"></div>
+				<?php endif; ?>
 				<?php // #publicize-form
 
 				$publicize_form = ob_get_clean();


### PR DESCRIPTION
The presence of a div with ID `pub-connection-tests` causes an AJAX request to be triggered which in turns becomes NUM_PUBLICIZE_CONNECTIONS requests to WPCOM.

This is not very useful when the publicize UI is disabled, so I remove that div when a post has already been publicized.