### PR TITLE
Sync: Clear our old jetpack_sync_send_db_checksum cron job on upgrade

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -323,12 +323,18 @@ class Jetpack_Sync_Actions {
 		$full_sync_cron_schedule = apply_filters( 'jetpack_sync_full_sync_interval', self::DEFAULT_SYNC_CRON_INTERVAL );
 		self::maybe_schedule_sync_cron( $full_sync_cron_schedule, 'jetpack_sync_full_cron' );
 	}
+
+	static function cleanup_on_upgrade() {
+		if ( wp_next_scheduled( 'jetpack_sync_send_db_checksum' ) ) {
+			wp_clear_scheduled_hook( 'jetpack_sync_send_db_checksum' );
+		}
+	}
 }
 
 /**
  * If the site is using alternate cron, we need to init the listener and sender before cron
  * runs. So, we init at a priority of 9.
- * 
+ *
  * If the site is using a regular cron job, we init at a priority of 90 which gives plugins a chance
  * to add filters before we initialize.
  */
@@ -340,3 +346,4 @@ if ( defined( 'ALTERNATE_WP_CRON' ) && ALTERNATE_WP_CRON ) {
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );
+add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ) );

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -121,6 +121,17 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( '4.2.1', $event->args[1] );
 	}
 
+	function test_cleanup_old_cron_job_on_update() {
+		wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', 'jetpack_sync_send_db_checksum' );
+
+		$this->assertInternalType( 'integer', wp_next_scheduled( 'jetpack_sync_send_db_checksum' ) );
+
+		/** This action is documented in class.jetpack.php */
+		do_action( 'updating_jetpack_version', '4.3', '4.2.1' );
+
+		$this->assertFalse( wp_next_scheduled( 'jetpack_sync_send_db_checksum' ) );
+	}
+
 	/**
 	 * Utility functions
 	 */


### PR DESCRIPTION
While reviewing #5709, @enejb pointed out that there was an old cron job `jetpack_sync_send_db_checksum` that we should get rid of.

To test:

- Checkout `update/clear-jetpack-sync-checksum-cron` branch
- Ensure tests pass
- Simulate an upgrade by changing the version number and then ensure the `jetpack_sync_send_db_checksum` does not exist