### PR TITLE
Verification Tools: use appropriate links for each service.

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -460,7 +460,7 @@ export let VerificationToolsSettings = React.createClass( {
 				<FormFieldset>
 					<p className="jp-form-setting-explanation">
 						{
-							__( 'Enter your meta key "content" value to verify your blog with {{a}}Google Search Console{{/a}}, {{a}}Bing Webmaster Center{{/a}} and {{a}}Pinterest Site Verification{{/a}}.', {
+							__( 'Enter your meta key "content" value to verify your blog with {{a}}Google Search Console{{/a}}, {{a1}}Bing Webmaster Center{{/a1}} and {{a2}}Pinterest Site Verification{{/a2}}.', {
 								components: {
 									a: <a href="https://www.google.com/webmasters/tools/" target="_blank" />,
 									a1: <a href="http://www.bing.com/webmaster/" target="_blank" />,

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 * To improve sync performance, add snapTW to the list of post meta data that won't be synchronized for each post. That meta data can be 45mb+ per post. #5092
 * Admin Page: make sure all translated strings are encoded properly. #5101
 * Admin Page: only use POST requests for updating the state of Jetpack, to avoid issues on servers not allowing PUT requests. #5100
+* Verification tools: in the Settings card, use appropriate link for each service. #5106
 
 = 4.3 =
 


### PR DESCRIPTION
Each one of the 3 links previously redirected to the Google Search Console.

Reported here:
https://wordpress.org/support/topic/jetpack-verification-links-all-go-to-google/