### PR TITLE
Fix Protect for OVH

### DIFF
--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -16,6 +16,7 @@ import {
 	getJetpackStateNoticesMessageCode,
 	getJetpackStateNoticesErrorDescription
 } from 'state/jetpack-notices';
+import NoticeAction from 'components/notice/notice-action.jsx';
 
 const JetpackStateNotices = React.createClass( {
 	displayName: 'JetpackStateNotices',
@@ -160,8 +161,9 @@ const JetpackStateNotices = React.createClass( {
 	},
 
 	getMessageFromKey: function( key ) {
-		let message = '';
-		let status = 'is-info';
+		let message = '',
+			status = 'is-info',
+			action;
 		switch ( key ) {
 			// This is the message that is shown on first page load after a Jetpack plugin update.
 			case 'modules_activated' :
@@ -188,17 +190,29 @@ const JetpackStateNotices = React.createClass( {
 				message = __( "You're fueled up and ready to go." );
 				status = 'is-success';
 				break;
+			case 'protect_misconfigured_ip' :
+				message = __( "Your server is misconfigured, which means that Jetpack Protect is unable to effectively protect your site." );
+				status = 'is-info';
+				action = (
+					<NoticeAction
+						href="https://jetpack.com/support/protect/"
+					>
+						{ __( 'Learn More' ) }
+					</NoticeAction>
+				);
+				break;
 
 			default:
 				message = key;
 		}
 
-		return [ message, status ];
+		return [ message, status, action ];
 	},
 
 	renderContent: function() {
-		let status = 'is-info';
-		let noticeText = '';
+		let status = 'is-info',
+			noticeText = '',
+			action;
 		const error = this.props.jetpackStateNoticesErrorCode,
 			message = this.props.jetpackStateNoticesMessageCode;
 
@@ -217,14 +231,16 @@ const JetpackStateNotices = React.createClass( {
 			const messageData = this.getMessageFromKey( message );
 			noticeText = messageData[0];
 			status = messageData[1];
+			action = messageData[2]
 		}
 
 		return (
 			<SimpleNotice
 				status={ status }
 				onDismissClick={ this.dismissJetpackStateNotice }
+			    text={ noticeText }
 			>
-				{ noticeText }
+				{ action }
 			</SimpleNotice>
 		);
 	},

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -195,7 +195,7 @@ const JetpackStateNotices = React.createClass( {
 				status = 'is-info';
 				action = (
 					<NoticeAction
-						href="https://jetpack.com/support/protect/"
+						href="https://jetpack.com/support/security/troubleshooting-protect/"
 					>
 						{ __( 'Learn More' ) }
 					</NoticeAction>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2519,6 +2519,16 @@ class Jetpack {
 			}
 		}
 
+		// Protect won't work with mis-configured IPs
+		if ( 'protect' === $module ) {
+			include_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';
+			if ( ! jetpack_protect_get_ip() ) {
+				error_log( 'hello' );
+				Jetpack::state( 'message', 'protect_misconfigured_ip' );
+				return false;
+			}
+		}
+
 		// Check the file for fatal errors, a la wp-admin/plugins.php::activate
 		Jetpack::state( 'module', $module );
 		Jetpack::state( 'error', 'module_activation_failed' ); // we'll override this later if the plugin can be included without fatal error

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -425,6 +425,14 @@ class Jetpack_Protect_Module {
 	function check_login_ability( $preauth = false ) {
 		$ip = jetpack_protect_get_ip();
 		
+		// Server is misconfigured and we can't get an IP
+		if( ! $ip ) {
+			/*
+				TODO turn off protect / show message
+			*/
+			return true;
+		}
+		
 		/**
 		 * Short-circuit check_login_ability. 
 		 *

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -426,7 +426,7 @@ class Jetpack_Protect_Module {
 		$ip = jetpack_protect_get_ip();
 
 		// Server is misconfigured and we can't get an IP
-		if ( ! $ip ) {
+		if ( ! $ip && class_exists( 'Jetpack' ) ) {
 			Jetpack::deactivate_module( 'protect' );
 			ob_start();
 			Jetpack::state( 'message', 'protect_misconfigured_ip' );

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -424,12 +424,13 @@ class Jetpack_Protect_Module {
 	 */
 	function check_login_ability( $preauth = false ) {
 		$ip = jetpack_protect_get_ip();
-		
+
 		// Server is misconfigured and we can't get an IP
-		if( ! $ip ) {
-			/*
-				TODO turn off protect / show message
-			*/
+		if ( ! $ip ) {
+			Jetpack::deactivate_module( 'protect' );
+			ob_start();
+			Jetpack::state( 'message', 'protect_misconfigured_ip' );
+			ob_end_clean();
 			return true;
 		}
 		

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -167,6 +167,11 @@ function jetpack_protect_get_ip() {
 	} else {
 		$ip = $_SERVER['REMOTE_ADDR'];
 	}
+	
+	if ( ! $ip ) {
+		return false;
+	}
+	
 	$ips = explode( ',', $ip );
 	if ( ! isset( $segments ) || ! $segments ) {
 		$segments = 1;
@@ -193,6 +198,11 @@ function jetpack_protect_get_ip() {
  * @return $ip IP.
  */
 function jetpack_clean_ip( $ip ) {
+	
+	// Some misconfigured servers give back extra info, which comes after "unless"
+	$ips = explode( ' unless ', $ip );
+	$ip = $ips[0];
+	
 	$ip = trim( $ip );
 	// Check for IPv4 IP cast as IPv6.
 	if ( preg_match( '/^::ffff:(\d+\.\d+\.\d+\.\d+)$/', $ip, $matches ) ) {


### PR DESCRIPTION
Deactivate Protect and show an admin notice if we can't get an IP address, which can be caused by a misconfigured server.

To test the UX with a fine IP: 
- Activate Protect
- force `jetpack_protect_get_ip()` to return `false`
- Log out/log back in.  When you visit your Jetpack admin, you should see a notice and Protect should be deactivated. 
- Try to activate protect.  It should fail, and on page reload it will tell you why.  