### PR TITLE
Admin - Email Subscriptions: remove unwanted text in checkbox label

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -190,8 +190,7 @@ export let SubscriptionsSettings = React.createClass( {
 					<ModuleSettingCheckbox
 						name={ 'stc_enabled' }
 						{ ...this.props }
-						label={ __( 'Show a "follow comments" option in the comment form.' ) +
-							' (Currently does not work)' } />
+						label={ __( 'Show a "follow comments" option in the comment form.' ) } />
 					<FormButton
 						className="is-primary"
 						isSubmitting={ this.props.isSavingAnyOption() }


### PR DESCRIPTION
Fixes #5161

#### Changes proposed in this Pull Request:
- Removes the extra text "Currently does not work"

#### Testing instructions:
* go to Jetpack > Settings > Engagement, expand Email Subscriptions and make sure the mentioned text is no longer there.

