### PR TITLE
REST API: Add Error Handling for Term Update Endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
@@ -121,6 +121,10 @@ class WPCOM_JSON_API_Update_Term_Endpoint extends WPCOM_JSON_API_Taxonomy_Endpoi
 		}
 
 		$data = wp_update_term( $term->term_id, $taxonomy, $update );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
 		$term = get_term_by( 'id', $data['term_id'], $taxonomy );
 
 		$return = $this->get_taxonomy( $term->slug, $taxonomy, $args['context'] );


### PR DESCRIPTION
An bug was recently found while working on the taxonomy manager in calypso, see https://github.com/Automattic/wp-calypso/issues/9496 for more details. When updating a term /sites/%s/taxonomies/%s/terms/slug:%s, there is currently an issue where if you attempt to update to an existing term name that already exists, a fatal is thrown. The root cause here is some validation logic in wp_update_term does a check to see if the name already exists, regardless of if the term is hierarchical or not.

This API patch has been deployed on WPCOM, so adding the change here to keep the endpoint in sync for Jetpack.

Additional info + tests at D3504-code
