### PR TITLE
Properly use monthly plans with SEO.

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -102,10 +102,15 @@ export const Engagement = ( props ) => {
 				configure_url: ''
 			},
 			isModuleActive = isModuleActivated( element[0] ),
-			hasBusiness = false;
+			hasBusiness = false,
+			planLoaded = false;
+
+		if ( 'undefined' !== typeof props.sitePlan.product_slug ) {
+			planLoaded = true
+		}
 
 		if (
-			undefined !== typeof props.sitePlan.product_slug
+			planLoaded
 			&& (
 				props.sitePlan.product_slug === 'jetpack_business'
 				|| props.sitePlan.product_slug === 'jetpack_business_monthly'

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -101,14 +101,25 @@ export const Engagement = ( props ) => {
 				module: element[0],
 				configure_url: ''
 			},
-			isModuleActive = isModuleActivated( element[0] );
+			isModuleActive = isModuleActivated( element[0] ),
+			hasBusiness = false;
+
+		if (
+			undefined !== typeof props.sitePlan.product_slug
+			&& (
+				props.sitePlan.product_slug === 'jetpack_business'
+				|| props.sitePlan.product_slug === 'jetpack_business_monthly'
+			)
+		) {
+			hasBusiness = true;
+		}
 
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );
 		} else if ( isAdmin ) {
-			if ( isPro && 'undefined' !== typeof props.sitePlan.product_slug && props.sitePlan.product_slug !== 'jetpack_business' ) {
+			if ( isPro && ! hasBusiness ) {
 				toggle = <ProStatus proFeature={ element[0] } />;
-			} else if ( ! isPro || ( 'undefined' !== typeof props.sitePlan.product_slug && props.sitePlan.product_slug === 'jetpack_business' ) ) {
+			} else if ( ! isPro || hasBusiness ) {
 				toggle = <ModuleToggle slug={ element[0] }
 									   activated={ isModuleActive }
 									   toggling={ isTogglingModule( element[0] ) }

--- a/_inc/client/engagement/test/component.js
+++ b/_inc/client/engagement/test/component.js
@@ -88,7 +88,7 @@ describe( 'Engagement', () => {
 		const wrapper = shallow( <Engagement { ...testProps } /> );
 
 		it( "don't display the toggle", () => {
-			expect( wrapper.find( 'FoldableCard' ).props().summary ).to.be.equal( '' );
+			expect( wrapper.find( 'FoldableCard' ).props().summary.type.displayName ).to.not.equal( 'ModuleToggle' );
 		} );
 
 	} );

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -84,7 +84,7 @@ const ProStatus = React.createClass( {
 				}
 			}
 
-			if ( 'seo-tools' === feature && 'jetpack_business' !== sitePlan.product_slug ) {
+			if ( 'seo-tools' === feature ) {
 				return (
 					<Button
 						compact={ true }

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -45,6 +45,7 @@ export const SearchResults = ( {
 	getModule,
 	getModules,
 	searchTerm,
+	sitePlan,
 	unavailableInDevMode,
 	isFetchingPluginsData,
 	isPluginActive
@@ -73,6 +74,7 @@ export const SearchResults = ( {
 				'backup restore pro security'
 			]
 		],
+		hasBusiness = false,
 		cards;
 
 	forEach( modules, function( m ) {
@@ -89,8 +91,22 @@ export const SearchResults = ( {
 		] ) : '';
 	} );
 
+	if (
+		undefined !== typeof sitePlan.product_slug
+		&& (
+			sitePlan.product_slug === 'jetpack_business'
+			|| sitePlan.product_slug === 'jetpack_business_monthly'
+		)
+	) {
+		hasBusiness = true;
+	}
+
 	cards = moduleList.map( ( element ) => {
-		let isPro = 'scan' === element[0] || 'akismet' === element[0] || 'backups' === element[0] || 'videopress' === element[0],
+		let isPro = 'scan' === element[0]
+				 || 'akismet' === element[0]
+				 || 'backups' === element[0]
+				 || 'videopress' === element[0]
+				 || 'seo-tools' === element[0],
 			proProps = {},
 			unavailableDevMode = unavailableInDevMode( element[0] ),
 			toggle = unavailableDevMode ? __( 'Unavailable in Dev Mode' ) : (
@@ -108,7 +124,16 @@ export const SearchResults = ( {
 				module: element[0],
 				configure_url: ''
 			};
-			toggle = <ProStatus proFeature={ element[0] } siteAdminUrl={ siteAdminUrl } />;
+
+			if (
+				'seo-tools' !== element[0]
+				|| (
+					'seo-tools' === element[0]
+					&& ! hasBusiness
+				)
+			) {
+				toggle = <ProStatus proFeature={ element[0] } siteAdminUrl={ siteAdminUrl } />;
+			}
 
 			// Add a "pro" button next to the header title
 			element[1] = <span>
@@ -193,7 +218,7 @@ export default connect(
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			getModules: () => _getModules( state ),
 			searchTerm: () => getSearchTerm( state ),
-			sitePlan: () => getSitePlan( state ),
+			sitePlan: getSitePlan( state ),
 			unavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
 			isFetchingPluginsData: isFetchingPluginsData( state ),
 			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug )


### PR DESCRIPTION
Fixes #5729 cc @johnHackworth  

#### Changes proposed in this Pull Request:
* Show and let users enable SEO tools on Business Monthly.
* Properly show SEO tools in search according to different plans.

#### Testing instructions:
* Make sure SEO tools are shown properly in all plans both in Engagement and Search tabs.
