### PR TITLE
Authors Widget: add from wpcom

### DIFF
--- a/modules/widgets/authors.php
+++ b/modules/widgets/authors.php
@@ -66,8 +66,9 @@ class Widget_Authors extends WP_Widget {
 				'no_found_rows'  => true,
 			) );
 
-			if ( ! $r->have_posts() && ! $instance['all'] )
+			if ( ! $r->have_posts() && ! $instance['all'] ) {
 				continue;
+			}
 
 			echo '<li>';
 
@@ -75,15 +76,17 @@ class Widget_Authors extends WP_Widget {
 			if ( $r->have_posts() ) {
 				echo '<a href="' . get_author_posts_url( $author->ID ) . '">';
 
-				if ( $instance['avatar_size'] > 1 )
+				if ( $instance['avatar_size'] > 1 ) {
 					echo ' ' . get_avatar( $author->ID, $instance['avatar_size'], '', true ) . ' ';
+				}
 
 				echo '<strong>' . esc_html( $author->display_name ) . '</strong>';
 				echo '</a>';
 			}
 			else if ( $instance['all'] ) {
-				if ( $instance['avatar_size'] > 1 )
+				if ( $instance['avatar_size'] > 1 ) {
 					echo get_avatar( $author->ID, $instance['avatar_size'], '', true ) . ' ';
+				}
 
 				echo '<strong>' . esc_html( $author->display_name ) . '</strong>';
 			}
@@ -95,18 +98,18 @@ class Widget_Authors extends WP_Widget {
 
 			// Display a short list of recent posts for this author
 
-
-			if ( $r->have_posts() ){
+			if ( $r->have_posts() ) {
 				echo '<ul>';
 
 				while ( $r->have_posts() ) {
 					$r->the_post();
 					echo '<li><a href="' . get_permalink() . '">';
 
-					if ( get_the_title() )
+					if ( get_the_title() ) {
 						echo get_the_title();
-					else
+					} else {
 						echo get_the_ID();
+					}
 
 					echo '</a></li>';
 				}
@@ -122,8 +125,9 @@ class Widget_Authors extends WP_Widget {
 
 		wp_reset_postdata();
 
-		if ( '%BEG_OF_TITLE%' != $args['before_title'] )
-			wp_cache_add( $cache_bucket, ob_get_flush(), 'widget');
+		if ( '%BEG_OF_TITLE%' != $args['before_title'] ) {
+			wp_cache_add( $cache_bucket, ob_get_flush(), 'widget' );
+		}
 
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', 'authors' );
@@ -165,6 +169,13 @@ class Widget_Authors extends WP_Widget {
 		<?php
 	}
 
+	/**
+	 * Updates the widget on save and flushes cache.
+	 *
+	 * @param array $new_instance
+	 * @param array $old_instance
+	 * @return array
+	 */
 	public function update( $new_instance, $old_instance ) {
 		$new_instance['title'] = strip_tags( $new_instance['title'] );
 		$new_instance['all'] = isset( $new_instance['all'] );
@@ -177,6 +188,7 @@ class Widget_Authors extends WP_Widget {
 	}
 }
 
-add_action( 'widgets_init', function () {
+add_action( 'widgets_init', 'jetpack_register_widget_authors' );
+function jetpack_register_widget_authors() {
 	register_widget( 'Widget_Authors' );
-} );
+};

--- a/modules/widgets/authors.php
+++ b/modules/widgets/authors.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * Widget to display blog authors with avatars and recent posts.
+ *
+ * Configurable parameters include:
+ * 1. Whether to display authors who haven't written any posts
+ * 2. The number of posts to be displayed per author (defaults to 0)
+ * 3. Avatar size
+ */
+class Widget_Authors extends WP_Widget {
+	public function __construct() {
+		parent::__construct(
+			'authors',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
+			apply_filters( 'jetpack_widget_name', __( 'Authors', 'jetpack' ) ),
+			array( 'classname' => 'widget_authors', 'description' => __( 'Display blogs authors with avatars and recent posts.' ) ),
+			array( 'width' => 300 )
+		);
+
+		add_action( 'publish_post', array( __CLASS__, 'flush_cache' ) );
+		add_action( 'deleted_post', array( __CLASS__, 'flush_cache' ) );
+		add_action( 'switch_theme', array( __CLASS__, 'flush_cache' ) );
+	}
+
+	public static function flush_cache() {
+		wp_cache_delete( 'widget_authors', 'widget' );
+		wp_cache_delete( 'widget_authors_ssl', 'widget' );
+	}
+
+	public function widget( $args, $instance ) {
+		global $wpdb;
+
+		$cache_bucket = is_ssl() ? 'widget_authors_ssl' : 'widget_authors';
+
+		if ( '%BEG_OF_TITLE%' != $args['before_title'] ) {
+			if ( $output = wp_cache_get( $cache_bucket, 'widget') ) {
+				echo $output;
+				return;
+			}
+
+			ob_start();
+		}
+
+		$instance = wp_parse_args( $instance, array( 'title' => __( 'Authors' ), 'all' => false, 'number' => 5, 'avatar_size' => 48 ) );
+		$instance['number'] = min( 10, max( 0, (int) $instance['number'] ) );
+
+		// We need to query at least one post to determine whether an author has written any posts or not
+		$query_number = max( $instance['number'], 1 );
+
+		$authors = get_users( array(
+			'fields' => 'all',
+			'who' => 'authors'
+		) );
+
+		echo $args['before_widget'];
+		echo $args['before_title'] . esc_html( $instance['title'] ) . $args['after_title'];
+		echo '<ul>';
+
+		foreach ( $authors as $author ) {
+			$r = new WP_Query( array(
+				'author'         => $author->ID,
+				'posts_per_page' => $query_number,
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'no_found_rows'  => true,
+			) );
+
+			if ( ! $r->have_posts() && ! $instance['all'] )
+				continue;
+
+			echo '<li>';
+
+			// Display avatar and author name
+			if ( $r->have_posts() ) {
+				echo '<a href="' . get_author_posts_url( $author->ID ) . '">';
+
+				if ( $instance['avatar_size'] > 1 )
+					echo ' ' . get_avatar( $author->ID, $instance['avatar_size'], '', true ) . ' ';
+
+				echo '<strong>' . esc_html( $author->display_name ) . '</strong>';
+				echo '</a>';
+			}
+			else if ( $instance['all'] ) {
+				if ( $instance['avatar_size'] > 1 )
+					echo get_avatar( $author->ID, $instance['avatar_size'], '', true ) . ' ';
+
+				echo '<strong>' . esc_html( $author->display_name ) . '</strong>';
+			}
+
+			if ( 0 == $instance['number'] ) {
+				echo '</li>';
+				continue;
+			}
+
+			// Display a short list of recent posts for this author
+
+
+			if ( $r->have_posts() ){
+				echo '<ul>';
+
+				while ( $r->have_posts() ) {
+					$r->the_post();
+					echo '<li><a href="' . get_permalink() . '">';
+
+					if ( get_the_title() )
+						echo get_the_title();
+					else
+						echo get_the_ID();
+
+					echo '</a></li>';
+				}
+
+				echo '</ul>';
+			}
+
+			echo '</li>';
+		}
+
+		echo '</ul>';
+		echo $args['after_widget'];
+
+		wp_reset_postdata();
+
+		if ( '%BEG_OF_TITLE%' != $args['before_title'] )
+			wp_cache_add( $cache_bucket, ob_get_flush(), 'widget');
+
+		/** This action is documented in modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'widget_view', 'authors' );
+	}
+
+	public function form( $instance ) {
+		$instance = wp_parse_args( $instance, array( 'title' => '', 'all' => false, 'avatar_size' => 48, 'number' => 0 ) );
+
+		?>
+		<p>
+			<label>
+				<?php _e( 'Title:' ); ?>
+				<input class="widefat" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
+			</label>
+		</p>
+		<p>
+			<label>
+				<input class="checkbox" type="checkbox" <?php checked( $instance['all'] ); ?> name="<?php echo $this->get_field_name( 'all' ); ?>" />
+				<?php _e( 'Display all authors (including those who have not written any posts)' ); ?>
+			</label>
+		</p>
+		<p>
+			<label>
+				<?php _e( 'Number of posts to show for each author:' ); ?>
+				<input style="width: 50px; text-align: center;" name="<?php echo $this->get_field_name( 'number' ); ?>" type="text" value="<?php echo esc_attr( $instance['number'] ); ?>" />
+				<?php _e( '(at most 10)' ); ?>
+			</label>
+		</p>
+		<p>
+			<label>
+				<?php _e( 'Avatar Size (px):' ); ?>
+				<select name="<?php echo $this->get_field_name( 'avatar_size' ); ?>">
+					<?php foreach( array( '1' => __( 'No Avatars' ), '16' => '16x16', '32' => '32x32', '48' => '48x48', '96' => '96x96', '128' => '128x128' ) as $value => $label ) { ?>
+						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $instance['avatar_size'] ); ?>><?php echo esc_html( $label ); ?></option>
+					<?php } ?>
+				</select>
+			</label>
+		</p>
+		<?php
+	}
+
+	public function update( $new_instance, $old_instance ) {
+		$new_instance['title'] = strip_tags( $new_instance['title'] );
+		$new_instance['all'] = isset( $new_instance['all'] );
+		$new_instance['number'] = (int) $new_instance['number'];
+		$new_instance['avatar_size'] = (int) $new_instance['avatar_size'];
+
+		Widget_Authors::flush_cache();
+
+		return $new_instance;
+	}
+}
+
+add_action( 'widgets_init', function () {
+	register_widget( 'Widget_Authors' );
+} );

--- a/modules/widgets/authors.php
+++ b/modules/widgets/authors.php
@@ -14,7 +14,7 @@ class Widget_Authors extends WP_Widget {
 			'authors',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', __( 'Authors', 'jetpack' ) ),
-			array( 'classname' => 'widget_authors', 'description' => __( 'Display blogs authors with avatars and recent posts.' ) ),
+			array( 'classname' => 'widget_authors', 'description' => __( 'Display blogs authors with avatars and recent posts.', 'jetpack' ) ),
 			array( 'width' => 300 )
 		);
 
@@ -42,7 +42,7 @@ class Widget_Authors extends WP_Widget {
 			ob_start();
 		}
 
-		$instance = wp_parse_args( $instance, array( 'title' => __( 'Authors' ), 'all' => false, 'number' => 5, 'avatar_size' => 48 ) );
+		$instance = wp_parse_args( $instance, array( 'title' => __( 'Authors', 'jetpack' ), 'all' => false, 'number' => 5, 'avatar_size' => 48 ) );
 		$instance['number'] = min( 10, max( 0, (int) $instance['number'] ) );
 
 		// We need to query at least one post to determine whether an author has written any posts or not
@@ -135,28 +135,28 @@ class Widget_Authors extends WP_Widget {
 		?>
 		<p>
 			<label>
-				<?php _e( 'Title:' ); ?>
+				<?php _e( 'Title:', 'jetpack' ); ?>
 				<input class="widefat" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
 			</label>
 		</p>
 		<p>
 			<label>
 				<input class="checkbox" type="checkbox" <?php checked( $instance['all'] ); ?> name="<?php echo $this->get_field_name( 'all' ); ?>" />
-				<?php _e( 'Display all authors (including those who have not written any posts)' ); ?>
+				<?php _e( 'Display all authors (including those who have not written any posts)', 'jetpack' ); ?>
 			</label>
 		</p>
 		<p>
 			<label>
-				<?php _e( 'Number of posts to show for each author:' ); ?>
+				<?php _e( 'Number of posts to show for each author:', 'jetpack' ); ?>
 				<input style="width: 50px; text-align: center;" name="<?php echo $this->get_field_name( 'number' ); ?>" type="text" value="<?php echo esc_attr( $instance['number'] ); ?>" />
-				<?php _e( '(at most 10)' ); ?>
+				<?php _e( '(at most 10)', 'jetpack' ); ?>
 			</label>
 		</p>
 		<p>
 			<label>
-				<?php _e( 'Avatar Size (px):' ); ?>
+				<?php _e( 'Avatar Size (px):', 'jetpack' ); ?>
 				<select name="<?php echo $this->get_field_name( 'avatar_size' ); ?>">
-					<?php foreach( array( '1' => __( 'No Avatars' ), '16' => '16x16', '32' => '32x32', '48' => '48x48', '96' => '96x96', '128' => '128x128' ) as $value => $label ) { ?>
+					<?php foreach( array( '1' => __( 'No Avatars', 'jetpack' ), '16' => '16x16', '32' => '32x32', '48' => '48x48', '96' => '96x96', '128' => '128x128' ) as $value => $label ) { ?>
 						<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $instance['avatar_size'] ); ?>><?php echo esc_html( $label ); ?></option>
 					<?php } ?>
 				</select>


### PR DESCRIPTION
Adds the authors widget from wpcom. 

There was no stylesheet included in wordpress.com, because this widget is styled on a theme-by-theme basis.  We have some styles for the widget included in twentyfourteen compat files, but none other.  It seems this is consistent with wpcom, but pasting a screenshot anyway of how it looks in twentyfifteen.

![screen shot 2016-12-06 at 3 10 48 pm](https://cloud.githubusercontent.com/assets/7129409/20941801/34678ea2-bbc6-11e6-97d5-32cb2ea17c56.png)

To test: 
- Make sure the behavior here is the same as in wpcom when using the widget.  
- https://en.support.wordpress.com/widgets/authors-widget/
- PLease test the wpcom patch as well D3595 

Also thanks to @jeherve's great suggestions, there has been some added functionality and customizability: 
- New filter `jetpack_widget_authors_exclude` for excluding specific authors
- New filter `jetpack_widget_authors_post_types` for customizing which post types are displayed
- added selective refresh support
- hiding posts that have passwords
- namespaced the class name


