### PR TITLE
API: Add theme installation hooks

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
@@ -28,6 +28,8 @@ class Jetpack_JSON_API_Themes_Delete_Endpoint extends Jetpack_JSON_API_Themes_En
 			 * The filter can also return an instance of WP_Error; in which case the endpoint response will
 			 * contain this error.
 			 *
+			 * @module json-api
+			 *
 			 * @since 4.4.2
 			 *
 			 * @param bool   $use_alternative_delete_method Whether to use the alternative method of deleting

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
@@ -21,7 +21,20 @@ class Jetpack_JSON_API_Themes_Delete_Endpoint extends Jetpack_JSON_API_Themes_En
 				continue;
 			}
 
-			// Allow alternative theme deletion mechanism.
+			/**
+			 * Filters whether to use an alternative process for deleting a WordPress.com theme.
+			 * The alternative process can be executed during the filter.
+			 *
+			 * The filter can also return an instance of WP_Error; in which case the endpoint response will
+			 * contain this error.
+			 *
+			 * @since 4.4.2
+			 *
+			 * @param bool   $use_alternative_delete_method Whether to use the alternative method of deleting
+			 *                                              a WPCom theme.
+			 * @param string $theme_slug                    Theme name (slug). If it is a WPCom theme,
+			 *                                              it should be suffixed with `-wpcom`.
+			 */
 			$result = apply_filters( 'jetpack_wpcom_theme_delete', false, $theme );
 
 			if ( ! $result ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
@@ -21,14 +21,18 @@ class Jetpack_JSON_API_Themes_Delete_Endpoint extends Jetpack_JSON_API_Themes_En
 				continue;
 			}
 
-			$result = delete_theme( $theme );
+			// Allow alternative theme deletion mechanism.
+			$result = apply_filters( 'jetpack_wpcom_theme_delete', false, $theme );
+
+			if ( ! $result ) {
+				$result = delete_theme( $theme );
+			}
 
 			if ( is_wp_error( $result ) ) {
 				$error = $this->log[ $theme ]['error'] = $result->get_error_messages;
 			} else {
 				$this->log[ $theme ][] = 'Theme deleted';
 			}
