### PR TITLE
Sharing: avoid Fatals when the Sharing_Service class doesn't exist.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -852,17 +852,19 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$hidden = array();
 
 			// Set some sharing settings
-			$sharing = new Sharing_Service();
-			$sharing_options['global'] = array(
-				'button_style'  => 'icon',
-				'sharing_label' => $sharing->default_sharing_label,
-				'open_links'    => 'same',
-				'show'          => array( 'post' ),
-				'custom'        => isset( $sharing_options['global']['custom'] ) ? $sharing_options['global']['custom'] : array()
-			);
+			if ( class_exists( 'Sharing_Service' ) ) {
+				$sharing = new Sharing_Service();
+				$sharing_options['global'] = array(
+					'button_style'  => 'icon',
+					'sharing_label' => $sharing->default_sharing_label,
+					'open_links'    => 'same',
+					'show'          => array( 'post' ),
+					'custom'        => isset( $sharing_options['global']['custom'] ) ? $sharing_options['global']['custom'] : array()
+				);
 
-			$result['sharing_options']  = update_option( 'sharing-options', $sharing_options );
-			$result['sharing_services'] = update_option( 'sharing-services', array( 'visible' => $visible, 'hidden' => $hidden ) );
+				$result['sharing_options']  = update_option( 'sharing-options', $sharing_options );
+				$result['sharing_services'] = update_option( 'sharing-services', array( 'visible' => $visible, 'hidden' => $hidden ) );
+			}
 		}
 
 		// If all Jumpstart modules were activated

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -580,6 +580,10 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'sharing_services':
+					if ( ! class_exists( 'Sharing_Service' ) && ! @include( JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php' ) ) {
+						break;
+					}
+
 					$sharer = new Sharing_Service();
 
 					// If option value was the same, consider it done.
@@ -589,14 +593,22 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'button_style':
 				case 'sharing_label':
 				case 'show':
-					$sharer                   = new Sharing_Service();
-					$grouped_options          = $sharer->get_global_options();
-					$grouped_options[$option] = $value;
-					$updated                  = $sharer->set_global_options( $grouped_options );
+					if ( ! class_exists( 'Sharing_Service' ) && ! @include( JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php' ) ) {
+						break;
+					}
+
+					$sharer = new Sharing_Service();
+					$grouped_options = $sharer->get_global_options();
+					$grouped_options[ $option ] = $value;
+					$updated = $sharer->set_global_options( $grouped_options );
 					break;
 
 				case 'custom':
-					$sharer  = new Sharing_Service();
+					if ( ! class_exists( 'Sharing_Service' ) && ! @include( JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php' ) ) {
+						break;
+					}
+
+					$sharer = new Sharing_Service();
 					$updated = $sharer->new_service( stripslashes( $value['sharing_name'] ), stripslashes( $value['sharing_url'] ), stripslashes( $value['sharing_icon'] ) );
 
 					// Return new custom service
@@ -604,7 +616,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'sharing_delete_service':
-					$sharer  = new Sharing_Service();
+					if ( ! class_exists( 'Sharing_Service' ) && ! @include( JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php' ) ) {
+						break;
+					}
+
+					$sharer = new Sharing_Service();
 					$updated = $sharer->delete_service( $value );
 					break;
 

--- a/json-endpoints/class.wpcom-json-api-sharing-buttons-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-sharing-buttons-endpoint.php
@@ -7,7 +7,9 @@ abstract class WPCOM_JSON_API_Sharing_Button_Endpoint extends WPCOM_JSON_API_End
 	protected $sharing_service;
 
 	protected function setup() {
-		$this->sharing_service = new Sharing_Service();
+		if ( class_exists( 'Sharing_Service' ) ) {
+			$this->sharing_service = new Sharing_Service();
+		}
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return new WP_Error( 'forbidden', 'You do not have the capability to manage sharing buttons for this site', 403 );
@@ -30,7 +32,7 @@ abstract class WPCOM_JSON_API_Sharing_Button_Endpoint extends WPCOM_JSON_API_End
 			// Status is either "disabled" or the visibility value
 			$response['visibility'] = $this->get_button_visibility( $button );
 		}
-		
+
 		if ( ! empty( $button->icon ) ) {
 			// Only pre-defined sharing buttons include genericon
 			$response['genericon'] = $button->icon;


### PR DESCRIPTION
In some cases, site owners may get Fatals when the `Sharing_Service` class doesn't exist.

This should fix things.

`PHP Fatal error:  Class 'Sharing_Service' not found in /wp-content/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php on line 792`
#### Proposed changelog entry for your changes:
- JSON API: avoid errors when the Sharing module isn't available.
