### PR TITLE
Add IDC Notice error messages 

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -107,7 +107,7 @@
 			},
 			error: function( error ) {
 				erroredAction = 'confirm';
-				displayErrorNotice( error.responseJSON.message );
+				displayErrorNotice( error );
 				enableDopsButtons();
 			}
 		} );
@@ -136,7 +136,7 @@
 			},
 			error: function( error ) {
 				erroredAction = 'migrate';
-				displayErrorNotice( error.responseJSON.message );
+				displayErrorNotice( error );
 				enableDopsButtons();
 			}
 		} );
@@ -171,7 +171,7 @@
 			},
 			error: function( error ) {
 				erroredAction = 'start-fresh';
-				displayErrorNotice( error.responseJSON.message );
+				displayErrorNotice( error );
 				enableDopsButtons();
 			}
 		} );
@@ -180,11 +180,16 @@
 	/**
 	 * Displays an error message from the REST endpoints we're hitting.
 	 *
-	 * @param errorMessage String of the error message details
+	 * @param error {Object} Object containing the errored response from the API
 	 */
-	function displayErrorNotice( errorMessage ) {
+	function displayErrorNotice( error ) {
+		var errorDescription = $( '.jp-idc-error__desc' );
+		if ( error && error.responseJSON && error.responseJSON.message ) {
+			errorDescription.html( error.responseJSON.message );
+		} else {
+			errorDescription.html( '' );
+		}
 		errorNotice.css( 'display', 'flex' );
-		$( '.jp-idc-error__desc' ).html( errorMessage );
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -712,6 +712,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool | WP_Error True if option is properly set.
 	 */
 	public static function confirm_safe_mode() {
+		return new WP_Error( 'error_confirming_safe_mode', esc_html__( 'Jetpack could not confirm safe mode.', 'jetpack' ), array( 'status' => 500 ) );
 		$updated = Jetpack_Options::update_option( 'safe_mode_confirmed', true );
 		if ( $updated ) {
 			return rest_ensure_response(
@@ -735,6 +736,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool | WP_Error True if option is properly set.
 	 */
 	public static function migrate_stats_and_subscribers() {
+		return new WP_Error(
+			'error_setting_jetpack_migrate',
+			esc_html__( 'Could not confirm migration.', 'jetpack' ),
+			array( 'status' => 500 )
+		);
+
 		$deleted = Jetpack_Options::delete_option( 'sync_error_idc' );
 
 		if ( ! $deleted ) {
@@ -773,6 +780,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function start_fresh_connection() {
+		return new WP_Error( 'build_connect_url_failed', esc_html__( 'Unable to build the connect URL.  Please reload the page and try again.', 'jetpack' ), array( 'status' => 400 ) );
+
 		// First clear the options / disconnect.
 		Jetpack::disconnect();
 		return self::build_connect_url();

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -712,7 +712,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool | WP_Error True if option is properly set.
 	 */
 	public static function confirm_safe_mode() {
-		return new WP_Error( 'error_confirming_safe_mode', esc_html__( 'Jetpack could not confirm safe mode.', 'jetpack' ), array( 'status' => 500 ) );
 		$updated = Jetpack_Options::update_option( 'safe_mode_confirmed', true );
 		if ( $updated ) {
 			return rest_ensure_response(
@@ -736,12 +735,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool | WP_Error True if option is properly set.
 	 */
 	public static function migrate_stats_and_subscribers() {
-		return new WP_Error(
-			'error_setting_jetpack_migrate',
-			esc_html__( 'Could not confirm migration.', 'jetpack' ),
-			array( 'status' => 500 )
-		);
-
 		$deleted = Jetpack_Options::delete_option( 'sync_error_idc' );
 
 		if ( ! $deleted ) {
@@ -780,8 +773,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function start_fresh_connection() {
-		return new WP_Error( 'build_connect_url_failed', esc_html__( 'Unable to build the connect URL.  Please reload the page and try again.', 'jetpack' ), array( 'status' => 400 ) );
-
 		// First clear the options / disconnect.
 		Jetpack::disconnect();
 		return self::build_connect_url();

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -270,6 +270,31 @@ class Jetpack_IDC {
 		<div class="jp-idc-notice__separator"></div>
 	<?php }
 
+	/**
+	 * Is a container for the error notices.
+	 * Will be shown/controlled by jQuery in idc-notice.js
+	 */
+	function render_error_notice() { ?>
+		<div class="jp-idc-error__notice dops-notice is-error">
+			<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" viewBox="0 0 24 24">
+				<g>
+					<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path>
+				</g>
+			</svg>
+			<div class="dops-notice__content">
+				<span class="dops-notice__text">
+					<?php esc_html_e( 'Something went wrong:', 'jetpack' ); ?>
+					<span class="jp-idc-error__desc"></span>
+				</span>
+				<a class="dops-notice__action" href="javascript:void(0);">
+					<span id="jp-idc-error__action">
+						<?php esc_html_e( 'Try Again', 'jetpack' ); ?>
+					</span>
+				</a>
+			</div>
+		</div>
+	<?php }
+
 	function render_notice_first_step() { ?>
 		<div class="jp-idc-notice__first-step">
 			<div class="jp-idc-notice__content-header">
@@ -281,6 +306,8 @@ class Jetpack_IDC {
 					<?php echo $this->get_first_step_header_explanation(); ?>
 				</p>
 			</div>
+
+			<?php $this->render_error_notice(); ?>
 
 			<div class="jp-idc-notice__actions">
 				<div class="jp-idc-notice__action">
@@ -311,6 +338,8 @@ class Jetpack_IDC {
 					<?php echo $this->get_second_step_header_lead(); ?>
 				</h3>
 			</div>
+
+			<?php $this->render_error_notice(); ?>
 
 			<div class="jp-idc-notice__actions">
 				<div class="jp-idc-notice__action">

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -34,16 +34,17 @@
 	}
 }
 
-.jp-idc-notice {
-	a,
-	a:visited {
+.jp-idc-notice a:not( .dops-notice__action ) {
+	color: $blue-wordpress;
+	text-decoration: none;
+
+	&:visited {
 		color: $blue-wordpress;
-		text-decoration: none;
 	}
 
-	a:hover,
-	a:focus,
-	a:active {
+	&:hover,
+	&:focus,
+	&:active {
 		color: $link-highlight;
 	}
 }

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -181,3 +181,12 @@
 .jp-idc-notice .jp-idc-notice__unsure-prompt {
 	margin: 16px 0 0;
 }
+
+.jp-idc-error__notice {
+	display: none;
+
+	.dops-notice__icon {
+		height: auto;
+		width: auto;
+	}
+}

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -191,3 +191,9 @@
 		width: auto;
 	}
 }
+
+@media only screen and ( min-width: 683px ) {
+	.jp-idc-error__notice .dops-notice__text {
+		line-height: 24px;
+	}
+}


### PR DESCRIPTION
Closes #5531

![screen shot 2016-11-07 at 6 38 58 pm](https://cloud.githubusercontent.com/assets/7129409/20080817/c6f5e9d0-a519-11e6-99ed-f2270ce7379d.png)

This will show a notice within the notice (notice-ception) if there are API errors during the mitigation. 

To Test: 
- `git revert 12c132f` (this will force the API to error for these endpoints)
- Expect that `Confirm Staging`, `Migrate Stats` & `Start Fresh` buttons will all throw an error
- Make sure that `Try Again` button actually tries again (check network console for correct API requests)
- Make sure the styles look ok and consistent with dops-components. 
- Make sure everything is still tracking