### PR TITLE
IDC: Add tests to verify constant behavior for IDC optin

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5351,8 +5351,8 @@ p {
 	 * @return bool
 	 */
 	public static function sync_idc_optin() {
-		if ( defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) {
-			$default = JETPACK_SYNC_IDC_OPTIN;
+		if ( Jetpack_Constants::is_defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) {
+			$default = Jetpack_Constants::get_constant( 'JETPACK_SYNC_IDC_OPTIN' );
 		} else {
 			$default = false;
 		}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -11,6 +11,10 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 	static $activated_modules = array();
 	static $deactivated_modules = array();
 
+	function tearDown() {
+		Jetpack_Constants::clear_constants();
+	}
+
 	/**
 	 * @author blobaugh
 	 * @covers Jetpack::init
@@ -415,6 +419,10 @@ EXPECTED;
 		$this->assertFalse( Jetpack::get_other_linked_admins() );
 	}
 
+	function test_idc_optin_defaults_to_false() {
+		$this->assertFalse( Jetpack::sync_idc_optin() );
+	}
+
 	function test_idc_optin_filter_overrides_development_version() {
 		add_filter( 'jetpack_development_version', '__return_true' );
 		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
@@ -426,7 +434,24 @@ EXPECTED;
 	function test_idc_optin_casts_to_bool() {
 		add_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
 		$this->assertTrue( Jetpack::sync_idc_optin() );
-		add_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
+		remove_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
+	}
+
+	function test_idc_optin_true_when_constant_true() {
+		Jetpack_Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
+		$this->assertTrue( Jetpack::sync_idc_optin() );
+	}
+
+	function test_idc_optin_false_when_constant_false() {
+		Jetpack_Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
+		$this->assertFalse( Jetpack::sync_idc_optin() );
+	}
+
+	function test_idc_optin_filter_overrides_constant() {
+		Jetpack_Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
+		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
+		$this->assertFalse( Jetpack::sync_idc_optin() );
+		remove_filter( 'jetpack_sync_idc_optin', '__return_false' );
 	}
 
 	function test_sync_error_idc_validation_returns_false_if_no_option() {


### PR DESCRIPTION
This PR simply adds tests towards verifying the behavior of the `Jetpack::sync_idc_optin()` method when using the `JETPACK_SYNC_IDC_OPTIN` constant.

As long as tests pass, this should be mergeable.

After looking into #5338 and verifying that the constant works as expected here, it looks like the issue is that when I refactored I removed the logic that removed the option if a user opted out. 

I'll fix that in another PR and add tests so I don't break it again.

cc @dereksmart @roccotripaldi for review.