### PR TITLE
General: load the compatibility routines for WPML at the right time

### DIFF
--- a/3rd-party/wpml.php
+++ b/3rd-party/wpml.php
@@ -1,9 +1,28 @@
 <?php
+/**
+ * Only load these if WPML plugin is installed and active.
+ */
 
-// Only load these if WPML is active.
-if ( defined( 'ICL_SITEPRESS_VERSION' ) ) :
+/**
+ * Load routines only if WPML is loaded.
+ *
+ * @since 4.4.0
+ */
+function wpml_jetpack_init() {
+	add_action( 'jetpack_widget_get_top_posts', 'wpml_jetpack_widget_get_top_posts', 10, 3 );
+	add_filter( 'grunion_contact_form_field_html', 'grunion_contact_form_field_html_filter', 10, 3 );
+}
+add_action( 'wpml_loaded', 'wpml_jetpack_init' );
 
-add_action( 'jetpack_widget_get_top_posts', 'wpml_jetpack_widget_get_top_posts', 10, 3 );
+/**
+ * Filter the Top Posts and Pages by language.
+ *
+ * @param array  $posts    Array of the most popular posts.
+ * @param array  $post_ids Array of Post IDs.
+ * @param string $count    Number of Top Posts we want to display.
+ *
+ * @return array
+ */
 function wpml_jetpack_widget_get_top_posts( $posts, $post_ids, $count ) {
 	global $sitepress;
 
@@ -18,7 +37,15 @@ function wpml_jetpack_widget_get_top_posts( $posts, $post_ids, $count ) {
 	return $posts;
 }
 
-add_filter( 'grunion_contact_form_field_html', 'grunion_contact_form_field_html_filter', 10, 3 );
+/**
+ * Filter the HTML of the Contact Form and output the one requested by language.
+ *
+ * @param string   $r           Contact Form HTML output.
+ * @param string   $field_label Field label.
+ * @param int|null $id          Post ID.
+ *
+ * @return string
+ */
 function grunion_contact_form_field_html_filter( $r, $field_label, $id ){
 	global $sitepress;
 
@@ -31,5 +58,3 @@ function grunion_contact_form_field_html_filter( $r, $field_label, $id ){
 
 	return $r;
 }
-
-endif;


### PR DESCRIPTION
Previously, the file was checking if the constant ICL_SITEPRESS_VERSION was defined,
but at the time it did so, it wasn't.

#### Changes proposed in this Pull Request:
This patch attemps to hook the initialization routines to an specific WPML action, so they're initialized when the action fires.

#### Testing instructions:
Important: do **NOT** check this branch until pointed later in the steps❗️ 
0. make sure you have a few posts translated to test this
1. create a file in `modules/widgets/` and put this in it:
```php
<?php
class Jetpack_WPML_Compat_Test extends WP_Widget {

	public function __construct() {
		parent::__construct( 'jetpack-wpml-compat-test', 'Jetpack WPML Compat Test' );
	}

	public function widget( $args, $instance ) {
		$posts = new WP_Query( apply_filters( 'widget_posts_args', array(
			'posts_per_page'      => 5,
			'no_found_rows'       => true,
			'post_status'         => 'publish',
			'ignore_sticky_posts' => true
		) ) );

		if ( $posts->have_posts() ) {
			echo $args['before_widget'] . $args['before_title'] . 'A Test Widget' . $args['after_title'];
			while ( $posts->have_posts() ) {
				$posts->the_post();
				echo '<p><a href="' . get_permalink() . '">' . get_the_title() . '</a>';
				
				// An action in 3rd-party/wpml.php will be hooked to this
				do_action( 'jetpack_wpml_compat_test', get_the_ID() );
				
				echo '</p>';
			}
			echo $args['after_widget'];
			wp_reset_postdata();
		}
	}
}

add_action( 'widgets_init', function() {
	register_widget( 'Jetpack_WPML_Compat_Test' );
} );
```

2. edit `3rd-party/wpml.php` and at the beginning, paste
```php
add_action( 'jetpack_wpml_compat_test', function( $post_id ) {
	echo ' ' . substr( wpml_get_language_information( $post_id )['locale'], 0, 2 );
} );
```

3. add the widget to a sidebar and verify that the posts displayed by the widget are in the right language BUT they don't have the language next to them, meaning that the compatibility routines aren't loaded
<img width="261" alt="captura de pantalla 2016-11-10 a las 19 35 05" src="https://cloud.githubusercontent.com/assets/1041600/20197170/ced57886-a77c-11e6-8b10-727defe657fd.png">

4. checkout the branch. You'll have to clean the changes and recreate the widget file and paste its contents again as well as editing the `3rd-party/wpml.php`. Trust me, we're almost there. This time the place to add the code for `3rd-party/wpml.php` is at the end of the `jetpack_wpml_init` function.

5. check the widget in front end again. This time, they are still in the correct language, but additionally they have the language next to them:
<img width="301" alt="captura de pantalla 2016-11-10 a las 19 34 34" src="https://cloud.githubusercontent.com/assets/1041600/20197157/bf39ae7e-a77c-11e6-971f-ccd06e9586bc.png">

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
WPML compatibility: fixed the loading of the compatibility file for WPML so it loads at the right time.

cc @vukvukovich would be great to have your feedback here.