### PR TITLE
Make VideoPress default HD to true

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -40,10 +40,7 @@ class Jetpack_VideoPress {
 	 */
 	public function on_init() {
 		add_action( 'wp_enqueue_media', array( $this, 'enqueue_admin_scripts' ) );
-
 		add_filter( 'plupload_default_settings', array( $this, 'videopress_pluploder_config' ) );
-
-		add_filter( 'videopress_shortcode_options', array( $this, 'videopress_shortcode_options' ) );
 		add_filter( 'wp_get_attachment_url', array( $this, 'update_attachment_url_for_videopress' ), 10, 2 );
 
 		VideoPress_Scheduler::init();
@@ -101,22 +98,6 @@ class Jetpack_VideoPress {
 		$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 
 		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
-	}
-
-	/**
-	 * Filters the VideoPress shortcode options, makes sure that
-	 * the settings set in Jetpack's VideoPress module are applied.
-	 */
-	public function videopress_shortcode_options( $options ) {
-		$videopress_options = VideoPress_Options::get_options();
-
-		if ( false === $options['freedom'] ) {
-			$options['freedom'] = $videopress_options['freedom'];
-		}
-
-		$options['hd'] = $videopress_options['hd'];
-
-		return $options;
 	}
 
 	/**

--- a/modules/videopress/class.videopress-options.php
+++ b/modules/videopress/class.videopress-options.php
@@ -21,21 +21,12 @@ class VideoPress_Options {
 		}
 
 		$defaults = array(
-			'freedom'        => false,
-			'hd'             => true,
 			'meta'           => array(
 				'max_upload_size' => 0,
 			),
 		);
 
 		self::$options = Jetpack_Options::get_option( self::$option_name, array() );
-
-		// If options have not been saved yet, check for older VideoPress plugin options.
-		if ( empty( self::$options ) ) {
-			self::$options['freedom'] = (bool) get_option( 'video_player_freedom', false );
-			self::$options['hd']      = (bool) get_option( 'video_player_high_quality', false );
-		}
-
 		self::$options = array_merge( $defaults, self::$options );
 
 		// Make sure that the shadow blog id never comes from the options, but instead uses the

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -39,7 +39,7 @@ function videopress_shortcode_callback( $attr ) {
 	$defaults = array(
 		'w'               => 0,     // Width of the video player, in pixels
 		'at'              => 0,     // How many seconds in to initially seek to
-		'hd'              => false, // Whether to display a high definition version
+		'hd'              => true,  // Whether to display a high definition version
 		'loop'            => false, // Whether to loop the video repeatedly
 		'freedom'         => false, // Whether to use only free/libre codecs
 		'autoplay'        => false, // Whether to autoplay the video on load


### PR DESCRIPTION
Fixes #5628 

#### Changes proposed in this Pull Request:

- Make sure HD is defaulted to on.
- Remove pulling settings from the options, since there are no more interfaces for them.

#### Testing instructions:

* Verify that an uploaded video defaults to HD when inserted.
