### PR TITLE
Admin: Standardizing American English within the plugin

### DIFF
--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -27,7 +27,7 @@ const DashPhoton = React.createClass( {
 					label={ labelName }
 					module="photon"
 					status="is-working" >
-					<p className="jp-dash-item__description">{ __( 'Jetpack is improving and optimising your image speed.' ) }</p>
+					<p className="jp-dash-item__description">{ __( 'Jetpack is improving and optimizing your image speed.' ) }</p>
 				</DashItem>
 			);
 		}

--- a/_inc/jetpack-strings.php
+++ b/_inc/jetpack-strings.php
@@ -62,7 +62,7 @@ __( "Loading…", "jetpack" ), // _inc/client/at-a-glance/monitor.jsx:36
 __( "Downtime Monitoring", "jetpack" ), // _inc/client/at-a-glance/monitor.jsx:23
 __( "{{a}}Activate Photon{{/a}} to enhance the performance and speed of your images.", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:43
 __( "Unavailable in Dev Mode", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:42
-__( "Jetpack is improving and optimising your image speed.", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:29
+__( "Jetpack is improving and optimizing your image speed.", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:29
 __( "Image Performance %(photon)s", "jetpack" ), // _inc/client/at-a-glance/photon.jsx:20
 __( "{{a}}Activate Manage{{/a}} to turn on auto updates and manage your plugins from WordPress.com.", "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:99
 __( "All plugins are up-to-date. Awesome work!", "jetpack" ), // _inc/client/at-a-glance/plugins.jsx:98


### PR DESCRIPTION
**Before:** 
<img width="404" alt="screen shot 2016-09-30 at 5 54 45 pm" src="https://cloud.githubusercontent.com/assets/214813/19008123/12f5e0c0-8737-11e6-848e-0ed4e7e551bd.png">


**After:**
<img width="416" alt="screen shot 2016-09-30 at 6 37 10 pm" src="https://cloud.githubusercontent.com/assets/214813/19008934/03e76904-873d-11e6-8e27-5d80e7157e24.png">

@beaulebens are there any other spots in the plugin that you've noticed with non-american style english? I've done a search for "colour" and don't see anything user facing. 

Fixes: https://github.com/Automattic/jetpack/issues/5234