### PR TITLE
Widgets: various fixes in Customizer and Widgets admin screen

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -757,14 +757,12 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			'description' => esc_html__( 'Add an email signup form to allow people to subscribe to your blog.', 'jetpack' ),
 			'customize_selective_refresh' => true,
 		);
-		$control_ops = array( 'width' => 300 );
 
 		parent::__construct(
 			'blog_subscription',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', __( 'Blog Subscriptions', 'jetpack' ) ),
-			$widget_ops,
-			$control_ops
+			$widget_ops
 		);
 
 		if ( is_active_widget( false, false, $this->id_base ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -1024,7 +1024,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 <p>
 	<label for="<?php echo $this->get_field_id( 'subscribe_text' ); ?>">
 		<?php _e( 'Optional text to display to your readers:', 'jetpack' ); ?>
-		<textarea style="width: 95%" id="<?php echo $this->get_field_id( 'subscribe_text' ); ?>" name="<?php echo $this->get_field_name( 'subscribe_text' ); ?>" type="text"><?php echo esc_html( $subscribe_text ); ?></textarea>
+		<textarea class="widefat" id="<?php echo $this->get_field_id( 'subscribe_text' ); ?>" name="<?php echo $this->get_field_name( 'subscribe_text' ); ?>" rows="3"><?php echo esc_html( $subscribe_text ); ?></textarea>
 	</label>
 </p>
 <p>
@@ -1042,7 +1042,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 <p>
 	<label for="<?php echo $this->get_field_id( 'success_message' ); ?>">
 		<?php _e( 'Success Message Text:', 'jetpack' ); ?>
-		<textarea style="width: 95%" id="<?php echo $this->get_field_id( 'success_message' ); ?>" name="<?php echo $this->get_field_name( 'success_message' ); ?>" type="text"><?php echo esc_html( $success_message ); ?></textarea>
+		<textarea class="widefat" id="<?php echo $this->get_field_id( 'success_message' ); ?>" name="<?php echo $this->get_field_name( 'success_message' ); ?>" rows="5"><?php echo esc_html( $success_message ); ?></textarea>
 	</label>
 </p>
 <p>

--- a/modules/widgets/authors.php
+++ b/modules/widgets/authors.php
@@ -18,8 +18,7 @@ class Jetpack_Widget_Authors extends WP_Widget {
 				'classname' => 'widget_authors',
 				'description' => __( 'Display blogs authors with avatars and recent posts.', 'jetpack' ),
 				'customize_selective_refresh' => true,
-			),
-			array( 'width' => 300 )
+			)
 		);
 
 		add_action( 'publish_post', array( __CLASS__, 'flush_cache' ) );

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -20,7 +20,6 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 			'description' => __( 'Display a photo gallery or slideshow', 'jetpack' ),
 			'customize_selective_refresh' => true,
 		);
