### PR TITLE
IDC: Add method to clear all IDC options

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -131,8 +131,8 @@ class Jetpack_Client_Server {
 			Jetpack::activate_default_modules( false, false, array(), $redirect_on_activation_error );
 		}
 
-		// Since this is a fresh connection, be sure to clear out the IDC sync error option
-		Jetpack_Options::delete_option( 'sync_error_idc' );
+		// Since this is a fresh connection, be sure to clear out IDC options
+		Jetpack_IDC::clear_all_idc_options();
 
 		// Start nonce cleaner
 		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -158,6 +158,19 @@ class Jetpack_IDC {
 		return untrailingslashit( Jetpack::normalize_url_protocol_agnostic( $url ) );
 	}
 
+	/**
+	 * Clears all IDC specific options. This method is used on disconnect and reconnect.
+	 */
+	static function clear_all_idc_options() {
+		Jetpack_Options::delete_option(
+			array(
+				'sync_error_idc',
+				'safe_mode_confirmed',
+				'migrate_for_idc',
+			)
+		);
+	}
+
 	function display_non_admin_idc_notice() {
 		$classes = 'jp-idc-notice is-non-admin notice notice-warning';
 		if ( isset( self::$current_screen ) && 'toplevel_page_jetpack' != self::$current_screen->id ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2608,9 +2608,10 @@ p {
 				'master_user',
 				'time_diff',
 				'fallback_no_verify_ssl_certs',
-				'sync_error_idc',
 			)
 		);
+
+		Jetpack_IDC::clear_all_idc_options();
 
 		if ( $update_activated_state ) {
 			Jetpack_Options::update_option( 'activated', 4 );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,6 +64,9 @@
 		</testsuite>
 		<testsuite name="restapi">
 			<directory prefix="test_" suffix="rest-api-endpoints.php">tests/php/_inc/lib</directory>
+		</testsuites>
+		<testsuite name="idc">
+			<file>tests/php/test_class.jetpack-idc.php</file>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,7 +64,7 @@
 		</testsuite>
 		<testsuite name="restapi">
 			<directory prefix="test_" suffix="rest-api-endpoints.php">tests/php/_inc/lib</directory>
-		</testsuites>
+		</testsuite>
 		<testsuite name="idc">
 			<file>tests/php/test_class.jetpack-idc.php</file>
 		</testsuite>

--- a/tests/php/test_class.jetpack-idc.php
+++ b/tests/php/test_class.jetpack-idc.php
@@ -1,0 +1,22 @@
+<?php
+
+class WP_Test_Jetpack_IDC extends WP_UnitTestCase {
+	function test_clear_all_idc_options_clears_expected() {
+		$options = array(
+			'sync_error_idc',
+			'safe_mode_confirmed',
+			'migrate_for_idc',
+		);
+
+		foreach ( $options as $option ) {
+			Jetpack_Options::update_option( $option, true );
+			$this->assertTrue( Jetpack_Options::get_option( $option ) );
+		}
+
+		Jetpack_IDC::clear_all_idc_options();
+
+		foreach ( $options as $option ) {
+			$this->assertFalse( Jetpack_Options::get_option( $option ) );
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a test file to begin testing the `Jetpack_IDC` class and also adds the `Jetpack_IDC:: clear_all_idc_options()` method to assist in clearing all IDC specific options on disconnect/reconnect.

To test:

- Checkout `update/idc-clear-all-options` branch
- Run tests with `phpunit --filter=WP_Test_Jetpack_IDC`



