### PR TITLE
IDC: Style "Safe Mode" notice

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -6,12 +6,12 @@
 		notice = $( '.jp-idc-notice' );
 
 	// Confirm Safe Mode
-	$( '#idc-confirm-safe-mode' ).click( function() {
+	$( '#jp-idc-confirm-safe-mode-action' ).click( function() {
 		confirmSafeMode();
 	} );
 
 	// Confirm Safe Mode
-	$( '#idc-fix-connection' ).click( function() {
+	$( '#jp-idc-fix-connection-action' ).click( function() {
 		fixJetpackConnection();
 	} );
 
@@ -25,7 +25,7 @@
 			url: route,
 			data: {},
 			success: function( response ){
-				$( '.jp-idc' ).hide();
+				$( '.jp-idc-notice' ).hide();
 				alert( JSON.stringify( response, null, 4 ) );
 			},
 			error: function( response ) {

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -2,7 +2,8 @@
 
 ( function( $ ) {
 	var restNonce = idcL10n.nonce,
-		restRoot = idcL10n.apiRoot;
+		restRoot = idcL10n.apiRoot,
+		notice = $( '.jp-idc-notice' );
 
 	// Confirm Safe Mode
 	$( '#idc-confirm-safe-mode' ).click( function() {
@@ -34,20 +35,6 @@
 	}
 
 	function fixJetpackConnection() {
-		var route = restRoot + 'jetpack/v4/site';
-		$.ajax( {
-			method: 'GET',
-			beforeSend : function ( xhr ) {
-				xhr.setRequestHeader( 'X-WP-Nonce', restNonce );
-			},
-			url: route,
-			data: {},
-			success: function( response ){
-				alert( JSON.stringify( response, null, 4 ) );
-			},
-			error: function( response ) {
-				console.log( response.responseText );
-			}
-		} );
+		notice.addClass( 'jp-idc-show-second-step' );
 	}
 })( jQuery );

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -18,6 +18,12 @@ class Jetpack_IDC {
 	 */
 	static $wpcom_home_url;
 
+	/**
+	 * The link to the support document used to explain Safe Mode to users
+	 * @var string
+	 */
+	const SAFE_MODE_DOC_LINK = 'https://jetpack.com/support/safe-mode';
+
 	static function init() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Jetpack_IDC;
@@ -51,7 +57,6 @@ class Jetpack_IDC {
 			return;
 		}
 
-		$safe_mode_doc_link = 'https://jetpack.com/support/safe-mode';
 		?>
 		<div class="jp-idc-notice notice notice-warning">
 			<div class="jp-idc-notice__header">
@@ -63,6 +68,52 @@ class Jetpack_IDC {
 				</p>
 			</div>
 
+			<?php $this->render_notice_first_step(); ?>
+		</div>
+	<?php }
+
+	/**
+	 * Enqueue scripts for the notice
+	 */
+	function enqueue_idc_notice_files() {
+		if ( ! $this->should_show_idc_notice() ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'jetpack-idc-js',
+			plugins_url( '_inc/idc-notice.js', JETPACK__PLUGIN_FILE ),
+			array( 'jquery' ),
+			JETPACK__VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'jetpack-idc-js',
+			'idcL10n',
+			array(
+				'apiRoot' => esc_url_raw( rest_url() ),
+				'nonce' => wp_create_nonce( 'wp_rest' ),
+			)
+		);
+
+		wp_register_style(
+			'jetpack-dops-style',
+			plugins_url( '_inc/build/admin.dops-style.css', JETPACK__PLUGIN_FILE ),
+			array(),
+			JETPACK__VERSION
+		);
+
+		wp_enqueue_style(
+			'jetpack-idc-css',
+			plugins_url( 'css/jetpack-idc.css', JETPACK__PLUGIN_FILE ),
+			array( 'jetpack-dops-style' ),
+			JETPACK__VERSION
+		);
+	}
+
+	function render_notice_first_step() { ?>
+		<div class="jp-idc-notice__first-step">
 			<div class="jp-idc-notice__content-header">
 				<h3 class="jp-idc-notice__content-header__lead">
 					<?php
@@ -72,7 +123,7 @@ class Jetpack_IDC {
 								'Jetpack has been placed into <a href="%1$s">Safe mode</a> because we noticed this is an exact copy of <a href="%2$s">%2$s</a>.',
 								'jetpack'
 							),
-							esc_url( $safe_mode_doc_link ),
+							esc_url( self::SAFE_MODE_DOC_LINK ),
 							esc_url( untrailingslashit( self::$wpcom_home_url ) )
 						),
 						array( 'a' => array( 'href' => array() ) )
@@ -89,7 +140,7 @@ class Jetpack_IDC {
 								more about Safe Mode</a>.',
 								'jetpack'
 							),
-							esc_url( $safe_mode_doc_link )
+							esc_url( self::SAFE_MODE_DOC_LINK )
 						),
 						array( 'a' => array( 'href' => array() ) )
 					);
@@ -142,46 +193,6 @@ class Jetpack_IDC {
 			</div>
 		</div>
 	<?php }
-
-	/**
-	 * Enqueue scripts for the notice
-	 */
-	function enqueue_idc_notice_files() {
-		if ( ! $this->should_show_idc_notice() ) {
-			return;
-		}
-
-		wp_enqueue_script(
-			'jetpack-idc-js',
-			plugins_url( '_inc/idc-notice.js', JETPACK__PLUGIN_FILE ),
-			array( 'jquery' ),
-			JETPACK__VERSION,
-			true
-		);
-
-		wp_localize_script(
-			'jetpack-idc-js',
-			'idcL10n',
-			array(
-				'apiRoot' => esc_url_raw( rest_url() ),
-				'nonce' => wp_create_nonce( 'wp_rest' ),
-			)
-		);
-
-		wp_register_style(
-			'jetpack-dops-style',
-			plugins_url( '_inc/build/admin.dops-style.css', JETPACK__PLUGIN_FILE ),
-			array(),
-			JETPACK__VERSION
-		);
-
-		wp_enqueue_style(
-			'jetpack-idc-css',
-			plugins_url( 'css/jetpack-idc.css', JETPACK__PLUGIN_FILE ),
-			array( 'jetpack-dops-style' ),
-			JETPACK__VERSION
-		);
-	}
 }
 
 Jetpack_IDC::init();

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -53,63 +53,92 @@ class Jetpack_IDC {
 
 		$safe_mode_doc_link = 'https://jetpack.com/support/safe-mode';
 		?>
-		<div class="jp-idc notice notice-warning">
-			<div class="jp-emblem">
-				<?php echo Jetpack::get_jp_emblem(); ?>
+		<div class="jp-idc-notice notice notice-warning">
+			<div class="jp-idc-notice__header">
+				<div class="jp-idc-notice__header__emblem">
+					<?php echo Jetpack::get_jp_emblem(); ?>
+				</div>
+				<p class="jp-idc-notice__header__text">
+					<?php esc_html_e( 'Jetpack Safe Mode', 'jetpack' ); ?>
+				</p>
 			</div>
-			<p class="msg-top">
-				<?php esc_html_e( 'Jetpack Safe Mode.', 'jetpack' ); ?>
-			</p>
-			<hr />
-			<div class="msg-bottom-head">
-				<?php
+
+			<div class="jp-idc-notice__content-header">
+				<h3 class="jp-idc-notice__content-header__lead">
+					<?php
 					echo wp_kses(
 						sprintf(
 							__(
-								'Jetpack has been placed into <a href="%1$s">Safe mode</a> because we noticed this is an exact copy of %2$s.
-								Please confirm Safe Mode or fix the Jetpack connection. Select one of the options below or <a href="%1$s">learn 
+								'Jetpack has been placed into <a href="%1$s">Safe mode</a> because we noticed this is an exact copy of <a href="%2$s">%2$s</a>.',
+								'jetpack'
+							),
+							esc_url( $safe_mode_doc_link ),
+							esc_url( self::$wpcom_home_url )
+						),
+						array( 'a' => array( 'href' => array() ) )
+					);
+					?>
+				</h3>
+
+				<p class="jp-idc-notice__content-header__explanation">
+					<?php
+					echo wp_kses(
+						sprintf(
+							__(
+								'Please confirm Safe Mode or fix the Jetpack connection. Select one of the options below or <a href="%1$s">learn 
 								more about Safe Mode</a>.',
 								'jetpack'
 							),
-							esc_url( $safe_mode_doc_link ),
-							Jetpack::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) )
+							esc_url( $safe_mode_doc_link )
 						),
 						array( 'a' => array( 'href' => array() ) )
 					);
-				?>
+					?>
+				</p>
 			</div>
-			<div style="width: 49%; display: inline-block;">
-				<?php
-					echo wp_kses(
-						sprintf(
-							__(
-								'Is this website a temporary duplicate of <a href="%1$s">%2$s</a> for the purposes of testing, staging or development? If so, we recommend keeping it in Safe Mode.',
-								'jetpack'
+
+			<div class="jp-idc-notice__actions">
+				<div class="jp-idc-notice__action">
+					<p class="jp-idc-notice__action__explanation">
+						<?php
+						echo wp_kses(
+							sprintf(
+								__(
+									'Is this website a temporary duplicate of <a href="%1$s">%1$s</a> for the purposes 
+									of testing, staging or development? If so, we recommend keeping it in Safe Mode.',
+									'jetpack'
+								),
+								esc_url( self::$wpcom_home_url )
 							),
-							esc_url( self::$wpcom_home_url ),
-							Jetpack::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) )
-						),
-						array( 'a' => array( 'href' => array() ) )
-					);
-				?>
-				<button id="idc-confirm-safe-mode"><?php esc_html_e( 'Confirm Safe Mode' ); ?></button>
-			</div>
-			<div style="width: 49%; display: inline-block;">
-				<?php
-					echo wp_kses(
-						sprintf(
-							__(
-								'If this is a separate and new website, or the new home of <a href="%1$s">%2$s</a>, we recommend turning Safe Mode off,
-								and re-establishing your connection to WordPress.com.',
-								'jetpack'
+							array( 'a' => array( 'href' => array() ) )
+						);
+						?>
+					</p>
+					<button id="idc-confirm-safe-mode" class="dops-button">
+						<?php esc_html_e( 'Confirm Safe Mode' ); ?>
+					</button>
+				</div>
+
+				<div class="jp-idc-notice__action">
+					<p class="jp-idc-notice__action__explanation">
+						<?php
+						echo wp_kses(
+							sprintf(
+								__(
+									'If this is a separate and new website, or the new home of <a href="%1$s">%1$s</a>, 
+									we recommend turning Safe Mode off, and re-establishing your connection to WordPress.com.',
+									'jetpack'
+								),
+								esc_url( self::$wpcom_home_url )
 							),
-							esc_url( $safe_mode_doc_link ),
-							Jetpack::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) )
-						),
-						array( 'a' => array( 'href' => array() ) )
-					);
-				?>
-				<button  id="idc-fix-connection"><?php esc_html_e( "Fix Jetpack's Connection" ); ?></button>
+							array( 'a' => array( 'href' => array() ) )
+						);
+						?>
+					</p>
+					<button id="idc-fix-connection" class="dops-button">
+						<?php esc_html_e( "Fix Jetpack's Connection" ); ?>
+					</button>
+				</div>
 			</div>
 		</div>
 	<?php }
