### PR TITLE
Admin Page: remove extra wp-admin from CPT configuration links.

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -613,7 +613,7 @@ export let CustomContentTypesSettings = React.createClass( {
 				'' :
 				<Button
 					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
-					href={ this.props.siteAdminUrl + '/wp-admin/edit.php?post_type=jetpack-portfolio' }
+					href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-portfolio' }
 					compact={ true }
 				>{ __( 'Configure Portfolios' ) }</Button>;
 		};
@@ -623,7 +623,7 @@ export let CustomContentTypesSettings = React.createClass( {
 				'' :
 				<Button
 					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
-					href={ this.props.siteAdminUrl + '/wp-admin/edit.php?post_type=jetpack-testimonial' }
+					href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-testimonial' }
 					compact={ true }
 				>{ __( 'Configure Testimonials' ) }</Button>;
 		};


### PR DESCRIPTION
Fixes #5148

#### Testing instructions:

1. Go to Jetpack > Settings > Writing
2. Activate both the Portfolio and the Testimonial CPT.
3. Save your changes.
4. Make sure both configuration links point to the right page.

#### Proposed changelog entry for your changes:

Admin Page: remove extra wp-admin from CPT configuration links.