### PR TITLE
General: Adds Jetpack_Constants class for testing purposes

### DIFF
--- a/class.jetpack-constants.php
+++ b/class.jetpack-constants.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Class Jetpack_Constants
+ *
+ * Testing constants is hard. Once you define a constant, it's defined. Jetpack_Constants is an
+ * abstraction layer so that unit tests can set "constants" for tests.
+ *
+ * To test your code, you'll need to swap out `defined( 'CONSTANT' )` with `Jetpack_Constants::is_defined( 'CONSTANT' )`
+ * and replace `CONSTANT` with `Jetpack_Constants::get_constant( 'CONSTANT' )`. Then in the unit test, you can set the
+ * constant with `Jetpack::set_constant( 'CONSTANT', $value )` and then clean up after each test with something like
+ * this:
+ *
+ * function tearDown() {
+ *     Jetpack_Constants::clear_constants();
+ * }
+ */
+class Jetpack_Constants {
+	static $set_constants = array();
+
+	/**
+	 * Checks if a "constant" has been set in Jetpack_Constants, and if not,
+	 * checks if the constant was defined with define( 'name', 'value ).
+	 *
+	 * @param $name string The name of the constant
+	 *
+	 * @return bool
+	 */
+	public static function is_defined( $name ) {
+		return isset( self::$set_constants[ $name ] )
+			? true
+			: defined( $name );
+	}
+
+	/**
+	 * Attempts to retrieve the "constant" from Jetpack_Constants, and if it hasn't been set,
+	 * then attempst to get the constant with the constant() function.
+	 *
+	 * @param $name
+	 *
+	 * @return mixed null if the constant does not exist or the value of the constant.
+	 */
+	public static function get_constant( $name ) {
+		if ( isset( self::$set_constants[ $name ] ) ) {
+			return self::$set_constants[ $name ];
+		}
+
+		return defined( $name ) ? constant( $name ) : null;
+	}
+
+	/**
+	 * Sets the value of the "constant" within Jetpack_Constants.
+	 *
+	 * @param $name  string The name of the "constant"
+	 * @param $value string The value of the "constant"
+	 */
+	public static function set_constant( $name, $value ) {
+		self::$set_constants[ $name ] = $value;
+	}
+
+	/**
+	 * Will unset a "constant" from Jetpack_Constants if the constant exists.
+	 *
+	 * @param $name string The name of the "constant"
+	 *
+	 * @return bool Whether the constant was removed.
+	 */
+	public static function clear_single_constant( $name ) {
+		if ( ! isset( self::$set_constants[ $name ] ) ) {
+			return false;
+		}
+
+		unset( self::$set_constants[ $name ] );
+		return true;
+	}
+
+	/**
+	 * Resets all of the constants within Jetpack_Constants.
+	 */
+	public static function clear_constants() {
+		self::$set_constants = array();
+	}
+}

--- a/class.jetpack-constants.php
+++ b/class.jetpack-constants.php
@@ -34,7 +34,7 @@ class Jetpack_Constants {
 
 	/**
 	 * Attempts to retrieve the "constant" from Jetpack_Constants, and if it hasn't been set,
-	 * then attempst to get the constant with the constant() function.
+	 * then attempts to get the constant with the constant() function.
 	 *
 	 * @param $name
 	 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1229,7 +1229,7 @@ class Jetpack {
 		 */
 		return (bool) apply_filters(
 			'jetpack_development_version',
-			! preg_match( '/^\d+(\.\d+)+$/', JETPACK__VERSION )
+			! preg_match( '/^\d+(\.\d+)+$/', Jetpack_Constants::get_constant( 'JETPACK__VERSION' ) )
 		);
 	}
 

