### PR TITLE
	IDC: If site is opted out, return false for validation and clean up

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5323,8 +5323,8 @@ p {
 		$is_valid = false;
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
 
-		// Does the stored sync_error_idc option match what we now generate?
-		if ( $sync_error ) {
+		// Is the site opted in and does the stored sync_error_idc option match what we now generate?
+		if ( $sync_error && self::sync_idc_optin() ) {
 			$error_diff = array_diff_assoc( $sync_error, self::get_sync_error_idc_option() );
 			if ( empty( $error_diff ) ) {
 				$is_valid = true;

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -484,6 +484,14 @@ EXPECTED;
 		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
 	}
 
+	function test_sync_error_idc_validation_returns_false_and_cleans_up_when_opted_out() {
+		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
+		Jetpack_Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
+
+		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
+		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
+	}
+
 	function test_is_staging_site_true_when_sync_error_idc_is_valid() {
 		add_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
 		$this->assertTrue( Jetpack::is_staging_site() );


### PR DESCRIPTION
Fixes #5338


In #5338, it was reported that the constant was not opting a site out. But, after further inspection, it appears that we were opting a site out, but we weren't returning false for validation and cleaning up, which was a regression. 😞 

This PR fixes that behavior and adds a test so we don't do it again.

