### PR TITLE
Bypass options API for sync status

### DIFF
--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -288,7 +288,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	private function get_status_option( $name, $default = null ) {
-		$value = Jetpack_Sync_Options::read_option( self::STATUS_OPTION_PREFIX . "_$name", $default );
+		$value = Jetpack_Sync_Options::get_option( self::STATUS_OPTION_PREFIX . "_$name", $default );
 
 		return is_numeric( $value ) ? intval( $value ) : $value;
 	}
@@ -302,7 +302,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	private function get_enqueue_status() {
-		return Jetpack_Sync_Options::read_option( 'jetpack_sync_full_enqueue_status' );
+		return Jetpack_Sync_Options::get_option( 'jetpack_sync_full_enqueue_status' );
 	}
 
 	private function set_config( $config ) {
@@ -310,7 +310,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 	
 	private function get_config() {
-		return Jetpack_Sync_Options::read_option( 'jetpack_sync_full_config' );
+		return Jetpack_Sync_Options::get_option( 'jetpack_sync_full_config' );
 	}
 
 	private function write_option( $name, $value ) {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -269,14 +269,14 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 
 	public function clear_status() {
 		$prefix = self::STATUS_OPTION_PREFIX;
-		delete_option( "{$prefix}_started" );
-		delete_option( "{$prefix}_params" );
-		delete_option( "{$prefix}_queue_finished" );
-		delete_option( "{$prefix}_send_started" );
-		delete_option( "{$prefix}_finished" );
+		Jetpack_Sync_Options::delete_option( "{$prefix}_started" );
+		Jetpack_Sync_Options::delete_option( "{$prefix}_params" );
+		Jetpack_Sync_Options::delete_option( "{$prefix}_queue_finished" );
+		Jetpack_Sync_Options::delete_option( "{$prefix}_send_started" );
+		Jetpack_Sync_Options::delete_option( "{$prefix}_finished" );
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
-			delete_option( "{$prefix}_{$module->name()}_sent" );
+			Jetpack_Sync_Options::delete_option( "{$prefix}_{$module->name()}_sent" );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -294,11 +294,11 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	private function update_status_option( $name, $value, $autoload = false ) {
-		Jetpack_Sync_Options::write_option( self::STATUS_OPTION_PREFIX . "_$name", $value, $autoload );
+		Jetpack_Sync_Options::update_option( self::STATUS_OPTION_PREFIX . "_$name", $value, $autoload );
 	}
 
 	private function set_enqueue_status( $new_status ) {
-		Jetpack_Sync_Options::write_option( 'jetpack_sync_full_enqueue_status', $new_status );
+		Jetpack_Sync_Options::update_option( 'jetpack_sync_full_enqueue_status', $new_status );
 	}
 
 	private function get_enqueue_status() {
@@ -306,7 +306,7 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	private function set_config( $config ) {
-		Jetpack_Sync_Options::write_option( 'jetpack_sync_full_config', $config );
+		Jetpack_Sync_Options::update_option( 'jetpack_sync_full_config', $config );
 	}
 	
 	private function get_config() {

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-options.php';
+
 /**
  * This class does a full resync of the database by
  * enqueuing an outbound action for every single object
@@ -286,37 +288,29 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 	}
 
 	private function get_status_option( $name, $default = null ) {
-		$prefix = self::STATUS_OPTION_PREFIX;
-
-		$value = get_option( "{$prefix}_{$name}", $default );
-		
-		if ( ! $value ) {
-			// don't cast to int if we didn't find a value - we want to preserve null or false as sentinals
-			return $default;
-		}
+		$value = Jetpack_Sync_Options::read_option( self::STATUS_OPTION_PREFIX . "_$name", $default );
 
 		return is_numeric( $value ) ? intval( $value ) : $value;
 	}
 
 	private function update_status_option( $name, $value, $autoload = false ) {
-		$prefix = self::STATUS_OPTION_PREFIX;
-		update_option( "{$prefix}_{$name}", $value, $autoload );
+		Jetpack_Sync_Options::write_option( self::STATUS_OPTION_PREFIX . "_$name", $value, $autoload );
 	}
 
 	private function set_enqueue_status( $new_status ) {
-		$this->write_option( 'jetpack_sync_full_enqueue_status', $new_status );
+		Jetpack_Sync_Options::write_option( 'jetpack_sync_full_enqueue_status', $new_status );
 	}
 
 	private function get_enqueue_status() {
-		return $this->read_option( 'jetpack_sync_full_enqueue_status' );
+		return Jetpack_Sync_Options::read_option( 'jetpack_sync_full_enqueue_status' );
 	}
 
 	private function set_config( $config ) {
-		$this->write_option( 'jetpack_sync_full_config', $config );
+		Jetpack_Sync_Options::write_option( 'jetpack_sync_full_config', $config );
 	}
 	
 	private function get_config() {
-		return $this->read_option( 'jetpack_sync_full_config' );
+		return Jetpack_Sync_Options::read_option( 'jetpack_sync_full_config' );
 	}
 
 	private function write_option( $name, $value ) {

--- a/sync/class.jetpack-sync-options.php
+++ b/sync/class.jetpack-sync-options.php
@@ -42,7 +42,7 @@ class Jetpack_Sync_Options {
 		return $updated_num;
 	}
 
-	static function read_option( $name, $default = null ) {
+	static function get_option( $name, $default = null ) {
 		global $wpdb;
 		$value = $wpdb->get_var( 
 			$wpdb->prepare(

--- a/sync/class.jetpack-sync-options.php
+++ b/sync/class.jetpack-sync-options.php
@@ -7,6 +7,11 @@
 
 class Jetpack_Sync_Options {
 
+	static function delete_option( $name ) {
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name = %s", $name ) );
+	}
+
 	static function write_option( $name, $value, $autoload = false ) {
 
 		$autoload_value = $autoload ? 'yes' : 'no';

--- a/sync/class.jetpack-sync-options.php
+++ b/sync/class.jetpack-sync-options.php
@@ -12,7 +12,7 @@ class Jetpack_Sync_Options {
 		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->options WHERE option_name = %s", $name ) );
 	}
 
-	static function write_option( $name, $value, $autoload = false ) {
+	static function update_option( $name, $value, $autoload = false ) {
 
 		$autoload_value = $autoload ? 'yes' : 'no';
 

--- a/sync/class.jetpack-sync-options.php
+++ b/sync/class.jetpack-sync-options.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Simple class to read/write to the options table, bypassing 
+ * problematic caching with get_option/set_option
+ **/
+
+class Jetpack_Sync_Options {
+
+	static function write_option( $name, $value, $autoload = false ) {
+
+		$autoload_value = $autoload ? 'yes' : 'no';
+
+		// we write our own option updating code to bypass filters/caching/etc on set_option/get_option
+		global $wpdb;
+		$serialized_value = maybe_serialize( $value );
+		// try updating, if no update then insert
+		// TODO: try to deal with the fact that unchanged values can return updated_num = 0
+		// below we used "insert ignore" to at least suppress the resulting error
+		$updated_num = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s", 
+				$serialized_value,
+				$name
+			)
+		);
+
+		if ( ! $updated_num ) {
+			$updated_num = $wpdb->query(
+				$wpdb->prepare(
+					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, '$autoload_value' )", 
+					$name,
+					$serialized_value
+				)
+			);
+		}
+		return $updated_num;
+	}
+
+	static function read_option( $name, $default = null ) {
+		global $wpdb;
+		$value = $wpdb->get_var( 
+			$wpdb->prepare(
+				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", 
+				$name
+			)
+		);
+		$value = maybe_unserialize( $value );
+
+		if ( $value === null && $default !== null ) {
+			return $default;
+		}
+
+		return $value;
+	}
+	
+}


### PR DESCRIPTION
alloptions caching wreaks havoc on important sync values like send_started, so we should bypass it by reusing our direct-to-mysql approach from the config variable.