### PR TITLE
Add new method & endpoint for deleting connection options

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -741,6 +741,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 							'message' => esc_html__( 'Connection options cleared.', 'jetpack' ),
 						) );
 					}
+
+					return new WP_Error(
+						'invalid_option_name',
+						esc_html__( 'Reset connection options failed. Likely due to an invalid option name.', 'jetpack' ),
+						array( 'status' => 400 )
+					);
 					break;
 
 				default:

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -734,6 +734,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 					) );
 					break;
 
+				case 'connection' :
+					if ( Jetpack::clear_all_connection_options() ) {
+						return rest_ensure_response( array(
+							'code' => 'success',
+							'message' => esc_html__( 'Connection options cleared.', 'jetpack' ),
+						) );
+					}
+					break;
+
 				default:
 					return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
 			}

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -203,6 +203,7 @@ class Jetpack_Options {
 	 * Updates jetpack_options and/or deletes jetpack_$name as appropriate.
 	 *
 	 * @param string|array $names
+	 * @return boolean
 	 */
 	public static function delete_option( $names ) {
 		$result = true;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2586,9 +2586,14 @@ p {
 	 * You would then use this before connecting to spin up a NEW shadow site using this new URL (rather than
 	 * move the connection from the old URL).
 	 *
+	 * @param bool $check_idc If false, it will skip the check if in IDC
 	 * @return bool True if success, False if not.
 	 */
-	public static function clear_all_connection_options() {
+	public static function clear_all_connection_options( $check_idc = true ) {
+		if ( $check_idc && get_home_url() !== Jetpack_Options::get_option( 'sync_error_idc' ) ) {
+			return false; // No IDC here... don't mess up connection by deleting options.
+		}
+
 		return Jetpack_Options::delete_option(
 			array(
 				'id',
@@ -2617,7 +2622,7 @@ p {
 		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.deregister' );
 
-		self::clear_all_connection_options();
+		self::clear_all_connection_options( false );
 
 		if ( $update_activated_state ) {
 			Jetpack_Options::update_option( 'activated', 4 );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2575,6 +2575,35 @@ p {
 		}
 	}
 
+	/*
+	 * This will clear all the options that the Jetpack connection needs to survive.
+	 *
+	 * This should only be used if:
+	 * 1. wpcom thinks the site is disconnected, AND there are left-over connection options in the local DB.
+	 * (i.e. connection errors like invalid client_id)
+	 *
+	 * 2. An IDC was detected (the site's url has changed), and wpcom was not updated with the new URL changes.
+	 * You would then use this before connecting to spin up a NEW shadow site using this new URL (rather than
+	 * move the connection from the old URL).
+	 *
+	 * @return bool True if success, False if not.
+	 */
+	public static function clear_all_connection_options() {
+		return Jetpack_Options::delete_option(
+			array(
+				'id',
+				'register',
+				'blog_token',
+				'user_token',
+				'user_tokens',
+				'master_user',
+				'time_diff',
+				'fallback_no_verify_ssl_certs',
+				'authorize',
+			)
+		);
+	}
+
 	/**
 	 * Disconnects from the Jetpack servers.
 	 * Forgets all connection details and tells the Jetpack servers to do the same.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2617,17 +2617,7 @@ p {
 		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.deregister' );
 
-		Jetpack_Options::delete_option(
-			array(
-				'register',
-				'blog_token',
-				'user_token',
-				'user_tokens',
-				'master_user',
-				'time_diff',
-				'fallback_no_verify_ssl_certs',
-			)
-		);
+		self::clear_all_connection_options();
 
 		if ( $update_activated_state ) {
 			Jetpack_Options::update_option( 'activated', 4 );

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -452,7 +452,7 @@ EXPECTED;
 			Jetpack_Options::update_option( $option, 'fake.test-value123' );
 		}
 
-		Jetpack::clear_all_connection_options();
+		Jetpack::clear_all_connection_options( false );
 
 		$cleared_options = true;
 		foreach ( $options_to_delete as $option ) {

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -435,6 +435,26 @@ EXPECTED;
 		add_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
 	}
 
+	function test_clear_all_connection_options_clears_all_connection_options() {
+		Jetpack_Options::update_options(
+			array(
+				'id' => 'testConnectionOption_id',
+				'register' => 'testConnectionOption_register',
+				'blog_token' => 'testConnectionOption_blog_token',
+				'user_token' => 'testConnectionOption_user_token',
+				'user_tokens' => array(
+					'1' => 'testConnectionOption_user_tokens1',
+					'2' => 'testConnectionOption_user_tokens2',
+				),
+				'master_user' => 'testConnectionOption_master_user',
+				'time_diff' => 'testConnectionOption_time_diff',
+				'fallback_no_verify_ssl_certs' => 'testConnectionOption_fallback',
+				'authorize' => 'testConnectionOption_authorize',
+			)
+		);
+		$this->assertTrue( Jetpack::clear_all_connection_options() );
+	}
+
 	function __return_string_1() {
 		return '1';
 	}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -436,23 +436,32 @@ EXPECTED;
 	}
 
 	function test_clear_all_connection_options_clears_all_connection_options() {
-		Jetpack_Options::update_options(
-			array(
-				'id' => 'testConnectionOption_id',
-				'register' => 'testConnectionOption_register',
-				'blog_token' => 'testConnectionOption_blog_token',
-				'user_token' => 'testConnectionOption_user_token',
-				'user_tokens' => array(
-					'1' => 'testConnectionOption_user_tokens1',
-					'2' => 'testConnectionOption_user_tokens2',
-				),
-				'master_user' => 'testConnectionOption_master_user',
-				'time_diff' => 'testConnectionOption_time_diff',
-				'fallback_no_verify_ssl_certs' => 'testConnectionOption_fallback',
-				'authorize' => 'testConnectionOption_authorize',
-			)
+		$options_to_delete = array(
+			'id',
+			'register',
+			'blog_token',
+			'user_token',
+			'user_tokens',
+			'master_user',
+			'time_diff',
+			'fallback_no_verify_ssl_certs',
+			'authorize',
 		);
-		$this->assertTrue( Jetpack::clear_all_connection_options() );
+
+		foreach ( $options_to_delete as $option ) {
+			Jetpack_Options::update_option( $option, 'fake.test-value123' );
+		}
+
+		Jetpack::clear_all_connection_options();
+
+		$cleared_options = true;
+		foreach ( $options_to_delete as $option ) {
+			if ( false !== Jetpack_Options::get_option( $option ) ) {
+				$cleared_options = $option;
+			}
+		}
+
+		$this->assertTrue( $cleared_options );
 	}
 
 	function __return_string_1() {


### PR DESCRIPTION
New method `Jetpack::clear_all_connection_options()` that will do just that.  Clear all the connection options that the wp.com connection needs to survive, authenticate, and verify.  

**There are two primary reasons this will be useful:** 
1. When we auto-detect an IDC, and it so happens that this new URL is intended to be a _completely separate_ site from the one it was spun up from, clearing these options before trying to disconnect/reconnect will prevent the old URL from disconnecting, as well as provisioning a brand new shadow blog for the new URL.  
2. Sometimes HE's run into reports of Jetpack disconnecting while leaving traces of these options in the local DB.  This causes errors on the remote site when trying to connect (you may see invalid_client_id and others).  The fix for this many times is to clear these options locally.  We could use this in the debugger UI to "nuke all Jetpack connection options".  It's also much more accessible via wp-cli and such.  

There is also a new route parameter `/connection` for the `reset_jetpack_options()` callback, which allows us to do this via wp-api as well.  `/wp-json/jetpack/v4/options/connection`.  