### PR TITLE
Replace Monitor email checkbox with a link

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -31,6 +31,8 @@ import {
 
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 
+import ExternalLink from 'components/external-link';
+
 export let VideoPressSettings = React.createClass( {
 	render() {
 		return (
@@ -308,28 +310,16 @@ ProtectSettings = moduleSettingsForm( ProtectSettings );
 export let MonitorSettings = React.createClass( {
 	render() {
 		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<ModuleSettingCheckbox
-						name={ 'monitor_receive_notifications' }
-						{ ...this.props }
-						label={ __( 'Receive Monitor Email Notifications' ) } />
-					<span className="jp-form-setting-explanation">{ __( 'Emails will be sent to ' ) + this.props.adminEmailAddress }. <span>
-						&nbsp;
-						{
-							__( '{{a}}Edit{{/a}}', {
-								components: {
-									a: <a href={ 'https://wordpress.com/settings/account/' } />
-								}
-							} )
+			<span className="jp-form-setting-explanation"><span>
+				{
+
+					__( '{{link}}Configure your Monitor notificaton settings on WordPress.com{{/link}}', {
+						components: {
+							link: <ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={  'https://wordpress.com/settings/security/' + this.props.module.raw_url } />,
 						}
-					</span></span>
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
+					} )
+				}
+			</span></span>
 		)
 	}
 } );

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -33,6 +33,7 @@ import ExternalLink from 'components/external-link';
 
 import {
 	getSiteAdminUrl,
+	getSiteRawUrl
 } from 'state/initial-state';
 
 const AllModuleSettingsComponent = React.createClass( {
@@ -68,6 +69,7 @@ const AllModuleSettingsComponent = React.createClass( {
 			case 'protect':
 				return ( <ProtectSettings module={ module }  /> );
 			case 'monitor':
+				module.raw_url = this.props.siteRawUrl;
 				return ( <MonitorSettings module={ module }  /> );
 			case 'scan':
 				return '' === module.configure_url ? (
@@ -188,7 +190,8 @@ const AllModuleSettingsComponent = React.createClass( {
 export const AllModuleSettings = connect(
 	( state ) => {
 		return {
-			adminUrl: getSiteAdminUrl( state )
+			adminUrl: getSiteAdminUrl( state ),
+			siteRawUrl: getSiteRawUrl( state )
 		};
 	}
 )( AllModuleSettingsComponent );


### PR DESCRIPTION
Replaces "Receive Monitor Email Notifications" checkbox with a link to the Monitor settings page on WordPress.com. This PR is related to D2984, but can be merged without waiting on that.

New link at Jetpack > Settings > Security looks like:

![selection_037](https://cloud.githubusercontent.com/assets/15386509/20580389/dd44f25c-b186-11e6-889d-148cf55d68a3.png)
