### PR TITLE
Jetpack Sync: Add unlock queue api endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -221,15 +221,41 @@ class Jetpack_JSON_API_Sync_Now_Endpoint extends Jetpack_JSON_API_Sync_Endpoint 
 			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', 400 );
 		}
 
-		$queue_name = $args['queue'];
-
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 
 		$sender = Jetpack_Sync_Sender::get_instance();
-		$response = $sender->do_sync_for_queue( new Jetpack_Sync_Queue( $queue_name ) );
+		$response = $sender->do_sync_for_queue( new Jetpack_Sync_Queue( $args['queue'] ) );
 
 		return array(
 			'response' => $response
+		);
+	}
+}
+
+class Jetpack_JSON_API_Sync_Unlock_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
+	protected function result() {
+		$args = $this->input();
+
+		if ( ! isset( $args['queue'] ) ) {
+			return new WP_Error( 'invalid_queue', 'Queue name is required', 400 );
+		}
+
+		if ( ! in_array( $args['queue'], array( 'sync', 'full_sync' ) ) ) {
+			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', 400 );
+		}
+
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-queue.php';
+		$queue = new Jetpack_Sync_Queue( $args['queue'] );
+
+		// If false it means that there was no lock to delete.
+		$response = $queue->unlock();
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return array(
+			'success' => $response
 		);
 	}
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -739,6 +739,25 @@ new Jetpack_JSON_API_Sync_Now_Endpoint( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/now?queue=full_sync'
 ) );
 
+// POST /sites/%s/sync/unlock
+new Jetpack_JSON_API_Sync_Unlock_Endpoint( array(
+	'description'     => 'Unlock the queue in case it gets locked by a process.',
+	'method'          => 'POST',
+	'path'            => '/sites/%s/sync/unlock',
+	'group'           => '__do_not_document',
+	'stat'            => 'sync-unlock',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'request_format' => array(
+		'queue'      => '(string) sync or full_sync',
+	),
+	'response_format' => array(
+		'success' => '(bool) Unlocking the queue successful?'
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/unlock'
+) );
+
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-log-endpoint.php' );
 
 new Jetpack_JSON_API_Jetpack_Log_Endpoint( array(

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -321,7 +321,7 @@ class Jetpack_Sync_Queue {
 	}
 
 	function unlock() {
-		$this->delete_checkout_id();
+		return $this->delete_checkout_id();
 	}
 
 	private function get_checkout_id() {
@@ -371,13 +371,14 @@ class Jetpack_Sync_Queue {
 	private function delete_checkout_id() {
 		global $wpdb;
 		// rather than delete, which causes fragmentation, we update in place
-		$wpdb->query( 
+		return $wpdb->query(
 			$wpdb->prepare( 
 				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
 				"0:0",
 				$this->get_lock_option_name() 
 			) 
 		);
+
 	}
 
 	private function get_lock_option_name() {


### PR DESCRIPTION
Add a new API endpoint that lets us unlock a queue. By deleting the transite, this can help sites that experience a queue lock and doesn't have a mechanism to unlock it. 

#### Changes proposed in this Pull Request:
- A new api endpoint. sites/site.com/sync/unlock body: queue=sync or full_sync


#### Testing instructions:
* go to https://developer.wordpress.com/docs/api/console/ and try the api endpoint for your site. Does it return data as expected?

This API endpoint should be used in case the queue doesn't get unlocked
automatically after 5 minutes.