### PR TITLE
Sync: Do not sync post meta related to post_types that are blacklisted

### DIFF
--- a/sync/class.jetpack-sync-module-meta.php
+++ b/sync/class.jetpack-sync-module-meta.php
@@ -104,8 +104,8 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 		return true;
 	}
 
-	function is_post_type_allowed( $object_id ) {
-		$post = get_post( $object_id );
+	function is_post_type_allowed( $post_id ) {
+		$post = get_post( $post_id );
 		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
 		}

--- a/sync/class.jetpack-sync-module-meta.php
+++ b/sync/class.jetpack-sync-module-meta.php
@@ -70,14 +70,12 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 	}
 
 	public function init_listeners( $callable ) {
-
-
 		foreach ( $this->meta_types as $meta_type ) {
-			$whitelist_handler = array( $this, 'filter_meta_' . $meta_type );
 			add_action( "added_{$meta_type}_meta", $callable, 10, 4 );
 			add_action( "updated_{$meta_type}_meta", $callable, 10, 4 );
 			add_action( "deleted_{$meta_type}_meta", $callable, 10, 4 );
 
+			$whitelist_handler = array( $this, 'filter_meta_' . $meta_type );
 			add_filter( "jetpack_sync_before_enqueue_added_{$meta_type}_meta", $whitelist_handler );
 			add_filter( "jetpack_sync_before_enqueue_updated_{$meta_type}_meta", $whitelist_handler );
 			add_filter( "jetpack_sync_before_enqueue_deleted_{$meta_type}_meta", $whitelist_handler );
@@ -106,7 +104,7 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 		return true;
 	}
 
-	function is_object_allowed( $object_id ) {
+	function is_post_type_allowed( $object_id ) {
 		$post = get_post( $object_id );
 		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
@@ -115,7 +113,7 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 	}
 
 	function filter_meta_post( $args ) {
-		if ( ! $this->is_object_allowed( $args[1] ) ) {
+		if ( ! $this->is_post_type_allowed( $args[1] ) ) {
 			return false;
 		}
 		return $this->filter_meta( $args );
@@ -129,7 +127,6 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 		if ( ! $this->is_meta_key_allowed( $args[2] ) ) {
 			return false;
 		}
-
 		return $args;
 	}
 }

--- a/sync/class.jetpack-sync-module-meta.php
+++ b/sync/class.jetpack-sync-module-meta.php
@@ -70,9 +70,10 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 	}
 
 	public function init_listeners( $callable ) {
-		$whitelist_handler = array( $this, 'filter_meta' );
+
 
 		foreach ( $this->meta_types as $meta_type ) {
+			$whitelist_handler = array( $this, 'filter_meta_' . $meta_type );
 			add_action( "added_{$meta_type}_meta", $callable, 10, 4 );
 			add_action( "updated_{$meta_type}_meta", $callable, 10, 4 );
 			add_action( "deleted_{$meta_type}_meta", $callable, 10, 4 );
@@ -103,6 +104,25 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 		}
 
 		return true;
+	}
+
+	function is_object_allowed( $object_id ) {
+		$post = get_post( $object_id );
+		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	function filter_meta_post( $args ) {
+		if ( ! $this->is_object_allowed( $args[1] ) ) {
+			return false;
+		}
+		return $this->filter_meta( $args );
+	}
+
+	function filter_meta_comment( $args ) {
+		return $this->filter_meta( $args );
 	}
 
 	function filter_meta( $args ) {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -453,6 +453,24 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
 	}
 
+	function test_filters_out_blacklisted_post_types_and_their_post_meta() {
+		$args = array(
+			'public' => true,
+			'label'  => 'Snitch'
+		);
+		register_post_type( 'snitch', $args );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'snitch' ) );
+		add_post_meta( $post_id, 'hello', 123 );
+
+		$this->sender->do_sync();
+
+		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
+
+		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'hello', true ) );
+
+	}
+
 	function test_post_types_blacklist_can_be_appended_in_settings() {
 		register_post_type( 'filter_me', array( 'public' => true, 'label' => 'Filter Me' ) );
 


### PR DESCRIPTION
We shouldn't be syncing post meta of post types that are black listed
since they just add to the meta data but we would never use it.

This adds a condition that checks if the post is also suppose to be synced. before symcing the post meta.

