### PR TITLE
Sync: publish post should be send multiple times

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -179,7 +179,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		}
 
 		/**
-		 * Filter that is used to not expand some type of shortcodes.
+		 * Filter prevents some shortcodes from expanding.
 		 *
 		 * Since we can can expand some type of shortcode better on the .com side and make the
 		 * expansion more relevant to contexts. For example [galleries] and subscription emails
@@ -241,7 +241,25 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 				if ( $post_ID !== $just_published_post_ID ) {
 					$post = get_post( $just_published_post_ID );
 				}
+
+				/**
+				 * Filter that is used to add to the post flags ( meta data ) when a post gets published
+				 *
+				 * @since 4.4.0
+				 *
+				 * @param mixed array post flags that are added to the post
+				 * @param mixed $post WP_POST object
+				 */
 				$flags = apply_filters( 'jetpack_published_post_flags', array(), $post );
+
+				/**
+				 * Action that gets synced when a post type gets published.
+				 *
+				 * @since 4.4.0
+				 *
+				 * @param int post_id
+				 * @param mixed array post flags that are added to the post
+				 */
 				do_action( 'jetpack_published_post', $just_published_post_ID, $flags );
 			}
 			$this->just_published = array();

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -234,7 +234,9 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	public function send_published( $post_ID, $post, $update ) {
 		if ( ! empty( $this->just_published ) ) {
 			$published = array_reverse( array_unique( $this->just_published ) );
-			// in pre 4.7 version of WP send_published might not always happen everytime a save_published call is made
+			
+			// Pre 4.7 WP does not have run though send_published for every save_published call
+			// So lets clear out any just_published that we recorded 
 			foreach ( $published as $just_published_post_ID ) {
 				if ( $post_ID !== $just_published_post_ID ) {
 					$post = get_post( $just_published_post_ID );

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -4,7 +4,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 
 class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
-	private $just_published;
+	private $just_published = array();
 
 	public function name() {
 		return 'posts';
@@ -226,14 +226,16 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function save_published( $new_status, $old_status, $post ) {
+
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
-			$this->just_published = $post->ID;
+			$this->just_published[] = $post->ID;
 		}
 	}
 
 	public function send_published( $post_ID, $post, $update ) {
-		if ( $this->just_published === $post->ID ) {
-			$this->just_published = null;
+		$found_key = array_search( $post->ID, $this->just_published );
+		if ( false !== $found_key ) {
+			unset( $this->just_published[ $found_key ] );
 			$flags = apply_filters( 'jetpack_published_post_flags', array(), $post );
 			do_action( 'jetpack_published_post', $post_ID, $flags );
 		}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -934,8 +934,9 @@ That was a cool video.';
 
 	public function test_sync_jetpack_publish_post_works_with_interjecting_plugins() {
 		$this->server_event_storage->reset();
+		$this->test_already = false;
 		add_action( 'wp_insert_post', array( $this, 'add_a_hello_post_type' ), 9 );
-		$post_id    = $this->factory->post->create( array( 'post_type' => 'post' ) );
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
 		remove_action( 'wp_insert_post', array( $this, 'add_a_hello_post_type' ), 9 );
 
 		$this->sender->do_sync();
@@ -950,7 +951,7 @@ That was a cool video.';
 	function add_a_hello_post_type() {
 		if ( ! $this->test_already  ) {
 			$this->test_already = true;
-			$post_id    = $this->factory->post->create( array( 'post_type' => 'hello' ) );
+			$post_id = $this->factory->post->create( array( 'post_type' => 'hello' ) );
 			return;
 		}
 	}


### PR DESCRIPTION
Sometimes plugins hook into wp_insert_post and insert post during that.
This PR fixes this by making sure that we can send the action multiple
times for different posts.

This fixes #5801

#### Changes proposed in this Pull Request:


#### Testing instructions:

* Make sure that the tests pass. 
* Add the https://en-ca.wordpress.org/plugins/wp-recipe-maker 
and make sure that subscriptions get sent out as expected. 


