### PR TITLE
Bypass w3 total cache for sync queue requests

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -10,6 +10,7 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/wpml.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/w3-total-cache.php' );
 
 // We can't load this conditionally since polldaddy add the call in class constuctor.
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );

--- a/3rd-party/w3-total-cache.php
+++ b/3rd-party/w3-total-cache.php
@@ -5,8 +5,6 @@
 add_filter( 'w3tc_config_default_values', 'jetpack_bypass_w3_total_cache' );
 
 function jetpack_bypass_w3_total_cache( $default_values ) {
-
-	error_log( print_r( 'This is loaded...',1 ) );
 	$default_values['dbcache.reject.words']['default'][] = '\bjpsq_\w';
 	return $default_values;
 }

--- a/3rd-party/w3-total-cache.php
+++ b/3rd-party/w3-total-cache.php
@@ -1,0 +1,12 @@
+<?php
+
+
+// tell w3 total cache not to cache queue queries
+add_filter( 'w3tc_config_default_values', 'jetpack_bypass_w3_total_cache' );
+
+function jetpack_bypass_w3_total_cache( $default_values ) {
+
+	error_log( print_r( 'This is loaded...',1 ) );
+	$default_values['dbcache.reject.words']['default'][] = '\bjpsq_\w';
+	return $default_values;
+}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -38,6 +38,9 @@ class Jetpack_Sync_Actions {
 		// publicize filter to prevent publicizing blacklisted post types
 		add_filter( 'publicize_should_publicize_published_post', array( __CLASS__, 'prevent_publicize_blacklisted_posts' ), 10, 2 );
 
+		// tell w3 total cache not to cache queue queries
+		add_filter( 'w3tc_config_default_values', array( __CLASS__, 'bypass_w3_total_cache' ) );
+
 		/**
 		 * Fires on every request before default loading sync listener code.
 		 * Return false to not load sync listener code that monitors common
@@ -102,6 +105,11 @@ class Jetpack_Sync_Actions {
 		}
 
 		return $should_publicize;
+	}
+
+	static function bypass_w3_total_cache( $default_values ) {
+		$default_values['dbcache.reject.words']['default'][] = '\bjpsq_\w'
+		return $default_values;
 	}
 
 	static function set_is_importing_true() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -38,9 +38,6 @@ class Jetpack_Sync_Actions {
 		// publicize filter to prevent publicizing blacklisted post types
 		add_filter( 'publicize_should_publicize_published_post', array( __CLASS__, 'prevent_publicize_blacklisted_posts' ), 10, 2 );
 
-		// tell w3 total cache not to cache queue queries
-		add_filter( 'w3tc_config_default_values', array( __CLASS__, 'bypass_w3_total_cache' ) );
-
 		/**
 		 * Fires on every request before default loading sync listener code.
 		 * Return false to not load sync listener code that monitors common
@@ -105,11 +102,6 @@ class Jetpack_Sync_Actions {
 		}
 
 		return $should_publicize;
-	}
-
-	static function bypass_w3_total_cache( $default_values ) {
-		$default_values['dbcache.reject.words']['default'][] = '\bjpsq_\w'
-		return $default_values;
 	}
 
 	static function set_is_importing_true() {


### PR DESCRIPTION
There have been multiple issues reported with the w3 total cache plugin and sync, including the sync status (e.g. queue sizes) not changing even when we have disabled/re-enabled sync (which absolutely should clear them).

Some of these issues appear to stem from DB query caching. This PR adds a default value for the query cache "skip words" setting that should fix this issue for users who haven't customised that value in their W3 Total Cache settings.