### PR TITLE
Sync: Add whitelist for post_meta and comment_meta to settings

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -666,6 +666,8 @@ $sync_settings_response = array(
 	'max_queue_lag'        => '(int|bool=false) Maximum queue lag in seconds used to prevent the DB from filling up. Needs to also meet the max_queue_size limit.',
 	'queue_max_writes_sec' => '(int|bool=false) Maximum writes per second to allow to the queue during full sync.',
 	'post_types_blacklist' => '(array|string|bool=false) List of post types to exclude from sync. Send "empty" to unset.',
+	'post_meta_whitelist'  => '(array|string|bool=false) List of post meta to be included in sync. Send "empty" to unset.',
+	'comment_meta_whitelist' => '(array|string|bool=false) List of comment meta to be included in sync. Send "empty" to unset.',
 	'disable'              => '(int|bool=false) Set to 1 or true to disable sync entirely.',
 	'render_filtered_content' => '(int|bool=true) Set to 1 or true to render filtered content.',
 );

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -182,7 +182,7 @@ class Jetpack_Sync_Defaults {
 		'network_enable_administration_menus' => array( 'Jetpack', 'network_enable_administration_menus' ),
 	);
 
-	static $default_post_meta_whitelist = array(
+	static $post_meta_whitelist = array(
 		'_feedback_akismet_values',
 		'_feedback_email',
 		'_feedback_extra_fields',
@@ -221,7 +221,7 @@ class Jetpack_Sync_Defaults {
 		'vimeo_poster_image',
 	);
 
-	static $default_comment_meta_whitelist = array(
+	static $comment_meta_whitelist = array(
 		'hc_avatar',
 		'hc_post_as',
 		'hc_wpcom_id_sig',
@@ -286,6 +286,8 @@ class Jetpack_Sync_Defaults {
 	static $default_max_queue_lag = 900; // 15 minutes
 	static $default_queue_max_writes_sec = 100; // 100 rows a second
 	static $default_post_types_blacklist = array();
+	static $default_post_meta_whitelist = array();
+	static $default_comment_meta_whitelist = array();
 	static $default_disable = 0; // completely disable sending data to wpcom
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -182,7 +182,7 @@ class Jetpack_Sync_Defaults {
 		'network_enable_administration_menus' => array( 'Jetpack', 'network_enable_administration_menus' ),
 	);
 
-	static $default_whitelist_post_meta_keys = array(
+	static $default_post_meta_whitelist = array(
 		'_feedback_akismet_values',
 		'_feedback_email',
 		'_feedback_extra_fields',
@@ -221,7 +221,7 @@ class Jetpack_Sync_Defaults {
 		'vimeo_poster_image',
 	);
 
-	static $default_whitelist_comment_meta_keys = array(
+	static $default_comment_meta_whitelist = array(
 		'hc_avatar',
 		'hc_post_as',
 		'hc_wpcom_id_sig',

--- a/sync/class.jetpack-sync-module-meta.php
+++ b/sync/class.jetpack-sync-module-meta.php
@@ -2,15 +2,9 @@
 
 class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 	private $meta_types = array( 'post', 'comment' );
-	private $post_meta_whitelist = array();
 
 	public function name() {
 		return 'meta';
-	}
-
-	public function set_defaults() {
-		$this->post_meta_whitelist = Jetpack_Sync_Defaults::$default_whitelist_post_meta_keys;
-		$this->comment_meta_whitelist = Jetpack_Sync_Defaults::$default_whitelist_comment_meta_keys;
 	}
 
 	/**
@@ -88,30 +82,22 @@ class Jetpack_Sync_Module_Meta extends Jetpack_Sync_Module {
 		}
 	}
 	// POST Meta
-	function set_post_meta_whitelist( $post_meta ) {
-
-		$this->post_meta_whitelist = (array) $post_meta;
-	}
-
 	function get_post_meta_whitelist() {
-		return $this->post_meta_whitelist;
+		return Jetpack_Sync_Settings::get_setting( 'post_meta_whitelist' );
 	}
 
 	function is_whitelisted_post_meta( $meta_key ) {
-		return in_array( $meta_key, $this->post_meta_whitelist ) || wp_startswith( $meta_key, '_wpas_skip_' );
+		// _wpas_skip_ is used by publicize
+		return in_array( $meta_key, $this->get_post_meta_whitelist() ) || wp_startswith( $meta_key, '_wpas_skip_' );
 	}
 
 	// Comment Meta
-	function set_comment_meta_whitelist( $comment_meta ) {
-		$this->comment_meta_whitelist = (array) $comment_meta;
-	}
-
 	function get_comment_meta_whitelist() {
-		return $this->comment_meta_whitelist;
+		return Jetpack_Sync_Settings::get_setting( 'comment_meta_whitelist' );
 	}
 
 	function is_whitelisted_comment_meta( $meta_key ) {
-		return in_array( $meta_key, $this->comment_meta_whitelist );
+		return in_array( $meta_key, $this->get_comment_meta_whitelist() );
 	}
 
 	function is_post_type_allowed( $post_id ) {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -17,6 +17,8 @@ class Jetpack_Sync_Settings {
 		'post_types_blacklist' => true,
 		'disable'              => true,
 		'render_filtered_content' => true,
+		'post_meta_whitelist' => true,
+		'comment_meta_whitelist' => true,
 	);
 
 	static $is_importing;
@@ -58,9 +60,16 @@ class Jetpack_Sync_Settings {
 			$value = intval( $value );
 		}
 
-		// specifically for the post_types blacklist, we want to include the hardcoded settings
-		if ( $setting === 'post_types_blacklist' ) {
-			$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$blacklisted_post_types ) );
+		switch( $setting ) {
+			case 'post_types_blacklist':
+				$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$blacklisted_post_types ) );
+				break;
+			case 'post_meta_whitelist':
+				$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$default_post_meta_whitelist ) );
+				break;
+			case 'comment_meta_whitelist':
+				$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$default_comment_meta_whitelist ) );
+				break;
 		}
 
 		self::$settings_cache[ $setting ] = $value;

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -59,17 +59,25 @@ class Jetpack_Sync_Settings {
 		if ( is_numeric( $value ) ) {
 			$value = intval( $value );
 		}
-
+		$default_array_value = null;
 		switch( $setting ) {
 			case 'post_types_blacklist':
-				$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$blacklisted_post_types ) );
+				$default_array_value = Jetpack_Sync_Defaults::$blacklisted_post_types;
 				break;
 			case 'post_meta_whitelist':
-				$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$default_post_meta_whitelist ) );
+				$default_array_value = Jetpack_Sync_Defaults::$post_meta_whitelist;
 				break;
 			case 'comment_meta_whitelist':
-				$value = array_unique( array_merge( $value, Jetpack_Sync_Defaults::$default_comment_meta_whitelist ) );
+				$default_array_value = Jetpack_Sync_Defaults::$comment_meta_whitelist;
 				break;
+		}
+
+		if ( $default_array_value ) {
+			if ( is_array( $value ) ) {
+				$value = array_unique( array_merge( $value, $default_array_value ) );
+			} else {
+				$value = $default_array_value;
+			}
 		}
 
 		self::$settings_cache[ $setting ] = $value;

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -366,8 +366,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	function test_full_sync_sends_all_post_meta() {
 		$post_id = $this->factory->post->create();
-		$meta_module = Jetpack_Sync_Modules::get_module( "meta" );
-		$meta_module->set_post_meta_whitelist( array( 'test_meta_key', 'test_meta_array' ) );
+
+		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( 'test_meta_key', 'test_meta_array' ) ) );
 
 		add_post_meta( $post_id, 'test_meta_key', 'foo' );
 		add_post_meta( $post_id, 'test_meta_array', array( 'foo', 'bar' ) );
@@ -388,13 +388,16 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
 		$this->assertEquals( array( 'foo', 'bar' ), $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
+
+		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( ) ) );
+
 	}
 
 	function test_full_sync_doesnt_sends_forbiden_private_or_public_post_meta() {
 		$post_id = $this->factory->post->create();
 		
 		$meta_module = Jetpack_Sync_Modules::get_module( "meta" );
-		$meta_module->set_post_meta_whitelist( array( '_wp_attachment_metadata', 'a_public_meta' ) );
+		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( 'a_public_meta' ) ) );
 
 		// forbidden private meta
 		add_post_meta( $post_id, '_test_meta_key', 'foo1' );
@@ -428,7 +431,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'snapTW', true ) );
 		$this->assertEquals( 'foo4', $this->server_replica_storage->get_metadata( 'post', $post_id, '_wp_attachment_metadata', true ) );
 		$this->assertEquals( 'foo5', $this->server_replica_storage->get_metadata( 'post', $post_id, 'a_public_meta', true ) );
-
+		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( ) ) );
 	}
 
 	function test_full_sync_sends_all_post_terms() {
@@ -455,8 +458,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$comment_ids = $this->factory->comment->create_post_comments( $post_id );
 		$comment_id  = $comment_ids[0];
 
-		$meta_module = Jetpack_Sync_Modules::get_module( "meta" );
-		$meta_module->set_comment_meta_whitelist( array( 'test_meta_key' ) );
+		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array( 'test_meta_key' ) ) );
 
 		add_comment_meta( $comment_id, 'test_meta_key', 'foo' );
 
@@ -473,6 +475,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'comment', $comment_id, 'test_meta_key', true ) );
+		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array( ) ) );
 	}
 
 	function test_full_sync_sends_theme_info() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -388,9 +388,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_key', true ) );
 		$this->assertEquals( array( 'foo', 'bar' ), $this->server_replica_storage->get_metadata( 'post', $post_id, 'test_meta_array', true ) );
-
-		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( ) ) );
-
 	}
 
 	function test_full_sync_doesnt_sends_forbiden_private_or_public_post_meta() {
@@ -431,7 +428,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $post_id, 'snapTW', true ) );
 		$this->assertEquals( 'foo4', $this->server_replica_storage->get_metadata( 'post', $post_id, '_wp_attachment_metadata', true ) );
 		$this->assertEquals( 'foo5', $this->server_replica_storage->get_metadata( 'post', $post_id, 'a_public_meta', true ) );
-		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( ) ) );
 	}
 
 	function test_full_sync_sends_all_post_terms() {
@@ -475,7 +471,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_metadata( 'comment', $comment_id, 'test_meta_key', true ) );
-		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array( ) ) );
 	}
 
 	function test_full_sync_sends_theme_info() {

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -7,13 +7,14 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
 	protected $meta_module;
 
-	protected $whitelisted_post_meta = 'content_width';
+	protected $whitelisted_post_meta = 'foobar';
 
 	public function setUp() {
 		parent::setUp();
 
 		// create a post
 		$this->meta_module = Jetpack_Sync_Modules::get_module( "meta" );
+		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( 'foobar' ) ) );
 		$this->post_id = $this->factory->post->create();
 		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
 		$this->sender->do_sync();
@@ -36,7 +37,6 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
-		error_log( print_r( $meta_key_array,1 ));
 		$this->assertEquals( array( 'foo', 'bar' ), $meta_key_array );
 	}
 
@@ -129,7 +129,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array() ) );
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options
-		$white_listed_post_meta = Jetpack_Sync_Defaults::$default_post_meta_whitelist;
+		$white_listed_post_meta = Jetpack_Sync_Defaults::$post_meta_whitelist;
 
 		// update all the opyions.
 		foreach ( $white_listed_post_meta as $meta_key ) {
@@ -155,7 +155,7 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array() ) );
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options
-		$white_listed_comment_meta = Jetpack_Sync_Defaults::$default_comment_meta_whitelist;
+		$white_listed_comment_meta = Jetpack_Sync_Defaults::$comment_meta_whitelist;
 
 		$comment_ids = $this->factory->comment->create_post_comments( $this->post_id );
 

--- a/tests/php/sync/test_class.jetpack-sync-meta.php
+++ b/tests/php/sync/test_class.jetpack-sync-meta.php
@@ -7,91 +7,86 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
 	protected $meta_module;
 
+	protected $whitelisted_post_meta = 'content_width';
+
 	public function setUp() {
 		parent::setUp();
 
 		// create a post
 		$this->meta_module = Jetpack_Sync_Modules::get_module( "meta" );
-		$this->meta_module->set_post_meta_whitelist( array( 'test_meta_key' ) );
 		$this->post_id = $this->factory->post->create();
-		add_post_meta( $this->post_id, 'test_meta_key', 'foo' );
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
 		$this->sender->do_sync();
 	}
 
 	public function test_added_post_meta_is_synced() {
 
-		$meta_key_value = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_key', true );
-		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_key' );
+		$meta_key_value = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta, true );
+		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
 
 		$this->assertEquals( 'foo', $meta_key_value );
 		$this->assertEquals( array( 'foo' ), $meta_key_array );
 	}
 
 	public function test_added_multiple_post_meta_is_synced() {
-		$this->meta_module->set_post_meta_whitelist( array( 'test_meta_key_array' ) );
 
-		add_post_meta( $this->post_id, 'test_meta_key_array', 'foo' );
-		add_post_meta( $this->post_id, 'test_meta_key_array', 'bar' );
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo', true );
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'bar' );
 
 		$this->sender->do_sync();
 
-		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_key_array' );
-
+		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
+		error_log( print_r( $meta_key_array,1 ));
 		$this->assertEquals( array( 'foo', 'bar' ), $meta_key_array );
 	}
 
 	public function test_add_then_updated_post_meta_is_synced() {
-		$this->meta_module->set_post_meta_whitelist( array( 'test_meta_key_array_2' ) );
-		add_post_meta( $this->post_id, 'test_meta_key_array_2', 'foo' );
-		update_post_meta( $this->post_id, 'test_meta_key_array_2', 'bar', 'foo' );
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
+		update_post_meta( $this->post_id, $this->whitelisted_post_meta, 'bar', 'foo' );
 
 		$this->sender->do_sync();
 
-		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_key_array_2' );
-
-		$this->assertEquals( get_post_meta( $this->post_id, 'test_meta_key_array_2' ), $meta_key_array );
+		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta ), $meta_key_array );
 	}
 
 	public function test_updated_post_meta_is_synced() {
-		$this->meta_module->set_post_meta_whitelist( array( 'test_meta_key_array_3' ) );
-		update_post_meta( $this->post_id, 'test_meta_key_array_3', 'foo' );
-		update_post_meta( $this->post_id, 'test_meta_key_array_3', 'bar', 'foo' );
+		update_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
+		update_post_meta( $this->post_id, $this->whitelisted_post_meta, 'bar', 'foo' );
 
 		$this->sender->do_sync();
 
-		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_key_array_3' );
-		$this->assertEquals( get_post_meta( $this->post_id, 'test_meta_key_array_3' ), $meta_key_array );
+		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta ), $meta_key_array );
 	}
 
 	public function test_deleted_post_meta_is_synced() {
-		$this->meta_module->set_post_meta_whitelist( array( 'test_meta_delete' ) );
-		add_post_meta( $this->post_id, 'test_meta_delete', 'foo' );
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
 
-		delete_post_meta( $this->post_id, 'test_meta_delete', 'foo' );
+		delete_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
 		$this->sender->do_sync();
 
-		$meta_key_value = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_delete', true );
-		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_delete' );
+		$meta_key_value = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta, true );
+		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
 
-		$this->assertEquals( get_post_meta( $this->post_id, 'test_meta_delete', true ), $meta_key_value );
-		$this->assertEquals( get_post_meta( $this->post_id, 'test_meta_delete' ), $meta_key_array );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta, true ), $meta_key_value );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta ), $meta_key_array );
 	}
 
 	public function test_delete_all_post_meta_is_synced() {
-		$this->meta_module->set_post_meta_whitelist( array( 'test_meta_delete_all' ) );
-		add_post_meta( $this->post_id, 'test_meta_delete_all', 'foo' );
 
-		delete_metadata( 'post', $this->post_id, 'test_meta_delete_all', '', true );
+		add_post_meta( $this->post_id, $this->whitelisted_post_meta, 'foo' );
+
+		delete_metadata( 'post', $this->post_id, $this->whitelisted_post_meta, '', true );
 		$this->sender->do_sync();
 
-		$meta_key_value = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_delete_all', true );
-		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, 'test_meta_delete_all' );
-		$this->assertEquals( get_post_meta( $this->post_id, 'test_meta_delete_all', true ), $meta_key_value );
-		$this->assertEquals( get_post_meta( $this->post_id, 'test_meta_delete_all' ), $meta_key_array );
+		$meta_key_value = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta, true );
+		$meta_key_array = $this->server_replica_storage->get_metadata( 'post', $this->post_id, $this->whitelisted_post_meta );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta, true ), $meta_key_value );
+		$this->assertEquals( get_post_meta( $this->post_id, $this->whitelisted_post_meta ), $meta_key_array );
 	}
 
 	public function test_doesn_t_sync_private_meta() {
-		// $ignore_meta_keys = array( '_edit_lock', '_pingme', '_encloseme' );
 		add_post_meta( $this->post_id, '_private_meta', 'foo' );
 
 		$this->sender->do_sync();
@@ -99,10 +94,42 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $this->post_id, '_private_meta', true ) );
 	}
 
+	public function test_post_meta_whitelist_cab_be_appened_in_settings() {
+		add_post_meta( $this->post_id, '_private_meta', 'foo' );
+		$this->sender->do_sync();
+
+		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'post', $this->post_id, '_private_meta', true ) );
+
+		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array( '_private_meta' ) ) );
+		
+		add_post_meta( $this->post_id, '_private_meta', 'boo' );
+		
+		$this->sender->do_sync();
+
+		$this->assertEquals( 'boo', $this->server_replica_storage->get_metadata( 'post', $this->post_id, '_private_meta', true ) );
+	}
+
+	public function test_comment_meta_whitelist_cab_be_appened_in_settings() {
+		$comment_ids = $this->factory->comment->create_post_comments( $this->post_id );
+		
+		add_comment_meta( $comment_ids[0], '_private_meta', 'foo' );
+		$this->sender->do_sync();
+
+		$this->assertEquals( null, $this->server_replica_storage->get_metadata( 'comment', $comment_ids[0], '_private_meta', true ) );
+
+		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array( '_private_meta' ) ) );
+
+		add_comment_meta( $comment_ids[0], '_private_meta', 'boo' );
+		$this->sender->do_sync();
+
+		$this->assertEquals( 'boo', $this->server_replica_storage->get_metadata( 'comment', $comment_ids[0], '_private_meta', true ) );
+	}
+
 	public function test_sync_whitelisted_post_meta() {
+		Jetpack_Sync_Settings::update_settings( array( 'post_meta_whitelist' => array() ) );
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options
-		$white_listed_post_meta = Jetpack_Sync_Defaults::$default_whitelist_post_meta_keys;
+		$white_listed_post_meta = Jetpack_Sync_Defaults::$default_post_meta_whitelist;
 
 		// update all the opyions.
 		foreach ( $white_listed_post_meta as $meta_key ) {
@@ -125,9 +152,10 @@ class WP_Test_Jetpack_Sync_Meta extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_sync_whitelisted_comment_meta() {
+		Jetpack_Sync_Settings::update_settings( array( 'comment_meta_whitelist' => array() ) );
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options
-		$white_listed_comment_meta = Jetpack_Sync_Defaults::$default_whitelist_comment_meta_keys;
+		$white_listed_comment_meta = Jetpack_Sync_Defaults::$default_comment_meta_whitelist;
 
 		$comment_ids = $this->factory->comment->create_post_comments( $this->post_id );
 


### PR DESCRIPTION
Adds post and comment whitelist to the settings so that we can update them for old versions (once this version is old) or if we find that we missed some. 

We remove the ability to set_post_meta and comment_meta to the sync-module-meta since that was only needed for tests.

Update the test to pass.