### PR TITLE
Do full sync without queue

### DIFF
--- a/sync/class.jetpack-full-sync.php
+++ b/sync/class.jetpack-full-sync.php
@@ -1,0 +1,11 @@
+<?php
+
+class Jetpack_Full_Sync {
+	static function do_sync() {
+		// get state
+		
+		// continue sync
+		// save state
+		// return result
+	}
+}

--- a/sync/class.jetpack-full-sync.php
+++ b/sync/class.jetpack-full-sync.php
@@ -1,11 +1,176 @@
 <?php
 
 class Jetpack_Full_Sync {
+
+	// writes out a config item for each enabled module containing total items & input config
+	static function start( $modules = null ) {
+		// todo detect if config already set and/or sync already in progress
+
+		$config = array();
+
+		if ( ! is_array( $modules ) ) {
+			$modules = array();
+		}
+
+		if ( isset( $modules['users'] ) && 'initial' === $modules['users'] ) {
+			$user_module = Jetpack_Sync_Modules::get_module( 'users' );
+			$modules['users'] = $user_module->get_initial_sync_user_config();
+		}
+
+		// by default, all modules are fully enabled
+		if ( count( $modules ) === 0 ) {
+			$default_module_config = true;
+		} else {
+			$default_module_config = false;
+		}
+
+		// set default configuration, calculate totals, and save configuration if totals > 0
+		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+			$module_name = $module->name();
+			if ( ! isset( $modules[ $module_name ] ) ) {
+				$modules[ $module_name ] = $default_module_config;
+			}
+
+			// check if this module is enabled
+			if ( ! ( $module_config = $modules[ $module_name ] ) ) {
+				continue;
+			}
+
+			$total_items = $module->estimate_full_sync_actions( $module_config );
+
+			if ( ! is_null( $total_items ) && $total_items > 0 ) {
+				$config[ $module_name ] = array(
+					'total' => $total_items,
+					'config' => $module_config,
+				);
+			}
+		}
+
+		self::set_config( $config );
+
+		// now let's set an initial status
+		$status = array();
+		foreach( $config as $module => $params ) {
+			$status[ $module ] = array();
+		}
+
+		self::set_status( $status );
+	}
+
 	static function do_sync() {
+		$config = self::get_config();
+		$status = self::get_status();
+
+		error_log("Got config: ".print_r($config,1));
+		
+		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+			if ( isset( $status[ $module->name() ][ 'finished' ] ) ) {
+				continue;
+			}
+
+			// do work
+			Jetpack_Sync_Settings::set_is_sending( true );
+			$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id );
+			Jetpack_Sync_Settings::set_is_sending( false );
+		}
 		// get state
 		
 		// continue sync
 		// save state
 		// return result
 	}
+
+	private static function set_config( $config ) {
+		self::write_option( 'jetpack_sync_full_config', $config );
+	}
+
+	private static function get_config() {
+		return self::read_option( 'jetpack_sync_full_config' );
+	}
+
+	private static function set_status( $status ) {
+		self::write_option( 'jetpack_sync_full_status', $status );
+	}
+
+	private static function get_status() {
+		return self::read_option( 'jetpack_sync_full_status' );
+	}
+
+	private static function write_option( $name, $value ) {
+		// we write our own option updating code to bypass filters/caching/etc on set_option/get_option
+		global $wpdb;
+
+		$serialized_value = maybe_serialize( $value );
+
+		// try updating, if no update then insert
+		$updated_num = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
+				$serialized_value,
+				$name
+			)
+		);
+
+		if ( ! $updated_num ) {
+			$updated_num = $wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
+					$name,
+					$serialized_value
+				)
+			);
+		}
+
+		return $updated_num;
+	}
+
+	private static function read_option( $name ) {
+		global $wpdb;
+
+		$value = $wpdb->get_var( 
+			$wpdb->prepare(
+				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", 
+				$name
+			)
+		);
+
+		return maybe_unserialize( $value );
+	}
+
+	// private function set_checkout_id( $checkout_id ) {
+	// 	global $wpdb;
+
+	// 	$expires = time() + Jetpack_Sync_Defaults::$default_sync_queue_lock_timeout;
+	// 	$updated_num = $wpdb->query(
+	// 		$wpdb->prepare(
+	// 			"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
+	// 			"$checkout_id:$expires",
+	// 			self::get_lock_option_name()
+	// 		)
+	// 	);
+
+	// 	if ( ! $updated_num ) {
+	// 		$updated_num = $wpdb->query(
+	// 			$wpdb->prepare(
+	// 				"INSERT INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
+	// 				self::get_lock_option_name(),
+	// 				"$checkout_id:$expires"
+	// 			)
+	// 		);
+	// 	}
+
+	// 	return $updated_num;
+	// }
+
+	// private function delete_checkout_id() {
+	// 	global $wpdb;
+	// 	// rather than delete, which causes fragmentation, we update in place
+	// 	return $wpdb->query(
+	// 		$wpdb->prepare( 
+	// 			"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
+	// 			"0:0",
+	// 			self::get_lock_option_name() 
+	// 		) 
+	// 	);
+	// }
 }

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -303,6 +303,7 @@ class Jetpack_Sync_Defaults {
 	static $default_comment_meta_whitelist = array();
 	static $default_disable = 0; // completely disable sending data to wpcom
 	static $default_avoid_wp_cron = 0; // don't use cron to enqueue full syncs - do it inline. Warning: Can time out for larger sites!
+	static $default_real_time_full_sync = 0; // real-time full sync currently disabled by default
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -378,7 +378,6 @@ class Jetpack_Sync_Queue {
 				$this->get_lock_option_name() 
 			) 
 		);
