### PR TITLE
Build: Begin uglifying frontend JS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,27 @@ npm-debug.log
 tests/php/files/jetpack-150x150.jpg
 *.unison.tmp
 
+## Minified JS that should not be source-controlled.
+## See frontendjs array in gulpfile.js
+_inc/facebook-embed.min.js
+_inc/jquery.spin.min.js
+_inc/spin.min.js
+_inc/twitter-timeline.min.js
+modules/carousel/jetpack-carousel.min.js
+modules/holiday-snow/snowstorm.min.js
+modules/infinite-scroll/infinity.min.js
+modules/photon/photon.min.js
+modules/related-posts/related-posts.min.js
+modules/sharedaddy/sharing.min.js
+modules/shortcodes/js/gist.min.js
+modules/shortcodes/js/instagram.min.js
+modules/shortcodes/js/main.min.js
+modules/shortcodes/js/recipes-printthis.min.js
+modules/shortcodes/js/recipes.min.js
+modules/shortcodes/js/slideshow-shortcode.min.js
+modules/tiled-gallery/tiled-gallery/tiled-gallery.min.js
+modules/wpgroho.min.js
+
 ## Things we will need in release branches
 /_inc/build
 /modules/**/*.min.css

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -797,6 +797,21 @@ class Jetpack {
 	}
 
 	/**
+	 * Helper function to determine whether minified JS should be loaded.
+	 *
+	 * @since 4.8.0
+	 *
+	 * @return bool
+	 */
+	public static function should_load_minified_js() {
+		return (
+			! is_admin() &&
+			! ( Jetpack_Constants::is_defined( 'SCRIPT_DEBUG' ) && Jetpack_Constants::get_constant( 'SCRIPT_DEBUG') ) &&
+			! ( Jetpack_Constants::is_defined( 'IS_WPCOM' ) && Jetpack_Constants::get_constant( 'IS_WPCOM' ) )
+		);
+	}
+
+	/**
 	 * Register assets for use in various modules and the Jetpack admin page.
 	 *
 	 * @uses wp_script_is, wp_register_script, plugins_url
@@ -804,12 +819,19 @@ class Jetpack {
 	 * @return null
 	 */
 	public function register_assets() {
+		$load_minified = self::should_load_minified_js();
 		if ( ! wp_script_is( 'spin', 'registered' ) ) {
-			wp_register_script( 'spin', plugins_url( '_inc/spin.js', JETPACK__PLUGIN_FILE ), false, '1.3' );
+			$file_path = $load_minified
+				? '_inc/spin.min.js'
+				: '_inc/spin.js';
+			wp_register_script( 'spin', plugins_url( $file_path, JETPACK__PLUGIN_FILE ), false, '1.3' );
 		}
 
 		if ( ! wp_script_is( 'jquery.spin', 'registered' ) ) {
-			wp_register_script( 'jquery.spin', plugins_url( '_inc/jquery.spin.js', JETPACK__PLUGIN_FILE ) , array( 'jquery', 'spin' ), '1.3' );
+			$file_path = $load_minified
+				? '_inc/jquery.spin.min.js'
+				: '_inc/jquery.spin.js';
+			wp_register_script( 'jquery.spin', plugins_url( $file_path, JETPACK__PLUGIN_FILE ) , array( 'jquery', 'spin' ), '1.3' );
 		}
 
 		if ( ! wp_script_is( 'jetpack-gallery-settings', 'registered' ) ) {
@@ -817,11 +839,17 @@ class Jetpack {
 		}
 
 		if ( ! wp_script_is( 'jetpack-twitter-timeline', 'registered' ) ) {
-			wp_register_script( 'jetpack-twitter-timeline', plugins_url( '_inc/twitter-timeline.js', JETPACK__PLUGIN_FILE ) , array( 'jquery' ), '4.0.0', true );
+			$file_path = $load_minified
+				? '_inc/twitter-timeline.min.js'
+				: '_inc/twitter-timeline.js';
+			wp_register_script( 'jetpack-twitter-timeline', plugins_url( $file_path, JETPACK__PLUGIN_FILE ) , array( 'jquery' ), '4.0.0', true );
 		}
 
 		if ( ! wp_script_is( 'jetpack-facebook-embed', 'registered' ) ) {
-			wp_register_script( 'jetpack-facebook-embed', plugins_url( '_inc/facebook-embed.js', __FILE__ ), array( 'jquery' ), null, true );
+			$file_path = $load_minified
+				? '_inc/facebook-embed.min.js'
+				: '_inc/facebook-embed.js';
+			wp_register_script( 'jetpack-facebook-embed', plugins_url( $file_path, __FILE__ ), array( 'jquery' ), null, true );
 
 			/** This filter is documented in modules/sharedaddy/sharing-sources.php */
 			$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );

--- a/class.photon.php
+++ b/class.photon.php
@@ -984,6 +984,16 @@ class Jetpack_Photon {
 	 * @return null
 	 */
 	public function action_wp_enqueue_scripts() {
-		wp_enqueue_script( 'jetpack-photon', plugins_url( 'modules/photon/photon.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), 20130122, true );
+		$file_path = Jetpack::should_load_minified_js()
+			? 'modules/photon/photon.min.js'
+			: 'modules/photon/photon.js';
+
+		wp_enqueue_script(
+			'jetpack-photon',
+			plugins_url( $file_path, JETPACK__PLUGIN_FILE ),
+			array( 'jquery' ),
+			20130122,
+			true
+		);
 	}
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,9 @@ var autoprefixer = require( 'gulp-autoprefixer' ),
 	util = require( 'gulp-util' ),
 	webpack = require( 'webpack' );
 
-var admincss, frontendcss,
+var admincss,
+	frontendcss,
+	frontendjs,
 	meta = require( './package.json' );
 
 function onBuild( done ) {
@@ -65,7 +67,7 @@ function onBuild( done ) {
 				.pipe( uglify() )
 				.pipe( gulp.dest( '_inc/build' ) )
 				.on( 'end', function() {
-					gutil.log( 'Your JS is now uglified!' );
+					gutil.log( 'Your admin page JS is now uglified!' );
 				} );;
 		}
 
@@ -292,6 +294,29 @@ frontendcss = [
 	'modules/widgets/flickr/style.css'
 ];
 
+frontendjs = [
+	'modules/carousel/jetpack-carousel.js',
+	'modules/holiday-snow/snowstorm.js',
+	'modules/infinite-scroll/infinity.js',
+	'modules/photon/photon.js',
+	'modules/related-posts/related-posts.js',
+	'modules/sharedaddy/sharing.js',
+	'modules/tiled-gallery/tiled-gallery/tiled-gallery.js',
+	'modules/shortcodes/js/gist.js',
+	'modules/shortcodes/js/instagram.js',
+	'modules/shortcodes/js/impress.js',
+	'modules/shortcodes/js/jquery.cycle.js',
+	'modules/shortcodes/js/main.js',
+	'modules/shortcodes/js/recipes.js',
+	'modules/shortcodes/js/recipes-printthis.js',
+	'modules/shortcodes/js/slideshow-shortcode.js',
+	'modules/wpgroho.js',
+	'_inc/spin.js',
+	'_inc/jquery.spin.js',
+	'_inc/twitter-timeline.js',
+	'_inc/facebook-embed.js'
+];
+
 gulp.task( 'old-styles:watch', function() {
 	gulp.watch( 'scss/**/*.scss', ['old-sass'] );
 } );
@@ -351,6 +376,19 @@ gulp.task( 'frontendcss', function() {
 		.pipe( gulp.dest( 'css' ) )
 		.on( 'end', function() {
 			console.log( 'Front end modules CSS finished.' );
+		} );
+} );
+
+gulp.task( 'frontendjs', function() {
+	return gulp.src( frontendjs )
+		.pipe( uglify() )
+		.pipe( banner( '/* Do not modify this file directly. It is minified from other JS files. */\n' ) )
+		.pipe( rename( { suffix: '.min' } ) )
+		.pipe( gulp.dest( function( file ) {
+			return file.base;
+		} ) )
+		.on( 'end', function() {
+			console.log( 'Your frontend JS is now uglified.' );
 		} );
 } );
 
@@ -637,11 +675,12 @@ gulp.task( 'languages:extract', function( done ) {
 // Default task
 gulp.task(
 	'default',
-	['react:build', 'old-styles', 'checkstrings', 'php:lint', 'js:hint', 'php:module-headings']
+	['react:build', 'old-styles', 'checkstrings', 'php:lint', 'js:hint', 'php:module-headings', 'frontendjs']
+
 );
 gulp.task(
 	'watch',
-	['react:watch', 'sass:watch', 'old-styles:watch']
+	['react:watch', 'sass:watch', 'old-styles:watch', 'frontendjs']
 );
 
 gulp.task( 'jshint', ['js:hint'] );

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -197,7 +197,10 @@ class Jetpack_Carousel {
 
 	function enqueue_assets() {
 		if ( $this->first_run ) {
-			wp_enqueue_script( 'jetpack-carousel', plugins_url( 'jetpack-carousel.js', __FILE__ ), array( 'jquery.spin' ), $this->asset_version( '20170209' ), true );
+			$file_name = Jetpack::should_load_minified_js()
+				? 'jetpack-carousel.js'
+				: 'jetpack-carousel.min.js';
+			wp_enqueue_script( 'jetpack-carousel', plugins_url( $file_name, __FILE__ ), array( 'jquery.spin' ), $this->asset_version( '20170209' ), true );
 
 			// Note: using  home_url() instead of admin_url() for ajaxurl to be sure  to get same domain on wpcom when using mapped domains (also works on self-hosted)
 			// Also: not hardcoding path since there is no guarantee site is running on site root in self-hosted context.

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -186,7 +186,18 @@ function grofiles_attach_cards() {
 	}
 
 	wp_enqueue_script( 'grofiles-cards', ( is_ssl() ? 'https://secure' : 'http://s' ) . '.gravatar.com/js/gprofiles.js', array( 'jquery' ), GROFILES__CACHE_BUSTER, true );
-	wp_enqueue_script( 'wpgroho', plugins_url( 'wpgroho.js', __FILE__ ), array( 'grofiles-cards' ), false, true );
+
+	$file_name = Jetpack::should_load_minified_js()
+		? 'wpgroho.min.js'
+		: 'wpgroho.js';
+
+	wp_enqueue_script(
+		'wpgroho',
+		plugins_url( $file_name, __FILE__ ),
+		array( 'grofiles-cards' ),
+		false,
+		true
+	);
 	if ( is_user_logged_in() ) {
 		$cu = wp_get_current_user();
 		$my_hash = md5( $cu->user_email );

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -405,8 +405,18 @@ class The_Neverending_Home_Page {
 		if ( empty( $id ) )
 			return;
 
+		$file_name = Jetpack::should_load_minified_js()
+			? 'infinity.min.js'
+			: 'infinity.js';
+
 		// Add our scripts.
-		wp_register_script( 'the-neverending-homepage', plugins_url( 'infinity.js', __FILE__ ), array( 'jquery' ), '4.0.0', true );
+		wp_register_script(
+			'the-neverending-homepage',
+			plugins_url( $file_name, __FILE__ ),
+			array( 'jquery' ),
+			'4.0.0',
+			true
+		);
 
 		// Add our default styles.
 		wp_register_style( 'the-neverending-homepage', plugins_url( 'infinity.css', __FILE__ ), array(), '20140422' );

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1449,7 +1449,16 @@ EOT;
 	protected function _enqueue_assets( $script, $style ) {
 		$dependencies = is_customize_preview() ? array( 'customize-base' ) : array( 'jquery' );
 		if ( $script ) {
-			wp_enqueue_script( 'jetpack_related-posts', plugins_url( 'related-posts.js', __FILE__ ), $dependencies, self::VERSION );
+			$file_name = Jetpack::should_load_minified_js()
+				? 'related-posts.min.js'
+				: 'related-posts.js';
+
+			wp_enqueue_script(
+				'jetpack_related-posts',
+				plugins_url( $file_name, __FILE__ ),
+				$dependencies,
+				self::VERSION
+			);
 			$related_posts_js_options = array(
 				/**
 				 * Filter each Related Post Heading structure.

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -785,7 +785,16 @@ function sharing_display( $text = '', $echo = false ) {
 			} else {
 				$ver = '20141212';
 			}
-			wp_register_script( 'sharing-js', plugin_dir_url( __FILE__ ).'sharing.js', array( 'jquery' ), $ver );
+
+			$file_name = Jetpack::should_load_minified_js()
+				? 'sharing.min.js'
+				:'sharing.js';
+			wp_register_script(
+				'sharing-js',
+				plugins_url( $file_name, __FILE__ ),
+				array( 'jquery' ),
+				$ver
+			);
 
 			// Enqueue scripts for the footer
 			add_action( 'wp_footer', 'sharing_add_footer' );

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -54,7 +54,17 @@ function github_gist_shortcode( $atts, $content = '' ) {
 		return '<!-- Invalid Gist ID -->';
 	}
 
-	wp_enqueue_script( 'jetpack-gist-embed', plugins_url( 'js/gist.js', __FILE__ ), array( 'jquery' ), false, true );
+	$file_path = Jetpack::should_load_minified_js()
+		? 'js/gist.min.js'
+		: 'js/gist.js';
+
+	wp_enqueue_script(
+		'jetpack-gist-embed',
+		plugins_url( $file_path, __FILE__ ),
+		array( 'jquery' ),
+		false,
+		true
+	);
 
 	if ( false !== strpos( $id, '#file-' ) ) {
 		// URL points to a specific file in the gist

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -145,7 +145,17 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 	}
 
 	if ( ! empty( $response_body->html ) ) {
-		wp_enqueue_script( 'jetpack-instagram-embed', plugins_url( 'js/instagram.js', __FILE__ ), array( 'jquery' ), false, true );
+		$file_path = Jetpack::should_load_minified_js()
+			? 'js/instagram.min.js'
+			: 'js/instagram.js';
+
+		wp_enqueue_script(
+			'jetpack-instagram-embed',
+			plugins_url( $file_path, __FILE__ ),
+			array( 'jquery' ),
+			false,
+			true
+		);
 		// there's a script in the response, which we strip on purpose since it's added by this ^ script
 		$ig_embed = preg_replace( '@<(script)[^>]*?>.*?</\\1>@si', '', $response_body->html );
 

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -120,8 +120,25 @@ class Jetpack_Recipes {
 		// add $themecolors-defined styles.
 		wp_add_inline_style( 'jetpack-recipes-style', self::themecolor_styles() );
 
-		wp_enqueue_script( 'jetpack-recipes-printthis', plugins_url( '/js/recipes-printthis.js', __FILE__ ), array( 'jquery' ), '20170202' );
-		wp_enqueue_script( 'jetpack-recipes-js',        plugins_url( '/js/recipes.js', __FILE__ ), array( 'jquery', 'jetpack-recipes-printthis' ), '20131230' );
+		$file_path = Jetpack::should_load_minified_js()
+			? 'js/recipes-printthis.min.js'
+			: 'js/recipes-printthis.js';
+		wp_enqueue_script(
+			'jetpack-recipes-printthis',
+			plugins_url( $file_path, __FILE__ ),
+			array( 'jquery' ),
+			'20170202'
+		);
+
+		$file_path = ! is_admin() && ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG )
+			? '/js/recipes.min.js'
+			: '/js/recipes.js';
+		wp_enqueue_script(
+			'jetpack-recipes-js',
+			plugins_url( $file_path, __FILE__ ),
+			array( 'jquery', 'jetpack-recipes-printthis' ),
+			'20131230'
+		);
 
 		$title_var     = wp_title( '|', false, 'right' );
 		$print_css_var = plugins_url( '/css/recipes-print.css', __FILE__ );

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -268,9 +268,20 @@ class Jetpack_Slideshow_Shortcode {
 	 * Actually enqueues the scripts and styles.
 	 */
 	function enqueue_scripts() {
-
 		wp_enqueue_script( 'jquery-cycle', plugins_url( '/js/jquery.cycle.min.js', __FILE__ ), array( 'jquery' ), '20161231', true );
-		wp_enqueue_script( 'jetpack-slideshow', plugins_url( '/js/slideshow-shortcode.js', __FILE__ ), array( 'jquery-cycle' ), '20160119.1', true );
+
+		$file_path = Jetpack::should_load_minified_js()
+			? '/js/slideshow-shortcode.min.js'
+			: '/js/slideshow-shortcode.js';
+
+		wp_enqueue_script(
+			'jetpack-slideshow',
+			plugins_url( $file_path, __FILE__ ),
+			array( 'jquery-cycle' ),
+			'20160119.1',
+			true
+		);
+
 		if ( is_rtl() ) {
 			wp_enqueue_style( 'jetpack-slideshow', plugins_url( '/css/rtl/slideshow-shortcode-rtl.css', __FILE__ ) );
 		} else {

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -89,7 +89,16 @@ class Jetpack_Tiled_Gallery {
 	}
 
 	public static function default_scripts_and_styles() {
-		wp_enqueue_script( 'tiled-gallery', plugins_url( 'tiled-gallery/tiled-gallery.js', __FILE__ ), array( 'jquery' ) );
+		$file_path = Jetpack::should_load_minified_js()
+			? 'tiled-gallery/tiled-gallery.min.js'
+			: 'tiled-gallery/tiled-gallery.js';
+
+		wp_enqueue_script(
+			'tiled-gallery',
+			plugins_url( $file_path, __FILE__ ),
+			array( 'jquery' )
+		);
+
 		if( is_rtl() ) {
 			wp_enqueue_style( 'tiled-gallery', plugins_url( 'tiled-gallery/rtl/tiled-gallery-rtl.css', __FILE__ ), array(), '2012-09-21' );
 		} else {

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -580,6 +580,18 @@ EXPECTED;
 		$this->assertTrue( '123.456.789.0/' === $url_normalized );
 	}
 
+	function test_should_load_minified_js() {
+		Jetpack_Constants::set_constant( 'SCRIPT_DEBUG', false );
+		Jetpack_Constants::set_constant( 'IS_WPCOM', false );
+		$this->assertTrue( Jetpack::should_load_minified_js() );
+
+		Jetpack_Constants::set_constant( 'IS_WPCOM', true );
+		$this->assertFalse( Jetpack::should_load_minified_js() );
+
+		Jetpack_Constants::set_constant( 'SCRIPT_DEBUG', true );
+		$this->assertFalse( Jetpack::should_load_minified_js() );
+	}
+
 	/**
 	 * The generate_secrets method should return and store the secret.
 	 *


### PR DESCRIPTION
After running a performance report on my site this weekend, I realized that the frontend JS that we use for our modules is not minified/uglified. 😞 

### Before

![screen shot 2016-11-28 at 4 13 37 pm](https://cloud.githubusercontent.com/assets/1126811/20688441/5e25e7fc-b586-11e6-8dc4-a413008aa373.png)

This PR seeks to use the uglified versions of much of the frontend JS that we load. Here is an after for comparison.

### After

![screen shot 2016-11-28 at 4 03 02 pm](https://cloud.githubusercontent.com/assets/1126811/20688472/83716252-b586-11e6-88d1-e530164ce477.png)

### The pros

You can see that I was able to knock off about 25 Kb with this PR. So, that's great! Plus, you can also see that the YSlow and  PageSpeed scores both went up for my site. This will be welcomed by users.

Another pro is that we are only loading the uglified versions of these files on the frontend and when `SCRIPT_DEBUG` is not `true`. This will allow users the ability to opt out of the minified files if it is an issue for their setup.

### The cons

The biggest cons I can think of are that this is not an automated solution. Future work will require that we first add the target file to `gulpfile.js` and then we must conditionally enqueue that. 😞 

I had considered implementing a module to minify and concatenate all JS into one file, but that gets pretty interesting and is a bit out of this initial scope.

### To test

- Checkout `update/gulp-minify-js` branch
- `yarn build`
- Create test posts with tiled gallery, gist embed, recipe embed, instagram embed, and facebook embed
- Ensure that minified files are loaded `*.min.js`
- Ensure everything works and there are no JS errors
- In `wp-config.php`, set `define( 'SCRIPT_DEBUG', true );`
- Ensure that non-minified files are loaded
- Check same posts and ensure everything works

