### PR TITLE
JSON API: Include site_icon option in site settings endpoint

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -2493,6 +2493,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'jetpack_testimonial_posts_per_page'   => '(int) Number of testimonials to show per page',
 		'jetpack_portfolio'                    => '(bool) Whether portfolio custom post type is enabled for the site',
 		'jetpack_portfolio_posts_per_page'     => '(int) Number of portfolio projects to show per page',
+		'site_icon'                            => '(int) Media attachment ID to use as site icon. Set to zero or an otherwise empty value to clear',
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -77,6 +77,23 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	}
 
 	/**
+	 * Returns an option value as the result of the callable being applied to
+	 * it if a value is set, otherwise null.
+	 *
+	 * @param (string) $option_name Option name
+	 * @param (callable) $cast_callable Callable to invoke on option value
+	 * @return (int|null) Numeric option value or null
+	 */
+	protected function get_cast_option_value_or_null( $option_name, $cast_callable ) {
+		$option_value = get_option( $option_name, null );
+		if ( is_null( $option_value ) ) {
+			return $option_value;
+		}
+
+		return call_user_func( $cast_callable, $option_value );
+	}
+
+	/**
 	 * Collects the necessary information to return for a get settings response.
 	 *
 	 * @return (array)
@@ -136,11 +153,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					)
 				);
 
-				$eventbrite_api_token = (int) get_option( 'eventbrite_api_token' );
-				if ( 0 === $eventbrite_api_token ) {
-					$eventbrite_api_token = null;
-				}
-
 				$holiday_snow = false;
 				if ( function_exists( 'jetpack_holiday_snow_option_name' ) ) {
 					$holiday_snow = (bool) get_option( jetpack_holiday_snow_option_name() );
@@ -191,7 +203,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'jetpack_comment_likes_enabled' => (bool) get_option( 'jetpack_comment_likes_enabled', false ),
 					'twitter_via'             => (string) get_option( 'twitter_via' ),
 					'jetpack-twitter-cards-site-tag' => (string) get_option( 'jetpack-twitter-cards-site-tag' ),
-					'eventbrite_api_token'    => $eventbrite_api_token,
+					'eventbrite_api_token'    => $this->get_cast_option_value_or_null( 'eventbrite_api_token', 'intval' ),
 					'holidaysnow'             => $holiday_snow,
 					'gmt_offset'              => get_option( 'gmt_offset' ),
 					'timezone_string'         => get_option( 'timezone_string' ),
@@ -199,6 +211,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'jetpack_testimonial_posts_per_page' => (int) get_option( 'jetpack_testimonial_posts_per_page', '10' ),
 					'jetpack_portfolio'       => (bool) get_option( 'jetpack_portfolio', '0' ),
 					'jetpack_portfolio_posts_per_page' => (int) get_option( 'jetpack_portfolio_posts_per_page', '10' ),
+					'site_icon'               => $this->get_cast_option_value_or_null( 'site_icon', 'intval' ),
 				);
 
 				//allow future versions of this endpoint to support additional settings keys
@@ -417,10 +430,25 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$value = '';
 					}
 
-					// Always set timezone_string either with the given value or with an 
+					// Always set timezone_string either with the given value or with an
 					// empty string
 					if ( update_option( $key, $value ) ) {
 						$updated[ $key ] = $value;
+					}
+					break;
+
+				case 'site_icon':
+					// settings are stored as deletable numeric (all empty
+					// values as delete intent), validated as media image
+					if ( empty( $value ) || WPCOM_JSON_API::is_falsy( $value ) ) {
+						if ( delete_option( $key ) ) {
+							$updated[ $key ] = null;
+						}
+					} else if ( is_numeric( $value ) ) {
+						$coerce_value = (int) $value;
+						if ( wp_attachment_is_image( $coerce_value ) && update_option( $key, $coerce_value ) ) {
+							$updated[ $key ] = $coerce_value;
+						}
 					}
 					break;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This pull request seeks to include `site_icon` as an option to be managed by the `/sites/%s/settings` endpoints. This will enable consumers to manage the [Site Icon feature](https://make.wordpress.org/core/2015/07/27/site-icon/) for their site.

Support was added for this field on WordPress.com in r143429-wpcom
#### Testing instructions:
1. Apply changes
2. Navigate to [REST API console](https://developer.wordpress.com/docs/api/console/)
3. Enter `GET /sites/%s/settings` as URL substituting your site domain or ID
4. Note that the response settings object includes `site_icon`, either `null` or the ID of the media item assigned to Site Icon if configured
5. Enter `POST /sites/%s/settings` as URL substituting your site domain or ID
6. In the "body" field, enter `site_icon=%d` substituting a media ID (can be found in the URL of an attachment detail page in wp-admin as `?item=` query argument)
7. Note that the response includes the updated media ID
