### PR TITLE
Add wpcom shortcodes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -273,6 +273,7 @@ frontendcss = [
 	'modules/sharedaddy/sharing.css',
 	'modules/shortcodes/css/slideshow-shortcode.css',
 	'modules/shortcodes/css/style.css', // TODO: Should be renamed to shortcode-presentations
+	'modules/shortcodes/css/quiz.css',
 	'modules/subscriptions/subscriptions.css',
 	'modules/theme-tools/responsive-videos/responsive-videos.css',
 	'modules/theme-tools/social-menu/social-menu.css',

--- a/modules/shortcodes.php
+++ b/modules/shortcodes.php
@@ -166,4 +166,29 @@ if ( ! function_exists( 'jetpack_shortcode_get_videopress_id' ) ) {
 	}
 }
 
+/**
+ * Common element attributes parsing and sanitizing for src, width and height.
+ *
+ * @since 4.5.0
+ *
+ * @param array $attrs  With original values.
+ *
+ * @return array $attrs With sanitized values.
+ */
+function wpcom_shortcodereverse_parseattr( $attrs ) {
+	$defaults = array(
+		'src'    => false,
+		'width'  => false,
+		'height' => false,
+	);
+
+	$attrs = shortcode_atts( $defaults, $attrs );
+
+	$attrs['src']    = strip_tags( $attrs['src'] ); // For sanity
+	$attrs['width']  = ( is_numeric( $attrs['width'] ) ) ? abs( intval( $attrs['width'] ) ) : $defaults['width'];
+	$attrs['height'] = ( is_numeric( $attrs['height'] ) ) ? abs( intval( $attrs['height'] ) ) : $defaults['height'];
+
+	return $attrs;
+}
+
 jetpack_load_shortcodes();

--- a/modules/shortcodes/archiveorg-book.php
+++ b/modules/shortcodes/archiveorg-book.php
@@ -1,0 +1,129 @@
+<?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+/*
+[archiveorg-book goodytwoshoes00newyiala]
+[archiveorg-book http://www.archive.org/stream/goodytwoshoes00newyiala]
+[archiveorg id=goodytwoshoes00newyiala width=480 height=430]
+
+<iframe src='https://www.archive.org/stream/goodytwoshoes00newyiala?ui=embed#mode/1up' width='480px' height='430px' frameborder='0' ></iframe>
+*/
+
+/**
+ * Get ID of requested archive.org book embed.
+ *
+ * @since 4.5.0
+ *
+ * @param $atts
+ *
+ * @return int|string
+ */
+function jetpack_shortcode_get_archiveorg_book_id( $atts ) {
+	if ( isset( $atts[0] ) ) {
+		$atts[0] = trim( $atts[0] , '=' );
+		if ( preg_match( '#archive.org/stream/(.+)/?$#i', $atts[0], $match ) ) {
+			$id = $match[1];
+		} else {
+			$id = $atts[0];
+		}
+		return $id;
+	}
+	return 0;
+}
+
+/**
+ * Convert an archive.org book shortcode into an embed code.
+ *
+ * @since 4.5.0
+ *
+ * @param array $atts An array of shortcode attributes.
+ * @return string The embed code for the Archive.org book
+ */
+function jetpack_archiveorg_book_shortcode( $atts ) {
+	global $content_width;
+
+	if ( isset( $atts[0] ) && empty( $atts['id'] ) ) {
+		$atts['id'] = jetpack_shortcode_get_archiveorg_book_id( $atts );
+	}
+
+	$atts = shortcode_atts( array(
+		'id'       => '',
+		'width'    => 480,
+		'height'   => 430,
+	), $atts );
+
+	if ( ! $atts['id'] ) {
+		return '<!-- error: missing archive.org book ID -->';
+	}
+
+	$id = $atts['id'];
+
+	if ( ! $atts['width'] ) {
+		$width = absint( $content_width );
+	} else {
+		$width = intval( $atts['width'] );
+	}
+
+	if ( ! $atts['height'] ) {
+		$height = round( ( $width / 640 ) * 360 );
+	} else {
+		$height = intval( $atts['height'] );
+	}
+
+	$url = esc_url( set_url_scheme( "http://archive.org/stream/{$id}?ui=embed#mode/1up" ) );
+
+	$html = "<div class='embed-archiveorg-book' style='text-align:center;'><iframe src='$url' width='$width' height='$height' frameborder='0' webkitallowfullscreen='true' mozallowfullscreen='true' allowfullscreen></iframe></div>";
+	return $html;
+}
+
+add_shortcode( 'archiveorg-book', 'jetpack_archiveorg_book_shortcode' );
+
+/**
+ * Compose shortcode from archive.org book iframe.
+ *
+ * @since 4.5.0
+ *
+ * @param string $content
+ *
+ * @return mixed
+ */
+function jetpack_archiveorg_book_embed_to_shortcode( $content ) {
+	if ( false === stripos( $content, 'archive.org/stream/' ) ) {
+		return $content;
+	}
+
+	$regexp = '!<iframe\s+src=[\'"](http|https)://(www.archive|archive)\.org/stream/([^\'"]+)[\'"]((?:\s+\w+(=[\'"][^\'"]*[\'"])?)*)\s></iframe>!i';
+
+	if ( ! preg_match_all( $regexp, $content, $matches, PREG_SET_ORDER ) ) {
+		return $content;
+	}
+
+	foreach ( $matches as $match ) {
+		$url = explode( '?', $match[3] );
+		$id = $url[0];
+
+		$params = $match[4];
+
+		$params = wp_kses_hair( $params, array( 'http' ) );
+
+		$width = isset( $params['width'] ) ? absint( $params['width']['value'] ) : 0;
+		$height = isset( $params['height'] ) ? absint( $params['height']['value'] ) : 0;
+
+		$wh = '';
+		if ( $width && $height ) {
+			$wh = ' width=' . $width . ' height=' . $height;
+		}
+
+		$shortcode = '[archiveorg-book ' . $id . $wh . ']';
+		$content = str_replace( $match[0], $shortcode, $content );
+	}
+
+	return $content;
+}
+
+add_filter( 'pre_kses', 'jetpack_archiveorg_book_embed_to_shortcode' );

