### PR TITLE
Sync: Users: Avoid warning when `$user->data` is not set

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -64,7 +64,10 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function sanitize_user( $user ) {
 		// this create a new user object and stops the passing of the object by reference.
 		$user = unserialize( serialize( $user ) );
-		unset( $user->data->user_pass );
+
+		if ( is_object( $user->data ) ) {
+			unset( $user->data->user_pass );
+		}
 
 		return $user;
 	}


### PR DESCRIPTION
Reported in: https://wordpress.org/support/topic/module-error/

cc @jeherve 