### PR TITLE
Subscriptions: fix checkbox status when saving a draft.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -223,9 +223,7 @@ class Jetpack_Subscriptions {
 	}
 
 	function set_post_flags( $flags, $post ) {
-		if ( ! $this->should_email_post_to_subscribers( $post ) ) {
-			$flags['_jetpack_dont_email_post_to_subs'] = true;
-		}
+		$flags['send_subscription'] = $this->should_email_post_to_subscribers( $post );
 		return $flags;
 	}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -147,11 +147,19 @@ class Jetpack_Subscriptions {
 	 * @param $post obj - The post object
 	 */
 	function maybe_send_subscription_email( $new_status, $old_status, $post ) {
-		// Only do things on publish
-		if ( 'publish' !== $new_status ) {
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+
+		// Make sure that the checkbox is preseved
+		if ( ! empty( $_POST['disable_subscribe_nonce'] ) && wp_verify_nonce( $_POST['disable_subscribe_nonce'], 'disable_subscribe' ) ) {
+			$set_checkbox = isset( $_POST['_jetpack_dont_email_post_to_subs'] ) ? 1 : 0;
+			update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', $set_checkbox );
+		}
+
+		// Only do things on publish
+		if ( 'publish' !== $new_status ) {
 			return;
 		}
 
@@ -210,12 +218,7 @@ class Jetpack_Subscriptions {
 			$should_email = false;
 		}
 
-		// Email the post, depending on the checkbox option
-		if ( ! empty( $_POST['disable_subscribe_nonce'] ) && wp_verify_nonce( $_POST['disable_subscribe_nonce'], 'disable_subscribe' ) ) {
-			if ( isset( $_POST['_jetpack_dont_email_post_to_subs'] ) ) {
-				$should_email = false;
-			}
-		}
+
 		return $should_email;
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -210,10 +210,9 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function send_published( $post_ID, $post, $update ) {
-		if ( $this->just_published === $post->ID && ! get_post_meta( $post_ID, '_jetpack_published_post' , true ) ) {
+		if ( $this->just_published === $post->ID ) {
 			$this->just_published = null;
 			$flags = apply_filters( 'jetpack_published_post_flags', array(), $post );
-			update_post_meta( $post_ID, '_jetpack_published_post' , true );
 			do_action( 'jetpack_published_post', $post_ID, $flags );
 		}
 	}

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -210,9 +210,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function send_published( $post_ID, $post, $update ) {
-		if ( $this->just_published === $post->ID ) {
+		if ( $this->just_published === $post->ID && ! get_post_meta( $post_ID, '_jetpack_published_post' , true ) ) {
 			$this->just_published = null;
 			$flags = apply_filters( 'jetpack_published_post_flags', array(), $post );
+			update_post_meta( $post_ID, '_jetpack_published_post' , true );
 			do_action( 'jetpack_published_post', $post_ID, $flags );
 		}
 	}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -838,7 +838,7 @@ That was a cool video.';
 	public function test_sync_jetpack_published_post_should_set_send_subscription_to_false() {
 		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
 		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
- 		Jetpack_Subscriptions::init();
+ 		new Jetpack_Subscriptions; // call instead of Jetpack_Subscriptions::init() so that actions get reinitialized
 
 		$post_id = $this->factory->post->create( array(  'post_status' => 'draft' ) );
 
@@ -857,7 +857,7 @@ That was a cool video.';
 		$this->server_event_storage->reset();
 		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
 		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
-		Jetpack_Subscriptions::init();
+		new Jetpack_Subscriptions; // call instead of Jetpack_Subscriptions::init() so that actions get reinitialized
 
 		wp_update_post( array(
 			'ID'          => $this->post->ID,
@@ -874,9 +874,9 @@ That was a cool video.';
 		$this->sender->do_sync();
 		
 		$events = $this->server_event_storage->get_all_events( 'jetpack_published_post' );
-		$post_flags = $this->server_event_storage->get_most_recent_event( 'jetpack_published_post' )->args[1];
-
 		$this->assertEquals( count( $events ), 1 );
+
+		$post_flags = $events[0]->args[1];		
 		$this->assertTrue( $post_flags['send_subscription'] );
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -854,6 +854,7 @@ That was a cool video.';
 	}
 
 	public function test_sync_jetpack_published_post_should_set_set_send_subscription_to_true() {
+		$this->server_event_storage->reset();
 		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
 		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
 		Jetpack_Subscriptions::init();
@@ -871,8 +872,8 @@ That was a cool video.';
 		) );
 		
 		$this->sender->do_sync();
+		
 		$events = $this->server_event_storage->get_all_events( 'jetpack_published_post' );
-
 		$post_flags = $this->server_event_storage->get_most_recent_event( 'jetpack_published_post' )->args[1];
 
 		$this->assertEquals( count( $events ), 1 );

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -802,27 +802,24 @@ That was a cool video.';
 	}
 
 	public function test_sync_jetpack_published_post() {
-		wp_update_post( array(
-			'ID'          => $this->post->ID,
-			'post_status' => 'draft',
-		) );
+		$post_id = $this->factory->post->create( array(  'post_status' => 'draft' ) );
 
 		$this->sender->do_sync();
 
-		$remote_post = $this->server_replica_storage->get_post( $this->post->ID );
+		$remote_post = $this->server_replica_storage->get_post( $post_id );
 		$this->assertEquals( 'draft', $remote_post->post_status );
 
-		wp_publish_post( $this->post->ID );
+		wp_publish_post( $post_id );
 
 		$this->sender->do_sync();
 
-		$remote_post = $this->server_replica_storage->get_post( $this->post->ID );
+		$remote_post = $this->server_replica_storage->get_post( $post_id );
 		$this->assertEquals( 'publish', $remote_post->post_status );
 
 		$event = $this->server_event_storage->get_most_recent_event();
 
 		$this->assertEquals( 'jetpack_published_post', $event->action );
-		$this->assertEquals( $this->post->ID, $event->args[0] );
+		$this->assertEquals( $post_id, $event->args[0] );
 	}
 
 	public function test_sync_jetpack_update_post_to_draft_shouldnt_publish() {
@@ -843,19 +840,16 @@ That was a cool video.';
 		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
  		Jetpack_Subscriptions::init();
 
-		wp_update_post( array(
-			'ID'          => $this->post->ID,
-			'post_status' => 'draft',
-		) );
+		$post_id = $this->factory->post->create( array(  'post_status' => 'draft' ) );
 
-		update_post_meta( $this->post->ID, '_jetpack_dont_email_post_to_subs', 1 );
+		update_post_meta( $post_id, '_jetpack_dont_email_post_to_subs', 1 );
 
-		wp_publish_post( $this->post->ID );
+		wp_publish_post( $post_id );
 
 		$this->sender->do_sync();
 
 		$post_flags = $this->server_event_storage->get_most_recent_event( 'jetpack_published_post' )->args[1];
-		error_log( print_r( $post_flags,1 ));
+
 		$this->assertFalse( $post_flags['send_subscription'] );
 	}
 
@@ -880,7 +874,7 @@ That was a cool video.';
 		$events = $this->server_event_storage->get_all_events( 'jetpack_published_post' );
 
 		$post_flags = $this->server_event_storage->get_most_recent_event( 'jetpack_published_post' )->args[1];
-		
+
 		$this->assertEquals( count( $events ), 1 );
 		$this->assertTrue( $post_flags['send_subscription'] );
 	}


### PR DESCRIPTION
Fixes an issue where the checkbox to not send email to subscribers does not stay checked off when in draft mode. 

Also sends an send_subscription flag that is a boolean to .com instead. 

This flag normally only gets set when the module is enabled. Which is more direct then the current do not email flag. Which only gets added when you are not supposed to send out an email.

cc: @lezama 

