### PR TITLE
General: Update 4.4.0 docblocks to 4.3.2

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5309,7 +5309,7 @@ p {
 	 * Returns the value of the jetpack_sync_idc_optin filter, or constant.
 	 * If set to true, the site will be put into staging mode.
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.2
 	 * @return bool
 	 */
 	public static function sync_idc_optin() {
@@ -5326,9 +5326,9 @@ p {
 		 * URL or site URL do not match what WordPress.com expects. The default value is either false, or the value of
 		 * JETPACK_SYNC_IDC_OPTIN constant if set.
 		 *
-		 * @since 4.4.0
+		 * @since 4.3.2
 		 *
-		 * @param bool
+		 * @param bool $default Whether the site is opted in to IDC mitigation.
 		 */
 		return (bool) apply_filters( 'jetpack_sync_idc_optin', $default );
 	}

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1017,9 +1017,9 @@ class Jetpack_SSO {
 	 *
 	 * @since 4.3.2
 	 *
-	 * @param $message
+	 * @param string $message All other notices that will be displayed in the login form.
 	 *
-	 * @return string
+	 * @return string         An HTML string that includes the identity crisis error notice.
 	 */
 	public function error_msg_identity_crisis( $message ) {
 		$error = esc_html__( 'Logging in with WordPress.com is not currently available because this site is experiencing connection problems.', 'jetpack' );
@@ -1033,9 +1033,9 @@ class Jetpack_SSO {
 	 *
 	 * @since 4.3.2
 	 *
-	 * @param $message
+	 * @param string $message All other notices that will be displayed in the login form.
 	 *
-	 * @return string
+	 * @return string         An HTML string that includes the invalid response data error notice.
 	 */
 	public function error_invalid_response_data( $message ) {
 		$error = esc_html__(
@@ -1052,9 +1052,9 @@ class Jetpack_SSO {
 	 *
 	 * @since 4.3.2
 	 *
-	 * @param $message
+	 * @param string $message All other notices that will be displayed in the login form.
 	 *
-	 * @return string
+	 * @return string         An HTML string that includes the unable to create user error notice.
 	 */
 	public function error_unable_to_create_user( $message ) {
 		$error = esc_html__(

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1015,7 +1015,7 @@ class Jetpack_SSO {
 	/**
 	 * Error message that is displayed when the current site is in an identity crisis and SSO can not be used.
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.2
 	 *
 	 * @param $message
 	 *
@@ -1031,7 +1031,7 @@ class Jetpack_SSO {
 	 * Error message that is displayed when we are not able to verify the SSO nonce due to an XML error or
 	 * failed validation. In either case, we prompt the user to try again or log in with username and password.
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.2
 	 *
 	 * @param $message
 	 *
@@ -1050,7 +1050,7 @@ class Jetpack_SSO {
 	 * Error message that is displayed when we were not able to automatically create an account for a user
 	 * after a user has logged in via SSO. By default, this message is triggered after trying to create an account 5 times.
 	 *
-	 * @since 4.4.0
+	 * @since 4.3.2
 	 *
 	 * @param $message
 	 *

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -197,7 +197,7 @@ class Jetpack_SSO_Helpers {
 		 *
 		 * @module sso
 		 *
-		 * @since 4.4.0
+		 * @since 4.3.2
 		 *
 		 * @param int 5 By default, SSO will attempt to random generate a user up to 5 times.
 		 */

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -348,7 +348,7 @@ class Jetpack_Sync_Actions {
 		/**
 		 * Allows overriding of the default incremental sync cron schedule which defaults to once per minute.
 		 *
-		 * @since 4.4.0
+		 * @since 4.3.2
 		 *
 		 * @param string self::DEFAULT_SYNC_CRON_INTERVAL
 		 */
@@ -358,7 +358,7 @@ class Jetpack_Sync_Actions {
 		/**
 		 * Allows overriding of the full sync cron schedule which defaults to once per minute.
 		 *
-		 * @since 4.4.0
+		 * @since 4.3.2
 		 *
 		 * @param string self::DEFAULT_SYNC_CRON_INTERVAL
 		 */


### PR DESCRIPTION
This PR updates docblocks that incorrectly had `@since 4.4.0` to `@since 4.3.2` and adds a bit more clarification to the default value passed to the `jetpack_sync_idc_optin` filter.