### PR TITLE
Save full sync status during enqueue

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -94,13 +94,6 @@ class Jetpack_Debugger {
 
 		$debug_info .= "\r\n". sprintf( esc_html__( 'Jetpack Sync Full Status: `%1$s`', 'jetpack' ), print_r( $human_readable_sync_status, 1 ) );
 
-		$next_schedules = wp_next_scheduled( 'jetpack_sync_full' );
-		if( $next_schedules ) {
-			$debug_info .= "\r\n". sprintf( esc_html__( 'Next Jetpack Full Sync Schedule: `%1$s`', 'jetpack' ), date( 'r', $next_schedules ) );
-		} else {
-			$debug_info .= "\r\n". esc_html__( "Next Jetpack Full Sync Schedule: Not Scheduled", 'jetpack' );
-		}
-
 		require_once JETPACK__PLUGIN_DIR. 'sync/class.jetpack-sync-sender.php';
 
 		$queue = Jetpack_Sync_Sender::get_instance()->get_sync_queue();

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -88,7 +88,7 @@ class Jetpack_Debugger {
 		$human_readable_sync_status = array();
 		foreach( $sync_statuses  as $sync_status => $sync_status_value ) {
 			$human_readable_sync_status[ $sync_status ] =
-				in_array( $sync_status, array( 'started', 'queue_finished', 'sent_started', 'finished' ) )
+				in_array( $sync_status, array( 'started', 'queue_finished', 'send_started', 'finished' ) )
 				? date( 'r', $sync_status_value ) : $sync_status_value ;
 		}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -59,10 +59,14 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 		$sender      = Jetpack_Sync_Sender::get_instance();
 		$queue       = $sender->get_sync_queue();
 		$full_queue  = $sender->get_full_sync_queue();
+		$cron_timestamps = array_keys( _get_cron_array() );
+		$cron_age = microtime( true ) - $cron_timestamps[0];
 
 		return array_merge(
 			$sync_module->get_status(),
 			array(
+				'cron_size'             => count( $cron_timestamps ),
+				'oldest_cron'           => $cron_age,
 				'queue_size'            => $queue->size(),
 				'queue_lag'             => $queue->lag(),
 				'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -34,7 +34,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 			$modules = null;
 		}
 
-		return array( 'scheduled' => Jetpack_Sync_Actions::schedule_full_sync( $modules ) );
+		return array( 'started' => Jetpack_Sync_Actions::do_full_sync( $modules ) );
 	}
 
 	protected function validate_queue( $query ) {
@@ -60,15 +60,9 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 		$queue       = $sender->get_sync_queue();
 		$full_queue  = $sender->get_full_sync_queue();
 
-		$cron_timestamps = array_keys( _get_cron_array() );
-		$cron_age = microtime( true ) - $cron_timestamps[0];
-
 		return array_merge(
 			$sync_module->get_status(),
 			array(
-				'is_scheduled'          => Jetpack_Sync_Actions::is_scheduled_full_sync(),
-				'cron_size'             => count( $cron_timestamps ),
-				'oldest_cron'           => $cron_age,
 				'queue_size'            => $queue->size(),
 				'queue_lag'             => $queue->lag(),
 				'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -672,7 +672,6 @@ $sync_settings_response = array(
 	'comment_meta_whitelist' => '(array|string|bool=false) List of comment meta to be included in sync. Send "empty" to unset.',
 	'disable'              => '(int|bool=false) Set to 1 or true to disable sync entirely.',
 	'render_filtered_content' => '(int|bool=true) Set to 1 or true to render filtered content.',
-	'avoid_wp_cron'        => '(int|bool=false) Set to 1 or true to avoid running wp-cron for enqueuing full syncs.',
 );
 
 // GET /sites/%s/sync/settings

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -598,7 +598,7 @@ new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 	'response_format' => array(
 		'started' => '(int|null) The unix timestamp when the last sync started',
 		'queue_finished' => '(int|null) The unix timestamp when the enqueuing was done for the last sync',
-		'sent_started' => '(int|null) The unix timestamp when the last sent process started',
+		'send_started' => '(int|null) The unix timestamp when the last sent process started',
 		'finished' => '(int|null) The unix timestamp when the last sync finished',
 		'total'  => '(array) Count of actions that could be sent',
 		'queue'  => '(array) Count of actions that have been added to the queue',

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -581,7 +581,7 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 		'users'    => '(string) Comma-delimited list of user IDs to sync',
 	),
 	'response_format' => array(
-		'scheduled' => '(bool) Whether or not the synchronisation was scheduled'
+		'started' => '(bool) Whether or not the synchronisation was started'
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync'
 ) );
@@ -610,8 +610,6 @@ new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 		'full_queue_size' => '(int) Number of items in the full sync queue',
 		'full_queue_lag' => '(float) Time delay of the oldest item in the full sync queue',
 		'full_queue_next_sync' => '(float) Time in seconds before trying to sync the full sync queue again',
-		'is_scheduled' => '(bool) Is a full sync scheduled via cron?',
-		'cron_size'     => '(int) Size of the current cron array',
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status'
 ) );

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -672,6 +672,8 @@ $sync_settings_response = array(
 	'comment_meta_whitelist' => '(array|string|bool=false) List of comment meta to be included in sync. Send "empty" to unset.',
 	'disable'              => '(int|bool=false) Set to 1 or true to disable sync entirely.',
 	'render_filtered_content' => '(int|bool=true) Set to 1 or true to render filtered content.',
+	'max_enqueue_full_sync'   => '(int|bool=false) Maximum number of rows to enqueue during each full sync process',
+	'max_queue_size_full_sync'=> '(int|bool=false) Maximum queue size that full sync is allowed to use',
 );
 
 // GET /sites/%s/sync/settings

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -610,6 +610,8 @@ new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 		'full_queue_size' => '(int) Number of items in the full sync queue',
 		'full_queue_lag' => '(float) Time delay of the oldest item in the full sync queue',
 		'full_queue_next_sync' => '(float) Time in seconds before trying to sync the full sync queue again',
+		'cron_size' => '(int) Size of the current cron array',
+		'oldest_cron' => '(int) Age in seconds of the oldest scheduled cron job - a good indicator if cron isn\'t running',
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status'
 ) );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -247,10 +247,6 @@ class Jetpack_Sync_Actions {
 			remove_action( 'shutdown', array( self::$sender, 'do_sync' ) );
 		}
 
-		$full_sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-
-		$full_sync_module->enable_queue_rate_limit();
-
 		do {
 			$next_sync_time = self::$sender->get_next_sync_time( 'full_sync' );
 
@@ -265,8 +261,6 @@ class Jetpack_Sync_Actions {
 
 			$result = self::$sender->do_full_sync();
 		} while ( $result );
-
-		$full_sync_module->disable_queue_rate_limit();
 	}
 
 	static function initialize_listener() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -156,7 +156,7 @@ class Jetpack_Sync_Actions {
 		return $rpc->getResponse();
 	}
 
