### PR TITLE
Fix/5776 nova php warning

### DIFF
--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -433,9 +433,12 @@ class Nova_Restaurant {
 		add_action( 'current_screen', array( $this, 'current_screen_load' ) );
 
 		//Adjust 'Add Many Items' submenu position
-		$submenu_item = array_pop( $GLOBALS['submenu']['edit.php?post_type=' . self::MENU_ITEM_POST_TYPE] );
-		$GLOBALS['submenu']['edit.php?post_type=' . self::MENU_ITEM_POST_TYPE][11] = $submenu_item;
-		ksort( $GLOBALS['submenu']['edit.php?post_type=' . self::MENU_ITEM_POST_TYPE] );
+		if ( isset( $GLOBALS['submenu']['edit.php?post_type=' . self::MENU_ITEM_POST_TYPE] ) ) {
+			$submenu_item = array_pop( $GLOBALS['submenu']['edit.php?post_type=' . self::MENU_ITEM_POST_TYPE] );
+			$GLOBALS['submenu']['edit.php?post_type=' . self::MENU_ITEM_POST_TYPE][11] = $submenu_item;
+			ksort( $GLOBALS['submenu']['edit.php?post_type=' . self::MENU_ITEM_POST_TYPE] );
+		}
+
 
 		$this->setup_menu_item_columns();
 

--- a/modules/custom-post-types/nova.php
+++ b/modules/custom-post-types/nova.php
@@ -872,7 +872,7 @@ class Nova_Restaurant {
 				'post_title'   => $_POST['nova_title'][$key],
 				'tax_input'    => array(
 					self::MENU_ITEM_LABEL_TAX => $_POST['nova_labels'][$key],
-					self::MENU_TAX            => $_POST['nova_menu_tax'],
+					self::MENU_TAX            => isset( $_POST['nova_menu_tax'] ) ? $_POST['nova_menu_tax'] : null,
 				),
 			);
 


### PR DESCRIPTION
Fixes #5776

#### Changes proposed in this Pull Request:


#### Testing instructions:

* Select a theme that support the nova menu. 
* Switch to a user that is an author. Notice that the php warning go away. 

* Switch back to a admin role. Remove all Menu Sections taxonomies. 
* Go to Add Many Items notice that the php notice is not that and you are able to add the menu items as expected. 