### PR TITLE
Admin Page: Make the Jetpack REST API not depend on PUT and DELETE request methods

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -35,11 +35,13 @@ function JetpackRestApiClient( root, nonce ) {
 		} )
 		.then( response => response.json() ),
 		disconnectSite: () => fetch( `${ apiRoot }jetpack/v4/connection`, {
-			method: 'delete',
+			method: 'post',
 			credentials: 'same-origin',
 			headers: {
-				'X-WP-Nonce': apiNonce
-			}
+				'X-WP-Nonce': apiNonce,
+				'Content-type': 'application/json'
+			},
+			body: JSON.stringify( { isActive: false } )
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		fetchConnectUrl: () => fetch( `${ apiRoot }jetpack/v4/connection/url`, {
@@ -50,12 +52,13 @@ function JetpackRestApiClient( root, nonce ) {
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		unlinkUser: () => fetch( `${ apiRoot }jetpack/v4/connection/user`, {
-			method: 'delete',
+			method: 'post',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,
 				'Content-type': 'application/json'
-			}
+			},
+			body: JSON.stringify( { linked: false } )
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		jumpStart: ( action ) => {
@@ -129,12 +132,13 @@ function JetpackRestApiClient( root, nonce ) {
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		resetOptions: ( options ) => fetch( `${ apiRoot }jetpack/v4/options/${ options }`, {
-			method: 'delete',
+			method: 'post',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,
 				'Content-type': 'application/json'
-			}
+			},
+			body: JSON.stringify( { reset: true } )
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		getVaultPressData: () => fetch( `${ apiRoot }jetpack/v4/module/vaultpress/data`, {
@@ -211,12 +215,13 @@ function JetpackRestApiClient( root, nonce ) {
 			} );
 		},
 		dismissJetpackNotice: ( notice ) => fetch( `${ apiRoot }jetpack/v4/notice/${ notice }`, {
-			method: 'delete',
+			method: 'post',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,
 				'Content-type': 'application/json'
-			}
+			},
+			body: JSON.stringify( { dismissed: true } )
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		fetchPluginsData: () => fetch( `${ apiRoot }jetpack/v4/plugins`, {

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -92,7 +92,7 @@ function JetpackRestApiClient( root, nonce ) {
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		activateModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
-			method: 'put',
+			method: 'post',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,
@@ -102,7 +102,7 @@ function JetpackRestApiClient( root, nonce ) {
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		deactivateModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
-			method: 'put',
+			method: 'post',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,
@@ -111,7 +111,7 @@ function JetpackRestApiClient( root, nonce ) {
 			body: JSON.stringify( { active: false } )
 		} ),
 		updateModuleOptions: ( slug, newOptionValues ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }`, {
-			method: 'put',
+			method: 'post',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -186,7 +186,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		// Reset all Jetpack options
 		register_rest_route( 'jetpack/v4', '/options/(?P<options>[a-z\-]+)', array(
-			'methods' => WP_REST_Server::DELETABLE,
+			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::reset_jetpack_options',
 			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
 		) );
@@ -677,7 +677,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error True if options were reset. Otherwise, a WP_Error instance with the corresponding error.
 	 */
 	public static function reset_jetpack_options( $data ) {
-		if ( isset( $data['options'] ) ) {
+		$param = $data->get_json_params();
+
+		if ( isset( $param['reset'] ) && $param['reset'] === true && isset( $data['options'] ) ) {
 			$data = $data['options'];
 
 			switch( $data ) {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -227,7 +227,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		// Dismiss Jetpack Notices
 		register_rest_route( 'jetpack/v4', '/notice/(?P<notice>[a-z\-_]+)', array(
-			'methods' => WP_REST_Server::DELETABLE,
+			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::dismiss_notice',
 			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 		) );
@@ -279,7 +279,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function dismiss_notice( $data ) {
 		$notice = $data['notice'];
-		if ( isset( $notice ) && ! empty( $notice ) ) {
+		$param = $data->get_json_params();
+
+		if ( isset( $param['dismissed'] ) && $param['dismissed'] === true && isset( $notice ) && ! empty( $notice ) ) {
 			switch( $notice ) {
 				case 'feedback_dash_request':
 				case 'welcome':

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -85,7 +85,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		// Disconnect/unlink user from WordPress.com servers
 		register_rest_route( 'jetpack/v4', '/connection/user', array(
-			'methods' => WP_REST_Server::DELETABLE,
+			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::unlink_user',
 			'permission_callback' => __CLASS__ . '::link_user_permission_callback',
 			'args' => array(
@@ -622,7 +622,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error True if user successfully unlinked.
 	 */
 	public static function unlink_user( $data ) {
-		if ( isset( $data['id'] ) && Jetpack::unlink_user( $data['id'] ) ) {
+		$param = $data->get_json_params();
+
+		if ( isset( $param['linked'] ) && $param['linked'] === false && isset( $data['id'] ) && Jetpack::unlink_user( $data['id'] ) ) {
 			return rest_ensure_response(
 				array(
 					'code' => 'success'

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -281,7 +281,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$notice = $data['notice'];
 		$param = $data->get_json_params();
 
-		if ( isset( $param['dismissed'] ) && $param['dismissed'] === true && isset( $notice ) && ! empty( $notice ) ) {
+		if ( isset( $param['dismissed'] ) && $param['dismissed'] === true
+		&& isset( $notice ) && ! empty( $notice ) ) {
 			switch( $notice ) {
 				case 'feedback_dash_request':
 				case 'welcome':
@@ -626,7 +627,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function unlink_user( $data ) {
 		$param = $data->get_json_params();
 
-		if ( isset( $param['linked'] ) && $param['linked'] === false && isset( $data['id'] ) && Jetpack::unlink_user( $data['id'] ) ) {
+		if ( isset( $param['linked'] ) && $param['linked'] === false
+		&& isset( $data['id'] ) && Jetpack::unlink_user( $data['id'] ) ) {
 			return rest_ensure_response(
 				array(
 					'code' => 'success'

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -80,7 +80,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		register_rest_route( 'jetpack/v4', '/connection', array(
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::disconnect_site',
-			'permission_callback' => __CLASS__ . '::disconnect_site_permission_callback',
+			'permission_callback' => __CLASS__ . '::disconnect_site_permission_callback'
 		) );
 
 		// Disconnect/unlink user from WordPress.com servers
@@ -496,8 +496,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 * @return bool|WP_Error True if Jetpack successfully disconnected.
 	 */
-	public static function disconnect_site() {
-		if ( Jetpack::is_active() ) {
+	public static function disconnect_site( $data ) {
+		$param = $data->get_json_params();
+
+		if ( Jetpack::is_active() && $param['isActive'] === false ) {
 			Jetpack::disconnect();
 			return rest_ensure_response( array( 'code' => 'success' ) );
 		}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -80,7 +80,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		register_rest_route( 'jetpack/v4', '/connection', array(
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::disconnect_site',
-			'permission_callback' => __CLASS__ . '::disconnect_site_permission_callback'
+			'permission_callback' => __CLASS__ . '::disconnect_site_permission_callback',
 		) );
 
 		// Disconnect/unlink user from WordPress.com servers
@@ -281,8 +281,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$notice = $data['notice'];
 		$param = $data->get_json_params();
 
-		if ( isset( $param['dismissed'] ) && $param['dismissed'] === true
-		&& isset( $notice ) && ! empty( $notice ) ) {
+		if ( ! isset( $param['dismissed'] ) || $param['dismissed'] !== true ) {
+			return new WP_Error( 'invalid_param', esc_html__( 'Invalid parameter "dismissed".', 'jetpack' ), array( 'status' => 404 ) );
+		}
+
+		if ( isset( $notice ) && ! empty( $notice ) ) {
 			switch( $notice ) {
 				case 'feedback_dash_request':
 				case 'welcome':
@@ -502,7 +505,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function disconnect_site( $data ) {
 		$param = $data->get_json_params();
 
-		if ( Jetpack::is_active() && $param['isActive'] === false ) {
+		if ( ! isset( $param['isActive'] ) || $param['isActive'] !== false ) {
+			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
+		}
+
+		if ( Jetpack::is_active() ) {
 			Jetpack::disconnect();
 			return rest_ensure_response( array( 'code' => 'success' ) );
 		}
@@ -627,8 +634,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function unlink_user( $data ) {
 		$param = $data->get_json_params();
 
-		if ( isset( $param['linked'] ) && $param['linked'] === false
-		&& isset( $data['id'] ) && Jetpack::unlink_user( $data['id'] ) ) {
+		if ( ! isset( $param['linked'] ) || $param['linked'] !== false ) {
+			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
+		}
+
+		if ( isset( $data['id'] ) && Jetpack::unlink_user( $data['id'] ) ) {
 			return rest_ensure_response(
 				array(
 					'code' => 'success'
@@ -683,7 +693,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function reset_jetpack_options( $data ) {
 		$param = $data->get_json_params();
 
-		if ( isset( $param['reset'] ) && $param['reset'] === true && isset( $data['options'] ) ) {
+		if ( ! isset( $param['reset'] ) || $param['reset'] !== true ) {
+			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
+		}
+
+		if ( isset( $data['options'] ) ) {
 			$data = $data['options'];
 
 			switch( $data ) {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -78,7 +78,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		// Disconnect site from WordPress.com servers
 		register_rest_route( 'jetpack/v4', '/connection', array(
-			'methods' => WP_REST_Server::DELETABLE,
+			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::disconnect_site',
 			'permission_callback' => __CLASS__ . '::disconnect_site_permission_callback',
 		) );

--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ The Jetpack Pit Crew is comprised of @dereksmart, @samhotchkiss, @zinigor, @elio
 
 Contributions have been and continue to be made by dozens of other Automatticians, like:
 
-@georgestephanis, @jeffgolenski, @jessefriedman, @richardmuscat, @justinkropp, @aliso, @allendav, @alternatekev, @apeatling, @azaozz, @bazza, @beaulebens, @cfinke, @daniloercoli, @enejb, @eoigal, @ethitter, @gibrown, @hugobaeta, @jasmussen, @jblz, @jkudish, @johnjamesjacoby, @justinshreve, @koke, @kovshenin, @lancewillett, @lezama, @martinremy, @MichaelArestad, @mtias, @mcsf, @mdawaffe, @nickmomrik, @obenland, @pento, @rase-, @roccotripaldi, @skeltoac, @stephdau, @tmoorewp, @Viper007Bond, @xyu and @yoavf.
+@georgestephanis, @jeffgolenski, @jessefriedman, @richardmuscat, @justinkropp, @aliso, @allendav, @alternatekev, @apeatling, @azaozz, @bazza, @beaulebens, @cfinke, @daniloercoli, @enejb, @eoigal, @ethitter, @gibrown, @hugobaeta, @jasmussen, @jblz, @jkudish, @johnjamesjacoby, @justinshreve, @koke, @kovshenin, @lancewillett, @lezama, @martinremy, @MichaelArestad, @mtias, @mcsf, @mdawaffe, @nickmomrik, @obenland, @oskosk, @pento, @rase-, @roccotripaldi, @skeltoac, @stephdau, @tmoorewp, @Viper007Bond, @xyu and @yoavf.
 
 Our _awesome_ happiness engineers are @jeherve, @richardmtl, @csonnek, @rcowles, @kraftbj, @chaselivingston, @jenhooks, @aheckler, @ntpixels, @macmanx2, @lschuyler, @seejacobscott, @davoraltman, @lamdayap, @rachelsquirrel, @scarstocea, @stefmattana, @jamilabreu, @cena, @v18, @bikedorkjon, @drpottex, @gregwp, @annezazuu, and @danjjohnson.
 

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 * Make sure concatenated CSS is generated for RTL languages. #5095
 * To improve sync performance, add snapTW to the list of post meta data that won't be synchronized for each post. That meta data can be 45mb+ per post. #5092
 * Admin Page: make sure all translated strings are encoded properly. #5101
+* Admin Page: only use POST requests for updating the state of Jetpack, to avoid issues on servers not allowing PUT requests. #5100
 
 = 4.3 =
 


### PR DESCRIPTION
This PR ensures that we only use POST requests for updating the state of Jetpack, settings, and module options.

### Why?

* Some users are getting a 405 response when trying to activate/deactivate a module stating the method is not allowed (in reference to a PUT request done on module activation). 
* Also The reporting user's server replies with this header on a `DELETE` request
  `Allow:GET,HEAD,POST,OPTIONS`

This may be due to several reasons but mainly to an Apache behaviour (maybe default for the installation) on which the request Methods are limited to GET, HEAD, POST and OPTIONS.

### Changes proposed in this Pull Request:

* Updates the **REST API JS client** to always use POST requests for editable endpoints. The WP-API extensions mechanism allow for this as the editable endpoint behave the same with both request methods.
* Updates some endpoints (and related client methods) to not depend on `DELETE` request smethods anymore by updating them to be POST requests with JSON parameters in the body.
  * **Site disconnection** - Updates the endpoint to `POST /connection` accepting a `{ isActive: false }` body.
  * **User unlinking** - Updates the endpoint to `POST /connection/user` accepting a `{ linked: false }` body.
  * **Notice dismissing** - Updates the endpoint to `POST /notice/:notice_id` accepting a `{ dismissed: true }` body.
  * **Options reset** - Updates the endpoint to `POST /options/options` accepting a `{ reset: true }` body



### Testing instructions:

_There's no need for testing those client methods that are changed to make POST request against the API as the **wp-api** extension interfaces provides support for both POST and PUT request for an `EDITABLE` route_

1 Clone this branch and run `npm run build-client`.

**Test User unlinking**.

1. As a non-admin user, get to the Admin Page **Connection Settings** and unlink your user.
1. Expect to be unlinked normally

**Test resetting Options**

1. ~~As an Admin User, edit `jetpack.php` and update `JETPACK__VERSION` to be `4.3-rc3` )~~. _Version has been bumped to 4.3.1 so this step is no longer necessary_
1. Refresh the Admin Page.
1. Click the Reset Options link on the footer.
1. Expect to be noticed about options being reset.

**Test Site disconnection**

1. As an admin user, get to the Admin Page **Connection Settings** and disconnect your site.
1. Expect to see the screen where you're shown that your site is disconnected

**Test Notice dismissal**

1. As an admin user, get to the Jetpack Admin Page Dashboard (At a Glance) and close the feedback support notice below the stats. 
1. Expect it to close normally

