### PR TITLE
Update/plugins endpoint add translations updates

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -35,7 +35,7 @@ class Jetpack_Autoupdate {
 			add_filter( 'auto_update_plugin', array( $this, 'autoupdate_plugin' ), 10, 2 );
 			add_filter( 'auto_update_theme', array( $this, 'autoupdate_theme' ), 10, 2 );
 			add_filter( 'auto_update_core', array( $this, 'autoupdate_core' ), 10, 2 );
-			add_filter( 'auto_update_translation', array( $this, 'autoupdate_translation', 10, 2 ) );
+			add_filter( 'auto_update_translation', array( $this, 'autoupdate_translation' ), 10, 2 );
 			add_action( 'automatic_updates_complete', array( $this, 'automatic_updates_complete' ), 999, 1 );
 		}
 	}
@@ -52,6 +52,7 @@ class Jetpack_Autoupdate {
 	}
 
 	public function autoupdate_translation( $update, $item ) {
+		// Themes
 		$autoupdate_themes_translations = Jetpack_Options::get_option( 'autoupdate_themes_translations', array() );
 		$autoupdate_theme_list          = Jetpack_Options::get_option( 'autoupdate_themes', array() );
 
@@ -70,8 +71,21 @@ class Jetpack_Autoupdate {
 		       || in_array( $item->slug, $autoupdate_theme_list ) )
 		     && 'theme' === $item->type
 		) {
-			$this->expect( $item->slug, 'theme' );
+			$this->expect( $item->slug, 'translation' );
 
+			return true;
+		}
+
+		// Plugins
+		$autoupdate_plugin_translations = Jetpack_Options::get_option( 'autoupdate_plugins_translations', array() );
+		$autoupdate_plugin_list         = Jetpack_Options::get_option( 'autoupdate_plugins', array() );
+		$plugin_files = array_unique( array_merge( $autoupdate_plugin_list, $autoupdate_plugin_translations ) );
+		$plugin_slugs = array_map( array( __CLASS__, 'get_plugin_slug' ), $plugin_files );
+
+		if ( in_array( $item->slug, $plugin_slugs )
+		     && 'plugin' === $item->type
+		) {
+			$this->expect( $item->slug, 'translation' );
 			return true;
 		}
 
@@ -126,7 +140,7 @@ class Jetpack_Autoupdate {
 
 		Jetpack::init();
 
-		$items_to_log = array( 'plugin', 'theme' );
+		$items_to_log = array( 'plugin', 'theme', 'translation' );
 		foreach ( $items_to_log as $items ) {
 			$this->log_items( $items );
 		}
@@ -148,7 +162,6 @@ class Jetpack_Autoupdate {
 	 * @param $items 'plugin' or 'theme'
 	 */
 	private function log_items( $items ) {
-
 		if ( ! isset( $this->expected[ $items ] ) ) {
 			return;
 		}
@@ -225,6 +238,10 @@ class Jetpack_Autoupdate {
 						break;
 					case 'plugin':
 						$successful_updates[] = $result->item->plugin;
+						break;
+					case 'translation':
+						$successful_updates[] = $result->item->slug;
+						break;
 				}
 			}
 		}
@@ -275,6 +292,29 @@ class Jetpack_Autoupdate {
 		}
 
 		return $result;
+	}
+
+	static function get_plugin_slug( $plugin_file ) {
+		$update_plugins   = get_site_transient( 'update_plugins' );
+		if ( isset( $update_plugins->no_update ) ) {
+			if ( isset( $update_plugins->no_update[ $plugin_file ] ) ) {
+				$slug = $update_plugins->no_update[ $plugin_file ]->slug;
+			}
+		}
+		if ( empty( $slug ) && isset( $update_plugins->response ) ) {
+			if ( isset( $update_plugins->response[ $plugin_file ] ) ) {
+				$slug = $update_plugins->response[ $plugin_file ]->slug;
+			}
+		}
+
+		// Try to infer from the plugin file if not cached
+		if ( empty( $slug) ) {
+			$slug = dirname( $plugin_file );
+			if ( '.' === $slug ) {
+				$slug = preg_replace("/(.+)\.php$/", "$1", $plugin_file );
+			}
+		}
+		return $slug;
 	}
 
 }

