### PR TITLE
Sync: Add a passing test that shows how to prevent shortcodes from expanding

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -178,10 +178,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$post->post_password = 'auto-' . wp_generate_password( 10, false );
 		}
 
-		$default_removed_shortcodes = array(
-			'gallery' => $shortcode_tags['gallery'],
-			'slideshow' => $shortcode_tags['slideshow'],
-		);
 		/**
 		 * Filter that is used to not expand some type of shortcodes.
 		 *
@@ -190,20 +186,24 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 *
 		 * @since 4.5.0
 		 *
-		 * @param array associative array of shortcode tags and callbacks.
+		 * @param array of shortcode tags to remove.
 		 */
-		$shortcodes_to_remove  = apply_filters( 'jetpack_sync_do_not_expand_shortcode', $default_removed_shortcodes );
-		foreach( $shortcodes_to_remove as $shortcode => $callback ) {
-			remove_shortcode( $shortcode );
+		$shortcodes_to_remove = apply_filters( 'jetpack_sync_do_not_expand_shortcodes', array( 'gallery', 'slideshow' ) );
+		foreach ( $shortcodes_to_remove as $shortcode ) {
+			if ( isset ( $shortcode_tags[ $shortcode ] )  ) {
+				$shortcodes_and_callbacks_to_remove[ $shortcode ] =  $shortcode_tags[ $shortcode ];
+			}
 		}
+
+		array_map( 'remove_shortcode' , array_keys( $shortcodes_and_callbacks_to_remove ) );
+
 		/** This filter is already documented in core. wp-includes/post-template.php */
 		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) && $post_type->public  ) {
-
 			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
 			$post->post_excerpt_filtered   = apply_filters( 'the_excerpt', $post->post_excerpt );
 		}
 
-		foreach( $shortcodes_to_remove as $shortcode => $callback ) {
+		foreach ( $shortcodes_and_callbacks_to_remove as $shortcode => $callback ) {
 			add_shortcode( $shortcode, $callback );
 		}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -177,12 +177,29 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( 0 < strlen( $post->post_password ) ) {
 			$post->post_password = 'auto-' . wp_generate_password( 10, false );
 		}
-		
+		/**
+		 * Filter that is used to not expand some type of shortcodes.
+		 *
+		 * Since we can can expand some type of shortcode better on the .com side and make the
+		 * expansion more relevant to contexts. For example [galleries] and subscription emails
+		 *
+		 * @since 4.5.0
+		 *
+		 * @param array associative array of shortcode tags and callbacks.
+		 */
+		$shortcodes_to_remove  = apply_filters( 'jetpack_sync_do_not_expand_shortcode', array() );
+		foreach( $shortcodes_to_remove as $shortcode => $callback ) {
+			remove_shortcode( $shortcode );
+		}
 		/** This filter is already documented in core. wp-includes/post-template.php */
 		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) && $post_type->public  ) {
 
 			$post->post_content_filtered   = apply_filters( 'the_content', $post->post_content );
 			$post->post_excerpt_filtered   = apply_filters( 'the_excerpt', $post->post_excerpt );
+		}
+
+		foreach( $shortcodes_to_remove as $shortcode => $callback ) {
+			add_shortcode( $shortcode, $callback );
 		}
 
 		$this->add_embed();

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -181,8 +181,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$default_removed_shortcodes = array(
 			'gallery' => $shortcode_tags['gallery'],
 			'slideshow' => $shortcode_tags['slideshow'],
-			'contact-form' => array( 'Grunion_Contact_Form', 'parse' ),
-			'contact-field' => array( 'Grunion_Contact_Form', 'parse_contact_field' )
 		);
 		/**
 		 * Filter that is used to not expand some type of shortcodes.

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -133,7 +133,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	// Expands wp_insert_post to include filtered content
 	function filter_post_content_and_add_links( $post_object ) {
-		global $post;
+		global $post, $shortcode_tags;
 		$post = $post_object;
 
 		// return non existant post 
@@ -177,6 +177,13 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( 0 < strlen( $post->post_password ) ) {
 			$post->post_password = 'auto-' . wp_generate_password( 10, false );
 		}
+
+		$default_removed_shortcodes = array(
+			'gallery' => $shortcode_tags['gallery'],
+			'slideshow' => $shortcode_tags['slideshow'],
+			'contact-form' => array( 'Grunion_Contact_Form', 'parse' ),
+			'contact-field' => array( 'Grunion_Contact_Form', 'parse_contact_field' )
+		);
 		/**
 		 * Filter that is used to not expand some type of shortcodes.
 		 *
@@ -187,7 +194,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 *
 		 * @param array associative array of shortcode tags and callbacks.
 		 */
-		$shortcodes_to_remove  = apply_filters( 'jetpack_sync_do_not_expand_shortcode', array() );
+		$shortcodes_to_remove  = apply_filters( 'jetpack_sync_do_not_expand_shortcode', $default_removed_shortcodes );
 		foreach( $shortcodes_to_remove as $shortcode => $callback ) {
 			remove_shortcode( $shortcode );
 		}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -326,8 +326,9 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_sync_post_filter_do_not_expand_jetpack_shortcodes() {
-		add_filter( 'jetpack_sync_do_not_expand_shortcode', array( $this, 'do_not_expand_shortcode' ) );
+		add_filter( 'jetpack_sync_do_not_expand_shortcodes', array( $this, 'do_not_expand_shortcode' ) );
 		add_shortcode( 'foo', array( $this, 'foo_shortcode' ) );
+
 		$this->post->post_content = "[foo]";
 
 		wp_update_post( $this->post );
@@ -341,7 +342,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function do_not_expand_shortcode( $shortcodes ) {
-		$shortcodes['foo'] = array( $this, 'foo_shortcode' );
+		$shortcodes[] = 'foo';
 		return $shortcodes;
 	}
 


### PR DESCRIPTION
part of #869

#### Changes proposed in this Pull Request:
Add a filter that lets us not expand some shortcode because we can expand them later at a different time from .com. 

#### Testing instructions:
* Do the unit tests pass? 
* Do the data that comes in to the .com shadow site reflect what we want to see? 

Adds a filter that can be used to filter out some type of shortcodes
that can be expanded on the .com side in a more relevant context.