### PR TITLE
Subscriptions: Remove unused "post_is_public" function

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5466,7 +5466,7 @@ p {
 		 * Format:
 		 * deprecated_filter_name => replacement_name
 		 *
-		 * If there is no replacement us null for replacement_name
+		 * If there is no replacement, use null for replacement_name
 		 */
 		$deprecated_list = array(
 			'jetpack_bail_on_shortcode'                              => 'jetpack_shortcodes_to_include',
@@ -5489,6 +5489,7 @@ p {
 			'add_option_jetpack_main_network_site'                   => null,
 			'jetpack_sync_all_registered_options'                    => null,
 			'jetpack_has_identity_crisis'                            => 'jetpack_sync_error_idc_validation',
+			'jetpack_is_post_mailable'                               => null,
 		);
 
 		// This is a silly loop depth. Better way?

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -77,25 +77,6 @@ class Jetpack_Subscriptions {
 		add_action( 'transition_post_status', array( $this, 'maybe_send_subscription_email' ), 10, 3 );
 	}
 
-	function post_is_public( $the_post ) {
-		if ( !$post = get_post( $the_post ) ) {
-			return false;
-		}
-
-		if ( 'publish' === $post->post_status && strlen( (string) $post->post_password ) < 1 ) {
-			/**
-			 * Filter whether posts can be emailed to subscribers.
-			 *
-			 * @module subscriptions
-			 *
-			 * @since 2.4.0
-			 *
-			 * @param bool true Can the post be emailed to Subscribers. Default to true.
-			 */
-			return apply_filters( 'jetpack_is_post_mailable', true );
-		}
-	}
-
 	/**
 	 * Jetpack_Subscriptions::xmlrpc_methods()
 	 *


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Remove unused "post_is_public" function.

```
Air: jetpack $ git grep post_is_public
modules/subscriptions.php:  function post_is_public( $the_post ) {
```
#### Testing instructions:

N/A
#### Proposed changelog entry for your changes:

N/A
---
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

Fixes #5330 
