### PR TITLE
Sync: Send `jetpack_published_post` action right after `wp_insert_post`

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -169,7 +169,8 @@ class Jetpack_Subscriptions {
 	}
 
 	public function should_email_post_to_subscribers( $post ) {
-		if ( get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs' ) ) {
+		$should_email = true;
+		if ( get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) ) {
 			return false;
 		}
 
@@ -188,7 +189,7 @@ class Jetpack_Subscriptions {
 
 		// Never email posts from these categories
 		if ( ! empty( $excluded_categories ) && in_category( $excluded_categories, $post->ID ) ) {
-			return false;
+			$should_email = false;
 		}
 
 		/**
@@ -206,16 +207,16 @@ class Jetpack_Subscriptions {
 
 		// Only emails posts from these categories
 		if ( ! empty( $only_these_categories ) && ! in_category( $only_these_categories, $post->ID ) ) {
-			return false;
+			$should_email = false;
 		}
 
 		// Email the post, depending on the checkbox option
 		if ( ! empty( $_POST['disable_subscribe_nonce'] ) && wp_verify_nonce( $_POST['disable_subscribe_nonce'], 'disable_subscribe' ) ) {
 			if ( isset( $_POST['_jetpack_dont_email_post_to_subs'] ) ) {
-				return false;
+				$should_email = false;
 			}
 		}
-		return true;
+		return $should_email;
 	}
 
 	function set_post_flags( $flags, $post ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -189,8 +189,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	public function send_published( $post_ID, $post, $update ) {
 		if ( $this->just_published === $post ) {
 			$this->just_published = null;
-			$meta = apply_filters( 'jetpack_published_post_meta', array() );
-			do_action( 'jetpack_published_post', $post_ID, $meta );
+			$flags = apply_filters( 'jetpack_published_post_flags', array(), $post );
+			do_action( 'jetpack_published_post', $post_ID, $flags );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -26,7 +26,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'wp_insert_post', array( $this, 'send_published'), 11, 3 );
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
-		add_action( 'jetpack_published_post', $callable, 10, 4 );
+		add_action( 'jetpack_published_post', $callable, 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'save_published' ), 10, 3 );
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'filter_blacklisted_post_types' ) );
 	}
@@ -190,7 +190,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( $this->just_published === $post ) {
 			$this->just_published = null;
 			$meta = apply_filters( 'jetpack_published_post_meta', array() );
-			do_action( 'jetpack_published_post', $post_ID, $post, $update, $meta );
+			do_action( 'jetpack_published_post', $post_ID, $meta );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -4,6 +4,8 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 
 class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
+	private $just_published;
+
 	public function name() {
 		return 'posts';
 	}
@@ -21,8 +23,11 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function init_listeners( $callable ) {
 		add_action( 'wp_insert_post', $callable, 10, 3 );
+		add_action( 'wp_insert_post', array( $this, 'send_published'), 11, 3 );
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
+		add_action( 'jetpack_published_post', $callable, 10, 4 );
+		add_action( 'transition_post_status', array( $this, 'save_published' ), 10, 3 );
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'filter_blacklisted_post_types' ) );
 	}
 
@@ -173,6 +178,20 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 				true; // Don't email subscription if the subscription module is not active.
 
 		return $post;
+	}
+
+	public function save_published( $new_status, $old_status, $post ) {
+		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
+			$this->just_published = $post;
+		}
+	}
+
+	public function send_published( $post_ID, $post, $update ) {
+		if ( $this->just_published === $post ) {
+			$this->just_published = null;
+			$meta = apply_filters( 'jetpack_published_post_meta', array() );
+			do_action( 'jetpack_published_post', $post_ID, $post, $update, $meta );
+		}
 	}
 
 	public function expand_post_ids( $args ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -182,12 +182,12 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function save_published( $new_status, $old_status, $post ) {
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
-			$this->just_published = $post;
+			$this->just_published = $post->ID;
 		}
 	}
 
 	public function send_published( $post_ID, $post, $update ) {
-		if ( $this->just_published === $post ) {
+		if ( $this->just_published === $post->ID ) {
 			$this->just_published = null;
 			$flags = apply_filters( 'jetpack_published_post_flags', array(), $post );
 			do_action( 'jetpack_published_post', $post_ID, $flags );

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -365,10 +365,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_includes_dont_email_post_to_subs_when_subscription_is_not_active() {
-		$active_modules = Jetpack::get_active_modules();
 		Jetpack_Options::update_option( 'active_modules', array() );
-		// Subscription is not an active module
-		$this->assertTrue( ! in_array( 'subscriptions', Jetpack::get_active_modules() ) );
+		
 		$post_id = $this->factory->post->create();
 
 		$this->sender->do_sync();
@@ -844,8 +842,8 @@ That was a cool video.';
 
 	public function test_sync_jetpack_published_post_should_set_dont_send_to_subscribers_flag() {
 		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
-		// Subscription is an active module
-		$this->assertTrue( in_array( 'subscriptions', Jetpack::get_active_modules() ) );
+		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
+ 		Jetpack_Subscriptions::init();
 
 		wp_update_post( array(
 			'ID'          => $this->post->ID,

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -374,8 +374,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$post_on_server = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->args[1];
 
 		$this->assertEquals( true, $post_on_server->dont_email_post_to_subs );
-
-		Jetpack_Options::update_option( 'active_modules', $active_modules );
 	}
 
 	function test_sync_post_includes_feature_image_meta_when_featured_image_set() {


### PR DESCRIPTION
@gravityrail @enejb, what do you think about doing something like this to detect post publishing?

Later we can adapt publicize and subscriptions to use `jetpack_published_post_meta` filter in order to set specific flags.