### PR TITLE
IDC Notice: Provision a fresh new connection (with new endpoint)

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -23,6 +23,12 @@
 		fixJetpackConnection();
 	} );
 
+
+	// Confirm Safe Mode
+	$( '#jp-idc-reconnect-site-action' ).click( function() {
+		startFreshConnection();
+	} );
+
 	function disableDopsButtons() {
 		idcButtons.prop( 'disabled', true );
 	}
@@ -52,6 +58,30 @@
 
 	function fixJetpackConnection() {
 		notice.addClass( 'jp-idc-show-second-step' );
+	}
+
+	/**
+	 * On successful request of the endpoint, we will redirect to the
+	 * connection auth flow after appending a specific 'from=' param for tracking.
+	 */
+	function startFreshConnection() {
+		var route = restRoot + 'jetpack/v4/identity-crisis/start-fresh';
+		disableDopsButtons();
+		$.ajax( {
+			method: 'POST',
+			beforeSend : function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', restNonce );
+			},
+			url: route,
+			data: {},
+			success: function( connectUrl ){
+				// Add a from param and take them to connect.
+				window.location = connectUrl + '&from=idc-notice';
+			},
+			error: function() {
+				enableDopsButtons();
+			}
+		} );
 	}
 
 	/**

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -26,6 +26,7 @@
 
 	// Confirm Safe Mode
 	$( '#jp-idc-reconnect-site-action' ).click( function() {
+		trackAndBumpMCStats( 'start_fresh' );
 		startFreshConnection();
 	} );
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -104,6 +104,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
 		) );
 
+		// IDC resolve: create an entirely new shadow site for this URL.
+		register_rest_route( 'jetpack/v4', '/identity-crisis/start-fresh', array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => __CLASS__ . '::start_fresh_connection',
+			'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
+		) );
+
 		// Return all modules
 		self::route(
 			'module/all',
@@ -684,6 +691,22 @@ class Jetpack_Core_Json_Api_Endpoints {
 			);
 		}
 		return new WP_Error( 'error_confirming_safe_mode', esc_html__( 'Jetpack could not confirm safe mode.', 'jetpack' ), array( 'status' => 500 ) );
+	}
+
+	/**
+	 * This IDC resolution will disconnect the site and re-connect to a completely new
+	 * and separate shadow site than the original.
+	 *
+	 * It will first will disconnect the site without phoning home as to not disturb the production site.
+	 * It then builds a fresh connection URL and sends it back along with the response.
+	 *
+	 * @since 4.4.0
+	 * @return bool|WP_Error
+	 */
+	public static function start_fresh_connection() {
+		// First clear the options / disconnect.
+		Jetpack::disconnect();
+		return self::build_connect_url();
 	}
 
 	/**


### PR DESCRIPTION
Closes #5447

This IDC resolution will disconnect the site and re-connect to a completely new and separate shadow site than the original.

It will first will disconnect the site without phoning home as to not disturb the production site. 

It adds a new route `/identity-crisis/start-fresh`, along with a new endpoint.  Doc blocks will explain what they do.  

To Test: 
- It's going to be very difficult to test FULLY, but if you truly have your site in an IDC, and wpcom knows nothing about the new URL, then clicking "Start Fresh and Create new connection" should do just that. 
- Make sure that `&from=idc-notice` is appended to the connect URL 
- Make sure the `jetpack_idc_start_fresh` tracks event gets logged
- Make sure the `start-fresh` MC stat gets bumped
