### PR TITLE
General: Adds Jetpack_Feature_Rollout to allow percentage based rollouts

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -92,6 +92,11 @@ class Jetpack_Debugger {
 				? date( 'r', $sync_status_value ) : $sync_status_value ;
 		}
 
+		$debug_info .= "\r\n". sprintf(
+			esc_html__( 'Enabled Features: %1$s', 'jetpack' ),
+			print_r( Jetpack_Feature_Rollout::init()->get_features(), true )
+		);
+
 		$debug_info .= "\r\n". sprintf( esc_html__( 'Jetpack Sync Full Status: `%1$s`', 'jetpack' ), print_r( $human_readable_sync_status, 1 ) );
 
 		require_once JETPACK__PLUGIN_DIR. 'sync/class.jetpack-sync-sender.php';

--- a/class.jetpack-feature-rollout.php
+++ b/class.jetpack-feature-rollout.php
@@ -38,6 +38,8 @@ class Jetpack_Feature_Rollout {
 
 	/**
 	 * The URL to make a GET request to in order to get the features that are enabled.
+	 *
+	 * @var string
 	 */
 	const JETPACK_FEATURES_REQUEST_URL = 'https://jetpack.com/get-feature-rollout/';
 

--- a/class.jetpack-feature-rollout.php
+++ b/class.jetpack-feature-rollout.php
@@ -36,13 +36,6 @@ class Jetpack_Feature_Rollout {
 	 */
 	const JETPACK_FEATURES_TRANSIENT_NAME = 'jetpack_feature_rollout';
 
-	/**
-	 * The URL to make a GET request to in order to get the features that are enabled.
-	 *
-	 * @var string
-	 */
-	const JETPACK_FEATURES_REQUEST_URL = 'https://jetpack.com/get-feature-rollout/';
-
 	static function init() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new Jetpack_Feature_Rollout();

--- a/class.jetpack-feature-rollout.php
+++ b/class.jetpack-feature-rollout.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * This class will handle rolling out features to a percentage of users. Should only be used for sites connected to
+ * WordPress.com since this calls home to get the percentage.
+ *
+ * This should help us to minimize breakage by rolling out at a small percentage and increasing that over time.
+ *
+ * @since 4.4.0
+ */
+class Jetpack_Feature_Rollout {
+	/**
+	 * @var Jetpack_Feature_Rollout
+	 */
+	private static $instance = null;
+
+	/**
+	 * False if the value has not been initialized with a call to WordPress.com, or an associative array if the
+	 * we have the enabled features and their percentages.
+	 *
+	 * @var bool|array
+	 */
+	protected $features;
+
+	/**
+	 * The option name for storing the features.
+	 *
+	 * @var string
+	 */
+	const JETPACK_FEATURES_OPTION_NAME = 'feature_rollout';
+
+	/**
+	 * The transient name for determining when to refetch features
+	 *
+	 * @var string
+	 */
+	const JETPACK_FEATURES_TRANSIENT_NAME = 'jetpack_feature_rollout';
+
+	/**
+	 * The URL to make a GET request to in order to get the features that are enabled.
+	 */
+	const JETPACK_FEATURES_REQUEST_URL = 'https://jetpack.com/get-feature-rollout/';
+
+	static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new Jetpack_Feature_Rollout();
+		}
+
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_action( 'init', array( $this, 'wordpress_init' ), 1 );
+	}
+
+	/**
+	 * Initialize the class after WordPress is initialized.
+	 */
+	function wordpress_init() {
+		if ( ! $this->should_load() ) {
+			return;
+		}
+
+		$this->features = Jetpack_Options::get_option( self::JETPACK_FEATURES_OPTION_NAME );
+
+		// If we haven't already fetched features at least once or if we need to fetch again, then fetch.
+		if ( false === $this->features || false === get_transient( self::JETPACK_FEATURES_TRANSIENT_NAME ) ) {
+			$this->update_features_option_and_transient();
+		}
+	}
+
+	/**
+	 * Returns a boolean for whether we should load the Jetpack_Feature_Rollout functionality.
+	 *
+	 * This method is mocked in PHPUnit to ensure that we load the class.
+	 *
+	 * @return bool
+	 */
+	function should_load() {
+		return Jetpack::is_active();
+	}
+
+	/**
+	 * Will fetch features from WordPress.com if the features transient is not set.
+	 *
+	 * This method is mocked in PHPUnit tests so that we can simulate different
+	 * values being returned from WordPress.com.
+	 */
+	function fetch_features_from_wpcom() {
+		Jetpack::load_xml_rpc_client();
+		$xml = new Jetpack_IXR_Client();
+		$xml->query( 'jetpack.getFeatureRollout' );
+
+		if ( $xml->isError() ) {
+			return $xml->get_jetpack_error();
+		} else {
+			return $xml->getResponse();
+		}
+	}
+
+	/**
+	 * Fetches features from WordPress.com via the fetch_features_from_wpcom() method and then stores the features
+	 * and sets a transient to minimize requests.
+	 */
+	function update_features_option_and_transient() {
+		$fetched = $this->fetch_features_from_wpcom();
+
+		if ( is_wp_error( $fetched ) ) {
+			$features = false;
+			$transient_duration = 5 * MINUTE_IN_SECONDS;
+		} else {
+			$features = (array) $fetched;
+			$transient_duration = HOUR_IN_SECONDS;
+		}
+
+		// Only update the features option if we successfully retrieved features.
+		if ( false !== $features ) {
+			Jetpack_Options::update_option( self::JETPACK_FEATURES_OPTION_NAME, $features, true );
+			$this->features = $features;
+		}
+
+		set_transient( self::JETPACK_FEATURES_TRANSIENT_NAME, '1', $transient_duration );
+	}
+
+	/**
+	 * Returns a boolean for whether the featured is enabled or not.
+	 *
+	 * @param string $feature The name of the featured.
+	 *
+	 * @return bool           Is the feature enabled?
+	 */
+	function is_enabled( $feature ) {
+		$is_enabled = (
+			isset( $this->features, $this->features[ $feature ] ) &&
+			! empty( $this->features[ $feature ] )
+		);
+
+		/**
+		 * Fires on every call to Jetpack_Feature_Rollout:is_enabled() and allows a developer to
+		 * force a certain feature to be on.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param bool $is_enabled Is the feature enabled?
+		 * @param string $feature  The name of the feature that is being  checked.
+		 */
+		return (bool) apply_filters( 'jetpack_feature_rollout_enabled', $is_enabled, $feature );
+	}
+
+	/**
+	 * Gets the array of features that have been returned from WordPress.com.
+	 *
+	 * @return array|bool
+	 */
+	function get_features() {
+		return $this->features;
+	}
+}
+
+Jetpack_Feature_Rollout::init();

