### PR TITLE
Admin: fix SEO Tools activation

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -122,7 +122,7 @@ export const Engagement = ( props ) => {
 								<Button compact={ true } href="#/plans">
 									{ __( 'Pro' ) }
 								</Button>
-							</span>;
+							 </span>;
 			}
 		}
 

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -103,37 +103,27 @@ export const Engagement = ( props ) => {
 			},
 			isModuleActive = isModuleActivated( element[0] );
 
-		if ( isPro ) {
-
-			toggle = <ProStatus proFeature={ element[0] } />;
-
-			// Add a "pro" button next to the header title
-			element[1] = <span>
-				{ element[1] }
-				<Button
-					compact={ true }
-					href="#/plans"
-				>
-					{ __( 'Pro' ) }
-				</Button>
-			</span>;
-		}
-
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );
-		} else if ( 'seo-tools' === element[0] && 'jetpack_business' !== props.sitePlan.product_slug ) {
-			toggle = <Button
-				compact={ true }
-				primary={ true }
-				href={ 'https://wordpress.com/plans/' + props.siteRawUrl }
-			>
-				{ __( 'Upgrade' ) }
-			</Button>;
 		} else if ( isAdmin ) {
-			toggle = <ModuleToggle slug={ element[0] }
-						activated={ isModuleActive }
-						toggling={ isTogglingModule( element[0] ) }
-						toggleModule={ toggleModule } />;
+			if ( isPro && 'undefined' !== typeof props.sitePlan.product_slug && props.sitePlan.product_slug !== 'jetpack_business' ) {
+				toggle = <ProStatus proFeature={ element[0] } />;
+			} else if ( ! isPro || ( 'undefined' !== typeof props.sitePlan.product_slug && props.sitePlan.product_slug === 'jetpack_business' ) ) {
+				toggle = <ModuleToggle slug={ element[0] }
+									   activated={ isModuleActive }
+									   toggling={ isTogglingModule( element[0] ) }
+									   toggleModule={ toggleModule } />;
+			}
+
+			if ( isPro ) {
+				// Add a "pro" button next to the header title
+				element[1] = <span>
+								{ element[1] }
+								<Button compact={ true } href="#/plans">
+									{ __( 'Pro' ) }
+								</Button>
+							</span>;
+			}
 		}
 
 		let moduleDescription = isModuleActive ?

--- a/_inc/client/engagement/test/component.js
+++ b/_inc/client/engagement/test/component.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { Engagement } from '../index';
+
+describe( 'Engagement', () => {
+
+	let testProps = {
+		toggleModule: () => true,
+		isModuleActivated: () => false,
+		isTogglingModule:  () => false,
+		getModule: () => {
+			return {
+				'name': 'SEO Tools',
+				'description': 'Better results on search engines and social media.',
+				'learn_more_button': 'https://support.wordpress.com/seo-tools/'
+			}
+		},
+		isUnavailableInDevMode: () => false,
+		siteAdminUrl: 'https://example.org/wp-admin/',
+		siteRawUrl: 'https://example.org/',
+		isSitePublic: true,
+		sitePlan: {
+			'product_slug': 'jetpack_premium'
+		},
+		userCanManageModules: true,
+		moduleList: {
+			'seo-tools': {
+				activated                : false,
+				additional_search_queries: 'search engine optimization, social preview, meta description, custom title format',
+				auto_activate            : 'No',
+				available                : true,
+				changed                  : '',
+				configurable             : false,
+				configure_url            : 'https://example.org/wp-admin/admin.php?page=jetpack&configure=seo-tools',
+				deactivate               : true,
+				description              : 'Better results on search engines and social media.',
+				feature                  : ['Traffic', 'Jumpstart'],
+				free                     : true,
+				introduced               : '4.4',
+				jumpstart_desc           : 'Better results on search engines and social media.',
+				learn_more_button        : 'https://support.wordpress.com/seo-tools/',
+				long_description         : 'Better results on search engines and social media.',
+				module                   : 'seo-tools',
+				module_tags              : ['Social', 'Appearance'],
+				name                     : 'SEO Tools',
+				options                  : [],
+				recommendation_order     : 15,
+				requires_connection      : true,
+				search_terms             : 'search engine optimization, social preview, meta description, custom title format',
+				short_description        : 'Better results on search engines and social media.',
+				sort                     : 35
+			}
+		}
+	};
+
+	describe( 'Initially', () => {
+
+		const wrapper = shallow( <Engagement { ...testProps } /> );
+
+		it( 'renders a card for SEO Tools', () => {
+			expect( wrapper.find( 'FoldableCard' ) ).to.have.length( 1 );
+			expect( wrapper.find( 'FoldableCard' ).props().header.props.children[0] ).to.have.string( testProps.getModule().name );
+		} );
+
+		it( "SEO Tools is not available in 'jetpack_premium' plan", () => {
+			expect( wrapper.find( 'FoldableCard' ).props().summary.type.displayName ).to.be.not.equal( 'ModuleToggle' );
+		} );
+
+	} );
+
+	describe( "if site has 'jetpack_business' plan", () => {
+
+		testProps = Object.assign( testProps, {
+			sitePlan: {
+				'product_slug': 'jetpack_premium'
+			}
+		} );
+
+		const wrapper = shallow( <Engagement { ...testProps } /> );
+
+		it( "SEO Tools is available in 'jetpack_business' plan", () => {
+			expect( wrapper.find( 'FoldableCard' ).props().summary.type.displayName ).to.be.equal( 'Connect(ProStatus)' );
+		} );
+
+	} );
+
+} );
+

