### PR TITLE
Stats: add menu item back.

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -280,7 +280,7 @@ function stats_admin_menu() {
 		}
 	}
 
-	$hook = add_submenu_page( null, __( 'Site Stats', 'jetpack' ), __( 'Site Stats', 'jetpack' ), 'view_stats', 'stats', 'stats_reports_page' );
+	$hook = add_submenu_page( 'jetpack', __( 'Site Stats', 'jetpack' ), __( 'Site Stats', 'jetpack' ), 'view_stats', 'stats', 'stats_reports_page' );
 	add_action( "load-$hook", 'stats_reports_load' );
 }
 


### PR DESCRIPTION
Fixes #5007
Removed in 8ae260952b2e6dd25e45afac1ad432037f16a182

#### Proposed changelog entry for your changes:

Stats: add Jetpack submenu item back.