### PR TITLE
VideoPress: Fix processing icon URL

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -324,7 +324,7 @@ class Jetpack_VideoPress {
 			return $icon;
 		}
 
-		return get_site_url() . '/wp-content/plugins/jetpack/images/media-video-processing-icon.png';
+		return plugins_url( 'images/media-video-processing-icon.png', JETPACK__PLUGIN_FILE );
 	}
 }
 


### PR DESCRIPTION
During testing, I noticed that the VideoPress processing icon wasn't working properly. After looking in the code, I realized it was because we were hardcoding `jetpack` in to the URL. This PR fixes that by using `plugins_url()`.

To test:

- Create a new post
- Click "Add media"
- Upload a video
- Immediately after uploading, ensure that the icon image is not broken