### PR TITLE
Admin Page - Connect Button: convert state props from functions to values

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -26,34 +26,32 @@ export const ConnectButton = React.createClass( {
 
 	propTypes: {
 		connectUser: React.PropTypes.bool,
-		from: React.PropTypes.string,
+		from: React.PropTypes.string
 	},
 
 	getDefaultProps() {
 		return {
 			connectUser: false,
-			from: '',
+			from: ''
 		};
 	},
 
 	renderUserButton: function() {
-		const fetchingUrl = this.props.fetchingConnectUrl( this.props );
-		const isUnlinking = this.props.isUnlinking( this.props );
 
 		// Already linked
-		if ( this.props.isLinked( this.props ) ) {
+		if ( this.props.isLinked ) {
 			return (
 				<div>
 					<Button
 						onClick={ this.props.unlinkUser }
-						disabled={ isUnlinking } >
+						disabled={ this.props.isUnlinking } >
 						{ __( 'Unlink me from WordPress.com' ) }
 					</Button>
 				</div>
 			);
 		}
 
-		let connectUrl = this.props.connectUrl( this.props );
+		let connectUrl = this.props.connectUrl;
 		if ( this.props.from ) {
 			connectUrl += `&from=${ this.props.from }`;
 			connectUrl += '&additional-user';
@@ -63,7 +61,7 @@ export const ConnectButton = React.createClass( {
 			<Button
 				className="is-primary jp-jetpack-connect__button"
 				href={ connectUrl }
-				disabled={ fetchingUrl } >
+				disabled={ this.props.fetchingConnectUrl } >
 				{ __( 'Link to WordPress.com' ) }
 			</Button>
 		);
@@ -76,24 +74,21 @@ export const ConnectButton = React.createClass( {
 	},
 
 	renderContent: function() {
-		const fetchingUrl = this.props.fetchingConnectUrl( this.props );
-		const disconnecting = this.props.isDisconnecting( this.props );
-
 		if ( this.props.connectUser ) {
 			return this.renderUserButton();
 		}
 
-		if ( this.props.isSiteConnected( this.props ) ) {
+		if ( this.props.isSiteConnected ) {
 			return (
 				<Button
 					onClick={ this.disconnectSite }
-					disabled={ disconnecting }>
+					disabled={ this.props.isDisconnecting }>
 					{ __( 'Disconnect Jetpack' ) }
 				</Button>
 			);
 		}
 
-		let connectUrl = this.props.connectUrl( this.props );
+		let connectUrl = this.props.connectUrl;
 		if ( this.props.from ) {
 			connectUrl += `&from=${ this.props.from }`;
 		}
@@ -102,7 +97,7 @@ export const ConnectButton = React.createClass( {
 			<Button
 				className="is-primary jp-jetpack-connect__button"
 				href={ connectUrl }
-				disabled={ fetchingUrl }>
+				disabled={ this.props.fetchingConnectUrl }>
 				{ __( 'Connect Jetpack' ) }
 			</Button>
 		);
@@ -121,12 +116,12 @@ export const ConnectButton = React.createClass( {
 export default connect(
 	state => {
 		return {
-			isSiteConnected: () => _getSiteConnectionStatus( state ),
-			isDisconnecting: () => _isDisconnectingSite( state ),
-			fetchingConnectUrl: () => _isFetchingConnectUrl( state ),
-			connectUrl: () => _getConnectUrl( state ),
-			isLinked: () => _isCurrentUserLinked( state ),
-			isUnlinking: () => _isUnlinkingUser( state )
+			isSiteConnected: _getSiteConnectionStatus( state ),
+			isDisconnecting: _isDisconnectingSite( state ),
+			fetchingConnectUrl: _isFetchingConnectUrl( state ),
+			connectUrl: _getConnectUrl( state ),
+			isLinked: _isCurrentUserLinked( state ),
+			isUnlinking: _isUnlinkingUser( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/components/connect-button/test/component.js
+++ b/_inc/client/components/connect-button/test/component.js
@@ -14,13 +14,13 @@ import { ConnectButton } from '../index';
 describe( 'ConnectButton', () => {
 
 	let testProps = {
-		fetchingConnectUrl: () => true,
-		connectUrl        : () => 'https://jetpack.wordpress.com/jetpack.authorize/1/',
+		fetchingConnectUrl: true,
+		connectUrl        : 'https://jetpack.wordpress.com/jetpack.authorize/1/',
 		connectUser       : true,
-		isSiteConnected   : () => false,
-		isDisconnecting   : () => false,
-		isLinked          : () => false,
-		isUnlinking       : () => false
+		isSiteConnected   : false,
+		isDisconnecting   : false,
+		isLinked          : false,
+		isUnlinking       : false
 	};
 
 	const wrapper = shallow( <ConnectButton { ...testProps } /> );
@@ -81,16 +81,16 @@ describe( 'ConnectButton', () => {
 	describe( 'Button to connect a site', () => {
 
 		Object.assign( testProps, {
-			connectUrl     : () => 'http://example.org/wp-admin/admin.php?page=jetpack&action=register',
-			isSiteConnected: () => false,
-			isLinked       : () => false,
+			connectUrl     : 'http://example.org/wp-admin/admin.php?page=jetpack&action=register',
+			isSiteConnected: false,
+			isLinked       : false,
 			connectUser    : false
 		} );
 
 		const wrapper = shallow( <ConnectButton { ...testProps } /> );
 
 		it( 'has a link to Jetpack admin page in register mode', () => {
-			expect( wrapper.find( 'Button' ).props().href ).to.be.equal( 'http://example.org/wp-admin/admin.php?page=jetpack&action=register' );
+			expect( wrapper.find( 'Button' ).props().href ).to.have.string( 'http://example.org/wp-admin/admin.php?page=jetpack&action=register' );
 		} );
 
 	} );
@@ -98,7 +98,7 @@ describe( 'ConnectButton', () => {
 	describe( 'Button to disconnect a site', () => {
 
 		Object.assign( testProps, {
-			isSiteConnected: () => true
+			isSiteConnected: true
 		} );
 
 		const wrapper = shallow( <ConnectButton { ...testProps } /> );

--- a/_inc/client/components/connect-button/test/component.js
+++ b/_inc/client/components/connect-button/test/component.js
@@ -17,32 +17,35 @@ describe( 'ConnectButton', () => {
 		fetchingConnectUrl: true,
 		connectUrl        : 'https://jetpack.wordpress.com/jetpack.authorize/1/',
 		connectUser       : true,
+		from              : '',
 		isSiteConnected   : false,
 		isDisconnecting   : false,
 		isLinked          : false,
 		isUnlinking       : false
 	};
 
-	const wrapper = shallow( <ConnectButton { ...testProps } /> );
+	describe( 'Initially', () => {
 
-	it( 'queries URL to connect', () => {
-		expect( wrapper.find( 'QueryConnectUrl' ) ).to.exist;
-		expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
-	} );
+		const wrapper = shallow( <ConnectButton { ...testProps } /> );
 
-	it( 'renders a button to connect or link', () => {
-		expect( wrapper.find( 'Button' ) ).to.exist;
-		expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
-	} );
+		it( 'queries URL to connect', () => {
+			expect( wrapper.find( 'QueryConnectUrl' ) ).to.exist;
+		} );
 
-	it( 'disables the button while fetching the connect URL', () => {
-		expect( wrapper.find( 'Button' ).props().disabled ).to.be.true;
+		it( 'renders a button to connect or link', () => {
+			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
+		} );
+
+		it( 'disables the button while fetching the connect URL', () => {
+			expect( wrapper.find( 'Button' ).props().disabled ).to.be.true;
+		} );
+
 	} );
 
 	// Fetching done
-	testProps.fetchingConnectUrl = () => false;
+	testProps.fetchingConnectUrl = false;
 
-	describe( 'Button to link a user', () => {
+	describe( 'When it is used to link a user', () => {
 
 		const wrapper = shallow( <ConnectButton { ...testProps } /> );
 
@@ -52,12 +55,12 @@ describe( 'ConnectButton', () => {
 
 	} );
 
-	describe( 'Button to unlink a user', () => {
+	describe( 'When it is used to unlink a user', () => {
 
 		const unlinkUser = sinon.spy();
 
 		Object.assign( testProps, {
-			isLinked  : () => true,
+			isLinked  : true,
 			unlinkUser: unlinkUser
 		} );
 
@@ -78,7 +81,7 @@ describe( 'ConnectButton', () => {
 
 	} );
 
-	describe( 'Button to connect a site', () => {
+	describe( 'When it is used to connect a site', () => {
 
 		Object.assign( testProps, {
 			connectUrl     : 'http://example.org/wp-admin/admin.php?page=jetpack&action=register',
@@ -93,20 +96,23 @@ describe( 'ConnectButton', () => {
 			expect( wrapper.find( 'Button' ).props().href ).to.have.string( 'http://example.org/wp-admin/admin.php?page=jetpack&action=register' );
 		} );
 
+		const wrapper2 = shallow( <ConnectButton { ...testProps } from="somewhere" /> );
+
+		it( "if prop 'from' has something, it's included in the link", () => {
+			expect( wrapper2.find( 'Button' ).props().href ).to.have.string( 'http://example.org/wp-admin/admin.php?page=jetpack&action=register&from=somewhere' );
+		} );
+
 	} );
 
-	describe( 'Button to disconnect a site', () => {
+	describe( 'When it is used to disconnect a site', () => {
 
-		Object.assign( testProps, {
-			isSiteConnected: true
-		} );
+		testProps.isSiteConnected = true;
 
 		const wrapper = shallow( <ConnectButton { ...testProps } /> );
 
 		it( 'does not link to a URL', () => {
 			expect( wrapper.find( 'Button' ).props().href ).to.not.exist;
 		} );
-
 
 		it( 'when clicked, disconnectSite() is called once', () => {
 


### PR DESCRIPTION
Improves speed because Redux does a shallow checking of the state props when it calls `mapStateToProps`. With the previous code that this PR replaces, a function reference was saved so Redux had to resolve that function and get its value. With the new code, a value reference is saved so the shallow checking can use those values and doesn't need to resolve all the functions.
Syntax and tests will be also cleaner.
#### Changes proposed in this Pull Request:
- Replace returned state props functions with values.
- Convert function calls to properties.
- Remove redundant `const`s.
#### Testing instructions:
- Test that you can connect the site, disconnect the site, link a user, unlink a user.
