### PR TITLE
Add REST API tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -62,6 +62,9 @@
 		<testsuite name="uninstall">
 			<directory prefix="test_" suffix=".php">tests/php/uninstall</directory>
 		</testsuite>
+		<testsuite name="restapi">
+			<directory prefix="test_" suffix="rest-api-endpoints.php">tests/php/_inc/lib</directory>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Class for REST API endpoints testing.
+ *
+ * @since 4.4.0
+ */
+class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
+
+	/**
+	 * Setup environment for REST API endpoints test.
+	 *
+	 * @since 4.4.0
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		require_once dirname( __FILE__ ) . '/../../../../_inc/lib/class.core-rest-api-endpoints.php';
+	}
+
+	/**
+	 * Test permission to connect Jetpack site or link user.
+	 *
+	 * @since 4.4.0
+	 */
+	public function test_connection_permission() {
+
+		// Current user doesn't have credentials, so checking permissions should fail
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::connect_url_permission_callback() );
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::link_user_permission_callback() );
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::get_user_connection_data_permission_callback() );
+
+		// Setup a new current user with specified capability
+		$user = $this->factory->user->create_and_get( array(
+			'user_login' => 'user_connect_url',
+			'user_pass'  => 'password_connect_url',
+		) );
+
+		// Add Jetpack capability
+		$user->add_cap( 'jetpack_connect_user' );
+
+		// Setup global variables so this is the current user
+		wp_set_current_user( $user->ID );
+
+		// User has capability so this should work this time
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::connect_url_permission_callback() );
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::link_user_permission_callback() );
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::get_user_connection_data_permission_callback() );
+
+		// It should not work in Dev Mode
+		add_filter( 'jetpack_development_mode', '__return_true' );
+
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::connect_url_permission_callback() );
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::link_user_permission_callback() );
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::get_user_connection_data_permission_callback() );
+
+		remove_filter( 'jetpack_development_mode', '__return_true' );
+	}
+
+	/**
+	 * Test permission to disconnect Jetpack site.
+	 *
+	 * @since 4.4.0
+	 */
+	public function test_disconnection_permission() {
+
+		// Current user doesn't have credentials, so checking permissions should fail
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::disconnect_site_permission_callback() );
+
+		$user = $this->factory->user->create_and_get( array(
+			'user_login' => 'user_disconnect_url',
+			'user_pass'  => 'password_disconnect_url',
+			'role' 		 => 'administrator',
+		) );
+
+		// Add Jetpack capability
+		$user->add_cap( 'jetpack_disconnect' );
+
+		// Setup global variables so this is the current user
+		wp_set_current_user( $user->ID );
+
+		// User has capability so this should work this time
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::disconnect_site_permission_callback() );
+
+	}
+
+} // class end

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -27,7 +27,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		// Current user doesn't have credentials, so checking permissions should fail
 		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::connect_url_permission_callback() );
-		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::link_user_permission_callback() );
 		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::get_user_connection_data_permission_callback() );
 
 		// Setup a new current user with specified capability
@@ -44,14 +43,12 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		// User has capability so this should work this time
 		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::connect_url_permission_callback() );
-		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::link_user_permission_callback() );
 		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::get_user_connection_data_permission_callback() );
 
 		// It should not work in Dev Mode
 		add_filter( 'jetpack_development_mode', '__return_true' );
 
 		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::connect_url_permission_callback() );
-		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::link_user_permission_callback() );
 		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::get_user_connection_data_permission_callback() );
 
 		remove_filter( 'jetpack_development_mode', '__return_true' );
@@ -70,7 +67,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$user = $this->factory->user->create_and_get( array(
 			'user_login' => 'user_disconnect_url',
 			'user_pass'  => 'password_disconnect_url',
-			'role' 		 => 'administrator',
+			'role'       => 'administrator',
 		) );
 
 		// Add Jetpack capability
@@ -82,6 +79,74 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// User has capability so this should work this time
 		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::disconnect_site_permission_callback() );
 
