### PR TITLE
Tests: don't define class WP_Test_REST_Controller_Testcase if it already exists

### DIFF
--- a/tests/php/lib/class-wp-test-rest-controller-testcase.php
+++ b/tests/php/lib/class-wp-test-rest-controller-testcase.php
@@ -1,42 +1,44 @@
 <?php
+if ( ! class_exists( 'WP_Test_REST_Controller_Testcase' ) ) {
 
-abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
+	abstract class WP_Test_REST_Controller_Testcase extends WP_Test_REST_TestCase {
 
-	protected $server;
+		protected $server;
 
-	public function setUp() {
-		parent::setUp();
+		public function setUp() {
+			parent::setUp();
 
-		/** @var WP_REST_Server $wp_rest_server */
-		global $wp_rest_server;
-		$this->server = $wp_rest_server = new WP_Test_Spy_REST_Server;
-		do_action( 'rest_api_init' );
+			/** @var WP_REST_Server $wp_rest_server */
+			global $wp_rest_server;
+			$this->server = $wp_rest_server = new WP_Test_Spy_REST_Server;
+			do_action( 'rest_api_init' );
+		}
+
+		public function tearDown() {
+			parent::tearDown();
+
+			/** @var WP_REST_Server $wp_rest_server */
+			global $wp_rest_server;
+			$wp_rest_server = null;
+		}
+
+		abstract public function test_register_routes();
+
+		abstract public function test_context_param();
+
+		abstract public function test_get_items();
+
+		abstract public function test_get_item();
+
+		abstract public function test_create_item();
+
+		abstract public function test_update_item();
+
+		abstract public function test_delete_item();
+
+		abstract public function test_prepare_item();
+
+		abstract public function test_get_item_schema();
+
 	}
-
-	public function tearDown() {
-		parent::tearDown();
-
-		/** @var WP_REST_Server $wp_rest_server */
-		global $wp_rest_server;
-		$wp_rest_server = null;
-	}
-
-	abstract public function test_register_routes();
-
-	abstract public function test_context_param();
-
-	abstract public function test_get_items();
-
-	abstract public function test_get_item();
-
-	abstract public function test_create_item();
-
-	abstract public function test_update_item();
-
-	abstract public function test_delete_item();
-
-	abstract public function test_prepare_item();
-
-	abstract public function test_get_item_schema();
-
 }


### PR DESCRIPTION
This is to provide compatibility with WP 4.7. Without this, running `phpunit` results in
```
PHP Fatal error:  Cannot redeclare class WP_Test_REST_Controller_Testcase in .../jetpack/tests/php/lib/class-wp-test-rest-controller-testcase.php on line 42
```

#### Changes proposed in this Pull Request:
- check if class `WP_Test_REST_Controller_Testcase` exists. If it doesn't, it will define it.

#### Testing instructions:
Install WP 4.7-beta3-39201-src or newer
* run `phpunit` and verify that it doesn't throw an error.