### PR TITLE
Sharing: Fix ReCaptcha error if ReCaptcha is defined but not on the page

### DIFF
--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -357,7 +357,7 @@ var updateLinkedInCount = function( data ) {
 					$( '#sharing_email form a.sharing_cancel' ).show();
 
 					// Reset reCATPCHA if exists.
-					if ( 'object' === typeof grecaptcha && 'function' === typeof grecaptcha.reset ) {
+					if ( 'object' === typeof grecaptcha && 'function' === typeof grecaptcha.reset && window['___grecaptcha_cfg'].count ) {
 						grecaptcha.reset();
 					}
 


### PR DESCRIPTION
Fixes #5546

#### Changes proposed in this Pull Request:
- Update sharing.js to check if any ReCaptcha widgets are on page

#### Testing instructions:
- `gulp js:hint`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Sharing: ReCaptcha error fix for emails

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