--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -71,7 +71,7 @@ class Jetpack_Autoupdate {
 		       || in_array( $item->slug, $autoupdate_theme_list ) )
 		     && 'theme' === $item->type
 		) {
-			$this->expect( $item->slug, 'translation' );
+			$this->expect( $item->type + ':' + $item->slug, 'translation' );
 
 			return true;
 		}
@@ -85,7 +85,7 @@ class Jetpack_Autoupdate {
 		if ( in_array( $item->slug, $plugin_slugs )
 		     && 'plugin' === $item->type
 		) {
-			$this->expect( $item->slug, 'translation' );
+			$this->expect( $item->type + ':' + $item->slug, 'translation' );
 			return true;
 		}
 
@@ -96,7 +96,6 @@ class Jetpack_Autoupdate {
 		$autoupdate_theme_list = Jetpack_Options::get_option( 'autoupdate_themes', array() );
 		if ( in_array( $item->theme, $autoupdate_theme_list ) ) {
 			$this->expect( $item->theme, 'theme' );
-
 			return true;
 		}
 
@@ -240,7 +239,7 @@ class Jetpack_Autoupdate {
 						$successful_updates[] = $result->item->plugin;
 						break;
 					case 'translation':
-						$successful_updates[] = $result->item->slug;
+						$successful_updates[] = $result->item->type + ':' + $result->item->slug;
 						break;
 				}
 			}

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -24,6 +24,7 @@ class Jetpack_Options {
 				'relatedposts',
 				'file_data',
 				'autoupdate_plugins',          // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated
+				'autoupdate_plugins_translations', // (array)  An array of plugin ids ( eg. jetpack/jetpack ) that should be autoupdated translation files.
 				'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
 				'autoupdate_themes_translations', // (array)  An array of theme ids ( eg. twentyfourteen ) that should autoupdated translation files.
 				'autoupdate_core',             // (bool)   Whether or not to autoupdate core

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -25,6 +25,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		'author_url'      => '(url)  The authors web site address',
 		'network'         => '(boolean) Whether the plugin can only be activated network wide.',
 		'autoupdate'      => '(boolean) Whether the plugin is automatically updated',
+		'autoupdate_translation' => '(boolean) Whether the plugin is automatically updating translations',
 		'next_autoupdate' => '(string) Y-m-d H:i:s for next scheduled update event',
 		'log'             => '(array:safehtml) An array of update log strings.',
 		'uninstallable'   => '(boolean) Whether the plugin is unistallable.',
@@ -68,7 +69,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			$this->bulk = false;
 			$this->plugins[] = urldecode( $plugin );
 		}
-
+		
 		if ( is_wp_error( $error = $this->validate_plugins() ) ) {
 			return $error;
 		};
@@ -89,17 +90,19 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 				$plugin =  $plugin . '.php';
 				$this->plugins[ $index ] = $plugin;
 			}
-			if ( is_wp_error( $error = $this->validate_plugin( $plugin ) ) ) {
-				return $error;
+			$valid = $this->validate_plugin( urldecode( $plugin ) ) ;
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
 			}
 		}
+
 		return true;
 	}
 
 	protected function format_plugin( $plugin_file, $plugin_data ) {
 		$plugin = array();
 		$plugin['id']              = preg_replace("/(.+)\.php$/", "$1", $plugin_file );
-		$plugin['slug']            = $this->get_plugin_slug( $plugin_file );
+		$plugin['slug']            = Jetpack_Autoupdate::get_plugin_slug( $plugin_file );
 		$plugin['active']          = Jetpack::is_plugin_active( $plugin_file );
 		$plugin['name']            = $plugin_data['Name'];
 		$plugin['plugin_url']      = $plugin_data['PluginURI'];
@@ -110,8 +113,15 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		$plugin['network']         = $plugin_data['Network'];
 		$plugin['update']          = $this->get_plugin_updates( $plugin_file );
 		$plugin['next_autoupdate'] = date( 'Y-m-d H:i:s', wp_next_scheduled( 'wp_maybe_auto_update' ) );
-		$plugin['autoupdate']      = in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins', array() ) );
+
+		$autoupdate = in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins', array() ) );
+		$plugin['autoupdate']      = $autoupdate;
+		
+		$autoupdate_translation = in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins_translations', array() ) );
+		$plugin['autoupdate_translation'] = $autoupdate || $autoupdate_translation;
+
 		$plugin['uninstallable']   = is_uninstallable_plugin( $plugin_file );
+
 		if ( ! empty ( $this->log[ $plugin_file ] ) ) {
 			$plugin['log'] = $this->log[ $plugin_file ];
 		}
@@ -159,7 +169,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			return new WP_Error( 'missing_plugin', __( 'You are required to specify a plugin to activate.', 'jetpack' ), 400 );
 		}
 