-
 	}
 
 	private function get_lock_option_name() {

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-queue.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-full-sync.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-defaults.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-json-deflate-array-codec.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-modules.php';
@@ -57,7 +58,11 @@ class Jetpack_Sync_Sender {
 	}
 
 	public function do_full_sync() {
-		return $this->do_sync_and_set_delays( $this->full_sync_queue );
+		if ( Jetpack_Sync_Settings::get_setting( 'real_time_full_sync' ) ) {
+			return Jetpack_Full_Sync::do_sync();
+		} else {
+			return $this->do_sync_and_set_delays( $this->full_sync_queue );
+		}
 	}
 
 	public function do_sync() {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -16,6 +16,7 @@ class Jetpack_Sync_Settings {
 		'queue_max_writes_sec' => true,
 		'post_types_blacklist' => true,
 		'disable'              => true,
+		'real_time_full_sync'  => true,
 		'render_filtered_content' => true,
 		'post_meta_whitelist' => true,
 		'comment_meta_whitelist' => true,

--- a/tests/php/sync/test_class.jetpack-full-sync.php
+++ b/tests/php/sync/test_class.jetpack-full-sync.php
@@ -1,0 +1,14 @@
+<?php
+require_once 'test_class.jetpack-sync-base.php';
+
+class WP_Test_Jetpack_Full_Sync extends WP_Test_Jetpack_Sync_Base {
+	function test_full_sync_sends_post_processed_posts() {
+		$post_id = $this->factory->post->create();
+		$post = get_post( $post_id );
+
+		Jetpack_Full_Sync::do_sync();
+
+		$post = Jetpack_Sync_Modules::get_module( 'posts' )->filter_post_content_and_add_links( $post );
+		$this->assertEquals( $post, $this->server_replica_storage->get_post( $post_id ) );
+	}
+}

--- a/tests/php/sync/test_class.jetpack-full-sync.php
+++ b/tests/php/sync/test_class.jetpack-full-sync.php
@@ -6,6 +6,7 @@ class WP_Test_Jetpack_Full_Sync extends WP_Test_Jetpack_Sync_Base {
 		$post_id = $this->factory->post->create();
 		$post = get_post( $post_id );
 
+		Jetpack_Full_Sync::start();
 		Jetpack_Full_Sync::do_sync();
 
 		$post = Jetpack_Sync_Modules::get_module( 'posts' )->filter_post_content_and_add_links( $post );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -13,7 +13,12 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function setUp() {
 		parent::setUp();
+		Jetpack_Sync_Settings::update_settings( array( 'real_time_full_sync' => 1 ) );
 		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
+	}
+
+	function tearDown() {
+		Jetpack_Sync_Settings::update_settings( array( 'real_time_full_sync' => 0 ) );
 	}
 
 	function test_enqueues_sync_start_action() {
@@ -58,28 +63,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$cancelled_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_cancelled' );
 
 		$this->assertTrue( $cancelled_event !== false );
-	}
-
-	function test_full_sync_lock_has_one_hour_timeout() {
-		$this->started_sync_count = 0;
-
-		add_action( 'jetpack_full_sync_start', array( $this, 'count_full_sync_start' ) );
-
-		$this->full_sync->start();
-
-		$this->assertEquals( 1, $this->started_sync_count );
-
-		// fake the last sync being over an hour ago
-		$prefix = Jetpack_Sync_Module_Full_Sync::STATUS_OPTION_PREFIX;
-		update_option( "{$prefix}_started", time() - 3700 );
-
-		$this->full_sync->start();
-
-		$this->assertEquals( 2, $this->started_sync_count );
-	}
-
-	function count_full_sync_start() {
-		$this->started_sync_count += 1;
 	}
 
 	function test_full_sync_can_select_modules() {


### PR DESCRIPTION
Fixes issues with syncing large databases, where saving off all the IDs in to the DB would cause a glut of writes and sometimes overwhelm the available storage.