### PR TITLE
JSON API: Add parent param to Term new/update endpoints.

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -2030,6 +2030,7 @@ new WPCOM_JSON_API_Update_Term_Endpoint( array(
 	'request_format' => array(
 		'name'        => '(string) Name of the term',
 		'description' => '(string) A description of the term',
+		'parent'      => '(int) The parent ID for the term, if hierarchical',
 	),
 	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/taxonomies/post_tag/terms/new',
 	'example_request_data' => array(
@@ -2056,6 +2057,7 @@ new WPCOM_JSON_API_Update_Term_Endpoint( array(
 	'request_format' => array(
 		'name'        => '(string) Name of the term',
 		'description' => '(string) A description of the term',
+		'parent'      => '(int) The parent ID for the term, if hierarchical',
 	),
 	'example_request'      => 'https://public-api.wordpress.com/rest/v1/sites/82974409/taxonomies/post_tag/terms/slug:testing-term',
 	'example_request_data' => array(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/9929

@jeherve discovered when testing the new Taxonomy Manager in calypso that you could not create a new category with a parent for a Jetpack site.  It appears that the `request_format` for the term new/update endpoints was never properly updated in Jetpack.  This branch adds `parent` to the `request_format`s in the new/update term endpoints.

#### Testing instructions:
* Apply this branch to a test site
* Using calypso in staging or local development environment, create a new term with a parent, verify the term is created correctly and is nested under the chosen parent