### PR TITLE
Move setup phase after listener/sender init so other plugins can inject sync modules

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -30,10 +30,10 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 	protected $server_event_storage;
 
 	public function setUp() {
-		parent::setUp();
-
 		$this->listener = Jetpack_Sync_Listener::get_instance();
 		$this->sender   = Jetpack_Sync_Sender::get_instance();
+		
+		parent::setUp();
 
 		$this->setSyncClientDefaults();
 


### PR DESCRIPTION
This fixes an issue with depending on Jetpack from third-party tests that implement sync modules.

Without this change, hooks added by sync modules get cleared after the first test run.