### PR TITLE
Admin - Static: fetch files with file_get_contents

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -136,21 +136,33 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		/** This action is already documented in views/admin/admin-page.php */
 		do_action( 'jetpack_notices' );
 
-		$static_html = wp_remote_get( esc_url( plugins_url( '/_inc/build/static.html', JETPACK__PLUGIN_FILE ) ) );
-		echo 200 == wp_remote_retrieve_response_code( $static_html )
-			? wp_remote_retrieve_body( $static_html )
-			: esc_html__( 'Error fetching static.html.', 'jetpack' );
+		// Try fetching by patch
+		$static_html = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' );
+
+		if ( false === $static_html ) {
+
+			// If we still have nothing, display an error
+			esc_html_e( 'Error fetching static.html.', 'jetpack' );
+		} else {
+
+			// We got the static.html so let's display it
+			echo $static_html;
+		}
 	}
 
 	function get_i18n_data() {
-		$locale_data = wp_remote_get( esc_url( plugins_url( '/languages/json/jetpack-' . get_locale() . '.json', JETPACK__PLUGIN_FILE ) ) );
-		$locale_data = 200 == wp_remote_retrieve_response_code( $locale_data )
-			? wp_remote_retrieve_body( $locale_data )
-			: false;
-		if ( $locale_data ) {
-			return $locale_data;
-		} else {
+
+		// Try fetching by patch
+		$locale_data = @file_get_contents( JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . get_locale() . '.json' );
+
+		if ( false === $locale_data ) {
+
+			// Return empty if we have nothing to return so it doesn't fail when parsed in JS
 			return '{}';
+		} else {
+
+			// We got the json file so let's return it
+			return $locale_data;
 		}
 	}
 

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -156,7 +156,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	 */
 	function additional_styles() {
 		$rtl = is_rtl() ? '.rtl' : '';
-		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/static.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/admin.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 	}
 

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -19,32 +19,19 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	// actions to activate/deactivate and configure modules
 	function page_render() {
 		$list_table = new Jetpack_Modules_List_Table;
-		$build_url = esc_url( plugins_url( '/_inc/build/',  JETPACK__PLUGIN_FILE ) );
 
-		$static_html = wp_remote_get( $build_url . 'static.html' );
-		if ( 200 == wp_remote_retrieve_response_code( $static_html ) ) {
-			$static_html = wp_remote_retrieve_body( $static_html );
-		} else {
+		$static_html = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' );
+
+		// If static.html isn't there, there's nothing else we can do.
+		if ( false === $static_html ) {
 			esc_html_e( 'Error fetching static.html.', 'jetpack' );
-
-			// If static.html isn't there, there's nothing else we can do.
 			return;
 		}
 
-		$noscript_notice = wp_remote_get( $build_url . 'static-noscript-notice.html' );
-		$noscript_notice = 200 == wp_remote_retrieve_response_code( $noscript_notice )
-			? wp_remote_retrieve_body( $noscript_notice )
-			: '';
-
-		$version_notice = wp_remote_get( $build_url . 'static-version-notice.html' );
-		$version_notice = 200 == wp_remote_retrieve_response_code( $version_notice )
-			? wp_remote_retrieve_body( $version_notice )
-			: '';
-
-		$ie_notice = wp_remote_get( $build_url . 'static-ie-notice.html' );
-		$ie_notice = 200 == wp_remote_retrieve_response_code( $ie_notice )
-			? wp_remote_retrieve_body( $ie_notice )
-			: '';
+		// We have static.html so let's continue trying to fetch the others
+		$noscript_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' );
+		$version_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
+		$ie_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-ie-notice.html' );
 
 		$noscript_notice = str_replace(
 			'#HEADER_TEXT#',

--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,6 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 * Make sure concatenated CSS is generated for RTL languages. #5095
 * To improve sync performance, add snapTW to the list of post meta data that won't be synchronized for each post. That meta data can be 45mb+ per post. #5092
 * Admin Page: make sure all translated strings are encoded properly. #5101
-* Admin Page: fix error when Admin Page resources could not be fetched with `wp_remote_get`. #5096
 
 = 4.3 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 * Make sure concatenated CSS is generated for RTL languages. #5095
 * To improve sync performance, add snapTW to the list of post meta data that won't be synchronized for each post. That meta data can be 45mb+ per post. #5092
 * Admin Page: make sure all translated strings are encoded properly. #5101
+* Admin Page: fix error when Admin Page resources could not be fetched with `wp_remote_get`. #5096
 
 = 4.3 =
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
1. instead of fetching files with `wp_remote_get`, will try to fetch files with `file_get_contents`.
2. fix URL to load `admin.dops-style$rtl.css` correctly.

#### Testing instructions:
- go to the `wp-admin/admin.php?page=jetpack` and `wp-admin/admin.php?page=jetpack_modules` and make sure they look good.
- disable JavaScript and make sure the notice saying that JS is disabled with orange background is displayed
- edit `wp-includes/version.php` and set the version to `4.3`. Make sure the notice saying that WP version is too old with orange background is displayed.