### PR TITLE
IDC: Implement admin bar menu to show notice

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -43,6 +43,7 @@
 		// Otherwise, there's a weird flow where if the user dismisses the notice, then shows the notice, then clicks
 		// the confirm safe mode button again, and then reloads the page, then the notice never disappears.
 		if ( window.location.search && -1 !== window.location.search.indexOf( 'jetpack_idc_clear_confirmation' ) ) {
+			trackAndBumpMCStats( 'clear_confirmation_clicked' );
 
 			// If push state is available, let's use that to minimize reloading the page.
 			// Otherwise, we can clear the args by reloading the page.

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -80,9 +80,15 @@ class Jetpack_IDC {
 
 		$href = wp_nonce_url( $href, 'jetpack_idc_clear_confirmation' );
 
+		$title = sprintf(
+			'<span class="jp-idc-admin-bar">%s %s</span>',
+			'<span class="dashicons dashicons-warning"></span>',
+			esc_html__( 'Jetpack Safe Mode', 'jetpack' )
+		);
+
 		$menu = array(
 			'id'     => 'jetpack-idc',
-			'title'  => esc_html__( 'Jetpack Safe Mode', 'jetpack' ),
+			'title'  => $title,
 			'href'   => esc_url( $href ),
 			'parent' => 'top-secondary',
 		);
@@ -121,7 +127,7 @@ class Jetpack_IDC {
 		wp_enqueue_style(
 			'jetpack-idc-admin-bar-css',
 			plugins_url( 'css/jetpack-idc-admin-bar.css', JETPACK__PLUGIN_FILE ),
-			array(),
+			array( 'dashicons' ),
 			JETPACK__VERSION
 		);
 	}

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -62,6 +62,7 @@ class Jetpack_IDC {
 			self::$is_safe_mode_confirmed = (bool) Jetpack_Options::get_option( 'safe_mode_confirmed' );
 		}
 
+		// 121 Priority so that it's the most inner Jetpack item in the admin bar.
 		add_action( 'admin_bar_menu', array( $this, 'display_admin_bar_button' ), 121 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_bar_css' ) );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -285,7 +285,8 @@ frontendcss = [
 	'modules/widgets/social-media-icons/style.css',
 	'modules/widgets/top-posts/style.css',
 	'modules/widgets/my-community/style.css',
-	'modules/widgets/widgets.css' // TODO Moved to image-widget/style.css
+	'modules/widgets/widgets.css', // TODO Moved to image-widget/style.css
+	'css/jetpack-idc-admin-bar.css'
 ];
 
 gulp.task( 'old-styles:watch', function() {

--- a/jetpack.php
+++ b/jetpack.php
@@ -65,12 +65,12 @@ require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-tracks.php'        );
 require_once( JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php'   );
 require_once( JETPACK__PLUGIN_DIR . 'modules/module-headings.php');
 require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-constants.php');
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php'  );
 
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-jitm.php'      );
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-debugger.php'  );
-	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php'  );
 }
 
 // Play nice with http://wp-cli.org/

--- a/scss/jetpack-idc-admin-bar.scss
+++ b/scss/jetpack-idc-admin-bar.scss
@@ -3,15 +3,20 @@
 }
 
 #wp-admin-bar-jetpack-idc .jp-idc-admin-bar {
-	background: #eee;
+	background: #fff;
 	border-radius: 2px;
 	color: #23282d;
-	padding: 2px 8px;
+	padding: 4px 8px;
+	font-size: 12px;
 }
 
 #wpadminbar #wp-admin-bar-jetpack-idc .dashicons {
 	color: #23282d;
 	font-family: 'dashicons';
+
+	&:before {
+		font-size: 16px;
+	}
 }
 
 #wpadminbar #wp-admin-bar-jetpack-idc:hover {
@@ -20,6 +25,6 @@
 	}
 
 	.jp-idc-admin-bar {
-		background: #fefefe;
+		background: #eee;
 	}
 }

--- a/scss/jetpack-idc-admin-bar.scss
+++ b/scss/jetpack-idc-admin-bar.scss
@@ -1,0 +1,3 @@
+#wp-admin-bar-jetpack-idc.hide {
+	display: none;
+}

--- a/scss/jetpack-idc-admin-bar.scss
+++ b/scss/jetpack-idc-admin-bar.scss
@@ -1,3 +1,25 @@
 #wp-admin-bar-jetpack-idc.hide {
 	display: none;
 }
+
+#wp-admin-bar-jetpack-idc .jp-idc-admin-bar {
+	background: #eee;
+	border-radius: 2px;
+	color: #23282d;
+	padding: 2px 8px;
+}
+
+#wpadminbar #wp-admin-bar-jetpack-idc .dashicons {
+	color: #23282d;
+	font-family: 'dashicons';
+}
+
+#wpadminbar #wp-admin-bar-jetpack-idc:hover {
+	.ab-item {
+		background: inherit;
+	}
+
+	.jp-idc-admin-bar {
+		background: #fefefe;
+	}
+}


### PR DESCRIPTION
Closes #5495 

This PR adds the "Jetpack Safe Mode" link that allows admins to show the safe mode notice after it has been disabled.

Here's a demo:

![admin_bar](https://cloud.githubusercontent.com/assets/1126811/19993100/04ff9142-a211-11e6-98a0-bd8514dc622f.gif)

To test:

- Checkout `update/idc-admin-bar-button` branch
- `yarn build`
- Put your site in IDC. We have a helper plugin to handle this. Ping if you need help.
- Click the "Confirm Safe Mode" button and ensure notice disappears
- Reload page and ensure notice is still gone
- Click the "Jetpack Safe Mode" admin menu item and ensure notice reappears
- Click "Confirm Safe Mode" button again
- Go to frontend of site
- Ensure "Jetpack Safe Mode" admin menu item shows
- Click it
- Ensure you land on admin dashboard and that the notice shows

cc @jeffgolenski for design review. Some specific things to look at:

- Is that the right icon? 
- What should the hover state look like?
- Are there specific colors, and how should we handle different admin color schemes?