### PR TITLE
Sync Custom admin menus

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -156,6 +156,7 @@ class Jetpack_Sync_Defaults {
 		'hosting_provider'                 => array( 'Jetpack_Sync_Functions', 'get_hosting_provider' ),
 		'locale'                           => 'get_locale',
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
+		'admin_menu_items'                 => array( 'Jetpack_Sync_Functions', 'get_custom_admin_menu_items' ),
 	);
 
 	static $blacklisted_post_types = array(

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -191,7 +191,7 @@ class Jetpack_Sync_Functions {
 	    do_action( 'admin_menu', '' );
 	    /** Lets clean up user switch */
 	    wp_set_current_user( $current_user_id );
-	    return array( menu => $menu, submenu => $submenu );
+	    return array( 'menu' => $menu, 'submenu' => $submenu );
 	}
 
 	public static function wp_version() {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -176,6 +176,24 @@ class Jetpack_Sync_Functions {
 		return apply_filters( 'all_plugins', get_plugins() );
 	}
 
+	/**
+	 * Returns items inserted to wp-admin admin page menu by custom plugins and themes.
+	 * They usually do that bu hooking in admin_menu and calling add_menu_page and add_submenu_page.
+	 * @return array
+	 **/
+	public static function get_custom_admin_menu_items() {
+	    global $menu, $submenu;
+
+	    /** Since some of the menu items are displayed only for certain capability, we need user switcharoo */
+	    $current_user_id = get_current_user_id();
+	    wp_set_current_user( Jetpack_Options::get_option( 'master_user' ) );
+	    /** add_menu_page and add_submenu_page hook into admin_menu. Documented in wp-admin/includes/menu.php  */
+	    do_action( 'admin_menu', '' );
+	    /** Lets clean up user switch */
+	    wp_set_current_user( $current_user_id );
+	    return array( menu => $menu, submenu => $submenu );
+	}
+
 	public static function wp_version() {
 		global $wp_version;
 

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -38,10 +38,10 @@ class Jetpack_Sync_Functions {
 		}
 		if ( defined( 'MM_BASE_DIR' ) ) {
 			return 'bh';
-		} 
+		}
 		if ( defined( 'IS_PRESSABLE' ) ) {
 			return 'pressable';
-		} 
+		}
 		if ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ) {
 			return 'wpe';
 		}
@@ -182,16 +182,18 @@ class Jetpack_Sync_Functions {
 	 * @return array
 	 **/
 	public static function get_custom_admin_menu_items() {
-	    global $menu, $submenu;
+		global $menu, $submenu;
 
-	    /** Since some of the menu items are displayed only for certain capability, we need user switcharoo */
-	    $current_user_id = get_current_user_id();
-	    wp_set_current_user( Jetpack_Options::get_option( 'master_user' ) );
-	    /** add_menu_page and add_submenu_page hook into admin_menu. Documented in wp-admin/includes/menu.php  */
-	    do_action( 'admin_menu', '' );
-	    /** Lets clean up user switch */
-	    wp_set_current_user( $current_user_id );
-	    return array( 'menu' => $menu, 'submenu' => $submenu );
+		// Since some of the menu items are displayed only for certain capability, we need user switcharoo
+		$current_user_id = get_current_user_id();
+		wp_set_current_user( Jetpack_Options::get_option( 'master_user' ) );
+
+		// add_menu_page and add_submenu_page hook into admin_menu. Documented in wp-admin/includes/menu.php
+		do_action( 'admin_menu', '' );
+
+		// Lets clean up user switch
+		wp_set_current_user( $current_user_id );
+		return array( 'menu' => $menu, 'submenu' => $submenu );
 	}
 
 	public static function wp_version() {


### PR DESCRIPTION
## Why?

One of the problems with Calypso for Jetpack users is that users not only don't have custom functionality from plugins / themes, but they also don't have **any link nor indication** about this custom functionality.

This can be especially annoying for AT customers.

## Solution

- Call 'admin_menu'
- Capture custom items
- Sync

## API

WPCOM part of this: D3506-code

![screen shot 2016-11-25 at 21 08 57 pm](https://cloud.githubusercontent.com/assets/3775068/20634782/b0069cee-b354-11e6-921a-7649db2833b7.png)

## Calypso side

Calypso side of this needs some thinking. In the above example submenus for `edit.php?post_type=event` need to hook into Menu items created by Custom Post Type **event**, hence pinging @aduth.

CC @enej