### PR TITLE
Sync: Do initial users sync when old version is false

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -156,7 +156,7 @@ class Jetpack_Sync_Actions {
 			'constants' => true,
 		);
 
-		if ( $old_version && ( version_compare( $old_version, '4.2', '<' ) ) ) {
+		if ( ! $old_version || ( version_compare( $old_version, '4.2', '<' ) ) ) {
 			$initial_sync_config['users'] = 'initial';
 		}
 


### PR DESCRIPTION
There are a few cases where we end up passing a falsey value for the `$old_version` argument of the `updating_jetpack_version` action.

- https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L1290
- https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L1697
- https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L2501

I believe the intended functionality is to not sync low level users on initial sync. But, unless I am misunderstanding, we would be syncing all users when the `$old_version` is falsey.

cc @gravityrail @lezama for review.