### PR TITLE
IDC: Hide the Jetpack Admin UI while in IDC

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -75,6 +75,11 @@
 			success: function() {
 				$( '.jp-idc-notice' ).hide();
 				adminBarMenu.removeClass( 'hide' );
+
+				// We must refresh the Jetpack admin UI page in order for the React UI to render.
+				if ( window.location.search && 1 === window.location.search.indexOf( 'page=jetpack' ) ) {
+					window.location.reload();
+				}
 			},
 			error: function() {
 				enableDopsButtons();

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -71,7 +71,13 @@ abstract class Jetpack_Admin_Page {
 
 	// Render the page with a common top and bottom part, and page specific content
 	function render() {
+		// We're in an IDC: we need a decision made before we show the UI again.
+		if ( Jetpack::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' ) ) {
+			return;
+		}
+
 		$this->page_render();
+		$this->additional_styles();
 	}
 
 	function admin_help() {
@@ -104,8 +110,6 @@ abstract class Jetpack_Admin_Page {
 		wp_enqueue_style( 'jetpack-admin', plugins_url( "css/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons' ), JETPACK__VERSION . '-20121016' );
 		wp_style_add_data( 'jetpack-admin', 'rtl', 'replace' );
 		wp_style_add_data( 'jetpack-admin', 'suffix', $min );
-
-		$this->additional_styles();
 	}
 
 	function is_wp_version_too_old() {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -36,9 +36,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		// Adding a redirect meta tag wrapped in noscript tags for all browsers in case they have JavaScript disabled
 		add_action( 'admin_head', array( $this, 'add_noscript_head_meta' ) );
 
-		// Enqueue admin page styles in head
-		add_action( 'admin_enqueue_scripts', array( $this, 'page_admin_styles' ) );
-
 		// Adding a redirect tag wrapped in browser conditional comments
 		add_action( 'admin_head', array( $this, 'add_legacy_browsers_head_script' ) );
 	}
@@ -128,11 +125,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	function page_render() {
-		// We're in an IDC: we need a decision made before we show the UI again.
-		if ( Jetpack::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' ) ) {
-			return false;
-		}
-
 		// Handle redirects to configuration pages
 		if ( ! empty( $_GET['configure'] ) ) {
 			return $this->render_nojs_configurable( $_GET['configure'] );
@@ -189,7 +181,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		return $dismissed_notices;
 	}
 
-	function page_admin_styles() {
+	function additional_styles() {
 		$rtl = is_rtl() ? '.rtl' : '';
 
 		wp_enqueue_style( 'dops-css', plugins_url( "_inc/build/admin.dops-style$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -128,6 +128,11 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	function page_render() {
+		// We're in an IDC: we need a decision made before we show the UI again.
+		if ( Jetpack::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' ) ) {
+			return false;
+		}
+
 		// Handle redirects to configuration pages
 		if ( ! empty( $_GET['configure'] ) ) {
 			return $this->render_nojs_configurable( $_GET['configure'] );


### PR DESCRIPTION
Closes #5450 

This PR simply stops the render of the React UI when the site is in an IDC and there has been no action taken.  

![screen shot 2016-11-04 at 5 45 56 pm](https://cloud.githubusercontent.com/assets/7129409/20023513/e04fd4be-a2b6-11e6-9587-2ac33d6ba137.png)

To Test: 
- Put your site in IDC 
- Visit the Jetpack admin page and see only the notice.  
- Verify that clicking "Confirm Safe Mode" will show the admin UI.
- Verify that clicking the admin bar `safe mode` notice will re-hide the UI.  