### PR TITLE
Connection Banner: Always show connection notice when site is not connected

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -65,6 +65,8 @@ class Jetpack_Connection_Banner {
 	 * Will initialize hooks to display the new and legacy connection banners if the current user can
 	 * connect Jetpack, if Jetpack has not been deactivated, and if the current page is the plugins page.
 	 *
+	 * This method should not be called if the site is connected to WordPress.com or if the site is in development mode.
+	 *
 	 * @since 4.4.0
 	 *
 	 * @param $current_screen
@@ -76,12 +78,6 @@ class Jetpack_Connection_Banner {
 		}
 
 		if ( ! current_user_can( 'jetpack_connect' ) ) {
-			return;
-		}
-
-		// Make sure that the current state is not disconnected. The activated option is set to "4"
-		// in the Jetpack::disconnect() method.
-		if ( ! in_array( Jetpack_Options::get_option( 'activated' ), array( 1, 2, 3 ) ) ) {
 			return;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2882,9 +2882,7 @@ p {
 		}
 
 		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
-			if ( 4 != Jetpack_Options::get_option( 'activated' ) ) {
-				Jetpack_Connection_Banner::init();
-			}
+			Jetpack_Connection_Banner::init();
 		} elseif ( false === Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' ) ) {
 			// Upgrade: 1.1 -> 1.1.1
 			// Check and see if host can verify the Jetpack servers' SSL certificate


### PR DESCRIPTION
Fixes #5639.

This PR matches the logic to show this connection banner to that of the dashboard widget that prompts the user to connect.

To test:

- Checkout `update/connection-banner-not-connected` branch
- Deactivate Jetpack
- Activate Jetpack. You should see the connection banner (Note: you may see the old one since we're A/B testing. If you want to change it to the new banner, go to `/wp-admin/options.php` and set `jetpack_connection_banner_ab` to 2).
- After connecting, you should not see the banner on the plugins admin page
- Disconnect Jetpack
- You should now see the banner on the plugins admin page