### PR TITLE
CSS: Do not oversanitize CSS when switching to preprocessor

### DIFF
--- a/modules/custom-css/custom-css-4.7.php
+++ b/modules/custom-css/custom-css-4.7.php
@@ -711,9 +711,18 @@ class Jetpack_Custom_CSS_Enhancements {
 	 */
 	public static function sanitize_css_callback( $css, $setting ) {
 		global $wp_customize;
-		return self::sanitize_css( $css, array(
-			'preprocessor' => $wp_customize->get_setting( 'jetpack_custom_css[preprocessor]' )->value(),
-		) );
+		$args = array(
+			'preprocessor' => $wp_customize->get_setting('jetpack_custom_css[preprocessor]')->value(),
+		);
+
+		if ( ! empty( $_POST['customized'] ) ) {
+			$customized = json_decode( $_POST['customized'] );
+			if ( isset( $customized[ 'jetpack_custom_css[preprocessor]' ] ) ) {
+				$args['preprocessor'] = $customized[ 'jetpack_custom_css[preprocessor]' ];
+			}
+		}
+
+		return self::sanitize_css( $css, $args );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:


#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).