@@ -139,10 +168,17 @@ class Jetpack_IDC {
 			)
 		);
 
+		wp_register_style(
+			'jetpack-dops-style',
+			plugins_url( '_inc/build/admin.dops-style.css', JETPACK__PLUGIN_FILE ),
+			array(),
+			JETPACK__VERSION
+		);
+
 		wp_enqueue_style(
 			'jetpack-idc-css',
 			plugins_url( 'css/jetpack-idc.css', JETPACK__PLUGIN_FILE ),
-			array(),
+			array( 'jetpack-dops-style' ),
 			JETPACK__VERSION
 		);
 	}

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -69,6 +69,7 @@ class Jetpack_IDC {
 			</div>
 
 			<?php $this->render_notice_first_step(); ?>
+			<?php $this->render_notice_second_step(); ?>
 		</div>
 	<?php }
 
@@ -188,6 +189,65 @@ class Jetpack_IDC {
 					</p>
 					<button id="idc-fix-connection" class="dops-button">
 						<?php esc_html_e( "Fix Jetpack's Connection" ); ?>
+					</button>
+				</div>
+			</div>
+		</div>
+	<?php }
+
+	function render_notice_second_step() { ?>
+		<div class="jp-idc-notice__second-step">
+			<div class="jp-idc-notice__content-header">
+				<h3 class="jp-idc-notice__content-header__lead">
+					<?php
+						printf(
+							esc_html__(
+								'Is %1$s the new home of %2$s?',
+								'jetpack'
+							),
+							untrailingslashit( Jetpack::normalize_url_protocol_agnostic( get_home_url() ) ),
+							untrailingslashit( Jetpack::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) ) )
+						)
+					?>
+				</h3>
+			</div>
+
+			<div class="jp-idc-notice__actions">
+				<div class="jp-idc-notice__action">
+					<p class="jp-idc-notice__action__explanation">
+						<?php
+							printf(
+								esc_html__(
+									'Yes. %1$s is replacing %2$s. I would like to migrate my stats and subscribers from 
+									%2$s to %1$s.',
+									'jetpack'
+								),
+								untrailingslashit( Jetpack::normalize_url_protocol_agnostic( get_home_url() ) ),
+								untrailingslashit( Jetpack::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) ) )
+							)
+						?>
+					</p>
+					<button id="idc-confirm-migrate" class="dops-button">
+						<?php esc_html_e( 'Migrate stats &amp; and Subscribers' ); ?>
+					</button>
+				</div>
+
+				<div class="jp-idc-notice__action">
+					<p class="jp-idc-notice__action__explanation">
+						<?php
+							printf(
+								esc_html__(
+									'No. %1$s is a new and different website that\'s separate from %2$s. It requires 
+									a new connection to WordPress.com for new stats and subscribers.',
+									'jetpack'
+								),
+								untrailingslashit( Jetpack::normalize_url_protocol_agnostic( get_home_url() ) ),
+								untrailingslashit( Jetpack::normalize_url_protocol_agnostic( esc_url_raw( self::$wpcom_home_url ) ) )
+							)
+						?>
+					</p>
+					<button id="idc-fix-connection" class="dops-button">
+						<?php esc_html_e( 'Start fresh &amp; create new connection' ); ?>
 					</button>
 				</div>
 			</div>

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -73,7 +73,7 @@ class Jetpack_IDC {
 								'jetpack'
 							),
 							esc_url( $safe_mode_doc_link ),
