### PR TITLE
Fixes #4309 - flickr shortcode: size parameter not used anywhere

### DIFF
--- a/modules/shortcodes/flickr.php
+++ b/modules/shortcodes/flickr.php
@@ -102,7 +102,6 @@ function flickr_shortcode_handler( $atts ) {
 			'w'         => 400,
 			'h'         => 300,
 			'secret'    => 0,
-			'size'      => 0,
 		), $atts, 'flickr'
 	);
 


### PR DESCRIPTION
Rebased version of #4311 

Props: @bobbingwide 