### PR TITLE
Widgets - My Community: fix PHP notice, add Selective Refresh support

### DIFF
--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -60,9 +60,19 @@ jetpack_load_widgets();
 /**
  * Enqueue utilities to work with widgets in Customizer.
  *
- * @since 4.0.0
+ * @since 4.4.0
  */
-function jetpack_widgets_customizer_assets() {
+function jetpack_widgets_customizer_assets_preview() {
 	wp_enqueue_script( 'jetpack-customizer-widget-utils', plugins_url( '/widgets/customizer-utils.js', __FILE__ ), array( 'customize-base' ) );
 }
-add_action( 'customize_preview_init', 'jetpack_widgets_customizer_assets' );
+add_action( 'customize_preview_init', 'jetpack_widgets_customizer_assets_preview' );
+
+/**
+ * Enqueue styles to stylize widgets in Customizer.
+ *
+ * @since 4.4.0
+ */
+function jetpack_widgets_customizer_assets_controls() {
+	wp_enqueue_style( 'jetpack-customizer-widget-controls', plugins_url( '/widgets/customizer-controls.css', __FILE__ ), array( 'customize-widgets' ) );
+}
+add_action( 'customize_controls_enqueue_scripts', 'jetpack_widgets_customizer_assets_controls' );

--- a/modules/widgets/customizer-controls.css
+++ b/modules/widgets/customizer-controls.css
@@ -1,0 +1,6 @@
+/**
+ * Utilities to stylize widget in Customizer controls.
+ */
+
+/* My Community */
+#available-widgets [class*="community"] .widget-title:before { content: "\f307"; }

--- a/modules/widgets/my-community.php
+++ b/modules/widgets/my-community.php
@@ -37,10 +37,11 @@ class Jetpack_My_Community_Widget extends WP_Widget {
 			apply_filters( 'jetpack_widget_name', esc_html__( 'My Community', 'jetpack' ) ),
 			array(
 				'description' => esc_html__( 'A sampling of users from your blog.', 'jetpack' ),
+				'customize_selective_refresh' => true,
 			)
 		);
 
-		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) ) {
+		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 		}
 
@@ -157,7 +158,15 @@ class Jetpack_My_Community_Widget extends WP_Widget {
 	 * @param array $instance Saved values from database.
 	 */
 	function widget( $args, $instance ) {
-		$title = isset( $instance['title' ] ) ? $instance['title'] : false;
+		$instance = wp_parse_args( $instance, array(
+			'title'              => false,
+			'number'             => true,
+			'include_likers'     => true,
+			'include_followers'  => true,
+			'include_commenters' => true,
+		) );
+
+		$title = $instance['title'];
 
 		if ( false === $title ) {
 			$title = $this->default_title;


### PR DESCRIPTION
There's a companion D3214 that is related, and while they don't depend on each other, it must be introduced before the widget is released in 4.4. If you review this, please review D3214.

#### Changes proposed in this Pull Request:
- avoid PHP notice in Customizer preview due to undefined values.
- add support for Customizer's Selective Refresh.
- adds a stylesheet to introduce styles for the Customizer controls so the widget looks like this in Customizer
<img width="325" alt="after" src="https://cloud.githubusercontent.com/assets/1041600/19968053/a24967c6-a1b1-11e6-8627-73d3cee504fe.png">

#### Testing instructions:
use TwentySixteen theme (make sure it's updated), go to Customizer and add the widget:
* make sure widget works supporting Selective Refresh, that is, when a change is made in the widget form, only the widget portion refreshes in the preview
* there should not be PHP notices output in the widget area in the Customizer preview

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
NOTE: while this is a fix and enhancement there's no need for a changelog since 4.4 is the first time the widget is introduced and this fix must be included in 4.4.

❗️❗️ If you review/merge this PR please also review/merge this https://github.com/Automattic/jetpack/pull/5485 ❗️❗️