### PR TITLE
API: Allow a user to delete themself through the API

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-user-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-user-endpoint.php
@@ -42,10 +42,6 @@ class WPCOM_JSON_API_Update_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return new WP_Error( 'invalid_input', 'A valid user ID must be specified.', 400 );
 		}
 
-		if ( get_current_user_id() == $user_id ) {
-			return new WP_Error( 'invalid_input', 'User can not remove or delete self through this endpoint.', 400 );
-		}
-
 		if ( ! $this->user_exists( $user_id ) ) {
 			return new WP_Error( 'invalid_input', 'A user does not exist with that ID.', 400 );
 		}


### PR DESCRIPTION
WIP to fix Automattic/wp-calypso#3321, which is allowing users to remove themself from a site

See r145681-wpcom for corresponding WPCOM API deployment.

To test:

- Checkout `update/api-allow-deleting-self` branch
- Go to WP.com API console
- Make request to `/sites/$site/users/$user_id/delete` 
- Where `$site` is the Jetpack site with this branch and `$user_id` is the remote user's ID and you are logged in to the WP.com account that `$user_id` is connected to.
- Load users list on `$site` and ensure the user was successfully deleted