### PR TITLE
Tools/grunt wp i18n

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -10,6 +10,7 @@ phpunit.xml.dist
 tests
 tools
 package.json
+Gruntfile.js
 gulpfile.js
 node_modules
 languages/jetpack.pot

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,42 @@
+/* global module, require */
+
+module.exports = function(grunt) {
+    var path = require( 'path' ),
+        cfg = {
+            pkg: grunt.file.readJSON('package.json'),
+            makepot: {
+                jetpack: {
+                    options: {
+                        domainPath: '/languages',
+                        exclude: [
+                            'node_modules',
+                            'tests',
+                            'tools'
+                        ],
+                        mainFile:    'jetpack.php',
+                        potFilename: 'jetpack.pot'
+                    }
+                }
+            },
+            addtextdomain: {
+                jetpack: {
+                    options: {
+                        textdomain: 'jetpack'
+                    },
+                    files: {
+                        src: [
+                            '*.php',
+                            '**/*.php',
+                            '!node_modules/**',
+                            '!tests/**',
+                            '!tools/**'
+                        ]
+                    }
+                }
+            }
+        };
+
+    grunt.initConfig( cfg );
+
+    grunt.loadNpmTasks('grunt-wp-i18n');
+};

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -251,7 +251,7 @@ class Jetpack_IDC {
 						?>
 					</p>
 					<button id="jp-idc-confirm-safe-mode-action" class="dops-button">
-						<?php esc_html_e( 'Confirm Safe Mode' ); ?>
+						<?php esc_html_e( 'Confirm Safe Mode', 'jetpack' ); ?>
 					</button>
 				</div>
 
@@ -273,7 +273,7 @@ class Jetpack_IDC {
 						?>
 					</p>
 					<button id="jp-idc-fix-connection-action" class="dops-button">
-						<?php esc_html_e( "Fix Jetpack's Connection" ); ?>
+						<?php esc_html_e( "Fix Jetpack's Connection", 'jetpack' ); ?>
 					</button>
 				</div>
 			</div>
@@ -318,7 +318,7 @@ class Jetpack_IDC {
 						?>
 					</p>
 					<button id="jp-idc-migrate-action" class="dops-button">
-						<?php esc_html_e( 'Migrate stats &amp; and Subscribers' ); ?>
+						<?php esc_html_e( 'Migrate stats &amp; and Subscribers', 'jetpack' ); ?>
 					</button>
 				</div>
 
@@ -342,7 +342,7 @@ class Jetpack_IDC {
 						?>
 					</p>
 					<button id="jp-idc-reconnect-site-action" class="dops-button">
-						<?php esc_html_e( 'Start fresh &amp; create new connection' ); ?>
+						<?php esc_html_e( 'Start fresh &amp; create new connection', 'jetpack' ); ?>
 					</button>
 				</div>
 

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -114,7 +114,7 @@ function videopress_download_poster_image( $url, $attachment_id ) {
 	// Set variables for storage, fix file filename for query strings.
 	preg_match( '/[^\?]+\.(jpe?g|jpe|gif|png)\b/i', $url, $matches );
 	if ( ! $matches ) {
-		return new WP_Error( 'image_sideload_failed', __( 'Invalid image URL' ) );
+		return new WP_Error( 'image_sideload_failed', __( 'Invalid image URL', 'jetpack' ) );
 	}
 
 	$file_array = array();

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -265,7 +265,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 					<?php _e( 'Google Maps API Key', 'jetpack' ); ?>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'apikey' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['apikey'] ); ?>" />
 					<br />
-					<small><?php printf( wp_kses( __( 'Google now requires an API key to use their maps on your site. <a href="%s">See our documentation</a> for instructions on acquiring a key.' ), array( 'a' => array( 'href' => true ) ) ), 'https://jetpack.com/support/extra-sidebar-widgets/contact-info-widget/' ); ?></small>
+					<small><?php printf( wp_kses( __( 'Google now requires an API key to use their maps on your site. <a href="%s">See our documentation</a> for instructions on acquiring a key.', 'jetpack' ), array( 'a' => array( 'href' => true ) ) ), 'https://jetpack.com/support/extra-sidebar-widgets/contact-info-widget/' ); ?></small>
 				</label>
 			</p>
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,9 @@
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "sinon-qunit": "~2.0.0",
-    "webpack-dev-server": "1.14.0"
+    "webpack-dev-server": "1.14.0",
+    "grunt": "^0.4.2",
+    "grunt-wp-i18n": "~0.4.6"
   },
   "engines": {
     "node": ">=0.8"

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -159,7 +159,7 @@ class Jetpack_Sync_Actions {
 
 			return new WP_Error(
 				'sync_error_idc',
-				__( 'Sync has been blocked from WordPress.com because it would cause an identity crisis' )
+				__( 'Sync has been blocked from WordPress.com because it would cause an identity crisis', 'jetpack' )
 			);
 		}
 
@@ -196,7 +196,7 @@ class Jetpack_Sync_Actions {
 		if( ! isset( $schedules["1min"] ) ) {
 			$schedules["1min"] = array(
 				'interval' => 60,
-				'display' => __( 'Every minute' )
+				'display' => __( 'Every minute', 'jetpack' )
 			);
 		}
 		return $schedules;


### PR DESCRIPTION
Add back Grunt to handle `addtextdomain` calls to ensure we don't ship any strings that are missing our textdomain.

As we're able, we'll transition this functionality over to Gulp, but this should cover us in the interim.