### PR TITLE
Jetpack Shortcodes: Add Pinterest embed handling.

### DIFF
--- a/modules/shortcodes/pinterest.php
+++ b/modules/shortcodes/pinterest.php
@@ -21,8 +21,9 @@ function pinterest_embed_handler( $matches, $attr, $url ) {
 	} elseif ( preg_match( '#^/([^/]+)/([^/]+)/?$#', $path ) ) {
 		$embed_type = 'embedBoard';
 	} else {
-		if ( current_user_can( 'edit_posts' ) )
+		if ( current_user_can( 'edit_posts' ) ) {
 			return __( 'Sorry, that Pinterest URL was not recognized.', 'jetpack' );
+		}
 		return;
 	}
 

--- a/modules/shortcodes/pinterest.php
+++ b/modules/shortcodes/pinterest.php
@@ -11,7 +11,8 @@ wp_embed_register_handler( 'pinterest', '#https?://(?:www\.)?(?:[a-z]{2}\.)?pint
 
 function pinterest_embed_handler( $matches, $attr, $url ) {
 	// Pinterest's JS handles making the embed
-	wp_enqueue_script( 'pinterest-embed', '//assets.pinterest.com/js/pinit.js', array(), false, true );
+    $script_src = '//assets.pinterest.com/js/pinit.js';
+	wp_enqueue_script( 'pinterest-embed', $script_src, array(), false, true );
 
 	$path = parse_url( $url, PHP_URL_PATH );
 	if ( 0 === strpos( $path, '/pin/' ) ) {
@@ -27,5 +28,12 @@ function pinterest_embed_handler( $matches, $attr, $url ) {
 		return;
 	}
 
-	return sprintf( '<a data-pin-do="%s" href="%s"></a>', esc_attr( $embed_type ), esc_url( $url ) );
+	$return = sprintf( '<a data-pin-do="%s" href="%s"></a>', esc_attr( $embed_type ), esc_url( $url ) );
+
+	// If we're generating an embed view for the WordPress Admin via ajax...
+	if ( doing_action( 'wp_ajax_parse-embed' ) ) {
+		$return .= sprintf( '<script src="%s"></script>', esc_url( $script_src ) );
+	}
+
+	return $return;
 }

--- a/modules/shortcodes/pinterest.php
+++ b/modules/shortcodes/pinterest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Pinterest embeds
+ *
+ * Based on "Board Widget" example here: http://business.pinterest.com/widget-builder/#code
+ */
+
+// Example URL: http://pinterest.com/pinterest/pin-pets/
+// Second Example URL: https://uk.pinterest.com/annsawesomepins/travel/
+wp_embed_register_handler( 'pinterest', '#https?://(?:www\.)?(?:[a-z]{2}\.)?pinterest\.com/([^/]+)(/[^/]+)?#', 'pinterest_embed_handler' );
+
+function pinterest_embed_handler( $matches, $attr, $url ) {
+	// Pinterest's JS handles making the embed
+	wp_enqueue_script( 'pinterest-embed', '//assets.pinterest.com/js/pinit.js', array(), false, true );
+
+	$path = parse_url( $url, PHP_URL_PATH );
+	if ( 0 === strpos( $path, '/pin/' ) ) {
+		$embed_type = 'embedPin';
+	} elseif ( preg_match( '#^/([^/]+)/?$#', $path ) ) {
+		$embed_type = 'embedUser';
+	} elseif ( preg_match( '#^/([^/]+)/([^/]+)/?$#', $path ) ) {
+		$embed_type = 'embedBoard';
+	} else {
+		if ( current_user_can( 'edit_posts' ) )
+			return __( 'Sorry, that Pinterest URL was not recognized.', 'jetpack' );
+		return;
+	}
+
+	return sprintf( '<a data-pin-do="%s" href="%s"></a>', esc_attr( $embed_type ), esc_url( $url ) );
+}


### PR DESCRIPTION
Fixes #2347
#### Changes proposed in this Pull Request:

Support Pinterest embeds, to mirror WPCOM behavior.
#### Testing instructions:
- Publish a post containing urls to Pinterest users, boards, or pins on their own lines, oEmbed style.

```
This is a pin board:

https://www.pinterest.com/elizabeth/dining-finely/

This is a user profile:

http://pinterest.com/elizabeth/

This is an individual pin:

http://pinterest.com/pin/463307880386596731/

The end!
```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Shortcode Embeds: You can now embed Pinterest users, boards, or pins by pasting in the url to the post editor.
---
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