-							esc_url( self::$wpcom_home_url )
+							esc_url( untrailingslashit( self::$wpcom_home_url ) )
 						),
 						array( 'a' => array( 'href' => array() ) )
 					);
@@ -108,7 +108,7 @@ class Jetpack_IDC {
 									of testing, staging or development? If so, we recommend keeping it in Safe Mode.',
 									'jetpack'
 								),
-								esc_url( self::$wpcom_home_url )
+								esc_url( untrailingslashit( self::$wpcom_home_url ) )
 							),
 							array( 'a' => array( 'href' => array() ) )
 						);
@@ -129,7 +129,7 @@ class Jetpack_IDC {
 									we recommend turning Safe Mode off, and re-establishing your connection to WordPress.com.',
 									'jetpack'
 								),
-								esc_url( self::$wpcom_home_url )
+								esc_url( untrailingslashit( self::$wpcom_home_url ) )
 							),
 							array( 'a' => array( 'href' => array() ) )
 						);

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -166,7 +166,7 @@ class Jetpack_IDC {
 						);
 						?>
 					</p>
-					<button id="idc-confirm-safe-mode" class="dops-button">
+					<button id="jp-idc-confirm-safe-mode-action" class="dops-button">
 						<?php esc_html_e( 'Confirm Safe Mode' ); ?>
 					</button>
 				</div>
