### PR TITLE
Stats in Admin Page: Auto bump w.js version weekly

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -214,7 +214,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 		if ( ! $is_dev_mode ) {
 			// Required for Analytics
-			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js?48', array(), JETPACK__VERSION, true );
+			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 
 		$localeSlug = explode( '_', get_locale() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Version bump `w.js` in admin pages weekly.

#### Testing instructions:

* Load the admin page and see that w.js is loaded with the year and week number as the version instead of the Jetpack version.

-------------------

We sometimes make changes to our analytics JS file `w.js` which is outside of the Jetpack upgrade cycle. In order for clients to load the latest file we should just force a new version weekly. This way we still take advantage of caching as the JS file is only loaded once a week in the worst case scenario. This is similar to how we handle the stats script in the stats module:

https://github.com/Automattic/jetpack/blob/6d6681e0df12402010d3331cb6e9dc5c674b5dfe/modules/stats.php#L125