--- a/class.jetpack-feature-rollout.php
+++ b/class.jetpack-feature-rollout.php
@@ -58,8 +58,8 @@ class Jetpack_Feature_Rollout {
 
 		$this->features = Jetpack_Options::get_option( self::JETPACK_FEATURES_OPTION_NAME );
 
-		// If we haven't already fetched features at least once or if we need to fetch again, then fetch.
-		if ( false === $this->features || false === get_transient( self::JETPACK_FEATURES_TRANSIENT_NAME ) ) {
+		// Fetch features from WordPress.com if the transient has expired
+		if ( false === get_transient( self::JETPACK_FEATURES_TRANSIENT_NAME ) ) {
 			$this->update_features_option_and_transient();
 		}
 	}

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -51,6 +51,7 @@ class Jetpack_Options {
 				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
 				'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
+				'feature_rollout',             // (array) An arrayof features that are enabled or disabled.
 			);
 
 		case 'private' :

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -51,7 +51,7 @@ class Jetpack_Options {
 				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
 				'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
-				'feature_rollout',             // (array) An arrayof features that are enabled or disabled.
+				'feature_rollout',             // (array) An array of features that are enabled or disabled.
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -472,7 +472,7 @@ class Jetpack {
 				add_filter( 'xmlrpc_methods', array( $this->xmlrpc_server, 'bootstrap_xmlrpc_methods' ) );
 			}
 
-			// Now that no one can authenticate, and we're whitelisting all te methods, force enable_xmlrpc on.
+			// Now that no one can authenticate, and we're whitelisting all XML-RPC methods, force enable_xmlrpc on.
 			add_filter( 'pre_option_enable_xmlrpc', '__return_true' );
 		} elseif ( is_admin() && isset( $_POST['action'] ) && 'jetpack_upload_file' == $_POST['action'] ) {
 			$this->require_jetpack_authentication();

--- a/jetpack.php
+++ b/jetpack.php
@@ -68,30 +68,32 @@ function jetpack_require_lib_dir() {
 add_filter( 'jetpack_require_lib_dir', 'jetpack_require_lib_dir' );
 
 // @todo: Abstract out the admin functions, and only include them if is_admin()
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack.php'               );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-network.php'       );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-client.php'        );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-data.php'          );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-client-server.php' );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-feature-rollout.php'   );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack.php'                   );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-network.php'           );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-client.php'            );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-data.php'              );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-client-server.php'     );
 require_once( JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-actions.php' );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-options.php'       );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-user-agent.php'    );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-post-images.php'   );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-error.php'         );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-heartbeat.php'     );
