### PR TITLE
IDC: Sync: Fix error due to Jetpack_Sync_Module_Callables not being d…

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -735,9 +735,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool | WP_Error True if option is properly set.
 	 */
 	public static function migrate_stats_and_subscribers() {
-		$deleted = Jetpack_Options::delete_option( 'sync_error_idc' );
-
-		if ( ! $deleted ) {
+		if ( Jetpack_Options::get_option( 'sync_error_idc' ) && ! Jetpack_Options::delete_option( 'sync_error_idc' ) ) {
 			return new WP_Error(
 				'error_deleting_sync_error_idc',
 				esc_html__( 'Could not delete sync error option.', 'jetpack' ),
@@ -747,8 +745,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$updated = Jetpack_Options::update_option( 'migrate_for_idc', true );
 		if ( $updated ) {
-			// Deleting this transient will force the callables to sync faster.
-			delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
 			return rest_ensure_response(
 				array(
 					'code' => 'success'

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -743,8 +743,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			);
 		}
 
-		$updated = Jetpack_Options::update_option( 'migrate_for_idc', true );
-		if ( $updated ) {
+		if ( Jetpack_Options::get_option( 'migrate_for_idc' ) || Jetpack_Options::update_option( 'migrate_for_idc', true ) ) {
 			return rest_ensure_response(
 				array(
 					'code' => 'success'

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -24,7 +24,12 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
 
 		// For some options, we should always send the change right away!
-		$always_send_updates_to_these_options = array( 'jetpack_active_modules', 'home', 'siteurl' );
+		$always_send_updates_to_these_options = array(
+			'jetpack_active_modules',
+			'home',
+			'siteurl',
+			'jetpack_sync_error_idc'
+		);
 		foreach( $always_send_updates_to_these_options as $option ) {
 			add_action( "update_option_{$option}", array( $this, 'unlock_sync_callable' ) );
 		}


### PR DESCRIPTION
While testing IDC today, I noticed that I was getting several errors while trying to allow migration of subs/stats.

After a bit of debugging, it turns out that this was caused by an uncaught error where we were trying to get a constant from `Jetpack_Module_Sync_Callables`. Now, instead of trying to delete the transient within the endpoint, we rely on the `update_option_$option` being triggered for `jetpack_sync_error_idc` and then clearing the transient with the `Jetpack_Sync_Module_Callables` class.

To test:

- Checkout `update/jetpack-options-delete-option` branch
- Put your site in IDC (ping me if you don't know how
- In IDC notice, click "Fix Jetpack's connection" and then click the migrate button on the left
- Ensure that you don't get an error notice