### PR TITLE
Shorter send timeout when sending in shutdown hook

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -126,12 +126,14 @@ class Jetpack_Sync_Actions {
 			$query_args['migrate_for_idc'] = true;
 		}
 
+		$query_args['timeout'] = Jetpack_Sync_Settings::is_doing_cron() ? 30 : 15;
+
 		$url = add_query_arg( $query_args, Jetpack::xmlrpc_api_url() );
 
 		$rpc = new Jetpack_IXR_Client( array(
 			'url'     => $url,
 			'user_id' => JETPACK_MASTER_USER,
-			'timeout' => 30,
+			'timeout' => $query_args['timeout'],
 		) );
 
 		$result = $rpc->query( 'jetpack.syncActions', $data );


### PR DESCRIPTION
We go to great lengths to ensure that we finish the necessary sync work in < 15 seconds when sending during shutdown, but the XMLRPC call to WPCOM can take up to 30 seconds, which would cause a 502 response on many configurations.

This change reduces the maximum send time to 15 seconds.

It also sends the timeout as a GET parameter to WPCOM so we can use that to limit how much time we spend processing.