### PR TITLE
Allow to toggle multiple modules, update multiple module options, and general settings

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -954,14 +954,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'white' => esc_html__( 'White', 'jetpack' ),
 				),
 				'validate_callback' => __CLASS__ . '::validate_list_item',
-				'module'            => 'carousel',
+				'jp_group'          => 'carousel',
 			),
 			'carousel_display_exif' => array(
 				'description'       => wp_kses( sprintf( __( 'Show photo metadata (<a href="http://en.wikipedia.org/wiki/Exchangeable_image_file_format" target="_blank">Exif</a>) in carousel, when available.', 'jetpack' ) ), array( 'a' => array( 'href' => true, 'target' => true ) ) ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'carousel',
+				'jp_group'          => 'carousel',
 			),
 
 			// Comments
@@ -970,7 +970,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => esc_html__( 'Leave a Reply', 'jetpack' ),
 				'sanitize_callback' => 'sanitize_text_field',
-				'module'            => 'comments',
+				'jp_group'          => 'comments',
 			),
 			'jetpack_comment_form_color_scheme' => array(
 				'description'       => esc_html__( "Color Scheme", 'jetpack' ),
@@ -982,7 +982,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'transparent' => esc_html__( 'Transparent', 'jetpack' ),
 				),
 				'validate_callback' => __CLASS__ . '::validate_list_item',
-				'module'            => 'comments',
+				'jp_group'          => 'comments',
 			),
 
 			// Custom Content Types
@@ -991,28 +991,28 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'custom-content-types',
+				'jp_group'          => 'custom-content-types',
 			),
 			'jetpack_portfolio_posts_per_page' => array(
 				'description'       => esc_html__( 'Number of entries to show at most in Portfolio pages.', 'jetpack' ),
 				'type'              => 'integer',
 				'default'           => 10,
 				'validate_callback' => __CLASS__ . '::validate_posint',
-				'module'            => 'custom-content-types',
+				'jp_group'          => 'custom-content-types',
 			),
 			'jetpack_testimonial' => array(
 				'description'       => esc_html__( 'Enable or disable Jetpack testimonial post type.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'custom-content-types',
+				'jp_group'          => 'custom-content-types',
 			),
 			'jetpack_testimonial_posts_per_page' => array(
 				'description'       => esc_html__( 'Number of entries to show at most in Testimonial pages.', 'jetpack' ),
 				'type'              => 'integer',
 				'default'           => 10,
 				'validate_callback' => __CLASS__ . '::validate_posint',
-				'module'            => 'custom-content-types',
+				'jp_group'          => 'custom-content-types',
 			),
 
 			// Galleries
@@ -1021,7 +1021,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'tiled-gallery',
+				'jp_group'          => 'tiled-gallery',
 			),
 
 			'gravatar_disable_hovercards' => array(
@@ -1034,7 +1034,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'disabled' => esc_html__( 'Disabled', 'jetpack' ),
 				),
 				'validate_callback' => __CLASS__ . '::validate_list_item',
-				'module'            => 'gravatar-hovercards',
+				'jp_group'          => 'gravatar-hovercards',
 			),
 
 			// Infinite Scroll
@@ -1043,14 +1043,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'infinite-scroll',
+				'jp_group'          => 'infinite-scroll',
 			),
 			'infinite_scroll_google_analytics' => array(
 				'description'       => esc_html__( 'Use Google Analytics with Infinite Scroll', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'infinite-scroll',
+				'jp_group'          => 'infinite-scroll',
 			),
 
 			// Likes
@@ -1063,14 +1063,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'off' => esc_html__( 'Turned on per post', 'jetpack' ),
 				),
 				'validate_callback' => __CLASS__ . '::validate_list_item',
-				'module'            => 'likes',
+				'jp_group'          => 'likes',
 			),
 			'social_notifications_like' => array(
 				'description'       => esc_html__( 'Send email notification when someone likes a post', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'likes',
+				'jp_group'          => 'likes',
 			),
 
 			// Markdown
@@ -1079,7 +1079,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'markdown',
+				'jp_group'          => 'markdown',
 			),
 
 			// Mobile Theme
