### PR TITLE
Admin Page Make the Admin Page REST client correctly forge the request URL for stats data

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -166,7 +166,7 @@ function JetpackRestApiClient( root, nonce ) {
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		fetchStatsData: ( range ) => fetch(
-			`${ apiRoot }jetpack/v4/module/stats/data/${ encodeURIComponent( range ) }`,
+			statsDataUrl( range ),
 			{
 				credentials: 'same-origin',
 				headers: {
@@ -233,6 +233,16 @@ function JetpackRestApiClient( root, nonce ) {
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() )
+	}
+
+	function statsDataUrl( range ) {
+		let url = `${ apiRoot }jetpack/v4/module/stats/data`;
+		if ( url.indexOf( '?' ) !== -1 ) {
+			url = url + `&range=${ encodeURIComponent( range ) }`
+		} else {
+			url = url + `?range=${ encodeURIComponent( range ) }`
+		}
+		return url;
 	}
 
 	assign( this, methods );

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -166,7 +166,7 @@ function JetpackRestApiClient( root, nonce ) {
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		fetchStatsData: ( range ) => fetch(
-			`${ apiRoot }jetpack/v4/module/stats/data?range=${ encodeURIComponent( range ) }`,
+			`${ apiRoot }jetpack/v4/module/stats/data/${ encodeURIComponent( range ) }`,
 			{
 				credentials: 'same-origin',
 				headers: {


### PR DESCRIPTION
Fixes #5112

#### Changes proposed in this Pull Request:

Makes the client properly forge the URL for requesting stats data taking in account whether permalinks disabled

#### Testing instructions:

1. Clone this branch
1. Get to the Jetpack Admin Page Dashboard
1. Expect to see the stats loading
1. Disable permalinks for your site (Change the option to **Simple** permalinks)
1. Get back to the Jetpack Admin Page Dashboard
1. Expect to see the stats loading. 
