### PR TITLE
Jetpack Sync: send home, siteurl with each sync if user opts in

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5310,6 +5310,27 @@ p {
 	}
 
 	/**
+	 * Returns the value of the jetpack_sync_idc_optin filter, or constant.
+	 * If set to true, the site will be put into staging mode.
+	 *
+	 * @since 4.4.0
+	 * @return bool
+	 */
+	public static function sync_idc_optin() {
+		/**
+		 * Allows sites to optin to IDC mitigation which blocks the site from syncing to WordPress.com when the home
+		 * URL or site URL do not match what WordPress.com expects.
+		 * The default value is either false, or the value of JETPACK_SYNC_IDC_OPTIN constant if set
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param bool
+		 */
+		$default = ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) ? JETPACK_SYNC_IDC_OPTIN : false;
+		return apply_filters( 'jetpack_sync_idc_optin', $default );
+	}
+
+	/**
 	 * Maybe Use a .min.css stylesheet, maybe not.
 	 *
 	 * Hooks onto `plugins_url` filter at priority 1, and accepts all 3 args.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5326,7 +5326,7 @@ p {
 		 *
 		 * @param bool
 		 */
-		$default = ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) ? JETPACK_SYNC_IDC_OPTIN : false;
+		$default = ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) ? JETPACK_SYNC_IDC_OPTIN : self::is_development_version();
 		return (bool) apply_filters( 'jetpack_sync_idc_optin', $default );
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5319,15 +5319,15 @@ p {
 	public static function sync_idc_optin() {
 		/**
 		 * Allows sites to optin to IDC mitigation which blocks the site from syncing to WordPress.com when the home
-		 * URL or site URL do not match what WordPress.com expects.
-		 * The default value is either false, or the value of JETPACK_SYNC_IDC_OPTIN constant if set
+		 * URL or site URL do not match what WordPress.com expects. The default value is either false, or the value of
+		 * JETPACK_SYNC_IDC_OPTIN constant if set.
 		 *
 		 * @since 4.4.0
 		 *
 		 * @param bool
 		 */
 		$default = ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) ? JETPACK_SYNC_IDC_OPTIN : false;
-		return apply_filters( 'jetpack_sync_idc_optin', $default );
+		return (bool) apply_filters( 'jetpack_sync_idc_optin', $default );
 	}
 
 	/**

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -120,14 +120,14 @@ class Jetpack_Sync_Actions {
 		Jetpack::load_xml_rpc_client();
 
 		$query_args = array(
-			'sync'      => '1', // add an extra parameter to the URL so we can tell it's a sync action
-			'codec'     => $codec_name, // send the name of the codec used to encode the data
+			'sync'      => '1',             // add an extra parameter to the URL so we can tell it's a sync action
+			'codec'     => $codec_name,     // send the name of the codec used to encode the data
 			'timestamp' => $sent_timestamp, // send current server time so we can compensate for clock differences
-			'queue'     => $queue_id, // sync or full_sync
+			'queue'     => $queue_id,       // sync or full_sync
 		);
 
 		if ( Jetpack::sync_idc_optin() || Jetpack::is_development_version() ) {
-			$query_args['home']    = get_home_url();    // Send home url option to check for Identity Crisis server-side
+			$query_args['home']    = get_home_url(); // Send home url option to check for Identity Crisis server-side
 			$query_args['siteurl'] = get_site_url(); // Send home url option to check for Identity Crisis server-side
 		}
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -119,12 +119,19 @@ class Jetpack_Sync_Actions {
 	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id ) {
 		Jetpack::load_xml_rpc_client();
 
-		$url = add_query_arg( array(
+		$query_args = array(
 			'sync'      => '1', // add an extra parameter to the URL so we can tell it's a sync action
 			'codec'     => $codec_name, // send the name of the codec used to encode the data
 			'timestamp' => $sent_timestamp, // send current server time so we can compensate for clock differences
 			'queue'     => $queue_id, // sync or full_sync
-		), Jetpack::xmlrpc_api_url() );
+		);
+
+		if ( Jetpack::sync_idc_optin() || Jetpack::is_development_version() ) {
+			$query_args['home']    = get_home_url();    // Send home url option to check for Identity Crisis server-side
+			$query_args['siteurl'] = get_site_url(); // Send home url option to check for Identity Crisis server-side
+		}
+
+		$url = add_query_arg( $query_args, Jetpack::xmlrpc_api_url() );
 
 		$rpc = new Jetpack_IXR_Client( array(
 			'url'     => $url,

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -126,7 +126,7 @@ class Jetpack_Sync_Actions {
 			'queue'     => $queue_id,       // sync or full_sync
 		);
 
-		if ( Jetpack::sync_idc_optin() || Jetpack::is_development_version() ) {
+		if ( Jetpack::sync_idc_optin() ) {
 			$query_args['home']    = get_home_url(); // Send home url option to check for Identity Crisis server-side
 			$query_args['siteurl'] = get_site_url(); // Send home url option to check for Identity Crisis server-side
 		}

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -8,8 +8,6 @@ class Jetpack_Sync_Defaults {
 	static $default_options_whitelist = array(
 		'stylesheet',
 		'blogname',
-		'home',
-		'siteurl',
 		'blogdescription',
 		'blog_charset',
 		'permalink_structure',

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -65,8 +65,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 		$options = array(
 			'stylesheet'                           => 'test',
 			'blogname'                             => 'test',
-			'home'                                 => 'http://test.com',
-			'siteurl'                              => 'http://test.com',
 			'blogdescription'                      => 'banana',
 			'blog_charset'                         => 'stuffs',
 			'permalink_structure'                  => '%postname%',

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -10,7 +10,7 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	static $activated_modules = array();
 	static $deactivated_modules = array();
-
+	
 	/**
 	 * @author blobaugh
 	 * @covers Jetpack::init
@@ -271,7 +271,15 @@ EXPECTED;
 		$this->assertCount( 0, $errors );
 	}
 
-
+	/**
+	 * @author roccotrip
+	 * @covers Jetpack::sync_idc_optin
+	 * @since 4.4.0
+	 */
+	public function test_sync_idc_optin_will_not_sync_unless_filter_is_set() {
+		
+	}
+	
 	/**
 	 * @author tonykova
 	 * @covers Jetpack::implode_frontend_css

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -270,15 +270,6 @@ EXPECTED;
 	public function pre_test_check_identity_crisis_will_not_report_crisis_if_a_siteurl_mismatch_when_forcing_ssl( $errors ){
 		$this->assertCount( 0, $errors );
 	}
-
-	/**
-	 * @author roccotrip
-	 * @covers Jetpack::sync_idc_optin
-	 * @since 4.4.0
-	 */
-	public function test_sync_idc_optin_will_not_sync_unless_filter_is_set() {
-		
-	}
 	
 	/**
 	 * @author tonykova

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -10,7 +10,7 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 
 	static $activated_modules = array();
 	static $deactivated_modules = array();
-	
+
 	/**
 	 * @author blobaugh
 	 * @covers Jetpack::init
@@ -413,6 +413,30 @@ EXPECTED;
 	function test_other_linked_admins_transient_set_to_zero_returns_false() {
 		set_transient( 'jetpack_other_linked_admins', 0, HOUR_IN_SECONDS );
 		$this->assertFalse( Jetpack::get_other_linked_admins() );
+	}
+
+	function test_idc_optin_defaults_to_development_version() {
+		add_filter( 'jetpack_development_version', '__return_true' );
+		$this->assertTrue( Jetpack::sync_idc_optin() );
+		remove_filter( 'jetpack_development_version', '__return_true' );
+	}
+
+	function test_idc_optin_filter_overrides_development_version() {
+		add_filter( 'jetpack_development_version', '__return_true' );
+		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
+		$this->assertFalse( Jetpack::sync_idc_optin() );
+		remove_filter( 'jetpack_development_version', '__return_true' );
+		remove_filter( 'jetpack_sync_idc_optin', '__return_false' );
+	}
+
+	function test_idc_optin_casts_to_bool() {
+		add_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
+		$this->assertTrue( Jetpack::sync_idc_optin() );
+		add_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
+	}
+
+	function __return_string_1() {
+		return '1';
 	}
 
 	static function reset_tracking_of_module_activation() {


### PR DESCRIPTION
A truncated version of #5251 
We wanted to keep the syncing logic separate from UI changes.

To test:
- Check out this branch
- Ensure there are no regressions with sync

cc: @ebinnion 