### PR TITLE
GitHub Templates: update PR template to mention changelogs.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ Fixes #
 
 *
 
+<!-- Add the following only if this is meant to be in changelog -->
 #### Proposed changelog entry for your changes:
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,14 @@
-Fixes # .
+Fixes #
 
 #### Changes proposed in this Pull Request:
 
 
 #### Testing instructions:
--
+
+*
+
+#### Proposed changelog entry for your changes:
+
 
 -------------------
 - [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).


### PR DESCRIPTION
cc @eliorivero @MichaelArestad since we discussed this yesterday.

I also created 2 new labels to track changelog status for PRs, as we discussed.