### PR TITLE
Add Jumpstart status REST API endpoint

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -233,19 +233,19 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		// Return current Jumpstart status
 		register_rest_route( 'jetpack/v4', '/jumpstart', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::jumpstart_status',
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => __CLASS__ . '::jumpstart_status',
 			'permission_callback' => __CLASS__ . '::update_settings_permission_check',
 		) );
 
 		// Update Jumpstart
 		register_rest_route( 'jetpack/v4', '/jumpstart', array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::jumpstart_toggle',
+			'methods'             => WP_REST_Server::EDITABLE,
+			'callback'            => __CLASS__ . '::jumpstart_toggle',
 			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
-			'args' => array(
+			'args'                => array(
 				'active' => array(
-					'required' => true,
+					'required'          => true,
 					'validate_callback' => __CLASS__  . '::validate_boolean',
 				),
 			),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -231,7 +231,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
 		) );
 
-		// Jumpstart
+		// Return current Jumpstart status
+		register_rest_route( 'jetpack/v4', '/jumpstart', array(
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => __CLASS__ . '::jumpstart_status',
+			'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+		) );
+
+		// Update Jumpstart
 		register_rest_route( 'jetpack/v4', '/jumpstart', array(
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::jumpstart_toggle',
@@ -825,6 +832,19 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return new WP_Error( 'required_param', esc_html__( 'Missing parameter "type".', 'jetpack' ), array( 'status' => 404 ) );
+	}
+
+	/**
+	 * Retrieves the current status of Jumpstart.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @return bool
+	 */
+	public static function jumpstart_status() {
+		return array(
+			'status' => Jetpack_Options::get_option( 'jumpstart' )
+		);
 	}
 
 	/**

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -356,6 +356,42 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test permission to read and manage Jetpack Jumpstart.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_read_manage_jumpstart_permission() {
+
+		// Current user doesn't have credentials, so checking permissions should fail
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::manage_modules_permission_check() );
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::update_settings_permission_check() );
+
+		// Create a user
+		$user = $this->create_and_get_user();
+
+		// Add Jetpack capability
+		$user->add_cap( 'jetpack_configure_modules' );
+
+		// Setup global variables so this is the current user
+		wp_set_current_user( $user->ID );
+
+		// User is not admin, so this should still fail
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::manage_modules_permission_check() );
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::update_settings_permission_check() );
+
+		// Set user as admin
+		$user->set_role( 'administrator' );
+
+		// Reset user and setup globals again to reflect the role change.
+		wp_set_current_user( 0 );
+		wp_set_current_user( $user->ID );
+
+		// User has the capability and is connected so this should work this time
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::manage_modules_permission_check() );
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::update_settings_permission_check() );
+	}
+
+	/**
 	 * Test information about connection status.
 	 *
 	 * @since 4.4.0
@@ -734,6 +770,41 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'jetpack_holiday_snow_enabled', $response_data );
 		$this->assertTrue( $response_data['jetpack_holiday_snow_enabled'] );
 
+	}
+
+	/**
+	 * Test fetching current Jumpstart status when not authenticated.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_fetch_current_jumpstart_status_noauth() {
+		// Create REST request in JSON format and dispatch
+		$response = $this->create_and_get_request( 'jumpstart', array(), 'GET' );
+
+		// Fails because user is not authenticated
+		$this->assertResponseStatus( 401, $response );
+		$this->assertResponseData( array( 'code' => 'invalid_user_permission_manage_settings' ), $response );
+	}
+
+	/**
+	 * Test fetching and managing Jumpstart when authenticated.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_fetch_manage_current_jumpstart_status_auth() {
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_configure_modules' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		// Test retrieval of current Jumpstart status
+		$response = $this->create_and_get_request( 'jumpstart', 'GET' );
+		$this->assertResponseStatus( 200, $response );
+
+		// Test deactivation of Jumpstart
+		$response = $this->create_and_get_request( 'jumpstart', array( 'active' => false ), 'POST' );
+		$this->assertResponseStatus( 200, $response );
 	}
 
 } // class end


### PR DESCRIPTION
This PR introduces a simple endpoint for retrieving current Jumpstart status. Includes tests.

We will eventually use this endpoint in Calypso for enabling the Jumpstart functionality there. So in addition to being able to run the currently existing jumpstart endpoint, we'll need the current status in order to determine whether the Jumpstart functionality should be available or not. Already merged PR that relies on this endpoint can be found here: https://github.com/Automattic/wp-calypso/pull/9868. 

To test:

* Checkout this branch.
* Verify all tests pass ✅ .