### PR TITLE
Add Twitch to the Social Media Icons widget #5755

### DIFF
--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -59,6 +59,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'googleplus_username' => '',
 			'flickr_username'     => '',
 			'wordpress_username'  => '',
+			'twitch_username'     => '',
 		);
 		$this->services = array(
 			'facebook'   => array( 'Facebook', 'https://www.facebook.com/%s/' ),
@@ -72,6 +73,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'googleplus' => array( 'Google+', 'https://plus.google.com/u/0/%s/' ),
 			'flickr'     => array( 'Flickr', 'https://www.flickr.com/photos/%s/' ),
 			'wordpress'  => array( 'WordPress.org', 'https://profiles.wordpress.org/%s/' ),
+			'twitch'     => array( 'Twitch', 'https://www.twitch.tv/%s/' ),
 		);
 		if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );


### PR DESCRIPTION
Fixes #5755 

#### Changes proposed in this Pull Request:

Add field so users can enter their Tumblr username and it's displayed in the widget.

#### Testing instructions:

Go to Appearance > Widgets, add a Social Icons widget and make sure it displays Twitch username:
Enter your Twitch username in it and save.