### PR TITLE
Endpoints - Stats: improve response time of Stats initial data load

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -795,23 +795,28 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 			require_once( JETPACK__PLUGIN_DIR . 'modules/stats.php' );
 		}
 
-		$response = array(
-			'general' => stats_get_from_restapi(),
-		);
-
 		switch ( $range ) {
-			case 'day':
-				$response['day'] = stats_get_from_restapi( array(), 'visits?unit=day&quantity=30' );
-				break;
-			case 'week':
-				$response['week'] = stats_get_from_restapi( array(), 'visits?unit=week&quantity=14' );
-				break;
-			case 'month':
-				$response['month'] = stats_get_from_restapi( array(), 'visits?unit=month&quantity=12&' );
-				break;
-		}
 
-		return rest_ensure_response( $response );
+			// This is always called first on page load
+			case 'day':
+				$initial_stats = stats_get_from_restapi();
+				return rest_ensure_response( array(
+					'general' => $initial_stats,
+
+					// Build data for 'day' as if it was stats_get_from_restapi( array(), 'visits?unit=day&quantity=30' );
+					'day' => isset( $initial_stats->visits )
+						? $initial_stats->visits
+						: array(),
+				) );
+			case 'week':
+				return rest_ensure_response( array(
+					'week' => stats_get_from_restapi( array(), 'visits?unit=week&quantity=14' ),
+				) );
+			case 'month':
+				return rest_ensure_response( array(
+					'month' => stats_get_from_restapi( array(), 'visits?unit=month&quantity=12&' ),
+				) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- reduce one `stats_get_from_restapi` call.
- use initial `general` data fetch to build data for 'day' range since those are returned.
- don't create response array (and add array item by key) but return as soon as possible.

#### Testing instructions:
* go to Jetpack > Dashboard and verify that Stats are displaying normally.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Improve response time when fetching stats data

@jeherve can you please test if this improves the results on your site?