### PR TITLE
Fix/custom content types configure display

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -613,7 +613,7 @@ export let CustomContentTypesSettings = React.createClass( {
 				'' :
 				<Button
 					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
-					href="/wp-admin/edit.php?post_type=jetpack-portfolio"
+					href={ this.props.siteAdminUrl + '/wp-admin/edit.php?post_type=jetpack-portfolio' }
 					compact={ true }
 				>{ __( 'Configure Portfolios' ) }</Button>;
 		};
@@ -623,7 +623,7 @@ export let CustomContentTypesSettings = React.createClass( {
 				'' :
 				<Button
 					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
-					href="/wp-admin/edit.php?post_type=jetpack-testimonial"
+					href={ this.props.siteAdminUrl + '/wp-admin/edit.php?post_type=jetpack-testimonial' }
 					compact={ true }
 				>{ __( 'Configure Testimonials' ) }</Button>;
 		};

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -609,7 +609,7 @@ PostByEmailSettings = moduleSettingsForm( PostByEmailSettings );
 export let CustomContentTypesSettings = React.createClass( {
 	render() {
 		let portfolioConfigure = () => {
-			return ! this.props.getOptionValue( 'jetpack_portfolio' ) ?
+			return ! this.props.getOptionCurrentValue( this.props.module.module, 'jetpack_portfolio' ) ?
 				'' :
 				<Button
 					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
@@ -619,7 +619,7 @@ export let CustomContentTypesSettings = React.createClass( {
 		};
 
 		let testimonialConfigure = () => {
-			return ! this.props.getOptionValue( 'jetpack_testimonial' ) ?
+			return ! this.props.getOptionCurrentValue( this.props.module.module, 'jetpack_testimonial' ) ?
 				'' :
 				<Button
 					disabled={ ! this.props.shouldSaveButtonBeDisabled() }

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -101,7 +101,7 @@ export const Writing = ( props ) => {
 				) }
 			>
 				{ isModuleActivated( element[0] ) || 'scan' === element[0] ?
-					<AllModuleSettings module={ getModule( element[0] ) } /> :
+					<AllModuleSettings module={ getModule( element[0] ) } siteAdminUrl={ props.siteAdminUrl } /> :
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}


### PR DESCRIPTION
Fixes #5080

Also fixes an issue seen in my local server: the links to portfolio and testimonial edit screens were broken, leading nowhere.

#### Changes proposed in this Pull Request:
- Admin: show or hide Configure {CPT} only after settings are saved
- Admin: fix urls to portfolio and testimonial edit screens

#### Testing instructions:
- go to Jetpack > Settings > Writing, expand Custom Content Types. Tick the Portfolio checkbox, the button Configure Portfolios shouldn't show up. Now save settings, the button should show up now. Same for Testimonials.

- verify that the link where Configure Portfolios goes is correct. Again, this was only visible in my local server.

cc @zinigor for review
