### PR TITLE
Sync: Allow unlocking callables via action

### DIFF
--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -29,6 +29,10 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			add_action( "update_option_{$option}", array( $this, 'unlock_sync_callable' ) );
 		}
 
+		// Provide a hook so that hosts can send changes to certain callables right away.
+		// Especially useful when a host uses constants to change home and siteurl.
+		add_action( 'jetpack_sync_unlock_sync_callable', array( $this, 'unlock_sync_callable' ) );
+
 		// get_plugins and wp_version
 		// gets fired when new code gets installed, updates etc.
 		add_action( 'upgrader_process_complete', array( $this, 'unlock_sync_callable' ) );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -213,6 +213,13 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		add_filter( 'option_siteurl', array( $this, 'return_https_site_com_blog' ) );
 
 		// By calling this action, we simulate wp_schedule_single_event()
+
+		/**
+		 * Used to signal that the callables await transient should be cleared. Clearing the await transient is useful
+		 * in cases where we need to sync values to WordPress.com sooner than the default wait time.
+		 *
+		 * @since 4.4.0
+		 */
 		do_action( 'jetpack_sync_unlock_sync_callable' );
 
 		$this->sender->do_sync();


### PR DESCRIPTION
Fixes #5358 

The original issue calls for using the home and siteurl values that we send with each sync request. But, the more I think about it, I believe we should hold off on that for now. We haven't really dug in to WPML and domain mapping, and what we learn there could be valuable. So, before we change a very important part of sync, I believe we should do some more due diligence.

I previously tried adding this in #5305. This action would allow a developer to clear the callable await transient with something like `wp_schedule_single_event( time() + 1, 'jetpack_sync_unlock_sync_callable' )`.

Previously, we didn't include this because a developer could call the public method directly. But, scheduling a single event does seem simpler and also less prone to errors if we, say, change the name of the method in the future. For example, we already changed `Jetpack_Sync_Actions::schedule_full_sync()` to `Jetpack_Sync_Actions::do_full_sync()`.

The use case for this is to help hosts provide more real-time sync of the home and siteurl options when the home and siteurl options are set via constant.

I considered a few other approaches, one of which included checking if the home or siteurl values were different from their checksum on the `shutdown` action, but then we could run into cases where the constant is defined dynamically based on what is in ` $_SERVER['HTTP_HOST']` or where the home and siteurl change often because of domain mapping or WPML.

Something like this seems to be the safest change for all hosts. We are allowing them the option to help sync faster than 2-3 minutes, but not adding more potential issues.

cc @lezama @enejb @gravityrail for code review.