### PR TITLE
Manage: Make a "default" module.

### DIFF
--- a/modules/manage.php
+++ b/modules/manage.php
@@ -7,9 +7,9 @@
  * Recommendation Order: 3
  * First Introduced: 3.4
  * Requires Connection: Yes
- * Auto Activate: No
+ * Auto Activate: Yes
  * Module Tags: Centralized Management, Recommended
- * Feature: General, Jumpstart
+ * Feature: General
  * Additional Search Queries: manage, management, remote
  */
 add_action( 'customize_register', 'add_wpcom_to_allowed_redirect_hosts' );


### PR DESCRIPTION
fixes #5682 

Manage is already activated during the connection flow, and we've already removed the UI for deactivating it since 4.1

Since this was not listed as a default module, it was causing some bugginess when testing Jump Start after "Reset Options".  Since the modules were reset to default, manage was deactivated and then during connection it was activated again, thus confusing Jump Start into thinking a user had taken action so it would not show.

This also removes Manage from the Jump Start list, when you click Learn More. 

To Test: 
- Disconnect
- Reset all options 
- COnnect to wp.com
- select the Free plan
- You should see Jump Start. 

- Also test this on a new site if you can. 