### PR TITLE
Add a setting to avoid using wp-cron to enqueue full syncs

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -268,6 +268,9 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 		$sender = Jetpack_Sync_Sender::get_instance();
 
+		// try to give ourselves as much time as possible
+		set_time_limit( 0 );
+
 		// let's delete the checkin state
 		if ( $args['force'] ) {
 			$queue->unlock();

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -672,6 +672,7 @@ $sync_settings_response = array(
 	'comment_meta_whitelist' => '(array|string|bool=false) List of comment meta to be included in sync. Send "empty" to unset.',
 	'disable'              => '(int|bool=false) Set to 1 or true to disable sync entirely.',
 	'render_filtered_content' => '(int|bool=true) Set to 1 or true to render filtered content.',
+	'avoid_wp_cron'        => '(int|bool=false) Set to 1 or true to avoid running wp-cron for enqueuing full syncs.',
 );
 
 // GET /sites/%s/sync/settings

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -182,6 +182,12 @@ class Jetpack_Sync_Actions {
 			return false;
 		}
 
+		if ( Jetpack_Sync_Settings::get_setting( 'avoid_wp_cron' ) ) {
+			// run queuing inline
+			self::do_full_sync( $modules );
+			return false;
+		}
+
 		if ( self::is_scheduled_full_sync() ) {
 			self::unschedule_all_full_syncs();
 		}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -184,6 +184,7 @@ class Jetpack_Sync_Actions {
 
 		if ( Jetpack_Sync_Settings::get_setting( 'avoid_wp_cron' ) ) {
 			// run queuing inline
+			set_time_limit( 0 );
 			self::do_full_sync( $modules );
 			return false;
 		}

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -300,6 +300,7 @@ class Jetpack_Sync_Defaults {
 	static $default_post_meta_whitelist = array();
 	static $default_comment_meta_whitelist = array();
 	static $default_disable = 0; // completely disable sending data to wpcom
+	static $default_avoid_wp_cron = 0; // don't use cron to enqueue full syncs - do it inline. Warning: Can time out for larger sites!
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -75,8 +75,6 @@ class Jetpack_Sync_Sender {
 			return false;
 		}
 
-		set_time_limit( 0 );
-
 		$start_time = microtime( true );
 
 		Jetpack_Sync_Settings::set_is_syncing( true );

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -75,6 +75,8 @@ class Jetpack_Sync_Sender {
 			return false;
 		}
 
+		set_time_limit( 0 );
+
 		$start_time = microtime( true );
 
 		Jetpack_Sync_Settings::set_is_syncing( true );

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -19,6 +19,7 @@ class Jetpack_Sync_Settings {
 		'render_filtered_content' => true,
 		'post_meta_whitelist' => true,
 		'comment_meta_whitelist' => true,
+		'avoid_wp_cron'        => true,
 	);
 
 	static $is_importing;


### PR DESCRIPTION
On sites with a broken CRON implementation, this shortcuts the scheduling of full syncs and enqueues them directly. The trade-off here is that if the cron enqueuing exceeds PHP's max_execution_time, it will fail or be partially completed.