### PR TITLE
Subscriptions: Add flag to not send email if updating published post

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -173,6 +173,14 @@ class Jetpack_Subscriptions {
 		}
 
 		/**
+		 * If we're updating the post, let's make sure the flag to not send to subscribers
+		 * is set to minimize the chances of sending posts multiple times.
+		 */
+		if ( 'publish' == $old_status ) {
+			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
+		}
+
+		/**
 		 * Array of categories that will never trigger subscription emails.
 		 *
 		 * Will not send subscription emails from any post from within these categories.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -52,6 +52,9 @@
 		<testsuite name="sso">
 			<directory prefix="test_" suffix=".php">tests/php/modules/sso</directory>
 		</testsuite>
+		<testsuite name="subscriptions">
+			<directory prefix="test_" suffix=".php">tests/php/modules/subscriptions</directory>
+		</testsuite>
 		<testsuite name="sync">
 			<directory prefix="test_" suffix=".php">tests/php/sync</directory>
 		</testsuite>

--- a/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
+++ b/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
@@ -1,0 +1,27 @@
+<?php
+require dirname( __FILE__ ) . '/../../../../modules/subscriptions.php';
+
+class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
+	static function setupBeforeClass() {
+		Jetpack_Subscriptions::init();
+	}
+
+	function test_publishing_post_first_time_does_not_set_do_not_send_subscription_flag() {
+		$post_id = $this->factory->post->create();
+		wp_publish_post( $post_id );
+		$this->assertEmpty( get_post_meta( $post_id, '_jetpack_dont_email_post_to_subs', true ) );
+	}
+
+	function test_updating_post_sets_do_not_send_subscription_flag() {
+		$post_id = $this->factory->post->create();
+
+		// Publish and then immediately update the post, which should set the do not send flag
+		wp_publish_post( $post_id );
+		wp_update_post( array(
+			'ID'           => $post_id,
+			'post_content' => 'The updated post content',
+		) );
+
+		$this->assertEquals( '1',  get_post_meta( $post_id, '_jetpack_dont_email_post_to_subs', true ) );
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -19,6 +19,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		parent::setUp();
 
 		$this->callable_module = Jetpack_Sync_Modules::get_module( "functions" );
+		set_current_screen( 'post-user' ); // this only works in is_admin()
 	}
 
 	function test_white_listed_function_is_synced() {


### PR DESCRIPTION
It's been reported recently that when a user updates a post that subscription emails can be sent out for that post.

In my testing, I was able to reproduce when I deleted the synced post on WPCOM along with its meta. So, if the meta that signaled we had sent a post was missing for some reason on the WPCOM side, we would send that subscription again.

This changeset ensures that we set the `_jetpack_dont_email_post_to_subs` meta whenever we are updating an already published post.

To test:

- Checkout `update/dont-send-sub-email-old-update-post` branch
- Publish a post on your site and ensure subscription email goes out
- Delete the post on WPCOM
- Update post
- Ensure no subscription email goes out

cc @lezama @gravityrail for code review