### PR TITLE
Admin Page: Fix redirection URL after clicking the enable manage link in Plugins Dashboard Card

### DIFF
--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -25,7 +25,7 @@ const DashPluginUpdates = React.createClass( {
 	activateAndRedirect: function( e ) {
 		e.preventDefault();
 		this.props.activateManage()
-			.then( window.location = 'https://wordpress.com/plugins/' + props.siteRawUrl )
+			.then( window.location = 'https://wordpress.com/plugins/' + this.props.siteRawUrl )
 			.catch( console.log( 'Error activating Manage' ) );
 	},
 


### PR DESCRIPTION
Fixes non-working redirection to WordPress.com site's plugins page after enabling **Manage** from the Admin Page's Dashboard Plugins widget.

#### Changes proposed in this Pull Request:

* Fixes wrong reference to component's property

#### Testing instructions:

1. Disable **Manage**
  1. Use the search box, type "Manage"
  1. Disable the **Manage** module.
1. Get to the Jetpack Dashboard
1. Reach the Plugins (**Manage**) card.
1. Click the link _Activate Manage and turn on auto updates_.
1. Expect to be redirected to Calypso' plugins page for this site.

<!-- Add the following only if this is meant to be in changelog -->

#### Proposed changelog entry for your changes:

Implements a redirection to WordPress.com Site plugins page for managing plugins after enabling the Manage module from the Jetpack Dashboard. 