### PR TITLE
Add email_post_to_subscribers_event instead of a post object attribute.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -222,6 +222,14 @@ class Jetpack_Subscriptions {
 				update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', $_POST['_jetpack_dont_email_post_to_subs'] );
 			}
 		}
+
+		if ( ! Jetpack::is_module_active( 'subscriptions' )  ) {
+			return;
+		}
+
+		if ( ! get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs' ) ) {
+			do_action( 'jetpack_email_post_to_subscribers', $post->ID );
+		}
 	}
 
 	/**

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -30,6 +30,8 @@ class Jetpack_Subscriptions {
 
 	public static $hash;
 
+	static $send_email = false;
+
 	/**
 	 * Singleton
 	 * @static
@@ -75,6 +77,7 @@ class Jetpack_Subscriptions {
 		add_action( 'post_submitbox_misc_actions', array( $this, 'subscription_post_page_metabox' ) );
 
 		add_action( 'transition_post_status', array( $this, 'maybe_send_subscription_email' ), 10, 3 );
+		add_action( 'wp_insert_post', array( $this, 'maybe_trigger_send_email_action' ), 11, 3 );
 	}
 
 	function post_is_public( $the_post ) {
@@ -223,12 +226,18 @@ class Jetpack_Subscriptions {
 			}
 		}
 
+		if ( ! get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs' ) ) {
+			self::$send_email = $post->ID;
+		}
+
+	}
+
+	function maybe_trigger_send_email_action( $post_ID ) {
 		if ( ! Jetpack::is_module_active( 'subscriptions' )  ) {
 			return;
 		}
-
-		if ( ! get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs' ) ) {
-			do_action( 'jetpack_email_post_to_subscribers', $post->ID );
+		if ( self::$send_email === $post_ID ) {
+			do_action( 'jetpack_email_post_to_subscribers', $post_ID );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -23,6 +23,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'wp_insert_post', $callable, 10, 3 );
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
+		add_action( 'jetpack_email_post_to_subscribers', $callable );
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'filter_blacklisted_post_types' ) );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -364,10 +364,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( true, $post_on_server->dont_email_post_to_subs );
 	}
 
-	function test_sync_posts_triggers_email_post_to_suscribers() {
+	function test_sync_posts_triggers_email_post_to_subscribers() {
 
 		// Activate subscription module
-		$active_modules = Jetpack_Options::get_option( 'active_modules' );
 		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
 		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
 		Jetpack_Subscriptions::init();
@@ -375,24 +374,16 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$post_id = $this->factory->post->create();
 		$this->sender->do_sync();
 
-		// Revert back
-		Jetpack_Options::update_option( 'active_modules', $active_modules );
-
 		$email_post_id = $this->server_event_storage->get_most_recent_event( 'jetpack_email_post_to_subscribers' )->args[0];
 		$this->assertEquals( $post_id, $email_post_id );
 
 	}
 
 	function test_sync_post_includes_dont_email_post_to_subs_when_subscription_is_not_active() {
-		$active_modules = Jetpack::get_active_modules();
-		Jetpack_Options::update_option( 'active_modules', array() );
-		// Subscription is not an active module
-		$this->assertTrue( ! in_array( 'subscriptions', Jetpack::get_active_modules() ) );
 		$post_id = $this->factory->post->create();
 
 		$this->sender->do_sync();
-		// restore back to normal
-		Jetpack_Options::update_option( 'active_modules', $active_modules );
+
 		$post_on_server = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->args[1];
 
 		$email_post_to_subscribers_event = $this->server_event_storage->get_most_recent_event( 'jetpack_email_post_to_subscribers' );


### PR DESCRIPTION
Creates a do action for when a subscription to the users should go out. This works more like the current publicize action. Which gets sent to us when a subscription is supposed to go out. 

This PR still needs the .com side to be done. 

Replaces https://github.com/Automattic/jetpack/pull/5491 

cc: @lezama, @gravityrail, @zinigor 
