### PR TITLE
Sync: Add checkout and close API Endpoints.

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -36,6 +36,17 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 		return array( 'scheduled' => Jetpack_Sync_Actions::schedule_full_sync( $modules ) );
 	}
+
+	protected function validate_queue( $query ) {
+		if ( ! isset( $query ) ) {
+			return new WP_Error( 'invalid_queue', 'Queue name is required', 400 );
+		}
+
+		if ( ! in_array( $query, array( 'sync', 'full_sync' ) ) ) {
+			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', 400 );
+		}
+		return $query;
+	}
 }
 
 // GET /sites/%s/sync/status
@@ -212,13 +223,10 @@ class Jetpack_JSON_API_Sync_Object extends Jetpack_JSON_API_Sync_Endpoint {
 class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
 		$args = $this->input();
+		$queue_name = $this->validate_queue( $args['queue'] );
 
-		if ( ! isset( $args['queue'] ) ) {
-			return new WP_Error( 'invalid_queue', 'Queue name is required', 400 );
-		}
-
-		if ( ! in_array( $args['queue'], array( 'sync', 'full_sync' ) ) ) {
-			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', 400 );
+		if ( is_wp_error( $queue_name ) ){
+			return $queue_name;
 		}
 
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
@@ -229,6 +237,123 @@ class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint 
 		return array(
 			'response' => $response
 		);
+	}
+}
+
+class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
+	protected function result() {
+		$args = $this->input();
+		$queue_name = $this->validate_queue( $args['queue'] );
+
+		if ( is_wp_error( $queue_name ) ){
+			return $queue_name;
+		}
+
+		if ( $args[ 'number_of_items' ] < 1 || $args[ 'number_of_items' ] > 100  ) {
+			return new WP_Error( 'invalid_number_of_items', 'Number of items needs to be an integer that is larger than 0 and less then 100', 400 );
+		}
+
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-queue.php';
+		$queue = new Jetpack_Sync_Queue( $queue_name );
+
+		if ( 0 === $queue->size() ) {
+			return new WP_Error( 'queue_size', 'The queue is empty and there is nothing to send', 400 );
+		}
+
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
+		$sender = Jetpack_Sync_Sender::get_instance();
+		
+		// let's delete the checkin state
+		if ( $args['force'] ) {
+			$queue->unlock();
+		}
+
+		$buffer = $this->get_buffer( $queue, $args[ 'number_of_items' ] );
+		
+		// Check that the $buffer is not checkout out already
+		if ( is_wp_error( $buffer ) ) {
+			return new WP_Error( 'buffer_open', "We couldn't get the buffer it is currently checked out", 400 );
+		}
+		
+		if ( ! is_object( $buffer ) ) {
+			return new WP_Error( 'buffer_non-object', 'Buffer is not an object', 400 );
+		}
+
+		list( $items_to_send, $skipped_items_ids, $items ) = $sender->get_items_to_send( $buffer, $args['encode'] );
+
+		return array(
+			'buffer_id'      => $buffer->id,
+			'items'          => $items_to_send,
+			'skipped_items'  => $skipped_items_ids,
+			'codec'          => $args['encode'] ? $sender->get_codec()->name() : null,
+			'sent_timestamp' => time(),
+		);
+	}
+
+	protected function get_buffer( $queue, $number_of_items ) {
+		$start = time();
+		$max_duration = 5; // this will try to get the buffer
+
+		$buffer = $queue->checkout( $number_of_items );
+		$duration = time() - $start;
+
+		while( is_wp_error( $buffer ) && $duration < $max_duration ) {
+			sleep( 2 );
+			$duration = time() - $start;
+			$buffer = $queue->checkout( $number_of_items );
+		}
+
+		if ( $buffer === false ) {
+			return new WP_Error( 'queue_size', 'The queue is empty and there is nothing to send', 400 );
+		}
+
+		return $buffer;
+	}
+}
+
+class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
+	protected function result() {
+		$request_body = $this->input();
+		$queue_name = $this->validate_queue( $request_body['queue'] );
+
+		if ( is_wp_error( $queue_name ) ) {
+			return $queue_name;
+		}
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-queue.php';
+
+		if ( ! isset( $request_body['buffer_id'] ) ) {
+			return new WP_Error( 'missing_buffer_id', 'Please provide a buffer id', 400 );
+		}
+
+		if ( ! isset( $request_body['item_ids'] ) || ! is_array( $request_body['item_ids'] ) ) {
+			return new WP_Error( 'missing_item_ids', 'Please provide a list of item ids in the item_ids argument', 400 );
+		}
+
+		//Limit to A-Z,a-z,0-9,_,-
+		$request_body ['buffer_id'] = preg_replace( '/[^A-Za-z0-9]/', '', $request_body['buffer_id'] );
+		$request_body['item_ids'] = array_filter( array_map( array( 'Jetpack_JSON_API_Sync_Close_Endpoint', 'sanitize_item_ids' ), $request_body['item_ids'] ) );
+
+		$buffer = new Jetpack_Sync_Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
+		$queue = new Jetpack_Sync_Queue( $queue_name );
+
+		$response = $queue->close( $buffer, $request_body['item_ids'] );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return array(
+			'success' => $response
+		);
+	}
+
+	protected static function sanitize_item_ids( $item ) {
+		// lets not delete any options that don't start with jpsq_sync-
+		if ( substr( $item, 0, 5 ) !== 'jpsq_' ) {
+			return null;
+		}
+		//Limit to A-Z,a-z,0-9,_,-,.
+		return preg_replace( '/[^A-Za-z0-9-_.]/', '', $item );
 	}
 }
 
