### PR TITLE
Sync: Full Sync on update on MU

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -82,6 +82,7 @@ class Jetpack_Options {
 			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
 			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
+			'jetpack_network_version'       // (int)    The version the network is on. Used to stagger the initial full sync.
 		);
 	}
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -82,7 +82,7 @@ class Jetpack_Options {
 			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
 			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
-			'jetpack_network_version'       // (int)    The version the network is on. Used to stagger the initial full sync.
+			'network_version'               // (int)    The version the network is on. Used to stagger the initial full sync.
 		);
 	}
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -11,7 +11,7 @@ class Jetpack_Sync_Actions {
 	static $listener = null;
 	const DEFAULT_SYNC_CRON_INTERVAL_NAME = 'jetpack_sync_interval';
 	const DEFAULT_SYNC_CRON_INTERVAL_VALUE = 300; // 5 * MINUTE_IN_SECONDS;
-	
+
 	const NETWORK_UPDATE_RAMP_UP_BLOGS_PER_SECOND = 10;
 
 	static function init() {
@@ -44,7 +44,10 @@ class Jetpack_Sync_Actions {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-users.php';
 
 		// publicize filter to prevent publicizing blacklisted post types
-		add_filter( 'publicize_should_publicize_published_post', array( __CLASS__, 'prevent_publicize_blacklisted_posts' ), 10, 2 );
+		add_filter( 'publicize_should_publicize_published_post', array(
+			__CLASS__,
+			'prevent_publicize_blacklisted_posts'
+		), 10, 2 );
 
 		/**
 		 * Fires on every request before default loading sync listener code.
@@ -72,8 +75,8 @@ class Jetpack_Sync_Actions {
 		}
 		// Previous
 		$previous_version_and_time = Jetpack_Options::get_option( 'old_version', 0 );
-		$previous_version = explode( ':', $previous_version_and_time );
-		self::do_initial_sync( JETPACK__VERSION, $previous_version[ 0 ], true );
+		$previous_version          = explode( ':', $previous_version_and_time );
+		self::do_initial_sync( JETPACK__VERSION, $previous_version[0], true );
 	}
 
 	static function can_do_initial_sync( $current_blog_id = null, $current_time = null ) {
@@ -85,12 +88,12 @@ class Jetpack_Sync_Actions {
 		}
 
 		$version_with_time = explode( ':', Jetpack_Options::get_option( 'version', 0 ) );
-		if ( ! isset( $version_with_time[ 1 ] ) ) {
+		if ( ! isset( $version_with_time[1] ) ) {
 			// This is not very likely to happen.
 			// lets set it to 0 so that the update happends right away
-			$version_with_time[ 1 ] = 0;
+			$version_with_time[1] = 0;
 		}
-		$version_updated = $version_with_time[ 1 ];
+		$version_updated = $version_with_time[1];
 
 		/**
 		 * Allows the dev to change the number of blogs that the nework is allowed update per second.
@@ -102,9 +105,9 @@ class Jetpack_Sync_Actions {
 		 * @param int the number of blogs per second that should be allowed to update.
 		 */
 		$blogs_per_seconds = (int) apply_filters( 'jetpack_network_ramp_up_blogs_per_second', self::NETWORK_UPDATE_RAMP_UP_BLOGS_PER_SECOND );
-		$time_difference = ( $current_time - $version_updated );
+		$time_difference   = ( $current_time - $version_updated );
 
-		return ( $current_blog_id <= ( $time_difference  * $blogs_per_seconds ) );
+		return ( $current_blog_id <= ( $time_difference * $blogs_per_seconds ) );
 	}
 
 	static function add_sender_shutdown() {
@@ -139,12 +142,14 @@ class Jetpack_Sync_Actions {
 
 	static function sync_allowed() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
+
 		return ( ! Jetpack_Sync_Settings::get_setting( 'disable' ) && Jetpack::is_active() && ! ( Jetpack::is_development_mode() || Jetpack::is_staging_site() ) )
-			   || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
+		       || defined( 'PHPUNIT_JETPACK_TESTSUITE' );
 	}
 
 	static function sync_via_cron_allowed() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
+
 		return ( Jetpack_Sync_Settings::get_setting( 'sync_via_cron' ) );
 	}
 
@@ -166,14 +171,22 @@ class Jetpack_Sync_Actions {
 		Jetpack::load_xml_rpc_client();
 
 		$query_args = array(
-			'sync'      => '1',             // add an extra parameter to the URL so we can tell it's a sync action
-			'codec'     => $codec_name,     // send the name of the codec used to encode the data
-			'timestamp' => $sent_timestamp, // send current server time so we can compensate for clock differences
-			'queue'     => $queue_id,       // sync or full_sync
-			'home'      => get_home_url(),  // Send home url option to check for Identity Crisis server-side
-			'siteurl'   => get_site_url(),  // Send siteurl option to check for Identity Crisis server-side
-			'cd'        => sprintf( '%.4f', $checkout_duration),   // Time spent retrieving queue items from the DB
-			'pd'        => sprintf( '%.4f', $preprocess_duration), // Time spent converting queue items into data to send
+			'sync'      => '1',
+			// add an extra parameter to the URL so we can tell it's a sync action
+			'codec'     => $codec_name,
+			// send the name of the codec used to encode the data
+			'timestamp' => $sent_timestamp,
+			// send current server time so we can compensate for clock differences
+			'queue'     => $queue_id,
+			// sync or full_sync
+			'home'      => get_home_url(),
+			// Send home url option to check for Identity Crisis server-side
+			'siteurl'   => get_site_url(),
+			// Send siteurl option to check for Identity Crisis server-side
+			'cd'        => sprintf( '%.4f', $checkout_duration ),
+			// Time spent retrieving queue items from the DB
+			'pd'        => sprintf( '%.4f', $preprocess_duration ),
+			// Time spent converting queue items into data to send
 		);
 
 		// Has the site opted in to IDC mitigation?
@@ -205,7 +218,7 @@ class Jetpack_Sync_Actions {
 
 		// Check if WordPress.com IDC mitigation blocked the sync request
 		if ( is_array( $response ) && isset( $response['error_code'] ) ) {
-			$error_code = $response['error_code'];
+			$error_code              = $response['error_code'];
 			$allowed_idc_error_codes = array(
 				'jetpack_url_mismatch',
 				'jetpack_home_url_mismatch',
@@ -243,10 +256,10 @@ class Jetpack_Sync_Actions {
 
 	static function get_update_full_sync_config() {
 		return array(
-			'options' => true,
+			'options'         => true,
 			'network_options' => true,
-			'functions' => true,
-			'constants' => true,
+			'functions'       => true,
+			'constants'       => true,
 		);
 	}
 
@@ -264,12 +277,13 @@ class Jetpack_Sync_Actions {
 		if ( ! isset( $schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] ) ) {
 			$schedules[ self::DEFAULT_SYNC_CRON_INTERVAL_NAME ] = array(
 				'interval' => self::DEFAULT_SYNC_CRON_INTERVAL_VALUE,
-				'display' => sprintf(
+				'display'  => sprintf(
 					esc_html__( 'Every %d minutes', 'jetpack' ),
 					self::DEFAULT_SYNC_CRON_INTERVAL_VALUE / 60
 				)
 			);
 		}
+
 		return $schedules;
 	}
 
@@ -342,7 +356,7 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function sanitize_filtered_sync_cron_schedule( $schedule ) {
-		$schedule = sanitize_key( $schedule );
+		$schedule  = sanitize_key( $schedule );
 		$schedules = wp_get_schedules();
 
 		// Make sure that the schedule has actually been registered using the `cron_intervals` filter.
@@ -409,23 +423,23 @@ class Jetpack_Sync_Actions {
 	static function get_sync_status() {
 		self::initialize_sender();
 
-		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-		$queue       = self::$sender->get_sync_queue();
-		$full_queue  = self::$sender->get_full_sync_queue();
+		$sync_module     = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$queue           = self::$sender->get_sync_queue();
+		$full_queue      = self::$sender->get_full_sync_queue();
 		$cron_timestamps = array_keys( _get_cron_array() );
-		$next_cron = $cron_timestamps[0] - time();
+		$next_cron       = $cron_timestamps[0] - time();
 
 		return array_merge(
 			$sync_module->get_status(),
 			array(
-				'cron_size'             => count( $cron_timestamps ),
-				'next_cron'             => $next_cron,
-				'queue_size'            => $queue->size(),
-				'queue_lag'             => $queue->lag(),
-				'queue_next_sync'       => ( self::$sender->get_next_sync_time( 'sync' ) - microtime( true ) ),
-				'full_queue_size'       => $full_queue->size(),
-				'full_queue_lag'        => $full_queue->lag(),
-				'full_queue_next_sync'  => ( self::$sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
+				'cron_size'            => count( $cron_timestamps ),
+				'next_cron'            => $next_cron,
+				'queue_size'           => $queue->size(),
+				'queue_lag'            => $queue->lag(),
+				'queue_next_sync'      => ( self::$sender->get_next_sync_time( 'sync' ) - microtime( true ) ),
+				'full_queue_size'      => $full_queue->size(),
+				'full_queue_lag'       => $full_queue->lag(),
+				'full_queue_next_sync' => ( self::$sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
 			)
 		);
 	}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -257,11 +257,12 @@ class Jetpack_Sync_Actions {
 
 	static function get_ramp_up_increment() {
 		/**
-		 * Allows you to change the percantage at which the update ramp up happends.
+		 * Allows you to change the percentage at which the update ramp up happens.
 		 * This value should be a integer less then 100
 		 *
 		 * Default is self::UPDATE_RAMP_UP_INCREMENT
 		 * @since 4.5.0
+		 * @param int increment value
 		 */
 		$increment = (int) apply_filters( 'jetpack_sync_network_upgrade_ramp_up_increment', self::UPDATE_RAMP_UP_INCREMENT );
 		return ( $increment >= 1 && $increment <= 100 ) ? $increment : self::UPDATE_RAMP_UP_INCREMENT;
@@ -269,12 +270,12 @@ class Jetpack_Sync_Actions {
 
 	static function get_next_ramp_up_interval() {
 		/**
-		 * Allows you to change the percantage at which the update ramp up happends.
+		 * Allows you to change the percentage at which the update ramp up happens.
 		 * This value should be a integer less then 100
 		 *
 		 * Default is self::UPDATE_RAMP_UP_INCREMENT
 		 * @since 4.5.0
-		 * @param int interval value in seconds at which point the next ramp up is suppose to happen.
+		 * @param int interval value in seconds at which point the next ramp up is supposed to happen.
 		 */
 		return (int) apply_filters( 'jetpack_sync_network_upgrade_ramp_up_interval', self::UPDATE_RAMP_UP_INTERVAL_VALUE );
 	}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -103,7 +103,7 @@ class Jetpack_Sync_Actions {
 		 */
 		$blogs_per_seconds = (int) apply_filters( 'jetpack_network_ramp_up_blogs_per_second', self::NETWORK_UPDATE_RAMP_UP_BLOGS_PER_SECOND );
 		$time_difference = ( $current_time - $version_updated );
-		
+
 		return ( $current_blog_id <= ( $time_difference  * $blogs_per_seconds ) );
 	}
 
@@ -235,7 +235,7 @@ class Jetpack_Sync_Actions {
 			$initial_sync_config['users'] = 'initial';
 		}
 
-		if ( $network_site || ! is_multisite() ) {
+		if ( $network_site || is_main_site() ) {
 			self::do_full_sync( $initial_sync_config );
 			Jetpack_Options::update_option( 'network_version', JETPACK__VERSION );
 		}

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -191,7 +191,9 @@ class Jetpack_Sync_Actions {
 			$include_users = true;
 		}
 
-		if ( is_multisite()  ) {
+		if ( is_multisite() &&
+		     // Is Jetpack network activated
+		     in_array( 'jetpack/jetpack.php' , array_keys( get_site_option( 'active_sitewide_plugins' ) ) ) ) {
 			// stagger initial syncs for multisite blogs so they don't all pile on top of each other
 			if ( is_main_site() ) {
 				wp_schedule_single_event( time() , 'jetpack_full_sync_on_multisite_jetpack_upgrade_cron', array( $include_users ) );

--- a/tests/php.multisite.xml
+++ b/tests/php.multisite.xml
@@ -5,6 +5,7 @@
     <php>
         <const name="WP_TESTS_MULTISITE" value="1" />
         <const name="PHPUNIT_JETPACK_TESTSUITE" value="true"/>
+        <env name="NETWORK_ACTIVE" value="false"/>
     </php>
     <testsuites>
         <testsuite name="general">

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -50,6 +50,10 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 		$this->server_event_storage = new Jetpack_Sync_Server_Eventstore();
 		$this->server_event_storage->init();
+
+		if ( is_multisite() && getenv( 'NETWORK_ACTIVE' ) ) { //
+			add_filter( 'pre_site_option_active_sitewide_plugins', array( $this, 'jetpack_network_active' ) );
+		}
 	}
 
 	public function setSyncClientDefaults() {
@@ -103,6 +107,10 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 	function serverReceive( $data, $codec, $sent_timestamp, $queue_id ) {
 		return $this->server->receive( $data, null, $sent_timestamp, $queue_id );
+	}
+	// Add 
+	function jetpack_network_active() {
+		return array( 'jetpack/jetpack.php' => time() );
 	}
 }
 

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -51,7 +51,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		$this->server_event_storage = new Jetpack_Sync_Server_Eventstore();
 		$this->server_event_storage->init();
 
-		if ( is_multisite() && getenv( 'NETWORK_ACTIVE' ) ) { //
+		if ( is_multisite() && getenv( 'NETWORK_ACTIVE' ) ) {
 			add_filter( 'pre_site_option_active_sitewide_plugins', array( $this, 'jetpack_network_active' ) );
 		}
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1083,10 +1083,16 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		);
 
 		$full_sync_status = $this->full_sync->get_status();
-		$this->assertEquals(
-			$expected_sync_config,
-			$full_sync_status[ 'config' ]
-		);
+		if ( is_multisite() ) {
+			$event = wp_next_scheduled( 'jetpack_full_sync_on_multisite_jetpack_upgrade_cron', array( true ) );
+			$this->assertTrue( ! empty( $event ) );
+		} else {
+			$this->assertEquals(
+				$expected_sync_config,
+				$full_sync_status[ 'config' ]
+			);
+		}
+
 	}
 
 	function test_full_sync_enqueues_limited_number_of_items() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1056,6 +1056,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_initial_sync_doesnt_sync_subscribers() {
+		if ( is_plugin_active_for_network( 'jetpack/jetpack.php' ) && ! is_main_site() ) {
+			$this->markTestSkipped( 'Not applicable for jetpack sites that are part of a network but not the main site' );
+		}
 		$this->factory->user->create( array( 'user_login' => 'theauthor', 'role' => 'author' ) );
 		$this->factory->user->create( array( 'user_login' => 'theadmin', 'role' => 'administrator' ) );
 		foreach( range( 1, 10 ) as $i ) {
@@ -1083,15 +1086,11 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		);
 
 		$full_sync_status = $this->full_sync->get_status();
-		if ( is_multisite() ) {
-			$event = wp_next_scheduled( 'jetpack_full_sync_on_multisite_jetpack_upgrade_cron', array( true ) );
-			$this->assertTrue( ! empty( $event ) );
-		} else {
-			$this->assertEquals(
-				$expected_sync_config,
-				$full_sync_status[ 'config' ]
-			);
-		}
+		$this->assertEquals(
+			$expected_sync_config,
+			$full_sync_status[ 'config' ]
+		);
+
 
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -24,12 +24,12 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 		global $wpdb;
 
-		$expected_sync_config = array( 
-			'options' => true, 
+		$expected_sync_config = array(
+			'options'         => true,
 			'network_options' => true,
-			'functions' => true, 
-			'constants' => true, 
-			'users' => 'initial'
+			'functions'       => true,
+			'constants'       => true,
+			'users'           => 'initial'
 		);
 
 		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
@@ -46,19 +46,30 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		if ( ! is_main_site() ) {
 			$this->markTestSkipped( 'Not applicable for jetpack when it is not network activated.' );
 		}
-		$initial_sync_without_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'network_options' => true );
-		$initial_sync_with_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'network_options' => true, 'users' => 'initial' );
+		$initial_sync_without_users_config = array(
+			'options'         => true,
+			'functions'       => true,
+			'constants'       => true,
+			'network_options' => true
+		);
+		$initial_sync_with_users_config    = array(
+			'options'         => true,
+			'functions'       => true,
+			'constants'       => true,
+			'network_options' => true,
+			'users'           => 'initial'
+		);
 
 		do_action( 'updating_jetpack_version', '4.3', '4.2' );
 		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
-		$sync_config = $sync_status[ 'config' ];
+		$sync_config = $sync_status['config'];
 
 		$this->assertEquals( $initial_sync_without_users_config, $sync_config );
 		$this->assertNotEquals( $initial_sync_with_users_config, $sync_config );
 
 		do_action( 'updating_jetpack_version', '4.2', '4.1' );
 		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
-		$sync_config = $sync_status[ 'config' ];
+		$sync_config = $sync_status['config'];
 
 		$this->assertEquals( $initial_sync_with_users_config, $sync_config );
 
@@ -70,7 +81,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$timestamp = wp_next_scheduled( 'jetpack_sync_cron' );
 		// we need to check a while in the past because the task got scheduled at
 		// the beginning of the entire test run, not at the beginning of this test :)
-		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );
+		$this->assertTrue( $timestamp > time() - HOUR_IN_SECONDS );
 	}
 
 	function test_default_schedule_incremental_sync_cron() {
@@ -93,7 +104,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 	function test_schedules_full_sync_cron() {
 		Jetpack_Sync_Actions::init_sync_cron_jobs();
 		$timestamp = wp_next_scheduled( 'jetpack_sync_full_cron' );
-		$this->assertTrue( $timestamp > time()-HOUR_IN_SECONDS );
+		$this->assertTrue( $timestamp > time() - HOUR_IN_SECONDS );
 	}
 
 	function test_default_schedule_full_sync_cron() {
@@ -152,7 +163,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 
 	function test_adds_full_sync_on_jetpack_plugin_update() {
-		if( ! is_multisite() ) {
+		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Not applicable for jetpack not running as part of MU.' );
 		}
 
@@ -161,31 +172,37 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		Jetpack_Sync_Settings::reset_data();
 
 		$full_config = array(
-			'constants' => 1,
-			'functions' => 1,
-            'options' => 1,
-            'network_options' => 1
+			'constants'       => 1,
+			'functions'       => 1,
+			'options'         => 1,
+			'network_options' => 1
 		);
 
 		$count = 0;
-		while( $count < 5 ) {
+		while ( $count < 5 ) {
 			$this->factory->blog->create();
-			$count++;
+			$count ++;
 		}
 
 		// one more just for good measuer
 		$blog_id = $this->factory->blog->create();
 		$this->server_replica_storage->reset();
 
-		add_filter( 'jetpack_network_ramp_up_blogs_per_second', array( $this, 'jetpack_network_ramp_up_blogs_per_second' ) );
+		add_filter( 'jetpack_network_ramp_up_blogs_per_second', array(
+			$this,
+			'jetpack_network_ramp_up_blogs_per_second'
+		) );
 
 		self::fake_version_update();
 		// Main site should have the right version right away
 		$this->assertEquals( JETPACK__VERSION, Jetpack_Options::get_option( 'network_version', 0 ), 'Main site doesnt have the right version' );
-		
+
 		switch_to_blog( $blog_id );
 
-		$this->assertTrue( (bool) has_action( 'shutdown', array( 'Jetpack_Sync_Actions', 'maybe_start_initial_sync' ) ), 'No shutdown event registed' );
+		$this->assertTrue( (bool) has_action( 'shutdown', array(
+			'Jetpack_Sync_Actions',
+			'maybe_start_initial_sync'
+		) ), 'No shutdown event registed' );
 
 		// Pretend that the site gets a visit
 		self::fake_version_update();


### PR DESCRIPTION
Do a full sync in a job if we are doing a full sync because of an
update to the plugin. Which send the full sync data such as options,
callbacks, network_options and constants for each of the sites on the
network.

This is supposed to reduce the load when updating Jetpack to a new
version.

- [x] Test the query for sites that run pre 4.6 version of WP. 
- [x] Add tests. 
- [x]  Add a test for the case where  the main site is not connected. 


