### PR TITLE
Fix multiple upload problem with VideoPress override script

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -128,29 +128,33 @@ class Jetpack_VideoPress {
 		}
 
 		if ( $this->should_override_media_uploader() ) {
-			wp_enqueue_script( 'videopress-uploader', plugins_url( 'js/videopress-uploader.js', __FILE__ ), array(
-				'jquery',
-				'wp-plupload'
-			), $this->version );
+			// We're going to replace the standard wp-plupload with our own ... messy, I know, but as of now the
+			// hooks in it are not good enough for us to be able to override / add in just the code we need.
+			// P.S. Please don't take this as an example of good behavior, this is a temporary fix until I
+			// can get a more permanent action / filter system added into the core wp-plupload.js to make this
+			// type of override unnecessary.
+			wp_dequeue_script( 'wp-plupload' );
+
+			wp_enqueue_script(
+				'videopress-plupload',
+				plugins_url( 'js/videopress-plupload.js', __FILE__ ),
+				array(
+					'jquery'
+				),
+				$this->version
+			);
+
+			wp_enqueue_script(
+				'videopress-uploader',
+				plugins_url( 'js/videopress-uploader.js', __FILE__ ),
+				array(
+					'videopress-plupload'
+				),
+				$this->version
+			);
 		}
 
 		wp_enqueue_style( 'videopress-admin', plugins_url( 'videopress-admin.css', __FILE__ ), array(), $this->version );
