### PR TITLE
JSON API: Media: Add meta object to response format

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1209,7 +1209,8 @@ new WPCOM_JSON_API_List_Media_v1_1_Endpoint( array(
 
 	'response_format' => array(
 		'media' => '(array) Array of media objects',
-		'found' => '(int) The number of total results found'
+		'found' => '(int) The number of total results found',
+		'meta'  => '(object) Meta data',
 	),
 
 	'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/media',


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/issues/1191
Related: https://github.com/Automattic/wp-calypso/issues/9165
WordPress.com: r145158-wpcom

#### Changes proposed in this Pull Request:

This pull request seeks to add missing `meta` property to the response format of the media list v1.1 endpoint. The [media endpoint assigns this property](https://github.com/Automattic/jetpack/blob/c9b319fdcf9efb7411b8d53bf4d4b16b206c1371/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php#L114-L115) but because it was never included in the response format, it was stripped for Jetpack sites. You can see in the [posts endpoint](https://github.com/Automattic/jetpack/blob/c9b319fdcf9efb7411b8d53bf4d4b16b206c1371/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php#L12), for example, how this `meta` response format is detailed.

#### Testing instructions:

Because this is already fixed on WordPress.com where the whitelisting takes place, there's nothing to test here, aside from verifying that a REST API request to a `/sites/%s/media` endpoint includes the `meta` property if more media exists on the site than included in the response (you can reduce request `number` query argument if your site has fewer than 20 media).

https://developer.wordpress.com/docs/api/console/

cc @jeherve @gwwar 