-		$control_ops 	= array( 'width' => 250 );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 
@@ -28,8 +27,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 			'gallery',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', __( 'Gallery', 'jetpack' ) ),
-			$widget_ops,
-			$control_ops
+			$widget_ops
 		);
 
 		if ( is_customize_preview() ) {

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -59,10 +59,20 @@ class Milestone_Widget extends WP_Widget {
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
 		add_action( 'wp_footer', array( $this, 'localize_script' ) );
+		add_action( 'customize_controls_enqueue_scripts', array( __CLASS__, 'enqueue_admin' ) );
 
 		if ( is_active_widget( false, false, $this->id_base, true ) || is_active_widget( false, false, 'monster', true ) || is_customize_preview() ) {
 			add_action( 'wp_head', array( __class__, 'styles_template' ) );
 		}
+	}
+
+	/**
+	 * Enqueue assets for Customizer widget control.
+	 *
+	 * @since 4.5.0
+	 */
+	public static function customizer_controls_assets() {
+		wp_enqueue_style( 'milestone-customizer', plugins_url( 'style-admin.css', __FILE__ ), array(), '20161215' );
 	}
 
 	public static function enqueue_admin( $hook_suffix ) {

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -8,16 +8,10 @@ Author URI: http://automattic.com/
 License: GPLv2 or later
 */
 
-class Jetpack_Milestone {
-	public static function init() {
-		add_action( 'widgets_init', array( __class__, 'register_widget' ) );
-	}
-	public static function register_widget() {
-		register_widget( 'Milestone_Widget' );
-	}
+function jetpack_register_widget_milestone() {
+	register_widget( 'Milestone_Widget' );
 }
-
-Jetpack_Milestone::init();
+add_action( 'widgets_init', 'jetpack_register_widget_milestone' );
 
 class Milestone_Widget extends WP_Widget {
 	private static $dir       = null;
@@ -59,25 +53,15 @@ class Milestone_Widget extends WP_Widget {
 		add_action( 'wp_enqueue_scripts', array( __class__, 'enqueue_template' ) );
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
 		add_action( 'wp_footer', array( $this, 'localize_script' ) );
-		add_action( 'customize_controls_enqueue_scripts', array( __CLASS__, 'enqueue_admin' ) );
 
 		if ( is_active_widget( false, false, $this->id_base, true ) || is_active_widget( false, false, 'monster', true ) || is_customize_preview() ) {
 			add_action( 'wp_head', array( __class__, 'styles_template' ) );
 		}
 	}
 
-	/**
-	 * Enqueue assets for Customizer widget control.
-	 *
-	 * @since 4.5.0
-	 */
-	public static function customizer_controls_assets() {
-		wp_enqueue_style( 'milestone-customizer', plugins_url( 'style-admin.css', __FILE__ ), array(), '20161215' );
-	}
-
 	public static function enqueue_admin( $hook_suffix ) {
 		if ( 'widgets.php' == $hook_suffix ) {
-			wp_enqueue_style( 'milestone-admin', self::$url . 'style-admin.css', array(), '20111212' );
+			wp_enqueue_style( 'milestone-admin', self::$url . 'style-admin.css', array(), '20161215' );
 		}
 	}
 
@@ -342,9 +326,8 @@ class Milestone_Widget extends WP_Widget {
         </p>
 
 		<fieldset class="jp-ms-data-time">
-			<legend><?php _e( 'Date and Time', 'jetpack' ); ?></legend>
+			<legend><?php esc_html_e( 'Date', 'jetpack' ); ?></legend>
 
-			<label class="jp-ms-mobile-heading"><?php esc_html_e( 'Date', 'jetpack' ); ?></label>
 			<label for="<?php echo $this->get_field_id( 'month' ); ?>" class="assistive-text"><?php _e( 'Month', 'jetpack' ); ?></label>
 			<select id="<?php echo $this->get_field_id( 'month' ); ?>" class="month" name="<?php echo $this->get_field_name( 'month' ); ?>"><?php
 				global $wp_locale;
@@ -359,9 +342,10 @@ class Milestone_Widget extends WP_Widget {
 
 			<label for="<?php echo $this->get_field_id( 'year' ); ?>" class="assistive-text"><?php _e( 'Year', 'jetpack' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'year' ); ?>" class="year" name="<?php echo $this->get_field_name( 'year' ); ?>" type="text" value="<?php echo esc_attr( $instance['year'] ); ?>">
+		</fieldset>
 
-			<span class="date-time-separator">@</span>
-			<label class="jp-ms-mobile-heading"><?php esc_html_e( 'Time', 'jetpack' ); ?></label>
+		<fieldset class="jp-ms-data-time">
+			<legend><?php esc_html_e( 'Time', 'jetpack' ); ?></legend>
 
 			<label for="<?php echo $this->get_field_id( 'hour' ); ?>" class="assistive-text"><?php _e( 'Hour', 'jetpack' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'hour' ); ?>" class="hour" name="<?php echo $this->get_field_name( 'hour' ); ?>" type="text" value="<?php echo esc_attr( $instance['hour'] ); ?>">

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -32,16 +32,11 @@ class Milestone_Widget extends WP_Widget {
 			'description' => __( 'Display a countdown to a certain date.', 'jetpack' ),
 		);
 
-		$control = array(
-			'width' => 251, // Chrome needs a little extra room for the date fields.
-		);
-
 		parent::__construct(
 			'Milestone_Widget',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', __( 'Milestone', 'jetpack' ) ),
-			$widget,
-			$control
+			$widget
 		);
 
 		self::$dir = trailingslashit( dirname( __FILE__ ) );

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -341,9 +341,10 @@ class Milestone_Widget extends WP_Widget {
         	<input class="widefat" id="<?php echo $this->get_field_id( 'event' ); ?>" name="<?php echo $this->get_field_name( 'event' ); ?>" type="text" value="<?php echo esc_attr( $instance['event'] ); ?>" />
         </p>
 
-		<fieldset>
+		<fieldset class="jp-ms-data-time">
 			<legend><?php _e( 'Date and Time', 'jetpack' ); ?></legend>
 
+			<label class="jp-ms-mobile-heading"><?php esc_html_e( 'Date', 'jetpack' ); ?></label>
 			<label for="<?php echo $this->get_field_id( 'month' ); ?>" class="assistive-text"><?php _e( 'Month', 'jetpack' ); ?></label>
 			<select id="<?php echo $this->get_field_id( 'month' ); ?>" class="month" name="<?php echo $this->get_field_name( 'month' ); ?>"><?php
 				global $wp_locale;
@@ -359,16 +360,22 @@ class Milestone_Widget extends WP_Widget {
 			<label for="<?php echo $this->get_field_id( 'year' ); ?>" class="assistive-text"><?php _e( 'Year', 'jetpack' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'year' ); ?>" class="year" name="<?php echo $this->get_field_name( 'year' ); ?>" type="text" value="<?php echo esc_attr( $instance['year'] ); ?>">
 
-			@ <label for="<?php echo $this->get_field_id( 'hour' ); ?>" class="assistive-text"><?php _e( 'Hour', 'jetpack' ); ?></label>
+			<span class="date-time-separator">@</span>
+			<label class="jp-ms-mobile-heading"><?php esc_html_e( 'Time', 'jetpack' ); ?></label>
+
+			<label for="<?php echo $this->get_field_id( 'hour' ); ?>" class="assistive-text"><?php _e( 'Hour', 'jetpack' ); ?></label>
 			<input id="<?php echo $this->get_field_id( 'hour' ); ?>" class="hour" name="<?php echo $this->get_field_name( 'hour' ); ?>" type="text" value="<?php echo esc_attr( $instance['hour'] ); ?>">
 
 			<label for="<?php echo $this->get_field_id( 'min' ); ?>" class="assistive-text"><?php _e( 'Minutes', 'jetpack' ); ?></label>
-			: <input id="<?php echo $this->get_field_id( 'min' ); ?>" class="minutes" name="<?php echo $this->get_field_name( 'min' ); ?>" type="text" value="<?php echo esc_attr( $instance['min'] ); ?>">
+
+			<span class="time-separator">:</span>
+
+			<input id="<?php echo $this->get_field_id( 'min' ); ?>" class="minutes" name="<?php echo $this->get_field_name( 'min' ); ?>" type="text" value="<?php echo esc_attr( $instance['min'] ); ?>">
 		</fieldset>
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'message' ); ?>"><?php _e( 'Message', 'jetpack' ); ?></label>
-			<textarea id="<?php echo $this->get_field_id( 'message' ); ?>" name="<?php echo $this->get_field_name( 'message' ); ?>" class="widefat"><?php echo esc_textarea( $instance['message'] ); ?></textarea>
+			<textarea id="<?php echo $this->get_field_id( 'message' ); ?>" name="<?php echo $this->get_field_name( 'message' ); ?>" class="widefat" rows="3"><?php echo esc_textarea( $instance['message'] ); ?></textarea>
 		</p>
 	</div>
 

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -60,7 +60,7 @@ class Milestone_Widget extends WP_Widget {
 		add_action( 'admin_enqueue_scripts', array( __class__, 'enqueue_admin' ) );
 		add_action( 'wp_footer', array( $this, 'localize_script' ) );
 
-		if ( is_active_widget( false, false, $this->id_base, true ) || is_active_widget( false, false, 'monster', true ) ) {
+		if ( is_active_widget( false, false, $this->id_base, true ) || is_active_widget( false, false, 'monster', true ) || is_customize_preview() ) {
 			add_action( 'wp_head', array( __class__, 'styles_template' ) );
 		}
 	}

--- a/modules/widgets/milestone/style-admin.css
+++ b/modules/widgets/milestone/style-admin.css
@@ -1,19 +1,63 @@
 .milestone-widget fieldset {
 	margin-bottom: 1em;
 }
-.milestone-widget .day,
-.milestone-widget .hour,
-.milestone-widget .minutes,
-.milestone-widget .seconds {
-	text-align: right;
-	width: 2em;
+
+.milestone-widget fieldset * {
+	vertical-align: middle;
 }
-.milestone-widget .year {
-	text-align: right;
-	width: 3.25em;
+
+.jp-ms-mobile-heading {
+	display: none;
 }
-.milestone-widget .assistive-text {
+
+.jp-ms-data-time input[type="text"] {
+	text-align: right;
+	width: 2.1em;
+}
+
+.jp-ms-data-time .month {
+	width: 5.4em;
+	height: 25px;
+}
+
+.customize-control .jp-ms-data-time .month {
+	height: 26px;
+}
+
+.jp-ms-data-time .year[type="text"] {
+	text-align: right;
+	width: 3.2em;
+}
+
+.jp-ms-data-time .assistive-text {
 	position: absolute !important;
 	clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
 	clip: rect(1px, 1px, 1px, 1px);
+}
+
+@media screen and (max-width: 782px) {
+	.jp-ms-mobile-heading {
+		display: block;
+		font-weight: 400;
+	}
+
+	.jp-ms-data-time legend {
+		display: none;
+	}
+
+	.date-time-separator {
+		display: block;
+		text-indent: -9999em;
+	}
+
+	.jp-ms-data-time input[type="text"],
+	.jp-ms-data-time .year[type="text"] {
+		width: 3.8em;
+		height: 30px;
+	}
+
+	#wpbody .jp-ms-data-time .month,
+	.customize-control .jp-ms-data-time .month {
+		height: 30px;
+	}
 }

--- a/modules/widgets/milestone/style-admin.css
+++ b/modules/widgets/milestone/style-admin.css
@@ -6,10 +6,6 @@
 	vertical-align: middle;
 }
 
-.jp-ms-mobile-heading {
-	display: none;
-}
-
 .jp-ms-data-time input[type="text"] {
 	text-align: right;
 	width: 2.1em;
@@ -17,16 +13,21 @@
 
 .jp-ms-data-time .month {
 	width: 5.4em;
-	height: 25px;
-}
 
-.customize-control .jp-ms-data-time .month {
-	height: 26px;
 }
 
 .jp-ms-data-time .year[type="text"] {
 	text-align: right;
 	width: 3.2em;
+}
+
+.jp-ms-data-time input[type="text"] {
+	text-align: right;
+	width: 3.2em;
+}
+
+.jp-ms-data-time .year[type="text"] {
+	width: 4.5em;
 }
 
 .jp-ms-data-time .assistive-text {
@@ -36,28 +37,13 @@
 }
 
 @media screen and (max-width: 782px) {
-	.jp-ms-mobile-heading {
-		display: block;
-		font-weight: 400;
-	}
-
-	.jp-ms-data-time legend {
-		display: none;
-	}
-
-	.date-time-separator {
-		display: block;
-		text-indent: -9999em;
-	}
-
 	.jp-ms-data-time input[type="text"],
 	.jp-ms-data-time .year[type="text"] {
-		width: 3.8em;
-		height: 30px;
+		width: 2.8em;
+
 	}
 
-	#wpbody .jp-ms-data-time .month,
-	.customize-control .jp-ms-data-time .month {
-		height: 30px;
+	.jp-ms-data-time .year[type="text"] {
+		width: 4em;
 	}
 }

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -731,13 +731,21 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', 'display_posts' );
 
-		/** This filter is documented in core/src/wp-includes/default-widgets.php */
-		$title = apply_filters( 'widget_title', $instance['title'] );
-
 		// Enqueue front end assets.
 		$this->enqueue_scripts();
 
 		echo $args['before_widget'];
+
+		if ( empty( $instance['url'] ) ) {
+			if ( current_user_can( 'manage_options' ) ) {
+				echo '<p>';
+				/* Translators: the "Blog URL" field mentioned is the input field labeled as such in the widget form. */
+				esc_html_e( 'The Blog URL is not properly setup in the widget.', 'jetpack' );
+				echo '</p>';
+			}
+			echo $args['after_widget'];
+			return;
+		}
 
 		$data = $this->get_blog_data( $instance['url'] );
 
@@ -751,8 +759,10 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 		$site_info = $data['site_info']['data'];
 
-		if ( ! empty( $title ) ) {
-			echo $args['before_title'] . esc_html( $title . ': ' . $site_info->name ) . $args['after_title'];
+		if ( ! empty( $instance['title'] ) ) {
+			/** This filter is documented in core/src/wp-includes/default-widgets.php */
+			$instance['title'] = apply_filters( 'widget_title', $instance['title'] );
+			echo $args['before_title'] . esc_html( $instance['title'] . ': ' . $site_info->name ) . $args['after_title'];
 		}
 		else {
 			echo $args['before_title'] . esc_html( $site_info->name ) . $args['after_title'];


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- fix widgets extending outside the Customizer panel width fixes #5811
- increase number of visible rows in text boxes for Subscription widget
- fix undefined indexes for title and url in WordPress Posts widget fixes #5893
- always load Milestone front end stylesheet so it's stylized when it's first added and previewed in Customizer, fixes #5907
- enqueue stylesheet for Customizer control for Milestone widget
- stylize controls for Milestone widget in admin screen and Customizer Fixes #5889
    - Previously the styles were broken in mobile screen sizes, this patch fixes it.
    - It introduces distinctive separated labels for Date and Time in mobile screen sizes.
    - Balances height of elements and aligns them in admin and Customizer.
    - Increase number of visible rows in message text box.
    - Synced to wpcom in r147481-wpcom

View of the widget in Customizer.
<img width="292" alt="captura de pantalla 2016-12-15 a las 14 33 43" src="https://cloud.githubusercontent.com/assets/1041600/21237360/805516ae-c2dd-11e6-8213-8bebdcef3d13.png">

View of the widget in Widgets admin screen in mobile screen size. The layout at this size in Customizer is similar.
<img width="440" alt="captura de pantalla 2016-12-15 a las 14 33 51" src="https://cloud.githubusercontent.com/assets/1041600/21237361/805b03f2-c2dd-11e6-82c0-baac34521add.png">


#### Testing instructions:
* add these widgets: 
```
Subscriptions
Authors
Gallery
Milestone
WordPress Posts
```
- make sure they don't extend beyond the Customizer width.
- the first time you add a Milestone widget to Customizer, make sure it's stylized in the preview
- the Milestone widget control in Customizer should be stylized
- add WordPress Posts in Customizer and make sure there are no PHP warnings regarding title and url array indexes

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix: adding a WordPress Posts widget in Customizer no longer displays PHP warnings
Fix: the Subscriptions and Authors widgets no longer extend beyond the Customizer width
