### PR TITLE
IDC: Add non-admins notice, and allow it to be dismissed on non-Jetpa…

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -17,7 +17,6 @@
 
 	// If the user dismisses the notice, set a cookie for one week so we don't display it for that time.
 	notice.on( 'click.wp-dismiss-notice', function() {
-		console.log( 'dismissed' );
 		var secure = ( 'https:' === window.location.protocol );
 		wpCookies.set( 'jetpack_idc_dismiss_notice', '1', 7 * 24 * 60 * 60, false, false, secure );
 	} );

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -1,4 +1,4 @@
-/* global idcL10n, jQuery, analytics, history */
+/* global idcL10n, jQuery, analytics, history, wpCookies */
 
 ( function( $ ) {
 	var restNonce = idcL10n.nonce,
@@ -14,6 +14,13 @@
 	analytics.initialize( tracksUser.userid, tracksUser.username );
 	trackAndBumpMCStats( 'notice_view' );
 	clearConfirmationArgsFromUrl();
+
+	// If the user dismisses the notice, set a cookie for one week so we don't display it for that time.
+	notice.on( 'click.wp-dismiss-notice', function() {
+		console.log( 'dismissed' );
+		var secure = ( 'https:' === window.location.protocol );
+		wpCookies.set( 'jetpack_idc_dismiss_notice', '1', 7 * 24 * 60 * 60, false, false, secure );
+	} );
 
 	// Confirm Safe Mode
 	confirmSafeModeButton.click( function() {

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -25,6 +25,12 @@ class Jetpack_IDC {
 	static $is_safe_mode_confirmed;
 
 	/**
+	 * The current screen, which is set if the current user is a non-admin and this is an admin page.
+	 * @var WP_Screen
+	 */
+	static $current_screen;
+
+	/**
 	 * The link to the support document used to explain Safe Mode to users
 	 * @var string
 	 */
@@ -48,7 +54,10 @@ class Jetpack_IDC {
 	}
 
 	function wordpress_init() {
-		if ( ! current_user_can( 'jetpack_disconnect' ) ) {
+		if ( ! current_user_can( 'jetpack_disconnect' ) && is_admin() ) {
+			add_action( 'admin_notices', array( $this, 'display_non_admin_idc_notice' ) );
+			add_action( 'admin_enqueue_scripts', array( $this,'enqueue_idc_notice_files' ) );
+			add_action( 'current_screen', array( $this, 'non_admins_current_screen_check' ) );
 			return;
 		}
 
@@ -69,6 +78,20 @@ class Jetpack_IDC {
 		if ( is_admin() && ! self::$is_safe_mode_confirmed ) {
 			add_action( 'admin_notices', array( $this, 'display_idc_notice' ) );
 			add_action( 'admin_enqueue_scripts', array( $this,'enqueue_idc_notice_files' ) );
+		}
+	}
+
+	function non_admins_current_screen_check( $current_screen ) {
+		self::$current_screen = $current_screen;
+		if ( isset( $current_screen->id ) && 'toplevel_page_jetpack' == $current_screen->id ) {
+			return null;
+		}
+
+		// If the user has dismissed the notice, and we're not currently on a Jetpack page,
+		// then do not show the non-admin notice.
+		if ( isset( $_COOKIE, $_COOKIE['jetpack_idc_dismiss_notice'] ) ) {
+			remove_action( 'admin_notices', array( $this, 'display_non_admin_idc_notice' ) );
+			remove_action( 'admin_enqueue_scripts', array( $this,'enqueue_idc_notice_files' ) );
 		}
 	}
 
@@ -107,6 +130,27 @@ class Jetpack_IDC {
 		return untrailingslashit( Jetpack::normalize_url_protocol_agnostic( $url ) );
 	}
 
+	function display_non_admin_idc_notice() {
+		$classes = 'jp-idc-notice is-non-admin notice notice-warning';
+		if ( isset( self::$current_screen ) && 'toplevel_page_jetpack' != self::$current_screen->id ) {
+			$classes .= ' is-dismissible';
+		}
+		?>
+
+		<div class="<?php echo $classes; ?>">
+			<?php $this->render_notice_header(); ?>
+			<div class="jp-idc-notice__content-header">
+				<h3 class="jp-idc-notice__content-header__lead">
+					<?php echo $this->get_non_admin_notice_text(); ?>
+				</h3>
+
+				<p class="jp-idc-notice__content-header__explanation">
+					<?php echo $this->get_non_admin_contact_admin_text(); ?>
+				</p>
+			</div>
+		</div>
+	<?php }
+
 	/**
 	 * First "step" of the IDC mitigation. Will provide some messaging and two options/buttons.
 	 * "Confirm Staging" - Dismiss the notice and continue on with our lives in staging mode.
@@ -114,17 +158,7 @@ class Jetpack_IDC {
 	 */
 	function display_idc_notice() { ?>
 		<div class="jp-idc-notice notice notice-warning">
-			<div class="jp-idc-notice__header">
-				<div class="jp-idc-notice__header__emblem">
-					<?php echo Jetpack::get_jp_emblem(); ?>
-				</div>
-				<p class="jp-idc-notice__header__text">
-					<?php esc_html_e( 'Jetpack Safe Mode', 'jetpack' ); ?>
-				</p>
-			</div>
-
-			<div class="jp-idc-notice__separator"></div>
-
+			<?php $this->render_notice_header(); ?>
 			<?php $this->render_notice_first_step(); ?>
 			<?php $this->render_notice_second_step(); ?>
 		</div>
@@ -159,7 +193,7 @@ class Jetpack_IDC {
 				'apiRoot' => esc_url_raw( rest_url() ),
 				'nonce' => wp_create_nonce( 'wp_rest' ),
 				'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
-				'currentUrl' => remove_query_arg( '_wpnonce', remove_query_arg( 'jetpack_idc_clear_confirmation' ) ),
+				'currentUrl' => remove_query_arg( '_wpnonce', remove_query_arg( 'jetpack_idc_clear_confirmation' ) )
 			)
 		);
 
@@ -194,6 +228,19 @@ class Jetpack_IDC {
 			false
 		);
 	}
+
+	function render_notice_header() { ?>
+		<div class="jp-idc-notice__header">
+			<div class="jp-idc-notice__header__emblem">
+				<?php echo Jetpack::get_jp_emblem(); ?>
+			</div>
+			<p class="jp-idc-notice__header__text">
+				<?php esc_html_e( 'Jetpack Safe Mode', 'jetpack' ); ?>
+			</p>
+		</div>
+
+		<div class="jp-idc-notice__separator"></div>
+	<?php }
 
 	function render_notice_first_step() { ?>
 		<div class="jp-idc-notice__first-step">
@@ -503,6 +550,41 @@ class Jetpack_IDC {
 		 * @param string $html The HTML to be displayed
 		 */
 		return apply_filters( 'jetpack_idc_unsure_prompt', $html );
+	}
+
+	function get_non_admin_notice_text() {
+		$html = wp_kses(
+			sprintf(
+				__(
+					'Jetpack has been placed into Safe Mode. <a href="%1$s">Click Here</a> for more information.',
+					'jetpack'
+				),
+				esc_url( self::SAFE_MODE_DOC_LINK )
+			),
+			array( 'a' => array( 'href' => array() ) )
+		);
+
+		/**
+		 * Allows overriding of the default text that is displayed to non-admin on the Jetpack admin page.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param string $html The HTML to be displayed
+		 */
+		return apply_filters( 'jetpack_idc_non_admin_notice_text', $html );
+	}
+
+	function get_non_admin_contact_admin_text() {
+		$string = esc_html__( 'An administrator of this site can take Jetpack out of Safe Mode.', 'jetpack' );
+
+		/**
+		 * Allows overriding of the default text that is displayed to non-admins prompting them to contact an admin.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param string $string The string to be displayed
+		 */
+		return apply_filters( 'jetpack_idc_non_admin_contact_admin_text', $string );
 	}
 }
 

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -556,7 +556,7 @@ class Jetpack_IDC {
 		$html = wp_kses(
 			sprintf(
 				__(
-					'Jetpack has been placed into Safe Mode. <a href="%1$s">Click Here</a> for more information.',
+					'Jetpack has been placed into Safe Mode. Learn more about <a href="%1$s">Safe Mode</a>.',
 					'jetpack'
 				),
 				esc_url( self::SAFE_MODE_DOC_LINK )

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -1,13 +1,26 @@
 @import '../_inc/client/scss/variables/_colors.scss';
 
+@media all and ( min-width: 783px ) {
+	body.toplevel_page_jetpack {
+		.jp-idc-notice {
+			margin-top: 40px;
+		}
+	}
+}
+
 .jp-idc-notice, 
 .jp-idc-notice * {
 	box-sizing: border-box;
 }
 
 .jp-idc-notice {
+	overflow: auto;
 	padding-bottom: 16px;
 	padding-top: 0;
+
+	&.is-non-admin {
+		padding-bottom: 0;
+	}
 }
 
 .jp-idc-notice p {
@@ -151,9 +164,17 @@
 	height: 1px;
 }
 
+.jp-idc-notice.is-dismissible .jp-idc-notice__separator {
+	margin-right: -46px;
+}
+
 @media only screen and ( min-width: 782px ) {
 	.jp-idc-notice__separator {
 		margin: 0 -12px 0 -12px;
+	}
+
+	.jp-idc-notice.is-dismissible .jp-idc-notice__separator {
+		margin-right: -38px;
 	}
 }
 


### PR DESCRIPTION
Closes #5532. 

Since we decided to hide the Jetpack admin page UI while in IDC, we need to show some basic UI for non-admins who happen to be in this state. We anticipate that this is an edge case, but we needed at least something so we're not showing a blank page.

So, what we decided to do was show a notice for non-admins that lets the non-admin know that Jetpack is in "Safe Mode", points them to documentation, and prompts the user to contact an admin to take the site out of "Safe Mode".

This notice is displayed throughout the admin, until it is dismissed. After that, it is only shown on the Jetpack page.

To test:

- Checkout `update/idc-non-admins-notice` 
- Put your site in IDC (ping me if you need help with this)
- While signed in as an admin, ensure that you see a notice like this throughout the admin area

    <img width="903" alt="screen shot 2016-11-07 at 1 52 09 pm" src="https://cloud.githubusercontent.com/assets/1126811/20073349/7e6845e6-a4f1-11e6-9b2c-c7a4098afd09.png">
- Log in as a non-admin
- Go to your profile page
- Ensure that you can dismiss the notice
- Reload the page
- Ensure the notice does not show again
- Go to the `Jetpack` admin menu
- Ensure that you see the notice


### Screenshots

![screen shot 2016-11-07 at 1 49 01 pm](https://cloud.githubusercontent.com/assets/1126811/20073226/ffa6b026-a4f0-11e6-98bd-1737b46a9cb6.png)

![screen shot 2016-11-07 at 1 48 52 pm](https://cloud.githubusercontent.com/assets/1126811/20073229/ffc06462-a4f0-11e6-94da-11b04c291eb5.png)

![screen shot 2016-11-07 at 1 48 55 pm](https://cloud.githubusercontent.com/assets/1126811/20073228/ffbec21a-a4f0-11e6-8f20-03270a7860a7.png)


![screen shot 2016-11-07 at 1 49 04 pm](https://cloud.githubusercontent.com/assets/1126811/20073227/ffb78568-a4f0-11e6-8fb4-65a0aaa951a4.png)

