### PR TITLE
ATD Settings: Make sure that non-admins can also modify ATD Settings

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -675,8 +675,9 @@ class Jetpack_Core_API_Module_Endpoint
 		if ( 'GET' === $request->get_method() ) {
 			return current_user_can( 'jetpack_admin_page' );
 		} else {
-			// User is trying to create, regenerate or delete its PbE address.
-			if ( 'post-by-email' === Jetpack_Core_Json_Api_Endpoints::get_module_requested() ) {
+			$module = Jetpack_Core_Json_Api_Endpoints::get_module_requested();
+			// User is trying to create, regenerate or delete its PbE || ATD settings.
+			if ( 'post-by-email' === $module || 'after-the-deadline' === $module ) {
 				return current_user_can( 'edit_posts' ) && current_user_can( 'jetpack_admin_page' );
 			}
 			return current_user_can( 'jetpack_configure_modules' );


### PR DESCRIPTION
Fixes a bug in which non-admins cannot save changes to their ATD settings.  
![screen shot 2016-09-07 at 3 25 37 pm](https://cloud.githubusercontent.com/assets/7129409/18326079/2682e336-7512-11e6-8aec-5d21c0d54b22.png)

It's a user-level option, so they should be allowed. 

TO Test: 
- Log in as a non-admin user (editor)
- Make sure you can make changes to the ATD settings 
- Make sure that you can still make changes as an admin 
- Make sure the admin/editor settings are unique to eachother.  