### PR TITLE
API: Update the sync status api endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -60,13 +60,13 @@ class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoi
 		$queue       = $sender->get_sync_queue();
 		$full_queue  = $sender->get_full_sync_queue();
 		$cron_timestamps = array_keys( _get_cron_array() );
-		$cron_age = microtime( true ) - $cron_timestamps[0];
+		$next_cron = $cron_timestamps[0] - time();
 
 		return array_merge(
 			$sync_module->get_status(),
 			array(
 				'cron_size'             => count( $cron_timestamps ),
-				'oldest_cron'           => $cron_age,
+				'next_cron'             => $next_cron,
 				'queue_size'            => $queue->size(),
 				'queue_lag'             => $queue->lag(),
 				'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -611,7 +611,7 @@ new Jetpack_JSON_API_Sync_Status_Endpoint( array(
 		'full_queue_lag' => '(float) Time delay of the oldest item in the full sync queue',
 		'full_queue_next_sync' => '(float) Time in seconds before trying to sync the full sync queue again',
 		'cron_size' => '(int) Size of the current cron array',
-		'oldest_cron' => '(int) Age in seconds of the oldest scheduled cron job - a good indicator if cron isn\'t running',
+		'next_cron' => '(int) The number of seconds till the next item in cron.',
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status'
 ) );


### PR DESCRIPTION
We never passed in oldest_cron to be rendered in the sync status.
I would suggest for clarity that the endpoint returns the next_cron
instead of oldest cron.

Since what we are really returning is the number of seconds till the
next cron. This number ideally should never be larger then 60 seconds.

Since we have 2 crons scheduled to happen every 1 minute.

If the number is negative we know that the cron is behind and we can
call try to trigger it.

cc: @lezama, @gravityrail 
