### PR TITLE
Revert breaking initial state: Load in initial state via localized data

### DIFF
--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -26,20 +26,7 @@ import {
 } from 'state/action-types';
 import { getModulesThatRequireConnection } from 'state/modules';
 
-export const initialConnectionState = {
-	isActive : false,
-	isPublic : false,
-	isStaging: false,
-	devMode: {
-		isActive: false,
-		constant: false,
-		filter  : false,
-		url     : false
-	},
-	isInIdentityCrisis: false
-};
-
-export const status = ( state = { siteConnected: initialConnectionState }, action ) => {
+export const status = ( state = { siteConnected: window.Initial_State.connectionStatus }, action ) => {
 	switch ( action.type ) {
 		case JETPACK_CONNECTION_STATUS_FETCH:
 			return assign( {}, state, { siteConnected: action.siteConnected } );
@@ -61,18 +48,7 @@ export const connectUrl = ( state = '', action ) => {
 	}
 };
 
-export const initialUserDataState = {
-	currentUser: {
-		username   : '',
-		gravatar   : '',
-		isConnected: false,
-		isMaster   : false,
-		permissions: {},
-		wpcomUser  : {}
-	}
-};
-
-export const user = ( state = initialUserDataState, action ) => {
+export const user = ( state = window.Initial_State.userData, action ) => {
 	switch ( action.type ) {
 		case USER_CONNECTION_DATA_FETCH_SUCCESS:
 			return assign( {}, state, action.userConnectionData );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -9,7 +9,7 @@ import get from 'lodash/get';
  */
 import { JETPACK_SET_INITIAL_STATE } from 'state/action-types';
 
-export const initialState = ( state = {}, action ) => {
+export const initialState = ( state = window.Initial_State, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SET_INITIAL_STATE:
 			return assign( {}, state, action.initialState );

--- a/_inc/client/state/jetpack-notices/reducer.js
+++ b/_inc/client/state/jetpack-notices/reducer.js
@@ -35,7 +35,7 @@ const notice = ( state = false, action ) => {
 	}
 };
 
-const dismissed = ( state = [], action ) => {
+const dismissed = ( state = window.Initial_State.dismissedNotices, action ) => {
 	switch ( action.type ) {
 		case JETPACK_ACTION_NOTICES_DISMISS:
 			return assign( {}, state, { [ action.notice ]: true } );


### PR DESCRIPTION
#5390 attempted to reduce the reliance on `window` to set our initial state, but it seemed to be too much as we were getting undefined errors throughout the Main.jsx component.  This is a temporary revert of the breaking piece until we figure out how to more reliably roll in this state.  

cc @eliorivero @zinigor 