### PR TITLE
IDC: Horizontally align notice header with content

### DIFF
--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -60,7 +60,7 @@
 }
 
 .jp-idc-notice > div {
-	padding: 0 16px;
+	padding: 0 8px;
 }
 
 .jp-idc-notice__first-step {
@@ -82,7 +82,8 @@
 }
 
 .jp-idc-notice .jp-idc-notice__header {
-	padding: 8px 0;
+	padding-top: 8px;
+	padding-bottom: 8px;
 }
 
 .jp-idc-notice__header__emblem {


### PR DESCRIPTION
@rickybanister pointed out that the header of the notice didn't horizontally align with the content. This PR fixes that.

To test:

- Checkout `update/idc-section-header-left-padding` branch
- `yarn build`
- Put your site in IDC. Ping if you need help
- Check styles for notice

### Screenshots

<img width="1060" alt="screen shot 2016-11-11 at 12 19 55 pm" src="https://cloud.githubusercontent.com/assets/1126811/20225524/74ecb7e8-a809-11e6-9439-dc08e6609c3b.png">
<img width="550" alt="screen shot 2016-11-11 at 12 20 07 pm" src="https://cloud.githubusercontent.com/assets/1126811/20225525/74f26ed6-a809-11e6-9b42-d9439eb2f895.png">
