### PR TITLE
Widgets: add Blog Stats Widget

### DIFF
--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -29,13 +29,13 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 	function __construct() {
 		$widget_ops = array(
 			'classname' => 'blog-stats',
-			'description' => __( 'Show a hit counter for your blog.', 'jetpack' ),
+			'description' => esc_html__( 'Show a hit counter for your blog.', 'jetpack' ),
 			'customize_selective_refresh' => true,
 		);
 		parent::__construct(
 			'blog-stats',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
-			apply_filters( 'jetpack_widget_name', __( 'Blog Stats', 'jetpack' ) ),
+			apply_filters( 'jetpack_widget_name', esc_html__( 'Blog Stats', 'jetpack' ) ),
 			$widget_ops
 		);
 		$this->alt_option_name = 'widget_statscounter';
@@ -50,9 +50,9 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 	 */
 	public function defaults() {
 		return array(
-			'title' => __( 'Blog Stats', 'jetpack' ),
+			'title' => esc_html__( 'Blog Stats', 'jetpack' ),
 			/* Translators: Number of views, plural */
-			'hits'  => __( 'hits', 'jetpack' ),
+			'hits'  => esc_html__( 'hits', 'jetpack' ),
 		);
 	}
 

--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -148,7 +148,7 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 
 		if ( isset( $views ) && ! empty( $views ) ) {
 			printf(
-				'<ul><li>$1%s $2%s</li></ul>',
+				'<ul><li>%1$s %2$s</li></ul>',
 				number_format_i18n( $views ),
 				isset( $instance['hits'] ) ? esc_html( $instance['hits'] ) : ''
 			);

--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -51,6 +51,7 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 	public function defaults() {
 		return array(
 			'title' => __( 'Blog Stats', 'jetpack' ),
+			/* Translators: Number of views, plural */
 			'hits'  => __( 'hits', 'jetpack' ),
 		);
 	}

--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -165,9 +165,8 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
  * @since 4.5.0
  */
 function jetpack_blog_stats_widget_init() {
-	if ( ! function_exists( 'stats_get_from_restapi' ) ) {
-		return;
+	if ( function_exists( 'stats_get_from_restapi' ) ) {
+		register_widget( 'Jetpack_Blog_Stats_Widget' );
 	}
-	register_widget( 'Jetpack_Blog_Stats_Widget' );
 }
 add_action( 'widgets_init', 'jetpack_blog_stats_widget_init' );

--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -142,7 +142,7 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 		// Get the Site Stats.
 		$views = $this->get_stats();
 
-		if ( isset( $views ) && ! empty( $views ) ) {
+		if ( ! empty( $views ) ) {
 			printf(
 				'<ul><li>%1$s %2$s</li></ul>',
 				number_format_i18n( $views ),

--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -68,11 +68,7 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 		// Get data from the WordPress.com Stats REST API endpoint.
 		$stats = stats_get_from_restapi( array( 'fields' => 'stats' ) );
 
-		if (
-			isset( $stats )
-			&& ! empty( $stats )
-			&& isset( $stats->stats->views )
-		) {
+		if ( isset( $stats->stats->views ) ) {
 			return $stats->stats->views;
 		} else {
 			return false;

--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -97,7 +97,7 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'hits' ) ); ?>"><?php echo number_format_i18n( '12,345' ); ?></label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'hits' ) ); ?>"><?php echo number_format_i18n( '12345' ); ?></label>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'hits' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'hits' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['hits'] ); ?>" />
 		</p>
 		<p><?php esc_html_e( 'Hit counter is delayed by up to 60 seconds.', 'jetpack' ); ?></p>

--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Blog Stats Widget.
+ *
+ * @since 4.5.0
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Disable direct access/execution to/of the widget code.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Blog Stats Widget.
+ *
+ * Displays all time stats for that site.
+ *
+ * @since 4.5.0
+ */
+class Jetpack_Blog_Stats_Widget extends WP_Widget {
+
+	/**
+	 * Constructor
+	 */
+	function __construct() {
+		$widget_ops = array(
+			'classname' => 'blog-stats',
+			'description' => __( 'Show a hit counter for your blog.', 'jetpack' ),
+			'customize_selective_refresh' => true,
+		);
+		parent::__construct(
+			'blog-stats',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
+			apply_filters( 'jetpack_widget_name', __( 'Blog Stats', 'jetpack' ) ),
+			$widget_ops
+		);
+		$this->alt_option_name = 'widget_statscounter';
+	}
+
+	/**
+	 * Return an associative array of default values
+	 *
+	 * These values are used in new widgets.
+	 *
+	 * @return array Array of default values for the Widget's options
+	 */
+	public function defaults() {
+		return array(
+			'title' => __( 'Blog Stats', 'jetpack' ),
+			'hits'  => __( 'hits', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * Return All Time Stats for that blog.
+	 *
+	 * We query the WordPress.com Stats REST API endpoint.
+	 *
+	 * @uses stats_get_from_restapi(). That function caches data locally for 5 minutes.
+	 *
+	 * @return string|false $views All Time Stats for that blog.
+	 */
+	public function get_stats() {
+		// Get data from the WordPress.com Stats REST API endpoint.
+		$stats = stats_get_from_restapi( array( 'fields' => 'stats' ) );
+
+		if (
+			isset( $stats )
+			&& ! empty( $stats )
+			&& isset( $stats->stats->views )
+		) {
+			return $stats->stats->views;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Back-end widget form.
+	 *
+	 * @see WP_Widget::form()
+	 *
+	 * @param array $instance Previously saved values from database.
+	 *
+	 * @return void
+	 */
+	function form( $instance ) {
+		$instance = wp_parse_args( $instance, $this->defaults() );
+		?>
+
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+		</p>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'hits' ) ); ?>"><?php echo number_format_i18n( '12,345' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'hits' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'hits' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['hits'] ); ?>" />
+		</p>
+		<p><?php esc_html_e( 'Hit counter is delayed by up to 60 seconds.', 'jetpack' ); ?></p>
+
+		<?php
+	}
+
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @see WP_Widget::update()
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 *
+	 * @return array Updated safe values to be saved.
+	 */
+	function update( $new_instance, $old_instance ) {
+		$instance          = array();
+		$instance['title'] = wp_kses( $new_instance['title'], array() );
+		$instance['hits']  = wp_kses( $new_instance['hits'], array() );
+
+		return $instance;
+	}
+
+	/**
+	 * Front-end display of widget.
+	 *
+	 * @see WP_Widget::widget()
+	 *
+	 * @param array $args     Widget arguments.
+	 * @param array $instance Saved values from database.
+	 */
+	function widget( $args, $instance ) {
+		$instance = wp_parse_args( $instance, $this->defaults() );
+
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
+		$title = apply_filters( 'widget_title', $instance['title'] );
+
+		echo $args['before_widget'];
+
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+		}
+
+		// Get the Site Stats.
+		$views = $this->get_stats();
+
+		if ( isset( $views ) && ! empty( $views ) ) {
+			printf(
+				'<ul><li>$1%s $2%s</li></ul>',
+				number_format_i18n( $views ),
+				isset( $instance['hits'] ) ? esc_html( $instance['hits'] ) : ''
+			);
+		} else {
+			esc_html_e( 'No hits.', 'jetpack' );
+		}
+
+		echo $args['after_widget'];
+
+		/** This action is already documented in modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'widget_view', 'blog_stats' );
+	}
+}
+
+/**
+ * If the Stats module is active in a recent version of Jetpack, register the widget.
+ *
+ * @since 4.5.0
+ */
+function jetpack_blog_stats_widget_init() {
+	if ( ! function_exists( 'stats_get_from_restapi' ) ) {
+		return;
+	}
+	register_widget( 'Jetpack_Blog_Stats_Widget' );
+}
+add_action( 'widgets_init', 'jetpack_blog_stats_widget_init' );


### PR DESCRIPTION
#5493

#### Changes proposed in this Pull Request:

New Blog Stats widget, similar to [the widget used on WordPress.com](https://en.support.wordpress.com/widgets/blog-stats-widget/), but using the WordPress.com Stats REST API.

#### Testing instructions:

1. Go to Appearance > Widgets, or Appearance > Customize
2. Add the new Blog Stats widget to your sidebar.
3. Change options such as title or the word used in the widget ("hits".)
4. The widget should be displayed properly in your sidebar.
5. Deactivate the Stats module; the widget should disappear.

![screen shot 2016-11-03 at 12 35 20](https://cloud.githubusercontent.com/assets/426388/19964454/05ee5bfa-a1c2-11e6-904a-08b042de2daf.png)

![screen shot 2016-11-03 at 12 35 51](https://cloud.githubusercontent.com/assets/426388/19964461/132f6ce6-a1c2-11e6-8e04-3e9aa13c1e95.png)

#### Proposed changelog entry for your changes:

- Widgets: new Blog Stats Widget used to display all time stats on your site.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.