### PR TITLE
Decouple full sync processing from incremental sync

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -48,11 +48,11 @@ class Jetpack_Sync_Sender {
 	}
 
 	public function get_next_sync_time( $queue_name ) {
-		return (double) get_option( self::NEXT_SYNC_TIME_OPTION_NAME.'_'.$queue_name, 0 );
+		return (double) get_option( self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name, 0 );
 	}
 
 	public function set_next_sync_time( $time, $queue_name ) {
-		return update_option( self::NEXT_SYNC_TIME_OPTION_NAME.'_'.$queue_name, $time, true );
+		return update_option( self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name, $time, true );
 	}
 
 	public function do_all_sync() {
@@ -73,7 +73,7 @@ class Jetpack_Sync_Sender {
 		if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
 			return false;
 		}
-		
+
 		// don't sync if we are throttled
 		if ( $this->get_next_sync_time( $queue->id ) > microtime( true ) ) {
 			return false;
@@ -128,8 +128,8 @@ class Jetpack_Sync_Sender {
 		$items         = $buffer->get_items();
 
 		// set up current screen to avoid errors rendering content
-		require_once(ABSPATH . 'wp-admin/includes/class-wp-screen.php');
-		require_once(ABSPATH . 'wp-admin/includes/screen.php');
+		require_once( ABSPATH . 'wp-admin/includes/class-wp-screen.php' );
+		require_once( ABSPATH . 'wp-admin/includes/screen.php' );
 		set_current_screen( 'sync' );
 
 		$skipped_items_ids = array();
@@ -196,7 +196,7 @@ class Jetpack_Sync_Sender {
 			// returning a WP_Error is a sign to the caller that we should wait a while
 			// before syncing again
 			return new WP_Error( 'server_error' );
-			
+
 		} else {
 
 			// detect if the last item ID was an error
@@ -229,9 +229,9 @@ class Jetpack_Sync_Sender {
 			// before syncing again
 			if ( $had_wp_error ) {
 				return $wp_error;
-			} 
+			}
 		}
-		
+
 		return true;
 	}
 
@@ -290,9 +290,9 @@ class Jetpack_Sync_Sender {
 	}
 
 	function set_defaults() {
-		$this->sync_queue = new Jetpack_Sync_Queue( 'sync' );
+		$this->sync_queue      = new Jetpack_Sync_Queue( 'sync' );
 		$this->full_sync_queue = new Jetpack_Sync_Queue( 'full_sync' );
-		$this->codec      = new Jetpack_Sync_JSON_Deflate_Array_Codec();
+		$this->codec           = new Jetpack_Sync_JSON_Deflate_Array_Codec();
 
 		// saved settings
 		Jetpack_Sync_Settings::set_importing( null );

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -55,11 +55,6 @@ class Jetpack_Sync_Sender {
 		return update_option( self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name, $time, true );
 	}
 
-	public function do_all_sync() {
-		$this->do_full_sync();
-		$this->do_sync();
-	}
-
 	public function do_full_sync() {
 		return $this->do_sync_and_set_delays( $this->full_sync_queue );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -18,7 +18,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_enqueues_sync_start_action() {
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
 		$this->assertTrue( $start_event !== false );
@@ -27,17 +27,17 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	// this only applies to the test replicastore - in production we overlay data
 	function test_sync_start_resets_storage() {
 		$this->factory->post->create();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 
 		do_action( 'jetpack_full_sync_start' );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 0, $this->server_replica_storage->post_count() );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 	}
@@ -53,7 +53,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start();
 
 		$this->assertEquals( $initial_full_sync_queue_size + 1, $this->sender->get_full_sync_queue()->size() );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 		
 		$cancelled_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_cancelled' );
 
@@ -89,7 +89,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->full_sync->start( array( 'options' => true ) );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
 
@@ -109,7 +109,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		global $wp_version;
 		$this->assertEquals( $wp_version, $this->server_replica_storage->get_callable( 'wp_version' ) );
@@ -125,7 +125,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$post_on_server = $this->server_replica_storage->get_post( $post->ID );
 		$this->assertEquals( $post_on_server->post_content, '[foo]' );
@@ -145,7 +145,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$comments = $this->server_replica_storage->get_comments();
 		$this->assertEquals( 11, count( $comments ) );
@@ -162,7 +162,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$terms = $this->server_replica_storage->get_terms( 'post_tag' );
 		$this->assertEquals( 11, count( $terms ) );
@@ -178,7 +178,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$users = get_users();
 		// 10 + 1 = 1 users gets always created.
@@ -232,7 +232,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( in_array( $user_id, $this->synced_user_ids ) );
 		$this->assertFalse( in_array( $mu_blog_user_id, $this->synced_user_ids ) );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		// admin user, our current-blog-created user and our "added" user
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
@@ -256,7 +256,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// third should be synced, as it's a member of created blog
 		$this->assertTrue( in_array( $mu_blog_user_id, $this->synced_user_ids ) );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 2, $this->server_replica_storage->user_count() );
 
@@ -274,7 +274,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		define( 'TEST_SYNC_ALL_CONSTANTS', 'foo' );
 
 		Jetpack_Sync_Modules::get_module( "constants" )->set_constants_whitelist( array( 'TEST_SYNC_ALL_CONSTANTS' ) );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
@@ -282,14 +282,14 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'TEST_SYNC_ALL_CONSTANTS' ) );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_constant( 'TEST_SYNC_ALL_CONSTANTS' ) );
 	}
 
 	function test_full_sync_sends_all_functions() {
 		Jetpack_Sync_Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
@@ -297,7 +297,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'the value', $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
 	}
