### PR TITLE
Bring back the `from` parameter on Connect buttons

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -56,6 +56,7 @@ const ConnectButton = React.createClass( {
 		let connectUrl = this.props.connectUrl( this.props );
 		if ( this.props.from ) {
 			connectUrl += `&from=${ this.props.from }`;
+			connectUrl += '&additional-user';
 		}
 
 		return (

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -25,7 +25,7 @@ const ConnectButton = React.createClass( {
 	displayName: 'ConnectButton',
 
 	propTypes: {
-		type: React.PropTypes.bool
+		connectUser: React.PropTypes.bool,
 	},
 
 	getDefaultProps() {

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -26,11 +26,13 @@ const ConnectButton = React.createClass( {
 
 	propTypes: {
 		connectUser: React.PropTypes.bool,
+		from: React.PropTypes.string,
 	},
 
 	getDefaultProps() {
 		return {
-			connectUser: false
+			connectUser: false,
+			from: '',
 		};
 	},
 
@@ -51,10 +53,15 @@ const ConnectButton = React.createClass( {
 			);
 		}
 
+		let connectUrl = this.props.connectUrl( this.props );
+		if ( this.props.from ) {
+			connectUrl += `&from=${ this.props.from }`;
+		}
+
 		return (
 			<Button
 				className="is-primary jp-jetpack-connect__button"
-				href={ this.props.connectUrl( this.props ) }
+				href={ connectUrl }
 				disabled={ fetchingUrl } >
 				{ __( 'Link to WordPress.com' ) }
 			</Button>
@@ -85,10 +92,15 @@ const ConnectButton = React.createClass( {
 			);
 		}
 
+		let connectUrl = this.props.connectUrl( this.props );
+		if ( this.props.from ) {
+			connectUrl += `&from=${ this.props.from }`;
+		}
+
 		return (
 			<Button
 				className="is-primary jp-jetpack-connect__button"
-				href={ this.props.connectUrl( this.props ) }
+				href={ connectUrl }
 				disabled={ fetchingUrl }>
 				{ __( 'Connect Jetpack' ) }
 			</Button>

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -29,7 +29,7 @@ const JetpackConnect = React.createClass( {
 					<p className="jp-jetpack-connect__description">
 						{ __( 'Please connect to or create a WordPress.com account to start using Jetpack. This will enable powerful security, traffic, and customization services.' ) }
 					</p>
-					<ConnectButton />
+					<ConnectButton from="landing-page-top" />
 					<p>
 						<a href={ newAccountUrl } className="jp-jetpack-connect__link">
 							{ __( 'No account? Create one for free…' ) }
@@ -216,7 +216,7 @@ const JetpackConnect = React.createClass( {
 							'We\'re passionate about WordPress and here to make your life easier.'
 						) }
 					</p>
-					<ConnectButton />
+					<ConnectButton from="landing-page-bottom" />
 					<p>
 						<a href={ newAccountUrl } className="jp-jetpack-connect__link">
 							{ __( 'No account? Create one for free…' ) }

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -174,7 +174,7 @@ export const UserUnlinked = React.createClass( {
 					text={ text }
 				>
 					<NoticeAction
-						href={ this.props.connectUrl }
+						href={ `${ this.props.connectUrl }&from=unlinked-user-connect` }
 					>
 						{ __( 'Link to WordPress.com' ) }
 					</NoticeAction>

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -575,7 +575,7 @@ export let PostByEmailSettings = React.createClass( {
 						<div className="jp-connection-settings">
 							<div className="jp-connection-settings__headline">{ __( 'Link your account to WordPress.com to start using this feature.' ) }</div>
 							<div className="jp-connection-settings__actions">
-								<ConnectButton connectUser={ true } />
+								<ConnectButton connectUser={ true } from="post-by-email" />
 							</div>
 						</div>
 					}

--- a/_inc/client/general-settings/connection-settings.jsx
+++ b/_inc/client/general-settings/connection-settings.jsx
@@ -28,7 +28,7 @@ const ConnectionSettings = React.createClass( {
 
 		const maybeShowLinkUnlinkBtn = this.props.userIsMaster
 			? null
-			: <ConnectButton connectUser={ true } />;
+			: <ConnectButton connectUser={ true } from="connection-settings" />;
 
 		return this.props.isDevMode ?
 			(


### PR DESCRIPTION
This PR adds a new prop to `ConnectButton`, which lets developers pass in `from`, which will identify where in the app a button is (a descriptive identifier). The prop is not required, and should be a string.

The prop is added to the connection URL, where we'll track it as part of the connection flow to WordPress.com.

To test:

- With PR applied to a disconnected Jetpack site, visit the Jetpack dashboard
- Click/inspect the "Connect Jetpack" button's `href`
- The top button's href should end with `&from=landing-page-top`
- The bottom button's href should end with `&from=landing-page-bottom`

cc @jessefriedman @dereksmart 