### PR TITLE
Admin: remove usage of window.Initial_State when setting initial state in some reducers

### DIFF
--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -26,7 +26,20 @@ import {
 } from 'state/action-types';
 import { getModulesThatRequireConnection } from 'state/modules';
 
-export const status = ( state = { siteConnected: window.Initial_State.connectionStatus }, action ) => {
+export const initialConnectionState = {
+	isActive : false,
+	isPublic : false,
+	isStaging: false,
+	devMode: {
+		isActive: false,
+		constant: false,
+		filter  : false,
+		url     : false
+	},
+	isInIdentityCrisis: false
+};
+
+export const status = ( state = { siteConnected: initialConnectionState }, action ) => {
 	switch ( action.type ) {
 		case JETPACK_CONNECTION_STATUS_FETCH:
 			return assign( {}, state, { siteConnected: action.siteConnected } );
@@ -48,7 +61,18 @@ export const connectUrl = ( state = '', action ) => {
 	}
 };
 
-export const user = ( state = window.Initial_State.userData, action ) => {
+export const initialUserDataState = {
+	currentUser: {
+		username   : '',
+		gravatar   : '',
+		isConnected: false,
+		isMaster   : false,
+		permissions: {},
+		wpcomUser  : {}
+	}
+};
+
+export const user = ( state = initialUserDataState, action ) => {
 	switch ( action.type ) {
 		case USER_CONNECTION_DATA_FETCH_SUCCESS:
 			return assign( {}, state, action.userConnectionData );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -9,7 +9,7 @@ import get from 'lodash/get';
  */
 import { JETPACK_SET_INITIAL_STATE } from 'state/action-types';
 
-export const initialState = ( state = window.Initial_State, action ) => {
+export const initialState = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SET_INITIAL_STATE:
 			return assign( {}, state, action.initialState );

--- a/_inc/client/state/jetpack-notices/reducer.js
+++ b/_inc/client/state/jetpack-notices/reducer.js
@@ -35,7 +35,7 @@ const notice = ( state = false, action ) => {
 	}
 };
 
-const dismissed = ( state = window.Initial_State.dismissedNotices, action ) => {
+const dismissed = ( state = [], action ) => {
 	switch ( action.type ) {
 		case JETPACK_ACTION_NOTICES_DISMISS:
 			return assign( {}, state, { [ action.notice ]: true } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- remove reference to window.Initial_State when setting the initial state in reducers for connection, user data and notices.
#### Testing instructions:
- make sure connection still works, user data is still the same and dismissed and not dismissed notices are still the same
