### PR TITLE
Blacklist wp_automatic_cache

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -220,6 +220,7 @@ class Jetpack_Sync_Defaults {
 		'mip_post_views_count',
 		'esml_socialcount_LAST_UPDATED',
 		'wprss_last_update_items',
+		'wp_automatic_cache',
 	);
 
 	// TODO: move this to server? - these are theme support values


### PR DESCRIPTION
wp_automatic_cache is written by a plugin (yet to be identified) and often contains hundreds of megabytes of data per post. This causes trouble when it's synced.

This PR blacklists the meta.