-
 		}
 
 		if( ! $this->bulk && isset( $error ) ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -21,6 +21,8 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			 * The filter can also return an instance of WP_Error; in which case the endpoint response will
 			 * contain this error.
 			 *
+			 * @module json-api
+			 *
 			 * @since 4.4.2
 			 *
 			 * @param bool   $use_alternative_install_method Whether to use the alternative method of installing
@@ -89,6 +91,8 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			 *
 			 * The filter can also return an instance of WP_Error; in which case the endpoint response will
 			 * contain this error.
+			 *
+			 * @module json-api
 			 *
 			 * @since 4.4.2
 			 *

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -14,6 +14,12 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 
 		foreach ( $this->themes as $theme ) {
 
+			// hook to allow alternative install method
+			if ( wp_endswith( $theme, '-wpcom' )
+				&& apply_filters( 'jetpack_wpcom_theme_install', false, $theme ) ) {
+				continue;
+			}
+
 			$skin      = new Jetpack_Automatic_Install_Skin();
 			$upgrader  = new Theme_Upgrader( $skin );
 
@@ -60,6 +66,10 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			}
 
 			if ( wp_endswith( $theme, '-wpcom' ) ) {
+				if ( apply_filters( 'jetpack_wpcom_theme_skip_download', false, $theme ) ) {
+					continue;
+				}
+
 				$file = self::download_wpcom_theme_to_file( $theme );
 				if ( is_wp_error( $file ) ) {
 					return $file;

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -70,7 +70,11 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 			}
 
 			if ( wp_endswith( $theme, '-wpcom' ) ) {
-				if ( apply_filters( 'jetpack_wpcom_theme_skip_download', false, $theme ) ) {
+				$skip_download_filter_result = apply_filters( 'jetpack_wpcom_theme_skip_download', false, $theme );
+
+				if ( is_wp_error( $skip_download_filter_result ) ) {
+					return $skip_download_filter_result;
+				} elseif ( $skip_download_filter_result ) {
 					continue;
 				}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -69,16 +69,17 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 				return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
 			}
 
+			$skip_download_filter_result = apply_filters( 'jetpack_wpcom_theme_skip_download', false, $theme );
+
+			if ( is_wp_error( $skip_download_filter_result ) ) {
+				return $skip_download_filter_result;
+			} elseif ( $skip_download_filter_result ) {
+				continue;
+			}
+
 			if ( wp_endswith( $theme, '-wpcom' ) ) {
-				$skip_download_filter_result = apply_filters( 'jetpack_wpcom_theme_skip_download', false, $theme );
-
-				if ( is_wp_error( $skip_download_filter_result ) ) {
-					return $skip_download_filter_result;
-				} elseif ( $skip_download_filter_result ) {
-					continue;
-				}
-
 				$file = self::download_wpcom_theme_to_file( $theme );
+
 				if ( is_wp_error( $file ) ) {
 					return $file;
 				}

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -16,7 +16,7 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 
 			// hook to allow alternative install method
 			if ( wp_endswith( $theme, '-wpcom' )
-				&& apply_filters( 'jetpack_wpcom_theme_install', false, $theme ) ) {
+				 && apply_filters( 'jetpack_wpcom_theme_install', false, $theme ) ) {
 				continue;
 			}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -14,7 +14,20 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 
 		foreach ( $this->themes as $theme ) {
 
-			// hook to allow alternative install method
+			/**
+			 * Filters whether to use an alternative process for installing a WordPress.com theme.
+			 * The alternative process can be executed during the filter.
+			 *
+			 * The filter can also return an instance of WP_Error; in which case the endpoint response will
+			 * contain this error.
+			 *
+			 * @since 4.4.2
+			 *
+			 * @param bool   $use_alternative_install_method Whether to use the alternative method of installing
+			 *                                               a WPCom theme.
+			 * @param string $theme_slug                     Theme name (slug). If it is a WPCom theme,
+			 *                                               it should be suffixed with `-wpcom`.
+			 */
 			$result = apply_filters( 'jetpack_wpcom_theme_install', false, $theme );
 
 			$skin = null;
@@ -69,6 +82,21 @@ class Jetpack_JSON_API_Themes_Install_Endpoint extends Jetpack_JSON_API_Themes_E
 				return new WP_Error( 'theme_already_installed', __( 'The theme is already installed', 'jetpack' ) );
 			}
 
+			/**
+			 * Filters whether to skip the standard method of downloading and validating a WordPress.com
+			 * theme. An alternative method of WPCom theme download and validation can be
+			 * executed during the filter.
+			 *
+			 * The filter can also return an instance of WP_Error; in which case the endpoint response will
+			 * contain this error.
+			 *
+			 * @since 4.4.2
+			 *
+			 * @param bool   $skip_download_filter_result Whether to skip the standard method of downloading
+			 *                                            and validating a WPCom theme.
+			 * @param string $theme_slug                  Theme name (slug). If it is a WPCom theme,
+			 *                                            it should be suffixed with `-wpcom`.
+			 */
 			$skip_download_filter_result = apply_filters( 'jetpack_wpcom_theme_skip_download', false, $theme );
 
 			if ( is_wp_error( $skip_download_filter_result ) ) {


### PR DESCRIPTION
Allows alternate installation technique for wpcom themes.

For example, themes could be already checked out somewhere on the filesystem and only require symlinking in `wp-content/themes` to install instead of downloading and extracting.

cc @lamosty 

Example plugin implementation:

```
<?php
/*
 *Plugin Name: Theme Installer
 */

// $theme_slug will always end in -wpcom
function theme_installer_symlink_theme( $installed, $theme_slug ) {
    // create the symlink for $theme_slug
    return true;
}

// $theme_slug will always end in -wpcom
function theme_installer_theme_exists_on_filesystem( $installed, $theme_slug ) {
    // check that $theme_slug exists
    return true;
}

add_filter( 'jetpack_wpcom_theme_skip_download', 'theme_installer_theme_exists_on_filesystem', 10, 2 );
add_filter( 'jetpack_wpcom_theme_install', 'theme_installer_symlink_theme', 10, 2 );
```