-require_once( JETPACK__PLUGIN_DIR . 'class.photon.php'                );
-require_once( JETPACK__PLUGIN_DIR . 'functions.photon.php'            );
-require_once( JETPACK__PLUGIN_DIR . 'functions.global.php'            );
-require_once( JETPACK__PLUGIN_DIR . 'functions.compat.php'            );
-require_once( JETPACK__PLUGIN_DIR . 'functions.gallery.php'           );
-require_once( JETPACK__PLUGIN_DIR . 'require-lib.php'                 );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php'    );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-tracks.php'        );
-require_once( JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php'   );
-require_once( JETPACK__PLUGIN_DIR . 'modules/module-headings.php');
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-constants.php');
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php'  );
-require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php'  );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-options.php'           );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-user-agent.php'        );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-post-images.php'       );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-error.php'             );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-heartbeat.php'         );
+require_once( JETPACK__PLUGIN_DIR . 'class.photon.php'                    );
+require_once( JETPACK__PLUGIN_DIR . 'functions.photon.php'                );
+require_once( JETPACK__PLUGIN_DIR . 'functions.global.php'                );
+require_once( JETPACK__PLUGIN_DIR . 'functions.compat.php'                );
+require_once( JETPACK__PLUGIN_DIR . 'functions.gallery.php'               );
+require_once( JETPACK__PLUGIN_DIR . 'require-lib.php'                     );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php'        );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-tracks.php'            );
+require_once( JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php'       );
+require_once( JETPACK__PLUGIN_DIR . 'modules/module-headings.php'         );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-constants.php'         );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php'               );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php' );
+require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-feature-rollout.php'   );
 
 if ( is_admin() ) {
 	require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php'     );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -70,6 +70,9 @@
 		<testsuite name="idc">
 			<file>tests/php/test_class.jetpack-idc.php</file>
 		</testsuite>
+		<testsuite name="feature-rollout">
+			<file>tests/php/test_class.jetpack-feature-rollout.php</file>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -95,10 +95,7 @@ class Jetpack_Sync_Actions {
 
 	static function sync_via_cron_allowed() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
-		return (
-			Jetpack_Feature_Rollout::init()->is_enabled( 'sync_via_cron' ) ||
-			Jetpack_Sync_Settings::get_setting( 'sync_via_cron' )
-		);
+		return ( Jetpack_Sync_Settings::get_setting( 'sync_via_cron' ) );
 	}
 
 	static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -95,7 +95,10 @@ class Jetpack_Sync_Actions {
 
 	static function sync_via_cron_allowed() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
-		return ( Jetpack_Sync_Settings::get_setting( 'sync_via_cron' ) );
+		return (
+			Jetpack_Feature_Rollout::init()->is_enabled( 'sync_via_cron' ) &&
+			Jetpack_Sync_Settings::get_setting( 'sync_via_cron' )
+		);
 	}
 
 	static function prevent_publicize_blacklisted_posts( $should_publicize, $post ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -96,7 +96,7 @@ class Jetpack_Sync_Actions {
 	static function sync_via_cron_allowed() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 		return (
-			Jetpack_Feature_Rollout::init()->is_enabled( 'sync_via_cron' ) &&
+			Jetpack_Feature_Rollout::init()->is_enabled( 'sync_via_cron' ) ||
 			Jetpack_Sync_Settings::get_setting( 'sync_via_cron' )
 		);
 	}

--- a/tests/php/test_class.jetpack-feature-rollout.php
+++ b/tests/php/test_class.jetpack-feature-rollout.php
@@ -1,0 +1,135 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/../../class.jetpack-feature-rollout.php';
+
+// Extend with a public constructor so we can test
+class MockJetpackFeatureRollout extends Jetpack_Feature_Rollout  {
+	public function __construct() {
+	}
+}
+
+class WP_Test_Jetpack_Feature_Rollout extends WP_UnitTestCase {
+	function setUp() {
+		delete_transient( Jetpack_Feature_Rollout::JETPACK_FEATURES_TRANSIENT_NAME );
+		delete_option( Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME );
+	}
+
+	function get_stub( $return_value ) {
+		// Create a stub for the SomeClass class.
+		$stub = $this->getMockBuilder( 'MockJetpackFeatureRollout' )
+			->setMethods( array( 'fetch_features_from_wpcom', 'should_load' ) )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stub->method( 'fetch_features_from_wpcom' )
+			->will( $this->returnValue( $return_value ) );
+
+		$stub->method( 'should_load' )
+		     ->will( $this->returnValue( true ) );
+
+		return $stub;
+	}
+
+	function test_features_initializes_to_false_if_errored_and_never_fetched() {
+		$stub = $this->get_stub( $this->__get_features_wp_errored() );
+
+		$this->assertNull( $stub->get_features() );
+		$stub->wordpress_init();
+		$this->assertFalse( $stub->get_features() );
+	}
+
+	function test_features_doesnt_change_if_404() {
+		$initial = array(
+			'idc' => true,
+			'sync_via_shutdown' => true
+		);
+		update_option( Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
+
+		$stub = $this->get_stub( $this->__get_features_wp_errored() );
+
+		$this->assertNull( $stub->get_features() );
+		$stub->wordpress_init();
+		$this->assertSame( $initial, $stub->get_features() );
+	}
+
+	function test_features_updates_when_successful() {
+		$initial = array(
+			'idc' => false,
+			'sync_via_shutdown' => true
+		);
+		update_option( Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
+		set_transient( Jetpack_Feature_Rollout::JETPACK_FEATURES_TRANSIENT_NAME, '1', HOUR_IN_SECONDS );
+
+		$stub = $this->get_stub( $this->__get_features_successful() );
+
+		$stub->wordpress_init();
+		$this->assertSame( $initial, $stub->get_features() );
+
+		delete_transient( Jetpack_Feature_Rollout::JETPACK_FEATURES_TRANSIENT_NAME );
+		$stub->update_features_option_and_transient();
+		$this->assertSame(
+			array( 'idc'=> true, 'sync_via_shutdown' => true ),
+			$stub->get_features()
+		);
+	}
+
+	function test_features_doesnt_fetch_if_transient_not_timed_out() {
+		$initial = array(
+			'idc' => true,
+			'sync_via_shutdown' => true
+		);
+		update_option( Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
+		set_transient( Jetpack_Feature_Rollout::JETPACK_FEATURES_TRANSIENT_NAME, '1', HOUR_IN_SECONDS );
+
+		$stub = $this->get_stub( $this->__get_features_only_sync_via_shutdown() );
+
+		$stub->wordpress_init();
+		$this->assertSame( $initial, $stub->get_features() );
+	}
+
+	function test_features_is_enabled_returns_false_if_feature_not_set() {
+		$stub = $this->get_stub( $this->__get_features_successful() );
+		$stub->update_features_option_and_transient();
+		$this->assertFalse( $stub->is_enabled( 'foo' ) );
+
+		$this->setUp();
+
+		$stub->method( 'fetch_features_from_wpcom' )
+			->will( $this->returnValue( $this->__get_features_wp_errored() ) );
+
+		$stub->update_features_option_and_transient();
+		$this->assertTrue( $stub->is_enabled( 'idc' ) );
+	}
+
+	function test_features_is_enabled_returns_false_if_features_set_and_disabled() {
+		$stub = $this->get_stub( $this->__get_features_only_sync_via_shutdown() );
+
+		$stub->update_features_option_and_transient();
+		$this->assertFalse( $stub->is_enabled( 'idc' ) );
+	}
+
+	function test_features_is_enabled_returns_true_if_features_set_and_enabled() {
+		$stub = $this->get_stub( $this->__get_features_only_sync_via_shutdown() );
+
+		$stub->update_features_option_and_transient();
+		$this->assertTrue( $stub->is_enabled( 'sync_via_shutdown' ) );
+	}
+
+	function __get_features_successful() {
+		return array(
+			'idc'               => true,
+			'sync_via_shutdown' => true
+		);
+	}
+
+	function __get_features_only_sync_via_shutdown() {
+		return array(
+			'idc'               => false,
+			'sync_via_shutdown' => true
+		);
+	}
+
+	function __get_features_wp_errored() {
+		return new WP_Error( 'get_features_failed' );
+	}
+}

--- a/tests/php/test_class.jetpack-feature-rollout.php
+++ b/tests/php/test_class.jetpack-feature-rollout.php
@@ -11,7 +11,7 @@ class MockJetpackFeatureRollout extends Jetpack_Feature_Rollout  {
 class WP_Test_Jetpack_Feature_Rollout extends WP_UnitTestCase {
 	function setUp() {
 		delete_transient( Jetpack_Feature_Rollout::JETPACK_FEATURES_TRANSIENT_NAME );
-		delete_option( Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME );
+		delete_option( 'jetpack_' . Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME );
 	}
 
 	function get_stub( $return_value ) {
@@ -21,11 +21,13 @@ class WP_Test_Jetpack_Feature_Rollout extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$stub->method( 'fetch_features_from_wpcom' )
+		$stub->expects( $this->any() )
+			->method( 'fetch_features_from_wpcom' )
 			->will( $this->returnValue( $return_value ) );
 
-		$stub->method( 'should_load' )
-		     ->will( $this->returnValue( true ) );
+		$stub->expects( $this->any() )
+			->method( 'should_load' )
+			->will( $this->returnValue( true ) );
 
 		return $stub;
 	}
@@ -43,7 +45,7 @@ class WP_Test_Jetpack_Feature_Rollout extends WP_UnitTestCase {
 			'idc' => true,
 			'sync_via_shutdown' => true
 		);
-		update_option( Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
+		update_option( 'jetpack_' . Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
 
 		$stub = $this->get_stub( $this->__get_features_wp_errored() );
 
@@ -57,16 +59,11 @@ class WP_Test_Jetpack_Feature_Rollout extends WP_UnitTestCase {
 			'idc' => false,
 			'sync_via_shutdown' => true
 		);
-		update_option( Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
-		set_transient( Jetpack_Feature_Rollout::JETPACK_FEATURES_TRANSIENT_NAME, '1', HOUR_IN_SECONDS );
+		update_option( 'jetpack_' . Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
 
 		$stub = $this->get_stub( $this->__get_features_successful() );
-
 		$stub->wordpress_init();
-		$this->assertSame( $initial, $stub->get_features() );
 
-		delete_transient( Jetpack_Feature_Rollout::JETPACK_FEATURES_TRANSIENT_NAME );
-		$stub->update_features_option_and_transient();
 		$this->assertSame(
 			array( 'idc'=> true, 'sync_via_shutdown' => true ),
 			$stub->get_features()
@@ -78,7 +75,7 @@ class WP_Test_Jetpack_Feature_Rollout extends WP_UnitTestCase {
 			'idc' => true,
 			'sync_via_shutdown' => true
 		);
-		update_option( Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
+		update_option( 'jetpack_' . Jetpack_Feature_Rollout::JETPACK_FEATURES_OPTION_NAME, $initial );
 		set_transient( Jetpack_Feature_Rollout::JETPACK_FEATURES_TRANSIENT_NAME, '1', HOUR_IN_SECONDS );
 
 		$stub = $this->get_stub( $this->__get_features_only_sync_via_shutdown() );
@@ -94,7 +91,8 @@ class WP_Test_Jetpack_Feature_Rollout extends WP_UnitTestCase {
 
 		$this->setUp();
 
-		$stub->method( 'fetch_features_from_wpcom' )
+		$stub->expects( $this->any() )
+			->method( 'fetch_features_from_wpcom' )
 			->will( $this->returnValue( $this->__get_features_wp_errored() ) );
 
 		$stub->update_features_option_and_transient();

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -316,50 +316,68 @@ EXPECTED;
 	}
 
 	function test_idc_optin_default() {
+		add_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 		if ( is_multisite() ) {
 			$this->assertFalse( Jetpack::sync_idc_optin() );
 		} else {
 			$this->assertTrue( Jetpack::sync_idc_optin() );
 		}
+		remove_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 	}
 
 	function test_idc_optin_false_when_sunrise() {
+		add_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 		Jetpack_Constants::set_constant( 'SUNRISE', true );
 
 		$this->assertFalse( Jetpack::sync_idc_optin() );
 
 		Jetpack_Constants::clear_constants();
+		remove_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 	}
 
 	function test_idc_optin_filter_overrides_development_version() {
+		add_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 		add_filter( 'jetpack_development_version', '__return_true' );
 		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
 		$this->assertFalse( Jetpack::sync_idc_optin() );
 		remove_filter( 'jetpack_development_version', '__return_true' );
 		remove_filter( 'jetpack_sync_idc_optin', '__return_false' );
+		remove_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 	}
 
 	function test_idc_optin_casts_to_bool() {
+		add_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 		add_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
 		$this->assertTrue( Jetpack::sync_idc_optin() );
 		remove_filter( 'jetpack_sync_idc_optin', array( $this, '__return_string_1' ) );
+		remove_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 	}
 
 	function test_idc_optin_true_when_constant_true() {
+		add_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 		Jetpack_Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
 		$this->assertTrue( Jetpack::sync_idc_optin() );
+		remove_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 	}
 
 	function test_idc_optin_false_when_constant_false() {
+		add_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 		Jetpack_Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', false );
 		$this->assertFalse( Jetpack::sync_idc_optin() );
+		remove_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 	}
 
 	function test_idc_optin_filter_overrides_constant() {
+		add_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
 		Jetpack_Constants::set_constant( 'JETPACK_SYNC_IDC_OPTIN', true );
 		add_filter( 'jetpack_sync_idc_optin', '__return_false' );
 		$this->assertFalse( Jetpack::sync_idc_optin() );
 		remove_filter( 'jetpack_sync_idc_optin', '__return_false' );
+		remove_filter( 'jetpack_feature_rollout_enabled', '__return_true' );
+	}
+
+	function test_idc_optin_returns_false_when_feature_disabled() {
+		$this->assertFalse( Jetpack::sync_idc_optin() );
 	}
 
 	function test_sync_error_idc_validation_returns_false_if_no_option() {
@@ -400,71 +418,6 @@ EXPECTED;
 
 		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
 		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
-	}
-
-	function test_sync_error_idc_validation_success_when_idc_allowed() {
-		add_filter( 'pre_http_request', array( $this, '__idc_is_allowed' ) );
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
-
-		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
-		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
-
-		// Cleanup
-		remove_filter( 'pre_http_request', array( $this, '__idc_is_allowed' ) );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		delete_transient( 'jetpack_idc_allowed' );
-	}
-
-	function test_sync_error_idc_validation_fails_when_idc_disabled() {
-		add_filter( 'pre_http_request', array( $this, '__idc_is_disabled' ) );
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
-		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
-
-		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
-		$this->assertEquals( '0', get_transient( 'jetpack_idc_allowed' ) );
-
-		// Cleanup
-		remove_filter( 'pre_http_request', array( $this, '__idc_is_disabled' ) );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		delete_transient( 'jetpack_idc_allowed' );
-	}
-
-	function test_sync_error_idc_validation_success_when_idc_errored() {
-		add_filter( 'pre_http_request', array( $this, '__idc_check_errored' ) );
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
-
-		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
-		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
-
-		// Cleanup
-		remove_filter( 'pre_http_request', array( $this, '__idc_is_errored' ) );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		delete_transient( 'jetpack_idc_allowed' );
-	}
-
-	function test_sync_error_idc_validation_success_when_idc_404() {
-		add_filter( 'pre_http_request', array( $this, '__idc_check_404' ) );
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
-
-		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
-		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
-
-		// Cleanup
-		remove_filter( 'pre_http_request', array( $this, '__idc_check_404' ) );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		delete_transient( 'jetpack_idc_allowed' );
 	}
 
 	function test_is_staging_site_true_when_sync_error_idc_is_valid() {
@@ -584,36 +537,7 @@ EXPECTED;
 		return '1';
 	}
 
-	function __idc_is_allowed() {
-		return array(
-			'response' => array(
-				'code' => 200
-			),
-			'body' => '{"result":true}'
-		);
-	}
 
-	function __idc_is_disabled() {
-		return array(
-			'response' => array(
-				'code' => 200
-			),
-			'body' => '{"result":false}'
-		);
-	}
-
-	function __idc_check_errored() {
-		return new WP_Error( 'idc-request-failed' );
-	}
-
-	function __idc_check_404() {
-		return array(
-			'response' => array(
-				'code' => 404
-			),
-			'body' => '<div>some content</div>'
-		);
-	}
 
 	static function reset_tracking_of_module_activation() {
 		self::$activated_modules = array();


### PR DESCRIPTION
This afternoon, @samhotchkiss requested the ability to rollout the feature to sync on shutdown to a percentage of sites at a time.

This PR adds the `Jetpack_Feature_Rollout` class which abstracts the IDC kill switch functionality in a way that we can now handle feature rollouts. We should still be able to handle the IDC kill switch by rolling out to 100% or 0% on the WPCOM side.

WPCOM patch: D3381

To test:

- Checkout `add/feature-rollout` to production Jetpack site
- Apply the D3381 WPCOM patch
- Clone site from production to local and ensure you get IDC notice
- Change the WPCOM side so that the IDC feature is 0
- Clear jetpack_feature_rollout transient and option on production Jetpack site
- Migrate site from production to local again
- Your site should not be opted in, so you should not see an IDC notice
- If you check WordPress.com network admin, your production site home and siteurl values should be from the cloned site 😱 

This PR does not include the `sync_via_shutdown` feature since it seems like Poseidon may change our opinion about that feature. Once we get this framework in though, it should be easy to add that and other features in the future.

The enabled features information has also been added to the debugger per @kraftbj's suggestion below.

![screen shot 2016-11-17 at 1 52 52 am](https://cloud.githubusercontent.com/assets/1126811/20380591/a4a886d4-ac68-11e6-9ee6-29ac42400da5.png)
