### PR TITLE
Admin Page: Removed feedback prompt from masthead

### DIFF
--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -38,14 +38,6 @@ const Masthead = React.createClass( {
 								</span>
 							</a>
 						</li>
-						<li className="jp-masthead__link-li">
-							<a href={ 'http://surveys.jetpack.me/research-plugin?rel=' + this.props.currentVersion } target="_blank" className="jp-masthead__link">
-								<span className="dashicons dashicons-admin-comments" title={ __( 'Send us Feedback' ) } />
-								<span>
-									{ __( 'Send us Feedback' ) }
-								</span>
-							</a>
-						</li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #5231.

I tested in Chrome and IE10 and the "Send us Feedback" link was no longer there in either.

- IE10
![screen shot 2016-09-30 at 2 24 26 pm](https://cloud.githubusercontent.com/assets/1126811/19004120/e3cc9dce-8719-11e6-8241-c6a9f1ee4421.png)

To test:

- Checkout `update/admin-page-remove-feedback-prompt` branch
- `npm run build` 
- Load "Jetpack" admin page
- Notice link is missing from top of masthead