### PR TITLE
Increased contrast of .jp-form-setting-explanation

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -35,7 +35,7 @@
 }
 
 .jp-form-setting-explanation {
-	color: $gray;
+	color: darken( $gray, 20% );
 	display: block;
 	margin: rem( 5px ) 0 0 0;
 	font-size: rem( 13px );


### PR DESCRIPTION
Fixes #4942

#### Changes proposed in this Pull Request:
* increases contrast on .jp-form-setting-explanation

#### Testing instructions:

* go to settings, and toggle open a bunch of the modules.(https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/19009125/7f7b9bc0-8725-11e6-85eb-f67743860c71.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/19009103/55f5f160-8725-11e6-9df9-025f65e18aa5.png)
