### PR TITLE
Add secupress to sync blacklist

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -156,6 +156,7 @@ class Jetpack_Sync_Defaults {
 	static $blacklisted_post_types = array(
 		'ai1ec_event',
 		'snitch',
+		'secupress_log_action',
 	);
 
 	static $default_post_checksum_columns = array(


### PR DESCRIPTION
This has the same issue that the `snitch` post type had - recursive syncing!