### PR TITLE
Build, Readme: update commands to build with Yarn. Update readme to recommend Yarn version.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ The javascript and CSS components of this plugin's admin interface need to be bu
 
 * Node 6.x
 * npm 3.8.x
+* yarn 0.16.1
 
 #### A note on Node versions used for the build tasks
 

--- a/tools/deploy-to-master-stable-branch.sh
+++ b/tools/deploy-to-master-stable-branch.sh
@@ -40,9 +40,10 @@ fi
 echo ""
 
 echo "Building Jetpack"
-npm run distclean
-npm install
-NODE_ENV=production npm run build-client
+npm install -g yarn
+yarn run distclean
+yarn
+NODE_ENV=production yarn run build-client
 echo "Done"
 
 # Prep a home to drop our new files in. Just make it in /tmp so we can start fresh each time.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Tools - Build: update commands to build with yarn instead of npm
Readme: state that recommended Yarn version is 0.16.1