### PR TITLE
IDC: Fix non_admin_notice_dismiss stat

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -26,7 +26,7 @@
 	clearConfirmationArgsFromUrl();
 
 	// If the user dismisses the notice, set a cookie for one week so we don't display it for that time.
-	notice.on( 'click.wp-dismiss-notice', function() {
+	notice.on( 'click', '.notice-dismiss', function() {
 		var secure = ( 'https:' === window.location.protocol );
 		wpCookies.set( 'jetpack_idc_dismiss_notice', '1', 7 * 24 * 60 * 60, false, false, secure );
 		trackAndBumpMCStats( 'non_admin_notice_dismiss', { 'page': tracksEvent.currentScreen } );


### PR DESCRIPTION
This was firing on any click within the `.jp-idc-notice` element.  Only fire when the dismiss button is clicked.  

To Test: 
- console.log() something in that `on()` function, and make sure that it doesn't fire unless you're a non-admin clicking dismiss.  