@@ -1092,7 +1092,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'disabled' => esc_html__( 'Show full posts on front page and on archive pages', 'jetpack' ),
 				),
 				'validate_callback' => __CLASS__ . '::validate_list_item',
-				'module'            => 'minileven',
+				'jp_group'          => 'minileven',
 			),
 			'wp_mobile_featured_images' => array(
 				'description'       => esc_html__( 'Featured Images', 'jetpack' ),
@@ -1103,14 +1103,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'disabled' => esc_html__( 'Hide all featured images', 'jetpack' ),
 				),
 				'validate_callback' => __CLASS__ . '::validate_list_item',
-				'module'            => 'minileven',
+				'jp_group'          => 'minileven',
 			),
 			'wp_mobile_app_promos' => array(
 				'description'       => esc_html__( 'Show a promo for the WordPress mobile apps in the footer of the mobile theme.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'minileven',
+				'jp_group'          => 'minileven',
 			),
 
 			// Monitor
@@ -1119,7 +1119,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'monitor',
+				'jp_group'          => 'monitor',
 			),
 
 			// Post by Email
@@ -1134,7 +1134,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'delete'     => esc_html__( 'Delete Post by Email address', 'jetpack' ),
 				),
 				'validate_callback' => __CLASS__ . '::validate_list_item',
-				'module'            => 'post-by-email',
+				'jp_group'          => 'post-by-email',
 			),
 
 			// Protect
@@ -1143,7 +1143,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_alphanum',
-				'module'            => 'protect',
+				'jp_group'          => 'protect',
 			),
 			'jetpack_protect_global_whitelist' => array(
 				'description'       => esc_html__( 'Protect global whitelist', 'jetpack' ),
@@ -1151,7 +1151,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_string',
 				'sanitize_callback' => 'esc_textarea',
-				'module'            => 'protect',
+				'jp_group'          => 'protect',
 			),
 
 			// Sharing
@@ -1163,7 +1163,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'hidden'  => array(),
 				),
 				'validate_callback' => __CLASS__ . '::validate_services',
-				'module'            => 'sharedaddy',
+				'jp_group'          => 'sharedaddy',
 			),
 			'button_style' => array(
 				'description'       => esc_html__( 'Button Style', 'jetpack' ),
@@ -1176,7 +1176,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'official'  => esc_html__( 'Official buttons', 'jetpack' ),
 				),
 				'validate_callback' => __CLASS__ . '::validate_list_item',
-				'module'            => 'sharedaddy',
+				'jp_group'          => 'sharedaddy',
 			),
 			'sharing_label' => array(
 				'description'       => esc_html__( 'Sharing Label', 'jetpack' ),
@@ -1184,14 +1184,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_string',
 				'sanitize_callback' => 'esc_html',
-				'module'            => 'sharedaddy',
+				'jp_group'          => 'sharedaddy',
 			),
 			'show' => array(
 				'description'       => esc_html__( 'Views where buttons are shown', 'jetpack' ),
 				'type'              => 'array',
 				'default'           => array( 'post' ),
 				'validate_callback' => __CLASS__ . '::validate_sharing_show',
-				'module'            => 'sharedaddy',
+				'jp_group'          => 'sharedaddy',
 			),
 			'jetpack-twitter-cards-site-tag' => array(
 				'description'       => esc_html__( "The Twitter username of the owner of this site's domain.", 'jetpack' ),
@@ -1199,14 +1199,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_twitter_username',
 				'sanitize_callback' => 'esc_html',
-				'module'            => 'sharedaddy',
+				'jp_group'          => 'sharedaddy',
 			),
 			'sharedaddy_disable_resources' => array(
 				'description'       => esc_html__( 'Disable CSS and JS', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'sharedaddy',
+				'jp_group'          => 'sharedaddy',
 			),
 			'custom' => array(
 				'description'       => esc_html__( 'Custom sharing services added by user.', 'jetpack' ),
@@ -1217,7 +1217,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'sharing_icon' => '',
 				),
 				'validate_callback' => __CLASS__ . '::validate_custom_service',
-				'module'            => 'sharedaddy',
+				'jp_group'          => 'sharedaddy',
 			),
 			// Not an option, but an action that can be perfomed on the list of custom services passing the service ID.
 			'sharing_delete_service' => array(
@@ -1225,7 +1225,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_custom_service_id',
-				'module'            => 'sharedaddy',
+				'jp_group'          => 'sharedaddy',
 			),
 
 			// SSO
