### PR TITLE
IDC: Handles actions to confirm safe mode

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -1,9 +1,10 @@
-/* global idcL10n, jQuery, alert, JSON, console */
+/* global idcL10n, jQuery */
 
 ( function( $ ) {
 	var restNonce = idcL10n.nonce,
 		restRoot = idcL10n.apiRoot,
-		notice = $( '.jp-idc-notice' );
+		notice = $( '.jp-idc-notice' ),
+		idcButtons = $( '.jp-idc-notice .dops-button' );
 
 	// Confirm Safe Mode
 	$( '#jp-idc-confirm-safe-mode-action' ).click( function() {
@@ -15,21 +16,29 @@
 		fixJetpackConnection();
 	} );
 
+	function disableDopsButtons() {
+		idcButtons.prop( 'disabled', true );
+	}
+
+	function enableDopsButtons() {
+		idcButtons.prop( 'disabled', false );
+	}
+
 	function confirmSafeMode() {
-		var route = restRoot + 'jetpack/v4/site';
+		var route = restRoot + 'jetpack/v4/identity-crisis/confirm-safe-mode';
+		disableDopsButtons();
 		$.ajax( {
-			method: 'GET',
+			method: 'POST',
 			beforeSend : function ( xhr ) {
 				xhr.setRequestHeader( 'X-WP-Nonce', restNonce );
 			},
 			url: route,
 			data: {},
-			success: function( response ){
+			success: function(){
 				$( '.jp-idc-notice' ).hide();
-				alert( JSON.stringify( response, null, 4 ) );
 			},
-			error: function( response ) {
-				console.log( response.responseText );
+			error: function() {
+				enableDopsButtons();
 			}
 		} );
 	}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -668,14 +668,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * Dismisses identity crisis notice, and confirms that the site should remain in staging mode.
+	 * Sets a flag
 	 *
 	 * @since 4.4.0
 	 *
-	 * @return bool|WP_Error True if site was successfully set to staging mode.
+	 * @return bool True
 	 */
 	public static function confirm_staging_mode() {
-		error_log( 'staging mode confirmed' );
+		Jetpack_Options::update_option( 'auto_staging_confirmed', true );
 		return rest_ensure_response(
 			array(
 				'code' => 'success'

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -98,9 +98,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		// Confirm that a site in identity crisis should be in staging mode
-		register_rest_route( 'jetpack/v4', '/identity-crisis/confirm-staging-mode', array(
+		register_rest_route( 'jetpack/v4', '/identity-crisis/confirm-safe-mode', array(
 			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::confirm_staging_mode',
+			'callback' => __CLASS__ . '::confirm_safe_mode',
 			'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
 		) );
 
@@ -668,19 +668,22 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * Sets a flag
+	 * Sets a flag to confirm safe mode.
 	 *
 	 * @since 4.4.0
 	 *
 	 * @return bool True
 	 */
-	public static function confirm_staging_mode() {
-		Jetpack_Options::update_option( 'auto_staging_confirmed', true );
-		return rest_ensure_response(
-			array(
-				'code' => 'success'
-			)
-		);
+	public static function confirm_safe_mode() {
+		$updated = Jetpack_Options::update_option( 'safe_mode_confirmed', true );
+		if ( $updated ) {
+			return rest_ensure_response(
+				array(
+					'code' => 'success'
+				)
+			);
+		}
+		return new WP_Error( 'error_confirming_safe_mode', esc_html__( 'Jetpack could not confirm safe mode.', 'jetpack' ), array( 'status' => 500 ) );
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -97,6 +97,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 		) );
 
+		// Confirm that a site in identity crisis should be in staging mode
+		register_rest_route( 'jetpack/v4', '/identity-crisis/confirm-staging-mode', array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => __CLASS__ . '::confirm_staging_mode',
+			'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
+		) );
+
 		// Return all modules
 		self::route(
 			'module/all',
@@ -409,6 +416,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
+	 * Verify that user can mitigate an identity crisis.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @return bool Whether user has capability 'jetpack_disconnect'.
+	 */
+	public static function identity_crisis_mitigation_permission_check() {
+		if ( current_user_can( 'jetpack_disconnect' ) ) {
+			return true;
+		}
+
+		return new WP_Error( 'invalid_user_permission_identity_crisis', self::$user_permissions_error_msg, array( 'status' => self::rest_authorization_required_code() ) );
+	}
+
+	/**
 	 * Verify that user can update Jetpack options.
 	 *
 	 * @since 4.3.0
@@ -645,6 +667,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 		return new WP_Error( 'site_id_missing', esc_html__( 'The ID of this site does not exist.', 'jetpack' ), array( 'status' => 404 ) );
 	}
 
+	/**
+	 * Dismisses identity crisis notice, and confirms that the site should remain in staging mode.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @return bool|WP_Error True if site was successfully set to staging mode.
+	 */
+	public static function confirm_staging_mode() {
+		error_log( 'staging mode confirmed' );
+		return rest_ensure_response(
+			array(
+				'code' => 'success'
+			)
+		);
+	}
 
 	/**
 	 * Reset Jetpack options

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -35,7 +35,7 @@ class Jetpack_Options {
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
 				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
-				'auto_staging_confirmed'       // (bool) True if someone confirms that a site was correctly put into staging mode automatically after an identity crisis is discovered.
+				'safe_mode_confirmed'          // (bool) True if someone confirms that a site was correctly put into safe mode automatically after an identity crisis is discovered.
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -35,6 +35,7 @@ class Jetpack_Options {
 				'unique_connection',           // (array)  A flag to determine a unique connection to wordpress.com two values "connected" and "disconnected" with values for how many times each has occured
 				'protect_whitelist',           // (array) IP Address for the Protect module to ignore
 				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
+				'auto_staging_confirmed'       // (bool) True if someone confirms that a site was correctly put into staging mode automatically after an identity crisis is discovered.
 			);
 
 		case 'private' :


### PR DESCRIPTION
Closes #5444 

This creates an endpoint that will confirm safe mode, and dismiss the IDC notice permanently.

Here is a rough screen cast:
![jp-idc-confirm-rough](https://cloud.githubusercontent.com/assets/2694219/19943755/3d67829a-a10f-11e6-8d38-4e3fd3f5008f.gif)


To test:
- get your site into identity crisis. the fastest way to do this is via `wp shell`
 - run this command `Jetpack_Options::update_option( 'sync_error_idc', array_merge( Jetpack::get_sync_error_idc_option(), array( 'wpcom_home' => 'fakehome.com', 'wpcom_siteurl' => 'fakesite.com' ) ) );`
- You should see the IDC notice
- Click 'Confirm Safe Mode'
- You should get an alert confirming your choice
- When you reload the page, the notice should be gone

To clean up, run the following in `wp shell`
- `Jetpack_Options::delete_option( 'safe_mode_confirmed' );`
- `Jetpack_Options::delete_option( 'sync_error_idc' );`


This is a little rough at the moment. We can smooth it out as we iterate. If the logic looks good here, we can merge.