### PR TITLE
Sync: First pass at normalizing URL schemes

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -122,14 +122,10 @@ class Jetpack_Sync_Functions {
 		}
 
 		$scheme = $parsed_url['scheme'];
-
 		$scheme_history = get_option( $option_key, array() );
-
-		// Add the current scheme to the history.
 		$scheme_history[] = $scheme;
 
-		// Limit to last 9 items. An odd number so we don't have to deal with equals.
-		// Ex. 5 https and 5 http if we have 10 items.
+		// Limit length to self::HTTPS_CHECK_HISTORY
 		$scheme_history = array_slice( $scheme_history, ( self::HTTPS_CHECK_HISTORY * -1 ) );
 
 		update_option( $option_key, $scheme_history );

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -115,8 +115,10 @@ class Jetpack_Sync_Functions {
 
 		$parsed_url = wp_parse_url( $new_value );
 		if ( ! $parsed_url ) {
-			// If we can't parse, then just return the value.
-			return $new_value;
+			return new WP_Error(
+				'parse-error',
+				__( 'Could not parse the URL, so can not determine if https is supported', 'jetpack' )
+			);
 		}
 
 		$scheme = $parsed_url['scheme'];

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -5,6 +5,7 @@
  */
 
 class Jetpack_Sync_Functions {
+	const URL_NORMALIZATION_OPTION_PREFIX = 'jetpack_sync_url_normalization_';
 
 	public static function get_modules() {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php' );
@@ -106,6 +107,35 @@ class Jetpack_Sync_Functions {
 
 	public static function main_network_site_url() {
 		return self::preserve_scheme( 'siteurl', 'network_site_url', false );
+	}
+
+	public static function normalize_url_protocols_over_time( $callable, $new_value ) {
+		$option_key = self::URL_NORMALIZATION_OPTION_PREFIX . $callable;
+
+		$parsed_url = wp_parse_url( $new_value );
+		if ( ! $parsed_url ) {
+			// If we can't parse, then just return the value.
+			return $new_value;
+		}
+
+		$scheme = $parsed_url['scheme'];
+
+		$callable_history = get_option( $option_key, array() );
+
+		// Add the current scheme to the history.
+		$callable_history[] = $scheme;
+
+		// Limit to last 9 items. An odd number so we don't have to deal with equals.
+		// Ex. 5 https and 5 http if we have 10 items.
+		$callable_history = array_slice( $callable_history, -9 );
+
+		update_option( $option_key, $callable_history );
+
+		// Get the most common scheme
+		$counted_values = array_count_values( $callable_history );
+		$most_common_scheme = array_search( max( $counted_values ), $counted_values );
+
+		return set_url_scheme( $new_value, $most_common_scheme );
 	}
 
 	public static function preserve_scheme( $option, $url_function, $normalize_www = false ) {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -99,11 +99,17 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function home_url() {
-		return self::get_protocol_normalized_url( 'home_url', get_home_url() );
+		return self::get_protocol_normalized_url(
+			'home_url',
+			self::normalize_www_in_url( 'home', 'home_url' )
+		);
 	}
 
 	public static function site_url() {
-		return self::get_protocol_normalized_url( 'site_url', get_site_url() );
+		return self::get_protocol_normalized_url(
+			'site_url',
+			self::normalize_www_in_url( 'siteurl', 'site_url' )
+		);
 	}
 
 	public static function main_network_site_url() {
@@ -130,6 +136,38 @@ class Jetpack_Sync_Functions {
 		$forced_scheme =  in_array( 'https', $scheme_history ) ? 'https' : 'http';
 
 		return set_url_scheme( $new_value, $forced_scheme );
+	}
+
+	public static function normalize_www_in_url( $option, $url_function ) {
+		$url        = call_user_func( $url_function );
+		$option_url = get_option( $option );
+
+		$option_url = wp_parse_url( $option_url );
+		$url        = wp_parse_url( $url );
+
+		if ( ! $option_url || ! $url ) {
+			return $url;
+		}
+
+		if ( $url[ 'host' ] === "www.{$option_url[ 'host' ]}" ) {
+			// remove www if not present in option URL
+			$url[ 'host' ] = $option_url[ 'host' ];
+		}
+		if ( $option_url[ 'host' ] === "www.{$url[ 'host' ]}" ) {
+			// add www if present in option URL
+			$url[ 'host' ] = $option_url[ 'host' ];
+		}
+
+		$normalized_url = "{$url['scheme']}://{$url['host']}";
+		if ( isset( $url['path'] ) ) {
+			$normalized_url .= "{$url['path']}";
+		}
+
+		if ( isset( $url['query'] ) ) {
+			$normalized_url .= "?{$url['query']}";
+		}
+
+		return $normalized_url;
 	}
 
 	public static function get_plugins() {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -139,11 +139,8 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function normalize_www_in_url( $option, $url_function ) {
-		$url        = call_user_func( $url_function );
-		$option_url = get_option( $option );
-
-		$option_url = wp_parse_url( $option_url );
-		$url        = wp_parse_url( $url );
+		$url        = wp_parse_url( call_user_func( $url_function ) );
+		$option_url = wp_parse_url( get_option( $option ) );
 
 		if ( ! $option_url || ! $url ) {
 			return $url;

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -52,6 +52,11 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	public function reset_data() {
 		delete_option( self::CALLABLES_CHECKSUM_OPTION_NAME );
 		delete_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME );
+
+		$url_callables = array( 'home_url', 'site_url', 'main_network_site_url' );
+		foreach( $url_callables as $callable ) {
+			delete_option( Jetpack_Sync_Functions::HTTPS_CHECK_OPTION_PREFIX . $callable );
+		}
 	}
 
 	function set_callable_whitelist( $callables ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -335,14 +335,19 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		unset( $_SERVER['HTTPS'] );
 	}
 
-	function test_normalize_url_protocols_returns_same_scheme_with_no_history() {
+	function test_is_https_supported_works_with_no_history() {
 		$callable_type = 'home_url';
-		$option_key = Jetpack_Sync_Functions::URL_NORMALIZATION_OPTION_PREFIX . $callable_type;
+		$option_key = Jetpack_Sync_Functions::HTTPS_CHECK_OPTION_PREFIX . $callable_type;
 		delete_option( $option_key );
 
-		$this->assertEquals(
-			$this->return_example_com(),
-			Jetpack_Sync_Functions::normalize_url_protocols_over_time( $callable_type, $this->return_example_com() )
+		$this->assertFalse(
+			Jetpack_Sync_Functions::is_https_supported( $callable_type, $this->return_example_com() )
+		);
+
+		delete_option( $option_key );
+
+		$this->assertTrue(
+			Jetpack_Sync_Functions::is_https_supported( $callable_type, $this->return_https_example_com() )
 		);
 
 		$this->assertCount( 1, get_option( $option_key ) );
@@ -350,49 +355,39 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		delete_option( $option_key );
 	}
 
-	function test_normalize_url_protocols_stores_max_history_of_9() {
+	function test_is_https_supported_stores_max_history() {
 		$callable_type = 'home_url';
-		$option_key = Jetpack_Sync_Functions::URL_NORMALIZATION_OPTION_PREFIX . $callable_type;
+		$option_key = Jetpack_Sync_Functions::HTTPS_CHECK_OPTION_PREFIX . $callable_type;
 		delete_option( $option_key );
 		for ( $i = 0; $i < 20; $i++ ) {
-			Jetpack_Sync_Functions::normalize_url_protocols_over_time( $callable_type, $this->return_example_com() );
+			Jetpack_Sync_Functions::is_https_supported( $callable_type, $this->return_example_com() );
 		}
 
-		$this->assertCount( 9, get_option( $option_key ) );
+		$this->assertCount( Jetpack_Sync_Functions::HTTPS_CHECK_HISTORY, get_option( $option_key ) );
 		delete_option( $option_key );
 	}
 
-	function test_normalize_url_protocols_returns_average_scheme() {
+	function test_is_https_supported_returns_http_when_https_falls_off() {
 		$callable_type = 'home_url';
-		$option_key = Jetpack_Sync_Functions::URL_NORMALIZATION_OPTION_PREFIX . $callable_type;
+		$option_key = Jetpack_Sync_Functions::HTTPS_CHECK_OPTION_PREFIX . $callable_type;
 		delete_option( $option_key );
 
-		// Start with 5 http schemes
-		for ( $i = 1; $i <= 5; $i++ ) {
-			$this->assertEquals(
-				Jetpack_Sync_Functions::normalize_url_protocols_over_time( $callable_type, $this->return_example_com() ),
-				$this->return_example_com()
+		// Start with one https scheme
+		$this->assertTrue(
+			Jetpack_Sync_Functions::is_https_supported( $callable_type, $this->return_https_example_com() )
+		);
+
+		// Now add enough http schemes to fill up the history
+		for ( $i = 1; $i < Jetpack_Sync_Functions::HTTPS_CHECK_HISTORY; $i++ ) {
+			$this->assertTrue(
+				Jetpack_Sync_Functions::is_https_supported( $callable_type, $this->return_example_com() )
 			);
 		}
 
-		// Now let's add 5 https schemes
-		for ( $i = 1; $i <= 5; $i++ ) {
-			// When we've added 5 https URLs, we will have 4 http and 5 https schemes in the history. So, we should
-			// get back an https URL.
-			$expected_equals = ( $i == 5 )
-				? $this->return_https_example_com()
-				: $this->return_example_com();
-
-			$this->assertEquals(
-				Jetpack_Sync_Functions::normalize_url_protocols_over_time(
-					$callable_type,
-					$this->return_https_example_com()
-				),
-				$expected_equals
-			);
-		}
-
-		delete_option( $option_key );
+		// Now that the history is full, this one should cause the function to return false.
+		$this->assertFalse(
+			Jetpack_Sync_Functions::is_https_supported( $callable_type, $this->return_example_com() )
+		);
 	}
 
 	function test_subdomain_switching_to_www_does_not_cause_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -163,8 +163,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		// Let's see if the original values get synced
 		$this->sender->do_sync();
-		$synced_home_url = $synced_value = $this->server_replica_storage->get_callable( 'home_url' );
-		$synced_site_url   = $synced_value = $this->server_replica_storage->get_callable( 'site_url' );
+		$synced_home_url = $this->server_replica_storage->get_callable( 'home_url' );
+		$synced_site_url = $this->server_replica_storage->get_callable( 'site_url' );
 
 		$this->assertEquals( $original_home_option, $synced_home_url );
 		$this->assertEquals( $original_siteurl_option, $synced_site_url );
@@ -179,8 +179,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$synced_home_url = $synced_value = $this->server_replica_storage->get_callable( 'home_url' );
-		$synced_site_url   = $synced_value = $this->server_replica_storage->get_callable( 'site_url' );
+		$synced_home_url = $this->server_replica_storage->get_callable( 'home_url' );
+		$synced_site_url = $this->server_replica_storage->get_callable( 'site_url' );
 
 		$this->assertEquals( $updated_home_option, $synced_home_url );
 		$this->assertEquals( $updated_siteurl_option, $synced_site_url );
@@ -200,8 +200,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		// Let's see if the original values get synced. This will also set the await transient.
 		$this->sender->do_sync();
-		$synced_home_url = $synced_value = $this->server_replica_storage->get_callable( 'home_url' );
-		$synced_site_url   = $synced_value = $this->server_replica_storage->get_callable( 'site_url' );
+		$synced_home_url = $this->server_replica_storage->get_callable( 'home_url' );
+		$synced_site_url = $this->server_replica_storage->get_callable( 'site_url' );
 
 		$this->assertEquals( $original_home_option, $synced_home_url );
 		$this->assertEquals( $original_siteurl_option, $synced_site_url );
@@ -212,8 +212,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		add_filter( 'option_home',    array( $this, 'return_https_site_com_blog' ) );
 		add_filter( 'option_siteurl', array( $this, 'return_https_site_com_blog' ) );
 
-		// By calling this action, we simulate wp_schedule_single_event()
-
 		/**
 		 * Used to signal that the callables await transient should be cleared. Clearing the await transient is useful
 		 * in cases where we need to sync values to WordPress.com sooner than the default wait time.
@@ -222,15 +220,18 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		 */
 		do_action( 'jetpack_sync_unlock_sync_callable' );
 
+		$_SERVER['HTTPS'] = 'on';
+
 		$this->sender->do_sync();
 
-		$synced_home_url = $synced_value = $this->server_replica_storage->get_callable( 'home_url' );
-		$synced_site_url   = $synced_value = $this->server_replica_storage->get_callable( 'site_url' );
+		$synced_home_url = $this->server_replica_storage->get_callable( 'home_url' );
+		$synced_site_url = $this->server_replica_storage->get_callable( 'site_url' );
 
 		$this->assertEquals( $this->return_https_site_com_blog(), $synced_home_url );
 		$this->assertEquals( $this->return_https_site_com_blog(), $synced_site_url );
 
 		// Cleanup
+		unset( $_SERVER['HTTPS'] );
 		remove_filter( 'option_home',    array( $this, 'return_https_site_com_blog' ) );
 		remove_filter( 'option_siteurl', array( $this, 'return_https_site_com_blog' ) );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -359,6 +359,23 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		);
 	}
 
+	function test_get_protocol_normalized_url_cleared_on_reset_data() {
+		Jetpack_Sync_Functions::get_protocol_normalized_url( 'home_url', get_home_url() );
+		Jetpack_Sync_Functions::get_protocol_normalized_url( 'site_url', get_site_url() );
+		Jetpack_Sync_Functions::get_protocol_normalized_url( 'main_network_site_url', network_site_url() );
+
+		$url_callables = array( 'home_url', 'site_url', 'main_network_site_url' );
+		foreach( $url_callables as $callable ) {
+			$this->assertInternalType( 'array', get_option( Jetpack_Sync_Functions::HTTPS_CHECK_OPTION_PREFIX . $callable) );
+		}
+
+		Jetpack_Sync_Sender::get_instance()->uninstall();
+
+		foreach( $url_callables as $callable ) {
+			$this->assertFalse( get_option( Jetpack_Sync_Functions::HTTPS_CHECK_OPTION_PREFIX . $callable ) );
+		}
+	}
+
 	function test_subdomain_switching_to_www_does_not_cause_sync() {
 		// a lot of sites accept www.domain.com or just domain.com, and we want to prevent lots of 
 		// switching back and forth, so we force the domain to be the one in the siteurl option

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -390,6 +390,11 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		);
 	}
 
+	function test_is_https_supported_returns_wp_error_cannot_parse() {
+		$https_supported = Jetpack_Sync_Functions::is_https_supported( 'home_url', 'http:///example.com' );
+		$this->assertTrue( is_wp_error( $https_supported ) );
+	}
+
 	function test_subdomain_switching_to_www_does_not_cause_sync() {
 		// a lot of sites accept www.domain.com or just domain.com, and we want to prevent lots of 
 		// switching back and forth, so we force the domain to be the one in the siteurl option


### PR DESCRIPTION
We have some functionality in `preserve_scheme()` that is meant to send us the specific option that the user set. Which should handle some of the http/https protocol switching. But, I have still occasionally ran into an IDC on my MOH site that is due to http/https switching.

This PR is a first pass at functionality that will normalize URL protocols over time. It will be useful to minimize an issue we have seen where a protocol is sometimes switched from https to http incorrectly. Our working theory for this is that it is caused when a request goes through as http, and then a plugin redirects to https.

Note: This function is not currently implemented. This PR is meant to hold discussion and decide on whether we think this a good approach. If we are OK with this approach, I'd like to consider replacing the current `https` checks we have in `preserve_scheme()` with a call to this method.

cc @lezama @enejb and @gravityrail for review
