### PR TITLE
Add a setting to disable rendering of filtered content for posts

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -666,6 +666,7 @@ $sync_settings_response = array(
 	'post_types_blacklist' => '(array|string|bool=false) List of post types to exclude from sync. Send "empty" to unset.',
 	'meta_blacklist'       => '(array|string|bool=false) List of meta keys to exclude from sync. Send "empty" to unset.',
 	'disable'              => '(int|bool=false) Set to 1 or true to disable sync entirely.',
+	'render_filtered_content' => '(int|bool=true) Set to 1 or true to render filtered content.',
 );
 
 // GET /sites/%s/sync/settings

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -275,6 +275,7 @@ class Jetpack_Sync_Defaults {
 	static $default_post_types_blacklist = array();
 	static $default_meta_blacklist = array();
 	static $default_disable = 0; // completely disable sending data to wpcom
+	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 }

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -117,8 +117,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$post->post_password = 'auto-' . wp_generate_password( 10, false );
 		}
 		/** This filter is already documented in core. wp-includes/post-template.php */
-		$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
-		$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
+		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) ) {
+			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
+			$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );	
+		}
 		$post->permalink               = get_permalink( $post->ID );
 		$post->shortlink               = wp_get_shortlink( $post->ID );
 		$post->dont_email_post_to_subs = Jetpack::is_module_active( 'subscriptions' ) ?

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -17,6 +17,7 @@ class Jetpack_Sync_Settings {
 		'post_types_blacklist' => true,
 		'meta_blacklist'       => true,
 		'disable'              => true,
+		'render_filtered_content' => true,
 	);
 
 	static $is_importing;

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -294,6 +294,23 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( trim( $post_on_server->post_content_filtered ), 'bar' );
 	}
 
+	function test_sync_disabled_post_filtered_content() {
+		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 0 ) );
+
+		add_shortcode( 'foo', array( $this, 'foo_shortcode' ) );
+		$this->post->post_content = "[foo]";
+
+		wp_update_post( $this->post );
+		$this->sender->do_sync();
+
+		$post_on_server = $this->server_replica_storage->get_post( $this->post->ID );
+		$this->assertEquals( $post_on_server->post_content, '[foo]' );
+		$this->assertTrue( empty( $post_on_server->post_content_filtered ) );
+		// $this->assertEquals( trim( $post_on_server->post_content_filtered ), 'bar' );
+
+		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
+	}
+
 	function test_sync_post_filtered_excerpt_was_filtered() {
 		add_shortcode( 'foo', array( $this, 'foo_shortcode' ) );
 		$this->post->post_excerpt = "[foo]";

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -306,7 +306,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$post_on_server = $this->server_replica_storage->get_post( $this->post->ID );
 		$this->assertEquals( $post_on_server->post_content, '[foo]' );
 		$this->assertTrue( empty( $post_on_server->post_content_filtered ) );
-		// $this->assertEquals( trim( $post_on_server->post_content_filtered ), 'bar' );
 
 		Jetpack_Sync_Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-settings.php
+++ b/tests/php/sync/test_class.jetpack-sync-settings.php
@@ -13,6 +13,7 @@ class WP_Test_Jetpack_Sync_Settings extends WP_Test_Jetpack_Sync_Base {
 				'max_queue_size',
 				'max_queue_lag',
 				'disable',
+				'render_filtered_content',
 			) as $key
 		) {
 			$this->assertTrue( isset( $settings[ $key ] ) );


### PR DESCRIPTION
Workaround for when sites appear to have sync failing due to errors rendering certain posts.

cc @lezama 