@@ -249,11 +374,6 @@ class Jetpack_JSON_API_Sync_Unlock_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 
 		// If false it means that there was no lock to delete.
 		$response = $queue->unlock();
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
 		return array(
 			'success' => $response
 		);

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -372,7 +372,7 @@ class Jetpack_JSON_API_Sync_Unlock_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-queue.php';
 		$queue = new Jetpack_Sync_Queue( $args['queue'] );
 
-		// If false it means that there was no lock to delete.
+		// False means that there was no lock to delete.
 		$response = $queue->unlock();
 		return array(
 			'success' => $response

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -739,6 +739,7 @@ new Jetpack_JSON_API_Sync_Now_Endpoint( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/now?queue=full_sync'
 ) );
 
+
 // POST /sites/%s/sync/unlock
 new Jetpack_JSON_API_Sync_Unlock_Endpoint( array(
 	'description'     => 'Unlock the queue in case it gets locked by a process.',
@@ -756,6 +757,53 @@ new Jetpack_JSON_API_Sync_Unlock_Endpoint( array(
 		'success' => '(bool) Unlocking the queue successful?'
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/unlock'
+) );
+
+// POST /sites/%s/sync/checkout
+new Jetpack_JSON_API_Sync_Checkout_Endpoint( array(
+	'description'     => 'Locks the queue and returns items and the buffer ID.',
+	'method'          => 'POST',
+	'path'            => '/sites/%s/sync/checkout',
+	'group'           => '__do_not_document',
+	'stat'            => 'sync-checkout',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'request_format' => array(
+		'queue'             => '(string) sync or full_sync',
+		'number_of_items'   => '(int=10) Maximum number of items from the queue to be returned',
+		'encode'            => '(bool=true) Use the default encode method',
+		'force'             => '(bool=false) Force unlock the queue',
+	),
+	'response_format' => array(
+		'buffer_id' => '(string) Buffer ID that we are using',
+		'items'             => '(array) Items from the queue that are ready to be processed by the sync server',
+		'skipped_items'     => '(array) Skipped item ids',
+		'codec'             => '(string) The name of the codec used to encode the data',
+		'sent_timestamp'    => '(int) Current timestamp of the server',
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/checkout'
+) );
+
+// POST /sites/%s/sync/close
+new Jetpack_JSON_API_Sync_Close_Endpoint( array(
+	'description'     => 'Closes the buffer and delete the processed items from the queue.',
+	'method'          => 'POST',
+	'path'            => '/sites/%s/sync/close',
+	'group'           => '__do_not_document',
+	'stat'            => 'sync-close',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'request_format' => array(
+		'item_ids'  => '(array) Item IDs to delete from the queue.',
+		'queue'      => '(string) sync or full_sync',
+		'buffer_id'  => '(string) buffer ID that was opened during the checkout step.',
+	),
+	'response_format' => array(
+		'success' => '(bool) Closed the buffer successfully?'
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/close'
 ) );
 
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-log-endpoint.php' );

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -80,7 +80,7 @@ class Jetpack_Sync_Sender {
 		$sync_result = $this->do_sync_for_queue( $queue );
 
 		$exceeded_sync_wait_threshold = ( microtime( true ) - $start_time ) > (double) $this->get_sync_wait_threshold();
-
+		
 		if ( is_wp_error( $sync_result ) ) {
 			if ( 'unclosed_buffer' === $sync_result->get_error_code() ) {
 				$this->set_next_sync_time( time() + self::QUEUE_LOCKED_SYNC_DELAY, $queue->id );
@@ -99,18 +99,14 @@ class Jetpack_Sync_Sender {
 	public function get_items_to_send( $buffer, $encode = true ) {
 		// track how long we've been processing so we can avoid request timeouts
 		$start_time = microtime( true );
-
 		$upload_size   = 0;
 		$items_to_send = array();
 		$items         = $buffer->get_items();
-
 		// set up current screen to avoid errors rendering content
 		require_once( ABSPATH . 'wp-admin/includes/class-wp-screen.php' );
 		require_once( ABSPATH . 'wp-admin/includes/screen.php' );
 		set_current_screen( 'sync' );
-
 		$skipped_items_ids = array();
-
 		// we estimate the total encoded size as we go by encoding each item individually
 		// this is expensive, but the only way to really know :/
 		foreach ( $items as $key => $item ) {
@@ -132,17 +128,12 @@ class Jetpack_Sync_Sender {
 				$skipped_items_ids[] = $key;
 				continue;
 			}
-
 			$encoded_item = $encode ? $this->codec->encode( $item ) : $item;
-
 			$upload_size += strlen( $encoded_item );
-
 			if ( $upload_size > $this->upload_max_bytes && count( $items_to_send ) > 0 ) {
 				break;
 			}
-
 			$items_to_send[ $key ] = $encoded_item;
-
 			if ( microtime(true) - $start_time > $this->max_dequeue_time ) {
 				break;
 			}
@@ -154,31 +145,25 @@ class Jetpack_Sync_Sender {
 	public function do_sync_for_queue( $queue ) {
 
 		do_action( 'jetpack_sync_before_send_queue_' . $queue->id );
-
 		if ( $queue->size() === 0 ) {
 			return false;
 		}
-
 		// now that we're sure we are about to sync, try to
 		// ignore user abort so we can avoid getting into a
 		// bad state
 		if ( function_exists( 'ignore_user_abort' ) ) {
 			ignore_user_abort( true );
 		}
-
 		$buffer = $queue->checkout_with_memory_limit( $this->dequeue_max_bytes, $this->upload_max_rows );
-
 		if ( ! $buffer ) {
 			// buffer has no items
 			return false;
 		}
-
 		if ( is_wp_error( $buffer ) ) {
-			// another buffer is currently sending
-			return false;
+			return $buffer;
 		}
 
-		list( $items_to_send, $skipped_items_ids, $items ) = $this->get_items_to_send( $buffer );
+		list( $items_to_send, $skipped_items_ids, $items ) = $this->get_items_to_send( $buffer, true );
 
 		/**
 		 * Fires when data is ready to send to the server.
@@ -193,39 +178,29 @@ class Jetpack_Sync_Sender {
 		 * @param string $queue The queue used to send ('sync' or 'full_sync')
 		 */
 		$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id );
-
 		if ( ! $processed_item_ids || is_wp_error( $processed_item_ids ) ) {
 			$checked_in_item_ids = $queue->checkin( $buffer );
-
 			if ( is_wp_error( $checked_in_item_ids ) ) {
 				error_log( 'Error checking in buffer: ' . $checked_in_item_ids->get_error_message() );
 				$queue->force_checkin();
 			}
-
 			if ( is_wp_error( $processed_item_ids ) ) {
 				return $processed_item_ids;
 			}
-
 			// returning a WP_Error is a sign to the caller that we should wait a while
 			// before syncing again
 			return new WP_Error( 'server_error' );
-
 		} else {
-
 			// detect if the last item ID was an error
 			$had_wp_error = is_wp_error( end( $processed_item_ids ) );
-
 			if ( $had_wp_error ) {
 				$wp_error = array_pop( $processed_item_ids );
 			}
-
 			// also checkin any items that were skipped
 			if ( count( $skipped_items_ids ) > 0 ) {
 				$processed_item_ids = array_merge( $processed_item_ids, $skipped_items_ids );
 			}
-
 			$processed_items = array_intersect_key( $items, array_flip( $processed_item_ids ) );
-
 			/**
 			 * Allows us to keep track of all the actions that have been sent.
 			 * Allows us to calculate the progress of specific actions.
@@ -235,16 +210,13 @@ class Jetpack_Sync_Sender {
 			 * @param array $processed_actions The actions that we send successfully.
 			 */
 			do_action( 'jetpack_sync_processed_actions', $processed_items );
-
 			$queue->close( $buffer, $processed_item_ids );
-
 			// returning a WP_Error is a sign to the caller that we should wait a while
 			// before syncing again
 			if ( $had_wp_error ) {
 				return $wp_error;
 			}
 		}
-
 		return true;
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -284,7 +284,6 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$next_sync_time = $this->sender->get_next_sync_time( 'sync' );
-
 		$this->assertTrue( $next_sync_time > time() + 5 );
 		$this->assertTrue( $next_sync_time < time() + 15 );
 	}


### PR DESCRIPTION
This 2 api endpoints allow us to fetch items from the queue and remove
them from the queue as well once they are processed.

I have tested these 2 api endpoints by blocking data from being sent and then trying to query for the queue. 

It seems to work as expected. 
But please test some more. 

