### PR TITLE
REST API: Fix the single theme get endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-get-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-get-endpoint.php
@@ -2,5 +2,5 @@
 
 class Jetpack_JSON_API_Themes_Get_Endpoint extends Jetpack_JSON_API_Themes_Endpoint {
 	// GET  /sites/%s/themes/%s
-	protected $needed_capabilities = 'activate_themes';
+	protected $needed_capabilities = 'switch_themes';
 }

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -105,7 +105,7 @@ new Jetpack_JSON_API_Themes_Get_Endpoint( array(
 	'description'     => 'Get a single theme on a jetpack blog',
 	'group'           => '__do_not_document',
 	'stat'            => 'themes:get:1',
-	'method'          => 'POST',
+	'method'          => 'GET',
 	'path'            => '/sites/%s/themes/%s',
 	'path_labels' => array(
 		'$site'   => '(int|string) The site ID, The site domain',


### PR DESCRIPTION
Fix a couple of bugs with the theme get endpoint, allowing details to be fetched for a single theme.

Endpoint is enabled on wpcom side in D3436-code

cc @ockham 