-
-		$caps = array();
-		foreach ( array( 'edit_videos', 'delete_videos' ) as $cap ) {
-			$caps[ $cap ] = $this->can( $cap );
-		}
-
-		// Leaving these as we may need to encorporate them somewhere else
-		$l10n = array(
-			'selectVideoFile'         => __( 'Please select a video file to upload.', 'jetpack' ),
-			'videoUploading'          => __( 'Your video is uploading... Please do not close this window.', 'jetpack' ),
-			'unknownError'            => __( 'An unknown error has occurred. Please try again later.', 'jetpack' ),
-			'videoUploaded'           => __( 'Your video has successfully been uploaded. It will appear in your VideoPress Library shortly.', 'jetpack' ),
-			'VideoPressLibraryRouter' => __( 'VideoPress Library', 'jetpack' ),
-			'uploadVideoRouter'       => __( 'Upload a Video', 'jetpack' ),
-			'insertVideoButton'       => __( 'Insert Video', 'jetpack' ),
-		);
 
 		/**
 		 * Fires after VideoPress scripts are enqueued in the dashboard.

--- a/modules/videopress/js/videopress-plupload.js
+++ b/modules/videopress/js/videopress-plupload.js
@@ -1,0 +1,462 @@
+/* global pluploadL10n, plupload, _wpPluploadSettings */
+
+window.wp = window.wp || {};
+
+( function( exports, $ ) {
+    var Uploader, vp;
+
+    if ( typeof _wpPluploadSettings === 'undefined' ) {
+        return;
+    }
+
+    /**
+     * A WordPress uploader.
+     *
+     * The Plupload library provides cross-browser uploader UI integration.
+     * This object bridges the Plupload API to integrate uploads into the
+     * WordPress back end and the WordPress media experience.
+     *
+     * @param {object} options           The options passed to the new plupload instance.
+     * @param {object} options.container The id of uploader container.
+     * @param {object} options.browser   The id of button to trigger the file select.
+     * @param {object} options.dropzone  The id of file drop target.
+     * @param {object} options.plupload  An object of parameters to pass to the plupload instance.
+     * @param {object} options.params    An object of parameters to pass to $_POST when uploading the file.
+     *                                   Extends this.plupload.multipart_params under the hood.
+     */
+    Uploader = function( options ) {
+        var self = this,
+            isIE = navigator.userAgent.indexOf('Trident/') != -1 || navigator.userAgent.indexOf('MSIE ') != -1,
+            elements = {
+                container: 'container',
+                browser:   'browse_button',
+                dropzone:  'drop_element'
+            },
+            key, error;
+
+        this.supports = {
+            upload: Uploader.browser.supported
+        };
+
+        this.supported = this.supports.upload;
+
+        if ( ! this.supported ) {
+            return;
+        }
+
+        // Arguments to send to pluplad.Uploader().
+        // Use deep extend to ensure that multipart_params and other objects are cloned.
+        this.plupload = $.extend( true, { multipart_params: {} }, Uploader.defaults );
+        this.container = document.body; // Set default container.
+
+        // Extend the instance with options.
+        //
+        // Use deep extend to allow options.plupload to override individual
+        // default plupload keys.
+        $.extend( true, this, options );
+
+        // Proxy all methods so this always refers to the current instance.
+        for ( key in this ) {
+            if ( $.isFunction( this[ key ] ) ) {
+                this[ key ] = $.proxy( this[ key ], this );
+            }
+        }
+
+        // Ensure all elements are jQuery elements and have id attributes,
+        // then set the proper plupload arguments to the ids.
+        for ( key in elements ) {
+            if ( ! this[ key ] ) {
+                continue;
+            }
+
+            this[ key ] = $( this[ key ] ).first();
+
+            if ( ! this[ key ].length ) {
+                delete this[ key ];
+                continue;
+            }
+
+            if ( ! this[ key ].prop('id') ) {
+                this[ key ].prop( 'id', '__wp-uploader-id-' + Uploader.uuid++ );
+            }
+
+            this.plupload[ elements[ key ] ] = this[ key ].prop('id');
+        }
+
+        // If the uploader has neither a browse button nor a dropzone, bail.
+        if ( ! ( this.browser && this.browser.length ) && ! ( this.dropzone && this.dropzone.length ) ) {
+            return;
+        }
+
+        // Make sure flash sends cookies (seems in IE it does without switching to urlstream mode)
+        if ( ! isIE && 'flash' === plupload.predictRuntime( this.plupload ) &&
+            ( ! this.plupload.required_features || ! this.plupload.required_features.hasOwnProperty( 'send_binary_string' ) ) ) {
+
+            this.plupload.required_features = this.plupload.required_features || {};
+            this.plupload.required_features.send_binary_string = true;
+        }
+
+        // Initialize the plupload instance.
+        this.uploader = new plupload.Uploader( this.plupload );
+        delete this.plupload;
+
+        // Set default params and remove this.params alias.
+        this.param( this.params || {} );
+        delete this.params;
+
+        // Make sure that the VideoPress object is available
+        if ( typeof exports.VideoPress !== 'undefined' ) {
+            vp = exports.VideoPress;
+
+        } else {
+            console.error( 'The VideoPress object was not loaded. Errors may occur.' );
+        }
+
+        /**
+         * Custom error callback.
+         *
+         * Add a new error to the errors collection, so other modules can track
+         * and display errors. @see wp.Uploader.errors.
+         *
+         * @param  {string}        message
+         * @param  {object}        data
+         * @param  {plupload.File} file     File that was uploaded.
+         */
+        error = function( message, data, file ) {
+            if ( file.attachment ) {
+                file.attachment.destroy();
+            }
+
+            Uploader.errors.unshift({
+                message: message || pluploadL10n.default_error,
+                data:    data,
+                file:    file
+            });
+
+            self.error( message, data, file );
+        };
+
+        /**
+         * After the Uploader has been initialized, initialize some behaviors for the dropzone.
+         *
+         * @param {plupload.Uploader} uploader Uploader instance.
+         */
+        this.uploader.bind( 'init', function( uploader ) {
+            var timer, active, dragdrop,
+                dropzone = self.dropzone;
+
+            dragdrop = self.supports.dragdrop = uploader.features.dragdrop && ! Uploader.browser.mobile;
+
+            // Generate drag/drop helper classes.
+            if ( ! dropzone ) {
+                return;
+            }
+
+            dropzone.toggleClass( 'supports-drag-drop', !! dragdrop );
+
+            if ( ! dragdrop ) {
+                return dropzone.unbind('.wp-uploader');
+            }
+
+            // 'dragenter' doesn't fire correctly, simulate it with a limited 'dragover'.
+            dropzone.bind( 'dragover.wp-uploader', function() {
+                if ( timer ) {
+                    clearTimeout( timer );
+                }
+
+                if ( active ) {
+                    return;
+                }
+
+                dropzone.trigger('dropzone:enter').addClass('drag-over');
+                active = true;
+            });
+
+            dropzone.bind('dragleave.wp-uploader, drop.wp-uploader', function() {
+                // Using an instant timer prevents the drag-over class from
+                // being quickly removed and re-added when elements inside the
+                // dropzone are repositioned.
+                //
+                // @see https://core.trac.wordpress.org/ticket/21705
+                timer = setTimeout( function() {
+                    active = false;
+                    dropzone.trigger('dropzone:leave').removeClass('drag-over');
+                }, 0 );
+            });
+
+            self.ready = true;
+            $(self).trigger( 'uploader:ready' );
+        });
+
+        this.uploader.bind( 'postinit', function( up ) {
+            up.refresh();
+            self.init();
+        });
+
+        this.uploader.init();
+
+        if ( this.browser ) {
+            this.browser.on( 'mouseenter', this.refresh );
+        } else {
+            this.uploader.disableBrowse( true );
+            // If HTML5 mode, hide the auto-created file container.
+            $('#' + this.uploader.id + '_html5_container').hide();
+        }
+
+        /**
+         * After files were filtered and added to the queue, create a model for each.
+         *
+         * @event FilesAdded
+         * @param {plupload.Uploader} uploader Uploader instance.
+         * @param {Array}             files    Array of file objects that were added to queue by the user.
+         */
+        this.uploader.bind( 'FilesAdded', function( up, files ) {
+            _.each( files, function( file ) {
+                var attributes, image;
+
+                // Ignore failed uploads.
+                if ( plupload.FAILED === file.status ) {
+                    return;
+                }
+
+                // Generate attributes for a new `Attachment` model.
+                attributes = _.extend({
+                    file:      file,
+                    uploading: true,
+                    date:      new Date(),
+                    filename:  file.name,
+                    menuOrder: 0,
+                    uploadedTo: wp.media.model.settings.post.id
+                }, _.pick( file, 'loaded', 'size', 'percent' ) );
+
+                // Handle early mime type scanning for images.
+                image = /(?:jpe?g|png|gif)$/i.exec( file.name );
+
+                // For images set the model's type and subtype attributes.
+                if ( image ) {
+                    attributes.type = 'image';
+
+                    // `jpeg`, `png` and `gif` are valid subtypes.
+                    // `jpg` is not, so map it to `jpeg`.
+                    attributes.subtype = ( 'jpg' === image[0] ) ? 'jpeg' : image[0];
+                }
+
+                // Create a model for the attachment, and add it to the Upload queue collection
+                // so listeners to the upload queue can track and display upload progress.
+                file.attachment = wp.media.model.Attachment.create( attributes );
+                Uploader.queue.add( file.attachment );
+
+                self.added( file.attachment );
+            });
+
+            up.refresh();
+            up.start();
+        });
+
+        this.uploader.bind( 'UploadProgress', function( up, file ) {
+            file.attachment.set( _.pick( file, 'loaded', 'percent' ) );
+            self.progress( file.attachment );
+        });
+
+        /**
+         * After a file is successfully uploaded, update its model.
+         *
+         * @param {plupload.Uploader} uploader Uploader instance.
+         * @param {plupload.File}     file     File that was uploaded.
+         * @param {Object}            response Object with response properties.
+         * @return {mixed}
+         */
+        this.uploader.bind( 'FileUploaded', function( up, file, response ) {
+            var complete;
+
+            try {
+                response = JSON.parse( response.response );
+            } catch ( e ) {
+                return error( pluploadL10n.default_error, e, file );
+            }
+
+            if ( typeof response.media !== 'undefined' ) {
+                response = vp.handleRestApiResponse( response, file );
+            } else {
+                response = vp.handleStandardResponse( response, file );
+            }
+
+            _.each(['file','loaded','size','percent'], function( key ) {
+                file.attachment.unset( key );
+            });
+
+            file.attachment.set( _.extend( response.data, { uploading: false }) );
+            wp.media.model.Attachment.get( response.data.id, file.attachment );
+
+            complete = Uploader.queue.all( function( attachment ) {
+                return ! attachment.get('uploading');
+            });
+
+            if ( complete ) {
+                vp && vp.resetToOriginalOptions( up );
+                Uploader.queue.reset();
+            }
+
+            self.success( file.attachment );
+        });
+
+        /**
+         * When plupload surfaces an error, send it to the error handler.
+         *
+         * @param {plupload.Uploader} uploader Uploader instance.
+         * @param {Object}            error    Contains code, message and sometimes file and other details.
+         */
+        this.uploader.bind( 'Error', function( up, pluploadError ) {
+            var message = pluploadL10n.default_error,
+                key;
+
+            // Check for plupload errors.
+            for ( key in Uploader.errorMap ) {
+                if ( pluploadError.code === plupload[ key ] ) {
+                    message = Uploader.errorMap[ key ];
+
+                    if ( _.isFunction( message ) ) {
+                        message = message( pluploadError.file, pluploadError );
+                    }
+
+                    break;
+                }
+            }
+
+            error( message, pluploadError, pluploadError.file );
+            vp && vp.resetToOriginalOptions( up );
+            up.refresh();
+        });
+
+        /**
+         * Add in a way for the uploader to reset itself when uploads are complete.
+         */
+        this.uploader.bind( 'UploadComplete', function( up ) {
+            vp && vp.resetToOriginalOptions( up );
+        });
+
+        /**
+         * Before we upload, check to see if this file is a videopress upload, if so, set new options and save the old ones.
+         */
+        this.uploader.bind( 'BeforeUpload', function( up, file ) {
+            if ( typeof file.videopress !== 'undefined' ) {
+                vp.originalOptions.url = up.getOption( 'url' );
+                vp.originalOptions.multipart_params = up.getOption( 'multipart_params' );
+                vp.originalOptions.file_data_name = up.getOption( 'file_data_name' );
+
+                up.setOption( 'file_data_name', 'media[]' );
+                up.setOption( 'url', file.videopress.upload_action_url );
+                up.setOption( 'multipart_params', { 'media_ids[]': file.videopress.upload_media_id } );
+                up.setOption( 'headers', {
+                    Authorization: 'X_UPLOAD_TOKEN token="' + file.videopress.upload_token + '" blog_id="' + file.videopress.upload_blog_id + '"'
+                });
+            }
+        });
+    };
+
+    // Adds the 'defaults' and 'browser' properties.
+    $.extend( Uploader, _wpPluploadSettings );
+
+    Uploader.uuid = 0;
+
+    // Map Plupload error codes to user friendly error messages.
+    Uploader.errorMap = {
+        'FAILED':                 pluploadL10n.upload_failed,
+        'FILE_EXTENSION_ERROR':   pluploadL10n.invalid_filetype,
+        'IMAGE_FORMAT_ERROR':     pluploadL10n.not_an_image,
+        'IMAGE_MEMORY_ERROR':     pluploadL10n.image_memory_exceeded,
+        'IMAGE_DIMENSIONS_ERROR': pluploadL10n.image_dimensions_exceeded,
+        'GENERIC_ERROR':          pluploadL10n.upload_failed,
+        'IO_ERROR':               pluploadL10n.io_error,
+        'HTTP_ERROR':             pluploadL10n.http_error,
+        'SECURITY_ERROR':         pluploadL10n.security_error,
+
+        'FILE_SIZE_ERROR': function( file ) {
+            return pluploadL10n.file_exceeds_size_limit.replace('%s', file.name);
+        }
+    };
+
+    $.extend( Uploader.prototype, {
+        /**
+         * Acts as a shortcut to extending the uploader's multipart_params object.
+         *
+         * param( key )
+         *    Returns the value of the key.
+         *
+         * param( key, value )
+         *    Sets the value of a key.
+         *
+         * param( map )
+         *    Sets values for a map of data.
+         */
+        param: function( key, value ) {
+            if ( arguments.length === 1 && typeof key === 'string' ) {
+                return this.uploader.settings.multipart_params[ key ];
+            }
+
+            if ( arguments.length > 1 ) {
+                this.uploader.settings.multipart_params[ key ] = value;
+            } else {
+                $.extend( this.uploader.settings.multipart_params, key );
+            }
+        },
+
+        /**
+         * Make a few internal event callbacks available on the wp.Uploader object
+         * to change the Uploader internals if absolutely necessary.
+         */
+        init:     function() {},
+        error:    function() {},
+        success:  function() {},
+        added:    function() {},
+        progress: function() {},
+        complete: function() {},
+        refresh:  function() {
+            var node, attached, container, id;
+
+            if ( this.browser ) {
+                node = this.browser[0];
+
+                // Check if the browser node is in the DOM.
+                while ( node ) {
+                    if ( node === document.body ) {
+                        attached = true;
+                        break;
+                    }
+                    node = node.parentNode;
+                }
+
+                // If the browser node is not attached to the DOM, use a
+                // temporary container to house it, as the browser button
+                // shims require the button to exist in the DOM at all times.
+                if ( ! attached ) {
+                    id = 'wp-uploader-browser-' + this.uploader.id;
+
+                    container = $( '#' + id );
+                    if ( ! container.length ) {
+                        container = $('<div class="wp-uploader-browser" />').css({
+                            position: 'fixed',
+                            top: '-1000px',
+                            left: '-1000px',
+                            height: 0,
+                            width: 0
+                        }).attr( 'id', 'wp-uploader-browser-' + this.uploader.id ).appendTo('body');
+                    }
+
+                    container.append( this.browser );
+                }
+            }
+
+            this.uploader.refresh();
+        }
+    });
+
+    // Create a collection of attachments in the upload queue,
+    // so that other modules can track and display upload progress.
+    Uploader.queue = new wp.media.model.Attachments( [], { query: false });
+
+    // Create a collection to collect errors incurred while attempting upload.
+    Uploader.errors = new Backbone.Collection();
+
+    exports.Uploader = Uploader;
+})( wp, jQuery );

