### PR TITLE
IDC: First pass at automatically putting a site in staging mode

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -17,7 +17,7 @@ import {
 } from 'state/initial-state';
 import { resetOptions } from 'state/dev-version';
 import { disconnectSite } from 'state/connection';
-import { getSiteConnectionStatus } from 'state/connection';
+import { getSiteConnectionStatus, isInIdentityCrisis } from 'state/connection';
 import { isDevMode as _isDevMode } from 'state/connection';
 import { getSiteAdminUrl } from 'state/initial-state';
 
@@ -25,7 +25,10 @@ export const Footer = React.createClass( {
 	displayName: 'Footer',
 
 	disconnectSite() {
-		if ( window.confirm( __( 'Do you really want to disconnect your site from WordPress.com?' ) ) ) {
+		if (
+			this.props.isInIdentityCrisis ||
+			window.confirm( __( 'Do you really want to disconnect your site from WordPress.com?' ) )
+		) {
 			this.props.disconnectSite();
 		}
 	},
@@ -141,7 +144,8 @@ export default connect(
 			isDevVersion: _isDevVersion( state ),
 			isDevMode: _isDevMode( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
-			siteAdminUrl: getSiteAdminUrl( state )
+			siteAdminUrl: getSiteAdminUrl( state ),
+			isInIdentityCrisis: isInIdentityCrisis( state )
 		}
 	},
 	( dispatch ) => {

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -12,7 +12,7 @@ import NoticesList from 'components/global-notices';
  * Internal dependencies
  */
 import JetpackStateNotices from './state-notices';
-import { getSiteConnectionStatus, getSiteDevMode, isStaging } from 'state/connection';
+import { getSiteConnectionStatus, getSiteDevMode, isStaging, isInIdentityCrisis } from 'state/connection';
 import { isDevVersion } from 'state/initial-state';
 import DismissableNotices from './dismissable';
 import { getConnectUrl as _getConnectUrl } from 'state/connection';
@@ -183,6 +183,32 @@ UserUnlinked.propTypes = {
 	siteConnected: React.PropTypes.bool.isRequired
 };
 
+export const IdentityCrisis = React.createClass( {
+	displayName: 'IdentityCrisis',
+
+	render() {
+		if ( this.props.isInIdentityCrisis ) {
+			const text = __( 'Are you feeling like yourself? Seems like you are having a crisis' );
+
+			return (
+				<SimpleNotice
+					showDismiss={ false }
+					status="is-error"
+				>
+					{ text }
+				</SimpleNotice>
+			);
+		}
+
+		return false;
+	}
+
+} );
+
+IdentityCrisis.propTypes = {
+	isInIdentityCrisis: React.PropTypes.bool.isRequired
+};
+
 const JetpackNotices = React.createClass( {
 	displayName: 'JetpackNotices',
 
@@ -197,6 +223,7 @@ const JetpackNotices = React.createClass( {
 					siteConnectionStatus={ this.props.siteConnectionStatus }
 					siteDevMode={ this.props.siteDevMode } />
 				<StagingSiteNotice isStaging={ this.props.isStaging } />
+				<IdentityCrisis isInIdentityCrisis={ this.props.isInIdentityCrisis } />
 				<DismissableNotices />
 				<UserUnlinked
 					connectUrl={ this.props.connectUrl }
@@ -213,7 +240,9 @@ export default connect(
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 			isDevVersion: isDevVersion( state ),
 			siteDevMode: getSiteDevMode( state ),
-			isStaging: isStaging( state )
+			isStaging: isStaging( state ),
+			isInIdentityCrisis: isInIdentityCrisis( state )
+
 		};
 	}
 )( JetpackNotices );

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -52,21 +52,36 @@ export const StagingSiteNotice = React.createClass( {
 
 	render() {
 		if ( this.props.isStaging ) {
-			const text = __( 'You are running Jetpack on a {{a}}staging server{{/a}}.',
-				{
-					components: {
-						a: <a href="https://jetpack.com/support/staging-sites/" target="_blank" />
+			const isIDC = this.props.isInIdentityCrisis;
+			const stagingSiteSupportLink = <a href="https://jetpack.com/support/staging-sites/" target="_blank" />;
+
+			let props = {
+				text: 	__( 'You are running Jetpack on a {{a}}staging server{{/a}}.',
+					{
+						components: {
+							a: stagingSiteSupportLink
+						}
 					}
-				}
-			);
+				),
+				status: 'is-basic',
+				showDismiss: false
+			};
+
+			if ( isIDC ) {
+				props.text = __(
+					'Your site was automatically put in staging mode because we think this is a ' +
+					'{{a}}staging server{{/a}}.',
+					{
+						components: {
+							a: stagingSiteSupportLink
+						}
+					}
+				);
+				props.status = 'is-info';
+			}
 
 			return (
-				<SimpleNotice
-					showDismiss={ false }
-					status="is-basic"
-				>
-					{ text }
-				</SimpleNotice>
+				<SimpleNotice { ... props } />
 			);
 		}
 
@@ -76,7 +91,8 @@ export const StagingSiteNotice = React.createClass( {
 } );
 
 StagingSiteNotice.propTypes = {
-	isStaging: React.PropTypes.bool.isRequired
+	isStaging: React.PropTypes.bool.isRequired,
+	isInIdentityCrisis: React.PropTypes.bool.isRequired
 };
 
 export const DevModeNotice = React.createClass( {
@@ -183,32 +199,6 @@ UserUnlinked.propTypes = {
 	siteConnected: React.PropTypes.bool.isRequired
 };
 
-export const IdentityCrisis = React.createClass( {
-	displayName: 'IdentityCrisis',
-
-	render() {
-		if ( this.props.isInIdentityCrisis ) {
-			const text = __( 'Are you feeling like yourself? Seems like you are having a crisis' );
-
-			return (
-				<SimpleNotice
-					showDismiss={ false }
-					status="is-error"
-				>
-					{ text }
-				</SimpleNotice>
-			);
-		}
-
-		return false;
-	}
-
-} );
-
-IdentityCrisis.propTypes = {
-	isInIdentityCrisis: React.PropTypes.bool.isRequired
-};
-
 const JetpackNotices = React.createClass( {
 	displayName: 'JetpackNotices',
 
@@ -222,8 +212,9 @@ const JetpackNotices = React.createClass( {
 				<DevModeNotice
 					siteConnectionStatus={ this.props.siteConnectionStatus }
 					siteDevMode={ this.props.siteDevMode } />
-				<StagingSiteNotice isStaging={ this.props.isStaging } />
-				<IdentityCrisis isInIdentityCrisis={ this.props.isInIdentityCrisis } />
+				<StagingSiteNotice
+					isStaging={ this.props.isStaging }
+					isInIdentityCrisis={ this.props.isInIdentityCrisis } />
 				<DismissableNotices />
 				<UserUnlinked
 					connectUrl={ this.props.connectUrl }

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -53,35 +53,28 @@ export const StagingSiteNotice = React.createClass( {
 	render() {
 		if ( this.props.isStaging ) {
 			const isIDC = this.props.isInIdentityCrisis;
-			const stagingSiteSupportLink = <a href="https://jetpack.com/support/staging-sites/" target="_blank" />;
+			let stagingSiteSupportLink = 'https://jetpack.com/support/staging-sites/';
 
 			let props = {
-				text: 	__( 'You are running Jetpack on a {{a}}staging server{{/a}}.',
-					{
-						components: {
-							a: stagingSiteSupportLink
-						}
-					}
-				),
+				text: 	__( 'You are running Jetpack on a staging server.' ),
 				status: 'is-basic',
 				showDismiss: false
 			};
 
 			if ( isIDC ) {
-				props.text = __(
-					'Your site was automatically put in staging mode because we think this is a ' +
-					'{{a}}staging server{{/a}}.',
-					{
-						components: {
-							a: stagingSiteSupportLink
-						}
-					}
-				);
+				props.text = __( 'Your site was automatically put in staging mode because we think this is a staging server.' );
 				props.status = 'is-info';
+				stagingSiteSupportLink = 'https://jetpack.com/support/identity-crisis';
 			}
 
 			return (
-				<SimpleNotice { ... props } />
+				<SimpleNotice { ... props }>
+					<NoticeAction
+						href={ stagingSiteSupportLink }
+					>
+						{ __( 'More Info' ) }
+					</NoticeAction>
+				</SimpleNotice>
 			);
 		}
 

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -218,6 +218,16 @@ export function isStaging( state ) {
 }
 
 /**
+ * Checks if the site is currently in an Identity Crisis.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {boolean} True if site is in IDC. False otherwise.
+ */
+export function isInIdentityCrisis( state ) {
+	return get( state.jetpack.connection.status, [ 'siteConnected', 'isInIdentityCrisis' ], false );
+}
+
+/**
  * Checks if the module requires connection.
  *
  * @param  {Object}  state Global state tree

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -257,6 +257,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),
 				),
 				'isPublic'	=> '1' == get_option( 'blog_public' ),
+				'isInIdentityCrisis' => Jetpack_Options::get_option( 'sync_error_idc' ),
 			),
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),
 			'isDevVersion' => Jetpack::is_development_version(),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -257,7 +257,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),
 				),
 				'isPublic'	=> '1' == get_option( 'blog_public' ),
-				'isInIdentityCrisis' => Jetpack_Options::get_option( 'sync_error_idc' ),
+				'isInIdentityCrisis' => Jetpack_Options::get_option( 'sync_error_idc' ) == get_home_url(),
 			),
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),
 			'isDevVersion' => Jetpack::is_development_version(),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -257,7 +257,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),
 				),
 				'isPublic'	=> '1' == get_option( 'blog_public' ),
-				'isInIdentityCrisis' => Jetpack_Options::get_option( 'sync_error_idc' ) == get_home_url(),
+				'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),
 			),
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),
 			'isDevVersion' => Jetpack::is_development_version(),

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -130,7 +130,10 @@ class Jetpack_Client_Server {
 		} else {
 			Jetpack::activate_default_modules( false, false, array(), $redirect_on_activation_error );
 		}
-		
+
+		// Since this is a fresh connection, be sure to clear out the IDC sync error option
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+
 		// Start nonce cleaner
 		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
 		wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -33,7 +33,8 @@ class Jetpack_Options {
 				'dismissed_manage_banner',     // (bool) Dismiss Jetpack manage banner allows the user to dismiss the banner permanently
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
-				'protect_whitelist'            // (array) IP Address for the Protect module to ignore
+				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
+				'sync_error_idc',              // (bool|string) false or string of the local site's URL
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2584,9 +2584,13 @@ p {
 		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
 		Jetpack::clean_nonces( true );
 
-		Jetpack::load_xml_rpc_client();
-		$xml = new Jetpack_IXR_Client();
-		$xml->query( 'jetpack.deregister' );
+		// If the site is in an IDC because sync is not allowed,
+		// let's make sure to not disconnect the production site.
+		if ( ! self::validate_sync_error_idc_option() ) {
+			Jetpack::load_xml_rpc_client();
+			$xml = new Jetpack_IXR_Client();
+			$xml->query( 'jetpack.deregister' );
+		}
 
 		Jetpack_Options::delete_option(
 			array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2597,6 +2597,7 @@ p {
 				'master_user',
 				'time_diff',
 				'fallback_no_verify_ssl_certs',
+				'sync_error_idc',
 			)
 		);
 
@@ -5292,6 +5293,16 @@ p {
 				if ( defined( $constant ) && constant( $constant ) ) {
 					$is_staging = true;
 				}
+			}
+		}
+
+		// Last, let's check if sync is erroring due to an IDC. If so, set the site to staging mode.
+		if ( ! $is_staging ) {
+			$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
+			if ( $sync_error && $sync_error === get_home_url() ) {
+				$is_staging = true;
+			} else if ( $sync_error ) {
+				Jetpack_Options::delete_option( 'sync_error_idc' );
 			}
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5297,12 +5297,14 @@ p {
 		}
 
 		// Last, let's check if sync is erroring due to an IDC. If so, set the site to staging mode.
-		if ( ! $is_staging ) {
-			$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
-			if ( $sync_error && $sync_error === get_home_url() ) {
-				$is_staging = true;
-			} else if ( $sync_error ) {
+		if ( ! $is_staging && ( $sync_error = Jetpack_Options::get_option( 'sync_error_idc' ) ) ) {
+			 if ( ! self::sync_idc_optin() || $sync_error !== get_home_url() ) {
+				// If the values do not match, or the site is no longer opted in,
+				// delete the `jetpack_sync_error_idc` option
 				Jetpack_Options::delete_option( 'sync_error_idc' );
+			} else {
+				// If the value stored in $sync_error is the same as get_home_url(), then put the site in staging.
+				$is_staging = true;
 			}
 		}
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Plugin Name: Jetpack by Savory
+ * Plugin Name: Jetpack by WordPress.com
  * Plugin URI: http://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
@@ -23,7 +23,7 @@ define( 'JETPACK__PLUGIN_FILE',        __FILE__ );
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' )   or define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 defined( 'JETPACK_CLIENT__HTTPS' )           or define( 'JETPACK_CLIENT__HTTPS', 'AUTO' );
 defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) or define( 'JETPACK__GLOTPRESS_LOCALES_PATH', JETPACK__PLUGIN_DIR . 'locales.php' );
-defined( 'JETPACK__API_BASE' )               or define( 'JETPACK__API_BASE', 'https://dsmartsandbox.wordpress.com/jetpack.' );
+defined( 'JETPACK__API_BASE' )               or define( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
 defined( 'JETPACK_PROTECT__API_HOST' )       or define( 'JETPACK_PROTECT__API_HOST', 'https://api.bruteprotect.com/' );
 defined( 'JETPACK__WPCOM_JSON_API_HOST' )    or define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Plugin Name: Jetpack by WordPress.com
+ * Plugin Name: Jetpack by Savory
  * Plugin URI: http://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
@@ -23,7 +23,7 @@ define( 'JETPACK__PLUGIN_FILE',        __FILE__ );
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' )   or define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 defined( 'JETPACK_CLIENT__HTTPS' )           or define( 'JETPACK_CLIENT__HTTPS', 'AUTO' );
 defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) or define( 'JETPACK__GLOTPRESS_LOCALES_PATH', JETPACK__PLUGIN_DIR . 'locales.php' );
-defined( 'JETPACK__API_BASE' )               or define( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
+defined( 'JETPACK__API_BASE' )               or define( 'JETPACK__API_BASE', 'https://dsmartsandbox.wordpress.com/jetpack.' );
 defined( 'JETPACK_PROTECT__API_HOST' )       or define( 'JETPACK_PROTECT__API_HOST', 'https://api.bruteprotect.com/' );
 defined( 'JETPACK__WPCOM_JSON_API_HOST' )    or define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -142,8 +142,12 @@ class Jetpack_Sync_Actions {
 		$result = $rpc->query( 'jetpack.syncActions', $data );
 
 		if ( ! $result ) {
-			Jetpack_Options::update_option( 'sync_error_idc', get_home_url() );
-			return $rpc->get_jetpack_error();
+			$error = $rpc->get_jetpack_error();
+			if ( 'jetpack_url_mismatch' === $error->get_error_code() ) {
+				Jetpack_Options::update_option( 'sync_error_idc', get_home_url() );
+			}
+			
+			return $error;
 		}
 
 		return $rpc->getResponse();

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -142,6 +142,7 @@ class Jetpack_Sync_Actions {
 		$result = $rpc->query( 'jetpack.syncActions', $data );
 
 		if ( ! $result ) {
+			Jetpack_Options::update_option( 'sync_error_idc', get_home_url() );
 			return $rpc->get_jetpack_error();
 		}
 

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -435,6 +435,28 @@ EXPECTED;
 		add_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
 	}
 
+	function test_sync_error_idc_validation_returns_false_if_no_option() {
+		Jetpack_Options::delete_option( 'sync_error_idc' );
+		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
+	}
+
+	function test_sync_error_idc_validation_returns_true_when_option_matches_expected() {
+		Jetpack_Options::update_option( 'sync_error_idc', get_home_url() );
+		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
+	}
+
+	function test_sync_error_idc_validation_cleans_up_when_validation_fails() {
+		Jetpack_Options::update_option( 'sync_error_idc', 'http://nonsenseurl.com' );
+		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
+		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
+	}
+
+	function test_is_staging_site_true_when_sync_error_idc_is_valid() {
+		add_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
+		$this->assertTrue( Jetpack::is_staging_site() );
+		remove_filter( 'jetpack_sync_error_idc_validation', '__return_false' );
+	}
+
 	function __return_string_1() {
 		return '1';
 	}


### PR DESCRIPTION
Identity crises in Jetpack are painful for all. 

This PR is a first pass at automatically putting a site into staging mode if the site is attempting to update the shadow site on WordPress.com in such a way that could cause an identity crisis.

On the WordPress.com side, for sites that have opted in, we check if the new home and siteurl options that are sent from the Jetpack site match what we have on the WPCOM side. If so, then we allow sync. If not, we return an error.

This PR, when it gets the error back, puts the site into staging mode and shows some very basic UI like this:

<img width="758" alt="screen shot 2016-10-06 at 5 27 30 pm" src="https://cloud.githubusercontent.com/assets/1126811/19175840/5ec7fe22-8c08-11e6-9080-6ff1466cb221.png">

It doesn't currently allow for any actions. But, a user can take their site out of staging mode by opting out the IDC mitigation (after which, we'll cleanup the flag we set) or by filtering `jetpack_is_staging_site`.

This is a rough early design for the notice. For now, we're trying to help out VIPs, who are experiencing IDC issues when cloning a site to a local development server and the `home` and `siteurl` values overriding those on the shadow site 😞 cc @simonwheatley @joshbetz @rickybanister for thoughts on this early flow.

To test:

- Checkout `update/sync-auto-staging-notice-first` branch
- In `wp-config.php`, `define( 'JETPACK_SYNC_IDC_OPTIN', true );`
- Ensure your site is connected to WPCOM
- Go to `General > Settings`
- Change home and siteurl options
- Wait a minute or so, and then go to `Jetpack > Dashboard`
- Verify you see a notice like the above
- Ensure that SSO module is turned on
- Verify that you get a message that you can't use SSO because of an IDC (you're in IDC because your local options don't match WPCOM because we didn't update 😉 );;
- Log back in with username and pass
- Opt out of IDC mitigation by removing the filter or constant
- Wait a minute, then reload admin. Then go to `Jetpack > Dashboard`. You should not see a notice
- Log out
- You should be able to SSO now. The IDC is cleared since we updated the value.
