### PR TITLE
Tracks: Make sure to only track one page view for old stats

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -360,8 +360,6 @@ function stats_reports_page( $main_chart_only = false ) {
 	$blog_id = stats_get_option( 'blog_id' );
 	$domain = Jetpack::build_raw_urls( get_home_url() );
 
-	JetpackTracking::record_user_event( 'wpa_page_view', array( 'path' => 'old_stats' ) );
-
 	if ( ! $main_chart_only && !isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) {
 		$nojs_url = add_query_arg( 'nojs', '1' );
 		$http = is_ssl() ? 'https' : 'http';
@@ -481,6 +479,11 @@ echo esc_url(
 		$body = stats_convert_admin_urls( $body );
 		echo $body;
 	}
+
+	if ( isset( $_GET['page'] ) && 'stats' === $_GET['page'] && ! isset( $_GET['chart'] ) ) {
+		JetpackTracking::record_user_event( 'wpa_page_view', array( 'path' => 'old_stats' ) );
+	}
+
 	if ( isset( $_GET['noheader'] ) )
 		die;
 }


### PR DESCRIPTION
The ensures we only track one view event per page load of the old stats page.  Before it was loading multiple times on old stats page load, and once on the wp-admin dashboard stats.  

**To Test:** 
- Enable `define( 'WP_DEBUG_LOG', true )` in wp-config
- Add an `error_log( 'whatever' );` within the if block added in this changeset 
- Load `/wp-admin/admin.php?page=stats` and observe that only one log appears 
- Load `/wp-admin/index.php` and observe that no logs appear
- Load miscellaneous wp-admin pages and observe that no logs appear

cc @lezama for review 