### PR TITLE
Jetpack: build_connect_url()

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3848,6 +3848,17 @@ p {
 				? get_site_icon_url()
 				: false;
 
+			/**
+			 * Filter the type of authorization.
+			 * 'calypso' completes authorization on wordpress.com/jetpack/connect
+			 * while 'jetpack' ( or any other value ) completes the authorization at jetpack.wordpress.com.
+			 *
+			 * @since 4.3.3
+			 *
+			 * @param string $auth_type Defaults to 'calypso', can also be 'jetpack'.
+			 */
+			$auth_type = apply_filters( 'jetpack_auth_type', 'calypso' );
+
 			$args = urlencode_deep(
 				array(
 					'response_type' => 'code',
@@ -3866,7 +3877,7 @@ p {
 					'user_login'    => $user->user_login,
 					'is_active'     => Jetpack::is_active(),
 					'jp_version'    => JETPACK__VERSION,
-					'auth_type'     => 'calypso',
+					'auth_type'     => $auth_type,
 					'secret'        => $secret,
 					'locale'        => isset( $gp_locale->slug ) ? $gp_locale->slug : '',
 					'blogname'      => get_option( 'blogname' ),


### PR DESCRIPTION
Allow `$auth_type` to be filtered so that folks can choose where their site completes authorization.

To test:

- run this branch on an unconnected jetpack site
 - ensure there are no regressions in the connection process, ie when you click any of the 'connect' buttons, and that the connection is completed at wordpress.com/jetpack/connect
- disconnect your site
- in functions.php of your theme add this code:

```
function jetpack_filter_auth_type() {
    return 'jetpack';
}
add_filter( 'jetpack_auth_type', 'jetpack_filter_auth_type' );
```
- try connecting again, and ensure that the connection is completed at jetpack.wordpress.com