--- a/modules/videopress/js/videopress-plupload.js
+++ b/modules/videopress/js/videopress-plupload.js
@@ -1,4 +1,4 @@
-/* global pluploadL10n, plupload, _wpPluploadSettings */
+/* global pluploadL10n, plupload, _wpPluploadSettings, JSON */
 
 window.wp = window.wp || {};
 
@@ -26,7 +26,7 @@ window.wp = window.wp || {};
      */
     Uploader = function( options ) {
         var self = this,
-            isIE = navigator.userAgent.indexOf('Trident/') != -1 || navigator.userAgent.indexOf('MSIE ') != -1,
+            isIE = navigator.userAgent.indexOf('Trident/') !== -1 || navigator.userAgent.indexOf('MSIE ') !== -1,
             elements = {
                 container: 'container',
                 browser:   'browse_button',
@@ -109,7 +109,7 @@ window.wp = window.wp || {};
             vp = exports.VideoPress;
 
         } else {
-            console.error( 'The VideoPress object was not loaded. Errors may occur.' );
+            window.console && window.console.error( 'The VideoPress object was not loaded. Errors may occur.' );
         }
 
         /**

--- a/modules/videopress/js/videopress-uploader.js
+++ b/modules/videopress/js/videopress-uploader.js
@@ -1,4 +1,4 @@
-/* globals plupload, pluploadL10n, JSON */
+/* globals plupload, pluploadL10n, error */
 window.wp = window.wp || {};
 
 ( function( wp ) {

--- a/modules/videopress/js/videopress-uploader.js
+++ b/modules/videopress/js/videopress-uploader.js
@@ -1,202 +1,106 @@
 /* globals plupload, pluploadL10n, JSON */
 window.wp = window.wp || {};
 
-( function( wp, $ ) {
+( function( wp ) {
+	var VideoPress = {
+		originalOptions: {},
+
+		/**
+		 * This is the standard uploader response handler.
+		 */
+		handleStandardResponse: function( response, file ) {
+			if ( ! _.isObject( response ) || _.isUndefined( response.success ) ) {
+				return error(pluploadL10n.default_error, null, file);
+
+			} else if ( ! response.success ) {
+				return error(response.data && response.data.message, response.data, file);
+			}
+
+			return response;
+		},
+
+		/**
+		 * Handle response from the WPCOM Rest API.
+		 */
+		handleRestApiResponse: function( response, file ) {
+			if ( response.media.length !== 1) {
+				return error( pluploadL10n.default_error, null, file );
+			}
+
+			var media = response.media[0],
+				mimeParts = media.mime_type.split('/'),
+				data = {
+					alt : '',
+					author : media.author_ID || 0,
+					authorName: '',
+					caption: '',
+					compat: { item: '', meta: '' },
+					date: media.date || '',
+					dateFormatted: media.date || '',
+					description: media.description || '',
+					editLink: '',
+					filename: media.file || '',
+					filesizeHumanReadable: '',
+					filesizeInBytes: '',
+					height: media.height,
+					icon: media.icon || '',
+					id: media.ID || '',
+					link: media.URL || '',
+					menuOrder: 0,
+					meta: false,
+					mime: media.mime_type || '',
+					modified: 0,
+					name: '',
+					nonces: { update: '', 'delete': '', edit: '' },
+					orientation: '',
+					sizes: {},
+					status: '',
+					subtype: mimeParts[1] || '',
+					title: media.title || '',
+					type: mimeParts[0] || '',
+					uploadedTo: 1,
+					uploadedToLink: '',
+					uploadedToTitle: '',
+					url: media.URL || '',
+					width: media.width,
+					success: '',
+					videopress: {
+						guid: media.videopress_guid || null,
+						processing_done: media.videopress_processing_done || false
+					}
+				};
+
+			response.data = data;
+
+			return response;
+		},
+
+		/**
+		 * Make sure that all of the original variables have been reset, so the uploader
+		 * doesn't try to go to VideoPress again next time.
+		 *
+		 * @param up
+		 */
+		resetToOriginalOptions: function( up ) {
+			if ( typeof VideoPress.originalOptions.url !== 'undefined' ) {
+				up.setOption( 'url', VideoPress.originalOptions.url );
+				delete VideoPress.originalOptions.url;
+			}
+
+			if ( typeof VideoPress.originalOptions.multipart_params !== 'undefined' ) {
+				up.setOption( 'multipart_params', VideoPress.originalOptions.multipart_params );
+				delete VideoPress.originalOptions.multipart_params;
+			}
+
+			if ( typeof VideoPress.originalOptions.file_data_name !== 'undefined' ) {
+				up.setOption( 'file_data_name', VideoPress.originalOptions.file_data_name );
+				delete VideoPress.originalOptions.file_data_name;
+			}
+		}
+	};
+
 	if (typeof wp.Uploader !== 'undefined') {
-		var Uploader = wp.Uploader,
-			media = wp.media;
-
-		var error = function( message, data, file ) {
-			if ( file.attachment ) {
-				file.attachment.destroy();
-			}
-
-			var error_msg = {
-				message: message || pluploadL10n.default_error,
-				data:    data,
-				file:    file
-			};
-
-			Uploader.errors.unshift( error_msg );
-		};
-
-		$.extend( Uploader.prototype, {
-
-			/**
-			 * Custom error callback.
-			 *
-			 * Add a new error to the errors collection, so other modules can track
-			 * and display errors. @see wp.Uploader.errors.
-			 *
-			 * @param  {string}        message
-			 * @param  {object}        data
-			 * @param  {plupload.File} file     File that was uploaded.
-			 */
-
-
-			/**
-			 * Initialization routine that allows us to add in more uploader events.
-			 */
-			init: function () {
-				var self = this;
-				self.origOptions = self.origOptions || {};
-
-				this.uploader.bind( 'BeforeUpload', function( up, file ) {
-					if ( typeof file.videopress !== 'undefined' ) {
-						self.origOptions.url = up.getOption( 'url' );
-						self.origOptions.multipart_params = up.getOption( 'multipart_params' );
-						self.origOptions.file_data_name = up.getOption( 'file_data_name' );
-
-						up.setOption( 'file_data_name', 'media[]' );
-						up.setOption( 'url', file.videopress.upload_action_url );
-						up.setOption( 'multipart_params', { 'media_ids[]': file.videopress.upload_media_id } );
-						up.setOption( 'headers', {
-							Authorization: 'X_UPLOAD_TOKEN token="' + file.videopress.upload_token + '" blog_id="' + file.videopress.upload_blog_id + '"'
-						});
-					}
-				});
-
-				this.uploader.bind( 'UploadComplete', function( up ) {
-					self.resetToOriginalOptions( up );
-				});
-
-				this.uploader.bind( 'Error', function( up ) {
-					self.resetToOriginalOptions( up );
-				});
-
-				// remove the normal file uploader check.
-				this.uploader.unbind( 'FileUploaded' );
-
-				/**
-				 * After a file is successfully uploaded, update its model.
-				 *
-				 * @param {plupload.Uploader} uploader Uploader instance.
-				 * @param {plupload.File}     file     File that was uploaded.
-				 * @param {Object}            response Object with response properties.
-				 * @return {mixed}
-				 */
-				this.uploader.bind( 'FileUploaded', function( up, file, response ) {
-					var complete, id;
-
-					try {
-						response = JSON.parse( response.response );
-					} catch ( e ) {
-						return error( pluploadL10n.default_error, e, file );
-					}
-
-					if ( typeof response.media !== 'undefined' ) {
-						id = self.handleRestApiResponse( response, file );
-					} else {
-						id = self.handleStandardResponse( response, file );
-					}
-
-					_.each(['file','loaded','size','percent'], function( key ) {
-						file.attachment.unset( key );
-					});
-
-					wp.media.model.Attachment.get( id, file.attachment );
-
-					complete = Uploader.queue.all( function( attachment ) {
-						return ! attachment.get('uploading');
-					});
-
-					if ( complete ) {
-						Uploader.queue.reset();
-					}
-
-					self.success( file.attachment );
-				});
-			},
-
-			handleStandardResponse: function( response, file ) {
-				if ( ! _.isObject( response ) || _.isUndefined( response.success ) ) {
-					return error(pluploadL10n.default_error, null, file);
-				} else if ( ! response.success ) {
-					return error(response.data && response.data.message, response.data, file);
-				}
-
-				file.attachment.set( _.extend( response.data, { uploading: false }) );
-
-				return response.data.id;
-			},
-
-			handleRestApiResponse: function( response, file ) {
-
-				if ( response.media.length !== 1) {
-					return error( pluploadL10n.default_error, null, file );
-				}
-
-				var media = response.media[0],
-					mimeParts = media.mime_type.split('/'),
-					data = {
-						alt : '',
-						author : media.author_ID || 0,
-						authorName: '',
-						caption: '',
-						compat: { item: '', meta: '' },
-						date: media.date || '',
-						dateFormatted: media.date || '',
-						description: media.description || '',
-						editLink: '',
-						filename: media.file || '',
-						filesizeHumanReadable: '',
-						filesizeInBytes: '',
-						height: media.height,
-						icon: media.icon || '',
-						id: media.ID || '',
-						link: media.URL || '',
-						menuOrder: 0,
-						meta: false,
-						mime: media.mime_type || '',
-						modified: 0,
-						name: '',
-						nonces: { update: '', 'delete': '', edit: '' },
-						orientation: '',
-						sizes: {},
-						status: '',
-						subtype: mimeParts[1] || '',
-						title: media.title || '',
-						type: mimeParts[0] || '',
-						uploadedTo: 1,
-						uploadedToLink: '',
-						uploadedToTitle: '',
-						url: media.URL || '',
-						width: media.width,
-						success: '',
-						videopress: {
-							guid: media.videopress_guid || null,
-							processing_done: media.videopress_processing_done || false
-						}
-					};
-
-				file.attachment.set( _.extend( data, { uploading: false }) );
-
-				return media.ID;
-			},
-
-			/**
-			 * Make sure that all of the original variables have been reset, so the uploader
-			 * doesn't try to go to VideoPress again next time.
-			 *
-			 * @param up
-			 */
-			resetToOriginalOptions: function( up ) {
-				if ( typeof this.origOptions.url !== 'undefined' ) {
-					up.setOption( 'url', this.origOptions.url );
-					delete this.origOptions.url;
-				}
-
-				if ( typeof this.origOptions.multipart_params !== 'undefined' ) {
-					up.setOption( 'multipart_params', this.origOptions.multipart_params );
-					delete this.origOptions.multipart_params;
-				}
-
-				if ( typeof this.origOptions.file_data_name !== 'undefined' ) {
-					up.setOption( 'file_data_name', this.origOptions.file_data_name );
-					delete this.origOptions.file_data_name;
-				}
-			}
-		});
+		var media = wp.media;
 
 		/**
 		 * A plupload code specifically for videopress failures.
@@ -221,7 +125,7 @@ window.wp = window.wp || {};
 				}).fail( function ( response ) {
 					self.trigger( 'Error', {
 						code : plupload.VIDEOPRESS_TOKEN_FAILURE,
-						message : plupload.translate( 'Could not get the videopress token needed for uploading' ),
+						message : plupload.translate( 'Could not get the VideoPress token needed for uploading' ),
 						file : file,
 						response : response
 					} );
@@ -236,7 +140,7 @@ window.wp = window.wp || {};
 				if (file.size !== undef && maxSize && file.size > maxSize) {
 					this.trigger('Error', {
 						code: plupload.FILE_SIZE_ERROR,
-						message: plupload.translate('File size error.'),
+						message: plupload.translate( 'File size error.' ),
 						file: file
 					});
 					cb(false);
@@ -246,5 +150,8 @@ window.wp = window.wp || {};
 			}
 		});
 	}
-} )( window.wp, jQuery );
+
+	wp.VideoPress = VideoPress;
+
+} )( window.wp );
 


### PR DESCRIPTION
Fixes #5584

#### Changes proposed in this Pull Request:

Replaces the uploader code with a direct core override to fix multi-uploading problems. This is a hopefully temporary measure until we can make the core code more directly extendable. 

Note for the future: if core changes wp-plupload.js, then the override will need to be changes as well.

#### Testing instructions:

Check that you can upload multiple files again into the media library uploader.
