### PR TITLE
Delete cached user data on disconnect

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2778,6 +2778,10 @@ p {
 			Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
 		}
 
+		// Delete cached connected user data
+		$transient_key = "jetpack_connected_user_data_" . get_current_user_id();
+		delete_transient( $transient_key );
+
 		// Delete all the sync related data. Since it could be taking up space.
 		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 		Jetpack_Sync_Sender::get_instance()->uninstall();


### PR DESCRIPTION
This fixes an issue reported by @pmciano  and @rachelsquirrel 

**To reproduce:**
- go to the Jetpack Settings page on a connected Jetpack site
- open the 'Connection Settings' accordion and make note of the user listed
- disconnect the site
- re-connect the site using a different wpcom user, and when you return to 'Connection Settings', it will continue to list the initial user

**Screen Cast:** https://cloudup.com/cA_9Bg6jWuv

**To test:**
- apply this PR to your Jetpack site
- repeat the steps above, and ensure that the proper user is listed when reconnecting

**Proposed changelog entry for your changes:**
Fixes a bug that would display the wrong connected user for up to 24 hours after they disconnect.