### PR TITLE
Carousel: moved close icon location to the top right

### DIFF
--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -237,7 +237,7 @@ div.jp-carousel-buttons a:hover {
 	letter-spacing: 0 !important;
 	padding:0.35em 0 0;
 	position: absolute;
-	text-align: left;
+	text-align: right;
 	width: 90%;
 }
 
@@ -252,7 +252,7 @@ div.jp-carousel-buttons a:hover {
 	cursor: pointer;
 	background-color: black;
 	background-color: rgba(0,0,0,0.8);
-	display: block;
+	display: inline-block;
 	height: 22px;
 	font: 400 24px/1 "Helvetica Neue", sans-serif !important;
 	line-height: 22px;


### PR DESCRIPTION
Fixes #4285
#### Changes proposed in this Pull Request:
- moves the close icon to the top right
#### Testing instructions:
- create a carousel
- publish it
- open it
- close it
#### Before

![image](https://cloud.githubusercontent.com/assets/1123119/19009370/0e13a0c4-8728-11e6-942e-e71aae6ecd0e.png)
#### After

![image](https://cloud.githubusercontent.com/assets/1123119/19009453/f0684b50-8728-11e6-9fb0-82939d506ff6.png)

And even looks good on mobile, still!
![image](https://cloud.githubusercontent.com/assets/1123119/19009460/027d633e-8729-11e6-87da-ee69ffdc9b90.png)

![image](https://cloud.githubusercontent.com/assets/1123119/19009479/417a11f4-8729-11e6-93a6-cad8017765e1.png)
