### PR TITLE
Connection Banner: aligning buttons to bottom of content area

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -67,7 +67,12 @@
 }
 
 .jp-wpcom-connect__content-container {
+	position: relative;
 	padding: rem( 32px );
+
+	@include minbreakpoint(tablet) {
+		padding: rem( 32px ) rem( 32px ) rem( 96px ) rem( 32px );
+	};
 }
 
 .jp-wpcom-connect__content-container p {
@@ -91,6 +96,13 @@
 	&.jp__slide-is-active {
 		display: block;
 	}
+}
+
+.jp-banner__button-container {
+	@include minbreakpoint(tablet) {
+		position: absolute;
+		bottom: rem( 16px );
+	};
 }
 
 .jp-banner__button-container .dops-button {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/5624

On larger screens, I've quickly implemented a light solution to align the CTA buttons to the bottom of the content area, on screens larger than 782px wide (tablet breakpoint).

![connection-banner-buttons](https://cloud.githubusercontent.com/assets/214813/20367033/bc28aaca-ac1b-11e6-842f-2388cd89fdcb.gif)


_Disclaimer. This is a simple, lightweight css fix, so if the content exceeds the height of the vertical nav the buttons will be pushed lower and we may see some "jumping."_

**To test:** 
- Checkout `fix/connection-banner-btn-alignment` branch
- Disconnect from Jetpack
- View the plugins page within wp-admin. You should see the connection banner (Note: you may see the old one since we're A/B testing. If you want to change it to the new banner, go to `/wp-admin/options.php` and set `jetpack_connection_banner_ab` to 2).

cc @jeherve 
