### PR TITLE
Added a check for yarn instead of trying to install it.

### DIFF
--- a/tools/deploy-to-master-stable-branch.sh
+++ b/tools/deploy-to-master-stable-branch.sh
@@ -40,7 +40,14 @@ fi
 echo ""
 
 echo "Building Jetpack"
-npm install -g yarn@0.16.1
+
+# Checking for yarn
+hash yarn 2>/dev/null || {
+    echo >&2 "This script requires you to have yarn package manager installed."
+    echo >&2 "Please install it following the instructions on https://yarnpkg.com. Aborting.";
+    exit 1;
+}
+
 yarn run distclean
 yarn cache clean
 yarn


### PR DESCRIPTION
Since yarn doesn't work properly when installed locally, you always need to install it globally. But we can't do that in the deploy script because we'd need to have superuser privileges in some cases. So it's better to check for yarn and bail if it's not available.
