### PR TITLE
Admin Page: remove form legend for default Tiled Gallery settings.

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -541,7 +541,6 @@ export let TiledGallerySettings = React.createClass( {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
 				<FormFieldset>
-					<FormLegend>{ __( 'Excerpts' ) }</FormLegend>
 					<ModuleSettingCheckbox
 						name={ 'tiled_galleries' }
 						{ ...this.props }


### PR DESCRIPTION
- That field is not related to excerpts.
- No further explanation is needed for that field.

#### Proposed changelog entry for your changes:

- Admin Page: remove wrong legend for Tiled Gallery settings.
