### PR TITLE
Use custom SQL instead of transient for queue lock

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -288,5 +288,5 @@ class Jetpack_Sync_Defaults {
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
-	static $default_sync_queue_lock_timeout = 2 * MINUTE_IN_SECONDS;
+	static $default_sync_queue_lock_timeout = 120; // 2 minutes
 }

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -288,4 +288,5 @@ class Jetpack_Sync_Defaults {
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
+	static $default_sync_queue_lock_timeout = 5 * MINUTE_IN_SECONDS;
 }

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -288,5 +288,5 @@ class Jetpack_Sync_Defaults {
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
-	static $default_sync_queue_lock_timeout = 5 * MINUTE_IN_SECONDS;
+	static $default_sync_queue_lock_timeout = MINUTE_IN_SECONDS;
 }

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -288,5 +288,5 @@ class Jetpack_Sync_Defaults {
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
-	static $default_sync_queue_lock_timeout = MINUTE_IN_SECONDS;
+	static $default_sync_queue_lock_timeout = 2 * MINUTE_IN_SECONDS;
 }

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -346,7 +346,7 @@ class Jetpack_Sync_Queue {
 	private function set_checkout_id( $checkout_id ) {
 		global $wpdb;
 
-		$expires = time() + ( 5 * 60 );
+		$expires = time() + Jetpack_Sync_Defaults::$default_sync_queue_lock_timeout;
 		$updated_num = $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
@@ -356,8 +356,8 @@ class Jetpack_Sync_Queue {
 		);
 
 		if ( ! $updated_num ) {
-			$wpdb->query(
-				$updated_num = $wpdb->prepare(
+			$updated_num = $wpdb->query(
+				$wpdb->prepare(
 					"INSERT INTO $wpdb->options ( option_name, option_value ) VALUES ( %s, %s )", 
 					$this->get_lock_option_name(),
 					"$checkout_id:$expires"

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -335,7 +335,7 @@ class Jetpack_Sync_Queue {
 
 		if ( $checkout_value ) {
 			list( $checkout_id, $timestamp ) = explode( ':', $checkout_value );
-			if ( $timestamp > time() ) {
+			if ( intval( $timestamp ) > time() ) {
 				return $checkout_id;
 			}
 		}
@@ -370,7 +370,14 @@ class Jetpack_Sync_Queue {
 
 	private function delete_checkout_id() {
 		global $wpdb;
-		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name = %s", $this->get_lock_option_name() ) );
+		// rather than delete, which causes fragmentation, we update in place
+		$wpdb->query( 
+			$wpdb->prepare( 
+				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
+				"0:0",
+				$this->get_lock_option_name() 
+			) 
+		);
 	}
 
 	private function get_lock_option_name() {

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -358,7 +358,7 @@ class Jetpack_Sync_Queue {
 		if ( ! $updated_num ) {
 			$updated_num = $wpdb->query(
 				$wpdb->prepare(
-					"INSERT INTO $wpdb->options ( option_name, option_value ) VALUES ( %s, %s )", 
+					"INSERT INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
 					$this->get_lock_option_name(),
 					"$checkout_id:$expires"
 				)


### PR DESCRIPTION
It seems that sometimes transients don't work the way we expect - in essence, the expiry is too unreliable for our purposes, and can leave sync queues permanently locked.

This PR implements the sync queue lock in pure SQL in order to avoid caching and other weirdness.

cc @lezama 

**Proposed changelog**

Use SQL for queue lock as transients have had caching and infinite timeout issues