### PR TITLE
Stats: minor naming change for widgets views

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -114,7 +114,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		echo $after_widget;
 
 		/** This action is already documented in modules/widgets/gravatar-profile.php */
-		do_action( 'jetpack_stats_extra', 'widget', 'facebook-likebox' );
+		do_action( 'jetpack_stats_extra', 'widget_view', 'facebook-likebox' );
 	}
 
 	function update( $new_instance, $old_instance ) {

--- a/modules/widgets/goodreads.php
+++ b/modules/widgets/goodreads.php
@@ -87,7 +87,7 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 		echo $args['after_widget'];
 
 		/** This action is already documented in modules/widgets/gravatar-profile.php */
-		do_action( 'jetpack_stats_extra', 'widget', 'goodreads' );
+		do_action( 'jetpack_stats_extra', 'widget_view', 'goodreads' );
 	}
 
 	function goodreads_user_id_exists( $user_id ) {

--- a/modules/widgets/googleplus-badge.php
+++ b/modules/widgets/googleplus-badge.php
@@ -127,7 +127,7 @@ class WPCOM_Widget_GooglePlus_Badge extends WP_Widget {
 		echo $args['after_widget'];
 
 		/** This action is already documented in modules/widgets/gravatar-profile.php */
-		do_action( 'jetpack_stats_extra', 'widget', 'googleplus-badge' );
+		do_action( 'jetpack_stats_extra', 'widget_view', 'googleplus-badge' );
 	}
 
 	function update( $new_instance, $old_instance ) {

--- a/modules/widgets/gravatar-profile.php
+++ b/modules/widgets/gravatar-profile.php
@@ -126,7 +126,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 			 * @param string widget Item type (e.g. widget, or embed).
 			 * @param string grofile Item description (e.g. grofile, goodreads).
 			 */
-			do_action( 'jetpack_stats_extra', 'widget', 'grofile' );
+			do_action( 'jetpack_stats_extra', 'widget_view', 'grofile' );
 
 		} else {
 			if ( current_user_can( 'edit_theme_options' ) ) {

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -144,7 +144,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		echo $args['after_widget'];
 
 		/** This action is documented in modules/widgets/social-media-icons.php */
-		do_action( 'jetpack_bump_stats_extras', 'widget', 'twitter_timeline' );
+		do_action( 'jetpack_bump_stats_extras', 'widget_view', 'twitter_timeline' );
 	}
 
 


### PR DESCRIPTION
Janitorial naming fix, minor.

The stat name changed on the WP.com side, and this reflects that — it's more specific.
