### PR TITLE
Gulp: Make sure to create a jetpack-rtl.css for the front end

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -340,6 +340,9 @@ gulp.task( 'frontendcss', function() {
 			'*/\n'
 		) )
 		.pipe( gulp.dest( 'css' ) )
+		.pipe( rtlcss() )
+		.pipe( rename( { suffix: '-rtl' } ) )
+		.pipe( gulp.dest( 'css' ) )
 		.on( 'end', function() {
 			console.log( 'Front end modules CSS finished.' );
 		} );


### PR DESCRIPTION
Fixes #5093

We were not creating an rtl version of the jetpack.css frontend styles.  This does so.  

**To test:** 
- Switch to a language that uses RTL (Hebrew)
- Run `gulp frontendcss`
- Verify that `css/jetpack-rtl.css` has been created and it looks ok 
- Verify that the styles load properly on the front end of your site.  You can test this by visiting a page that has the sharing icons displayed.  There should be no console errors.  