### PR TITLE
API: Don't treat WP_Error::get_error_messages as class prop but metho

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
@@ -24,7 +24,7 @@ class Jetpack_JSON_API_Themes_Delete_Endpoint extends Jetpack_JSON_API_Themes_En
 			$result = delete_theme( $theme );
 
 			if ( is_wp_error( $result ) ) {
-				$error = $this->log[ $theme ]['error'] = $result->get_error_messages;
+				$error = $this->log[ $theme ]['error'] = $result->get_error_messages();
 			} else {
 				$this->log[ $theme ][] = 'Theme deleted';
 			}


### PR DESCRIPTION
While working on #5704, I stumbled upon a small typo in the theme deletion endpoint in which the method `get_error_messages` of `WP_Error` is treated like a class property instead of a class method.

## Testing instructions

Well, you need to somehow trigger an error in the `delete_theme` function in order to get into this condition. It's not easy to reproduce without having all of the code I currently work on (#5704) and also I don't think it's necessary as this is just a very minor fix. :)

This was the error message I was getting without this fix:

![selection_225](https://cloud.githubusercontent.com/assets/4988512/20565694/d2cb22b8-b192-11e6-8a76-7f81beb5ac95.png)

/cc @roccotripaldi and also @seear as you might have more context for this. :)