### PR TITLE
Sharing: wrap JS request in a jquery ready event handler.

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -496,7 +496,7 @@ class Share_Email extends Sharing_Source {
 
 			<?php endif; ?>
 			<input type="text" id="jetpack-source_f_name" name="source_f_name" class="input" value="" size="25" autocomplete="off" />
-			<script> document.getElementById('jetpack-source_f_name').value = ''; </script>
+			<script>jQuery( document ).ready( function(){ document.getElementById('jetpack-source_f_name').value = '' });</script>
 			<?php
 				/**
 				 * Fires when the Email sharing dialog is loaded.


### PR DESCRIPTION
Avoids issues with plugins that change the way JavaScript is enqueued.
@see https://github.com/Automattic/jetpack/issues/448#issuecomment-252424650

#### Proposed changelog entry for your changes:

Sharing: fix conflict between the Email button and the Autoptimize plugin.

cc @paulprins 