### PR TITLE
Return wp_error if returned from sync queue

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -111,7 +111,7 @@ class Jetpack_Sync_Sender {
 
 		if ( is_wp_error( $buffer ) ) {
 			// another buffer is currently sending
-			return false;
+			return $buffer;
 		}
 
 		$upload_size   = 0;


### PR DESCRIPTION
We currently suppress errors from the sync queue by returning false when we're trying to send items.

This PR returns the error from the sync queue if it's a WP_Error.