### PR TITLE
Translate Widget: display default title by default.

### DIFF
--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -62,6 +62,10 @@ class Google_Translate_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		// We never should show more than 1 instance of this.
 		if ( null === self::$instance ) {
+			$instance = wp_parse_args( $instance, array(
+				'title' => $this->default_title,
+			) );
+
 			wp_localize_script( 'google-translate-init', '_wp_google_translate_widget', array( 'lang' => get_locale() ) );
 			wp_enqueue_script( 'google-translate-init' );
 			wp_enqueue_script( 'google-translate' );

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -68,7 +68,7 @@ class Google_Translate_Widget extends WP_Widget {
 
 			$title = $instance['title'];
 
-			if ( false === $title ) {
+			if ( ! isset( $title ) ) {
 				$title = $this->default_title;
 			}
 


### PR DESCRIPTION
Until now, no title was displayed if you hadn't set a custom title.

#### Proposed changelog entry for your changes:

Translate Widget: display default title if no custom title was set.
