### PR TITLE
(re)-add old landing page php file

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-landing-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-landing-page.php
@@ -1,0 +1,3 @@
+<?php
+// This is intentionally left empty as a stub because some sites were caching the require()
+// @see https://github.com/Automattic/jetpack/issues/5091


### PR DESCRIPTION
Fixes #5091

Though this php file is not currently being required/loaded in the current version, some sites still think it is (caching?) and is throwing fatals for it.  This ensures that something will actually be loaded.  