### PR TITLE
Themes API: Fixed typo in "Themes_New" endpoint

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -78,7 +78,7 @@ require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-themes-get-e
 require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-themes-new-endpoint.php' );
 
 // POST /sites/%s/themes/%new
-new Jetpack_JSON_API_Themes_new_Endpoint( array(
+new Jetpack_JSON_API_Themes_New_Endpoint( array(
 	'description'     => 'Install a theme to your jetpack blog',
 	'group'           => '__do_not_document',
 	'stat'            => 'themes:new',


### PR DESCRIPTION
Class name is Jetpack_JSON_API_Themes_New_Endpoint but usage was using "new" with a lowercase N. Fixed to uppercase.
Since class names are case insensitive in PHP (http://stackoverflow.com/questions/5260168/capital-letters-in-class-name-php) there should be no effect on functionality, only coding standards.