### PR TITLE
Sync: By default, do not opt site in if sunrise is defined

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5317,6 +5317,8 @@ p {
 	 * @return bool
 	 */
 	public static function sync_idc_optin() {
+		$default = ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) ? JETPACK_SYNC_IDC_OPTIN : self::is_development_version();
+
 		/**
 		 * Allows sites to optin to IDC mitigation which blocks the site from syncing to WordPress.com when the home
 		 * URL or site URL do not match what WordPress.com expects. The default value is either false, or the value of
@@ -5326,7 +5328,6 @@ p {
 		 *
 		 * @param bool
 		 */
-		$default = ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) ? JETPACK_SYNC_IDC_OPTIN : self::is_development_version();
 		return (bool) apply_filters( 'jetpack_sync_idc_optin', $default );
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5317,7 +5317,13 @@ p {
 	 * @return bool
 	 */
 	public static function sync_idc_optin() {
-		$default = ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) ? JETPACK_SYNC_IDC_OPTIN : self::is_development_version();
+		if ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) {
+			$default = JETPACK_SYNC_IDC_OPTIN;
+		} else if ( defined( 'SUNRISE' ) ) {
+			$default = SUNRISE;
+		} else {
+			$default = self::is_development_version();
+		}
 
 		/**
 		 * Allows sites to optin to IDC mitigation which blocks the site from syncing to WordPress.com when the home


### PR DESCRIPTION
Let's go ahead and not opt-in sites that have `SUNRISE` defined. We are not currently handling mapped domains or multi-language in our mitigation efforts, so we could inadvertently break sites more than we are helping.

We will still opt the site in if `JETPACK_SYNC_IDC_OPTIN` is defined and is truthy or if the site returns true for the `jetpack_sync_idc_optin` filter.

cc @dereksmart for review.