### PR TITLE
Site Verification: Remove "and others" since Bing is the only other option

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -188,7 +188,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'verification-tools' => array(
 				'name' => _x( 'Site Verification', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Verify your site or domain with Google Search Console, Pinterest, and others.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Verify your site or domain with Google Search Console, Pinterest, and Bing.', 'Module Description', 'jetpack' ),
 			),
 
 			'videopress' => array(


### PR DESCRIPTION
Site verification includes Google Search Console, Pinterest, and Bing. Rather than the description saying "and others" when Bing is the only other, let's just be clear and include Bing.