### PR TITLE
Admin: Do not check public accessiblity before activating modules

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -68,17 +68,6 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 			);
 		}
 
-		if (
-			in_array( $module_slug, $this->modules_requiring_public )
-			&& ! $this->is_site_public()
-		) {
-			return new WP_Error(
-				'rest_cannot_publish',
-				esc_html__( 'This module requires your site to be set to publicly accessible.', 'jetpack' ),
-				array( 'status' => 424 )
-			);
-		}
-
 		if ( Jetpack::activate_module( $module_slug, false, false ) ) {
 			return rest_ensure_response( array(
 				'code' 	  => 'success',

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -7,19 +7,6 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 	/**
-	 * List of modules that require WPCOM public access.
-	 *
-	 * @since 4.3.0
-	 *
-	 * @var array
-	 */
-	private $modules_requiring_public = array(
-		'photon',
-		'enhanced-distribution',
-		'json-api',
-	);
-
-	/**
 	 * Check if the module requires the site to be publicly accessible from WPCOM.
 	 * If the site meets this requirement, the module is activated. Otherwise an error is returned.
 	 *


### PR DESCRIPTION
Removes the check to WP.com to determine if a site is public accessible (which is done via the site's RSS feed).

Opting to remove it vs the 4.7-dependent check since it will be awhile until 4.7 is the minimum support version and unsure why we need the check.

Fixes #5481 cc: @zinigor 