### PR TITLE
GPlus Badge and Twitter Timeline Widgets: Do not show widget title if the u…

### DIFF
--- a/modules/widgets/googleplus-badge.php
+++ b/modules/widgets/googleplus-badge.php
@@ -96,7 +96,10 @@ class WPCOM_Widget_GooglePlus_Badge extends WP_Widget {
 		$title = apply_filters( 'widget_title', $instance['title'] );
 
 		echo $args['before_widget'];
-		echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+		}
 
 		switch( $instance['type'] ) {
 			case 'person':

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -81,9 +81,10 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		echo $args['before_widget'];
 
 		$title = isset( $instance['title'] ) ? $instance['title'] : '';
+		
+		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title );
 		if ( ! empty( $title ) ) {
-			/** This filter is documented in core/src/wp-includes/default-widgets.php */
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -80,9 +80,11 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 
 		echo $args['before_widget'];
 
-		if ( isset( $instance['title'] ) ) {
+		$title = isset( $instance['title'] ) ? $instance['title'] : '';
+		$title = apply_filters( 'widget_title', $title );
+		if ( ! empty( $title ) ) {
 			/** This filter is documented in core/src/wp-includes/default-widgets.php */
-			echo $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'];
+			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
 		// Start tag output


### PR DESCRIPTION
Fixes #5753

#### Changes proposed in this Pull Request:
Do not show `$args['before_title'] . $title . $args['after_title']` if the title is empty in the following widgets:
- Google+ Badge
- Twitter Timeline


#### Testing instructions:
Details here: [https://github.com/Automattic/jetpack/issues/5753](https://github.com/Automattic/jetpack/issues/5753)

#### Proposed changelog entry for your changes:
Widgets: Removed widget title if this is empty in Google Plus Badge and Twitter Timeline