### PR TITLE
Photon: Default to HTTPS

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -142,7 +142,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	 * @param string http://i{$subdomain}.wp.com Domain used by Photon. $subdomain is a random number between 0 and 2.
 	 * @param string $image_url URL of the image to be photonized.
 	 */
-	$photon_domain = apply_filters( 'jetpack_photon_domain', "http://i{$subdomain}.wp.com", $image_url );
+	$photon_domain = apply_filters( 'jetpack_photon_domain', "https://i{$subdomain}.wp.com", $image_url );
 	$photon_domain = trailingslashit( esc_url( $photon_domain ) );
 	$photon_url  = $photon_domain . $image_host_path;
 
@@ -235,7 +235,7 @@ add_filter( 'jetpack_photon_any_extension_for_domain',   'jetpack_photon_allow_f
 
 function jetpack_photon_url_scheme( $url, $scheme ) {
 	if ( ! in_array( $scheme, array( 'http', 'https', 'network_path' ) ) ) {
-		$scheme = is_ssl() ? 'https' : 'http';
+		$scheme = 'https';
 	}
 
 	if ( 'network_path' == $scheme ) {

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -139,7 +139,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	 *
 	 * @since 3.4.2
 	 *
-	 * @param string http://i{$subdomain}.wp.com Domain used by Photon. $subdomain is a random number between 0 and 2.
+	 * @param string https://i{$subdomain}.wp.com Domain used by Photon. $subdomain is a random number between 0 and 2.
 	 * @param string $image_url URL of the image to be photonized.
 	 */
 	$photon_domain = apply_filters( 'jetpack_photon_domain', "https://i{$subdomain}.wp.com", $image_url );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/4601

#### Changes proposed in this Pull Request:

Currently, Photon respects the current host's scheme (via `is_ssl`) when deciding how to generate a Photon URL. I argue that in an effort to adopt universal HTTPS, we should always default to HTTPS, unless explicitly overridden by the `$scheme` argument on `jetpack_photon_url`. It may be that HTTPS was previously not the default due to the myth that TLS is slower and therefore not a good default. See also: https://istlsfastyet.com/

#### Testing instructions:

Verify that Photon continues to display as expected.

In [the Calypso post editor](https://wordpress.com/post) in a browser with strict [mixed content](https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content#passive-mixed-content) settings, note that gallery previews are shown correctly as long as Photon is enabled.

cc @lancewillett 