@@ -308,7 +308,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		update_option( 'my_prefix_value', 'bar' );
 		update_option( 'my_non_synced_option', 'baz' );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		// confirm sync worked as expected
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_option( 'my_option' ) );
@@ -322,7 +322,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_option( 'my_prefix_value' ) );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_option( 'my_option' ) );
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_option( 'my_prefix_value' ) );
@@ -343,7 +343,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		update_site_option( 'my_prefix_value', 'bar' );
 		update_site_option( 'my_non_synced_option', 'baz' );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		// confirm sync worked as expected
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_site_option( 'my_option' ), '' );
@@ -357,7 +357,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_site_option( 'my_prefix_value' ) );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_site_option( 'my_option' ), 'Network options not synced during full sync' );
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_site_option( 'my_prefix_value' ) );
@@ -369,7 +369,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		add_post_meta( $post_id, 'test_meta_key', 'foo' );
 		add_post_meta( $post_id, 'test_meta_array', array( 'foo', 'bar' ) );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
 		$this->assertEquals( array( 'foo', 'bar' ), $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
@@ -381,7 +381,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
 		$this->assertEquals( array( 'foo', 'bar' ), $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
@@ -399,7 +399,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// ok public meta
 		add_post_meta( $post_id, 'a_public_meta', 'foo5' );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, '_test_meta_key', true ) );
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, '_test_meta_array', true ) );
@@ -417,7 +417,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'a_public_meta', true ) );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, '_test_meta_key', true ) );
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, '_test_meta_array', true ) );
@@ -431,7 +431,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$post_id = $this->factory->post->create();
 		wp_set_object_terms( $post_id, 'tag', 'post_tag' );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 		$terms = get_the_terms( $post_id, 'post_tag' );
 
 		$this->assertEqualsObject( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Initial sync doesn\'t work' );
@@ -440,7 +440,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( null, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag', 'Not empty' ) );
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$terms = array_map( array( $this, 'upgrade_terms_to_pass_test' ), $terms );
 		$this->assertEqualsObject( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Full sync doesn\'t work' );
@@ -452,7 +452,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$comment_id  = $comment_ids[0];
 		add_comment_meta( $comment_id, 'test_meta_key', 'foo' );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'comment', $comment_id, 'test_meta_key', true ) );
 
@@ -462,7 +462,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'comment', $comment_id, 'test_meta_key', true ) );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'comment', $comment_id, 'test_meta_key', true ) );
 	}
@@ -473,7 +473,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		switch_theme( 'twentyfourteen' );
 		set_theme_mod( 'foo', 'bar' );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'twentyfourteen', $this->server_replica_storage->get_option( 'stylesheet' ) );
 
@@ -483,7 +483,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// full sync should restore the value
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertEquals( 'twentyfourteen', $this->server_replica_storage->get_option( 'stylesheet' ) );
 		$local_option = get_option( 'theme_mods_twentyfourteen' );
@@ -514,7 +514,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_update_plugins();
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
@@ -526,7 +526,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// full sync should re-check for plugin updates
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
 		$this->assertNotNull( $updates );
@@ -541,7 +541,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_update_themes();
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
@@ -555,7 +555,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// full sync should re-check for plugin updates
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
 		$this->assertNotNull( $updates );
