### PR TITLE
Admin - Dev Mode: stylize label displayed next to logo

### DIFF
--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -14,7 +14,7 @@ import { getCurrentVersion } from 'state/initial-state';
 const Masthead = React.createClass( {
 	render: function() {
 		let devNotice = this.props.siteConnectionStatus === 'dev'
-			? <code>[Dev Mode]</code>
+			? <code>Dev Mode</code>
 			: '';
 
 		return (

--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -31,10 +31,19 @@
 .jp-masthead__logo-link {
 	display: inline-block;
 	outline: none;
+	vertical-align: middle;
 
 	&:focus {
 		line-height: 0; // fixes rectangle gap
 		box-shadow: 0 0 0 2px $blue-light;
+	}
+
+	& + code {
+		margin: 0 10px;
+		padding: 5px 9px;
+		border-radius: 2px;
+		background: #e6ecf1;
+		color: #647a88;
 	}
 }
 


### PR DESCRIPTION
Fixes #5175.

#### Changes proposed in this Pull Request:
- center the Dev Mode label, remove brackets and add style.

BEFORE
<img width="746" alt="captura de pantalla 2016-09-19 a las 12 41 40" src="https://cloud.githubusercontent.com/assets/1041600/18646462/77cdd874-7e66-11e6-959c-c53ae20c4e3d.png">

AFTER
<img width="752" alt="captura de pantalla 2016-09-19 a las 12 38 33" src="https://cloud.githubusercontent.com/assets/1041600/18646362/05f00b6e-7e66-11e6-8ef6-34415f02985b.png">

#### Testing instructions:
- put the site in Dev Mode, go to Jetpack admin. The label should display as above.
