### PR TITLE
Highlight SEO in list of available features when linking to Calypso v…

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -89,7 +89,7 @@ const ProStatus = React.createClass( {
 					<Button
 						compact={ true }
 						primary={ true }
-						href={ 'https://wordpress.com/plans/' + this.props.siteRawUrl }
+						href={ 'https://wordpress.com/plans/' + this.props.siteRawUrl + '?feature=advanced-seo' }
 					>
 						{ __( 'Upgrade' ) }
 					</Button>


### PR DESCRIPTION
Fixes #5726

#### Changes proposed in this Pull Request:
- Highlights SEO tools when linking to Calypso via Upgrade button in SEO settings.

#### Testing instructions:
- Click on "Upgrade" in the SEO Tools module when not using a plan.
- Ensure that SEO Tools is highlighted in the Plan selection page.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

…ia upgrade button.