### PR TITLE
Sync: Update the post_excerpt_filtered to use the_excerpt filter instead of the_content

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -140,7 +140,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		/** This filter is already documented in core. wp-includes/post-template.php */
 		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) ) {
 			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
-			$post->post_excerpt_filtered   = apply_filters( 'the_content', $post->post_excerpt );
+			$post->post_excerpt_filtered   = apply_filters( 'the_excerpt', $post->post_excerpt );
 		}
 
 		$this->add_embed();

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -644,6 +644,34 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( "\n", $synced_post->post_content_filtered );
 	}
 
+	function test_that_we_apply_the_right_filters_to_post_content_and_excerpt() {
+		add_filter( 'the_content', array( $this, 'the_content_filter' ), 1000 );
+		add_filter( 'the_excerpt', array( $this, 'the_excerpt_filter' ), 1000 );
+
+		$this->post->post_content = 'hello';
+		$this->post->post_excerpt = 'world';
+
+		wp_update_post( $this->post );
+
+		$this->sender->do_sync();
+
+		$synced_post = $this->server_replica_storage->get_post( $this->post->ID );
+
+		$this->assertEquals( 'the_content', $synced_post->post_content_filtered );
+		$this->assertEquals( 'the_excerpt', $synced_post->post_excerpt_filtered );
+
+		add_filter( 'the_content', array( $this, 'the_content_filter' ) );
+		add_filter( 'the_excerpt', array( $this, 'the_excerpt_filter' ) );
+	}
+	
+	function the_content_filter( $content ) {
+		return 'the_content';
+	}
+
+	function the_excerpt_filter( $content ) {
+		return 'the_excerpt';
+	}
+	
 	function test_embed_is_disabled_on_the_content_filter_during_sync() {
 		global $wp_version;
 		$content =

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -321,7 +321,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$post_on_server = $this->server_replica_storage->get_post( $this->post->ID );
 		$this->assertEquals( $post_on_server->post_excerpt, '[foo]' );
-		$this->assertEquals( trim( $post_on_server->post_excerpt_filtered ), 'bar' );
+		// The excerpt by default should not contain shortcodes so we do not expand them.
+		$this->assertEquals( trim( $post_on_server->post_excerpt_filtered ), '[foo]' );
 	}
 
 	function test_sync_changed_post_password() {


### PR DESCRIPTION
We are currently using the wrong filter for the excerpt since when display excerpt. 
We only should be using the except filter instead of the_content. 

This PR adds a test that confirms that we sync the right filter.