### PR TITLE
Admin: if theme doesn't support Infinite Scroll, add notice

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -6,9 +6,12 @@ import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import Popover from 'components/popover';
+import Tooltip from 'components/tooltip';
 import { translate as __ } from 'i18n-calypso';
 import includes from 'lodash/includes';
 import analytics from 'lib/analytics';
+import ExternalLink from 'components/external-link';
 
 /**
  * Internal dependencies
@@ -31,115 +34,141 @@ import {
 	getThemeData
 } from 'state/initial-state';
 import Settings from 'components/settings';
-import CardMessages from 'components/card-messages';
 
-export const Page = ( props ) => {
-	let {
-		toggleModule,
-		isModuleActivated,
-		isTogglingModule,
-		getModule
-	} = props,
-		isAdmin = props.userCanManageModules,
-		infiniteScrollDesc = getModule( 'infinite-scroll' ).description,
-		noInfiniteScrollSupport = ! props.themeData.support.infiniteScroll,
-		moduleList = Object.keys( props.moduleList );
+export const Page = React.createClass( {
+	getInitialState() {
+		return { showPopover: false };
+	},
 
-	if ( noInfiniteScrollSupport ) {
-		infiniteScrollDesc = <CardMessages module="infinite-scroll" desc={ infiniteScrollDesc } themeData={ props.themeData } />;
-	}
+	toggleInfo: function(){
+		this.setState( { showPopover: ! this.state.showPopover } );
+	},
 
-	var cards = [
-		[ 'tiled-gallery', getModule( 'tiled-gallery' ).name, getModule( 'tiled-gallery' ).description, getModule( 'tiled-gallery' ).learn_more_button ],
-		[ 'photon', getModule( 'photon' ).name, getModule( 'photon' ).description, getModule( 'photon' ).learn_more_button ],
-		[ 'carousel', getModule( 'carousel' ).name, getModule( 'carousel' ).description, getModule( 'carousel' ).learn_more_button ],
-		[ 'widgets', getModule( 'widgets' ).name, getModule( 'widgets' ).description, getModule( 'widgets' ).learn_more_button ],
-		[ 'widget-visibility', getModule( 'widget-visibility' ).name, getModule( 'widget-visibility' ).description, getModule( 'widget-visibility' ).learn_more_button ],
-		[ 'custom-css', getModule( 'custom-css' ).name, getModule( 'custom-css' ).description, getModule( 'custom-css' ).learn_more_button ],
-		[ 'infinite-scroll', getModule( 'infinite-scroll' ).name, infiniteScrollDesc, getModule( 'infinite-scroll' ).learn_more_button ],
-		[ 'minileven', getModule( 'minileven' ).name, getModule( 'minileven' ).description, getModule( 'minileven' ).learn_more_button ]
-	].map( ( element ) => {
-		if ( ! includes( moduleList, element[0] ) ) {
-			return null;
-		}
-		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
-			toggle = (
-				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
-					<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-								toggling={ isTogglingModule( element[0] ) }
-								toggleModule={ toggleModule } />
-			),
-			customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
+	render() {
+		let {
+				toggleModule,
+				isModuleActivated,
+				isTogglingModule,
+				getModule
+			} = this.props,
+			isAdmin = this.props.userCanManageModules,
+			infiniteScrollDesc = getModule( 'infinite-scroll' ).description,
+			noInfiniteScrollSupport = ! this.props.themeData.support.infiniteScroll,
+			moduleList = Object.keys( this.props.moduleList );
 
-		let moduleDescription = isModuleActivated( element[0] ) ?
-			<AllModuleSettings module={ getModule( element[ 0 ] ) } /> :
-			// Render the long_description if module is deactivated
-			<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />;
+		var cards = [
+			[ 'tiled-gallery', getModule( 'tiled-gallery' ).name, getModule( 'tiled-gallery' ).description, getModule( 'tiled-gallery' ).learn_more_button ],
+			[ 'photon', getModule( 'photon' ).name, getModule( 'photon' ).description, getModule( 'photon' ).learn_more_button ],
+			[ 'carousel', getModule( 'carousel' ).name, getModule( 'carousel' ).description, getModule( 'carousel' ).learn_more_button ],
+			[ 'widgets', getModule( 'widgets' ).name, getModule( 'widgets' ).description, getModule( 'widgets' ).learn_more_button ],
+			[ 'widget-visibility', getModule( 'widget-visibility' ).name, getModule( 'widget-visibility' ).description, getModule( 'widget-visibility' ).learn_more_button ],
+			[ 'custom-css', getModule( 'custom-css' ).name, getModule( 'custom-css' ).description, getModule( 'custom-css' ).learn_more_button ],
+			[ 'infinite-scroll', getModule( 'infinite-scroll' ).name, infiniteScrollDesc, getModule( 'infinite-scroll' ).learn_more_button ],
+			[ 'minileven', getModule( 'minileven' ).name, getModule( 'minileven' ).description, getModule( 'minileven' ).learn_more_button ]
+		].map( ( element ) => {
+			if ( ! includes( moduleList, element[0] ) ) {
+				return null;
+			}
+			var unavailableInDevMode = this.props.isUnavailableInDevMode( element[0] ),
+				toggle = (
+					unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
+						<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
+									  toggling={ isTogglingModule( element[0] ) }
+									  toggleModule={ toggleModule } />
+				),
+				toggleExpanded = toggle,
+				customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
 
-		let learnMore = (
-			<div className="jp-module-settings__learn-more">
-				<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
-			</div>
-		);
+			let moduleDescription = isModuleActivated( element[0] ) ?
+				<AllModuleSettings module={ getModule( element[ 0 ] ) } /> :
+				// Render the long_description if module is deactivated
+				<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />;
 
-		if ( 'infinite-scroll' === element[0] && noInfiniteScrollSupport ) {
-			toggle = __( 'Theme support required' );
-			moduleDescription = '';
-			learnMore = '';
-			customClasses += ' jp-card-no-expand';
-		}
+			let learnMore = (
+				<div className="jp-module-settings__learn-more">
+					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+				</div>
+			);
 
-		let componentProps = {
-			className          : customClasses,
-			key                : `module-card_${element[0]}` /* https://fb.me/react-warning-keys */,
-			header             : element[1],
-			subheader          : element[2],
-			summary            : toggle,
-			expandedSummary    : toggle,
-			clickableHeaderText: true,
-			onOpen             : () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-				{
-					card: element[0],
-					path: props.route.path
-				}
-			)
-		};
+			if ( 'infinite-scroll' === element[0] && noInfiniteScrollSupport ) {
+				let tooltipRef = element[0] + '_button';
+				toggle = (
+					<Button borderless compact onClick={ this.toggleInfo } ref={ tooltipRef } className="jp-info__button">
+						<Gridicon icon="info-outline" size={ 18 }/><span className="screen-reader-text">{ __( 'Learn More' ) }</span>
+						<Popover context={ this.refs && this.refs[ tooltipRef ] }
+								 isVisible={ this.state.showPopover }
+								 onClose={ () => {} }
+								 className="jp-info__tooltip"
+								 id={ 'popover__' + element[0] }
+								 position="bottom">
+							<ExternalLink icon={ true } iconSize={ 16 } href={ element[3] } target="_blank" onClick={ () => {
+								this.setState( { showPopover: false } );
+							} }>
+								{
+									__( 'Theme support required.' )
+								}
+							</ExternalLink>
+						</Popover>
+					</Button>
+				);
+				toggleExpanded = '';
+				moduleDescription = '';
+				learnMore = '';
+				customClasses += ' jp-card-no-expand';
+			}
 
