### PR TITLE
Tracks: fix event name to prefix instead of the prop

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -159,7 +159,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			$static_html
 		);
 
-		JetpackTracking::record_user_event( 'page_view', array( 'path' => 'wpa_old_settings' ) );
+		JetpackTracking::record_user_event( 'wpa_page_view', array( 'path' => 'old_settings' ) );
 	}
 
 	/**

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -360,7 +360,7 @@ function stats_reports_page( $main_chart_only = false ) {
 	$blog_id = stats_get_option( 'blog_id' );
 	$domain = Jetpack::build_raw_urls( get_home_url() );
 
-	JetpackTracking::record_user_event( 'page_view', array( 'path' => 'wpa_old_stats' ) );
+	JetpackTracking::record_user_event( 'wpa_page_view', array( 'path' => 'old_stats' ) );
 
 	if ( ! $main_chart_only && !isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) {
 		$nojs_url = add_query_arg( 'nojs', '1' );


### PR DESCRIPTION
This correctly prefixes the event names for the old stats and settings page views.  Before we were incorrectly prefixing the prop names.  

Changes from `jetpack_page_view / prop: wpa_old_stats` to `jetpack_wpa_page_view / prop: old_stats` 

This will make it easier to parse pageviews at a single glance in Tracks.  