### PR TITLE
Fix hidden help tabs in wp-admin

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -41,10 +41,6 @@ abstract class Jetpack_Admin_Page {
 		self::$block_page_rendering_for_idc = (
 			Jetpack::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' )
 		);
-
-		if ( ! self::$block_page_rendering_for_idc ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'additional_styles' ) );
-		}
 	}
 
 	function add_actions() {
@@ -70,6 +66,10 @@ abstract class Jetpack_Admin_Page {
 
 		add_action( "admin_print_styles-$hook",  array( $this, 'admin_styles'    ) );
 		add_action( "admin_print_scripts-$hook", array( $this, 'admin_scripts'   ) );
+
+		if ( ! self::$block_page_rendering_for_idc ) {
+			add_action( "admin_print_styles-$hook", array( $this, 'additional_styles' ) );
+		}
 
 		// Check if the site plan changed and deactivate modules accordingly.
 		add_action( 'current_screen', array( $this, 'check_plan_deactivate_modules' ) );


### PR DESCRIPTION
fixes #5747

Changes when/how we load the additional styles for the Jetpack admin page.  No longer will load these styles on non-jetpack admin pages.  

To Test: 
- Admin help tab should be hidden in Jetpack admin pages `/wp-admin/admin.php?page=jetpack_modules` && `/wp-admin/admin.php?page=jetpack`
- Admin help tab should show on non-jetpack admin pages, such as wp-admin dashboard.  
- There should be no delay in the css loading in the Jetpack admin pages. 