### PR TITLE
Fixes the build-module-headings-translations script and add to plugin build tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -543,6 +543,28 @@ gulp.task( 'languages:build', [ 'languages:get' ], function( done ) {
 	} );
 } );
 
+gulp.task( 'php:module-headings', function( callback ) {
+	var process = spawn(
+		'php',
+		[
+			'tools/build-module-headings-translations.php'
+		]
+	);
+
+	process.stderr.on( 'data', function( data ) {
+		gutil.log( data.toString() );
+	} );
+	process.stdout.on( 'data', function( data ) {
+		gutil.log( data.toString() );
+	} );
+	process.on( 'exit', function( code ) {
+		if ( 0 !== code ) {
+			gutil.log( 'Failed building module headings translations: process exited with code ', code );
+		}
+		callback();
+	} );
+} );
+
 gulp.task( 'languages:cleanup', [ 'languages:build' ], function( done ) {
 	var language_packs = [];
 
@@ -595,7 +617,7 @@ gulp.task( 'languages:extract', function( done ) {
 // Default task
 gulp.task(
 	'default',
-	['react:build', 'old-styles', 'checkstrings', 'php:lint', 'js:hint']
+	['react:build', 'old-styles', 'checkstrings', 'php:lint', 'js:hint', 'php:module-headings']
 );
 gulp.task(
 	'watch',

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -14,34 +14,34 @@ function jetpack_get_module_i18n( $key ) {
 		$modules = array(
 			'after-the-deadline' => array(
 				'name' => _x( 'Spelling and Grammar', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Check your spelling, style, and grammar with the After the Deadline proofreading service.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Check your spelling, style, and grammar.', 'Module Description', 'jetpack' ),
 			),
 
 			'carousel' => array(
 				'name' => _x( 'Carousel', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Transform standard image galleries into full-screen slideshows.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Transform image galleries into gorgeous, full-screen slideshows.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Brings your photos and images to life as full-size, easily navigable galleries.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'comments' => array(
 				'name' => _x( 'Comments', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Let readers comment with WordPress.com, Twitter, Facebook, or Google+ accounts.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Allow comments with WordPress.com, Twitter, Facebook, or Google+.', 'Module Description', 'jetpack' ),
 			),
 
 			'contact-form' => array(
 				'name' => _x( 'Contact Form', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Insert a contact form anywhere on your site.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Insert a customizable contact form anywhere on your site.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Adds a button to your post and page editors, allowing you to build simple forms to help visitors stay in touch.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'custom-content-types' => array(
 				'name' => _x( 'Custom Content Types', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Organize and display different types of content on your site, separate from posts and pages.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Organize and display different types of content on your site.', 'Module Description', 'jetpack' ),
 			),
 
 			'custom-css' => array(
 				'name' => _x( 'Custom CSS', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Customize your site’s CSS without modifying your theme.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Tweak your site’s CSS without modifying your theme.', 'Module Description', 'jetpack' ),
 			),
 
 			'enhanced-distribution' => array(
@@ -57,27 +57,27 @@ function jetpack_get_module_i18n( $key ) {
 
 			'infinite-scroll' => array(
 				'name' => _x( 'Infinite Scroll', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Add support for infinite scroll to your theme.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Automatically load new content when a visitor scrolls.', 'Module Description', 'jetpack' ),
 			),
 
 			'json-api' => array(
 				'name' => _x( 'JSON API', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Allow applications to securely access your content through the cloud.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Allow applications to securely access your content.', 'Module Description', 'jetpack' ),
 			),
 
 			'latex' => array(
 				'name' => _x( 'Beautiful Math', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Use LaTeX markup language in posts and pages for complex equations and other geekery.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Use LaTeX markup for complex equations and other geekery.', 'Module Description', 'jetpack' ),
 			),
 
 			'likes' => array(
 				'name' => _x( 'Likes', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Give visitors an easy way to show their appreciation for your content.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Give visitors an easy way to show they appreciate your content.', 'Module Description', 'jetpack' ),
 			),
 
 			'manage' => array(
 				'name' => _x( 'Manage', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Manage all your sites from a centralized place, https://wordpress.com/sites.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Manage all of your sites from a centralized dashboard.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Helps you remotely manage plugins, turn on automated updates, and more from <a href="https://wordpress.com/plugins/" target="_blank">wordpress.com</a>.', 'Jumpstart Description', 'jetpack' ),
 			),
 
@@ -88,22 +88,22 @@ function jetpack_get_module_i18n( $key ) {
 
 			'minileven' => array(
 				'name' => _x( 'Mobile Theme', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Optimize your site with a mobile-friendly theme for smartphones.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Optimize your site for smartphones and tablets.', 'Module Description', 'jetpack' ),
 			),
 
 			'monitor' => array(
 				'name' => _x( 'Monitor', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Reports on site downtime.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Receive immediate notifications if your site goes down, 24/7.', 'Module Description', 'jetpack' ),
 			),
 
 			'notes' => array(
 				'name' => _x( 'Notifications', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Receive notification of site activity via the admin toolbar and your Mobile devices.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Receive instant notifications of site comments and likes.', 'Module Description', 'jetpack' ),
 			),
 
 			'omnisearch' => array(
 				'name' => _x( 'Omnisearch', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Search your entire database from a single field in your Dashboard.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Search your entire database from a single field in your dashboard.', 'Module Description', 'jetpack' ),
 			),
 
 			'photon' => array(
@@ -114,102 +114,102 @@ function jetpack_get_module_i18n( $key ) {
 
 			'post-by-email' => array(
 				'name' => _x( 'Post by Email', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Publish posts by email, using any device and email client.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Publish posts by sending an email.', 'Module Description', 'jetpack' ),
 			),
 
 			'protect' => array(
 				'name' => _x( 'Protect', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Prevent brute force attacks.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Prevent and block malicious login attempts.', 'Module Description', 'jetpack' ),
 			),
 
 			'publicize' => array(
 				'name' => _x( 'Publicize', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Automatically promote content.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Automated social marketing.', 'Module Description', 'jetpack' ),
 			),
 
 			'related-posts' => array(
 				'name' => _x( 'Related Posts', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Display similar content.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Increase page views by showing related content to your visitors.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Keep visitors engaged on your blog by highlighting relevant and new content at the bottom of each published post.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'seo-tools' => array(
-				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
+				'name' => _x( 'SEO tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Better results on search engines and social media.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'sharedaddy' => array(
 				'name' => _x( 'Sharing', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Visitors can share your content.', 'Module Description', 'jetpack' ),
-				'recommended description' => _x( 'Places Twitter, Facebook and Google+ buttons at the bottom of each post, making it easy for visitors to share your content.', 'Jumpstart Description', 'jetpack' ),
+				'description' => _x( 'Allow visitors to share your content.', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Twitter, Facebook and Google+ buttons at the bottom of each post, making it easy for visitors to share your content.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'shortcodes' => array(
 				'name' => _x( 'Shortcode Embeds', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Embed content from YouTube, Vimeo, SlideShare, and more, no coding necessary.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Embed media from popular sites without any coding.', 'Module Description', 'jetpack' ),
 			),
 
 			'shortlinks' => array(
 				'name' => _x( 'WP.me Shortlinks', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Enable WP.me-powered shortlinks for all posts and pages.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Create short and simple links for all posts and pages.', 'Module Description', 'jetpack' ),
 			),
 
 			'sitemaps' => array(
 				'name' => _x( 'Sitemaps', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Creates sitemaps to allow your site to be easily indexed by search engines.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Make it easy for search engines to find your site.', 'Module Description', 'jetpack' ),
 			),
 
 			'sso' => array(
 				'name' => _x( 'Single Sign On', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Secure user authentication.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Secure user authentication with WordPress.com.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'stats' => array(
 				'name' => _x( 'Site Stats', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Collect traffic stats and insights.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Collect valuable traffic stats and insights.', 'Module Description', 'jetpack' ),
 			),
 
 			'subscriptions' => array(
 				'name' => _x( 'Subscriptions', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Allow users to subscribe to your posts and comments and receive notifications via email.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Notify your readers of new posts and comments by email.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Give visitors two easy subscription options — while commenting, or via a separate email subscription widget you can display.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'tiled-gallery' => array(
 				'name' => _x( 'Tiled Galleries', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Display your image galleries in a variety of sleek, graphic arrangements.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Display image galleries in a variety of elegant arrangements.', 'Module Description', 'jetpack' ),
 			),
 
 			'vaultpress' => array(
 				'name' => _x( 'Data Backups', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Daily or real-time backups.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Off-site backups, security scans, and automatic fixes.', 'Module Description', 'jetpack' ),
 			),
 
 			'verification-tools' => array(
 				'name' => _x( 'Site Verification', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Verify your site or domain with Google Search Console, Pinterest, Bing, and Yandex.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Establish your site\'s authenticity with external services.', 'Module Description', 'jetpack' ),
 			),
 
 			'videopress' => array(
 				'name' => _x( 'VideoPress', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Upload and embed videos right on your site.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Powerful, simple video hosting for WordPress', 'Module Description', 'jetpack' ),
 			),
 
 			'widget-visibility' => array(
 				'name' => _x( 'Widget Visibility', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Specify which widgets appear on which pages of your site.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Control where widgets appear on your site.', 'Module Description', 'jetpack' ),
 			),
 
 			'widgets' => array(
 				'name' => _x( 'Extra Sidebar Widgets', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Add images, Twitter streams, your site’s RSS links, and more to your sidebar.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Add images, Twitter streams, and more to your sidebar.', 'Module Description', 'jetpack' ),
 			),
 
 			'wordads' => array(
-				'name' => _x( 'Ads', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Earn income by allowing Jetpack to insert high quality ads.', 'Module Description', 'jetpack' ),
+				'name' => _x( 'WordAds', 'Module Name', 'jetpack' ),
+				'description' => _x( 'Harness WordPress.com\'s advertising partners for your own website.', 'Module Description', 'jetpack' ),
 			),
 		);
 	}
@@ -255,6 +255,7 @@ function jetpack_get_module_i18n_tag( $key ) {
 			//  - modules/gravatar-hovercards.php
 			//  - modules/likes.php
 			//  - modules/publicize.php
+			//  - modules/seo-tools.php
 			//  - modules/sharedaddy.php
 			//  - modules/shortcodes.php
 			//  - modules/shortlinks.php
@@ -268,6 +269,7 @@ function jetpack_get_module_i18n_tag( $key ) {
 			//  - modules/infinite-scroll.php
 			//  - modules/minileven.php
 			//  - modules/photon.php
+			//  - modules/seo-tools.php
 			//  - modules/shortcodes.php
 			//  - modules/widget-visibility.php
 			//  - modules/widgets.php

--- a/tools/build-module-headings-translations.php
+++ b/tools/build-module-headings-translations.php
@@ -42,6 +42,7 @@ foreach ( $files as $file ) {
 	foreach ( $all_headers as $field => $regex ) {
 		if ( preg_match( '/^[ \t\/*#@]*' . preg_quote( $regex, '/' ) . ':(.*)$/mi', $file_data, $match ) && $match[1] ) {
 			$string = trim( preg_replace( "/\s*(?:\*\/|\?>).*/", '', $match[1] ) );
+			$string = addcslashes( $string, "''" );
 			if ( 'Module Tags' === $regex ) {
 				$module_tags = array_map( 'trim', explode( ',', $string ) );
 				foreach ( $module_tags as $tag ) {


### PR DESCRIPTION
- Build-module-headings translation script: auto-escape quotes
Sometimes the module descriptions will have apostrophes that need to be escaped.  make sure we do this so we don't generate  broken files.

- Gulp: new task php:module-headings
this new task will run the tools/build-module-headings-translations.php script, which will build the module headings for translation.

To Test: 
- run `gulp php:module-headings`: it should generate new strings in the `modules/module-headings.php` file. 
- `yarn build` command should now also generate the new stings in the same fashion.  