### PR TITLE
IDC: Fix JSHint warning during build

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -1,7 +1,6 @@
-/* global idcL10n, jQuery */
+/* global idcL10n, jQuery, alert, JSON, console */
 
 ( function( $ ) {
-	
 	var restNonce = idcL10n.nonce,
 		restRoot = idcL10n.apiRoot;
 


### PR DESCRIPTION
@dbspringer pinged me because JSHint warnings were being thrown during building. The warnings were being thrown because `JSON`, `alert`, and `console` weren't defined, at least according to JSHint. 

Updating the configuration comment at the top of the file fixes this issue.

To test:

- Checkout `fix/idc-js-hint-warning` branch
- `yarn build`
- Make sure there are no warnings