### PR TITLE
Remove unused code that is not needed any more

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -48,7 +48,6 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 		$sender      = Jetpack_Sync_Sender::get_instance();
 		$queue       = $sender->get_sync_queue();
 		$full_queue  = $sender->get_full_sync_queue();
-		$next_sync_time = $sender->get_next_sync_time() - microtime( true );
 
 		return array_merge(
 			$sync_module->get_status(),


### PR DESCRIPTION
This removed code that is not used  and causes a PHP Warning. 
```
PHP Warning:  Missing argument 1 for Jetpack_Sync_Sender::get_next_sync_time(), called in /home/enej/public_html/aaa/wp-content/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php on line 63 and defined in /home/enej/public_html/aaa/wp-content/plugins/jetpack/sync/class.jetpack-sync-sender.php on line 50
[23-Sep-2016 18:36:58 UTC] PHP Notice:  Undefined variable: queue_name in /home/enej/public_html/aaa/wp-content/plugins/jetpack/sync/class.jetpack-sync-sender.php on line 51
```

Part of the reason why this code is not needed any more is that we already call `$sender->get_next_sync_time( 'full_sync' ) ` and `$sender->get_next_sync_time( 'sync' )` inline. 

#### Changes proposed in this Pull Request:
- Removes code that is not used any more.

#### Testing instructions:
Does the API Endpoint still return the expected result?
Try `/v1.1/sites/80172965/sync/status` in https://developer.wordpress.com/docs/api/console/ 
