### PR TITLE
General: Admin Page: Fix slow query that sometimes caused OOM errors

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -281,7 +281,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'jetpack_holiday_snow_enabled' => function_exists( 'jetpack_holiday_snow_option_name' ) ? jetpack_holiday_snow_option_name() : false,
 			),
 			'userData' => array(
-				'othersLinked' => jetpack_get_other_linked_users(),
+				'othersLinked' => Jetpack::get_other_linked_admins(),
 				'currentUser'  => jetpack_current_user_data(),
 			),
 			'locale' => $this->get_i18n_data(),
@@ -359,37 +359,6 @@ function jetpack_show_jumpstart() {
 	}
 
 	return true;
-}
-
-/*
- * Checks to see if there are any other users available to become primary
- * Users must both:
- * - Be linked to wpcom
- * - Be an admin
- *
- * @return mixed False if no other users are linked, Int if there are.
- */
-function jetpack_get_other_linked_users() {
-	// If only one admin
-	$all_users = count_users();
-	if ( 2 > $all_users['avail_roles']['administrator'] ) {
-		return false;
-	}
-
-	$users = get_users();
-	$available = array();
-	// If no one else is linked to dotcom
-	foreach ( $users as $user ) {
-		if ( isset( $user->caps['administrator'] ) && Jetpack::is_user_connected( $user->ID ) ) {
-			$available[] = $user->ID;
-		}
-	}
-
-	if ( 2 > count( $available ) ) {
-		return false;
-	}
-
-	return count( $available );
 }
 
 /*

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -281,7 +281,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'jetpack_holiday_snow_enabled' => function_exists( 'jetpack_holiday_snow_option_name' ) ? jetpack_holiday_snow_option_name() : false,
 			),
 			'userData' => array(
-				'othersLinked' => Jetpack::get_other_linked_admins(),
+//				'othersLinked' => Jetpack::get_other_linked_admins(),
 				'currentUser'  => jetpack_current_user_data(),
 			),
 			'locale' => $this->get_i18n_data(),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -564,7 +564,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		require_once( JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class.jetpack-react-page.php' );
 
 		$response = array(
-			'othersLinked' => Jetpack::get_other_linked_admins(),
+//			'othersLinked' => Jetpack::get_other_linked_admins(),
 			'currentUser'  => jetpack_current_user_data(),
 		);
 		return rest_ensure_response( $response );

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -564,7 +564,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		require_once( JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class.jetpack-react-page.php' );
 
 		$response = array(
-			'othersLinked' => jetpack_get_other_linked_users(),
+			'othersLinked' => Jetpack::get_other_linked_admins(),
 			'currentUser'  => jetpack_current_user_data(),
 		);
 		return rest_ensure_response( $response );

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 * Admin Page: fix error when Post By Email could not be enabled when the browser's dev console was enabled.
 * Admin Page: make sure all translated strings are encoded properly.
 * Admin Page: only use POST requests for updating the state of Jetpack, to avoid issues on servers not allowing PUT requests.
+* Admin Page: less calls to the database means faster load time.
 * General: Improve random number generation for compatibility with more hosts.
 * General: Add deprecated PHP file (class.jetpack-landing-page.php) back as an empty file, to avoid generating fatal errors on sites with aggressive caching.
 * General: Ensure concatenated CSS is generated for RTL languages.

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -380,8 +380,8 @@ EXPECTED;
 		) );
 
 		$other_admins = Jetpack::get_other_linked_admins();
-		$this->assertNotFalse( $other_admins );
-		$this->assertNotFalse( get_transient( 'jetpack_other_linked_admins' ) );
+		$this->assertInternalType( 'int', $other_admins );
+		$this->assertInternalType( 'int', get_transient( 'jetpack_other_linked_admins' ) );
 	}
 
 	public function test_promoting_admin_clears_other_linked_admins_transient() {


### PR DESCRIPTION
Fixes #5133.

In #5133, a user reported some issues with how we were checking for other linked admins. As I understand, the issue were:

- Unbounded query lead to OOM error
- Query was slow
- Query ran on every page load

To address those issues I:

- Factored the `jetpack_get_other_linked_users()` out of the admin page code and into the main `Jetpack` class to make it more easily testable.
- Only query for admins. Previously, we queried for all users and iterated over them, even though we only wanted admins.
- Set transient with the results found
- Since we set a transient, clear that transient on user role changing

While this changeset is a pretty straight forward replacement, I did have one question which we could cover in another PR. The logic, as I understand, doesn't return the count of other linked admins, or previously the count of other linked users. It returns the total number of linked admins. So, should we rename the function?

To test:

- Checkout `update/improve-performance-other-linked-users` branch
- Run tests
- Drop some debug code to make sure we are using the transient properly

cc @dereksmart for thoughts and review