### PR TITLE
IDC: Minimize reposition jank by rendering notice inline

### DIFF
--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -182,8 +182,9 @@ class Jetpack_IDC {
 		}
 
 		$current_screen = get_current_screen();
+		$tabs = $current_screen->get_help_tabs();
 
-		return ! empty( $current_screen->get_help_tabs() );
+		return ! empty( $tabs );
 	}
 
 	function display_non_admin_idc_notice() {

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -171,10 +171,29 @@ class Jetpack_IDC {
 		);
 	}
 
+	/**
+	 * Does the current admin page have help tabs?
+	 *
+	 * @return bool
+	 */
+	function admin_page_has_help_tabs() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		$current_screen = get_current_screen();
+
+		return ! empty( $current_screen->get_help_tabs() );
+	}
+
 	function display_non_admin_idc_notice() {
-		$classes = 'jp-idc-notice is-non-admin notice notice-warning';
+		$classes = 'jp-idc-notice inline is-non-admin notice notice-warning';
 		if ( isset( self::$current_screen ) && 'toplevel_page_jetpack' != self::$current_screen->id ) {
 			$classes .= ' is-dismissible';
+		}
+
+		if ( $this->admin_page_has_help_tabs() ) {
+			$classes .= ' has-help-tabs';
 		}
 		?>
 
@@ -197,8 +216,13 @@ class Jetpack_IDC {
 	 * "Confirm Staging" - Dismiss the notice and continue on with our lives in staging mode.
 	 * "Fix Jetpack Connection" - Will disconnect the site and start the mitigation...
 	 */
-	function display_idc_notice() { ?>
-		<div class="jp-idc-notice notice notice-warning">
+	function display_idc_notice() {
+		$classes = 'jp-idc-notice inline notice notice-warning';
+		if ( $this->admin_page_has_help_tabs() ) {
+			$classes .= ' has-help-tabs';
+		}
+		?>
+		<div class="<?php echo $classes; ?>">
 			<?php $this->render_notice_header(); ?>
 			<?php $this->render_notice_first_step(); ?>
 			<?php $this->render_notice_second_step(); ?>

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -1,25 +1,30 @@
 @import '../_inc/client/scss/variables/_colors.scss';
 
-@media all and ( min-width: 783px ) {
-	body.toplevel_page_jetpack {
-		.jp-idc-notice {
-			margin-top: 40px;
-		}
-	}
-}
-
-.jp-idc-notice, 
+.jp-idc-notice,
 .jp-idc-notice * {
 	box-sizing: border-box;
 }
 
 .jp-idc-notice {
-	overflow: auto;
+	margin-left: 0;
+	margin-right: 10px;
+	margin-top: 10px;
 	padding-bottom: 16px;
 	padding-top: 0;
 
 	&.is-non-admin {
 		padding-bottom: 0;
+	}
+}
+
+@media all and ( min-width: 783px ) {
+	.jp-idc-notice {
+		margin-right: 20px;
+		margin-top: 20px;
+
+		&.has-help-tabs {
+			margin-top: 48px;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR begins rendering the notice inline (not below an admin page h2) to minimize reposition jankiness.

This PR also handles a style issue that I introduced in with [this line](https://github.com/Automattic/jetpack/pull/5533/files#diff-bbd36c26bf305f48f4959e07ad6699e4R17). Specifically, on admin page that have the contextual help menu, the notice doesn't go full width. 😢 

Below are several screenshots. There is a mobile and desktop section. In each respective section, the screenshots are in this order:

- Jetpack admin page (without rendered JS)
- WP dashboard (notice the contextual help menu)
- Sharing settings (notice the lack of a contextual help menu)

To test:

- Checkout `update/idc-minimize-jank` branch
- Go to each of the above pages
- Ensure that mobile and desktop styles appear OK
- Ensure there is no repositioning

cc @jeffgolenski for review.

Mobile screenshots
==============
<img width="419" alt="screen shot 2016-11-07 at 9 45 03 pm" src="https://cloud.githubusercontent.com/assets/1126811/20086189/f21a49fc-a533-11e6-8c65-237d3863b6d3.png">

<img width="454" alt="screen shot 2016-11-07 at 9 45 26 pm" src="https://cloud.githubusercontent.com/assets/1126811/20086186/f219cb12-a533-11e6-9cc4-b9cd575766a6.png">

<img width="623" alt="screen shot 2016-11-07 at 9 44 35 pm" src="https://cloud.githubusercontent.com/assets/1126811/20086187/f21a04f6-a533-11e6-8ee1-c095bafb0168.png">

Desktop screenshots
===============
<img width="1273" alt="screen shot 2016-11-07 at 9 44 52 pm" src="https://cloud.githubusercontent.com/assets/1126811/20086188/f219f79a-a533-11e6-97eb-fa2177841400.png">

<img width="1223" alt="screen shot 2016-11-07 at 9 45 17 pm" src="https://cloud.githubusercontent.com/assets/1126811/20086190/f21a56e0-a533-11e6-9d66-5479fd936de0.png">

<img width="1271" alt="screen shot 2016-11-07 at 9 44 44 pm" src="https://cloud.githubusercontent.com/assets/1126811/20086191/f21c5076-a533-11e6-86cc-afa328ec2e3e.png">