### PR TITLE
Admin: if request doesn't have params, don't send it as application/json

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -126,8 +126,7 @@ function JetpackRestApiClient( root, nonce ) {
 		getProtectCount: () => fetch( `${ apiRoot }jetpack/v4/module/protect/data`, {
 			credentials: 'same-origin',
 			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
+				'X-WP-Nonce': apiNonce
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
@@ -144,16 +143,14 @@ function JetpackRestApiClient( root, nonce ) {
 		getVaultPressData: () => fetch( `${ apiRoot }jetpack/v4/module/vaultpress/data`, {
 			credentials: 'same-origin',
 			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
+				'X-WP-Nonce': apiNonce
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
 		getAkismetData: () => fetch( `${ apiRoot }jetpack/v4/module/akismet/data`, {
 			credentials: 'same-origin',
 			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
+				'X-WP-Nonce': apiNonce
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
@@ -170,8 +167,7 @@ function JetpackRestApiClient( root, nonce ) {
 		getPluginUpdates: () => fetch( `${ apiRoot }jetpack/v4/updates/plugins`, {
 			credentials: 'same-origin',
 			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
+				'X-WP-Nonce': apiNonce
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() ),
@@ -197,8 +193,7 @@ function JetpackRestApiClient( root, nonce ) {
 				method: 'get',
 				credentials: 'same-origin',
 				headers: {
-					'X-WP-Nonce': apiNonce,
-					'Content-type': 'application/json'
+					'X-WP-Nonce': apiNonce
 				}
 			} )
 			.then( checkStatus ).then( response => response.json() )
@@ -220,8 +215,7 @@ function JetpackRestApiClient( root, nonce ) {
 			method: 'get',
 			credentials: 'same-origin',
 			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
+				'X-WP-Nonce': apiNonce
 			}
 		} )
 		.then( checkStatus ).then( response => response.json() )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Don't set content-type to 'application-json' when requests to REST API are not sending parameters

#### Testing instructions:
* build and check dashboard. All network calls should be 200, specially 
protect/data
vaultpress/data
akismet/data
update/plugins
site
plugins

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Admin: updated to work with 4.7 upcoming changes in error handling in REST API.

cc @dereksmart for review