### PR TITLE
Integrate WooCommerce with Jetpack Sync

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -398,7 +398,7 @@ class Jetpack_Sync_Actions {
 add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
 
 // Check for WooCommerce support
-add_action( 'init', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
+add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -403,4 +403,4 @@ add_action( 'init', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ) );
-add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'setup_woocommerce' ) );
+

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -286,6 +286,21 @@ class Jetpack_Sync_Actions {
 		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 6 );
 	}
 
+	static function initialize_woocommerce() {
+		if ( in_array( 
+				'woocommerce/woocommerce.php', 
+				apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) 
+			) ) {
+			add_filter( 'jetpack_sync_modules', array( 'Jetpack_Sync_Actions', 'add_woocommerce_sync_module' ) );
+		}
+	}
+
+	static function add_woocommerce_sync_module( $sync_modules ) {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-woocommerce.php';
+		$sync_modules[] = 'Jetpack_Sync_Module_WooCommerce';
+		return $sync_modules;
+	}
+
 	static function sanitize_filtered_sync_cron_schedule( $schedule ) {
 		$schedule = sanitize_key( $schedule );
 		$schedules = wp_get_schedules();
@@ -388,3 +403,4 @@ add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ) );
+add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'setup_woocommerce' ) );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -287,10 +287,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function initialize_woocommerce() {
-		if ( in_array( 
-				'woocommerce/woocommerce.php', 
-				apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) 
-			) ) {
+		if ( class_exists( 'WooCommerce' ) ) {
 			add_filter( 'jetpack_sync_modules', array( 'Jetpack_Sync_Actions', 'add_woocommerce_sync_module' ) );
 		}
 	}
