### PR TITLE
IDC: Opt-in single site installs by default

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5402,7 +5402,7 @@ p {
 		if ( Jetpack_Constants::is_defined( 'JETPACK_SYNC_IDC_OPTIN' ) ) {
 			$default = Jetpack_Constants::get_constant( 'JETPACK_SYNC_IDC_OPTIN' );
 		} else {
-			$default = false;
+			$default = ! Jetpack_Constants::is_defined( 'SUNRISE' ) && ! is_multisite();
 		}
 
 		/**

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -419,8 +419,20 @@ EXPECTED;
 		$this->assertFalse( Jetpack::get_other_linked_admins() );
 	}
 
-	function test_idc_optin_defaults_to_false() {
+	function test_idc_optin_default() {
+		if ( is_multisite() ) {
+			$this->assertFalse( Jetpack::sync_idc_optin() );
+		} else {
+			$this->assertTrue( Jetpack::sync_idc_optin() );
+		}
+	}
+
+	function test_idc_optin_false_when_sunrise() {
+		Jetpack_Constants::set_constant( 'SUNRISE', true );
+
 		$this->assertFalse( Jetpack::sync_idc_optin() );
+
+		Jetpack_Constants::clear_constants();
 	}
 
 	function test_idc_optin_filter_overrides_development_version() {


### PR DESCRIPTION
Closes #5452 

This PR opts-in single site installs to our IDC mitigation work. We are only opting in this small selection of sites for now that way we have more time to test multisite and other interesting things such as domain mapping and multi-language.

To test:

- Ensure tests pass