### PR TITLE
Add padding to Sharedaddy buttons on mobile

### DIFF
--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -184,6 +184,8 @@ body.highlander-dark h3.sd-title:before {
 	margin: 0 5px 5px 0;
 	padding: 0;
 }
+/* Add more pading on touch devices */
+.jp-sharing-input-touch .sd-content ul li { padding-left: 10px; }
 
 /* Text + icon & Official */
 .sd-social-icon-text .sd-content ul li a span,

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -267,6 +267,8 @@ var updateLinkedInCount = function( data ) {
 				} );
 				$more_sharing_buttons.data( 'timer', false );
 			} );
+		} else {
+			$( document.body ).addClass( 'jp-sharing-input-touch' );
 		}
 
 		$( document ).click(function() {


### PR DESCRIPTION
Fixes: #2658

Add additional padding to Sharedaddy buttons on mobile, to prevent Google Webmaster Tools reporting mobile usability issues, because the clickable elements are too close.