### PR TITLE
Shortcodes: Change low Instagram embed widths to min, not max

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -82,8 +82,10 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 	), $atts );
 
 	$atts['width'] = absint( $atts['width'] );
-	if ( $atts['width'] > $max_width || $min_width > $atts['width'] ) {
+	if ( $atts['width'] > $max_width ) {
 		$atts['width'] = $max_width;
+	} elseif ( $atts['width'] < $min_width ) {
+		$atts['width'] = $min_width;
 	}
 
 	// remove the modal param from the URL


### PR DESCRIPTION
Fixes #4312
#### Changes proposed in this Pull Request:

Previously, if the user specified an Instagram embed width that was too low, it would be changed to the maximum width, which is unintuitive. This corrects that behavior so that low embed widths now get bumped up to the minimum width.
#### Testing instructions:

With Jetpack 4.3.1 installed, make a new post with this shortcode:

`[instagram url="http://instagram.com/p/PSbF9sEIGP/" width="300"]`

Since the minimum width is 320, this embed will be bumped to the _maximum_ width, due to this code:

https://github.com/Automattic/jetpack/blob/4.3.1/modules/shortcodes/instagram.php#L85-L87

Apply this fix and the same embed will only be bumped to the _minimum_ width.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
## Shortcodes - Instagram: bump embeds below minimum width up to minimum, not maximum.
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
