### PR TITLE
Endpoints: update code to cope with changes in core 4.7

### DIFF
--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -183,8 +183,16 @@ export function getModuleOption( state, module_slug, option_name ) {
 	return get( state.jetpack.modules.items, [ module_slug, 'options', option_name, 'current_value' ] );
 }
 
-export function getModuleOptionValidValues( state, module_slug, option_name ) {
-	return get( state.jetpack.modules.items, [ module_slug, 'options', option_name, 'enum' ], false );
+/**
+ * Return a list of key & value pairs admitted.
+ *
+ * @param  {Object}  state   Global state tree.
+ * @param  {String}  group   Slug of the set of settings to check.
+ * @param  {String}  setting Setting to check for valid values.
+ * @return {Array}           The list of key => value pairs.
+ */
+export function getModuleOptionValidValues( state, group, setting ) {
+	return get( state.jetpack.modules.items, [ group, 'options', setting, 'enum_labels' ], false );
 }
 
 /**

--- a/_inc/client/state/modules/test/reducer.js
+++ b/_inc/client/state/modules/test/reducer.js
@@ -3,7 +3,8 @@ import { expect } from 'chai';
 import {
 	items as itemsReducer,
 	requests as requestsReducer,
-	initialRequestsState
+	initialRequestsState,
+	getModuleOptionValidValues
 } from '../reducer';
 
 describe( 'items reducer', () => {
@@ -26,17 +27,47 @@ describe( 'items reducer', () => {
 				}
 			}
 		},
+		'module-c': {
+			module: 'module-c',
+			activated: true,
+			options: {
+				color: {
+					currentValue: 'black',
+					enum: [ 'black', 'red', 'fuchsia' ],
+					enum_labels: {
+						black: 'Make it black.',
+						red: 'Make it red.',
+						fuchsia: 'Make it fuchsia, whatever that is.'
+					}
+				}
+			}
+		},
 	};
 
-	describe( '#modulesFetch', () => {
-		it( 'should replace .items with the modules list', () => {
+	describe( 'upon module list receive', () => {
+		let stateOut, action;
+
+		before( () => {
 			const stateIn = {}
-			const action = {
+			action = {
 				type: 'JETPACK_MODULES_LIST_RECEIVE',
 				modules: modules
 			};
-			let stateOut = itemsReducer( stateIn, action );
-			expect( Object.keys( stateOut ).length ).to.equal( Object.keys( action.modules ).length );
+			stateOut = itemsReducer( stateIn, action );
+		} );
+
+		describe( '#modulesFetch', () => {
+			it( 'should replace .items with the modules list', () => {
+				expect( Object.keys( stateOut ).length ).to.equal( Object.keys( action.modules ).length );
+			} );
+		} );
+
+		describe( '#getModuleOptionValidValues', () => {
+			it( 'should report valid values from the result data', () => {
+				let state = { jetpack: { modules: { items: stateOut } } };
+				expect( getModuleOptionValidValues( state, 'module-c', 'color' ) )
+					.to.equal( modules['module-c'].options.color.enum_labels );
+			} );
 		} );
 	} );
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1294,6 +1294,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'show' => array(
 				'description'       => esc_html__( 'Views where buttons are shown', 'jetpack' ),
 				'type'              => 'array',
+				'items'             => array(
+					'type' => 'string'
+				),
 				'default'           => array( 'post' ),
 				'validate_callback' => __CLASS__ . '::validate_sharing_show',
 				'jp_group'          => 'sharedaddy',
@@ -1529,6 +1532,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'roles' => array(
 				'description'       => esc_html__( 'Select the roles that will be able to view stats reports.', 'jetpack' ),
 				'type'              => 'array',
+				'items'             => array(
+					'type' => 'string'
+				),
 				'default'           => array( 'administrator' ),
 				'validate_callback' => __CLASS__ . '::validate_stats_roles',
 				'sanitize_callback' => __CLASS__ . '::sanitize_stats_allowed_roles',
@@ -1537,6 +1543,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'count_roles' => array(
 				'description'       => esc_html__( 'Count the page views of registered users who are logged in.', 'jetpack' ),
 				'type'              => 'array',
+				'items'             => array(
+					'type' => 'string'
+				),
 				'default'           => array( 'administrator' ),
 				'validate_callback' => __CLASS__ . '::validate_stats_roles',
 				'jp_group'          => 'stats',
@@ -1767,6 +1776,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function validate_sharing_show( $value, $request, $param ) {
 		$views = array( 'index', 'post', 'page', 'attachment', 'jetpack-portfolio' );
+		if ( ! is_array( $value ) ) {
+			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be an array of post types.', 'jetpack' ), $param ) );
+		}
 		if ( ! array_intersect( $views, $value ) ) {
 			return new WP_Error( 'invalid_param', sprintf(
 				/* Translators: first variable is the name of a parameter passed to endpoint holding the post type where Sharing will be displayed, the second is a list of post types where Sharing can be displayed */

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1018,6 +1018,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => 'black',
 				'enum'              => array(
+					'black',
+					'white',
+				),
+				'enum_labels' => array(
 					'black' => esc_html__( 'Black', 'jetpack' ),
 					'white' => esc_html__( 'White', 'jetpack' ),
 				),
@@ -1045,6 +1049,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => 'light',
 				'enum'              => array(
+					'light',
+					'dark',
+					'transparent',
+				),
+				'enum_labels' => array(
 					'light'       => esc_html__( 'Light', 'jetpack' ),
 					'dark'        => esc_html__( 'Dark', 'jetpack' ),
 					'transparent' => esc_html__( 'Transparent', 'jetpack' ),
@@ -1098,6 +1107,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => 'enabled',
 				// Not visible. This is used as the checkbox value.
 				'enum'              => array(
+					'enabled',
+					'disabled',
+				),
+				'enum_labels' => array(
 					'enabled'  => esc_html__( 'Enabled', 'jetpack' ),
 					'disabled' => esc_html__( 'Disabled', 'jetpack' ),
 				),
@@ -1127,6 +1140,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => 'on',
 				'enum'              => array(
+					'on',
+					'off',
+				),
+				'enum_labels' => array(
 					'on'  => esc_html__( 'On for all posts', 'jetpack' ),
 					'off' => esc_html__( 'Turned on per post', 'jetpack' ),
 				),
@@ -1156,6 +1173,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => 'disabled',
 				'enum'              => array(
+					'enabled',
+					'disabled',
+				),
+				'enum_labels' => array(
 					'enabled'  => esc_html__( 'Enable excerpts on front page and on archive pages', 'jetpack' ),
 					'disabled' => esc_html__( 'Show full posts on front page and on archive pages', 'jetpack' ),
 				),
@@ -1167,6 +1188,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => 'disabled',
 				'enum'              => array(
+					'enabled',
+					'disabled',
+				),
+				'enum_labels' => array(
 					'enabled'  => esc_html__( 'Display featured images', 'jetpack' ),
 					'disabled' => esc_html__( 'Hide all featured images', 'jetpack' ),
 				),
@@ -1196,6 +1221,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => 'noop',
 				'enum'              => array(
+					'noop',
+					'create',
+					'regenerate',
+					'delete',
+				),
+				'enum_labels' => array(
 					'noop'       => '',
 					'create'     => esc_html__( 'Create Post by Email address', 'jetpack' ),
 					'regenerate' => esc_html__( 'Regenerate Post by Email address', 'jetpack' ),
@@ -1225,7 +1256,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			// Sharing
 			'sharing_services' => array(
 				'description'       => esc_html__( 'Enabled Services and those hidden behind a button', 'jetpack' ),
-				'type'              => 'array',
+				'type'              => 'object',
 				'default'           => array(
 					'visible' => array( 'twitter', 'facebook', 'google-plus-1' ),
 					'hidden'  => array(),
@@ -1238,6 +1269,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'type'              => 'string',
 				'default'           => 'icon',
 				'enum'              => array(
+					'icon-text',
+					'icon',
+					'text',
+					'official',
+				),
+				'enum_labels' => array(
 					'icon-text' => esc_html__( 'Icon + text', 'jetpack' ),
 					'icon'      => esc_html__( 'Icon only', 'jetpack' ),
 					'text'      => esc_html__( 'Text only', 'jetpack' ),
@@ -1278,7 +1315,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			),
 			'custom' => array(
 				'description'       => esc_html__( 'Custom sharing services added by user.', 'jetpack' ),
-				'type'              => 'array',
+				'type'              => 'object',
 				'default'           => array(
 					'sharing_name' => '',
 					'sharing_url'  => '',

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -646,4 +646,29 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 403, $response );
 
 	}
+
+	/**
+	 * Test that a setting using 'enum' property is saved correctly.
+	 *
+	 * @since 4.4.0
+	 */
+	public function test_setting_enum_save() {
+
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		Jetpack::update_active_modules( array( 'carousel' ) );
+
+		// Test endpoint that will be removed in 4.5
+		$response = $this->create_and_get_request( 'module/carousel', array( 'carousel_background_color' => 'black' ), 'POST' );
+		$this->assertResponseStatus( 200, $response );
+
+		// Test endpoint that will be implemented in 4.5
+		$response = $this->create_and_get_request( 'settings/carousel', array( 'carousel_background_color' => 'white' ), 'POST' );
+		$this->assertResponseStatus( 200, $response );
+
+	}
+
 } // class end

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -669,6 +669,32 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$response = $this->create_and_get_request( 'settings/carousel', array( 'carousel_background_color' => 'white' ), 'POST' );
 		$this->assertResponseStatus( 200, $response );
 
+		$response = $this->create_and_get_request( 'settings', array( 'carousel_background_color' => 'black' ), 'POST' );
+		$this->assertResponseStatus( 200, $response );
+
+	}
+
+	/**
+	 * Test that an arg with array type can be saved.
+	 *
+	 * @since 4.4.0
+	 */
+	public function test_setting_array_type() {
+
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		Jetpack::update_active_modules( array( 'sharedaddy' ) );
+
+		// Verify that saving another thing fails
+		$response = $this->create_and_get_request( 'settings', array( 'show' => 'post' ), 'POST' );
+		$this->assertResponseStatus( 400, $response );
+
+		$response = $this->create_and_get_request( 'settings', array( 'show' => array( 'post', 'page' ) ), 'POST' );
+		$this->assertResponseStatus( 200, $response );
+
 	}
 
 } // class end


### PR DESCRIPTION
Fixes #5653

#### Changes proposed in this Pull Request:
- use `enum` property as JSON schema dictates ([read more](https://github.com/json-schema/json-schema/wiki/Enum#valid-values))
- introduce a custom `enum_labels` property that it's used to have the values and labels sent so they're rendered in the UI
- adapt `getModuleOptionValidValues` reducer to use this new `enum_labels` property instead of old `enum`
- change type `array` to `object` so it's correctly validated

#### Testing instructions:
* test with WP 4.7 and 4.6 that modules activate and deactivate, and that settings save.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Admin: updates to provide compatibility for REST API changes in 4.7.