### PR TITLE
Fixes production build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "url": "https://github.com/Automattic/jetpack/issues"
   },
   "scripts": {
-    "watch": "gulp watch",
+    "watch": "./node_modules/.bin/gulp watch",
     "clean-client": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html",
     "distclean": "rm -rf node_modules",
-    "build": "yarn && gulp",
-    "build-client": "gulp",
-    "build-production": "yarn run clean && yarn run build && yarn run build-languages && gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn run build",
-    "build-languages": "gulp languages",
+    "build": "yarn && yarn build-client",
+    "build-client": "./node_modules/.bin/gulp",
+    "build-production": "yarn clean-client && yarn build-languages && ./node_modules/.bin/gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build",
+    "build-languages": "./node_modules/.bin/gulp languages",
     "lint": "eslint _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "./node_modules/.bin/grunt addtextdomain",

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -31,8 +31,7 @@ else
 
     gem install sass
     gem install compass
-    npm install -g yarn@0.16.1
-    yarn add gulp-cli
+    npm install yarn@0.16.1
     yarn
 
     if $WP_TRAVISCI; then


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Makes the package script use local gulp to avoid having to install gulp globally and requiring super user privileges.
* Removes yarn cache purging for Travis to make use of caching.
* Fixes the broken `build-production` command.
* Makes Travis use local version of gulp.

#### Testing instructions:

* Try to run yarn commands after a distclean.
* Try to run yarn commands without global gulp.
* See that Travis has no problems.
* Try to use the master-stable deploy script.
