### PR TITLE
Ban “data” meta and "http" post type

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -155,6 +155,7 @@ class Jetpack_Sync_Defaults {
 		'ai1ec_event',
 		'snitch',
 		'secupress_log_action',
+		'http',
 	);
 
 	static $default_post_checksum_columns = array(

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -222,6 +222,7 @@ class Jetpack_Sync_Defaults {
 		'wprss_last_update_items',
 		'wp_automatic_cache',
 		'snapTW',
+		'data', // securpress - bummer to blacklist something so general, but necessary
 	);
 
 	// TODO: move this to server? - these are theme support values


### PR DESCRIPTION
Fixes an issue where securpress was logging enormous metas. 

This is a pretty general meta_key to ban, and I'm open to finding another way, but for now this was the simplest.