### PR TITLE
Widgets: add Flickr to Social Icons

### DIFF
--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -35,6 +35,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'youtube_username'   => '',
 			'vimeo_username'     => '',
 			'googleplus_username' => '',
+			'flickr_username'    => '',
 		);
 
 		$this->services = array(
@@ -47,6 +48,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'youtube'    => array( 'YouTube', 'https://www.youtube.com/%s/' ),
 			'vimeo'      => array( 'Vimeo', 'https://vimeo.com/%s/' ),
 			'googleplus' => array( 'Google+', 'https://plus.google.com/u/0/%s/' ),
+			'flickr'     => array( 'Flickr', 'https://www.flickr.com/photos/%s/' ),
 		);
 
 		if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {


### PR DESCRIPTION
Fixes #5248

#### Changes proposed in this Pull Request:
- add field so users can enter their Flickr username and it's displayed in widget front end rendering

#### Testing instructions:
* go to Appearance > Widgets, add a **Social Icons (Jetpack)** widget and make sure it displays the field _Flickr username:_.
* enter your Flickr username in it and save.
* check site in front end. Make sure the widget displays the corresponding Flickr icon linked to the Flickr user profile

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Widgets - Social Icons: add Flickr to the list of social media profile links that can be displayed
