### PR TITLE
Don’t load the sender in cron

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -71,8 +71,6 @@ class Jetpack_Sync_Actions {
 				is_admin()
 				||
 				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
-				||
-				defined( 'DOING_CRON' ) && DOING_CRON
 			)
 		) ) {
 			self::initialize_sender();

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -213,11 +213,6 @@ class Jetpack_Sync_Actions {
 
 		self::initialize_sender();
 
-		// remove shutdown hook - no need to sync twice
-		if ( has_action( 'shutdown', array( self::$sender, 'do_sync' ) ) ) {
-			remove_action( 'shutdown', array( self::$sender, 'do_sync' ) );
-		}
-
 		do {
 			$next_sync_time = self::$sender->get_next_sync_time( 'sync' );
 
@@ -240,11 +235,6 @@ class Jetpack_Sync_Actions {
 		}
 
 		self::initialize_sender();
-
-		// remove shutdown hook - no need to sync twice
-		if ( has_action( 'shutdown', array( self::$sender, 'do_sync' ) ) ) {
-			remove_action( 'shutdown', array( self::$sender, 'do_sync' ) );
-		}
 
 		do {
 			$next_sync_time = self::$sender->get_next_sync_time( 'full_sync' );


### PR DESCRIPTION
Fixes an issue where WP_ALTERNATE_CRON is loaded a low init level (which is just the way WordPress works) and does its processing and exits before all plugins are necessarily loaded (since they're hooked to a higher init level). That can mean that callables are being synced with weird values, or content is rendered with missing shortcodes, among other things.

So let's just not send during shutdown of cron at all, and let it happen on regular requests, or during the actual cron jobs.