### PR TITLE
General: don't check if esc_like exists

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4709,11 +4709,7 @@ p {
 		global $wpdb;
 
 		$sql = "DELETE FROM `$wpdb->options` WHERE `option_name` LIKE %s";
-		if ( method_exists ( $wpdb , 'esc_like' ) ) {
-			$sql_args = array( $wpdb->esc_like( 'jetpack_nonce_' ) . '%' );
-		} else {
-			$sql_args = array( like_escape( 'jetpack_nonce_' ) . '%' );
-		}
+		$sql_args = array( $wpdb->esc_like( 'jetpack_nonce_' ) . '%' );
 
 		if ( true !== $all ) {
 			$sql .= ' AND CAST( `option_value` AS UNSIGNED ) < %d';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
General: don't check if esc_like exists anymore since it was introduced in WP 4.0

#### Testing instructions:
* Connect Jetpack, disconnect it, and make sure that all `jetpack_nonce_*` nonces are deleted from WP options table.