### PR TITLE
Don’t full sync after import

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -20,9 +20,6 @@ class Jetpack_Sync_Actions {
 		// On jetpack authorization, schedule a full sync
 		add_action( 'jetpack_client_authorized', array( __CLASS__, 'schedule_full_sync' ), 10, 0 );
 
-		// When imports are finished, schedule a full sync
-		add_action( 'import_end', array( __CLASS__, 'schedule_full_sync' ) );
-
 		// When importing via cron, do not sync
 		add_action( 'wp_cron_importer_hook', array( __CLASS__, 'set_is_importing_true' ), 1 );
 

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -150,11 +150,6 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );
 	}
 
-	function test_enqueues_full_sync_after_import() {
-		do_action( 'import_end' );
-		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );
-	}
-
 	function test_is_scheduled_full_sync_works_with_different_args() {
 		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync() );
 


### PR DESCRIPTION
We used to schedule a full sync after import because we weren't always successfully tracking changes during imports.

Now that that's fixed, we no longer need to full sync after an import.