### PR TITLE
Admin Page: Update the 'engines' field in package.json to >=5.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
     "webpack-dev-server": "1.14.0"
   },
   "engines": {
-    "node": ">=0.8"
+    "node": ">=5.11.1"
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates the `package.json` file `engines` field to read `>=5.11.1`
#### Testing instructions:
- Nothing should work differently. For now this is only a declaration of which Node engine is needed for building. 
#### Why

To make run environments that are aware of this field (CI services, deploy services, etc) leverage the appropriate version of NodeJS needed to run the npm scripts defined in `package.json`.
