### PR TITLE
Sync: Disable oembed when syncing 

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -85,6 +85,25 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		return $args;
 	}
 
+	function remove_embed() {
+		global $wp_embed;
+		remove_filter( 'the_content', array( $wp_embed, 'run_shortcode' ), 8 );
+		// Shortcode placeholder for strip_shortcodes()
+		remove_shortcode( 'embed', array( $wp_embed, 'shortcode' ) );
+		remove_shortcode( 'embed', '__return_false' );
+		// Attempts to embed all URLs in a post
+		remove_filter( 'the_content', array( $wp_embed, 'autoembed' ), 8 );
+	}
+
+	function add_embed() {
+		global $wp_embed;
+		add_filter( 'the_content', array( $wp_embed, 'run_shortcode' ), 8 );
+		// Shortcode placeholder for strip_shortcodes()
+		add_shortcode( 'embed', '__return_false' );
+		// Attempts to embed all URLs in a post
+		add_filter( 'the_content', array( $wp_embed, 'autoembed' ), 8 );
+	}
+
 	// Expands wp_insert_post to include filtered content
 	function filter_post_content_and_add_links( $post_object ) {
 		global $post;
@@ -113,6 +132,9 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			return $blocked_post;
 		}
 
+		// lets not do oembed just yet.
+		$this->remove_embed();
+
 		if ( 0 < strlen( $post->post_password ) ) {
 			$post->post_password = 'auto-' . wp_generate_password( 10, false );
 		}
@@ -121,6 +143,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
 			$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
 		}
