### PR TITLE
Add new media endpoints

### DIFF
--- a/_inc/lib/class.media.php
+++ b/_inc/lib/class.media.php
@@ -1,0 +1,504 @@
+<?php
+
+require_once( JETPACK__PLUGIN_DIR . 'sal/class.json-api-date.php' );
+
+/**
+ * Class to handle different actions related to media.
+ */
+class Jetpack_Media {
+	public static $WP_ORIGINAL_MEDIA = '_wp_original_post_media';
+	public static $WP_REVISION_HISTORY = '_wp_revision_history';
+	public static $REVISION_HISTORY_MAXIMUM_AMOUNT = 0;
+	public static $WP_ATTACHMENT_IMAGE_ALT = '_wp_attachment_image_alt';
+
+	/**
+	 * Generate a filename in function of the original filename of the media.
+	 * The returned name has the `{basename}-{hash}-{random-number}.{ext}` shape.
+	 * The hash is built according to the filename trying to avoid name collisions
+	 * with other media files.
+	 * 
+	 * @param  number $media_id - media post ID
+	 * @param  string $new_filename - the new filename
+	 * @return string A random filename.
+	 */
+	public static function generate_new_filename( $media_id, $new_filename ) {
+		// get the right filename extension
+		$new_filename_paths = pathinfo( $new_filename );
+		$new_file_ext = $new_filename_paths['extension'];
+
+		// take out filename from the original file or from the current attachment
+		$original_media = (array) self::get_original_media( $media_id );
+
+		if ( ! empty( $original_media ) ) {
+			$original_file_parts = pathinfo( $original_media['file'] );
+			$filename_base = $original_file_parts['filename'];
+		} else {
+			$current_file = get_attached_file( $media_id );
+			$current_file_parts = pathinfo( $current_file );
+			$current_file_ext = $current_file_parts['filename'];
+			$filename_base = $current_file_parts['filename'];
+		}
+
+		// add unique seed based on the filename
+		$filename_base .=  '-' . crc32( $filename_base ) . '-';
+
+		$number_suffix = time() . rand( 100, 999 );
+
+		do {
+			$filename = $filename_base;
+			$filename .= $number_suffix;
+			$file_ext = $new_file_ext ? $new_file_ext : $current_file_ext;
+
+			$new_filename = "{$filename}.{$file_ext}";
+			$new_path = "{$current_file_parts['dirname']}/$new_filename";
+			$number_suffix++;
+		} while( file_exists( $new_path ) );
+
+		return $new_filename;
+	}
+
+	/**
+	 * File urls use the post (image item) date to generate a folder path.
+	 * Post dates can change, so we use the original date used in the `guid`
+	 * url so edits can remain in the same folder. In the following function
+	 * we capture a string in the format of `YYYY/MM` from the guid.
+	 *
+	 * For example with a guid of
+	 * "http://test.files.wordpress.com/2016/10/test.png" the resulting string
+	 * would be: "2016/10"
+	 *
+	 * @param  number $media_id
+	 * @return string
+	 */
+	private function get_time_string_from_guid( $media_id ) {
+		$time = date( "Y/m", strtotime( current_time( 'mysql' ) ) );
+
+		if ( $media = get_post( $media_id ) ) {
+			$pattern = '/\/(\d{4}\/\d{2})\//';
+			preg_match( $pattern, $media->guid, $matches );
+			if ( count( $matches ) > 1 ) {
+				$time = $matches[1];
+			}
+		}
+		return $time;
+	}
+
+	/**
+	 * Return an array of allowed mime_type items used to upload a media file.
+	 * 	
+	 * @return array mime_type array
+	 */
+	static function get_allowed_mime_types( $default_mime_types ) {
+		return array_unique( array_merge( $default_mime_types, array(
+			'application/msword',                                                         // .doc
+			'application/vnd.ms-powerpoint',                                              // .ppt, .pps
+			'application/vnd.ms-excel',                                                   // .xls
+			'application/vnd.openxmlformats-officedocument.presentationml.presentation',  // .pptx
+			'application/vnd.openxmlformats-officedocument.presentationml.slideshow',     // .ppsx
+			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',          // .xlsx
+			'application/vnd.openxmlformats-officedocument.wordprocessingml.document',    // .docx
+			'application/vnd.oasis.opendocument.text',                                    // .odt
+			'application/pdf',                                                            // .pdf
+		) ) );
+	}
+
+	/**
+	 * Checks that the mime type of the file
+	 * is among those in a filterable list of mime types.
+	 *
+	 * @param  string $file Path to file to get its mime type.
+	 * @return bool
+	 */
+	protected static function is_file_supported_for_sideloading( $file ) {
+		if ( class_exists( 'finfo' ) ) { // php 5.3+
+			$finfo = new finfo( FILEINFO_MIME );
+			$mime = explode( '; ', $finfo->file( $file ) );
+			$type = $mime[0];
+
+		} elseif ( function_exists( 'mime_content_type' ) ) { // PHP 5.2
+			$type = mime_content_type( $file );
+
+		} else {
+			return false;
+		}
+
+		/**
+		 * Filter the list of supported mime types for media sideloading.
+		 *
+		 * @since 4.0
+		 *
+		 * @module json-api
+		 *
+		 * @param array $supported_mime_types Array of the supported mime types for media sideloading.
+		 */
+		$supported_mime_types = apply_filters( 'jetpack_supported_media_sideload_types', array(
+			'image/png',
+			'image/jpeg',
+			'image/gif',
+			'image/bmp',
+			'video/quicktime',
+			'video/mp4',
+			'video/mpeg',
+			'video/ogg',
+			'video/3gpp',
+			'video/3gpp2',
+			'video/h261',
+			'video/h262',
+			'video/h264',
+			'video/x-msvideo',
+			'video/x-ms-wmv',
+			'video/x-ms-asf',
+		) );
+
+		// If the type returned was not an array as expected, then we know we don't have a match.
+		if ( ! is_array( $supported_mime_types ) ) {
+			return false;
+		}
+
+		return in_array( $type, $supported_mime_types );
+	}
+
+	/**
+	 * Try to remove the temporal file from the given file array.
+	 * 	
+	 * @param  array $file_array Array with data about the temporal file
+	 * @return bool `true` if the file has been removed. `false` either the file doesn't exist or it couldn't be removed.
+	 */
+	private static function remove_tmp_file( $file_array ) {
+		if ( ! file_exists ( $file_array['tmp_name'] ) ) {
+			return false;
+		}
+		return @unlink( $file_array['tmp_name'] );
+	}
+
+	/**
+	 * Save the given temporal file considering file type, 
+	 * correct location according to the original file path, etc.
+	 * The file type control is done through of `jetpack_supported_media_sideload_types` filter,
+	 * which allows define to the users their own file types list.
+	 * 
+	 * @param  array  $file_array file to save
+	 * @param  number $media_id
+	 * @return array|WP_Error an array with information about the new file saved or a WP_Error is something went wrong.
+	 */
+	public static function save_temporary_file( $file_array, $media_id ) {
+		$tmp_filename = $file_array['tmp_name'];
+
+		if ( ! file_exists( $tmp_filename ) ) {
+			return new WP_Error( 'invalid_input', 'No media provided in input.' );
+		}
+
+		// add additional mime_types through of the `jetpack_supported_media_sideload_types` filter
+		$mime_type_static_filter = array(
+			'Jetpack_Media',
+			'get_allowed_mime_types'
+		);
+
+		add_filter( 'jetpack_supported_media_sideload_types', $mime_type_static_filter );
+		if (
+			! self::is_file_supported_for_sideloading( $tmp_filename ) &&
+			! file_is_displayable_image( $tmp_filename )
+		) {
+			@unlink( $tmp_filename );
+			return new WP_Error( 'invalid_input', 'Invalid file type.', 403 );
+		}
+		remove_filter( 'jetpack_supported_media_sideload_types', $mime_type_static_filter );
+
+		// generate a new file name
+		$tmp_new_filename = self::generate_new_filename( $media_id, $file_array[ 'name' ] );
+
+		// start to create the parameters to move the temporal file
+		$overrides = array( 'test_form' => false );
+
+		// get time according to the original filaname
+		$time = self::get_time_string_from_guid( $media_id );
+
+		$file_array['name'] = $tmp_new_filename;
+		$file = wp_handle_sideload( $file_array, $overrides, $time );
+
+		self::remove_tmp_file( $file_array );
+
+		if ( isset( $file['error'] ) ) {
+			return new WP_Error( 'upload_error', $file['error'] );
+		}
+
+		return $file;
+	}
+
+	/**
+	 * Return an object with an snapshot of a revision item.
+	 * 
+	 * @param  object $media_item - media post object
+	 * @return object a revision item 
+	 */
+	public static function get_snapshot( $media_item ) {
+		$current_file = get_attached_file( $media_item->ID );
+		$file_paths = pathinfo( $current_file );
+
+		$snapshot = array(
+			'date'             => (string) WPCOM_JSON_API_Date::format_date( $media_item->post_modified_gmt, $media_item->post_modified ),
+			'URL'              => (string) wp_get_attachment_url( $media_item->ID ),
+			'file'             => (string) $file_paths['basename'],
+			'extension'        => (string) $file_paths['extension'],
+			'mime_type'        => (string) $media_item->post_mime_type,
+			'size'             => (int) filesize( $current_file ) 
+		);
+
+		return (object) $snapshot;
+	}
+
+	/**
+	 * Add a new item into revision_history array.
+	 * 
+	 * @param  object $media_item - media post object
+	 * @param  file $file - file recently added
+	 * @param  bool $has_original_media - condition is the original media has been already added
+	 * @return bool `true` if the item has been added. Otherwise `false`.
+	 */
+	public static function register_revision( $media_item, $file, $has_original_media ) {
+		if ( is_wp_error( $file ) || ! $has_original_media ) {
+			return false;
+		}
+
+		add_post_meta( $media_item->ID, self::$WP_REVISION_HISTORY, self::get_snapshot( $media_item ) );
+	}
+	/**
+	 * Return the `revision_history` of the given media.
+	 * 
+	 * @param  number $media_id - media post ID
+	 * @return array `revision_history` array
+	 */
+	public static function get_revision_history( $media_id ) {
+		return array_reverse( get_post_meta( $media_id, self::$WP_REVISION_HISTORY ) );
+	}
+
+	/**
+	 * Return the original media data
+	 */
+	public static function get_original_media( $media_id ) {
+		$original = get_post_meta( $media_id, self::$WP_ORIGINAL_MEDIA, true );
+		$original = $original ? $original : array();
+		return $original;
+	}
+
+	public static function delete_file( $pathname ) {
+		if ( ! file_exists( $pathname ) || ! is_file( $pathname ) ) {
+			// let's touch a fake file to try to `really` remove the media file
+			touch( $pathname );
+		}
+
+		return wp_delete_file( $pathname );
+	}
+
+	/**
+	 * Try to delete a file according to the dirname of
+	 * the media attached file and the filename.
+	 * 
+	 * @param  number $media_id - media post ID
+	 * @param  string $filename - basename of the file ( name-of-file.ext )
+	 * @return bool `true` is the file has been removed, `false` if not.
+	 */
+	private static function delete_media_history_file( $media_id, $filename ) {
+		$attached_path = get_attached_file( $media_id );
+		$attached_parts = pathinfo( $attached_path );
+		$dirname = $attached_parts['dirname'];
+
+		$pathname = $dirname . '/' . $filename;
+
+		// remove thumbnails
+		$metadata = wp_generate_attachment_metadata( $media_id, $pathname );
+
+		if ( isset( $metadata ) && isset( $metadata['sizes'] ) ) {
+			foreach ( $metadata['sizes'] as $size => $properties ) {
+				self::delete_file( $dirname . '/' . $properties['file'] );
+			}
+		}
+
+		// remove primary file
+		self::delete_file( $pathname );
+	}
+
+	/**
+	 * Remove specific items from the `revision history` array
+	 * depending on the given criteria: array(
+	 *   'from' => (int) <from>,
+	 *   'to' =>   (int) <to>,
+	 * )
+	 * 
+	 * Also, it removes the file defined in each item.
+	 *
+	 * @param  number $media_id - media post ID
+	 * @param  object $criteria - criteria to remove the items
+	 * @param  array [$revision_history] - revision history array
+	 * @return array `revision_history` array updated.
+	 */
+	public static function remove_items_from_revision_history( $media_id, $criteria = array(), $revision_history ) {
+		if ( ! isset ( $revision_history ) ) {
+			$revision_history = self::get_revision_history( $media_id );
+		}
+
+		$from = $criteria['from'];
+		$to = $criteria['to'] ? $criteria['to'] : ( $from + 1 );
+
+		for ( $i = $from; $i < $to; $i++ ) {
+			$removed_item = array_slice( $revision_history, $from, 1 );
+			if ( ! $removed_item ) {
+				break;
+			}
+
+			array_splice( $revision_history, $from, 1 );
+			self::delete_media_history_file( $media_id, $removed_item[0]->file );
+		}
+
+		// override all history items
+		delete_post_meta( $media_id, self::$WP_REVISION_HISTORY );
+		$revision_history = array_reverse( $revision_history );
+		foreach ( $revision_history as &$item ) {
+			add_post_meta( $media_id, self::$WP_REVISION_HISTORY, $item );
+		}
+
+		return $revision_history;
+	}
+
+	/**
+	 * Limit the number of items of the `revision_history` array.
+	 * When the stack is overflowing the oldest item is remove from there (FIFO).
+	 * 
+	 * @param  number $media_id - media post ID
+	 * @param  number [$limit] - maximun amount of items. 20 as default.
+	 * @return array items removed from `revision_history`
+	 */
+	public static function limit_revision_history( $media_id, $limit = null) {
+		if ( is_null( $limit ) ) {
+			$limit = self::$REVISION_HISTORY_MAXIMUM_AMOUNT;
+		}
+
+		$revision_history = self::get_revision_history( $media_id );
+
+		$total = count( $revision_history );
+
+		if ( $total < $limit ) {
+			return array();
+		}
+
+		self::remove_items_from_revision_history(
+			$media_id,
+			array( 'from' => $limit, 'to' => $total ),
+			$revision_history
+		);
+
+		return self::get_revision_history( $media_id );
+	}
+
+	/**
+	 * Remove the original file and clean the post metadata.
+	 * 
+	 * @param  number $media_id - media post ID
+	 */
+	public static function clean_original_media( $media_id ) {
+		$original_file = self::get_original_media( $media_id );
+
+		if ( ! $original_file ) {
+			return null;
+		}
+
+		self::delete_media_history_file( $media_id, $original_file->file );
+		return delete_post_meta( $media_id, self::$WP_ORIGINAL_MEDIA );
+	}
+
+	/**
+	 * Clean `revision_history` of the given $media_id. it means:
+	 *   - remove all media files tied to the `revision_history` items.
+	 *   - clean `revision_history` meta data.
+	 *   - remove and clean the `original_media`
+	 * 
+	 * @param  number $media_id - media post ID
+	 * @return array results of removing these files
+	 */
+	public static function clean_revision_history( $media_id ) {
+		self::clean_original_media( $media_id );
+
+		$revision_history = self::get_revision_history( $media_id );
+		$total = count( $revision_history );
+		$updated_history = array();
+
+		if ( $total < 1 ) {
+			return $updated_history;
+		}
+
+		$updated_history = self::remove_items_from_revision_history(
+			$media_id,
+			array( 'from' => 0, 'to' => $total ),
+			$revision_history
+		);
+
+		return $updated_history;
+	}
+
+	/**
+	 * Edit media item process:
+	 *
+	 * - update attachment file
+	 * - preserve original media file
+	 * - trace revision history
+	 * 
+	 * @param  number $media_id - media post ID
+	 * @param  array $file_array - temporal file
+	 * @return {Post|WP_Error} Updated media item or a WP_Error is something went wrong.
+	 */
+	public static function edit_media_file( $media_id, $file_array ) {
+		$media_item = get_post( $media_id );
+		$has_original_media = self::get_original_media( $media_id );
+
+		if ( ! $has_original_media ) {
+			// The first time that the media is updated
+			// the original media is stored into the revision_history
+			$snapshot = self::get_snapshot( $media_item );
+			add_post_meta( $media_id, self::$WP_ORIGINAL_MEDIA, $snapshot, true );
+		}
+
+		// save temporary file in the correct location
+		$uploaded_file = self::save_temporary_file( $file_array, $media_id );
+
+		if ( is_wp_error( $uploaded_file ) ) {
+			self::remove_tmp_file( $file_array );
+			return $uploaded_file;
+		}
+
+		// revision_history control
+		self::register_revision( $media_item, $uploaded_file, $has_original_media );
+
+		$uploaded_path = $uploaded_file['file'];
+		$udpated_mime_type = $uploaded_file['type'];
+		$was_updated = update_attached_file( $media_id, $uploaded_path );
+
+		if ( ! $was_updated ) {
+			return WP_Error( 'update_error', 'Media update error' );
+		}
+
+		$new_metadata = wp_generate_attachment_metadata( $media_id, $uploaded_path );
+		wp_update_attachment_metadata( $media_id, $new_metadata );
+
+		// check maximum amount of revision_history
+		self::limit_revision_history( $media_id );
+
+		$edited_action = wp_update_post( (object) array(
+			'ID'              => $media_id,
+			'post_mime_type'  => $udpated_mime_type
+		), true );
+
+		if ( is_wp_error( $edited_action ) ) {
+			return $edited_action;
+		}
+
+		return $media_item;
+	}
+}
+
+// hook: clean revision history when the media item is deleted
+function clean_revision_history( $media_id ) {
+	Jetpack_Media::clean_revision_history( $media_id );
+};
+
+add_action( 'delete_attachment', 'clean_revision_history' );
+

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -88,6 +88,10 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-post-v1-2-endpo
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-site-settings-v1-2-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-2-endpoint.php' );
 
