### PR TITLE
Sync: IDC: Add get_raw_url method to Jetpack_Sync_Functions

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -10,6 +10,7 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/wpml.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php' );
 
 // We can't load this conditionally since polldaddy add the call in class constuctor.
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );

--- a/3rd-party/domain-mapping.php
+++ b/3rd-party/domain-mapping.php
@@ -31,7 +31,6 @@ class Jetpack_3rd_Party_Domain_Mapping {
 	}
 
 	private function __construct() {
-		error_log( 'domain mapping construct called' );
 		add_action( 'plugins_loaded', array( $this, 'attempt_to_hook_domain_mapping_plugins' ) );
 	}
 

--- a/3rd-party/domain-mapping.php
+++ b/3rd-party/domain-mapping.php
@@ -17,7 +17,7 @@ class Jetpack_3rd_Party_Domain_Mapping {
 	 *
 	 * @var array
 	 */
-	const TEST_METHODS = array(
+	static $test_methods = array(
 		'hook_wordpress_mu_domain_mapping',
 		'hook_wpmu_dev_domain_mapping'
 	);
@@ -31,11 +31,12 @@ class Jetpack_3rd_Party_Domain_Mapping {
 	}
 
 	private function __construct() {
+		error_log( 'domain mapping construct called' );
 		add_action( 'plugins_loaded', array( $this, 'attempt_to_hook_domain_mapping_plugins' ) );
 	}
 
 	/**
-	 * This function is called on the plugins_loaded action and will loop through the TEST_METHODS
+	 * This function is called on the plugins_loaded action and will loop through the $test_methods
 	 * to try and hook a domain mapping plugin to the Jetpack sync filters for the home_url and site_url callables.
 	 */
 	function attempt_to_hook_domain_mapping_plugins() {
@@ -44,9 +45,9 @@ class Jetpack_3rd_Party_Domain_Mapping {
 		}
 
 		$hooked = false;
-		$count = count( self::TEST_METHODS );
+		$count = count( self::$test_methods );
 		for ( $i = 0; $i < $count && ! $hooked; $i++ ) {
-			$hooked = call_user_func( array( $this, self::TEST_METHODS[ $i ] ) );
+			$hooked = call_user_func( array( $this, self::$test_methods[ $i ] ) );
 		}
 	}
 

--- a/3rd-party/domain-mapping.php
+++ b/3rd-party/domain-mapping.php
@@ -1,0 +1,37 @@
+<?php
+
+if ( Jetpack_Constants::is_defined( 'SUNRISE' ) ) :
+	function jetpack_domain_mapping_check_compatible_plugins() {
+		// Once we've satisfied a condition for adding domain mapping compatibility, then bail
+		$hooked = jetpack_domain_mapping_maybe_support_wordpress_mu_domain_mapping();
+
+		if ( ! $hooked ) {
+			jetpack_domain_mapping_maybe_add_wpmu_dev_domain_mapping_support();
+		}
+	}
+	add_action( 'plugins_loaded', 'jetpack_domain_mapping_compatibility' );
+
+	// Compatibility with Donncha's WordPress MU Domain Mapping plugin
+	function jetpack_domain_mapping_maybe_support_wordpress_mu_domain_mapping() {
+		if ( ! Jetpack_Constants::is_defined( 'DOMAIN_MAPPING' ) || function_exists( 'domain_mapping_siteurl' ) ) {
+			return false;
+		}
+
+		add_filter( 'jetpack_sync_home_url', 'domain_mapping_siteurl' );
+		add_filter( 'jetpack_sync_site_url', 'domain_mapping_siteurl' );
+
+		return true;
+	}
+
+
+	// Compatibility with WPMU DEV's Domain Mapping plugin
+	function jetpack_domain_mapping_maybe_add_wpmu_dev_domain_mapping_support() {
+		if ( ! class_exists( 'domain_map' ) || ! method_exists( 'domain_map', 'utils' ) ) {
+			return false;
+		}
+
+		$utils = domain_map::utils();
+		add_filter( 'jetpack_sync_home_url', array( $utils, 'swap_to_mapped_url' ) );
+		add_filter( 'jetpack_sync_site_url', array( $utils, 'swap_to_mapped_url' ) );
+	}
+endif;

--- a/3rd-party/domain-mapping.php
+++ b/3rd-party/domain-mapping.php
@@ -1,37 +1,62 @@
 <?php
 
 if ( Jetpack_Constants::is_defined( 'SUNRISE' ) ) :
-	function jetpack_domain_mapping_check_compatible_plugins() {
-		// Once we've satisfied a condition for adding domain mapping compatibility, then bail
-		$hooked = jetpack_domain_mapping_maybe_support_wordpress_mu_domain_mapping();
 
-		if ( ! $hooked ) {
-			jetpack_domain_mapping_maybe_add_wpmu_dev_domain_mapping_support();
-		}
-	}
-	add_action( 'plugins_loaded', 'jetpack_domain_mapping_compatibility' );
+	/**
+	 * Class Jetpack_3rd_Party_Domain_Mapping
+	 *
+	 * This class contains methods that are used to provide compatibility between Jetpack sync and domain mapping plugins.
+	 */
+	class Jetpack_3rd_Party_Domain_Mapping {
 
-	// Compatibility with Donncha's WordPress MU Domain Mapping plugin
-	function jetpack_domain_mapping_maybe_support_wordpress_mu_domain_mapping() {
-		if ( ! Jetpack_Constants::is_defined( 'DOMAIN_MAPPING' ) || function_exists( 'domain_mapping_siteurl' ) ) {
-			return false;
-		}
+		/**
+		 * This method will test for a constant and function that are known to be used with Donncha's WordPress MU
+		 * Domain Mapping plugin. If conditions are met, we hook the domain_mapping_siteurl() function to Jetpack sync
+		 * filters for home_url and site_url callables.
+		 *
+		 * @return bool
+		 */
+		static function hook_wordpress_mu_domain_mapping() {
+			if ( ! Jetpack_Constants::is_defined( 'DOMAIN_MAPPING' ) || function_exists( 'domain_mapping_siteurl' ) ) {
+				return false;
+			}
 
-		add_filter( 'jetpack_sync_home_url', 'domain_mapping_siteurl' );
-		add_filter( 'jetpack_sync_site_url', 'domain_mapping_siteurl' );
+			add_filter( 'jetpack_sync_home_url', 'domain_mapping_siteurl' );
+			add_filter( 'jetpack_sync_site_url', 'domain_mapping_siteurl' );
 
-		return true;
-	}
-
-
-	// Compatibility with WPMU DEV's Domain Mapping plugin
-	function jetpack_domain_mapping_maybe_add_wpmu_dev_domain_mapping_support() {
-		if ( ! class_exists( 'domain_map' ) || ! method_exists( 'domain_map', 'utils' ) ) {
-			return false;
+			return true;
 		}
 
-		$utils = domain_map::utils();
-		add_filter( 'jetpack_sync_home_url', array( $utils, 'swap_to_mapped_url' ) );
-		add_filter( 'jetpack_sync_site_url', array( $utils, 'swap_to_mapped_url' ) );
+		/**
+		 * This method will test for a class and method known to be used in WPMU Dev's domain mapping plugin. If the
+		 * method exists, then we'll hook the swap_to_mapped_url() to our Jetpack sync fitlers for home_url and site_url.
+		 *
+		 * @return bool
+		 */
+		static function hook_wpmu_dev_domain_mapping() {
+			if ( ! class_exists( 'domain_map' ) || ! method_exists( 'domain_map', 'utils' ) ) {
+				return false;
+			}
+
+			$utils = domain_map::utils();
+			add_filter( 'jetpack_sync_home_url', array( $utils, 'swap_to_mapped_url' ) );
+			add_filter( 'jetpack_sync_site_url', array( $utils, 'swap_to_mapped_url' ) );
+
+			return true;
+		}
 	}
+
+	/**
+	 * This function is called on the plugins_loaded action and will loop through the methods of
+	 * Jetpack_3rd_Party_Domain_Mapping to try and hook a domain mapping plugin to the Jetpack sync
+	 * filters for the home_url and site_url callables.
+	 */
+	function jetpack_domain_mapping_hook_compatible_plugins() {
+		$methods = get_class_methods( 'Jetpack_3rd_Party_Domain_Mapping' );
+		do {
+			$method = array_pop( $methods );
+			$hooked = call_user_func( 'Jetpack_3rd_Party_Domain_Mapping', $method );
+		} while( ! $hooked && ! empty( $methods ) );
+	}
+	add_action( 'plugins_loaded', 'jetpack_domain_mapping_hook_compatible_plugins' );
 endif;

--- a/3rd-party/domain-mapping.php
+++ b/3rd-party/domain-mapping.php
@@ -58,7 +58,7 @@ class Jetpack_3rd_Party_Domain_Mapping {
 	 * @return bool
 	 */
 	function hook_wordpress_mu_domain_mapping() {
-		if ( ! Jetpack_Constants::is_defined( 'DOMAIN_MAPPING' ) || ! $this->function_exists( 'domain_mapping_siteurl' ) ) {
+		if ( ! Jetpack_Constants::is_defined( 'SUNRISE_LOADED' ) || ! $this->function_exists( 'domain_mapping_siteurl' ) ) {
 			return false;
 		}
 

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -340,9 +340,10 @@ class Jetpack_XMLRPC_Server {
 	 * @return array
 	 */
 	function validate_urls_for_idc_mitigation() {
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-functions.php';
 		return array(
-			'home'    => get_home_url(),
-			'siteurl' => get_site_url(),
+			'home'    => Jetpack_Sync_Functions::home_url(),
+			'siteurl' => Jetpack_Sync_Functions::site_url(),
 		);
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5797,9 +5797,10 @@ p {
 	 * @return array Array of the local urls, wpcom urls, and error code
 	 */
 	public static function get_sync_error_idc_option( $response = array() ) {
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-functions.php';
 		$local_options = array(
-			'home' => get_home_url(),
-			'siteurl' => get_site_url(),
+			'home'    => Jetpack_Sync_Functions::home_url(),
+			'siteurl' => Jetpack_Sync_Functions::site_url(),
 		);
 
 		$options = array_merge( $local_options, $response );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -80,6 +80,9 @@
 		<testsuite name="jitm">
 			<file>tests/php/test_class.jetpack-jitm.php</file>
 		</testsuite>
+		<testsuite name="3rd-party">
+			<directory prefix="test_" suffix=".php">tests/php/3rd-party</directory>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -113,6 +113,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration ) {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-functions.php';
 		Jetpack::load_xml_rpc_client();
 
 		$query_args = array(
@@ -120,8 +121,8 @@ class Jetpack_Sync_Actions {
 			'codec'     => $codec_name,     // send the name of the codec used to encode the data
 			'timestamp' => $sent_timestamp, // send current server time so we can compensate for clock differences
 			'queue'     => $queue_id,       // sync or full_sync
-			'home'      => get_home_url(),  // Send home url option to check for Identity Crisis server-side
-			'siteurl'   => get_site_url(),  // Send siteurl option to check for Identity Crisis server-side
+			'home'      => Jetpack_Sync_Functions::home_url(),  // Send home url option to check for Identity Crisis server-side
+			'siteurl'   => Jetpack_Sync_Functions::site_url(),  // Send siteurl option to check for Identity Crisis server-side
 			'cd'        => sprintf( '%.4f', $checkout_duration),   // Time spent retrieving queue items from the DB
 			'pd'        => sprintf( '%.4f', $preprocess_duration), // Time spent converting queue items into data to send
 		);

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -225,7 +225,7 @@ class Jetpack_Sync_Functions {
 		} else {
 			// Let's get the option from the database so that we can bypass filters. This will help
 			// ensure that we get more uniform values.
-			$value = Jetpack_Sync_Options::get_option( $option_name );
+			$value = Jetpack_Options::get_raw_option( $option_name );
 		}
 
 		if ( is_ssl() ) {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -144,17 +144,28 @@ class Jetpack_Sync_Functions {
 		return false;
 	}
 
-	public static function home_url() {
+	/**
+	 * Helper function that is used when getting home or siteurl values. Decides
+	 * whether to get the raw or filtered value.
+	 *
+	 * @return string
+	 */
+	public static function get_raw_or_filtered_url( $url_type, $url_function) {
 		if (
 			! Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) ||
 			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
 		) {
-			$home_url = self::get_raw_url( 'home' );
+			$url = self::get_raw_url( $url_type );
 		} else {
-			$home_url = self::normalize_www_in_url( 'home', 'home_url' );
+			$url = self::normalize_www_in_url( $url_type, $url_function );
+			$url = self::get_protocol_normalized_url( $url_function, $url );
 		}
 
-		$home_url = self::get_protocol_normalized_url( 'home_url', $home_url );
+		return $url;
+	}
+
+	public static function home_url() {
+		$url = self::get_raw_or_filtered_url( 'home', 'home_url' );
 
 		/**
 		 * Allows overriding of the home_url value that is synced back to WordPress.com.
@@ -163,20 +174,11 @@ class Jetpack_Sync_Functions {
 		 *
 		 * @param string $home_url
 		 */
-		return esc_url_raw( apply_filters( 'jetpack_sync_home_url', $home_url ) );
+		return esc_url_raw( apply_filters( 'jetpack_sync_home_url', $url ) );
 	}
 
 	public static function site_url() {
-		if (
-			! Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) ||
-			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
-		) {
-			$site_url =  self::get_raw_url( 'siteurl' );
-		} else {
-			$site_url = self::normalize_www_in_url( 'siteurl', 'site_url' );
-		}
-
-		$site_url =  self::get_protocol_normalized_url( 'site_url', $site_url );
+		$url = self::get_raw_or_filtered_url( 'siteurl', 'site_url' );
 
 		/**
 		 * Allows overriding of the site_url value that is synced back to WordPress.com.
@@ -185,7 +187,7 @@ class Jetpack_Sync_Functions {
 		 *
 		 * @param string $site_url
 		 */
-		return esc_url_raw( apply_filters( 'jetpack_sync_site_url', $site_url ) );
+		return esc_url_raw( apply_filters( 'jetpack_sync_site_url', $url ) );
 	}
 
 	public static function main_network_site_url() {
@@ -215,8 +217,6 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function get_raw_url( $option_name ) {
-		global $wpdb;
-
 		$value = null;
 		if ( 'home' == $option_name && Jetpack_Constants::is_defined( 'WP_HOME' ) ) {
 			$value = Jetpack_Constants::get_constant( 'WP_HOME' );
@@ -227,14 +227,6 @@ class Jetpack_Sync_Functions {
 			// ensure that we get more uniform values.
 			$value = Jetpack_Options::get_raw_option( $option_name );
 		}
-
-		if ( is_ssl() ) {
-			$scheme = 'https';
-		} else {
-			$scheme = parse_url( $value, PHP_URL_SCHEME );
-		}
-
-		$value = set_url_scheme( $value, $scheme );
 
 		return $value;
 	}

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -225,12 +225,7 @@ class Jetpack_Sync_Functions {
 		} else {
 			// Let's get the option from the database so that we can bypass filters. This will help
 			// ensure that we get more uniform values.
-			$value = $wpdb->get_var(
-				$wpdb->prepare(
-					"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
-					$option_name
-				)
-			);
+			$value = Jetpack_Sync_Options::get_option( $option_name );
 		}
 
 		if ( is_ssl() ) {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -150,13 +150,16 @@ class Jetpack_Sync_Functions {
 	 *
 	 * @return string
 	 */
-	public static function get_raw_or_filtered_url( $url_type, $url_function) {
+	public static function get_raw_or_filtered_url( $url_type ) {
 		if (
 			! Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) ||
 			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
 		) {
 			$url = self::get_raw_url( $url_type );
 		} else {
+			$url_function = ( 'home' == $url_type )
+				? 'home_url'
+				: 'site_url';
 			$url = self::normalize_www_in_url( $url_type, $url_function );
 			$url = self::get_protocol_normalized_url( $url_function, $url );
 		}
@@ -165,7 +168,7 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function home_url() {
-		$url = self::get_raw_or_filtered_url( 'home', 'home_url' );
+		$url = self::get_raw_or_filtered_url( 'home' );
 
 		/**
 		 * Allows overriding of the home_url value that is synced back to WordPress.com.
@@ -178,7 +181,7 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function site_url() {
-		$url = self::get_raw_or_filtered_url( 'siteurl', 'site_url' );
+		$url = self::get_raw_or_filtered_url( 'siteurl' );
 
 		/**
 		 * Allows overriding of the site_url value that is synced back to WordPress.com.
@@ -218,10 +221,12 @@ class Jetpack_Sync_Functions {
 
 	public static function get_raw_url( $option_name ) {
 		$value = null;
-		if ( 'home' == $option_name && Jetpack_Constants::is_defined( 'WP_HOME' ) ) {
-			$value = Jetpack_Constants::get_constant( 'WP_HOME' );
-		} else if ( 'siteurl' == $option_name && Jetpack_Constants::is_defined( 'WP_SITEURL' ) ) {
-			$value = Jetpack_Constants::get_constant( 'WP_SITEURL' );
+		$constant = ( 'home' == $option_name )
+			? 'WP_HOME'
+			: 'WP_SITEURL';
+
+		if ( Jetpack_Constants::is_defined( $constant ) ) {
+			$value = Jetpack_Constants::get_constant( $constant );
 		} else {
 			// Let's get the option from the database so that we can bypass filters. This will help
 			// ensure that we get more uniform values.

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -184,6 +184,28 @@ class Jetpack_Sync_Functions {
 		return set_url_scheme( $new_value, $forced_scheme );
 	}
 
+	public static function get_raw_url( $option_name ) {
+		global $wpdb;
+
+		$value = null;
+		if ( 'home' == $option_name && Jetpack_Constants::is_defined( 'WP_HOME' ) ) {
+			$value = Jetpack_Constants::get_constant( 'WP_HOME' );
+		} else if ( 'siteurl' == $option_name && Jetpack_Constants::is_defined( 'WP_SITEURL' ) ) {
+			$value = Jetpack_Constants::get_constant( 'WP_SITEURL' );
+		} else {
+			// Let's get the option from the database so that we can bypass filters. This will help
+			// ensure that we get more uniform values.
+			$value = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
+					$option_name
+				)
+			);
+		}
+
+		return $value;
+	}
+
 	public static function normalize_www_in_url( $option, $url_function ) {
 		$url        = wp_parse_url( call_user_func( $url_function ) );
 		$option_url = wp_parse_url( get_option( $option ) );

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -170,7 +170,7 @@ class Jetpack_Sync_Functions {
 		/**
 		 * Allows overriding of the home_url value that is synced back to WordPress.com.
 		 *
-		 * @since 4.6
+		 * @since 5.2
 		 *
 		 * @param string $home_url
 		 */
@@ -183,7 +183,7 @@ class Jetpack_Sync_Functions {
 		/**
 		 * Allows overriding of the site_url value that is synced back to WordPress.com.
 		 *
-		 * @since 4.6
+		 * @since 5.2
 		 *
 		 * @param string $site_url
 		 */

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -145,6 +145,13 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function home_url() {
+		if (
+			Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) &&
+			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
+		) {
+			return self::get_raw_url( 'home' );
+		}
+
 		return self::get_protocol_normalized_url(
 			'home_url',
 			self::normalize_www_in_url( 'home', 'home_url' )
@@ -152,6 +159,13 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function site_url() {
+		if (
+			Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) &&
+			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
+		) {
+			return self::get_raw_url( 'siteurl' );
+		}
+
 		return self::get_protocol_normalized_url(
 			'site_url',
 			self::normalize_www_in_url( 'siteurl', 'site_url' )

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -203,6 +203,14 @@ class Jetpack_Sync_Functions {
 			);
 		}
 
+		if ( is_ssl() ) {
+			$scheme = 'https';
+		} else {
+			$scheme = parse_url( $value, PHP_URL_SCHEME );
+		}
+
+		$value = set_url_scheme( $value, $scheme );
+
 		return $value;
 	}
 

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -146,7 +146,7 @@ class Jetpack_Sync_Functions {
 
 	public static function home_url() {
 		if (
-			Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) &&
+			! Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) ||
 			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
 		) {
 			$home_url = self::get_raw_url( 'home' );
@@ -168,7 +168,7 @@ class Jetpack_Sync_Functions {
 
 	public static function site_url() {
 		if (
-			Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) &&
+			! Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) ||
 			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
 		) {
 			$site_url =  self::get_raw_url( 'siteurl' );

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -149,13 +149,21 @@ class Jetpack_Sync_Functions {
 			Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) &&
 			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
 		) {
-			return self::get_raw_url( 'home' );
+			$home_url = self::get_raw_url( 'home' );
+		} else {
+			$home_url = self::normalize_www_in_url( 'home', 'home_url' );
 		}
 
-		return self::get_protocol_normalized_url(
-			'home_url',
-			self::normalize_www_in_url( 'home', 'home_url' )
-		);
+		$home_url = self::get_protocol_normalized_url( 'home_url', $home_url );
+
+		/**
+		 * Allows overriding of the home_url value that is synced back to WordPress.com.
+		 *
+		 * @since 4.6
+		 *
+		 * @param string $home_url
+		 */
+		return esc_url_raw( apply_filters( 'jetpack_sync_home_url', $home_url ) );
 	}
 
 	public static function site_url() {
@@ -163,13 +171,21 @@ class Jetpack_Sync_Functions {
 			Jetpack_Constants::is_defined( 'JETPACK_SYNC_USE_RAW_URL' ) &&
 			Jetpack_Constants::get_constant( 'JETPACK_SYNC_USE_RAW_URL' )
 		) {
-			return self::get_raw_url( 'siteurl' );
+			$site_url =  self::get_raw_url( 'siteurl' );
+		} else {
+			$site_url = self::normalize_www_in_url( 'siteurl', 'site_url' );
 		}
 
-		return self::get_protocol_normalized_url(
-			'site_url',
-			self::normalize_www_in_url( 'siteurl', 'site_url' )
-		);
+		$site_url =  self::get_protocol_normalized_url( 'site_url', $site_url );
+
+		/**
+		 * Allows overriding of the site_url value that is synced back to WordPress.com.
+		 *
+		 * @since 4.6
+		 *
+		 * @param string $site_url
+		 */
+		return esc_url_raw( apply_filters( 'jetpack_sync_site_url', $site_url ) );
 	}
 
 	public static function main_network_site_url() {

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -145,7 +145,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$callable_checksums = (array) Jetpack_Sync_Options::get_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
+		$callable_checksums = (array) Jetpack_Options::get_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
 
 		// only send the callables that have changed
 		foreach ( $callables as $name => $value ) {
@@ -166,7 +166,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 				$callable_checksums[ $name ] = $checksum;
 			}
 		}
-		Jetpack_Sync_Options::update_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
+		Jetpack_Options::update_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
 	}
 
 	public function expand_callables( $args ) {

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -145,7 +145,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$callable_checksums = (array) get_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
+		$callable_checksums = (array) Jetpack_Sync_Options::get_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
 
 		// only send the callables that have changed
 		foreach ( $callables as $name => $value ) {
@@ -166,7 +166,7 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 				$callable_checksums[ $name ] = $checksum;
 			}
 		}
-		update_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
+		Jetpack_Sync_Options::update_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
 	}
 
 	public function expand_callables( $args ) {

--- a/tests/php/3rd-party/test_class.jetpack-domain-mapping.php
+++ b/tests/php/3rd-party/test_class.jetpack-domain-mapping.php
@@ -55,7 +55,7 @@ class WP_Test_Domain_Mapping extends WP_UnitTestCase {
 	}
 
 	function test_domain_mapping_mu_domain_mapping_not_hooked_when_function_not_exists() {
-		Jetpack_Constants::set_constant( 'DOMAIN_MAPPING', true );
+		Jetpack_Constants::set_constant( 'SUNRISE_LOADED', true );
 
 		$stub = $this->getMockBuilder( 'MockDomainMapping' )
 			->setMethods( array( 'function_exists' ) )
@@ -74,7 +74,7 @@ class WP_Test_Domain_Mapping extends WP_UnitTestCase {
 	}
 
 	function test_domain_mapping_mu_domain_mapping_hooked_when_function_exists() {
-		Jetpack_Constants::set_constant( 'DOMAIN_MAPPING', true );
+		Jetpack_Constants::set_constant( 'SUNRISE_LOADED', true );
 
 		$stub = $this->getMockBuilder( 'MockDomainMapping' )
 			->setMethods( array( 'function_exists' ) )

--- a/tests/php/3rd-party/test_class.jetpack-domain-mapping.php
+++ b/tests/php/3rd-party/test_class.jetpack-domain-mapping.php
@@ -1,0 +1,152 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php';
+
+// Extend with a public constructor so we can test
+class MockDomainMapping extends Jetpack_3rd_Party_Domain_Mapping  {
+	public function __construct() {
+	}
+}
+
+class WP_Test_Domain_Mapping extends WP_UnitTestCase {
+	function tearDown() {
+		Jetpack_Constants::clear_constants();
+		foreach ( $this->get_jetpack_sync_filters() as $filter ) {
+			remove_all_filters( $filter );
+		}
+	}
+
+	function test_domain_mapping_should_not_try_to_hook_when_sunrise_disable() {
+		$stub = $this->getMockBuilder( 'MockDomainMapping' )
+			->setMethods( array( 'hook_wordpress_mu_domain_mapping', 'hook_wpmu_dev_domain_mapping' ) )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Both of these methods should not be called
+		$stub->expects( $this->exactly( 0 ) )
+			->method( 'hook_wordpress_mu_domain_mapping' )
+			->will( $this->returnValue( false ) );
+
+		$stub->expects( $this->exactly( 0 ) )
+			->method( 'hook_wpmu_dev_domain_mapping' )
+			->will( $this->returnValue( false ) );
+
+		$stub->attempt_to_hook_domain_mapping_plugins();
+	}
+
+	function test_domain_mapping_should_stop_search_after_hooking_once() {
+		Jetpack_Constants::set_constant( 'SUNRISE', true );
+
+		$stub = $this->getMockBuilder( 'MockDomainMapping' )
+			->setMethods( array( 'hook_wordpress_mu_domain_mapping', 'hook_wpmu_dev_domain_mapping' ) )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// The first method in the array should be the only one called.
+		$stub->expects( $this->exactly( 1 ) )
+			->method( 'hook_wordpress_mu_domain_mapping' )
+			->will( $this->returnValue( true ) );
+
+		$stub->expects( $this->exactly( 0 ) )
+			->method( 'hook_wpmu_dev_domain_mapping' )
+			->will( $this->returnValue( false ) );
+
+		$stub->attempt_to_hook_domain_mapping_plugins();
+	}
+
+	function test_domain_mapping_mu_domain_mapping_not_hooked_when_function_not_exists() {
+		Jetpack_Constants::set_constant( 'DOMAIN_MAPPING', true );
+
+		$stub = $this->getMockBuilder( 'MockDomainMapping' )
+			->setMethods( array( 'function_exists' ) )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stub->expects( $this->once() )
+			->method( 'function_exists' )
+			->will( $this->returnValue( false ) );
+
+		$this->assertFalse( $stub->hook_wordpress_mu_domain_mapping() );
+
+		foreach ( $this->get_jetpack_sync_filters() as $filter ) {
+			$this->assertFalse( $this->filter_has_hook( $filter ) );
+		}
+	}
+
+	function test_domain_mapping_mu_domain_mapping_hooked_when_function_exists() {
+		Jetpack_Constants::set_constant( 'DOMAIN_MAPPING', true );
+
+		$stub = $this->getMockBuilder( 'MockDomainMapping' )
+			->setMethods( array( 'function_exists' ) )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stub->expects( $this->once() )
+			->method( 'function_exists' )
+			->will( $this->returnValue( true ) );
+
+		$this->assertTrue( $stub->hook_wordpress_mu_domain_mapping() );
+
+		foreach ( $this->get_jetpack_sync_filters() as $filter ) {
+			$this->assertTrue( $this->filter_has_hook( $filter ) );
+		}
+	}
+
+	function test_domain_mapping_wpmu_dev_domain_mapping_not_hooked_when_functions_not_exist() {
+		$stub = $this->getMockBuilder( 'MockDomainMapping' )
+			->setMethods( array( 'class_exists', 'method_exists' ) )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stub->expects( $this->once() )
+			->method( 'class_exists' )
+			->will( $this->returnValue( false ) );
+
+		$stub->expects( $this->exactly( 0 ) )
+			->method( 'method_exists' )
+			->will( $this->returnValue( false ) );
+
+		$this->assertFalse( $stub->hook_wpmu_dev_domain_mapping() );
+
+		foreach ( $this->get_jetpack_sync_filters() as $filter ) {
+			$this->assertFalse( $this->filter_has_hook( $filter ) );
+		}
+	}
+
+	function test_domain_mapping_wpmu_dev_domain_mapping_hooked_when_functions_exist() {
+		$stub = $this->getMockBuilder( 'MockDomainMapping' )
+			->setMethods( array( 'class_exists', 'method_exists', 'get_domain_mapping_utils_instance' ) )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stub->expects( $this->once() )
+			->method( 'class_exists' )
+			->will( $this->returnValue( true ) );
+
+		$stub->expects( $this->once() )
+			->method( 'method_exists' )
+			->will( $this->returnValue( true ) );
+
+		$stub->expects( $this->once() )
+			->method( 'get_domain_mapping_utils_instance' )
+			->will( $this->returnValue( new stdClass() ) );
+
+		$this->assertTrue( $stub->hook_wpmu_dev_domain_mapping() );
+
+		foreach ( $this->get_jetpack_sync_filters() as $filter ) {
+			$this->assertTrue( $this->filter_has_hook( $filter ) );
+		}
+	}
+
+	function filter_has_hook( $hook ) {
+		global $wp_filter;
+		return isset( $wp_filter[ $hook ] ) && ! empty( $wp_filter[ $hook ] );
+	}
+
+	function get_jetpack_sync_filters() {
+		return array(
+			'jetpack_sync_home_url',
+			'jetpack_sync_site_url',
+		);
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -519,7 +519,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Constants::clear_constants();
 	}
 
-	function test_get_raw_url_returns_with_https_if_is_ssl() {
+	function test_get_raw_url_returns_with_http_if_is_ssl() {
 		$home_option = get_option( 'home' );
 
 		// Test without https first
@@ -528,7 +528,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		// Now, with https
 		$_SERVER['HTTPS'] = 'on';
 		$this->assertEquals(
-			set_url_scheme( $home_option, 'https' ),
+			set_url_scheme( $home_option, 'http' ),
 			Jetpack_Sync_Functions::get_raw_url( 'home' )
 		);
 		unset( $_SERVER['HTTPS'] );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -517,7 +517,29 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomy( (object) array( 'rest_controller_class' => 'WP_REST_Terms_Controller' ) );
 
 		$this->assertEquals( $sanitized->rest_controller_class, 'WP_REST_Terms_Controller' );
+}
+	function test_get_raw_url_by_option_bypasses_filters() {
+		add_filter( 'option_home', array( $this, '__return_filtered_url' ) );
+		$this->assertTrue( 'http://filteredurl.com' !== Jetpack_Sync_Functions::get_raw_url( 'home' ) );
+		remove_filter( 'option_home', array( $this, '__return_filtered_url' ) );
+	}
 
+	function test_get_raw_url_by_constant_bypasses_filters() {
+		Jetpack_Constants::set_constant( 'WP_HOME', 'http://constanturl.com' );
+		Jetpack_Constants::set_constant( 'WP_SITEURL', 'http://constanturl.com' );
+		add_filter( 'option_home', array( $this, '__return_filtered_url' ) );
+		add_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
+
+		$this->assertEquals( 'http://constanturl.com', Jetpack_Sync_Functions::get_raw_url( 'home' ) );
+		$this->assertEquals( 'http://constanturl.com', Jetpack_Sync_Functions::get_raw_url( 'siteurl' ) );
+
+		remove_filter( 'option_home', array( $this, '__return_filtered_url' ) );
+		remove_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
+		Jetpack_Constants::clear_constants();
+	}
+
+	function __return_filtered_url() {
+		return 'http://filteredurl.com';
 	}
 	
 	function add_www_subdomain_to_siteurl( $url ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -553,6 +553,22 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		unset( $_SERVER['HTTPS'] );
 	}
 
+	function test_urls_are_raw_with_use_raw_url_constant() {
+		add_filter( 'option_home', array( $this, '__return_filtered_url' ) );
+		add_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
+
+		// Test with constant first
+		Jetpack_Constants::set_constant( 'JETPACK_SYNC_USE_RAW_URL', true );
+		$this->assertTrue( 'http://filteredurl.com' !== Jetpack_Sync_Functions::home_url() );
+		Jetpack_Constants::clear_constants();
+
+		// Now, without, which should return the filtered URL
+		$this->assertEquals( $this->__return_filtered_url(), Jetpack_Sync_Functions::home_url() );
+
+		remove_filter( 'option_home', array( $this, '__return_filtered_url' ) );
+		remove_filter( 'option_siteurl', array( $this, '__return_filtered_url' ) );
+	}
+
 	function __return_filtered_url() {
 		return 'http://filteredurl.com';
 	}

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -538,6 +538,21 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Constants::clear_constants();
 	}
 
+	function test_get_raw_url_returns_with_https_if_is_ssl() {
+		$home_option = get_option( 'home' );
+
+		// Test without https first
+		$this->assertEquals( $home_option, Jetpack_Sync_Functions::get_raw_url( 'home' ) );
+
+		// Now, with https
+		$_SERVER['HTTPS'] = 'on';
+		$this->assertEquals(
+			set_url_scheme( $home_option, 'https' ),
+			Jetpack_Sync_Functions::get_raw_url( 'home' )
+		);
+		unset( $_SERVER['HTTPS'] );
+	}
+
 	function __return_filtered_url() {
 		return 'http://filteredurl.com';
 	}

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -323,14 +323,6 @@ EXPECTED;
 		}
 	}
 
-	function test_idc_optin_false_when_sunrise() {
-		Jetpack_Constants::set_constant( 'SUNRISE', true );
-
-		$this->assertFalse( Jetpack::sync_idc_optin() );
-
-		Jetpack_Constants::clear_constants();
-	}
-
 	function test_idc_optin_filter_overrides_development_version() {
 		add_filter( 'jetpack_development_version', '__return_true' );
 		add_filter( 'jetpack_sync_idc_optin', '__return_false' );


### PR DESCRIPTION
For sites that use domain mapping and multi language, it can be quite hard to sync uniform URLs back to WP.com, which can cause the site to be put in IDC.

To address this, I'd like to start syncing the unfiltered values for `home` and `siteurl`. This will introduced some jankiness where we sync the non-mapped domain for domain mapped sites. But, we can then address that by adding support for the top multi language and domain mapping plugins.

I've added support for Donncha's and WPMU Dev's domain mapping plugins. But, it's untested at the moment.

To test:

- Create network and point domains to network
- Checkout branch
- Install and configure one of the domain mapping plugins
- Ensure that the mapped domain gets sent to WPCOM
- You can comment out [this line](https://github.com/Automattic/jetpack/pull/5852/files#diff-2f6072543fb2336fcfb4dcbb3949b0f3R113) to make sure that the non-mapped domain gets synced properly as well (this simulates the raw URL getting synced when a non-supported domain mapping plugin is used
- Repeat steps for other domain mapping plugin
- Ensure there are no errors


Note: it could take several minutes the URLs to be synced each time you change. 
