### PR TITLE
Sync PHP version

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -127,6 +127,7 @@ class Jetpack_Sync_Defaults {
 		'DISABLE_WP_CRON',
 		'ALTERNATE_WP_CRON',
 		'WP_CRON_LOCK_TIMEOUT',
+		'PHP_VERSION'
 	);
 
 	static $default_callable_whitelist = array(


### PR DESCRIPTION
PHP_VERSION was the only remaining piece of Heartbeat that we weren't syncing, so let's sync it!