+	}
+
+	/**
+	 * Test permission to activate plugins.
+	 *
+	 * @since 4.4.0
+	 */
+	public function test_plugin_activation_permission() {
+
+		// Current user doesn't have credentials, so checking permissions should fail
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::activate_plugins_permission_check() );
+
+		$user = $this->factory->user->create_and_get( array(
+			'user_login' => 'user_no_activate_plugins',
+			'user_pass'  => 'password_no_activate_plugins',
+		) );
+
+		// Add Jetpack capability
+		$user->add_cap( 'jetpack_admin_page' );
+
+		// Setup global variables so this is the current user
+		wp_set_current_user( $user->ID );
+
+		// Should fail because requires more capabilities
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::activate_plugins_permission_check() );
+
+		// Add Jetpack capability
+		$user->add_cap( 'activate_plugins' );
+
+		// Reset current user and setup global variables to refresh the capability we just added.
+		wp_set_current_user( 0 );
+		wp_set_current_user( $user->ID );
+
+		// User has capability so this should work this time
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::activate_plugins_permission_check() );
+
+	}
+
+	/**
+	 * Test permission to disconnect Jetpack site for a user that is connected.
+	 *
+	 * @since 4.4.0
+	 */
+	public function test_admin_user_unlink_permission() {
+
+		// Current user doesn't have credentials, so checking permissions should fail
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::unlink_user_permission_callback() );
+
+		// Create a user
+		$user = $this->factory->user->create_and_get( array(
+			'user_login' => 'user_connected',
+			'user_pass'  => 'password_unlink_url',
+		) );
+
+		// Add Jetpack capability
+		$user->add_cap( 'jetpack_connect_user' );
+
+		// Setup global variables so this is the current user
+		wp_set_current_user( $user->ID );
+
+		// This should still fail because user is not connected
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::unlink_user_permission_callback() );
+
+		// Mock that it's connected
+		Jetpack_Options::update_option( 'user_tokens', array( $user->ID => "honey.badger.$user->ID" ) );
+
+		// User has the capability and is connected so this should work this time
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::unlink_user_permission_callback() );
 	}
 
 } // class end

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -73,17 +73,23 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param string $route  REST API path to be append to /jetpack/v4/
-	 * @param array  $params When present, parameters are added to request in JSON format
-	 * @param string $method Request method to use, GET or POST
+	 * @param string $route       REST API path to be append to /jetpack/v4/
+	 * @param array  $json_params When present, parameters are added to request in JSON format
+	 * @param string $method      Request method to use, GET or POST
+	 * @param array  $params      Parameters to add to endpoint
 	 *
 	 * @return WP_REST_Response
 	 */
-	protected function create_and_get_request( $route = '', $params = array(), $method = 'GET' ) {
+	protected function create_and_get_request( $route = '', $json_params = array(), $method = 'GET', $params = array() ) {
 		$request = new WP_REST_Request( $method, "/jetpack/v4/$route" );
 		$request->set_header( 'content-type', 'application/json' );
-		if ( ! empty( $params ) ) {
-			$request->set_body( json_encode( $params ) );
+		if ( ! empty( $json_params ) ) {
+			$request->set_body( json_encode( $json_params ) );
+		}
+		if ( ! empty( $params ) && is_array( $params ) ) {
+			foreach ( $params as $key => $value ) {
+				$request->set_param( $key, $value );
+			}
 		}
 		return $this->server->dispatch( $request );
 	}
@@ -589,4 +595,46 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Test unlink user.
+	 *
+	 * @since 4.4.0
+	 */
+	public function test_unlink_user() {
+
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user();
+		$user->add_cap( 'jetpack_connect_user' );
+		wp_set_current_user( $user->ID );
+
+		// Mock site already registered
+		Jetpack_Options::update_option( 'user_tokens', array( $user->ID => "honey.badger.$user->ID" ) );
+
+		// Create REST request in JSON format and dispatch
+		$response = $this->create_and_get_request( 'connection/user', array( 'linked' => false ), 'POST' );
+
+		// Success status, users can unlink themselves
+		$this->assertResponseStatus( 200, $response );
+
+		// Set up user as master user
+		Jetpack_Options::update_option( 'master_user', $user->ID );
+
+		// Create REST request in JSON format and dispatch
+		$response = $this->create_and_get_request( 'connection/user', array( 'linked' => false ), 'POST' );
+
+		// User can't unlink because doesn't have permission
+		$this->assertResponseStatus( 403, $response );
+
+		// Add proper permission
+		$user->set_role( 'administrator' );
+		wp_set_current_user( 0 );
+		wp_set_current_user( $user->ID );
+
+		// Create REST request in JSON format and dispatch
+		$response = $this->create_and_get_request( 'connection/user', array( 'linked' => false ), 'POST' );
+
+		// No way. Master user can't be unlinked. This is intended
+		$this->assertResponseStatus( 403, $response );
+
+	}
 } // class end

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -7,6 +7,15 @@
 class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 	/**
+	 * Used to store an instance of the WP_REST_Server.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
 	 * Setup environment for REST API endpoints test.
 	 *
 	 * @since 4.4.0
@@ -60,7 +69,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 *
 	 * @param string $role
 	 *
-	 * @return array
+	 * @return WP_User
 	 */
 	protected function create_and_get_user( $role = '' ) {
 		return $this->factory->user->create_and_get( array(
@@ -99,8 +108,8 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param $status
-	 * @param $response
+	 * @param integer          $status
+	 * @param WP_REST_Response $response
 	 */
 	protected function assertResponseStatus( $status, $response ) {
 		$this->assertEquals( $status, $response->get_status() );
@@ -111,8 +120,8 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param $data
-	 * @param $response
+	 * @param array            $data
+	 * @param WP_REST_Response $response
 	 */
 	protected function assertResponseData( $data, $response ) {
 		$response_data = $response->get_data();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Introduces tests for REST API endpoints 
#### Testing instructions:

`phpunit --testsuite restapi`
#### Proposed changelog entry for your changes:
Tests: introduce tests for the WP REST API endpoints in Jetpack.