### PR TITLE
VideoPress: Update description when module is active.

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -34,9 +34,14 @@ import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-sett
 export let VideoPressSettings = React.createClass( {
 	render() {
 		return (
-			<span className="jp-form-setting-explanation">
-				{ __( 'The easiest way to upload ad-free and unbranded videos to your site. You get stats on video playback and shares and the player is lightweight and responsive.' ) }
-			</span>
+			<div>
+				<p className="jp-form-setting-explanation">
+					{ __( 'The easiest way to upload ad-free and unbranded videos to your site. You get stats on video playback and shares and the player is lightweight and responsive.' ) }
+				</p>
+				<p className="jp-form-setting-explanation">
+					{ __( 'To get started, click on Add Media in your post editor and upload a video; we’ll take care of the rest!' ) }
+				</p>
+			</div>
 		)
 	}
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When VideoPress is not active, use the following description in the module settings:
![screen shot 2016-11-12 at 1 06 28 am](https://cloud.githubusercontent.com/assets/5528445/20236044/46e26922-a874-11e6-8afb-22dbb4033b10.png)

When VideoPress is active, use the following description in the module settings:
![screen shot 2016-11-12 at 1 04 26 am](https://cloud.githubusercontent.com/assets/5528445/20236038/1c3e6bc6-a874-11e6-8663-af5f722aedf4.png)

#### Testing instructions:

* Take not of the description in the VideoPress module settings on a site without a plan.
* Apply a Jetpack plan to the site and ensure that the module description changes.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

