### PR TITLE
Gulp watch: removed an error and replaced it with a warning.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,12 +228,10 @@ function doStatic( done ) {
 
 
 		} catch ( err ) {
-			util.log( util.colors.red( "doStatic errored" ) );
-			util.log( util.colors.red( err.stack ) );
-			if ( done ) {
-				done( err );
-
-			}
+			util.log( util.colors.yellow(
+				"Warning: gulp was unable to update static HTML files.\n\n" +
+				"If this is happening during watch, this warning is OK to dismiss: sometimes webpack fires watch handlers when source code is not yet built."
+			) );
 		}
 
 	} );


### PR DESCRIPTION
This error has been troubling people, while it's completely OK for that to happen during a `gulp watch` cycle. Webpack sometimes fires change handlers when the static built file is not yet present. This PR aims to reduce panic and explain what happened.
### To test
- Run `yarn watch`
- Change something in the code
- Observe an error with a stack trace
- Check this PR out
- Repeat, see no more errors, but a friendly warning.
