### PR TITLE
ProStatus: fix `Set Up` button link for the Scan cards

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -97,10 +97,14 @@ const ProStatus = React.createClass( {
 			}
 
 			if ( sitePlan.product_slug ) {
-				let btnVals = {};
+				let btnVals = {},
+					featureSlug = ( 'scan' === feature || 'backups' === feature )
+						? 'vaultpress'
+						: feature;
+
 				if ( 'jetpack_free' !== sitePlan.product_slug ) {
 					btnVals = {
-						href: `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }`,
+						href: `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ featureSlug }`,
 						text: __( 'Set up' )
 					}
 				} else {


### PR DESCRIPTION
Fixes a bug in the ProStatus component where we were using the wrong slug when linking to "Set Up" the pro service.  

![screen shot 2016-11-10 at 4 18 06 pm](https://cloud.githubusercontent.com/assets/7129409/20194663/4b5dfb7e-a761-11e6-8587-e67c692433a4.png)

To Test: 
- Make sure you have a premium/pro account
- Deactivate and/or delete VaultPress
- Navigate to the dashboard and click the "Set Up" button in the "Malware Scanning" card. 
- You should be taken to `https://wordpress.com/plugins/setup/<SITEURL>?only=vaultpress`, and it should set it up. 

I also changed the slug for Backups, but that one was working before, so just done for consistency.  
