### PR TITLE
Fix bug with VideoPress [video] shortcode override

### DIFF
--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -155,7 +155,7 @@ function videopress_shortcode_override_for_core_shortcode( $raw_attr, $contents,
 	if ( isset( $attr['videopress_guid'] ) ) {
 		$videopress_guid = $attr['videopress_guid'];
 
-	} else {
+	} elseif ( isset( $attr['mp4'] ) ) {
 		$url = $attr['mp4'];
 
 		if ( preg_match( '@videos.videopress.com/([a-z0-9]{8})/@', $url, $matches ) ) {


### PR DESCRIPTION
Fixes #5599

#### Changes proposed in this Pull Request:

- Make sure that the [video] shortcode override still works with a src link.

#### Testing instructions:

- Verify that adding a video url into a shortcode like [video src="$url"] into a post does not cause an error.