+// Media
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-media-v1-2-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-edit-media-v1-2-endpoint.php' );
+
 // Jetpack Only Endpoints
 $json_jetpack_endpoints_dir = dirname( __FILE__ ) . '/json-endpoints/jetpack/';
 
@@ -1296,6 +1300,52 @@ new WPCOM_JSON_API_Get_Media_v1_1_Endpoint( array(
 	)
 ) );
 
+new WPCOM_JSON_API_Get_Media_v1_2_Endpoint( array(
+	'description' => 'Get a single media item (by ID).',
+	'group'       => 'media',
+	'stat'        => 'media:1',
+	'min_version' => '1.2',
+	'max_version' => '1.2',
+	'method'      => 'GET',
+	'path'        => '/sites/%s/media/%d',
+	'path_labels' => array(
+		'$site'    => '(int|string) Site ID or domain',
+		'$media_ID' => '(int) The ID of the media item',
+	),
+	'response_format' => array(
+		'ID'               => '(int) The ID of the media item',
+		'date'             => '(ISO 8601 datetime) The date the media was uploaded',
+		'post_ID'          => '(int) ID of the post this media is attached to',
+		'author_ID'        => '(int) ID of the user who uploaded the media',
+		'URL'              => '(string) URL to the file',
+		'guid'             => '(string) Unique identifier',
+		'file'             => '(string) Filename',
+		'extension'        => '(string) File extension',
+		'mime_type'        => '(string) File MIME type',
+		'title'            => '(string) Filename',
+		'caption'          => '(string) User-provided caption of the file',
+		'description'      => '(string) Description of the file',
+		'alt'              => '(string)  Alternative text for image files.',
+		'thumbnails'       => '(object) Media item thumbnail URL options',
+		'height'           => '(int) (Image & video only) Height of the media item',
+		'width'            => '(int) (Image & video only) Width of the media item',
+		'length'           => '(int) (Video & audio only) Duration of the media item, in seconds',
+		'exif'             => '(array) (Image & audio only) Exif (meta) information about the media item',
+		'videopress_guid'  => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
+		'videopress_processing_done'  => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.',
+		'revision_history' => '(array) An array of snapshots of the previous images of this Media.' .
+                                'Each item has useful data such as `URL`, `date, `extension`, `width` and `height`,' .
+		                        '`mime_type` and the `thumbnails` array.'
+	),
+
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1.2/sites/82974409/media/934',
+	'example_request_data' =>  array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		)
+	)
+) );
+
 new WPCOM_JSON_API_Upload_Media_Endpoint( array(
 	'description' => 'Upload a new media item.',
 	'group'       => 'media',
@@ -1464,6 +1514,77 @@ new WPCOM_JSON_API_Update_Media_v1_1_Endpoint( array(
 	)
 ) );
 
+new WPCOM_JSON_API_Edit_Media_v1_2_Endpoint( array(
+	'description' => 'Edit a media item.',
+	'group'       => 'media',
+	'stat'        => 'media:1:POST',
+	'min_version' => '1',
+	'max_version' => '1.2',
+	'method'      => 'POST',
+	'path'        => '/sites/%s/media/%d/edit',
+	'path_labels' => array(
+		'$site'    => '(int|string) Site ID or domain',
+		'$media_ID' => '(int) The ID of the media item',
+	),
+
+	'request_format' => array(
+		'parent_id'   => '(int) ID of the post this media is attached to',
+		'title'       => '(string) The file name.',
+		'caption'     => '(string) File caption.',
+		'description' => '(HTML) Description of the file.',
+		'alt'         => "(string) Alternative text for image files.",
+		'artist'      => "(string) Audio Only. Artist metadata for the audio track.",
+		'album'       => "(string) Audio Only. Album metadata for the audio track.",
+		'media'       => "(object) An object file to attach to the post. To upload media, " .
+		                   "the entire request should be multipart/form-data encoded. " .
+		                   "Multiple media items will be displayed in a gallery. Accepts " .
+		                   "jpg, jpeg, png, gif, pdf, doc, ppt, odt, pptx, docx, pps, ppsx, xls, xlsx, key. " .
+		                   "Audio and Video may also be available. See <code>allowed_file_types</code> " .
+		                   "in the options response of the site endpoint. " .
+		                   "<br /><br /><strong>Example</strong>:<br />" .
+		 				   "<code>curl \<br />--form 'title=Image' \<br />--form 'media=@/path/to/file.jpg' \<br />-H 'Authorization: BEARER your-token' \<br />'https://public-api.wordpress.com/rest/v1/sites/123/posts/new'</code>",
+		'attrs'       => "(object) An Object of attributes (`title`, `description` and `caption`) " .
+		                   "are supported to assign to the media uploaded via the `media` or `media_url`",
+		'media_url'   => "(string) An URL of the image to attach to a post.",
+	),
+
+	'response_format' => array(
+		'ID'               => '(int) The ID of the media item',
+		'date'             => '(ISO 8601 datetime) The date the media was uploaded',
+		'post_ID'          => '(int) ID of the post this media is attached to',
+		'author_ID'        => '(int) ID of the user who uploaded the media',
+		'URL'              => '(string) URL to the file',
+		'guid'             => '(string) Unique identifier',
+		'file'             => '(string) File name',
+		'extension'        => '(string) File extension',
+		'mime_type'        => '(string) File mime type',
+		'title'            => '(string) File name',
+		'caption'          => '(string) User provided caption of the file',
+		'description'      => '(string) Description of the file',
+		'alt'              => '(string)  Alternative text for image files.',
+		'thumbnails'       => '(object) Media item thumbnail URL options',
+		'height'           => '(int) (Image & video only) Height of the media item',
+		'width'            => '(int) (Image & video only) Width of the media item',
+		'length'           => '(int) (Video & audio only) Duration of the media item, in seconds',
+		'exif'             => '(array) (Image & audio only) Exif (meta) information about the media item',
+		'videopress_guid'  => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
+		'videopress_processing_done'  => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.',
+		'revision_history' => '(object) An object with `items` and `original` keys. ' .
+		                        '`original` is an object with data about the original image. ' .
+		                        '`items` is an array of snapshots of the previous images of this Media. ' .
+		                        'Each item has the `URL`, `file, `extension`, `date`, and `mime_type` fields.'
+	),
+
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1.2/sites/82974409/media/446',
+	'example_request_data' =>  array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+		'body' => array(
+			'title' => 'Updated Title'
+		)
+	)
+) );
 
 new WPCOM_JSON_API_Delete_Media_Endpoint( array(
 	'description' => 'Delete a piece of media.',

--- a/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -1,0 +1,171 @@
+<?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+jetpack_require_lib( 'class.media' );
+
+class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Media_v1_1_Endpoint {
+	/**
+	 * Update the media post grabbing the post values from
+	 * the `attrs` parameter
+	 *
+	 * @param  {Number} $media_id - post media ID
+	 * @param  {Object} $attrs - `attrs` parameter sent from the client in the request body
+	 * @return
+	 */
+	private function update_by_attrs_parameter( $media_id, $attrs ) {
+		$insert = array();
+
+		// Attributes: Title, Caption, Description
+		if ( isset( $attrs['title'] ) ) {
+			$insert['post_title'] = $attrs['title'];
+		}
+
+		if ( isset( $attrs['caption'] ) ) {
+			$insert['post_excerpt'] = $attrs['caption'];
+		}
+
+		if ( isset( $attrs['description'] ) ) {
+			$insert['post_content'] = $attrs['description'];
+		}
+
+		if ( ! empty( $insert ) ) {
+			$insert['ID'] = $media_id;
+			$update_action = wp_update_post( (object) $insert );
+			if ( is_wp_error( $update_action ) ) {
+				return $update_action;
+			}
+		}
+
+		// Attributes: Alt
+		if ( isset( $attrs['alt'] ) ) {
+			$alt = wp_strip_all_tags( $attrs['alt'], true );
+			update_post_meta( $media_id, Jetpack_Media::$WP_ATTACHMENT_IMAGE_ALT, $alt );
+		}
+
+		// Attributes: Artist, Album
+		$id3_meta = array();
+
+		foreach ( array( 'artist', 'album' ) as $key ) {
+			if ( isset( $attrs[ $key ] ) ) {
+				$id3_meta[ $key ] = wp_strip_all_tags( $attrs[ $key ], true );
+			}
+		}
+
+		if ( ! empty( $id3_meta ) ) {
+			// Before updating metadata, ensure that the item is audio
+			$item = $this->get_media_item_v1_1( $media_id );
+			if ( 0 === strpos( $item->mime_type, 'audio/' ) ) {
+				$update_action = wp_update_attachment_metadata( $media_id, $id3_meta );
+				if ( is_wp_error( $update_action ) ) {
+					return $update_action;
+				}
+			}
+		}
+
+		return $post_update_action;
+	}
+
+	/**
+	 * Get the image from a remote url and then save it locally.
+	 *
+	 * @param  {Number} $media_id - media post ID
+	 * @param  {String} $url - image URL to save locally
+	 * @return {Array|WP_Error} An array with information about the new file saved or a WP_Error is something went wrong.
+	 */
+	private function build_file_array_from_url( $media_id, $url ) {
+		if ( ! $url ) {
+			return null;
+		}
+
+		// if we didn't get a URL, let's bail
+		$parsed = @parse_url( $url );
+		if ( empty( $parsed ) ) {
+			return new WP_Error( 'invalid_url', 'No media provided in url.' );
+		}
+
+		// save the remote image into a tmp file
+		$tmp = download_url( $url );
+		if ( is_wp_error( $tmp ) ) {
+			return $tmp;
+		}
+
+		return array(
+			'name' => basename( $url ),
+			'tmp_name' => $tmp
+		);
+	}
+
+	function callback( $path = '', $blog_id = 0, $media_id = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		$media_item = get_post( $media_id );
+
+		if ( ! $media_item ) {
+			return new WP_Error( 'unknown_media', 'Unknown Media', 404 );
+		}
+
+		if ( is_wp_error( $media_item ) ) {
+			return $media_item;
+		}
+
+		if ( ! current_user_can( 'upload_files', $media_id ) ) {
+			return new WP_Error( 'unauthorized', 'User cannot view media', 403 );
+		}
+
+		$input = $this->input( true );
+
+		// images
+		$media_url = $input['media_url'];
+		$media_attrs = $input['attrs'] ? (array) $input['attrs'] : null;
+
+		if ( isset( $media_url ) ) {
+			$user_can_upload_files = current_user_can( 'upload_files' ) || $this->api->is_authorized_with_upload_token();
+
+			if ( ! $user_can_upload_files  ) {
+				return new WP_Error( 'unauthorized', 'User cannot upload media.', 403 );
+			}
+
+			// save the temporal file locally 
+			$temporal_file = $this->build_file_array_from_url( $media_id, $media_url );
+
+			$edited_media_item = Jetpack_Media::edit_media_file( $media_id, $temporal_file );
+
+			if ( is_wp_error( $edited_media_item ) ) {
+				return $edited_media_item;
+			}
+
+			unset( $input['media'] );
+			unset( $input['media_url'] );
+			unset( $input['attrs'] );
+
+			// update media through of `attrs` value it it's defined
+			if ( $media_attrs ) {
+				$updated_by_attrs = $this->update_by_attrs_parameter( $media_id, $media_attrs );
+
+				if ( is_wp_error( $updated_by_attrs ) ) {
+					return $updated_by_attrs;
+				}
+			}
+		}
+
+		// call parent method
+		$response = parent::callback( $path, $blog_id, $media_id );
+
+		// expose `revision_history` object
+		$response->revision_history = (object) array(
+			'items'       => (array) Jetpack_Media::get_revision_history( $media_id ),
+			'original'    => (object) Jetpack_Media::get_original_media( $media_id )
+		);
+
+		return $response;
+	}
+}
+

--- a/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -1,10 +1,4 @@
 <?php
-/*
- * WARNING: This file is distributed verbatim in Jetpack.
- * There should be nothing WordPress.com specific in this file.
- *
- * @hide-in-jetpack
- */
 
 jetpack_require_lib( 'class.media' );
 
@@ -15,7 +9,7 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 	 *
 	 * @param  {Number} $media_id - post media ID
 	 * @param  {Object} $attrs - `attrs` parameter sent from the client in the request body
-	 * @return
+	 * @return bool|WP_Error `WP_Error` on failure. `true` on success.
 	 */
 	private function update_by_attrs_parameter( $media_id, $attrs ) {
 		$insert = array();
@@ -37,7 +31,7 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 			$insert['ID'] = $media_id;
 			$update_action = wp_update_post( (object) $insert );
 			if ( is_wp_error( $update_action ) ) {
-				return $update_action;
+				$update_action;
 			}
 		}
 
@@ -60,14 +54,11 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 			// Before updating metadata, ensure that the item is audio
 			$item = $this->get_media_item_v1_1( $media_id );
 			if ( 0 === strpos( $item->mime_type, 'audio/' ) ) {
-				$update_action = wp_update_attachment_metadata( $media_id, $id3_meta );
-				if ( is_wp_error( $update_action ) ) {
-					return $update_action;
-				}
+				wp_update_attachment_metadata( $media_id, $id3_meta );
 			}
 		}
 
-		return $post_update_action;
+		return $update_action;
 	}
 
 	/**

--- a/json-endpoints/class.wpcom-json-api-get-media-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-media-v1-2-endpoint.php
@@ -1,0 +1,23 @@
+<?php
+require_once( JETPACK__PLUGIN_DIR . 'sal/class.json-api-date.php' );
+
+class WPCOM_JSON_API_Get_Media_v1_2_Endpoint extends WPCOM_JSON_API_Get_Media_v1_1_Endpoint {
+	function callback( $path = '', $blog_id = 0, $media_id = 0 ) {
+		$response = parent::callback( $path, $blog_id, $media_id );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$media_item = get_post( $media_id );
+		$response->modified = WPCOM_JSON_API_Date::format_date( $media_item->post_modified_gmt, $media_item->post_modified );
+
+		// expose `revision_history` object
+		$response->revision_history = (object) array(
+			'items'       => (array) Jetpack_Media::get_revision_history( $media_id ),
+			'original'    => (object) Jetpack_Media::get_original_media( $media_id )
+		);
+
+		return $response;
+	}
+}


### PR DESCRIPTION
This PR adds new versions of `get-media` endpoint and add the new `edit-media` endpoint to the WP COM API.

### Changes proposed in this Pull Request:

#### Add v1.2 `[POST]` `/sites/$site/media/$mediaID/edit`

The `edit-media` endpoint was added into the WP COM API a while ago. This patch adds the needed code to support the `edit-media` endpoint now for Jetpack sites.
The hardest part of this process is to detect when a media item should be added (`new-media` endpoint) or when it should be updated (`edit-media` endpoint).

The right action to take depends on the action parameter into the request body. it could be `jetpack_upload_action` (the only one action used at the moment) and `jetpack_update_action`. When the action is the last one, the attached metadata of the media item is updated according to the new uploaded media file instead of creating a new media item.
Also, other tasks are done in this editing process, such as store the original media file, keep the revision history, clean the remaining files when the media item is deleted, etc.

#### Add v1.2 `[GET]` `/sites/$site/media/$mediaID`

There aren't significant changes in this endpoint. It just adds some fields to the response body.
