### PR TITLE
Connection Banner: Fix old banner styles

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -98,7 +98,7 @@
 	}
 }
 
-.jp-banner__button-container {
+.jp-wpcom-connect__content-container .jp-banner__button-container {
 	@include minbreakpoint(tablet) {
 		position: absolute;
 		bottom: rem( 16px );


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/5675

A generic selector allowed for some styles form the old connection banner to be changed. I added a more specific selector, so the old connection banner remains undisturbed when the new one is modded.

**Before:**
![image](https://cloud.githubusercontent.com/assets/574752/20368583/ec7a9fb2-ac11-11e6-91b6-1df255d62a5d.png)

After:
<img width="1092" alt="banner-before" src="https://cloud.githubusercontent.com/assets/214813/19896727/a9d391ec-a02b-11e6-9f41-b97a62555d2e.png">