### PR TITLE
Sync: Add setting to completely opt out from doing sync via cron

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -13,8 +13,14 @@ class Jetpack_Sync_Actions {
 
 	static function init() {
 
-		// Add a custom "every minute" cron schedule
-		add_filter( 'cron_schedules', array( __CLASS__, 'minute_cron_schedule' ) );
+		// everything below this point should only happen if we're a valid sync site
+		if ( ! self::sync_allowed() ) {
+			return;
+		}
+
+		if ( self::sync_via_cron_allowed() ) {
+			self::init_sync_cron_jobs();
+		}
 
 		// On jetpack authorization, schedule a full sync
 		add_action( 'jetpack_client_authorized', array( __CLASS__, 'do_full_sync' ), 10, 0 );
@@ -25,20 +31,8 @@ class Jetpack_Sync_Actions {
 		// Sync connected user role changes to .com
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
 
-		// everything below this point should only happen if we're a valid sync site
-		if ( ! self::sync_allowed() ) {
-			return;
-		}
-
 		// publicize filter to prevent publicizing blacklisted post types
 		add_filter( 'publicize_should_publicize_published_post', array( __CLASS__, 'prevent_publicize_blacklisted_posts' ), 10, 2 );
-
-		// cron hooks
-		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ), 10, 1 );
-		add_action( 'jetpack_sync_cron', array( __CLASS__, 'do_cron_sync' ) );
-		add_action( 'jetpack_sync_full_cron', array( __CLASS__, 'do_cron_full_sync' ) );
-
-		self::init_sync_cron_jobs();
 
 		/**
 		 * Fires on every request before default loading sync listener code.
@@ -92,6 +86,11 @@ class Jetpack_Sync_Actions {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 		return ( ! Jetpack_Sync_Settings::get_setting( 'disable' ) && Jetpack::is_active() && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
 			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
+	}
+
+	static function sync_via_cron_allowed() {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
+		return ( Jetpack_Sync_Settings::get_setting( 'sync_via_cron' ) );
 	}
 
 	static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {
@@ -303,6 +302,15 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function init_sync_cron_jobs() {
+		// Add a custom "every minute" cron schedule
+		add_filter( 'cron_schedules', array( __CLASS__, 'minute_cron_schedule' ) );
+
+		// cron hooks
+		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ), 10, 1 );
+
+		add_action( 'jetpack_sync_cron', array( __CLASS__, 'do_cron_sync' ) );
+		add_action( 'jetpack_sync_full_cron', array( __CLASS__, 'do_cron_full_sync' ) );
+
 		/**
 		 * Allows overriding of the default incremental sync cron schedule which defaults to once per minute.
 		 *

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -305,6 +305,7 @@ class Jetpack_Sync_Defaults {
 	static $default_post_meta_whitelist = array();
 	static $default_comment_meta_whitelist = array();
 	static $default_disable = 0; // completely disable sending data to wpcom
+	static $default_sync_via_cron = 1; // use cron to sync
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_max_enqueue_full_sync = 100; // max number of items to enqueue at a time when running full sync
 	static $default_max_queue_size_full_sync = 1000; // max number of total items in the full sync queue

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -305,7 +305,7 @@ class Jetpack_Sync_Defaults {
 	static $default_post_meta_whitelist = array();
 	static $default_comment_meta_whitelist = array();
 	static $default_disable = 0; // completely disable sending data to wpcom
-	static $default_sync_via_cron = 1; // use cron to sync
+	static $default_sync_via_cron = 0; // use cron to sync
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_max_enqueue_full_sync = 100; // max number of items to enqueue at a time when running full sync
 	static $default_max_queue_size_full_sync = 1000; // max number of total items in the full sync queue

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -22,6 +22,7 @@ class Jetpack_Sync_Settings {
 		'comment_meta_whitelist'  => true,
 		'max_enqueue_full_sync'   => true,
 		'max_queue_size_full_sync'=> true,
+		'sync_via_cron'           => true,
 	);
 
 	static $is_importing;


### PR DESCRIPTION
To test we need to set `'sync_via_cron'` to `0`, it can be done via `wp shell`

```
wp> require_once WP_CONTENT_DIR . '/plugins/jetpack/sync/class.jetpack-sync-settings.php';
wp> Jetpack_Sync_Settings::update_settings( array( 'sync_via_cron' => 0 ) );
```

cc @jeherve @enejb @gravityrail 

Should improve cases like #5513