### PR TITLE
Yarn: install specific stable version in build script. 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ $ yarn distclean
 
 3. Install [yarn](https://www.npmjs.com/package/yarn) package.
     ```
-    npm install -g yarn
+    npm install -g yarn@0.16.1
     ```
 
 4. Make sure the Jetpack plugin is active and run

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -31,7 +31,7 @@ else
 
     gem install sass
     gem install compass
-    npm install -g yarn
+    npm install -g yarn@0.16.1
     yarn add gulp-cli
     yarn
 

--- a/tools/deploy-to-master-stable-branch.sh
+++ b/tools/deploy-to-master-stable-branch.sh
@@ -40,8 +40,9 @@ fi
 echo ""
 
 echo "Building Jetpack"
-npm install -g yarn
+npm install -g yarn@0.16.1
 yarn run distclean
+yarn cache clean
 yarn
 NODE_ENV=production yarn run build-client
 echo "Done"


### PR DESCRIPTION
Yarn 0.17.0 has some issues installing dependencies from external repositories.  Let's make sure to install only the yarn version that works until we have time to test upcoming yarn releases, as this breaks the build when using the build script, and fails travis.

related yarn issue: https://github.com/yarnpkg/yarn/issues/1818

This PR also makes sure to clear the yarn cache during the build.  

cc @eliorivero for review. 