### PR TITLE
Milestone Widget: fix call to non-static method

### DIFF
--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -63,7 +63,7 @@ class Milestone_Widget extends WP_Widget {
 
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
-		add_action( 'wp_footer', array( __class__, 'localize_script' ) );
+		add_action( 'wp_footer', array( $this, 'localize_script' ) );
 
 		if ( is_active_widget( false, false, $this->id_base, true ) || is_active_widget( false, false, 'monster', true ) ) {
 			add_action( 'wp_head', array( __class__, 'styles_template' ) );


### PR DESCRIPTION
with WP_DEBUG_LOG enabled, you will see errors in the debug.log file when loading The milestone widget.  

`PHP Deprecated:  Non-static method Milestone_Widget::localize_script() should not be called statically in /home/dereksma/public_html/wp-includes/class-wp-hook.php on line 298`