### PR TITLE
Admin Page: if REST API access is restricted through filters, redirect user to fallback page.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -136,9 +136,33 @@ abstract class Jetpack_Admin_Page {
 		wp_style_add_data( 'jetpack-admin', 'suffix', $min );
 	}
 
+	/**
+	 * Checks if WordPress version is too old to have REST API.
+	 *
+	 * @since 4.3
+	 *
+	 * @return bool
+	 */
 	function is_wp_version_too_old() {
 		global $wp_version;
 		return ( ! function_exists( 'rest_api_init' ) || version_compare( $wp_version, '4.4-z', '<=' ) );
+	}
+
+	/**
+	 * Checks if REST API is enabled.
+	 *
+	 * @since 4.4.2
+	 *
+	 * @return bool
+	 */
+	function is_rest_api_enabled() {
+		return
+			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
+			apply_filters( 'rest_enabled', true ) &&
+			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
+			apply_filters( 'rest_jsonp_enabled', true ) &&
+			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
+			apply_filters( 'rest_authentication_errors', true );
 	}
 
 	/**

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -27,8 +27,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return; // No need to handle the fallback redirection if we are not on the Jetpack page
 		}
 
-		// Adding a redirect meta tag for older WordPress versions
-		if ( $this->is_wp_version_too_old() ) {
+		// Adding a redirect meta tag for older WordPress versions or if the REST API is disabled
+		if ( $this->is_wp_version_too_old() || ! $this->is_rest_api_enabled() ) {
 			$this->is_redirecting = true;
 			add_action( 'admin_head', array( $this, 'add_fallback_head_meta' ) );
 		}
@@ -280,6 +280,23 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			'currentIp' => function_exists( 'jetpack_protect_get_ip' ) ? jetpack_protect_get_ip() : false
 		) );
+	}
+
+	/**
+	 * Checks if REST API is enabled.
+	 *
+	 * @since 4.4.2
+	 *
+	 * @return bool
+	 */
+	function is_rest_api_enabled() {
+		return
+			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
+			apply_filters( 'rest_enabled', true ) &&
+			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
+			apply_filters( 'rest_jsonp_enabled', true ) &&
+			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
+			apply_filters( 'rest_authentication_errors', true );
 	}
 }
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -281,23 +281,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'currentIp' => function_exists( 'jetpack_protect_get_ip' ) ? jetpack_protect_get_ip() : false
 		) );
 	}
-
-	/**
-	 * Checks if REST API is enabled.
-	 *
-	 * @since 4.4.2
-	 *
-	 * @return bool
-	 */
-	function is_rest_api_enabled() {
-		return
-			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
-			apply_filters( 'rest_enabled', true ) &&
-			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
-			apply_filters( 'rest_jsonp_enabled', true ) &&
-			/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
-			apply_filters( 'rest_authentication_errors', true );
-	}
 }
 
 /*

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -35,23 +35,23 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 		$noscript_notice = str_replace(
 			'#HEADER_TEXT#',
-			esc_html( __( 'You have JavaScript disabled', 'jetpack' ) ),
+			esc_html__( 'You have JavaScript disabled', 'jetpack' ),
 			$noscript_notice
 		);
 		$noscript_notice = str_replace(
 			'#TEXT#',
-			esc_html( __( "Turn on JavaScript to unlock Jetpack's full potential!", 'jetpack' ) ),
+			esc_html__( "Turn on JavaScript to unlock Jetpack's full potential!", 'jetpack' ),
 			$noscript_notice
 		);
 
 		$version_notice = str_replace(
 			'#HEADER_TEXT#',
-			esc_html( __( 'You are using an outdated version of WordPress', 'jetpack' ) ),
+			esc_html__( 'You are using an outdated version of WordPress', 'jetpack' ),
 			$version_notice
 		);
 		$version_notice = str_replace(
 			'#TEXT#',
-			esc_html( __( "Update WordPress to unlock Jetpack's full potential!", 'jetpack' ) ),
+			esc_html__( "Update WordPress to unlock Jetpack's full potential!", 'jetpack' ),
 			$version_notice
 		);
 
@@ -68,12 +68,12 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 		$ie_notice = str_replace(
 			'#HEADER_TEXT#',
-			esc_html( __( 'You are using an unsupported browser version.', 'jetpack' ) ),
+			esc_html__( 'You are using an unsupported browser version.', 'jetpack' ),
 			$ie_notice
 		);
 		$ie_notice = str_replace(
 			'#TEXT#',
-			esc_html( __( "Update your browser to unlock Jetpack's full potential!", 'jetpack' ) ),
+			esc_html__( "Update your browser to unlock Jetpack's full potential!", 'jetpack' ),
 			$ie_notice
 		);
 

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -30,7 +30,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 		// We have static.html so let's continue trying to fetch the others
 		$noscript_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' );
-		$version_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
+		$version_notice = $rest_api_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
 		$ie_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-ie-notice.html' );
 
 		$noscript_notice = str_replace(
@@ -55,6 +55,17 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 			$version_notice
 		);
 
+		$rest_api_notice = str_replace(
+			'#HEADER_TEXT#',
+			esc_html( __( 'WordPress REST API is disabled', 'jetpack' ) ),
+			$rest_api_notice
+		);
+		$rest_api_notice = str_replace(
+			'#TEXT#',
+			esc_html( __( "Enable WordPress REST API to unlock Jetpack's full potential!", 'jetpack' ) ),
+			$rest_api_notice
+		);
+
 		$ie_notice = str_replace(
 			'#HEADER_TEXT#',
 			esc_html( __( 'You are using an unsupported browser version.', 'jetpack' ) ),
@@ -72,6 +83,9 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 		if ( $this->is_wp_version_too_old() ) {
 			echo $version_notice;
+		}
+		if ( ! $this->is_rest_api_enabled() ) {
+			echo $rest_api_notice;
 		}
 		echo $noscript_notice;
 		echo $ie_notice;


### PR DESCRIPTION
Fixes #5596

#### Changes proposed in this Pull Request:
Check if filters `rest_enabled` or `rest_jsonp_enabled` are set to false, in which case it will redirect user to fallback page for proper functioning.

NOTE: this only takes into account the REST API that was originally merged into core. Other filters like `json_enabled` and `json_jsonp_enabled` never made it to core so we don't take them into account.

#### Testing instructions:
* checkout this branch, do
```
 wp plugin install disable-json-api --activate 
```
* and try to go to Admin page, it should take you to fallback page.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Admin page: if REST API access is restricted through filters `rest_enabled` or `rest_jsonp_enabled`, redirect user to fallback page.