@@ -187,7 +187,7 @@ class Jetpack_IDC {
 						);
 						?>
 					</p>
-					<button id="idc-fix-connection" class="dops-button">
+					<button id="jp-idc-fix-connection-action" class="dops-button">
 						<?php esc_html_e( "Fix Jetpack's Connection" ); ?>
 					</button>
 				</div>
@@ -227,7 +227,7 @@ class Jetpack_IDC {
 							)
 						?>
 					</p>
-					<button id="idc-confirm-migrate" class="dops-button">
+					<button id="jp-idc-migrate-action" class="dops-button">
 						<?php esc_html_e( 'Migrate stats &amp; and Subscribers' ); ?>
 					</button>
 				</div>
@@ -246,7 +246,7 @@ class Jetpack_IDC {
 							)
 						?>
 					</p>
-					<button id="idc-fix-connection" class="dops-button">
+					<button id="jp-idc-reconnect-site-action" class="dops-button">
 						<?php esc_html_e( 'Start fresh &amp; create new connection' ); ?>
 					</button>
 				</div>

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -1,6 +1,65 @@
-.jp-emblem {
-  width: 25px;
-  height: 25px;
-  margin: .40em 1em 0 auto;
-  float: left;
+@import '../_inc/client/scss/variables/_colors.scss';
+
+.jp-idc-notice p {
+	margin: 0;
+	padding: 0;
+}
+
+.jp-idc-notice__header {
+	border-bottom: 1px solid $gray-light;
+	margin-bottom: 16px;
+	padding: 8px 0;
+}
+
+.jp-idc-notice__header__emblem {
+	fill: $green-primary;
+	width: 25px;
+	height: 25px;
+	margin: 0 1em 0 auto;
+	float: left;
+}
+
+.jp-idc-notice__header__text {
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 25px;
+	margin: 0;
+}
+
+.jp-idc-notice__content-header {
+	margin-bottom: 16px;
+}
+
+.jp-idc-notice__content-header__lead {
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 21px;
+	margin: 0;
+}
+
+.jp-idc-notice__content-header .jpc-idc-notice-content-header__explanation {
+	margin: 0;
+}
+
+.jp-idc-notice__actions {
+	display: flex;
+}
+
+.jp-idc-notice__action {
+	width: 49%;
+	display: block;
+	flex: 1;
+	margin-bottom: 24px;
+}
+
+.jp-idc-notice__action:first-child {
+	padding-right: 24px;
+}
+
+.jp-idc-notice__action:last-child {
+	padding-left: 24px;
+}
+
+.jp-idc-notice .jp-idc-notice__action__explanation {
+	margin: 0 0 16px 0;
 }

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -64,7 +64,6 @@
 }
 
 .jp-idc-notice__action {
-	width: 49%;
 	display: block;
 	flex: 1;
 	margin-bottom: 24px;

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -5,6 +5,24 @@
 	padding: 0;
 }
 
