### PR TITLE
Set the user count to -1 for very large networks

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2856,7 +2856,7 @@ p {
 
 		if ( function_exists( 'wp_is_large_network' ) ) {
 			if ( wp_is_large_network( 'users' ) ) {
-				return 10101; // Not a real value but should tell us that we are dealing with a large network.
+				return -1; // Not a real value but should tell us that we are dealing with a large network.
 			}
 		}
 		if ( false === ( $user_count = get_transient( 'jetpack_site_user_count' ) ) ) {


### PR DESCRIPTION
Returns -1 instead of 10101 as a user count for large networks (where counting users is likely to be inefficient), so that we can more easily detect on the WPCOM side and avoid messing with stats.