### PR TITLE
API: Install .com themes by using -wpcom suffix

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -18,6 +18,8 @@ class Jetpack_Client {
 			'timeout' => 10,
 			'redirection' => 0,
 			'headers' => array(),
+			'stream' => false,
+			'filename' => null,
 		);
 
 		$args = wp_parse_args( $args, $defaults );
@@ -38,8 +40,10 @@ class Jetpack_Client {
 		$timeout = intval( $args['timeout'] );
 
 		$redirection = $args['redirection'];
+		$stream = $args['stream'];
+		$filename = $args['filename'];
 
-		$request = compact( 'method', 'body', 'timeout', 'redirection' );
+		$request = compact( 'method', 'body', 'timeout', 'redirection', 'stream', 'filename' );
 
 		@list( $token_key, $secret ) = explode( '.', $token->secret );
 		if ( empty( $token ) || empty( $secret ) ) {
@@ -270,6 +274,8 @@ class Jetpack_Client {
 			'method'      => 'string',
 			'timeout'     => 'int',
 			'redirection' => 'int',
+			'stream'      => 'boolean',
+			'filename'    => 'string',
 		) );
 
 		/**

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -48,6 +48,18 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			return new WP_Error( 'missing_themes', __( 'No themes found.', 'jetpack' ) );
 		}
 		foreach( $this->themes as $index => $theme ) {
+			$prefixed_theme = explode( 'wpcom:', $theme );
+			if ( $prefixed_theme ) {
+				// install from wpcom
+				$wpcom_theme_slug = $prefixed_theme[0];
+
+				if ( self::is_installed_theme( $wpcom_theme_slug ) ) {
+					return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
+				}
+				$url = "https://public-api.wordpress.com/rest/v1/themes/download/$wpcom_theme_slug";
+				$this->download_links[ $theme ] = $url;
+				continue;
+			}
 
 			if ( self::is_installed_theme( $theme ) ) {
 				return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -21,9 +21,8 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			$result = $upgrader->install( $link );
 
 			if ( file_exists( $link ) ) {
-			// Delete if link was tmp local file
-				 error_log( 'deleting' );
-				 error_log( unlink( $link ) );
+				// Delete if link was tmp local file
+				unlink( $link );
 			}
 
 			if ( ! $this->bulk && is_wp_error( $result ) ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -17,6 +17,8 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			$skin      = new Automatic_Upgrader_Skin();
 			$upgrader  = new Theme_Upgrader( $skin );
 
+			$link = $this->download_links[ $theme ];
+
 			$result = $upgrader->install( $this->download_links[ $theme ] );
 
 			if ( ! $this->bulk && is_wp_error( $result ) ) {
@@ -48,15 +50,14 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			return new WP_Error( 'missing_themes', __( 'No themes found.', 'jetpack' ) );
 		}
 		foreach( $this->themes as $index => $theme ) {
-			$prefixed_theme = explode( 'wpcom:', $theme );
-			if ( $prefixed_theme ) {
+			if ( wp_endswith( $theme, '-wpcom' ) ) {
 				// install from wpcom
-				$wpcom_theme_slug = $prefixed_theme[0];
+				$wpcom_theme_slug = preg_replace( '/-wpcom$/', '', $theme );
 
 				if ( self::is_installed_theme( $wpcom_theme_slug ) ) {
 					return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
 				}
-				$url = "https://public-api.wordpress.com/rest/v1/themes/download/$wpcom_theme_slug";
+				$url = "https://public-api.wordpress.com/rest/v1/themes/download/$wpcom_theme_slug.zip";
 				$this->download_links[ $theme ] = $url;
 				continue;
 			}
@@ -88,7 +89,5 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 		$wp_theme = wp_get_theme( $theme );
 		return $wp_theme->exists();
 	}
-
-
 }
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -81,6 +81,11 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			if ( is_wp_error( $theme_data ) ) {
 				return $theme_data;
 			}
+
+			if ( ! is_object( $theme_data ) && !isset( $theme_data->download_link ) ) {
+				return new WP_Error( 'theme_not_found', __( 'This theme does not exits') , 404 );
+			}
+
 			$this->download_links[ $theme ] = $theme_data->download_link;
 
 		}

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -115,6 +115,7 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 
 		$response =  $result[ 'response' ];
 		if ( $response[ 'code' ] !== 200 ) {
+			unlink( $file );
 			return new WP_Error( 'problem_fetching_theme', __( 'Problem downloading theme' ) );
 		}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -54,6 +54,10 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			return new WP_Error( 'missing_themes', __( 'No themes found.', 'jetpack' ) );
 		}
 		foreach( $this->themes as $index => $theme ) {
+			if ( self::is_installed_theme( $theme ) ) {
+				return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
+			}
+
 			if ( wp_endswith( $theme, '-wpcom' ) ) {
 				$file = self::download_wpcom_theme_to_file( $theme );
 				if ( is_wp_error( $file ) ) {
@@ -62,10 +66,6 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 
 				$this->download_links[ $theme ] = $file;
 				continue;
-			}
-
-			if ( self::is_installed_theme( $theme ) ) {
-				return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
 			}
 
 			$params = (object) array( 'slug' => $theme );
@@ -99,10 +99,6 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 
 	protected static function download_wpcom_theme_to_file( $theme ) {
 		$wpcom_theme_slug = preg_replace( '/-wpcom$/', '', $theme );
-
-		if ( self::is_installed_theme( $wpcom_theme_slug ) ) {
-			return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
-		}
 
 		$file = wp_tempnam( 'theme' );
 		if ( ! $file ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -54,6 +54,7 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			return new WP_Error( 'missing_themes', __( 'No themes found.', 'jetpack' ) );
 		}
 		foreach( $this->themes as $index => $theme ) {
+
 			if ( self::is_installed_theme( $theme ) ) {
 				return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
 			}

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -104,21 +104,18 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
 		}
 
-		$url = "themes/download/$theme.zip";
-		$result = Jetpack_Client::wpcom_json_api_request_as_blog( $url );
-
-		$response =  $result[ 'response' ];
-		if ( $response[ 'code' ] !== 200 ) {
-			return new WP_Error( 'problem_fetching_theme', __( 'Problem downloading theme' ) );
-		}
-
 		$file = wp_tempnam( 'theme' );
 		if ( ! $file ) {
 			return new WP_Error( 'problem_creating_theme_file', __( 'Problem creating file for theme download', 'jetpack' ) );
 		}
 
-		if ( file_put_contents( $file, $result[ 'body' ] ) === false ) {
-			return new WP_Error( 'problem_writing_theme_file', __( 'Problem downloading theme', 'jetpack' ) );
+		$url = "themes/download/$theme.zip";
+		$args = array( 'stream' => true, 'filename' => $file );
+		$result = Jetpack_Client::wpcom_json_api_request_as_blog( $url, '1.1', $args );
+
+		$response =  $result[ 'response' ];
+		if ( $response[ 'code' ] !== 200 ) {
+			return new WP_Error( 'problem_fetching_theme', __( 'Problem downloading theme' ) );
 		}
 
 		return $file;

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -117,16 +117,10 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			return new WP_Error( 'problem_creating_theme_file', __( 'Problem creating file for theme download', 'jetpack' ) );
 		}
 
-		$handle = fopen( $file, 'wb' );
-		if ( ! $handle ) {
-			return new WP_Error( 'problem_opening_theme_file', __( 'Problem opening file for theme download', 'jetpack' ) );
-		}
-
-		if ( ! fwrite( $handle, $result[ 'body' ] ) ) {
+		if ( file_put_contents( $file, $result[ 'body' ] ) === false ) {
 			return new WP_Error( 'problem_writing_theme_file', __( 'Problem downloading theme', 'jetpack' ) );
 		}
 
-		fclose( $handle );
 		return $file;
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -14,7 +14,7 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 
 		foreach ( $this->themes as $theme ) {
 
-			$skin      = new Automatic_Upgrader_Skin();
+			$skin      = new Jetpack_Automatic_Install_Skin();
 			$upgrader  = new Theme_Upgrader( $skin );
 
 			$link = $this->download_links[ $theme ];

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -102,6 +102,11 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 		$url = "themes/download/$theme.zip";
 		$result = Jetpack_Client::wpcom_json_api_request_as_blog( $url );
 
+		$response =  $result[ 'response' ];
+		if ( $response[ 'code' ] !== 200 ) {
+			return new WP_Error( 'problem_fetching_theme', __( 'Problem downloading theme' ) );
+		}
+
 		$file = wp_tempnam( 'theme' );
 		if ( ! $file ) {
 			return new WP_Error( 'problem_creating_theme_file', __( 'Problem creating file for theme download', 'jetpack' ) );
@@ -112,7 +117,7 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			return new WP_Error( 'problem_opening_theme_file', __( 'Problem opening file for theme download', 'jetpack' ) );
 		}
 
-		if ( ! fwrite( $handle, $result[ "body" ] ) ) {
+		if ( ! fwrite( $handle, $result[ 'body' ] ) ) {
 			return new WP_Error( 'problem_writing_theme_file', __( 'Problem downloading theme', 'jetpack' ) );
 		}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -55,14 +55,7 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 		}
 		foreach( $this->themes as $index => $theme ) {
 			if ( wp_endswith( $theme, '-wpcom' ) ) {
-				// install from wpcom
-				$wpcom_theme_slug = preg_replace( '/-wpcom$/', '', $theme );
-
-				if ( self::is_installed_theme( $wpcom_theme_slug ) ) {
-					return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
-				}
-
-				$file = self::download_wpcom_theme_to_file( $wpcom_theme_slug );
+				$file = self::download_wpcom_theme_to_file( $theme );
 				if ( is_wp_error( $file ) ) {
 					return $file;
 				}
@@ -100,10 +93,16 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 	}
 
 	protected static function download_wpcom_theme_to_file( $theme ) {
+		$wpcom_theme_slug = preg_replace( '/-wpcom$/', '', $theme );
+
+		if ( self::is_installed_theme( $wpcom_theme_slug ) ) {
+			return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
+		}
+
 		$url = "themes/download/$theme.zip";
 		$result = Jetpack_Client::wpcom_json_api_request_as_blog( $url );
 
-		$file = tempnam( sys_get_temp_dir(), 'theme' );
+		$file = wp_tempnam( 'theme' );
 		if ( ! $file ) {
 			return new WP_Error( 'problem_creating_theme_file', __( 'Problem creating file for theme download', 'jetpack' ) );
 		}


### PR DESCRIPTION
Use existing theme install API to install themes from wpcom by suffixing the supplied theme slug with `-wpcom`

**To Test**
* Use associated wpcom change D3059-code
* Make sure jetpack hits your wpcom sandbox when making REST API requests:
```
(in jetpack.php)
define( 'JETPACK__WPCOM_JSON_API_HOST', 'mytestblog.wordpress.com' );
```
* Sent a post request, For example:
`POST /sites/example.com/themes/twentyseventeen-wpcom`
* Theme should be installed on example.com

*Note* Further wpcom-side changes are necessary for this to work with premium themes.

