### PR TITLE
Do not sync non public post types filtered post content and excerpt.

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -107,6 +107,18 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	function filter_post_content_and_add_links( $post_object ) {
 		global $post;
 		$post = $post_object;
+
+		// return non existant post 
+		$post_type = get_post_type_object( $post->post_type );
+		if ( empty( $post_type) || ! is_object( $post_type ) ) {
+			$non_existant_post                    = new stdClass();
+			$non_existant_post->ID                = $post->ID;
+			$non_existant_post->post_modified     = $post->post_modified;
+			$non_existant_post->post_modified_gmt = $post->post_modified_gmt;
+			$non_existant_post->post_status       = 'jetpack_sync_non_registered_post_type';
+			
+			return $non_existant_post;
+		}
 		/**
 		 * Filters whether to prevent sending post data to .com
 		 *
@@ -137,10 +149,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( 0 < strlen( $post->post_password ) ) {
 			$post->post_password = 'auto-' . wp_generate_password( 10, false );
 		}
-
-		$post_type = get_post_type_object( $post->post_type );
+		
 		/** This filter is already documented in core. wp-includes/post-template.php */
 		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) && $post_type->public  ) {
+
 			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
 			$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
 		}

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -137,8 +137,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( 0 < strlen( $post->post_password ) ) {
 			$post->post_password = 'auto-' . wp_generate_password( 10, false );
 		}
+
+		$post_type = get_post_type_object( $post->post_type );
 		/** This filter is already documented in core. wp-includes/post-template.php */
-		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) ) {
+		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) && $post_type->public  ) {
 			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
 			$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
 		}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -684,6 +684,22 @@ That was a cool video.';
 		}
 	}
 
+	function test_do_not_sync_non_public_post_types_filtered_post_content() {
+		$args = array(
+			'public' => false,
+			'label'  => 'Non Public'
+		);
+		register_post_type( 'non_public', $args );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'non_public' ) );
+
+		$this->sender->do_sync();
+		$synced_post = $this->server_replica_storage->get_post( $post_id );
+
+		$this->assertEquals( '', $synced_post->post_content_filtered );
+		$this->assertEquals( '', $synced_post->post_excerpt_filtered );
+	}
+
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {
 
 		global $wp_version;

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -403,7 +403,32 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$post_on_server = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->args[1];
 		$this->assertObjectNotHasAttribute( 'featured_image', $post_on_server );
+	}
 
+	function test_do_not_sync_non_existant_post_types() {
+		$args = array(
+			'public' => true,
+			'label'  => 'unregister post type'
+		);
+		register_post_type( 'unregister_post_type', $args );
+		$post_id = $this->factory->post->create( array( 'post_type' => 'unregister_post_type' ) );
+		unregister_post_type( 'unregister_post_type' );
+		
+		$this->sender->do_sync();
+		$synced_post = $this->server_replica_storage->get_post( $post_id );
+
+		$this->assertEquals( 'jetpack_sync_non_registered_post_type', $synced_post->post_status );
+		$this->assertEquals( '', $synced_post->post_content_filtered );
+		$this->assertEquals( '', $synced_post->post_excerpt_filtered );
+
+		// Also works for post type that was never registed
+		$post_id = $this->factory->post->create( array( 'post_type' => 'does_not_exist' ) );
+		$this->sender->do_sync();
+		$synced_post = $this->server_replica_storage->get_post( $post_id );
+
+		$this->assertEquals( 'jetpack_sync_non_registered_post_type', $synced_post->post_status );
+		$this->assertEquals( '', $synced_post->post_content_filtered );
+		$this->assertEquals( '', $synced_post->post_excerpt_filtered );
 	}
 
 	function test_sync_post_jetpack_sync_prevent_sending_post_data_filter() {
@@ -428,8 +453,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( strtotime( $this->post->post_modified ) <= strtotime( $post->post_modified ) );
 		$this->assertTrue( strtotime( $this->post->post_modified_gmt ) <= strtotime( $post->post_modified_gmt ) );
 		$this->assertEquals( 'jetpack_sync_blocked', $post->post_status );
-		$this->assertFalse( isset( $post->post_content ) );
-		$this->assertFalse( isset( $post->post_excerpt ) );
+
 
 		// Since the filter is not there any more the sync should happen as expected.
 		$this->post->post_content = "foo bar";
@@ -698,6 +722,7 @@ That was a cool video.';
 
 		$this->assertEquals( '', $synced_post->post_content_filtered );
 		$this->assertEquals( '', $synced_post->post_excerpt_filtered );
+
 	}
 
 	function test_embed_shortcode_is_disabled_on_the_content_filter_during_sync() {


### PR DESCRIPTION
The reason why we don't want to sync that content is that it takes
resources to generate and the filtered content but likely good that we
would use it is very small. Since the post type is internal anyway.

cc: @lezama, @gravityrail 