-	static function schedule_initial_sync( $new_version = null, $old_version = null ) {
+	static function do_initial_sync( $new_version = null, $old_version = null ) {
 		$initial_sync_config = array(
 			'options' => true,
 			'network_options' => true,
@@ -166,17 +166,6 @@ class Jetpack_Sync_Actions {
 
 		if ( $old_version && ( version_compare( $old_version, '4.2', '<' ) ) ) {
 			$initial_sync_config['users'] = 'initial';
-		}
-
-		// we need this function call here because we have to run this function
-		// reeeeally early in init, before WP_CRON_LOCK_TIMEOUT is defined.
-		wp_functionality_constants();
-
-		if ( is_multisite() ) {
-			// stagger initial syncs for multisite blogs so they don't all pile on top of each other
-			$time_offset = ( rand() / getrandmax() ) * self::INITIAL_SYNC_MULTISITE_INTERVAL * get_blog_count();
-		} else {
-			$time_offset = 1;
 		}
 
 		self::do_full_sync( $initial_sync_config );
@@ -341,4 +330,4 @@ if ( defined( 'ALTERNATE_WP_CRON' ) && ALTERNATE_WP_CRON ) {
 }
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
-add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'schedule_initial_sync' ), 10, 2 );
+add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -1,5 +1,4 @@
 <?php
-require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -101,11 +100,13 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function sync_allowed() {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 		return ( ! Jetpack_Sync_Settings::get_setting( 'disable' ) && Jetpack::is_active() && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
 			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
 	}
 
 	static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
 		}
@@ -114,6 +115,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function set_is_importing_true() {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 		Jetpack_Sync_Settings::set_importing( true );
 	}
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -9,7 +9,6 @@
 class Jetpack_Sync_Actions {
 	static $sender = null;
 	static $listener = null;
-	const INITIAL_SYNC_MULTISITE_INTERVAL = 10;
 	const DEFAULT_SYNC_CRON_INTERVAL = '1min';
 
 	static function init() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -95,6 +95,7 @@ class Jetpack_Sync_Actions {
 		) ) {
 			self::initialize_sender();
 			add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
+			add_action( 'shutdown', array( self::$sender, 'do_full_sync' ) );
 		}
 
 	}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -178,7 +178,6 @@ class Jetpack_Sync_Actions {
 
 		self::initialize_listener();
 		Jetpack_Sync_Modules::get_module( 'full-sync' )->start( $modules );
-		self::do_cron_full_sync(); // immediately run a cron full sync, which sends pending data
 
 		return true;
 	}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -245,6 +245,10 @@ class Jetpack_Sync_Actions {
 			remove_action( 'shutdown', array( self::$sender, 'do_sync' ) );
 		}
 
+		$full_sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+
+		$full_sync_module->enable_queue_rate_limit();
+
 		do {
 			$next_sync_time = self::$sender->get_next_sync_time( 'full_sync' );
 
@@ -259,6 +263,8 @@ class Jetpack_Sync_Actions {
 
 			$result = self::$sender->do_full_sync();
 		} while ( $result );
+
+		$full_sync_module->disable_queue_rate_limit();
 	}
 
 	static function initialize_listener() {

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -302,7 +302,6 @@ class Jetpack_Sync_Defaults {
 	static $default_post_meta_whitelist = array();
 	static $default_comment_meta_whitelist = array();
 	static $default_disable = 0; // completely disable sending data to wpcom
-	static $default_avoid_wp_cron = 0; // don't use cron to enqueue full syncs - do it inline. Warning: Can time out for larger sites!
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_max_enqueue_full_sync = 100; // max number of items to enqueue at a time when running full sync
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -304,6 +304,7 @@ class Jetpack_Sync_Defaults {
 	static $default_disable = 0; // completely disable sending data to wpcom
 	static $default_avoid_wp_cron = 0; // don't use cron to enqueue full syncs - do it inline. Warning: Can time out for larger sites!
 	static $default_render_filtered_content = 1; // render post_filtered_content
+	static $default_max_enqueue_full_sync = 100; // max number of items to enqueue at a time when running full sync
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 	static $default_sync_queue_lock_timeout = 120; // 2 minutes

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -305,6 +305,7 @@ class Jetpack_Sync_Defaults {
 	static $default_disable = 0; // completely disable sending data to wpcom
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_max_enqueue_full_sync = 100; // max number of items to enqueue at a time when running full sync
+	static $default_max_queue_size_full_sync = 1000; // max number of total items in the full sync queue
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 	static $default_sync_queue_lock_timeout = 120; // 2 minutes

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -295,6 +295,7 @@ class Jetpack_Sync_Defaults {
 	static $default_upload_max_rows = 500;
 	static $default_sync_wait_time = 10; // seconds, between syncs
 	static $default_sync_wait_threshold = 5; // only wait before next send if the current send took more than X seconds
+	static $default_enqueue_wait_time = 10; // wait between attempting to continue a full sync, via requests
 	static $default_max_queue_size = 1000;
 	static $default_max_queue_lag = 900; // 15 minutes
 	static $default_queue_max_writes_sec = 100; // 100 rows a second

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -75,7 +75,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		return call_user_func( $callable );
 	}
 
-	public function enqueue_full_sync_actions( $config ) {
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		/**
 		 * Tells the client to sync all callables to the server
 		 *
@@ -85,7 +85,8 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_full_sync_callables', true );
 
-		return 1; // The number of actions enqueued
+		// The number of actions enqueued, and next module state (true == done)
+		return array( 1, true ); 
 	}
 
 	public function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -55,9 +55,9 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_comments', array( $this, 'expand_comment_ids' ) );
 	}
 
-	public function enqueue_full_sync_actions( $config ) {
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		global $wpdb;
-		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', $this->get_where_sql( $config ) );
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_comments', $wpdb->comments, 'comment_ID', $this->get_where_sql( $config ), $max_items_to_enqueue, $state );
 	}
 
 	public function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -44,7 +44,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		return $this->constants_whitelist;
 	}
 
-	function enqueue_full_sync_actions( $config ) {
+	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		/**
 		 * Tells the client to sync all constants to the server
 		 *
@@ -54,7 +54,8 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_full_sync_constants', true );
 
-		return 1;
+		// The number of actions enqueued, and next module state (true == done)
+		return array( 1, true );
 	}
 
 	function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -361,7 +361,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return $value;
 	}
 
-	private function enable_queue_rate_limit() {
+	public function enable_queue_rate_limit() {
 		$this->queue_rate_limit = Jetpack_Sync_Settings::get_setting( 'queue_max_writes_sec' );
 		$this->items_added_since_last_pause = 0;
 		$this->last_pause_time = microtime( true );
@@ -370,7 +370,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		add_action( 'jpsq_items_added', array( $this, 'queue_items_added' ) );
 	}
 
-	private function disable_queue_rate_limit() {
+	public function disable_queue_rate_limit() {
 		remove_action( 'jpsq_item_added', array( $this, 'queue_item_added' ) );
 		remove_action( 'jpsq_items_added', array( $this, 'queue_items_added' ) );
 	}

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -265,16 +265,16 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return $status;
 	}
 
-	public function clear_status() {		
-		$prefix = self::STATUS_OPTION_PREFIX;		
+	public function clear_status() {
+		$prefix = self::STATUS_OPTION_PREFIX;
 		delete_option( "{$prefix}_started" );
 		delete_option( "{$prefix}_params" );
-		delete_option( "{$prefix}_queue_finished" );		
-		delete_option( "{$prefix}_send_started" );		
-		delete_option( "{$prefix}_finished" );		
-		
+		delete_option( "{$prefix}_queue_finished" );
+		delete_option( "{$prefix}_send_started" );
+		delete_option( "{$prefix}_finished" );
+
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
-			delete_option( "{$prefix}_{$module->name()}_sent" );		
+			delete_option( "{$prefix}_{$module->name()}_sent" );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -125,10 +125,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$enqueue_status = $this->get_enqueue_status();
 		}
 
-		// error_log(print_r($enqueue_status,1));
-
-		$this->enable_queue_rate_limit();
-
 		$remaining_items_to_enqueue = Jetpack_Sync_Settings::get_setting( 'max_enqueue_full_sync' );
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
@@ -155,13 +151,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 			if ( 0 >= $remaining_items_to_enqueue ) {
 				// drop out, we're not allowed to process more items than this
-				$this->disable_queue_rate_limit();
 				$this->set_enqueue_status( $enqueue_status );
 				return;
 			}
 		}
-
-		$this->disable_queue_rate_limit();
+		
 		$this->set_enqueue_status( $enqueue_status );
 		$this->update_status_option( 'queue_finished', time() );
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -113,6 +113,10 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	function continue_enqueuing( $configs = null, $enqueue_status = null ) {
+		if ( $this->get_status_option( 'queue_finished' ) ) {
+			return;
+		}
+
 		if ( ! $configs ) {
 			$configs = $this->get_config();
 		}
@@ -126,12 +130,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();
 
-			if ( ! isset( $configs[ $module_name ] ) ) {
-				continue;
-			}
-
 			// skip module if not configured for this sync or module is done
-			if ( ! $configs[ $module_name ] || ! $enqueue_status[ $module_name ] || true === $enqueue_status[ $module_name ][ 2 ] ) {
+			if ( ! isset( $configs[ $module_name ] ) 
+				|| // no module config
+					! $configs[ $module_name ] 
+				|| // no enqueue status
+					! $enqueue_status[ $module_name ] 
+				|| // finished enqueuing
+					true === $enqueue_status[ $module_name ][ 2 ] ) {
 				continue;
 			}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -185,7 +185,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		}
 
 		if ( isset( $actions_with_counts['jetpack_full_sync_start'] ) ) {
-			$this->update_status_option( 'sent_started', time() );
+			$this->update_status_option( 'send_started', time() );
 		}
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
@@ -228,7 +228,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$status = array(
 			'started'        => $this->get_status_option( 'started' ),
 			'queue_finished' => $this->get_status_option( 'queue_finished' ),
-			'sent_started'   => $this->get_status_option( 'sent_started' ),
+			'send_started'   => $this->get_status_option( 'send_started' ),
 			'finished'       => $this->get_status_option( 'finished' ),
 			'sent'           => array(),
 			'queue'          => array(),
@@ -274,7 +274,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		$prefix = self::STATUS_OPTION_PREFIX;		
 		delete_option( "{$prefix}_started" );		
 		delete_option( "{$prefix}_queue_finished" );		
-		delete_option( "{$prefix}_sent_started" );		
+		delete_option( "{$prefix}_send_started" );		
 		delete_option( "{$prefix}_finished" );		
 		
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
@@ -337,11 +337,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				$name
 			)
 		);
-		// error_log("updated $name: $updated_num for ".$wpdb->last_query." - ".$wpdb->last_error);
+
 		if ( ! $updated_num ) {
 			$updated_num = $wpdb->query(
 				$wpdb->prepare(
-					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
+					"INSERT INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
 					$name,
 					$serialized_value
 				)

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -138,13 +138,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				continue;
 			}
 
-			if ( 0 >= $remaining_items_to_enqueue ) {
-				// drop out, we're not allowed to process more items than this
-				$this->disable_queue_rate_limit();
-				$this->set_enqueue_status( $enqueue_status );
-				return;
-			}
-
 			// skip module if not configured for this sync or module is done
 			if ( ! $configs[ $module_name ] || ! $enqueue_status[ $module_name ] || true === $enqueue_status[ $module_name ][ 2 ] ) {
 				continue;
@@ -159,8 +152,15 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				$enqueue_status[ $module_name ][ 1 ] += $items_enqueued;
 				$remaining_items_to_enqueue -= $items_enqueued;
 			}
-		}
 
+			if ( 0 >= $remaining_items_to_enqueue ) {
+				// drop out, we're not allowed to process more items than this
+				$this->disable_queue_rate_limit();
+				$this->set_enqueue_status( $enqueue_status );
+				return;
+			}
+		}
+		
 		$this->disable_queue_rate_limit();
 		$this->set_enqueue_status( $enqueue_status );
 		$this->update_status_option( 'queue_finished', time() );

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -106,7 +106,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	function continue_enqueuing( $configs = null, $enqueue_status = null ) {
-		if ( $this->get_status_option( 'queue_finished' ) ) {
+		if ( ! $this->is_started() || $this->get_status_option( 'queue_finished' ) ) {
 			return;
 		}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -129,7 +129,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 					! $configs[ $module_name ] 
 				|| // no enqueue status
 					! $enqueue_status[ $module_name ] 
-				|| // finished enqueuing
+				|| // finished enqueuing this module
 					true === $enqueue_status[ $module_name ][ 2 ] ) {
 				continue;
 			}
@@ -144,15 +144,17 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				$remaining_items_to_enqueue -= $items_enqueued;
 			}
 
+			// stop processing if we've reached our limit of items to enqueue
 			if ( 0 >= $remaining_items_to_enqueue ) {
-				// drop out, we're not allowed to process more items than this
 				$this->set_enqueue_status( $enqueue_status );
 				return;
 			}
 		}
 		
 		$this->set_enqueue_status( $enqueue_status );
-		$this->update_status_option( 'queue_finished', time() );
+
+		// setting autoload to true means that it's faster to check whether we should continue enqueuing
+		$this->update_status_option( 'queue_finished', time(), true );
 
 		/**
 		 * Fires when a full sync ends. This action is serialized
@@ -286,9 +288,9 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return is_numeric( $value ) ? intval( $value ) : $value;
 	}
 
-	private function update_status_option( $name, $value ) {
+	private function update_status_option( $name, $value, $autoload = false ) {
 		$prefix = self::STATUS_OPTION_PREFIX;
-		update_option( "{$prefix}_{$name}", $value, false );
+		update_option( "{$prefix}_{$name}", $value, $autoload );
 	}
 
 	private function set_enqueue_status( $new_status ) {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -36,7 +36,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		add_action( 'jetpack_sync_processed_actions', array( $this, 'update_sent_progress_action' ) );
 	}
 
-	function start( $modules = null ) {
+	function start( $module_configs = null ) {
 		$was_already_running = $this->is_started() && ! $this->is_finished();
 
 		// remove all evidence of previous full sync items and status
@@ -57,21 +57,21 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 *
 		 * @since 4.2.0
 		 */
-		do_action( 'jetpack_full_sync_start', $modules );
+		do_action( 'jetpack_full_sync_start', $module_configs );
 		$this->update_status_option( 'started', time() );
 
 		// configure modules
-		if ( ! is_array( $modules ) ) {
-			$modules = array();
+		if ( ! is_array( $module_configs ) ) {
+			$module_configs = array();
 		}
 
-		if ( isset( $modules['users'] ) && 'initial' === $modules['users'] ) {
+		if ( isset( $module_configs['users'] ) && 'initial' === $module_configs['users'] ) {
 			$user_module = Jetpack_Sync_Modules::get_module( 'users' );
-			$modules['users'] = $user_module->get_initial_sync_user_config();
+			$module_configs['users'] = $user_module->get_initial_sync_user_config();
 		}
 
 		// by default, all modules are fully enabled
-		if ( count( $modules ) === 0 ) {
+		if ( count( $module_configs ) === 0 ) {
 			$default_module_config = true;
 		} else {
 			$default_module_config = false;
@@ -80,12 +80,12 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		// set default configuration, calculate totals, and save configuration if totals > 0
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();
-			if ( ! isset( $modules[ $module_name ] ) ) {
-				$modules[ $module_name ] = $default_module_config;
+			if ( ! isset( $module_configs[ $module_name ] ) ) {
+				$module_configs[ $module_name ] = $default_module_config;
 			}
 
 			// check if this module is enabled
-			if ( ! ( $module_config = $modules[ $module_name ] ) ) {
+			if ( ! ( $module_config = $module_configs[ $module_name ] ) ) {
 				continue;
 			}
 
@@ -97,17 +97,17 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			}
 		}
 
-		$this->continue_enqueuing();
+		$this->continue_enqueuing( $module_configs );
 
 		return true;
 	}
 
-	function continue_enqueuing() {
+	function continue_enqueuing( $module_configs ) {
 		$this->enable_queue_rate_limit();
-		
+
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name   = $module->name();
-			$module_config = $modules[ $module_name ];
+			$module_config = $module_configs[ $module_name ];
 
 			// check if this module is enabled
 			if ( ! $module_config ) {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -335,7 +335,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		if ( ! $updated_num ) {
 			$updated_num = $wpdb->query(
 				$wpdb->prepare(
-					"INSERT INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
+					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
 					$name,
 					$serialized_value
 				)

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -109,7 +109,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 *
 		 * @since 4.2.0
 		 */
-		do_action( 'jetpack_full_sync_start', $module_configs );
+		do_action( 'jetpack_full_sync_start', $full_sync_config );
 
 		$this->continue_enqueuing( $full_sync_config, $enqueue_status );
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -110,6 +110,18 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			return;
 		}
 
+		// if full sync queue is full, don't enqueue more items
+		$max_queue_size_full_sync = Jetpack_Sync_Settings::get_setting( 'max_queue_size_full_sync' );
+		$full_sync_queue = new Jetpack_Sync_Queue( 'full_sync' );
+		
+		$available_queue_slots = $max_queue_size_full_sync - $full_sync_queue->size();
+
+		if ( $available_queue_slots <= 0 ) {
+			return;
+		} else {
+			$remaining_items_to_enqueue = min( Jetpack_Sync_Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
+		}
+
 		if ( ! $configs ) {
 			$configs = $this->get_config();
 		}
@@ -117,8 +129,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		if ( ! $enqueue_status ) {
 			$enqueue_status = $this->get_enqueue_status();
 		}
-
-		$remaining_items_to_enqueue = Jetpack_Sync_Settings::get_setting( 'max_enqueue_full_sync' );
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$module_name = $module->name();

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -51,14 +51,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			do_action( 'jetpack_full_sync_cancelled' );
 		}
 
-		/**
-		 * Fires when a full sync begins. This action is serialized
-		 * and sent to the server so that it knows a full sync is coming.
-		 *
-		 * @since 4.2.0
-		 */
-		do_action( 'jetpack_full_sync_start', $module_configs );
+		// TODO: migrate old status options to new single status array
+		// OR separate sent-status from enqueue status
 		$this->update_status_option( 'started', time() );
+		$enqueue_status = array();
+		$full_sync_config = array();
 
 		// configure modules
 		if ( ! is_array( $module_configs ) ) {
@@ -84,6 +81,8 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				$module_configs[ $module_name ] = $default_module_config;
 			}
 
+			$enqueue_status[ $module_name ] = false;
+
 			// check if this module is enabled
 			if ( ! ( $module_config = $module_configs[ $module_name ] ) ) {
 				continue;
@@ -92,35 +91,78 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			$total_items = $module->estimate_full_sync_actions( $module_config );
 
 			if ( ! is_null( $total_items ) && $total_items > 0 ) {
-				$this->update_status_option( "{$module_name}_total", $total_items );
-				$this->update_status_option( "{$module_name}_config", $module_config );
+				$full_sync_config[ $module_name ] = $module_config;
+				$enqueue_status[ $module_name ] = array(
+					$total_items,   // total
+					0,              // queued
+					false,          // current state
+				);
 			}
 		}
 
-		$this->continue_enqueuing( $module_configs );
+		$this->set_config( $full_sync_config );
+		$this->set_enqueue_status( $enqueue_status );
+
+		/**
+		 * Fires when a full sync begins. This action is serialized
+		 * and sent to the server so that it knows a full sync is coming.
+		 *
+		 * @since 4.2.0
+		 */
+		do_action( 'jetpack_full_sync_start', $module_configs );
+
+		$this->continue_enqueuing( $full_sync_config, $enqueue_status );
 
 		return true;
 	}
 
-	function continue_enqueuing( $module_configs ) {
+	function continue_enqueuing( $configs = null, $enqueue_status = null ) {
+		if ( ! $configs ) {
+			$configs = $this->get_config();
+		}
+
+		if ( ! $enqueue_status ) {
+			$enqueue_status = $this->get_enqueue_status();
+		}
+
+		// error_log(print_r($enqueue_status,1));
+
 		$this->enable_queue_rate_limit();
 
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
-			$module_name   = $module->name();
-			$module_config = $module_configs[ $module_name ];
+		$remaining_items_to_enqueue = Jetpack_Sync_Settings::get_setting( 'max_enqueue_full_sync' );
 
-			// check if this module is enabled
-			if ( ! $module_config ) {
+		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+			$module_name = $module->name();
+
+			if ( ! isset( $configs[ $module_name ] ) ) {
 				continue;
 			}
 
-			$items_enqueued = $module->enqueue_full_sync_actions( $module_config );
+			if ( 0 >= $remaining_items_to_enqueue ) {
+				// drop out, we're not allowed to process more items than this
+				$this->disable_queue_rate_limit();
+				$this->set_enqueue_status( $enqueue_status );
+				return;
+			}
 
+			// skip module if not configured for this sync or module is done
+			if ( ! $configs[ $module_name ] || ! $enqueue_status[ $module_name ] || true === $enqueue_status[ $module_name ][ 2 ] ) {
+				continue;
+			}
+
+			list( $items_enqueued, $next_enqueue_state ) = $module->enqueue_full_sync_actions( $configs[ $module_name ], $remaining_items_to_enqueue, $enqueue_status[ $module_name ][ 2 ] );
+
+			$enqueue_status[ $module_name ][ 2 ] = $next_enqueue_state;
+
+			// if items were processed, subtract them from the limit
 			if ( ! is_null( $items_enqueued ) && $items_enqueued > 0 ) {
-				$this->update_status_option( "{$module_name}_queued", $items_enqueued );
+				$enqueue_status[ $module_name ][ 1 ] += $items_enqueued;
+				$remaining_items_to_enqueue -= $items_enqueued;
 			}
 		}
 
+		$this->disable_queue_rate_limit();
+		$this->set_enqueue_status( $enqueue_status );
 		$this->update_status_option( 'queue_finished', time() );
 
 		/**
@@ -131,8 +173,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		 * @since 4.2.0
 		 */
 		do_action( 'jetpack_full_sync_end', '' );
-
-		$this->disable_queue_rate_limit();
 	}
 
 	function update_sent_progress_action( $actions ) {
@@ -196,55 +236,52 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 			'total'          => array(),
 		);
 
+		$enqueue_status = $this->get_enqueue_status();
+		$module_config = $this->get_config();
+
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$name = $module->name();
 
-			if ( $total = $this->get_status_option( "{$name}_total" ) ) {
+			if ( ! isset( $module_config[ $name ] ) ) {
+				continue;
+			} else if ( $config = $module_config[ $name ] ) {
+				$status[ 'config' ][ $name ] = $config;
+			}
+
+			if ( false === $enqueue_status[ $name ] ) {
+				continue;
+			}
+
+			list( $total, $queued, $state ) = $enqueue_status[ $name ];
+
+			if ( $total ) {
 				$status[ 'total' ][ $name ] = $total;
 			}
 
-			if ( $queued = $this->get_status_option( "{$name}_queued" ) ) {
+			if ( $queued ) {
 				$status[ 'queue' ][ $name ] = $queued;
 			}
 			
 			if ( $sent = $this->get_status_option( "{$name}_sent" ) ) {
 				$status[ 'sent' ][ $name ] = $sent;
 			}
-
-			if ( $config = $this->get_status_option( "{$name}_config" ) ) {
-				$status[ 'config' ][ $name ] = $config;
-			}
 		}
 
 		return $status;
 	}
 
-	public function clear_status() {
-		$prefix = self::STATUS_OPTION_PREFIX;
-		delete_option( "{$prefix}_started" );
-		delete_option( "{$prefix}_queue_finished" );
-		delete_option( "{$prefix}_sent_started" );
-		delete_option( "{$prefix}_finished" );
-
-		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
-			delete_option( "{$prefix}_{$module->name()}_total" );
-			delete_option( "{$prefix}_{$module->name()}_queued" );
-			delete_option( "{$prefix}_{$module->name()}_sent" );
-			delete_option( "{$prefix}_{$module->name()}_config" );
-		}
-	}
-
 	public function reset_data() {
-		$this->clear_status();
+		// $this->set_config( null ); // setting to null is quicker than deleting and re-adding
+		// $this->set_status( null ); // TODO: not sure if clearing these is really necessary...
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 		$listener = Jetpack_Sync_Listener::get_instance();
 		$listener->get_full_sync_queue()->reset();
 	}
 
-	private function get_status_option( $option, $default = null ) {
+	private function get_status_option( $name, $default = null ) {
 		$prefix = self::STATUS_OPTION_PREFIX;
 
-		$value = get_option( "{$prefix}_{$option}", $default );
+		$value = get_option( "{$prefix}_{$name}", $default );
 		
 		if ( ! $value ) {
 			// don't cast to int if we didn't find a value - we want to preserve null or false as sentinals
@@ -257,6 +294,66 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	private function update_status_option( $name, $value ) {
 		$prefix = self::STATUS_OPTION_PREFIX;
 		update_option( "{$prefix}_{$name}", $value, false );
+	}
+
+	private function set_enqueue_status( $new_status ) {
+		$this->write_option( 'jetpack_sync_full_enqueue_status', $new_status );
+	}
+
+	private function get_enqueue_status() {
+		return $this->read_option( 'jetpack_sync_full_enqueue_status' );
+	}
+
+	private function set_config( $config ) {
+		$this->write_option( 'jetpack_sync_full_config', $config );
+	}
+	
+	private function get_config() {
+		return $this->read_option( 'jetpack_sync_full_config' );
+	}
+
+	private function write_option( $name, $value ) {
+		// we write our own option updating code to bypass filters/caching/etc on set_option/get_option
+		global $wpdb;
+		$serialized_value = maybe_serialize( $value );
+		// try updating, if no update then insert
+		// TODO: try to deal with the fact that unchanged values can return updated_num = 0
+		// below we used "insert ignore" to at least suppress the resulting error
+		$updated_num = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
+				$serialized_value,
+				$name
+			)
+		);
+		// error_log("updated $name: $updated_num for ".$wpdb->last_query." - ".$wpdb->last_error);
+		if ( ! $updated_num ) {
+			$updated_num = $wpdb->query(
+				$wpdb->prepare(
+					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )", 
+					$name,
+					$serialized_value
+				)
+			);
+		}
+		return $updated_num;
+	}
+
+	private function read_option( $name, $default = null ) {
+		global $wpdb;
+		$value = $wpdb->get_var( 
+			$wpdb->prepare(
+				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", 
+				$name
+			)
+		);
+		$value = maybe_unserialize( $value );
+
+		if ( $value === null && $default !== null ) {
+			return $default;
+		}
+
+		return $value;
 	}
 
 	private function enable_queue_rate_limit() {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -160,7 +160,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 				return;
 			}
 		}
-		
+
 		$this->disable_queue_rate_limit();
 		$this->set_enqueue_status( $enqueue_status );
 		$this->update_status_option( 'queue_finished', time() );
@@ -270,9 +270,20 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		return $status;
 	}
 
+	public function clear_status() {		
+		$prefix = self::STATUS_OPTION_PREFIX;		
+		delete_option( "{$prefix}_started" );		
+		delete_option( "{$prefix}_queue_finished" );		
+		delete_option( "{$prefix}_sent_started" );		
+		delete_option( "{$prefix}_finished" );		
+		
+		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
+			delete_option( "{$prefix}_{$module->name()}_sent" );		
+		}
+	}
+
 	public function reset_data() {
-		// $this->set_config( null ); // setting to null is quicker than deleting and re-adding
-		// $this->set_status( null ); // TODO: not sure if clearing these is really necessary...
+		$this->clear_status();
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';
 		$listener = Jetpack_Sync_Listener::get_instance();
 		$listener->get_full_sync_queue()->reset();

--- a/sync/class.jetpack-sync-module-network-options.php
+++ b/sync/class.jetpack-sync-module-network-options.php
@@ -43,9 +43,9 @@ class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
 		$this->network_options_whitelist = Jetpack_Sync_Defaults::$default_network_options_whitelist;
 	}
 
-	function enqueue_full_sync_actions( $config ) {
+	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		if ( ! is_multisite() ) {
-			return 0;
+			return array( 0, true );
 		}
 
 		/**
@@ -57,7 +57,8 @@ class Jetpack_Sync_Module_Network_Options extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_full_sync_network_options', true );
 
-		return 1; // The number of actions enqueued
+		// The number of actions enqueued, and next module state (true == done)
+		return array( 1, true );
 	}
 
 	function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -37,7 +37,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		$this->update_options_whitelist();
 	}
 
-	function enqueue_full_sync_actions( $config ) {
+	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		/**
 		 * Tells the client to sync all options to the server
 		 *
@@ -47,7 +47,8 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_full_sync_options', true );
 
-		return 1; // The number of actions enqueued
+		// The number of actions enqueued, and next module state (true == done)
+		return array( 1, true );
 	}
 
 	public function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -37,10 +37,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
 	}
 
-	public function enqueue_full_sync_actions( $config ) {
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		global $wpdb;
 
-		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $this->get_where_sql( $config ) );
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_posts', $wpdb->posts, 'ID', $this->get_where_sql( $config ), $max_items_to_enqueue, $state );
 	}
 
 	public function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -180,6 +180,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		$posts = array_filter( array_map( array( 'WP_Post', 'get_instance' ), $post_ids ) );
 		$posts = array_map( array( $this, 'filter_post_content_and_add_links' ), $posts );
+		$posts = array_values( $posts ); // reindex in case posts were deleted
 
 		return array(
 			$posts,

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -25,8 +25,10 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_terms', array( $this, 'expand_term_ids' ) );
 	}
 
-	function enqueue_full_sync_actions( $config ) {
+	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		global $wpdb;
+
+		// TODO: process state
 
 		$taxonomies           = get_taxonomies();
 		$total_chunks_counter = 0;
@@ -43,7 +45,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 			}
 		}
 
-		return $total_chunks_counter;
+		return array( $total_chunks_counter, true );
 	}
 
 	function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -26,7 +26,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		do_action( 'jetpack_sync_current_theme_support' , $this->get_theme_support_info() );
 	}
 
-	public function enqueue_full_sync_actions( $config ) {
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		/**
 		 * Tells the client to sync all theme data to the server
 		 *
@@ -35,7 +35,9 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		 * @param boolean Whether to expand theme data (should always be true)
 		 */
 		do_action( 'jetpack_full_sync_theme_data', true );
-		return 1; // The number of actions enqueued
+
+		// The number of actions enqueued, and next module state (true == done)
+		return array( 1, true );
 	}
 
 	public function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -29,7 +29,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
 	}
 
-	public function enqueue_full_sync_actions( $config ) {
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		/**
 		 * Tells the client to sync all updates to the server
 		 *
@@ -39,7 +39,8 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		 */
 		do_action( 'jetpack_full_sync_updates', true );
 
-		return 1; // The number of actions enqueued
+		// The number of actions enqueued, and next module state (true == done)
+		return array( 1, true );
 	}
 
 	public function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -173,9 +173,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		}
 	}
 
-	public function enqueue_full_sync_actions( $config ) {
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		global $wpdb;
-		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->usermeta, 'user_id', $this->get_where_sql( $config ) );
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->usermeta, 'user_id', $this->get_where_sql( $config ), $max_items_to_enqueue, $state );
 	}
 
 	public function estimate_full_sync_actions( $config ) {

--- a/sync/class.jetpack-sync-module.php
+++ b/sync/class.jetpack-sync-module.php
@@ -82,7 +82,9 @@ abstract class Jetpack_Sync_Module {
 				$remaining_items = array_slice( $chunked_ids, 0, $remaining_items_count );
 
 				$listener->bulk_enqueue_full_sync_actions( $action_name, $remaining_items );
-				return array( $remaining_items_count + $chunk_count, end( $remaining_items ) );
+
+				$last_chunk = end( $remaining_items );
+				return array( $remaining_items_count + $chunk_count, end( $last_chunk ) );
 			}
 
 			$listener->bulk_enqueue_full_sync_actions( $action_name, $chunked_ids );

--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -55,8 +55,6 @@ class Jetpack_Sync_Queue {
 			) );
 			$added      = ( 0 !== $rows_added );
 		}
-
-		do_action( 'jpsq_item_added' );
 	}
 
 	// Attempts to insert all the items in a single SQL query. May be subject to query size limits!
@@ -79,8 +77,6 @@ class Jetpack_Sync_Queue {
 		if ( count( $items ) === $rows_added ) {
 			return new WP_Error( 'row_count_mismatch', "The number of rows inserted didn't match the size of the input array" );
 		}
-
-		do_action( 'jpsq_items_added', $rows_added );
 	}
 
 	// Peek at the front-most item on the queue without checking it out

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -6,20 +6,21 @@ class Jetpack_Sync_Settings {
 	const SETTINGS_OPTION_PREFIX = 'jetpack_sync_settings_';
 
 	static $valid_settings = array(
-		'dequeue_max_bytes'    => true,
-		'upload_max_bytes'     => true,
-		'upload_max_rows'      => true,
-		'sync_wait_time'       => true,
-		'sync_wait_threshold'  => true,
-		'max_queue_size'       => true,
-		'max_queue_lag'        => true,
-		'queue_max_writes_sec' => true,
-		'post_types_blacklist' => true,
-		'disable'              => true,
+		'dequeue_max_bytes'       => true,
+		'upload_max_bytes'        => true,
+		'upload_max_rows'         => true,
+		'sync_wait_time'          => true,
+		'sync_wait_threshold'     => true,
+		'max_queue_size'          => true,
+		'max_queue_lag'           => true,
+		'queue_max_writes_sec'    => true,
+		'post_types_blacklist'    => true,
+		'disable'                 => true,
 		'render_filtered_content' => true,
-		'post_meta_whitelist' => true,
-		'comment_meta_whitelist' => true,
-		'avoid_wp_cron'        => true,
+		'post_meta_whitelist'     => true,
+		'comment_meta_whitelist'  => true,
+		'avoid_wp_cron'           => true,
+		'max_enqueue_full_sync'   => true,
 	);
 
 	static $is_importing;

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -21,6 +21,7 @@ class Jetpack_Sync_Settings {
 		'post_meta_whitelist'     => true,
 		'comment_meta_whitelist'  => true,
 		'max_enqueue_full_sync'   => true,
+		'max_queue_size_full_sync'=> true,
 	);
 
 	static $is_importing;

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -11,6 +11,7 @@ class Jetpack_Sync_Settings {
 		'upload_max_rows'         => true,
 		'sync_wait_time'          => true,
 		'sync_wait_threshold'     => true,
+		'enqueue_wait_time'       => true,
 		'max_queue_size'          => true,
 		'max_queue_lag'           => true,
 		'queue_max_writes_sec'    => true,

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -19,7 +19,6 @@ class Jetpack_Sync_Settings {
 		'render_filtered_content' => true,
 		'post_meta_whitelist'     => true,
 		'comment_meta_whitelist'  => true,
-		'avoid_wp_cron'           => true,
 		'max_enqueue_full_sync'   => true,
 	);
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1121,7 +1121,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start( array( 'posts' => true ) );
 
 		// test number of items in full sync queue - should be 4 (= full_sync_start + 2xposts + full_sync_end)
-		$this->assertEquals( 4, $this->sender->get_full_sync_queue()->size() );
+		$this->assertEquals( 3, $this->sender->get_full_sync_queue()->size() );
 
 		$this->full_sync->continue_enqueuing();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -605,14 +605,14 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$standard_config = array( 
 			'constants' => true,
-    		'functions' => true,
-    		'options' => true,
-    		'network_options' => true,
-    		'terms' => true,
-    		'themes' => true,
-    		'users' => true,
-    		'updates' => true,
-    		'posts' => true
+			'functions' => true,
+			'options' => true,
+			'network_options' => true,
+			'terms' => true,
+			'themes' => true,
+			'users' => true,
+			'updates' => true,
+			'posts' => true
 		);
 
 		$this->full_sync->start();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -930,21 +930,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $keep_user_id, $users[ $existing_user_count ]->ID );
 	}
 
-	function test_full_sync_doesnt_exceed_options_write_rate_limit() {
-		// need to bump max_enqueue_full_sync too because otherwise we quit early!
-		Jetpack_Sync_Settings::update_settings( array( 'queue_max_writes_sec' => 2, 'max_enqueue_full_sync' => 3000 ) );
-
-		foreach( range( 1, 2100 ) as $i ) { // 200 items+
-			$this->factory->user->create();
-		}
-
-		$start_time = microtime( true );
-
-		$this->full_sync->start();
-
-		$this->assertTrue( microtime( true ) > ( $start_time + 2.0 ) );
-	}
-
 	function test_full_sync_has_correct_sent_count_even_if_some_actions_unsent() {
 		// if actions get filtered out after dequeue, this can lead to the sent count 
 		// not matching the queued count - we should make sure the count is incremented even for late-deleted items

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1078,7 +1078,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
-		Jetpack_Sync_Actions::schedule_initial_sync( '4.2', '4.1' );
+		Jetpack_Sync_Actions::do_initial_sync( '4.2', '4.1' );
 
 		$full_sync_status = $this->full_sync->get_status();
 		$this->assertEquals(

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -931,7 +931,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_doesnt_exceed_options_write_rate_limit() {
-		Jetpack_Sync_Settings::update_settings( array( 'queue_max_writes_sec' => 2 ) );
+		// need to bump max_enqueue_full_sync too because otherwise we quit early!
+		Jetpack_Sync_Settings::update_settings( array( 'queue_max_writes_sec' => 2, 'max_enqueue_full_sync' => 3000 ) );
 
 		foreach( range( 1, 2100 ) as $i ) { // 200 items+
 			$this->factory->user->create();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -607,6 +607,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 			'constants' => true,
     		'functions' => true,
     		'options' => true,
+    		'network_options' => true,
     		'terms' => true,
     		'themes' => true,
     		'users' => true,
@@ -702,7 +703,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		);
 		if ( is_multisite() ) {
 			$should_be_status['queue']['network_options'] = 1;
-			$should_be_status['config']['network_options'] = 1;
 		}
 
 		$this->assertEquals( $should_be_status['queue'], $full_sync_status['queue'] );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -805,8 +805,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$posts = $synced_posts_event->args[0];
 
 		$this->assertEquals( 2, count( $posts ) );
-		$this->assertEquals( $sync_post_id, $posts[0]->ID );
-		$this->assertEquals( $sync_post_id_2, $posts[1]->ID );
+		$this->assertEquals( $sync_post_id_2, $posts[0]->ID );
+		$this->assertEquals( $sync_post_id, $posts[1]->ID );
 
 		$sync_status = $this->full_sync->get_status();
 		$this->assertEquals( array( $sync_post_id, $sync_post_id_2 ), $sync_status['config']['posts'] );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -674,7 +674,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 				'total'          => array(),
 				'sent'           => array(),
 				'queue'          => array(),
-				'config'         => array(),
+				'config'         => null,
 			)
 		);
 	}
@@ -698,17 +698,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 				'users'     => 1,
 				'terms'     => 1,
 			),
-			'config' => array(
-				'constants' => true,
-				'functions' => true,
-				'options'   => true,
-				'posts'     => true,
-				'comments'  => true,
-				'themes'    => true,
-				'updates'   => true,
-				'users'     => true,
-				'terms'     => true,
-			)
+			'config' => null
 		);
 		if ( is_multisite() ) {
 			$should_be_status['queue']['network_options'] = 1;
@@ -1080,15 +1070,18 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
 		Jetpack_Sync_Actions::do_initial_sync( '4.2', '4.1' );
 
+		$expected_sync_config = array( 
+			'options' => true, 
+			'network_options' => true,
+			'functions' => true, 
+			'constants' => true, 
+			'users' => 'initial'
+		);
+
 		$full_sync_status = $this->full_sync->get_status();
 		$this->assertEquals(
-			$full_sync_status[ 'config' ],
-			array(
-				'options' => true,
-				'functions' => true,
-				'constants' => true,
-				'users' => $user_ids,
-			)
+			$expected_sync_config,
+			$full_sync_status[ 'config' ]
 		);
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1117,6 +1117,14 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $queue_size, $this->sender->get_full_sync_queue()->size() );
 	}
 