@@ -570,7 +570,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		_maybe_update_core();
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'core' );
@@ -584,7 +584,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// full sync should re-check for plugin updates
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$updates = $this->server_replica_storage->get_updates( 'core' );
 		$this->assertNotNull( $updates );
@@ -610,9 +610,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		add_action( 'jetpack_full_sync_end', array( $this, 'record_full_sync_end_checksum' ), 10, 1 );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
-		$this->sender->do_sync();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
+		$this->sender->do_all_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertTrue( isset( $this->full_sync_end_checksum ) );
 		$this->assertTrue( isset( $this->full_sync_end_checksum['posts'] ) );
@@ -708,7 +708,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->create_dummy_data_and_empty_the_queue();
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$full_sync_status = $this->full_sync->get_status();
 
@@ -757,7 +757,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->comment->create_post_comments( $post_id, 3 );
 
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		remove_filter( 'jetpack_sync_prevent_sending_comment_data', '__return_true' );
 		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
@@ -778,7 +778,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( empty( $non_existent_user ) );
 
 		$this->full_sync->start( array( 'posts' => array( $non_existent_id ), 'comments' => array( $non_existent_id ), 'users' => array( $non_existent_id ) )  );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' ) );
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' ) );
@@ -791,7 +791,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$no_sync_post_id = $this->factory->post->create();
 
 		$this->full_sync->start( array( 'posts' => array( $sync_post_id, $sync_post_id_2 ) ) );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
 
@@ -814,7 +814,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		list( $sync_comment_id, $no_sync_comment_id, $sync_comment_id_2 ) = $this->factory->comment->create_post_comments( $post_id, 3 );
 
 		$this->full_sync->start( array( 'comments' => array( $sync_comment_id, $sync_comment_id_2 ) ) );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$synced_comments_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
 
@@ -836,7 +836,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$no_sync_user_id = $this->factory->user->create();
 
 		$this->full_sync->start( array( 'users' => array( $sync_user_id, $sync_user_id_2) ) );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
 
@@ -860,7 +860,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_delete_post( $delete_post_id, true );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
 
@@ -879,7 +879,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_delete_comment( $delete_comment_id, true );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$synced_comments_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
 
@@ -901,7 +901,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_delete_user( $delete_user_id );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
 		$users = $synced_users_event->args;
@@ -928,7 +928,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// if actions get filtered out after dequeue, this can lead to the sent count 
 		// not matching the queued count - we should make sure the count is incremented even for late-deleted items
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_users', array( $this, 'dont_sync_users' ) );
 
@@ -938,9 +938,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		
 		$this->full_sync->start( array( 'users' => true ) );
 		
-		$this->sender->do_sync();
-		$this->sender->do_sync();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
+		$this->sender->do_all_sync();
+		$this->sender->do_all_sync();
 
 		$full_sync_status = $this->full_sync->get_status();
 
@@ -962,15 +962,15 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->full_sync->start();
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 		$full_sync_status = $this->full_sync->get_status();
 		$this->assertEquals( 0, $full_sync_status['finished'] );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 		$full_sync_status = $this->full_sync->get_status();
 		$this->assertEquals( 0, $full_sync_status['finished'] );
 
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 
 		$full_sync_status = $this->full_sync->get_status();
 
@@ -1051,25 +1051,25 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( is_array( $wp_taxonomies['category']->rewrite ) );
 		$this->setSyncClientDefaults();
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 		$this->assertTrue( is_array( $wp_taxonomies['category']->rewrite ) );
 	}
 
