### PR TITLE
General: Begin testing Jetpack_Options class

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -2,6 +2,10 @@
 
 class Jetpack_Options {
 
+	/**
+	 * An array that maps a grouped option type to an option name.
+	 * @var array
+	 */
 	private static $grouped_options = array(
 		'compact' => 'jetpack_options',
 		'private' => 'jetpack_private_options'

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -7,6 +7,13 @@ class Jetpack_Options {
 		'private' => 'jetpack_private_options'
 	);
 
+	/**
+	 * Returns an array of option names for a given type.
+	 *
+	 * @param string $type The type of option to return. Defaults to 'compact'.
+	 *
+	 * @return array
+	 */
 	public static function get_option_names( $type = 'compact' ) {
 		switch ( $type ) {
 		case 'non-compact' :
@@ -73,6 +80,14 @@ class Jetpack_Options {
 		);
 	}
 
+	/**
+	 * Is the option name valid?
+	 *
+	 * @param string      $name  The name of the option
+	 * @param string|null $group The name of the group that the option is in. Default to null, which will search non_compact.
+	 *
+	 * @return bool Is the option name valid?
+	 */
 	public static function is_valid( $name, $group = null ) {
 		if ( is_array( $name ) ) {
 			$compact_names = array();
@@ -107,6 +122,8 @@ class Jetpack_Options {
 	 *
 	 * @param string $name Option name
 	 * @param mixed $default (optional)
+	 *
+	 * @return mixed
 	 */
 	public static function get_option( $name, $default = false ) {
 		if ( self::is_valid( $name, 'non_compact' ) ) {
@@ -160,6 +177,8 @@ class Jetpack_Options {
 	 * @param string $name Option name
 	 * @param mixed $value Option value
 	 * @param string $autoload If not compact option, allows specifying whether to autoload or not.
+	 *
+	 * @return bool Was the option successfully updated?
 	 */
 	public static function update_option( $name, $value, $autoload = null ) {
 		/**
@@ -209,6 +228,8 @@ class Jetpack_Options {
 	 * Updates jetpack_options and/or deletes jetpack_$name as appropriate.
 	 *
 	 * @param string|array $names
+	 *
+	 * @return bool Was the option successfully deleted?
 	 */
 	public static function delete_option( $names ) {
 		$result = true;
@@ -216,7 +237,6 @@ class Jetpack_Options {
 
 		if ( ! self::is_valid( $names ) ) {
 			trigger_error( sprintf( 'Invalid Jetpack option names: %s', print_r( $names, 1 ) ), E_USER_WARNING );
-
 			return false;
 		}
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
 			<file>tests/php/test_class.jetpack-heartbeat.php</file>
 			<file>tests/php/test_class.jetpack-constants.php</file>
 			<file>tests/php/test_class.jetpack-connection-banner.php</file>
+			<file>tests/php/test_class.jetpack-options.php</file>
 		</testsuite>
 		<testsuite name="core-api">
 			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>

--- a/tests/php/test_class.jetpack-options.php
+++ b/tests/php/test_class.jetpack-options.php
@@ -1,0 +1,18 @@
+<?php
+
+class WP_Test_Jetpack_Options extends WP_UnitTestCase {
+	function test_delete_non_compact_option_returns_true_when_successfully_deleted() {
+		Jetpack_Options::update_option( 'migrate_for_idc', true );
+
+		// Make sure the option is set
+		$this->assertTrue( Jetpack_Options::get_option( 'migrate_for_idc' ) );
+
+		$deleted = Jetpack_Options::delete_option( 'migrate_for_idc' );
+
+		// Was the option successfully deleted?
+		$this->assertFalse( Jetpack_Options::get_option( 'migrate_for_idc' ) );
+
+		// Did Jetpack_Options::delete_option() properly return true?
+		$this->assertTrue( $deleted );
+	}
+}


### PR DESCRIPTION
While looking at some code today, I noticed that we don't have unit tests for the `Jetpack_Options` class. Having better code coverage of Jetpack is a requisite to running master on Pressable and also increases the perceived quality of Jetpack.

This PR updates and adds docblocks to the `Jetpack_Options` class and then stubs out a test class for `Jetpack_Options` with a single test.

Why one test, you ask? I created the test to assist in my debugging with this issue: #5563. We can either write most tests in this PR or follow up in other PRs. This PR dips our toe in to testing `Jetpack_Options`.