+	function test_full_sync_continue_does_nothing_if_no_sync_started() {
+		$full_sync_queue_size_before = $this->sender->get_full_sync_queue()->size();
+		
+		$this->full_sync->continue_enqueuing();
+
+		$this->assertEquals( $full_sync_queue_size_before, $this->sender->get_full_sync_queue()->size() );
+	}
+
 	function _do_cron() {
 		$_GET['check'] = wp_hash( '187425' );
 		require( ABSPATH . '/wp-cron.php' );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1112,11 +1112,16 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 5, $this->sender->get_full_sync_queue()->size() );
 
-		// assert that all our created posts got synced
-		// foreach( $synced_post_ids as $post_id ) {
-		// 	error_log(print_r($this->server_replica_storage->get_post( $post_id ), 1 );
-		// 	$this->assertNotSame( false, $this->server_replica_storage->get_post( $post_id ) );
-		// }
+		// should not keep adding full_sync_end or other items afterward
+		$queue_size = $this->sender->get_full_sync_queue()->size();
+
+		// continuing to enqueue shouldn't add more items
+		$this->full_sync->continue_enqueuing();
+		$this->assertEquals( $queue_size, $this->sender->get_full_sync_queue()->size() );
+		$this->full_sync->continue_enqueuing();
+		$this->assertEquals( $queue_size, $this->sender->get_full_sync_queue()->size() );
+		$this->full_sync->continue_enqueuing();
+		$this->assertEquals( $queue_size, $this->sender->get_full_sync_queue()->size() );
 	}
 
 	function _do_cron() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -607,13 +607,16 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 			'constants' => true,
 			'functions' => true,
 			'options' => true,
