### PR TITLE
Sync: Use wp_parse_url when parsing URL

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -124,8 +124,12 @@ class Jetpack_Sync_Functions {
 		}
 
 		// turn them both into parsed format
-		$option_url = parse_url( $option_url );
-		$url        = parse_url( $url );
+		$option_url = wp_parse_url( $option_url );
+		$url        = wp_parse_url( $url );
+
+		if ( ! $option_url || ! $url ) {
+			return $url;
+		}
 
 		if ( $normalize_www ) {
 			if ( $url['host'] === "www.{$option_url[ 'host' ]}" ) {


### PR DESCRIPTION
While looking through some code for when we sync the home and site url, I noticed that we're not using `wp_parse_url()`. We should use this function instead of `parse_url()` since the WP function will suppress warnings and can edge cases such as protocol-less URLs.

I also made a change that just returns the `$url` if we couldn't parse it. 

cc @lezama for code review