-	public function test_initial_sync_doesnt_sync_subscribers() {
+	function test_initial_sync_doesnt_sync_subscribers() {
 		$this->factory->user->create( array( 'user_login' => 'theauthor', 'role' => 'author' ) );
 		$this->factory->user->create( array( 'user_login' => 'theadmin', 'role' => 'administrator' ) );
 		foreach( range( 1, 10 ) as $i ) {
 			$this->factory->user->create( array( 'role' => 'subscriber' ) );
 		}
 		$this->full_sync->start();
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 		$this->assertEquals( 13, $this->server_replica_storage->user_count() );
 		$this->server_replica_storage->reset();
 		$this->assertEquals( 0, $this->server_replica_storage->user_count() );
 		$user_ids = Jetpack_Sync_Modules::get_module( 'users' )->get_initial_sync_user_config();
 		$this->assertEquals( 3, count( $user_ids ) );
 		$this->full_sync->start( array( 'users' => 'initial' ) );
-		$this->sender->do_sync();
+		$this->sender->do_all_sync();
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
 		Jetpack_Sync_Actions::schedule_initial_sync( '4.2', '4.1' );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -18,7 +18,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_enqueues_sync_start_action() {
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
 		$this->assertTrue( $start_event !== false );
@@ -27,17 +27,17 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	// this only applies to the test replicastore - in production we overlay data
 	function test_sync_start_resets_storage() {
 		$this->factory->post->create();
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 
 		do_action( 'jetpack_full_sync_start' );
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 0, $this->server_replica_storage->post_count() );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 1, $this->server_replica_storage->post_count() );
 	}
@@ -53,7 +53,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start();
 
 		$this->assertEquals( $initial_full_sync_queue_size + 1, $this->sender->get_full_sync_queue()->size() );
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 		
 		$cancelled_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_cancelled' );
 
@@ -89,7 +89,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->full_sync->start( array( 'options' => true ) );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
 
@@ -109,7 +109,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		global $wp_version;
 		$this->assertEquals( $wp_version, $this->server_replica_storage->get_callable( 'wp_version' ) );
@@ -125,7 +125,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$post_on_server = $this->server_replica_storage->get_post( $post->ID );
 		$this->assertEquals( $post_on_server->post_content, '[foo]' );
@@ -145,7 +145,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$comments = $this->server_replica_storage->get_comments();
 		$this->assertEquals( 11, count( $comments ) );
@@ -162,7 +162,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$terms = $this->server_replica_storage->get_terms( 'post_tag' );
 		$this->assertEquals( 11, count( $terms ) );
@@ -178,7 +178,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$users = get_users();
 		// 10 + 1 = 1 users gets always created.
@@ -232,7 +232,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( in_array( $user_id, $this->synced_user_ids ) );
 		$this->assertFalse( in_array( $mu_blog_user_id, $this->synced_user_ids ) );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		// admin user, our current-blog-created user and our "added" user
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
@@ -256,7 +256,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// third should be synced, as it's a member of created blog
 		$this->assertTrue( in_array( $mu_blog_user_id, $this->synced_user_ids ) );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 2, $this->server_replica_storage->user_count() );
 
@@ -274,7 +274,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		define( 'TEST_SYNC_ALL_CONSTANTS', 'foo' );
 
 		Jetpack_Sync_Modules::get_module( "constants" )->set_constants_whitelist( array( 'TEST_SYNC_ALL_CONSTANTS' ) );
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
@@ -282,14 +282,14 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'TEST_SYNC_ALL_CONSTANTS' ) );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_constant( 'TEST_SYNC_ALL_CONSTANTS' ) );
 	}
 
 	function test_full_sync_sends_all_functions() {
 		Jetpack_Sync_Modules::get_module( "functions" )->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_full_sync_callable' ) );
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
@@ -297,7 +297,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'the value', $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
 	}
@@ -308,7 +308,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		update_option( 'my_prefix_value', 'bar' );
 		update_option( 'my_non_synced_option', 'baz' );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		// confirm sync worked as expected
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_option( 'my_option' ) );
@@ -322,7 +322,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_option( 'my_prefix_value' ) );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_option( 'my_option' ) );
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_option( 'my_prefix_value' ) );
@@ -343,7 +343,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		update_site_option( 'my_prefix_value', 'bar' );
 		update_site_option( 'my_non_synced_option', 'baz' );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		// confirm sync worked as expected
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_site_option( 'my_option' ), '' );
@@ -357,7 +357,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_site_option( 'my_prefix_value' ) );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_site_option( 'my_option' ), 'Network options not synced during full sync' );
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_site_option( 'my_prefix_value' ) );
@@ -369,7 +369,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		add_post_meta( $post_id, 'test_meta_key', 'foo' );
 		add_post_meta( $post_id, 'test_meta_array', array( 'foo', 'bar' ) );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
 		$this->assertEquals( array( 'foo', 'bar' ), $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
@@ -381,7 +381,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
 		$this->assertEquals( array( 'foo', 'bar' ), $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
@@ -399,7 +399,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// ok public meta
 		add_post_meta( $post_id, 'a_public_meta', 'foo5' );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, '_test_meta_key', true ) );
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, '_test_meta_array', true ) );
@@ -417,7 +417,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'a_public_meta', true ) );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, '_test_meta_key', true ) );
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, '_test_meta_array', true ) );
@@ -431,7 +431,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$post_id = $this->factory->post->create();
 		wp_set_object_terms( $post_id, 'tag', 'post_tag' );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 		$terms = get_the_terms( $post_id, 'post_tag' );
 
 		$this->assertEqualsObject( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Initial sync doesn\'t work' );
