### PR TITLE
VideoPress: add notice for media-new.php

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -386,6 +386,34 @@ class Jetpack_JITM {
 		$jetpack->do_stats( 'server_side' );
 	}
 
+	/**
+	 * Display a JITM style message for the media-new page.
+	 *
+	 * @since 4.5
+	 */
+	function videopress_media_upload_warning_msg() {
+		$jitm_stats_url = Jetpack::build_stats_url( array( 'x_jetpack-jitm' => 'videopress' ) );
+
+		$upload_url   = admin_url( 'upload.php' );
+		$new_post_url = admin_url( 'post-new.php' );
+
+		$msg = sprintf( __( 'Only videos uploaded from within the <a href="%s">media library</a> or while creating a <a href="%s">new post</a> will be fully hosted by WordPress.com.', 'jetpack' ), esc_url( $upload_url ), esc_url( $new_post_url ) );
+		?>
+        <div class="jp-jitm" data-track="videopress-upload-warning" data-stats_url="<?php echo esc_url( $jitm_stats_url ); ?>">
+            <!-- <a href="#" data-module="videopress" class="dismiss"><span class="genericon genericon-close"></span></a>-->
+
+			<?php echo self::get_emblem(); ?>
+
+            <p class="msg">
+				<?php echo $msg; ?>
+            </p>
+            <p>
+                <a href="<?php echo esc_url( $upload_url ); ?>" title="<?php esc_attr_e( 'Upload a Video', 'jetpack' ); ?>" data-module="videopress" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-videopress-upload" class="button button-jetpack launch jptracks"><?php esc_html_e( 'Upload a Video Now', 'jetpack' ); ?></a>
+            </p>
+        </div>
+		<?php
+	}
+
 	/*
 	* Function to enqueue jitm css and js
 	*/

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -52,6 +52,8 @@ class Jetpack_VideoPress {
 
 		add_filter( 'wp_mime_type_icon', array( $this, 'wp_mime_type_icon' ), 10, 3 );
 
+		$this->add_media_new_notice();
+
 		VideoPress_Scheduler::init();
 		VideoPress_XMLRPC::init();
 	}
@@ -107,6 +109,22 @@ class Jetpack_VideoPress {
 		$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 
 		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
+	}
+
+	/**
+	 * Add a notice to the top of the media-new.php to let the user know how to upload a video.
+	 */
+	public function add_media_new_notice() {
+		global $pagenow;
+
+		if ( $pagenow != 'media-new.php' ) {
+			return;
+		}
+
+		$jitm = Jetpack_JITM::init();
+
+		add_action( 'admin_enqueue_scripts', array( $jitm, 'jitm_enqueue_files' ) );
+		add_action( 'admin_notices', array( $jitm, 'videopress_media_upload_warning_msg' ) );
 	}
 
 	/**


### PR DESCRIPTION
Currently, uploading to VideoPress is a tad confusing since you cannot upload via the media-new.php, as this is an older uploader.

This adds a notice to that page informing users where to go.

<img width="1049" alt="screen shot 2016-12-15 at 1 38 28 pm" src="https://cloud.githubusercontent.com/assets/195095/21239286/d5f62e8e-c2cb-11e6-9b99-def048847304.png">

## Testing

1) Add Jetpack Professional
2) Go to Media -> Add New
3) Verify the message is there
4) Make sure it isn't appearing in other places in the admin

