### PR TITLE
Sync: remove sharedaddy on sync

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -582,6 +582,9 @@ add_action( 'template_redirect', 'sharing_process_requests', 9 );
 
 function sharing_display( $text = '', $echo = false ) {
 	global $post, $wp_current_filter;
+	if ( Jetpack_Sync_Settings::is_syncing() ) {
+		return $text;
+	}
 
 	if ( empty( $post ) )
 		return $text;

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -598,10 +598,10 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function enable_services() {
-		return array( 'all' => array( 'print'  => new Share_Print( 'print', array( ) ) ),
-		              'visible' => array( 'print'  => new Share_Print( 'print', array( ) ) ),
-			'hidden' => array()
-
+		return array(
+			'all' => array( 'print'  => new Share_Print( 'print', array( ) ) ),
+			'visible' => array( 'print'  => new Share_Print( 'print', array( ) ) ),
+			'hidden' => array(),
 		);
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -581,16 +581,28 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	function test_remove_sharedaddy_from_filtered_content() {
 		require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php';
-
+		set_current_screen( 'front' );
+		add_filter( 'sharing_show', '__return_true' );
+		add_filter( 'sharing_enabled', array( $this, 'enable_services' ) );
 		$this->post->post_content = 'The new post content';
 
 		wp_update_post( $this->post );
 
+		$this->assertContains( 'class="sharedaddy sd-sharing-enabled"', apply_filters( 'the_content', $this->post->post_content ) );
+		
 		$this->sender->do_sync();
 
 		$synced_post = $this->server_replica_storage->get_post( $this->post->ID );
 
 		$this->assertEquals( '<p>' . $synced_post->post_content . "</p>\n", $synced_post->post_content_filtered );
+	}
+
+	function enable_services() {
+		return array( 'all' => array( 'print'  => new Share_Print( 'print', array( ) ) ),
+		              'visible' => array( 'print'  => new Share_Print( 'print', array( ) ) ),
+			'hidden' => array()
+
+		);
 	}
 
 	function test_remove_related_posts_from_filtered_content() {


### PR DESCRIPTION
cc: @lezama 
Fixes the test Sharedaddy test, and sharedaddy to show that we don't sync sharedaddy filtered content. 
