### PR TITLE
Admin: query site data when Engagement tab is focused

### DIFF
--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -89,6 +89,8 @@ export const AllModuleSettings = React.createClass( {
 							{ __( 'Your Jetpack plan doesn’t include SEO tools, you must upgrade to Jetpack Professional to use SEO tools.' ) }
 						</div>
 					);
+				} else if ( 'checking' === module.configure_url ) {
+					return null;
 				} else if ( 'inactive' === module.configure_url ) {
 					return (
 						<div>

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -83,15 +83,25 @@ export const AllModuleSettings = React.createClass( {
 			case 'sso':
 				return ( <SingleSignOnSettings module={ module }  /> );
 			case 'seo-tools':
-				return '' === module.configure_url ? (
-					<div>
-						{ __( 'Your Jetpack plan doesn’t include SEO tools, you must upgrade to Jetpack Professional to use SEO tools.' ) }
-					</div>
-				) : (
-					<div>
-						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url }>{ __( 'Configure your SEO settings.' ) }</ExternalLink>
-					</div>
-				);
+				if ( '' === module.configure_url ) {
+					return (
+						<div>
+							{ __( 'Your Jetpack plan doesn’t include SEO tools, you must upgrade to Jetpack Professional to use SEO tools.' ) }
+						</div>
+					);
+				} else if ( 'inactive' === module.configure_url ) {
+					return (
+						<div>
+							{ __( 'You have the Professional plan! Activate this module to use the advanced SEO tools.' ) }
+						</div>
+					);
+				} else {
+					return (
+						<div>
+							<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url }>{ __( 'Configure your SEO settings.' ) }</ExternalLink>
+						</div>
+					);
+				}
 			case 'stats':
 				return ( <StatsSettings module={ module }  /> );
 			case 'related-posts':

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -86,7 +86,7 @@ export const AllModuleSettings = React.createClass( {
 				if ( '' === module.configure_url ) {
 					return (
 						<div>
-							{ __( 'Your Jetpack plan doesn’t include SEO tools, you must upgrade to Jetpack Professional to use SEO tools.' ) }
+							{ __( 'Your Jetpack plan doesn’t include SEO tools. You must upgrade to Jetpack Professional to use SEO tools.' ) }
 						</div>
 					);
 				} else if ( 'checking' === module.configure_url ) {

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -100,7 +100,7 @@ export const Engagement = ( props ) => {
 			proProps = {},
 			isModuleActive = isModuleActivated( element[0] );
 
-		if ( isPro && props.sitePlan.product_slug !== 'jetpack_business' ) {
+		if ( isPro && 'undefined' !== typeof props.sitePlan.product_slug && props.sitePlan.product_slug !== 'jetpack_business' ) {
 			proProps = {
 				module: element[0],
 				configure_url: ''

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -33,6 +33,7 @@ import {
 	userCanManageModules as _userCanManageModules
 } from 'state/initial-state';
 import { getSitePlan } from 'state/site';
+import QuerySite from 'components/data/query-site';
 
 export const Engagement = ( props ) => {
 	let {
@@ -196,6 +197,7 @@ export const Engagement = ( props ) => {
 	} );
 	return (
 		<div>
+			<QuerySite />
 			{ cards }
 		</div>
 	);

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -97,14 +97,13 @@ export const Engagement = ( props ) => {
 			toggle = '',
 			adminAndNonAdmin = isAdmin || includes( nonAdminAvailable, element[0] ),
 			isPro = 'seo-tools' === element[0],
-			proProps = {},
-			isModuleActive = isModuleActivated( element[0] );
-
-		if ( isPro && 'undefined' !== typeof props.sitePlan.product_slug && props.sitePlan.product_slug !== 'jetpack_business' ) {
 			proProps = {
 				module: element[0],
 				configure_url: ''
-			};
+			},
+			isModuleActive = isModuleActivated( element[0] );
+
+		if ( isPro && 'undefined' !== typeof props.sitePlan.product_slug && props.sitePlan.product_slug !== 'jetpack_business' ) {
 
 			toggle = <ProStatus proFeature={ element[0] } />;
 
@@ -136,7 +135,9 @@ export const Engagement = ( props ) => {
 
 		if ( element[0] === 'seo-tools' ) {
 			if ( props.sitePlan.product_slug === 'jetpack_business' ) {
-				proProps.configure_url = 'https://wordpress.com/settings/seo/' + props.siteRawUrl;
+				proProps.configure_url = isModuleActive
+					? 'https://wordpress.com/settings/seo/' + props.siteRawUrl
+					: 'inactive';
 			}
 
 			moduleDescription = <AllModuleSettings module={ proProps } />;

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -134,12 +134,14 @@ export const Engagement = ( props ) => {
 			<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />;
 
 		if ( element[0] === 'seo-tools' ) {
-			if ( 'undefined' === typeof props.sitePlan.product_slug ) {
+			if ( 'undefined' === typeof props.sitePlan.product_slug && ! unavailableInDevMode ) {
 				proProps.configure_url = 'checking';
-			} else if ( props.sitePlan.product_slug === 'jetpack_business' ) {
-				proProps.configure_url = isModuleActive
-					? 'https://wordpress.com/settings/seo/' + props.siteRawUrl
-					: 'inactive';
+			} else {
+				if ( props.sitePlan.product_slug === 'jetpack_business' ) {
+					proProps.configure_url = isModuleActive
+						? 'https://wordpress.com/settings/seo/' + props.siteRawUrl
+						: 'inactive';
+				}
 			}
 
 			moduleDescription = <AllModuleSettings module={ proProps } />;

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -134,7 +134,9 @@ export const Engagement = ( props ) => {
 			<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />;
 
 		if ( element[0] === 'seo-tools' ) {
-			if ( props.sitePlan.product_slug === 'jetpack_business' ) {
+			if ( 'undefined' === typeof props.sitePlan.product_slug ) {
+				proProps.configure_url = 'checking';
+			} else if ( props.sitePlan.product_slug === 'jetpack_business' ) {
 				proProps.configure_url = isModuleActive
 					? 'https://wordpress.com/settings/seo/' + props.siteRawUrl
 					: 'inactive';


### PR DESCRIPTION
This allows the SEO Tools card to be properly displayed according to the plan the site has.

#### Changes proposed in this Pull Request:
- use QuerySite component to fetch site information, including the plan

#### Testing instructions:
* go to Jetpack admin
* focus the Engagement tab
* reload, so the Engagement tab is the first thing loaded
* the SEO Tools card should be displayed correctly: if site has a Professional plan, it should not display the PRO badge or the message in the card body saying it needs a Professional plan as it was done before this PR.