### PR TITLE
Sync: Add cron size to the status api endpoint.

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -70,6 +70,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 				'full_queue_size'       => $full_queue->size(),
 				'full_queue_lag'        => $full_queue->lag(),
 				'full_queue_next_sync'  => ( $sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
+				'cron_size'             => count( _get_cron_array() ),
 			)
 		);
 	}

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -611,6 +611,7 @@ new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 		'full_queue_lag' => '(float) Time delay of the oldest item in the full sync queue',
 		'full_queue_next_sync' => '(float) Time in seconds before trying to sync the full sync queue again',
 		'is_scheduled' => '(bool) Is a full sync scheduled via cron?',
+		'cron_size'     => '(int) Size of the current cron array',
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status'
 ) );


### PR DESCRIPTION
This lets us know the size the cron array size is. Which helps in the
debugging of why a site might have problems syncing stuff to us.
