### PR TITLE
Grunion: use dashicon instead of non-existent image

### DIFF
--- a/modules/contact-form/class-grunion-contact-form-endpoint.php
+++ b/modules/contact-form/class-grunion-contact-form-endpoint.php
@@ -18,7 +18,7 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 				return new WP_Error(
 					'rest_cannot_view',
 					__( 'Sorry, you cannot view this resource.' ),
-					array( 'status' => rest_authorization_required_code() )
+					array( 'status' => 401 )
 				);
 			}
 
@@ -36,7 +36,7 @@ if ( class_exists( 'WP_REST_Posts_Controller' ) ) {
 				return new WP_Error(
 					'rest_cannot_view',
 					__( 'Sorry, you cannot view this resource.' ),
-					array( 'status' => rest_authorization_required_code() )
+					array( 'status' => 401 )
 				);
 			}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -127,7 +127,7 @@ class Grunion_Contact_Form_Plugin {
 				'not_found'          => __( 'No feedback found', 'jetpack' ),
 				'not_found_in_trash' => __( 'No feedback found', 'jetpack' )
 			),
-			'menu_icon'         	=> GRUNION_PLUGIN_URL . '/images/grunion-menu.png',
+			'menu_icon'         	=> 'dashicons-feedback',
 			'show_ui'           	=> TRUE,
 			'show_in_admin_bar' 	=> FALSE,
 			'public'            	=> FALSE,


### PR DESCRIPTION
#5408 starting referencing an image that doesn't exist: `contact-form/images/grunion-menu.png`

#### Steps to reproduce the issue
Load wp-admin with Contact Forms enabled.  Look in your browser's js console.  

#### To Test: 
- Enable contact forms.
- Make sure the icon looks ok and there's no console error. 

@timmyc Is there any reason to use the image over the dashicon?  
cc @zinigor