@@ -440,7 +440,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( null, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag', 'Not empty' ) );
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$terms = array_map( array( $this, 'upgrade_terms_to_pass_test' ), $terms );
 		$this->assertEqualsObject( $terms, $this->server_replica_storage->get_the_terms( $post_id, 'post_tag' ), 'Full sync doesn\'t work' );
@@ -452,7 +452,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$comment_id  = $comment_ids[0];
 		add_comment_meta( $comment_id, 'test_meta_key', 'foo' );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'comment', $comment_id, 'test_meta_key', true ) );
 
@@ -462,7 +462,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'comment', $comment_id, 'test_meta_key', true ) );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'comment', $comment_id, 'test_meta_key', true ) );
 	}
@@ -473,7 +473,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		switch_theme( 'twentyfourteen' );
 		set_theme_mod( 'foo', 'bar' );
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		$this->assertEquals( 'twentyfourteen', $this->server_replica_storage->get_option( 'stylesheet' ) );
 
@@ -483,7 +483,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// full sync should restore the value
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'twentyfourteen', $this->server_replica_storage->get_option( 'stylesheet' ) );
 		$local_option = get_option( 'theme_mods_twentyfourteen' );
@@ -514,7 +514,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_update_plugins();
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
@@ -526,7 +526,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// full sync should re-check for plugin updates
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
 		$this->assertNotNull( $updates );
@@ -541,7 +541,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_update_themes();
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
@@ -555,7 +555,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// full sync should re-check for plugin updates
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$updates = $this->server_replica_storage->get_updates( 'themes' );
 		$this->assertNotNull( $updates );
@@ -570,7 +570,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		_maybe_update_core();
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		// check that an update just finished
 		$updates = $this->server_replica_storage->get_updates( 'core' );
@@ -584,7 +584,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// full sync should re-check for plugin updates
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$updates = $this->server_replica_storage->get_updates( 'core' );
 		$this->assertNotNull( $updates );
@@ -610,9 +610,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		add_action( 'jetpack_full_sync_end', array( $this, 'record_full_sync_end_checksum' ), 10, 1 );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
-		$this->sender->do_all_sync();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
+		$this->sender->do_full_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertTrue( isset( $this->full_sync_end_checksum ) );
 		$this->assertTrue( isset( $this->full_sync_end_checksum['posts'] ) );
@@ -708,7 +708,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->create_dummy_data_and_empty_the_queue();
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$full_sync_status = $this->full_sync->get_status();
 
@@ -757,7 +757,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->comment->create_post_comments( $post_id, 3 );
 
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		remove_filter( 'jetpack_sync_prevent_sending_comment_data', '__return_true' );
 		remove_filter( 'jetpack_sync_prevent_sending_post_data', '__return_true' );
@@ -778,7 +778,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( empty( $non_existent_user ) );
 
 		$this->full_sync->start( array( 'posts' => array( $non_existent_id ), 'comments' => array( $non_existent_id ), 'users' => array( $non_existent_id ) )  );
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' ) );
 		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' ) );
@@ -791,7 +791,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$no_sync_post_id = $this->factory->post->create();
 
 		$this->full_sync->start( array( 'posts' => array( $sync_post_id, $sync_post_id_2 ) ) );
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
 
@@ -814,7 +814,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		list( $sync_comment_id, $no_sync_comment_id, $sync_comment_id_2 ) = $this->factory->comment->create_post_comments( $post_id, 3 );
 
 		$this->full_sync->start( array( 'comments' => array( $sync_comment_id, $sync_comment_id_2 ) ) );
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$synced_comments_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
 
@@ -836,7 +836,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$no_sync_user_id = $this->factory->user->create();
 
 		$this->full_sync->start( array( 'users' => array( $sync_user_id, $sync_user_id_2) ) );
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
 
@@ -860,7 +860,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_delete_post( $delete_post_id, true );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$synced_posts_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_posts' );
 
@@ -879,7 +879,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_delete_comment( $delete_comment_id, true );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$synced_comments_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_comments' );
 
