### PR TITLE
Sync: Increase default cron interval to 5 and sync via cron by default

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -281,7 +281,7 @@ class Jetpack_Sync_Actions {
 			return $schedule;
 		}
 
-		return self::DEFAULT_SYNC_CRON_INTERVAL;
+		return self::DEFAULT_SYNC_CRON_INTERVAL_NAME;
 	}
 
 	static function maybe_schedule_sync_cron( $schedule, $hook ) {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -20,6 +20,9 @@ class Jetpack_Sync_Actions {
 
 		if ( self::sync_via_cron_allowed() ) {
 			self::init_sync_cron_jobs();
+		} else if ( wp_next_scheduled( 'jetpack_sync_cron' ) ) {
+			wp_clear_scheduled_hook( 'jetpack_sync_cron' );
+			wp_clear_scheduled_hook( 'jetpack_sync_full_cron' );
 		}
 
 		// On jetpack authorization, schedule a full sync

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -9,7 +9,7 @@
 class Jetpack_Sync_Actions {
 	static $sender = null;
 	static $listener = null;
-	const DEFAULT_SYNC_CRON_INTERVAL = '1min';
+	const DEFAULT_SYNC_CRON_INTERVAL = '5min';
 
 	static function init() {
 
@@ -193,11 +193,11 @@ class Jetpack_Sync_Actions {
 		return true;
 	}
 
-	static function minute_cron_schedule( $schedules ) {
-		if( ! isset( $schedules['1min'] ) ) {
-			$schedules['1min'] = array(
-				'interval' => 60,
-				'display' => esc_html__( 'Every minute', 'jetpack' )
+	static function jetpack_cron_schedule( $schedules ) {
+		if( ! isset( $schedules['5min'] ) ) {
+			$schedules['5min'] = array(
+				'interval' => 5 * 60,
+				'display' => esc_html__( 'Every 5 minutes', 'jetpack' )
 			);
 		}
 		return $schedules;
@@ -295,7 +295,7 @@ class Jetpack_Sync_Actions {
 
 	static function init_sync_cron_jobs() {
 		// Add a custom "every minute" cron schedule
-		add_filter( 'cron_schedules', array( __CLASS__, 'minute_cron_schedule' ) );
+		add_filter( 'cron_schedules', array( __CLASS__, 'jetpack_cron_schedule' ) );
 
 		// cron hooks
 		add_action( 'jetpack_sync_full', array( __CLASS__, 'do_full_sync' ), 10, 1 );
@@ -304,7 +304,7 @@ class Jetpack_Sync_Actions {
 		add_action( 'jetpack_sync_full_cron', array( __CLASS__, 'do_cron_full_sync' ) );
 
 		/**
-		 * Allows overriding of the default incremental sync cron schedule which defaults to once per minute.
+		 * Allows overriding of the default incremental sync cron schedule which defaults to once every 5 minutes.
 		 *
 		 * @since 4.3.2
 		 *
@@ -314,7 +314,7 @@ class Jetpack_Sync_Actions {
 		self::maybe_schedule_sync_cron( $incremental_sync_cron_schedule, 'jetpack_sync_cron' );
 
 		/**
-		 * Allows overriding of the full sync cron schedule which defaults to once per minute.
+		 * Allows overriding of the full sync cron schedule which defaults to once every 5 minutes.
 		 *
 		 * @since 4.3.2
 		 *

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -10,7 +10,7 @@ class Jetpack_Sync_Actions {
 	static $sender = null;
 	static $listener = null;
 	const DEFAULT_SYNC_CRON_INTERVAL_NAME = 'jetpack_sync_interval';
-	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 5 * 60;
+	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 300; // 5 * SECONDS_IN_MINUTE;
 
 	static function init() {
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -9,7 +9,8 @@
 class Jetpack_Sync_Actions {
 	static $sender = null;
 	static $listener = null;
-	const DEFAULT_SYNC_CRON_INTERVAL = '5min';
+	const DEFAULT_SYNC_CRON_INTERVAL_NAME = 'jetpack_sync_interval';
+	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 5 * 60;
 
 	static function init() {
 
@@ -197,10 +198,13 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function jetpack_cron_schedule( $schedules ) {
-		if( ! isset( $schedules['5min'] ) ) {
-			$schedules['5min'] = array(
-				'interval' => 5 * 60,
-				'display' => esc_html__( 'Every 5 minutes', 'jetpack' )
+		if( ! isset( $schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] ) ) {
+			$schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] = array(
+				'interval' => self::DEFAULT_SYNC_CRON_INTERVAL_VALUE,
+				'display' => sprintf(
+					esc_html__( 'Every %d minutes', 'jetpack' ),
+					self::DEFAULT_SYNC_CRON_INTERVAL_VALUE / 60
+				)
 			);
 		}
 		return $schedules;
@@ -311,9 +315,9 @@ class Jetpack_Sync_Actions {
 		 *
 		 * @since 4.3.2
 		 *
-		 * @param string self::DEFAULT_SYNC_CRON_INTERVAL
+		 * @param string self::DEFAULT_SYNC_CRON_INTERVAL_NAME
 		 */
-		$incremental_sync_cron_schedule = apply_filters( 'jetpack_sync_incremental_sync_interval', self::DEFAULT_SYNC_CRON_INTERVAL );
+		$incremental_sync_cron_schedule = apply_filters( 'jetpack_sync_incremental_sync_interval', self::DEFAULT_SYNC_CRON_INTERVAL_NAME );
 		self::maybe_schedule_sync_cron( $incremental_sync_cron_schedule, 'jetpack_sync_cron' );
 
 		/**
@@ -321,9 +325,9 @@ class Jetpack_Sync_Actions {
 		 *
 		 * @since 4.3.2
 		 *
-		 * @param string self::DEFAULT_SYNC_CRON_INTERVAL
+		 * @param string self::DEFAULT_SYNC_CRON_INTERVAL_NAME
 		 */
-		$full_sync_cron_schedule = apply_filters( 'jetpack_sync_full_sync_interval', self::DEFAULT_SYNC_CRON_INTERVAL );
+		$full_sync_cron_schedule = apply_filters( 'jetpack_sync_full_sync_interval', self::DEFAULT_SYNC_CRON_INTERVAL_NAME );
 		self::maybe_schedule_sync_cron( $full_sync_cron_schedule, 'jetpack_sync_full_cron' );
 	}
 }

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -198,7 +198,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function jetpack_cron_schedule( $schedules ) {
-		if( ! isset( $schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] ) ) {
+		if ( ! isset( $schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] ) ) {
 			$schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] = array(
 				'interval' => self::DEFAULT_SYNC_CRON_INTERVAL_VALUE,
 				'display' => sprintf(

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -10,7 +10,7 @@ class Jetpack_Sync_Actions {
 	static $sender = null;
 	static $listener = null;
 	const DEFAULT_SYNC_CRON_INTERVAL_NAME = 'jetpack_sync_interval';
-	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 300; // 5 * SECONDS_IN_MINUTE;
+	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 300; // 5 * MINUTE_IN_SECONDS;
 
 	static function init() {
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -311,7 +311,7 @@ class Jetpack_Sync_Defaults {
 	static $default_post_meta_whitelist = array();
 	static $default_comment_meta_whitelist = array();
 	static $default_disable = 0; // completely disable sending data to wpcom
-	static $default_sync_via_cron = 0; // use cron to sync
+	static $default_sync_via_cron = 1; // use cron to sync
 	static $default_render_filtered_content = 1; // render post_filtered_content
 	static $default_max_enqueue_full_sync = 100; // max number of items to enqueue at a time when running full sync
 	static $default_max_queue_size_full_sync = 1000; // max number of total items in the full sync queue

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -67,7 +67,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_default_schedule_incremental_sync_cron() {
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( '5min', wp_get_schedule( 'jetpack_sync_cron' ) );
+		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_cron' ) );
 	}
 
 	function test_filtered_schedule_incremental_sync_cron_works() {
@@ -79,7 +79,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_filtered_schedule_incremental_sync_cron_bad_schedule_sanitized() {
 		add_filter( 'jetpack_sync_incremental_sync_interval', array( $this, '__return_nonexistent_schedule' ) );
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( '5min', wp_get_schedule( 'jetpack_sync_cron' ) );
+		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_cron' ) );
 	}
 
 	function test_schedules_full_sync_cron() {
@@ -90,7 +90,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_default_schedule_full_sync_cron() {
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( '5min', wp_get_schedule( 'jetpack_sync_full_cron' ) );
+		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
 	function test_filtered_schedule_full_sync_cron_works() {
@@ -102,7 +102,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_filtered_schedule_full_sync_cron_bad_schedule_sanitized() {
 		add_filter( 'jetpack_sync_full_sync_interval', array( $this, '__return_nonexistent_schedule' ) );
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( '5min', wp_get_schedule( 'jetpack_sync_full_cron' ) );
+		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
 	function test_starts_full_sync_on_client_authorized() {

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -67,7 +67,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_default_schedule_incremental_sync_cron() {
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( '1min', wp_get_schedule( 'jetpack_sync_cron' ) );
+		$this->assertEquals( '5min', wp_get_schedule( 'jetpack_sync_cron' ) );
 	}
 
 	function test_filtered_schedule_incremental_sync_cron_works() {
@@ -79,7 +79,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_filtered_schedule_incremental_sync_cron_bad_schedule_sanitized() {
 		add_filter( 'jetpack_sync_incremental_sync_interval', array( $this, '__return_nonexistent_schedule' ) );
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( '1min', wp_get_schedule( 'jetpack_sync_cron' ) );
+		$this->assertEquals( '5min', wp_get_schedule( 'jetpack_sync_cron' ) );
 	}
 
 	function test_schedules_full_sync_cron() {
@@ -90,7 +90,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 	function test_default_schedule_full_sync_cron() {
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( '1min', wp_get_schedule( 'jetpack_sync_full_cron' ) );
+		$this->assertEquals( '5min', wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
 	function test_filtered_schedule_full_sync_cron_works() {
@@ -102,7 +102,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_filtered_schedule_full_sync_cron_bad_schedule_sanitized() {
 		add_filter( 'jetpack_sync_full_sync_interval', array( $this, '__return_nonexistent_schedule' ) );
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
-		$this->assertEquals( '1min', wp_get_schedule( 'jetpack_sync_full_cron' ) );
+		$this->assertEquals( '5min', wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
 	function test_starts_full_sync_on_client_authorized() {


### PR DESCRIPTION
Several users have mentioned that their cron jobs are piling on top of each other, which is largely in part because we spawn a cron job every minute. This PR seeks to increase that interval to every 5 minutes.

![screen shot 2016-11-17 at 1 45 42 pm](https://cloud.githubusercontent.com/assets/1126811/20404877/4fbd8d5e-accc-11e6-9864-385b5cc1dc20.png)

It seems like we'll be implementing this PR instead of enabling non-cron-sync by default. 

To test:

- Checkout `update/jetpack-sync-cron-default` branch
- Make sure tests pass
- To to `jetpack-sync-actions.php` file and short-circuit `sync_via_cron_allowed()` to always return true
- Go to admin of site and check that `jetpack_sync_cron` and `jetpack_sync_full_cron` have schedules of 5 minutes

