### PR TITLE
General: Remove commented old sync code in Jetpack class

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -98,12 +98,6 @@ if ( Jetpack::is_module_active( 'photon' ) ) {
 	add_filter( 'jetpack_photon_url', 'jetpack_photon_url', 10, 3 );
 }
 
-/*
-if ( is_admin() && ! Jetpack::check_identity_crisis() ) {
-	Jetpack_Sync::sync_options( __FILE__, 'db_version', 'jetpack_active_modules', 'active_plugins' );
-}
-*/
-
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php' );
 
 Jetpack::init();


### PR DESCRIPTION
This code was commented out in f0d64f331fea6dcb0add97a62059dbdca2b8725d over 3 years ago. Let's just get rid of it.