### PR TITLE
Top Posts: make sure attachment pages can be displayed as well.

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -524,7 +524,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			}
 
 			// hide private and password protected posts
-			if ( 'publish' != $post->post_status || ! empty( $post->post_password ) || empty( $post->ID ) ) {
+			if ( 'publish' != $post->post_status || ! empty( $post->post_password ) ) {
 				continue;
 			}
 

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -510,12 +510,23 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		foreach ( (array) $post_ids as $post_id ) {
 			$post = get_post( $post_id );
 
-			if ( ! $post )
+			if ( ! $post ) {
 				continue;
+			}
+
+			/**
+			 * Attachment pages use the 'inherit' post status by default.
+			 * To be able to remove attachment pages from private and password protect posts,
+			 * we need to replace their post status by the parent post' status.
+			 */
+			if ( 'inherit' == $post->post_status && 'attachment' == $post->post_type ) {
+				$post->post_status = get_post_status( $post_id );
+			}
 
 			// hide private and password protected posts
-			if ( 'publish' != $post->post_status || ! empty( $post->post_password ) || empty( $post->ID ) )
+			if ( 'publish' != $post->post_status || ! empty( $post->post_password ) || empty( $post->ID ) ) {
 				continue;
+			}
 
 			// Both get HTML stripped etc on display
 			if ( empty( $post->post_title ) ) {


### PR DESCRIPTION
The Top Posts widget includes an option to display "Media", i.e. Attachment pages, if there are any among the Top Posts returned for a site.
However, attachment pages use the 'inherit' post status by default. Since we filter out any post that doesn't have the 'publish' post status, attachment pages were never displayed.

This commit overwrites the attachments' post status, to use the parent post's status instead. It uses `get_post_status` to do that; this function will return the parent post status if given post ID is of an attachment.