### PR TITLE
Security Tab: add missing pro cards

### DIFF
--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -51,9 +51,6 @@ export const Page = ( props ) => {
 		[ 'backups', __( 'Site Backups' ), __( 'Automatically backup your entire site.' ), 'https://vaultpress.com/jetpack/' ],
 		[ 'sso', getModule( 'sso' ).name, getModule( 'sso' ).description, getModule( 'sso' ).learn_more_button ]
 	].map( ( element ) => {
-		if ( ! includes( moduleList, element[0] ) ) {
-			return null;
-		}
 		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
 			toggle = (
 				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
@@ -64,6 +61,10 @@ export const Page = ( props ) => {
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
 			isPro = 'scan' === element[0] || 'akismet' === element[0] || 'backups' === element[0],
 			proProps = {};
+
+		if ( ! includes( moduleList, element[0] ) && ! isPro ) {
+			return null;
+		}
 
 		if ( isPro ) {
 			proProps = {


### PR DESCRIPTION
Fixes a bug that was excluding the Pro settings cards from the /security tab. 

To Test: 
- Navigate to the `/security` tab and verify that you see cards for akismet, backups, and scan.  