### PR TITLE
Admin: move learn more icon in cards

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -83,7 +83,7 @@ export const Page = ( props ) => {
 				) }
 			>
 				{ moduleDescription }
-				<div className="jp-module-settings__read-more">
+				<div className="jp-module-settings__learn-more">
 					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
 				</div>
 			</FoldableCard>

--- a/_inc/client/components/foldable-card/style.scss
+++ b/_inc/client/components/foldable-card/style.scss
@@ -8,6 +8,11 @@
 			width: 100px;
 		}
 	}
+
+	&.is-expanded .dops-foldable-card__content {
+		position: relative;
+		padding: 16px 47px 16px 16px;
+	}
 }
 
 .dops-foldable-card__main {

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -37,7 +37,7 @@
 .jp-form-setting-explanation {
 	color: darken( $gray, 20% );
 	display: block;
-	margin: rem( 5px ) 0 0 0;
+	margin: rem( 5px ) rem( 14px ) 0 0;
 	font-size: rem( 13px );
 	font-style: italic;
 	font-weight: 400;

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -50,6 +50,8 @@
 
 .jp-form-fieldset {
 
+	margin-bottom: 4em;
+
 	.jp-form-legend + .jp-form-setting-explanation {
 		margin-top: rem( 8px );
 	}

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -26,6 +26,12 @@
 	}
 }
 
+.jp-module-settings__learn-more {
+	position: absolute;
+	top: 12px;
+	right: 17px;
+}
+
 // Connection Settings styles
 .jp-connection-settings {
 	margin: rem( 24px ) 0;

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -11,18 +11,8 @@
 	}
 
 	.dops-button.is-compact.is-borderless,
-	.jp-module-settings__more-sep,
 	.jp-module-settings__more-text {
 		vertical-align: middle;
-	}
-
-	.jp-module-settings__more-sep {
-		background: #ddd;
-		width: rem( 2px );
-		height: rem( 14px );
-		margin-left: rem( 10px );
-		margin-right: rem( 10px );
-		display: inline-block;
 	}
 }
 

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -181,7 +181,6 @@ export const Engagement = ( props ) => {
 						'stats' === element[0] && isModuleActive
 							? <div className="jp-module-settings__read-more">
 								<span>
-									<span className="jp-module-settings__more-sep" />
 									<span className="jp-module-settings__more-text">{
 										__( 'View {{a}}All Stats{{/a}}', {
 											components: {
@@ -197,7 +196,6 @@ export const Engagement = ( props ) => {
 						'subscriptions' === element[0] && isModuleActive
 							? <div className="jp-module-settings__read-more">
 								<span>
-									<span className="jp-module-settings__more-sep" />
 									<span className="jp-module-settings__more-text">{
 										__( 'View your {{a}}Email Followers{{/a}}', {
 											components: {

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -174,37 +174,42 @@ export const Engagement = ( props ) => {
 				{
 					moduleDescription
 				}
-				<div className="jp-module-settings__read-more">
+				<div className="jp-module-settings__learn-more">
 					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
-					{
-						'stats' === element[0] && isModuleActive ? (
-							<span>
-								<span className="jp-module-settings__more-sep" />
-								<span className="jp-module-settings__more-text">{
-									__( 'View {{a}}All Stats{{/a}}', {
-										components: {
-											a: <a href={ props.siteAdminUrl + 'admin.php?page=stats' } />
-										}
-									} )
-								}</span>
-							</span>
-						) : ''
-					}
-					{
-						'subscriptions' === element[0] && isModuleActive ? (
-							<span>
-								<span className="jp-module-settings__more-sep" />
-								<span className="jp-module-settings__more-text">{
-									__( 'View your {{a}}Email Followers{{/a}}', {
-										components: {
-											a: <a href={ 'https://wordpress.com/people/email-followers/' + props.siteRawUrl } />
-										}
-									} )
-								}</span>
-							</span>
-						) : ''
-					}
 				</div>
+					{
+						'stats' === element[0] && isModuleActive
+							? <div className="jp-module-settings__read-more">
+								<span>
+									<span className="jp-module-settings__more-sep" />
+									<span className="jp-module-settings__more-text">{
+										__( 'View {{a}}All Stats{{/a}}', {
+											components: {
+												a: <a href={ props.siteAdminUrl + 'admin.php?page=stats' } />
+											}
+										} )
+									}</span>
+								</span>
+							  </div>
+							: ''
+					}
+					{
+						'subscriptions' === element[0] && isModuleActive
+							? <div className="jp-module-settings__read-more">
+								<span>
+									<span className="jp-module-settings__more-sep" />
+									<span className="jp-module-settings__more-text">{
+										__( 'View your {{a}}Email Followers{{/a}}', {
+											components: {
+												a: <a href={ 'https://wordpress.com/people/email-followers/' + props.siteRawUrl } />
+											}
+										} )
+									}</span>
+								</span>
+							  </div>
+							: ''
+					}
+
 			</FoldableCard>
 		) : false;
 	} );

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -75,7 +75,7 @@ export const GeneralSettings = ( props ) => {
 				) }
 			>
 				<div className="jp-form-setting-explanation"><div dangerouslySetInnerHTML={ renderLongDescription( getModule( module_slug ) ) } /></div>
-				<div className="jp-module-settings__read-more">
+				<div className="jp-module-settings__learn-more">
 					<Button borderless compact href={ getModule( module_slug ).learn_more_button }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
 				</div>
 			</FoldableCard>

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -159,7 +159,7 @@ export const SearchResults = ( {
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
 				<br/>
-				<div className="jp-module-settings__read-more">
+				<div className="jp-module-settings__learn-more">
 					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
 				</div>
 			</FoldableCard>

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -115,7 +115,7 @@ export const Page = ( props ) => {
 						// Render the long_description if module is deactivated
 						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
-				<div className="jp-module-settings__read-more">
+				<div className="jp-module-settings__learn-more">
 					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
 				</div>
 			</FoldableCard>

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -128,7 +128,7 @@ export const Writing = ( props ) => {
 					// Render the long_description if module is deactivated
 					<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
 				}
-				<div className="jp-module-settings__read-more">
+				<div className="jp-module-settings__learn-more">
 					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
 				</div>
 			</FoldableCard>


### PR DESCRIPTION
Fixes #5680

#### Changes proposed in this Pull Request:
- move ( ? ) icon to the top right of the text
- add margin to the bottom of the fieldset so primary button doesn't overlap
- remove separator no longer needed in email subscriptions and stats

#### Testing instructions:
* check that everything looks properly aligned, with enough space and no overlaps

cc @beaulebens