### PR TITLE
Always load the sync listener

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -52,17 +52,7 @@ class Jetpack_Sync_Actions {
 		 *
 		 * @param bool should we load sync listener code for this request
 		 */
-		if ( apply_filters( 'jetpack_sync_listener_should_load',
-			(
-				( isset( $_SERVER["REQUEST_METHOD"] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] )
-				||
-				is_user_logged_in()
-				||
-				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
-				||
-				defined( 'DOING_CRON' ) && DOING_CRON
-			)
-		) ) {
+		if ( apply_filters( 'jetpack_sync_listener_should_load', true ) ) {
 			self::initialize_listener();
 		}
 


### PR DESCRIPTION
The sync listener (which listens for changes to the DB and stores them to the sync queue) doesn't always load - it tries to only load during cases where we are likely to modify data.

However this means that data modified from PHP scripts, wp cli, and potentially many other places doesn't get synced. This could interfere with proper operation of things like subscriptions and publicize, where we need to be guaranteed that data will be saved at the moment a post is published.

This PR changes it to always load. Only occasionally loading was probably premature optimisation, given that the overhead of loading the listener is very small.

cc @lezama @enejb 