### PR TITLE
Add/carousel lightbox single image

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1423,6 +1423,12 @@ jQuery(document).ready(function($) {
 		// process links that contain img tag with attribute data-attachment-id
 		$( 'a img[data-attachment-id]' ).each(function() {
 			var container = $( this ).parent();
+
+			// skip if image was already added to gallery by shortcode
+			if( container.parent( '.gallery-icon' ).length ) {
+				return;
+			}
+
 			var valid = false;
 
 			// if link points to 'Media File' and flag is set allow it

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1415,7 +1415,7 @@ jQuery(document).ready(function($) {
 		// process links that have rel=attachment and img tag inside
 		$( 'a[rel*="attachment"] img' ).each(function() {
 			var container = $( this ).parent();
-			if( $( container ).attr( 'href' ) == $( this ).attr( 'data-orig-file' ) ) {
+			if( $( container ).attr( 'href' ) === $( this ).attr( 'data-orig-file' ) ) {
 				// if link points to 'Media File', skip it
 				return;
 			}

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -37,14 +37,18 @@ jQuery(document).ready(function($) {
 				break;
 			case 39: // right
 				e.preventDefault();
-				gallery.jp_carousel('clearCommentTextAreaValue');
-				gallery.jp_carousel('next');
+				if( gallery.jp_carousel('slides').length > 1 ) {
+					gallery.jp_carousel('clearCommentTextAreaValue');
+					gallery.jp_carousel('next');
+				}
 				break;
 			case 37: // left
 			case 8: // backspace
 				e.preventDefault();
-				gallery.jp_carousel('clearCommentTextAreaValue');
-				gallery.jp_carousel('previous');
+				if( gallery.jp_carousel('slides').length > 1 ) {
+					gallery.jp_carousel('clearCommentTextAreaValue');
+					gallery.jp_carousel('previous');
+				}
 				break;
 			case 27: // escape
 				e.preventDefault();

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -414,15 +414,11 @@ jQuery(document).ready(function($) {
 				$( '.jp-carousel-wrap' ).touchwipe( {
 					wipeLeft : function ( e ) {
 						e.preventDefault();
-						if ( gallery.jp_carousel( 'hasMultipleImages' ) ) {
-							gallery.jp_carousel( 'next' );
-						}
+						gallery.jp_carousel( 'next' );
 					},
 					wipeRight : function ( e ) {
 						e.preventDefault();
-						if ( gallery.jp_carousel( 'hasMultipleImages' ) ) {
-							gallery.jp_carousel( 'previous' );
-						}
+						gallery.jp_carousel( 'previous' );
 					},
 					preventDefaultEvents : false
 				} );

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1450,8 +1450,8 @@ jQuery(document).ready(function($) {
 
 			// make this node a gallery recognizable by event listener above
 			$( container ).addClass( 'single-image-gallery' ) ;
-			// method 'open' needs this attribute to distinguish from default WP gallery
-			container.data( 'carousel-extra', { single_image: true } );
+			// blog_id is needed to allow posting comments to correct blog 
+			$( container ).data( 'carousel-extra', { blog_id: Number( jetpackCarouselStrings.blog_id ) } );
 		});
 	}
 

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1415,8 +1415,10 @@ jQuery(document).ready(function($) {
 		// process links that have rel=attachment and img tag inside
 		$( 'a[rel*="attachment"] img' ).each(function() {
 			var container = $( this ).parent();
-			if( $( container ).attr( 'href' ) === $( this ).attr( 'data-orig-file' ) ) {
-				// if link points to 'Media File', skip it
+			// if link points to 'Media File' and flag is not set skip it
+			if ( $( container ).attr( 'href' ) === $( this ).attr( 'data-orig-file' ) &&
+				0 === Number( jetpackCarouselStrings.single_image_gallery_media_file )
+			) {
 				return;
 			}
 			// make this node a gallery recognizable by event listener above

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -37,7 +37,7 @@ jQuery(document).ready(function($) {
 				break;
 			case 39: // right
 				e.preventDefault();
-				if( gallery.jp_carousel('slides').length > 1 ) {
+				if ( gallery.jp_carousel('slides').length > 1 ) {
 					gallery.jp_carousel('clearCommentTextAreaValue');
 					gallery.jp_carousel('next');
 				}
@@ -45,7 +45,7 @@ jQuery(document).ready(function($) {
 			case 37: // left
 			case 8: // backspace
 				e.preventDefault();
-				if( gallery.jp_carousel('slides').length > 1 ) {
+				if ( gallery.jp_carousel('slides').length > 1 ) {
 					gallery.jp_carousel('clearCommentTextAreaValue');
 					gallery.jp_carousel('previous');
 				}
@@ -197,13 +197,15 @@ jQuery(document).ready(function($) {
 				.addClass('jp-carousel-next-button')
 				.css({
 					'right'    : '15px'
-				});
+				})
+				.hide();
 
 			previousButton = $('<div><span></span></div>')
 				.addClass('jp-carousel-previous-button')
 				.css({
 					'left'     : 0
-				});
+				})
+				.hide();
 
 			nextButton.add( previousButton ).css( {
 				'position' : 'fixed',
@@ -391,6 +393,8 @@ jQuery(document).ready(function($) {
 					$(window).unbind('keydown', keyListener);
 					$(window).unbind('resize', resizeListener);
 					$(window).scrollTop(scroll);
+					$( '.jp-carousel-previous-button' ).hide();
+					$( '.jp-carousel-next-button' ).hide();
 				})
 				.bind('jp_carousel.afterClose', function(){
 					if ( window.location.hash && history.back ) {

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -37,22 +37,15 @@ jQuery(document).ready(function($) {
 				break;
 			case 39: // right
 				e.preventDefault();
-				if ( gallery.jp_carousel('slides').length > 1 ) {
-					gallery.jp_carousel('clearCommentTextAreaValue');
-					gallery.jp_carousel('next');
-				}
+				gallery.jp_carousel('next');
 				break;
 			case 37: // left
 			case 8: // backspace
 				e.preventDefault();
-				if ( gallery.jp_carousel('slides').length > 1 ) {
-					gallery.jp_carousel('clearCommentTextAreaValue');
-					gallery.jp_carousel('previous');
-				}
+				gallery.jp_carousel('previous');
 				break;
 			case 27: // escape
 				e.preventDefault();
-				gallery.jp_carousel('clearCommentTextAreaValue');
 				container.jp_carousel('close');
 				break;
 			default:
@@ -421,13 +414,13 @@ jQuery(document).ready(function($) {
 				$( '.jp-carousel-wrap' ).touchwipe( {
 					wipeLeft : function ( e ) {
 						e.preventDefault();
-						if ( gallery.jp_carousel( 'slides' ).length > 1 ) {
+						if ( gallery.jp_carousel( 'hasMultipleImages' ) ) {
 							gallery.jp_carousel( 'next' );
 						}
 					},
 					wipeRight : function ( e ) {
 						e.preventDefault();
-						if ( gallery.jp_carousel( 'slides' ).length > 1 ) {
+						if ( gallery.jp_carousel( 'hasMultipleImages' ) ) {
 							gallery.jp_carousel( 'previous' );
 						}
 					},
@@ -535,6 +528,7 @@ jQuery(document).ready(function($) {
 			// make sure to let the page scroll again
 			$('body').css('overflow', originalOverflow);
 			$('html').css('overflow', originalHOverflow);
+			this.jp_carousel( 'clearCommentTextAreaValue' );
 			return container
 				.trigger('jp_carousel.beforeClose')
 				.fadeOut('fast', function(){
@@ -544,21 +538,25 @@ jQuery(document).ready(function($) {
 
 		},
 
-		next : function(){
-			var slide = gallery.jp_carousel( 'nextSlide' );
-			container.animate({scrollTop:0}, 'fast');
-
-			if ( slide ) {
-				this.jp_carousel('selectSlide', slide);
-			}
+		next : function() {
+			this.jp_carousel( 'previousOrNext', 'nextSlide' );
 		},
 
-		previous : function(){
-			var slide = gallery.jp_carousel( 'prevSlide' );
-			container.animate({scrollTop:0}, 'fast');
+		previous : function() {
+			this.jp_carousel( 'previousOrNext', 'prevSlide' );
+		},
+
+		previousOrNext : function ( slideSelectionMethodName ) {
+			if ( ! this.jp_carousel( 'hasMultipleImages' ) ) {
+				return false;
+			}
+
+			var slide = gallery.jp_carousel( slideSelectionMethodName );
 
 			if ( slide ) {
-				this.jp_carousel('selectSlide', slide);
+				container.animate( { scrollTop: 0 }, 'fast' );
+				this.jp_carousel( 'clearCommentTextAreaValue' );
+				this.jp_carousel( 'selectSlide', slide );
 			}
 		},
 
@@ -1386,6 +1384,10 @@ jQuery(document).ready(function($) {
 
 				image.data( 'loaded', 1 );
 			}
+		},
+
+		hasMultipleImages : function () {
+			return gallery.jp_carousel('slides').length > 1;
 		}
 	};
 
@@ -1450,7 +1452,7 @@ jQuery(document).ready(function($) {
 
 			// make this node a gallery recognizable by event listener above
 			$( container ).addClass( 'single-image-gallery' ) ;
-			// blog_id is needed to allow posting comments to correct blog 
+			// blog_id is needed to allow posting comments to correct blog
 			$( container ).data( 'carousel-extra', { blog_id: Number( jetpackCarouselStrings.blog_id ) } );
 		});
 	}

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1417,17 +1417,30 @@ jQuery(document).ready(function($) {
 	// handle lightbox (single image gallery) for images linking to 'Attachment Page'
 	if ( 1 === Number( jetpackCarouselStrings.single_image_gallery ) ) {
 		// process links that have rel=attachment and img tag inside
-		$( 'a[rel*="attachment"] img' ).each(function() {
+		$( 'a img[data-attachment-id]' ).each(function() {
 			var container = $( this ).parent();
-			// if link points to 'Media File' and flag is not set skip it
+			var valid = false;
+
+			// if link points to 'Media File' and flag is set allow it
 			if ( $( container ).attr( 'href' ) === $( this ).attr( 'data-orig-file' ) &&
-				0 === Number( jetpackCarouselStrings.single_image_gallery_media_file )
+				1 === Number( jetpackCarouselStrings.single_image_gallery_media_file )
 			) {
+				valid = true;
+			}
+
+			// if link points to 'Attachment Page' allow it
+			if( $( container ).attr( 'href' ) === $( this ).attr( 'data-permalink' ) ) {
+				valid = true;
+			}
+
+			// links to 'Custom URL' or 'Media File' when flag not set are not valid
+			if( ! valid ) {
 				return;
 			}
+
 			// make this node a gallery recognizable by event listener above
 			$( container ).addClass( 'single-image-gallery') ;
-			// method 'open' needs this attribute to distinguish from defailt WP gallery
+			// method 'open' needs this attribute to distinguish from default WP gallery
 			container.data( 'carousel-extra', { single_image: true } );
 		});
 	}

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -421,11 +421,15 @@ jQuery(document).ready(function($) {
 				$( '.jp-carousel-wrap' ).touchwipe( {
 					wipeLeft : function ( e ) {
 						e.preventDefault();
-						gallery.jp_carousel( 'next' );
+						if ( gallery.jp_carousel( 'slides' ).length > 1 ) {
+							gallery.jp_carousel( 'next' );
+						}
 					},
 					wipeRight : function ( e ) {
 						e.preventDefault();
-						gallery.jp_carousel( 'previous' );
+						if ( gallery.jp_carousel( 'slides' ).length > 1 ) {
+							gallery.jp_carousel( 'previous' );
+						}
 					},
 					preventDefaultEvents : false
 				} );
@@ -1416,7 +1420,7 @@ jQuery(document).ready(function($) {
 
 	// handle lightbox (single image gallery) for images linking to 'Attachment Page'
 	if ( 1 === Number( jetpackCarouselStrings.single_image_gallery ) ) {
-		// process links that have rel=attachment and img tag inside
+		// process links that contain img tag with attribute data-attachment-id
 		$( 'a img[data-attachment-id]' ).each(function() {
 			var container = $( this ).parent();
 			var valid = false;
@@ -1439,7 +1443,7 @@ jQuery(document).ready(function($) {
 			}
 
 			// make this node a gallery recognizable by event listener above
-			$( container ).addClass( 'single-image-gallery') ;
+			$( container ).addClass( 'single-image-gallery' ) ;
 			// method 'open' needs this attribute to distinguish from default WP gallery
 			container.data( 'carousel-extra', { single_image: true } );
 		});

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -460,7 +460,7 @@ jQuery(document).ready(function($) {
 
 		open: function(options) {
 			var settings = {
-				'items_selector' : '.gallery-item [data-attachment-id], .tiled-gallery-item [data-attachment-id]',
+				'items_selector' : '.gallery-item [data-attachment-id], .tiled-gallery-item [data-attachment-id], img[data-attachment-id]',
 				'start_index': 0
 			},
 			data = $(this).data('carousel-extra');
@@ -1391,7 +1391,7 @@ jQuery(document).ready(function($) {
 	};
 
 	// register the event listener for starting the gallery
-	$( document.body ).on( 'click.jp-carousel', 'div.gallery,div.tiled-gallery', function(e) {
+	$( document.body ).on( 'click.jp-carousel', 'div.gallery,div.tiled-gallery, a.single-image-gallery', function(e) {
 		if ( ! $(this).jp_carousel( 'testForData', e.currentTarget ) ) {
 			return;
 		}
@@ -1405,6 +1405,22 @@ jQuery(document).ready(function($) {
 		e.stopPropagation();
 		$(this).jp_carousel('open', {start_index: $(this).find('.gallery-item, .tiled-gallery-item').index($(e.target).parents('.gallery-item, .tiled-gallery-item'))});
 	});
+
+	// handle lightbox (single image gallery) for images linking to 'Attachment Page'
+	if ( 1 === Number( jetpackCarouselStrings.single_image_gallery ) ) {
+		// process links that have rel=attachment and img tag inside
+		$( 'a[rel*="attachment"] img' ).each(function() {
+			var container = $( this ).parent();
+			if( $( container ).attr( 'href' ) == $( this ).attr( 'data-orig-file' ) ) {
+				// if link points to 'Media File', skip it
+				return;
+			}
+			// make this node a gallery recognizable by event listener above
+			$( container ).addClass( 'single-image-gallery') ;
+			// method 'open' needs this attribute to distinguish from defailt WP gallery
+			container.data( 'carousel-extra', { single_image: true } );
+		});
+	}
 
 	// Makes carousel work on page load and when back button leads to same URL with carousel hash (ie: no actual document.ready trigger)
 	$( window ).on( 'hashchange.jp-carousel', function () {
@@ -1432,7 +1448,7 @@ jQuery(document).ready(function($) {
 		last_known_location_hash = window.location.hash;
 		matches = window.location.hash.match( hashRegExp );
 		attachmentId = parseInt( matches[1], 10 );
-		galleries = $( 'div.gallery, div.tiled-gallery' );
+		galleries = $( 'div.gallery, div.tiled-gallery, a.single-image-gallery' );
 
 		// Find the first thumbnail that matches the attachment ID in the location
 		// hash, then open the gallery that contains it.
@@ -1447,6 +1463,7 @@ jQuery(document).ready(function($) {
 			if ( selectedThumbnail ) {
 				$( selectedThumbnail.gallery )
 					.jp_carousel( 'openOrSelectSlide', selectedThumbnail.index );
+				return false;
 			}
 		});
 	});

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -101,6 +101,8 @@ class Jetpack_Carousel {
 		 *
 		 * @module carousel
 		 *
+		 * @since 4.5.0
+		 *
 		 * @param bool false Should Carousel be disabled for single images? Default to false.
 		 */
 		return apply_filters( 'jp_carousel_maybe_disable_single_images', false );

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -46,6 +46,8 @@ class Jetpack_Carousel {
 			add_action( 'wp_ajax_nopriv_get_attachment_comments', array( $this, 'get_attachment_comments' ) );
 			add_action( 'wp_ajax_post_attachment_comment', array( $this, 'post_attachment_comment' ) );
 			add_action( 'wp_ajax_nopriv_post_attachment_comment', array( $this, 'post_attachment_comment' ) );
+			// TODO: add setting checkbox for "single_image_linked_to_self", check for it here
+			add_filter( 'image_send_to_editor', array( $this, 'handle_single_image' ), 10, 8 );
 		} else {
 			if ( ! $this->in_jetpack ) {
 				if ( 0 == $this->test_1or0_option( get_option( 'carousel_enable_it' ), true ) )
@@ -71,6 +73,16 @@ class Jetpack_Carousel {
 		if ( $this->in_jetpack && method_exists( 'Jetpack', 'module_configuration_load' ) ) {
 			Jetpack::enable_module_configurable( dirname( dirname( __FILE__ ) ) . '/carousel.php' );
 			Jetpack::module_configuration_load( dirname( dirname( __FILE__ ) ) . '/carousel.php', array( $this, 'jetpack_configuration_load' ) );
+		}
+	}
+
+	function handle_single_image( $html, $id, $caption, $title, $align, $url, $size, $alt ) {
+		$url_without_extension = substr( $url, 0, strrpos( $url, '.' ) );
+		if( $url && strpos( $html, "src=\"$url_without_extension" ) !== false ) {
+			// image links to itself when img src contains same location as $url (a href value)
+			return "[gallery columns=\"1\" size=\"{$size}\" ids=\"{$id}\"]";
+		} else {
+			return $html;
 		}
 	}
 

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -26,6 +26,8 @@ class Jetpack_Carousel {
 
 	public $single_image_gallery_enabled = false;
 
+	public $single_image_gallery_enabled_media_file = false;
+
 	function __construct() {
 		add_action( 'init', array( $this, 'init' ) );
 	}
@@ -37,6 +39,7 @@ class Jetpack_Carousel {
 		$this->in_jetpack = ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'enable_module_configurable' ) ) ? true : false;
 
 		$this->single_image_gallery_enabled = !$this->maybe_disable_jp_carousel_single_images();
+		$this->single_image_gallery_enabled_media_file = $this->maybe_enable_jp_carousel_single_images_media_file();
 
 		if ( is_admin() ) {
 			// Register the Carousel-related related settings
@@ -106,6 +109,20 @@ class Jetpack_Carousel {
 		 * @param bool false Should Carousel be disabled for single images? Default to false.
 		 */
 		return apply_filters( 'jp_carousel_maybe_disable_single_images', false );
+	}
+
+	function maybe_enable_jp_carousel_single_images_media_file() {
+		/**
+		 * Allow third-party plugins or themes to enable Carousel
+		 * for single images linking to 'Media File' (full size image).
+		 *
+		 * @module carousel
+		 *
+		 * @since 4.5.0
+		 *
+		 * @param bool false Should Carousel be enabled for single images linking to 'Media File'? Default to false.
+		 */
+		return apply_filters( 'jp_carousel_load_for_images_linked_to_file', false );
 	}
 
 	function jetpack_configuration_load() {
@@ -197,6 +214,7 @@ class Jetpack_Carousel {
 				'display_exif'         => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', true ) ),
 				'display_geo'          => $this->test_1or0_option( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_geo', true ) ),
 				'single_image_gallery' => $this->single_image_gallery_enabled,
+				'single_image_gallery_media_file' => $this->single_image_gallery_enabled_media_file,
 				'background_color'     => $this->carousel_background_color_sanitize( Jetpack_Options::get_option_and_ensure_autoload( 'carousel_background_color', '' ) ),
 				'comment'              => __( 'Comment', 'jetpack' ),
 				'post_comment'         => __( 'Post Comment', 'jetpack' ),

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -337,7 +337,7 @@ class Jetpack_Carousel {
 		}
 
 		foreach ( $selected_images as $attachment_id => $image_html ) {
-			$attachment = WP_Post::get_instance( $attachment_id );
+			$attachment = get_post( $attachment_id );
 			$attributes = $this->add_data_to_images( array(), $attachment );
 			$attributes_html = '';
 			foreach( $attributes as $k => $v ) {

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -421,6 +421,7 @@ class Jetpack_Carousel {
 		$img_meta = json_encode( array_map( 'strval', $img_meta ) );
 
 		$attr['data-attachment-id']     = $attachment_id;
+		$attr['data-permalink']         = esc_attr( get_permalink( $attachment->ID ) );
 		$attr['data-orig-file']         = esc_attr( $orig_file );
 		$attr['data-orig-size']         = $size;
 		$attr['data-comments-opened']   = $comments_opened;

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -235,6 +235,7 @@ class Jetpack_Carousel {
 				'require_name_email'   => $require_name_email,
 				/** This action is documented in core/src/wp-includes/link-template.php */
 				'login_url'            => wp_login_url( apply_filters( 'the_permalink', get_permalink() ) ),
+				'blog_id'              => (int) get_current_blog_id(),
 			);
 
 			if ( ! isset( $localize_strings['jetpack_comments_iframe_src'] ) || empty( $localize_strings['jetpack_comments_iframe_src'] ) ) {

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -71,7 +71,7 @@ class Jetpack_Carousel {
 			add_filter( 'gallery_style', array( $this, 'add_data_to_container' ) );
 			add_filter( 'wp_get_attachment_image_attributes', array( $this, 'add_data_to_images' ), 10, 2 );
 			if ( $this->single_image_gallery_enabled ) {
-				add_filter( 'the_content', array( $this, 'add_data_to_single_images' ) );
+				add_filter( 'the_content', array( $this, 'add_data_to_single_images_html' ) );
 				$this->enqueue_assets();
 			}
 		}
@@ -318,7 +318,7 @@ class Jetpack_Carousel {
 	 * @param string $content HTML content of the post
 	 * @return string Modified HTML content of the post
 	 */
-	function add_data_to_single_images( $content ) {
+	function add_data_to_single_images_html( $content ) {
 		if ( ! preg_match_all( '/<img [^>]+>/', $content, $matches ) ) {
 			return $content;
 		}


### PR DESCRIPTION
Fixes #5431

This PR replaces changes from branch [`add/carousel-for-single-image`](https://github.com/Automattic/jetpack/pull/5397) that got broken.

#### Changes proposed in this Pull Request:
Single image when linking to its 'Attachment Page' should open the image in the same view as it is presented in Carousel gallery (Lightbox). 'Attachment Page' will not be displayed.

#### Testing instructions:
* Image linking to Attachment Page should open Lightbox view.
* With Carousel disabled Attachment Page should be open instead of Lightbox
* Image linking to Custom URL should open that URL
* Image linking to Media File should open that Media File
* Navigating directly to Lightbox view (URL with hash e.g. #jp-carousel-31) should go to the post with the Lightbox open
* This behavior should be correct for:
  * Post with single image only
  * Post with gallery
  * Post with multiple galleries and single images
  * Multiple post view (e.g. home page)


