### PR TITLE
Don’t compute constants and callables on every sync test

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -32,7 +32,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 	public function setUp() {
 		$this->listener = Jetpack_Sync_Listener::get_instance();
 		$this->sender   = Jetpack_Sync_Sender::get_instance();
-		
+
 		parent::setUp();
 
 		$this->setSyncClientDefaults();
@@ -57,6 +57,14 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		Jetpack_Sync_Modules::set_defaults();
 		$this->sender->set_dequeue_max_bytes( 5000000 ); // process 5MB of items at a time
 		$this->sender->set_sync_wait_time( 0 ); // disable rate limiting
+		// don't sync callables or constants every time - slows down tests
+		set_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
+		set_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
+	}
+
+	protected function resetCallableAndConstantTimeouts() {
+		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
+		delete_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );	
 	}
 
 	public function test_pass() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -18,6 +18,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	public function setUp() {
 		parent::setUp();
 
+		$this->resetCallableAndConstantTimeouts();
+
 		$this->callable_module = Jetpack_Sync_Modules::get_module( "functions" );
 		set_current_screen( 'post-user' ); // this only works in is_admin()
 	}
@@ -47,7 +49,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_sync_callable_whitelist() {
-		$this->setSyncClientDefaults();
+		// $this->setSyncClientDefaults();
 
 		$callables = array(
 			'wp_max_upload_size'               => wp_max_upload_size(),
@@ -134,9 +136,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_always_sync_changes_to_modules_right_away() {
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
-		$this->setSyncClientDefaults();
 		Jetpack::update_active_modules( array( 'stats' ) );
 
 		$this->sender->do_sync();
@@ -154,10 +153,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_always_sync_changes_to_home_siteurl_right_away() {
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
-		$this->setSyncClientDefaults();
-
 		$original_home_option    = get_option( 'home' );
 		$original_siteurl_option = get_option( 'siteurl' );
 
@@ -191,10 +186,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_jetpack_sync_unlock_sync_callable_action_allows_syncing_siteurl_changes() {
-		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_option( Jetpack_Sync_Module_Callables::CALLABLES_CHECKSUM_OPTION_NAME );
-		$this->setSyncClientDefaults();
-
 		$original_home_option    = get_option( 'home' );
 		$original_siteurl_option = get_option( 'siteurl' );
 

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -10,6 +10,8 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 	public function setUp() {
 		parent::setUp();
 
+		$this->resetCallableAndConstantTimeouts();
+
 		$this->constant_module = Jetpack_Sync_Modules::get_module( "constants" );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -131,12 +131,14 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_all_plugins_filter_is_respected() {
+		$this->sender->do_sync();
 		$plugins = get_plugins();
 
 		if ( ! isset( $plugins['hello.php'] ) ) {
 			$this->markTestSkipped( 'Plugin hello dolly is not available' );
 		}
 		add_filter( 'all_plugins', array( $this, 'remove_hello_dolly' ) );
+		$this->resetCallableAndConstantTimeouts();
 		$this->sender->do_sync();
 
 		remove_filter( 'all_plugins', array( $this, 'remove_hello_dolly' ) );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -7,6 +7,9 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	protected $encoded_data;
 
 	function test_add_post_fires_sync_data_action_with_codec_and_timestamp_on_do_sync() {
+		// some trivial action so that there's an item in the queue
+		$this->factory->post->create();
+
 		$start_test_timestamp   = microtime( true );
 		$this->action_ran       = false;
 		$this->action_codec     = null;

--- a/tests/php/sync/test_class.jetpack-sync-sso.php
+++ b/tests/php/sync/test_class.jetpack-sync-sso.php
@@ -4,6 +4,11 @@
  * Testing sync of values for SSO.
  */
 class WP_Test_Jetpack_Sync_SSO extends WP_Test_Jetpack_Sync_Base {
+	function setUp() {
+		parent::setUp();
+		$this->resetCallableAndConstantTimeouts();
+	}
+	
 	function test_sync_sso_is_two_step_required_filter_true() {
 		add_filter( 'jetpack_sso_require_two_step', '__return_true' );
 		$this->sender->do_sync();


### PR DESCRIPTION
Improves test performance by avoiding computing callables and constants to sync, except when we need to for the test.