### PR TITLE
Fix: Jetpack svg on user connected list for IE11

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6203,6 +6203,10 @@ p {
 				.fixed .column-user_jetpack {
 					width: 21px;
 				}
+				.jp-emblem-user-admin svg {
+					width: 20px;
+					height: 20px;
+				}
 				.jp-emblem-user-admin path {
 					fill: #8cc258;
 				}


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/5725

IE11 Before:
![screen shot 2016-11-19 at 11 11 32 am](https://cloud.githubusercontent.com/assets/1126811/20457205/840ffd50-ae4b-11e6-8247-1c935a907a19.png)

IE11 After:
<img width="360" alt="screen shot 2016-12-07 at 3 54 12 pm" src="https://cloud.githubusercontent.com/assets/214813/20986240/c3ca9e84-bc95-11e6-8fb8-45af1b198bd1.png">

#trashpickup
cc @ebinnion 