-			'network_options' => true,
 			'terms' => true,
 			'themes' => true,
 			'users' => true,
 			'updates' => true,
 			'posts' => true
 		);
+
+		if ( is_multisite() ) {
+			$standard_config['network_options'] = true;
+		}
 
 		$this->full_sync->start();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1094,15 +1094,15 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
 		Jetpack_Sync_Actions::schedule_initial_sync( '4.2', '4.1' );
-		$this->assertTrue(
-			!! Jetpack_Sync_Actions::is_scheduled_full_sync(
-				array(
-					'options' => true,
-					'network_options' => true,
-					'functions' => true,
-					'constants' => true,
-					'users' => 'initial',
-				)
+
+		$full_sync_status = $this->full_sync->get_status();
+		$this->assertEquals(
+			$full_sync_status[ 'config' ],
+			array(
+				'options' => true,
+				'functions' => true,
+				'constants' => true,
+				'users' => $user_ids,
 			)
 		);
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -963,13 +963,14 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_full_sync();
 		$full_sync_status = $this->full_sync->get_status();
-		$this->assertEquals( 0, $full_sync_status['finished'] );
+		$this->assertSame( null, $full_sync_status['finished'] );
 
 		$this->sender->do_full_sync();
 		$full_sync_status = $this->full_sync->get_status();
-		$this->assertEquals( 0, $full_sync_status['finished'] );
+		$this->assertSame( null, $full_sync_status['finished'] );
 
 		$this->sender->do_full_sync();
+		$this->sender->do_full_sync(); // juuuust in case - otherwise we use too many bytes for multisite
 
 		$full_sync_status = $this->full_sync->get_status();
 
@@ -1011,7 +1012,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		if ( is_multisite() ) {
 			$should_be_status['queue']['network_options'] = 1;
 			$should_be_status['sent']['network_options']  = 1;
-			$should_be_status['total']['network_options']  = 1;
+			$should_be_status['total']['network_options'] = 1;
 		}
 
 		$this->assertEquals( $full_sync_status['queue'], $should_be_status['queue'] );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -669,7 +669,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 			array(
 				'started'        => null,
 				'queue_finished' => null,
-				'sent_started'   => null,
+				'send_started'   => null,
 				'finished'       => null,
 				'total'          => array(),
 				'sent'           => array(),
@@ -719,7 +719,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $should_be_status['config'], $full_sync_status['config'] );
 		$this->assertInternalType( 'int', $full_sync_status['started'] );
 		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
-		$this->assertNull( $full_sync_status['sent_started'] );
+		$this->assertNull( $full_sync_status['send_started'] );
 		$this->assertNull( $full_sync_status['finished'] );
 		$this->assertInternalType( 'array', $full_sync_status['sent'] );
 	}
@@ -765,7 +765,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $full_sync_status['sent'], $should_be_status['sent'] );
 		$this->assertInternalType( 'int', $full_sync_status['started'] );
 		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
