### PR TITLE
Load sender if data was enqueued

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -204,6 +204,12 @@ class Jetpack_Sync_Listener {
 			microtime( true ),
 			Jetpack_Sync_Settings::is_importing()
 		) );
+
+		// since we've added some items, let's try to load the sender so we can send them as quickly as possible
+		if ( ! Jetpack_Sync_Actions::$sender ) {
+			add_filter( 'jetpack_sync_sender_should_load', '__return_true' );
+			Jetpack_Sync_Actions::add_sender_shutdown();
+		}
 	}
 
 	function set_defaults() {

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -132,6 +132,16 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( wp_next_scheduled( 'jetpack_sync_send_db_checksum' ) );
 	}
 
+	function test_loads_sender_if_listener_queues_actions() {
+		remove_all_filters( 'jetpack_sync_sender_should_load' );
+		Jetpack_Sync_Actions::$sender = null;
+
+		$this->listener->enqueue_action( 'test_action', array( 'test_arg' ), $this->listener->get_sync_queue() );
+
+		$this->assertTrue( !! has_filter( 'jetpack_sync_sender_should_load', '__return_true' ) );
+		$this->assertTrue( Jetpack_Sync_Actions::$sender !== null );
+	}
+
 	/**
 	 * Utility functions
 	 */


### PR DESCRIPTION
Sometimes we modify data in background processes (e.g. scheduled posts) and don't necessarily send it from those processes immediately, but only the next time the sender is loaded (e.g. user logs into wp-admin)

This change ensures that if we do actually enqueue data from the listener, then we load the sender on shutdown and try to send.