### PR TITLE
General: fix e-mail as email according to WordPress terminology

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -193,7 +193,7 @@ const PlanBody = React.createClass( {
 						includes( [ 'jetpack_business', 'jetpack_business_monthly' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Surveys & Polls' ) }</h3>
-								<p>{ __( 'Unlimited surveys, unlimited responses. Use the survey editor to create surveys quickly and easily. Collect responses via your website, e-mail or on your iPad or iPhone.' ) }</p>
+								<p>{ __( 'Unlimited surveys, unlimited responses. Use the survey editor to create surveys quickly and easily. Collect responses via your website, email or on your iPad or iPhone.' ) }</p>
 								<Button href="https://polldaddy.com/dashboard/" className="is-primary">
 									{ __( 'Create a new poll' ) }
 								</Button>

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -298,7 +298,7 @@ class Jetpack_Debugger {
 					</div>
 
 					<div id="email_div" class="formbox">
-						<label class="h" for="your_email"><?php esc_html_e( 'E-mail', 'jetpack' ); ?></label>
+						<label class="h" for="your_email"><?php esc_html_e( 'Email', 'jetpack' ); ?></label>
 			  			<span class="errormsg"><?php esc_html_e( 'Use a valid email address.', 'jetpack' ); ?></span>
 						<input name="your_email" type="text" id="your_email" value="<?php esc_html_e( $current_user->user_email, 'jetpack'); ?>" size="40">
 					</div>

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -64,7 +64,7 @@ function sharing_email_check_for_spam_via_akismet( $data ) {
 }
 
 function sharing_email_send_post_content( $data ) {
-	/* translators: included in e-mail when post is shared via e-mail. First item is sender's name. Second is sender's e-mail address. */
+	/* translators: included in email when post is shared via email. First item is sender's name. Second is sender's email address. */
 	$content  = sprintf( __( '%1$s (%2$s) thinks you may be interested in the following post:', 'jetpack' ), $data['name'], $data['source'] );
 	$content .= "\n\n";
 	$content .= $data['post']->post_title."\n";


### PR DESCRIPTION
Fixes #5619

#### Testing instructions:
* make sure Plans and Debugger have email not e-mail or E-mail 