### PR TITLE
VideoPress: Ensure the module is automatically activated when a qualifying plan is owned

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -697,7 +697,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$results = json_decode( $response['body'], true );
 
 			if ( is_array( $results ) && isset( $results['plan'] ) ) {
-				update_option( 'jetpack_active_plan_2', $results['plan'] );
+				update_option( 'jetpack_active_plan', $results['plan'] );
 			}
 
 			return rest_ensure_response( array(

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -693,6 +693,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				return new WP_Error( 'site_data_fetch_failed', esc_html__( 'Failed fetching site data. Try again later.', 'jetpack' ), array( 'status' => 400 ) );
 			}
 
+			// Save plan details in the database for future use without API calls
+			$results = json_decode( $response['body'], true );
+
+			if ( is_array( $results ) && isset( $results['plan'] ) ) {
+				update_option( 'jetpack_active_plan_2', $results['plan'] );
+			}
+
 			return rest_ensure_response( array(
 					'code' => 'success',
 					'message' => esc_html__( 'Site data correctly received.', 'jetpack' ),

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -85,7 +85,9 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 				if ( item === undefined ) return; #>
 				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
 					<th scope="row" class="check-column">
+						<# if ( 'videopress' !== item.module ) { #>
 						<input type="checkbox" name="modules[]" value="{{{ item.module }}}" />
+						<# } #>
 					</th>
 					<td class='name column-name'>
 						<span class='info'><a href="{{{item.learn_more_button}}}" target="blank">{{{ item.name }}}</a></span>
@@ -93,9 +95,9 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 						<# if ( item.configurable ) { #>
 							<span class='configure'>{{{ item.configurable }}}</span>
 						<# } #>
-						<# if ( item.activated && 'vaultpress' !== item.module && item.available ) { #>
+						<# if ( item.activated && 'vaultpress' !== item.module && item.available && 'videopress' !== item.module ) { #>
 							<span class='delete'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=deactivate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.deactivate_nonce }}}"><?php _e( 'Deactivate', 'jetpack' ); ?></a></span>
-						<# } else if ( item.available ) { #>
+						<# } else if ( item.available && 'videopress' !== item.module ) { #>
 							<span class='activate'><a href="<?php echo admin_url( 'admin.php' ); ?>?page=jetpack&#038;action=activate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.activate_nonce }}}"><?php _e( 'Activate', 'jetpack' ); ?></a></span>
 						<# } #>
 						</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2270,11 +2270,8 @@ class Jetpack {
 			$active = array_diff( $active, array( 'vaultpress' ) );
 		}
 
-		// Get the current site plan
-		$plan = Jetpack::get_active_plan();
-
 		// If this plan supports videopress, force activate module
