### PR TITLE
Widgets - Google Translate: change a PHP 5.4 array syntax, check if title is defined

### DIFF
--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -23,7 +23,10 @@ class Google_Translate_Widget extends WP_Widget {
 			'google_translate_widget',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', __( 'Google Translate', 'jetpack' ) ),
-			array( 'description' => __( 'Automatic translation of your site content', 'jetpack' ) )
+			array(
+				'description' => __( 'Automatic translation of your site content', 'jetpack' ),
+				'customize_selective_refresh' => true
+			)
 		);
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class Google_Translate_Widget extends WP_Widget {

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -1,5 +1,13 @@
 <?php
-
+/**
+ * Plugin Name: Google Translate Widget for WordPress.com
+ * Plugin URI: http://automattic.com
+ * Description: Add a widget for automatic translation
+ * Author: Artur Piszek
+ * Version: 0.1
+ * Author URI: http://automattic.com
+ * Text Domain: jetpack
+ */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -23,7 +23,7 @@ class Google_Translate_Widget extends WP_Widget {
 			array( 'description' => __( 'Automatic translation of your site content', 'jetpack' ) )
 		);
 		wp_register_script( 'google-translate-init', plugins_url( 'google-translate/google-translate.js', __FILE__ ) );
-		wp_register_script( 'google-translate', '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit', [ 'google-translate-init' ] );
+		wp_register_script( 'google-translate', '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit', array( 'google-translate-init' ) );
 	}
 
 	/**
@@ -38,7 +38,7 @@ class Google_Translate_Widget extends WP_Widget {
 		// We never should show more than 1 instance of this.
 		if ( null === self::$instance ) {
 			/** This filter is documented in core/src/wp-includes/default-widgets.php */
-			$title = apply_filters( 'widget_title', $instance['title'] );
+			$title = apply_filters( 'widget_title', isset( $instance['title'] ) ? $instance['title'] : '' );
 			echo $args['before_widget'];
 			if ( ! empty( $title ) ) {
 				echo $args['before_title'] . esc_html( $title ) . $args['after_title'];

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -1,13 +1,8 @@
 <?php
-/**
- * Plugin Name: Google Translate Widget for WordPress.com
- * Plugin URI: http://automattic.com
- * Description: Add a widget for automatic translation
- * Author: Artur Piszek
- * Version: 0.1
- * Author URI: http://automattic.com
- * Text Domain: jetpack
- */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 class Google_Translate_Widget extends WP_Widget {
 	static $instance = null;

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -87,7 +87,7 @@ class Google_Translate_Widget extends WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) {
 		$instance = array();
-		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
+		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? sanitize_text_field( $new_instance['title'] ) : '';
 		return $instance;
 	}
 

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -17,8 +17,18 @@ class Google_Translate_Widget extends WP_Widget {
 			apply_filters( 'jetpack_widget_name', __( 'Google Translate', 'jetpack' ) ),
 			array( 'description' => __( 'Automatic translation of your site content', 'jetpack' ) )
 		);
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Enqueue frontend JS scripts.
+	 */
+	public function enqueue_scripts() {
 		wp_register_script( 'google-translate-init', plugins_url( 'google-translate/google-translate.js', __FILE__ ) );
 		wp_register_script( 'google-translate', '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit', array( 'google-translate-init' ) );
+		// Admin bar is also displayed on top of the site which causes google translate bar to hide beneath.
+		// This is a hack to show google translate bar a bit lower.
+		wp_add_inline_style( 'admin-bar', '.goog-te-banner-frame { top:32px !important }' );
 	}
 
 	/**
@@ -32,23 +42,19 @@ class Google_Translate_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		// We never should show more than 1 instance of this.
 		if ( null === self::$instance ) {
+			wp_localize_script( 'google-translate-init', '_wp_google_translate_widget', array( 'lang' => get_locale() ) );
+			wp_enqueue_script( 'google-translate-init' );
+			wp_enqueue_script( 'google-translate' );
+
 			/** This filter is documented in core/src/wp-includes/default-widgets.php */
 			$title = apply_filters( 'widget_title', isset( $instance['title'] ) ? $instance['title'] : '' );
 			echo $args['before_widget'];
 			if ( ! empty( $title ) ) {
 				echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
 			}
-			wp_localize_script( 'google-translate-init', '_wp_google_translate_widget', array( 'lang' => get_locale() ) );
-			wp_enqueue_script( 'google-translate-init' );
-			wp_enqueue_script( 'google-translate' );
 			echo '<div id="google_translate_element"></div>';
 			echo $args['after_widget'];
 			self::$instance = $instance;
-			// Admin bar is also displayed on top of the site which causes google translate bar to hide beneath.
-			// This is a hack to show google translate bar a bit lower.
-			if ( is_admin_bar_showing() ) {
-				echo '<style>.goog-te-banner-frame { top:32px !important } </style>';
-			}
 			/** This action is documented in modules/widgets/gravatar-profile.php */
 			do_action( 'jetpack_stats_extra', 'widget_view', 'google-translate' );
 		}

--- a/modules/widgets/google-translate/google-translate.js
+++ b/modules/widgets/google-translate/google-translate.js
@@ -4,13 +4,13 @@
 function googleTranslateElementInit() {
 	var lang = 'en';
 	var langParam;
-	var langRegex = /[?&#]lang=([a-z]+)/;
+	var langRegex = /[?&#]lang=([a-zA-Z\-_]+)/;
 	if ( typeof _wp_google_translate_widget === 'object' && typeof _wp_google_translate_widget.lang === 'string' ) {
 		lang = _wp_google_translate_widget.lang;
 	}
 	langParam = window.location.href.match( langRegex );
 	if ( langParam ) {
-		window.location.href = window.location.href.replace( langRegex, '' ).replace( /#googtrans\([a-zA-Z|]+\)/, '' ) + '#googtrans(' + lang + '|' + langParam[ 1 ] + ')';
+		window.location.href = window.location.href.replace( langRegex, '' ).replace( /#googtrans\([a-zA-Z\-_|]+\)/, '' ) + '#googtrans(' + lang + '|' + langParam[ 1 ] + ')';
 	}
 	new google.translate.TranslateElement( {
 		pageLanguage: lang,


### PR DESCRIPTION
Fixes a couple of major issues spotted in https://github.com/Automattic/jetpack/pull/5386/files

#### Changes proposed in this Pull Request:
- change a PHP 5.4 array syntax into PHP 5.2
- check if title is defined to avoid issuing a PHP notice in Customizer
- add support for Customizer's Selective Refresh
- prefixes global JS function to avoid conflicts

#### Testing instructions:
- make sure you can see PHP errors, go to Customizer, add the Google Translate widget. There should not be a PHP notice
- when you update the widget in Customizer, make sure it's selectively refreshed, that is, only its portion is refreshed, rather than the whole page.
  
  @artpi I was concerned about these two changes, so I opened this. You can continue adding other changes here.
