### PR TITLE
Fixed the supports method for VideoPress to work properly.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1248,7 +1248,7 @@ class Jetpack {
 		);
 
 		if ( in_array( $plan['product_slug'], $business_plans ) ) {
-			$plan['supports'][] = array(
+			$plan['supports'] = array(
 				'videopress',
 				'akismet',
 				'vaultpress',


### PR DESCRIPTION
Fixes #5585 

#### Changes proposed in this Pull Request:
* Fixes the `active_plan_supports` method to properly create an array that determines the supported features.

#### Testing instructions:
* Disable VideoPress module using wp-cli while having your site on premium or business.
* Make sure you can still upload videos.

cc @jeherve 