-		if ( is_wp_error( $error = validate_plugin( urldecode( $plugin ) ) ) ) {
+		if ( is_wp_error( $error = validate_plugin( $plugin ) ) ) {
 			return new WP_Error( 'unknown_plugin', $error->get_error_messages() , 404 );
 		}
 
@@ -172,29 +182,5 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			return $plugin_updates[ $plugin_file ]->update;
 		}
 		return null;
-	}
-
-	protected function get_plugin_slug( $plugin_file ) {
-		$update_plugins   = get_site_transient( 'update_plugins' );
-		if ( isset( $update_plugins->no_update ) ) {
-			if ( isset( $update_plugins->no_update[ $plugin_file ] ) ) {
-				$slug = $update_plugins->no_update[ $plugin_file ]->slug;
-			}
-		}
-
-		if ( empty( $slug ) && isset( $update_plugins->response ) ) {
-			if ( isset( $update_plugins->response[ $plugin_file ] ) ) {
-				$slug = $update_plugins->response[ $plugin_file ]->slug;
-			}
-		}
-
-		// Try to infer from the plugin file if not cached
-		if ( empty( $slug) ) {
-			$slug = dirname( $plugin_file );
-			if ( '.' === $slug ) {
-				$slug = preg_replace("/(.+)\.php$/", "$1", $plugin_file );
-			}
-		}
-		return $slug;
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -3,14 +3,17 @@
 class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_Endpoint {
 	// POST  /sites/%s/plugins/%s
 	// POST  /sites/%s/plugins
-
+	protected $slug = null;
 	protected $needed_capabilities = 'activate_plugins';
 	protected $action              = 'default_action';
-	protected $expected_actions    = array( 'update', 'install', 'delete' );
+	protected $expected_actions    = array( 'update', 'install', 'delete', 'update_translations' );
 
 	public function callback( $path = '', $blog_id = 0, $object = null ) {
 		Jetpack_JSON_API_Endpoint::validate_input( $object );
 		switch ( $this->action ) {
+			case 'delete':
+				$this->needed_capabilities = 'delete_plugins';
+			case 'update_translations':
 			case 'update' :
 				$this->needed_capabilities = 'update_plugins';
 				break;
@@ -18,7 +21,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				$this->needed_capabilities = 'install_plugins';
 				break;
 		}
-		if ( isset( $args['autoupdate'] ) ) {
+
+		if ( isset( $args['autoupdate'] ) || isset( $args['autoupdate_translations'] ) ) {
 			$this->needed_capabilities = 'update_plugins';
 		}
 
@@ -44,6 +48,14 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 		}
 
+		if ( isset( $args['autoupdate_translations'] ) && is_bool( $args['autoupdate_translations'] ) ) {
+			if ( $args['autoupdate_translations'] ) {
+				$this->autoupdate_translations_on();
+			} else {
+				$this->autoupdate_translations_off();
+			}
+		}
+
 		return true;
 	}
 
@@ -57,6 +69,18 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		$autoupdate_plugins = Jetpack_Options::get_option( 'autoupdate_plugins', array() );
 		$autoupdate_plugins = array_diff( $autoupdate_plugins, $this->plugins );
 		Jetpack_Options::update_option( 'autoupdate_plugins', $autoupdate_plugins );
+	}
+
+	protected function autoupdate_translations_on() {
+		$autoupdate_plugins = Jetpack_Options::get_option( 'autoupdate_plugins_translations', array() );
+		$autoupdate_plugins = array_unique( array_merge( $autoupdate_plugins, $this->plugins ) );
+		Jetpack_Options::update_option( 'autoupdate_plugins_translations', $autoupdate_plugins );
+	}
+
+	protected function autoupdate_translations_off() {
+		$autoupdate_plugins = Jetpack_Options::get_option( 'autoupdate_plugins_translations', array() );
+		$autoupdate_plugins = array_diff( $autoupdate_plugins, $this->plugins );
+		Jetpack_Options::update_option( 'autoupdate_plugins_translations', $autoupdate_plugins );
 	}
 
 	protected function activate() {
@@ -151,7 +175,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		$result = false;
 
 		foreach ( $this->plugins as $plugin ) {
-
+	
 			if ( ! in_array( $plugin, $plugin_updates_needed ) ) {
 				$this->log[ $plugin ][] = __( 'No update needed', 'jetpack' );
 				continue;
@@ -166,7 +190,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			 * @param array $plugin Array of plugin objects
 			 * @param bool $updated_attempted false for the first update, true subsequently
 			 */
-			do_action('jetpack_pre_plugin_upgrade', $plugin, $this->plugins, $update_attempted);
+			do_action( 'jetpack_pre_plugin_upgrade', $plugin, $this->plugins, $update_attempted );
 
 			$update_attempted = true;
 
@@ -179,7 +203,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			defined( 'DOING_CRON' ) or define( 'DOING_CRON', true );
 			$result = $upgrader->upgrade( $plugin );
 
-			$this->log[ $plugin ][] = $upgrader->skin->get_upgrade_messages();
+			$this->log[ $plugin ] = $upgrader->skin->get_upgrade_messages();
 		}
 
 		if ( ! $this->bulk && ! $result && $update_attempted ) {
@@ -187,5 +211,63 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		}
 
 		return $this->default_action();
+	}
+
+	function update_translations() {
+		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		// Clear the cache.
+		wp_clean_plugins_cache();
+		ob_start();
+		wp_update_plugins(); // Check for Plugin updates
+		ob_end_clean();
+
+		$available_updates = get_site_transient( 'update_plugins' );
+		if ( ! isset( $available_updates->translations ) || empty( $available_updates->translations ) ) {
+			return new WP_Error( 'nothing_to_translate' );
+		}
+
+		$update_attempted = false;
+		$result = false;
+		foreach( $this->plugins as $plugin ) {
+			$this->slug = Jetpack_Autoupdate::get_plugin_slug( $plugin );
+			$translation = array_filter( $available_updates->translations, array( $this, 'get_translation' ) );
+			
+			if ( empty( $translation ) ) {
+				$this->log[ $plugin ][] = __( 'No update needed', 'jetpack' );
+				continue;
+			}
+			
+			/**
+			 * Pre-upgrade action
+			 *
+			 * @since 4.4
+			 *
+			 * @param array $plugin Plugin data
+			 * @param array $plugin Array of plugin objects
+			 * @param bool $updated_attempted false for the first update, true subsequently
+			 */
+			do_action( 'jetpack_pre_plugin_upgrade_translations', $plugin, $this->plugins, $update_attempted );
+
+			$update_attempted = true;
+			
+			$skin = new Automatic_Upgrader_Skin();
+			$upgrader = new Language_Pack_Upgrader( $skin );
+			$upgrader->init();
+
+			$result   = $upgrader->upgrade( (object) $translation[0] );
+		
+			$this->log[ $plugin ] = $upgrader->skin->get_upgrade_messages();
+		}
+
+		if ( ! $this->bulk && ! $result ) {
+			return new WP_Error( 'update_fail', __( 'There was an error updating your plugin', 'jetpack' ), 400 );
+		}
+
+		return true;
+	}
+	
+	protected function get_translation( $translation ) {
+		return ( $translation['slug'] === $this->slug );
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -232,12 +232,12 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		foreach( $this->plugins as $plugin ) {
 			$this->slug = Jetpack_Autoupdate::get_plugin_slug( $plugin );
 			$translation = array_filter( $available_updates->translations, array( $this, 'get_translation' ) );
-			
+
 			if ( empty( $translation ) ) {
 				$this->log[ $plugin ][] = __( 'No update needed', 'jetpack' );
 				continue;
 			}
-			
+
 			/**
 			 * Pre-upgrade action
 			 *

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
@@ -25,7 +25,7 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 		'tags'         => '(array) Tags indicating styles and features of the theme.',
 		'log'          => '(array) An array of log strings',
 		'autoupdate'   => '(bool) Whether the theme is automatically updated',
-		'autoupdate_translations' => '(bool) Whether the theme is automatically updating translations',
+		'autoupdate_translation' => '(bool) Whether the theme is automatically updating translations',
 	);
 
 	protected function result() {
@@ -119,16 +119,13 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 		$update_themes = get_site_transient( 'update_themes' );
 		$formatted_theme['update'] = ( isset( $update_themes->response[ $id ] ) ) ? $update_themes->response[ $id ] : null;
 
-		$autoupdate_themes = Jetpack_Options::get_option( 'autoupdate_themes', array() );
-		$autoupdate_themes_translations = Jetpack_Options::get_option( 'autoupdate_themes', array() );
+		$autoupdate = in_array( $id, Jetpack_Options::get_option( 'autoupdate_themes', array() ) );
+		$formatted_theme['autoupdate'] =  $autoupdate;
 
-		$autoupdate = in_array( $id, $autoupdate_themes );
-		$autoupdate_translations = in_array( $id, $autoupdate_themes_translations );
-		$formatted_theme['autoupdate'] = $autoupdate;
-		$formatted_theme['autoupdate_translations'] = $autoupdate || $autoupdate_translations;
+		$autoupdate_translation = in_array( $id, Jetpack_Options::get_option( 'autoupdate_themes_translations', array() ) );
+		$formatted_theme['autoupdate_translation'] = $autoupdate || $autoupdate_translation;
 
-
-		if( isset( $this->log[ $id ] ) ) {
+		if ( isset( $this->log[ $id ] ) ) {
 			$formatted_theme['log'] = $this->log[ $id ];
 		}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
@@ -92,34 +92,32 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 		$available_themes_updates = get_site_transient( 'update_themes' );
 		
 		if ( ! isset( $available_themes_updates->translations ) || empty( $available_themes_updates->translations ) ) {
-			
 			return new WP_Error( 'nothing_to_translate' );
 		}
 
 		foreach( $available_themes_updates->translations as $translation ) {
+			$theme = $translation['slug'] ;
 			if ( ! in_array( $translation['slug'], $this->themes )  ) {
+				$this->log[ $theme ][] = __( 'No update needed', 'jetpack' );
 				continue;
 			}
-
-			$theme = $translation['slug'] ;
-
 
 			/**
 			 * Pre-upgrade action
 			 *
-			 * @since 3.9.3
+			 * @since 4.4
 			 *
 			 * @param object $theme WP_Theme object
 			 * @param array $themes Array of theme objects
 			 */
-			do_action('jetpack_pre_theme_upgrade', $theme, $this->themes);
+			do_action( 'jetpack_pre_theme_upgrade_translations', $theme, $this->themes );
 			// Objects created inside the for loop to clean the messages for each theme
 			$skin = new Automatic_Upgrader_Skin();
 			$upgrader = new Language_Pack_Upgrader( $skin );
 			$upgrader->init();
 
 			$result   = $upgrader->upgrade( (object) $translation );
-			$this->log[ $theme ][] = $upgrader->skin->get_upgrade_messages();
+			$this->log[ $theme ] = $upgrader->skin->get_upgrade_messages();
 		}
 
 		if ( ! $this->bulk && ! $result ) {

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -78,6 +78,7 @@ class Jetpack_Sync_Defaults {
 		'jetpack_activated',
 		'jetpack_available_modules',
 		'jetpack_autoupdate_plugins',
+		'jetpack_autoupdate_plugins_translations',
 		'jetpack_autoupdate_themes',
 		'jetpack_autoupdate_themes_translations',
 		'jetpack_autoupdate_core',

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -135,6 +135,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_activated'                    => 'pineapple',
 			'jetpack_available_modules'            => 'pineapple',
 			'jetpack_autoupdate_plugins'           => 'pineapple',
+			'jetpack_autoupdate_plugins_translations' => 'pineapple',
 			'jetpack_autoupdate_themes'            => 'pineapple',
 			'jetpack_autoupdate_themes_translations' => 'pineapple',
 			'jetpack_autoupdate_core'              => 'pineapple',


### PR DESCRIPTION
cc: @lezama 

Add autoupdates of translation to the plugins api endpoint. It also fixes some items on the theme endpoint to be more constant with the plugin one in regards to the updating of translations.

To test:
Go to wp-content/languages/plugins/ and delete the following files
`rm akismet-en_CA.mo akismet-en_CA.po` 
in the developer console try https://developer.wordpress.com/docs/api/console/
url : /sites/$s/plugins/
action=update_translations&plugins[]=akismet%2Fakismet&plugins[]=jetpack%2Fjetpack

to test the autoupdates work.
on your sandbox try:
Go to wp-content/languages/plugins/ and delete the following files
`rm akismet-en_CA.mo akismet-en_CA.po` 
`wp shell`
run ` wp_maybe_auto_update();`

This should autoupdate the translations for you. 





