### PR TITLE
IDC: Save wpcom URL values to the sync_error_idc option -- Refactor check_crisis() method 

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -151,9 +151,11 @@ class Jetpack_Debugger {
 
 		$identity_crisis_message = '';
 		if ( $identity_crisis = Jetpack::check_identity_crisis() ) {
-			foreach( $identity_crisis as $key => $value ) {
-				$identity_crisis_message .= sprintf( __( 'Your `%1$s` option is set up as `%2$s`, but your WordPress.com connection lists it as `%3$s`!', 'jetpack' ), $key, (string) Jetpack::normalize_url_protocol_agnostic( get_option( $key ) ), $value ) . "\r\n";
-			}
+			$identity_crisis_message .= sprintf(
+				__( 'Your url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`!', 'jetpack' ),
+				$identity_crisis['home'],
+				$identity_crisis['wpcom_home']
+			);
 			$identity_crisis = new WP_Error( 'identity-crisis', $identity_crisis_message, $identity_crisis );
 		} else {
 			$identity_crisis = 'PASS';

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -152,7 +152,7 @@ class Jetpack_Debugger {
 		$identity_crisis_message = '';
 		if ( $identity_crisis = Jetpack::check_identity_crisis() ) {
 			foreach( $identity_crisis as $key => $value ) {
-				$identity_crisis_message .= sprintf( __( 'Your `%1$s` option is set up as `%2$s`, but your WordPress.com connection lists it as `%3$s`!', 'jetpack' ), $key, (string) get_option( $key ), $value ) . "\r\n";
+				$identity_crisis_message .= sprintf( __( 'Your `%1$s` option is set up as `%2$s`, but your WordPress.com connection lists it as `%3$s`!', 'jetpack' ), $key, (string) Jetpack::normalize_url_protocol_agnostic( get_option( $key ) ), $value ) . "\r\n";
 			}
 			$identity_crisis = new WP_Error( 'identity-crisis', $identity_crisis_message, $identity_crisis );
 		} else {

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -150,7 +150,7 @@ class Jetpack_Debugger {
 		$tests['HTTPS']['fail_message'] = esc_html__( 'Your site isn’t securely reaching the Jetpack servers.', 'jetpack' );
 
 		$identity_crisis_message = '';
-		if ( $identity_crisis = Jetpack::check_identity_crisis( true ) ) {
+		if ( $identity_crisis = Jetpack::check_identity_crisis() ) {
 			foreach( $identity_crisis as $key => $value ) {
 				$identity_crisis_message .= sprintf( __( 'Your `%1$s` option is set up as `%2$s`, but your WordPress.com connection lists it as `%3$s`!', 'jetpack' ), $key, (string) get_option( $key ), $value ) . "\r\n";
 			}

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -114,7 +114,7 @@ class Jetpack_Heartbeat {
 		$return["{$prefix}language"]       = get_bloginfo( 'language' );
 		$return["{$prefix}charset"]        = get_bloginfo( 'charset' );
 		$return["{$prefix}is-multisite"]   = is_multisite() ? 'multisite' : 'singlesite';
-		$return["{$prefix}identitycrisis"] = Jetpack::check_identity_crisis( 1 ) ? 'yes' : 'no';
+		$return["{$prefix}identitycrisis"] = Jetpack::check_identity_crisis() ? 'yes' : 'no';
 		$return["{$prefix}plugins"]        = implode( ',', Jetpack::get_active_plugins() );
 
 		$return["{$prefix}single-user-site"]= Jetpack::is_single_user_site();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5310,7 +5310,7 @@ p {
 	 *     @type string 'siteurl' The current site URL.
 	 * }
 	 */
-	public static function get_sync_error_idc_option( $option = NULL ) {
+	public static function get_sync_error_idc_option( $option = null ) {
 		if ( 'jetpack_home_url_mismatch' === $option ) {
 			$options = array(
 				'home' => get_home_url()

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5297,11 +5297,8 @@ p {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param string $option
-	 * @return array {
-	 *     @type string 'home'    The current home URL.
-	 *     @type string 'siteurl' The current site URL.
-	 * }
+	 * @param array $response
+	 * @return array Array of the local urls, wpcom urls, and error code
 	 */
 	public static function get_sync_error_idc_option( $response = array() ) {
 		$local_options = array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5200,30 +5200,27 @@ p {
 					continue;
 				}
 
-				// And it's not been added to the whitelist...
-				if ( ! self::is_identity_crisis_value_whitelisted( $cloud_key, $cloud_value ) ) {
-					/*
-					 * This should be a temporary hack until a cleaner solution is found.
-					 *
-					 * The siteurl and home can be set to use http in General > Settings
-					 * however some constants can be defined that can force https in wp-admin
-					 * when this happens wpcom can confuse wporg with a fake identity
-					 * crisis with a mismatch of http vs https when it should be allowed.
-					 * we need to check that here.
-					 *
-					 * @see https://github.com/Automattic/jetpack/issues/1006
-					 */
-					if ( ( 'home' == $cloud_key || 'siteurl' == $cloud_key )
-						&& ( substr( $cloud_value, 0, 8 ) == "https://" )
-						&& Jetpack::init()->is_ssl_required_to_visit_site() ) {
-						// Ok, we found a mismatch of http and https because of wp-config, not an invalid url
-						continue;
-					}
-
-
-					// Then kick an error!
-					$errors[ $cloud_key ] = $cloud_value;
+				/*
+				 * This should be a temporary hack until a cleaner solution is found.
+				 *
+				 * The siteurl and home can be set to use http in General > Settings
+				 * however some constants can be defined that can force https in wp-admin
+				 * when this happens wpcom can confuse wporg with a fake identity
+				 * crisis with a mismatch of http vs https when it should be allowed.
+				 * we need to check that here.
+				 *
+				 * @see https://github.com/Automattic/jetpack/issues/1006
+				 */
+				if ( ( 'home' == $cloud_key || 'siteurl' == $cloud_key )
+				     && ( substr( $cloud_value, 0, 8 ) == "https://" )
+				     && Jetpack::init()->is_ssl_required_to_visit_site() ) {
+					// Ok, we found a mismatch of http and https because of wp-config, not an invalid url
+					continue;
 				}
+
+
+				// Then kick an error!
+				$errors[ $cloud_key ] = $cloud_value;
 			}
 		}
 
@@ -5235,22 +5232,6 @@ p {
 		 * @param array $errors Array of Identity Crisis errors.
 		 */
 		return apply_filters( 'jetpack_has_identity_crisis', $errors );
-	}
-
-	/**
-	 * Checks whether a value is already whitelisted.
-	 *
-	 * @param string $key The option name that we're checking the value for.
-	 * @param string $value The value that we're curious to see if it's on the whitelist.
-	 *
-	 * @return bool Whether the value is whitelisted.
-	 */
-	public static function is_identity_crisis_value_whitelisted( $key, $value ) {
-		$whitelist = Jetpack_Options::get_option( 'identity_crisis_whitelist', array() );
-		if ( ! empty( $whitelist[ $key ] ) && is_array( $whitelist[ $key ] ) && in_array( $value, $whitelist[ $key ] ) ) {
-			return true;
-		}
-		return false;
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5254,7 +5254,14 @@ p {
 
 		// Is the site opted in and does the stored sync_error_idc option match what we now generate?
 		if ( $sync_error && self::sync_idc_optin() ) {
-			$error_diff = array_diff_assoc( $sync_error, self::get_sync_error_idc_option() );
+			if ( isset( $sync_error['home'], $sync_error['siteurl'] ) ) {
+				$error_diff = array_diff_assoc( $sync_error, self::get_sync_error_idc_option() );
+			} else if ( isset( $sync_error['home'] ) ) {
+				$error_diff = array_diff_assoc( $sync_error, self::get_sync_error_idc_option( 'jetpack_home_url_mismatch' ) );
+			} else {
+				$error_diff = array_diff_assoc( $sync_error, self::get_sync_error_idc_option( 'jetpack_site_url_mismatch' ) );
+			}
+
 			if ( empty( $error_diff ) ) {
 				$is_valid = true;
 			}
@@ -5282,16 +5289,27 @@ p {
 	 *
 	 * @since 4.4.0
 	 *
+	 * @param string $option
 	 * @return array {
 	 *     @type string 'home'    The current home URL.
 	 *     @type string 'siteurl' The current site URL.
 	 * }
 	 */
-	public static function get_sync_error_idc_option() {
-		$options = array(
-			'home'    => get_home_url(),
-			'siteurl' => get_site_url(),
-		);
+	public static function get_sync_error_idc_option( $option = NULL ) {
+		if ( 'jetpack_home_url_mismatch' === $option ) {
+			$options = array(
+				'home' => get_home_url()
+			);
+		} else if ( 'jetpack_site_url_mismatch' === $option ) {
+			$options = array(
+				'siteurl' => get_site_url()
+			);
+		} else {
+			$options = array(
+				'home'    => get_home_url(),
+				'siteurl' => get_site_url(),
+			);
+		}
 
 		$returned_values = array();
 		foreach( $options as $key => $option ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -147,10 +147,11 @@ class Jetpack_Sync_Actions {
 
 		if ( ! $result ) {
 			$error = $rpc->get_jetpack_error();
-			if ( 'jetpack_url_mismatch' === $error->get_error_code() ) {
+			$error_code = $error->get_error_code();
+			if ( in_array( $error_code, array( 'jetpack_url_mismatch', 'jetpack_home_url_mismatch', 'jetpack_site_url_mismatch' ) ) ) {
 				Jetpack_Options::update_option(
 					'sync_error_idc',
-					Jetpack::get_sync_error_idc_option()
+					Jetpack::get_sync_error_idc_option( $error_code )
 				);
 			}
 			

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -163,7 +163,7 @@ class Jetpack_Sync_Actions {
 			if ( in_array( $error_code, $allowed_idc_error_codes ) ) {
 				Jetpack_Options::update_option(
 					'sync_error_idc',
-					Jetpack::get_sync_error_idc_option( $error_code )
+					Jetpack::get_sync_error_idc_option( $response )
 				);
 			}
 

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -351,6 +351,20 @@ EXPECTED;
 		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
 	}
 
+	function test_sync_error_idc_validation_returns_true_when_siteurl_matches_expected() {
+		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
+		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option( 'jetpack_home_url_mismatch' ) );
+		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
+		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
+	}
+
+	function test_sync_error_idc_validation_returns_true_when_home_url_matches_expected() {
+		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
+		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option( 'jetpack_site_url_mismatch' ) );
+		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
+		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
+	}
+
 	function test_sync_error_idc_validation_cleans_up_when_validation_fails() {
 		Jetpack_Options::update_option( 'sync_error_idc', array(
 			'home'    => 'coolsite.com/',

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -445,6 +445,44 @@ EXPECTED;
 		update_option( 'siteurl', $original_siteurl );
 	}
 
+	function test_normalize_url_protocol_agnostic_strips_protocol_and_www_for_subdir_subdomain() {
+		$url = 'https://www.subdomain.myfaketestsite.com/what';
+		$url_normalized = Jetpack::normalize_url_protocol_agnostic( $url );
+		$this->assertTrue( 'subdomain.myfaketestsite.com/what/' === $url_normalized );
+
+		$url = 'http://subdomain.myfaketestsite.com';
+		$url_normalized = Jetpack::normalize_url_protocol_agnostic( $url );
+		$this->assertTrue( 'subdomain.myfaketestsite.com/' === $url_normalized );
+
+		$url = 'www.subdomain.myfaketestsite.com';
+		$url_normalized = Jetpack::normalize_url_protocol_agnostic( $url );
+		$this->assertTrue( 'subdomain.myfaketestsite.com/' === $url_normalized );
+	}
+
+	function test_normalize_url_protocol_agnostic_strips_protocol_and_www_for_normal_urls() {
+		$url = 'https://www.myfaketestsite.com';
+		$url_normalized = Jetpack::normalize_url_protocol_agnostic( $url );
+		$this->assertTrue( 'myfaketestsite.com/' === $url_normalized );
+
+		$url = 'www.myfaketestsite.com';
+		$url_normalized = Jetpack::normalize_url_protocol_agnostic( $url );
+		$this->assertTrue( 'myfaketestsite.com/' === $url_normalized );
+
+		$url = 'myfaketestsite.com';
+		$url_normalized = Jetpack::normalize_url_protocol_agnostic( $url );
+		$this->assertTrue( 'myfaketestsite.com/' === $url_normalized );
+	}
+
+	function test_normalize_url_protocol_agnostic_strips_protocol_for_ip() {
+		$url = 'http://123.456.789.0';
+		$url_normalized = Jetpack::normalize_url_protocol_agnostic( $url );
+		$this->assertTrue( '123.456.789.0/' === $url_normalized );
+
+		$url = '123.456.789.0';
+		$url_normalized = Jetpack::normalize_url_protocol_agnostic( $url );
+		$this->assertTrue( '123.456.789.0/' === $url_normalized );
+	}
+
 	function __return_string_1() {
 		return '1';
 	}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -351,20 +351,6 @@ EXPECTED;
 		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
 	}
 
-	function test_sync_error_idc_validation_returns_true_when_siteurl_matches_expected() {
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option( 'jetpack_home_url_mismatch' ) );
-		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-	}
-
-	function test_sync_error_idc_validation_returns_true_when_home_url_matches_expected() {
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option( 'jetpack_site_url_mismatch' ) );
-		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-	}
-
 	function test_sync_error_idc_validation_cleans_up_when_validation_fails() {
 		Jetpack_Options::update_option( 'sync_error_idc', array(
 			'home'    => 'coolsite.com/',

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -142,7 +142,7 @@ EXPECTED;
 
 		add_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_report_crisis_if_an_http_site_and_siteurl_mismatch' ) );
 
-		$this->assertTrue( false !== MockJetpack::check_identity_crisis( true ) );
+		$this->assertTrue( false !== MockJetpack::check_identity_crisis() );
 		remove_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_report_crisis_if_an_http_site_and_siteurl_mismatch' ) );
 	}
 
@@ -228,7 +228,7 @@ EXPECTED;
 		// Attach hook for checking the errors
 		add_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_not_report_crisis_if_matching_siteurl' ) );
 
-		$this->assertTrue( false !== MockJetpack::check_identity_crisis( true ) );
+		$this->assertTrue( false !== MockJetpack::check_identity_crisis() );
 		remove_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_not_report_crisis_if_matching_siteurl' ) );
 	}
 
@@ -267,7 +267,7 @@ EXPECTED;
 		// Attach hook for checking the errors
 		add_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_not_report_crisis_if_a_siteurl_mismatch_when_forcing_ssl') );
 
-		$this->assertTrue( false !== MockJetpack::check_identity_crisis( true ) );
+		$this->assertTrue( false !== MockJetpack::check_identity_crisis() );
 		remove_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_not_report_crisis_if_a_siteurl_mismatch_when_forcing_ssl') );
 	}
 

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -112,45 +112,6 @@ EXPECTED;
 	}
 
 	/**
-	 * @author tonykova
-	 * @covers Jetpack::check_identity_crisis
-	 * @since 3.2.0
-	 */
-	public function test_check_identity_crisis_will_report_crisis_if_an_http_site_and_siteurl_mismatch() {
-		// Store master user data
-		Jetpack_Options::update_option( 'master_user', 'test' );
-		Jetpack_Options::update_option( 'user_tokens', array( 'test' => 'herp.derp.test' ) );
-		add_filter( 'jetpack_development_mode', '__return_false', 1, 1 );
-
-		// Mock get_cloud_site_options
-		$jp	= $this->getMockBuilder( 'MockJetpack' )
-			->setMethods( array( 'get_cloud_site_options' ) )
-			->getMock();
-
-		$jp->init();
-		Jetpack::$instance = $jp;
-
-		$jp->expects( $this->any() )
-			->method( 'get_cloud_site_options' )
-			->will( $this->returnValue( array( 'siteurl' => 'https://test.site.com' ) ) );
-
-		// Save the mismatching option for comparison
-		// Using @ to prevent throwing an error on a bug in WP core when attempting to change .htaccess
-		@update_option( 'siteurl', 'http://test.site.com' );
-
-		// Attach hook for checking the errors
-
-		add_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_report_crisis_if_an_http_site_and_siteurl_mismatch' ) );
-
-		$this->assertTrue( false !== MockJetpack::check_identity_crisis() );
-		remove_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_report_crisis_if_an_http_site_and_siteurl_mismatch' ) );
-	}
-
-	public function pre_test_check_identity_crisis_will_report_crisis_if_an_http_site_and_siteurl_mismatch( $errors ){
-		$this->assertCount( 1, $errors );
-	}
-
-	/**
 	 * @author  kraftbj
 	 * @covers Jetpack::is_staging_site
 	 * @since  3.9.0
@@ -196,83 +157,6 @@ EXPECTED;
 		}
 
 		$this->assertTrue( $seen_bundle );
-	}
-
-	/**
-	 * @author tonykova
-	 * @covers Jetpack::check_identity_crisis
-	 * @since 3.2.0
-	 */
-	public function test_check_identity_crisis_will_not_report_crisis_if_matching_siteurl() {
-		// Store master user data
-		Jetpack_Options::update_option( 'master_user', 'test' );
-		Jetpack_Options::update_option( 'user_tokens', array( 'test' => 'herp.derp.test' ) );
-		add_filter( 'jetpack_development_mode', '__return_false', 1, 1 );
-
-		// Mock get_cloud_site_options
-		$jp	= $this->getMockBuilder( 'MockJetpack' )
-			->setMethods( array( 'get_cloud_site_options' ) )
-			->getMock();
-
-		$jp->init();
-		Jetpack::$instance = $jp;
-
-		$jp->expects( $this->any() )
-			->method( 'get_cloud_site_options' )
-			->will( $this->returnValue( array( 'siteurl' => 'https://test.site.com' ) ) );
-
-		// Save the mismatching option for comparison
-		// Using @ to prevent throwing an error on a bug in WP core when attempting to change .htaccess
-		@update_option( 'siteurl', 'https://test.site.com' );
-
-		// Attach hook for checking the errors
-		add_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_not_report_crisis_if_matching_siteurl' ) );
-
-		$this->assertTrue( false !== MockJetpack::check_identity_crisis() );
-		remove_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_not_report_crisis_if_matching_siteurl' ) );
-	}
-
-	public function pre_test_check_identity_crisis_will_not_report_crisis_if_matching_siteurl( $errors ){
-		$this->assertCount( 0, $errors );
-	}
-
-	/**
-	 * @author tonykova
-	 * @covers Jetpack::check_identity_crisis
-	 * @since 3.2.0
-	 */
-	public function test_check_identity_crisis_will_not_report_crisis_if_a_siteurl_mismatch_when_forcing_ssl() {
-		// Kick in with force ssl and store master user data
-		force_ssl_admin( true );
-		Jetpack_Options::update_option( 'master_user', 'test' );
-		Jetpack_Options::update_option( 'user_tokens', array( 'test' => 'herp.derp.test' ) );
-		add_filter( 'jetpack_development_mode', '__return_false', 1, 1 );
-
-		// Mock get_cloud_site_options
-		$jp = $this->getMockBuilder( 'MockJetpack' )
-		    ->setMethods( array( 'get_cloud_site_options' ) )
-		    ->getMock();
-
-		$jp->init();
-		Jetpack::$instance = $jp;
-
-		$jp->expects( $this->any() )
-			->method( 'get_cloud_site_options' )
-			->will( $this->returnValue( array( 'siteurl' => 'https://test.site.com' ) ) );
-
-		// Save the mismatching option for comparison
-		// Using @ to prevent throwing an error on a bug in WP core when attempting to change .htaccess
-		@update_option( 'siteurl', 'http://test.site.com' );
-
-		// Attach hook for checking the errors
-		add_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_not_report_crisis_if_a_siteurl_mismatch_when_forcing_ssl') );
-
-		$this->assertTrue( false !== MockJetpack::check_identity_crisis() );
-		remove_filter( 'jetpack_has_identity_crisis', array( $this, 'pre_test_check_identity_crisis_will_not_report_crisis_if_a_siteurl_mismatch_when_forcing_ssl') );
-	}
-
-	public function pre_test_check_identity_crisis_will_not_report_crisis_if_a_siteurl_mismatch_when_forcing_ssl( $errors ){
-		$this->assertCount( 0, $errors );
 	}
 	
 	/**

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -343,10 +343,12 @@ EXPECTED;
 		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
 	}
 
-	function _returns_true_when_option_matches_expected() {
+	function test_sync_error_idc_validation_returns_true_when_option_matches_expected() {
+		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
 		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
 		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
 		Jetpack_Options::delete_option( 'sync_error_idc' );
+		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
 	}
 
 	function test_sync_error_idc_validation_cleans_up_when_validation_fails() {


### PR DESCRIPTION
Fixes: #5367, closes #3091

There may be times where only one of the URL's (site/home) is in an IDC.  This refactor, along with the wpcom patch, will save only that option => value into the `sync_error_idc`, which we use for validating an IDC.  

This also refactors the check_identity_crisis() method to take advantage of the new validate_sync_error_idc_option() check, but it will still behave the same by returning false or an array of the IDC URLs

Also added in this PR is a new method for normalizing URLs.  It will strip the protocol and www, as well as add a trailing slash.  

To Test: 
- Apply wpcom patch D3167, and connect Jetpack to your sandbox
- Follow the instructions in that phab diff to "spoof" an IDC for one or both of the URLs
- Trigger a sync.
- Your site should be put into staging, and `the sync_error_idc` Jetpack option should only have the key => values that are offending.  
- While your site is in the IDC, check the wp-admin Jetpack debugger and It should show you an error message with the offending URLs, as it did before.  
