### PR TITLE
IDC: Fix issues with IDC mitigation opt-in

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5354,10 +5354,8 @@ p {
 	public static function sync_idc_optin() {
 		if ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) {
 			$default = JETPACK_SYNC_IDC_OPTIN;
-		} else if ( defined( 'SUNRISE' ) ) {
-			$default = SUNRISE;
 		} else {
-			$default = self::is_development_version();
+			$default = false;
 		}
 
 		/**

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -124,11 +124,13 @@ class Jetpack_Sync_Actions {
 			'codec'     => $codec_name,     // send the name of the codec used to encode the data
 			'timestamp' => $sent_timestamp, // send current server time so we can compensate for clock differences
 			'queue'     => $queue_id,       // sync or full_sync
+			'home'      => get_home_url(),  // Send home url option to check for Identity Crisis server-side
+			'siteurl'   => get_site_url(),  // Send siteurl option to check for Identity Crisis server-side
 		);
 
+		// Has the site opted in to IDC mitigation?
 		if ( Jetpack::sync_idc_optin() ) {
-			$query_args['home']    = get_home_url(); // Send home url option to check for Identity Crisis server-side
-			$query_args['siteurl'] = get_site_url(); // Send home url option to check for Identity Crisis server-side
+			$query_args['idc'] = true;
 		}
 
 		$url = add_query_arg( $query_args, Jetpack::xmlrpc_api_url() );

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -415,12 +415,6 @@ EXPECTED;
 		$this->assertFalse( Jetpack::get_other_linked_admins() );
 	}
 
-	function test_idc_optin_defaults_to_development_version() {
-		add_filter( 'jetpack_development_version', '__return_true' );
-		$this->assertTrue( Jetpack::sync_idc_optin() );
-		remove_filter( 'jetpack_development_version', '__return_true' );
-	}
-
 	function test_idc_optin_filter_overrides_development_version() {
 		add_filter( 'jetpack_development_version', '__return_true' );
 		add_filter( 'jetpack_sync_idc_optin', '__return_false' );


### PR DESCRIPTION
We noticed an uptick in the number of sites that we were returning sync errors for today, which seems to coincide with the 4.3.2 release. After looking into it, it seems that we had some bad logic that was always opting in sites that had defined sunrise.

So, I removed the bad logic for sites with sunrise enabled and I removed the logic for opting-in sites that are on a development version.

Now that we have some sites that were improperly opted in, we also need to change what we send when we opt a site in. So, from here on out, all sites will send `home` and `siteurl` with sync requests, and then we will rely on `sync` being set to consider a site opted in.