@@ -1234,14 +1234,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'sso',
+				'jp_group'          => 'sso',
 			),
 			'jetpack_sso_match_by_email' => array(
 				'description'       => esc_html__( 'Match by Email', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'sso',
+				'jp_group'          => 'sso',
 			),
 
 			// Site Icon
@@ -1250,14 +1250,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'integer',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_posint',
-				'module'            => 'site-icon',
+				'jp_group'          => 'site-icon',
 			),
 			'site_icon_url' => array(
 				'description'       => esc_html__( 'Site Icon URL', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'esc_url',
-				'module'            => 'site-icon',
+				'jp_group'          => 'site-icon',
 			),
 
 			// Subscriptions
@@ -1266,14 +1266,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'subscriptions',
+				'jp_group'          => 'subscriptions',
 			),
 			'stc_enabled' => array(
 				'description'       => esc_html__( "Show a <em>'follow comments'</em> option in the comment form", 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'subscriptions',
+				'jp_group'          => 'subscriptions',
 			),
 
 			// Related Posts
@@ -1282,14 +1282,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'related-posts',
+				'jp_group'          => 'related-posts',
 			),
 			'show_thumbnails' => array(
 				'description'       => esc_html__( 'Use a large and visually striking layout', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'related-posts',
+				'jp_group'          => 'related-posts',
 			),
 
 			// Spelling and Grammar - After the Deadline
@@ -1298,105 +1298,105 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'onupdate' => array(
 				'description'       => esc_html__( 'Proofread when a post or page is updated.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Bias Language' => array(
 				'description'       => esc_html__( 'Bias Language', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Cliches' => array(
 				'description'       => esc_html__( 'Clichés', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Complex Expression' => array(
 				'description'       => esc_html__( 'Complex Phrases', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Diacritical Marks' => array(
 				'description'       => esc_html__( 'Diacritical Marks', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Double Negative' => array(
 				'description'       => esc_html__( 'Double Negatives', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Hidden Verbs' => array(
 				'description'       => esc_html__( 'Hidden Verbs', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Jargon Language' => array(
 				'description'       => esc_html__( 'Jargon', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Passive voice' => array(
 				'description'       => esc_html__( 'Passive Voice', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Phrases to Avoid' => array(
 				'description'       => esc_html__( 'Phrases to Avoid', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'Redundant Expression' => array(
 				'description'       => esc_html__( 'Redundant Phrases', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'guess_lang' => array(
 				'description'       => esc_html__( 'Use automatically detected language to proofread posts and pages', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'ignored_phrases' => array(
 				'description'       => esc_html__( 'Add Phrase to be ignored', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'esc_html',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 			'unignore_phrase' => array(
 				'description'       => esc_html__( 'Remove Phrase from being ignored', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'esc_html',
-				'module'            => 'after-the-deadline',
+				'jp_group'          => 'after-the-deadline',
 			),
 
 			// Verification Tools
@@ -1405,21 +1405,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_alphanum',
-				'module'            => 'verification-tools',
+				'jp_group'          => 'verification-tools',
 			),
 			'bing' => array(
 				'description'       => esc_html__( 'Bing Webmaster Center', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_alphanum',
-				'module'            => 'verification-tools',
+				'jp_group'          => 'verification-tools',
 			),
 			'pinterest' => array(
 				'description'       => esc_html__( 'Pinterest Site Verification', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_alphanum',
-				'module'            => 'verification-tools',
+				'jp_group'          => 'verification-tools',
 			),
 
 			// Stats
@@ -1428,7 +1428,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'stats',
+				'jp_group'          => 'stats',
 			),
 			'roles' => array(
 				'description'       => esc_html__( 'Select the roles that will be able to view stats reports.', 'jetpack' ),
@@ -1436,42 +1436,42 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => array( 'administrator' ),
 				'validate_callback' => __CLASS__ . '::validate_stats_roles',
 				'sanitize_callback' => __CLASS__ . '::sanitize_stats_allowed_roles',
-				'module'            => 'stats',
+				'jp_group'          => 'stats',
 			),
 			'count_roles' => array(
 				'description'       => esc_html__( 'Count the page views of registered users who are logged in.', 'jetpack' ),
 				'type'              => 'array',
 				'default'           => array( 'administrator' ),
 				'validate_callback' => __CLASS__ . '::validate_stats_roles',
-				'module'            => 'stats',
+				'jp_group'          => 'stats',
 			),
 			'blog_id' => array(
 				'description'       => esc_html__( 'Blog ID.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'stats',
+				'jp_group'          => 'stats',
 			),
 			'do_not_track' => array(
 				'description'       => esc_html__( 'Do not track.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'stats',
+				'jp_group'          => 'stats',
 			),
 			'hide_smile' => array(
 				'description'       => esc_html__( 'Hide the stats smiley face image.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'stats',
+				'jp_group'          => 'stats',
 			),
 			'version' => array(
 				'description'       => esc_html__( 'Version.', 'jetpack' ),
 				'type'              => 'integer',
 				'default'           => 9,
 				'validate_callback' => __CLASS__ . '::validate_posint',
-				'module'            => 'stats',
+				'jp_group'          => 'stats',
 			),
 
 			// Settings - Not a module
@@ -1480,34 +1480,50 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'module'            => 'settings',
+				'jp_group'          => 'settings',
 			),
 
 		);
 
-		if ( is_array( $selector ) ) {
-			$options = array_intersect_key( $options, $selector );
-			return $options;
-		}
-
-		if ( 'any' === $selector ) {
-			return $options;
-		}
-
-		if ( empty( $selector ) ) {
-			$selector = self::get_module_requested();
-		}
-
-		$selected = array();
-
-		foreach ( $options as $option => $attributes ) {
-
-			// Not adding an isset( $attributes['module'] ) because if it's not set, it must be fixed, otherwise options will fail.
-			if ( $selector === $attributes['module'] ) {
-				$selected[ $option ] = $attributes;
+		// Add modules to list so they can be toggled
+		$modules = Jetpack::get_available_modules();
+		if ( is_array( $modules ) && ! empty( $modules ) ) {
+			$module_args = array(
+				'description'       => '',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'modules',
+			);
+			foreach( $modules as $module ) {
+				$options[ $module ] = $module_args;
 			}
 		}
 
+		if ( is_array( $selector ) ) {
+
+			// Return only those options whose keys match $selector keys
+			return array_intersect_key( $options, $selector );
+		}
+
+		if ( 'any' === $selector ) {
+
+			// Toggle module or update any module option or any general setting
+			return $options;
+		}
+
+		// We're updating the options for a single module.
+		if ( empty( $selector ) ) {
+			$selector = self::get_module_requested();
+		}
+		$selected = array();
+		foreach ( $options as $option => $attributes ) {
+
+			// Not adding an isset( $attributes['jp_group'] ) because if it's not set, it must be fixed, otherwise options will fail.
+			if ( $selector === $attributes['jp_group'] ) {
+				$selected[ $option ] = $attributes;
+			}
+		}
 		return $selected;
 	}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1460,6 +1460,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_posint',
 				'module'            => 'stats',
 			),
+
+			// Settings - Not a module
+			jetpack_holiday_snow_option_name() => array(
+				'description'       => '',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'module'            => 'settings',
+			),
+
 		);
 
 		if ( is_array( $selector ) ) {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -187,19 +187,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		// Update any Jetpack module option or setting
 		self::route(
-			'/update',
+			'/settings',
 			'Jetpack_Core_API_Data',
 			WP_REST_Server::EDITABLE,
 			new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) ),
 			self::get_updateable_parameters( 'any' )
 		);
 
-		// Reset all Jetpack options
-		register_rest_route( 'jetpack/v4', '/options/(?P<options>[a-z\-]+)', array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::reset_jetpack_options',
-			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
-		) );
+		// Update a module
+		self::route(
+			'/settings/(?P<slug>[a-z\-]+)',
+			'Jetpack_Core_API_Data',
+			WP_REST_Server::EDITABLE,
+			new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) ),
+			self::get_updateable_parameters()
+		);
 
 		// Return miscellaneous settings
 		register_rest_route( 'jetpack/v4', '/settings', array(
@@ -208,11 +210,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 		) );
 
-		// Update miscellaneous setting
-		register_rest_route( 'jetpack/v4', '/settings', array(
+		// Reset all Jetpack options
+		register_rest_route( 'jetpack/v4', '/options/(?P<options>[a-z\-]+)', array(
 			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::update_setting',
-			'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+			'callback' => __CLASS__ . '::reset_jetpack_options',
+			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
 		) );
 
 		// Jumpstart

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -555,7 +555,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function get_settings() {
 		$response = array(
-			jetpack_holiday_snow_option_name() => get_option( jetpack_holiday_snow_option_name() ) == 'letitsnow',
+			self::holiday_snow_option_name() => get_option( self::holiday_snow_option_name() ) == 'letitsnow',
 		);
 		return rest_ensure_response( $response );
 	}
@@ -579,7 +579,19 @@ class Jetpack_Core_Json_Api_Endpoints {
 		return rest_ensure_response( $response );
 	}
 
-
+	/**
+	 * Returns the proper name for Jetpack Holiday Snow setting.
+	 * When the REST route starts, the holiday-snow.php file where jetpack_holiday_snow_option_name() function is defined is not loaded,
+	 * so where using this to replicate it and have the same functionality.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @return string
+	 */
+	public static function holiday_snow_option_name() {
+		/** This filter is documented in modules/holiday-snow.php */
+		return apply_filters( 'jetpack_holiday_snow_option_name', 'jetpack_holiday_snow_enabled' );
+	}
 
 	/**
 	 * Update a single miscellaneous setting for this Jetpack installation, like Holiday Snow.
@@ -607,7 +619,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$updated = false;
 
 		switch ( $option ) {
-			case jetpack_holiday_snow_option_name():
+			case self::holiday_snow_option_name():
 				$updated = update_option( $option, ( true == (bool) $value ) ? 'letitsnow' : '' );
 				break;
 		}
@@ -1463,7 +1475,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 
 			// Settings - Not a module
-			jetpack_holiday_snow_option_name() => array(
+			self::holiday_snow_option_name() => array(
 				'description'       => '',
 				'type'              => 'boolean',
 				'default'           => 0,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -921,13 +921,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 * @since 4.4.0 Accepts 'any' as a parameter which will make it return the entire list.
 	 *
-	 * @param string $module Module slug.
-	 *                       If empty, it's assumed we're updating a module and we'll try to get its slug.
-	 *                       If 'any' a custom list is returned.
+	 * @param string|array $selector Module slug or array of parameters.
+	 *                               If empty, it's assumed we're updating a module and we'll try to get its slug.
+	 *                               If 'any' a custom list is returned.
 	 *
 	 * @return array
 	 */
-	public static function get_module_available_options( $module = '' ) {
+	public static function get_module_available_options( $selector = '' ) {
 
 		$options = array(
 
@@ -1462,12 +1462,17 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 		);
 
-		if ( 'any' === $module ) {
+		if ( is_array( $selector ) ) {
+			$options = array_intersect_key( $options, $selector );
 			return $options;
 		}
 
-		if ( empty( $module ) ) {
-			$module = self::get_module_requested();
+		if ( 'any' === $selector ) {
+			return $options;
+		}
+
+		if ( empty( $selector ) ) {
+			$selector = self::get_module_requested();
 		}
 
 		$selected = array();
@@ -1475,7 +1480,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		foreach ( $options as $option => $attributes ) {
 
 			// Not adding an isset( $attributes['module'] ) because if it's not set, it must be fixed, otherwise options will fail.
-			if ( $module === $attributes['module'] ) {
+			if ( $selector === $attributes['module'] ) {
 				$selected[ $option ] = $attributes;
 			}
 		}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -599,7 +599,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$updated = $grouped_options_current != $grouped_options ? update_option( 'stats_options', $grouped_options ) : true;
 					break;
 
-				case jetpack_holiday_snow_option_name():
+				case Jetpack_Core_Json_Api_Endpoints::holiday_snow_option_name():
 					$updated = get_option( $option ) != $value ? update_option( $option, (bool) $value ? 'letitsnow' : '' ) : true;
 					break;
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -154,6 +154,15 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 
 class Jetpack_Core_API_Module_List_Endpoint {
 
+	/**
+	 * A WordPress REST API callback method that accepts a request object and decides what to do with it.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @since 4.3.0
+	 *
+	 * @return bool|Array|WP_Error a resulting value or object, or an error.
+	 */
 	public function process( $request ) {
 		if ( 'GET' === $request->get_method() ) {
 			return $this->get_modules( $request );
@@ -272,6 +281,16 @@ class Jetpack_Core_API_Module_List_Endpoint {
 		);
 	}
 
+	/**
+	 * A WordPress REST API permission callback method that accepts a request object and decides
+	 * if the current user has enough privileges to act.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return bool does the current user have enough privilege.
+	 */
 	public function can_request( $request ) {
 		if ( 'GET' === $request->get_method() ) {
 			return current_user_can( 'jetpack_admin_page' );
@@ -1079,6 +1098,16 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 		}
 	}
 
+	/**
+	 * A WordPress REST API permission callback method that accepts a request object and
+	 * decides if the current user has enough privileges to act.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return bool does a current user have enough privileges.
+	 */
 	public function can_request() {
 		return current_user_can( 'jetpack_admin_page' );
 	}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -583,6 +583,10 @@ class Jetpack_Core_API_Module_Endpoint
 					$updated = $grouped_options_current != $grouped_options ? update_option( 'stats_options', $grouped_options ) : true;
 					break;
 
+				case jetpack_holiday_snow_option_name():
+					$updated = get_option( $option ) != $value ? update_option( $option, (bool) $value ? 'letitsnow' : '' ) : true;
+					break;
+
 				case 'wp_mobile_featured_images':
 				case 'wp_mobile_excerpt':
 					$value = ( 'enabled' === $value ) ? '1' : '0';

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -273,14 +273,30 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	}
 }
 
-class Jetpack_Core_API_Module_Endpoint
-	extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
+/**
+ * Class that manages updating of Jetpack module options and general Jetpack settings or retrieving module data.
+ *
+ * @since 4.3.0
+ * @since 4.4.0 Renamed Jetpack_Core_API_Module_Endpoint from to Jetpack_Core_API_Data.
+ *
+ * @author Automattic
+ */
+class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
+	/**
+	 * Process request by returning the module or updating it.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $data
+	 *
+	 * @return bool|mixed|void|WP_Error
+	 */
 	public function process( $data ) {
 		if ( 'GET' === $data->get_method() ) {
 			return $this->get_module( $data );
 		} else {
-			return $this->update_module( $data );
+			return $this->update_data( $data );
 		}
 	}
 
@@ -344,12 +360,12 @@ class Jetpack_Core_API_Module_Endpoint
 	 *
 	 * @return bool|WP_Error True if module was updated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public function update_module( $data ) {
+	public function update_data( $data ) {
 
 		// If it's null, we're trying to update many module options from different modules.
 		if ( is_null( $data['slug'] ) ) {
 
-			// Value admitted by Jetpack_Core_Json_Api_Endpoints::get_module_available_options that will make it return all module options.
+			// Value admitted by Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list that will make it return all module options.
 			// It will not be passed. It's just checked in this method to pass that method a string or array.
 			$data['slug'] = 'any';
 		} else {
@@ -371,7 +387,7 @@ class Jetpack_Core_API_Module_Endpoint
 		}
 
 		// Get available module options.
-		$options = Jetpack_Core_Json_Api_Endpoints::get_module_available_options( 'any' === $data['slug']
+		$options = Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list( 'any' === $data['slug']
 			? $params
 			: $data['slug']
 		);
@@ -590,7 +606,7 @@ class Jetpack_Core_API_Module_Endpoint
 				case 'wp_mobile_featured_images':
 				case 'wp_mobile_excerpt':
 					$value = ( 'enabled' === $value ) ? '1' : '0';
-					// break intentionally omitted
+				// break intentionally omitted
 				default:
 					// If option value was the same, consider it done.
 					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;
@@ -612,7 +628,7 @@ class Jetpack_Core_API_Module_Endpoint
 			$error = '';
 			if ( $invalid_count > 0 ) {
 				$error = sprintf(
-					/* Translators: the plural variable is a comma-separated list. Example: dog, cat, bird. */
+				/* Translators: the plural variable is a comma-separated list. Example: dog, cat, bird. */
 					_n( 'Invalid option for this module: %s.', 'Invalid options for this module: %s.', $invalid_count, 'jetpack' ),
 					join( ', ', $invalid )
 				);
@@ -622,7 +638,7 @@ class Jetpack_Core_API_Module_Endpoint
 				foreach ( $not_updated as $not_updated_option => $not_updated_message ) {
 					if ( ! empty( $not_updated_message ) ) {
 						$not_updated_messages[] = sprintf(
-							/* Translators: the first variable is a module option name. The second is the error message . */
+						/* Translators: the first variable is a module option name. The second is the error message . */
 							__( 'Extra info for %1$s: %2$s', 'jetpack' ),
 							$not_updated_option, $not_updated_message );
 					}
@@ -631,7 +647,7 @@ class Jetpack_Core_API_Module_Endpoint
 					$error .= ' ';
 				}
 				$error .= sprintf(
-					/* Translators: the plural variable is a comma-separated list. Example: dog, cat, bird. */
+				/* Translators: the plural variable is a comma-separated list. Example: dog, cat, bird. */
 					_n( 'Option not updated: %s.', 'Options not updated: %s.', $not_updated_count, 'jetpack' ),
 					join( ', ', array_keys( $not_updated ) ) );
 				if ( ! empty( $not_updated_messages ) ) {
@@ -681,7 +697,7 @@ class Jetpack_Core_API_Module_Endpoint
 	/**
 	 * Check if user is allowed to perform the update.
 	 *
-	 * @since 4.3
+	 * @since 4.3.0
 	 *
 	 * @param WP_REST_Request $request
 	 *

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -345,12 +345,21 @@ class Jetpack_Core_API_Module_Endpoint
 	 * @return bool|WP_Error True if module was updated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
 	public function update_module( $data ) {
-		if ( ! Jetpack::is_module( $data['slug'] ) ) {
-			return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
-		}
 
-		if ( ! Jetpack::is_module_active( $data['slug'] ) ) {
-			return new WP_Error( 'inactive', esc_html__( 'The requested Jetpack module is inactive.', 'jetpack' ), array( 'status' => 409 ) );
+		// If it's null, we're trying to update many module options from different modules.
+		if ( is_null( $data['slug'] ) ) {
+
+			// Value admitted by Jetpack_Core_Json_Api_Endpoints::get_module_available_options that will make it return all module options.
+			// It will not be passed. It's just checked in this method to pass that method a string or array.
+			$data['slug'] = 'any';
+		} else {
+			if ( ! Jetpack::is_module( $data['slug'] ) ) {
+				return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
+			}
+
+			if ( ! Jetpack::is_module_active( $data['slug'] ) ) {
+				return new WP_Error( 'inactive', esc_html__( 'The requested Jetpack module is inactive.', 'jetpack' ), array( 'status' => 409 ) );
+			}
 		}
 
 		// Get parameters to update the module.
@@ -362,7 +371,10 @@ class Jetpack_Core_API_Module_Endpoint
 		}
 
 		// Get available module options.
-		$options = Jetpack_Core_Json_Api_Endpoints::get_module_available_options( $data['slug'] );
+		$options = Jetpack_Core_Json_Api_Endpoints::get_module_available_options( 'any' === $data['slug']
+			? $params
+			: $data['slug']
+		);
 
 		// Options that are invalid or failed to update.
 		$invalid = array();

--- a/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -14,6 +14,9 @@ abstract class Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	protected $xmlrpc;
 
 	/**
+	 *
+	 * @since 4.3.0
+	 *
 	 * @param Jetpack_IXR_Client $xmlrpc
 	 */
 	public function __construct( $xmlrpc ) {
@@ -22,6 +25,9 @@ abstract class Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 	/**
 	 * Checks if the site is public and returns the result.
+	 *
+	 * @since 4.3.0
+	 *
 	 * @return Boolean $is_public
 	 */
 	protected function is_site_public() {

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -43,8 +43,8 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 		return array(
 			array( '/jetpack/v4/module/all', 'GET', 'Jetpack_Core_API_Module_List_Endpoint' ),
 			array( '/jetpack/v4/module/all/active', 'POST', 'Jetpack_Core_API_Module_List_Endpoint' ),
-			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'GET', 'Jetpack_Core_API_Module_Endpoint' ),
-			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'POST', 'Jetpack_Core_API_Module_Endpoint' ),
+			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'GET', 'Jetpack_Core_API_Data' ),
+			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'POST', 'Jetpack_Core_API_Data' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/data', 'GET', 'Jetpack_Core_API_Module_Data_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/active', 'POST', 'Jetpack_Core_API_Module_Toggle_Endpoint' ),
 		);


### PR DESCRIPTION
- [x] allow to update any option from any module
- [x] allow to update any setting, even combined with module options
- [x] allow to toggle modules at the same time, even together with options: if module is inactive and there's a request to activate it and set an option, activate it first and set it.

#### Changes proposed in this Pull Request:
- allow to return the entire list of module options to be updated.
    - add empty option value to post_by_email_address so it doesn't fail when it's not passed.
    - set default site icon id to 1 instead of 0 so it passes positive integer validation.
- allow to update any module option.
    - the method that returns the list of admitted options can now accept as parameter an associative array. This array can be a list of options to update. The returned list of admitted options to update matches the options that will attempt to be updated and fires validation (and sanitization where needed) for each value trying to be saved.
- allow to toggle modules in the same request. If a module option is attempted to be set, in the same request the module must be activated.
For example, let's assume Infinite Scroll is deactivated. A request with this data won't set the `infinite_scroll_google_analytics` module option:
    ```js
    {
        'carousel_background_color': 'white',
        'infinite_scroll_google_analytics': false,
        'jetpack_holiday_snow_enabled': false
    }
    ``` 
    but this one will succeed:
    ```js
    {
        'carousel_background_color': 'white',
        'infinite_scroll_google_analytics': false,
        'infinite-scroll': true,
        'jetpack_holiday_snow_enabled': false
    }
    ```
    the modules are passed as any other item to update.

#### Testing instructions:
##### Multiple options in multiple modules
* Go to Jetpack admin, and set these modules:
active: Carousel and Tiled Galleries
inactive: Infinite Scroll, Custom CSS
Leave Holiday Snow turned off.
Open the JS console and test with something like:
```js
jQuery.ajax( {
    url: 'http://localhost/your-awesome-site/wp-json/jetpack/v4/settings',
    method: 'POST',
    beforeSend: function ( xhr ) {
        xhr.setRequestHeader( 'X-WP-Nonce', Initial_State.WP_API_nonce );
    },
    data: JSON.stringify( {
        'carousel_background_color': 'white',
        'tiled-gallery': true,
        'infinite_scroll_google_analytics': false,
        'infinite-scroll': true,
        'jetpack_holiday_snow_enabled': false,
        'custom-css': true
    } ),
    contentType: "application/json",
    dataType: "json"
} ).done( function ( response ) {
    console.log( response );
} ).error( function ( error ) {
    console.log( error.responseText );
} );
```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Endpoints: a new endpoint `/jetpack/v4/update` allows to toggle multiple modules, update multiple modules options and update multiple general settings. It validates (and sanitizes where needed) each module, module option, and general setting value.

@samhotchkiss @zinigor 