### PR TITLE
Sync: Subscriptions do not work as expected.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -171,7 +171,7 @@ class Jetpack_Subscriptions {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
-
+		
 		/**
 		 * If we're updating the post, let's make sure the flag to not send to subscribers
 		 * is set to minimize the chances of sending posts multiple times.
@@ -222,6 +222,12 @@ class Jetpack_Subscriptions {
 				update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', $_POST['_jetpack_dont_email_post_to_subs'] );
 			}
 		}
+		
+		// If _jetpack_dont_email_post_to_subs is set to false and the post status is set to true.
+		// Lets set a pending email post to subs flag.
+ 		if ( ! get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) ) {
+			add_post_meta( $post->ID, '_jetpack_set_pending_email_post_to_subs', 1, true );
+		} 
 	}
 
 	/**

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -168,11 +168,26 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		$post->permalink               = get_permalink( $post->ID );
 		$post->shortlink               = wp_get_shortlink( $post->ID );
-		$post->dont_email_post_to_subs = Jetpack::is_module_active( 'subscriptions' ) ?
-				get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) :
-				true; // Don't email subscription if the subscription module is not active.
+		$post->dont_email_post_to_subs = self::do_not_send_post( $post->ID, $post->post_status );
 
 		return $post;
+	}
+
+	public function do_not_send_post( $post_id, $post_status ) {
+		if ( 'publish' !== $post_status ) {
+			return true;
+		}
+		$pending = get_post_meta( $post_id, '_jetpack_set_pending_email_post_to_subs', true );
+
+		if ( $pending ) {
+			delete_post_meta( $post_id, '_jetpack_set_pending_email_post_to_subs' );
+
+			return Jetpack::is_module_active( 'subscriptions' ) ?
+				false :
+				true; // Don't email subscription if the subscription module is not active.
+		}
+
+		return true;
 	}
 
 	public function expand_post_ids( $args ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -57,7 +57,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		// config is a list of post IDs to sync
 		if ( is_array( $config ) ) {
-			$where_sql   .= ' AND ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
+			$where_sql .= ' AND ID IN (' . implode( ',', array_map( 'intval', $config ) ) . ')';
 		}
 
 		return $where_sql;
@@ -110,13 +110,15 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		// return non existant post 
 		$post_type = get_post_type_object( $post->post_type );
-		if ( empty( $post_type) || ! is_object( $post_type ) ) {
-			$non_existant_post                    = new stdClass();
-			$non_existant_post->ID                = $post->ID;
-			$non_existant_post->post_modified     = $post->post_modified;
-			$non_existant_post->post_modified_gmt = $post->post_modified_gmt;
-			$non_existant_post->post_status       = 'jetpack_sync_non_registered_post_type';
-			
+		if ( empty( $post_type ) || ! is_object( $post_type ) ) {
+			$non_existant_post                          = new stdClass();
+			$non_existant_post->ID                      = $post->ID;
+			$non_existant_post->post_modified           = $post->post_modified;
+			$non_existant_post->post_modified_gmt       = $post->post_modified_gmt;
+			$non_existant_post->post_status             = 'jetpack_sync_non_registered_post_type';
+			$non_existant_post->dont_email_post_to_subs = true;
+			$non_existant_post->post_type               = $post->post_type;
+
 			return $non_existant_post;
 		}
 		/**
@@ -134,11 +136,12 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 */
 		if ( apply_filters( 'jetpack_sync_prevent_sending_post_data', false, $post ) ) {
 			// We only send the bare necessary object to be able to create a checksum.
-			$blocked_post                    = new stdClass();
-			$blocked_post->ID                = $post->ID;
-			$blocked_post->post_modified     = $post->post_modified;
-			$blocked_post->post_modified_gmt = $post->post_modified_gmt;
-			$blocked_post->post_status       = 'jetpack_sync_blocked';
+			$blocked_post                          = new stdClass();
+			$blocked_post->ID                      = $post->ID;
+			$blocked_post->post_modified           = $post->post_modified;
+			$blocked_post->post_modified_gmt       = $post->post_modified_gmt;
+			$blocked_post->post_status             = 'jetpack_sync_blocked';
+			$blocked_post->dont_email_post_to_subs = true;
 
 			return $blocked_post;
 		}
@@ -149,12 +152,12 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( 0 < strlen( $post->post_password ) ) {
 			$post->post_password = 'auto-' . wp_generate_password( 10, false );
 		}
-		
-		/** This filter is already documented in core. wp-includes/post-template.php */
-		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) && $post_type->public  ) {
 
-			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
-			$post->post_excerpt_filtered   = apply_filters( 'the_excerpt', $post->post_excerpt );
+		/** This filter is already documented in core. wp-includes/post-template.php */
+		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) && $post_type->public ) {
+
+			$post->post_content_filtered = apply_filters( 'the_content', $post->post_content );
+			$post->post_excerpt_filtered = apply_filters( 'the_excerpt', $post->post_excerpt );
 		}
 
 		$this->add_embed();

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -365,12 +365,13 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 
-	function test_sync_publicize_works_as_expected() {
+	function test_sync_subscriptions_to_works_as_expected() {
 
-		// activate subsriptions
+		// activate subscription module.
 		$active = Jetpack_Options::get_option( 'active_modules' );
 		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
-
+		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
+		Jetpack_Subscriptions::init();
 		// create a draft
 		$new_post_id = $this->factory->post->create(  array( 'post_status' => 'draft' ) );
 
@@ -383,11 +384,11 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 			) );
 		
 		$this->sender->do_sync();
+
 		// revert back to what it used to be.
 		Jetpack_Options::update_option( 'active_modules', $active );
 
 		$all_wp_insert_post_events = $this->server_event_storage->get_all_events( 'wp_insert_post' );
-
 		foreach( $all_wp_insert_post_events as $event ) {
 			list( $post_id, $post ) = $event->args;
 			
@@ -398,9 +399,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 			if ( 'updated' === $post->post_content || 'publish' !== $post->post_status ) {
 				// Only the updated post should have the do not send flag.
-				$this->assertEquals( true, $post->dont_email_post_to_subs );
+				$this->assertEquals( true, $post->dont_email_post_to_subs, 'Post status:'. $post->post_status .' Should not send email to subscripbers.' );
 			} else {
-				$this->assertEquals( false, $post->dont_email_post_to_subs );
+				$this->assertEquals( false, $post->dont_email_post_to_subs, 'Post status:'. $post->post_status .' Should send email to subscripbers.' );
 			}
 		}
 	}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -366,6 +366,11 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 
 	function test_sync_publicize_works_as_expected() {
+
+		// activate subsriptions
+		$active = Jetpack_Options::get_option( 'active_modules' );
+		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
+
 		// create a draft
 		$new_post_id = $this->factory->post->create(  array( 'post_status' => 'draft' ) );
 
@@ -378,6 +383,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 			) );
 		
 		$this->sender->do_sync();
+		// revert back to what it used to be.
+		Jetpack_Options::update_option( 'active_modules', $active );
 
 		$all_wp_insert_post_events = $this->server_event_storage->get_all_events( 'wp_insert_post' );
 
@@ -389,7 +396,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 				continue;
 			}
 
-			if ( 'updated' === $post->post_content ) {
+			if ( 'updated' === $post->post_content || 'publish' !== $post->post_status ) {
 				// Only the updated post should have the do not send flag.
 				$this->assertEquals( true, $post->dont_email_post_to_subs );
 			} else {


### PR DESCRIPTION
This test should pass since all the items in the queue should be independent independent of each other. This is currently not the case as this test demonstrates. 

