### PR TITLE
IDC: Fix visual regression in IDC notice

### DIFF
--- a/scss/jetpack-idc.scss
+++ b/scss/jetpack-idc.scss
@@ -9,6 +9,7 @@
 	margin-left: 0;
 	margin-right: 10px;
 	margin-top: 10px;
+	overflow: hidden;
 	padding-bottom: 16px;
 	padding-top: 0;
 


### PR DESCRIPTION
While testing #5732, I noticed a visual regression when looking at the IDC notice as a non-admin.
<img width="1006" alt="screen shot 2016-11-21 at 5 10 58 pm" src="https://cloud.githubusercontent.com/assets/1126811/20504609/fd08840c-b00d-11e6-8fd9-438037889527.png">

Note the lack of any bottom padding.

This PR fixes that by adding `overflow: hidden` to the notice container.

To test:

- Checkout `update/idc-notice-overflow-bottom-margin` branch
- `yarn build`
- Put site in IDC
- Log in as a non-admin
- Ensure notice looks like the image below

<img width="1007" alt="screen shot 2016-11-21 at 5 11 20 pm" src="https://cloud.githubusercontent.com/assets/1126811/20504626/1266daec-b00e-11e6-8024-4abb037f0b8e.png">

<img width="916" alt="screen shot 2016-11-21 at 5 12 27 pm" src="https://cloud.githubusercontent.com/assets/1126811/20504639/169875e4-b00e-11e6-8198-239cf84ac0fd.png">

<img width="495" alt="screen shot 2016-11-21 at 5 12 37 pm" src="https://cloud.githubusercontent.com/assets/1126811/20504641/1a4ea73a-b00e-11e6-8673-0f94fd503789.png">
