### PR TITLE
IDC: Add kill switch

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5249,15 +5249,14 @@ p {
 		$idc_allowed = get_transient( 'jetpack_idc_allowed' );
 		if ( false === $idc_allowed ) {
 			$response = wp_remote_get( 'https://jetpack.com/is-idc-allowed/' );
-			if ( is_wp_error( $response ) ) {
-				// If the request failed for some reason, assume IDC is allowed.
-				$idc_allowed = '1';
-				$transient_duration = 5 * MINUTE_IN_SECONDS;
-			} else {
-				$body = wp_remote_retrieve_body( $response );
-				$json = json_decode( $body );
+			if ( 200 === (int) wp_remote_retrieve_response_code( $response ) ) {
+				$json = json_decode( wp_remote_retrieve_body( $response ) );
 				$idc_allowed = isset( $json, $json->result ) && $json->result ? '1' : '0';
 				$transient_duration = HOUR_IN_SECONDS;
+			} else {
+				// If the request failed for some reason, then assume IDC is allowed and set shorter transient.
+				$idc_allowed = '1';
+				$transient_duration = 5 * MINUTE_IN_SECONDS;
 			}
 
 			set_transient( 'jetpack_idc_allowed', $idc_allowed, $transient_duration );

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -411,6 +411,22 @@ EXPECTED;
 		delete_transient( 'jetpack_idc_allowed' );
 	}
 
+	function test_sync_error_idc_validation_success_when_idc_errored() {
+		add_filter( 'pre_http_request',array( $this, '__idc_check_errored' ) );
+		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
+
+		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
+		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
+
+		$this->assertNotFalse( get_transient( 'jetpack_idc_allowed' ) );
+		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
+
+		// Cleanup
+		remove_filter( 'pre_http_request',array( $this, '__idc_is_allowed' ) );
+		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
+		delete_transient( 'jetpack_idc_allowed' );
+	}
+
 	function test_is_staging_site_true_when_sync_error_idc_is_valid() {
 		add_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
 		$this->assertTrue( Jetpack::is_staging_site() );
@@ -532,6 +548,10 @@ EXPECTED;
 		return array(
 			'body' => '{"result":false}'
 		);
+	}
+
+	function __idc_check_errored() {
+		return new WP_Error( 'idc-request-failed' );
 	}
 
 	static function reset_tracking_of_module_activation() {

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -385,7 +385,7 @@ EXPECTED;
 		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
 		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
 
-		$this->assertNotFalse( get_transient( 'jetpack_idc_allowed' ) );
+		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
 		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
 
 		// Cleanup
@@ -402,7 +402,7 @@ EXPECTED;
 		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
 		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
 
-		$this->assertNotFalse( get_transient( 'jetpack_idc_allowed' ) );
+		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
 		$this->assertEquals( '0', get_transient( 'jetpack_idc_allowed' ) );
 
 		// Cleanup
@@ -418,7 +418,7 @@ EXPECTED;
 		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
 		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
 
-		$this->assertNotFalse( get_transient( 'jetpack_idc_allowed' ) );
+		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
 		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
 
 		// Cleanup

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -378,6 +378,39 @@ EXPECTED;
 		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
 	}
 
+	function test_sync_error_idc_validation_success_when_idc_allowed() {
+		add_filter( 'pre_http_request',array( $this, '__idc_is_allowed' ) );
+		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
+
+		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
+		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
+
+		$this->assertNotFalse( get_transient( 'jetpack_idc_allowed' ) );
+		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
+
+		// Cleanup
+		remove_filter( 'pre_http_request',array( $this, '__idc_is_allowed' ) );
+		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
+		delete_transient( 'jetpack_idc_allowed' );
+	}
+
+	function test_sync_error_idc_validation_fails_when_idc_allowed() {
+		add_filter( 'pre_http_request',array( $this, '__idc_is_disabled' ) );
+		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
+
+		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
+		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
+		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
+
+		$this->assertNotFalse( get_transient( 'jetpack_idc_allowed' ) );
+		$this->assertEquals( '0', get_transient( 'jetpack_idc_allowed' ) );
+
+		// Cleanup
+		remove_filter( 'pre_http_request',array( $this, '__idc_is_allowed' ) );
+		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
+		delete_transient( 'jetpack_idc_allowed' );
+	}
+
 	function test_is_staging_site_true_when_sync_error_idc_is_valid() {
 		add_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
 		$this->assertTrue( Jetpack::is_staging_site() );
@@ -487,6 +520,18 @@ EXPECTED;
 
 	function __return_string_1() {
 		return '1';
+	}
+
+	function __idc_is_allowed() {
+		return array(
+			'body' => '{"result":true}'
+		);
+	}
+
+	function __idc_is_disabled() {
+		return array(
+			'body' => '{"result":false}'
+		);
 	}
 
 	static function reset_tracking_of_module_activation() {

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -379,7 +379,7 @@ EXPECTED;
 	}
 
 	function test_sync_error_idc_validation_success_when_idc_allowed() {
-		add_filter( 'pre_http_request',array( $this, '__idc_is_allowed' ) );
+		add_filter( 'pre_http_request', array( $this, '__idc_is_allowed' ) );
 		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
 
 		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
@@ -389,13 +389,13 @@ EXPECTED;
 		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
 
 		// Cleanup
-		remove_filter( 'pre_http_request',array( $this, '__idc_is_allowed' ) );
+		remove_filter( 'pre_http_request', array( $this, '__idc_is_allowed' ) );
 		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
 		delete_transient( 'jetpack_idc_allowed' );
 	}
 
 	function test_sync_error_idc_validation_fails_when_idc_allowed() {
-		add_filter( 'pre_http_request',array( $this, '__idc_is_disabled' ) );
+		add_filter( 'pre_http_request', array( $this, '__idc_is_disabled' ) );
 		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
 
 		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
@@ -406,13 +406,13 @@ EXPECTED;
 		$this->assertEquals( '0', get_transient( 'jetpack_idc_allowed' ) );
 
 		// Cleanup
-		remove_filter( 'pre_http_request',array( $this, '__idc_is_allowed' ) );
+		remove_filter( 'pre_http_request', array( $this, '__idc_is_allowed' ) );
 		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
 		delete_transient( 'jetpack_idc_allowed' );
 	}
 
 	function test_sync_error_idc_validation_success_when_idc_errored() {
-		add_filter( 'pre_http_request',array( $this, '__idc_check_errored' ) );
+		add_filter( 'pre_http_request', array( $this, '__idc_check_errored' ) );
 		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
 
 		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
@@ -422,7 +422,7 @@ EXPECTED;
 		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
 
 		// Cleanup
-		remove_filter( 'pre_http_request',array( $this, '__idc_is_allowed' ) );
+		remove_filter( 'pre_http_request', array( $this, '__idc_is_allowed' ) );
 		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
 		delete_transient( 'jetpack_idc_allowed' );
 	}


### PR DESCRIPTION
Closes #5451

Last time we launched some UI around IDC, we ended up confusing users more than helping, which frustrated users and increased support load.

This time, we're going to launch a kill switch along with our IDC work that way we can choose to kill the IDC notice remotely if necessary.

To test:

- Verify that logic in tests seems reasonable


Note: The validate method is started to get a bit overwhelming. It might be worth splitting up the method once we move all of our IDC code out of the `Jetpack` class into a `Jetpack_IDC` class.

cc @roccotripaldi @dereksmart for review.