### PR TITLE
Contact Form: add horizontal line between message content and meta

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2033,6 +2033,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		array_push(
 			$message,
 			"", // Empty line left intentionally
+			'<hr />',
 			__( 'Time:', 'jetpack' ) . ' ' . $time . '<br />',
 			__( 'IP Address:', 'jetpack' ) . ' ' . $comment_author_IP . '<br />',
 			__( 'Contact Form URL:', 'jetpack' ) . " " . $url . '<br />'


### PR DESCRIPTION
@see https://wordpress.org/support/topic/need-to-modify-jetpack-contact-form-add-horizontal-line-after-comment/
#### Proposed changelog entry for your changes:

Contact Form: add horizontal line between message content and meta data