-		$this->assertInternalType( 'int', $full_sync_status['sent_started'] );
+		$this->assertInternalType( 'int', $full_sync_status['send_started'] );
 		$this->assertInternalType( 'int', $full_sync_status['finished'] );
 	}
 
@@ -1041,7 +1041,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $full_sync_status['total'], $should_be_status['total'] );
 		$this->assertInternalType( 'int', $full_sync_status['started'] );
 		$this->assertInternalType( 'int', $full_sync_status['queue_finished'] );
-		$this->assertInternalType( 'int', $full_sync_status['sent_started'] );
+		$this->assertInternalType( 'int', $full_sync_status['send_started'] );
 		$this->assertInternalType( 'int', $full_sync_status['finished'] );
 
 		// Reset all the defaults

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -598,14 +598,27 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_start_sends_configuration() {
+		$post_ids = $this->factory->post->create_many( 3 );
+
 		// this is so that on WPCOM we can tell what has been synchronized in the past
 		add_action( 'jetpack_full_sync_start', array( $this, 'record_full_sync_start_config' ), 10, 1 );
 
+		$standard_config = array( 
+			'constants' => true,
+    		'functions' => true,
+    		'options' => true,
+    		'terms' => true,
+    		'themes' => true,
+    		'users' => true,
+    		'updates' => true,
+    		'posts' => true
+		);
+
 		$this->full_sync->start();
 
-		$this->assertEquals( null, $this->full_sync_start_config );
+		$this->assertEquals( $standard_config, $this->full_sync_start_config );
 
-		$custom_config = array( 'posts' => array( 1, 2, 3, ) );
+		$custom_config = array( 'posts' => $post_ids );
 
 		$this->full_sync->start( $custom_config );
 

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -125,22 +125,6 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( array( 'users' => true ) ) ) >= time() + 199 );
 	}
 