-		if ( in_array( 'videopress', $plan['supports'] ) ) {
+		if ( Jetpack::active_plan_supports( 'videopress' ) ) {
 			$active[] = 'videopress';
 		} else {
 			$active = array_diff( $active, array( 'videopress' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1181,16 +1181,16 @@ class Jetpack {
 			$result = Jetpack_Client::wpcom_json_api_request_as_blog( $request, '1.1' );
 
 			// Bail if there is an error
-			if ( is_wp_error( $results ) ) {
-				return false;
+			if ( is_wp_error( $result ) ) {
+				return array( 'supports' => array() );
 			}
 
 			// Decode response and extract the plan data
 			$response = json_decode( $result['body'], true );
-			$plan = $response['plan'];
+			$plan = (array) $response['plan'];
 
 			// Cache the results for 10 minutes since this makes an API request on each call
-			set_transient( 'jetpack_active_plan', $plan, 600 );
+			set_transient( 'jetpack_active_plan', $plan, 3600 );
 		}
 
 		// Add in an array of supported features

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1158,40 +1158,6 @@ class Jetpack {
 	}
 
 	/**
-	 * Make an API call to WordPress.com for plan status
-	 *
-	 * @uses Jetpack_Options::get_option()
-	 * @uses Jetpack_Client::wpcom_json_api_request_as_blog()
-	 * @uses update_option()
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @return bool True if plan updated, false if no update
-	 */
-	public static function refresh_active_plan_from_wpcom() {
-		// Make the API request
-		$request = sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) );
-		$response = Jetpack_Client::wpcom_json_api_request_as_blog( $request, '1.1' );
-
-		// Bail if there was an error or malformed response
-		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
-			return false;
-		}
-
-		// Decode the results
-		$results = json_decode( $response['body'], true );
-
-		// Bail if there were no results or plan details returned
-		if ( ! is_array( $results ) || ! isset( $results['plan'] ) ) {
-			return false;
-		}
-
-		// Store the option and return true if updated
-		return update_option( 'jetpack_active_plan', $results['plan'] );
-	}
-
-	/**
 	 * Get the plan that this Jetpack site is currently using
 	 *
 	 * @uses get_option()

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1239,6 +1239,10 @@ class Jetpack {
 			$plan['supports'][] = 'vaultpress';
 		}
 
+		if ( ! isset( $plan['supports'] ) ) {
+			$plan['supports'] = array();
+		}
+
 		return $plan;
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1196,8 +1196,15 @@ class Jetpack {
 		// Add in an array of supported features
 		$plan['supports'] = array();
 
-		// If a site is on a premium or business plan, we support VideoPress, Akismet, and VaultPress
-		if ( 'jetpack_premium' === $plan['product_slug'] || 'jetpack_business' === $plan['product_slug'] ) {
+		$premium_plans = array(
+			'jetpack_premium',
+			'jetpack_premium_monthly',
+			'jetpack_business',
+			'jetpack_business_monthly',
+		);
+
+		// If a site has a premium plan, add in supports details.
+		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
 			$plan['supports'][] = 'videopress';
 			$plan['supports'][] = 'akismet';
 			$plan['supports'][] = 'vaultpress';

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1222,23 +1222,41 @@ class Jetpack {
 		);
 
 		if ( in_array( $plan['product_slug'], $personal_plans ) ) {
-			$plan['supports'][] = 'akismet';
+			$plan['supports'] = array(
+				'akismet',
+			);
 		}
 
 		// Define what paid modules are supported by premium plans
 		$premium_plans = array(
 			'jetpack_premium',
 			'jetpack_premium_monthly',
+		);
+
+		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
+			$plan['supports'] = array(
+				'videopress',
+				'akismet',
+				'vaultpress',
+			);
+		}
+
+		// Define what paid modules are supported by professional plans
+		$business_plans = array(
 			'jetpack_business',
 			'jetpack_business_monthly',
 		);
 
-		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
-			$plan['supports'][] = 'videopress';
-			$plan['supports'][] = 'akismet';
-			$plan['supports'][] = 'vaultpress';
+		if ( in_array( $plan['product_slug'], $business_plans ) ) {
+			$plan['supports'][] = array(
+				'videopress',
+				'akismet',
+				'vaultpress',
+				'seo-tools',
+			);
 		}
 
+		// Make sure we have an array here in the event database data is stale
 		if ( ! isset( $plan['supports'] ) ) {
 			$plan['supports'] = array();
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2206,12 +2206,25 @@ class Jetpack {
 	 */
 	public static function get_active_modules() {
 		$active = Jetpack_Options::get_option( 'active_modules' );
-		if ( ! is_array( $active ) )
+		
+		if ( ! is_array( $active ) ) {
 			$active = array();
+		}
+
 		if ( class_exists( 'VaultPress' ) || function_exists( 'vaultpress_contact_service' ) ) {
 			$active[] = 'vaultpress';
 		} else {
 			$active = array_diff( $active, array( 'vaultpress' ) );
+		}
+
+		// Get the current site plan
+		$plan = Jetpack::get_active_plan();
+
+		// If this plan supports videopress, force activate module
+		if ( in_array( 'videopress', $plan['supports'] ) ) {
+			$active[] = 'videopress';
+		} else {
+			$active = array_diff( $active, array( 'videopress' ) );
 		}
 
 		//If protect is active on the main site of a multisite, it should be active on all sites.

--- a/modules/videopress/class.videopress-options.php
+++ b/modules/videopress/class.videopress-options.php
@@ -42,11 +42,8 @@ class VideoPress_Options {
 		// associated shadow blog id, if videopress is enabled.
 		self::$options['shadow_blog_id'] = 0;
 
-		// Get the active Jetpack plan
-		$plan = Jetpack::get_active_plan();
-
 		// Use the Jetpack ID for the shadow blog ID if we have a plan that supports VideoPress
-		if ( in_array( 'videopress', $plan['supports'] ) ) {
+		if ( Jetpack::active_plan_supports( 'videopress' ) ) {
 			self::$options['shadow_blog_id'] = Jetpack_Options::get_option( 'id' );
 		}
 

--- a/modules/videopress/class.videopress-options.php
+++ b/modules/videopress/class.videopress-options.php
@@ -41,7 +41,12 @@ class VideoPress_Options {
 		// Make sure that the shadow blog id never comes from the options, but instead uses the
 		// associated shadow blog id, if videopress is enabled.
 		self::$options['shadow_blog_id'] = 0;
-		if ( self::isVideoPressIncludedInJetpackPlan() ) {
+
+		// Get the active Jetpack plan
+		$plan = Jetpack::get_active_plan();
+
+		// Use the Jetpack ID for the shadow blog ID if we have a plan that supports VideoPress
+		if ( in_array( 'videopress', $plan['supports'] ) ) {
 			self::$options['shadow_blog_id'] = Jetpack_Options::get_option( 'id' );
 		}
 
@@ -66,23 +71,4 @@ class VideoPress_Options {
 		self::$options = array();
 	}
 
-
-	/**
-	 * Does the site have a Jetpack plan attached to it that includes VideoPress
-	 *
-	 * @todo We might want to cache this.
-	 * @return bool
-	 */
-	protected static function isVideoPressIncludedInJetpackPlan() {
-		$site_id = Jetpack_Options::get_option( 'id' );
-		$result  = Jetpack_Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', $site_id ), '1.1' );
-
-		if ( is_wp_error( $result ) ) {
-			return false;
-		}
-
-		$response = json_decode( $result['body'], true );
-
-		return in_array( $response['plan']['product_slug'], self::$jetpack_plans_with_videopress );
-	}
 }


### PR DESCRIPTION
Fixes #5585 

#### Changes proposed in this Pull Request:
* Adds `Jetpack::get_active_plan()` which returns the plan a site is on based on WPCOM API
* Forces active status of VideoPress module if a site is on a qualifying plan
* Forces inactive status of VideoPress module if a site is not on a qualifying plan
* Retrofits `VideoPress_Options` to use `Jetpack::get_active_plan()`

#### Testing instructions:

* On a site with no Jetpack plan (or free plan), ensure that VideoPress is inactive and reports as inactive in settings.
* On a site with a Jetpack premium or business plan, ensure that VideoPress is active, working, and reports as active in settings.
* On a site with a freshly purchased Jetpack plan, check to ensure that the status of VideoPress has automatically activated.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
