### PR TITLE
Admin - Dev Mode: fix requests that fail

### DIFF
--- a/_inc/client/components/data/query-connect-url/index.jsx
+++ b/_inc/client/components/data/query-connect-url/index.jsx
@@ -1,36 +1,40 @@
 /**
  * External dependencies
  */
-import { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
  */
-import { fetchConnectUrl } from 'state/connection';
+import {
+	fetchConnectUrl,
+	isFetchingConnectUrl
+} from 'state/connection';
+import { isDevMode } from 'state/connection';
 
-class QueryConnectUrl extends Component {
+export const QueryConnectUrl = React.createClass( {
 	componentWillMount() {
-		this.props.fetchConnectUrl();
-	}
+		if ( ! ( this.props.isFetchingConnectUrl || this.props.isDevMode ) ) {
+			this.props.fetchConnectUrl();
+		}
+	},
 
 	render() {
 		return null;
 	}
-}
+} );
 
-QueryConnectUrl.defaultProps = {
-	fetchConnectUrl: () => {}
-};
-
-export default connect( () => {
-	return {
-		fetchConnectUrl: fetchConnectUrl()
-	};
-}, ( dispatch ) => {
-	return bindActionCreators( {
-		fetchConnectUrl
-	}, dispatch );
-}
+export default connect(
+	( state ) => {
+		return {
+			isFetchingConnectUrl: isFetchingConnectUrl( state ),
+			isDevMode: isDevMode( state )
+		};
+	},
+	( dispatch ) => {
+		return {
+			fetchConnectUrl: () => dispatch( fetchConnectUrl() )
+		}
+	}
 )( QueryConnectUrl );

--- a/_inc/client/components/data/query-site/index.jsx
+++ b/_inc/client/components/data/query-site/index.jsx
@@ -11,10 +11,11 @@ import {
 	fetchSiteData,
 	isFetchingSiteData
 } from 'state/site';
+import { isDevMode } from 'state/connection';
 
 export const QuerySite = React.createClass( {
 	componentDidMount() {
-		if ( ! this.props.isFetchingSiteData ) {
+		if ( ! ( this.props.isFetchingSiteData || this.props.isDevMode ) ) {
 			this.props.fetchSiteData();
 		}
 	},
@@ -27,7 +28,8 @@ export const QuerySite = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			isFetchingSiteData: isFetchingSiteData( state )
+			isFetchingSiteData: isFetchingSiteData( state ),
+			isDevMode: isDevMode( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/components/data/query-user-connection/index.jsx
+++ b/_inc/client/components/data/query-user-connection/index.jsx
@@ -1,36 +1,40 @@
 /**
  * External dependencies
  */
-import { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
  */
-import { fetchUserConnectionData } from 'state/connection';
+import {
+	fetchUserConnectionData,
+	isFetchingUserData
+} from 'state/connection';
+import { isDevMode } from 'state/connection';
 
-class QueryUserConnectionData extends Component {
+export const QueryUserConnectionData = React.createClass( {
 	componentWillMount() {
-		this.props.fetchUserConnectionData();
-	}
+		if ( ! ( this.props.isFetchingUserData || this.props.isDevMode ) ) {
+			this.props.fetchUserConnectionData();
+		}
+	},
 
 	render() {
 		return null;
 	}
-}
+} );
 
-QueryUserConnectionData.defaultProps = {
-	fetchSiteConnectionStatus: () => {}
-};
-
-export default connect( () => {
-	return {
-		fetchUserConnectionData: fetchUserConnectionData()
-	};
-}, ( dispatch ) => {
-	return bindActionCreators( {
-		fetchUserConnectionData
-	}, dispatch );
-}
+export default connect(
+	( state ) => {
+		return {
+			isFetchingUserData: isFetchingUserData( state ),
+			isDevMode: isDevMode( state )
+		};
+	},
+	( dispatch ) => {
+		return {
+			fetchUserConnectionData: () => dispatch( fetchUserConnectionData() )
+		}
+	}
 )( QueryUserConnectionData );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -118,11 +118,11 @@ export function userIsMaster( state ) {
 }
 
 export function getUserWpComLogin( state ) {
-	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'login' ] );
+	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'login' ], '' );
 }
 
 export function getUserWpComEmail( state ) {
-	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'email' ] );
+	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'email' ], '' );
 }
 
 export function getUserWpComAvatar( state ) {


### PR DESCRIPTION
There are some requests that return a bad response status, and while we don't take them into account at those times it's better if we don't initiate them at all for a performance improvement.
They're specifically 3:
in At a Glance, `jetpack/v4/connection/url` and `jetpack/v4/site`. In Settings, expanding Connection Settings, `jetpack/v4/connection/data`. Additionally when this card is open there are warnings issued in the JS Console.

<img width="618" alt="captura de pantalla 2016-12-07 a las 11 14 16" src="https://cloud.githubusercontent.com/assets/1041600/20971002/9f9f2db2-bc6e-11e6-97df-d8c49dac54bf.png">

#### Changes proposed in this Pull Request:
- don't query site because it doesn't have an ID in dev mode so the request to wordpress.com will not be performed.

- don't query connect url because it's not possible to connect and it throws an error

- don't query user connection data because in Dev Mode the capability 'jetpack_connect_user' is mapped to 'do_not_allow'. No user has this capability and it causes the endpoint to return a error regarding permissions.

- return an empty value if no data is found because they're required props in ConnectionSettings.

#### Testing instructions:
* Test site in Dev Mode and verify that none of these bad requests is issued and that everything works normally.
* Test site in connected mode and verify that these requests are issued and everything works normally.