### PR TITLE
Sync Setting: Make sure that the class is loaded.

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1390,6 +1390,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * @return string HTML for the concat form.
 	 */
 	static function parse( $attributes, $content ) {
+		require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-settings.php';
 		if ( Jetpack_Sync_Settings::is_syncing() ) {
 			return '';
 		}

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -974,6 +974,7 @@ class Jetpack_Likes {
 	 * similar logic and filters apply here, too.
 	 */
 	function is_likes_visible() {
+		require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-settings.php';
 		if ( Jetpack_Sync_Settings::is_syncing() ) {
 			return false;
 		}

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -178,6 +178,7 @@ class Jetpack_RelatedPosts {
 	 * @returns string
 	 */
 	public function get_target_html() {
+		require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-settings.php';
 		if ( Jetpack_Sync_Settings::is_syncing() ) {
 			return '';
 		}
@@ -223,6 +224,7 @@ EOT;
 	 * @returns string
 	 */
 	public function get_target_html_unsupported() {
+		require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-settings.php';
 		if ( Jetpack_Sync_Settings::is_syncing() ) {
 			return '';
 		}

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -582,6 +582,8 @@ add_action( 'template_redirect', 'sharing_process_requests', 9 );
 
 function sharing_display( $text = '', $echo = false ) {
 	global $post, $wp_current_filter;
+
+	require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-settings.php';
 	if ( Jetpack_Sync_Settings::is_syncing() ) {
 		return $text;
 	}


### PR DESCRIPTION
Fixes an issue where a PHP Fatal error can when Jetpack_Sync_Settings hasn't been loaded yet. 

#### Changes proposed in this Pull Request:
Add a require_once before calling the method on the class. To make sure that the class is loaded. When needed.

#### Testing instructions:
Add the following code to theme functions.php 
add_action( 'init', 'test_stuff');

function test_stuff() {
   $the_query = new WP_Query('post_type=post');
        if ( $the_query->have_posts() ) {
                while ( $the_query->have_posts() ) {
                $the_query->the_post();
               $text = get_the_content('');
                $text = apply_filters('the_content', $text );
                }
        }
	return $text;
}

You should see a fatal error now. This PR should fix that fatal error. 
