### PR TITLE
OpenGraph: replace function getimagesize with standard WP function

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -322,9 +322,18 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		$blavatar_domain = blavatar_domain( site_url() );
 		if ( blavatar_exists( $blavatar_domain ) ) {
 			$image_url = blavatar_url( $blavatar_domain, 'img', $width, false, true );
-			$image_size = getimagesize( $image_url );
-			$img_width = $image_size[0];
-			$img_height = $image_size[1];
+
+			$img_width  = '';
+			$img_height = '';
+			$image_id = attachment_url_to_postid( $image_url );
+			$image_size = wp_get_attachment_image_src( $image_id, $width >= 512
+				? 'full'
+				: array( $width, $width ) );
+			if ( isset( $image_size[1], $image_size[2] ) ) {
+				$img_width  = $image_size[1];
+				$img_height = $image_size[2];
+			}
+
 			if (_jetpack_og_get_image_validate_size($img_width, $img_height, $width, $height)) {
 				$image['src']    = $image_url;
 				$image['width']  = $width;
@@ -349,10 +358,20 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 	// Third fall back, Core Site Icon, if valid in size. Added in WP 4.3.
 	if ( empty( $image ) && ( function_exists( 'has_site_icon') && has_site_icon() ) ) {
-		$image_url = get_site_icon_url( max( $width, $height ) );
-		$image_size = getimagesize( $image_url );
-		$img_width = $image_size[0];
-		$img_height = $image_size[1];
+		$max_side = max( $width, $height );
+		$image_url = get_site_icon_url( $max_side );
+
+		$img_width  = '';
+		$img_height = '';
+		$image_id = attachment_url_to_postid( $image_url );
+		$image_size = wp_get_attachment_image_src( $image_id, $max_side >= 512
+			? 'full'
+			: array( $max_side, $max_side ) );
+		if ( isset( $image_size[1], $image_size[2] ) ) {
+			$img_width  = $image_size[1];
+			$img_height = $image_size[2];
+		}
+
 		if (_jetpack_og_get_image_validate_size($img_width, $img_height, $width, $height)) {
 			$image['src']     = $image_url;
 			$image['width']   = $width;


### PR DESCRIPTION
Follow up to #3432 

The PHP function `getimagesize` doesn't work in a server where allow_url_fopen=0 and throws a warning

```
Warning: getimagesize(): http:// wrapper is disabled in the server configuration by allow_url_fopen=0 in .../jetpack/functions.opengraph.php on line 353

Warning: getimagesize(http://xxx.xxx/wp-content/uploads/2016/05/cropped-pizza-1-270x270.png): failed to open stream: no suitable wrapper could be found in .../jetpack/functions.opengraph.php on line 353
```
#### Changes proposed in this Pull Request:
- replace `getimagesize` and use a standard WP function instead.

#### Testing instructions:
* make sure site icon, blavatar, everything works correctly and the sizes belong to the image used.