### PR TITLE
Transients - Admin: if $old_roles is not passed, clear the transient

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -921,12 +921,17 @@ class Jetpack {
 	 * If a user has been promoted to or demoted from admin, we need to clear the
 	 * jetpack_other_linked_admins transient.
 	 *
-	 * @param $user_id
-	 * @param $role
-	 * @param $old_roles
+	 * @since 4.3.2
+	 * @since 4.4.0  $old_roles is null by default and if it's not passed, the transient is cleared.
+	 *
+	 * @param int    $user_id   The user ID whose role changed.
+	 * @param string $role      The new role.
+	 * @param array  $old_roles An array of the user's previous roles.
 	 */
-	function maybe_clear_other_linked_admins_transient( $user_id, $role, $old_roles ) {
-		if ( 'administrator' == $role || ( is_array( $old_roles ) && in_array( 'administrator', $old_roles ) )
+	function maybe_clear_other_linked_admins_transient( $user_id, $role, $old_roles = null ) {
+		if ( 'administrator' == $role
+			|| ( is_array( $old_roles ) && in_array( 'administrator', $old_roles ) )
+			|| is_null( $old_roles )
 		) {
 			delete_transient( 'jetpack_other_linked_admins' );
 		}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -158,7 +158,7 @@ EXPECTED;
 
 		$this->assertTrue( $seen_bundle );
 	}
-	
+
 	/**
 	 * @author tonykova
 	 * @covers Jetpack::implode_frontend_css
@@ -276,7 +276,7 @@ EXPECTED;
 		$editor_user = $this->factory->user->create( array( 'role' => 'editor' ) );
 		wp_update_user( array( 'ID' => $editor_user, 'role' => 'administrator' ) );
 
-		$this->assertEquals( 0, get_transient( 'jetpack_other_linked_admins' ) );
+		$this->assertFalse( get_transient( 'jetpack_other_linked_admins' ) );
 	}
 
 	public function test_demoting_admin_clear_other_linked_admins_transiet() {
@@ -284,7 +284,18 @@ EXPECTED;
 		$admin_user = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_update_user( array( 'ID' => $admin_user, 'role' => 'editor' ) );
 
-		$this->assertEquals( 0, get_transient( 'jetpack_other_linked_admins' ) );
+		$this->assertFalse( get_transient( 'jetpack_other_linked_admins' ) );
+	}
+
+	public function test_null_old_roles_clears_linked_admins_transient() {
+		set_transient( 'jetpack_other_linked_admins', 2, HOUR_IN_SECONDS );
+		$admin_user = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_update_user( array( 'ID' => $admin_user, 'role' => 'editor' ) );
+
+		/** This action is documented in wp-includes/class-wp-user.php */
+		do_action( 'set_user_role', $admin_user, 'contributor' );
+
+		$this->assertFalse( get_transient( 'jetpack_other_linked_admins' ) );
 	}
 
 	function test_changing_non_admin_roles_does_not_clear_other_linked_admins_transient() {
@@ -422,7 +433,7 @@ EXPECTED;
 		);
 
 		$this->assertSame( $expected, Jetpack::get_sync_error_idc_option() );
-		
+
 		// Cleanup
 		update_option( 'home', $original_home );
 		update_option( 'siteurl', $original_siteurl );


### PR DESCRIPTION
This PR solves an issue reported by an user:
https://wordpress.org/support/topic/maybe_clear_other_linked_admins_transient-problem/

One of the plugins the user is using fires `set_user_role` missing a parameter:
```php
function update_wp_user_Role($wp_user_id, $role) {
..
..
    do_action('set_user_role', $wp_user_id, $role); //Fire the action for other plugin(s)
```

- so the transient will not be cleared if the user has been demoted from administrator
- and it throws a notice:
```
Warning. Missing argument for Jetpack::maybe_clear_other_linked_admins_transient() in [path]plugins/jetpack/class.jetpack.php at line 927.
```

#### Changes proposed in this Pull Request:
- `$old_roles` is set to `null` by default. This solves the PHP notice.
- if `$old_roles` is `null` the transient 'jetpack_other_linked_admins' is cleared. This solves the transient not cleared.

#### Testing instructions:
* write a plugin that fires `set_user_role` without the third argument and demote an administrator user to editor or less: there should not be any warning and the transient `jetpack_other_linked_admins` must be cleared.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix: solve PHP warning when `set_user_role` is called without the third parameter.

cc @jeherve since he reported this.
@ebinnion since he introduced the method. Do you think this is ok?