### PR TITLE
Endpoints: fixes permissions check for plugin information retrieval

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -453,7 +453,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool Whether user has the capability 'jetpack_admin_page' and 'activate_plugins'.
 	 */
 	public static function activate_plugins_permission_check() {
-		if ( current_user_can( 'jetpack_admin_page', 'activate_plugins' ) ) {
+		if ( current_user_can( 'jetpack_admin_page' ) && current_user_can( 'activate_plugins' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Changes permission checking when fetching plugin information

#### Testing instructions:
* go to Jetpack admin make sure the AAG and any card that uses plugin information (like Akismet or VaultPress) is working normally.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Endpoints: permissions checking while fetching plugin information were fixed.

cc @samhotchkiss 