### PR TITLE
Sync: IDC: Attempt to sync home_url and site_url quicker

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -23,8 +23,11 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
 
-		// always send change to active modules right away
-		add_action( 'update_option_jetpack_active_modules', array( $this, 'unlock_sync_callable' ) );
+		// For some options, we should always send the change right away!
+		$always_send_updates_to_these_options = array( 'jetpack_active_modules', 'home', 'siteurl' );
+		foreach( $always_send_updates_to_these_options as $option ) {
+			add_action( "update_option_{$option}", array( $this, 'unlock_sync_callable' ) );
+		}
 
 		// get_plugins and wp_version
 		// gets fired when new code gets installed, updates etc.


### PR DESCRIPTION
This PR adds two changes that should allow syncing the home and siteurl values much quicker.

First, we sync the values as soon as the option changes.

Second, because the values can be controlled via filter or constant, this PR also adds an `jetpack_sync_unlock_sync_callable` action that developers can tie into with `wp_schedule_single_event( time() + 1, 'jetpack_sync_unlock_sync_callable' )` or something similar to clear the callables await transient and allow syncing the new value sooner.

For testing purposes, you can swap URLs on your site and observe how long it takes to update the URL, or you can run tests with `phpunit --filter=WP_Test_Jetpack_Sync_Functions`

cc @lezama for code review.