### PR TITLE
Sync: Begin syncing featured image with post objects

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -119,8 +119,16 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		/** This filter is already documented in core. wp-includes/post-template.php */
 		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) ) {
 			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
-			$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );	
+			$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
 		}
+
+		if ( has_post_thumbnail( $post->ID ) ) {
+			$image_attributes = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
+			if ( is_array( $image_attributes ) && isset( $image_attributes[0] ) ) {
+				$post->featured_image = $image_attributes[0];
+			}
+		}
+
 		$post->permalink               = get_permalink( $post->ID );
 		$post->shortlink               = wp_get_shortlink( $post->ID );
 		$post->dont_email_post_to_subs = Jetpack::is_module_active( 'subscriptions' ) ?


### PR DESCRIPTION
WPCOM diverges a bit with how we handle featured images, and because of this, we are occasionally running into issues where featured images are being returned in the API as the attachment post instead of the image source 😱 

It seems like the two ways we could fix this are:

1) Sync the featured image as post meta. This seems to be the most bulletproof option

2) Begin syncing the uploads directory and dynamically concatenate the `_wp_attached_file` post meta with the uploads directory to get the featured image URL.

While we should probably sync the uploads directory anyways, I think we should go with the simpler and less prone to error solution in this case, which is sending the featured image as meta.

I'm currently working on a WPCOM patch.