### PR TITLE
IDC: Fix incorrect display of error notice

### DIFF
--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -267,12 +267,14 @@ class Jetpack_IDC {
 			)
 		);
 
-		wp_register_style(
-			'jetpack-dops-style',
-			plugins_url( '_inc/build/admin.dops-style.css', JETPACK__PLUGIN_FILE ),
-			array(),
-			JETPACK__VERSION
-		);
+		if ( ! wp_style_is( 'jetpack-dops-style' ) ) {
+			wp_register_style(
+				'jetpack-dops-style',
+				plugins_url( '_inc/build/admin.dops-style.css', JETPACK__PLUGIN_FILE ),
+				array(),
+				JETPACK__VERSION
+			);
+		}
 
 		wp_enqueue_style(
 			'jetpack-idc-css',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3187,7 +3187,21 @@ p {
 	function admin_banner_styles() {
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-		wp_enqueue_style( 'jetpack', plugins_url( "css/jetpack-banners{$min}.css", JETPACK__PLUGIN_FILE ), false, JETPACK__VERSION . '-20121016' );
+		if ( ! wp_style_is( 'jetpack-dops-style' ) ) {
+			wp_register_style(
+				'jetpack-dops-style',
+				plugins_url( '_inc/build/admin.dops-style.css', JETPACK__PLUGIN_FILE ),
+				array(),
+				JETPACK__VERSION
+			);
+		}
+
+		wp_enqueue_style(
+			'jetpack',
+			plugins_url( "css/jetpack-banners{$min}.css", JETPACK__PLUGIN_FILE ),
+			array( 'jetpack-dops-style' ),
+			 JETPACK__VERSION . '-20121016'
+		);
 		wp_style_add_data( 'jetpack', 'rtl', 'replace' );
 		wp_style_add_data( 'jetpack', 'suffix', $min );
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2873,9 +2873,8 @@ p {
 				$args,
 				true
 			);
-		} else {
+		} else if ( $this->can_display_jetpack_manage_notice() && ! Jetpack_Options::get_option( 'dismissed_manage_banner' ) ) {
 			// Show the notice on the Dashboard only for now
-
 			add_action( 'load-index.php', array( $this, 'prepare_manage_jetpack_notice' ) );
 		}
 
@@ -3233,12 +3232,7 @@ p {
 		$screen = get_current_screen();
 
 		// Don't show the connect notice on the jetpack settings page.
-		if ( ! in_array( $screen->base, array( 'dashboard' ) ) || $screen->is_network || $screen->action )
-			return;
-
-		// Only show it if don't have the managment option set.
-		// And not dismissed it already.
-		if ( ! $this->can_display_jetpack_manage_notice() || Jetpack_Options::get_option( 'dismissed_manage_banner' ) ) {
+		if ( ! in_array( $screen->base, array( 'dashboard' ) ) || $screen->is_network || $screen->action ) {
 			return;
 		}
 

--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -188,7 +188,7 @@
 	margin: 16px 0 0;
 }
 
-.jp-idc-error__notice {
+.jp-idc-notice .jp-idc-error__notice {
 	display: none;
 
 	.dops-notice__icon {
@@ -198,7 +198,7 @@
 }
 
 @media only screen and ( min-width: 683px ) {
-	.jp-idc-error__notice .dops-notice__text {
+	.jp-idc-notice .jp-idc-error__notice .dops-notice__text {
 		line-height: 24px;
 	}
 }

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -1,9 +1,6 @@
 @import '_inc/client/scss/functions/rem';
 @import '_inc/client/scss/variables/colors';
 
-// importing dops-comp styles outside of react area. Talk to Jeff or Igor about a plan to clean this up
-@import '_inc/build/admin.dops-style';
-
 .updated { // utlizes some core styles, overrides some others
 	&.jp-banner {
 		position: relative;


### PR DESCRIPTION
While testing today, I noticed an issue where we initially rendered the IDC notice with an error notice. 😱  

![screen shot 2016-11-09 at 8 23 35 am](https://cloud.githubusercontent.com/assets/1126811/20141667/fcfd72bc-a656-11e6-98aa-b9e45364ea08.png)

After some digging, it seems like our CSS to hide that notice initially was being overriden.

![screen shot 2016-11-09 at 8 19 13 am](https://cloud.githubusercontent.com/assets/1126811/20141683/08e47274-a657-11e6-859c-b68893c75e59.png)

So, I handled this in two parts.

1) I increased the specificity of our selector to hide the notice
2) I enqueued the dops admin CSS instead of importing it into the banners css file. This will allow us to minimize including that CSS multiple times on the page

To test:

- Checkout `update/idc-fix-specificity` branch
- Put local site in IDC
- Ensure that the red error isn't displayed immediately
- Check the `jetpack-banners.css` file and ensure it isn't huge with all of the dops CSS
- Deactivate Jetpack and reactivate
- Ensure connection banner shows up properly on plugins page