--- a/_inc/client/engagement/test/component.js
+++ b/_inc/client/engagement/test/component.js
@@ -77,18 +77,34 @@ describe( 'Engagement', () => {
 
 	} );
 
+	describe( 'if polling site plan from wpcom', () => {
+
+		testProps = Object.assign( testProps, {
+			sitePlan: {
+				product_slug: undefined
+			}
+		} );
+
+		const wrapper = shallow( <Engagement { ...testProps } /> );
+
+		it( "don't display the toggle", () => {
+			expect( wrapper.find( 'FoldableCard' ).props().summary ).to.be.equal( '' );
+		} );
+
+	} );
+
 	describe( "if site has 'jetpack_business' plan", () => {
 
 		testProps = Object.assign( testProps, {
 			sitePlan: {
-				'product_slug': 'jetpack_premium'
+				'product_slug': 'jetpack_business'
 			}
 		} );
 
 		const wrapper = shallow( <Engagement { ...testProps } /> );
 
 		it( "SEO Tools is available in 'jetpack_business' plan", () => {
-			expect( wrapper.find( 'FoldableCard' ).props().summary.type.displayName ).to.be.equal( 'Connect(ProStatus)' );
+			expect( wrapper.find( 'FoldableCard' ).props().summary.type.displayName ).to.be.equal( 'ModuleToggle' );
 		} );
 
 	} );

--- a/_inc/client/engagement/test/component.js
+++ b/_inc/client/engagement/test/component.js
@@ -102,9 +102,18 @@ describe( 'Engagement', () => {
 		} );
 
 		const wrapper = shallow( <Engagement { ...testProps } /> );
+		let cardProps = wrapper.find( 'FoldableCard' ).props();
 
 		it( "SEO Tools is available in 'jetpack_business' plan", () => {
-			expect( wrapper.find( 'FoldableCard' ).props().summary.type.displayName ).to.be.equal( 'ModuleToggle' );
+			expect( cardProps.summary.type.displayName ).to.be.equal( 'ModuleToggle' );
+		} );
+
+		it( 'always displays a PRO badge next to the title', () => {
+			expect( cardProps.header.props.children[1].type.displayName ).to.be.equal( 'Button' );
+		} );
+
+		it( 'the PRO badge points to the Plans tab', () => {
+			expect( cardProps.header.props.children[1].props.href ).to.have.string( '#/plans' );
 		} );
 
 	} );


### PR DESCRIPTION
Right now if site plan is Premium, a toggle is shown in SEO Tools card, instead of the Upgrade badge that should be shown.

#### Changes proposed in this Pull Request:
- don't show a toggle for SEO Tools when site plan is 'jetpack_premium' and instead show the Upgrade badge
- if site plan is 'jetpack_business', show the toggle

#### Testing instructions:
* disable SEO Tools using whatever method and:
- in all cases while page is loading, there should be no toggle
<img width="737" alt="captura de pantalla 2016-11-17 a las 18 08 34" src="https://cloud.githubusercontent.com/assets/1041600/20407645/f7b20930-acf0-11e6-899f-899388ec0eff.png">
- check with your site in Premium plan, SEO Tools should be
    <img width="745" alt="premium no seo" src="https://cloud.githubusercontent.com/assets/1041600/20401818/1b3f904c-acd9-11e6-9488-9a85538ffbff.png">
- check with your site in Business plan, SEO Tools should be
<img width="766" alt="captura de pantalla 2016-11-17 a las 19 06 16" src="https://cloud.githubusercontent.com/assets/1041600/20409574/ef13aa42-acf8-11e6-8423-eee57a6704ac.png">
