### PR TITLE
SEO Tools: Fix verification services update error

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -22,6 +22,7 @@ $tools = array(
 	'seo-tools/jetpack-seo-utils.php',
 	'seo-tools/jetpack-seo-titles.php',
 	'seo-tools/jetpack-seo-posts.php',
+	'verification-tools/verification-tools-utils.php',
 );
 
 /**

--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -61,16 +61,6 @@ function jetpack_verification_print_meta() {
 }
 add_action( 'wp_head', 'jetpack_verification_print_meta', 1 );
 
-function jetpack_verification_get_code( $code ){
-	$pattern = '/content=["\']?([^"\' ]*)["\' ]/is';
-	preg_match( $pattern, $code, $match );
-	if ( $match ){
-		return urldecode( $match[1] );
-	} else {
-		return false;
-	}
-}
-
 function jetpack_verification_options_form() {
 	$verification_services_codes = get_option( 'verification_services_codes' );
 	?>

--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -71,32 +71,6 @@ function jetpack_verification_get_code( $code ){
 	}
 }
 
-function jetpack_verification_validate( $verification_services_codes ) {
-	foreach ( $verification_services_codes as $key => &$code ) {
-		// Parse html meta tags if present
-		if ( stripos( $code, 'meta' ) )
-			$code = jetpack_verification_get_code( $code );
-
-		$code = esc_attr( trim( $code ) );
-
-		// limit length to 100 chars.
-		$code = substr( $code, 0, 100 );
-
-		/**
-		 * Fire after each Verification code was validated.
-		 *
-		 * @module verification-tools
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param string $key Verification service name.
-		 * @param string $code Verification service code provided in field in the Tools menu.
-		 */
-		do_action( 'jetpack_site_verification_validate', $key, $code );
-	}
-	return $verification_services_codes;
-}
-
 function jetpack_verification_options_form() {
 	$verification_services_codes = get_option( 'verification_services_codes' );
 	?>

--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Helper functions that are called from API even when module is active should be added here.
+ * We will include this in module-extras.php
+ */
+
+function jetpack_verification_validate( $verification_services_codes ) {
+	foreach ( $verification_services_codes as $key => &$code ) {
+		// Parse html meta tags if present
+		if ( stripos( $code, 'meta' ) )
+			$code = jetpack_verification_get_code( $code );
+
+		$code = esc_attr( trim( $code ) );
+
+		// limit length to 100 chars.
+		$code = substr( $code, 0, 100 );
+
+		/**
+		 * Fire after each Verification code was validated.
+		 *
+		 * @module verification-tools
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $key Verification service name.
+		 * @param string $code Verification service code provided in field in the Tools menu.
+		 */
+		do_action( 'jetpack_site_verification_validate', $key, $code );
+	}
+	return $verification_services_codes;
+}

--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
- * Helper functions that are called from API even when module is active should be added here.
- * We will include this in module-extras.php
+ * Helper functions that are called from API even when module is inactive should be added here.
+ * This file will be included in module-extras.php.
  */
 
 function jetpack_verification_validate( $verification_services_codes ) {

--- a/modules/verification-tools/verification-tools-utils.php
+++ b/modules/verification-tools/verification-tools-utils.php
@@ -30,3 +30,13 @@ function jetpack_verification_validate( $verification_services_codes ) {
 	}
 	return $verification_services_codes;
 }
+
+function jetpack_verification_get_code( $code ){
+	$pattern = '/content=["\']?([^"\' ]*)["\' ]/is';
+	preg_match( $pattern, $code, $match );
+	if ( $match ){
+		return urldecode( $match[1] );
+	} else {
+		return false;
+	}
+}


### PR DESCRIPTION
Fixes #5591

#### Testing instructions

0. Your site should use the latest 4.4. Beta as well as a Jetpack Pro plan.
1. Activate the SEO Tools module, and deactivate the Site Verification Tools module.
2. Go to Settings > SEO on WordPress.com in the WordPress.com dashboard.
3. After you've picked your site, you should see a number of options on that page.
4. Try to make changes, and save your changes.
5. Verify that the settings are saved correctly.

Previously, when verification services module was inactive, updating site settings would fail because the function that is used in API endpoint was not defined.