### PR TITLE
Admin - Dev Mode: if user is not an admin, don't add the Jetpack menu item

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -26,9 +26,13 @@ abstract class Jetpack_Admin_Page {
 	}
 
 	function add_actions() {
-		/**
-		 * Don't add in the modules page unless modules are available!
-		 */
+
+		// If user is not an admin and site is in Dev Mode, don't do anything
+		if ( ! current_user_can( 'manage_options' ) && Jetpack::is_development_mode() ) {
+			return;
+		}
+
+		// Don't add in the modules page unless modules are available!
 		if ( $this->dont_show_if_not_active && ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
 			return;
 		}


### PR DESCRIPTION
Fixes #5274

#### Changes proposed in this Pull Request:
- when site is in Dev Mode and user is not an admin, don't add the menu item or any admin page

#### Testing instructions:
* put the site in Dev Mode, login as a non admin user. Make sure the Jetpack link is not displayed in the menu.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix: for non-admin users, when site is in Dev Mode, a Jetpack link leading to a blank page with a message "Sorry, you are not allowed to access this page." is no longer displayed.