### PR TITLE
Admin: in WP 4.7 or later send users to the Custom CSS in Customizer

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1984,33 +1984,39 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param string      $modules Can be a single module or a list of modules.
-	 * @param null|string $slug    Slug of the module in the first parameter.
+	 * @param array $modules Can be a single module or a list of modules.
 	 *
 	 * @return array
 	 */
-	public static function prepare_modules_for_response( $modules = '', $slug = null ) {
-		if ( get_option( 'permalink_structure' ) ) {
-			$sitemap_url = home_url( '/sitemap.xml' );
-			$news_sitemap_url = home_url( '/news-sitemap.xml' );
-		} else {
-			$sitemap_url = home_url( '/?jetpack-sitemap=true' );
-			$news_sitemap_url = home_url( '/?jetpack-news-sitemap=true' );
-		}
-		/** This filter is documented in modules/sitemaps/sitemaps.php */
-		$sitemap_url = apply_filters( 'jetpack_sitemap_location', $sitemap_url );
-		/** This filter is documented in modules/sitemaps/sitemaps.php */
-		$news_sitemap_url = apply_filters( 'jetpack_news_sitemap_location', $news_sitemap_url );
+	public static function prepare_modules_for_response( $modules = array() ) {
 
-		if ( is_null( $slug ) && isset( $modules['sitemaps'] ) ) {
-			// Is a list of modules
+		if ( isset( $modules['custom-css'] ) ) {
+			if ( function_exists( 'wp_get_custom_css' ) ) {
+				$modules['custom-css']['configure_url'] = add_query_arg( array(
+					'page' => 'editcss-customizer-redirect'
+				), admin_url( 'themes.php' ) );
+			}
+		}
+
+		if ( isset( $modules['sitemaps'] ) ) {
+			if ( get_option( 'permalink_structure' ) ) {
+				$sitemap_url = home_url( '/sitemap.xml' );
+				$news_sitemap_url = home_url( '/news-sitemap.xml' );
+			} else {
+				$sitemap_url = home_url( '/?jetpack-sitemap=true' );
+				$news_sitemap_url = home_url( '/?jetpack-news-sitemap=true' );
+			}
+
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$sitemap_url = apply_filters( 'jetpack_sitemap_location', $sitemap_url );
+
+			/** This filter is documented in modules/sitemaps/sitemaps.php */
+			$news_sitemap_url = apply_filters( 'jetpack_news_sitemap_location', $news_sitemap_url );
+
 			$modules['sitemaps']['extra']['sitemap_url'] = $sitemap_url;
 			$modules['sitemaps']['extra']['news_sitemap_url'] = $news_sitemap_url;
-		} elseif ( 'sitemaps' == $slug ) {
-			// It's a single module
-			$modules['extra']['sitemap_url'] = $sitemap_url;
-			$modules['extra']['news_sitemap_url'] = $news_sitemap_url;
 		}
+
 		return $modules;
 	}
 

--- a/modules/custom-css.php
+++ b/modules/custom-css.php
@@ -16,9 +16,6 @@ function jetpack_load_custom_css() {
 	// If WordPress has the core version of Custom CSS, load our new version.
 	// @see https://core.trac.wordpress.org/changeset/38829
 	if ( function_exists( 'wp_get_custom_css' ) ) {
-		if ( ! function_exists( 'wp_update_custom_css_post' ) ) {
-			wp_die( 'Please run a SVN up to get the latest version of trunk, or update to at least 4.7 RC1' );
-		}
 		if ( ! Jetpack_Options::get_option( 'custom_css_4.7_migration' ) ) {
 			include_once dirname( __FILE__ ) . '/custom-css/migrate-to-core.php';
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- modifies the link `Configure your Custom CSS Settings` so when users are on the latest WP 4.7 version, they're taken to the Custom CSS in the Customizer.
- removes the message that prompted users to do a `svn up` as requested by @samhotchkiss 

#### Testing instructions:
* Test with WP 4.6 and 4.7. Only in 4.7 should users be taken to Customizer.

