### PR TITLE
VideoPress: Add settings to the React interface

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -31,6 +31,18 @@ import {
 
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 
+export let VideoPressSettings = React.createClass( {
+	render() {
+		return (
+			<span className="jp-form-setting-explanation">
+				{ __( 'The easiest way to upload ad-free and unbranded videos to your site. You get stats on video playback and shares and the player is lightweight and responsive.' ) }
+			</span>
+		)
+	}
+} );
+
+VideoPressSettings = moduleSettingsForm( VideoPressSettings );
+
 export let SharedaddySettings = React.createClass( {
 	render() {
 		return (

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -25,7 +25,8 @@ import {
 	AfterTheDeadlineSettings,
 	MarkdownSettings,
 	VerificationToolsSettings,
-	SitemapsSettings
+	SitemapsSettings,
+	VideoPressSettings
 } from 'components/module-settings/';
 import ExternalLink from 'components/external-link';
 
@@ -33,6 +34,8 @@ export const AllModuleSettings = React.createClass( {
 	render() {
 		let { module } = this.props;
 		switch ( module.module ) {
+			case 'videopress':
+				return ( <VideoPressSettings module={ module } /> );
 			case 'omnisearch':
 				return (
 					<div>

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -26,6 +26,8 @@ import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
 import { isUnavailableInDevMode } from 'state/connection';
 import { userCanManageModules as _userCanManageModules } from 'state/initial-state';
+import QuerySite from 'components/data/query-site';
+import ProStatus from 'pro-status';
 
 export const Writing = ( props ) => {
 	let {
@@ -84,6 +86,27 @@ export const Writing = ( props ) => {
 			return ( <h1 key={ `section-header-${ i }` /* https://fb.me/react-warning-keys */ } >{ element[0] }</h1> );
 		}
 
+		var isVideoPress = 'videopress' === element[0];
+
+		if ( isVideoPress ) {
+			var vpProps = {
+				module: 'videopress',
+				configure_url: ''
+			};
+
+			toggle = <ProStatus proFeature={ 'videopress' } />;
+
+			element[1] = <span>
+				{ element[1] }
+				<Button
+					compact={ true }
+					href="#/plans"
+				>
+					{ __( 'Pro' ) }
+				</Button>
+			</span>;
+		}
+
 		return adminAndNonAdmin ? (
 			<FoldableCard
 				className={ customClasses }
@@ -101,7 +124,7 @@ export const Writing = ( props ) => {
 				) }
 			>
 				{ isModuleActivated( element[0] ) || 'scan' === element[0] ?
-					<AllModuleSettings module={ getModule( element[0] ) } siteAdminUrl={ props.siteAdminUrl } /> :
+					<AllModuleSettings module={ isVideoPress ? vpProps : getModule( element[0] ) } siteAdminUrl={ props.siteAdminUrl } /> :
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
@@ -114,6 +137,7 @@ export const Writing = ( props ) => {
 
 	return (
 		<div>
+			<QuerySite />
 			{ cards }
 		</div>
 	);

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -194,7 +194,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'videopress' => array(
 				'name' => _x( 'VideoPress', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Upload and embed videos right on your site. (Subscription required.)', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Upload and embed videos right on your site.', 'Module Description', 'jetpack' ),
 			),
 
 			'widget-visibility' => array(

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -39,11 +39,6 @@ class Jetpack_VideoPress {
 	 * Fires on init since is_connection_owner should wait until the user is initialized by $wp->init();
 	 */
 	public function on_init() {
-		// Only the connection owner can configure this module.
-		if ( $this->is_connection_owner() ) {
-			Jetpack::enable_module_configurable( $this->module );
-		}
-
 		add_action( 'wp_enqueue_media', array( $this, 'enqueue_admin_scripts' ) );
 
 		add_filter( 'plupload_default_settings', array( $this, 'videopress_pluploder_config' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removes stale VideoPress settings. Creates some modifications to the VideoPress React settings to make them compatible with Jetpack plans, and only active with the use of a plan.

#### Testing instructions:

* Apply this PR to a clean master branch, build, and test on a site without a Jetpack plan.
* Apply this PR to a clean master branch, build, and test on a site with a Jetpack plan.
* Ensure the interface is clean and all links work on both sites.
* Ensure the interface changes when a plan is purchased for a site.

#### Screenshots:

Interface without a Jetpack plan:
![a85fbcda-a203-11e6-90d8-90609bf4512d](https://cloud.githubusercontent.com/assets/5528445/20008893/b296c05c-a278-11e6-89af-f086aac100fe.png)

Interface with a Jetpack plan:
![ae80e3f0-a203-11e6-8ef5-60d4242fc9f0](https://cloud.githubusercontent.com/assets/5528445/20008906/b9bbd5fc-a278-11e6-952d-a870e69b3aa7.png)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

