### PR TITLE
SSO: Disable SSO for sites in staging mode

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -375,11 +375,8 @@ class Jetpack_SSO {
 				$this->handle_login();
 				$this->display_sso_login_form();
 			} else {
-				if ( Jetpack::check_identity_crisis() ) {
-					JetpackTracking::record_user_event( 'sso_login_redirect_failed', array(
-						'error_message' => 'identity_crisis'
-					) );
-					add_filter( 'login_message', array( 'Jetpack_SSO_Notices', 'error_msg_identity_crisis' ) );
+				if ( Jetpack::is_staging_site() ) {
+					add_filter( 'login_message', array( 'Jetpack_SSO_Notices', 'sso_not_allowed_in_staging' ) );
 				} else {
 					$this->maybe_save_cookie_redirect();
 					// Is it wiser to just use wp_redirect than do this runaround to wp_safe_redirect?
@@ -399,8 +396,8 @@ class Jetpack_SSO {
 	 * up the hooks required to display the SSO form.
 	 */
 	public function display_sso_login_form() {
-		if ( Jetpack::check_identity_crisis() ) {
-			add_filter( 'login_message', array( 'Jetpack_SSO_Notices', 'error_msg_identity_crisis' ) );
+		if ( Jetpack::is_staging_site() ) {
+			add_filter( 'login_message', array( 'Jetpack_SSO_Notices', 'sso_not_allowed_in_staging' ) );
 			return;
 		}
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -161,20 +161,37 @@ class Jetpack_SSO {
 		// Always add the jetpack-sso class so that we can add SSO specific styling even when the SSO form isn't being displayed.
 		$classes[] = 'jetpack-sso';
 
-		/**
-		 * Should we show the SSO login form?
-		 *
-		 * $_GET['jetpack-sso-default-form'] is used to provide a fallback in case JavaScript is not enabled.
-		 *
-		 * The default_to_sso_login() method allows us to dynamically decide whether we show the SSO login form or not.
-		 * The SSO module uses the method to display the default login form if we can not find a user to log in via SSO.
-		 * But, the method could be filtered by a site admin to always show the default login form if that is preferred.
-		 */
-		if ( empty( $_GET['jetpack-sso-show-default-form'] ) && Jetpack_SSO_Helpers::show_sso_login() ) {
-			$classes[] = 'jetpack-sso-form-display';
+		if ( ! Jetpack::is_staging_site() ) {
+			/**
+			 * Should we show the SSO login form?
+			 *
+			 * $_GET['jetpack-sso-default-form'] is used to provide a fallback in case JavaScript is not enabled.
+			 *
+			 * The default_to_sso_login() method allows us to dynamically decide whether we show the SSO login form or not.
+			 * The SSO module uses the method to display the default login form if we can not find a user to log in via SSO.
+			 * But, the method could be filtered by a site admin to always show the default login form if that is preferred.
+			 */
+			if ( empty( $_GET['jetpack-sso-show-default-form'] ) && Jetpack_SSO_Helpers::show_sso_login() ) {
+				$classes[] = 'jetpack-sso-form-display';
+			}
 		}
 
 		return $classes;
+	}
+
+	public function print_inline_admin_css() {
+		?>
+			<style>
+				.jetpack-sso .message {
+					margin-top: 20px;
+				}
+
+				.jetpack-sso #login .message:first-child,
+				.jetpack-sso #login h1 + .message {
+					margin-top: 0;
+				}
+			</style>
+		<?php
 	}
 
 	/**
@@ -396,6 +413,9 @@ class Jetpack_SSO {
 	 * up the hooks required to display the SSO form.
 	 */
 	public function display_sso_login_form() {
+		add_filter( 'login_body_class', array( $this, 'login_body_class' ) );
+		add_action( 'login_head',       array( $this, 'print_inline_admin_css' ) );
+
 		if ( Jetpack::is_staging_site() ) {
 			add_filter( 'login_message', array( 'Jetpack_SSO_Notices', 'sso_not_allowed_in_staging' ) );
 			return;
@@ -407,7 +427,6 @@ class Jetpack_SSO {
 		}
 
 		add_action( 'login_form',            array( $this, 'login_form' ) );
-		add_filter( 'login_body_class',      array( $this, 'login_body_class' ) );
 		add_action( 'login_enqueue_scripts', array( $this, 'login_enqueue_scripts' ) );
 	}
 

--- a/modules/sso/class.jetpack-sso-notices.php
+++ b/modules/sso/class.jetpack-sso-notices.php
@@ -171,13 +171,31 @@ class Jetpack_SSO_Notices {
 	 * @param string $message
 	 * @return string
 	 */
-	static function cant_find_user( $message ) {
+	public static function cant_find_user( $message ) {
 		$error = esc_html__(
 			"We couldn't find your account. If you already have an account, make sure you have connected to WordPress.com.",
 			'jetpack'
 		);
 		$message .= sprintf( '<p class="message" id="login_error">%s</p>', $error );
 
+		return $message;
+	}
+
+	/**
+	 * Error message that is displayed when the current site is in an identity crisis and SSO can not be used.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param $message
+	 *
+	 * @return string
+	 */
+	public static function sso_not_allowed_in_staging( $message ) {
+		$error = esc_html__(
+			'Logging in with WordPress.com is disabled for sites that are in staging mode.',
+			'jetpack'
+		);
+		$message .= sprintf( '<p class="message">%s</p>', $error );
 		return $message;
 	}
 }

--- a/modules/sso/jetpack-sso-login.css
+++ b/modules/sso/jetpack-sso-login.css
@@ -4,15 +4,6 @@
 	padding-bottom: 92px;
 }
 
-.jetpack-sso .message {
-	margin-top: 20px;
-}
-
-.jetpack-sso #login .message:first-child,
-.jetpack-sso #login h1 + .message {
-	margin-top: 0;
-}
-
 .jetpack-sso-repositioned #loginform {
 	padding-bottom: 26px;
 }


### PR DESCRIPTION
Fixes #5339.

This PR is an attempt to disable SSO when a site is in staging mode. The issue with allowing SSO while a site is in staging mode is that on WPCOM, after a user approves SSO, we always send the user to the URL that is synced. Not necessarily the one that the user came from.

Here's a screenshot of the UI change:

![screen shot 2016-10-17 at 4 13 42 pm](https://cloud.githubusercontent.com/assets/1126811/19455926/b3a0c602-9484-11e6-8c3b-a9cd6a36ef08.png)


To test: 

- Checkout PR
- Set `add_filter( 'jetpack_is_staging_site', '__return_true' )`
- Go to `$site.com/wp-admin`
- Ensure you see something like the above
- Turn off staging, and ensure that you can log in via SSO