### PR TITLE
SEO Tools: Use upgrade button instead of toggle when pro plan is not active

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -103,7 +103,7 @@ export const Engagement = ( props ) => {
 			},
 			isModuleActive = isModuleActivated( element[0] );
 
-		if ( isPro && 'undefined' !== typeof props.sitePlan.product_slug && props.sitePlan.product_slug !== 'jetpack_business' ) {
+		if ( isPro ) {
 
 			toggle = <ProStatus proFeature={ element[0] } />;
 
@@ -121,6 +121,14 @@ export const Engagement = ( props ) => {
 
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );
+		} else if ( 'seo-tools' === element[0] && 'jetpack_business' !== props.sitePlan.product_slug ) {
+			toggle = <Button
+				compact={ true }
+				primary={ true }
+				href={ 'https://wordpress.com/plans/' + props.siteRawUrl }
+			>
+				{ __( 'Upgrade' ) }
+			</Button>;
 		} else if ( isAdmin ) {
 			toggle = <ModuleToggle slug={ element[0] }
 						activated={ isModuleActive }


### PR DESCRIPTION
Fixes #5652

#### Changes proposed in this Pull Request:

* Show the "Upgrade" button instead of toggle for SEO Tools when an active Jetpack Pro plan is not owned.
* Keep the "Pro" button even when a plan is owned.

#### Testing instructions:
* Ensure the "Upgrade" button is present instead of a toggle switch next to SEO Tools when you do not own a Pro plan.
* Ensure the "Upgrade" button disappears and a toggle appears after purchasing a Pro plan.
* Ensure the "Pro" button is still present after purchasing a Pro plan.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

…owned, keep Pro button even when plan is active.