### PR TITLE
Tools: lock Yarn version to 0.17.9 to avoid issues.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ $ yarn distclean
 
 3. Install [yarn](https://www.npmjs.com/package/yarn) package.
     ```
-    npm install -g yarn@0.16.1
+    npm install -g yarn@0.17.9
     ```
 
 4. Make sure the Jetpack plugin is active and run

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -31,7 +31,7 @@ else
 
     gem install sass
     gem install compass
-    npm install yarn@0.16.1
+    npm install yarn@0.17.9
     yarn
 
     if $WP_TRAVISCI; then


### PR DESCRIPTION
The version in `tools/deploy-to-master-stable-branch.sh` wasn't updated because this is a companion to https://github.com/Automattic/jetpack/pull/5661 and the sentence there will disappear.

#### Changes proposed in this Pull Request:
Use latest version that doesn't have issues.

#### Testing instructions:
* update Yarn to 0.17.9 and test build
```
yarn self-update
yarn build
```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Tools: Yarn version in use is now 0.17.9.
