### PR TITLE
Don’t full sync blocked meta

### DIFF
--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -92,9 +92,16 @@ abstract class Jetpack_Sync_Module {
 			return array();
 		}
 
+		$private_meta_whitelist_sql = "'" . implode( "','", array_map( 'esc_sql', Jetpack_Sync_Defaults::$default_whitelist_meta_keys ) ) . "'";
+		$public_meta_blacklist_sql = "'" . implode( "','", array_map( 'esc_sql', Jetpack_Sync_Defaults::$default_blacklist_meta_keys ) ) . "'";
+
 		return array_map( 
 			array( $this, 'unserialize_meta' ), 
-			$wpdb->get_results( "SELECT $id, meta_key, meta_value, meta_id FROM $table WHERE $id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . ' )', OBJECT ) 
+			$wpdb->get_results( 
+				"SELECT $id, meta_key, meta_value, meta_id FROM $table WHERE $id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . ' )'.
+				" AND ( ( meta_key LIKE '\_%' AND meta_key IN ( $private_meta_whitelist_sql ) )".
+				" OR ( meta_key NOT LIKE '\_%' AND meta_key NOT IN ( $public_meta_blacklist_sql ) ) )",
+				OBJECT ) 
 		);
 	}
 


### PR DESCRIPTION
Our whitelist (for private meta) and blacklist (for public meta) weren't being enforced for full sync. 

This PR fixes that.