-	function test_can_avoid_wp_cron_when_scheduling_full_sync() {
-		$this->assertEquals( 0, Jetpack_Sync_Settings::get_setting( 'avoid_wp_cron' ) );
-
-		Jetpack_Sync_Settings::update_settings( array( 'avoid_wp_cron' => 1 ) );
-
-		$this->assertEquals( 1, Jetpack_Sync_Settings::get_setting( 'avoid_wp_cron' ) );
-
-		Jetpack_Sync_Actions::schedule_full_sync();
-
-		// assert that a sync was not scheduled...
-		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync() );
-
-		// but that one was enqueued instead
-		$this->sender->do_sync();
-		$this->assertTrue( !! $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' ) );
-	}
 
 	function test_sends_updating_jetpack_version_event() {
 		/** This action is documented in class.jetpack.php */

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -26,9 +26,10 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 		$expected_sync_config = array( 
 			'options' => true, 
+			'network_options' => true,
 			'functions' => true, 
 			'constants' => true, 
-			'users' => $wpdb->get_col( "SELECT ID FROM $wpdb->users ORDER BY ID ASC" )
+			'users' => 'initial'
 		);
 
 		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
@@ -38,11 +39,8 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_upgrading_from_42_plus_does_not_includes_users_in_initial_sync() {
 
-		global $wpdb;
-		$user_ids = $wpdb->get_col( "SELECT ID FROM $wpdb->users ORDER BY ID ASC" );
-
-		$initial_sync_without_users_config = array( 'options' => true, 'functions' => true, 'constants' => true );
-		$initial_sync_with_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'users' => $user_ids );
+		$initial_sync_without_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'network_options' => true );
+		$initial_sync_with_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'network_options' => true, 'users' => 'initial' );
 
 		do_action( 'updating_jetpack_version', '4.3', '4.2' );
 		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -22,21 +22,40 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		/** This action is documented in class.jetpack.php */
 		do_action( 'updating_jetpack_version', '4.2', '4.1' );
 
