### PR TITLE
Added OpenSSL fallback for cases when /dev/urandom is not available.

### DIFF
--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -38,7 +38,16 @@ class Jetpack_Sync_Queue {
 	function __construct( $id ) {
 		$this->id           = str_replace( '-', '_', $id ); // necessary to ensure we don't have ID collisions in the SQL
 		$this->row_iterator = 0;
-		$this->random_int = random_int( 1, 1000000 );
+
+		try {
+			$this->random_int = random_int( 1, 1000000 );
+		} catch ( Exception $ex ) {
+
+			// This exception can mean that PHP doesn't have
+			// access to /dev/urandom, so falling back to OpenSSL
+			// pseudorandom bytes implementation
+			$this->random_int = intval( bin2hex( openssl_random_pseudo_bytes( 128 ) ), 16 );
+		}
 	}
 
 	function add( $item ) {

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -38,16 +38,7 @@ class Jetpack_Sync_Queue {
 	function __construct( $id ) {
 		$this->id           = str_replace( '-', '_', $id ); // necessary to ensure we don't have ID collisions in the SQL
 		$this->row_iterator = 0;
-
-		try {
-			$this->random_int = random_int( 1, 1000000 );
-		} catch ( Exception $ex ) {
-
-			// This exception can mean that PHP doesn't have
-			// access to /dev/urandom, so falling back to OpenSSL
-			// pseudorandom bytes implementation
-			$this->random_int = intval( bin2hex( openssl_random_pseudo_bytes( 128 ) ), 16 );
-		}
+		$this->random_int = mt_rand( 1, 1000000 );
 	}
 
 	function add( $item ) {


### PR DESCRIPTION
Fixes #5105 

#### Changes proposed in this Pull Request:
- Adds a fallback method of computing a random integer for cases where `random_int` throws an exception.

cc @ebinnion 

The main problem here is that the OpenSSL extension is not available in PHP 5.2, but I hope that cases where `/dev/urandom` is not accessible are pretty rare in general.