### PR TITLE
Jetpack UI: Update professional slug to plans

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -56,7 +56,7 @@ function render() {
 					<Route path='/jumpstart' component={ Main } />
 					<Route path='/dashboard' name={ i18n.translate( 'At A Glance' ) } component={ Main } />
 					<Route path='/apps' name={ i18n.translate( 'Apps', { context: 'Navigation item.' } ) } component={ Main } />
-					<Route path='/professional' name={ i18n.translate( 'Plans', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/plans' name={ i18n.translate( 'Plans', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/settings' name={ i18n.translate( 'General', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/general' name={ i18n.translate( 'General', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/engagement' name={ i18n.translate( 'Engagement', { context: 'Navigation item.' } ) } component={ Main } />

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -89,7 +89,7 @@ const DashItem = React.createClass( {
 			proButton =
 				<Button
 					compact={ true }
-					href="#professional"
+					href="#/plans"
 				>
 					{ __( 'Pro' ) }
 				</Button>

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -24,17 +24,17 @@ const Navigation = React.createClass( {
 			navTabs = (
 				<NavTabs selectedText={ this.props.route.name }>
 					<NavItem
-						path="#dashboard"
+						path="#/dashboard"
 						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
-						path="#apps"
+						path="#/apps"
 						selected={ this.props.route.path === '/apps' }>
 						{ __( 'Apps', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
-						path="#plans"
+						path="#/plans"
 						selected={ this.props.route.path === '/plans' }>
 						{ __( 'Plans', { context: 'Navigation item.' } ) }
 					</NavItem>
@@ -45,7 +45,7 @@ const Navigation = React.createClass( {
 			if ( this.props.userCanViewStats || this.props.isModuleActivated( 'protect' ) ) {
 				dashboard = (
 					<NavItem
-						path="#dashboard"
+						path="#/dashboard"
 						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
@@ -55,7 +55,7 @@ const Navigation = React.createClass( {
 				<NavTabs selectedText={ this.props.route.name }>
 					{ dashboard }
 					<NavItem
-						path="#apps"
+						path="#/apps"
 						selected={ this.props.route.path === '/apps' }>
 						{ __( 'Apps', { context: 'Navigation item.' } ) }
 					</NavItem>

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -34,8 +34,8 @@ const Navigation = React.createClass( {
 						{ __( 'Apps', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
-						path="#professional"
-						selected={ this.props.route.path === '/professional' }>
+						path="#plans"
+						selected={ this.props.route.path === '/plans' }>
 						{ __( 'Plans', { context: 'Navigation item.' } ) }
 					</NavItem>
 				</NavTabs>

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -267,7 +267,7 @@ window.wpNavMenuClassChange = function() {
 
 	const $body = jQuery( 'body' );
 
-	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#security"], .dops-button[href="#plans"]', function() {
+	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#/security"], .dops-button[href="#/plans"]', function() {
 		window.scrollTo( 0, 0 );
 	} );
 

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -142,7 +142,7 @@ const Main = React.createClass( {
 			case '/apps':
 				pageComponent = <Apps siteRawUrl={ this.props.siteRawUrl } />;
 				break;
-			case '/professional':
+			case '/plans':
 				pageComponent = <Plans siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/settings':
@@ -244,7 +244,7 @@ window.wpNavMenuClassChange = function() {
 		'#/',
 		'#/dashboard',
 		'#/apps',
-		'#/professional'
+		'#/plans'
 	];
 
 	// Clear currents
@@ -267,7 +267,7 @@ window.wpNavMenuClassChange = function() {
 
 	const $body = jQuery( 'body' );
 
-	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#security"], .dops-button[href="#professional"]', function() {
+	$body.on( 'click', 'a[href$="#/dashboard"], a[href$="#/settings"], .jp-dash-section-header__settings[href="#security"], .dops-button[href="#plans"]', function() {
 		window.scrollTo( 0, 0 );
 	} );
 

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -115,7 +115,7 @@ export const SearchResults = ( {
 				{ element[1] }
 				<Button
 					compact={ true }
-					href="#/plan"
+					href="#/plans"
 				>
 					{ __( 'Pro' ) }
 				</Button>

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -115,7 +115,7 @@ export const SearchResults = ( {
 				{ element[1] }
 				<Button
 					compact={ true }
-					href="#professional"
+					href="#/plan"
 				>
 					{ __( 'Pro' ) }
 				</Button>

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -76,7 +76,7 @@ export const Page = ( props ) => {
 				{ element[1] }
 				<Button
 					compact={ true }
-					href="#/plan"
+					href="#/plans"
 				>
 					{ __( 'Pro' ) }
 				</Button>

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -76,7 +76,7 @@ export const Page = ( props ) => {
 				{ element[1] }
 				<Button
 					compact={ true }
-					href="#professional"
+					href="#/plan"
 				>
 					{ __( 'Pro' ) }
 				</Button>


### PR DESCRIPTION
Fixes issue where the slug in the url pass pointing to professionals instead of plans

#### Changes proposed in this Pull Request:
Update (hopefully) all places. 

#### Testing instructions:
Go to Jetpack dashboard click on plans. 
It should take you to /plans instead of /professional