--- a/jetpack.php
+++ b/jetpack.php
@@ -64,6 +64,7 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php'    );
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-tracks.php'        );
 require_once( JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php'   );
 require_once( JETPACK__PLUGIN_DIR . 'modules/module-headings.php');
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-constants.php');
 
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
 			<file>tests/php/test_class.jetpack-client-server.php</file>
 			<file>tests/php/test_class.jetpack-xmlrpc-server.php</file>
 			<file>tests/php/test_class.jetpack-heartbeat.php</file>
+			<file>tests/php/test_class.jetpack-constants.php</file>
 		</testsuite>
 		<testsuite name="core-api">
 			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>

--- a/tests/php/test_class.jetpack-constants.php
+++ b/tests/php/test_class.jetpack-constants.php
@@ -1,0 +1,69 @@
+<?php
+
+class WP_Test_Jetpack_Constants extends WP_UnitTestCase {
+	function tearDown() {
+		Jetpack_Constants::$set_constants = array();
+	}
+
+	// Jetpack_Constants::is_defined()
+
+	function test_jetpack_options_is_defined_when_constant_set_via_class() {
+		Jetpack_Constants::set_constant( 'TEST', 'hello' );
+		$this->assertTrue( Jetpack_Constants::is_defined( 'TEST' ) );
+	}
+
+	function test_jetpack_options_is_defined_false_when_constant_not_set() {
+		$this->assertFalse( Jetpack_Constants::is_defined( 'UNDEFINED' ) );
+	}
+
+	function test_jetpack_options_is_defined_true_when_set_with_define() {
+		$this->assertTrue( Jetpack_Constants::is_defined( 'JETPACK__VERSION' ) );
+	}
+
+	// Jetpack_Constants::get_constant()
+
+	function test_jetpack_options_default_to_constant() {
+		$this->assertEquals( Jetpack_Constants::get_constant( 'JETPACK__VERSION' ), JETPACK__VERSION );
+	}
+
+	function test_jetpack_constants_get_constant_null_when_not_set() {
+		$this->assertNull( Jetpack_Constants::get_constant( 'UNDEFINED' ) );
+	}
+
+	function test_jetpack_options_can_override_previously_defined_constant() {
+		$test_version = '1.0.0';
+		Jetpack_Constants::set_constant( 'JETPACK__VERSION', $test_version );
+		$this->assertEquals( Jetpack_Constants::get_constant( 'JETPACK__VERSION' ), $test_version );
+	}
+
+	// Jetpack_Constants::set_constant()
+
+	function test_jetpack_constants_set_constants_adds_to_set_constants_array() {
+		$key = 'TEST';
+		Jetpack_Constants::set_constant( $key, '1' );
+		$this->assertArrayHasKey( $key, Jetpack_Constants::$set_constants );
+		$this->assertEquals( '1', Jetpack_Constants::$set_constants[ $key ] );
+	}
+
+	// Jetpack_Constants::clear_constants()
+
+	function test_jetpack_options_can_clear_all_constants() {
+		Jetpack_Constants::set_constant( 'JETPACK__VERSION', '1.0.0' );
+		Jetpack_Constants::clear_constants();
+		$this->assertEmpty( Jetpack_Constants::$set_constants );
+	}
+
+	// Jetpack_Constants::clear_single_constant()
+
+	function test_jetpack_constants_can_clear_single_constant() {
+		Jetpack_Constants::set_constant( 'FIRST', '1' );
+		Jetpack_Constants::set_constant( 'SECOND', '2' );
+
+		$this->assertCount( 2, Jetpack_Constants::$set_constants );
+
+		Jetpack_Constants::clear_single_constant( 'FIRST' );
+
+		$this->assertCount( 1, Jetpack_Constants::$set_constants );
+		$this->assertContains( 'SECOND', array_keys( Jetpack_Constants::$set_constants ) );
+	}
+}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -457,6 +457,31 @@ EXPECTED;
 		remove_filter( 'jetpack_sync_error_idc_validation', '__return_false' );
 	}
 
+	function test_is_dev_version_true_with_alpha() {
+		Jetpack_Constants::set_constant( 'JETPACK__VERSION', '4.3.1-alpha' );
+		$this->assertTrue( Jetpack::is_development_version() );
+	}
+
+	function test_is_dev_version_true_with_beta() {
+		Jetpack_Constants::set_constant( 'JETPACK__VERSION', '4.3-beta2' );
+		$this->assertTrue( Jetpack::is_development_version() );
+	}
+
+	function test_is_dev_version_true_with_rc() {
+		Jetpack_Constants::set_constant( 'JETPACK__VERSION', '4.3-rc2' );
+		$this->assertTrue( Jetpack::is_development_version() );
+	}
+
+	function test_is_dev_version_false_with_number_dot_number() {
+		Jetpack_Constants::set_constant( 'JETPACK__VERSION', '4.3' );
+		$this->assertFalse( Jetpack::is_development_version() );
+	}
+
+	function test_is_dev_version_false_with_number_dot_number_dot_number() {
+		Jetpack_Constants::set_constant( 'JETPACK__VERSION', '4.3.1' );
+		$this->assertFalse( Jetpack::is_development_version() );
+	}
+
 	function __return_string_1() {
 		return '1';
 	}


### PR DESCRIPTION
We currently don't have a way to test constants in Jetpack. In the past, I've gotten around this by setting a [default value to be equal to a constant](https://github.com/Automattic/jetpack/blob/8ff0334728fae71dfa96af05a54e999131aac7af/modules/sso/class.jetpack-sso-helpers.php#L171), but this only works with constants that we know are set. Such, as the ones at the top of `jetpack.php`.

But, what about constants that can be conditionally set like `SUNRISE` or `DISABLE_WP_CRON`.

When I looked into this, it seems like the two approaches were to either:

1) Run each test in a separate process which could slow things down
2) Create a wrapper to get constants

I decided to with route option 2. 


To test:

I've added tests for everything, so it should just be a question of if you agree with the approach. ¯\_(ツ)_/¯ 

But, you should probably also look over the tests and make sure I didn't do anything silly. 😝 