### PR TITLE
Revert "Sync: Send `jetpack_published_post` action right after `wp_insert_post`"

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -157,7 +157,10 @@ class Jetpack_Subscriptions {
 		 * If we're updating the post, let's make sure the flag to not send to subscribers
 		 * is set to minimize the chances of sending posts multiple times.
 		 */
-		if ( 'publish' == $old_status ) {
+		if (
+			( strtotime( $post->post_modified_gmt ) - strtotime( $post->post_date_gmt ) > DAY_IN_SECONDS ) &&
+			'publish' == $old_status
+		) {
 			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 		}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -75,8 +75,6 @@ class Jetpack_Subscriptions {
 		add_action( 'post_submitbox_misc_actions', array( $this, 'subscription_post_page_metabox' ) );
 
 		add_action( 'transition_post_status', array( $this, 'maybe_send_subscription_email' ), 10, 3 );
-
-		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags' ), 10, 2 );
 	}
 
 	/**
@@ -163,17 +161,6 @@ class Jetpack_Subscriptions {
 			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 		}
 
-		if ( ! $this->should_email_post_to_subscribers( $post ) ) {
-			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
-		}
-	}
-
-	public function should_email_post_to_subscribers( $post ) {
-		$should_email = true;
-		if ( get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true ) ) {
-			return false;
-		}
-
 		/**
 		 * Array of categories that will never trigger subscription emails.
 		 *
@@ -189,7 +176,7 @@ class Jetpack_Subscriptions {
 
 		// Never email posts from these categories
 		if ( ! empty( $excluded_categories ) && in_category( $excluded_categories, $post->ID ) ) {
-			$should_email = false;
+			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 		}
 
 		/**
@@ -207,23 +194,15 @@ class Jetpack_Subscriptions {
 
 		// Only emails posts from these categories
 		if ( ! empty( $only_these_categories ) && ! in_category( $only_these_categories, $post->ID ) ) {
-			$should_email = false;
+			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 		}
 
 		// Email the post, depending on the checkbox option
 		if ( ! empty( $_POST['disable_subscribe_nonce'] ) && wp_verify_nonce( $_POST['disable_subscribe_nonce'], 'disable_subscribe' ) ) {
 			if ( isset( $_POST['_jetpack_dont_email_post_to_subs'] ) ) {
-				$should_email = false;
+				update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', $_POST['_jetpack_dont_email_post_to_subs'] );
 			}
 		}
-		return $should_email;
-	}
-
-	function set_post_flags( $flags, $post ) {
-		if ( ! $this->should_email_post_to_subscribers( $post ) ) {
-			$flags['_jetpack_dont_email_post_to_subs'] = true;
-		}
-		return $flags;
 	}
 
 	/**
@@ -739,7 +718,6 @@ class Jetpack_Subscriptions {
 			setcookie( 'jetpack_blog_subscribe_' . self::$hash, '', time() - 3600, $cookie_path, $cookie_domain );
 		}
 	}
-
 }
 
 Jetpack_Subscriptions::init();

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -4,8 +4,6 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 
 class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
-	private $just_published;
-
 	public function name() {
 		return 'posts';
 	}
@@ -23,11 +21,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	public function init_listeners( $callable ) {
 		add_action( 'wp_insert_post', $callable, 10, 3 );
-		add_action( 'wp_insert_post', array( $this, 'send_published'), 11, 3 );
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_publicize_post', $callable );
-		add_action( 'jetpack_published_post', $callable, 10, 2 );
-		add_action( 'transition_post_status', array( $this, 'save_published' ), 10, 3 );
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'filter_blacklisted_post_types' ) );
 	}
 
@@ -178,20 +173,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 				true; // Don't email subscription if the subscription module is not active.
 
 		return $post;
-	}
-
-	public function save_published( $new_status, $old_status, $post ) {
-		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
-			$this->just_published = $post->ID;
-		}
-	}
-
-	public function send_published( $post_ID, $post, $update ) {
-		if ( $this->just_published === $post->ID ) {
-			$this->just_published = null;
-			$flags = apply_filters( 'jetpack_published_post_flags', array(), $post );
-			do_action( 'jetpack_published_post', $post_ID, $flags );
-		}
 	}
 
 	public function expand_post_ids( $args ) {

--- a/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
+++ b/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
@@ -12,7 +12,7 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 		$this->assertEmpty( get_post_meta( $post_id, '_jetpack_dont_email_post_to_subs', true ) );
 	}
 
-	function test_updating_post_sets_do_not_send_subscription_flag() {
+	function test_updating_post_immediately_sets_doesnt_set_dont_email_flag() {
 		$post_id = $this->factory->post->create();
 
 		// Publish and then immediately update the post, which should set the do not send flag
@@ -22,6 +22,31 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 			'post_content' => 'The updated post content',
 		) );
 
+		echo get_post_meta( $post_id, '_jetpack_dont_email_post_to_subs', true );
+		$this->assertEmpty( get_post_meta( $post_id, '_jetpack_dont_email_post_to_subs', true ) );
+	}
+
+	function test_updating_post_after_day_sets_dont_email_flag() {
+		$post_id = $this->factory->post->create();
+
+		// Publish and then immediately update the post, which should set the do not send flag
+		wp_publish_post( $post_id );
+		add_filter( 'wp_insert_post_data', array( $this, '__set_post_modified_in_future' ) );
+		wp_update_post( array(
+			'ID'                 => $post_id,
+			'post_content'       => 'The updated post content',
+			'post_modified'      => gmdate( 'Y-m-d H:i:s', ( time() + 2 * DAY_IN_SECONDS ) ),
+			'post_modified_gmt'  => gmdate( 'Y-m-d H:i:s', ( time() + 2 * DAY_IN_SECONDS ) ),
+		) );
+		remove_filter( 'wp_insert_post_data', array( $this, '__set_post_modified_in_future' ) );
+
 		$this->assertEquals( '1',  get_post_meta( $post_id, '_jetpack_dont_email_post_to_subs', true ) );
+	}
+
+	function __set_post_modified_in_future( $post ) {
+		$post['post_modified']     = gmdate( 'Y-m-d H:i:s', ( time() + 2 * DAY_IN_SECONDS ) );
+		$post['post_modified_gmt'] = gmdate( 'Y-m-d H:i:s', ( time() + 2 * DAY_IN_SECONDS ) );
+
+		return $post;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -365,8 +365,10 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_includes_dont_email_post_to_subs_when_subscription_is_not_active() {
+		$active_modules = Jetpack::get_active_modules();
 		Jetpack_Options::update_option( 'active_modules', array() );
-		
+		// Subscription is not an active module
+		$this->assertTrue( ! in_array( 'subscriptions', Jetpack::get_active_modules() ) );
 		$post_id = $this->factory->post->create();
 
 		$this->sender->do_sync();
@@ -374,6 +376,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$post_on_server = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' )->args[1];
 
 		$this->assertEquals( true, $post_on_server->dont_email_post_to_subs );
+
+		Jetpack_Options::update_option( 'active_modules', $active_modules );
 	}
 
 	function test_sync_post_includes_feature_image_meta_when_featured_image_set() {
@@ -799,63 +803,5 @@ That was a cool video.';
 
 	function foo_shortcode() {
 		return 'bar';
-	}
-
-	public function test_sync_jetpack_published_post() {
-		wp_update_post( array(
-			'ID'          => $this->post->ID,
-			'post_status' => 'draft',
-		) );
-
-		$this->sender->do_sync();
-
-		$remote_post = $this->server_replica_storage->get_post( $this->post->ID );
-		$this->assertEquals( 'draft', $remote_post->post_status );
-
-		wp_publish_post( $this->post->ID );
-
-		$this->sender->do_sync();
-
-		$remote_post = $this->server_replica_storage->get_post( $this->post->ID );
-		$this->assertEquals( 'publish', $remote_post->post_status );
-
-		$event = $this->server_event_storage->get_most_recent_event();
-
-		$this->assertEquals( 'jetpack_published_post', $event->action );
-		$this->assertEquals( $this->post->ID, $event->args[0] );
-	}
-
-	public function test_sync_jetpack_update_post_to_draft_shouldnt_publish() {
-		$this->server_event_storage->reset();
-
-		wp_update_post( array(
-			'ID'          => $this->post->ID,
-			'post_status' => 'draft',
-		) );
-
-		$this->sender->do_sync();
-
-		$this->assertFalse( $this->server_event_storage->get_most_recent_event( 'jetpack_published_post' ) );
-	}
-
-	public function test_sync_jetpack_published_post_should_set_dont_send_to_subscribers_flag() {
-		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
-		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
- 		Jetpack_Subscriptions::init();
-
-		wp_update_post( array(
-			'ID'          => $this->post->ID,
-			'post_status' => 'draft',
-		) );
-
-		update_post_meta( $this->post->ID, '_jetpack_dont_email_post_to_subs', 1 );
-
-		wp_publish_post( $this->post->ID );
-
-		$this->sender->do_sync();
-
-		$post_flags = $this->server_event_storage->get_most_recent_event( 'jetpack_published_post' )->args[1];
-
-		$this->assertEquals( $post_flags['_jetpack_dont_email_post_to_subs'], 1 );
 	}
 }


### PR DESCRIPTION
In #5577 since we changed how we send the data to WP.com. We made that change, because of a weird issue we noticed where post updates that are sent to WP.com are not atomic. For example, if a user publishes a post, and that post is immediately updated before being synced, then subscriptions weren't going out. 

We knowingly made the decision to ship that PR yesterday because we thought we could handle the WP.com side quickly. If that is not the case though, we'll need to revert back and handle the issue another way.

This PR reverts Automattic/jetpack#5577 and adds a commit to only set the `_jetpack_dont_email_post_to_subs` post meta if a post is being updated after 1 day.

cc @lezama for review in case we decide we need to revert.

To test:

- Checkout `revert-5577-update/sync-posts-sync-jetpack_published_post-action` branch
- Publish a post
- Ensure you receive a subscription email