### PR TITLE
Add Themes New api endpoint.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3090,6 +3090,12 @@ p {
 					'type' => $attachment->post_mime_type,
 					'meta' => wp_get_attachment_metadata( $attachment_id ),
 				);
+				// Zip files uploads are not supported unless they are done for installation purposed
+				// lets delete them in case something goes wrong in this whole process
+				if ( 'application/zip' === $attachment->post_mime_type ) {
+					// Schedule a cleanup for 2 hours from now in case of failed install.
+					wp_schedule_single_event( time() + 2 * HOUR_IN_SECONDS, 'upgrader_scheduled_cleanup', array( $attachment_id ) );
+				}
 			}
 		}
 		if ( ! is_null( $global_post ) ) {

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -384,6 +384,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		case 'safehtml' :
 			$return[$key] = wp_kses( (string) $value, wp_kses_allowed_html() );
 			break;
+		case 'zip' :
 		case 'media' :
 			if ( is_array( $value ) ) {
 				if ( isset( $value['name'] ) && is_array( $value['name'] ) ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -12,7 +12,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
 	protected function install() {
 		foreach ( $this->plugins as $index => $slug ) {
 
-			$skin      = new Jetpack_Automatic_Plugin_Install_Skin();
+			$skin      = new Jetpack_Automatic_Install_Skin();
 			$upgrader  = new Plugin_Upgrader( $skin );
 			$zip_url   = self::generate_wordpress_org_plugin_download_link( $slug );
 
@@ -98,7 +98,7 @@ class Jetpack_JSON_API_Plugins_Install_Endpoint extends Jetpack_JSON_API_Plugins
  * Allows us to capture that the site doesn't have proper file system access.
  * In order to update the plugin.
  */
-class Jetpack_Automatic_Plugin_Install_Skin extends Automatic_Upgrader_Skin {
+class Jetpack_Automatic_Install_Skin extends Automatic_Upgrader_Skin {
 	/**
 	 * Stores the last error key;
 	 **/

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-new-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-new-endpoint.php
@@ -1,0 +1,82 @@
+<?php
+
+include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+include_once ABSPATH . 'wp-admin/includes/file.php';
+
+class Jetpack_JSON_API_Themes_New_Endpoint extends Jetpack_JSON_API_Themes_Endpoint {
+
+	// POST  /sites/%s/themes/%s/install
+	protected $needed_capabilities = 'install_themes';
+	protected $action              = 'install';
+	protected $download_links      = array();
+
+	protected function validate_call( $_blog_id, $capability, $check_manage_active = true ) {
+		$validate = parent::validate_call( $_blog_id, $capability, $check_manage_active );
+		if ( is_wp_error( $validate ) ) {
+			// Lets delete the attachment... if the user doesn't have the right permissions to do things.
+			$args = $this->input();
+			if ( isset( $args['zip'][0]['id'] ) ) {
+				wp_delete_attachment( $args['zip'][0]['id'], true );
+			}
+		}
+
+		return $validate;
+	}
+
+	protected function validate_input( $theme ) {
+		$this->bulk    = false;
+		$this->themes = array();
+	}
+
+	function install() {
+		$args = $this->input();
+
+		if ( isset( $args['zip'][0]['id'] ) ) {
+			$attachment_id = $args['zip'][0]['id'];
+			$local_file           = get_attached_file( $attachment_id );
+			if ( ! $local_file ) {
+				return new WP_Error( 'local-file-does-not-exist' );
+			}
+			$skin      = new Jetpack_Automatic_Install_Skin();
+			$upgrader  = new Theme_Upgrader( $skin );
+
+			$pre_install_list = wp_get_themes();
+			$result           = $upgrader->install( $local_file );
+
+			// clean up.
+			wp_delete_attachment( $attachment_id, true );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$after_install_list = wp_get_themes();
+			$plugin             = array_values( array_diff( array_keys( $after_install_list ), array_keys( $pre_install_list ) ) );
+
+			if ( ! $result ) {
+				$error_code = $upgrader->skin->get_main_error_code();
+				$message    = $upgrader->skin->get_main_error_message();
+				if ( empty( $message ) ) {
+					$message = __( 'An unknown error occurred during installation', 'jetpack' );
+				}
+
+				if ( 'download_failed' === $error_code ) {
+					$error_code = 'no_package';
+				}
+
+				return new WP_Error( $error_code, $message, 400 );
+			}
+
+			if ( empty( $plugin ) ) {
+				return new WP_Error( 'theme_already_installed' );
+			}
+
+			$this->themes            = $plugin;
+			$this->log[ $plugin[0] ] = $upgrader->skin->get_upgrade_messages();
+
+			return true;
+		}
+
+		return new WP_Error( 'no_theme_installed' );
+	}
+}

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -75,6 +75,32 @@ new Jetpack_JSON_API_Themes_List_Endpoint( array(
 ) );
 
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-themes-get-endpoint.php' );
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-themes-new-endpoint.php' );
+
+// POST /sites/%s/themes/%new
+new Jetpack_JSON_API_Themes_new_Endpoint( array(
+	'description'     => 'Install a theme to your jetpack blog',
+	'group'           => '__do_not_document',
+	'stat'            => 'themes:new',
+	'method'          => 'POST',
+	'path'            => '/sites/%s/themes/new',
+	'path_labels' => array(
+		'$site'   => '(int|string) The site ID, The site domain',
+	),
+	'request_format' => array(
+		'zip'       => '(zip) Theme package zip file. multipart/form-data encoded. ',
+	),
+	'response_format' => Jetpack_JSON_API_Themes_Endpoint::$_response_format,
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/themes/new'
+) );
+
+
+
 new Jetpack_JSON_API_Themes_Get_Endpoint( array(
 	'description'     => 'Get a single theme on a jetpack blog',
 	'group'           => '__do_not_document',


### PR DESCRIPTION
Add a new api endpoint that lets up install a new theme via the api.

Requires wpcom patch D3290-code

cc: @seear 

#5466 
very simular to https://github.com/Automattic/jetpack/pull/5507

would replace https://github.com/Automattic/jetpack/pull/5467

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

