### PR TITLE
Plugin Links: link to the new Settings page.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3192,7 +3192,7 @@ p {
 		if( current_user_can( 'jetpack_manage_modules' ) && ( Jetpack::is_active() || Jetpack::is_development_mode() ) ) {
 			return array_merge(
 				$jetpack_home,
-				array( 'settings' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack_modules' ), __( 'Settings', 'jetpack' ) ) ),
+				array( 'settings' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack#/settings' ), __( 'Settings', 'jetpack' ) ) ),
 				array( 'support' => sprintf( '<a href="%s">%s</a>', Jetpack::admin_url( 'page=jetpack-debugger '), __( 'Support', 'jetpack' ) ) ),
 				$actions
 				);


### PR DESCRIPTION
This will update this link, under the Plugins menu, when your site is connected to WordPress.com:

![screen shot 2016-10-27 at 11 21 11](https://cloud.githubusercontent.com/assets/426388/19761774/8a5a6b62-9c37-11e6-878a-4ec3814a472a.png)
