### PR TITLE
SSO: Extend auth cookie to expiration to 1 year for SSO

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -467,12 +467,6 @@ class Jetpack_SSO {
 			// Otherwise, if it's already set, purge it.
 			setcookie( 'jetpack_sso_redirect_to', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
 		}
-
-		if ( ! empty( $_GET['rememberme'] ) ) {
-			setcookie( 'jetpack_sso_remember_me', '1', time() + HOUR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false, true );
-		} elseif ( ! empty( $_COOKIE['jetpack_sso_remember_me'] ) ) {
-			setcookie( 'jetpack_sso_remember_me', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
-		}
 	}
 
 	/**
@@ -730,23 +724,9 @@ class Jetpack_SSO {
 			// Cache the user's details, so we can present it back to them on their user screen
 			update_user_meta( $user->ID, 'wpcom_user_data', $user_data );
 
-			$remember = false;
-			if ( ! empty( $_COOKIE['jetpack_sso_remember_me'] ) ) {
-				$remember = true;
-				// And then purge it
-				setcookie( 'jetpack_sso_remember_me', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
-			}
-			/**
-			 * Filter the remember me value.
-			 *
-			 * @module sso
-			 *
-			 * @since 2.8.0
-			 *
-			 * @param bool $remember Is the remember me option checked?
-			 */
-			$remember = apply_filters( 'jetpack_remember_login', $remember );
-			wp_set_auth_cookie( $user->ID, $remember );
+			add_filter( 'auth_cookie_expiration',    array( 'Jetpack_SSO_Helpers', 'extend_auth_cookie_expiration_for_sso' ) );
+			wp_set_auth_cookie( $user->ID, true );
+			remove_filter( 'auth_cookie_expiration', array( 'Jetpack_SSO_Helpers', 'extend_auth_cookie_expiration_for_sso' ) );
 
 			/** This filter is documented in core/src/wp-includes/user.php */
 			do_action( 'wp_login', $user->user_login, $user );

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -227,6 +227,19 @@ class Jetpack_SSO_Helpers {
 		
 		return $user;
 	}
+
+	static function extend_auth_cookie_expiration_for_sso() {
+		/**
+		 * Determines how long the auth cookie is valid for when a user logs in with SSO.
+		 *
+		 * @module sso
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param int YEAR_IN_SECONDS
+		 */
+		return intval( apply_filters( 'jetpack_sso_auth_cookie_expirtation', YEAR_IN_SECONDS ) );
+	}
 }
 
 endif;

--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -1,7 +1,5 @@
 jQuery( document ).ready( function( $ ) {
 	var body = $( 'body' ),
-		rememberMe = $( '#rememberme' ),
-		ssoButton = $( 'a.jetpack-sso.button' ),
 		toggleSSO = $( '.jetpack-sso-toggle' ),
 		userLogin = $( '#user_login' ),
 		ssoWrap   = $( '#jetpack-sso-wrap' ),
@@ -23,19 +21,6 @@ jQuery( document ).ready( function( $ ) {
 	// positioning of the SSO UI.
 	loginForm.append( ssoWrap );
 	body.addClass( 'jetpack-sso-repositioned' );
-
-	rememberMe.on( 'change', function() {
-		var url       = ssoButton.prop( 'href' ),
-			isChecked = rememberMe.prop( 'checked' ) ? 1 : 0;
-
-		if ( url.match( /&rememberme=\d/ ) ) {
-			url = url.replace( /&rememberme=\d/, '&rememberme=' + isChecked );
-		} else {
-			url += '&rememberme=' + isChecked;
-		}
-
-		ssoButton.prop( 'href', url );
-	} ).change();
 
 	toggleSSO.on( 'click', function( e ) {
 		e.preventDefault();

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -193,4 +193,18 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->factory->user->create( array( 'user_login' => $this->user_data->login ) );
 		$this->assertFalse( Jetpack_SSO_Helpers::generate_user( $this->user_data ) );
 	}
+
+	function test_extend_auth_cookie_casts_to_int() {
+		add_filter( 'jetpack_sso_auth_cookie_expirtation', array( $this, '__return_string_value' ) );
+		$this->assertSame( intval( $this->__return_string_value() ), Jetpack_SSO_Helpers::extend_auth_cookie_expiration_for_sso() );
+		remove_filter( 'jetpack_sso_auth_cookie_expirtation', array( $this, '__return_string_value' ) );
+	}
+
+	function test_extend_auth_cookie_default_value_greater_than_default() {
+		$this->assertGreaterThan( 2 * DAY_IN_SECONDS, Jetpack_SSO_Helpers::extend_auth_cookie_expiration_for_sso() );
+	}
+
+	function __return_string_value() {
+		return '1';
+	}
 }


### PR DESCRIPTION
Closes #5252.

@beaulebens recently suggested that it would be much more user friendly to have long lived auth cookies when a user logs in via SSO. This PR makes that happen.

First, this PR cleans up some old logic that was used pre 4.1 to handle the remember me. This logic no longer makes sense since the user needs to switch to logging with username and password and then switch back to SSO. My bad 😄 

Seconds, this PR sets the default expiration to 1 year and adds a filter around that so that sites can control that value themselves.

To test

- Checkout `update/sso-defaut-cookie-length` branch
- Go to `$site/wp-admin`
- Click "Login with WordPress.com" button and login
- Check that cookie is set for 1 year from now
- Optionally, use filter to set for a different time period

