### PR TITLE
GUI Tests: adapt GUI tests after the settings PR was reverted, fixes Travis builds

### DIFF
--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -39,9 +39,9 @@ describe( 'NavigationSettings', () => {
 		expect( wrapper.find( '.dops-navigation' ) ).to.have.length( 1 );
 	} );
 
-	it( 'accessing through /settings, it has /settings as selected navigation item', () => {
+	it( 'has /general as selected navigation item, accessing through /settings', () => {
 		expect( wrapper.find( 'NavItem' ).get( 0 ).props.selected ).to.be.true;
-		expect( wrapper.find( 'NavItem' ).get( 0 ).props.path ).to.equal( '#settings' );
+		expect( wrapper.find( 'NavItem' ).get( 0 ).props.path ).to.equal( '#general' );
 	} );
 
 	it( 'renders NavigationSettings, SectionNav, NavTabs', () => {
@@ -52,8 +52,8 @@ describe( 'NavigationSettings', () => {
 
 	describe( 'Subscriber user', () => {
 
-		it( 'renders only one tab: Settings', () => {
-			expect( wrapper.find( 'NavItem' ).children().text() ).to.be.equal( 'Settings' );
+		it( 'renders only one tab: General', () => {
+			expect( wrapper.find( 'NavItem' ).children().text() ).to.be.equal( 'General' );
 		} );
 
 		it( 'does not display Search', () => {
@@ -71,8 +71,8 @@ describe( 'NavigationSettings', () => {
 
 		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
 
-		it( 'renders tabs with General, Writing', () => {
-			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Writing' );
+		it( 'renders tabs with General, Engagement, Writing', () => {
+			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Engagement,Writing' );
 		} );
 
 		it( 'does not display Search', () => {
@@ -90,8 +90,8 @@ describe( 'NavigationSettings', () => {
 
 		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
 
-		it( 'renders tabs with Writing, Discussion, Traffic, Security', () => {
-			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'Writing,Discussion,Traffic,Security' );
+		it( 'renders tabs with General, Engagement, Security, Appearance, Writing', () => {
+			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Engagement,Security,Appearance,Writing' );
 		} );
 
 		it( 'displays Search', () => {


### PR DESCRIPTION
Let's get this in so builds pass.

TEST:
`yarn test-gui`

all tests should pass.