### PR TITLE
Don’t log hooked actions during send phase of sync

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -166,6 +166,11 @@ class Jetpack_Sync_Listener {
 	}
 
 	function enqueue_action( $current_filter, $args, $queue ) {
+		// don't enqueue an action during the outbound http request - this prevents recursion
+		if ( Jetpack_Sync_Settings::is_sending() ) {
+			return;
+		}
+
 		/**
 		 * Modify or reject the data within an action before it is enqueued locally.
 		 *

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -181,7 +181,10 @@ class Jetpack_Sync_Sender {
 		 * @param double $time The current time
 		 * @param string $queue The queue used to send ('sync' or 'full_sync')
 		 */
+		Jetpack_Sync_Settings::set_is_sending( true );
 		$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id );
+		Jetpack_Sync_Settings::set_is_sending( false );
+		
 		if ( ! $processed_item_ids || is_wp_error( $processed_item_ids ) ) {
 			$checked_in_item_ids = $queue->checkin( $buffer );
 			if ( is_wp_error( $checked_in_item_ids ) ) {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -23,6 +23,7 @@ class Jetpack_Sync_Settings {
 	static $is_importing;
 	static $is_doing_cron;
 	static $is_syncing;
+	static $is_sending;
 
 	static $settings_cache = array(); // some settings can be expensive to compute - let's cache them
 
@@ -102,6 +103,8 @@ class Jetpack_Sync_Settings {
 		}
 		self::set_importing( null );
 		self::set_doing_cron( null );
+		self::set_is_syncing( null );
+		self::set_is_sending( null );
 	}
 
 	static function set_importing( $is_importing ) {
@@ -136,5 +139,13 @@ class Jetpack_Sync_Settings {
 
 	static function set_is_syncing( $is_syncing ) {
 		self::$is_syncing = $is_syncing;
+	}
+
+	static function is_sending() {
+		return (bool) self::$is_sending;
+	}
+
+	static function set_is_sending( $is_sending ) {
+		self::$is_sending = $is_sending;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -368,6 +368,43 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		remove_filter( 'jetpack_sync_before_send_super_slow_action', array( $this, 'before_send_super_slow_action' ) );
 	}
 
+	function test_doesnt_log_actions_during_sync_send() {
+		// plugins like snitch and secupress create posts during http requests,
+		// which can result in recursive sync, or at least syncing a TON of data
+		// so we try to unhook right before send, and rehook right after
+
+		$args = array(
+			'public' => true,
+			'label'  => 'HttpListener'
+		);
+		register_post_type( 'http_listener', $args );
+
+		// register a trivial action we use to force sync
+		add_action( 'my_action', array( $this->listener, 'action_handler' ) ); 
+
+		// log http_listener during send data, since in test we're not sending real HTTP requests
+		add_filter( 'jetpack_sync_send_data', array( $this, 'create_http_listener_post_and_return_processed_ids' ), 10, 1 );
+
+		// hopefully no http_listener events created here
+		do_action( 'my_action' );
+		$this->sender->do_sync();
+
+		$this->server_event_storage->reset();
+
+		// do a trivial data change, then check we didn't enqueue a http_listener post
+		do_action( 'my_action' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+
+		$this->assertFalse( $event );
+	}
+
+	function create_http_listener_post_and_return_processed_ids( $data ) {
+		$post_id = $this->factory->post->create( array( 'post_type' => 'http_listener' ) );
+		return array_keys( $data );
+	}
+
 	function before_send_super_slow_action( $args, $user_id ) {
 		sleep( 3 );
 		return $args;


### PR DESCRIPTION
Fixes an issue where some plugins that hooked the `pre_http_request` filter or `http_api_debug` action as posts would end up in an infinite loop, generating more posts which generate more syncs which generate more posts...

cc @lezama @samhotchkiss