### PR TITLE
Admin Page: Use correct link to contact Jetpack

### DIFF
--- a/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
+++ b/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
@@ -31,7 +31,7 @@ const FeedbackDashRequest = React.createClass( {
 					text={ __( 'What would you like to see on your Jetpack Dashboard?' ) }
 				>
 					<NoticeAction
-						href="https://jetpack.com/contact"
+						href="https://jetpack.com/contact-support/"
 					>
 						{ __( 'Let us know!' ) }
 					</NoticeAction>


### PR DESCRIPTION
`/contact/` is not a page we use. Changing the URL to the direct link to save the redirections.

Since support is closed right now (GM 2016), going to put a quick survey at `/contact/` to capture feedback.