### PR TITLE
Sync: Add automatic_updates_complete action to sync

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -18,6 +18,8 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			$this,
 			'filter_upgrader_process_complete',
 		), 10, 2 );
+
+		add_action( 'automatic_updates_complete', $callable );
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -61,4 +61,17 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $wp_version, $this->server_replica_storage->get_callable( 'wp_version' ) );
 	}
 
+	public function test_automatic_updates_complete_sync_action() {
+		// wp_maybe_auto_update();
+		do_action( 'automatic_updates_complete', array( 'core' => array(
+			'item'     => array('somedata'),
+			'result'   => 'some more data',
+			'name'     => 'WordPress 4.7',
+			'messages' => array('it worked.') ) ) );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'automatic_updates_complete' );
+		$this->assertTrue( (bool) $event );
+	}
+
 }


### PR DESCRIPTION
This is useful for sending notifications for users that have autoupdates enabled.

Because it should let us know when an auto update happends.

To test:
Run wp_maybe_auto_update(); via cron if something got updated notice
that the action comes to the .com side.

cc: @lezama 