### PR TITLE
Widget Visibility: add filter to get_taxonomies

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -142,8 +142,12 @@ class Jetpack_Widget_Conditions {
 				?>
 				<option value=""><?php _e( 'All taxonomy pages', 'jetpack' ); ?></option>
 				<?php
-
-				$taxonomies = get_taxonomies( array( '_builtin' => false ), 'objects' );
+				/**
+				 * Filters args passed to get_taxonomies.
+				 * @see https://developer.wordpress.org/reference/functions/get_taxonomies/
+				 * @param array jetpack_widget_visibility_tax_args
+				 */
+				$taxonomies = get_taxonomies( apply_filters( 'jetpack_widget_visibility_tax_args', array( '_builtin' => false ) ), 'objects' );
 				usort( $taxonomies, array( __CLASS__, 'strcasecmp_name' ) );
 
 				$parts = explode( '_tax_', $minor );

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -144,10 +144,17 @@ class Jetpack_Widget_Conditions {
 				<?php
 				/**
 				 * Filters args passed to get_taxonomies.
+				 *
 				 * @see https://developer.wordpress.org/reference/functions/get_taxonomies/
+				 * @since 4.4.0
+				 * @module widget-visibility
+				 *
 				 * @param array jetpack_widget_visibility_tax_args
 				 */
-				$taxonomies = get_taxonomies( apply_filters( 'jetpack_widget_visibility_tax_args', array( '_builtin' => false ) ), 'objects' );
+				$taxonomies = get_taxonomies(
+					apply_filters( 'jetpack_widget_visibility_tax_args', array( '_builtin' => false )
+					), 'objects'
+				);
 				usort( $taxonomies, array( __CLASS__, 'strcasecmp_name' ) );
 
 				$parts = explode( '_tax_', $minor );


### PR DESCRIPTION
Fixes #5221 
#### Changes proposed in this Pull Request:

Adds a filter to the `get_taxonomies` args so people can pass their own args such as `'public' => true`
#### Testing instructions:

*
Add a an arg with the following:

```
add_filter( 'jetpack_widget_visibility_tax_args', function( $args ) {
    $args['public'] = true;
    return $args;
} );
```
---
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
