### PR TITLE
VideoPress: Use ProStatus-style module when VideoPress is returned in search results

### DIFF
--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -90,7 +90,7 @@ export const SearchResults = ( {
 	} );
 
 	cards = moduleList.map( ( element ) => {
-		let isPro = 'scan' === element[0] || 'akismet' === element[0] || 'backups' === element[0],
+		let isPro = 'scan' === element[0] || 'akismet' === element[0] || 'backups' === element[0] || 'videopress' === element[0],
 			proProps = {},
 			unavailableDevMode = unavailableInDevMode( element[0] ),
 			toggle = unavailableDevMode ? __( 'Unavailable in Dev Mode' ) : (


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Currently, the ProStatus-style module is only visible under the "Writing" settings section. When VideoPress is listed in search results, the module is toggleable, which is not correct. This PR converts the search result to use the ProStatus type settings block.

![screen shot 2016-11-11 at 11 12 36 pm](https://cloud.githubusercontent.com/assets/5528445/20235608/7412b146-a864-11e6-901c-d52aa5dc6d63.png)


#### Testing instructions:

* Search for something that will return VideoPress. Ensure that the ProStatus style is applied to the VideoPress result. 
* Ensure all buttons in the aforementioned section work as expected.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).