-		$modules = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => 'initial' );
-		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( $modules ) ) > time()-5 );
+		global $wpdb;
+
+		$expected_sync_config = array( 
+			'options' => true, 
+			'functions' => true, 
+			'constants' => true, 
+			'users' => $wpdb->get_col( "SELECT ID FROM $wpdb->users ORDER BY ID ASC" )
+		);
+
+		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
+		
+		$this->assertEquals( $sync_status['config'], $expected_sync_config );
 	}
 
 	function test_upgrading_from_42_plus_does_not_includes_users_in_initial_sync() {
 
-		$initial_sync_without_users_config = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true );
-		$initial_sync_with_users_config = array( 'options' => true, 'network_options' => true, 'functions' => true, 'constants' => true, 'users' => 'initial' );
+		global $wpdb;
+		$user_ids = $wpdb->get_col( "SELECT ID FROM $wpdb->users ORDER BY ID ASC" );
+
+		$initial_sync_without_users_config = array( 'options' => true, 'functions' => true, 'constants' => true );
+		$initial_sync_with_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'users' => $user_ids );
 
 		do_action( 'updating_jetpack_version', '4.3', '4.2' );
-		$this->assertTrue( Jetpack_Sync_Actions::is_scheduled_full_sync( $initial_sync_without_users_config ) );
-		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync( $initial_sync_with_users_config ) );
+		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
+		$sync_config = $sync_status[ 'config' ];
+
+		$this->assertEquals( $initial_sync_without_users_config, $sync_config );
+		$this->assertNotEquals( $initial_sync_with_users_config, $sync_config );
 
 		do_action( 'updating_jetpack_version', '4.2', '4.1' );
