### PR TITLE
General: Support null in Jetpack_Constants

### DIFF
--- a/class.jetpack-constants.php
+++ b/class.jetpack-constants.php
@@ -27,7 +27,7 @@ class Jetpack_Constants {
 	 * @return bool
 	 */
 	public static function is_defined( $name ) {
-		return isset( self::$set_constants[ $name ] )
+		return array_key_exists( $name, self::$set_constants )
 			? true
 			: defined( $name );
 	}
@@ -41,7 +41,7 @@ class Jetpack_Constants {
 	 * @return mixed null if the constant does not exist or the value of the constant.
 	 */
 	public static function get_constant( $name ) {
-		if ( isset( self::$set_constants[ $name ] ) ) {
+		if ( array_key_exists( $name,  self::$set_constants ) ) {
 			return self::$set_constants[ $name ];
 		}
 
@@ -66,7 +66,7 @@ class Jetpack_Constants {
 	 * @return bool Whether the constant was removed.
 	 */
 	public static function clear_single_constant( $name ) {
-		if ( ! isset( self::$set_constants[ $name ] ) ) {
+		if ( ! array_key_exists( $name, self::$set_constants ) ) {
 			return false;
 		}
 

--- a/tests/php/test_class.jetpack-constants.php
+++ b/tests/php/test_class.jetpack-constants.php
@@ -7,27 +7,27 @@ class WP_Test_Jetpack_Constants extends WP_UnitTestCase {
 
 	// Jetpack_Constants::is_defined()
 
-	function test_jetpack_options_is_defined_when_constant_set_via_class() {
+	function test_jetpack_constants_is_defined_when_constant_set_via_class() {
 		Jetpack_Constants::set_constant( 'TEST', 'hello' );
 		$this->assertTrue( Jetpack_Constants::is_defined( 'TEST' ) );
 	}
 
-	function test_jetpack_options_is_defined_false_when_constant_not_set() {
+	function test_jetpack_constants_is_defined_false_when_constant_not_set() {
 		$this->assertFalse( Jetpack_Constants::is_defined( 'UNDEFINED' ) );
 	}
 
-	function test_jetpack_options_is_defined_true_when_set_with_define() {
+	function test_jetpack_constants_is_defined_true_when_set_with_define() {
 		$this->assertTrue( Jetpack_Constants::is_defined( 'JETPACK__VERSION' ) );
 	}
 
-	function test_jetpack_options_is_defined_when_constant_set_to_null() {
+	function test_jetpack_constants_is_defined_when_constant_set_to_null() {
 		Jetpack_Constants::set_constant( 'TEST', null );
 		$this->assertTrue( Jetpack_Constants::is_defined( 'TEST' ) );
 	}
 
 	// Jetpack_Constants::get_constant()
 
-	function test_jetpack_options_default_to_constant() {
+	function test_jetpack_constants_default_to_constant() {
 		$this->assertEquals( Jetpack_Constants::get_constant( 'JETPACK__VERSION' ), JETPACK__VERSION );
 	}
 
@@ -35,7 +35,7 @@ class WP_Test_Jetpack_Constants extends WP_UnitTestCase {
 		$this->assertNull( Jetpack_Constants::get_constant( 'UNDEFINED' ) );
 	}
 
-	function test_jetpack_options_can_override_previously_defined_constant() {
+	function test_jetpack_constants_can_override_previously_defined_constant() {
 		$test_version = '1.0.0';
 		Jetpack_Constants::set_constant( 'JETPACK__VERSION', $test_version );
 		$this->assertEquals( Jetpack_Constants::get_constant( 'JETPACK__VERSION' ), $test_version );
@@ -57,7 +57,7 @@ class WP_Test_Jetpack_Constants extends WP_UnitTestCase {
 
 	// Jetpack_Constants::clear_constants()
 
-	function test_jetpack_options_can_clear_all_constants() {
+	function test_jetpack_constants_can_clear_all_constants() {
 		Jetpack_Constants::set_constant( 'JETPACK__VERSION', '1.0.0' );
 		Jetpack_Constants::clear_constants();
 		$this->assertEmpty( Jetpack_Constants::$set_constants );

--- a/tests/php/test_class.jetpack-constants.php
+++ b/tests/php/test_class.jetpack-constants.php
@@ -20,6 +20,11 @@ class WP_Test_Jetpack_Constants extends WP_UnitTestCase {
 		$this->assertTrue( Jetpack_Constants::is_defined( 'JETPACK__VERSION' ) );
 	}
 
+	function test_jetpack_options_is_defined_when_constant_set_to_null() {
+		Jetpack_Constants::set_constant( 'TEST', null );
+		$this->assertTrue( Jetpack_Constants::is_defined( 'TEST' ) );
+	}
+
 	// Jetpack_Constants::get_constant()
 
 	function test_jetpack_options_default_to_constant() {
@@ -34,6 +39,11 @@ class WP_Test_Jetpack_Constants extends WP_UnitTestCase {
 		$test_version = '1.0.0';
 		Jetpack_Constants::set_constant( 'JETPACK__VERSION', $test_version );
 		$this->assertEquals( Jetpack_Constants::get_constant( 'JETPACK__VERSION' ), $test_version );
+	}
+
+	function test_jetpack_constants_override_to_null_gets_null() {
+		Jetpack_Constants::set_constant( 'JETPACK__VERSION', null );
+		$this->assertNull( Jetpack_Constants::get_constant( 'JETPACK__VERSION' ) );
 	}
 
 	// Jetpack_Constants::set_constant()
@@ -65,5 +75,14 @@ class WP_Test_Jetpack_Constants extends WP_UnitTestCase {
 
 		$this->assertCount( 1, Jetpack_Constants::$set_constants );
 		$this->assertContains( 'SECOND', array_keys( Jetpack_Constants::$set_constants ) );
+	}
+
+	function test_jetpack_constants_can_clear_single_constant_when_null() {
+		Jetpack_Constants::set_constant( 'TEST', null );
+		$this->assertCount( 1, Jetpack_Constants::$set_constants );
+
+		Jetpack_Constants::clear_single_constant( 'TEST' );
+
+		$this->assertEmpty( Jetpack_Constants::$set_constants );
 	}
 }


### PR DESCRIPTION
@eliorivero put the new `Jetpack_Constants` to the test and was able to break it by setting a constant to `null`. I hadn't intended on that. This PR fixes that.

Developers should now be able to set constants to `null` and logic such as clearing a single constant or the checking if it's defined should work properly.

I wrote tests to support this, so this should be good to go after tests pass.

Note: I was a dummy before and named many of the tests as if I was testing the Jetpack_Options class when they in fact are meant to test Jetpack_Constants. So the second commit in this PR fixes that mistake. 😞 

cc @eliorivero for review