### PR TITLE
Carousel: fix potential infinite loop

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -360,6 +360,11 @@ class Jetpack_Carousel {
 
 		foreach ( $selected_images as $attachment_id => $image_html ) {
 			$attachment = get_post( $attachment_id );
+
+			if ( ! $attachment ) {
+				continue;
+			}
+
 			$attributes = $this->add_data_to_images( array(), $attachment );
 			$attributes_html = '';
 			foreach( $attributes as $k => $v ) {


### PR DESCRIPTION
see r147257-wpcom for more details. 

This was creating an infinite loop on posts that have attachments that were returning null.  