### PR TITLE
Sync: Add text domain to translated strings in Jetpack_Sync_Actions

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -159,7 +159,7 @@ class Jetpack_Sync_Actions {
 
 			return new WP_Error(
 				'sync_error_idc',
-				__( 'Sync has been blocked from WordPress.com because it would cause an identity crisis' )
+				esc_html__( 'Sync has been blocked from WordPress.com because it would cause an identity crisis', 'jetpack' )
 			);
 		}
 
@@ -193,10 +193,10 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function minute_cron_schedule( $schedules ) {
-		if( ! isset( $schedules["1min"] ) ) {
-			$schedules["1min"] = array(
+		if( ! isset( $schedules['1min'] ) ) {
+			$schedules['1min'] = array(
 				'interval' => 60,
-				'display' => __( 'Every minute' )
+				'display' => esc_html__( 'Every minute', 'jetpack' )
 			);
 		}
 		return $schedules;


### PR DESCRIPTION
While looking through the `Jetpack_Sync_Actions` class today, I noticed that there were a couple of spots where we weren't properly translating. Specifically, where we had left off the `jetpack` text domain. This PR fixes that as well as switches to `esc_html__()` for a bit more security.

To test:

- Checkout `fix/jetpack-sync-actions-translations` branch
- Make sure there are no errors when syncing that could be caused by improperly calling functions
