### PR TITLE
Connection Banners: Max width

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -67,6 +67,7 @@
 }
 
 .jp-wpcom-connect__content-container {
+	max-width: rem( 1200px );
 	position: relative;
 	padding: rem( 32px );
 
@@ -83,6 +84,7 @@
 .jp-wpcom-connect__content-container h2 {
 	margin-top: 0;
 	color: #4F748E;
+	line-height: 1.6;
 }
 
 .jp-wpcom-connect__content-icon {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/5677

Connection Banners: Add max-width to content area for better legibility
on larger screens, as well as adjusting header line-height. Content area will max out at an equivalent of a 1200px width.

Before:
![screen shot 2016-11-17 at 3 49 21 pm](https://cloud.githubusercontent.com/assets/214813/20406966/7767c2b4-acdd-11e6-9d3e-60450529c0f1.png)

After:
![screen shot 2016-11-17 at 3 46 25 pm](https://cloud.githubusercontent.com/assets/214813/20406975/7ee2e1d6-acdd-11e6-8507-f3b85196fa71.png)

Note, if I limit the max width of the entire container, it visually clashes with the rest of the plugins list, so I'm steering away from doing this...
![screen shot 2016-11-17 at 3 50 59 pm](https://cloud.githubusercontent.com/assets/214813/20407040/abc04bc6-acdd-11e6-9a73-a1f02567597c.png)

