### PR TITLE
Milestone Widget: fix 5.2 incompatibility

### DIFF
--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -44,7 +44,7 @@ class Milestone_Widget extends WP_Widget {
 			$control
 		);
 
-		self::$dir = trailingslashit( __DIR__ );
+		self::$dir = trailingslashit( dirname( __FILE__ ) );
 		self::$url = plugin_dir_url( __FILE__ );
 		self::$labels = array(
 			'year'    => __( 'year', 'jetpack' ),


### PR DESCRIPTION
`__DIR__` is not allowed in 5.2.  Was not caught due to broken Travis.  

To Test: 
- `gulp check:DIR`
- Make sure widget milestone still works properly
