### PR TITLE
Endpoints: check that VaultPress data fetch doesn't cause a fatal error if there's no data

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1093,9 +1093,9 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 		}
 
 		$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
-		if ( is_wp_error( $data ) ) {
+		if ( is_wp_error( $data ) || ! isset( $data->backups->last_backup ) ) {
 			return $data;
-		} else if ( ! $data->backups->last_backup ) {
+		} else if ( empty( $data->backups->last_backup ) ) {
 			return rest_ensure_response( array(
 				'code'    => 'success',
 				'message' => esc_html__( 'VaultPress is active and will back up your site soon.', 'jetpack' ),


### PR DESCRIPTION
Fixes #5721

#### Changes proposed in this Pull Request:
- verify data returned before accessing it

#### Testing instructions:
* check VaultPress when there's no registration key.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
- Endpoints: verify data returned by VaultPress to make sure it's valid before parsing it.

cc @zinigor 