### PR TITLE
Add Content Options module

### DIFF
--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -15,6 +15,7 @@ $tools = array(
 	'theme-tools/site-logo.php',
 	'theme-tools/site-breadcrumbs.php',
 	'theme-tools/social-menu.php',
+	'theme-tools/content-options.php',
 	'custom-post-types/comics.php',
 	'custom-post-types/testimonial.php',
 	'custom-post-types/nova.php',

--- a/modules/theme-tools/content-options.php
+++ b/modules/theme-tools/content-options.php
@@ -74,9 +74,9 @@ function jetpack_featured_images_get_settings() {
 	);
 
 	$settings        = array_merge( $settings, array(
-        'archive-option'  => get_option( 'jetpack_content_featured_images_archive', $settings['archive-default'] ),
-        'post-option'     => get_option( 'jetpack_content_featured_images_post', $settings['post-default'] ),
-        'page-option'     => get_option( 'jetpack_content_featured_images_page', $settings['page-default'] ),
+		'archive-option'  => get_option( 'jetpack_content_featured_images_archive', $settings['archive-default'] ),
+		'post-option'     => get_option( 'jetpack_content_featured_images_post', $settings['post-default'] ),
+		'page-option'     => get_option( 'jetpack_content_featured_images_page', $settings['page-default'] ),
 	) );
 
 	return $settings;

--- a/modules/theme-tools/content-options.php
+++ b/modules/theme-tools/content-options.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Content Options.
+ *
+ * This feature will only be activated for themes that declare their support.
+ * This can be done by adding code similar to the following during the
+ * 'after_setup_theme' action:
+ *
+	add_theme_support( 'jetpack-content-options', array(
+		'blog-display'       => 'content', // the default setting of the theme: 'content', 'excerpt' or array( 'content', 'excerpt' ) for themes mixing both display.
+		'author-bio'         => true, // display or not the author bio: true or false.
+		'author-bio-default' => false, // the default setting of the author bio, if it's being displayed or not: true or false (only required if false).
+		'masonry'            => '.site-main', // a CSS selector matching the elements that triggers a masonry refresh if the theme is using a masonry layout.
+		'post-details'       => array(
+			'stylesheet'      => 'themeslug-style', // name of the theme's stylesheet.
+			'date'            => '.posted-on', // a CSS selector matching the elements that display the post date.
+			'categories'      => '.cat-links', // a CSS selector matching the elements that display the post categories.
+			'tags'            => '.tags-links', // a CSS selector matching the elements that display the post tags.
+			'author'          => '.byline', // a CSS selector matching the elements that display the post author.
+		),
+		'featured-images'    => array(
+			'archive'         => true, // enable or not the featured image check for archive pages: true or false.
+			'archive-default' => false, // the default setting of the featured image on archive pages, if it's being displayed or not: true or false (only required if false).
+			'post'            => true, // enable or not the featured image check for single posts: true or false.
+			'post-default'    => false, // the default setting of the featured image on single posts, if it's being displayed or not: true or false (only required if false).
+			'page'            => true, // enable or not the featured image check for single pages: true or false.
+			'page-default'    => false, // the default setting of the featured image on single pages, if it's being displayed or not: true or false (only required if false).
+		),
+	) );
+ *
+ */
+
+/**
+ * Activate the Content Options plugin.
+ *
+ * @uses current_theme_supports()
+ */
+function jetpack_content_options_init() {
+	// If the theme doesn't support 'jetpack-content-options', don't continue.
+	if ( ! current_theme_supports( 'jetpack-content-options' ) ) {
+		return;
+	}
+
+	// Load the Customizer options.
+	require( dirname( __FILE__ ) . '/content-options/customizer.php' );
+
+	// Load Blog Display function.
+	require( dirname( __FILE__ ) . '/content-options/blog-display.php' );
+
+	// Load Author Bio function.
+	require( dirname( __FILE__ ) . '/content-options/author-bio.php' );
+
+	// Load Post Details function.
+	require( dirname( __FILE__ ) . '/content-options/post-details.php' );
+
+	// Load Featured Images function.
+	if ( jetpack_featured_images_should_load() ) {
+		require( dirname( __FILE__ ) . '/content-options/featured-images.php' );
+	}
+}
+add_action( 'init', 'jetpack_content_options_init' );
+
+function jetpack_featured_images_get_settings() {
+	$options         = get_theme_support( 'jetpack-content-options' );
+	$featured_images = ( ! empty( $options[0]['featured-images'] ) ) ? $options[0]['featured-images'] : null;
+
+	$settings        = array(
+		'archive'         => ( ! empty( $featured_images['archive'] ) ) ? $featured_images['archive'] : null,
+		'post'            => ( ! empty( $featured_images['post'] ) ) ? $featured_images['post'] : null,
+		'page'            => ( ! empty( $featured_images['page'] ) ) ? $featured_images['page'] : null,
+		'archive-default' => ( isset( $featured_images['archive-default'] ) && false === $featured_images['archive-default'] ) ? '' : 1,
+		'post-default'    => ( isset( $featured_images['post-default'] ) && false === $featured_images['post-default'] ) ? '' : 1,
+		'page-default'    => ( isset( $featured_images['page-default'] ) && false === $featured_images['page-default'] ) ? '' : 1,
+	);
+
+	$settings        = array_merge( $settings, array(
+        'archive-option'  => get_option( 'jetpack_content_featured_images_archive', $settings['archive-default'] ),
+        'post-option'     => get_option( 'jetpack_content_featured_images_post', $settings['post-default'] ),
+        'page-option'     => get_option( 'jetpack_content_featured_images_page', $settings['page-default'] ),
+	) );
+
+	return $settings;
+}
+
+function jetpack_featured_images_should_load() {
+	$opts = jetpack_featured_images_get_settings();
+
+	// If the theme doesn't support archive, post and page or if all the options are ticked, don't continue.
+	if ( ( true !== $opts['archive'] && true !== $opts['post'] && true !== $opts['page'] )
+		|| ( 1 === $opts['archive-option'] && 1 === $opts['post-option'] && 1 === $opts['page-option'] ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/modules/theme-tools/content-options/author-bio.php
+++ b/modules/theme-tools/content-options/author-bio.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * The function to display Author Bio in a theme.
+ */
+function jetpack_author_bio() {
+	// If the theme doesn't support 'jetpack-content-options', don't continue.
+	if ( ! current_theme_supports( 'jetpack-content-options' ) ) {
+		return;
+	}
+
+	$options            = get_theme_support( 'jetpack-content-options' );
+	$author_bio         = ( ! empty( $options[0]['author-bio'] ) ) ? $options[0]['author-bio'] : null;
+	$author_bio_default = ( isset( $options[0]['author-bio-default'] ) && false === $options[0]['author-bio-default'] ) ? '' : 1;
+
+	// If the theme doesn't support 'jetpack-content-options[ 'author-bio' ]', don't continue.
+	if ( true !== $author_bio ) {
+		return;
+	}
+
+	// If 'jetpack_content_author_bio' is false, don't continue.
+	if ( ! get_option( 'jetpack_content_author_bio', $author_bio_default ) ) {
+		return;
+	}
+
+	// If we aren't on a single post, don't continue.
+	if ( ! is_single() ) {
+		return;
+	}
+?>
+	<div class="entry-author">
+		<div class="author-avatar">
+			<?php
+			/**
+			 * Filter the author bio avatar size.
+			 *
+			 * @param int $size The avatar height and width size in pixels.
+			 */
+			$author_bio_avatar_size = apply_filters( 'jetpack_author_bio_avatar_size', 48 );
+
+			echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );
+			?>
+		</div><!-- .author-avatar -->
+
+		<div class="author-heading">
+			<h2 class="author-title"><?php printf( esc_html__( 'Published by %s', 'jetpack' ), '<span class="author-name">' . get_the_author() . '</span>' ); ?></h2>
+		</div><!-- .author-heading -->
+
+		<p class="author-bio">
+			<?php the_author_meta( 'description' ); ?>
+			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+				<?php printf( esc_html__( 'View all posts by %s', 'jetpack' ), get_the_author() ); ?>
+			</a>
+		</p><!-- .author-bio -->
+	</div><!-- .entry-auhtor -->
+<?php
+}

--- a/modules/theme-tools/content-options/author-bio.php
+++ b/modules/theme-tools/content-options/author-bio.php
@@ -34,6 +34,10 @@ function jetpack_author_bio() {
 			 * Filter the author bio avatar size.
 			 *
 			 * @param int $size The avatar height and width size in pixels.
+			 *
+			 * @module theme-tools
+			 *
+			 * @since 4.5.0
 			 */
 			$author_bio_avatar_size = apply_filters( 'jetpack_author_bio_avatar_size', 48 );
 

--- a/modules/theme-tools/content-options/blog-display.php
+++ b/modules/theme-tools/content-options/blog-display.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * The functions to display Content or Excerpt in a theme.
+ */
+
+/**
+ * If the theme doesn't support 'jetpack-content-options', don't continue.
+ */
+if ( ! current_theme_supports( 'jetpack-content-options' ) ) {
+	return;
+}
+
+/**
+ * Get the Blog Display setting.
+ * If theme is using both 'Content' and 'Excerpt' then this setting will be called 'Mixed'.
+ */
+$options      = get_theme_support( 'jetpack-content-options' );
+$blog_display = ( ! empty( $options[0]['blog-display'] ) ) ? $options[0]['blog-display'] : null;
+$blog_display = preg_grep( '/^(content|excerpt)$/', (array) $blog_display );
+sort( $blog_display );
+$blog_display = implode( ', ', $blog_display );
+$blog_display = ( 'content, excerpt' === $blog_display ) ? 'mixed' : $blog_display;
+
+/**
+ * If the theme doesn't support 'jetpack-content-options[ 'blog-display' ]', don't continue.
+ */
+if ( ! in_array( $blog_display, array( 'content', 'excerpt', 'mixed' ) ) ) {
+	return;
+}
+
+/**
+ * Apply Content filters.
+ */
+function jetpack_blog_display_custom_excerpt( $content ) {
+	$post = get_post();
+	if ( empty( $post->post_excerpt ) ) {
+		$text = strip_shortcodes( $post->post_content );
+		$text = str_replace( ']]>', ']]&gt;', $text );
+		$text = strip_tags( $text );
+		$excerpt_length = apply_filters( 'excerpt_length', 55 );
+		$excerpt_more = apply_filters( 'excerpt_more', ' ' . '[...]' );
+		$words = preg_split( "/[\n\r\t ]+/", $text, $excerpt_length + 1, PREG_SPLIT_NO_EMPTY );
+		if ( count( $words ) > $excerpt_length ) {
+			array_pop( $words );
+			$text = implode( ' ', $words );
+			$text = $text . $excerpt_more;
+		} else {
+			$text = implode( ' ', $words );
+		}
+	} else {
+		$text = wp_kses_post( $post->post_excerpt );
+	}
+	return sprintf( '<p>%s</p>', $text );
+}
+
+/**
+ * Display Excerpt instead of Content.
+ */
+function jetpack_the_content_to_the_excerpt( $content ) {
+	if ( is_home() || is_archive() ) {
+		if ( post_password_required() ) {
+			$content = sprintf( '<p>%s</p>', esc_html__( 'There is no excerpt because this is a protected post.' ) );
+		} else {
+			$content = jetpack_blog_display_custom_excerpt( $content );
+		}
+	}
+	return $content;
+}
+
+/**
+ * Display Content instead of Excerpt.
+ */
+function jetpack_the_excerpt_to_the_content( $content ) {
+	if ( is_home() || is_archive() ) {
+		ob_start();
+		the_content( sprintf(
+			/* translators: %s: Name of current post. */
+			wp_kses( __( 'Continue reading %s <span class="meta-nav">&rarr;</span>', 'jetpack' ), array( 'span' => array( 'class' => array() ) ) ),
+			the_title( '<span class="screen-reader-text">"', '"</span>', false )
+		) );
+		$content = ob_get_clean();
+	}
+	return $content;
+}
+
+/**
+ * Display both Content and Excerpt instead of Content in the Customizer so live preview can switch between them.
+ */
+function jetpack_the_content_customizer( $content ) {
+	$class = jetpack_the_content_customizer_class();
+	if ( is_home() || is_archive() ) {
+		if ( post_password_required() ) {
+			$excerpt = sprintf( '<p>%s</p>', esc_html__( 'There is no excerpt because this is a protected post.' ) );
+		} else {
+			$excerpt = jetpack_blog_display_custom_excerpt( $content );
+		}
+	}
+	if ( empty( $excerpt ) ) {
+		return $content;
+	} else {
+		return sprintf( '<div class="jetpack-blog-display %s jetpack-the-content">%s</div><div class="jetpack-blog-display %s jetpack-the-excerpt">%s</div>', $class, $content, $class, $excerpt );
+	}
+}
+
+/**
+ * Display both Content and Excerpt instead of Excerpt in the Customizer so live preview can switch between them.
+ */
+function jetpack_the_excerpt_customizer( $excerpt ) {
+	if ( is_home() || is_archive() ) {
+		ob_start();
+		the_content( sprintf(
+			/* translators: %s: Name of current post. */
+			wp_kses( __( 'Continue reading %s <span class="meta-nav">&rarr;</span>', 'jetpack' ), array( 'span' => array( 'class' => array() ) ) ),
+			the_title( '<span class="screen-reader-text">"', '"</span>', false )
+		) );
+		$content = ob_get_clean();
+	}
+	if ( empty( $content ) ) {
+		return $excerpt;
+	} else {
+		return sprintf( '<div class="jetpack-blog-display jetpack-the-content">%s</div><div class="jetpack-blog-display jetpack-the-excerpt">%s</div>', $content, $excerpt );
+	}
+}
+
+/**
+ * Display Content instead of Excerpt in the Customizer when theme uses a 'Mixed' display.
+ */
+function jetpack_the_excerpt_mixed_customizer( $content ) {
+	if ( is_home() || is_archive() ) {
+		jetpack_the_content_customizer_class( 'output-the-excerpt' );
+		ob_start();
+		the_content();
+		$content = ob_get_clean();
+	}
+	return $content;
+}
+
+/**
+ * Returns a class value, `output-the-content` by default.
+ * Used for themes with a 'Mixed' Blog Display so we can tell which output is by default.
+ */
+function jetpack_the_content_customizer_class( $new_class = null ) {
+	static $class;
+	if ( isset( $new_class ) ) {
+		// Assign a new class and return.
+		$class = $new_class;
+	} else if ( isset( $class ) ) {
+		// Reset the class after getting value.
+		$prev_class = $class;
+		$class = null;
+		return $prev_class;
+	} else {
+		// Return default class value.
+		return 'output-the-content';
+	}
+}
+
+if ( is_customize_preview() ) {
+	/*
+	 * Display Content and Excerpt if the default Blog Display is 'Content'
+	 * and we are in the Customizer.
+	 */
+	if ( 'content' === $blog_display ) {
+		add_filter( 'the_content', 'jetpack_the_content_customizer' );
+	}
+
+	/*
+	 * Display Content and Excerpt if the default Blog Display is 'Excerpt'
+	 * and we are in the Customizer.
+	 */
+	if ( 'excerpt' === $blog_display ) {
+		add_filter( 'the_excerpt', 'jetpack_the_excerpt_customizer' );
+	}
+
+	/*
+	 * Display Content and Excerpt if the default Blog Display is 'Mixed'
+	 * and we are in the Customizer.
+	 */
+	if ( 'mixed' === $blog_display ) {
+		add_filter( 'the_content', 'jetpack_the_content_customizer' );
+		add_filter( 'the_excerpt', 'jetpack_the_excerpt_mixed_customizer' );
+	}
+} else {
+	$display_option = get_option( 'jetpack_content_blog_display', $blog_display );
+
+	/*
+	 * Display Excerpt if the default Blog Display is 'Content'
+	 * or default Blog Display is 'Mixed'
+	 * and the Option picked is 'Post Excerpt'
+	 * and we aren't in the Customizer.
+	 */
+	if ( ( 'content' === $blog_display || 'mixed' === $blog_display ) && 'excerpt' === $display_option ) {
+		add_filter( 'the_content', 'jetpack_the_content_to_the_excerpt' );
+	}
+
+	/*
+	 * Display Content if the default Blog Display is 'Excerpt'
+	 * or default Blog Display is 'Mixed'
+	 * and the Option picked is 'Full Post'
+	 * and we aren't in the Customizer.
+	 */
+	if ( ( 'excerpt' === $blog_display || 'mixed' === $blog_display ) && 'content' === $display_option ) {
+		add_filter( 'the_excerpt', 'jetpack_the_excerpt_to_the_content' );
+	}
+}

--- a/modules/theme-tools/content-options/blog-display.php
+++ b/modules/theme-tools/content-options/blog-display.php
@@ -37,7 +37,9 @@ function jetpack_blog_display_custom_excerpt( $content ) {
 		$text = strip_shortcodes( $post->post_content );
 		$text = str_replace( ']]>', ']]&gt;', $text );
 		$text = strip_tags( $text );
+		/** This filter is documented in wp-includes/formatting.php */
 		$excerpt_length = apply_filters( 'excerpt_length', 55 );
+		/** This filter is documented in wp-includes/formatting.php */
 		$excerpt_more = apply_filters( 'excerpt_more', ' ' . '[...]' );
 		$words = preg_split( "/[\n\r\t ]+/", $text, $excerpt_length + 1, PREG_SPLIT_NO_EMPTY );
 		if ( count( $words ) > $excerpt_length ) {

--- a/modules/theme-tools/content-options/customizer.js
+++ b/modules/theme-tools/content-options/customizer.js
@@ -1,3 +1,5 @@
+/* global blogDisplay, postDetails */
+
 /**
  * customizer.js
  *

--- a/modules/theme-tools/content-options/customizer.js
+++ b/modules/theme-tools/content-options/customizer.js
@@ -1,0 +1,166 @@
+/**
+ * customizer.js
+ *
+ * Theme Customizer enhancements for a better user experience.
+ *
+ * Contains handlers to make Theme Customizer preview reload changes asynchronously.
+ */
+
+( function( $ ) {
+	// Blog Display
+	wp.customize( 'jetpack_content_blog_display', function( value ) {
+		if ( 'content' === blogDisplay.display ) {
+			$( '.jetpack-blog-display.jetpack-the-excerpt' ).css( {
+				'clip': 'rect(1px, 1px, 1px, 1px)',
+				'position': 'absolute'
+			} );
+			$(  '.jetpack-blog-display.jetpack-the-content' ).css( {
+				'clip': 'auto',
+				'position': 'relative'
+			} );
+		} else if ( 'excerpt' === blogDisplay.display ) {
+			$( '.jetpack-blog-display.jetpack-the-content' ).css( {
+				'clip': 'rect(1px, 1px, 1px, 1px)',
+				'position': 'absolute'
+			} );
+			$( '.jetpack-blog-display.jetpack-the-excerpt' ).css( {
+				'clip': 'auto',
+				'position': 'relative'
+			} );
+		} else if ( 'mixed' === blogDisplay.display ) {
+			$( '.jetpack-blog-display.jetpack-the-content.output-the-content' ).css( {
+				'clip': 'auto',
+				'position': 'relative'
+			} );
+			$( '.jetpack-blog-display.jetpack-the-excerpt.output-the-content' ).css( {
+				'clip': 'rect(1px, 1px, 1px, 1px)',
+				'position': 'absolute'
+			} );
+			$( '.jetpack-blog-display.jetpack-the-content.output-the-excerpt' ).css( {
+				'clip': 'rect(1px, 1px, 1px, 1px)',
+				'position': 'absolute'
+			} );
+			$( '.jetpack-blog-display.jetpack-the-excerpt.output-the-excerpt' ).css( {
+				'clip': 'auto',
+				'position': 'relative'
+			} );
+		}
+		value.bind( function( to ) {
+			if ( 'content' === to ) {
+				$( '.jetpack-blog-display.jetpack-the-excerpt' ).css( {
+					'clip': 'rect(1px, 1px, 1px, 1px)',
+					'position': 'absolute'
+				} );
+				$(  '.jetpack-blog-display.jetpack-the-content' ).css( {
+					'clip': 'auto',
+					'position': 'relative'
+				} );
+			} else if ( 'excerpt' === to ) {
+				$( '.jetpack-blog-display.jetpack-the-content' ).css( {
+					'clip': 'rect(1px, 1px, 1px, 1px)',
+					'position': 'absolute'
+				} );
+				$( '.jetpack-blog-display.jetpack-the-excerpt' ).css( {
+					'clip': 'auto',
+					'position': 'relative'
+				} );
+			} else if ( 'mixed' === to ) {
+				$( '.jetpack-blog-display.jetpack-the-content.output-the-content' ).css( {
+					'clip': 'auto',
+					'position': 'relative'
+				} );
+				$( '.jetpack-blog-display.jetpack-the-excerpt.output-the-content' ).css( {
+					'clip': 'rect(1px, 1px, 1px, 1px)',
+					'position': 'absolute'
+				} );
+				$( '.jetpack-blog-display.jetpack-the-content.output-the-excerpt' ).css( {
+					'clip': 'rect(1px, 1px, 1px, 1px)',
+					'position': 'absolute'
+				} );
+				$( '.jetpack-blog-display.jetpack-the-excerpt.output-the-excerpt' ).css( {
+					'clip': 'auto',
+					'position': 'relative'
+				} );
+			}
+			if ( blogDisplay.masonry ) {
+				$( blogDisplay.masonry ).masonry();
+			}
+		} );
+	} );
+
+	// Post Details: Date.
+	wp.customize( 'jetpack_content_post_details_date', function( value ) {
+		value.bind( function( to ) {
+			if ( false === to ) {
+				$( postDetails.date ).css( {
+					'clip': 'rect(1px, 1px, 1px, 1px)',
+					'position': 'absolute'
+				} );
+				$( 'body' ).addClass( 'date-hidden' );
+			} else {
+				$( postDetails.date ).css( {
+					'clip': 'auto',
+					'position': 'relative'
+				} );
+				$( 'body' ).removeClass( 'date-hidden' );
+			}
+		} );
+	} );
+
+	// Post Details: Categories.
+	wp.customize( 'jetpack_content_post_details_categories', function( value ) {
+		value.bind( function( to ) {
+			if ( false === to ) {
+				$( postDetails.categories ).css( {
+					'clip': 'rect(1px, 1px, 1px, 1px)',
+					'position': 'absolute'
+				} );
+				$( 'body' ).addClass( 'categories-hidden' );
+			} else {
+				$( postDetails.categories ).css( {
+					'clip': 'auto',
+					'position': 'relative'
+				} );
+				$( 'body' ).removeClass( 'categories-hidden' );
+			}
+		} );
+	} );
+
+	// Post Details: Tags.
+	wp.customize( 'jetpack_content_post_details_tags', function( value ) {
+		value.bind( function( to ) {
+			if ( false === to ) {
+				$( postDetails.tags ).css( {
+					'clip': 'rect(1px, 1px, 1px, 1px)',
+					'position': 'absolute'
+				} );
+				$( 'body' ).addClass( 'tags-hidden' );
+			} else {
+				$( postDetails.tags ).css( {
+					'clip': 'auto',
+					'position': 'relative'
+				} );
+				$( 'body' ).removeClass( 'tags-hidden' );
+			}
+		} );
+	} );
+
+	// Post Details: Author.
+	wp.customize( 'jetpack_content_post_details_author', function( value ) {
+		value.bind( function( to ) {
+			if ( false === to ) {
+				$( postDetails.author ).css( {
+					'clip': 'rect(1px, 1px, 1px, 1px)',
+					'position': 'absolute'
+				} );
+				$( 'body' ).addClass( 'author-hidden' );
+			} else {
+				$( postDetails.author ).css( {
+					'clip': 'auto',
+					'position': 'relative'
+				} );
+				$( 'body' ).removeClass( 'author-hidden' );
+			}
+		} );
+	} );
+} )( jQuery );

--- a/modules/theme-tools/content-options/customizer.php
+++ b/modules/theme-tools/content-options/customizer.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * Add Content section to the Theme Customizer.
+ *
+ * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+ */
+function jetpack_content_options_customize_register( $wp_customize ) {
+	$options            = get_theme_support( 'jetpack-content-options' );
+	$blog_display       = ( ! empty( $options[0]['blog-display'] ) ) ? $options[0]['blog-display'] : null;
+	$blog_display       = preg_grep( '/^(content|excerpt)$/', (array) $blog_display );
+	sort( $blog_display );
+	$blog_display       = implode( ', ', $blog_display );
+	$blog_display       = ( 'content, excerpt' === $blog_display ) ? 'mixed' : $blog_display;
+	$author_bio         = ( ! empty( $options[0]['author-bio'] ) ) ? $options[0]['author-bio'] : null;
+	$author_bio_default = ( isset( $options[0]['author-bio-default'] ) && false === $options[0]['author-bio-default'] ) ? '' : 1;
+	$post_details       = ( ! empty( $options[0]['post-details'] ) ) ? $options[0]['post-details'] : null;
+	$date               = ( ! empty( $post_details['date'] ) ) ? $post_details['date'] : null;
+	$categories         = ( ! empty( $post_details['categories'] ) ) ? $post_details['categories'] : null;
+	$tags               = ( ! empty( $post_details['tags'] ) ) ? $post_details['tags'] : null;
+	$author             = ( ! empty( $post_details['author'] ) ) ? $post_details['author'] : null;
+	$featured_images    = ( ! empty( $options[0]['featured-images'] ) ) ? $options[0]['featured-images'] : null;
+	$fi_archive         = ( ! empty( $featured_images['archive'] ) ) ? $featured_images['archive'] : null;
+	$fi_post            = ( ! empty( $featured_images['post'] ) ) ? $featured_images['post'] : null;
+	$fi_page            = ( ! empty( $featured_images['page'] ) ) ? $featured_images['page'] : null;
+	$fi_archive_default = ( isset( $featured_images['archive-default'] ) && false === $featured_images['archive-default'] ) ? '' : 1;
+	$fi_post_default    = ( isset( $featured_images['post-default'] ) && false === $featured_images['post-default'] ) ? '' : 1;
+	$fi_page_default    = ( isset( $featured_images['page-default'] ) && false === $featured_images['page-default'] ) ? '' : 1;
+
+	// If the theme doesn't support 'jetpack-content-options[ 'blog-display' ]', 'jetpack-content-options[ 'author-bio' ]', 'jetpack-content-options[ 'post-details' ]' and 'jetpack-content-options[ 'featured-images' ]', don't continue.
+	if ( ( ! in_array( $blog_display, array( 'content', 'excerpt', 'mixed' ) ) )
+	    && ( true !== $author_bio )
+	    && ( ( empty( $post_details['stylesheet'] ) )
+			&& ( empty( $date )
+				|| empty( $categories )
+				|| empty( $tags )
+				|| empty( $author ) ) )
+		&& ( true !== $fi_archive && true !== $fi_post && true !== $fi_page ) ) {
+	    return;
+	}
+
+	// New control type: Title.
+	class Jetpack_Customize_Control_Title extends WP_Customize_Control {
+		public $type = 'title';
+
+		public function render_content() {
+		?>
+			<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+		<?php
+		}
+	}
+
+	// Add Content section.
+	$wp_customize->add_section( 'jetpack_content_options', array(
+		'title'                        => esc_html__( 'Content Options', 'jetpack' ),
+		'theme_supports'               => 'jetpack-content-options',
+		'priority'                     => 100,
+	) );
+
+	// Add Blog Display option.
+	if ( in_array( $blog_display, array( 'content', 'excerpt', 'mixed' ) ) ) {
+		if ( 'mixed' === $blog_display ) {
+			$blog_display_choices = array(
+				'content' => esc_html__( 'Full post', 'jetpack' ),
+				'excerpt' => esc_html__( 'Post excerpt', 'jetpack' ),
+				'mixed'   => esc_html__( 'Default', 'jetpack' ),
+			);
+
+			$blog_display_description = esc_html__( 'Choose between a full post or an excerpt for the blog and archive pages, or opt for the theme\'s default combination of excerpt and full post.', 'jetpack' );
+		} else {
+			$blog_display_choices = array(
+				'content' => esc_html__( 'Full post', 'jetpack' ),
+				'excerpt' => esc_html__( 'Post excerpt', 'jetpack' ),
+			);
+
+			$blog_display_description = esc_html__( 'Choose between a full post or an excerpt for the blog and archive pages.', 'jetpack' );
+
+			if ( 'mixed' === get_option( 'jetpack_content_blog_display' ) ) {
+				update_option( 'jetpack_content_blog_display', $blog_display );
+			}
+		}
+
+		$wp_customize->add_setting( 'jetpack_content_blog_display', array(
+			'default'                  => $blog_display,
+			'type'                     => 'option',
+			'transport'                => 'postMessage',
+			'sanitize_callback'        => 'jetpack_content_options_sanitize_blog_display',
+		) );
+
+		$wp_customize->add_control( 'jetpack_content_blog_display', array(
+			'section'                  => 'jetpack_content_options',
+			'label'                    => esc_html__( 'Blog Display', 'jetpack' ),
+			'description'              => $blog_display_description,
+			'type'                     => 'radio',
+			'choices'                  => $blog_display_choices,
+		) );
+	}
+
+	// Add Author Bio option.
+	if ( true === $author_bio ) {
+		$wp_customize->add_setting( 'jetpack_content_author_bio_title' );
+
+		$wp_customize->add_control( new Jetpack_Customize_Control_Title( $wp_customize, 'jetpack_content_author_bio_title', array(
+			'section'                  => 'jetpack_content_options',
+			'label'                    => esc_html__( 'Author Bio', 'jetpack' ),
+			'type'                     => 'title',
+		) ) );
+
+		$wp_customize->add_setting( 'jetpack_content_author_bio', array(
+			'default'                  => $author_bio_default,
+			'type'                     => 'option',
+			'sanitize_callback'        => 'jetpack_content_options_sanitize_checkbox',
+		) );
+
+		$wp_customize->add_control( 'jetpack_content_author_bio', array(
+			'section'                  => 'jetpack_content_options',
+			'label'                    => esc_html__( 'Display on single posts', 'jetpack' ),
+			'type'                     => 'checkbox',
+		) );
+	}
+
+	// Add Post Details options.
+	if ( ( ! empty( $post_details ) )
+		&& ( ! empty( $post_details['stylesheet'] ) )
+		&& ( ! empty( $date )
+			|| ! empty( $categories )
+			|| ! empty( $tags )
+			|| ! empty( $author ) ) ) {
+		$wp_customize->add_setting( 'jetpack_content_post_details_title' );
+
+		$wp_customize->add_control( new Jetpack_Customize_Control_Title( $wp_customize, 'jetpack_content_post_details_title', array(
+			'section'                  => 'jetpack_content_options',
+			'label'                    => esc_html__( 'Post Details', 'jetpack' ),
+			'type'                     => 'title',
+		) ) );
+
+		// Post Details: Date
+		if ( ! empty( $date ) ) {
+			$wp_customize->add_setting( 'jetpack_content_post_details_date', array(
+				'default'              => 1,
+				'type'                 => 'option',
+				'transport'            => 'postMessage',
+				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
+			) );
+
+			$wp_customize->add_control( 'jetpack_content_post_details_date', array(
+				'section'              => 'jetpack_content_options',
+				'label'                => esc_html__( 'Display date', 'jetpack' ),
+				'type'                 => 'checkbox',
+			) );
+		}
+
+		// Post Details: Categories
+		if ( ! empty( $categories ) ) {
+			$wp_customize->add_setting( 'jetpack_content_post_details_categories', array(
+				'default'              => 1,
+				'type'                 => 'option',
+				'transport'            => 'postMessage',
+				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
+			) );
+
+			$wp_customize->add_control( 'jetpack_content_post_details_categories', array(
+				'section'              => 'jetpack_content_options',
+				'label'                => esc_html__( 'Display categories', 'jetpack' ),
+				'type'                 => 'checkbox',
+			) );
+		}
+
+		// Post Details: Tags
+		if ( ! empty( $tags ) ) {
+			$wp_customize->add_setting( 'jetpack_content_post_details_tags', array(
+				'default'              => 1,
+				'type'                 => 'option',
+				'transport'            => 'postMessage',
+				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
+			) );
+
+			$wp_customize->add_control( 'jetpack_content_post_details_tags', array(
+				'section'              => 'jetpack_content_options',
+				'label'                => esc_html__( 'Display tags', 'jetpack' ),
+				'type'                 => 'checkbox',
+			) );
+		}
+
+		// Post Details: Author
+		if ( ! empty( $author ) ) {
+			$wp_customize->add_setting( 'jetpack_content_post_details_author', array(
+				'default'              => 1,
+				'type'                 => 'option',
+				'transport'            => 'postMessage',
+				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
+			) );
+
+			$wp_customize->add_control( 'jetpack_content_post_details_author', array(
+				'section'              => 'jetpack_content_options',
+				'label'                => esc_html__( 'Display author', 'jetpack' ),
+				'type'                 => 'checkbox',
+			) );
+		}
+	}
+
+	// Add Featured Images options.
+	if ( true === $fi_archive || true === $fi_post || true === $fi_page ) {
+		$wp_customize->add_setting( 'jetpack_content_featured_images_title' );
+
+		$wp_customize->add_control( new Jetpack_Customize_Control_Title( $wp_customize, 'jetpack_content_featured_images_title', array(
+			'section'                  => 'jetpack_content_options',
+			'label'                    => esc_html__( 'Featured Images', 'jetpack' ),
+			'type'                     => 'title',
+		) ) );
+
+		// Featured Images: Archive
+		if ( true === $fi_archive ) {
+			$wp_customize->add_setting( 'jetpack_content_featured_images_archive', array(
+				'default'              => $fi_archive_default,
+				'type'                 => 'option',
+				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
+			) );
+
+			$wp_customize->add_control( 'jetpack_content_featured_images_archive', array(
+				'section'              => 'jetpack_content_options',
+				'label'                => esc_html__( 'Display on blog and archives', 'jetpack' ),
+				'type'                 => 'checkbox',
+			) );
+		}
+
+		// Featured Images: Post
+		if ( true === $fi_post ) {
+			$wp_customize->add_setting( 'jetpack_content_featured_images_post', array(
+				'default'              => $fi_post_default,
+				'type'                 => 'option',
+				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
+			) );
+
+			$wp_customize->add_control( 'jetpack_content_featured_images_post', array(
+				'section'              => 'jetpack_content_options',
+				'label'                => esc_html__( 'Display on single posts', 'jetpack' ),
+				'type'                 => 'checkbox',
+			) );
+		}
+
+		// Featured Images: Page
+		if ( true === $fi_page ) {
+			$wp_customize->add_setting( 'jetpack_content_featured_images_page', array(
+				'default'              => $fi_page_default,
+				'type'                 => 'option',
+				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
+			) );
+
+			$wp_customize->add_control( 'jetpack_content_featured_images_page', array(
+				'section'              => 'jetpack_content_options',
+				'label'                => esc_html__( 'Display on pages', 'jetpack' ),
+				'type'                 => 'checkbox',
+			) );
+		}
+	}
+}
+add_action( 'customize_register', 'jetpack_content_options_customize_register' );
+
+/**
+ * Sanitize the checkbox.
+ *
+ * @param int $input.
+ * @return boolean|string
+ */
+function jetpack_content_options_sanitize_checkbox( $input ) {
+	return ( 1 == $input ) ? 1 : '';
+}
+
+/**
+ * Sanitize the Display value.
+ *
+ * @param string $display.
+ * @return string.
+ */
+function jetpack_content_options_sanitize_blog_display( $display ) {
+	if ( ! in_array( $display, array( 'content', 'excerpt', 'mixed' ) ) ) {
+		$display = 'content';
+	}
+	return $display;
+}
+
+/**
+ * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
+ */
+function jetpack_content_options_customize_preview_js() {
+	$options      = get_theme_support( 'jetpack-content-options' );
+	$blog_display = ( ! empty( $options[0]['blog-display'] ) ) ? $options[0]['blog-display'] : null;
+	$blog_display = preg_grep( '/^(content|excerpt)$/', (array) $blog_display );
+	sort( $blog_display );
+	$blog_display = implode( ', ', $blog_display );
+	$blog_display = ( 'content, excerpt' === $blog_display ) ? 'mixed' : $blog_display;
+	$masonry      = ( ! empty( $options[0]['masonry'] ) ) ? $options[0]['masonry'] : null;
+	$post_details = ( ! empty( $options[0]['post-details'] ) ) ? $options[0]['post-details'] : null;
+	$date         = ( ! empty( $post_details['date'] ) ) ? $post_details['date'] : null;
+	$categories   = ( ! empty( $post_details['categories'] ) ) ? $post_details['categories'] : null;
+	$tags         = ( ! empty( $post_details['tags'] ) ) ? $post_details['tags'] : null;
+	$author       = ( ! empty( $post_details['author'] ) ) ? $post_details['author'] : null;
+
+	wp_enqueue_script( 'jetpack-content-options-customizer', plugins_url( 'customizer.js', __FILE__ ), array( 'customize-preview' ), '1.0', true );
+
+	wp_localize_script( 'jetpack-content-options-customizer', 'blogDisplay', array(
+		'display'    => get_option( 'jetpack_content_blog_display', $blog_display ),
+		'masonry'    => $masonry,
+	) );
+
+	wp_localize_script( 'jetpack-content-options-customizer', 'postDetails', array(
+		'date'       => $date,
+		'categories' => $categories,
+		'tags'       => $tags,
+		'author'     => $author,
+	) );
+}
+add_action( 'customize_preview_init', 'jetpack_content_options_customize_preview_js' );

--- a/modules/theme-tools/content-options/featured-images.php
+++ b/modules/theme-tools/content-options/featured-images.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * The function to prevent for Featured Images to be displayed in a theme.
+ */
+function jetpack_featured_images_remove_post_thumbnail( $metadata, $object_id, $meta_key, $single ) {
+	$opts = jetpack_featured_images_get_settings();
+
+	// Returns false if the archive option or singular option is unticked.
+	if ( ( true === $opts['archive'] && ( is_home() || is_archive() || is_search() ) && ! $opts['archive-option'] && ( isset( $meta_key ) && '_thumbnail_id' === $meta_key ) && in_the_loop() )
+		|| ( true === $opts['post'] && is_single() && ! $opts['post-option'] && ( isset( $meta_key ) && '_thumbnail_id' === $meta_key ) && in_the_loop() )
+		|| ( true === $opts['page'] && is_singular() && is_page() && ! $opts['page-option'] && ( isset( $meta_key ) && '_thumbnail_id' === $meta_key ) && in_the_loop() ) ) {
+		return false;
+	} else {
+		return $metadata;
+	}
+}
+add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', true, 4 );

--- a/modules/theme-tools/content-options/post-details.php
+++ b/modules/theme-tools/content-options/post-details.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * The function to include Post Details in a theme's stylesheet.
+ */
+function jetpack_post_details_enqueue_scripts() {
+	// Make sure we can proceed.
+	list( $should_run, $options, $definied, $post_details ) = jetpack_post_details_should_run();
+
+	if ( ! $should_run ) {
+		return;
+	}
+
+	list( $date_option, $categories_option, $tags_option, $author_option ) = $options;
+	list( $date, $categories, $tags, $author ) = $definied;
+
+	$elements = array();
+
+	// If date option is unticked, add it to the list of classes.
+	if ( 1 != $date_option && ! empty( $date ) ) {
+		$elements[] = $date;
+	}
+
+	// If categories option is unticked, add it to the list of classes.
+	if ( 1 != $categories_option && ! empty( $categories ) ) {
+		$elements[] = $categories;
+	}
+
+	// If tags option is unticked, add it to the list of classes.
+	if ( 1 != $tags_option && ! empty( $tags ) ) {
+		$elements[] = $tags;
+	}
+
+	// If author option is unticked, add it to the list of classes.
+	if ( 1 != $author_option && ! empty( $author ) ) {
+		$elements[] = $author;
+	}
+
+	// Get the list of classes.
+	$elements = implode( ', ', $elements );
+
+	// Hide the classes with CSS.
+	$css = $elements . ' { position: absolute; clip: rect(1px, 1px, 1px, 1px); }';
+
+	// Add the CSS to the stylesheet.
+	wp_add_inline_style( $post_details['stylesheet'], $css );
+}
+add_action( 'wp_enqueue_scripts', 'jetpack_post_details_enqueue_scripts' );
+
+/**
+ * Adds custom classes to the array of body classes.
+ */
+function jetpack_post_details_body_classes( $classes ) {
+	// Make sure we can proceed.
+	list( $should_run, $options, $definied ) = jetpack_post_details_should_run();
+
+	if ( ! $should_run ) {
+		return $classes;
+	}
+
+	list( $date_option, $categories_option, $tags_option, $author_option ) = $options;
+	list( $date, $categories, $tags, $author ) = $definied;
+
+	// If date option is unticked, add a class of 'date-hidden' to the body.
+	if ( 1 != $date_option && ! empty( $date ) ) {
+		$classes[] = 'date-hidden';
+	}
+
+	// If categories option is unticked, add a class of 'categories-hidden' to the body.
+	if ( 1 != $categories_option && ! empty( $categories ) ) {
+		$classes[] = 'categories-hidden';
+	}
+
+	// If tags option is unticked, add a class of 'tags-hidden' to the body.
+	if ( 1 != $tags_option && ! empty( $tags ) ) {
+		$classes[] = 'tags-hidden';
+	}
+
+	// If author option is unticked, add a class of 'author-hidden' to the body.
+	if ( 1 != $author_option && ! empty( $author ) ) {
+		$classes[] = 'author-hidden';
+	}
+
+	return $classes;
+}
+add_filter( 'body_class', 'jetpack_post_details_body_classes' );
+
+/**
+ * Determines if Post Details should run.
+ */
+function jetpack_post_details_should_run() {
+	// Empty value representing falsy return value.
+	$void = array( false, null, null, null );
+
+	// If the theme doesn't support 'jetpack-content-options', don't continue.
+	if ( ! current_theme_supports( 'jetpack-content-options' ) ) {
+		return $void;
+	}
+
+	$options      = get_theme_support( 'jetpack-content-options' );
+	$post_details = ( ! empty( $options[0]['post-details'] ) ) ? $options[0]['post-details'] : null;
+
+	// If the theme doesn't support 'jetpack-content-options[ 'post-details' ]', don't continue.
+	if ( empty( $post_details ) ) {
+		return $void;
+	}
+
+	$date       = ( ! empty( $post_details['date'] ) ) ? $post_details['date'] : null;
+	$categories = ( ! empty( $post_details['categories'] ) ) ? $post_details['categories'] : null;
+	$tags       = ( ! empty( $post_details['tags'] ) ) ? $post_details['tags'] : null;
+	$author     = ( ! empty( $post_details['author'] ) ) ? $post_details['author'] : null;
+
+	// If there is no stylesheet and there are no date, categories, tags or author declared, don't continue.
+	if ( empty( $post_details['stylesheet'] )
+		 && ( empty( $date )
+			 || empty( $categories )
+			 || empty( $tags )
+			 || empty( $author ) ) ) {
+		return $void;
+	}
+
+	$date_option       = get_option( 'jetpack_content_post_details_date', 1 );
+	$categories_option = get_option( 'jetpack_content_post_details_categories', 1 );
+	$tags_option       = get_option( 'jetpack_content_post_details_tags', 1 );
+	$author_option     = get_option( 'jetpack_content_post_details_author', 1 );
+
+	$options  = array( $date_option, $categories_option, $tags_option, $author_option );
+	$definied = array( $date, $categories, $tags, $author );
+
+	// If all the options are ticked, don't continue.
+	if ( array( 1, 1, 1, 1 ) === $options ) {
+		return $void;
+	}
+
+	return array( true, $options, $definied, $post_details );
+}


### PR DESCRIPTION
This new module adds a few options in the customiser to allow users
small tweaks. It’s currently being used on WordPress.com for a bunch of
recent Automattic themes.