### PR TITLE
Contact Form: require authentication to view Feedback via WP REST API.

### DIFF
--- a/modules/contact-form/class-grunion-contact-form-endpoint.php
+++ b/modules/contact-form/class-grunion-contact-form-endpoint.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Plugin Name: Feedback CPT Permissions over-ride
+ */
+
+if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
+
+	class Grunion_Contact_Form_Endpoint extends WP_REST_Posts_Controller {
+		/**
+		 * Check whether a given request has proper authoriztion to view feedback items.
+		 *
+		 * @param  WP_REST_Request $request Full details about the request.
+		 * @return WP_Error|boolean
+		 */
+		public function get_items_permissions_check( $request ) {
+			if ( ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
+				return new WP_Error(
+					'rest_cannot_view',
+					__( 'Sorry, you cannot view this resource.' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+
+			return true;
+		}
+
+		/**
+		 * Check whether a given request has proper authoriztion to view feedback item.
+		 *
+		 * @param  WP_REST_Request $request Full details about the request.
+		 * @return WP_Error|boolean
+		 */
+		public function get_item_permissions_check( $request ) {
+			if ( ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
+				return new WP_Error(
+					'rest_cannot_view',
+					__( 'Sorry, you cannot view this resource.' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+
+			return true;
+		}
+
+	}
+
+}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -13,8 +13,14 @@ License: GPLv2 or later
 define( 'GRUNION_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GRUNION_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
-if ( is_admin() )
+if ( is_admin() ) {
 	require_once GRUNION_PLUGIN_DIR . '/admin.php';
+}
+
+add_action( 'rest_api_init', 'grunion_contact_form_require_endpoint' );
+function grunion_contact_form_require_endpoint() {
+	require_once GRUNION_PLUGIN_DIR . '/class-grunion-contact-form-endpoint.php';
+}
 
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
@@ -121,15 +127,16 @@ class Grunion_Contact_Form_Plugin {
 				'not_found'          => __( 'No feedback found', 'jetpack' ),
 				'not_found_in_trash' => __( 'No feedback found', 'jetpack' )
 			),
-			'menu_icon'         => 'dashicons-feedback',
-			'show_ui'           => TRUE,
-			'show_in_admin_bar' => FALSE,
-			'public'            => FALSE,
-			'rewrite'           => FALSE,
-			'query_var'         => FALSE,
-			'capability_type'   => 'page',
-			'show_in_rest'      => true,
-			'capabilities'		=> array(
+			'menu_icon'         	=> GRUNION_PLUGIN_URL . '/images/grunion-menu.png',
+			'show_ui'           	=> TRUE,
+			'show_in_admin_bar' 	=> FALSE,
+			'public'            	=> FALSE,
+			'rewrite'           	=> FALSE,
+			'query_var'         	=> FALSE,
+			'capability_type'   	=> 'page',
+			'show_in_rest'      	=> true,
+			'rest_controller_class' => 'Grunion_Contact_Form_Endpoint',
+			'capabilities'			=> array(
 				'create_posts'        => false,
 				'publish_posts'       => 'publish_pages',
 				'edit_posts'          => 'edit_pages',
@@ -141,7 +148,7 @@ class Grunion_Contact_Form_Plugin {
 				'delete_post'         => 'delete_page',
 				'read_post'           => 'read_page',
 			),
-			'map_meta_cap'		=> true,
+			'map_meta_cap'			=> true,
 		) );
 
 		// Add to REST API post type whitelist


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

With the WP REST API [being merged](https://github.com/WordPress/WordPress/commit/e4a7c0a397b07764999aae94f4bf1567ebf4a9d1) in with 4.7, this change overrides the default behavior of the core PostsController endpoint.  By default, post endpoints will serve a list of GET item(s) to un-authed requests, this change makes it so the request must be authenticated, and the user must belong to the blog to view Feedback items.
#### Testing instructions:

To fully test this branch you will need to be running the WP REST API plugin, or `master` from https://github.com/WordPress/WordPress.  Then perform the following steps:
- Enable the contact form module
- Add a contact form submission via wp-admin or from a contact form displayed on a page
- Verify the contact form submission shows up in the WP-API at http://YOURDEVSITE/wp-json/wp/v2/feedback
- Apply this branch
- Verify the feedback item no longer shows up at http://YOURDEVSITE/wp-json/wp/v2/feedback
