### PR TITLE
Fix incorrect sync action comment

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -168,8 +168,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 		/**
 		 * Fires when a full sync ends. This action is serialized
-		 * and sent to the server with checksums so that we can confirm the
-		 * sync was successful.
+		 * and sent to the server.
 		 *
 		 * @since 4.2.0
 		 */


### PR DESCRIPTION
We no longer send checksums, this fixes a bad comment indicating that we do.