### PR TITLE
Use has_action() check instead of $wp_filter usage which breaks in 4.7

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5661,8 +5661,8 @@ p {
 
 		// This is a silly loop depth. Better way?
 		foreach( $deprecated_list AS $hook => $hook_alt ) {
-			if( isset( $wp_filter[ $hook ] ) && is_array( $wp_filter[ $hook ] ) ) {
-				foreach( $wp_filter[$hook] AS $func => $values ) {
+			if ( has_action( $hook ) ) {
+				foreach( $wp_filter[ $hook ] AS $func => $values ) {
 					foreach( $values AS $hooked ) {
 						_deprecated_function( $hook . ' used for ' . $hooked['function'], null, $hook_alt );
 					}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5664,7 +5664,12 @@ p {
 			if ( has_action( $hook ) ) {
 				foreach( $wp_filter[ $hook ] AS $func => $values ) {
 					foreach( $values AS $hooked ) {
-						_deprecated_function( $hook . ' used for ' . $hooked['function'], null, $hook_alt );
+						if ( is_callable( $hooked['function'] ) ) {
+							$function_name = 'an anonymous function';
+						} else {
+							$function_name = $hooked['function'];
+						}
+						_deprecated_function( $hook . ' used for ' . $function_name, null, $hook_alt );
 					}
 				}
 			}

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1475,17 +1475,30 @@ abstract class WPCOM_JSON_API_Endpoint {
 	function copy_hooks( $from_hook, $to_hook, $base_paths ) {
 		global $wp_filter;
 		foreach ( $wp_filter as $hook => $actions ) {
-			if ( $from_hook <> $hook )
+
+			if ( $from_hook != $hook ) {
 				continue;
+			}
+
 			foreach ( (array) $actions as $priority => $callbacks ) {
 				foreach( $callbacks as $callback_key => $callback_data ) {
 					$callback = $callback_data['function'];
-					$reflection = $this->get_reflection( $callback ); // use reflection api to determine filename where function is defined
+
+					// use reflection api to determine filename where function is defined
+					$reflection = $this->get_reflection( $callback );
+
 					if ( false !== $reflection ) {
 						$file_name = $reflection->getFileName();
 						foreach( $base_paths as $base_path ) {
-							if ( 0 === strpos( $file_name, $base_path ) ) { // only copy hooks with functions which are part of the specified files
-								$wp_filter[ $to_hook ][ $priority ][ 'cph' . $callback_key ] = $callback_data;
+
+							// only copy hooks with functions which are part of the specified files
+							if ( 0 === strpos( $file_name, $base_path ) ) {
+								add_action(
+									$to_hook,
+									$callback_data['function'],
+									$priority,
+									$callback_data['accepted_args']
+								);
 							}
 						}
 					}


### PR DESCRIPTION
Fixes #5137

This fixes the deprecated use of $wp_filter global usages found in Jetpack.  

To test: 
- Make sure you have WP version >= 4.7

To test `deprecated_hooks()` useage [#](https://github.com/Automattic/jetpack/blob/33ad09de0cca6c7c2bc0c07a9b565282630d54db/class.jetpack.php#L5385): 
- In a functionality plugin, use a deprecated filter such as `add_filter( 'jetpack_has_identity_crisis', '__return_false' );`
- turn on WP_DEBUG
- You should see a deprecated notice in the wp-admin (No notice will show without this patch)

The `copy_hooks()` useage has been tested on wpcom in D3560 and works nicely!
