### PR TITLE
General: Fixes an issue where could attempt to get `->slug` of undefi…

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3868,7 +3868,7 @@ p {
 					'jp_version'    => JETPACK__VERSION,
 					'auth_type'     => 'calypso',
 					'secret'        => $secret,
-					'locale'        => isset( $gp_locale->slug ) ? $gp_locale->slug : '',
+					'locale'        => ( isset( $gp_locale ) && isset( $gp_locale->slug ) ) ? $gp_locale->slug : '',
 					'blogname'      => get_option( 'blogname' ),
 					'site_url'      => site_url(),
 					'home_url'      => home_url(),


### PR DESCRIPTION
My IDE was yelling at me that `$gp_locale` might not have been defined within the ternary. I suppose the only way that would happen is if the include failed or we stopped defining the `JETPACK__GLOTPRESS_LOCALES_PATH` constant (which isn't likely to happen). But, ¯\_(ツ)_/¯ 

To test:

- Checkout branch
- Set language of site to something like Spanish
- Disconnect and reconnect site
- Ensure Calypso UI is presented in Spanish 