+.jp-idc-notice__first-step {
+	display: inline;
+}
+
+.jp-idc-notice__second-step {
+	display: none;
+}
+
+.jp-idc-notice.jp-idc-show-second-step {
+	.jp-idc-notice__first-step {
+		display: none;
+	}
+
+	.jp-idc-notice__second-step {
+		display: inline;
+	}
+}
+
 .jp-idc-notice__header {
 	border-bottom: 1px solid $gray-light;
 	margin-bottom: 16px;

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -5,8 +5,18 @@
 	padding: 0;
 }
 
+.jp-idc-notice {
+	h3, p {
+		color: $gray-dark;
+	}
+}
+
+.jp-idc-notice > div {
+	padding: 0 16px;
+}
+
 .jp-idc-notice__first-step {
-	display: inline;
+	display: inline-block;
 }
 
 .jp-idc-notice__second-step {
@@ -19,11 +29,11 @@
 	}
 
 	.jp-idc-notice__second-step {
-		display: inline;
+		display: inline-block;
 	}
 }
 
-.jp-idc-notice__header {
+.jp-idc-notice .jp-idc-notice__header {
 	border-bottom: 1px solid $gray-light;
 	margin-bottom: 16px;
 	padding: 8px 0;
@@ -45,22 +55,26 @@
 }
 
 .jp-idc-notice__content-header {
-	margin-bottom: 16px;
+	margin-bottom: 24px;
 }
 
 .jp-idc-notice__content-header__lead {
 	font-size: 16px;
-	font-weight: 400;
+	font-weight: 600;
 	line-height: 21px;
-	margin: 0;
+	margin: 0 0 8px 0;
+}
+
+@media only screen and ( min-width: 960px ) {
+	.jp-idc-notice__content-header__lead {
+		margin: 0 0 4px 0;
+	}
 }
 
 .jp-idc-notice__content-header .jpc-idc-notice-content-header__explanation {
+	font-size: 14px;
+	font-weight: 300;
 	margin: 0;
-}
-
-.jp-idc-notice__actions {
-	display: flex;
 }
 
 .jp-idc-notice__action {
@@ -69,12 +83,22 @@
 	margin-bottom: 24px;
 }
 
-.jp-idc-notice__action:first-child {
-	padding-right: 24px;
-}
+@media only screen and ( min-width: 960px ) {
+	.jp-idc-notice__actions {
+		display: flex;
+	}
 
-.jp-idc-notice__action:last-child {
-	padding-left: 24px;
+	.jp-idc-notice__action {
+		flex: 1;
+	}
+
+	.jp-idc-notice__action:first-child {
+		padding-right: 24px;
+	}
+
+	.jp-idc-notice__action:last-child {
+		padding-left: 24px;
+	}
 }
 
 .jp-idc-notice .jp-idc-notice__action__explanation {


### PR DESCRIPTION
We added a skeleton of the IDC notice in #5475. 

Now that we have final designs, we should get the notice in tip-top shape.

### To test

Checkout `update/idc-make-pretty` branch and then run this code somewhere: 
```
Jetpack_Options::update_option(
	'sync_error_idc',
	array_merge(
		Jetpack::get_sync_error_idc_option(),
		array(
			'wpcom_home' => 'fakehome.com',
			'wpcom_siteurl' => 'fakesite.com'
		)
	)
);
```

Then, to cleanup, run this bit of code somewhere:

`Jetpack_Options::delete_option( 'sync_error_idc' );`

### Screenshots

This is what the notice should look like.
![jetpack safe mode - after decision](https://cloud.githubusercontent.com/assets/1126811/19915047/94a9f0ac-a07d-11e6-871c-b9cdac7cc2c5.png)
![jetpack safe mode 03](https://cloud.githubusercontent.com/assets/1126811/19915046/94a7de48-a07d-11e6-8a14-1204bd6ca104.png)


At the time I created this PR, this is what the notice looks like:

<img width="917" alt="screen shot 2016-11-01 at 9 57 45 pm" src="https://cloud.githubusercontent.com/assets/1126811/19915157/3f6235e0-a07e-11e6-80c9-927f7fdba649.png">