### PR TITLE
Fix: Only send publicize action for post types that support it.

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -425,7 +425,7 @@ class Publicize extends Publicize_Base {
 	 */
 	function save_publicized( $post_ID, $post, $update ) {
 		// Only do this when a post transitions to being published
-		if ( get_post_meta( $post->ID, $this->PENDING ) ) {
+		if ( get_post_meta( $post->ID, $this->PENDING ) && $this->post_type_is_publicizeable( $post->post_type ) ) {
 			$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
 			if ( ! empty( $connected_services ) ) {
 				/**

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -56,6 +56,20 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 
 		$this->assertPublicized( false, $this->post );
 	}
+	
+	public function test_publicize_does_not_fire_on_post_types_that_do_not_support_it() {
+		$args = array(
+			'public' => true,
+			'label'  => 'unregister post type'
+		);
+		register_post_type( 'foo', $args );
+		$this->post->post_type = 'foo';
+		$this->post->post_status = 'publish';
+
+		wp_insert_post( $this->post->to_array() );
+
+		$this->assertPublicized( false, $this->post );
+	}
 
 	function assertPublicized( $should_have_publicized, $post ) {
 		if ( $should_have_publicized ) {


### PR DESCRIPTION
Currently we send out the publicize_post action for every post type. This should only happen for post types that support it. 

#### Testing instructions:
* Run the test. 
* Create a custom post type that supports publicize, create a new post, it should get publicized.
* Create a custom post type that doesn't supports publicize, create a new post, it should get not publicized. 
 