### PR TITLE
IDC: add tracking for non-admin page views

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -18,7 +18,7 @@
 	// Initialize Tracks and bump stats.
 	analytics.initialize( tracksUser.userid, tracksUser.username );
 	if ( tracksEvent.isAdmin ) {
-		trackAndBumpMCStats( 'notice_view' )
+		trackAndBumpMCStats( 'notice_view' );
 	} else {
 		trackAndBumpMCStats( 'non_admin_notice_view', { 'page': tracksEvent.currentScreen } );
 	}
@@ -169,9 +169,12 @@
 	 * @param eventName string
 	 * @param extraProps object
 	 */
-	function trackAndBumpMCStats( eventName, extraProps = {} ) {
-		if ( 'undefined' !== eventName && eventName.length ) {
+	function trackAndBumpMCStats( eventName, extraProps ) {
+		if ( 'undefined' === extraProps || typeof extraProps !== 'object' ) {
+			extraProps = {};
+		}
 
+		if ( 'undefined' !== eventName && eventName.length ) {
 			// Format for Tracks
 			eventName = eventName.replace( /-/g, '_' );
 			eventName = eventName.indexOf( 'jetpack_idc_' ) !== 0 ? 'jetpack_idc_' + eventName : eventName;

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -7,6 +7,7 @@
 		notice = $( '.jp-idc-notice' ),
 		idcButtons = $( '.jp-idc-notice .dops-button' ),
 		tracksUser = idcL10n.tracksUserData,
+		tracksEvent = idcL10n.tracksEventData,
 		adminBarMenu = $( '#wp-admin-bar-jetpack-idc' ),
 		confirmSafeModeButton = $( '#jp-idc-confirm-safe-mode-action' ),
 		fixConnectionButton = $( '#jp-idc-fix-connection-action' ),
@@ -16,7 +17,11 @@
 
 	// Initialize Tracks and bump stats.
 	analytics.initialize( tracksUser.userid, tracksUser.username );
-	trackAndBumpMCStats( 'notice_view' );
+	if ( tracksEvent.isAdmin ) {
+		trackAndBumpMCStats( 'notice_view' )
+	} else {
+		trackAndBumpMCStats( 'non_admin_notice_view', { 'page': tracksEvent.currentScreen } );
+	}
 	clearConfirmationArgsFromUrl();
 
 	// If the user dismisses the notice, set a cookie for one week so we don't display it for that time.
@@ -162,14 +167,15 @@
 	 * MC: Will not be prefixed, and will use dashes.
 	 *
 	 * @param eventName string
+	 * @param extraProps object
 	 */
-	function trackAndBumpMCStats( eventName ) {
+	function trackAndBumpMCStats( eventName, extraProps = {} ) {
 		if ( 'undefined' !== eventName && eventName.length ) {
 
 			// Format for Tracks
 			eventName = eventName.replace( /-/g, '_' );
 			eventName = eventName.indexOf( 'jetpack_idc_' ) !== 0 ? 'jetpack_idc_' + eventName : eventName;
-			analytics.tracks.recordEvent( eventName, {} );
+			analytics.tracks.recordEvent( eventName, { extraProps } );
 
 			// Now format for MC stats
 			eventName = eventName.replace( 'jetpack_idc_', '' );

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -28,6 +28,7 @@
 	notice.on( 'click.wp-dismiss-notice', function() {
 		var secure = ( 'https:' === window.location.protocol );
 		wpCookies.set( 'jetpack_idc_dismiss_notice', '1', 7 * 24 * 60 * 60, false, false, secure );
+		trackAndBumpMCStats( 'non_admin_notice_dismiss', { 'page': tracksEvent.currentScreen } );
 	} );
 
 	// Confirm Safe Mode

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -175,7 +175,7 @@
 			// Format for Tracks
 			eventName = eventName.replace( /-/g, '_' );
 			eventName = eventName.indexOf( 'jetpack_idc_' ) !== 0 ? 'jetpack_idc_' + eventName : eventName;
-			analytics.tracks.recordEvent( eventName, { extraProps } );
+			analytics.tracks.recordEvent( eventName, extraProps );
 
 			// Now format for MC stats
 			eventName = eventName.replace( 'jetpack_idc_', '' );

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -170,11 +170,11 @@
 	 * @param extraProps object
 	 */
 	function trackAndBumpMCStats( eventName, extraProps ) {
-		if ( 'undefined' === extraProps || typeof extraProps !== 'object' ) {
+		if ( 'undefined' === typeof extraProps || 'object' !== typeof extraProps ) {
 			extraProps = {};
 		}
 
-		if ( 'undefined' !== eventName && eventName.length ) {
+		if ( eventName && eventName.length ) {
 			// Format for Tracks
 			eventName = eventName.replace( /-/g, '_' );
 			eventName = eventName.indexOf( 'jetpack_idc_' ) !== 0 ? 'jetpack_idc_' + eventName : eventName;

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -221,7 +221,11 @@ class Jetpack_IDC {
 				'apiRoot' => esc_url_raw( rest_url() ),
 				'nonce' => wp_create_nonce( 'wp_rest' ),
 				'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
-				'currentUrl' => remove_query_arg( '_wpnonce', remove_query_arg( 'jetpack_idc_clear_confirmation' ) )
+				'currentUrl' => remove_query_arg( '_wpnonce', remove_query_arg( 'jetpack_idc_clear_confirmation' ) ),
+				'tracksEventData' => array(
+					'isAdmin' => current_user_can( 'jetpack_disconnect' ),
+					'currentScreen' => self::$current_screen ? self::$current_screen->id : false,
+				),
 			)
 		);
 


### PR DESCRIPTION
Closes #5517

This adds tracking data for non-admins who see an IDC notice. 

- Expect to see an MC stat `non-admin-notice-view`
- Expect to see a Tracks event `jetpack_idc_non_admin_notice_view` with a prop of `page: <page_slug>`
- Expect that admin page tracking should not change.