### PR TITLE
Connection Banner: Add expiration date to A/B test

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -33,8 +33,12 @@ class Jetpack_Connection_Banner {
 	 *
 	 * @return bool
 	 */
-	static function check_ab_test_allowed( $now = null ) {
+	static function check_ab_test_not_expired( $now = null ) {
+		// Get the current timestamp in GMT
 		$now = empty( $now ) ? current_time( 'timestamp', 1 ) : $now;
+
+		// Arguments are hour, minute, second, month, day, year. So, we are getting the timestamp for GMT timestamp
+		// for the 15th of December 2016.
 		$expiration = gmmktime( 0, 0, 0, 12, 15, 2016 );
 
 		return $expiration >= $now;
@@ -81,7 +85,7 @@ class Jetpack_Connection_Banner {
 			return;
 		}
 
-		if ( self::check_ab_test_allowed() && 2 == self::get_random_connection_banner_value() ) {
+		if ( self::check_ab_test_not_expired() && 2 == self::get_random_connection_banner_value() ) {
 			add_action( 'admin_notices', array( $this, 'render_banner' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_banner_scripts' ) );
 		} else {
@@ -129,7 +133,7 @@ class Jetpack_Connection_Banner {
 	 * Renders the legacy connection banner.
 	 */
 	function render_legacy_banner() {
-		$legacy_banner_from = self::check_ab_test_allowed()
+		$legacy_banner_from = self::check_ab_test_not_expired()
 			? 'banner-legacy'
 			: 'banner';
 		?>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -128,7 +128,11 @@ class Jetpack_Connection_Banner {
 	/**
 	 * Renders the legacy connection banner.
 	 */
-	function render_legacy_banner() { ?>
+	function render_legacy_banner() {
+		$legacy_banner_from = self::check_ab_test_allowed()
+			? 'banner-legacy'
+			: 'banner';
+		?>
 		<div id="message" class="updated jp-banner">
 			<a
 				href="<?php echo esc_url( $this->get_dismiss_and_deactivate_url() ); ?>"
@@ -148,7 +152,7 @@ class Jetpack_Connection_Banner {
 				</p>
 				<p class="jp-banner__button-container">
 					<a
-						href="<?php echo Jetpack::init()->build_connect_url( false, false, 'banner' ) ?>"
+						href="<?php echo Jetpack::init()->build_connect_url( false, false, $legacy_banner_from ) ?>"
 						class="button button-primary">
 						<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 					</a>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
 			<file>tests/php/test_class.jetpack-xmlrpc-server.php</file>
 			<file>tests/php/test_class.jetpack-heartbeat.php</file>
 			<file>tests/php/test_class.jetpack-constants.php</file>
+			<file>tests/php/test_class.jetpack-connection-banner.php</file>
 		</testsuite>
 		<testsuite name="core-api">
 			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>

--- a/tests/php/test_class.jetpack-connection-banner.php
+++ b/tests/php/test_class.jetpack-connection-banner.php
@@ -1,0 +1,17 @@
+<?php
+
+class WP_Test_Jetpack_Connection_Banner extends WP_UnitTestCase {
+	function test_ab_test_expiration_before_12_15() {
+		$this->assertTrue( Jetpack_Connection_Banner::check_ab_test_allowed( strtotime( '10 November 2016' ) ) );
+	}
+
+	function test_ab_test_expiration_after_12_15() {
+		$this->assertFalse( Jetpack_Connection_Banner::check_ab_test_allowed( strtotime( '17 December 2016' ) ) );
+	}
+
+	function test_get_random_connection_banner_value_if_not_set() {
+		Jetpack_Options::delete_option( 'connection_banner_ab' );
+		$this->assertNotEquals( false, Jetpack_Connection_Banner::get_random_connection_banner_value() );
+		$this->assertNotEquals( false, Jetpack_Options::get_option( 'connection_banner_ab' ) );
+	}
+}

--- a/tests/php/test_class.jetpack-connection-banner.php
+++ b/tests/php/test_class.jetpack-connection-banner.php
@@ -2,11 +2,11 @@
 
 class WP_Test_Jetpack_Connection_Banner extends WP_UnitTestCase {
 	function test_ab_test_expiration_before_12_15() {
-		$this->assertTrue( Jetpack_Connection_Banner::check_ab_test_allowed( strtotime( '10 November 2016' ) ) );
+		$this->assertTrue( Jetpack_Connection_Banner::check_ab_test_not_expired( strtotime( '10 November 2016' ) ) );
 	}
 
 	function test_ab_test_expiration_after_12_15() {
-		$this->assertFalse( Jetpack_Connection_Banner::check_ab_test_allowed( strtotime( '17 December 2016' ) ) );
+		$this->assertFalse( Jetpack_Connection_Banner::check_ab_test_not_expired( strtotime( '17 December 2016' ) ) );
 	}
 
 	function test_get_random_connection_banner_value_if_not_set() {


### PR DESCRIPTION
Today, @jessefriedman clarified that we needed to ship the A/B test with an expiration date since some hosts/software packages could bundle any version of Jetpack and we wouldn't have control over whether the A/B test was running or not.

To test:

- Ensure tests pass
- In your testing site, deactivate and then activate Jetpack
- Ensure you see a connection banner
- Hover over the various "Connect to WP.com" buttons and verify the `from` parameter is different for each button
- Check the other connection banner by 
    - Going to `$site.com/wp-admin/options.php`
    - Search for `jetpack_connection_banner_ab`
    - If value is `1`, change it to `2`. If value is `2`, change it to `1`
    - Submit form
- Go back to plugins page