@@ -901,7 +901,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		wp_delete_user( $delete_user_id );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$synced_users_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_users' );
 		$users = $synced_users_event->args;
@@ -928,7 +928,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// if actions get filtered out after dequeue, this can lead to the sent count 
 		// not matching the queued count - we should make sure the count is incremented even for late-deleted items
 
-		$this->sender->do_all_sync();
+		$this->sender->do_sync();
 
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_users', array( $this, 'dont_sync_users' ) );
 
@@ -938,9 +938,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		
 		$this->full_sync->start( array( 'users' => true ) );
 		
-		$this->sender->do_all_sync();
-		$this->sender->do_all_sync();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
+		$this->sender->do_full_sync();
+		$this->sender->do_full_sync();
 
 		$full_sync_status = $this->full_sync->get_status();
 
@@ -962,15 +962,15 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->full_sync->start();
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 		$full_sync_status = $this->full_sync->get_status();
 		$this->assertEquals( 0, $full_sync_status['finished'] );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 		$full_sync_status = $this->full_sync->get_status();
 		$this->assertEquals( 0, $full_sync_status['finished'] );
 
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 
 		$full_sync_status = $this->full_sync->get_status();
 
@@ -1051,7 +1051,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( is_array( $wp_taxonomies['category']->rewrite ) );
 		$this->setSyncClientDefaults();
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 		$this->assertTrue( is_array( $wp_taxonomies['category']->rewrite ) );
 	}
 
@@ -1062,14 +1062,14 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 			$this->factory->user->create( array( 'role' => 'subscriber' ) );
 		}
 		$this->full_sync->start();
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 		$this->assertEquals( 13, $this->server_replica_storage->user_count() );
 		$this->server_replica_storage->reset();
 		$this->assertEquals( 0, $this->server_replica_storage->user_count() );
 		$user_ids = Jetpack_Sync_Modules::get_module( 'users' )->get_initial_sync_user_config();
 		$this->assertEquals( 3, count( $user_ids ) );
 		$this->full_sync->start( array( 'users' => 'initial' ) );
-		$this->sender->do_all_sync();
+		$this->sender->do_full_sync();
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
 		Jetpack_Sync_Actions::schedule_initial_sync( '4.2', '4.1' );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -164,12 +164,12 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		sleep( 3 );
 
-		$next_sync_time = $this->sender->get_next_sync_time();
+		$next_sync_time = $this->sender->get_next_sync_time( 'sync' );
 		$this->assertTrue( $this->sender->do_sync() );
 		$this->assertEquals( 4, count( $this->server_event_storage->get_all_events( 'my_action' ) ) );
 
 		// because we synced, next sync time should be further in the future
-		$this->assertTrue( $next_sync_time < $this->sender->get_next_sync_time() );
+		$this->assertTrue( $next_sync_time < $this->sender->get_next_sync_time( 'sync' ) );
 
 		// doesn't sync second time
 		$this->assertFalse( $this->sender->do_sync() );
@@ -243,6 +243,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		do_action( 'my_full_sync_action' );
 
 		$this->sender->do_sync();
+		$this->sender->do_full_sync();
 
 		$incremental_event = $this->server_event_storage->get_most_recent_event( 'my_incremental_action' );
 		$full_sync_event = $this->server_event_storage->get_most_recent_event( 'my_full_sync_action' );
@@ -273,7 +274,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$this->sender->do_sync();
 
-		$this->assertTrue( $this->sender->get_next_sync_time() > time() + 55 );
+		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 55 );
 	}
 
 	function serverReceiveWithTrailingError( $data, $codec, $sent_timestamp ) {
@@ -292,7 +293,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$this->sender->do_sync();
 
-		$this->assertTrue( $this->sender->get_next_sync_time() > time() + 55 );
+		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 55 );
 	}
 
 	function serverReceiveWithError( $data, $codec, $sent_timestamp ) {
@@ -308,7 +309,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->factory->post->create();
 		$this->sender->do_sync();
 
-		$this->assertTrue( $this->sender->get_next_sync_time() > time() + 9 );	
+		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 9 );	
 	}
 
 	function serverReceiveWithThreeSecondDelay( $data, $codec, $sent_timestamp ) {


### PR DESCRIPTION
Fixes an issue where errors dequeuing and sending full sync items would prevent incremental sync items from being sent.

This change:
- only sends incremental sync items on the shutdown action
- separates the incremental and full sync cron jobs

cc @lezama