### PR TITLE
Heartbeat: Use `get_user_count` cached value instead of an extra db query

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -117,7 +117,7 @@ class Jetpack_Heartbeat {
 		$return["{$prefix}identitycrisis"] = Jetpack::check_identity_crisis() ? 'yes' : 'no';
 		$return["{$prefix}plugins"]        = implode( ',', Jetpack::get_active_plugins() );
 
-		$return["{$prefix}single-user-site"]= Jetpack::is_single_user_site();
+		$return["{$prefix}single-user-site"] = get_user_count() == 1;
 
 		$return["{$prefix}manage-enabled"] = Jetpack::is_module_active( 'manage' );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2837,7 +2837,7 @@ p {
 		global $wpdb;
 		$return["{$prefix}themes"]         = Jetpack::get_parsed_theme_data();
 		$return["{$prefix}plugins-extra"]  = Jetpack::get_parsed_plugin_data();
-		$return["{$prefix}users"]          = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->usermeta WHERE meta_key = '{$wpdb->prefix}capabilities'" );
+		$return["{$prefix}users"]          = (int) get_user_count();
 		$return["{$prefix}site-count"]     = 0;
 
 		if ( function_exists( 'get_blog_count' ) ) {


### PR DESCRIPTION
Alternative to #5389 

cc @enejb @gravityrail 