### PR TITLE
Admin - i18n json: check that file exists so it doesn't throw warning…

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -152,18 +152,17 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 	function get_i18n_data() {
 
-		// Try fetching by patch
-		$locale_data = @file_get_contents( JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . get_locale() . '.json' );
+		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . get_locale() . '.json';
 
-		if ( false === $locale_data ) {
-
-			// Return empty if we have nothing to return so it doesn't fail when parsed in JS
-			return '{}';
-		} else {
-
-			// We got the json file so let's return it
-			return $locale_data;
+		if ( is_file( $i18n_json ) && is_readable( $i18n_json ) ) {
+			$locale_data = @file_get_contents( $i18n_json );
+			if ( $locale_data ) {
+				return $locale_data;
+			}
 		}
+
+		// Return empty if we have nothing to return so it doesn't fail when parsed in JS
+		return '{}';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5163

#### Changes proposed in this Pull Request:
- checks that the i18n json file exists and is readable before attempting to get its contents

#### Testing instructions:
* go to Jetpack React and verify it loads correctly in different languages

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Avoid PHP warning when trying to fetch a non-existent `jetpack-en_US.json` by checking that the file is readable before attempting to get its contents.