### PR TITLE
SSO: Audit wp_die() usage

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -628,7 +628,7 @@ class Jetpack_SSO {
 		) );
 		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
 
-		if ( $xml->is_error() || empty( $user_data = $xml->getResponse() ) ) {
+		if ( $xml->isError() || empty( $user_data = $xml->getResponse() ) ) {
 			add_filter( 'jetpack_sso_default_to_sso_login', '__return_false' );
 			add_filter( 'login_message', array( $this, 'error_invalid_response_data' ) );
 			return;

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -628,7 +628,8 @@ class Jetpack_SSO {
 		) );
 		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
 
-		if ( $xml->isError() || empty( $user_data = $xml->getResponse() ) ) {
+		$user_data = $xml->isError() ? false : $xml->getResponse();
+		if ( empty( $user_data ) ) {
 			add_filter( 'jetpack_sso_default_to_sso_login', '__return_false' );
 			add_filter( 'login_message', array( $this, 'error_invalid_response_data' ) );
 			return;

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -702,7 +702,8 @@ class Jetpack_SSO {
 						JetpackTracking::record_user_event( 'sso_login_failed', array(
 							'error_message' => 'could_not_create_username'
 						) );
-						wp_die( __( "Error: Couldn't create suitable username.", 'jetpack' ) );
+						add_filter( 'login_message', array( $this, 'error_unable_to_create_user' ) );
+						return;
 					}
 				}
 
@@ -1059,6 +1060,25 @@ class Jetpack_SSO {
 	public function error_invalid_response_data( $message ) {
 		$error = esc_html__(
 			'There was an error logging you in via WordPress.com, please try again or try logging in with your username and password.',
+			'jetpack'
+		);
+		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );
+		return $message;
+	}
+
+	/**
+	 * Error message that is displayed when we were not able to automatically create an account for a user
+	 * after a user has logged in via SSO. By default, this message is triggered after trying to create an account 5 times.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param $message
+	 *
+	 * @return string
+	 */
+	public function error_unable_to_create_user( $message ) {
+		$error = esc_html__(
+			'There was an error creating a user for you. Please contact the administrator of your site.',
 			'jetpack'
 		);
 		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -188,6 +188,45 @@ class Jetpack_SSO_Helpers {
 
 		return array_unique( $hosts );
 	}
+
+	static function generate_user( $user_data ) {
+		$username = $user_data->login;
+
+		/**
+		 * Determines how many times the SSO module can attempt to randomly generate a user.
+		 *
+		 * @module sso
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param int 5 By default, SSO will attempt to random generate a user up to 5 times.
+		 */
+		$num_tries = intval( apply_filters( 'jetpack_sso_allowed_username_generate_retries', 5 ) );
+
+		$tries = 0;
+		while ( ( $exists = username_exists( $username ) ) && $tries++ < $num_tries ) {
+			$username = $user_data->login . '_' . $user_data->ID . '_' . mt_rand();
+		}
+
+		if ( $exists ) {
+			return false;
+		}
+
+		$password = wp_generate_password( 20 );
+		$user_id  = wp_create_user( $username, $password, $user_data->email );
+		$user     = get_userdata( $user_id );
+
+		$user->display_name = $user_data->display_name;
+		$user->first_name   = $user_data->first_name;
+		$user->last_name    = $user_data->last_name;
+		$user->url          = $user_data->url;
+		$user->description  = $user_data->description;
+		wp_update_user( $user );
+
+		update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
+		
+		return $user;
+	}
 }
 
 endif;

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -7,6 +7,25 @@ require_once( dirname( __FILE__ ) . '/../../../../modules/sso/class.jetpack-sso-
  * @since 4.1.0
  */
 class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
+	protected $user_data;
+
+	function setUp() {
+		$this->user_data = (object) array(
+			'ID'           => 123456789,
+			'email'        => 'ssouser@testautomattic.com',
+			'login'        => 'ssouser',
+			'display_name' => 'ssouser',
+			'first_name'   => 'sso',
+			'last_name'    => 'user',
+			'url'          => 'https://automattic.com',
+			'description'  => 'A user to test SSO',
+		);
+	}
+
+	function __return_one() {
+		return 1;
+	}
+
 	function test_sso_helpers_is_two_step_required_filter_true() {
 		add_filter( 'jetpack_sso_require_two_step', '__return_true' );
 		$this->assertTrue( Jetpack_SSO_Helpers::is_two_step_required() );
@@ -144,5 +163,34 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertCount( 4, $hosts );
 		$this->assertContains( 'fakesite.com', $hosts );
 		remove_filter( 'jetpack_development_version', '__return_true' );
+	}
+
+	function test_generate_user_returns_user_when_username_not_exists() {
+		$user = Jetpack_SSO_Helpers::generate_user( $this->user_data );
+		$this->assertInternalType( 'object', $user );
+		$this->assertInstanceOf( 'WP_User', $user );
+
+		wp_delete_user( $user->ID );
+	}
+
+	function test_generate_user_returns_user_if_username_exists_and_has_tries() {
+		add_filter( 'jetpack_sso_allowed_username_generate_retries', array( $this, '__return_one' )  );
+		$this->factory->user->create( array( 'user_login' => $this->user_data->login ) );
+
+		$user = Jetpack_SSO_Helpers::generate_user( $this->user_data );
+
+		$this->assertInternalType( 'object', $user );
+		$this->assertInstanceOf( 'WP_User', $user );
+
+		// If the username contains the user's ID, we know the username was generated with our random algo
+		$this->assertContains( (string) $this->user_data->ID, $user->user_login );
+
+		wp_delete_user( $user->ID );
+	}
+	
+	function test_generate_user_returns_false_when_no_more_tries_and_username_exists() {
+		add_filter( 'jetpack_sso_allowed_username_generate_retries', '__return_zero' );
+		$this->factory->user->create( array( 'user_login' => $this->user_data->login ) );
+		$this->assertFalse( Jetpack_SSO_Helpers::generate_user( $this->user_data ) );
 	}
 }


### PR DESCRIPTION
While `wp_die()` is functional when we are verifying nonces, etc. for SSO, it has some unexpected consequences. For example, some server environments pick up on the `500` error from `wp_die()` and show a generic error message.

This generic error message is a bad UX for users. The error does not show in the error log and the user has no other information to get debug help.

In lieu of `wp_die()` we can, show an error notice on the `login_message` filter.

Screenshots:

This first error message is shown when there was an error validating the nonce. This can happen because of an XML request error, the nonce was invalid, or even the user has not verified their email address on WP.com. Automattic/wp-calypso#8011 handles the email verification check, so I think a more generic error message fits here.

<img width="397" alt="screen shot 2016-09-16 at 3 16 41 pm" src="https://cloud.githubusercontent.com/assets/1126811/18603431/554a4aae-7c26-11e6-9fa5-a3d19c4d669c.png">

To test this, login to WordPress.com with a user that is not connected to your Jetpack site. Turn off match by email with `add_filter( 'jetpack_sso_match_by_email', '__return_false' )`, and then login with SSO as normal.

This second error message occurs when a site is having an identity crisis.

<img width="411" alt="screen shot 2016-09-16 at 12 55 16 pm" src="https://cloud.githubusercontent.com/assets/1126811/18603432/555d1c74-7c26-11e6-9713-d26f5f58f983.png">

To test this, I temporarily added a `return true;` to the top of `check_identity_crisis()` in `class.jetpack.php`.

I have not fully tested the error notice for creating a user failing. That failing would be very edge case since we would have already tried two combinations of usernames plus five more random usernames. I will, however, run through some tests on that to make sure that I didn't introduce a regression.
