### PR TITLE
Sync: Add 'ALTERNATE_WP_CRON' and 'WP_CRON_LOCK_TIMEOUT' to sync constants

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -121,6 +121,8 @@ class Jetpack_Sync_Defaults {
 		'JETPACK__VERSION',
 		'IS_PRESSABLE',
 		'DISABLE_WP_CRON',
+		'ALTERNATE_WP_CRON',
+		'WP_CRON_LOCK_TIMEOUT',
 	);
 
 	static $default_callable_whitelist = array(


### PR DESCRIPTION
This will allow us to debug and take action based on what cron is available for a site. 