### PR TITLE
Add IDC Tracking

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -1,18 +1,25 @@
-/* global idcL10n, jQuery */
+/* global idcL10n, jQuery, analytics */
 
 ( function( $ ) {
 	var restNonce = idcL10n.nonce,
 		restRoot = idcL10n.apiRoot,
 		notice = $( '.jp-idc-notice' ),
-		idcButtons = $( '.jp-idc-notice .dops-button' );
+		idcButtons = $( '.jp-idc-notice .dops-button' ),
+		tracksUser = idcL10n.tracksUserData;
+
+	// Initialize Tracks and bump stats.
+	analytics.initialize( tracksUser.userid, tracksUser.username );
+	trackAndBumpMCStats( 'notice_view' );
 
 	// Confirm Safe Mode
 	$( '#jp-idc-confirm-safe-mode-action' ).click( function() {
+		trackAndBumpMCStats( 'confirm_safe_mode' );
 		confirmSafeMode();
 	} );
 
-	// Confirm Safe Mode
+	// Fix connection
 	$( '#jp-idc-fix-connection-action' ).click( function() {
+		trackAndBumpMCStats( 'fix_connection' );
 		fixJetpackConnection();
 	} );
 
@@ -45,5 +52,29 @@
 
 	function fixJetpackConnection() {
 		notice.addClass( 'jp-idc-show-second-step' );
+	}
+
+	/**
+	 * This function will fire both a Tracks and MC stat.
+	 * It will make sure to format the event name properly for the given stat home.
+	 *
+	 * Tracks: Will be prefixed by 'jetpack_idc_' and use underscores.
+	 * MC: Will not be prefixed, and will use dashes.
+	 *
+	 * @param eventName string
+	 */
+	function trackAndBumpMCStats( eventName ) {
+		if ( 'undefined' !== eventName && eventName.length ) {
+
+			// Format for Tracks
+			eventName = eventName.replace( /-/g, '_' );
+			eventName = eventName.indexOf( 'jetpack_idc_' ) !== 0 ? 'jetpack_idc_' + eventName : eventName;
+			analytics.tracks.recordEvent( eventName, {} );
+
+			// Now format for MC stats
+			eventName = eventName.replace( 'jetpack_idc_', '' );
+			eventName = eventName.replace( /_/g, '-' );
+			analytics.mc.bumpStat( 'jetpack-idc', eventName );
+		}
 	}
 })( jQuery );

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -184,17 +184,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		return $dismissed_notices;
 	}
 
-	function jetpack_get_tracks_user_data() {
-		if ( ! $user_data = Jetpack::get_connected_user_data() ) {
-			return false;
-		}
-
-		return array(
-			'userid' => $user_data['ID'],
-			'username' => $user_data['login'],
-		);
-	}
-
 	function page_admin_styles() {
 		$rtl = is_rtl() ? '.rtl' : '';
 
@@ -291,7 +280,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'errorCode' => Jetpack::state( 'error' ),
 				'errorDescription' => Jetpack::state( 'error_description' ),
 			),
-			'tracksUserData' => $this->jetpack_get_tracks_user_data(),
+			'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			'currentIp' => function_exists( 'jetpack_protect_get_ip' ) ? jetpack_protect_get_ip() : false
 		) );
 	}

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -181,25 +181,4 @@ class Jetpack_Tracks_Client {
 			'username' => $user_data['login'],
 		);
 	}
-
-	/**
-	 * Enqueues Tracks functions and library
-	 */
-	static function enqueue_tracks_scripts() {
-		wp_enqueue_script(
-			'jp-tracks',
-			'//stats.wp.com/w.js?48',
-			array(),
-			JETPACK__VERSION,
-			true
-		);
-
-		wp_enqueue_script(
-			'jp-tracks-functions',
-			plugins_url( '_inc/lib/tracks/tracks-callables.js', JETPACK__PLUGIN_FILE ),
-			array(),
-			JETPACK__VERSION,
-			false
-		);
-	}
 }

--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -165,4 +165,41 @@ class Jetpack_Tracks_Client {
 
 		return $anon_id;
 	}
+
+	/**
+	 * Gets the WordPress.com user's Tracks identity, if connected.
+	 *
+	 * @return array|bool
+	 */
+	static function get_connected_user_tracks_identity() {
+		if ( ! $user_data = Jetpack::get_connected_user_data() ) {
+			return false;
+		}
+
+		return array(
+			'userid' => $user_data['ID'],
+			'username' => $user_data['login'],
+		);
+	}
+
+	/**
+	 * Enqueues Tracks functions and library
+	 */
+	static function enqueue_tracks_scripts() {
+		wp_enqueue_script(
+			'jp-tracks',
+			'//stats.wp.com/w.js?48',
+			array(),
+			JETPACK__VERSION,
+			true
+		);
+
+		wp_enqueue_script(
+			'jp-tracks-functions',
+			plugins_url( '_inc/lib/tracks/tracks-callables.js', JETPACK__PLUGIN_FILE ),
+			array(),
+			JETPACK__VERSION,
+			false
+		);
+	}
 }

