### PR TITLE
Shortcodes: add [blog_subscription_form]

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -752,7 +752,11 @@ Jetpack_Subscriptions::init();
 
 class Jetpack_Subscriptions_Widget extends WP_Widget {
 	function __construct() {
-		$widget_ops  = array( 'classname' => 'jetpack_subscription_widget', 'description' => __( 'Add an email signup form to allow people to subscribe to your blog.', 'jetpack' ) );
+		$widget_ops  = array(
+			'classname' => 'jetpack_subscription_widget',
+			'description' => esc_html__( 'Add an email signup form to allow people to subscribe to your blog.', 'jetpack' ),
+			'customize_selective_refresh' => true,
+		);
 		$control_ops = array( 'width' => 300 );
 
 		parent::__construct(
@@ -762,6 +766,20 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			$widget_ops,
 			$control_ops
 		);
+
+		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
+		}
+	}
+
+	/**
+	 * Enqueue the form's CSS.
+	 *
+	 * @since 4.5.0
+	 */
+	function enqueue_style() {
+		wp_register_style( 'jetpack-subscriptions', plugins_url( 'subscriptions/subscriptions.css', __FILE__ ) );
+		wp_enqueue_style( 'jetpack-subscriptions' );
 	}
 
 	function widget( $args, $instance ) {
@@ -806,10 +824,6 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		 * @param int $widget_id Widget ID.
 		 */
 		$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field', $widget_id );
-
-		// Enqueue the form's CSS
-		wp_register_style( 'jetpack-subscriptions', plugins_url( 'subscriptions/subscriptions.css', __FILE__ ) );
-		wp_enqueue_style( 'jetpack-subscriptions' );
 
 		// Display the subscription form
 		echo $args['before_widget'];

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -772,7 +772,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		) {
 			$subscribe_email = '';
 		} else {
-			global $current_user;
+			$current_user = wp_get_current_user();
 			if ( ! empty( $current_user->user_email ) ) {
 				$subscribe_email = esc_attr( $current_user->user_email );
 			} else {
@@ -1044,6 +1044,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 }
 
 add_shortcode( 'jetpack_subscription_form', 'jetpack_do_subscription_form' );
+add_shortcode( 'blog_subscription_form', 'jetpack_do_subscription_form' );
 
 function jetpack_do_subscription_form( $instance ) {
 	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) ? false : true;


### PR DESCRIPTION
Follow up to #5838

#### Changes proposed in this Pull Request:
- introduce the shortcode `[blog_subscription_form]`
- add support for Customizer's selective refresh for the widget
- replace a global access with a standard function

#### Testing instructions:
* use `[blog_subscription_form]` with and without the `show_subscribers_total` attribute:
```
[blog_subscription_form]

[blog_subscription_form show_subscribers_total=true]
```
* subscribe to the site, it should work normally
* the one with `show_subscribers_total` set to `true` should display the current number of site subscribers.