### PR TITLE
Sitemaps: do not add images with relative paths to sitemaps

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -355,6 +355,11 @@ function jetpack_print_sitemap() {
 				$one_image = array();
 
 				if ( isset( $item['src'] ) ) {
+					// Make all image links absolute
+					$check_url = parse_url( $item['src'] );
+					if( empty( $check_url['scheme'] ) && empty( $check_url['host'] ) ){
+						$item['src'] = network_site_url( $item['src'] );
+					}
 					$one_image['image:loc'] = esc_url( $item['src'] );
 					$one_image['image:title'] = sanitize_title_with_dashes( $name = pathinfo( $item['src'], PATHINFO_FILENAME ) );
 				}
@@ -573,6 +578,11 @@ function jetpack_print_news_sitemap() {
 			// Add image to sitemap
 			$post_thumbnail = Jetpack_PostImages::get_image( $post->ID );
 			if ( isset( $post_thumbnail['src'] ) ) {
+				// Make all news image links absolute
+				$check_url = parse_url( $post_thumbnail['src'] );
+				if( empty( $check_url['scheme'] ) && empty( $check_url['host'] ) ){
+					$post_thumbnail['src'] = network_site_url( $post_thumbnail['src'] );
+				}
 				$url['image:image'] = array( 'image:loc' => esc_url( $post_thumbnail['src'] ) );
 			}
 


### PR DESCRIPTION
Fixes #5256 
#### Changes proposed in this Pull Request:

Tests the URL of images to see if a scheme and host are specified. If not, it's a relative path and it then modified to be an absolute URL.
#### Testing instructions:
- Create a page or post with images that have a mix of relative and absolute paths.
- Update or publish the content to generate a new sitemap and all images will have absolute URLs.

<!-- Add the following only if this is meant to be in changelog -->
