### PR TITLE
Inline Docs: 4.3->4.3.0

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -17,7 +17,7 @@ abstract class Jetpack_Admin_Page {
 	/**
 	 * Function called after admin_styles to load any additional needed styles.
 	 *
-	 * @since 4.3
+	 * @since 4.3.0
 	 */
 	function additional_styles() {}
 

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -41,7 +41,7 @@ abstract class Jetpack_Admin_Page {
 		add_action( "load-$hook",                array( $this, 'admin_help'      ) );
 		add_action( "load-$hook",                array( $this, 'admin_page_load' ) );
 		add_action( "admin_head-$hook",          array( $this, 'admin_head'      ) );
-		
+
 		add_action( "admin_print_styles-$hook",  array( $this, 'admin_styles'    ) );
 		add_action( "admin_print_scripts-$hook", array( $this, 'admin_scripts'   ) );
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -49,7 +49,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 *
 	 * Works in Dev Mode or when user is connected.
 	 *
-	 * @since 4.3
+	 * @since 4.3.0
 	 */
 	function jetpack_add_dashboard_sub_nav_item() {
 		if ( Jetpack::is_development_mode() || Jetpack::is_active() ) {
@@ -65,7 +65,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	/**
 	 * If user is allowed to see the Jetpack Admin, add Settings sub-link.
 	 *
-	 * @since 4.3
+	 * @since 4.3.0
 	 */
 	function jetpack_add_settings_sub_nav_item() {
 		if ( ( Jetpack::is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) ) {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -186,7 +186,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 	function page_admin_styles() {
 		$rtl = is_rtl() ? '.rtl' : '';
-		
+
 		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/admin.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 	}

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -165,7 +165,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	/**
 	 * Load styles for static page.
 	 *
-	 * @since 4.3
+	 * @since 4.3.0
 	 */
 	function additional_styles() {
 		$rtl = is_rtl() ? '.rtl' : '';

--- a/class.frame-nonce-preview.php
+++ b/class.frame-nonce-preview.php
@@ -9,7 +9,7 @@ class Jetpack_Frame_Nonce_Preview {
 	/**
 	 * Returns the single instance of the Jetpack_Frame_Nonce_Preview object
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.0
 	 *
 	 * @return Jetpack_Frame_Nonce_Preview
 	 **/
@@ -30,7 +30,7 @@ class Jetpack_Frame_Nonce_Preview {
 	/**
 	 * Verify that frame nonce exists, and if so, validate the nonce by calling WP.com.
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.0
 	 *
 	 * @return bool
 	 */
@@ -53,7 +53,7 @@ class Jetpack_Frame_Nonce_Preview {
 	/**
 	 * Conditionally add a hook on posts_results if this is the main query, a preview, and singular.
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.0
 	 *
 	 * @param WP_Query $query
 	 *
@@ -74,7 +74,7 @@ class Jetpack_Frame_Nonce_Preview {
 	/**
 	 * Conditionally set the first post to 'publish' if the frame nonce is valid and there is a post.
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.0
 	 *
 	 * @param array $posts
 	 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1169,7 +1169,7 @@ class Jetpack {
 		 *
 		 * This filter is especially useful for tests.
 		 *
-		 * @since 4.4.0
+		 * @since 4.3.0
 		 *
 		 * @param bool $development_version Is this a develoment version of Jetpack?
 		 */

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -161,7 +161,7 @@ class Jetpack_SSO_Helpers {
 	 * Instead of accessing JETPACK__API_BASE within the method directly, we set it as the
 	 * default for $api_base due to restrictions with testing constants in our tests.
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.0
 	 *
 	 * @param array $hosts
 	 * @param string $api_base


### PR DESCRIPTION
A few inline docs had `@since 4.3` instead of `@since 4.3.0` as they should.