### PR TITLE
Limit dequeue time to 15 seconds to avoid going over PHP execution timeout

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -261,7 +261,7 @@ class Jetpack_Sync_Defaults {
 		$max_exec_time = intval( ini_get( 'max_execution_time' ) );
 		if ( $max_exec_time === 0 ) {
 			// 0 actually means "unlimited", but let's not treat it that way
-		    $max_exec_time = 60;
+			$max_exec_time = 60;
 		}
 		return floor( $max_exec_time / 3 );
 	}

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -271,6 +271,7 @@ class Jetpack_Sync_Defaults {
 	static $default_sync_wait_threshold = 5; // only wait before next send if the current send took more than X seconds
 	static $default_max_queue_size = 1000;
 	static $default_max_queue_lag = 900; // 15 minutes
+	static $default_max_dequeue_time = 15; // 15 seconds
 	static $default_queue_max_writes_sec = 100; // 100 rows a second
 	static $default_post_types_blacklist = array();
 	static $default_meta_blacklist = array();

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -259,7 +259,7 @@ class Jetpack_Sync_Defaults {
 
 	static function get_max_sync_execution_time() {
 		$max_exec_time = intval( ini_get( 'max_execution_time' ) );
-		if ( $max_exec_time === 0 ) {
+		if ( 0 === $max_exec_time ) {
 			// 0 actually means "unlimited", but let's not treat it that way
 			$max_exec_time = 60;
 		}

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -257,12 +257,22 @@ class Jetpack_Sync_Defaults {
 		return false;
 	}
 
+	static function get_max_sync_execution_time() {
+		$max_exec_time = intval( ini_get( 'max_execution_time' ) );
+		if ( $max_exec_time === 0 ) {
+			// 0 actually means "unlimited", but let's not treat it that way
+		    $max_exec_time = 60;
+		}
+		return floor( $max_exec_time / 3 );
+	}
+
 	static $default_network_options_whitelist = array(
 		'site_name',
 		'jetpack_protect_key',
 		'jetpack_protect_global_whitelist',
 		'active_sitewide_plugins',
 	);
+
 	static $default_taxonomy_whitelist = array();
 	static $default_dequeue_max_bytes = 500000; // very conservative value, 1/2 MB
 	static $default_upload_max_bytes = 600000; // a little bigger than the upload limit to account for serialization
@@ -271,7 +281,6 @@ class Jetpack_Sync_Defaults {
 	static $default_sync_wait_threshold = 5; // only wait before next send if the current send took more than X seconds
 	static $default_max_queue_size = 1000;
 	static $default_max_queue_lag = 900; // 15 minutes
-	static $default_max_dequeue_time = 15; // 15 seconds
 	static $default_queue_max_writes_sec = 100; // 100 rows a second
 	static $default_post_types_blacklist = array();
 	static $default_meta_blacklist = array();

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -308,9 +308,9 @@ class Jetpack_Sync_Sender {
 		$this->set_dequeue_max_bytes( $settings['dequeue_max_bytes'] );
 		$this->set_upload_max_bytes( $settings['upload_max_bytes'] );
 		$this->set_upload_max_rows( $settings['upload_max_rows'] );
-		$this->set_max_dequeue_time( $settings['max_dequeue_time'] );
 		$this->set_sync_wait_time( $settings['sync_wait_time'] );
 		$this->set_sync_wait_threshold( $settings['sync_wait_threshold'] );
+		$this->set_max_dequeue_time( Jetpack_Sync_Defaults::get_max_sync_execution_time() );
 	}
 
 	function reset_data() {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -17,6 +17,7 @@ class Jetpack_Sync_Settings {
 		'post_types_blacklist' => true,
 		'meta_blacklist'       => true,
 		'disable'              => true,
+		'max_dequeue_time'     => true,
 		'render_filtered_content' => true,
 	);
 

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -17,7 +17,6 @@ class Jetpack_Sync_Settings {
 		'post_types_blacklist' => true,
 		'meta_blacklist'       => true,
 		'disable'              => true,
-		'max_dequeue_time'     => true,
 		'render_filtered_content' => true,
 	);
 

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -312,6 +312,22 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 9 );	
 	}
 
+	function test_default_value_for_max_execution_time() {
+		// test with strings, non-strings, 0 and null
+
+		ini_set( 'max_execution_time', '30' );
+		$this->assertEquals( 10, Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+
+		ini_set( 'max_execution_time', 65 );
+		$this->assertEquals( 21, Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+
+		ini_set( 'max_execution_time', '0' );
+		$this->assertEquals( 20, Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+
+		ini_set( 'max_execution_time', null );
+		$this->assertEquals( 20, Jetpack_Sync_Defaults::get_max_sync_execution_time() );
+	}
+
 	function test_limits_execution_time_of_do_sync() {
 		// disable sync callables
 		set_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -312,6 +312,40 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 9 );	
 	}
 
+	function test_limits_execution_time_of_do_sync() {
+		// disable sync callables
+		set_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
+		$this->sender->do_sync();
+
+		$this->assertEquals( 0, $this->sender->get_sync_queue()->size() );
+
+		$this->sender->set_max_dequeue_time( 4 );
+
+		add_filter( 'jetpack_sync_before_send_super_slow_action', array( $this, 'before_send_super_slow_action' ), 10, 2 );
+
+		// register the action to be synced
+		add_action( 'super_slow_action', array( $this->listener, 'action_handler' ) );
+
+		// it should only dequeue 2 of these, because each takes 3 seconds to process, and 3*2 = 6, which is > 4
+		do_action( 'super_slow_action' );
+		do_action( 'super_slow_action' );
+		do_action( 'super_slow_action' );
+
+		$this->assertEquals( 3, $this->sender->get_sync_queue()->size() );
+
+		$this->sender->do_sync();
+
+		// should have aborted after 2 actions
+		$this->assertEquals( 1, $this->sender->get_sync_queue()->size() );
+
+		remove_filter( 'jetpack_sync_before_send_super_slow_action', array( $this, 'before_send_super_slow_action' ) );
+	}
+
+	function before_send_super_slow_action( $args, $user_id ) {
+		sleep( 3 );
+		return $args;
+	}
+
 	function serverReceiveWithThreeSecondDelay( $data, $codec, $sent_timestamp ) {
 		sleep( 3 );
 		return array_keys( $data );


### PR DESCRIPTION
Often PHP has a max execution time of 30 seconds. 

In most cases, the default number and data size of items being dequeued by sync can be processed in less than 30 seconds, but on some sites (particularly those that make RPC calls while rendering content) it can take longer, and in some of those cases it results in sync being permanently stuck.

This PR tries to fix the issue by checking the elapsed time after each queue item has been preprocessed (the most time-consuming part for these broken sites, in our testing) and skips to sending the data if more than 15 seconds has passed.

In addition, it adds a settings item, `max_dequeue_time`, which can be remotely configured if a site is still misbehaving.

cc @ebinnion 