### PR TITLE
IDC: Fix double and and capitalization of IDC buttons

### DIFF
--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -580,7 +580,7 @@ class Jetpack_IDC {
 	}
 
 	function get_migrate_site_button_text() {
-		$string = esc_html__( 'Migrate stats &amp; and Subscribers', 'jetpack' );
+		$string = esc_html__( 'Migrate Stats &amp; Subscribers', 'jetpack' );
 
 		/**
 		 * Allows overriding of the default text used for the migrate site action button.
@@ -619,7 +619,7 @@ class Jetpack_IDC {
 	}
 
 	function get_start_fresh_button_text() {
-		$string = esc_html__( 'Start fresh &amp; create new connection', 'jetpack' );
+		$string = esc_html__( 'Start Fresh &amp; Create New Connection', 'jetpack' );
 
 		/**
 		 * Allows overriding of the default text used for the start fresh action button.


### PR DESCRIPTION
@dereksmart pointed out to me that in the migrate action, we had `&` as well as the word `and`. This PR removes the word `and` in that action.

![screen shot 2016-11-09 at 2 13 20 pm](https://cloud.githubusercontent.com/assets/1126811/20151492/f2a323f6-a67f-11e6-8715-202e8cc8fa2b.png)


Further, I realized that the capitalization in our buttons was off. The start fresh action used sentence case and the migrate action just did its own thing. ¯\_(ツ)_/¯ 

This PR updates the action buttons to use title case, which seems to follow what's in the rest of the dashboard as well as the buttons in the first step of the notice.

cc @jeffgolenski for design review

Screenshots
=========

![screen shot 2016-11-09 at 1 27 17 pm](https://cloud.githubusercontent.com/assets/1126811/20151600/5054f060-a680-11e6-9bac-5d7bf0330116.png)
![screen shot 2016-11-09 at 1 27 24 pm](https://cloud.githubusercontent.com/assets/1126811/20151599/505391ca-a680-11e6-9ee5-84d248ed205b.png)
