### PR TITLE
IDC: Don't show React UI notice if in IDC

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -51,8 +51,7 @@ export const StagingSiteNotice = React.createClass( {
 	displayName: 'StagingSiteNotice',
 
 	render() {
-		if ( this.props.isStaging ) {
-			const isIDC = this.props.isInIdentityCrisis;
+		if ( this.props.isStaging && ! this.props.isInIdentityCrisis ) {
 			let stagingSiteSupportLink = 'https://jetpack.com/support/staging-sites/';
 
 			let props = {
@@ -60,12 +59,6 @@ export const StagingSiteNotice = React.createClass( {
 				status: 'is-basic',
 				showDismiss: false
 			};
-
-			if ( isIDC ) {
-				props.text = __( 'Your site was automatically put in staging mode because we think this is a staging server.' );
-				props.status = 'is-info';
-				stagingSiteSupportLink = 'https://jetpack.com/support/identity-crisis';
-			}
 
 			return (
 				<SimpleNotice { ... props }>


### PR DESCRIPTION
This removes the IDC notice from the React UI. 

To Test: 
- Put yourself in IDC (ping if you need help)
- Make sure you don't see a notice about staging or IDC in the React UI
- Take yourself out of IDC (ping if you need help)
- Put yourself in `staging mode` via `define( 'JETPACK_STAGING_MODE', true);` or the filter
- See that there IS a staging mode notice in the React UI.