-		// If there are no description or learn more to render, don't render children.
-		// This is in cases like when a theme doesn't support Infinite Scroll. We don't
-		// render the children so the arrow pointing downwards isn't rendered.
-		return '' !== moduleDescription || '' !== learnMore
-			? <FoldableCard { ...componentProps } >{ moduleDescription }{ learnMore }</FoldableCard>
-			: <FoldableCard { ...componentProps } ></FoldableCard>
-		;
-	} );
+			let componentProps = {
+				className          : customClasses,
+				key                : `module-card_${element[0]}` /* https://fb.me/react-warning-keys */,
+				header             : element[1],
+				subheader          : element[2],
+				summary            : toggle,
+				expandedSummary    : toggleExpanded,
+				clickableHeaderText: true,
+				onOpen             : () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+					{
+						card: element[0],
+						path: this.props.route.path
+					}
+				)
+			};
 
-	return (
-		<div>
-			<QuerySite />
-			{ cards }
+			// If there are no description or learn more to render, don't render children.
+			// This is in cases like when a theme doesn't support Infinite Scroll. We don't
+			// render the children so the arrow pointing downwards isn't rendered.
+			return '' !== moduleDescription || '' !== learnMore
+				? <FoldableCard { ...componentProps } >{ moduleDescription }{ learnMore }</FoldableCard>
+				: <FoldableCard { ...componentProps } ></FoldableCard>
+				;
+		} );
 
