### PR TITLE
Endpoints: remove unused permission callback.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -88,12 +88,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::unlink_user',
 			'permission_callback' => __CLASS__ . '::unlink_user_permission_callback',
-			'args' => array(
-				'id' => array(
-					'default' => get_current_user_id(),
-					'validate_callback' => __CLASS__  . '::validate_posint',
-				),
-			),
 		) );
 
 		// Get current site data
@@ -362,7 +356,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error True if user is able to unlink.
 	 */
 	public static function unlink_user_permission_callback() {
-		if ( current_user_can( 'jetpack_connect' ) && Jetpack::is_user_connected( get_current_user_id() ) ) {
+		if ( current_user_can( 'jetpack_connect_user' ) && Jetpack::is_user_connected( get_current_user_id() ) ) {
 			return true;
 		}
 
@@ -622,7 +616,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
 		}
 
-		if ( isset( $data['id'] ) && Jetpack::unlink_user( $data['id'] ) ) {
+		if ( Jetpack::unlink_user() ) {
 			return rest_ensure_response(
 				array(
 					'code' => 'success'

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -593,19 +593,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * Unlinks a user from the WordPress.com Servers.
-	 * Default $data['id'] will default to current_user_id if no value is given.
-	 *
-	 * Example: '/unlink?id=1234'
+	 * Unlinks current user from the WordPress.com Servers.
 	 *
 	 * @since 4.3.0
 	 * @uses  Jetpack::unlink_user
-	 *
-	 * @param WP_REST_Request $data {
-	 *     Array of parameters received by request.
-	 *
-	 *     @type int $id ID of user to unlink.
-	 * }
 	 *
 	 * @return bool|WP_Error True if user successfully unlinked.
 	 */

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -87,7 +87,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		register_rest_route( 'jetpack/v4', '/connection/user', array(
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::unlink_user',
-			'permission_callback' => __CLASS__ . '::link_user_permission_callback',
+			'permission_callback' => __CLASS__ . '::unlink_user_permission_callback',
 			'args' => array(
 				'id' => array(
 					'default' => get_current_user_id(),
@@ -335,21 +335,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * Verify that a user can use the link endpoint.
-	 *
-	 * @since 4.3.0
-	 *
-	 * @return bool|WP_Error True if user is able to link to WordPress.com
-	 */
-	public static function link_user_permission_callback() {
-		if ( current_user_can( 'jetpack_connect_user' ) ) {
-			return true;
-		}
-
-		return new WP_Error( 'invalid_user_permission_link_user', self::$user_permissions_error_msg, array( 'status' => self::rest_authorization_required_code() ) );
-	}
-
-	/**
 	 * Verify that a user can get the data about the current user.
 	 * Only those who can connect.
 	 *
@@ -364,12 +349,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return true;
 		}
 
-		return new WP_Error( 'invalid_user_permission_unlink_user', self::$user_permissions_error_msg, array( 'status' => self::rest_authorization_required_code() ) );
+		return new WP_Error( 'invalid_user_permission_user_connection_data', self::$user_permissions_error_msg, array( 'status' => self::rest_authorization_required_code() ) );
 	}
 
 	/**
-	 * Verify that a user can use the unlink endpoint.
-	 * Either needs to be an admin of the site, or for them to be currently linked.
+	 * Verify that a user can use the /connection/user endpoint. Has to be a registered user and be currently linked.
 	 *
 	 * @since 4.3.0
 	 *
@@ -378,7 +362,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error True if user is able to unlink.
 	 */
 	public static function unlink_user_permission_callback() {
-		if ( current_user_can( 'jetpack_connect' ) || Jetpack::is_user_connected( get_current_user_id() ) ) {
+		if ( current_user_can( 'jetpack_connect' ) && Jetpack::is_user_connected( get_current_user_id() ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Removes `Jetpack_Core_Json_Api_Endpoints::link_user_permission_callback` which is never 
used.
- If users are going to unlink, make sure they're currently connected.
- Amend error code for user connection data retrieval.

#### Testing instructions:
* verify that connections and disconnections for site and users continue to work
