### PR TITLE
Admin Page: Make the user confirm navigating away when there are unsaved settings…

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -54,16 +54,38 @@ const Main = React.createClass( {
 		restApi.setApiNonce( this.props.apiNonce );
 		this.initializeAnalyitics();
 
-		this.props.router.listenBefore( () => {
-			if ( this.props.areThereUnsavedModuleOptions ) {
-				const confirmLeave = confirm( __( 'There are unsaved settings in this tab that will be lost if you leave it. Proceed?' ) );
-				if ( confirmLeave ) {
-					this.props.clearUnsavedOptionFlag();
-				} else {
-					return false;
-				}
+		// Handles refresh, closing and navigating away from Jetpack's Admin Page
+		window.addEventListener( 'beforeunload', this.onBeforeUnload );
+		// Handles transition between routes handled by react-router
+		this.props.router.listenBefore( this.routerWillLeave );
+	},
+
+	/*
+	 * Returns a string if there are unsaved module settings thus showing a confirm dialog to the user
+	 * according to the `beforeunload` event handling specification
+	 */
+	onBeforeUnload( e ) {
+		const dialogText = __( 'There are unsaved settings in this tab that will be lost if you leave it. Proceed?' );
+		if ( this.props.areThereUnsavedModuleOptions ) {
+			e.returnValue = dialogText;
+			return dialogText;
+		}
+	},
+
+	/*
+ 	 * Shows a confirmation dialog if there are unsaved module settings.
+ 	 *
+ 	 * Return true or false according to the history.listenBefore specification which is part of react-router
+	 */
+	routerWillLeave() {
+		if ( this.props.areThereUnsavedModuleOptions ) {
+			const confirmLeave = confirm( __( 'There are unsaved settings in this tab that will be lost if you leave it. Proceed?' ) );
+			if ( confirmLeave ) {
+				this.props.clearUnsavedOptionFlag();
+			} else {
+				return false;
 			}
-		} );
+		}
 	},
 
 	initializeAnalyitics() {


### PR DESCRIPTION
Fixes #5051

#### Changes proposed in this Pull Request:

* Makes the Admin Page ask for confirmation if there are unsaved settings when refreshing the browser, following a link external to the Admin Page or closing the browser window/tab. 

#### Testing instructions:
- Get the settings page
- Update a module's setting withou saving afterwards
- Try to refresh the page, expect to be prompted for confirmation and choose to stay in the page
- Try to close the tab, expect to be prompted for confirmation and choose to stay in the page
- Try to click any Nav Menu Item not belonging to Jetpack, expect to be prompted for confirmation and choose to leave

