### PR TITLE
Admin Page: Performance - Remove direct access to the whole state tree from components

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -21,11 +21,10 @@ import {
 
 const DashAkismet = React.createClass( {
 	activateManageAndRedirect: function( e ) {
-		const props = this.props;
 		e.preventDefault();
 
 		this.props.activateModule( 'manage' )
-			.then( window.location = 'https://wordpress.com/plugins/akismet/' + props.siteRawUrl )
+			.then( window.location = 'https://wordpress.com/plugins/akismet/' + this.props.siteRawUrl )
 			.catch( console.log( 'Error: unable to activate Manage' ) );
 	},
 

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -151,6 +151,11 @@ const DashAkismet = React.createClass( {
 	}
 } );
 
+DashAkismet.propTypes = {
+	siteRawUrl: React.PropTypes.string.isRequired,
+	siteAdminUrl: React.PropTypes.string.isRequired
+};
+
 export default connect(
 	( state ) => {
 		return {

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -89,8 +89,7 @@ const DashBackups = React.createClass( {
 				module="backups"
 				className="jp-dash-item__is-inactive"
 				status={ hasSitePlan ? inactiveOrUninstalled : 'no-pro-uninstalled-or-inactive' }
-				pro={ true }
-			>
+				pro={ true } >
 				<p className="jp-dash-item__description">
 					{
 						this.props.isDevMode ? __( 'Unavailable in Dev Mode.' ) :
@@ -114,6 +113,7 @@ const DashBackups = React.createClass( {
 DashBackups.propTypes = {
 	vaultPressData: React.PropTypes.any.isRequired,
 	isDevMode: React.PropTypes.bool.isRequired,
+	siteRawUrl: React.PropTypes.string.isRequired,
 	sitePlan: React.PropTypes.object.isRequired
 };
 

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -25,11 +25,11 @@ import { isDevMode } from 'state/connection';
 const DashBackups = React.createClass( {
 	getContent: function() {
 		const labelName = __( 'Backups' ),
-			hasSitePlan = false !== this.props.getSitePlan(),
+			hasSitePlan = false !== this.props.sitePlan,
 			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
-			const vpData = this.props.getVaultPressData();
+			const vpData = this.props.vaultPressData;
 
 			if ( vpData === 'N/A' ) {
 				return (
@@ -93,7 +93,7 @@ const DashBackups = React.createClass( {
 			>
 				<p className="jp-dash-item__description">
 					{
-						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode.' ) :
+						this.props.isDevMode ? __( 'Unavailable in Dev Mode.' ) :
 							upgradeOrActivateText()
 					}
 				</p>
@@ -111,13 +111,20 @@ const DashBackups = React.createClass( {
 	}
 } );
 
+DashBackups.propTypes = {
+	vaultPressData: React.PropTypes.any.isRequired,
+	isDevMode: React.PropTypes.bool.isRequired,
+	sitePlan: React.PropTypes.object.isRequired
+};
+
 export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isFetchingModulesList: () => _isFetchingModulesList( state ),
-			getVaultPressData: () => _getVaultPressData( state ),
-			getSitePlan: () => getSitePlan( state ),
+			vaultPressData: _getVaultPressData( state ),
+			sitePlan: getSitePlan( state ),
+			isDevMode: isDevMode( state ),
 			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
 		};
 	},

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -30,6 +30,11 @@ import { isDevMode } from 'state/connection';
 
 const AtAGlance = React.createClass( {
 	render() {
+		const urls = {
+			siteAdminUrl: this.props.siteAdminUrl,
+			siteRawUrl: this.props.siteRawUrl
+		};
+
 		let securityHeader =
 				<DashSectionHeader
 					label={ __( 'Security' ) }
@@ -56,8 +61,8 @@ const AtAGlance = React.createClass( {
 				<div className="jp-at-a-glance">
 					<QuerySitePlugins />
 					<QuerySite />
-					<DashStats { ...this.props } />
-					<FeedbackDashRequest { ...this.props } />
+					<DashStats { ...urls } />
+					<FeedbackDashRequest />
 
 					{
 						// Site Security
@@ -65,26 +70,26 @@ const AtAGlance = React.createClass( {
 					}
 					<div className="jp-at-a-glance__item-grid">
 						<div className="jp-at-a-glance__left">
-							<DashProtect { ...this.props } />
+							<DashProtect />
 						</div>
 						<div className="jp-at-a-glance__right">
-							<DashScan { ...this.props } />
+							<DashScan siteRawUrl={ this.props.siteRawUrl } />
 						</div>
 					</div>
 					<div className="jp-at-a-glance__item-grid">
 						<div className="jp-at-a-glance__left">
-							<DashBackups { ...this.props } />
+							<DashBackups siteRawUrl={ this.props.siteRawUrl } />
 						</div>
 						<div className="jp-at-a-glance__right">
-							<DashMonitor { ...this.props } />
+							<DashMonitor />
 						</div>
 					</div>
 					<div className="jp-at-a-glance__item-grid">
 						<div className="jp-at-a-glance__left">
-							<DashAkismet { ...this.props } />
+							<DashAkismet { ...urls } />
 						</div>
 						<div className="jp-at-a-glance__right">
-							<DashPluginUpdates { ...this.props } />
+							<DashPluginUpdates { ...urls }/>
 						</div>
 					</div>
 
@@ -94,7 +99,7 @@ const AtAGlance = React.createClass( {
 					}
 					<div className="jp-at-a-glance__item-grid">
 						<div className="jp-at-a-glance__left">
-							<DashPhoton { ...this.props } />
+							<DashPhoton />
 						</div>
 					</div>
 				</div>
@@ -102,12 +107,12 @@ const AtAGlance = React.createClass( {
 		} else {
 			let stats = '';
 			if ( this.props.userCanViewStats ) {
-				stats = <DashStats { ...this.props } />;
+				stats = <DashStats { ...urls } />;
 			}
 
 			let protect = '';
 			if ( this.props.isModuleActivated( 'protect' ) ) {
-				protect = <DashProtect { ...this.props } />;
+				protect = <DashProtect />;
 			}
 
 			let nonAdminAAG = '';

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -14,7 +14,6 @@ import QueryLastDownTime from 'components/data/query-last-downtime';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
-	isFetchingModulesList as _isFetchingModulesList,
 	getModules
 } from 'state/modules';
 import { getLastDownTime as _getLastDownTime } from 'state/at-a-glance';
@@ -25,7 +24,7 @@ const DashMonitor = React.createClass( {
 		const labelName = __( 'Downtime Monitoring' );
 
 		if ( this.props.isModuleActivated( 'monitor' ) ) {
-			const lastDowntime = this.props.getLastDownTime();
+			const lastDowntime = this.props.lastDownTime;
 
 			if ( lastDowntime === 'N/A' ) {
 				return (
@@ -59,7 +58,7 @@ const DashMonitor = React.createClass( {
 			>
 				<p className="jp-dash-item__description">
 					{
-						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode.' ) :
+						this.props.isDevMode ? __( 'Unavailable in Dev Mode.' ) :
 						__( '{{a}}Activate Monitor{{/a}} to receive notifications if your site goes down.', {
 							components: {
 								a: <a href="javascript:void(0)" onClick={ this.props.activateMonitor } />
@@ -86,12 +85,17 @@ const DashMonitor = React.createClass( {
 	}
 } );
 
+DashMonitor.propTypes = {
+	lastDownTime: React.PropTypes.any.isRequired,
+	isDevMode: React.PropTypes.bool.isRequired
+};
+
 export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
-			isFetchingModulesList: () => _isFetchingModulesList( state ),
-			getLastDownTime: () => _getLastDownTime( state ),
+			lastDownTime: _getLastDownTime( state ),
+			isDevMode: isDevMode( state ),
 			moduleList: getModules( state )
 		};
 	},

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -26,8 +26,7 @@ const DashPhoton = React.createClass( {
 				<DashItem
 					label={ labelName }
 					module="photon"
-					status="is-working"
-				>
+					status="is-working" >
 					<p className="jp-dash-item__description">{ __( 'Jetpack is improving and optimising your image speed.' ) }</p>
 				</DashItem>
 			);
@@ -37,11 +36,10 @@ const DashPhoton = React.createClass( {
 			<DashItem
 				label={ labelName }
 				module="photon"
-				className="jp-dash-item__is-inactive"
-			>
+				className="jp-dash-item__is-inactive" >
 				<p className="jp-dash-item__description">
 					{
-						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode' ) :
+						this.props.isDevMode ? __( 'Unavailable in Dev Mode' ) :
 						__( '{{a}}Activate Photon{{/a}} to enhance the performance and speed of your images.', {
 							components: {
 								a: <a href="javascript:void(0)" onClick={ this.props.activatePhoton } />
@@ -67,10 +65,15 @@ const DashPhoton = React.createClass( {
 	}
 } );
 
+DashPhoton.propTypes = {
+	isDevMode: React.PropTypes.bool.isRequired
+};
+
 export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
+			isDevMode: isDevMode( state ),
 			moduleList: getModules( state )
 		};
 	},

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -118,6 +118,8 @@ const DashPluginUpdates = React.createClass( {
 
 DashPluginUpdates.propTypes = {
 	isDevMode: React.PropTypes.bool.isRequired,
+	siteRawUrl: React.PropTypes.string.isRequired,
+	siteAdminUrl: React.PropTypes.string.isRequired,
 	pluginUpdates: React.PropTypes.any.isRequired
 };
 

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -23,7 +23,6 @@ import { isDevMode } from 'state/connection';
 
 const DashPluginUpdates = React.createClass( {
 	activateAndRedirect: function( e ) {
-		const props = this.props;
 		e.preventDefault();
 		this.props.activateManage()
 			.then( window.location = 'https://wordpress.com/plugins/' + props.siteRawUrl )
@@ -32,7 +31,7 @@ const DashPluginUpdates = React.createClass( {
 
 	getContent: function() {
 		const labelName = __( 'Plugin Updates' );
-		const pluginUpdates = this.props.getPluginUpdates();
+		const pluginUpdates = this.props.pluginUpdates;
 		const manageActive = this.props.isModuleActivated( 'manage' );
 		const ctaLink = manageActive ?
 			'https://wordpress.com/plugins/' + this.props.siteRawUrl :
@@ -43,8 +42,7 @@ const DashPluginUpdates = React.createClass( {
 				<DashItem
 					label={ labelName }
 					module="manage"
-					status="is-working"
-				>
+					status="is-working" >
 					<QueryPluginUpdates />
 					<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
 				</DashItem>
@@ -56,8 +54,7 @@ const DashPluginUpdates = React.createClass( {
 				<DashItem
 					label={ labelName }
 					module="manage"
-					status="is-warning"
-				>
+					status="is-warning" >
 					<h2 className="jp-dash-item__count">
 						{
 							__( '%(number)s plugin', '%(number)s plugins', {
@@ -78,7 +75,7 @@ const DashPluginUpdates = React.createClass( {
 							} )
 						}
 						{
-							isDevMode( this.props ) ? '' :
+							this.props.isDevMode ? '' :
 							manageActive ?
 								__( '{{a}}Turn on plugin auto updates{{/a}}', { components: { a: <a href={ ctaLink } /> } } ) :
 								__( '{{a}}Activate Manage and turn on auto updates{{/a}}', { components: { a: <a onClick={ this.activateAndRedirect } href="javascript:void(0)" /> } } )
@@ -92,8 +89,7 @@ const DashPluginUpdates = React.createClass( {
 			<DashItem
 				label={ labelName }
 				module="manage"
-				status={ manageActive ? 'is-working' : 'is-inactive' }
-			>
+				status={ manageActive ? 'is-working' : 'is-inactive' } >
 				<p className="jp-dash-item__description">
 					{
 						manageActive ?
@@ -120,11 +116,17 @@ const DashPluginUpdates = React.createClass( {
 	}
 } );
 
+DashPluginUpdates.propTypes = {
+	isDevMode: React.PropTypes.bool.isRequired,
+	pluginUpdates: React.PropTypes.any.isRequired
+};
+
 export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
-			getPluginUpdates: () => _getPluginUpdates( state ),
+			pluginUpdates: _getPluginUpdates( state ),
+			isDevMode: isDevMode( state ),
 			moduleList: getModules( state )
 		};
 	},

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -14,7 +14,6 @@ import QueryProtectCount from 'components/data/query-dash-protect';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
-	isFetchingModulesList as _isFetchingModulesList,
 	getModules
 } from 'state/modules';
 import {
@@ -26,7 +25,7 @@ import { isDevMode } from 'state/connection';
 const DashProtect = React.createClass( {
 	getContent: function() {
 		if ( this.props.isModuleActivated( 'protect' ) ) {
-			const protectCount = this.props.getProtectCount();
+			const protectCount = this.props.protectCount;
 
 			if ( false === protectCount || '0' === protectCount || 'N/A' === protectCount ) {
 				return (
@@ -62,7 +61,7 @@ const DashProtect = React.createClass( {
 				className="jp-dash-item__is-inactive"
 			>
 				<p className="jp-dash-item__description">{
-					isDevMode( this.props ) ? __( 'Unavailable in Dev Mode' ) :
+					this.props.isDevMode ? __( 'Unavailable in Dev Mode' ) :
 					__( '{{a}}Activate Protect{{/a}} to keep your site protected from malicious login attempts.', {
 						components: {
 							a: <a href="javascript:void(0)" onClick={ this.props.activateProtect } />
@@ -88,12 +87,17 @@ const DashProtect = React.createClass( {
 	}
 } );
 
+DashProtect.propTypes = {
+	isDevMode: React.PropTypes.bool.isRequired,
+	protectCount: React.PropTypes.any.isRequired
+};
+
 export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
-			getProtectCount: () => _getProtectCount( state ),
-			isFetchingModulesList: () => _isFetchingModulesList( state ),
+			protectCount: _getProtectCount( state ),
+			isDevMode: isDevMode( state ),
 			moduleList: getModules( state )
 		};
 	},

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -26,8 +26,8 @@ import { isDevMode } from 'state/connection';
 const DashScan = React.createClass( {
 	getContent: function() {
 		const labelName = __( 'Malware Scanning' ),
-			hasSitePlan = false !== this.props.getSitePlan(),
-			vpData = this.props.getVaultPressData(),
+			hasSitePlan = false !== this.props.sitePlan,
+			vpData = this.props.vaultPressData,
 			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
@@ -40,7 +40,7 @@ const DashScan = React.createClass( {
 			}
 
 			// Check for threats
-			const threats = this.props.getScanThreats();
+			const threats = this.props.scanThreats;
 			if ( threats !== 0 ) {
 				return (
 					<DashItem
@@ -116,7 +116,7 @@ const DashScan = React.createClass( {
 			>
 				<p className="jp-dash-item__description">
 					{
-						isDevMode( this.props ) ? __( 'Unavailable in Dev Mode.' ) :
+						this.props.isDevMode ? __( 'Unavailable in Dev Mode.' ) :
 							upgradeOrActivateText()
 					}
 				</p>
@@ -134,14 +134,22 @@ const DashScan = React.createClass( {
 	}
 } );
 
+DashScan.propTypes = {
+	vaultPressData: React.PropTypes.any.isRequired,
+	scanThreats: React.PropTypes.any.isRequired,
+	isDevMode: React.PropTypes.bool.isRequired,
+	sitePlan: React.PropTypes.object.isRequired
+}
+
 export default connect(
 	( state ) => {
 		return {
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isFetchingModulesList: () => _isFetchingModulesList( state ),
-			getVaultPressData: () => _getVaultPressData( state ),
-			getScanThreats: () => _getVaultPressScanThreatCount( state ),
-			getSitePlan: () => getSitePlan( state ),
+			vaultPressData: _getVaultPressData( state ),
+			scanThreats: _getVaultPressScanThreatCount( state ),
+			sitePlan: getSitePlan( state ),
+			isDevMode: isDevMode( state ),
 			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
 		};
 	},

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -48,8 +48,7 @@ const DashScan = React.createClass( {
 						module="scan"
 						status="is-error"
 						statusText={ __( 'Threats found' ) }
-						pro={ true }
-					>
+						pro={ true } >
 						<h3>{
 							__(
 								'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.',
@@ -76,8 +75,7 @@ const DashScan = React.createClass( {
 						label={ labelName }
 						module="scan"
 						status="is-working"
-						pro={ true }
-					>
+						pro={ true } >
 						<p className="jp-dash-item__description">
 							{ __( "No threats found, you're good to go!" ) }
 						</p>
@@ -112,8 +110,7 @@ const DashScan = React.createClass( {
 				module="scan"
 				className="jp-dash-item__is-inactive"
 				status={ hasSitePlan ? inactiveOrUninstalled : 'no-pro-uninstalled-or-inactive' }
-				pro={ true }
-			>
+				pro={ true } >
 				<p className="jp-dash-item__description">
 					{
 						this.props.isDevMode ? __( 'Unavailable in Dev Mode.' ) :
@@ -138,6 +135,7 @@ DashScan.propTypes = {
 	vaultPressData: React.PropTypes.any.isRequired,
 	scanThreats: React.PropTypes.any.isRequired,
 	isDevMode: React.PropTypes.bool.isRequired,
+	siteRawUrl: React.PropTypes.string.isRequired,
 	sitePlan: React.PropTypes.object.isRequired
 }
 

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -21,6 +21,7 @@ import { imagePath } from 'constants';
 import { isDevMode } from 'state/connection';
 import {
 	getInitialStateStatsData,
+	getSiteRawUrl,
 	getSiteAdminUrl
 } from 'state/initial-state';
 import QueryStatsData from 'components/data/query-stats-data';
@@ -234,7 +235,10 @@ const DashStats = React.createClass( {
 } );
 
 DashStats.propTypes = {
-	isDevMode: React.PropTypes.bool.isRequired
+	isDevMode: React.PropTypes.bool.isRequired,
+	siteRawUrl: React.PropTypes.string.isRequired,
+	siteAdminUrl: React.PropTypes.string.isRequired,
+	statsData: React.PropTypes.any.isRequired
 };
 
 export default connect(

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -150,7 +150,7 @@ const DashStats = React.createClass( {
 					</div>
 					<div className="jp-at-a-glance__stats-inactive-text">
 						{
-							isDevMode( this.props ) ? __( 'Unavailable in Dev Mode' ) :
+							this.props.isDevMode ? __( 'Unavailable in Dev Mode' ) :
 							__( '{{a}}Activate Site Stats{{/a}} to see detailed stats, likes, followers, subscribers, and more! {{a1}}Learn More{{/a1}}', {
 								components: {
 									a: <a href="javascript:void(0)" onClick={ this.props.activateStats } />,
@@ -160,7 +160,7 @@ const DashStats = React.createClass( {
 						}
 					</div>
 						{
-							isDevMode( this.props ) ? '' : (
+							this.props.isDevMode ? '' : (
 								<div className="jp-at-a-glance__stats-inactive-button">
 									<Button
 										onClick={ this.props.activateStats }
@@ -225,13 +225,17 @@ const DashStats = React.createClass( {
 				<DashSectionHeader label={ __( 'Site Stats' ) }>
 					{ this.maybeShowStatsTabs() }
 				</DashSectionHeader>
-				<Card className={ 'jp-at-a-glance__stats-card ' + ( isDevMode( this.props ) ? 'is-inactive' : '' ) }>
+				<Card className={ 'jp-at-a-glance__stats-card ' + ( this.props.isDevMode ? 'is-inactive' : '' ) }>
 					{ this.renderStatsArea() }
 				</Card>
 			</div>
 		);
 	}
 } );
+
+DashStats.propTypes = {
+	isDevMode: React.PropTypes.bool.isRequired
+};
 
 export default connect(
 	( state ) => {
@@ -240,6 +244,7 @@ export default connect(
 			moduleList: getModules( state ),
 			isFetchingModules: () => _isFetchingModulesList( state ),
 			activeTab: () => _getActiveStatsTab( state ),
+			isDevMode: isDevMode( state ),
 			statsData: getStatsData( state ) !== 'N/A' ? getStatsData( state ) : getInitialStateStatsData( state )
 		};
 	},

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -29,7 +29,7 @@ const JetpackConnect = React.createClass( {
 					</p>
 					<ConnectButton />
 					<p>
-						<a href={ this.props.connectUrl( this.props ) } className="jp-jetpack-connect__link">
+						<a href={ this.props.connectUrl } className="jp-jetpack-connect__link">
 							{ __( 'No account? Create one for free…' ) }
 						</a>
 					</p>
@@ -229,7 +229,7 @@ const JetpackConnect = React.createClass( {
 export default connect(
 	state => {
 		return {
-			connectUrl: () => _getConnectUrl( state )
+			connectUrl: _getConnectUrl( state )
 		}
 	}
 )( JetpackConnect );

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -22,7 +22,7 @@ export const DevVersionNotice = React.createClass( {
 	displayName: 'DevVersionNotice',
 
 	render() {
-		if ( isDevVersion( this.props ) ) {
+		if ( this.props.isDevVersion ) {
 			return (
 				<SimpleNotice
 					showDismiss={ false }
@@ -43,11 +43,15 @@ export const DevVersionNotice = React.createClass( {
 
 } );
 
+DevVersionNotice.propTypes = {
+	isDevVersion: React.PropTypes.bool.isRequired
+};
+
 export const StagingSiteNotice = React.createClass( {
 	displayName: 'StagingSiteNotice',
 
 	render() {
-		if ( isStaging( this.props ) ) {
+		if ( this.props.isStaging ) {
 			const text = __( 'You are running Jetpack on a {{a}}staging server{{/a}}.',
 				{
 					components: {
@@ -71,12 +75,16 @@ export const StagingSiteNotice = React.createClass( {
 
 } );
 
+StagingSiteNotice.propTypes = {
+	isStaging: React.PropTypes.bool.isRequired
+};
+
 export const DevModeNotice = React.createClass( {
 	displayName: 'DevModeNotice',
 
 	render() {
-		if ( getSiteConnectionStatus( this.props ) === 'dev' ) {
-			const devMode = getSiteDevMode( this.props );
+		if ( this.props.siteConnectionStatus === 'dev' ) {
+			const devMode = this.props.siteDevMode;
 			let text;
 			if ( devMode.filter ) {
 				text = __( 'Currently in {{a}}Development Mode{{/a}} via the jetpack_development_mode filter.{{br/}}Some features are disabled.',
@@ -122,6 +130,17 @@ export const DevModeNotice = React.createClass( {
 
 } );
 
+DevModeNotice.propTypes = {
+	siteConnectionStatus: React.PropTypes.oneOfType( [
+		React.PropTypes.string,
+		React.PropTypes.bool
+	] ).isRequired,
+	siteDevMode: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
+};
+
 export const UserUnlinked = React.createClass( {
 	displayName: 'UserUnlinked',
 
@@ -159,6 +178,11 @@ export const UserUnlinked = React.createClass( {
 
 } );
 
+UserUnlinked.propTypes = {
+	connectUrl: React.PropTypes.string.isRequired,
+	siteConnected: React.PropTypes.bool.isRequired
+};
+
 const JetpackNotices = React.createClass( {
 	displayName: 'JetpackNotices',
 
@@ -168,14 +192,15 @@ const JetpackNotices = React.createClass( {
 				<QueryConnectUrl />
 				<NoticesList { ...this.props } />
 				<JetpackStateNotices />
-				<DevVersionNotice { ...this.props } />
-				<DevModeNotice { ...this.props } />
-				<StagingSiteNotice { ...this.props } />
+				<DevVersionNotice isDevVersion={ this.props.isDevVersion } />
+				<DevModeNotice
+					siteConnectionStatus={ this.props.siteConnectionStatus }
+					siteDevMode={ this.props.siteDevMode } />
+				<StagingSiteNotice isStaging={ this.props.isStaging } />
 				<DismissableNotices />
 				<UserUnlinked
-					connectUrl={ this.props.connectUrl( this.props ) }
-					siteConnected={ true === getSiteConnectionStatus( this.props ) }
-				/>
+					connectUrl={ this.props.connectUrl }
+					siteConnected={ true === this.props.siteConnectionStatus } />
 			</div>
 		);
 	}
@@ -184,7 +209,11 @@ const JetpackNotices = React.createClass( {
 export default connect(
 	state => {
 		return {
-			connectUrl: () => _getConnectUrl( state )
+			connectUrl: _getConnectUrl( state ),
+			siteConnectionStatus: getSiteConnectionStatus( state ),
+			isDevVersion: isDevVersion( state ),
+			siteDevMode: getSiteDevMode( state ),
+			isStaging: isStaging( state )
 		};
 	}
 )( JetpackNotices );

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -190,7 +190,7 @@ const JetpackNotices = React.createClass( {
 		return (
 			<div>
 				<QueryConnectUrl />
-				<NoticesList { ...this.props } />
+				<NoticesList />
 				<JetpackStateNotices />
 				<DevVersionNotice isDevVersion={ this.props.isDevVersion } />
 				<DevModeNotice

--- a/_inc/client/components/jumpstart/index.jsx
+++ b/_inc/client/components/jumpstart/index.jsx
@@ -27,11 +27,10 @@ const JumpStart = React.createClass( {
 
 	render: function() {
 		const trackLearnMore = () => analytics.tracks.recordEvent( 'jetpack_jumpstart_learn_more', {} );
-		let jumpstartModules = this.props.jumpstartFeatures( this.props ).map( ( module ) => (
+		let jumpstartModules = this.props.jumpstartFeatures.map( ( module ) => (
 			<div
 				className="jp-jumpstart__feature-list-column"
-				key={ `module-card_${ module.name }` /* https://fb.me/react-warning-keys */ }
-			>
+				key={ `module-card_${ module.name }` /* https://fb.me/react-warning-keys */ } >
 				<div className="jp-jumpstart__feature-content">
 					<h4
 						className="jp-jumpstart__feature-content-title"
@@ -50,7 +49,7 @@ const JumpStart = React.createClass( {
 				</h1>
 				<Card className="jp-jumpstart__cta-container">
 					<Card className="jp-jumpstart__cta">
-						{ this.props.jumpstarting( this.props ) ? <Spinner /> : null }
+						{ this.props.isJumpstarting ? <Spinner /> : null }
 						<p className="jp-jumpstart__description">
 							{ __( "Quickly enhance your site by activating Jetpack's recommended features." ) }
 						</p>
@@ -91,8 +90,8 @@ const JumpStart = React.createClass( {
 export default connect(
 	state => {
 		return {
-			jumpstarting: () => _isJumpstarting( state ),
-			jumpstartFeatures: () => _getModulesByFeature( state, 'Jumpstart' )
+			isJumpstarting: _isJumpstarting( state ),
+			jumpstartFeatures: _getModulesByFeature( state, 'Jumpstart' )
 		};
 	},
 	dispatch => bindActionCreators( { jumpStartActivate, jumpStartSkip }, dispatch )

--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -2,16 +2,18 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { getSiteConnectionStatus } from 'state/connection';
+import { getCurrentVersion } from 'state/initial-state';
 
 const Masthead = React.createClass( {
 	render: function() {
-		let devNotice = getSiteConnectionStatus( this.props ) === 'dev'
+		let devNotice = this.props.siteConnectionStatus === 'dev'
 			? <code>[Dev Mode]</code>
 			: '';
 
@@ -37,7 +39,7 @@ const Masthead = React.createClass( {
 							</a>
 						</li>
 						<li className="jp-masthead__link-li">
-							<a href={ 'http://surveys.jetpack.me/research-plugin?rel=' + this.props.jetpack.initialState.currentVersion } target="_blank" className="jp-masthead__link">
+							<a href={ 'http://surveys.jetpack.me/research-plugin?rel=' + this.props.currentVersion } target="_blank" className="jp-masthead__link">
 								<span className="dashicons dashicons-admin-comments" title={ __( 'Send us Feedback' ) } />
 								<span>
 									{ __( 'Send us Feedback' ) }
@@ -51,4 +53,11 @@ const Masthead = React.createClass( {
 	}
 } );
 
-module.exports = Masthead;
+export default connect(
+	state => {
+		return {
+			siteConnectionStatus: getSiteConnectionStatus( state ),
+			currentVersion: getCurrentVersion( state )
+		};
+	}
+)( Masthead );

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -15,7 +15,7 @@ import {
 	setUnsavedOptionFlag,
 	clearUnsavedOptionFlag
 } from 'state/modules';
-
+import { getCurrentIp, getSiteAdminUrl } from 'state/initial-state';
 import {
 	getSiteRoles,
 	getAdminEmailAddress
@@ -39,6 +39,8 @@ export function connectModuleOptions( Component ) {
 				getSiteRoles: () => getSiteRoles( state ),
 				isUpdating: ( option_name ) => isUpdatingModuleOption( state, ownProps.module.module, option_name ),
 				adminEmailAddress: getAdminEmailAddress( state ),
+				currentIp: getCurrentIp( state ),
+				siteAdminUrl: getSiteAdminUrl( state ),
 				isCurrentUserLinked: isCurrentUserLinked( state )
 			}
 		},

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -283,6 +283,10 @@ export let ProtectSettings = React.createClass( {
 	}
 } );
 
+ProtectSettings.propTypes = {
+	currentIp: React.PropTypes.string.isRequired
+};
+
 ProtectSettings = moduleSettingsForm( ProtectSettings );
 
 export let MonitorSettings = React.createClass( {
@@ -604,6 +608,10 @@ export let PostByEmailSettings = React.createClass( {
 	}
 } );
 
+PostByEmailSettings.propTypes = {
+	isCurrentUserLinked: React.PropTypes.bool.isRequired
+};
+
 PostByEmailSettings = moduleSettingsForm( PostByEmailSettings );
 
 export let CustomContentTypesSettings = React.createClass( {
@@ -653,6 +661,10 @@ export let CustomContentTypesSettings = React.createClass( {
 		)
 	}
 } );
+
+CustomContentTypesSettings.propTypes = {
+	siteAdminUrl: React.PropTypes.string.isRequired
+};
 
 CustomContentTypesSettings = moduleSettingsForm( CustomContentTypesSettings );
 

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -43,25 +43,25 @@ export const AllModuleSettings = React.createClass( {
 					</div>
 				);
 			case 'post-by-email':
-				return ( <PostByEmailSettings module={ module } { ...this.props } /> );
+				return ( <PostByEmailSettings module={ module }  /> );
 			case 'custom-content-types':
-				return ( <CustomContentTypesSettings module={ module } { ...this.props } /> );
+				return ( <CustomContentTypesSettings module={ module }  /> );
 			case 'after-the-deadline':
-				return ( <AfterTheDeadlineSettings module={ module } { ...this.props } /> );
+				return ( <AfterTheDeadlineSettings module={ module }  /> );
 			case 'markdown':
-				return ( <MarkdownSettings module={ module } { ...this.props } /> );
+				return ( <MarkdownSettings module={ module }  /> );
 			case 'tiled-gallery':
-				return ( <TiledGallerySettings module={ module } { ...this.props } /> );
+				return ( <TiledGallerySettings module={ module }  /> );
 			case 'minileven':
-				return ( <MinilevenSettings module={ module } { ...this.props } /> );
+				return ( <MinilevenSettings module={ module }  /> );
 			case 'carousel':
-				return ( <CarouselSettings module={ module } { ...this.props } /> );
+				return ( <CarouselSettings module={ module }  /> );
 			case 'infinite-scroll':
-				return ( <InfiniteScrollSettings module={ module } { ...this.props } /> );
+				return ( <InfiniteScrollSettings module={ module }  /> );
 			case 'protect':
-				return ( <ProtectSettings module={ module } { ...this.props } /> );
+				return ( <ProtectSettings module={ module }  /> );
 			case 'monitor':
-				return ( <MonitorSettings module={ module } { ...this.props } /> );
+				return ( <MonitorSettings module={ module }  /> );
 			case 'scan':
 				return '' === module.configure_url ? (
 					<div>
@@ -79,23 +79,23 @@ export const AllModuleSettings = React.createClass( {
 					</div>
 				);
 			case 'sso':
-				return ( <SingleSignOnSettings module={ module } { ...this.props } /> );
+				return ( <SingleSignOnSettings module={ module }  /> );
 			case 'stats':
-				return ( <StatsSettings module={ module } { ...this.props } /> );
+				return ( <StatsSettings module={ module }  /> );
 			case 'related-posts':
-				return ( <RelatedPostsSettings module={ module } { ...this.props } /> );
+				return ( <RelatedPostsSettings module={ module }  /> );
 			case 'comments':
-				return ( <CommentsSettings module={ module } { ...this.props } /> );
+				return ( <CommentsSettings module={ module }  /> );
 			case 'subscriptions':
-				return ( <SubscriptionsSettings module={ module } { ...this.props } /> );
+				return ( <SubscriptionsSettings module={ module }  /> );
 			case 'gravatar-hovercards':
-				return ( <GravatarHovercardsSettings module={ module } { ...this.props } /> );
+				return ( <GravatarHovercardsSettings module={ module }  /> );
 			case 'likes':
-				return ( <LikesSettings module={ module } { ...this.props } /> );
+				return ( <LikesSettings module={ module }  /> );
 			case 'verification-tools':
-				return ( <VerificationToolsSettings module={ module } { ...this.props } /> );
+				return ( <VerificationToolsSettings module={ module }  /> );
 			case 'sitemaps':
-				return ( <SitemapsSettings module={ module } { ...this.props } /> );
+				return ( <SitemapsSettings module={ module }  /> );
 			case 'contact-form':
 			case 'latex':
 			case 'shortlinks':

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -72,6 +72,10 @@ const Navigation = React.createClass( {
 	}
 } );
 
+Navigation.propTypes = {
+	route: React.PropTypes.object.isRequired
+};
+
 export default connect(
 	( state ) => {
 		return {

--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -19,6 +19,7 @@ import Engagement from 'engagement/index.jsx';
 import GeneralSettings from 'general-settings/index.jsx';
 import Writing from 'writing/index.jsx';
 import Apps from 'apps/index.jsx';
+import { getSiteConnectionStatus } from 'state/connection';
 
 const NonAdminView = React.createClass( {
 	componentWillMount: function() {
@@ -26,7 +27,8 @@ const NonAdminView = React.createClass( {
 	},
 
 	shouldComponentUpdate: function( nextProps ) {
-		return nextProps.jetpack.connection.status !== this.props.jetpack.connection.status || nextProps.route.path !== this.props.route.path;
+		return nextProps.siteConnectionStatus !== this.props.siteConnectionStatus ||
+			nextProps.route.path !== this.props.route.path;
 	},
 
 	renderMainContent: function( route ) {
@@ -84,10 +86,17 @@ const NonAdminView = React.createClass( {
 
 } );
 
+NonAdminView.propTypes = {
+	userCanViewStats: React.PropTypes.bool.isRequired,
+	isSubscriber: React.PropTypes.bool.isRequired,
+	siteConnectionStatus: React.PropTypes.any.isRequired
+}
+
 export default connect(
 	( state ) => {
 		return {
 			userCanViewStats: _userCanViewStats( state ),
+			siteConnectionStatus: getSiteConnectionStatus( state ),
 			isSubscriber: _userIsSubscriber( state ),
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name )
 		};

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import sample from 'lodash/sample';
 import { translate as __ } from 'i18n-calypso';
@@ -12,7 +13,7 @@ import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import { getHappinessGravatarIds } from 'state/initial-state';
 
-export default React.createClass( {
+const SupportCard = React.createClass( {
 	displayName: 'SupportCard',
 
 	render() {
@@ -21,7 +22,7 @@ export default React.createClass( {
 			'jp-support-card'
 		);
 
-		const randomGravID = sample( getHappinessGravatarIds( this.props ) );
+		const randomGravID = sample( this.props.happinessGravatarIds );
 
 		return (
 			<div className={ classes }>
@@ -116,3 +117,16 @@ export default React.createClass( {
 		);
 	}
 } );
+
+SupportCard.propTypes = {
+	className: React.PropTypes.string,
+	happinessGravatarIds: React.PropTypes.array.isRequired
+};
+
+export default connect(
+	state => {
+		return {
+			happinessGravatarIds: getHappinessGravatarIds( state )
+		}
+	}
+)( SupportCard );

--- a/_inc/client/general-settings/connection-settings.jsx
+++ b/_inc/client/general-settings/connection-settings.jsx
@@ -30,7 +30,7 @@ const ConnectionSettings = React.createClass( {
 			? null
 			: <ConnectButton connectUser={ true } />;
 
-		return isDevMode( this.props ) ?
+		return this.props.isDevMode ?
 			(
 				<div>
 					{
@@ -76,9 +76,21 @@ const ConnectionSettings = React.createClass( {
 	}
 } );
 
+ConnectionSettings.propTypes = {
+	isDevMode: React.PropTypes.bool.isRequired,
+	userCanDisconnectSite: React.PropTypes.bool.isRequired,
+	userIsMaster: React.PropTypes.bool.isRequired,
+	isLinked: React.PropTypes.bool.isRequired,
+	userWpComLogin: React.PropTypes.any.isRequired,
+	userWpComEmail: React.PropTypes.any.isRequired,
+	userWpComAvatar: React.PropTypes.any.isRequired,
+	username: React.PropTypes.any.isRequired
+};
+
 export default connect(
 	( state ) => {
 		return {
+			isDevMode: isDevMode( state ),
 			userCanDisconnectSite: _userCanDisconnectSite( state ),
 			userIsMaster: _userIsMaster( state ),
 			userWpComLogin: _getUserWpComLogin( state ),

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -121,7 +121,7 @@ const Main = React.createClass( {
 			return <NonAdminView { ...this.props } />
 		}
 
-		if ( ! getSiteConnectionStatus( this.props ) ) {
+		if ( ! this.props.siteConnectionStatus ) {
 			return <JetpackConnect { ...this.props } />
 		}
 
@@ -215,6 +215,7 @@ export default connect(
 		// This is tricky. We're passing the whole state as props of the main component
 		return  {
 			jumpStartStatus: getJumpStartStatus( state ),
+			siteConnectionStatus: getSiteConnectionStatus( state ),
 			siteRawUrl: getSiteRawUrl( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
 			apiRoot: getApiRootUrl( state ),

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -213,7 +213,7 @@ const Main = React.createClass( {
 export default connect(
 	state => {
 		// This is tricky. We're passing the whole state as props of the main component
-		return assign( {}, state, {
+		return  {
 			getJumpStartStatus: getJumpStartStatus( state ),
 			siteRawUrl: getSiteRawUrl( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
@@ -221,7 +221,7 @@ export default connect(
 			apiNonce: getApiNonce( state ),
 			tracksUserData: getTracksUserData( state ),
 			areThereUnsavedModuleOptions: areThereUnsavedModuleOptions( state )
-		} );
+		};
 	},
 	dispatch => bindActionCreators( { setInitialState, clearUnsavedOptionFlag }, dispatch )
 )( withRouter( Main ) );

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -78,7 +78,7 @@ const Main = React.createClass( {
 
 	shouldComponentUpdate: function( nextProps ) {
 		return nextProps.jetpack.connection.status !== this.props.jetpack.connection.status ||
-			nextProps.jetpack.jumpstart.status.showJumpStart !== getJumpStartStatus( this.props ) ||
+			nextProps.jetpack.jumpstart.status.showJumpStart !== this.props.jumpStartStatus ||
 			nextProps.route.path !== this.props.route.path;
 	},
 
@@ -111,7 +111,7 @@ const Main = React.createClass( {
 	},
 
 	renderMainContent: function( route ) {
-		const showJumpStart = getJumpStartStatus( this.props );
+		const showJumpStart = this.props.jumpStartStatus;
 		const canManageModules = window.Initial_State.userData.currentUser.permissions.manage_modules;
 
 		// Track page views
@@ -198,7 +198,7 @@ const Main = React.createClass( {
 						<JetpackNotices { ...this.props } />
 						{ this.renderMainContent( this.props.route.path ) }
 						{
-							this.props.getJumpStartStatus || '/apps' === this.props.route.path ?
+							this.props.jumpStartStatus || '/apps' === this.props.route.path ?
 							null :
 							<SupportCard { ...this.props } />
 						}
@@ -214,7 +214,7 @@ export default connect(
 	state => {
 		// This is tricky. We're passing the whole state as props of the main component
 		return  {
-			getJumpStartStatus: getJumpStartStatus( state ),
+			jumpStartStatus: getJumpStartStatus( state ),
 			siteRawUrl: getSiteRawUrl( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
 			apiRoot: getApiRootUrl( state ),

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import assign from 'lodash/assign';
 import includes from 'lodash/includes';
 import { createHistory } from 'history';
 import { withRouter } from 'react-router';
@@ -122,7 +121,7 @@ const Main = React.createClass( {
 		}
 
 		if ( ! this.props.siteConnectionStatus ) {
-			return <JetpackConnect { ...this.props } />
+			return <JetpackConnect />
 		}
 
 		if ( showJumpStart ) {
@@ -130,53 +129,53 @@ const Main = React.createClass( {
 				const history = createHistory();
 				history.push( window.location.pathname + '?page=jetpack#/jumpstart' );
 			} else if ( '/jumpstart' === route ) {
-				return <JumpStart { ...this.props } />
+				return <JumpStart />
 			}
 		}
 
 		let pageComponent,
-			navComponent = <Navigation { ...this.props } />;
+			navComponent = <Navigation route={ this.props.route }/>;
 		switch ( route ) {
 			case '/dashboard':
-				pageComponent = <AtAGlance { ...this.props } />;
+				pageComponent = <AtAGlance siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/apps':
-				pageComponent = <Apps siteRawUrl={ this.props.siteRawUrl } { ...this.props } />;
+				pageComponent = <Apps siteRawUrl={ this.props.siteRawUrl } />;
 				break;
 			case '/professional':
-				pageComponent = <Plans siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } { ...this.props } />;
+				pageComponent = <Plans siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/settings':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <GeneralSettings { ...this.props } />;
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <GeneralSettings route={ this.props.route } />;
 				break;
 			case '/general':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <GeneralSettings { ...this.props } />;
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <GeneralSettings route={ this.props.route } />;
 				break;
 			case '/engagement':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <Engagement { ...this.props } />;
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <Engagement route={ this.props.route } />;
 				break;
 			case '/security':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <Security { ...this.props } />;
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <Security route={ this.props.route } />;
 				break;
 			case '/appearance':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <Appearance { ...this.props } />;
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <Appearance route={ this.props.route } />;
 				break;
 			case '/writing':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <Writing { ...this.props } />;
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <Writing route={ this.props.route } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/search':
-				navComponent = <NavigationSettings { ...this.props } />;
-				pageComponent = <SearchPage { ...this.props } />;
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <SearchPage siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 
 			default:
-				pageComponent = <AtAGlance { ...this.props } />;
+				pageComponent = <AtAGlance siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 		}
 
 		window.wpNavMenuClassChange();
@@ -192,18 +191,18 @@ const Main = React.createClass( {
 	render: function() {
 		return (
 			<div>
-				<Masthead { ...this.props } />
+				<Masthead/>
 					<div className="jp-lower">
-						<AdminNotices { ...this.props } />
-						<JetpackNotices { ...this.props } />
+						<AdminNotices />
+						<JetpackNotices />
 						{ this.renderMainContent( this.props.route.path ) }
 						{
 							this.props.jumpStartStatus || '/apps' === this.props.route.path ?
 							null :
-							<SupportCard { ...this.props } />
+							<SupportCard />
 						}
 					</div>
-				<Footer { ...this.props } />
+				<Footer siteAdminUrl={ this.props.siteAdminUrl } />
 			</div>
 		);
 	}

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -18,7 +18,7 @@ import Navigation from 'components/navigation';
 import NavigationSettings from 'components/navigation-settings';
 import JetpackConnect from 'components/jetpack-connect';
 import JumpStart from 'components/jumpstart';
-import { getJumpStartStatus } from 'state/jumpstart';
+import { getJumpStartStatus, isJumpstarting } from 'state/jumpstart';
 import { getSiteConnectionStatus } from 'state/connection';
 import {
 	setInitialState,
@@ -77,14 +77,14 @@ const Main = React.createClass( {
 	},
 
 	shouldComponentUpdate: function( nextProps ) {
-		return nextProps.jetpack.connection.status !== this.props.jetpack.connection.status ||
-			nextProps.jetpack.jumpstart.status.showJumpStart !== this.props.jumpStartStatus ||
+		return nextProps.siteConnectionStatus !== this.props.siteConnectionStatus ||
+			nextProps.jumpStartStatus !== this.props.jumpStartStatus ||
 			nextProps.route.path !== this.props.route.path;
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.jetpack.jumpstart.status.showJumpStart !== this.props.jetpack.jumpstart.status.showJumpStart ||
-			nextProps.jetpack.jumpstart.status.isJumpstarting !== this.props.jetpack.jumpstart.status.isJumpstarting ) {
+		if ( nextProps.jumpStartStatus !== this.props.jumpStartStatus ||
+			nextProps.isJumpstarting !== this.props.isJumpstarting ) {
 			this.handleJumpstart( nextProps );
 		}
 	},
@@ -98,14 +98,14 @@ const Main = React.createClass( {
 	 */
 	handleJumpstart( nextProps ) {
 		const history = createHistory();
-		const willShowJumpStart = nextProps.jetpack.jumpstart.status.showJumpStart;
-		const willBeJumpstarting = nextProps.jetpack.jumpstart.status.isJumpstarting;
+		const willShowJumpStart = nextProps.jumpStartStatus;
+		const willBeJumpstarting = nextProps.isJumpstarting;
 
-		if ( ! this.props.showJumpStart && willShowJumpStart ) {
+		if ( ! this.props.jumpStartStatus && willShowJumpStart ) {
 			window.location.hash = 'jumpstart';
 			history.push( window.location.pathname + '?page=jetpack#/jumpstart' );
 		}
-		if ( ! this.props.jetpack.jumpstart.showJumpStart && ! willShowJumpStart && ! willBeJumpstarting ) {
+		if ( ! this.props.jumpStartStatus && ! willShowJumpStart && ! willBeJumpstarting ) {
 			history.push( window.location.pathname + '?page=jetpack#/dashboard' );
 		}
 	},
@@ -212,9 +212,9 @@ const Main = React.createClass( {
 
 export default connect(
 	state => {
-		// This is tricky. We're passing the whole state as props of the main component
 		return  {
 			jumpStartStatus: getJumpStartStatus( state ),
+			isJumpstarting: isJumpstarting( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 			siteRawUrl: getSiteRawUrl( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -32,15 +32,13 @@ import {
 	isFetchingPluginsData,
 	isPluginActive
 } from 'state/site/plugins';
-import { getCurrentIp } from 'state/initial-state';
 
 export const Page = ( props ) => {
 	let {
 		toggleModule,
 		isModuleActivated,
 		isTogglingModule,
-		getModule,
-		currentIp
+		getModule
 	} = props,
 		moduleList = Object.keys( props.moduleList );
 	var cards = [
@@ -112,7 +110,7 @@ export const Page = ( props ) => {
 			>
 				{
 					isModuleActivated( element[0] ) || isPro ?
-						<AllModuleSettings module={ isPro ? proProps : getModule( element[ 0 ] ) } currentIp={ currentIp } /> :
+						<AllModuleSettings module={ isPro ? proProps : getModule( element[ 0 ] ) } /> :
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
@@ -147,7 +145,6 @@ export default connect(
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
 			isFetchingPluginsData: isFetchingPluginsData( state ),
 			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
-			currentIp: getCurrentIp( state ),
 			moduleList: getModules( state )
 		};
 	},

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -131,8 +131,8 @@ export function getSiteConnectionStatus( state ) {
  * @return {bool|object} False if site is not in Dev Mode. If it is, returns an object with information about the Dev Mode.
  */
 export function getSiteDevMode( state ) {
-	if ( state.jetpack.connection.status.siteConnected.devMode.isActive ) {
-		return state.jetpack.connection.status.siteConnected.devMode;
+	if ( get( state.jetpack.connection.status, [ 'siteConnected', 'devMode', 'isActive'] ) ) {
+		return get( state.jetpack.connection.status, [ 'siteConnected', 'devMode'] );
 	}
 	return false;
 }

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -37,7 +37,7 @@ export function getHappinessGravatarIds( state ) {
  * @return {bool} true if dev version
  */
 export function isDevVersion( state ) {
-	return state.jetpack.initialState.isDevVersion;
+	return !! state.jetpack.initialState.isDevVersion;
 }
 
 /**


### PR DESCRIPTION
The `<Main />` component was using the whole state tree as `props` thus causing every child to refresh whenever any key of the state tree was updated. 

#### Changes proposed in this Pull Request:

* Removes the statement in the `<Main />` component which connected it to the whole state tree 
* Removes usage of `this.props` as a `state` substitute when using **state selectors** from inside some components.
* Removes usage of `...this.props` forwarding from `main.jsx` to its children
* Fixes two selectors that were not working properly

#### Testing instructions:

**Dashboard**

* [x] Hover on the button links in the Stats Widget  Check that your site's URL is present in the URLs
* [x] Hover on the button links in the Plugins Widget  Check that your site's URL is present in the URLs
* [x] Check that the threat information in the Scans widget is appropriate for your site. 
* [x] With the stats module disabled, check that you can enable it from the "Activate Site stats" widget button link.
* [x] Click on a chart bar with visitor count. Check that you're linked property to your site's stats	
* [x] Switch between weeks, day, month view and see that stats for that range are loaded
* [x] Hover on the Akismet widget link "please activate Akismet". Check that your site's URL is present in the URL
* [x] Hover on the "Pro" link in the Backups Widget  Check that your site's URL is present in the URL
* [x] If monitor is activated, check that you're correctly seeing last down time
* [x] If you're on dev mode, check that photon is disabled
* [x] If you're not on dev mode, check that you can enable/disable Photon from the widget's header toggle and the link in the description
* [x] Check that you can enable/disable Protect from the widget's header toggle
* [x] Check that you can enable/disable Monitor from the widget's header toggle and the link in the description


**Jetpack connection**

* [x] Verify you can disconnect properly
* [x] Verify you you can reconnect again

**User unlinking**

* [x] With a non admin user, verify that you can unlink/link the user to a WordPress.com account


**Staging mode**

* [x] If on a staging environment, verify you're seeing the "You are running Jetpack on a staging server" notice.


**Jumpstart**

* [x] With an admin user, verify that you can reset options and then jumpstart

**Masthead**

* [x] Verify that the link for "Send us Feedback" on the top properly links to the current plugin version survey.


**Settings**

* [x] Get to **Protect** settings. Verify that you see your current IP properly.
* [x] Randomly check that you can expand other settinsg cards, and alter/save options. 
* [x] Randomly check that you can expand plugins cards.

**Support Card**

* [x] Check that you see HEs normally in the card

**Navigation**

* [x] Check that you can switch tabs normally

