### PR TITLE
Admin: add width and height attributes to the Happiness Engineer avat…

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -31,6 +31,8 @@ export default React.createClass( {
 							src={ 'https://secure.gravatar.com/avatar/' + randomGravID }
 							alt={ __( 'Jetpack Happiness Engineer' ) }
 							className="jp-support-card__happiness-engineer-img"
+							width="72"
+							height="72"
 						/>
 					</div>
 					<div className="jp-support-card__happiness-contact">


### PR DESCRIPTION
Fixes #4837

#### Changes proposed in this Pull Request:
- add width and height attributes to the Happiness Engineer avatar at the bottom,

#### Testing instructions:
- go to Jetpack admin and make sure the HE avatar looks fine

cc @jeffgolenski for review