### PR TITLE
IDC: Be more defensive when tracking stats to minimize changes of err…

### DIFF
--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -17,7 +17,10 @@
 		erroredAction = false;
 
 	// Initialize Tracks and bump stats.
-	analytics.initialize( tracksUser.userid, tracksUser.username );
+	if ( analytics ) {
+		analytics.initialize( tracksUser.userid, tracksUser.username );
+	}
+
 	if ( tracksEvent.isAdmin ) {
 		trackAndBumpMCStats( 'notice_view' );
 	} else {

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -17,7 +17,7 @@
 		erroredAction = false;
 
 	// Initialize Tracks and bump stats.
-	if ( analytics ) {
+	if ( 'undefined' !== typeof analytics ) {
 		analytics.initialize( tracksUser.userid, tracksUser.username );
 	}
 
@@ -216,7 +216,7 @@
 			extraProps = {};
 		}
 
-		if ( eventName && eventName.length && analytics && analytics.tracks && analytics.mc ) {
+		if ( eventName && eventName.length && 'undefined' !== typeof analytics && analytics.tracks && analytics.mc ) {
 			// Format for Tracks
 			eventName = eventName.replace( /-/g, '_' );
 			eventName = eventName.indexOf( 'jetpack_idc_' ) !== 0 ? 'jetpack_idc_' + eventName : eventName;

--- a/_inc/idc-notice.js
+++ b/_inc/idc-notice.js
@@ -213,7 +213,7 @@
 			extraProps = {};
 		}
 
-		if ( eventName && eventName.length ) {
+		if ( eventName && eventName.length && analytics && analytics.tracks && analytics.mc ) {
 			// Format for Tracks
 			eventName = eventName.replace( /-/g, '_' );
 			eventName = eventName.indexOf( 'jetpack_idc_' ) !== 0 ? 'jetpack_idc_' + eventName : eventName;


### PR DESCRIPTION
A user reported a JS error after the IDC notice loaded.

```
TypeError: analytics.tracks is undefined[Learn More]  idc-notice.js:220:4
    trackAndBumpMCStats https://pressable.com/wp-content/plugins/jetpack/_inc/idc-notice.js:220:4
    fixJetpackConnection https://pressable.com/wp-content/plugins/jetpack/_inc/idc-notice.js:153:3
    n.event.dispatch https://pressable.com/wp-admin/load-scripts.php:3:12392
    n.event.add/r.handle https://pressable.com/wp-admin/load-scripts.php:3:9156
```

We weren't able to reproduce this error. But, after looking at the code, we can be a bit more defensive and only call `analytics.tracks` or `analytics.mc` when we know that the analytics code is loaded.

To test:

- Checkout branch
- Trigger an IDC on your site
- Click various buttons in the IDC notice, and verify in developer tools that network requests are being made
- Ensure no JS errors