### PR TITLE
SEO Tools: Fix empty configure URL when Business plan is present

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -27,7 +27,10 @@ import ProStatus from 'pro-status';
 import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
 import { isUnavailableInDevMode } from 'state/connection';
-import { userCanManageModules } from 'state/initial-state';
+import {
+	userCanManageModules,
+	getSiteRawUrl
+} from 'state/initial-state';
 import { getSitePlan } from 'state/site';
 import Settings from 'components/settings';
 
@@ -36,7 +39,8 @@ export const Page = ( props ) => {
 		toggleModule,
 		isModuleActivated,
 		isTogglingModule,
-		getModule
+		getModule,
+		siteRawUrl
 	} = props,
 		isAdmin = props.userCanManageModules,
 		moduleList = Object.keys( props.moduleList );
@@ -93,6 +97,14 @@ export const Page = ( props ) => {
 
 		if ( element[0] === 'seo-tools' ) {
 			moduleDescription = <AllModuleSettings module={ isPro ? proProps : getModule( element[ 0 ] ) } />;
+		}
+
+		if ( element[0] === 'seo-tools' ) {
+			if ( props.sitePlan.product_slug === 'jetpack_business' ) {
+				proProps.configure_url = 'https://wordpress.com/settings/seo/' + siteRawUrl;
+			}
+
+			moduleDescription = <AllModuleSettings module={ proProps } />;
 		}
 
 		return (
@@ -155,6 +167,7 @@ function renderLongDescription( module ) {
 export default connect(
 	( state ) => {
 		return {
+			siteRawUrl: getSiteRawUrl( state ),
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			isTogglingModule: ( module_name ) =>
 				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -89,7 +89,7 @@ export const AllModuleSettings = React.createClass( {
 					</div>
 				) : (
 					<div>
-						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href='https://wordpress.com/settings/seo/'>{ __( 'Configure your SEO settings.' ) }</ExternalLink>
+						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url }>{ __( 'Configure your SEO settings.' ) }</ExternalLink>
 					</div>
 				);
 			case 'stats':


### PR DESCRIPTION
Previously the SEO Tools configure URL was empty when Jetpack was on a business plan. This should fix it and direct it to `wordpress.com/settings/seo/{site_url}`. 

Note: until we deploy our Calypso PR this URL will redirect to general settings.

#### Testing instructions:

1. Make sure that you have a Jetpack Professional plan on your test site.
2. Navigate to Appearance tab in dashboard.
3. Verify that `Configure your SEO settings` has the correct `href`.