--- a/_inc/lib/tracks/tracks-callables.js
+++ b/_inc/lib/tracks/tracks-callables.js
@@ -1,0 +1,72 @@
+/**
+ * This was abstracted from wp-calypso's analytics lib: https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/README.md
+ * Some stuff was removed like GA tracking and other things not necessary for Jetpack tracking.
+ *
+ * This library should only be used and loaded if the Jetpack site is connected.
+ */
+
+// Load tracking scripts
+window._tkq = window._tkq || [];
+
+function buildQuerystring( group, name ) {
+	var uriComponent = '';
+
+	if ( 'object' === typeof group ) {
+		for ( var key in group ) {
+			uriComponent += '&x_' + encodeURIComponent( key ) + '=' + encodeURIComponent( group[ key ] );
+		}
+	} else {
+		uriComponent = '&x_' + encodeURIComponent( group ) + '=' + encodeURIComponent( name );
+	}
+
+	return uriComponent;
+}
+
+var analytics = {
+
+	initialize: function( userId, username ) {
+		analytics.setUser( userId, username );
+		analytics.identifyUser();
+	},
+
+	mc: {
+		bumpStat: function( group, name ) {
+			var uriComponent = buildQuerystring( group, name ); // prints debug info
+			new Image().src = document.location.protocol + '//pixel.wp.com/g.gif?v=wpcom-no-pv' + uriComponent + '&t=' + Math.random();
+		}
+	},
+
+	tracks: {
+		recordEvent: function( eventName, eventProperties ) {
+			eventProperties = eventProperties || {};
+
+			if ( eventName.indexOf( 'jetpack_' ) !== 0 ) {
+				debug( '- Event name must be prefixed by "jetpack_"' );
+				return;
+			}
+
+			window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
+		},
+
+		recordPageView: function( urlPath ) {
+			analytics.tracks.recordEvent( 'jetpack_page_view', {
+				'path': urlPath
+			} );
+		}
+	},
+
+	setUser: function( userId, username ) {
+		_user = { ID: userId, username: username };
+	},
+
+	identifyUser: function() {
+		// Don't identify the user if we don't have one
+		if ( _user ) {
+			window._tkq.push( [ 'identifyUser', _user.ID, _user.username ] );
+		}
+	},
+
+	clearedIdentity: function() {
+		window._tkq.push( [ 'clearIdentity' ] );
+	}
+};

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -97,6 +97,7 @@ class Jetpack_IDC {
 			array(
 				'apiRoot' => esc_url_raw( rest_url() ),
 				'nonce' => wp_create_nonce( 'wp_rest' ),
+				'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			)
 		);
 
@@ -112,6 +113,23 @@ class Jetpack_IDC {
 			plugins_url( 'css/jetpack-idc.css', JETPACK__PLUGIN_FILE ),
 			array( 'jetpack-dops-style' ),
 			JETPACK__VERSION
+		);
+
+		// Required for Tracks
+		wp_enqueue_script(
+			'jp-tracks',
+			'//stats.wp.com/w.js',
+			array(),
+			gmdate( 'YW' ),
+			true
+		);
+
+		wp_enqueue_script(
+			'jp-tracks-functions',
+			plugins_url( '_inc/lib/tracks/tracks-callables.js', JETPACK__PLUGIN_FILE ),
+			array(),
+			JETPACK__VERSION,
+			false
 		);
 	}
 


### PR DESCRIPTION
#5363

This PR seeks to add tracking ability for the IDC notice through Tracks and MC stats. 

- Adds an abstracted (loadable) version of wp-calypso's (and dops-components') `analytics` js functions, which allows us send Tracking events to both MC and Tracks from a vanilla js file.  
- JS function that allows you to send a Tracks event and MC stat with the same key
- All tracks events will be prefixed by `jetpack_idc_`, and will use underscores.
- MC stat will be grouped under the `jetpack-idc` stat, and the event names will not be prefixed and will use dashes.  
- Will send an anonymous ID if the use is not linked to wordpress.com

Events added in this PR: 
- `jetpack_idc_notice_viewed` (tracks) && `notice-viewed` (MC)
- `jetpack_idc_confirm_safe_mode` (tracks) && `confirm-safe-mode` (MC)
- `jetpack_idc_fix_connection` (tracks) && `fix-connection` (MC)
We will add more later.  

To Test: 
- View and click on the first steps as a linked user.  Look at the subsequent tracks/mc stats pages and verify that your events came through.  
- Do the same as an unlinked user.  