--- a/modules/shortcodes/archiveorg-book.php
+++ b/modules/shortcodes/archiveorg-book.php
@@ -93,7 +93,7 @@ add_shortcode( 'archiveorg-book', 'jetpack_archiveorg_book_shortcode' );
  * @return mixed
  */
 function jetpack_archiveorg_book_embed_to_shortcode( $content ) {
-	if ( false === stripos( $content, 'archive.org/stream/' ) ) {
+	if ( ! is_string( $content ) || false === stripos( $content, 'archive.org/stream/' ) ) {
 		return $content;
 	}
 

--- a/modules/shortcodes/archiveorg-book.php
+++ b/modules/shortcodes/archiveorg-book.php
@@ -77,7 +77,7 @@ function jetpack_archiveorg_book_shortcode( $atts ) {
 
 	$url = esc_url( set_url_scheme( "http://archive.org/stream/{$id}?ui=embed#mode/1up" ) );
 
-	$html = "<div class='embed-archiveorg-book' style='text-align:center;'><iframe src='$url' width='$width' height='$height' frameborder='0' webkitallowfullscreen='true' mozallowfullscreen='true' allowfullscreen></iframe></div>";
+	$html = "<div class='embed-archiveorg-book' style='text-align:center;'><iframe src='$url' width='$width' height='$height' style='border:0;' webkitallowfullscreen='true' mozallowfullscreen='true' allowfullscreen></iframe></div>";
 	return $html;
 }
 

--- a/modules/shortcodes/archiveorg.php
+++ b/modules/shortcodes/archiveorg.php
@@ -1,0 +1,157 @@
+<?php
+/*
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+
+/*
+[archiveorg Experime1940]
+[archiveorg http://archive.org/details/Experime1940 poster=http://archive.org/images/map.png]
+[archiveorg id=Experime1940 width=640 height=480 autoplay=1]
+
+<iframe src="http://archive.org/embed/Experime1940&autoplay=1&poster=http://archive.org/images/map.png" width="640" height="480" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe>
+*/
+
+/**
+ * Get ID of requested archive.org embed.
+ *
+ * @since 4.5.0
+ *
+ * @param array $atts
+ *
+ * @return int|string
+ */
+function jetpack_shortcode_get_archiveorg_id( $atts ) {
+	if ( isset( $atts[0] ) ) {
+		$atts[0] = trim( $atts[0] , '=' );
+		if ( preg_match( '#archive.org/(details|embed)/(.+)/?$#i', $atts[0], $match ) ) {
+			$id = $match[2];
+		} else {
+			$id = $atts[0];
+		}
+		return $id;
+	}
+	return 0;
+}
+
+/**
+ * Convert an archive.org shortcode into an embed code.
+ *
+ * @since 4.5.0
+ *
+ * @param array $atts An array of shortcode attributes.
+ * @return string The embed code for the archive.org video.
+ */
+function jetpack_archiveorg_shortcode( $atts ) {
+	global $content_width;
+
+	if ( isset( $atts[0] ) && empty( $atts['id'] ) ) {
+		$atts['id'] = jetpack_shortcode_get_archiveorg_id( $atts );
+	}
+
+	$atts = shortcode_atts( array(
+		'id'       => '',
+		'width'    => 640,
+		'height'   => 480,
+		'autoplay' => 0,
+		'poster'   => ''
+	), $atts );
+
+	if ( ! $atts['id'] ) {
+		return '<!-- error: missing archive.org ID -->';
+	}
+
+	$id = $atts['id'];
+
+	if ( ! $atts['width'] ) {
+		$width = absint( $content_width );
+	} else {
+		$width = intval( $atts['width'] );
+	}
+
+	if ( ! $atts['height'] ) {
+		$height = round( ( $width / 640 ) * 360 );
+	} else {
+		$height = intval( $atts['height'] );
+	}
+
+	if ( $atts['autoplay'] ) {
+		$autoplay = '&autoplay=1';
+	} else {
+		$autoplay = '';
+	}
+
+	if ( $atts['poster'] ) {
+		$poster = '&poster=' . $atts['poster'];
+	} else {
+		$poster = '';
+	}
+
+	$url = esc_url( set_url_scheme( "https://archive.org/embed/{$id}{$autoplay}{$poster}" ) );
+
+	$html = "<div class='embed-archiveorg-video' style='text-align:center;'><iframe src='$url' width='$width' height='$height' frameborder='0' webkitallowfullscreen='true' mozallowfullscreen='true' allowfullscreen></iframe></div>";
+	$html = apply_filters( 'video_embed_html', $html );
+	return $html;
+}
+
+add_shortcode( 'archiveorg', 'jetpack_archiveorg_shortcode' );
+
+/**
+ * Compose shortcode from archive.org iframe.
+ *
+ * @since 4.5.0
+ *
+ * @param string $content
+ *
+ * @return mixed
+ */
+function jetpack_archiveorg_embed_to_shortcode( $content ) {
+	if ( false === stripos( $content, 'archive.org/embed/' ) ) {
+		return $content;
+	}
+
+	$regexp = '!<iframe\s+src=[\'"]https?://archive\.org/embed/([^\'"]+)[\'"]((?:\s+\w+(=[\'"][^\'"]*[\'"])?)*)></iframe>!i';
+
+	if ( ! preg_match_all( $regexp, $content, $matches, PREG_SET_ORDER ) ) {
+		return $content;
+	}
+
+	foreach ( $matches as $match ) {
+		$url = explode( '&amp;', $match[1] );
+		$id = 'id=' . $url[0];
+
+		$autoplay = '';
+		$poster = '';
+		for ( $ii = 1; $ii < count( $url ); $ii++ ) {
+			if ( 'autoplay=1' === $url[$ii] ) {
+				$autoplay = ' autoplay="1"';
+			}
+
+			$map_matches = array();
+			if ( preg_match( '/^poster=(.+)$/', $url[$ii], $map_matches ) ) {
+				$poster = " poster=\"{$map_matches[1]}\"";
+			}
+		}
+
+		$params = $match[2];
+
+		$params = wp_kses_hair( $params, array( 'http' ) );
+
+		$width = isset( $params['width'] ) ? (int) $params['width']['value'] : 0;
+		$height = isset( $params['height'] ) ? (int) $params['height']['value'] : 0;
+
+		$wh = '';
+		if ( $width && $height ) {
+			$wh = ' width=' . $width . ' height=' . $height;
+		}
+
+		$shortcode = '[archiveorg ' . $id . $wh . $autoplay . $poster . ']';
+		$content = str_replace( $match[0], $shortcode, $content );
+	}
+
+	return $content;
+}
+
+add_filter( 'pre_kses', 'jetpack_archiveorg_embed_to_shortcode' );

--- a/modules/shortcodes/archiveorg.php
+++ b/modules/shortcodes/archiveorg.php
@@ -91,8 +91,8 @@ function jetpack_archiveorg_shortcode( $atts ) {
 
 	$url = esc_url( set_url_scheme( "https://archive.org/embed/{$id}{$autoplay}{$poster}" ) );
 
-	$html = "<div class='embed-archiveorg-video' style='text-align:center;'><iframe src='$url' width='$width' height='$height' frameborder='0' webkitallowfullscreen='true' mozallowfullscreen='true' allowfullscreen></iframe></div>";
-	$html = apply_filters( 'video_embed_html', $html );
+	$html = "<div class='embed-archiveorg' style='text-align:center;'><iframe src='$url' width='$width' height='$height' style='border:0;' webkitallowfullscreen='true' mozallowfullscreen='true' allowfullscreen></iframe></div>";
+
 	return $html;
 }
 

--- a/modules/shortcodes/archiveorg.php
+++ b/modules/shortcodes/archiveorg.php
@@ -108,7 +108,7 @@ add_shortcode( 'archiveorg', 'jetpack_archiveorg_shortcode' );
  * @return mixed
  */
 function jetpack_archiveorg_embed_to_shortcode( $content ) {
-	if ( false === stripos( $content, 'archive.org/embed/' ) ) {
+	if ( ! is_string( $content ) || false === stripos( $content, 'archive.org/embed/' ) ) {
 		return $content;
 	}
 

--- a/modules/shortcodes/brightcove.php
+++ b/modules/shortcodes/brightcove.php
@@ -3,6 +3,15 @@
 /**
  * Brightcove shortcode.
  *
+ * Brighcove had renovated their video player embedding code since they introduced their "new studio".
+ * See https://support.brightcove.com/en/video-cloud/docs.
+ * The new code is not 100% backward compatible, as long as a customized player is used.
+ * By the time I wrote this, there were about 150000+ posts embedded legacy players, so it would be a bad
+ * idea either to introduce a new brightcove shortcode, or to break those posts completely.
+ *
+ * That's why we introduce a less aggressive way: leaving the old embedding code untouched, and
+ * introduce a new set of shortcode parameters which are translated to the latest Brightcove embedding code.
+ *
  * e.g.
  * [brightcove video_id="12345" account_id="99999"] will be translated to the latest embedding code.
  * [brightcove exp=627045696&vid=1415670151] or [brightcove exp=1463233149&vref=1601200825] will be translated

--- a/modules/shortcodes/brightcove.php
+++ b/modules/shortcodes/brightcove.php
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * Brightcove shortcode.
+ *
+ * e.g.
+ * [brightcove video_id="12345" account_id="99999"] will be translated to the latest embedding code.
+ * [brightcove exp=627045696&vid=1415670151] or [brightcove exp=1463233149&vref=1601200825] will be translated
+ * to the legacy code.
+ *
+ */
+class Jetpack_Brightcove_Shortcode {
+    static $shortcode = 'brightcove';
+
+	/**
+	 * Parse shortcode arguments and render its output.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts Shortcode parameters.
+	 *
+	 * @return string
+	 */
+	static public function convert( $atts ) {
+		$normalized_atts = self::normalize_attributes( $atts );
+
+		if ( empty( $atts ) ) {
+			return '<!-- Missing Brightcove parameters -->';
+		}
+
+		return self::has_legacy_atts( $normalized_atts )
+			? self::convert_to_legacy_studio( $normalized_atts )
+			: self::convert_to_new_studio( $normalized_atts );
+	}
+
+	/**
+	 * We need to take care of two kinds of shortcode format here.
+	 * The latest: [shortcode a=1 b=2] and the legacy: [shortcode a=1&b=2]
+	 * For an old shortcode: [shortcode a=1&b=2&c=3], it would be parsed into array( 'a' => 1&b=2&c=3' ), which is useless.
+	 * However, since we want to determine whether to call convert_to_legacy_studio() or convert_to_new_studio() via passed parameters, we still need to parse the two properly.
+	 * See http://jetpack.wp-a2z.org/oik_api/shortcode_new_to_old_params/
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts Shortcode parameters.
+	 *
+	 * @return array
+	 */
+	static public function normalize_attributes( $atts ) {
+		if ( 1 == count( $atts ) ) { // this is the case we need to take care of.
+			$parsed_atts = array();
+			$params = shortcode_new_to_old_params( $atts );
+			$params = apply_filters( 'brightcove_dimensions', $params );
+			parse_str( $params, $parsed_atts );
+
+			return $parsed_atts;
+		} else {
+			return $atts;
+		}
+	}
+
+	/**
+	 * Check that it has legacy attributes.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts Shortcode parameters.
+	 *
+	 * @return bool
+	 */
+	static public function has_legacy_atts( $atts ) {
+		return ( isset( $atts[ 'vid' ] ) || isset( $atts[ 'vref' ] ) )
+			&& ( isset( $atts[ 'exp' ] ) || isset( $atts[ 'exp3' ] ) );
+	}
+
+	/**
+	 * Convert to latest player format.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts Shortcode parameters.
+	 *
+	 * @return string
+	 */
+    static public function convert_to_new_studio( $atts ) {
+        $defaults = array(
+            'account_id' => '',
+            'video_id' => '',
+            'player_id' => 'default',
+            'width' => '100%',
+            'height' => '100%',
+        );
+
+        $atts_applied = shortcode_atts( $defaults, $atts, self::$shortcode );
+
+		$player_url = sprintf( '//players.brightcove.net/%s/%s_default/index.html?videoId=%s',
+            esc_attr( $atts_applied[ 'account_id' ] ),
+            esc_attr( $atts_applied[ 'player_id' ] ),
+            esc_attr( $atts_applied[ 'video_id' ] )
+		);
+
+        $output_html = sprintf( '<iframe src="' . esc_url( $player_url ) . '" allowfullscreen webkitallowfullscreen mozallowfullscreen style="width: %spx; height: %spx;"></iframe>',
+            esc_attr( $atts_applied[ 'width' ] ),
+            esc_attr( $atts_applied[ 'height' ] )
+        );
+
+        return $output_html;
+    }
+
+	/**
+	 * Convert to legacy player format.
+	 *
+	 * [brightcove exp=627045696&vid=1415670151] for the older player and backward compatibility
+	 * [brightcove exp=1463233149&vref=1601200825] for the new player
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts Shortcode parameters.
+	 *
+	 * @return string
+	 */
+	static public function convert_to_legacy_studio( $atts ) {
+		$attr = shortcode_atts( array(
+			'bg'    => '',
+			'exp'   => '',
+			'exp3'  => '',
+			'h'     => '',
+			'lbu'   => '',
+			'pk'    => '',
+			'pubid' => '',
+			's'     => '',
+			'surl'  => '',
+			'vid'   => '',
+			'vref'  => '',
+			'w'     => '',
+		), $atts );
+
+		if ( isset( $attr['pk'] ) ) {
+			$attr['pk'] = rawurlencode( preg_replace( '/[^a-zA-Z0-9!*\'();:@&=+$,\/?#\[\]\-_.~ ]/', '', $attr['pk'] ) );
+		}
+
+		if ( isset( $attr['bg'] ) ) {
+			$attr['bg'] = preg_replace( '![^-a-zA-Z0-9#]!', '', $attr['bg'] );
+		}
+
+		$fv = array(
+			'viewerSecureGatewayURL' => 'https://services.brightcove.com/services/amfgateway',
+			'servicesURL'            => 'http://services.brightcove.com/services',
+			'cdnURL'                 => 'http://admin.brightcove.com',
+			'autoStart'              => 'false',
+		);
+
+		$js_tld = 'com';
+		$src    = '';
+		$name   = 'flashObj';
+		$html5  = false;
+
+		if ( isset( $attr['exp3'] ) ) {
+			if ( isset( $attr['surl'] ) && strpos( $attr['surl'], 'brightcove.co.jp' ) ) {
+				$js_tld = 'co.jp';
+			}
+			if ( ! isset( $attr['surl'] ) || ! preg_match( '#^https?://(?:[a-z\d-]+\.)*brightcove\.(?:com|co\.jp)/#', $attr['surl'] ) ) {
+				$attr['surl'] = 'http://c.brightcove.com/services';
+			}
+
+			$attr['exp3']  = intval( $attr['exp3'] );
+			$attr['pubid'] = intval( $attr['pubid'] );
+			$attr['vid']   = intval( $attr['vid'] );
+
+			$fv['servicesURL'] = $attr['surl'];
+			$fv['playerID']    = $attr['exp3'];
+			$fv['domain']      = 'embed';
+			$fv['videoID']     = intval( $attr['vid'] );
+
+			$src   = sprintf( '%s/viewer/federated_f9/%s?isVid=1&amp;isUI=1&amp;publisherID=%s',
+				$attr['surl'],
+				$attr['exp3'],
+				$attr['pubid']
+			);
+			$html5 = true;
+		} elseif ( isset( $attr['exp'] ) ) {
+			$attr['exp'] = intval( $attr['exp'] );
+			$src         = 'http://services.brightcove.com/services/viewer/federated_f8/' . $attr['exp'];
+			if ( $attr['vid'] ) {
+				$fv['videoId'] = $attr['vid'];
+			} else if ( $attr['vref'] ) {
+				$fv['videoRef'] = $attr['vref'];
+			}
+
+			$fv['playerId'] = $attr['exp'];
+			$fv['domain']   = 'embed';
+		} else {
+			return '<small>brightcove error: missing required parameter exp or exp3</small>';
+		}
+
+		if ( ! empty( $attr['lbu'] ) ) {
+			$fv['linkBaseURL'] = $attr['lbu'];
+		}
+
+		$flashvars = trim( add_query_arg( array_map( 'urlencode', $fv ), '' ), '?' );
+
+		$width = $height = null;
+		if ( ! empty( $attr['w'] ) && ! empty( $attr['h'] ) ) {
+			$w = abs( (int) $attr['w'] );
+			$h = abs( (int) $attr['h'] );
+			if ( $w && $h ) {
+				$width  = $w;
+				$height = $h;
+			}
+		} elseif ( empty( $attr['s'] ) || 'l' === $attr['s'] ) {
+			$width  = '480';
+			$height = '360';
+		}
+
+		if ( empty( $width ) || empty( $height ) ) {
+			$width  = '280';
+			$height = '210';
+		}
+
+		if ( $html5 ) {
+			wp_enqueue_script( 'brightcove-loader', plugins_url( 'js/brightcove.js', __FILE__ ), array( 'jquery' ), 20121127, false );
+			wp_localize_script( 'brightcove-loader', 'brightcoveData', array(
+				'tld' => esc_js( $js_tld )
+			) );
+
+			return '
+				<object id="myExperience" class="BrightcoveExperience">
+					<param name="bgcolor" value="' . esc_attr( $attr['bg'] ) . '" />
+					<param name="width" value="' . esc_attr( $width ) . '" />
+					<param name="height" value="' . esc_attr( $height ) . '" />
+					<param name="playerID" value="' . esc_attr( $attr['exp3'] ) . '" />
+					<param name="@videoPlayer" value="' . esc_attr( $attr['vid'] ) . '" />
+					<param name="playerKey" value="' . esc_attr( $attr['pk'] ) . '" />
+					<param name="isVid" value="1" />
+					<param name="isUI" value="1" />
+					<param name="dynamicStreaming" value="true" />
+					<param name="autoStart" value="false" />
+					<param name="secureConnections" value="true" />
+					<param name="secureHTMLConnections" value="true" />
+				</object>';
+		}
+
+		return sprintf( '<embed src="%s" bgcolor="#FFFFFF" flashvars="%s" base="http://admin.brightcove.com" name="%s" width="%s" height="%s" allowFullScreen="true" seamlesstabbing="false" type="application/x-shockwave-flash" swLiveConnect="true" pluginspage="http://www.macromedia.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash" />',
+			esc_url( $src ),
+			$flashvars,
+			esc_attr( $name ),
+			esc_attr( $width ),
+			esc_attr( $height )
+		);
+	}
+}
+
+add_shortcode( Jetpack_Brightcove_Shortcode::$shortcode, array( 'Jetpack_Brightcove_Shortcode', 'convert' ) );

--- a/modules/shortcodes/brightcove.php
+++ b/modules/shortcodes/brightcove.php
@@ -91,30 +91,32 @@ class Jetpack_Brightcove_Shortcode {
 	 *
 	 * @return string
 	 */
-    static public function convert_to_new_studio( $atts ) {
-        $defaults = array(
-            'account_id' => '',
-            'video_id' => '',
-            'player_id' => 'default',
-            'width' => '100%',
-            'height' => '100%',
-        );
-
-        $atts_applied = shortcode_atts( $defaults, $atts, self::$shortcode );
-
-		$player_url = sprintf( '//players.brightcove.net/%s/%s_default/index.html?videoId=%s',
-            esc_attr( $atts_applied[ 'account_id' ] ),
-            esc_attr( $atts_applied[ 'player_id' ] ),
-            esc_attr( $atts_applied[ 'video_id' ] )
+	static public function convert_to_new_studio( $atts ) {
+		$defaults = array(
+			'account_id' => '',
+			'video_id'   => '',
+			'player_id'  => 'default',
+			'width'      => '100%',
+			'height'     => '100%',
 		);
 
-        $output_html = sprintf( '<iframe src="' . esc_url( $player_url ) . '" allowfullscreen webkitallowfullscreen mozallowfullscreen style="width: %spx; height: %spx;"></iframe>',
-            esc_attr( $atts_applied[ 'width' ] ),
-            esc_attr( $atts_applied[ 'height' ] )
-        );
+		$atts_applied = shortcode_atts( $defaults, $atts, self::$shortcode );
 
-        return $output_html;
-    }
+		$player_url = sprintf(
+			'//players.brightcove.net/%s/%s_default/index.html?videoId=%s',
+			esc_attr( $atts_applied['account_id'] ),
+			esc_attr( $atts_applied['player_id'] ),
+			esc_attr( $atts_applied['video_id'] )
+		);
+
+		$output_html = sprintf(
+			'<iframe src="' . esc_url( $player_url ) . '" allowfullscreen webkitallowfullscreen mozallowfullscreen style="width: %spx; height: %spx;"></iframe>',
+			esc_attr( $atts_applied['width'] ),
+			esc_attr( $atts_applied['height'] )
+		);
+
+		return $output_html;
+	}
 
 	/**
 	 * Convert to legacy player format.

--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * The companion file to shortcodes.php
+ *
+ * This file contains the code that converts HTML embeds into shortcodes
+ * for when the user copy/pastes in HTML.
+ */
+
+add_filter( 'pre_kses', array( 'Filter_Embedded_HTML_Objects', 'filter' ), 11 );
+add_filter( 'pre_kses', array( 'Filter_Embedded_HTML_Objects', 'maybe_create_links' ), 100 ); // See WPCom_Embed_Stats::init()
+
+/**
+ * Helper class for identifying and parsing known HTML blocks
+ *
+ * @since 4.5.0
+ *
+ * @author mdawaffe
+ *
+ * Not completely done, but seems to work okay
+ * Stolen from Mike's Seaside presentation:
+ * @link http://mdawaffepresents.wordpress.com/?p=36
+ */
+
+class Filter_Embedded_HTML_Objects {
+	static public $strpos_filters = array();
+	static public $regexp_filters = array();
+	static public $current_element = false;
+	static public $html_strpos_filters = array();
+	static public $html_regexp_filters = array();
+	static public $failed_embeds = array();
+
+	static public function filter( $html ) {
+		if ( ! $html ) {
+			return $html;
+		}
+
+		$regexps = array(
+			'object' => '%<object[^>]*+>(?>[^<]*+(?><(?!/object>)[^<]*+)*)</object>%i',
+			'embed'  => '%<embed[^>]*+>(?:\s*</embed>)?%i',
+			'iframe' => '%<iframe[^>]*+>(?>[^<]*+(?><(?!/iframe>)[^<]*+)*)</iframe>%i',
+			'div'    => '%<div[^>]*+>(?>[^<]*+(?><(?!/div>)[^<]*+)*+)(?:</div>)+%i',
+			'script' => '%<script[^>]*+>(?>[^<]*+(?><(?!/script>)[^<]*+)*)</script>%i',
+		);
+
+		$unfiltered_content_tokens = array();
+
+		// Check here to make sure that SyntaxHighlighter is still used. (Just a little future proofing)
+		if ( class_exists( 'SyntaxHighlighter' ) ) {
+			// Replace any "code" shortcode blocks with a token that we'll later replace with its original text.
+			// This will keep the contents of the shortcode from being filtered
+
+			global $SyntaxHighlighter;
+
+			// Check to see if the $SyntaxHighlighter object has been created and is ready for use
+			if ( isset( $SyntaxHighlighter ) && is_array( $SyntaxHighlighter->shortcodes ) ) {
+				$shortcode_regex = implode( '|', array_map( 'preg_quote', $SyntaxHighlighter->shortcodes ) );
+				$html            = preg_replace_callback(
+					'/\[(' . $shortcode_regex . ')(\s[^\]]*)?\][\s\S]*?\[\/\1\]/m', function ( $match ) use ( &$unfiltered_content_tokens ) {
+					$token                             = '[prekses-filter-token-' . mt_rand() . '-' . md5( $match[0] ) . '-' . mt_rand() . ']';
+					$unfiltered_content_tokens[$token] = $match[0];
+
+					return $token;
+				}, $html
+				);
+			}
+		}
+
+		foreach ( $regexps as $element => $regexp ) {
+			self::$current_element = $element;
+
+			if ( false !== stripos( $html, "<$element" ) ) {
+				if ( $new_html = preg_replace_callback( $regexp, array( __CLASS__, 'dispatch' ), $html ) ) {
+					$html = $new_html;
+				}
+			}
+
+			if ( false !== stripos( $html, "&lt;$element" ) ) {
+				$regexp_entities = self::regexp_entities( $regexp );
+				if ( $new_html = preg_replace_callback( $regexp_entities, array( __CLASS__, 'dispatch_entities' ), $html ) ) {
+					$html = $new_html;
+				}
+			}
+		}
+
+		if ( count( $unfiltered_content_tokens ) > 0 ) {
+			// Replace any tokens generated earlier with their original unfiltered text
+			$html = str_replace( array_keys( $unfiltered_content_tokens ), $unfiltered_content_tokens, $html );
+		}
+
+		return $html;
+	}
+
+	static public function regexp_entities( $regexp ) {
+		return preg_replace(
+			'/\[\^&([^\]]+)\]\*\+/',
+			'(?>[^&]*+(?>&(?!\1)[^&])*+)*+',
+			str_replace( '?&gt;', '?' . '>', htmlspecialchars( $regexp, ENT_NOQUOTES ) )
+		);
+	}
+
+	static public function register( $match, $callback, $is_regexp = false, $is_html_filter = false ) {
+		if ( $is_html_filter ) {
+			if ( $is_regexp ) {
+				self::$html_regexp_filters[$match] = $callback;
+			} else {
+				self::$html_strpos_filters[$match] = $callback;
+			}
+		} else {
+			if ( $is_regexp ) {
+				self::$regexp_filters[$match] = $callback;
+			} else {
+				self::$strpos_filters[$match] = $callback;
+			}
+		}
+	}
+
+	static public function unregister( $match ) {
+		// Allow themes/plugins to remove registered embeds
+		unset( self::$regexp_filters[$match] );
+		unset( self::$strpos_filters[$match] );
+		unset( self::$html_regexp_filters[$match] );
+		unset( self::$html_strpos_filters[$match] );
+	}
+
+	static function dispatch_entities( $matches ) {
+		$matches[0] = html_entity_decode( $matches[0] );
+
+		return self::dispatch( $matches );
+	}
+
+	static function dispatch( $matches ) {
+		$html  = preg_replace( '%&#0*58;//%', '://', $matches[0] );
+		$attrs = self::get_attrs( $html );
+		if ( isset( $attrs['src'] ) ) {
+			$src = $attrs['src'];
+		} else if ( isset( $attrs['movie'] ) ) {
+			$src = $attrs['movie'];
+		} else {
+			// no src found, search html
+			foreach ( self::$html_strpos_filters as $match => $callback ) {
+				if ( false !== strpos( $html, $match ) ) {
+					return call_user_func( $callback, $attrs );
+				}
+			}
+
+			foreach ( self::$html_regexp_filters as $match => $callback ) {
+				if ( preg_match( $match, $html ) ) {
+					return call_user_func( $callback, $attrs );
+				}
+			}
+
+			return $matches[0];
+		}
+
+		$src = trim( $src );
+
+		// check source filter
+		foreach ( self::$strpos_filters as $match => $callback ) {
+			if ( false !== strpos( $src, $match ) ) {
+				return call_user_func( $callback, $attrs );
+			}
+		}
+
+		foreach ( self::$regexp_filters as $match => $callback ) {
+			if ( preg_match( $match, $src ) ) {
+				return call_user_func( $callback, $attrs );
+			}
+		}
+
+		// check html filters
+		foreach ( self::$html_strpos_filters as $match => $callback ) {
+			if ( false !== strpos( $html, $match ) ) {
+				return call_user_func( $callback, $attrs );
+			}
+		}
+
+		foreach ( self::$html_regexp_filters as $match => $callback ) {
+			if ( preg_match( $match, $html ) ) {
+				return call_user_func( $callback, $attrs );
+			}
+		}
+
+		// Log the strip
+		if ( function_exists( 'wp_kses_reject' ) ) {
+			wp_kses_reject( sprintf( __( '<code>%s</code> HTML tag removed as it is not allowed' ), '&lt;' . self::$current_element . '&gt;' ), array( self::$current_element => $attrs ) );
+		}
+
+		// Keep the failed match so we can later replace it with a link,
+		// but return the original content to give others a chance too.
+		self::$failed_embeds[] = array(
+			'match' => $matches[0],
+			'src'   => esc_url( $src ),
+		);
+
+		return $matches[0];
+	}
+
+	/**
+	 * Failed embeds are stripped, so let's convert them to links at least.
+	 *
+	 * @param string $string Failed embed string.
+	 *
+	 * @return string $string Linkified string.
+	 */
+	public static function maybe_create_links( $string ) {
+		if ( empty( self::$failed_embeds ) ) {
+			return $string;
+		}
+
+		foreach ( self::$failed_embeds as $entry ) {
+			$html   = sprintf( '<a href="%s">%s</a>', esc_url( $entry['src'] ), esc_url( $entry['src'] ) );
+			$string = str_replace( $entry['match'], $html, $string );
+		}
+
+		self::$failed_embeds = array();
+
+		return $string;
+	}
+
+	static function get_attrs( $html ) {
+		// We have to go through DOM, since it can load non-well-formed XML (i.e. HTML).  SimpleXML cannot.
+		$dom = new DOMDocument;
+		// The @ is not enough to suppress errors when dealing with libxml,
+		// we have to tell it directly how we want to handle errors.
+		libxml_use_internal_errors( TRUE );
+		@$dom->loadHTML( $html ); // suppress parser warnings
+		libxml_use_internal_errors( FALSE );
+		$xml = false;
+		foreach ( $dom->childNodes as $node ) {
+			// find the root node (html)
+			if ( XML_ELEMENT_NODE == $node->nodeType ) {
+				// Use simplexml_load_string rather than simplexml_import_dom as the later doesn't cope well if the XML is malformmed in the DOM See #1688-wpcom
+				libxml_use_internal_errors( true );
+				$xml = simplexml_load_string( $dom->saveXML( $node->firstChild->firstChild ) ); // html->body->object
+				libxml_clear_errors();
+				break;
+			}
+		}
+		if ( ! $xml ) {
+			return array();
+		}
+
+		$attrs              = array();
+		$attrs['_raw_html'] = $html;
+
+		// <param> elements
+		foreach ( $xml->param as $param ) {
+			$attrs[(string) $param['name']] = (string) $param['value'];
+		}
+
+		// <object> attributes
+		foreach ( $xml->attributes() as $name => $attr ) {
+			$attrs[$name] = (string) $attr;
+		}
+
+		// <embed> attributes
+		if ( $xml->embed ) {
+			foreach ( $xml->embed->attributes() as $name => $attr ) {
+				$attrs[$name] = (string) $attr;
+			}
+		}
+
+		return $attrs;
+	}
+}

--- a/modules/shortcodes/css/quiz.css
+++ b/modules/shortcodes/css/quiz.css
@@ -1,0 +1,56 @@
+div.quiz {
+	border: 1px solid #deede3;
+	background-color: #f3f3f3;
+	padding: 1em;
+	line-height: 1.3em;
+	margin-bottom: 2em;
+	border-radius: .2em;
+}
+
+div.quiz div.question {
+	margin-bottom: .5em;
+	font-weight: bold;
+}
+
+div.quiz div.answer {
+	cursor: pointer;
+	margin-bottom: .5em;
+	padding: 1em 0 1em 1em;
+	border-bottom: 1px dotted #999;
+}
+div.quiz div.answer.last {
+	padding-bottom: 0;
+	margin-bottom: 0;
+	border-bottom: 0;
+}
+
+div.quiz div.answer.correct {
+	color: green;
+}
+
+div.quiz div.answer.wrong {
+	color: red;
+}
+
+div.quiz div.answer div.explanation {
+	display: none;
+}
+
+div.quiz div.answer.correct div.explanation, div.quiz div.answer.wrong div.explanation {
+	display: block;
+	color: black;
+	font-size: 90%;
+	margin-top: 1em;
+}
+
+div.quiz div.answer.correct div.explanation tt, div.quiz div.answer.wrong div.explanation tt {
+	font-size: 85%;
+}
+
+div.quiz pre {
+	font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+	background: transparent;
+	margin: 0;
+	padding: 0;
+}
+

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -47,7 +47,7 @@ function jetpack_getty_enable_embeds( $site = 'wpcom' ) {
  * @return mixed
  */
 function wpcom_shortcodereverse_getty( $content ) {
-	if ( false === stripos( $content, 'embed.gettyimages.com/embed' ) )
+	if ( ! is_string( $content ) || false === stripos( $content, 'embed.gettyimages.com/embed' ) )
 		return $content;
 
 	$regexp = '!<iframe\s+src=[\'"](https?:)?//embed\.gettyimages\.com/embed(/|/?\?assets=)(\d+(,\d+)*)[^\'"]*?[\'"]((?:\s+\w+=[\'"][^\'"]*[\'"])*)((?:[\s\w]*))></iframe>!i';

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -83,7 +83,7 @@ function wpcom_shortcodereverse_getty( $content ) {
 
 	// strip out enclosing div and any other markup
 	$regexp = '%<div class="getty\s[^>]*+>.*?<div[^>]*+>(\[getty[^\]]*+\])\s*</div>.*?</div>%is';
-	$regexp_ent = str_replace( ['&amp;#0*58;', '[^&gt;]'], ['&amp;#0*58;|&#0*58;', '[^&]'], htmlspecialchars( $regexp, ENT_NOQUOTES ) );
+	$regexp_ent = str_replace( array( '&amp;#0*58;', '[^&gt;]' ), array( '&amp;#0*58;|&#0*58;', '[^&]' ), htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
 	foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
 		if ( !preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) )

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Getty shortcode
+ *
+ * [getty src="82278805" width="$width" height="$height"]
+ * <div class="getty embed image" style="background-color:#fff;display:inline-block;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;color:#a7a7a7;font-size:11px;width:100%;max-width:462px;"><div style="padding:0;margin:0;text-align:left;"><a href="http://www.gettyimages.com/detail/82278805" target="_blank" style="color:#a7a7a7;text-decoration:none;font-weight:normal !important;border:none;display:inline-block;">Embed from Getty Images</a></div><div style="overflow:hidden;position:relative;height:0;padding:80.086580% 0 0 0;width:100%;"><iframe src="//embed.gettyimages.com/embed/82278805?et=jGiu6FXXSpJDGf1SnwLV2g&sig=TFVNFtqghwNw5iJQ1MFWnI8f4Y40_sfogfZLhai6SfA=" width="462" height="370" scrolling="no" frameborder="0" style="display:inline-block;position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div><p style="margin:0;"></p></div>
+ */
+
+add_action( 'init', 'jetpack_getty_enable_embeds' );
+
+/**
+ * Register Getty as an oembed provider. Register shortcode.
+ *
+ * @since 4.5.0
+ */
+function jetpack_getty_enable_embeds() {
+	$caller = parse_url( get_home_url(), PHP_URL_HOST );
+
+	// Support their oEmbed Endpoint
+	wp_oembed_add_provider( '#https?://www\.gettyimages\.com/detail/.*#i', "https://embed.gettyimages.com/oembed/?caller=$caller", true );
+	wp_oembed_add_provider( '#https?://(www\.)?gty\.im/.*#i',              "https://embed.gettyimages.com/oembed/?caller=$caller", true );
+
+	// Allow iframes to be filtered to short code (so direct copy+paste can be done)
+	add_filter( 'pre_kses', 'wpcom_shortcodereverse_getty' );
+
+	// Actually display the Getty Embed
+	add_shortcode( 'getty', 'jetpack_getty_shortcode' );
+}
+
+/**
+ * Compose shortcode based on Getty iframes.
+ *
+ * @since 4.5.0
+ *
+ * @param string $content
+ *
+ * @return mixed
+ */
+function wpcom_shortcodereverse_getty( $content ) {
+	if ( false === stripos( $content, 'embed.gettyimages.com/embed' ) )
+		return $content;
+
+	$regexp = '!<iframe\s+src=[\'"](https?:)?//embed\.gettyimages\.com/embed(/|/?\?assets=)(\d+(,\d+)*)[^\'"]*?[\'"]((?:\s+\w+=[\'"][^\'"]*[\'"])*)((?:[\s\w]*))></iframe>!i';
+	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
+
+	foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
+		if ( !preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) )
+			continue;
+
+		foreach ( $matches as $match ) {
+			$ids = esc_html( $match[3] );
+
+			$params = $match[5];
+
+			if ( 'regexp_ent' == $reg )
+				$params = html_entity_decode( $params );
+
+			$params = wp_kses_hair( $params, array( 'http' ) );
+
+			$width = isset( $params['width'] ) ? (int) $params['width']['value'] : 0;
+			$height = isset( $params['height'] ) ? (int) $params['height']['value'] : 0;
+
+			$shortcode = '[getty src="' . esc_attr( $ids ) . '"';
+			if ( $width )
+				$shortcode .= ' width="' . esc_attr( $width ) . '"';
+			if ( $height )
+				$shortcode .= ' height="' . esc_attr( $height ) . '"';
+			$shortcode .= ']';
+
+			$content = str_replace( $match[0], $shortcode, $content );
+		}
+	}
+
+	// strip out enclosing div and any other markup
+	$regexp = '%<div class="getty\s[^>]*+>.*?<div[^>]*+>(\[getty[^\]]*+\])\s*</div>.*?</div>%is';
+	$regexp_ent = str_replace( ['&amp;#0*58;', '[^&gt;]'], ['&amp;#0*58;|&#0*58;', '[^&]'], htmlspecialchars( $regexp, ENT_NOQUOTES ) );
+
+	foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
+		if ( !preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) )
+			continue;
+
+		foreach ( $matches as $match ) {
+			$content = str_replace( $match[0], $match[1], $content );
+		}
+	}
+
+	/** This action is documented in modules/widgets/social-media-icons.php */
+	do_action( 'jetpack_bump_stats_extras', 'html_to_shortcode', 'getty' );
+
+	return $content;
+}
+
+/**
+ * Parse shortcode arguments and render its output.
+ *
+ * @since 4.5.0
+ *
+ * @param array  $atts    Shortcode parameters.
+ * @param string $content Content enclosed by shortcode tags.
+ *
+ * @return string
+ */
+function jetpack_getty_shortcode( $atts, $content = '' ) {
+
+	if ( ! empty( $content ) )
+		$src = $content;
+	elseif ( ! empty( $atts['src'] ) )
+		$src = $atts['src'];
+	elseif ( ! empty( $atts[0] ) )
+		$src = $atts[0];
+	else
+		return '<!-- Missing Getty Source ID -->';
+
+	$src = preg_replace( '/^(\d+(,\d+)*).*$/', '$1', $src );
+
+	return wp_oembed_get( 'https://gty.im/' . $src, array(
+		'width'  => (int) $atts['width'],
+		'height' => (int) $atts['height']
+	) );
+}

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -6,17 +6,36 @@
  * <div class="getty embed image" style="background-color:#fff;display:inline-block;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;color:#a7a7a7;font-size:11px;width:100%;max-width:462px;"><div style="padding:0;margin:0;text-align:left;"><a href="http://www.gettyimages.com/detail/82278805" target="_blank" style="color:#a7a7a7;text-decoration:none;font-weight:normal !important;border:none;display:inline-block;">Embed from Getty Images</a></div><div style="overflow:hidden;position:relative;height:0;padding:80.086580% 0 0 0;width:100%;"><iframe src="//embed.gettyimages.com/embed/82278805?et=jGiu6FXXSpJDGf1SnwLV2g&sig=TFVNFtqghwNw5iJQ1MFWnI8f4Y40_sfogfZLhai6SfA=" width="462" height="370" scrolling="no" frameborder="0" style="display:inline-block;position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div><p style="margin:0;"></p></div>
  */
 
-$jp_getty_caller = parse_url( get_home_url(), PHP_URL_HOST );
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	add_action( 'init', 'jetpack_getty_enable_embeds' );
+} else {
+	jetpack_getty_enable_embeds( 'jetpack' );
+}
 
-// Support their oEmbed Endpoint
-wp_oembed_add_provider( '#https?://www\.gettyimages\.com/detail/.*#i', "https://embed.gettyimages.com/oembed/?caller=$jp_getty_caller", true );
-wp_oembed_add_provider( '#https?://(www\.)?gty\.im/.*#i',              "https://embed.gettyimages.com/oembed/?caller=$jp_getty_caller", true );
+/**
+ * Register Getty as oembed provider. Add filter to reverse iframes to shortcode. Register [getty] shortcode.
+ *
+ * @since 4.5.0
+ *
+ * @param string $site Can be 'wpcom' or 'jetpack' and determines if we're in wpcom or in a Jetpack site.
+ */
+function jetpack_getty_enable_embeds( $site = 'wpcom' ) {
 
-// Allow iframes to be filtered to short code (so direct copy+paste can be done)
-add_filter( 'pre_kses', 'wpcom_shortcodereverse_getty' );
+	// Set the caller argument to pass to Getty's oembed provider.
+	$caller = 'jetpack' === $site
+		? parse_url( get_home_url(), PHP_URL_HOST )
+		: 'wordpress.com';
 
-// Actually display the Getty Embed
-add_shortcode( 'getty', 'jetpack_getty_shortcode' );
+	// Support their oEmbed Endpoint
+	wp_oembed_add_provider( '#https?://www\.gettyimages\.com/detail/.*#i', "https://embed.gettyimages.com/oembed/?caller=$caller", true );
+	wp_oembed_add_provider( '#https?://(www\.)?gty\.im/.*#i',              "https://embed.gettyimages.com/oembed/?caller=$caller", true );
+
+	// Allow iframes to be filtered to short code (so direct copy+paste can be done)
+	add_filter( 'pre_kses', 'wpcom_shortcodereverse_getty' );
+
+	// Actually display the Getty Embed
+	add_shortcode( 'getty', 'jetpack_getty_shortcode' );
+}
 
 /**
  * Compose shortcode based on Getty iframes.

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -6,26 +6,17 @@
  * <div class="getty embed image" style="background-color:#fff;display:inline-block;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;color:#a7a7a7;font-size:11px;width:100%;max-width:462px;"><div style="padding:0;margin:0;text-align:left;"><a href="http://www.gettyimages.com/detail/82278805" target="_blank" style="color:#a7a7a7;text-decoration:none;font-weight:normal !important;border:none;display:inline-block;">Embed from Getty Images</a></div><div style="overflow:hidden;position:relative;height:0;padding:80.086580% 0 0 0;width:100%;"><iframe src="//embed.gettyimages.com/embed/82278805?et=jGiu6FXXSpJDGf1SnwLV2g&sig=TFVNFtqghwNw5iJQ1MFWnI8f4Y40_sfogfZLhai6SfA=" width="462" height="370" scrolling="no" frameborder="0" style="display:inline-block;position:absolute;top:0;left:0;width:100%;height:100%;"></iframe></div><p style="margin:0;"></p></div>
  */
 
-add_action( 'init', 'jetpack_getty_enable_embeds' );
+$jp_getty_caller = parse_url( get_home_url(), PHP_URL_HOST );
 
-/**
- * Register Getty as an oembed provider. Register shortcode.
- *
- * @since 4.5.0
- */
-function jetpack_getty_enable_embeds() {
-	$caller = parse_url( get_home_url(), PHP_URL_HOST );
+// Support their oEmbed Endpoint
+wp_oembed_add_provider( '#https?://www\.gettyimages\.com/detail/.*#i', "https://embed.gettyimages.com/oembed/?caller=$jp_getty_caller", true );
+wp_oembed_add_provider( '#https?://(www\.)?gty\.im/.*#i',              "https://embed.gettyimages.com/oembed/?caller=$jp_getty_caller", true );
 
-	// Support their oEmbed Endpoint
-	wp_oembed_add_provider( '#https?://www\.gettyimages\.com/detail/.*#i', "https://embed.gettyimages.com/oembed/?caller=$caller", true );
-	wp_oembed_add_provider( '#https?://(www\.)?gty\.im/.*#i',              "https://embed.gettyimages.com/oembed/?caller=$caller", true );
+// Allow iframes to be filtered to short code (so direct copy+paste can be done)
+add_filter( 'pre_kses', 'wpcom_shortcodereverse_getty' );
 
-	// Allow iframes to be filtered to short code (so direct copy+paste can be done)
-	add_filter( 'pre_kses', 'wpcom_shortcodereverse_getty' );
-
-	// Actually display the Getty Embed
-	add_shortcode( 'getty', 'jetpack_getty_shortcode' );
-}
+// Actually display the Getty Embed
+add_shortcode( 'getty', 'jetpack_getty_shortcode' );
 
 /**
  * Compose shortcode based on Getty iframes.
@@ -113,8 +104,9 @@ function jetpack_getty_shortcode( $atts, $content = '' ) {
 
 	$src = preg_replace( '/^(\d+(,\d+)*).*$/', '$1', $src );
 
-	return wp_oembed_get( 'https://gty.im/' . $src, array(
-		'width'  => (int) $atts['width'],
-		'height' => (int) $atts['height']
-	) );
+	$args = array();
+	$args['width'] = isset( $atts['width'] ) ? (int) $atts['width'] : '462';
+	$args['height'] = isset( $atts['height'] ) ? (int) $atts['height'] : '370';
+
+	return wp_oembed_get( 'https://gty.im/' . $src, $args );
 }

--- a/modules/shortcodes/getty.php
+++ b/modules/shortcodes/getty.php
@@ -47,23 +47,26 @@ function jetpack_getty_enable_embeds( $site = 'wpcom' ) {
  * @return mixed
  */
 function wpcom_shortcodereverse_getty( $content ) {
-	if ( ! is_string( $content ) || false === stripos( $content, 'embed.gettyimages.com/embed' ) )
+	if ( ! is_string( $content ) || false === stripos( $content, 'embed.gettyimages.com/embed' ) ) {
 		return $content;
+	}
 
 	$regexp = '!<iframe\s+src=[\'"](https?:)?//embed\.gettyimages\.com/embed(/|/?\?assets=)(\d+(,\d+)*)[^\'"]*?[\'"]((?:\s+\w+=[\'"][^\'"]*[\'"])*)((?:[\s\w]*))></iframe>!i';
 	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
 	foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
-		if ( !preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) )
+		if ( ! preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) ) {
 			continue;
+		}
 
 		foreach ( $matches as $match ) {
 			$ids = esc_html( $match[3] );
 
 			$params = $match[5];
 
-			if ( 'regexp_ent' == $reg )
+			if ( 'regexp_ent' == $reg ) {
 				$params = html_entity_decode( $params );
+			}
 
 			$params = wp_kses_hair( $params, array( 'http' ) );
 
@@ -71,10 +74,12 @@ function wpcom_shortcodereverse_getty( $content ) {
 			$height = isset( $params['height'] ) ? (int) $params['height']['value'] : 0;
 
 			$shortcode = '[getty src="' . esc_attr( $ids ) . '"';
-			if ( $width )
+			if ( $width ) {
 				$shortcode .= ' width="' . esc_attr( $width ) . '"';
-			if ( $height )
+			}
+			if ( $height ) {
 				$shortcode .= ' height="' . esc_attr( $height ) . '"';
+			}
 			$shortcode .= ']';
 
 			$content = str_replace( $match[0], $shortcode, $content );
@@ -86,8 +91,9 @@ function wpcom_shortcodereverse_getty( $content ) {
 	$regexp_ent = str_replace( array( '&amp;#0*58;', '[^&gt;]' ), array( '&amp;#0*58;|&#0*58;', '[^&]' ), htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
 	foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
-		if ( !preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) )
+		if ( ! preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) ) {
 			continue;
+		}
 
 		foreach ( $matches as $match ) {
 			$content = str_replace( $match[0], $match[1], $content );
@@ -112,14 +118,15 @@ function wpcom_shortcodereverse_getty( $content ) {
  */
 function jetpack_getty_shortcode( $atts, $content = '' ) {
 
-	if ( ! empty( $content ) )
+	if ( ! empty( $content ) ) {
 		$src = $content;
-	elseif ( ! empty( $atts['src'] ) )
+	} elseif ( ! empty( $atts['src'] ) ) {
 		$src = $atts['src'];
-	elseif ( ! empty( $atts[0] ) )
+	} elseif ( ! empty( $atts[0] ) ) {
 		$src = $atts[0];
-	else
+	} else {
 		return '<!-- Missing Getty Source ID -->';
+	}
 
 	$src = preg_replace( '/^(\d+(,\d+)*).*$/', '$1', $src );
 

--- a/modules/shortcodes/googleapps.php
+++ b/modules/shortcodes/googleapps.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * Google Docs and Google Calendar Shortcode
+ *
+ * Presentation:
+ * <iframe src="https://docs.google.com/present/embed?id=dhfhrphh_123drp8s65c&interval=15&autoStart=true&loop=true&size=l" frameborder="0" width="700" height="559"></iframe>
+ * <iframe src="https://docs.google.com/presentation/embed?id=13ItX4jV0SOSdr-ZjHarcpTh9Lr4omfsHAp87jpxv8-0&start=false&loop=false&delayms=3000" frameborder="0" width="960" height="749" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+ *
+ * Document:
+ * <iframe src="https://docs.google.com/document/pub?id=1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4&amp;embedded=true"></iframe>
+ * <iframe src="https://docs.google.com/document/d/1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4/pub?embedded=true"></iframe>
+ * <iframe src="https://docs.google.com/document/d/e/2PACX-1vRkpIdasKL-eKXDjJgpEONduUspZTz0YmKaajfie0eJYnzikuyusuG1_V8X8T9XflN9l8A1oCM2sgEA/pub?embedded=true"></iframe>
+ *
+ * External document:
+ * <iframe width=100% height=560px frameborder=0 src=https://docs.google.com/a/pranab.in/viewer?a=v&pid=explorer&chrome=false&embedded=true&srcid=1VTMwdgGiDMt8MCr75-YkQP-4u9WmEp1Qvf6C26KYBgFilxU2qndpd-VHhBIn&hl=en></iframe>
+ *
+ * Spreadsheet Form:
+ * <iframe src="https://spreadsheets.google.com/embeddedform?formkey=dEVOYnMzZG5jMUpGbjFMYjFYNVB3NkE6MQ" width="760" height="710" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+ *
+ * Spreadsheet Widget:
+ * <iframe width='500' height='300' frameborder='0' src='https://spreadsheets1.google.com/a/petedavies.com/pub?hl=en&hl=en&key=0AjSij7nlnXvKdHNsNjRSWG12YmVfOEFwdlMxQ3J1S1E&single=true&gid=0&output=html&widget=true'></iframe>
+ * <iframe width='500' height='300' frameborder='0' src='https://spreadsheets.google.com/spreadsheet/pub?hl=en&hl=en&key=0AhInIwfvYrIUdGJiTXhtUEhBSFVPUzdRZU5OMDlqdnc&output=html&widget=true'></iframe>
+ *
+ * Calendar:
+ * <iframe src="https://www.google.com/calendar/embed?src=serjant%40gmail.com&ctz=Europe/Sofia" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+ * <iframe src="http://www.google.com/calendar/hosted/belcastro.com/embed?src=n8nr8sd6v9hnus3nmlk7ed1238%40group.calendar.google.com&ctz=Europe/Zurich" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+ *
+ * Customized calendar:
+ * <iframe src="https://www.google.com/calendar/embed?title=asdf&amp;showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;
+ * showTz=0&amp;mode=AGENDA&amp;height=300&amp;wkst=2&amp;hl=fi&amp;bgcolor=%23ffcccc&amp;src=m52gdmbgelo3itf00u1v44g0ns%40group.calendar.google.com&amp;color=%234E5D6C&amp;
+ * src=serjant%40gmail.com&amp;color=%235229A3&amp;ctz=Europe%2FRiga" style=" border:solid 1px #777 " width="500" height="300" frameborder="0" scrolling="no"></iframe>
+ *
+ * Generic
+ * <iframe src="https://docs.google.com/file/d/0B0SIdZW7iu-zX1RWREJpMXVHZVU/preview" width="640" height="480"></iframe>
+ */
+
+add_filter( 'pre_kses', 'googleapps_embed_to_shortcode' );
+add_shortcode( 'googleapps', 'googleapps_shortcode' );
+
+/**
+ * Reverse iframe embed to shortcode mapping HTML attributes to shortcode attributes.
+ *
+ * @since 4.5.0
+ *
+ * @param string $content
+ *
+ * @return mixed
+ */
+function googleapps_embed_to_shortcode( $content ) {
+	if ( ! is_string( $content ) || false === stripos( $content, '<iframe' ) && false === stripos( $content, '.google.com' ) ) {
+		return $content;
+	}
+
+	$regexp            = '#<iframe((?:\s+\w+="[^"]*")*?)\s*src="https?://(docs|drive|spreadsheets\d*|calendar|www)*\.google\.com/(?!maps)([-\w\./]+)(?:\?)?([^"]+)?"\s*((?:\s+\w+="[^"]*")*?)>.*?</iframe>#i';
+	$regexp_ent        = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
+	$regexp_squot      = str_replace( '"', "'", $regexp );
+	$regexp_ent_squot  = str_replace( '"', "'", $regexp_ent );
+	$regexp_noquot     = '!<iframe(.*?)src=https://(docs|drive)\.google\.com/[-\.\w/]*?(viewer)\?(.*?)>(.*?)</iframe>!';
+	$regexp_ent_noquot = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp_noquot, ENT_NOQUOTES ) );
+
+	foreach ( array( 'regexp', 'regexp_ent', 'regexp_squot', 'regexp_ent_squot', 'regexp_noquot', 'regexp_ent_noquot' ) as $reg ) {
+		if ( ! preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) ) {
+			continue;
+		}
+
+		foreach ( $matches as $match ) {
+			$params = $match[1] . $match[5];
+			if ( in_array( $reg, array( 'regexp_ent', 'regexp_ent_squot' ) ) ) {
+				$params = html_entity_decode( $params );
+			}
+
+			$params = wp_kses_hair( $params, array( 'http' ) );
+
+			$width = $height = 0;
+			if ( isset( $params['width'] ) ) {
+				$width = (int) $params['width']['value'];
+			}
+
+			if ( isset( $params['height'] ) ) {
+				$height = (int) $params['height']['value'];
+			}
+
+			// allow the user to specify width greater than 200 inside text widgets
+			if ( $width > 400 && isset( $_POST['widget-text'] ) ) {
+				$width  = 200;
+				$height = 200;
+			}
+
+			$attributes = '';
+			if ( isset( $params['width'] ) && '100%' == $params['width']['value'] ) {
+				$width = '100%';
+			}
+
+			if ( $width ) {
+				$attributes = ' width="' . $width . '"';
+			}
+
+			if ( $height ) {
+				$attributes .= ' height="' . $height . '"';
+			}
+
+			$domain = 'spreadsheets';
+			if ( in_array( $match[2], array( 'docs', 'drive', 'www', 'calendar' ) ) ) {
+				$domain = $match[2];
+			}
+
+			// Make sure this is actually something that the shortcode supports. If it's not, leave the HTML alone.
+			if ( ! googleapps_validate_domain_and_dir( $domain, $match[3] ) ) {
+				continue;
+			}
+
+			/** This action is documented in modules/widgets/social-media-icons.php */
+			do_action( 'jetpack_bump_stats_extras', 'html_to_shortcode', googleapps_service_name( $domain, $match[3] ) );
+
+			$content = str_replace( $match[0], '[googleapps domain="' . $domain . '" dir="' . $match[3] . '" query="' . esc_attr( $match[4] ) . '"' . $attributes . ' /]', $content );
+		}
+	}
+
+	return $content;
+}
+
+/**
+ * Parse shortcode attributes and output a Google Docs embed.
+ *
+ * @since 4.5.0
+ *
+ * @param array $atts
+ *
+ * @return string
+ */
+function googleapps_shortcode( $atts ) {
+	global $content_width;
+
+	$attr = shortcode_atts(
+		array(
+			'width'  => '100%',
+			'height' => '560',
+			'domain' => 'docs',
+			'dir'    => 'document',
+			'query'  => '',
+			'src'    => '',
+		), $atts
+	);
+
+	if ( isset( $content_width ) && is_numeric( $attr['width'] ) && $attr['width'] > $content_width ) {
+		$attr['width'] = $content_width;
+	}
+
+	if ( isset( $content_width ) && '560' === $attr['height'] ) {
+		$attr['height'] = $content_height = floor( $content_width * 3 / 4 );
+	}
+
+	if ( isset( $atts[0] ) && $atts[0] ) {
+		$attr['src'] = $atts[0];
+	}
+
+	if ( $attr['src'] && preg_match( '!https?://(docs|drive|spreadsheets\d*|calendar|www)*\.google\.com/([-\w\./]+)\?([^"]+)!', $attr['src'], $matches ) ) {
+		$attr['domain'] = $matches[1];
+		$attr['dir']    = $matches[2];
+		parse_str( htmlspecialchars_decode( $matches[3] ), $query_ar );
+		$query_ar['chrome']   = 'false';
+		$query_ar['embedded'] = 'true';
+		$attr['query']        = http_build_query( $query_ar );
+	}
+
+	if ( ! googleapps_validate_domain_and_dir( $attr['domain'], $attr['dir'] ) ) {
+		return '<!-- Unsupported URL -->';
+	}
+
+	$attr['query'] = $attr['dir'] . '?' . $attr['query'];
+
+	/** This action is documented in modules/widgets/social-media-icons.php */
+	do_action( 'jetpack_bump_stats_extras', 'embeds', googleapps_service_name( $attr['domain'], $attr['dir'] ) );
+
+	return sprintf(
+		'<iframe src="%s" frameborder="0" width="%s" height="%s" marginheight="0" marginwidth="0"></iframe>',
+		esc_url( 'https://' . $attr['domain'] . '.google.com/' . $attr['query'] ),
+		esc_attr( $attr['width'] ),
+		esc_attr( $attr['height'] )
+	);
+}
+
+/**
+ * Check that the domain blogs to a Google Apps domain.
+ *
+ * @since 4.5.0
+ *
+ * @param string $domain
+ * @param string $dir
+ *
+ * @return bool
+ */
+function googleapps_validate_domain_and_dir( $domain, $dir ) {
+	if ( ! in_array( $domain, array( 'docs', 'drive', 'www', 'spreadsheets', 'calendar' ) ) ) {
+		return false;
+	}
+
+	// Calendars
+	if ( ( 'www' === $domain || 'calendar' === $domain ) && 'calendar/' !== substr( $dir, 0, 9 ) ) {
+		return false;
+	}
+
+	// Docs
+	if ( in_array( $domain, array( 'docs', 'drive' ) ) && ! preg_match( '![-\.\w/]*(presentation/embed|presentation/d/(.*)|present/embed|document/pub|spreadsheets/d/(.*)|document/d/(e/)?[\w-]+/pub|file/d/[\w-]+/preview|viewer|forms/d/(.*)/viewform|spreadsheet/\w+)$!', $dir ) ) {
+		return false;
+	}
+
+	// Spreadsheets
+	if ( 'spreadsheets' == $domain && ! preg_match( '!^([-\.\w/]+/pub|[-\.\w/]*embeddedform)$!', $dir ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Get the name of the service we'll be embedding.
+ *
+ * @since 4.5.0
+ *
+ * @param string $domain
+ * @param string $dir
+ *
+ * @return string
+ */
+function googleapps_service_name( $domain, $dir ) {
+	switch ( $domain ) {
+		case 'drive':
+		case 'docs':
+			$service_name = ( 'present/embed' == $dir ) ? 'googledocs_presentation' : 'googledocs_document';
+			break;
+		case 'spreadsheets':
+			$service_name = ( 'embeddedform' == $dir ) ? 'googledocs_form' : 'googledocs_spreadsheet';
+			break;
+		case 'calendar':
+		default:
+			$service_name = 'google_calendar';
+	}
+
+	return $service_name;
+}

--- a/modules/shortcodes/gravatar.php
+++ b/modules/shortcodes/gravatar.php
@@ -1,0 +1,124 @@
+<?php
+
+add_shortcode( 'gravatar', 'gravatar_shortcode' );
+
+function gravatar_shortcode( $atts ) {
+	$atts = shortcode_atts( array(
+		'email' => '',
+		'size'  => 96,
+	), $atts );
+
+	if ( empty( $atts['email'] ) || ! is_email( $atts['email'] ) ) {
+		return false;
+	}
+
+	$atts['size'] = intval( $atts['size'] );
+	if ( 0 > $atts['size'] ) {
+		$atts['size'] = 96;
+	}
+
+	return get_avatar( $atts['email'], $atts['size'] );
+}
+
+/**
+ * Display Gravatar profile
+ *
+ * @param array $atts
+ *
+ * @uses shortcode_atts()
+ * @uses get_user_by()
+ * @uses is_email()
+ * @uses sanitize_email()
+ * @uses sanitize_user()
+ * @uses set_url_scheme()
+ * @uses wpcom_get_avatar_url()
+ * @uses get_user_attribute()
+ * @uses esc_url()
+ * @uses esc_html()
+ * @uses _e()
+ * @return string or false
+ */
+function gravatar_profile_shortcode( $atts ) {
+	// Give each use of the shortcode a unique ID
+	static $instance = 0;
+
+	// Process passed attributes
+	$atts = shortcode_atts( array(
+		'who' => null,
+	), $atts, 'gravatar_profile' );
+
+	// Can specify username, user ID, or email address
+	if ( is_numeric( $atts['who'] ) ) {
+		$user = get_user_by( 'id', (int) $atts['who'] );
+	} elseif ( is_email( $atts['who'] ) ) {
+		$user = get_user_by( 'email', sanitize_email( $atts['who'] ) );
+	} elseif ( is_string( $atts['who'] ) ) {
+		$user = get_user_by( 'login', sanitize_user( $atts['who'] ) );
+	} else {
+		$user = false;
+	}
+
+	// Bail if we don't have a user
+	if ( false === $user ) {
+		return false;
+	}
+
+	// Render the shortcode
+	$gravatar_url  = set_url_scheme( 'http://gravatar.com/' . $user->user_login );
+	$avatar_url    = wpcom_get_avatar_url( $user->ID, 96 );
+	$user_location = get_user_attribute( $user->ID, 'location' );
+
+	ob_start();
+
+	?>
+	<script type="text/javascript">
+		( function() {
+			if ( null === document.getElementById( 'gravatar-profile-embed-styles' ) ) {
+				var headID = document.getElementsByTagName( 'head' )[0];
+				var styleNode = document.createElement( 'style' );
+				styleNode.type = 'text/css';
+				styleNode.id = 'gravatar-profile-embed-styles';
+
+				var gCSS = '.grofile-wrap { border: solid 1px #eee; padding: 10px; } .grofile { padding: 0 0 5px 0; }  .grofile-left { float: left; display: block; width: 96px; margin-right: 15px; } .grofile .gravatar { margin-bottom: 5px; } .grofile-clear { clear: left; font-size: 1px; height: 1px; } .grofile ul li a { text-indent: -99999px; } .grofile .grofile-left a:hover { text-decoration: none !important; border: none !important; } .grofile-name { margin-top: 0; }';
+
+				if ( document.all ) {
+					styleNode.innerText = gCSS;
+				} else {
+					styleNode.textContent = gCSS;
+				}
+
+				headID.appendChild( styleNode );
+			}
+		} )();
+	</script>
+
+	<div class="grofile vcard" id="grofile-embed-<?php echo esc_attr( $instance ); ?>">
+		<div class="grofile-inner">
+			<div class="grofile-left">
+				<div class="grofile-img">
+					<a href="<?php echo esc_url( $gravatar_url ); ?>">
+						<img src="<?php echo esc_url( $avatar_url[0] ); ?>" width="96" height="96" class="no-grav gravatar photo" />
+					</a>
+				</div>
+			</div>
+			<div class="grofile-right">
+				<p class="grofile-name fn">
+					<strong><?php echo esc_html( $user->display_name ); ?></strong>
+					<?php if ( ! empty( $user_location ) ) : ?><br><span class="grofile-location adr"><?php echo esc_html( $user_location ); ?></span><?php endif; ?>
+				</p>
+				<p class="grofile-bio"><strong><?php _e( 'Bio:' ); ?></strong> <?php echo wp_kses_post( $user->description ); ?></p>
+				<p class="grofile-view">
+					<a href="<?php echo esc_url( $gravatar_url ); ?>"><?php _e( 'View complete profile' ); ?></a>
+				</p>
+			</div>
+			<span class="grofile-clear">&nbsp;</span>
+		</div>
+	</div><?php
+
+	// Increment and return the rendered profile
+	$instance++;
+
+	return ob_get_clean();
+}
+
+add_shortcode( 'gravatar_profile', 'gravatar_profile_shortcode' );

--- a/modules/shortcodes/gravatar.php
+++ b/modules/shortcodes/gravatar.php
@@ -1,8 +1,26 @@
 <?php
+/**
+ * Gravatar shortcode for avatar and profile.
+ *
+ * Usage:
+ *
+ * [gravatar email="user@example.org" size="48"]
+ * [gravatar_profile who="user@example.org"]
+ */
 
-add_shortcode( 'gravatar', 'gravatar_shortcode' );
+add_shortcode( 'gravatar', 'jetpack_gravatar_shortcode' );
+add_shortcode( 'gravatar_profile', 'jetpack_gravatar_profile_shortcode' );
 
-function gravatar_shortcode( $atts ) {
+/**
+ * Get gravatar using the email provided at the specified size.
+ *
+ * @since 4.5.0
+ *
+ * @param array $atts Shortcode attributes.
+ *
+ * @return bool|string
+ */
+function jetpack_gravatar_shortcode( $atts ) {
 	$atts = shortcode_atts( array(
 		'email' => '',
 		'size'  => 96,
@@ -23,7 +41,9 @@ function gravatar_shortcode( $atts ) {
 /**
  * Display Gravatar profile
  *
- * @param array $atts
+ * @since 4.5.0
+ *
+ * @param array $atts Shortcode attributes.
  *
  * @uses shortcode_atts()
  * @uses get_user_by()
@@ -36,16 +56,17 @@ function gravatar_shortcode( $atts ) {
  * @uses esc_url()
  * @uses esc_html()
  * @uses _e()
- * @return string or false
+ *
+ * @return string
  */
-function gravatar_profile_shortcode( $atts ) {
+function jetpack_gravatar_profile_shortcode( $atts ) {
 	// Give each use of the shortcode a unique ID
 	static $instance = 0;
 
 	// Process passed attributes
 	$atts = shortcode_atts( array(
 		'who' => null,
-	), $atts, 'gravatar_profile' );
+	), $atts, 'jetpack_gravatar_profile' );
 
 	// Can specify username, user ID, or email address
 	if ( is_numeric( $atts['who'] ) ) {
@@ -65,8 +86,15 @@ function gravatar_profile_shortcode( $atts ) {
 
 	// Render the shortcode
 	$gravatar_url  = set_url_scheme( 'http://gravatar.com/' . $user->user_login );
-	$avatar_url    = wpcom_get_avatar_url( $user->ID, 96 );
-	$user_location = get_user_attribute( $user->ID, 'location' );
+
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$avatar_url    = wpcom_get_avatar_url( $user->ID, 96 );
+		$avatar_url    = $avatar_url[0];
+		$user_location = get_user_attribute( $user->ID, 'location' );
+	} else {
+		$avatar_url    = get_avatar_url( $user->user_email, array( 'size' => 96 ) );
+		$user_location = get_user_meta( $user->ID, 'location', true );
+	}
 
 	ob_start();
 
@@ -97,7 +125,7 @@ function gravatar_profile_shortcode( $atts ) {
 			<div class="grofile-left">
 				<div class="grofile-img">
 					<a href="<?php echo esc_url( $gravatar_url ); ?>">
-						<img src="<?php echo esc_url( $avatar_url[0] ); ?>" width="96" height="96" class="no-grav gravatar photo" />
+						<img src="<?php echo esc_url( $avatar_url ); ?>" width="96" height="96" class="no-grav gravatar photo" />
 					</a>
 				</div>
 			</div>
@@ -120,5 +148,3 @@ function gravatar_profile_shortcode( $atts ) {
 
 	return ob_get_clean();
 }
-
-add_shortcode( 'gravatar_profile', 'gravatar_profile_shortcode' );

--- a/modules/shortcodes/gravatar.php
+++ b/modules/shortcodes/gravatar.php
@@ -134,9 +134,9 @@ function jetpack_gravatar_profile_shortcode( $atts ) {
 					<strong><?php echo esc_html( $user->display_name ); ?></strong>
 					<?php if ( ! empty( $user_location ) ) : ?><br><span class="grofile-location adr"><?php echo esc_html( $user_location ); ?></span><?php endif; ?>
 				</p>
-				<p class="grofile-bio"><strong><?php _e( 'Bio:' ); ?></strong> <?php echo wp_kses_post( $user->description ); ?></p>
+				<p class="grofile-bio"><strong><?php esc_html_e( 'Bio:', 'jetpack' ); ?></strong> <?php echo wp_kses_post( $user->description ); ?></p>
 				<p class="grofile-view">
-					<a href="<?php echo esc_url( $gravatar_url ); ?>"><?php _e( 'View complete profile' ); ?></a>
+					<a href="<?php echo esc_url( $gravatar_url ); ?>"><?php esc_html_e( 'View complete profile', 'jetpack' ); ?></a>
 				</p>
 			</div>
 			<span class="grofile-clear">&nbsp;</span>

--- a/modules/shortcodes/hulu.php
+++ b/modules/shortcodes/hulu.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Hulu Shortcode
+ *
+ * [hulu 369061]
+ * [hulu id=369061]
+ * [hulu id=369061 width=512 height=288 start_time="10" end_time="20" thumbnail_frame="10"]
+ * [hulu http://www.hulu.com/watch/369061]
+ * [hulu id=gQ6Z0I990IWv_VFQI2J7Eg width=512 height=288]
+ *
+ * <object width="512" height="288">
+ * <param name="movie" value="http://www.hulu.com/embed/gQ6Z0I990IWv_VFQI2J7Eg"></param>
+ * <param name="allowFullScreen" value="true"></param>
+ * <embed src="http://www.hulu.com/embed/gQ6Z0I990IWv_VFQI2J7Eg" type="application/x-shockwave-flash"  width="512" height="288" allowFullScreen="true"></embed>
+ * </object>
+*/
+
+if ( get_option( 'embed_autourls' ) ) {
+
+	// Convert hulu URLS to shortcodes for old comments, saved before comments for shortcodes were enabled
+	add_filter( 'comment_text', 'jetpack_hulu_link', 1 );
+}
+
+add_shortcode( 'hulu', 'jetpack_hulu_shortcode' );
+
+/**
+ * Return a Hulu video ID from a given set to attributes.
+ *
+ * @since 4.5.0
+ *
+ * @param array  $atts Shortcode parameters.
+ *
+ * @return string $id  Hulu video ID.
+ */
+function jetpack_shortcode_get_hulu_id( $atts ) {
+	// This will catch an id explicitly defined as such, or assume any param without a label is the id.  First found is used.
+	if ( isset( $atts['id'] ) ) {
+		// First we check to see if [hulu id=369061] or [hulu id=gQ6Z0I990IWv_VFQI2J7Eg] was used
+		$id = esc_attr( $atts['id'] );
+	} else if ( preg_match( '|www\.hulu\.com/watch/(\d+)|i', $atts[0], $match ) ) {
+		// this checks for [hulu http://www.hulu.com/watch/369061]
+		$id = (int) $match[1];
+	} else if ( isset( $atts[0] ) ) {
+		// This checks for [hulu 369061] or [hulu 65yppv6xqa45s5n7_m1wng]
+		$id = esc_attr( $atts[0] );
+	} else {
+		$id = 0;
+	}
+
+	return $id;
+}
+
+/**
+ * Convert a Hulu shortcode into an embed code.
+ *
+ * @since 4.5.0
+ *
+ * @param array $atts An array of shortcode attributes.
+ *
+ * @return string The embed code for the Hulu video.
+ */
+function jetpack_hulu_shortcode( $atts ) {
+	global $content_width;
+
+	// Set a default content width, if it's not specified.
+	$attr = shortcode_atts(
+		array(
+			'id'              => '',
+			'width'           => $content_width ? $content_width : 640,
+			'start_time'      => '',
+			'end_time'        => '',
+			'thumbnail_frame' => ''
+		), $atts
+	);
+
+	$id = jetpack_shortcode_get_hulu_id( $atts );
+	if ( ! $id ) {
+		return '<!-- Hulu Error: Hulu shortcode syntax invalid. -->';
+	}
+
+	$start_time = 0;
+	if ( is_numeric( $attr['start_time'] ) ) {
+		$start_time = intval( $attr['start_time'] );
+	}
+	if ( is_numeric( $attr['end_time'] ) && intval( $attr['end_time'] ) > $start_time ) {
+		$end_time = intval( $attr['end_time'] );
+	}
+	if ( is_numeric( $attr['thumbnail_frame'] ) ) {
+		$thumbnail_frame = intval( $attr['thumbnail_frame'] );
+	}
+
+	// check to see if $id is 76560 else we assume it's gQ6Z0I990IWv_VFQI2J7Eg
+	// If id is numeric, we'll send it off to the hulu oembed api to get the embed URL (and non-numeric id)
+	if ( is_numeric( $id ) ) {
+		$transient_key = "hulu-$id";
+		if ( false === ( $transient_value = get_transient( $transient_key ) ) ) {
+			// let's make a cross-site http request out to the hulu oembed api
+			$response         = wp_remote_get( 'http://www.hulu.com/api/oembed.json?url=' . urlencode( 'http://www.hulu.com/watch/' . esc_attr( $id ) ) );
+			$response_code    = wp_remote_retrieve_response_code( $response );
+			$response_message = wp_remote_retrieve_response_message( $response );
+			if ( 200 !== $response_code && ! empty( $response_message ) ) {
+				return "<!-- Hulu Error: Hulu shortcode http error $response_message -->";
+			} elseif ( 200 !== $response_code ) {
+				return "<!-- Hulu Error: Hulu shortcode unknown error occurred, $response_code -->";
+			} else {
+				$response_body = wp_remote_retrieve_body( $response );
+				$json          = json_decode( $response_body );
+
+				// Pull out id from embed url (from oembed API)
+				$embed_url_params = array();
+				parse_str( parse_url( $json->embed_url, PHP_URL_QUERY ), $embed_url_params );
+
+				if ( isset( $embed_url_params['eid'] ) ) {
+					$id = $embed_url_params['eid'];
+				}
+				// let's cache this response indefinitely.
+				set_transient( $transient_key, $id );
+			}
+		} else {
+			$id = $transient_value;
+		}
+	}
+
+	if ( ! $id ) {
+		return '<!-- Hulu Error: Not a Hulu video. -->';
+	}
+
+	$width  = intval( $attr['width'] );
+	$height = round( ( $width / 640 ) * 360 );
+
+	$iframe_url = 'http://www.hulu.com/embed.html';
+	if ( is_ssl() ) {
+		$iframe_url = 'https://secure.hulu.com/embed.html';
+	}
+
+	$query_args        = array();
+	$query_args['eid'] = esc_attr( $id );
+	if ( isset( $start_time ) ) {
+		$query_args['st'] = intval( $start_time );
+	}
+	if ( isset( $end_time ) ) {
+		$query_args['et'] = intval( $end_time );
+	}
+	if ( isset( $thumbnail_frame ) ) {
+		$query_args['it'] = 'i' . intval( $thumbnail_frame );
+	}
+
+	$iframe_url = add_query_arg( $query_args, $iframe_url );
+
+	$html = sprintf(
+		'<div class="embed-hulu" style="text-align: center;"><iframe src="%s" width="%s" height="%s" style="border:0;" scrolling="no" webkitAllowFullScreen
+mozallowfullscreen allowfullscreen></iframe></div>',
+		esc_url( $iframe_url ),
+		esc_attr( $width ),
+		esc_attr( $height )
+	);
+	$html = apply_filters( 'video_embed_html', $html );
+
+	return $html;
+}
+
+/**
+ * Callback to convert Hulu links in comments into a embed src.
+ *
+ * @since 4.5.0
+ *
+ * @param array $matches
+ *
+ * @return string
+ */
+function jetpack_hulu_link_callback( $matches ) {
+	$video_id = $matches[4];
+	$src = is_ssl()
+		? 'https://secure.hulu.com'
+		: 'http://www.hulu.com';
+
+	// Make up an embed src to pass to the shortcode reversal function
+	$attrs['src'] = $src . '/embed.html?eid=' . esc_attr( $video_id );
+
+	return wpcom_shortcodereverse_huluhelper( $attrs );
+}
+
+/**
+ * Convert Hulu links in comments into a Hulu shortcode.
+ *
+ * @since 4.5.0
+ *
+ * @param string $content
+ *
+ * @return string
+ */
+function jetpack_hulu_link( $content ) {
+	$content = preg_replace_callback( '!^(http(s)?://)?(www\.)?hulu\.com\/watch\/([0-9]+)$!im', 'jetpack_hulu_link_callback', $content );
+
+	return $content;
+}
+
+/**
+ * Makes a Hulu shortcode from $attrs and $pattern
+ *
+ * @since 4.5.0
+ *
+ * @param array $attrs
+ *
+ * @return string
+ */
+function wpcom_shortcodereverse_huluhelper( $attrs ) {
+	$attrs = wpcom_shortcodereverse_parseattr( $attrs );
+
+	$src_attributes = array();
+	parse_str( parse_url( $attrs['src'], PHP_URL_QUERY ), $src_attributes );
+
+	$attrs = array_merge( $attrs, $src_attributes );
+
+	// If we don't have an eid, we can't do anything.  Just send back the src string.
+	if ( ! isset( $attrs['eid'] ) ) {
+		return $attrs['src'];
+	}
+
+	$shortcode = '[hulu id=' . esc_attr( $attrs['eid'] );
+
+	if ( $attrs['width'] ) {
+		$shortcode .= ' width=' . intval( $attrs['width'] );
+	}
+
+	if ( $attrs['height'] ) {
+		$shortcode .= ' height=' . intval( $attrs['height'] );
+	}
+
+	if ( $attrs['st'] ) {
+		$shortcode .= ' start_time=' . intval( $attrs['st'] );
+	}
+
+	if ( $attrs['et'] ) {
+		$shortcode .= ' end_time=' . intval( $attrs['et'] );
+	}
+
+	if ( $attrs['it'] ) {
+		// the thumbnail frame attribute comes with an i in front of the value, so we've got to remove that
+		$shortcode .= ' thumbnail_frame=' . intval( ltrim( $attrs['it'], 'i' ) );
+	}
+	$shortcode .= ']';
+
+	return $shortcode;
+}
+
+/**
+ * Initiates process to convert iframe HTML into a Hulu shortcode.
+ *
+ * Example:
+ * <iframe width="512" height="288" src="http://www.hulu.com/embed.html?eid=nlg_ios3tutcfrhatkiaow&et=20&st=10&it=i11" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>
+ *
+ * Converts to:
+ * [hulu id=nlg_ios3tutcfrhatkiaow width=512 height=288 start_time=10 end_time=20 thumbnail_frame=11]
+ *
+ * @since 4.5.0
+ *
+ * @param array $attrs
+ *
+ * @return string
+ */
+function wpcom_shortcodereverse_huluembed( $attrs ) {
+
+	$shortcode = wpcom_shortcodereverse_huluhelper( $attrs );
+	if ( substr( $shortcode, 0, 1 ) == '[' ) {
+		/** This action is documented in modules/widgets/social-media-icons.php */
+		do_action( 'jetpack_bump_stats_extras', 'html_to_shortcode', 'hulu-embed' );
+	}
+
+	return $shortcode;
+}
+Filter_Embedded_HTML_Objects::register( '#^http://www.hulu.com/embed.html#i', 'wpcom_shortcodereverse_huluembed', true );

--- a/modules/shortcodes/hulu.php
+++ b/modules/shortcodes/hulu.php
@@ -37,7 +37,7 @@ function jetpack_shortcode_get_hulu_id( $atts ) {
 	if ( isset( $atts['id'] ) ) {
 		// First we check to see if [hulu id=369061] or [hulu id=gQ6Z0I990IWv_VFQI2J7Eg] was used
 		$id = esc_attr( $atts['id'] );
-	} else if ( preg_match( '|www\.hulu\.com/watch/(\d+)|i', $atts[0], $match ) ) {
+	} else if ( isset( $atts[0] ) && preg_match( '|www\.hulu\.com/watch/(\d+)|i', $atts[0], $match ) ) {
 		// this checks for [hulu http://www.hulu.com/watch/369061]
 		$id = (int) $match[1];
 	} else if ( isset( $atts[0] ) ) {

--- a/modules/shortcodes/js/brightcove.js
+++ b/modules/shortcodes/js/brightcove.js
@@ -1,6 +1,7 @@
+/* global brightcove, brightcoveData */
 (function($){
 	var script = document.createElement('script'),
-		tld    = ( brightcoveData.tld == 'co.jp' ) ? 'co.jp' : 'com',
+		tld    = 'co.jp' === brightcoveData.tld ? 'co.jp' : 'com',
 		timer  = false;
 
 	// Load Brightcove script
@@ -16,7 +17,7 @@
 	function try_brightcove() {
 		clearTimeout( timer );
 
-		if ( 'object' == typeof brightcove ) {
+		if ( 'object' === typeof brightcove ) {
 			$( document ).ready( brightcove.createExperiences );
 			$( 'body' ).on( 'post-load', brightcove.createExperiences );
 

--- a/modules/shortcodes/js/brightcove.js
+++ b/modules/shortcodes/js/brightcove.js
@@ -1,0 +1,28 @@
+(function($){
+	var script = document.createElement('script'),
+		tld    = ( brightcoveData.tld == 'co.jp' ) ? 'co.jp' : 'com',
+		timer  = false;
+
+	// Load Brightcove script
+	script.src = 'https://sadmin.brightcove.' + tld + '/js/BrightcoveExperiences.js';
+	script.type = 'text/javascript';
+	script.language = 'JavaScript';
+	document.head.appendChild( script );
+
+	// Start detection for Brightcove script loading in its object
+	try_brightcove();
+
+	// Detect if Brightcove script has loaded and bind some events once loaded
+	function try_brightcove() {
+		clearTimeout( timer );
+
+		if ( 'object' == typeof brightcove ) {
+			$( document ).ready( brightcove.createExperiences );
+			$( 'body' ).on( 'post-load', brightcove.createExperiences );
+
+			brightcove.createExperiences();
+		} else {
+			timer = setTimeout( try_brightcove, 100 );
+		}
+	}
+})(jQuery);

--- a/modules/shortcodes/js/quiz.js
+++ b/modules/shortcodes/js/quiz.js
@@ -16,7 +16,7 @@
         });
 
         return $(shuffled);
-	}
+	};
 })(jQuery);
 
 jQuery( function( $ ) {

--- a/modules/shortcodes/js/quiz.js
+++ b/modules/shortcodes/js/quiz.js
@@ -1,0 +1,55 @@
+(function($){
+	$.fn.shuffleQuiz = function() {
+        var allElems = this.get(),
+            getRandom = function(max) {
+                return Math.floor(Math.random() * max);
+            },
+            shuffled = $.map(allElems, function(){
+                var random = getRandom(allElems.length),
+                    randEl = $(allElems[random]).clone(true)[0];
+                allElems.splice(random, 1);
+                return randEl;
+           });
+
+        this.each(function(i){
+            $(this).replaceWith($(shuffled[i]));
+        });
+
+        return $(shuffled);
+	}
+})(jQuery);
+
+jQuery( function( $ ) {
+	$( '.quiz' ).each( function() {
+		var quiz = $(this);
+		quiz.find( 'div.answer' ).shuffleQuiz();
+		quiz.find( 'div[data-correct]' ).removeAttr( 'data-correct' ).data( 'correct', 1 );
+		quiz.find( 'div.answer:last' ).addClass( 'last' );
+	});
+
+	$( 'div.quiz' ).on( 'click', 'div.answer', function() {
+		var trackid, answer = $( this ),
+			quiz = answer.closest( 'div.quiz' );
+
+		if  ( quiz.data( 'a8ctraining' ) ) {
+			new Image().src = '//pixel.wp.com/b.gif?v=wpcom-no-pv&x_trainingchaos-' + quiz.data( 'username' ) + '=' + quiz.data( 'a8ctraining' ) + '&rand=' + Math.random();
+			quiz.data( 'a8ctraining', false );
+			quiz.data( 'trackid', false );
+		}
+
+		trackid = quiz.data( 'trackid' );
+		if ( answer.data( 'correct' ) ) {
+			answer.addClass( 'correct' );
+			if ( trackid ) {
+				new Image().src = '//pixel.wp.com/b.gif?v=wpcom-no-pv&x_quiz-' + trackid + '=correct&rand=' + Math.random();
+			}
+		} else {
+			answer.addClass( 'wrong' );
+			if ( trackid ) {
+				new Image().src = '//pixel.wp.com/b.gif?v=wpcom-no-pv&x_quiz-' + trackid + '=wrong&rand=' + Math.random();
+			}
+		}
+		// only track the first answer
+		quiz.data( 'trackid', false );
+	});
+} );

--- a/modules/shortcodes/kickstarter.php
+++ b/modules/shortcodes/kickstarter.php
@@ -48,31 +48,31 @@ function jetpack_kickstarter_embed_to_shortcode( $content ) {
 		return $content;
 	}
 
-    $regexp = '!<iframe((?:\s+\w+=[\'"][^\'"]*[\'"])*)\s+src=[\'"](http://www\.kickstarter\.com/projects/[^/]+/[^/]+)/[^\'"]+[\'"]((?:\s+\w+=[\'"][^\'"]*[\'"])*)>[\s]*</iframe>!i';
-    $regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
+	$regexp     = '!<iframe((?:\s+\w+=[\'"][^\'"]*[\'"])*)\s+src=[\'"](http://www\.kickstarter\.com/projects/[^/]+/[^/]+)/[^\'"]+[\'"]((?:\s+\w+=[\'"][^\'"]*[\'"])*)>[\s]*</iframe>!i';
+	$regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
 
-    foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
+	foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
 		if ( ! preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) ) {
 			continue;
 		}
 
-        foreach ( $matches as $match ) {
-            $url = esc_url( $match[2] );
+		foreach ( $matches as $match ) {
+			$url = esc_url( $match[2] );
 
-            $params = $match[1] . $match[3];
+			$params = $match[1] . $match[3];
 
 			if ( 'regexp_ent' == $reg ) {
 				$params = html_entity_decode( $params );
 			}
 
-            $params = wp_kses_hair( $params, array( 'http' ) );
+			$params = wp_kses_hair( $params, array( 'http' ) );
 
-            $width = isset( $params['width'] ) ? (int) $params['width']['value'] : 0;
+			$width = isset( $params['width'] ) ? (int) $params['width']['value'] : 0;
 
-            $shortcode = '[kickstarter url=' . $url . ( ( !empty( $width ) ) ? " width=$width" : '' ) . ']';
-            $content = str_replace( $match[0], $shortcode, $content );
-        }
-    }
+			$shortcode = '[kickstarter url=' . $url . ( ( ! empty( $width ) ) ? " width=$width" : '' ) . ']';
+			$content   = str_replace( $match[0], $shortcode, $content );
+		}
+	}
 
-    return $content;
+	return $content;
 }

--- a/modules/shortcodes/kickstarter.php
+++ b/modules/shortcodes/kickstarter.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Kickstarter shortcode
+ *
+ * Usage:
+ * [kickstarter url="https://www.kickstarter.com/projects/peaktoplateau/yak-wool-baselayers-from-tibet-to-the-world" width="480" height=""]
+ */
+
+add_shortcode( 'kickstarter', 'jetpack_kickstarter_shortcode' );
+add_filter( 'pre_kses', 'jetpack_kickstarter_embed_to_shortcode' );
+
+/**
+ * Parse shortcode arguments and render its output.
+ *
+ * @since 4.5.0
+ *
+ * @param array $atts Shortcode parameters.
+ *
+ * @return string
+ */
+function jetpack_kickstarter_shortcode( $atts ) {
+	if ( empty( $atts['url'] ) ) {
+		return '';
+	}
+
+	$url = esc_url_raw( $atts['url'] );
+	if ( ! preg_match( '#^(www\.)?kickstarter\.com$#i', parse_url( $url, PHP_URL_HOST ) ) ) {
+		return '<!-- Invalid Kickstarter URL -->';
+	}
+
+	global $wp_embed;
+	return $wp_embed->shortcode( $atts, $url );
+}
+
+/**
+ * Converts Kickstarter iframe embeds to a shortcode.
+ *
+ * EG: <iframe width="480" height="360" src="http://www.kickstarter.com/projects/deweymac/dewey-mac-kid-detective-book-make-diy-and-stem-spy/widget/video.html" frameborder="0" scrolling="no"> </iframe>
+ *
+ * @since 4.5.0
+ *
+ * @param string $content Entry content that possibly includes a Kickstarter embed.
+ *
+ * @return string
+ */
+function jetpack_kickstarter_embed_to_shortcode( $content ) {
+	if ( false === stripos( $content, 'www.kickstarter.com/projects' ) ) {
+		return $content;
+	}
+
+    $regexp = '!<iframe((?:\s+\w+=[\'"][^\'"]*[\'"])*)\s+src=[\'"](http://www\.kickstarter\.com/projects/[^/]+/[^/]+)/[^\'"]+[\'"]((?:\s+\w+=[\'"][^\'"]*[\'"])*)>[\s]*</iframe>!i';
+    $regexp_ent = str_replace( '&amp;#0*58;', '&amp;#0*58;|&#0*58;', htmlspecialchars( $regexp, ENT_NOQUOTES ) );
+
+    foreach ( array( 'regexp', 'regexp_ent' ) as $reg ) {
+		if ( ! preg_match_all( $$reg, $content, $matches, PREG_SET_ORDER ) ) {
+			continue;
+		}
+
+        foreach ( $matches as $match ) {
+            $url = esc_url( $match[2] );
+
+            $params = $match[1] . $match[3];
+
+			if ( 'regexp_ent' == $reg ) {
+				$params = html_entity_decode( $params );
+			}
+
+            $params = wp_kses_hair( $params, array( 'http' ) );
+
+            $width = isset( $params['width'] ) ? (int) $params['width']['value'] : 0;
+
+            $shortcode = '[kickstarter url=' . $url . ( ( !empty( $width ) ) ? " width=$width" : '' ) . ']';
+            $content = str_replace( $match[0], $shortcode, $content );
+        }
+    }
+
+    return $content;
+}

--- a/modules/shortcodes/kickstarter.php
+++ b/modules/shortcodes/kickstarter.php
@@ -44,7 +44,7 @@ function jetpack_kickstarter_shortcode( $atts ) {
  * @return string
  */
 function jetpack_kickstarter_embed_to_shortcode( $content ) {
-	if ( false === stripos( $content, 'www.kickstarter.com/projects' ) ) {
+	if ( ! is_string( $content ) || false === stripos( $content, 'www.kickstarter.com/projects' ) ) {
 		return $content;
 	}
 

--- a/modules/shortcodes/lytro.php
+++ b/modules/shortcodes/lytro.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Lytro.com Short Code
+ *
+ * Format:
+ *   [lytro photo='202' show_arrow='true' show_border='true' show_first_time_user='true' allow_full_view='true']
+ *   [lytro username='lytroweb' photo='431119']
+ *
+ * Legend:
+ *   username: the lytro.com username for newer embed format
+ *   photo: the ID or the URL of the photo on lytro.com
+ *   show_arrow: set to false to force-hide the menu in the lower right (not used in v2)
+ *   show_border: set to true to force-show the border
+ *   show_first_time_user: set to false to force-disable the first-time user experience (not used in v2)
+ *   allow_full_view: set to true to allow an external site to have a full-zoom mode (not used in v2)
+ *   enable_help: set to false to hide the question mark/help popup
+ *
+ * Output:
+ *   <iframe width="400" height="415" src="https://www.lytro.com/living-pictures/202/embed?showArrow=true&showBorder=true&showFTU=true" frameborder="0" allowfullscreen></iframe>
+ *   <iframe width="400" height="415" src="http://pictures.lytro.com/lytroweb/pictures/431119/embed" frameborder="0" allowfullscreen="" scrolling="no"></iframe>
+ */
+
+/**
+ * Lytro.com Short Code Attributes Definition
+ *
+ * This helper function returns an array all available
+ * shortcode attributes, their validation method, default
+ * value and more.
+ *
+ * Keys:
+ *   validate: a callable function or regular expression used to validate the input
+ *   default: default value for shortcode attribute
+ *   query_arg: the related lytro query argument name
+ *
+ * @since 4.5.0
+ */
+function jetpack_lytro_shortcode_attributes() {
+	return array(
+		'username'             => array(
+			'default' => '',
+		),
+		'photo'                => array( // could be ID or URL, validated separately
+			'default' => 0,
+		),
+		'width'                => array(
+			'validate' => '#^\d+$#',
+			'default'  => 400,
+		),
+		'height'               => array(
+			'validate' => '#^\d+$#',
+			'default'  => 415,
+		),
+		'show_arrow'           => array(
+			'query_arg' => 'showArrow',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'show_border'          => array(
+			'query_arg' => 'showBorder',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'show_first_time_user' => array(
+			'query_arg' => 'showFTU',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'allow_full_view'      => array(
+			'query_arg' => 'allowFullView',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'enable_help'          => array(
+			'query_arg' => 'enableHelp',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'enable_attribution'   => array(
+			'query_arg' => 'enableAttribution',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'enable_logo'          => array(
+			'query_arg' => 'enableLogo',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'enable_fullscreen'    => array(
+			'query_arg' => 'enableFullscreen',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'enable_play'          => array(
+			'query_arg' => 'enablePlay',
+			'validate'  => '#^(true|false)$#',
+			'default'   => 'true',
+		),
+		'bg_color'             => array(
+			'query_arg' => 'bgColor',
+			'validate'  => '/^#(?:[0-9a-fA-F]{3}){1,2}$/',
+			'default'   => '',
+		),
+	);
+}
+
+/**
+ * Lytro.com Shortcode
+ *
+ * Allows embedding Lytro "living pictures" using [lytro photo="200"] or
+ * [lytro photo="http://www.lytro.com/..."]. Additional attributes
+ * like show_border, show_arrow, etc have priority over the ones supplied
+ * in the URL.
+ *
+ * @since 4.5.0
+ *
+ * @param array $atts Shortcode attributes
+ *
+ * @uses jetpack_lytro_shortcode_attributes()
+ * @return string Embed HTML or a <!-- commented out error -->
+ */
+function jetpack_lytro_shortcode_handler( $atts ) {
+	$defaults   = array();
+	$attributes = jetpack_lytro_shortcode_attributes();
+	foreach ( $attributes as $key => $attribute ) {
+		if ( isset( $attribute['default'] ) ) {
+			$defaults[$key] = $attribute['default'];
+		}
+	}
+
+	$atts = shortcode_atts( $defaults, $atts );
+
+	// There has to at least be a photo attribute.
+	if ( empty( $atts['photo'] ) ) {
+		return '<!-- Lytro Shortcode Error: No Photo ID/URL -->';
+	}
+
+	// The photo attribute might be a URL
+	if ( ! is_numeric( $atts['photo'] ) ) {
+		$atts = array_merge( $atts, jetpack_lytro_shortcode_url_to_atts( $atts['photo'] ) );
+	}
+
+	// Validate all attributes by callable function or regular expression.
+	foreach ( $atts as $key => $value ) {
+		$attribute = $attributes[$key];
+		if ( isset( $attribute['validate'] ) ) {
+			$validate = $attribute['validate'];
+			$valid    = is_callable( $validate ) ? call_user_func( $validate, $value ) : preg_match( $validate, $value );
+			if ( ! $valid ) {
+				$atts[$key] = $defaults[$key];
+			}
+		}
+	}
+
+	// The photo attribute might have changed, make sure it's still valid.
+	if ( ! is_numeric( $atts['photo'] ) || ! $atts['photo'] ) {
+		return '<!-- Lytro Shortcode Error: Invalid Photo ID/URL -->';
+	}
+
+	// Build a query which is then appended to the iframe src.
+	$query_args = array();
+	foreach ( $atts as $key => $value ) {
+		$attribute = $attributes[$key];
+		if ( isset( $attribute['query_arg'] ) && ! empty( $attribute['query_arg'] ) && ! empty( $value ) ) {
+			$query_args[$attribute['query_arg']] = $value;
+		}
+	}
+
+	if ( ! empty( $atts['username'] ) ) {
+		$src = sprintf( 'https://pictures.lytro.com/%s/pictures/%d/embed', $atts['username'], $atts['photo'] );
+	} else {
+		$src = sprintf( 'https://www.lytro.com/living-pictures/%d/embed', $atts['photo'] );
+	}
+
+	// Add query args and build the iframe.
+	$src = add_query_arg( $query_args, $src );
+
+	return '<iframe width="' . esc_attr( $atts['width'] ) . '" height="' . esc_attr( $atts['height'] ) . '" src="' . esc_url( $src ) . '" frameborder="0" allowfullscreen scrolling="no"></iframe>';
+}
+
+add_shortcode( 'lytro', 'jetpack_lytro_shortcode_handler' );
+
+/**
+ * Lytro Shortcode URL to Shortcode Attributes
+ *
+ * This helper function parses a Lytro.com URL
+ * and returns an attributes array.
+ *
+ * @since 4.5.0
+ *
+ * @uses jetpack_lytro_shortcode_attributes()
+ */
+function jetpack_lytro_shortcode_url_to_atts( $url ) {
+	$attributes = jetpack_lytro_shortcode_attributes();
+	$atts       = array();
+
+	$url = str_replace( '&amp;', '&', $url );
+
+	if ( preg_match( '#^https?://(www\.)?lytro\.com/living-pictures/([0-9]+)/?#i', $url, $matches ) ) {
+		$atts['photo'] = $matches[2];
+	} elseif ( preg_match( '#^https?://(www\.)?pictures\.lytro\.com/([^/]+)/pictures/([0-9]+)/?#i', $url, $matches ) ) {
+		$atts['username'] = $matches[2];
+		$atts['photo']    = $matches[3];
+	}
+
+	$url = parse_url( $url );
+	if ( isset( $url['query'] ) ) {
+		parse_str( $url['query'], $qargs );
+
+		// Get the attributes with query_args and fill in the $atts array
+		foreach ( $attributes as $key => $attribute ) {
+			if ( isset( $attribute['query_arg'] ) && in_array( $attribute['query_arg'], array_keys( $qargs ) ) ) {
+				$atts[$key] = $qargs[$attribute['query_arg']];
+			}
+		}
+	}
+
+	return $atts;
+}
+
+/**
+ * Lytro Shortcode Reversal
+ *
+ * Example
+ * <iframe width="400" height="415" src="https://www.lytro.com/living-pictures/202/embed?showBorder=true" frameborder="0" allowfullscreen></iframe>
+ * <iframe width="400" height="415" src="http://pictures.lytro.com/lytroweb/pictures/431128/embed" frameborder="0" allowfullscreen="" scrolling="no"></iframe>
+ *
+ * Converts to:
+ * [lytro photo="202" show_border="true" width="400" height="415"]
+ *
+ * @since 4.5.0
+ *
+ * @uses jetpack_lytro_shortcode_url_to_atts()
+ * @uses wpcom_shortcodereverse_parseattr()
+ */
+function wpcom_shortcodereverse_lytro( $atts ) {
+	$atts           = wpcom_shortcodereverse_parseattr( $atts );
+	$shortcode_atts = array();
+
+	// Grab the src URL and convert to shortcode attributes
+	if ( $atts['src'] ) {
+		$shortcode_atts = jetpack_lytro_shortcode_url_to_atts( $atts['src'] );
+	}
+
+	// Width and height too
+	if ( $atts['width'] ) {
+		$shortcode_atts['width'] = $atts['width'];
+	}
+	if ( $atts['height'] ) {
+		$shortcode_atts['height'] = $atts['height'];
+	}
+
+	// Generate the shortcode.
+	$shortcode = '';
+	foreach ( $shortcode_atts as $key => $value ) {
+		$shortcode .= " $key='" . esc_attr( $value ) . "'";
+	}
+	$shortcode = "[lytro {$shortcode}]";
+
+	return $shortcode;
+}
+
+Filter_Embedded_HTML_Objects::register( '#^https?://(www\.)?lytro\.com/living-pictures/#i', 'wpcom_shortcodereverse_lytro', true );
+Filter_Embedded_HTML_Objects::register( '#^https?://(www\.)?pictures\.lytro\.com/([^/]+)/pictures/([0-9]+)/embed#i', 'wpcom_shortcodereverse_lytro', true );
+
+/**
+ * Register Embed Handler
+ *
+ * Registers a WordPress Embed handler to allow embedding
+ * Lytro images by publishing the Lytro URL on a line by itself.
+ *
+ * @since 4.5.0
+ *
+ * @uses wp_embed_register_handler
+ */
+function jetpack_lytro_register_embed_handler() {
+	wp_embed_register_handler( 'lytro', '#^https?://(www\.)?lytro\.com/living-pictures/([0-9]+)/?#i', 'jetpack_lytro_embed_handler' );
+	wp_embed_register_handler( 'lytro-v2', '#^https?://(www\.)?pictures\.lytro\.com/([^/]+)/pictures/([0-9]+)/?#i', 'jetpack_lytro_embed_handler' );
+}
+
+add_action( 'init', 'jetpack_lytro_register_embed_handler' );
+
+/**
+ * Lytro Embed Handler
+ *
+ * The embed handler function which converts a Lytro URL
+ * on a line by itself into an embedded Lytro image.
+ *
+ * @since 4.5.0
+ *
+ * @see  jetpack_lytro_register_embed_handler
+ * @uses jetpack_lytro_shortcode_url_to_atts
+ * @uses jetpack_lytro_shortcode_handler
+ */
+function jetpack_lytro_embed_handler( $matches, $attr, $url, $rawattr ) {
+	return jetpack_lytro_shortcode_handler( jetpack_lytro_shortcode_url_to_atts( $url ) );
+}

--- a/modules/shortcodes/lytro.php
+++ b/modules/shortcodes/lytro.php
@@ -168,7 +168,7 @@ function jetpack_lytro_shortcode_handler( $atts ) {
 	if ( ! empty( $atts['username'] ) ) {
 		$src = sprintf( 'https://pictures.lytro.com/%s/pictures/%d/embed', $atts['username'], $atts['photo'] );
 	} else {
-		$src = sprintf( 'https://www.lytro.com/living-pictures/%d/embed', $atts['photo'] );
+		$src = sprintf( 'https://pictures.lytro.com/pictures/%d/embed', $atts['photo'] );
 	}
 
 	// Add query args and build the iframe.

--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -83,7 +83,7 @@ class MailChimp_Subscriber_Popup {
 	 */
 	static function reversal( $content ) {
 		// Bail without the js src
-		if ( false === stripos( $content, 'downloads.mailchimp.com/js/signup-forms/popup/embed.js' ) ) {
+		if ( ! is_string( $content ) || false === stripos( $content, 'downloads.mailchimp.com/js/signup-forms/popup/embed.js' ) ) {
 			return $content;
 		}
 

--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * MailChimp Subscriber Popup Form shortcode
+ *
+ * Example:
+ * [mailchimp_subscriber_popup baseUrl="mc.us11.list-manage.com" uuid="1ca7856462585a934b8674c71" lid="2d24f1898b"]
+ *
+ * Embed code example:
+ * <script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"1ca7856462585a934b8674c71","lid":"2d24f1898b"}) })</script>
+ *
+ */
+
+/**
+ * Register [mailchimp_subscriber_popup] shortcode and add a filter to 'pre_kses' queue to reverse MailChimp iframe to shortcode.
+ *
+ * @since 4.5.0
+ */
+function jetpack_mailchimp_subscriber_popup() {
+	add_shortcode( 'mailchimp_subscriber_popup', array(
+		'MailChimp_Subscriber_Popup',
+		'shortcode'
+	) );
+	add_filter( 'pre_kses', array(
+		'MailChimp_Subscriber_Popup',
+		'reversal'
+	) );
+}
+
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	add_action( 'init', 'jetpack_mailchimp_subscriber_popup' );
+} else {
+	jetpack_mailchimp_subscriber_popup();
+}
+
+class MailChimp_Subscriber_Popup {
+
+	static $reversal_regexes = array(
+		/* raw examplejs */
+		'/<script type="text\/javascript" src="(https?:)?\/\/s3\.amazonaws.com\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/embed\.js" data-dojo-config="([^"]*?)"><\/script><script type="text\/javascript">require\(\["mojo\/signup-forms\/Loader"\]\, function\(L\) { L\.start\({([^}]*?)}\) }\)<\/script>/s',
+		/* visual editor */
+		'/&lt;script type="text\/javascript" src="(https?:)?\/\/s3\.amazonaws.com\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/embed\.js" data-dojo-config="([^"]*?)"&gt;&lt;\/script&gt;&lt;script type="text\/javascript"&gt;require\(\["mojo\/signup-forms\/Loader"]\, function\(L\) { L\.start\({([^}]*?)}\) }\)&lt;\/script&gt;/s',
+	);
+
+	static $allowed_config = array(
+		'usePlainJson' => 'true',
+		'isDebug'      => 'false',
+	);
+
+	static $allowed_js_vars = array(
+		'baseUrl',
+		'uuid',
+		'lid',
+	);
+
+	/**
+	 * Runs the whole reversal.
+	 * @param string $content Post Content
+	 * @return string Content with embeds replaced
+	 */
+	static function reversal( $content ) {
+		// Bail without the js src
+		if ( false === stripos( $content, 'downloads.mailchimp.com/js/signup-forms/popup/embed.js' ) ) {
+			return $content;
+		}
+
+		require_once( ABSPATH . WPINC . '/class-json.php' );
+		$wp_json = new Services_JSON();
+
+		// loop through our rules and find valid embeds
+		foreach ( self::$reversal_regexes as $regex ) {
+
+			if ( ! preg_match_all( $regex, $content, $matches ) ) {
+				continue;
+			}
+
+			foreach ( $matches[3] as $index => $js_vars ) {
+				// the regex rule for a specific embed
+				$replace_regex = sprintf( '#\s*%s\s*#', preg_quote( $matches[0][$index], '#' ) );
+
+				$attrs = $wp_json->decode( '{' . $js_vars . '}' );
+
+				if ( $matches[2][$index] ) {
+					$config_attrs = $wp_json->decode( '{' . $matches[2][$index] . '}' );
+					foreach ( $config_attrs as $key => $value ) {
+						$attrs->$key = ( 1 == $value ) ? 'true' : 'false';
+					}
+				}
+
+				$shortcode = self::build_shortcode_from_reversal_attrs( $attrs );
+
+				$content = preg_replace( $replace_regex, "\n\n$shortcode\n\n", $content );
+
+				/** This action is documented in modules/widgets/social-media-icons.php */
+				do_action( 'jetpack_bump_stats_extras', 'html_to_shortcode', 'mailchimp_subscriber_popup' );
+			}
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Builds the actual shortcode based on passed in attributes
+	 *
+	 * @param array $attrs A valid list of attributes (gets matched against self::$allowed_config and self::$allowed_js_vars)
+	 *
+	 * @return string
+	 */
+	static function build_shortcode_from_reversal_attrs( $attrs ) {
+		$shortcode = '[mailchimp_subscriber_popup ';
+
+		foreach ( $attrs as $key => $value ) {
+			// skip unsupported keys
+			if ( ! in_array( $key, array_keys( self::$allowed_config ) ) && ! in_array( $key, self::$allowed_js_vars ) ) {
+				continue;
+			}
+
+			$value      = esc_attr( $value );
+			$shortcode .= "$key='$value' ";
+		}
+		return trim( $shortcode ) . ']';
+	}
+
+	/**
+	 * Parses the shortcode back out to embedded information
+	 *
+	 * @param array $lcase_attrs
+	 *
+	 * @return string
+	 */
+	static function shortcode( $lcase_attrs ) {
+		static $displayed_once = false;
+
+		// Limit to one form per page load
+		if ( $displayed_once ) {
+			return '';
+		}
+
+		$defaults = array_fill_keys( self::$allowed_js_vars, '' );
+		$defaults = array_merge( $defaults, self::$allowed_config );
+
+		// Convert $attrs back to proper casing since they come through in all lowercase
+		$attrs = array();
+		foreach ( $defaults as $key => $value ) {
+			if ( array_key_exists( strtolower( $key ), $lcase_attrs ) ) {
+				$attrs[ $key ] = $lcase_attrs[ strtolower( $key ) ];
+			}
+		}
+		$attrs = array_map( 'esc_js', array_filter( shortcode_atts( $defaults, $attrs ) ) );
+
+		// Split config & js vars
+		$config_vars = $js_vars = array();
+		foreach ( $attrs as $key => $value ) {
+			if ( in_array( $key, self::$allowed_js_vars ) ) {
+				$js_vars[ $key ] = $value;
+			} else {
+				$config_vars[] = "$key: $value";
+			}
+		}
+
+		/** This action is already documented in modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'mailchimp_subscriber_popup', 'view' );
+
+		$displayed_once = true;
+
+		return "\n\n" . '<script type="text/javascript" data-dojo-config="' . esc_attr( implode( ', ', $config_vars ) ) . '">jQuery.getScript( "//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start(' . wp_json_encode( $js_vars ) . ') }); } );</script>' . "\n\n";
+	}
+}

--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -163,6 +163,10 @@ class MailChimp_Subscriber_Popup {
 			return '';
 		}
 
+		if ( empty( $lcase_attrs ) ) {
+			return '<!-- Missing MailChimp baseUrl, uuid or lid -->';
+		}
+
 		$defaults = array_fill_keys( self::$allowed_js_vars, '' );
 		$defaults = array_merge( $defaults, self::$allowed_config );
 
@@ -183,6 +187,11 @@ class MailChimp_Subscriber_Popup {
 			} else {
 				$config_vars[] = "$key: $value";
 			}
+		}
+
+		// If one of these parameters is missing we can't render the form so exist.
+		if ( empty( $js_vars['baseUrl'] ) || empty( $js_vars['uuid'] ) || empty( $js_vars['lid'] ) ) {
+			return '<!-- Missing MailChimp baseUrl, uuid or lid -->';
 		}
 
 		/** This action is already documented in modules/widgets/gravatar-profile.php */

--- a/modules/shortcodes/mailchimp.php
+++ b/modules/shortcodes/mailchimp.php
@@ -11,7 +11,7 @@
  */
 
 /**
- * Register [mailchimp_subscriber_popup] shortcode and add a filter to 'pre_kses' queue to reverse MailChimp iframe to shortcode.
+ * Register [mailchimp_subscriber_popup] shortcode and add a filter to 'pre_kses' queue to reverse MailChimp embed to shortcode.
  *
  * @since 4.5.0
  */
@@ -32,8 +32,18 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	jetpack_mailchimp_subscriber_popup();
 }
 
+/**
+ * Class MailChimp_Subscriber_Popup
+ *
+ * @since 4.5.0
+ */
 class MailChimp_Subscriber_Popup {
 
+	/**
+	 * Regular expressions to reverse script tags to shortcodes.
+	 *
+	 * @var array
+	 */
 	static $reversal_regexes = array(
 		/* raw examplejs */
 		'/<script type="text\/javascript" src="(https?:)?\/\/s3\.amazonaws.com\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/embed\.js" data-dojo-config="([^"]*?)"><\/script><script type="text\/javascript">require\(\["mojo\/signup-forms\/Loader"\]\, function\(L\) { L\.start\({([^}]*?)}\) }\)<\/script>/s',
@@ -41,11 +51,21 @@ class MailChimp_Subscriber_Popup {
 		'/&lt;script type="text\/javascript" src="(https?:)?\/\/s3\.amazonaws.com\/downloads\.mailchimp\.com\/js\/signup-forms\/popup\/embed\.js" data-dojo-config="([^"]*?)"&gt;&lt;\/script&gt;&lt;script type="text\/javascript"&gt;require\(\["mojo\/signup-forms\/Loader"]\, function\(L\) { L\.start\({([^}]*?)}\) }\)&lt;\/script&gt;/s',
 	);
 
+	/**
+	 * Allowed configuration attributes. Used in reversal when checking allowed attributes.
+	 *
+	 * @var array
+	 */
 	static $allowed_config = array(
 		'usePlainJson' => 'true',
 		'isDebug'      => 'false',
 	);
 
+	/**
+	 * Allowed JS variables. Used in reversal to whitelist variables.
+	 *
+	 * @var array
+	 */
 	static $allowed_js_vars = array(
 		'baseUrl',
 		'uuid',
@@ -54,7 +74,11 @@ class MailChimp_Subscriber_Popup {
 
 	/**
 	 * Runs the whole reversal.
+	 *
+	 * @since 4.5.0
+	 *
 	 * @param string $content Post Content
+	 *
 	 * @return string Content with embeds replaced
 	 */
 	static function reversal( $content ) {
@@ -99,7 +123,9 @@ class MailChimp_Subscriber_Popup {
 	}
 
 	/**
-	 * Builds the actual shortcode based on passed in attributes
+	 * Builds the actual shortcode based on passed in attributes.
+	 *
+	 * @since 4.5.0
 	 *
 	 * @param array $attrs A valid list of attributes (gets matched against self::$allowed_config and self::$allowed_js_vars)
 	 *
@@ -121,7 +147,9 @@ class MailChimp_Subscriber_Popup {
 	}
 
 	/**
-	 * Parses the shortcode back out to embedded information
+	 * Parses the shortcode back out to embedded information.
+	 *
+	 * @since 4.5.0
 	 *
 	 * @param array $lcase_attrs
 	 *

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -65,13 +65,11 @@ class Quiz_Shortcode {
 	 * @since 4.5.0
 	 */
 	public static function init() {
-		$obj = get_called_class();
-
-		add_shortcode( 'quiz', array( $obj, 'shortcode' ) );
-		add_shortcode( 'question', array( $obj, 'question_shortcode' ) );
-		add_shortcode( 'answer', array( $obj, 'answer_shortcode' ) );
-		add_shortcode( 'wrong', array( $obj, 'wrong_shortcode' ) );
-		add_shortcode( 'explanation', array( $obj, 'explanation_shortcode' ) );
+		add_shortcode( 'quiz', array( __CLASS__, 'shortcode' ) );
+		add_shortcode( 'question', array( __CLASS__, 'question_shortcode' ) );
+		add_shortcode( 'answer', array( __CLASS__, 'answer_shortcode' ) );
+		add_shortcode( 'wrong', array( __CLASS__, 'wrong_shortcode' ) );
+		add_shortcode( 'explanation', array( __CLASS__, 'explanation_shortcode' ) );
 	}
 
 	/**

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -129,6 +129,12 @@ class Quiz_Shortcode {
 	 * @return string
 	 */
 	public static function shortcode( $atts, $content = null ) {
+
+		// There's nothing to do if there's nothing enclosed.
+		if ( null == $content ) {
+			return '';
+		}
+
 		$id = '';
 
 		if ( self::is_javascript_unavailable() ) {
@@ -162,7 +168,7 @@ class Quiz_Shortcode {
 		}
 
 		$quiz = self::do_shortcode( $content );
-		return '<div class="quiz"' . $id . '>' . $quiz . '</div>'	;
+		return '<div class="quiz"' . $id . '>' . $quiz . '</div>';
 	}
 
 	/**
@@ -177,6 +183,9 @@ class Quiz_Shortcode {
 	private static function do_shortcode( $content ) {
 		// strip autoinserted line breaks
 		$content = preg_replace( '#(<(?:br /|/?p)>\n?)*(\[/?[a-z]+\])(<(?:br /|/?p)>\n?)*#', '$2', $content );
+
+		// Add internal parameter so it's only rendered when it has it
+		$content = preg_replace( '/\[(question|answer|wrong|explanation)\]/i', '[$1 quiz_item="true"]', $content );
 		$content = do_shortcode( $content );
 		$content = wp_kses( $content, array(
 			'tt' => array(),
@@ -201,7 +210,9 @@ class Quiz_Shortcode {
 	 * @return string
 	 */
 	public static function question_shortcode( $atts, $content = null ) {
-		return '<div class="question">' . self::do_shortcode( $content ) . '</div>';
+		return isset( $atts['quiz_item'] )
+			? '<div class="question">' . self::do_shortcode( $content ) . '</div>'
+			: '';
 	}
 
 	/**
@@ -219,7 +230,9 @@ class Quiz_Shortcode {
 			return self::noscript_info();
 		}
 
-		return '<div class="answer" data-correct="1">' . self::do_shortcode( $content ) . '</div>';
+		return isset( $atts['quiz_item'] )
+			? '<div class="answer" data-correct="1">' . self::do_shortcode( $content ) . '</div>'
+			: '';
 	}
 
 	/**
@@ -237,7 +250,9 @@ class Quiz_Shortcode {
 			return self::noscript_info();
 		}
 
-		return '<div class="answer">' . self::do_shortcode( $content ) . '</div>';
+		return isset( $atts['quiz_item'] )
+			? '<div class="answer">' . self::do_shortcode( $content ) . '</div>'
+			: '';
 	}
 
 	/**
@@ -255,7 +270,9 @@ class Quiz_Shortcode {
 			return self::noscript_info();
 		}
 
-		return '<div class="explanation">' . self::do_shortcode( $content ) . '</div>';
+		return isset( $atts['quiz_item'] )
+			? '<div class="explanation">' . self::do_shortcode( $content ) . '</div>'
+			: '';
 	}
 }
 

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -117,6 +117,17 @@ class Quiz_Shortcode {
 	}
 
 	/**
+	 * Check if we're in WordPress.com.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @return bool
+	 */
+	public static function is_wpcom() {
+		return defined( 'IS_WPCOM' ) && IS_WPCOM;
+	}
+
+	/**
 	 * Parse shortcode arguments and render its output.
 	 *
 	 * @since 4.5.0
@@ -146,9 +157,7 @@ class Quiz_Shortcode {
 				self::$scripts_enqueued = true;
 			}
 
-			$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
-
-			$default_atts = $is_wpcom
+			$default_atts = self::is_wpcom()
 				? array(
 					'trackid' => '',
 					'a8ctraining' => '',
@@ -163,7 +172,7 @@ class Quiz_Shortcode {
 			if ( ! empty( self::$quiz_params[ 'trackid' ] ) ) {
 				$id .= ' data-trackid="' . esc_attr( self::$quiz_params[ 'trackid' ] ) . '"';
 			}
-			if ( $is_wpcom && ! empty( self::$quiz_params[ 'a8ctraining' ] ) ) {
+			if ( self::is_wpcom() && ! empty( self::$quiz_params[ 'a8ctraining' ] ) ) {
 				if ( is_null( self::$username ) ) {
 					self::$username = wp_get_current_user()->user_login;
 				}

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Quiz shortcode.
+ *
+ * Usage:
+ *
+ * [quiz]
+ * [question]What's the right answer?[/question]
+ * [wrong]This one?[explanation]Nope[/explanation][/wrong]
+ * [answer]Yes, this is the one![explanation]Yay![/explanation][/answer]
+ * [wrong]Maybe this one[explanation]Keep trying[/explanation][/wrong]
+ * [wrong]How about this one?[explanation]Try again[/explanation][/wrong]
+ * [/quiz]
+ */
+class Quiz_Shortcode {
+
+	/**
+	 * Parameters admitted by [quiz] shortcode.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @var array
+	 */
+	private static $quiz_params = array();
+
+	/**
+	 * Whether the scripts were enqueued.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @var bool
+	 */
+	private static $scripts_enqueued = false;
+
+	/**
+	 * In a8c training, store user currently logged in.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @var null
+	 */
+	private static $username = null;
+
+	/**
+	 * Whether the noscript tag was already printed.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @var bool
+	 */
+	private static $noscript_info_printed = false;
+
+	/**
+	 * Whether JavaScript is available.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @var null
+	 */
+	private static $javascript_unavailable = null;
+
+	/**
+	 * Register all shortcodes.
+	 *
+	 * @since 4.5.0
+	 */
+	public static function init() {
+		$obj = get_called_class();
+
+		add_shortcode( 'quiz', array( $obj, 'shortcode' ) );
+		add_shortcode( 'question', array( $obj, 'question_shortcode' ) );
+		add_shortcode( 'answer', array( $obj, 'answer_shortcode' ) );
+		add_shortcode( 'wrong', array( $obj, 'wrong_shortcode' ) );
+		add_shortcode( 'explanation', array( $obj, 'explanation_shortcode' ) );
+	}
+
+	/**
+	 * Enqueue assets needed by the quiz,
+	 *
+	 * @since 4.5.0
+	 */
+	private static function enqueue_scripts() {
+		wp_enqueue_style( 'quiz', plugins_url( 'css/quiz.css', __FILE__ ) );
+		wp_enqueue_script( 'quiz', plugins_url( 'js/quiz.js', __FILE__ ), array( 'jquery' ), null, true );
+	}
+
+	/**
+	 * Check if this is a feed and thus JS is unavailable.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @return bool|null
+	 */
+	private static function is_javascript_unavailable() {
+		if ( ! is_null( self::$javascript_unavailable ) ) {
+			return self::$javascript_unavailable;
+		}
+
+		if ( is_feed() ) {
+			return self::$javascript_unavailable = true;
+		}
+
+		return self::$javascript_unavailable = false;
+	}
+
+	/**
+	 * Display message when JS is not available.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @return string
+	 */
+	private static function noscript_info() {
+		if ( self::$noscript_info_printed ) {
+			return '';
+		}
+		self::$noscript_info_printed = true;
+		return '<noscript><div><i>' . esc_html__( 'Please view this post in your web browser to complete the quiz.', 'jetpack' ) . '</i></div></noscript>';
+	}
+
+	/**
+	 * Parse shortcode arguments and render its output.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array  $atts    Shortcode parameters.
+	 * @param string $content Content enclosed by shortcode tags.
+	 *
+	 * @return string
+	 */
+	public static function shortcode( $atts, $content = null ) {
+		$id = '';
+
+		if ( self::is_javascript_unavailable() ) {
+			// in an e-mail print the question and the info sentence once per question, too
+			self::$noscript_info_printed = false;
+		} else {
+
+			if ( ! self::$scripts_enqueued ) {
+				// lazy enqueue cannot use the wp_enqueue_scripts action anymore
+				self::enqueue_scripts();
+				self::$scripts_enqueued = true;
+			}
+
+			self::$quiz_params = shortcode_atts(
+				array(
+					'type' => 'radio',
+					'trackid' => '',
+					'a8ctraining' => '',
+				),
+				$atts
+			);
+
+			if ( ! empty( self::$quiz_params[ 'trackid' ] ) ) {
+				$id .= ' data-trackid="' . esc_attr( self::$quiz_params[ 'trackid' ] ) . '"';
+			}
+			if ( ! empty( self::$quiz_params[ 'a8ctraining' ] ) ) {
+				if ( is_null( self::$username ) ) {
+					self::$username = wp_get_current_user()->user_login;
+				}
+				$id .= ' data-a8ctraining="'. esc_attr( self::$quiz_params[ 'a8ctraining' ] ) . '" data-username="' . esc_attr( self::$username ) . '"';
+			}
+		}
+
+		$quiz = self::do_shortcode( $content );
+		return '<div class="quiz"' . $id . '>' . $quiz . '</div>'	;
+	}
+
+	/**
+	 * Strip line breaks, restrict allowed HTML to a few whitelisted tags and execute nested shortcodes.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param string $content
+	 *
+	 * @return mixed|string
+	 */
+	private static function do_shortcode( $content ) {
+		// strip autoinserted line breaks
+		$content = preg_replace( '#(<(?:br /|/?p)>\n?)*(\[/?[a-z]+\])(<(?:br /|/?p)>\n?)*#', '$2', $content );
+		$content = do_shortcode( $content );
+		$content = wp_kses( $content, array(
+			'tt' => array(),
+			'pre' => array(),
+			'strong' => array(),
+			'i' => array(),
+			'br' => array(),
+			'img' => array( 'src' => true),
+			'div' => array( 'class' => true, 'data-correct' => 1, 'data-track-id' => 1, 'data-a8ctraining' => 1, 'data-username' => 1 ),
+		) );
+		return $content;
+	}
+
+	/**
+	 * Render question.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts
+	 * @param null  $content
+	 *
+	 * @return string
+	 */
+	public static function question_shortcode( $atts, $content = null ) {
+		return '<div class="question">' . self::do_shortcode( $content ) . '</div>';
+	}
+
+	/**
+	 * Render correct answer.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts
+	 * @param null  $content
+	 *
+	 * @return string
+	 */
+	public static function answer_shortcode( $atts, $content = null ) {
+		if ( self::is_javascript_unavailable() ) {
+			return self::noscript_info();
+		}
+
+		return '<div class="answer" data-correct="1">' . self::do_shortcode( $content ) . '</div>';
+	}
+
+	/**
+	 * Render wrong response.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts
+	 * @param null  $content
+	 *
+	 * @return string
+	 */
+	public static function wrong_shortcode( $atts, $content = null ) {
+		if ( self::is_javascript_unavailable() ) {
+			return self::noscript_info();
+		}
+
+		return '<div class="answer">' . self::do_shortcode( $content ) . '</div>';
+	}
+
+	/**
+	 * Render explanation for wrong or right answer.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts
+	 * @param null  $content
+	 *
+	 * @return string
+	 */
+	public static function explanation_shortcode( $atts, $content = null ) {
+		if ( self::is_javascript_unavailable() ) {
+			return self::noscript_info();
+		}
+
+		return '<div class="explanation">' . self::do_shortcode( $content ) . '</div>';
+	}
+}
+
+Quiz_Shortcode::init();

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -148,18 +148,24 @@ class Quiz_Shortcode {
 				self::$scripts_enqueued = true;
 			}
 
-			self::$quiz_params = shortcode_atts(
-				array(
+			$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
+			$default_atts = $is_wpcom
+				? array(
 					'trackid' => '',
 					'a8ctraining' => '',
-				),
-				$atts
-			);
+				)
+				: array(
+					'trackid' => '',
+				);
+
+
+			self::$quiz_params = shortcode_atts( $default_atts, $atts );
 
 			if ( ! empty( self::$quiz_params[ 'trackid' ] ) ) {
 				$id .= ' data-trackid="' . esc_attr( self::$quiz_params[ 'trackid' ] ) . '"';
 			}
-			if ( ! empty( self::$quiz_params[ 'a8ctraining' ] ) ) {
+			if ( $is_wpcom && ! empty( self::$quiz_params[ 'a8ctraining' ] ) ) {
 				if ( is_null( self::$username ) ) {
 					self::$username = wp_get_current_user()->user_login;
 				}

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -144,7 +144,6 @@ class Quiz_Shortcode {
 
 			self::$quiz_params = shortcode_atts(
 				array(
-					'type' => 'radio',
 					'trackid' => '',
 					'a8ctraining' => '',
 				),

--- a/modules/shortcodes/sitemap.php
+++ b/modules/shortcodes/sitemap.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Sitemap shortcode.
+ *
+ * Usage: [sitemap]
+ */
+
+add_shortcode( 'sitemap', 'jetpack_sitemap_shortcode' );
+
+/**
+ * Parse shortcode arguments and render its output.
+ *
+ * @since 4.5.0
+ *
+ * @param array  $atts    Shortcode parameters.
+ * @param string $content Content enclosed by shortcode tags.
+ *
+ * @return string
+ */
+function jetpack_sitemap_shortcode( $atts, $content ) {
+	return '<ul>' .	wp_list_pages( array(
+		'title_li' => '<b><a href="/">' . esc_html( get_bloginfo( 'name' ) ) . '</a></b>',
+		'exclude'  => get_option( 'page_on_front' ),
+		'echo'     => false,
+	) ) . '</ul>';
+}

--- a/modules/shortcodes/sitemap.php
+++ b/modules/shortcodes/sitemap.php
@@ -8,19 +8,19 @@
 add_shortcode( 'sitemap', 'jetpack_sitemap_shortcode' );
 
 /**
- * Parse shortcode arguments and render its output.
+ * Renders a tree of pages.
  *
  * @since 4.5.0
  *
- * @param array  $atts    Shortcode parameters.
- * @param string $content Content enclosed by shortcode tags.
- *
  * @return string
  */
-function jetpack_sitemap_shortcode( $atts, $content ) {
-	return '<ul>' .	wp_list_pages( array(
+function jetpack_sitemap_shortcode() {
+	$tree = wp_list_pages( array(
 		'title_li' => '<b><a href="/">' . esc_html( get_bloginfo( 'name' ) ) . '</a></b>',
 		'exclude'  => get_option( 'page_on_front' ),
 		'echo'     => false,
-	) ) . '</ul>';
+	) );
+	return empty( $tree )
+		? ''
+		: '<ul class="jetpack-sitemap-shortcode">' . $tree . '</ul>';
 }

--- a/modules/shortcodes/spotify.php
+++ b/modules/shortcodes/spotify.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Spotify shortcode.
+ *
+ * Usage:
+ * [spotify id="spotify:track:4bz7uB4edifWKJXSDxwHcs" width="400" height="100"]
+ */
+
+add_shortcode( 'spotify', 'jetpack_spotify_shortcode' );
+
+if ( get_option( 'embed_autourls' ) ) {
+	// If user enabled autourls, also convert syntax like spotify:track:4bz7uB4edifWKJXSDxwHcs
+	add_filter( 'the_content', 'jetpack_spotify_embed_ids', 7 );
+}
+
+/**
+ * Parse shortcode arguments and render its output.
+ *
+ * @since 4.5.0
+ *
+ * @param array  $atts
+ * @param string $content
+ *
+ * @return string
+ */
+function jetpack_spotify_shortcode( $atts = array(), $content = '' ) {
+
+	if ( ! empty( $content ) ) {
+		$id = $content;
+	} elseif ( ! empty( $atts['id'] ) ) {
+		$id = $atts['id'];
+	} elseif ( ! empty( $atts[0] ) ) {
+		$id = $atts[0];
+	} else {
+		return '<!-- Missing Spotify ID -->';
+	}
+
+	if ( empty( $atts['width'] ) ) {
+		$atts['width'] = 300;
+	}
+
+	if ( empty( $atts['height'] ) ) {
+		$atts['height'] = 380;
+	}
+
+	$atts['width']  = (int) $atts['width'];
+	$atts['height'] = (int) $atts['height'];
+
+	// Spotify accepts both URLs and their Spotify ID format, so let them sort it out and validate
+	$embed_url = add_query_arg( 'uri', urlencode( $id ), 'https://embed.spotify.com/' );
+
+	return '<iframe src="' . esc_url( $embed_url ) . '" style="display:block; margin:0 auto; width:' . esc_attr( $atts['width'] ) . 'px; height:' . esc_attr( $atts['height'] ) . 'px;" frameborder="0" allowtransparency="true"></iframe>';
+}
+
+/**
+ * Turn text like this on it's own line into an embed: spotify:track:4bz7uB4edifWKJXSDxwHcs
+ * The core WordPress embed functionality only works with URLs
+ * Modified version of WP_Embed::autoembed()
+ *
+ * @since 4.5.0
+ *
+ * @param $content
+ *
+ * @return string
+ */
+function jetpack_spotify_embed_ids( $content ) {
+	$textarr = wp_html_split( $content );
+
+	foreach ( $textarr as &$element ) {
+		if ( '' == $element || '<' === $element[0] ) {
+			continue;
+		}
+
+		if ( substr( ltrim( $element ), 0, 8 ) !== 'spotify:' ) {
+			continue;
+		}
+
+		$element = preg_replace_callback( '|^\s*(spotify:[^\s"]+:[^\s"]+)\s*$|im', 'jetpack_spotify_embed_ids_callback', $element );
+	}
+
+	return implode( '', $textarr );
+}
+
+/**
+ * Call shortcode with ID provided by matching pattern.
+ *
+ * @since 4.5.0
+ *
+ * @param array $matches
+ *
+ * @return string
+ */
+function jetpack_spotify_embed_ids_callback( $matches ) {
+	return "\n" . jetpack_spotify_shortcode( array(), $matches[1] ) . "\n";
+}

--- a/modules/shortcodes/spotify.php
+++ b/modules/shortcodes/spotify.php
@@ -6,11 +6,13 @@
  * [spotify id="spotify:track:4bz7uB4edifWKJXSDxwHcs" width="400" height="100"]
  */
 
-add_shortcode( 'spotify', 'jetpack_spotify_shortcode' );
+if ( ! shortcode_exists( 'spotify' ) ) {
+	add_shortcode( 'spotify', 'jetpack_spotify_shortcode' );
 
-if ( get_option( 'embed_autourls' ) ) {
-	// If user enabled autourls, also convert syntax like spotify:track:4bz7uB4edifWKJXSDxwHcs
-	add_filter( 'the_content', 'jetpack_spotify_embed_ids', 7 );
+	if ( get_option( 'embed_autourls' ) ) {
+		// If user enabled autourls, also convert syntax like spotify:track:4bz7uB4edifWKJXSDxwHcs
+		add_filter( 'the_content', 'jetpack_spotify_embed_ids', 7 );
+	}
 }
 
 /**

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Tweet shortcode.
+ * Params map to key value pairs, and all but tweet are optional:
+ * tweet = id or permalink url* (Required)
+ * align = none|left|right|center
+ * width = number in pixels  example: width="300"
+ * lang  =  en|fr|de|ko|etc...  language country code.
+ * hide_thread = true | false **
+ * hide_media  = true | false **
+ *
+ * Basic:
+ * [tweet https://twitter.com/jack/statuses/20 width="350"]
+ *
+ * More parameters and another tweet syntax admitted:
+ * [tweet tweet="https://twitter.com/jack/statuses/20" align="left" width="350" align="center" lang="es"]
+ */
+
+add_shortcode( 'tweet', array( 'Jetpack_Tweet', 'jetpack_tweet_shortcode' ) );
+
+class Jetpack_Tweet {
+
+	static $provider_args;
+
+	/**
+	 * Parse shortcode arguments and render its output.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param array $atts Shortcode parameters.
+	 *
+	 * @return string
+	 */
+	function jetpack_tweet_shortcode( $atts ) {
+		$default_atts = array(
+			'tweet'       => '',
+			'align'       => 'none',
+			'width'       => '',
+			'lang'        => 'en',
+			'hide_thread' => 'false',
+			'hide_media'  => 'false',
+		);
+
+		$attr = shortcode_atts( $default_atts, $atts );
+
+		self::$provider_args = $attr;
+
+		// figure out the tweet id for the requested tweet
+		// supporting both omitted attributes and tweet="tweet_id"
+		// and supporting both an id and a URL
+		if ( empty( $attr['tweet'] ) && ! empty( $atts[0] ) ) {
+			$attr['tweet'] = $atts[0];
+		}
+
+		preg_match( '/^http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)$/', $attr['tweet'], $urlbits );
+		if ( intval( $urlbits[5] ) ) {
+			$id = 'https://twitter.com/' . $urlbits[3] . '/status/' . intval( $urlbits[5] );
+		} else {
+			return '<!-- Invalid tweet id -->';
+		}
+
+		// Add shortcode arguments to provider URL
+		add_filter( 'oembed_fetch_url', array( 'Jetpack_Tweet', 'jetpack_tweet_url_extra_args' ), 10, 3 );
+
+		// Fetch tweet
+		$output = wp_oembed_get( $id, $atts );
+
+		// Clean up filter
+		remove_filter( 'oembed_fetch_url', array( 'Jetpack_Tweet', 'jetpack_tweet_url_extra_args' ), 10 );
+
+		// Add Twitter widgets.js script to the footer.
+		add_action( 'wp_footer', array( 'Jetpack_Tweet', 'jetpack_tweet_shortcode_script' ) );
+
+		/** This action is documented in modules/widgets/social-media-icons.php */
+		do_action( 'jetpack_bump_stats_extras', 'embeds', 'tweet' );
+
+		return $output;
+	}
+
+	/**
+	 * Adds parameters to URL used to fetch the tweet.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param string $provider URL of provider that supplies the tweet we're requesting.
+	 * @param string $url      URL of tweet to embed.
+	 * @param array  $args     Parameters supplied to shortcode and passed to wp_oembed_get
+	 *
+	 * @return string
+	 */
+	function jetpack_tweet_url_extra_args( $provider, $url, $args = array() ) {
+		foreach ( self::$provider_args as $key => $value ) {
+			switch ( $key ) {
+				case 'align':
+				case 'lang':
+				case 'hide_thread':
+				case 'hide_media':
+					$provider = add_query_arg( $key, $value, $provider );
+					break;
+			}
+		}
+
+		// Disable script since we're enqueing it in our own way in the footer
+		$provider = add_query_arg( 'omit_script', 'true', $provider );
+
+		// Twitter doesn't support maxheight so don't send it
+		$provider = remove_query_arg( 'maxheight', $provider );
+
+		return $provider;
+	}
+
+	/**
+	 * Enqueue front end assets.
+	 *
+	 * @since 4.5.0
+	 */
+	function jetpack_tweet_shortcode_script() {
+		if ( ! wp_script_is( 'twitter-widgets', 'registered' ) ) {
+			wp_register_script( 'twitter-widgets', set_url_scheme( 'http://platform.twitter.com/widgets.js' ), array(), JETPACK__VERSION, true );
+			wp_print_scripts( 'twitter-widgets' );
+		}
+	}
+
+} // class end

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -31,7 +31,7 @@ class Jetpack_Tweet {
 	 *
 	 * @return string
 	 */
-	function jetpack_tweet_shortcode( $atts ) {
+	static public function jetpack_tweet_shortcode( $atts ) {
 		$default_atts = array(
 			'tweet'       => '',
 			'align'       => 'none',
@@ -53,7 +53,7 @@ class Jetpack_Tweet {
 		}
 
 		preg_match( '/^http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)$/', $attr['tweet'], $urlbits );
-		if ( intval( $urlbits[5] ) ) {
+		if ( isset( $urlbits[5] ) && intval( $urlbits[5] ) ) {
 			$id = 'https://twitter.com/' . $urlbits[3] . '/status/' . intval( $urlbits[5] );
 		} else {
 			return '<!-- Invalid tweet id -->';
@@ -88,7 +88,7 @@ class Jetpack_Tweet {
 	 *
 	 * @return string
 	 */
-	function jetpack_tweet_url_extra_args( $provider, $url, $args = array() ) {
+	static public function jetpack_tweet_url_extra_args( $provider, $url, $args = array() ) {
 		foreach ( self::$provider_args as $key => $value ) {
 			switch ( $key ) {
 				case 'align':
@@ -114,7 +114,7 @@ class Jetpack_Tweet {
 	 *
 	 * @since 4.5.0
 	 */
-	function jetpack_tweet_shortcode_script() {
+	static public function jetpack_tweet_shortcode_script() {
 		if ( ! wp_script_is( 'twitter-widgets', 'registered' ) ) {
 			wp_register_script( 'twitter-widgets', set_url_scheme( 'http://platform.twitter.com/widgets.js' ), array(), JETPACK__VERSION, true );
 			wp_print_scripts( 'twitter-widgets' );

--- a/modules/shortcodes/ustream.php
+++ b/modules/shortcodes/ustream.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * ustream.tv shortcode
+ *
+ * Example:
+ * [ustream id=1524 live=1]
+ * [ustreamsocial id=12980237 width="500"]
+ *
+ * Embed code example, from http://www.ustream.tv/leolaporte
+ * <iframe src="http://www.ustream.tv/embed/recorded/1524?v=3&#038;wmode=direct" width="480" height="296" scrolling="no" frameborder="0" style="border: 0 none transparent;"></iframe>
+ */
+
+add_shortcode( 'ustream', 'ustream_shortcode' );
+add_shortcode( 'ustreamsocial', 'ustreamsocial_shortcode' );
+
+/**
+ * Parse shortcode arguments and render output for ustream single video.
+ *
+ * @since 4.5.0
+ *
+ * @param $atts array of user-supplied arguments.
+ *
+ * @return string HTML output.
+ */
+function ustream_shortcode( $atts ) {
+	if ( isset( $atts[0] ) ) {
+		return '<!-- ustream error: bad parameters -->';
+	}
+
+	$defaults = array(
+		'width'     => 480,
+		'height'    => 296,
+		'id'        => 0,
+		'live'      => 0,
+		'highlight' => 0,
+		'version'   => 3,
+		'hwaccel'   => 1,
+	);
+
+	$atts = array_map( 'intval', shortcode_atts( $defaults, $atts ) );
+
+	$ustream_id = $atts['id'];
+	$width      = $atts['width'];
+	$height     = $atts['height'];
+	$live       = $atts['live'];
+	$highlight  = $atts['highlight'];
+	$version    = $atts['version'];
+	$hwaccel    = $atts['hwaccel'];
+
+	$version = 'v=' . esc_attr( $version );
+
+	if ( 0 >= $ustream_id ) {
+		return '<!-- ustream error: bad video ID -->';
+	}
+
+	if ( 0 >= $height ) {
+		return '<!-- ustream error: height invalid -->';
+	}
+
+	if ( 0 >= $width ) {
+		return '<!-- ustream error: width invalid -->';
+	}
+
+	if ( $live ) {
+		$recorded = '';
+	} else {
+		$recorded = 'recorded/';
+	}
+
+	if ( ! $live && ( 0 < $highlight ) ) {
+		$highlight = "/highlight/$highlight";
+	} else {
+		$highlight = '';
+	}
+
+	if ( 0 < $hwaccel ) {
+		$wmode = '&amp;wmode=direct';
+	} else {
+		$wmode = '';
+	}
+
+	$url    = 'http://www.ustream.tv/embed/' . $recorded . esc_attr( $ustream_id ) . $highlight . '?' . $version . $wmode;
+	$url    = set_url_scheme( $url );
+	$output = '<iframe src="' . esc_url( $url ) . '" width="' . esc_attr( $width ) . '" height="' . esc_attr( $height ) . '" scrolling="no" style="border: 0 none transparent;"></iframe>';
+
+	return $output;
+}
+
+/**
+ * Parse shortcode arguments and render output for ustream's Social Stream.
+ *
+ * @since 4.5.0
+ *
+ * @param $atts array of user-supplied arguments.
+ *
+ * @return string HTML output.
+ */
+function ustreamsocial_shortcode( $atts ) {
+	$defaults = array(
+		'id'     => 0,
+		'height' => 420,
+		'width'  => 320,
+	);
+
+	$atts = array_map( 'intval', shortcode_atts( $defaults, $atts ) );
+
+	$ustream_id = $atts['id'];
+	$width      = $atts['width'];
+	$height     = $atts['height'];
+
+	if ( 0 >= $ustream_id ) {
+		return '<!-- ustreamsocial error: bad social stream ID -->';
+	}
+
+	if ( 0 >= $height ) {
+		return '<!-- ustreamsocial error: height invalid -->';
+	}
+
+	if ( 0 >= $width ) {
+		return '<!-- ustreamsocial error: width invalid -->';
+	}
+
+	$url = set_url_scheme( "http://www.ustream.tv/socialstream/$ustream_id" );
+
+	return '<iframe id="SocialStream" class="" name="SocialStream" width="' . esc_attr( $width ) . '" height="' . esc_attr( $height ) . '" scrolling="no" allowtransparency="true" src="' . esc_url( $url ) . '" style="visibility: visible; margin-top: 0; margin-bottom: 0; border: 0;"></iframe>';
+}

--- a/tests/php/modules/shortcodes/test_class.archiveorg.php
+++ b/tests/php/modules/shortcodes/test_class.archiveorg.php
@@ -1,0 +1,55 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_ArchiveOrg extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [archiveorg] and [archiveorg-book] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_exists() {
+		$this->assertEquals( shortcode_exists( 'archiveorg' ), true );
+		$this->assertEquals( shortcode_exists( 'archiveorg-book' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes() {
+		$content = '[archiveorg]';
+		$shortcode_content = do_shortcode( $content );
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- error: missing archive.org ID -->', $shortcode_content );
+
+		$content = '[archiveorg-book]';
+		$shortcode_content = do_shortcode( $content );
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- error: missing archive.org book ID -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the archiveorg shortcode returns a single ArchiveOrg element.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcode_single_element() {
+		$id = 'Wonderfu1958';
+		$content = "[archiveorg id='$id' width='600' height='300']";
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( "iframe src='http://archive.org/embed/$id' width='600' height='300'", $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the archiveorg-book shortcode returns an ArchiveOrg book.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcode_book() {
+		$id = 'goodytwoshoes00newyiala';
+		$content = "[archiveorg-book id='$id' width='600' height='300']";
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( "iframe src='http://archive.org/embed/$id' width='600' height='300'", $shortcode_content );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.archiveorg.php
+++ b/tests/php/modules/shortcodes/test_class.archiveorg.php
@@ -50,6 +50,6 @@ class WP_Test_Jetpack_Shortcodes_ArchiveOrg extends WP_UnitTestCase {
 		$id = 'goodytwoshoes00newyiala';
 		$content = "[archiveorg-book id='$id' width='600' height='300']";
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( "iframe src='http://archive.org/embed/$id' width='600' height='300'", $shortcode_content );
+		$this->assertContains( "iframe src='http://archive.org/stream/$id?ui=embed#mode/1up' width='600' height='300'", $shortcode_content );
 	}
 }

--- a/tests/php/modules/shortcodes/test_class.brightcove.php
+++ b/tests/php/modules/shortcodes/test_class.brightcove.php
@@ -1,0 +1,42 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Brightcove extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [brightcove] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_brightcove_exists() {
+		$this->assertEquals( shortcode_exists( 'brightcove' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_brightcove() {
+		$content = '[brightcove]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- Missing Brightcove parameters -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a Brightcove player.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_brightcove_video_id() {
+		$video_id = '68143720001';
+		$account_id = '57838016001';
+		$content = "[brightcove video_id='$video_id' account_id='$account_id']";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe src="//players.brightcove.net/' . $account_id . '/default_default/index.html?videoId=' . $video_id . '"', $shortcode_content );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.getty.php
+++ b/tests/php/modules/shortcodes/test_class.getty.php
@@ -1,0 +1,41 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Getty extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [getty] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_getty_exists() {
+		$this->assertEquals( shortcode_exists( 'getty' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_getty() {
+		$content = '[getty]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- Missing Getty Source ID -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a Getty image.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_getty_image() {
+		$image_id = '82278805';
+		$content = "[getty src='$image_id']";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe src="//embed.gettyimages.com/embed/' . $image_id, $shortcode_content );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.googleapps.php
+++ b/tests/php/modules/shortcodes/test_class.googleapps.php
@@ -41,13 +41,13 @@ class WP_Test_Jetpack_Shortcodes_GoogleApps extends WP_UnitTestCase {
 
 	function test_document_variation_1_to_embed() {
 		$embed           = '<iframe src="https://docs.google.com/document/pub?id=1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4&amp;embedded=true"></iframe>';
-		$expected_output = '<iframe src="https://docs.google.com/document/pub?id=1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4&#038;embedded=true" frameborder="0" width="100%" height="560" marginheight="0" marginwidth="0"></iframe>';
+		$expected_output = '<iframe src="https://docs.google.com/document/pub?id=1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4&#038;embedded=true" frameborder="0" width="100%"';
 
 		$shortcode = googleapps_embed_to_shortcode( $embed );
 		add_shortcode( 'googleapps', 'googleapps_shortcode' );
 		$to_embed = do_shortcode( $shortcode );
 
-		$this->assertEquals( $expected_output, $to_embed );
+		$this->assertContains( $expected_output, $to_embed );
 	}
 
 	function test_document_variation_2() {
@@ -79,14 +79,13 @@ class WP_Test_Jetpack_Shortcodes_GoogleApps extends WP_UnitTestCase {
 
 	function test_document_variation_2_to_embed() {
 		$embed           = '<iframe src="https://docs.google.com/document/d/1wy2kzRYYSQV0ZHe58DOvQwRQ8syrY5AhgUnKkKXk9N8/pub?embedded=true"></iframe>';
-		$expected_output = '<iframe src="https://docs.google.com/document/d/1wy2kzRYYSQV0ZHe58DOvQwRQ8syrY5AhgUnKkKXk9N8/pub?embedded=true" frameborder="0" width="100%" height="560" marginheight="0" marginwidth="0"></iframe>';
+		$expected_output = '<iframe src="https://docs.google.com/document/d/1wy2kzRYYSQV0ZHe58DOvQwRQ8syrY5AhgUnKkKXk9N8/pub?embedded=true" frameborder="0" width="100%"';
 
 		$shortcode = googleapps_embed_to_shortcode( $embed );
 		add_shortcode( 'googleapps', 'googleapps_shortcode' );
 		$to_embed = do_shortcode( $shortcode );
 
-		$this->assertEquals( $expected_output, $to_embed );
-
+		$this->assertContains( $expected_output, $to_embed );
 	}
 
 	function test_external_document() {

--- a/tests/php/modules/shortcodes/test_class.googleapps.php
+++ b/tests/php/modules/shortcodes/test_class.googleapps.php
@@ -1,0 +1,209 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_GoogleApps extends WP_UnitTestCase {
+
+	function test_presentation_variation_1() {
+		$embed     = '<iframe src="https://docs.google.com/present/embed?id=dhfhrphh_123drp8s65c&interval=15&autoStart=true&loop=true&size=l" frameborder="0" width="700" height="559"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="present/embed" query="id=dhfhrphh_123drp8s65c&amp;interval=15&amp;autoStart=true&amp;loop=true&amp;size=l" width="700" height="559" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_presentation_variation_2() {
+		$embed     = '<iframe src="https://docs.google.com/presentation/embed?id=13ItX4jV0SOSdr-ZjHarcpTh9Lr4omfsHAp87jpxv8-0&start=false&loop=false&delayms=3000" frameborder="0" width="960" height="749" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="presentation/embed" query="id=13ItX4jV0SOSdr-ZjHarcpTh9Lr4omfsHAp87jpxv8-0&amp;start=false&amp;loop=false&amp;delayms=3000" width="960" height="749" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_presentation_variation_3() {
+		$embed     = '<iframe src="https://docs.google.com/presentation/d/1eXExVGHF1G_8dqCshU1JNCxiScOkjDBn5Zux0NmYI_I/embed?start=false&loop=false&delayms=60000" height="389" width="480" allowfullscreen="true" frameborder="0"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="presentation/d/1eXExVGHF1G_8dqCshU1JNCxiScOkjDBn5Zux0NmYI_I/embed" query="start=false&amp;loop=false&amp;delayms=60000" width="480" height="389" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+
+	function test_document_variation_1() {
+		$embed     = '<iframe src="https://docs.google.com/document/pub?id=1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4&amp;embedded=true"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="document/pub" query="id=1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4&amp;embedded=true" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_document_variation_1_to_embed() {
+		$embed           = '<iframe src="https://docs.google.com/document/pub?id=1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4&amp;embedded=true"></iframe>';
+		$expected_output = '<iframe src="https://docs.google.com/document/pub?id=1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4&#038;embedded=true" frameborder="0" width="100%" height="560" marginheight="0" marginwidth="0"></iframe>';
+
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+		add_shortcode( 'googleapps', 'googleapps_shortcode' );
+		$to_embed = do_shortcode( $shortcode );
+
+		$this->assertEquals( $expected_output, $to_embed );
+	}
+
+	function test_document_variation_2() {
+		$embed     = '<iframe src="https://docs.google.com/document/d/1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4/pub?embedded=true"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="document/d/1kDatklacdZ_tZUOpWtt_ONzY97Ldj2zFcuO9LBY2Ln4/pub" query="embedded=true" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_document_variation_3() {
+		$embed     = '<iframe src="https://docs.google.com/document/d/1bEar7sbWCO86DAXa93OsbX0wxTLA4J7FNM6-YeRz-pw/pub?embedded=true"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="document/d/1bEar7sbWCO86DAXa93OsbX0wxTLA4J7FNM6-YeRz-pw/pub" query="embedded=true" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_document_variation_4() {
+		$embed     = '<iframe src="https://docs.google.com/document/d/e/2PACX-1vRkpIdasKL-eKXDjJgpEONduUspZTz0YmKaajfie0eJYnzikuyusuG1_V8X8T9XflN9l8A1oCM2sgEA/pub?embedded=true"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="document/d/e/2PACX-1vRkpIdasKL-eKXDjJgpEONduUspZTz0YmKaajfie0eJYnzikuyusuG1_V8X8T9XflN9l8A1oCM2sgEA/pub" query="embedded=true" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_document_variation_2_to_embed() {
+		$embed           = '<iframe src="https://docs.google.com/document/d/1wy2kzRYYSQV0ZHe58DOvQwRQ8syrY5AhgUnKkKXk9N8/pub?embedded=true"></iframe>';
+		$expected_output = '<iframe src="https://docs.google.com/document/d/1wy2kzRYYSQV0ZHe58DOvQwRQ8syrY5AhgUnKkKXk9N8/pub?embedded=true" frameborder="0" width="100%" height="560" marginheight="0" marginwidth="0"></iframe>';
+
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+		add_shortcode( 'googleapps', 'googleapps_shortcode' );
+		$to_embed = do_shortcode( $shortcode );
+
+		$this->assertEquals( $expected_output, $to_embed );
+
+	}
+
+	function test_external_document() {
+		$embed     = '<iframe width=100% height=560px frameborder=0 src=https://docs.google.com/a/pranab.in/viewer?a=v&pid=explorer&chrome=false&embedded=true&srcid=1VTMwdgGiDMt8MCr75-YkQP-4u9WmEp1Qvf6C26KYBgFilxU2qndpd-VHhBIn&hl=en></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="viewer" query="a=v&amp;pid=explorer&amp;chrome=false&amp;embedded=true&amp;srcid=1VTMwdgGiDMt8MCr75-YkQP-4u9WmEp1Qvf6C26KYBgFilxU2qndpd-VHhBIn&amp;hl=en" width="100%" height="560" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_spreadsheet_legacy_form() {
+		$embed     = '<iframe src="https://spreadsheets.google.com/embeddedform?formkey=dEVOYnMzZG5jMUpGbjFMYjFYNVB3NkE6MQ" width="760" height="710" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="spreadsheets" dir="embeddedform" query="formkey=dEVOYnMzZG5jMUpGbjFMYjFYNVB3NkE6MQ" width="760" height="710" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_spreadsheet_form() {
+		$embed     = '<iframe src="https://docs.google.com/forms/d/1Gy5FxtP_FwbvvLk6lxC-pO0wkIh2J9HwTcCS5f27iG8/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="forms/d/1Gy5FxtP_FwbvvLk6lxC-pO0wkIh2J9HwTcCS5f27iG8/viewform" query="embedded=true" width="760" height="500" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_spreadsheet_widget_variation_1() {
+		$embed     = "<iframe width='500' height='300' frameborder='0' src='https://spreadsheets1.google.com/a/petedavies.com/pub?hl=en&hl=en&key=0AjSij7nlnXvKdHNsNjRSWG12YmVfOEFwdlMxQ3J1S1E&single=true&gid=0&output=html&widget=true'></iframe>";
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="spreadsheets" dir="a/petedavies.com/pub" query="hl=en&amp;hl=en&amp;key=0AjSij7nlnXvKdHNsNjRSWG12YmVfOEFwdlMxQ3J1S1E&amp;single=true&amp;gid=0&amp;output=html&amp;widget=true" width="500" height="300" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_spreadsheet_widget_variation_2() {
+		$embed     = "<iframe width='500' height='300' frameborder='0' src='https://spreadsheets.google.com/spreadsheet/pub?hl=en&hl=en&key=0AhInIwfvYrIUdGJiTXhtUEhBSFVPUzdRZU5OMDlqdnc&output=html&widget=true'></iframe>";
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="spreadsheets" dir="spreadsheet/pub" query="hl=en&amp;hl=en&amp;key=0AhInIwfvYrIUdGJiTXhtUEhBSFVPUzdRZU5OMDlqdnc&amp;output=html&amp;widget=true" width="500" height="300" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_spreadsheet_widget_variation_3() {
+		$embed     = '<iframe src="https://docs.google.com/spreadsheets/d/1rKeXLwDYBmVuD1XYZFu2Id-9Xs1a1YHuPhZA-01tBPg/pubhtml?widget=true&amp;headers=false"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="spreadsheets/d/1rKeXLwDYBmVuD1XYZFu2Id-9Xs1a1YHuPhZA-01tBPg/pubhtml" query="widget=true&amp;headers=false" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_spreadsheet_widget_variation_4() {
+		$embed     = '<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQOnHvMNvmHbXUCDAyzUedmA8UWctJqSkUwS8cC7KHF1XASTzRdVYu09tYvDl5xAPwCsaNRNODADmzm/pubhtml?widget=true&amp;headers=false"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+		
+		$expected_shortcode = '[googleapps domain="docs" dir="spreadsheets/d/e/2PACX-1vQOnHvMNvmHbXUCDAyzUedmA8UWctJqSkUwS8cC7KHF1XASTzRdVYu09tYvDl5xAPwCsaNRNODADmzm/pubhtml" query="widget=true&amp;headers=false" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_calendar_variation_1() {
+		$embed     = '<iframe src="https://www.google.com/calendar/embed?src=serjant%40gmail.com&ctz=Europe/Sofia" style="border: 0;" width="800" height="600" frameborder="0" scrolling="no"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="www" dir="calendar/embed" query="src=serjant%40gmail.com&amp;ctz=Europe/Sofia" width="800" height="600" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_calendar_variation_2() {
+		$embed     = '<iframe src="http://www.google.com/calendar/hosted/belcastro.com/embed?src=n8nr8sd6v9hnus3nmlk7ed1238%40group.calendar.google.com&ctz=Europe/Zurich" style="border: 0;" width="800" height="600" frameborder="0" scrolling="no"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="www" dir="calendar/hosted/belcastro.com/embed" query="src=n8nr8sd6v9hnus3nmlk7ed1238%40group.calendar.google.com&amp;ctz=Europe/Zurich" width="800" height="600" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_calendar_variation_3() {
+		$embed     = '<iframe src="https://calendar.google.com/calendar/embed?src=jb4bu80jirp0u11a6niie21pp4%40group.calendar.google.com&ctz=America/New_York" style="border: 0;" width="800" height="600" frameborder="0" scrolling="no"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="calendar" dir="calendar/embed" query="src=jb4bu80jirp0u11a6niie21pp4%40group.calendar.google.com&amp;ctz=America/New_York" width="800" height="600" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_customized_calendar() {
+		$embed     = '<iframe src="https://www.google.com/calendar/embed?title=asdf&amp;showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=300&amp;wkst=2&amp;hl=fi&amp;bgcolor=%23ffcccc&amp;src=m52gdmbgelo3itf00u1v44g0ns%40group.calendar.google.com&amp;color=%234E5D6C&amp;src=serjant%40gmail.com&amp;color=%235229A3&amp;ctz=Europe%2FRiga" style="border: solid 1px #777;" width="500" height="300" frameborder="0" scrolling="no"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="www" dir="calendar/embed" query="title=asdf&amp;showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=300&amp;wkst=2&amp;hl=fi&amp;bgcolor=%23ffcccc&amp;src=m52gdmbgelo3itf00u1v44g0ns%40group.calendar.google.com&amp;color=%234E5D6C&amp;src=serjant%40gmail.com&amp;color=%235229A3&amp;ctz=Europe%2FRiga" width="500" height="300" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_generic_embed_variation_1() {
+		$embed     = '<iframe src="https://docs.google.com/file/d/0B0SIdZW7iu-zX1RWREJpMXVHZVU/preview" width="640" height="480"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="docs" dir="file/d/0B0SIdZW7iu-zX1RWREJpMXVHZVU/preview" query="" width="640" height="480" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+	function test_generic_embed_variation_2() {
+		$embed     = '<iframe src="https://drive.google.com/file/d/0B0SIdZW7iu-zX1RWREJpMXVHZVU/preview" width="640" height="480"></iframe>';
+		$shortcode = googleapps_embed_to_shortcode( $embed );
+
+		$expected_shortcode = '[googleapps domain="drive" dir="file/d/0B0SIdZW7iu-zX1RWREJpMXVHZVU/preview" query="" width="640" height="480" /]';
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+
+}

--- a/tests/php/modules/shortcodes/test_class.gravatar.php
+++ b/tests/php/modules/shortcodes/test_class.gravatar.php
@@ -1,0 +1,58 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [gravatar] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_gravatar_exists() {
+		$this->assertEquals( shortcode_exists( 'gravatar' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_gravatar() {
+		$content = '[gravatar]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the Gravatar shortcode returns an avatar image.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_gravatar_image() {
+		$content = "[gravatar email='user@example.org' size='48']";
+
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( "<img alt='' src='http://2.gravatar.com/avatar/572c3489ea700045927076136a969e27?s=48&#038;d=mm&#038;r=g'", $shortcode_content );
+		$this->assertContains( "class='avatar avatar-48 photo' height='48' width='48'", $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the Gravatar profile shortcode returns a profile.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_gravatar_profile() {
+		$email = 'user@example.org';
+		$content = "[gravatar_profile who='$email']";
+		$user = $this->factory->user->create_and_get( array(
+			'user_email' => $email,
+		) );
+		wp_set_current_user( $user->ID );
+
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="grofile vcard" id="grofile-embed-0">', $shortcode_content );
+		$this->assertContains( '<img src="http://2.gravatar.com/avatar/572c3489ea700045927076136a969e27?s=96&#038;d=mm&#038;r=g" width="96" height="96" class="no-grav gravatar photo"', $shortcode_content );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.hulu.php
+++ b/tests/php/modules/shortcodes/test_class.hulu.php
@@ -100,10 +100,10 @@ class WP_Test_Jetpack_Shortcodes_Hulu extends WP_UnitTestCase {
 
 
 	public function test_hulu_embed_to_shortcode() {
-		$embed     = '<iframe width="512" height="288" src="http://www.hulu.com/embed.html?eid=wP5CpYenOIRjJT50LDp2kQ&et=20&st=10&it=i11" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>';
-		$shortcode = wpcom_shortcodereverse_huluembed( $embed );
+		$embed     = '<iframe width="512" height="288" src="http://www.hulu.com/embed.html?eid=' . $this->video_eid . '&et=20&st=10&it=i11" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>';
+		$shortcode = apply_filters( 'pre_kses', $embed );
 
-		$expected_shortcode = "[hulu $this->video_id]";
+		$expected_shortcode = "[hulu id=$this->video_eid width=512 height=288 start_time=10 end_time=20 thumbnail_frame=11]";
 
 		$this->assertEquals( $expected_shortcode, $shortcode );
 	}

--- a/tests/php/modules/shortcodes/test_class.hulu.php
+++ b/tests/php/modules/shortcodes/test_class.hulu.php
@@ -1,0 +1,110 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Hulu extends WP_UnitTestCase {
+
+	/**
+	 * Stores the correct server to fetch Hulu embeds from.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @var string
+	 */
+	private $src;
+
+	/**
+	 * Stores a Hulu video ID.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @var string
+	 */
+	private $video_id;
+
+	/**
+	 * Stores a Hulu direct video eid.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @var string
+	 */
+	private $video_eid;
+
+	/**
+	 * Setup environment for Hulu embed.
+	 *
+	 * @since 4.5.0
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		$this->src = is_ssl()
+			? 'https://secure.hulu.com/embed.html?eid='
+			: 'http://www.hulu.com/embed.html?eid=';
+		$this->video_id = '771496';
+		$this->video_eid = '_hHzwnAcj3RrXMJFDDvkuw';
+	}
+
+	public function test_shortcodes_hulu_exists() {
+		$this->assertEquals( shortcode_exists( 'hulu' ), true );
+	}
+
+	public function test_shortcodes_hulu() {
+		$content = '[hulu]';
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+	}
+
+	public function test_shortcodes_hulu_id() {
+		$content  = "[hulu $this->video_id]";
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( $this->src . $this->video_eid, $shortcode_content );
+	}
+
+	public function test_shortcodes_hulu_url() {
+		$content  = "[hulu http://www.hulu.com/watch/$this->video_id]";
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( $this->src . $this->video_eid, $shortcode_content );
+	}
+
+	public function test_shortcodes_hulu_width_height() {
+		$width    = '350';
+		$height   = '500';
+		$content  = "[hulu $this->video_id width=$width height=$height ]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( $this->src . $this->video_eid, $shortcode_content );
+		$this->assertContains( 'width="' . $width . '"', $shortcode_content );
+
+		// The height is modified in the shortcode so the video always shows in landscape ratio.
+		$this->assertContains( 'height="197"', $shortcode_content );
+	}
+
+	public function test_shortcodes_hulu_start_end_time_thumbnail() {
+		$start     = '10';
+		$end       = '20';
+		$thumbnail = '10';
+		$content  = "[hulu $this->video_id start_time=$start end_time=$end thumbnail_frame=$thumbnail]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( $this->src . $this->video_eid, $shortcode_content );
+		$this->assertContains( 'st=' . $start, $shortcode_content );
+		$this->assertContains( 'et=' . $end, $shortcode_content );
+		$this->assertContains( 'it=i' . $thumbnail, $shortcode_content );
+	}
+
+
+	public function test_hulu_embed_to_shortcode() {
+		$embed     = '<iframe width="512" height="288" src="http://www.hulu.com/embed.html?eid=wP5CpYenOIRjJT50LDp2kQ&et=20&st=10&it=i11" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>';
+		$shortcode = wpcom_shortcodereverse_huluembed( $embed );
+
+		$expected_shortcode = "[hulu $this->video_id]";
+
+		$this->assertEquals( $expected_shortcode, $shortcode );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.kickstarter.php
+++ b/tests/php/modules/shortcodes/test_class.kickstarter.php
@@ -1,0 +1,54 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Kickstarter extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [kickstarter] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_kickstarter_exists() {
+		$this->assertEquals( shortcode_exists( 'kickstarter' ), true );
+	}
+
+	/**
+	 * Verify that executing the shortcode doesn't return the same content but empty, since it has no attributes.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_kickstarter() {
+		$content = '[kickstarter]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '', $shortcode_content );
+	}
+
+	/**
+	 * Verify that executing shortcode with an invalid URL fails.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_kickstarter_invalid_url() {
+		$content = '[kickstarter url="https://kikstarter.com"]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals( '<!-- Invalid Kickstarter URL -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a Kickstarter link.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_kickstarter_image() {
+		$url = 'https://www.kickstarter.com/projects/peaktoplateau/yak-wool-baselayers-from-tibet-to-the-world';
+		$content = "[kickstarter url='$url']";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<a href="https://www.kickstarter.com/projects/peaktoplateau/yak-wool-baselayers-from-tibet-to-the-world">', $shortcode_content );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.lytro.php
+++ b/tests/php/modules/shortcodes/test_class.lytro.php
@@ -1,0 +1,70 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Lytro extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [lytro] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_lytro_exists() {
+		$this->assertEquals( shortcode_exists( 'lytro' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_lytro() {
+		$content = '[lytro]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- Lytro Shortcode Error: No Photo ID/URL -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode with no username returns a Lytro image.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_lytro_image() {
+		$image_id = '431119';
+		$content = "[lytro photo=$image_id]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe width="400" height="415" src="https://pictures.lytro.com/pictures/' . $image_id . '/embed?', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode with many attributes returns a Lytro image properly formatted.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_lytro_complete() {
+		$image_id = '431119';
+		$content = "[lytro username=lytroweb photo=$image_id show_arrow='false' show_border='false' show_first_time_user='false' allow_full_view='false']";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe width="400" height="415" src="https://pictures.lytro.com/lytroweb/pictures/' . $image_id . '/embed?showArrow=false&#038;showBorder=false&#038;showFTU=false&#038;allowFullView=false', $shortcode_content );
+	}
+
+	/**
+	 * Verify iframe can be reversed to a shortcode.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_lytro_iframe_reverse() {
+		$image_id = '431119';
+		$content = '<iframe width="400" height="415" src="https://pictures.lytro.com/lytroweb/pictures/' . $image_id . '/embed?showArrow=false&#038;showBorder=true&#038;showFTU=false&#038;allowFullView=false&#038;enableHelp=true&#038;enableAttribution=true&#038;enableLogo=true&#038;enableFullscreen=true&#038;enablePlay=true" frameborder="0" allowfullscreen scrolling="no"></iframe>';
+
+		// Trigger iframe parsing and reversion to shortcode
+		$shortcode = apply_filters( 'pre_kses', $content );
+
+		$this->assertContains( "[lytro  username='lytroweb' photo='431119' show_arrow='false' show_border='true' show_first_time_user='false' allow_full_view='false' enable_help='true' enable_attribution='true' enable_logo='true' enable_fullscreen='true' enable_play='true' width='400' height='415']", $shortcode );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.mailchimp.php
+++ b/tests/php/modules/shortcodes/test_class.mailchimp.php
@@ -1,0 +1,42 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_MailChimp extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [mailchimp] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_mailchimp_exists() {
+		$this->assertEquals( shortcode_exists( 'mailchimp_subscriber_popup' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_mailchimp() {
+		$content = '[mailchimp_subscriber_popup]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- Missing MailChimp baseUrl, uuid or lid -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a MailChimp image.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_mailchimp_form() {
+		$uuid = '1ca7856462585a934b8674c71';
+		$lid = '2d24f1898b';
+		$content = "[mailchimp_subscriber_popup baseUrl=mc.us11.list-manage.com uuid=$uuid lid=$lid]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<script type="text/javascript" data-dojo-config="usePlainJson: true, isDebug: false">jQuery.getScript( "//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js", function( data, textStatus, jqxhr ) { require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"' . $uuid . '","lid":"' . $lid . '"}) }); } );</script>', $shortcode_content );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.quiz.php
+++ b/tests/php/modules/shortcodes/test_class.quiz.php
@@ -36,20 +36,6 @@ class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify [quiz] writes the correct track id and the a8c training id.
-	 *
-	 * @since 4.5.0
-	 */
-	public function test_shortcodes_quiz_id_wpcom() {
-		define( 'IS_WPCOM', true );
-		$user = $this->factory->user->create_and_get();
-		wp_set_current_user( $user->ID );
-
-		$shortcode_content = do_shortcode( '[quiz trackid="the-quiz" a8ctraining="a8c-quiz"][question]What is the right answer?[/question][/quiz]' );
-		$this->assertEquals( '<div class="quiz" data-trackid="the-quiz" data-a8ctraining="a8c-quiz" data-username="' . $user->user_login . '"><div class="question">What is the right answer?</div></div>', $shortcode_content );
-	}
-
-	/**
 	 * Verify that a [question] is not rendered when they're outside a [quiz].
 	 *
 	 * @since 4.5.0

--- a/tests/php/modules/shortcodes/test_class.quiz.php
+++ b/tests/php/modules/shortcodes/test_class.quiz.php
@@ -26,13 +26,27 @@ class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify [quiz] writes the correct id when passed as attribute.
+	 * Verify [quiz] writes the correct track id when passed as attribute.
 	 *
 	 * @since 4.5.0
 	 */
 	public function test_shortcodes_quiz_id() {
 		$shortcode_content = do_shortcode( '[quiz trackid="the-quiz"][question]What is the right answer?[/question][/quiz]' );
 		$this->assertEquals( '<div class="quiz" data-trackid="the-quiz"><div class="question">What is the right answer?</div></div>', $shortcode_content );
+	}
+
+	/**
+	 * Verify [quiz] writes the correct track id and the a8c training id.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_quiz_id_wpcom() {
+		define( 'IS_WPCOM', true );
+		$user = $this->factory->user->create_and_get();
+		wp_set_current_user( $user->ID );
+
+		$shortcode_content = do_shortcode( '[quiz trackid="the-quiz" a8ctraining="a8c-quiz"][question]What is the right answer?[/question][/quiz]' );
+		$this->assertEquals( '<div class="quiz" data-trackid="the-quiz" data-a8ctraining="a8c-quiz" data-username="' . $user->user_login . '"><div class="question">What is the right answer?</div></div>', $shortcode_content );
 	}
 
 	/**

--- a/tests/php/modules/shortcodes/test_class.quiz.php
+++ b/tests/php/modules/shortcodes/test_class.quiz.php
@@ -1,0 +1,101 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [quiz] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_quiz_exists() {
+		$this->assertEquals( shortcode_exists( 'quiz' ), true );
+	}
+
+	/**
+	 * Verify that calling shortcode doesn't return the same content and since it doesn't have content, return nothing.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_quiz() {
+		$content = '[quiz][/quiz]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '', $shortcode_content );
+	}
+
+	/**
+	 * Verify [quiz] writes the correct id when passed as attribute.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_quiz_id() {
+		$shortcode_content = do_shortcode( '[quiz trackid="the-quiz"][question]What is the right answer?[/question][/quiz]' );
+		$this->assertEquals( '<div class="quiz" data-trackid="the-quiz"><div class="question">What is the right answer?</div></div>', $shortcode_content );
+	}
+
+	/**
+	 * Verify that a [question] is not rendered when they're outside a [quiz].
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_question() {
+		$shortcode_content = do_shortcode( '[question]What is the right answer?[/question]' );
+		$this->assertEquals( '', $shortcode_content );
+
+		$shortcode_content = do_shortcode( '[quiz][question]What is the right answer?[/question][/quiz]' );
+		$this->assertEquals( '<div class="quiz"><div class="question">What is the right answer?</div></div>', $shortcode_content );
+	}
+
+	/**
+	 * Verify that an [answer] is not rendered when they're outside a [quiz].
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_answer() {
+		$shortcode_content = do_shortcode( '[answer]This is the right answer![/answer]' );
+		$this->assertEquals( '', $shortcode_content );
+
+		$shortcode_content = do_shortcode( '[quiz][answer]This is the right answer![/answer][/quiz]' );
+		$this->assertEquals( '<div class="quiz"><div class="answer" data-correct="1">This is the right answer!</div></div>', $shortcode_content );
+	}
+
+	/**
+	 * Verify that a [wrong] is not rendered when they're outside a [quiz].
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_wrong() {
+		$shortcode_content = do_shortcode( '[wrong]This is so wrong...[/wrong]' );
+		$this->assertEquals( '', $shortcode_content );
+
+		$shortcode_content = do_shortcode( '[quiz][wrong]This is so wrong...[/wrong][/quiz]' );
+		$this->assertEquals( '<div class="quiz"><div class="answer">This is so wrong...</div></div>', $shortcode_content );
+	}
+
+	/**
+	 * Verify that a [explanation] is not rendered when they're outside a [quiz].
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_explanation() {
+		$shortcode_content = do_shortcode( '[explanation]This is why this is right or wrong.[/explanation]' );
+		$this->assertEquals( '', $shortcode_content );
+
+		$shortcode_content = do_shortcode( '[quiz][explanation]This is why this is right or wrong.[/explanation][/quiz]' );
+		$this->assertEquals( '<div class="quiz"><div class="explanation">This is why this is right or wrong.</div></div>', $shortcode_content );
+	}
+
+	/**
+	 * Verify the shortcode renders correctly when it's correctly written.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_complete() {
+		$shortcode_content = do_shortcode( '[quiz][question]What is the right answer?[/question][wrong]This is so wrong...[explanation]This is why this is wrong.[/explanation][/wrong][answer]Yes, this is right![explanation]Yay![/explanation][/answer][/quiz]' );
+		$this->assertEquals( '<div class="quiz"><div class="question">What is the right answer?</div><div class="answer">This is so wrong...<div class="explanation">This is why this is wrong.</div></div><div class="answer" data-correct="1">Yes, this is right!<div class="explanation">Yay!</div></div></div>', $shortcode_content );
+	}
+
+
+}

--- a/tests/php/modules/shortcodes/test_class.sitemap.php
+++ b/tests/php/modules/shortcodes/test_class.sitemap.php
@@ -1,0 +1,57 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Sitemap extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [sitemap] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_sitemap_exists() {
+		$this->assertEquals( shortcode_exists( 'sitemap' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content and that its output is '' because we have no pages.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_sitemap() {
+		$content = '[sitemap]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns tree of pages since we now have pages.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_sitemap_image() {
+		$content = '[sitemap]';
+
+		$page_1_id = $this->factory->post->create( array(
+			'post_type'    => 'page',
+			'post_title'   => 'Jetpack Parent',
+			'post_content' => 'This is a parent page',
+		) );
+
+		$page_1_1_id = $this->factory->post->create( array(
+			'post_type'    => 'page',
+			'post_title'   => 'Jetpack Child',
+			'post_content' => 'This is another page, whose parent is ' . $page_1_id,
+			'post_parent'  => $page_1_id
+		) );
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<ul class="jetpack-sitemap-shortcode"><li class="pagenav">', $shortcode_content );
+		$this->assertContains( '<ul><li class="page_item page-item-' . $page_1_id . ' page_item_has_children"><a href="http://example.org/?page_id=21">Jetpack Parent</a>', $shortcode_content );
+		$this->assertContains( "<ul class='children'>", $shortcode_content );
+        $this->assertContains( '<li class="page_item page-item-' . $page_1_1_id . '"><a href="http://example.org/?page_id=22">Jetpack Child</a></li>',
+			$shortcode_content );
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.sitemap.php
+++ b/tests/php/modules/shortcodes/test_class.sitemap.php
@@ -49,9 +49,8 @@ class WP_Test_Jetpack_Shortcodes_Sitemap extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( '<ul class="jetpack-sitemap-shortcode"><li class="pagenav">', $shortcode_content );
-		$this->assertContains( '<ul><li class="page_item page-item-' . $page_1_id . ' page_item_has_children"><a href="http://example.org/?page_id=21">Jetpack Parent</a>', $shortcode_content );
+		$this->assertContains( '<ul><li class="page_item page-item-' . $page_1_id . ' page_item_has_children"><a href="http://example.org/?page_id=' . $page_1_id . '">Jetpack Parent</a>', $shortcode_content );
 		$this->assertContains( "<ul class='children'>", $shortcode_content );
-        $this->assertContains( '<li class="page_item page-item-' . $page_1_1_id . '"><a href="http://example.org/?page_id=22">Jetpack Child</a></li>',
-			$shortcode_content );
+        $this->assertContains( '<li class="page_item page-item-' . $page_1_1_id . '"><a href="http://example.org/?page_id=' . $page_1_1_id . '">Jetpack Child</a></li>', $shortcode_content );
 	}
 }

--- a/tests/php/modules/shortcodes/test_class.spotify.php
+++ b/tests/php/modules/shortcodes/test_class.spotify.php
@@ -1,0 +1,82 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Spotify extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [spotify] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_spotify_exists() {
+		$this->assertEquals( shortcode_exists( 'spotify' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_spotify() {
+		$content = '[spotify]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a Spotify player based on the ID.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_spotify_player_id() {
+		$track_id = '55fQ9iIkC2qajnlvI1iMWO';
+		$content = "[spotify spotify:track:$track_id]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( 'https://embed.spotify.com/?uri=' . urlencode( "spotify:track:$track_id" ), $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a Spotify player based on the URL.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_spotify_player_url() {
+		$track_id = '55fQ9iIkC2qajnlvI1iMWO';
+		$track_url = "https://play.spotify.com/track/$track_id";
+		$content = "[spotify $track_url]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( 'https://embed.spotify.com/?uri=' . urlencode( "https://play.spotify.com/track/$track_id" ), $shortcode_content );
+	}
+
+	/**
+	 * Verify that content like "spotify:track:55fQ9iIkC2qajnlvI1iMWO" on its own line, it will be converted to a player.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_spotify_player_content() {
+		$track_id = '55fQ9iIkC2qajnlvI1iMWO';
+		$content = "spotify:track:$track_id";
+
+		$content = apply_filters( 'the_content', $content );
+		$this->assertContains( 'https://embed.spotify.com/?uri=' . urlencode( "spotify:track:$track_id" ), $content );
+	}
+
+	/**
+	 * Verify that content like "spotify:track:55fQ9iIkC2qajnlvI1iMWO" that is not in its own line, won't be converted to a player.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_spotify_player_content_no_line() {
+		$track_id = '55fQ9iIkC2qajnlvI1iMWO';
+		$content = "This is another text spotify:track:$track_id surrounding this Spotify track.";
+
+		$content = apply_filters( 'the_content', $content );
+		$this->assertContains( "spotify:track:$track_id", $content );
+	}
+
+}

--- a/tests/php/modules/shortcodes/test_class.tweet.php
+++ b/tests/php/modules/shortcodes/test_class.tweet.php
@@ -1,0 +1,56 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Tweet extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [tweet] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_tweet_exists() {
+		$this->assertEquals( shortcode_exists( 'tweet' ), true );
+	}
+
+	/**
+	 * Verify that calling do_shortcode with the shortcode doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_tweet() {
+		$content = '[tweet]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- Invalid tweet id -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a tweet card.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_tweet_card() {
+		$content = "[tweet https://twitter.com/jetpack/status/759034293385502721]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<blockquote class="twitter-tweet"', $shortcode_content );
+		$this->assertContains( '<a href="https://twitter.com/jetpack/status/759034293385502721">', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode with custom parameters adds them to the tweet card.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_tweet_card_parameters() {
+		$content = "[tweet https://twitter.com/jetpack/status/759034293385502721 align=right lang=es]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( 'align="right"', $shortcode_content );
+		$this->assertContains( 'data-lang="es"', $shortcode_content );
+	}
+
+}

--- a/tests/php/modules/shortcodes/test_class.ustream.php
+++ b/tests/php/modules/shortcodes/test_class.ustream.php
@@ -1,0 +1,66 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Ustream extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [ustream] and [ustreamsocial] exists.
+	 *
+	 * @since  4.5.0
+	 */
+	public function test_shortcodes_ustream_exists() {
+		$this->assertEquals( shortcode_exists( 'ustream' ), true );
+		$this->assertEquals( shortcode_exists( 'ustreamsocial' ), true );
+	}
+
+	/**
+	 * Verify that executing ustream doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_ustream() {
+		$content           = '[ustream]';
+		$shortcode_content = do_shortcode( $content );
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- ustream error: bad video ID -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that executing ustreamsocial doesn't return the same content.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_ustreamsocial() {
+		$content = '[ustreamsocial]';
+		$shortcode_content = do_shortcode( $content );
+		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( '<!-- ustreamsocial error: bad social stream ID -->', $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a Ustream video.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_ustream_video() {
+		$id = '1524';
+		$content = "[ustream id='$id']";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe src="http://www.ustream.tv/embed/recorded/' . $id, $shortcode_content );
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a Ustream video.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_ustream_social_stream() {
+		$id = '12980237';
+		$content = "[ustreamsocial id='$id' width=500]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe id="SocialStream" class="" name="SocialStream" width="500" height="420" scrolling="no" allowtransparency="true" src="http://www.ustream.tv/socialstream/' . $id, $shortcode_content );
+	}
+}


### PR DESCRIPTION
Fixes #5518

#### Changes proposed in this Pull Request:
Introduce new shortcodes in Jetpack

#### Testing instructions:
* run phpunit tests
* test shortcodes in editor

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Shortcodes: new are 

([see this comment for example shortcodes](https://github.com/Automattic/jetpack/pull/5838#issuecomment-266050670))

- [x] [spotify]
- [x] [tweet]
- [x] [googleapps]
- [x] [brightcove]
- [x] [getty]
- [x] [archiveorg]
- [x] [hulu]
- [x] [kickstarter]
- [x] [gravatar]
- [x] [gravatar_profile]
- [x] [quiz]
- [x] [sitemap]
- [x] [lytro]
- [x] [mailchip_subscriber_popup]
- [x] [ustream]
- [x] [ustreamsocial]

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
