### PR TITLE
Sync: Fix issue where listener/sender not loading for alternate cron

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -283,9 +283,18 @@ class Jetpack_Sync_Actions {
 	}
 }
 
-// Allow other plugins to add filters before we initialize the actions.
-// Load the listeners if before modules get loaded so that we can capture version changes etc.
-add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
+/**
+ * If the site is using alternate cron, we need to init the listener and sender before cron
+ * runs. So, we init at a priority of 9.
+ * 
+ * If the site is using a regular cron job, we init at a priority of 90 which gives plugins a chance
+ * to add filters before we initialize.
+ */
+if ( defined( 'ALTERNATE_WP_CRON' ) && ALTERNATE_WP_CRON ) {
+	add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 9 );
+} else {
+	add_action( 'init', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
+}
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'schedule_initial_sync' ), 10, 2 );


### PR DESCRIPTION
After 4.3.1, there have been more reports about failing to send subscription emails and publicize for scheduled posts when a user has enabled alternate cron. I was able to fix this behavior with this PR.

In a nutshell, the big change here is to load the sync actions on `init` at a priority of `9` so that we can ensure we've loaded [before cron runs](https://github.com/WordPress/WordPress/blob/master/wp-includes/default-filters.php#L278.

The other change is that we always load the listener and sender if a site has enabled alternate cron. The downside to this is that we are likely adding some load time to the frontend. But, the alternative was that we add actions for when we call `set_transient()` since there's not an explicit start alternate cron action. This felt a bit hacky and prone to timing issues.

To test:

- Checkout `fix/sync-alternate-cron` branch
- Set `ALTERNATE_WP_CRON` to true in `wp-config.php`
- Schedule a post
- Ensure post gets synced and subscription email and publicize goes out
- Use regular cron and follow same steps

cc @gravityrail for review