### PR TITLE
Special action for emailing post to subs

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -153,12 +153,14 @@ class Jetpack_Subscriptions {
 			return;
 		}
 
+		$email_to_subs = ! get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true );
+
 		/**
 		 * If we're updating the post, let's make sure the flag to not send to subscribers
 		 * is set to minimize the chances of sending posts multiple times.
 		 */
 		if ( 'publish' == $old_status ) {
-			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
+			$email_to_subs = false;
 		}
 
 		/**
@@ -176,7 +178,7 @@ class Jetpack_Subscriptions {
 
 		// Never email posts from these categories
 		if ( ! empty( $excluded_categories ) && in_category( $excluded_categories, $post->ID ) ) {
-			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
+			$email_to_subs = false;
 		}
 
 		/**
@@ -194,15 +196,23 @@ class Jetpack_Subscriptions {
 
 		// Only emails posts from these categories
 		if ( ! empty( $only_these_categories ) && ! in_category( $only_these_categories, $post->ID ) ) {
-			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
+			$email_to_subs = false;
 		}
 
 		// Email the post, depending on the checkbox option
 		if ( ! empty( $_POST['disable_subscribe_nonce'] ) && wp_verify_nonce( $_POST['disable_subscribe_nonce'], 'disable_subscribe' ) ) {
 			if ( isset( $_POST['_jetpack_dont_email_post_to_subs'] ) ) {
-				update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', $_POST['_jetpack_dont_email_post_to_subs'] );
+				$email_to_subs = $_POST['_jetpack_dont_email_post_to_subs'];
 			}
 		}
+
+		// fire email to subs action
+		if ( $email_to_subs ) {
+			do_action( 'jetpack_email_post_to_subs', $post );	
+		}
+		
+		// this is now just here to stop us from emailing twice
+		update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 	}
 
 	/**

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -149,6 +149,7 @@ class Jetpack_Subscriptions {
 		if ( 'publish' !== $new_status ) {
 			return;
 		}
+
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
@@ -209,10 +210,10 @@ class Jetpack_Subscriptions {
 		// fire email to subs action
 		if ( $email_to_subs ) {
 			do_action( 'jetpack_email_post_to_subs', $post );	
+		} else {
+			// this is here to stop us from emailing twice
+			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 		}
-		
-		// this is now just here to stop us from emailing twice
-		update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 	}
 
 	/**

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -203,7 +203,7 @@ class Jetpack_Subscriptions {
 		// Email the post, depending on the checkbox option
 		if ( ! empty( $_POST['disable_subscribe_nonce'] ) && wp_verify_nonce( $_POST['disable_subscribe_nonce'], 'disable_subscribe' ) ) {
 			if ( isset( $_POST['_jetpack_dont_email_post_to_subs'] ) ) {
-				$email_to_subs = $_POST['_jetpack_dont_email_post_to_subs'];
+				$email_to_subs = ! $_POST['_jetpack_dont_email_post_to_subs'];
 			}
 		}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -23,8 +23,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'wp_insert_post', $callable, 10, 3 );
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
+		add_action( 'jetpack_email_post_to_subs', $callable );
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'filter_blacklisted_post_types' ) );
-		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'set_dont_email_post_flag' ) );
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -33,6 +33,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_wp_insert_post', array( $this, 'expand_wp_insert_post' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_email_post_to_subs', array( $this, 'jetpack_email_post_to_subs' ) );
 
 		// full sync
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_posts', array( $this, 'expand_post_ids' ) );
@@ -76,22 +77,16 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2] );
 	}
 
+	function jetpack_email_post_to_subs( $args ) {
+		return array( $this->filter_post_content_and_add_links( $args[0] ) );
+	}
+
 	function filter_blacklisted_post_types( $args ) {
 		$post = $args[1];
 
 		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
 		}
-
-		return $args;
-	}
-
-	function set_dont_email_post_flag( $args ) {
-		$post = $args[1];
-
-		$post->dont_email_post_to_subs = Jetpack::is_module_active( 'subscriptions' ) ?
-				get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) :
-				true; // Don't email subscription if the subscription module is not active.
 
 		return $args;
 	}

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -174,6 +174,9 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		$post->permalink               = get_permalink( $post->ID );
 		$post->shortlink               = wp_get_shortlink( $post->ID );
+		$post->dont_email_post_to_subs = Jetpack::is_module_active( 'subscriptions' ) ?
+				get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) :		
+				true; // Don't email subscription if the subscription module is not active.
 
 		return $post;
 	}

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -24,6 +24,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'filter_blacklisted_post_types' ) );
+		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'set_dont_email_post_flag' ) );
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -81,6 +82,16 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( in_array( $post->post_type, Jetpack_Sync_Settings::get_setting( 'post_types_blacklist' ) ) ) {
 			return false;
 		}
+
+		return $args;
+	}
+
+	function set_dont_email_post_flag( $args ) {
+		$post = $args[1];
+
+		$post->dont_email_post_to_subs = Jetpack::is_module_active( 'subscriptions' ) ?
+				get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) :
+				true; // Don't email subscription if the subscription module is not active.
 
 		return $args;
 	}
@@ -168,9 +179,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		$post->permalink               = get_permalink( $post->ID );
 		$post->shortlink               = wp_get_shortlink( $post->ID );
-		$post->dont_email_post_to_subs = Jetpack::is_module_active( 'subscriptions' ) ?
-				get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) :
-				true; // Don't email subscription if the subscription module is not active.
 
 		return $post;
 	}

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -622,10 +622,6 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		if ( isset( $object->extra ) ) {
 			$object->extra = (array) $object->extra;
 		}
-		// Lets unset the do not email post to subs object...
-		if ( isset( $object->dont_email_post_to_subs ) ) {
-			unset( $object->dont_email_post_to_subs );
-		}
 		$post = new WP_Post( $object );
 		return $post;
 	}

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -622,8 +622,11 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		if ( isset( $object->extra ) ) {
 			$object->extra = (array) $object->extra;
 		}
+		// Lets unset the do not email post to subs object...
+		if ( isset( $object->dont_email_post_to_subs ) ) {
+			unset( $object->dont_email_post_to_subs );
+		}
 		$post = new WP_Post( $object );
-
 		return $post;
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -505,20 +505,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $this->post->post_content, $synced_post->post_content );
 	}
 
-	function test_filters_out_blacklisted_post_types() {
-		$args = array(
-			'public' => true,
-			'label'  => 'Snitch'
-		);
-		register_post_type( 'snitch', $args );
-
-		$post_id = $this->factory->post->create( array( 'post_type' => 'snitch' ) );
-
-		$this->sender->do_sync();
-
-		$this->assertFalse( $this->server_replica_storage->get_post( $post_id ) );
-	}
-
 	function test_filters_out_blacklisted_post_types_and_their_post_meta() {
 		$args = array(
 			'public' => true,

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -386,7 +386,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_includes_dont_email_post_to_subs_when_subscription_is_not_active() {
-		$active_modules = Jetpack::get_active_modules();
 		Jetpack_Options::update_option( 'active_modules', array() );
 		// Subscription is not an active module
 		$this->assertTrue( ! in_array( 'subscriptions', Jetpack::get_active_modules() ) );
@@ -394,11 +393,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$post_on_server = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->args[1];
-
-		$this->assertEquals( true, $post_on_server->dont_email_post_to_subs );
-
-		Jetpack_Options::update_option( 'active_modules', $active_modules );
+		$this->assertEmpty( $this->server_event_storage->get_all_events( 'jetpack_email_post_to_subs' ) );
 	}
 
 	function test_sync_post_includes_feature_image_meta_when_featured_image_set() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -354,6 +354,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_sends_dont_email_post_to_subs_flag_when_post_status_changes() {
+		// Don't include post already created
+		$this->server_event_storage->reset();
 
 		// activate subscription module.
 		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -364,6 +364,45 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( true, $post_on_server->dont_email_post_to_subs );
 	}
 
+	function test_sync_sends_dont_email_post_to_subs_flag_when_post_status_changes() {
+
+		// activate subscription module.
+		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
+		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
+		Jetpack_Subscriptions::init();
+
+		// create a draft
+		$new_post_id = $this->factory->post->create(  array( 'post_status' => 'draft' ) );
+
+		// Publish and then immediately update the post
+		wp_publish_post( $new_post_id );
+
+		// update a published post which should set the do not send flag
+		wp_update_post( array(
+			'ID'           => $new_post_id,
+			'post_content' => 'updated',
+		) );
+		
+		$this->sender->do_sync();
+
+		$all_wp_insert_post_events = $this->server_event_storage->get_all_events( 'wp_insert_post' );
+		foreach( $all_wp_insert_post_events as $event ) {
+			list( $post_id, $post ) = $event->args;
+			
+			if ( $post_id !== $new_post_id ) {
+				// ignore events that do not have the have the same post_id.
+				continue;
+			}
+
+			if ( 'updated' === $post->post_content ) {
+				// Only the updated post should have the do not send flag.
+				$this->assertEquals( true, $post->dont_email_post_to_subs, 'Post status: '. $post->post_status .' Should not send email to subscribers.' );
+			} else {
+				$this->assertEquals( false, $post->dont_email_post_to_subs, 'Post status: '. $post->post_status .' Should send email to subscribers.' );
+			}
+		}
+	}
+
 	function test_sync_post_includes_dont_email_post_to_subs_when_subscription_is_not_active() {
 		$active_modules = Jetpack::get_active_modules();
 		Jetpack_Options::update_option( 'active_modules', array() );

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -388,6 +388,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_includes_dont_email_post_to_subs_when_subscription_is_not_active() {
+		$this->server_event_storage->reset();
+		
 		Jetpack_Options::update_option( 'active_modules', array() );
 		// Subscription is not an active module
 		$this->assertTrue( ! in_array( 'subscriptions', Jetpack::get_active_modules() ) );


### PR DESCRIPTION
Supersedes #5491.

Sends a special `jetpack_email_post_to_subs` action when the post status transitions and the post hasn't already been emailed to subs.

Fixes an issue where a post was sent long after it was modified (because the queue got temporarily stuck, for example). In this situation, by the time a post was sent, the meta which says whether to email to subs could already have been flipped to prevent sending.

This could be the root cause of many subscription issues.

This will definitely require changes on WPCOM.

