### PR TITLE
Return oldest cron item age to see if cron’s working

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -67,6 +67,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 			$sync_module->get_status(),
 			array(
 				'is_scheduled'          => Jetpack_Sync_Actions::is_scheduled_full_sync(),
+				'cron_size'             => count( $cron_timestamps ),
 				'oldest_scheduled_age'  => $cron_age,
 				'queue_size'            => $queue->size(),
 				'queue_lag'             => $queue->lag(),

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -68,7 +68,7 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 			array(
 				'is_scheduled'          => Jetpack_Sync_Actions::is_scheduled_full_sync(),
 				'cron_size'             => count( $cron_timestamps ),
-				'oldest_scheduled_age'  => $cron_age,
+				'oldest_cron'           => $cron_age,
 				'queue_size'            => $queue->size(),
 				'queue_lag'             => $queue->lag(),
 				'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -60,17 +60,20 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 		$queue       = $sender->get_sync_queue();
 		$full_queue  = $sender->get_full_sync_queue();
 
+		$cron_timestamps = array_keys( _get_cron_array() );
+		$cron_age = microtime( true ) - $cron_timestamps[0];
+
 		return array_merge(
 			$sync_module->get_status(),
 			array(
 				'is_scheduled'          => Jetpack_Sync_Actions::is_scheduled_full_sync(),
+				'oldest_scheduled_age'  => $cron_age,
 				'queue_size'            => $queue->size(),
 				'queue_lag'             => $queue->lag(),
 				'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),
 				'full_queue_size'       => $full_queue->size(),
 				'full_queue_lag'        => $full_queue->lag(),
 				'full_queue_next_sync'  => ( $sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
-				'cron_size'             => count( _get_cron_array() ),
 			)
 		);
 	}


### PR DESCRIPTION
Updates #5318 to return oldest cron item age instead of the size of cron. This is a better approximation of whether cron is working, and how often it runs.