### PR TITLE
SEO Tools: Fix archive date value for archive custom titles

### DIFF
--- a/modules/seo-tools/jetpack-seo-titles.php
+++ b/modules/seo-tools/jetpack-seo-titles.php
@@ -137,7 +137,7 @@ class Jetpack_SEO_Titles {
 				return single_tag_title( '', false );
 
 			case 'date':
-				return trim( single_month_title( ' ', false ) );
+				return self::get_date_for_title();
 
 			default:
 				return '';
@@ -173,6 +173,31 @@ class Jetpack_SEO_Titles {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Returns the value that should be used as a replacement for the date token,
+	 * depending on the archive path specified.
+	 *
+	 * @return string Token replacement for a given date, or empty string if no date is specified.
+	 */
+	public static function get_date_for_title() {
+		// If archive year, month, and day are specified.
+		if ( is_day() ) {
+			return get_the_date();
+		}
+
+		// If archive year, and month are specified.
+		if ( is_month() ) {
+			return trim( single_month_title( ' ', false ) );
+		}
+
+		// Only archive year is specified.
+		if ( is_year() ) {
+			return get_query_var( 'year' );
+		}
+
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5698

#### Changes proposed in this Pull Request:

Previously, the value for token was empty when specific day or only a year was specified in the archive URL.

#### Testing instructions:

* Follow the instructions provided in https://github.com/Automattic/jetpack/issues/5698, and verify that the correct values are displayed in cases **1** and **3**.

