### PR TITLE
Invoke cron full sync instead of regular sync after enqueuing

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -231,7 +231,7 @@ class Jetpack_Sync_Actions {
 
 		self::initialize_listener();
 		Jetpack_Sync_Modules::get_module( 'full-sync' )->start( $modules );
-		self::do_cron_sync(); // immediately run a cron sync, which sends pending data
+		self::do_cron_full_sync(); // immediately run a cron full sync, which sends pending data
 	}
 
 	static function minute_cron_schedule( $schedules ) {


### PR DESCRIPTION
Fixes a minor bug where we were trying to immediately sync the incremental sync queue instead of full sync queue after queuing a full sync. Doesn't affect any users in the "real world" yet because bug was introduced (and now fixed) after 4.3.1.