### PR TITLE
Fix/widget visibility empty cats

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -46,7 +46,7 @@ class Jetpack_Widget_Conditions {
 				<option value=""><?php _e( 'All category pages', 'jetpack' ); ?></option>
 				<?php
 
-				$categories = get_categories( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC' ) );
+				$categories = get_categories( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => apply_filters( 'jetpack_widget_conditions_show_empty_terms' , false , $major , $minor ) ) );
 				usort( $categories, array( __CLASS__, 'strcasecmp_name' ) );
 
 				foreach ( $categories as $category ) {
@@ -86,7 +86,7 @@ class Jetpack_Widget_Conditions {
 				<option value=""><?php _e( 'All tag pages', 'jetpack' ); ?></option>
 				<?php
 
-				$tags = get_tags( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC' ) );
+				$tags = get_tags( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => apply_filters( 'jetpack_widget_conditions_show_empty_terms' , false , $major , $minor ) ) );
 				usort( $tags, array( __CLASS__, 'strcasecmp_name' ) );
 
 				foreach ( $tags as $tag ) {

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -46,7 +46,7 @@ class Jetpack_Widget_Conditions {
 				<option value=""><?php _e( 'All category pages', 'jetpack' ); ?></option>
 				<?php
 
-				$categories = get_categories( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => apply_filters( 'jetpack_widget_conditions_show_empty_terms' , false , $major , $minor ) ) );
+				$categories = get_categories( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => false ) );
 				usort( $categories, array( __CLASS__, 'strcasecmp_name' ) );
 
 				foreach ( $categories as $category ) {
@@ -86,7 +86,7 @@ class Jetpack_Widget_Conditions {
 				<option value=""><?php _e( 'All tag pages', 'jetpack' ); ?></option>
 				<?php
 
-				$tags = get_tags( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => apply_filters( 'jetpack_widget_conditions_show_empty_terms' , false , $major , $minor ) ) );
+				$tags = get_tags( array( 'number' => 1000, 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => false ) );
 				usort( $tags, array( __CLASS__, 'strcasecmp_name' ) );
 
 				foreach ( $tags as $tag ) {


### PR DESCRIPTION
Replaces #1393

Allows display of empty categories in the dropdowns.  

See original PR for full discussion. 

cc @jwenerd 