### PR TITLE
Admin: show UI when non-admin users can't see Stats and Protect is inactive

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -50,6 +50,9 @@ const Navigation = React.createClass( {
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
 				);
+			} else if ( ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) ) {
+				this.props.route.path = '/apps';
+				this.props.route.name = 'Apps';
 			}
 			navTabs = (
 				<NavTabs selectedText={ this.props.route.name }>

--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -36,8 +36,12 @@ const NonAdminView = React.createClass( {
 			navComponent = <Navigation { ...this.props } />;
 		switch ( route ) {
 			case '/dashboard':
+			default:
 				if ( this.props.userCanViewStats || this.props.isModuleActivated( 'protect' ) ) {
 					pageComponent = <AtAGlance { ...this.props } />;
+				} else {
+					// If routing took us to Dashboard but user can't view anything, fallback to Apps
+					pageComponent = <Apps { ...this.props } />;
 				}
 				break;
 			case '/apps':
@@ -63,9 +67,6 @@ const NonAdminView = React.createClass( {
 					pageComponent = <Writing { ...this.props } />;
 				}
 				break;
-
-			default:
-				pageComponent = <AtAGlance { ...this.props } />;
 		}
 
 		window.wpNavMenuClassChange();


### PR DESCRIPTION
While doing GUI tests, I found that when a user, who is not an admin, tries to access At a Glance, and
- they are not allowed to see Stats

and
- Protect is inactive
the entire UI fails.

To reproduce bug: login as a non-admin user whose role can't view Stats and have Protect module deactivated. Then go to `wp-admin/admin.php?page=jetpack`.

#### Changes proposed in this Pull Request:
This PR aims to fix this by changing the routing to the Apps tab. So when routing tries to go to `/` or `/dashboard`, for a user of this characteristics, it will go to Apps instead. In this way the app UI continues working, users can see settings and go back to apps.

#### Testing instructions:
test with a non-admin user. Don't grant access to Stats to its role and deactivate the Protect module:
- make sure the UI work, as well as going to Settings, going back to Dashboard and being displayed Apps.
- grant them access to Stats and check again. At a Glance should now be visible.
- revoke access to Stats and activate Protect. Check again. At a Glance should still be visible.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix: when user is non admin, Protect module is inactive and they have no access to Stats, don't break the UI trying to go to At a Glance which isn't accessible by them and instead display Apps tab.