-			<FoldableCard
-				header={ __( 'Holiday Snow' ) }
-				subheader={ __( 'Show falling snow in the holiday period.' ) }
-				clickableHeaderText={ true }
-				disabled={ ! isAdmin }
-				summary={ isAdmin ? <Settings slug="snow" /> : '' }
-				expandedSummary={ isAdmin ? <Settings slug="snow" /> : '' }
-				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+		return (
+			<div>
+				<QuerySite />
+				{ cards }
+
+				<FoldableCard
+					header={ __( 'Holiday Snow' ) }
+					subheader={ __( 'Show falling snow in the holiday period.' ) }
+					clickableHeaderText={ true }
+					disabled={ ! isAdmin }
+					summary={ isAdmin ? <Settings slug="snow" /> : '' }
+					expandedSummary={ isAdmin ? <Settings slug="snow" /> : '' }
+					onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
 					{
 						card: 'holiday_snow',
-						path: props.route.path
+						path: this.props.route.path
 					}
 				) }
-			>
+				>
 				<span className="jp-form-setting-explanation">
 					{ __( 'Show falling snow on my blog from Dec 1st until Jan 4th.' ) }
 				</span>
-			</FoldableCard>
-		</div>
-	);
-};
+				</FoldableCard>
+			</div>
+		)
+	}
+} );
 
 function renderLongDescription( module ) {
 	// Rationale behind returning an object and not just the string

--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -6,12 +6,13 @@ import { connect } from 'react-redux';
 import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
-import Popover from 'components/popover';
+import InfoPopover from 'components/info-popover';
 import Tooltip from 'components/tooltip';
 import { translate as __ } from 'i18n-calypso';
 import includes from 'lodash/includes';
 import analytics from 'lib/analytics';
 import ExternalLink from 'components/external-link';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -36,14 +37,6 @@ import {
 import Settings from 'components/settings';
 
 export const Page = React.createClass( {
-	getInitialState() {
-		return { showPopover: false };
-	},
-
-	toggleInfo: function(){
-		this.setState( { showPopover: ! this.state.showPopover } );
-	},
-
 	render() {
 		let {
 				toggleModule,
@@ -91,25 +84,12 @@ export const Page = React.createClass( {
 			);
 
 			if ( 'infinite-scroll' === element[0] && noInfiniteScrollSupport ) {
-				let tooltipRef = element[0] + '_button';
 				toggle = (
-					<Button borderless compact onClick={ this.toggleInfo } ref={ tooltipRef } className="jp-info__button">
-						<Gridicon icon="info-outline" size={ 18 }/><span className="screen-reader-text">{ __( 'Learn More' ) }</span>
-						<Popover context={ this.refs && this.refs[ tooltipRef ] }
-								 isVisible={ this.state.showPopover }
-								 onClose={ () => {} }
-								 className="jp-info__tooltip"
-								 id={ 'popover__' + element[0] }
-								 position="bottom">
-							<ExternalLink icon={ true } iconSize={ 16 } href={ element[3] } target="_blank" onClick={ () => {
-								this.setState( { showPopover: false } );
-							} }>
-								{
-									__( 'Theme support required.' )
-								}
-							</ExternalLink>
-						</Popover>
-					</Button>
+					<InfoPopover screenReaderText={ __( 'Learn more' ) }>
+						<ExternalLink icon={ true } iconSize={ 14 } href={ element[3] } target="_blank">
+							{ __( 'Theme support required.' ) }
+						</ExternalLink>
+					</InfoPopover>
 				);
 				toggleExpanded = '';
 				moduleDescription = '';

--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -71,37 +71,47 @@ export const Page = ( props ) => {
 			),
 			customClasses = unavailableInDevMode ? 'devmode-disabled' : '';
 
-		if ( 'infinite-scroll' === element[0] && noInfiniteScrollSupport ) {
-			toggle = __( 'Theme support required' );
-		}
-
 		let moduleDescription = isModuleActivated( element[0] ) ?
 			<AllModuleSettings module={ getModule( element[ 0 ] ) } /> :
 			// Render the long_description if module is deactivated
 			<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />;
 
-		return (
-			<FoldableCard
-				className={ customClasses }
-				key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
-				header={ element[1] }
-				subheader={ element[2] }
-				summary={ toggle }
-				expandedSummary={ toggle }
-				clickableHeaderText={ true }
-				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-					{
-						card: element[0],
-						path: props.route.path
-					}
-				) }
-			>
-				{ moduleDescription }
-				<div className="jp-module-settings__learn-more">
-					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
-				</div>
-			</FoldableCard>
+		let learnMore = (
+			<div className="jp-module-settings__learn-more">
+				<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
+			</div>
 		);
+
+		if ( 'infinite-scroll' === element[0] && noInfiniteScrollSupport ) {
+			toggle = __( 'Theme support required' );
+			moduleDescription = '';
+			learnMore = '';
+			customClasses += ' jp-card-no-expand';
+		}
+
+		let componentProps = {
+			className          : customClasses,
+			key                : `module-card_${element[0]}` /* https://fb.me/react-warning-keys */,
+			header             : element[1],
+			subheader          : element[2],
+			summary            : toggle,
+			expandedSummary    : toggle,
+			clickableHeaderText: true,
+			onOpen             : () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+				{
+					card: element[0],
+					path: props.route.path
+				}
+			)
+		};
+
+		// If there are no description or learn more to render, don't render children.
+		// This is in cases like when a theme doesn't support Infinite Scroll. We don't
+		// render the children so the arrow pointing downwards isn't rendered.
+		return '' !== moduleDescription || '' !== learnMore
+			? <FoldableCard { ...componentProps } >{ moduleDescription }{ learnMore }</FoldableCard>
+			: <FoldableCard { ...componentProps } ></FoldableCard>
+		;
 	} );
 
 	return (

--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -31,6 +31,7 @@ import {
 	getThemeData
 } from 'state/initial-state';
 import Settings from 'components/settings';
+import CardMessages from 'components/card-messages';
 
 export const Page = ( props ) => {
 	let {
@@ -45,36 +46,7 @@ export const Page = ( props ) => {
 		moduleList = Object.keys( props.moduleList );
 
 	if ( noInfiniteScrollSupport ) {
-		infiniteScrollDesc =
-			<div>
-				{ infiniteScrollDesc }
-				<p className="jp-form-setting-explanation">
-					{
-						__( "Your theme %(theme)s doesn't currently support Infinite Scroll, which needs data from your theme to function properly.",
-							{
-								args: {
-									theme: props.themeData.name
-								}
-							}
-						)
-					}
-				</p>
-				{
-					props.themeData.hasUpdate
-						? <p className="jp-form-setting-explanation">
-						{
-							__( "There's an update available for your theme. Check if this update adds Infinite Scroll support in {{a}}WordPress Updates{{/a}}.",
-								{
-									components: {
-										a: <a href={ props.siteAdminUrl + 'update-core.php' } className="jetpack-js-stop-propagation" />
-									}
-								}
-							)
-						}
-						</p>
-						: ''
-				}
-			</div>;
+		infiniteScrollDesc = <CardMessages module="infinite-scroll" desc={ infiniteScrollDesc } themeData={ props.themeData } />;
 	}
 
 	var cards = [

--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -85,7 +85,10 @@ export const Page = React.createClass( {
 
 			if ( 'infinite-scroll' === element[0] && noInfiniteScrollSupport ) {
 				toggle = (
-					<InfoPopover screenReaderText={ __( 'Learn more' ) }>
+					<InfoPopover
+						className="jp-module-settings__infinite-scroll"
+						screenReaderText={ __( 'Learn more' ) }
+					>
 						<ExternalLink icon={ true } iconSize={ 14 } href={ element[3] } target="_blank">
 							{ __( 'Theme support required.' ) }
 						</ExternalLink>

--- a/_inc/client/components/card-messages/index.jsx
+++ b/_inc/client/components/card-messages/index.jsx
@@ -13,38 +13,6 @@ import { getSiteAdminUrl } from 'state/initial-state';
 export const CardMessages = props => {
 
 	switch ( props.module ) {
-		case 'infinite-scroll':
-			return (
-				<div>
-					{ props.desc }
-					<p className="jp-form-setting-explanation">
-						{
-							__( "The current version of your theme, {{strong}}%(theme)s{{/strong}}, doesn't support Infinite Scroll.", {
-									args: {
-										theme: props.themeData.name
-									},
-									components: {
-										strong: <strong />
-									}
-								}
-							)
-						}
-						{ ' ' }
-						{
-							props.themeData.hasUpdate
-								? __( "Check if the {{a}}latest version{{/a}} adds support.", {
-										components: {
-											a: <a href={ props.siteAdminUrl + 'update-core.php' } className="jetpack-js-stop-propagation" />
-										}
-									}
-								  )
-								: ''
-						}
-					</p>
-				</div>
-			);
-			break;
-
 		case 'sitemaps':
 			return (
 				<span>

--- a/_inc/client/components/card-messages/index.jsx
+++ b/_inc/client/components/card-messages/index.jsx
@@ -19,30 +19,28 @@ export const CardMessages = props => {
 					{ props.desc }
 					<p className="jp-form-setting-explanation">
 						{
-							__( "Your theme %(theme)s doesn't currently support Infinite Scroll, which needs data from your theme to function properly.",
-								{
+							__( "The current version of your theme, {{strong}}%(theme)s{{/strong}}, doesn't support Infinite Scroll.", {
 									args: {
 										theme: props.themeData.name
+									},
+									components: {
+										strong: <strong />
 									}
 								}
 							)
 						}
-					</p>
-					{
-						props.themeData.hasUpdate
-							? <p className="jp-form-setting-explanation">
-							{
-								__( "There's an update available for your theme. Check if this update adds Infinite Scroll support in {{a}}WordPress Updates{{/a}}.",
-									{
+						{ ' ' }
+						{
+							props.themeData.hasUpdate
+								? __( "Check if the {{a}}latest version{{/a}} adds support.", {
 										components: {
 											a: <a href={ props.siteAdminUrl + 'update-core.php' } className="jetpack-js-stop-propagation" />
 										}
 									}
-								)
-							}
-						</p>
-							: ''
-					}
+								  )
+								: ''
+						}
+					</p>
 				</div>
 			);
 			break;

--- a/_inc/client/components/card-messages/index.jsx
+++ b/_inc/client/components/card-messages/index.jsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteAdminUrl } from 'state/initial-state';
+
+export const CardMessages = props => {
+
+	switch ( props.module ) {
+		case 'infinite-scroll':
+			return (
+				<div>
+					{ props.desc }
+					<p className="jp-form-setting-explanation">
+						{
+							__( "Your theme %(theme)s doesn't currently support Infinite Scroll, which needs data from your theme to function properly.",
+								{
+									args: {
+										theme: props.themeData.name
+									}
+								}
+							)
+						}
+					</p>
+					{
+						props.themeData.hasUpdate
+							? <p className="jp-form-setting-explanation">
+							{
+								__( "There's an update available for your theme. Check if this update adds Infinite Scroll support in {{a}}WordPress Updates{{/a}}.",
+									{
+										components: {
+											a: <a href={ props.siteAdminUrl + 'update-core.php' } className="jetpack-js-stop-propagation" />
+										}
+									}
+								)
+							}
+						</p>
+							: ''
+					}
+				</div>
+			);
+			break;
+
+		case 'sitemaps':
+			return (
+				<span>
+					{ props.desc }
+					{ <p className="jp-form-setting-explanation">
+						{ __( 'Your site must be accessible by search engines for this feature to work properly. You can change this in {{a}}Reading Settings{{/a}}.', {
+							components: {
+								a: <a href={ props.siteAdminUrl + 'options-reading.php#blog_public' } className="jetpack-js-stop-propagation" />
+							}
+						} ) }
+					</p> }
+				</span>
+			);
+
+	}
+};
+
+export default connect(
+	( state ) => {
+		return {
+			siteAdminUrl: getSiteAdminUrl( state )
+		};
+	}
+)( CardMessages );

--- a/_inc/client/components/foldable-card/style.scss
+++ b/_inc/client/components/foldable-card/style.scss
@@ -67,3 +67,7 @@
 		}
 	}
 }
+
+.dops-foldable-card.jp-card-no-expand .dops-foldable-card__header.has-border .dops-foldable-card__summary {
+	margin-right: 7px;
+}

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -22,6 +22,10 @@
 	right: 17px;
 }
 
+.dops-info-popover__tooltip.jp-module-settings__infinite-scroll .dops-popover__inner {
+	white-space: nowrap;
+}
+
 // Connection Settings styles
 .jp-connection-settings {
 	margin: rem( 24px ) 0;

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -36,6 +36,7 @@ import {
 import { getSitePlan } from 'state/site';
 import QuerySite from 'components/data/query-site';
 import ExternalLink from 'components/external-link';
+import CardMessages from 'components/card-messages';
 
 export const Engagement = ( props ) => {
 	let {
@@ -49,16 +50,7 @@ export const Engagement = ( props ) => {
 		moduleList = Object.keys( props.moduleList );
 
 	if ( ! props.isSitePublic ) {
-		sitemapsDesc = <span>
-			{ sitemapsDesc }
-			{ <p className="jp-form-setting-explanation">
-				{ __( 'Your site must be accessible by search engines for this feature to work properly. You can change this in {{a}}Reading Settings{{/a}}.', {
-					components: {
-						a: <a href={ props.siteAdminUrl + 'options-reading.php#blog_public' } className="jetpack-js-stop-propagation" />
-					}
-				} ) }
-			</p> }
-		</span>;
+		sitemapsDesc = <CardMessages module="sitemaps" desc={ sitemapsDesc } />;
 	}
 
 	/**

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -184,7 +184,7 @@ const Main = React.createClass( {
 				break;
 			case '/appearance':
 				navComponent = <NavigationSettings route={ this.props.route } />;
-				pageComponent = <Appearance route={ this.props.route } />;
+				pageComponent = <Appearance route={ this.props.route } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/writing':
 				navComponent = <NavigationSettings route={ this.props.route } />;

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -70,15 +70,3 @@
 @keyframes pulse-light {
 	50% { background-color: lighten( $gray, 30% ); }
 }
-
-// Help tooltip
-.jp-info__tooltip {
-	.dops-popover__inner{
-		padding: 6px 8px;
-		color: #4f748e;
-
-		a, .gridicon {
-			vertical-align: text-bottom;
-		}
-	}
-}

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -70,3 +70,15 @@
 @keyframes pulse-light {
 	50% { background-color: lighten( $gray, 30% ); }
 }
+
+// Help tooltip
+.jp-info__tooltip {
+	.dops-popover__inner{
+		padding: 6px 8px;
+		color: #4f748e;
+
+		a, .gridicon {
+			vertical-align: text-bottom;
+		}
+	}
+}

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -18,6 +18,7 @@ import analytics from 'lib/analytics';
 import QuerySite from 'components/data/query-site';
 import { isUnavailableInDevMode } from 'state/connection';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
+import CardMessages from 'components/card-messages';
 import {
 	isModuleActivated as _isModuleActivated,
 	activateModule,
@@ -36,8 +37,12 @@ import {
 	isFetchingPluginsData,
 	isPluginActive
 } from 'state/site/plugins';
-import { getSiteRawUrl } from 'state/initial-state';
-import { WordAdsSubHeaderTos } from 'engagement'
+import { WordAdsSubHeaderTos } from 'engagement';
+import {
+	getSiteRawUrl,
+	getThemeData,
+	isSitePublic
+} from 'state/initial-state';
 
 export const SearchResults = ( {
 	siteAdminUrl,
@@ -51,7 +56,9 @@ export const SearchResults = ( {
 	unavailableInDevMode,
 	isFetchingPluginsData,
 	isPluginActive,
-	siteRawUrl
+	siteRawUrl,
+	themeData,
+	isSitePublic
 	} ) => {
 	let modules = getModules(),
 		moduleList = [
@@ -165,16 +172,31 @@ export const SearchResults = ( {
 			}
 		}
 
-		if ( 'videopress' === element[0] ) {
-			if ( ! sitePlan || 'jetpack_free' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
-				toggle = <Button
-					compact={ true }
-					primary={ true }
-					href={ 'https://jetpack.com/redirect/?source=upgrade-videopress&site=' + siteRawUrl }
-				>
-					{ __( 'Upgrade' ) }
-				</Button>;
-			}
+		switch ( element[0] ) {
+			case 'videopress':
+				if ( ! sitePlan || 'jetpack_free' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
+					toggle = <Button
+						compact={ true }
+						primary={ true }
+						href={ 'https://jetpack.com/redirect/?source=upgrade-videopress&site=' + siteRawUrl }
+					>
+						{ __( 'Upgrade' ) }
+					</Button>;
+				}
+				break;
+
+			case 'infinite-scroll':
+				if ( ! themeData.support.infiniteScroll ) {
+					element[2] = <CardMessages module="infinite-scroll" desc={ element[2] } themeData={ themeData } />;
+					toggle = __( 'Theme support required' );
+				}
+				break;
+
+			case 'sitemaps':
+				if ( ! isSitePublic ) {
+					element[2] = <CardMessages module="sitemaps" desc={ element[2] } />;
+				}
+				break;
 		}
 
 		if ( 1 === element.length ) {
@@ -243,7 +265,9 @@ export default connect(
 			unavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
 			isFetchingPluginsData: isFetchingPluginsData( state ),
 			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
-			siteRawUrl: getSiteRawUrl( state )
+			siteRawUrl: getSiteRawUrl( state ),
+			themeData: getThemeData( state ),
+			isSitePublic: isSitePublic( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -163,3 +163,14 @@ export function getCurrentIp( state ) {
 export function getLastPostUrl( state ) {
 	return get( state.jetpack.initialState, 'lastPostUrl' );
 }
+
+/**
+ * Get information about the current theme: name, if there's an update available and feature support.
+ *
+ * @param {Object} state Global state tree
+ *
+ * @return {Array} Information about theme.
+ */
+export function getThemeData( state ) {
+	return get( state.jetpack.initialState, 'theme', { name: '', hasUpdate: false, support: { infiniteScroll: false } } );
+}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -234,6 +234,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			$last_post = get_permalink( $last_post[0]->ID );
 		}
 
+		// Get information about current theme.
+		$current_theme = wp_get_theme();
+
 		// Add objects to be passed to the initial state of the app
 		wp_localize_script( 'react-plugin', 'Initial_State', array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
@@ -286,6 +289,23 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			'currentIp' => function_exists( 'jetpack_protect_get_ip' ) ? jetpack_protect_get_ip() : false,
 			'lastPostUrl' => esc_url( $last_post ),
+			'theme' => array(
+				'name'      => $current_theme->get( 'Name' ),
+				'hasUpdate' => (bool) get_theme_update_available( $current_theme ),
+				'support'   => array(
+					'infiniteScroll' => current_theme_supports( 'infinite-scroll' ) || in_array(
+						$current_theme->get_stylesheet(), array(
+							'twentyten',
+							'twentyeleven',
+							'twentytwelve',
+							'twentythirteen',
+							'twentyfourteen',
+							'twentyfifteen',
+							'twentysixteen',
+						)
+					),
+				),
+			),
 		) );
 	}
 }

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -237,6 +237,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		// Get information about current theme.
 		$current_theme = wp_get_theme();
 
+		// Get all themes that Infinite Scroll provides support for natively.
+		$is_support_themes = array();
+		foreach ( Jetpack::glob_php( JETPACK__PLUGIN_DIR . 'modules/infinite-scroll/themes/*.php' ) as $path ) {
+			if ( is_readable( $path ) ) {
+				$is_support_themes[] = basename( $path, '.php' );
+			}
+		}
+
 		// Add objects to be passed to the initial state of the app
 		wp_localize_script( 'react-plugin', 'Initial_State', array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
@@ -293,17 +301,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'name'      => $current_theme->get( 'Name' ),
 				'hasUpdate' => (bool) get_theme_update_available( $current_theme ),
 				'support'   => array(
-					'infiniteScroll' => current_theme_supports( 'infinite-scroll' ) || in_array(
-						$current_theme->get_stylesheet(), array(
-							'twentyten',
-							'twentyeleven',
-							'twentytwelve',
-							'twentythirteen',
-							'twentyfourteen',
-							'twentyfifteen',
-							'twentysixteen',
-						)
-					),
+					'infiniteScroll' => current_theme_supports( 'infinite-scroll' ) || in_array( $current_theme->get_stylesheet(), $is_support_themes ),
 				),
 			),
 		) );


### PR DESCRIPTION
Fixes #5824

#### Changes proposed in this Pull Request:
- pass information about current theme to Jetpack UI
- add reducer to obtain theme information, including name, whether there's an update available and for now, if it supports Infinite Scroll
-  if theme doesn't support Infinite Scroll replace toggle with informational button and tooltip
<img width="851" alt="captura de pantalla 2017-01-06 a las 02 13 32" src="https://cloud.githubusercontent.com/assets/1041600/21708289/c43d6644-d3b5-11e6-834b-f35273688a04.png">

#### Testing instructions:
switch to the branch.
do `yarn build`.
activate TwentySeventeen theme, which as of now, isn't supported by Jetpack.

* verify it displays the information button. After clicking it, the tooltip should be displayed.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Admin: added message when currently active theme doesn't support Infinite Scroll.

__________
Previous solutions explored
- if theme doesn't support Infinite Scroll add notice in card explaining user why the toggle is disabled.
<img width="740" alt="captura de pantalla 2016-12-19 a las 14 20 07" src="https://cloud.githubusercontent.com/assets/1041600/21322066/457b8768-c5f6-11e6-9101-d33eed3c70e4.png">
- if there's an update available for the theme, add notice mentioning it
<img width="743" alt="captura de pantalla 2016-12-19 a las 14 13 20" src="https://cloud.githubusercontent.com/assets/1041600/21322068/4a8ea730-c5f6-11e6-960d-1b7e4429f41d.png">