### PR TITLE
Related Posts: add headline markup filter.

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -186,7 +186,8 @@ class Jetpack_RelatedPosts {
 
 		if ( $options['show_headline'] ) {
 			$headline = sprintf(
-				'<h3 class="jp-relatedposts-headline"><em>%s</em></h3>',
+				/** This filter is already documented in modules/sharedaddy/sharing-service.php */
+				apply_filters( 'jetpack_sharing_headline_html', '<h3 class="jp-relatedposts-headline"><em>%s</em></h3>', esc_html__( 'Related', 'jetpack' ), 'related-posts' ),
 				esc_html__( 'Related', 'jetpack' )
 			);
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add a filter allowing site owners to customize the output of the Related Posts headline. The filter isn't new, it was added to Likes and Sharing in #5011.

#### Testing instructions:

1. Apply the patch.
2. Add the following to a functionality plugin.
3. make sure both Sharing and Related Posts headlines switch from H3 to H2.

```php
function jetpackcom_custom_heading( $headline, $label, $module ) {
        if ( 'sharing' == $module ) {
                $headline = sprintf(
                        '<h2 class="sd-title">%s</h2>',
                        esc_html( $label )
                );
        }
	if ( 'related-posts' == $module ) {
		$headline = sprintf(
                        '<h2 class="jp-relatedposts-headline">%s</h2>',
                        esc_html( $label )
		);
	}
        return $headline;
}
add_filter( 'jetpack_sharing_headline_html', 'jetpackcom_custom_heading', 10, 3 );
```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Related Posts: add a filter allowing site owners to customize the output of the Related Posts headline.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.