### PR TITLE
Ads: Fix for `wp jetpack` warning that HTTP_HOST isn't set.

### DIFF
--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -15,10 +15,16 @@ class WordAds_Params {
 			'enable_header_ad' => (bool) get_option( 'enable_header_ad', false )
 		);
 
-		$this->url = ( is_ssl() ? 'https' : 'http' ) . '://' . $_SERVER['HTTP_HOST']  . $_SERVER['REQUEST_URI'];
+		$host = 'localhost';
+		if ( isset( $_SERVER['HTTP_HOST'] ) ) {
+			$host = $_SERVER['HTTP_HOST'];
+		}
+
+		$this->url = ( is_ssl() ? 'https' : 'http' ) . '://' . $host . $_SERVER['REQUEST_URI'];
 		if ( ! ( false === strpos( $this->url, '?' ) ) && ! isset( $_GET['p'] ) ) {
 			$this->url = substr( $this->url, 0, strpos( $this->url, '?' ) );
 		}
+
 		$this->cloudflare = self::is_cloudflare();
 		$this->blog_id = Jetpack::get_option( 'id', 0 );
 		$this->mobile_device = jetpack_is_mobile( 'any', true );


### PR DESCRIPTION
![screen shot 2016-12-14 at 10 40 45 am](https://cloud.githubusercontent.com/assets/273708/21195719/cf932692-c1e9-11e6-8126-b1ce3549f122.png)

This warning only manifests itself when running `wp jetpack` from the command line. This fixes the warning by ensuring HTTP_HOST is set.