### PR TITLE
Admin: fix PHP warning when  is null instead of array

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -226,7 +226,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		foreach( get_editable_roles() as $slug => $role ) {
 			$stats_roles[ $slug ] = array(
 				'name' => translate_user_role( $role['name'] ),
-				'canView' => in_array( $slug, $enabled_roles, true ),
+				'canView' => is_array( $enabled_roles ) ? in_array( $slug, $enabled_roles, true ) : false,
 			);
 		}
 


### PR DESCRIPTION
Fixes 

```
Warning: in_array() expects parameter 2 to be array, null given in
/wp-content/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php on line 229
```

Convo at p1477589523004042-slack-jetpack-plugin
#### Changes proposed in this Pull Request:
- check to see if the list of roles we'll be checking with `in_array` is an array. If it's not, return false. Otherwise proceed to check with `in_array`
#### Testing instructions:
- delete `stats_options` option and try to access the admin page.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Admin: fix PHP warning when roles allowed to see Stats don't exist or haven't been saved yet.
