### PR TITLE
Protect: return a 401 error code on the math collection page.

### DIFF
--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -81,10 +81,10 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				<p><input type="submit" value="<?php esc_html_e( 'Continue &rarr;', 'jetpack' ); ?>"></p>
 			</form>
 		<?php
-			$mathage = ob_get_contents();
+			$mathpage = ob_get_contents();
 			ob_end_clean();
 			wp_die(
-				$mathage,
+				$mathpage,
 				'',
 				'401'
 			);

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -83,7 +83,11 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 		<?php
 			$mathage = ob_get_contents();
 			ob_end_clean();
-			wp_die( $mathage );
+			wp_die(
+				$mathage,
+				'',
+				'401'
+			);
 		}
 
 		public function process_generate_math_page() {


### PR DESCRIPTION
Related: #2352

Reported here:
https://wordpress.org/support/topic/http-status-500-on-capcha-validation/