### PR TITLE
IDC: Update sync_error_idc validation to include home and siteurl

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -34,7 +34,7 @@ class Jetpack_Options {
 				'restapi_stats_cache',         // (array) Stats Cache data.
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
-				'sync_error_idc',              // (bool|string) false or string of the local site's URL
+				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5348,6 +5348,8 @@ p {
 	/**
 	 * Gets the value that is to be saved in the jetpack_sync_error_idc option.
 	 *
+	 * @since 4.4.0
+	 *
 	 * @return array {
 	 *     @type string 'home'    The current home URL.
 	 *     @type string 'siteurl' The current site URL.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5322,7 +5322,9 @@ p {
 	public static function validate_sync_error_idc_option() {
 		$is_valid = false;
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
-		if ( $sync_error && $sync_error == get_home_url() ) {
+
+		// Does the stored sync_error_idc option match what we now generate?
+		if ( $sync_error && empty( array_diff_assoc( $sync_error, self::get_sync_error_idc_option() ) ) ) {
 			$is_valid = true;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5324,8 +5324,11 @@ p {
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
 
 		// Does the stored sync_error_idc option match what we now generate?
-		if ( $sync_error && empty( array_diff_assoc( $sync_error, self::get_sync_error_idc_option() ) ) ) {
-			$is_valid = true;
+		if ( $sync_error && empty( $error_diff ) ) {
+			$error_diff = array_diff_assoc( $sync_error, self::get_sync_error_idc_option() );
+			if ( empty( $error_diff ) ) {
+				$is_valid = true;
+			}
 		}
 
 		/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5324,7 +5324,7 @@ p {
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
 
 		// Does the stored sync_error_idc option match what we now generate?
-		if ( $sync_error && empty( $error_diff ) ) {
+		if ( $sync_error ) {
 			$error_diff = array_diff_assoc( $sync_error, self::get_sync_error_idc_option() );
 			if ( empty( $error_diff ) ) {
 				$is_valid = true;
@@ -5370,6 +5370,7 @@ p {
 
 			if ( ! $parsed_url ) {
 				$returned_values[ $key ] = $option;
+				continue;
 			}
 
 			$returned_values[ $key ] = preg_replace( '/^www\./i', '', $parsed_url['host'] . $parsed_url['path'] );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5344,6 +5344,34 @@ p {
 	}
 
 	/**
+	 * Gets the value that is to be saved in the jetpack_sync_error_idc option.
+	 *
+	 * @return array {
+	 *     @type string 'home'    The current home URL.
+	 *     @type string 'siteurl' The current site URL.
+	 * }
+	 */
+	public static function get_sync_error_idc_option() {
+		$options = array(
+			'home'    => get_option( 'home' ),
+			'siteurl' => get_option( 'siteurl' ),
+		);
+
+		$returned_values = array();
+		foreach( $options as $key => $option ) {
+			$parsed_url = parse_url( trailingslashit( $option ) );
+
+			if ( ! $parsed_url ) {
+				$returned_values[ $key ] = $option;
+			}
+
+			$returned_values[ $key ] = preg_replace( '/^www\./i', '', $parsed_url['host'] . $parsed_url['path'] );
+		}
+
+		return $returned_values;
+	}
+
+	/**
 	 * Returns the value of the jetpack_sync_idc_optin filter, or constant.
 	 * If set to true, the site will be put into staging mode.
 	 *

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5360,13 +5360,13 @@ p {
 	 */
 	public static function get_sync_error_idc_option() {
 		$options = array(
-			'home'    => get_option( 'home' ),
-			'siteurl' => get_option( 'siteurl' ),
+			'home'    => get_home_url(),
+			'siteurl' => get_site_url(),
 		);
 
 		$returned_values = array();
 		foreach( $options as $key => $option ) {
-			$parsed_url = parse_url( trailingslashit( $option ) );
+			$parsed_url = wp_parse_url( trailingslashit( esc_url_raw( $option ) ) );
 
 			if ( ! $parsed_url ) {
 				$returned_values[ $key ] = $option;

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -146,7 +146,10 @@ class Jetpack_Sync_Actions {
 		if ( ! $result ) {
 			$error = $rpc->get_jetpack_error();
 			if ( 'jetpack_url_mismatch' === $error->get_error_code() ) {
-				Jetpack_Options::update_option( 'sync_error_idc', get_home_url() );
+				Jetpack_Options::update_option(
+					'sync_error_idc',
+					Jetpack::get_sync_error_idc_option()
+				);
 			}
 			
 			return $error;

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -434,7 +434,7 @@ EXPECTED;
 		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
 	}
 
-	function test_sync_error_idc_validation_returns_true_when_option_matches_expected() {
+	function _returns_true_when_option_matches_expected() {
 		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
 		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
 		Jetpack_Options::delete_option( 'sync_error_idc' );

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -435,12 +435,26 @@ EXPECTED;
 	}
 
 	function test_sync_error_idc_validation_returns_true_when_option_matches_expected() {
-		Jetpack_Options::update_option( 'sync_error_idc', get_home_url() );
+		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
 		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
+		Jetpack_Options::delete_option( 'sync_error_idc' );
 	}
 
 	function test_sync_error_idc_validation_cleans_up_when_validation_fails() {
-		Jetpack_Options::update_option( 'sync_error_idc', 'http://nonsenseurl.com' );
+		Jetpack_Options::update_option( 'sync_error_idc', array(
+			'home'    => 'coolsite.com/',
+			'siteurl' => 'coolsite.com/wp/',
+		) );
+
+		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
+		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
+	}
+
+	function test_sync_error_idc_validation_cleans_up_when_part_of_validation_fails() {
+		$test = Jetpack::get_sync_error_idc_option();
+		$test['siteurl'] = 'coolsite.com/wp/';
+		Jetpack_Options::update_option( 'sync_error_idc', $test );
+
 		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
 		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
 	}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -476,6 +476,25 @@ EXPECTED;
 		$this->assertFalse( Jetpack::is_development_version() );
 	}
 
+	function test_get_sync_idc_option_sanitizes_out_www_and_protocol() {
+		$original_home    = get_option( 'home' );
+		$original_siteurl = get_option( 'siteurl' );
+
+		update_option( 'home', 'http://www.coolsite.com' );
+		update_option( 'siteurl', 'http://www.coolsite.com/wp' );
+
+		$expected = array(
+			'home' => 'coolsite.com/',
+			'siteurl' => 'coolsite.com/wp/'
+		);
+
+		$this->assertSame( $expected, Jetpack::get_sync_error_idc_option() );
+		
+		// Cleanup
+		update_option( 'home', $original_home );
+		update_option( 'siteurl', $original_siteurl );
+	}
+
 	function __return_string_1() {
 		return '1';
 	}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -509,6 +509,25 @@ EXPECTED;
 		update_option( 'siteurl', $original_siteurl );
 	}
 
+	function test_get_sync_idc_option_with_ip_address_in_option() {
+		$original_home    = get_option( 'home' );
+		$original_siteurl = get_option( 'siteurl' );
+
+		update_option( 'home', 'http://72.182.131.109/~wordpress' );
+		update_option( 'siteurl', 'http://72.182.131.109/~wordpress/wp' );
+
+		$expected = array(
+			'home' => '72.182.131.109/~wordpress/',
+			'siteurl' => '72.182.131.109/~wordpress/wp/'
+		);
+
+		$this->assertSame( $expected, Jetpack::get_sync_error_idc_option() );
+
+		// Cleanup
+		update_option( 'home', $original_home );
+		update_option( 'siteurl', $original_siteurl );
+	}
+
 	function __return_string_1() {
 		return '1';
 	}


### PR DESCRIPTION
Fixes #5341

Previously, we were only storing the home URL after a sync error, but what if changing the siteurl had caused the sync error? This PR adds validation for both home and siteurl.

cc @dereksmart and @roccotripaldi for review