-		$this->assertTrue( Jetpack_Sync_Actions::is_scheduled_full_sync( $initial_sync_with_users_config ) );
+		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
+		$sync_config = $sync_status[ 'config' ];
+
+		$this->assertEquals( $initial_sync_with_users_config, $sync_config );
 	}
 
 	function test_schedules_incremental_sync_cron() {
@@ -88,43 +107,10 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( '1min', wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
-	function test_schedules_ƒull_sync_on_client_authorized() {
-		do_action( 'jetpack_client_authorized', 'abcd1234' ); // Jetpack_Options::get_option( 'id' )
-		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full' ) !== false );
+	function test_starts_full_sync_on_client_authorized() {
+		do_action( 'jetpack_client_authorized', 'abcd1234' );
+		$this->assertTrue( Jetpack_Sync_Modules::get_module( 'full-sync' )->is_started() );
 	}
-
-	function test_is_scheduled_full_sync_works_with_different_args() {
-		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync() );
-
-		Jetpack_Sync_Actions::schedule_full_sync( array( 'posts' => true ) );
-
-		$this->assertTrue( (bool) Jetpack_Sync_Actions::is_scheduled_full_sync() );
-		$this->assertTrue( (bool) Jetpack_Sync_Actions::is_scheduled_full_sync( array( 'posts' => true ) ) );
-		$this->assertFalse( (bool) Jetpack_Sync_Actions::is_scheduled_full_sync( array( 'comments' => true ) ) );
-	}
-
-	function test_can_unschedule_all_full_syncs() {
-		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync() );
-
-		Jetpack_Sync_Actions::schedule_full_sync( array( 'posts' => true ) );
-		Jetpack_Sync_Actions::schedule_full_sync( array( 'users' => true ) );
-
-		$this->assertTrue( Jetpack_Sync_Actions::is_scheduled_full_sync() );
-
-		Jetpack_Sync_Actions::unschedule_all_full_syncs();
-
-		$this->assertFalse( Jetpack_Sync_Actions::is_scheduled_full_sync() );
-	}
-
-	function test_scheduling_a_full_sync_unschedules_all_future_full_syncs() {
-		Jetpack_Sync_Actions::schedule_full_sync( array( 'posts' => true ), 100 ); // 100 seconds in the future
-		Jetpack_Sync_Actions::schedule_full_sync( array( 'users' => true ), 200 ); // 200 seconds in the future
-
-		// users sync should have overridden posts sync
-		$this->assertFalse( wp_next_scheduled( 'jetpack_sync_full', array( array( 'posts' => true ) ) ) );
-		$this->assertTrue( wp_next_scheduled( 'jetpack_sync_full', array( array( 'users' => true ) ) ) >= time() + 199 );
-	}
-
 
 	function test_sends_updating_jetpack_version_event() {
 		/** This action is documented in class.jetpack.php */

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -263,7 +263,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		$full_sync->reset_data();
 		
-		$status = $full_sync->get_status();
+		// $status = $full_sync->get_status();
 		$this->assertFalse( $full_sync->is_started() );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -263,7 +263,6 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		$full_sync->reset_data();
 		
-		// $status = $full_sync->get_status();
 		$this->assertFalse( $full_sync->is_started() );
 	}
 


### PR DESCRIPTION
For very large sites, it can take a long time to enqueue a full sync, and currently it needs to be done in the scope of a single request.

This PR changes a number of things about this:
- enqueues from highest to lowest ID, hopefully sending newer posts first in case everything crashes
- periodically saves the state of the current module while enqueuing (e.g. max_post_id for posts) so we can resume from that point if it crashes
- stops trying to enqueue the full sync if the total number of items in the full sync queue is greater than a certain (configurable) number. We already have a failsafe in place for this for queues in general, so I'm not 100% sure it's worth implementing this part, unless we expect the queue to grow SO dramatically beyond that.
- allows full sync enqueues to happen purely in request shutdown, not just in cron, which should help us relieve our dependence on (frequently broken) wp-cron implementations.