@@ -399,6 +396,9 @@ class Jetpack_Sync_Actions {
  * to add filters before we initialize.
  */
 add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
+
+// Check for WooCommerce support
+add_action( 'init', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -3,7 +3,7 @@
 require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-module.php';
 
 class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
-	private $meta_types = array( 'order_item' );
+
 	private $meta_whitelist = array( 
 		'_product_id',
 		'_variation_id',

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -1,0 +1,113 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-module.php';
+
+class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
+	private $meta_types = array( 'order_item' );
+	private $meta_whitelist = array( 
+		'_product_id',
+		'_variation_id',
+		'_qty',
+		'_tax_class',
+		'_line_subtotal',
+		'_line_subtotal_tax',
+		'_line_total',
+		'_line_tax',
+		'_line_tax_data',
+	);
+
+	private $order_item_table_name;
+
+	public function __construct() {
+		global $wpdb;
+		$this->order_item_table_name = $wpdb->prefix . 'woocommerce_order_items';
+	}
+
+	function name() {
+		return "woocommerce";
+	}
+
+	public function init_listeners( $callable ) {
+		// orders
+		add_action( 'woocommerce_new_order', $callable, 10, 1 );
+		add_action( 'woocommerce_order_status_changed', $callable, 10, 3 );
+		add_action( 'woocommerce_payment_complete', $callable, 10, 1 );
+
+		// order items
+		add_action( 'woocommerce_new_order_item', $callable, 10, 4 );
+		add_action( 'woocommerce_update_order_item', $callable, 10, 4 );
+		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_order_item', array( $this, 'filter_order_item' ) );
+		add_filter( 'jetpack_sync_before_enqueue_woocommerce_update_order_item', array( $this, 'filter_order_item' ) );
+
+		// order item meta
+		$this->init_listeners_for_meta_type( 'order_item', $callable );
+	}
+
+	public function init_full_sync_listeners( $callable ) {
+		add_action( 'jetpack_full_sync_woocommerce_order_items', $callable ); // also sends post meta
+	}
+
+	public function get_full_sync_actions() {
+		return array( 'jetpack_full_sync_woocommerce_order_items' );
+	}
+
+	public function init_before_send() {
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_woocommerce_order_items', array( $this, 'expand_order_item_ids' ) );
+	}
+
+	public function filter_order_item( $args ) {
+		$args[1] = $this->build_order_item( $args[1] );
+		return $args;
+	}
+
+	public function expand_order_item_ids( $args ) {
+		$order_item_ids = $args[0];
+
+		global $wpdb;
+
+		$order_item_ids_sql = implode( ', ', array_map( 'intval', $order_item_ids ) );
+
+		$order_items = $wpdb->get_results( 
+			"SELECT * FROM $this->order_item_table_name WHERE order_item_id IN ( $order_item_ids_sql )"
+		);
+
+		return array(
+			$order_items,
+			$this->get_metadata( $order_item_ids, 'order_item', $this->meta_whitelist )
+		);
+	}
+
+	public function build_order_item( $order_item ) {
+		if ( is_numeric( $order_item ) ) {
+			global $wpdb;
+			return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $this->order_item_table_name WHERE order_item_id = %d", $order_item ) );
+		} else {
+			return (object)array(
+				'order_item_id'   => $order_item->get_id(),
+				'order_item_type' => $order_item->get_type(),
+				'order_item_name' => $order_item->get_name(),
+				'order_id'        => $order_item->get_order_id(),
+			);
+		}
+	}
+
+	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
+		global $wpdb;
+
+		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_woocommerce_order_items', $this->order_item_table_name, 'order_item_id', $this->get_where_sql( $config ), $max_items_to_enqueue, $state );
+	}
+
+	public function estimate_full_sync_actions( $config ) {
+		global $wpdb;
+
+		$query = "SELECT count(*) FROM $this->order_item_table_name WHERE " . $this->get_where_sql( $config );
+		$count = $wpdb->get_var( $query );
+
+		return (int) ceil( $count / self::ARRAY_CHUNK_SIZE );
+	}
+
+	private function get_where_sql( $config ) {
+		return '1=1';
+	}
+}

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -82,6 +82,8 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		if ( is_numeric( $order_item ) ) {
 			global $wpdb;
 			return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $this->order_item_table_name WHERE order_item_id = %d", $order_item ) );
+		} elseif ( is_array( $order_item ) ) {
+			return $order_item;
 		} else {
 			return (object)array(
 				'order_item_id'   => $order_item->get_id(),

--- a/tests/php/sync/test_class.jetpack-sync-woocommerce.php
+++ b/tests/php/sync/test_class.jetpack-sync-woocommerce.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * Testing WooCommerce Sync
+ */
+class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
+	protected $post;
+	protected $callable_module;
+	protected $full_sync;
+	static $woo_enabled;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		if ( "1" != getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
+			return; 
+		} 
+		
+		self::$woo_enabled = true;
+
+		$woo_tests_dir = dirname( __FILE__ ) . '/../../../../woocommerce/tests';
+
+		// This is taken from WooCommerce's bootstrap.php file
+
+		// factories
+		require_once( $woo_tests_dir . '/framework/factories/class-wc-unit-test-factory-for-webhook.php' );
+		require_once( $woo_tests_dir . '/framework/factories/class-wc-unit-test-factory-for-webhook-delivery.php' );
+
+		// framework
+		require_once( $woo_tests_dir . '/framework/class-wc-unit-test-factory.php' );
+		require_once( $woo_tests_dir . '/framework/class-wc-mock-session-handler.php' );
+		require_once( $woo_tests_dir . '/framework/class-wc-mock-wc-data.php' );
+		require_once( $woo_tests_dir . '/framework/class-wc-payment-token-stub.php' );
+		// require_once( $woo_tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php' );
+
+		// test cases
+		require_once( $woo_tests_dir . '/framework/class-wc-unit-test-case.php' );
+		require_once( $woo_tests_dir . '/framework/class-wc-api-unit-test-case.php' );
+		require_once( $woo_tests_dir . '/framework/class-wc-rest-unit-test-case.php' );
+
+		// Helpers
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-product.php' );
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-coupon.php' );
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-fee.php' );
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-shipping.php' );
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-customer.php' );
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-order.php' );
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-shipping-zones.php' );
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-payment-token.php' );
+		require_once( $woo_tests_dir . '/framework/helpers/class-wc-helper-settings.php' );
+	}
+
+	public function setUp() {
+		if ( ! self::$woo_enabled ) {
+			$this->markTestSkipped();
+			return;
+		}
+		parent::setUp();
+		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
+	}
+
+	function test_module_is_enabled() {
+		$this->assertTrue( !! Jetpack_Sync_Modules::get_module( "woocommerce" ) );
+	}
+
+	// Incremental sync
+	function test_orders_are_synced() {
+		$order = $this->createOrderWithItem();
+
+		$this->sender->do_sync();
+
+		$order_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_new_order' );
+
+		$this->assertTrue( !! $order_event );
+		$this->assertEquals( $order->get_id(), $order_event->args[0] );
+	}
+
+	function test_order_status_changes_are_synced() {
+		// registering a custom order status is necessary because the built-in ones leave
+		// unflushed content in the output buffer
+		add_filter( 'wc_order_statuses', array( $this, 'add_custom_order_status' ) );
+
+		$order = $this->createOrderWithItem();
+		$order->update_status( 'custom' );
+
+		$this->sender->do_sync();
+
+		$order_status_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_order_status_changed' );
+
+		$this->assertTrue( !! $order_status_event );
+		$this->assertEquals( $order->get_id(), $order_status_event->args[0] );
+		$this->assertEquals( 'pending', $order_status_event->args[1] );
+		$this->assertEquals( 'custom', $order_status_event->args[2] );
+	}
+
+	function test_order_status_payment_complete_is_synced() {
+		$order = $this->createOrderWithItem();
+
+		// pay
+		$order->payment_complete( '12345' );
+		
+		// just for fun
+		$this->assertEquals( 'processing', $order->get_status() );
+		$this->assertEquals( '12345', $order->get_transaction_id() );
+
+		$this->sender->do_sync();
+
+		$payment_complete_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_payment_complete' );
+
+		$this->assertTrue( !! $payment_complete_event );
+		$this->assertEquals( $order->get_id(), $payment_complete_event->args[0] );
+	}
+
+	function test_created_order_items_are_synced() {
+		$order = $this->createOrderWithItem();
+		$order_items = $order->get_items();
+		$order_item = reset( $order_items ); // first item
+
+		$this->sender->do_sync();
+
+		$create_order_item_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_new_order_item' );
+		
+		$this->assertTrue( !! $create_order_item_event );
+		$this->assertEquals( $order_item->get_id(), $create_order_item_event->args[0] );
+		$this->assertHasOrderItemProperties( $create_order_item_event->args[1], $order_item );
+		$this->assertEquals( $order->get_id(), $create_order_item_event->args[2] );
+	}
+
+	function test_updated_order_items_are_synced() {
+		$order = $this->createOrderWithItem();
+		$order_items = $order->get_items();
+		$order_item = reset( $order_items ); // first item
+
+		// trigger an update
+		$order_item->set_name( 'A new name' );
+		$order_item->save();
+
+		$this->sender->do_sync();
+
+		$update_order_item_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_update_order_item' );
+		
+		$this->assertTrue( !! $update_order_item_event );
+		$this->assertEquals( $order_item->get_id(), $update_order_item_event->args[0] );
+		$this->assertHasOrderItemProperties( $update_order_item_event->args[1], $order_item );
+		$this->assertEquals( $order->get_id(), $update_order_item_event->args[2] );
+	}
+
+	function test_updated_order_item_meta_is_synced() {
+		$order = $this->createOrderWithItem();
+		$order_items = $order->get_items();
+		$order_item = reset( $order_items ); // first item
+
+		wc_add_order_item_meta( $order_item->get_id(), 'foo', 'bar', true );
+		wc_update_order_item_meta( $order_item->get_id(), 'foo', 'baz' );
+		wc_delete_order_item_meta( $order_item->get_id(), 'foo' );
+
+		$this->sender->do_sync();
+
+		$added_order_item_meta_event = $this->server_event_storage->get_most_recent_event( 'added_order_item_meta' );
+		$this->assertTrue( !! $added_order_item_meta_event );
+
+		$updated_order_item_meta_event = $this->server_event_storage->get_most_recent_event( 'updated_order_item_meta' );
+		$this->assertTrue( !! $updated_order_item_meta_event );
+
+		$deleted_order_item_meta_event = $this->server_event_storage->get_most_recent_event( 'deleted_order_item_meta' );
+		$this->assertTrue( !! $deleted_order_item_meta_event );
+	}
+
+	// Full Sync
+
+	function test_full_sync_order_items() {
+		$order1 = $this->createOrderWithItem();
+		$order2 = $this->createOrderWithItem();
+
+		// order items
+		$order1_items = $order1->get_items();
+		$order1_item = reset( $order1_items ); // first item from order1
+		wc_update_order_item_meta( $order1_item->get_id(), '_line_subtotal', 10 );
+
+		$order2_items = $order2->get_items();
+		$order2_item = reset( $order2_items ); // first item from order2
+		wc_update_order_item_meta( $order2_item->get_id(), '_line_subtotal', 20 );
+
+		$this->full_sync->start();
+		$this->sender->do_full_sync();
+
+		$full_sync_order_items = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_woocommerce_order_items' );
+
+		$this->assertTrue( !! $full_sync_order_items );
+		$synced_order_items = $full_sync_order_items->args[0];
+
+		$found_order_item_1 = $found_order_item_2 = false;
+		foreach( $synced_order_items as $synced_order_item ) {
+			if ( $order1_item->get_id() == $synced_order_item->order_item_id ) {
+				$this->assertHasOrderItemProperties( $synced_order_item, $order1_item );
+				$found_order_item_1 = true;	
+				continue;	
+			}
+
+			if ( $order2_item->get_id() == $synced_order_item->order_item_id ) {
+				$this->assertHasOrderItemProperties( $synced_order_item, $order2_item );
+				$found_order_item_2 = true;
+				continue;
+			}
+		}
+
+		$synced_order_item_metas = $full_sync_order_items->args[1];
+
+		// find the _line_subtotal metas and assert they have the right values
+		$this->assertHasObjectMetaValue( $synced_order_item_metas, $order1_item->get_id(), '_line_subtotal', 10 );
+		$this->assertHasObjectMetaValue( $synced_order_item_metas, $order2_item->get_id(), '_line_subtotal', 20 );
+	}
+
+	private function assertHasOrderItemProperties( $object, $compare = false ) {
+		$this->assertObjectHasAttribute( 'order_item_id', $object );
+		$this->assertObjectHasAttribute( 'order_item_name', $object );
+		$this->assertObjectHasAttribute( 'order_item_type', $object );
+		$this->assertObjectHasAttribute( 'order_id', $object );
+
+		if ( $compare ) {
+			$this->assertEquals( $compare->get_id(), $object->order_item_id );
+			$this->assertEquals( $compare->get_type(), $object->order_item_type );
+			$this->assertEquals( $compare->get_name(), $object->order_item_name );
+			$this->assertEquals( $compare->get_order_id(), $object->order_id );
+		}
+	}
+
+	private function assertHasObjectMetaValue( $metas, $order_item_id, $expected_meta_key, $expected_meta_value ) {
+		$has_meta_entry = false;
+		foreach( $metas as $meta ) {
+			if ( $order_item_id == $meta->order_item_id && $expected_meta_key === $meta->meta_key ) {
+				$this->assertEquals( $expected_meta_value, $meta->meta_value );
+				$has_meta_entry = true;
+			}
+		}
+
+		$this->assertTrue( $has_meta_entry );
+	}
+
+	// Utility functions
+
+	public function add_custom_order_status( $statuses ) {
+		$statuses['wc-custom'] = 'Custom';
+		return $statuses;
+	}
+
+	private function createOrderWithItem() {
+		$product = WC_Helper_Product::create_simple_product();
+		$order = new WC_Order();
+		$item = new WC_Order_Item_Product( array(
+			'product'  => $product,
+			'quantity' => 4,
+		) );
+
+		$order->add_item( $item );
+		$order->save();
+
+		return $order;
+	}
+}
+


### PR DESCRIPTION
Syncs selected Woo data (order items and order item meta) to WPCOM using Jetpack Sync.

To test:
- ensure there is a checkout of the [WooCommerce](https://github.com/woocommerce/woocommerce) plugin in the same directory as the Jetpack plugin. This needs to be the original source, not the published plugin, so that it includes test files.
- Run `JETPACK_TEST_WOOCOMMERCE=1 phpunit --testsuite=sync --filter=WP_Test_Jetpack_Sync_WooCommerce`