+
+		$this->add_embed();
 
 		if ( has_post_thumbnail( $post->ID ) ) {
 			$image_attributes = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -88,9 +88,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	function remove_embed() {
 		global $wp_embed;
 		remove_filter( 'the_content', array( $wp_embed, 'run_shortcode' ), 8 );
-		// Shortcode placeholder for strip_shortcodes()
-		remove_shortcode( 'embed', array( $wp_embed, 'shortcode' ) );
-		remove_shortcode( 'embed', '__return_false' );
+		// remove the embed shortcode since we would do the part later.
+		remove_shortcode( 'embed' );
 		// Attempts to embed all URLs in a post
 		remove_filter( 'the_content', array( $wp_embed, 'autoembed' ), 8 );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -632,6 +632,68 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( "\n", $synced_post->post_content_filtered );
 	}
 
+	function test_embed_is_disabled_on_the_content_filter_during_sync() {
+		$content =
+'Check out this cool video:
+
+http://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+That was a cool video.';
+
+		$oembeded =
+'<p>Check out this cool video:</p>
+<p><iframe width="660" height="371" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+<p>That was a cool video.</p>'. "\n";
+
+		$filtered = '<p>Check out this cool video:</p>
+<p>http://www.youtube.com/watch?v=dQw4w9WgXcQ</p>
+<p>That was a cool video.</p>'. "\n";
+
+		$this->post->post_content = $content;
+
+		wp_update_post( $this->post );
+
+		$this->assertContains( $oembeded, apply_filters( 'the_content', $this->post->post_content ) );
+		$this->sender->do_sync();
+		$synced_post = $this->server_replica_storage->get_post( $this->post->ID );
+
+		$this->assertEquals( $filtered, $synced_post->post_content_filtered );
+
+		// do we get the same result after the sync?
+		$this->assertContains( $oembeded, apply_filters( 'the_content', $filtered ) );
+	}
+
+	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {
+		$content =
+			'Check out this cool video:
+
+[embed width="123" height="456"]http://www.youtube.com/watch?v=dQw4w9WgXcQ[/embed]
+
+That was a cool video.';
+
+		$oembeded =
+			'<p>Check out this cool video:</p>
+<p><iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
+<p>That was a cool video.</p>'. "\n";
+
+		$filtered = '<p>Check out this cool video:</p>
+<p>[embed width=&#8221;123&#8243; height=&#8221;456&#8243;]http://www.youtube.com/watch?v=dQw4w9WgXcQ[/embed]</p>
+<p>That was a cool video.</p>'. "\n";
+
+		$this->post->post_content = $content;
+
+		wp_update_post( $this->post );
+
+		$this->assertContains( $oembeded, apply_filters( 'the_content', $this->post->post_content ) );
+		$this->sender->do_sync();
+
+		$synced_post = $this->server_replica_storage->get_post( $this->post->ID );
+		$this->assertEquals( $filtered, $synced_post->post_content_filtered );
+
+		// do we get the same result after the sync?
+		$this->assertContains( $oembeded, apply_filters( 'the_content', $filtered ) );
+	}
+
 	function assertAttachmentSynced( $attachment_id ) {
 		$remote_attachment = $this->server_replica_storage->get_post( $attachment_id );
 		$attachment        = get_post( $attachment_id );

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -666,9 +666,10 @@ That was a cool video.';
 		$synced_post = $this->server_replica_storage->get_post( $this->post->ID );
 
 		$this->assertEquals( $filtered, $synced_post->post_content_filtered, '$filtered is NOT the same as $synced_post->post_content_filtered' );
-
-		// do we get the same result after the sync?
-		$this->assertContains( $oembeded, apply_filters( 'the_content', $filtered ), '$oembeded is NOT the same as filtered $filtered' );
+		if ( version_compare( $wp_version, '4.6', '>=' ) ) {
+			// do we get the same result after the sync?
+			$this->assertContains( $oembeded, apply_filters( 'the_content', $filtered ), '$oembeded is NOT the same as filtered $filtered' );
+		}
 	}
 
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -661,14 +661,14 @@ That was a cool video.';
 
 		wp_update_post( $this->post );
 
-		$this->assertContains( $oembeded, apply_filters( 'the_content', $this->post->post_content ) );
+		$this->assertContains( $oembeded, apply_filters( 'the_content', $this->post->post_content ), '$oembeded is NOT the same as filtered $this->post->post_content' );
 		$this->sender->do_sync();
 		$synced_post = $this->server_replica_storage->get_post( $this->post->ID );
 
-		$this->assertEquals( $filtered, $synced_post->post_content_filtered );
+		$this->assertEquals( $filtered, $synced_post->post_content_filtered, '$filtered is NOT the same as $synced_post->post_content_filtered' );
 
 		// do we get the same result after the sync?
-		$this->assertContains( $oembeded, apply_filters( 'the_content', $filtered ) );
+		$this->assertContains( $oembeded, apply_filters( 'the_content', $filtered ), '$oembeded is NOT the same as filtered $filtered' );
 	}
 
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {
@@ -681,7 +681,7 @@ That was a cool video.';
 [embed width="123" height="456"]http://www.youtube.com/watch?v=dQw4w9WgXcQ[/embed]
 
 That was a cool video.';
-		
+
 		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {
 			$oembeded =
 				'<p>Check out this cool video:</p>
@@ -702,14 +702,14 @@ That was a cool video.';
 
 		wp_update_post( $this->post );
 
-		$this->assertContains( $oembeded, apply_filters( 'the_content', $this->post->post_content ) );
+		$this->assertContains( $oembeded, apply_filters( 'the_content', $this->post->post_content ), '$oembeded is NOT the same as filtered $this->post->post_content' );
 		$this->sender->do_sync();
 
 		$synced_post = $this->server_replica_storage->get_post( $this->post->ID );
-		$this->assertEquals( $filtered, $synced_post->post_content_filtered );
+		$this->assertEquals( $filtered, $synced_post->post_content_filtered, '$filtered is NOT the same as $synced_post->post_content_filtered' );
 
 		// do we get the same result after the sync?
-		$this->assertContains( $oembeded, apply_filters( 'the_content', $filtered ) );
+		$this->assertContains( $oembeded, apply_filters( 'the_content', $filtered ), '$oembeded is NOT the same as filtered $filtered' );
 	}
 
 	function assertAttachmentSynced( $attachment_id ) {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -633,6 +633,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_embed_is_disabled_on_the_content_filter_during_sync() {
+		global $wp_version;
 		$content =
 'Check out this cool video:
 
@@ -640,11 +641,18 @@ http://www.youtube.com/watch?v=dQw4w9WgXcQ
 
 That was a cool video.';
 
-		$oembeded =
-'<p>Check out this cool video:</p>
+		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {
+			$oembeded =
+			'<p>Check out this cool video:</p>
+<p><span class="embed-youtube" style="text-align:center; display: block;"><iframe class=\'youtube-player\' type=\'text/html\' width=\'660\' height=\'402\' src=\'http://www.youtube.com/embed/dQw4w9WgXcQ?version=3&#038;rel=1&#038;fs=1&#038;autohide=2&#038;showsearch=0&#038;showinfo=1&#038;iv_load_policy=1&#038;wmode=transparent\' allowfullscreen=\'true\' style=\'border:0;\'></iframe></span></p>
+<p>That was a cool video.</p>'. "\n";
+		} else {
+			$oembeded =
+			'<p>Check out this cool video:</p>
 <p><iframe width="660" height="371" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
 <p>That was a cool video.</p>'. "\n";
-
+		}
+		
 		$filtered = '<p>Check out this cool video:</p>
 <p>http://www.youtube.com/watch?v=dQw4w9WgXcQ</p>
 <p>That was a cool video.</p>'. "\n";
@@ -664,17 +672,27 @@ That was a cool video.';
 	}
 
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {
+
+		global $wp_version;
+		
 		$content =
 			'Check out this cool video:
 
 [embed width="123" height="456"]http://www.youtube.com/watch?v=dQw4w9WgXcQ[/embed]
 
 That was a cool video.';
-
-		$oembeded =
-			'<p>Check out this cool video:</p>
+		
+		if ( version_compare( $wp_version, '4.7-alpha', '<' ) ) {
+			$oembeded =
+				'<p>Check out this cool video:</p>
+<p><span class="embed-youtube" style="text-align:center; display: block;"><iframe class=\'youtube-player\' type=\'text/html\' width=\'660\' height=\'402\' src=\'http://www.youtube.com/embed/dQw4w9WgXcQ?version=3&#038;rel=1&#038;fs=1&#038;autohide=2&#038;showsearch=0&#038;showinfo=1&#038;iv_load_policy=1&#038;wmode=transparent\' allowfullscreen=\'true\' style=\'border:0;\'></iframe></span></p>
+<p>That was a cool video.</p>'. "\n";
+		} else {
+			$oembeded =
+				'<p>Check out this cool video:</p>
 <p><iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allowfullscreen></iframe></p>
 <p>That was a cool video.</p>'. "\n";
+		}
 
 		$filtered = '<p>Check out this cool video:</p>
 <p>[embed width=&#8221;123&#8243; height=&#8221;456&#8243;]http://www.youtube.com/watch?v=dQw4w9WgXcQ[/embed]</p>


### PR DESCRIPTION
Calculating the oembed can be expensive since we often have to talk to outside services. The data is often already stored on the in the site already but if it is not or is out of data then calculating it can be pretty expensive. 

We should do the oembed part of the sync on our end when needed.

cc @lezama and @gravityrail