### PR TITLE
Shortcodes: allow to use only the status ID in the [tweet] shortcode

### DIFF
--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -57,6 +57,9 @@ class Jetpack_Tweet {
 			if ( false === $cached_url = get_transient( $transient ) ) {
 				$response = wp_remote_get( "https://twitter.com/statuses/{$attr['tweet']}" );
 				if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+
+					// Cache for 15 minutes to avoid making the request over and over.
+					set_transient( $transient, '', 60 * 15 );
 					return '';
 				}
 				if ( ! isset( $response['http_response'] ) ) {

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -56,13 +56,7 @@ class Jetpack_Tweet {
 			$transient = "jpt_{$attr['tweet']}";
 			if ( false === $cached_url = get_transient( $transient ) ) {
 				$response = wp_remote_get( "https://twitter.com/statuses/{$attr['tweet']}" );
-				if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-
-					// Cache for 15 minutes to avoid making the request over and over.
-					set_transient( $transient, '', 60 * 15 );
-					return '';
-				}
-				if ( ! isset( $response['http_response'] ) ) {
+				if ( 200 !== wp_remote_retrieve_response_code( $response ) || ! isset( $response['http_response'] ) ) {
 
 					// Cache for 15 minutes to avoid making the request over and over.
 					set_transient( $transient, '', 60 * 15 );

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -63,11 +63,17 @@ class Jetpack_Tweet {
 					return '';
 				}
 				if ( ! isset( $response['http_response'] ) ) {
+
+					// Cache for 15 minutes to avoid making the request over and over.
+					set_transient( $transient, '', 60 * 15 );
 					return '';
 				}
 				$http_response = $response['http_response'];
 				$http_response_object = $http_response->get_response_object();
 				if ( empty( $http_response_object->url ) ) {
+
+					// Cache for 15 minutes to avoid making the request over and over.
+					set_transient( $transient, '', 60 * 15 );
 					return '';
 				}
 				$cached_url = isset( $http_response_object->url ) && ! empty( $http_response_object->url )

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -52,6 +52,29 @@ class Jetpack_Tweet {
 			$attr['tweet'] = $atts[0];
 		}
 
+		if ( ctype_digit( $attr['tweet'] ) ) {
+			$transient = "jpt_{$attr['tweet']}";
+			if ( false === $cached_url = get_transient( $transient ) ) {
+				$response = wp_remote_get( "https://twitter.com/statuses/{$attr['tweet']}" );
+				if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+					return '';
+				}
+				if ( ! isset( $response['http_response'] ) ) {
+					return '';
+				}
+				$http_response = $response['http_response'];
+				$http_response_object = $http_response->get_response_object();
+				if ( empty( $http_response_object->url ) ) {
+					return '';
+				}
+				$cached_url = isset( $http_response_object->url ) && ! empty( $http_response_object->url )
+					? $http_response_object->url
+					: '';
+				set_transient( $transient, $cached_url, DAY_IN_SECONDS );
+			}
+			$attr['tweet'] = $cached_url;
+		}
+
 		preg_match( '/^http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)$/', $attr['tweet'], $urlbits );
 		if ( isset( $urlbits[5] ) && intval( $urlbits[5] ) ) {
 			$id = 'https://twitter.com/' . $urlbits[3] . '/status/' . intval( $urlbits[5] );

--- a/tests/php/modules/shortcodes/test_class.tweet.php
+++ b/tests/php/modules/shortcodes/test_class.tweet.php
@@ -53,4 +53,18 @@ class WP_Test_Jetpack_Shortcodes_Tweet extends WP_UnitTestCase {
 		$this->assertContains( 'data-lang="es"', $shortcode_content );
 	}
 
+	/**
+	 * Verify that rendering the shortcode with only the tweet ID produces a correct output.
+	 *
+	 * @since 4.5.0
+	 */
+	public function test_shortcodes_tweet_id_only() {
+		$content = "[tweet 759034293385502721]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<blockquote class="twitter-tweet"', $shortcode_content );
+		$this->assertContains( '<a href="https://twitter.com/jetpack/status/759034293385502721">', $shortcode_content );
+	}
+
 }


### PR DESCRIPTION
Follow up to #5838

#### Changes proposed in this Pull Request:
- allow the `[tweet]` shortcode to use the tweet status ID only.
- add phpunit test.

#### Testing instructions:
* add a tweet like
```
[tweet 759034293385502721]
```
it should display the tweet correctly.