### PR TITLE
Sync: Stop sending updates related transient changes

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -18,7 +18,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_action( 'jetpack_update_themes_change', $callable );
 		add_action( 'jetpack_update_core_change', $callable );
 
-		add_filter( 'jetpack_sync_before_enqueue_set_site_transient_update_plugins', array(
+		add_filter( 'jetpack_sync_before_enqueue_jetpack_update_plugins_change', array(
 			$this,
 			'filter_update_keys',
 		), 10, 2 );

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -39,15 +39,17 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
 	}
 
+	public function get_update_checksum( $value ) {
+		$a_value = (array) $value;
+
+		// ignore `last_checked`
+		unset( $a_value['last_checked'] );
+
+		return $this->get_check_sum( $a_value );
+	}
+
 	public function validate_update_change( $value, $expiration, $transient ) {
-		$value = (array) $value;
-		unset( $value['last_checked'] );
-
-		if ( empty( $value ) ) {
-			return;
-		}
-
-		$checksum = $this->get_check_sum( $value );
+		$checksum = $this->get_update_checksum( $value );
 
 		$checksums = get_option( self::UPDATES_CHECKSUM_OPTION_NAME, array() );
 		if ( isset( $checksums[ $transient ] ) && $checksums[ $transient ] === $checksum ) {

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -1,14 +1,22 @@
 <?php
 
 class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
+
+	const UPDATES_CHECKSUM_OPTION_NAME = 'jetpack_updates_sync_checksum';
+
 	function name() {
 		return 'updates';
 	}
 
 	public function init_listeners( $callable ) {
-		add_action( 'set_site_transient_update_plugins', $callable, 10, 1 );
-		add_action( 'set_site_transient_update_themes', $callable, 10, 1 );
-		add_action( 'set_site_transient_update_core', $callable, 10, 1 );
+
+		add_action( 'set_site_transient_update_plugins', array( $this, 'validate_update_change' ), 10, 3 );
+		add_action( 'set_site_transient_update_themes', array( $this, 'validate_update_change' ), 10, 3 );
+		add_action( 'set_site_transient_update_core', array( $this, 'validate_update_change' ), 10, 3 );
+
+		add_action( 'jetpack_update_plugins_change', $callable );
+		add_action( 'jetpack_update_themes_change', $callable );
+		add_action( 'jetpack_update_core_change', $callable );
 
 		add_filter( 'jetpack_sync_before_enqueue_set_site_transient_update_plugins', array(
 			$this,
@@ -29,6 +37,27 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	public function init_before_send() {
 		// full sync
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
+	}
+
+	public function validate_update_change( $value, $expiration, $transient ) {
+		$value = (array) $value;
+		unset( $value['last_checked'] );
+
+		if ( empty( $value ) ) {
+			return;
+		}
+
+		$checksum = $this->get_check_sum( $value );
+
+		$checksums = get_option( self::UPDATES_CHECKSUM_OPTION_NAME, array() );
+		if ( isset( $checksums[ $transient ] ) && $checksums[ $transient ] === $checksum ) {
+			return;
+		}
+		$checksums[ $transient ] = $checksum;
+
+		update_option( self::UPDATES_CHECKSUM_OPTION_NAME, $checksums );
+
+		do_action( "jetpack_{$transient}_change", $value );
 	}
 
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
@@ -55,9 +84,9 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 	public function get_all_updates() {
 		return array(
-			'core' => get_site_transient( 'update_core' ),
+			'core'    => get_site_transient( 'update_core' ),
 			'plugins' => get_site_transient( 'update_plugins' ),
-			'themes' => get_site_transient( 'update_themes' ),
+			'themes'  => get_site_transient( 'update_themes' ),
 		);
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -109,15 +109,15 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			// updates
-			case 'set_site_transient_update_plugins':
+			case 'jetpack_update_plugins_change':
 				list( $updates ) = $args;
 				$this->store->set_updates( 'plugins', $updates );
 				break;
-			case 'set_site_transient_update_themes':
+			case 'jetpack_update_themes_change':
 				list( $updates ) = $args;
 				$this->store->set_updates( 'themes', $updates );
 				break;
-			case 'set_site_transient_update_core':
+			case 'jetpack_update_core_change':
 				list( $updates ) = $args;
 				$this->store->set_updates( 'core', $updates );
 				break;


### PR DESCRIPTION
Core changes transients twice per `is_admin` request in order to update the `last_checked` value.

This PR tries to stop syncing does changes :)

