### PR TITLE
Admin: deactivate any active module that doesn't match the current site plan

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -38,6 +38,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 		// Adding a redirect tag wrapped in browser conditional comments
 		add_action( 'admin_head', array( $this, 'add_legacy_browsers_head_script' ) );
+
+		// Check if the site plan changed and deactivate modules accordingly.
+		$this->check_plan_deactivate_modules( $hook );
 	}
 
 	/**
@@ -188,41 +191,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		wp_enqueue_style( 'components-css', plugins_url( "_inc/build/style.min$rtl.css", JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 	}
 
-	/**
-	 * Checks the site plan and deactivates modules that were active but are no longer included in the plan.
-	 *
-	 * @since 4.4.0
-	 */
-	function check_plan_deactivate_modules() {
-		$previous = get_option( 'jetpack_active_plan', '' );
-		$response = rest_do_request( new WP_REST_Request( 'GET', '/jetpack/v4/site' ) );
-		$current = $response->get_data();
-		$current = json_decode( $current['data'] );
-		if ( isset( $current->plan->product_slug ) ) {
-			if ( empty( $previous ) || ! isset( $previous['product_slug'] ) || $previous['product_slug'] !== $current->plan->product_slug ) {
-				$active = Jetpack::get_active_modules();
-				$to_deactivate = array();
-				switch ( $current->plan->product_slug ) {
-					case 'jetpack_free':
-						$to_deactivate = array( 'seo-tools', 'videopress' );
-						break;
-					case 'jetpack_personal':
-					case 'jetpack_personal_monthly':
-						$to_deactivate = array( 'seo-tools', 'videopress' );
-						break;
-					case 'jetpack_premium':
-					case 'jetpack_premium_monthly':
-						$to_deactivate = array( 'seo-tools' );
-						break;
-				}
-				$to_deactivate = array_intersect( $active, $to_deactivate );
-				if ( ! empty( $to_deactivate ) ) {
-					Jetpack::update_active_modules( array_filter( array_diff( $active, $to_deactivate ) ) );
-				}
-			}
-		}
-	}
-
 	function page_admin_scripts() {
 		if ( $this->is_redirecting ) {
 			return; // No need for scripts on a fallback page
@@ -250,9 +218,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'canView' => is_array( $enabled_roles ) ? in_array( $slug, $enabled_roles, true ) : false,
 			);
 		}
-
-		// Check the site plan and deactivate modules accordingly
-		$this->check_plan_deactivate_modules();
 
 		$response = rest_do_request( new WP_REST_Request( 'GET', '/jetpack/v4/module/all' ) );
 		$modules = $response->get_data();

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -194,28 +194,31 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.4.0
 	 */
 	function check_plan_deactivate_modules() {
+		$previous = get_option( 'jetpack_active_plan', '' );
 		$response = rest_do_request( new WP_REST_Request( 'GET', '/jetpack/v4/site' ) );
-		$site_data = $response->get_data();
-		$site_data = json_decode( $site_data['data'] );
-		if ( isset( $site_data->plan->product_slug ) ) {
-			$active = Jetpack::get_active_modules();
-			$to_deactivate = array();
-			switch ( $site_data->plan->product_slug ) {
-				case 'jetpack_free':
-					$to_deactivate = array( 'seo-tools', 'videopress' );
-					break;
-				case 'jetpack_personal':
-				case 'jetpack_personal_monthly':
-					$to_deactivate = array( 'seo-tools', 'videopress' );
-					break;
-				case 'jetpack_premium':
-				case 'jetpack_premium_monthly':
-					$to_deactivate = array( 'seo-tools' );
-					break;
-			}
-			$to_deactivate = array_intersect( $active, $to_deactivate );
-			if ( ! empty( $to_deactivate ) ) {
-				Jetpack::update_active_modules( array_filter( array_diff( $active, $to_deactivate ) ) );
+		$current = $response->get_data();
+		$current = json_decode( $current['data'] );
+		if ( isset( $current->plan->product_slug ) ) {
+			if ( empty( $previous ) || ! isset( $previous['product_slug'] ) || $previous['product_slug'] !== $current->plan->product_slug ) {
+				$active = Jetpack::get_active_modules();
+				$to_deactivate = array();
+				switch ( $current->plan->product_slug ) {
+					case 'jetpack_free':
+						$to_deactivate = array( 'seo-tools', 'videopress' );
+						break;
+					case 'jetpack_personal':
+					case 'jetpack_personal_monthly':
+						$to_deactivate = array( 'seo-tools', 'videopress' );
+						break;
+					case 'jetpack_premium':
+					case 'jetpack_premium_monthly':
+						$to_deactivate = array( 'seo-tools' );
+						break;
+				}
+				$to_deactivate = array_intersect( $active, $to_deactivate );
+				if ( ! empty( $to_deactivate ) ) {
+					Jetpack::update_active_modules( array_filter( array_diff( $active, $to_deactivate ) ) );
+				}
 			}
 		}
 	}

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -8,7 +8,11 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	// Show the settings page only when Jetpack is connected or in dev mode
 	protected $dont_show_if_not_active = true;
 
-	function add_page_actions( $hook ) {} // There are no page specific actions to attach to the menu
+	function add_page_actions( $hook ) {
+
+		// Check if the site plan changed and deactivate modules accordingly.
+		$this->check_plan_deactivate_modules( $hook );
+	}
 
 	// Adds the Settings sub menu
 	function get_page_hook() {


### PR DESCRIPTION
Fixes #5612

#### Changes proposed in this Pull Request:
- checks the site plan and deactivates modules that were active but are no longer included in the plan.

#### Testing instructions:
1. add Professional to your account in Store Admin
2. in Jetpack admin, activate SEO Tools
3. downgrade to Premium in Store Admin
4. go to admin and verify that module is no longer active. You can also verify with
```
wp jetpack module list
```
