### PR TITLE
Ads: Updated Copy

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -760,12 +760,13 @@ export let WordAdsSettings = React.createClass( {
 	render() {
 		return (
 			<div>
+				<p>{ __( 'By default ads are shown at the end of every page, post, or the first article on your front page. You can also add them to the top of your site and to any widget area to increase your earnings!' ) }</p>
 				<form onSubmit={ this.props.onSubmit } >
 					<FormFieldset>
 						<ModuleSettingCheckbox
 							name={ 'enable_header_ad' }
 							{ ...this.props }
-							label={ __( 'Display an ad unit at the top of each page.' ) } />
+							label={ __( 'Display an ad unit at the top of your site.' ) } />
 						<FormButton
 							className="is-primary"
 							isSubmitting={ this.props.isSavingAnyOption() }

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -636,7 +636,7 @@ add_action( 'jetpack_learn_more_button_wordads', 'jetpack_wordads_more_link' );
 
 function jetpack_wordads_more_info() {
 	esc_html_e(
-		'By default, ads are shown at the end of every post. You can also add them to the top of your site and to any widget area to increase your earnings!'
+		'By default ads are shown at the end of every page, post, or the first article on your front page. You can also add them to the top of your site and to any widget area to increase your earnings!'
 		, 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_wordads', 'jetpack_wordads_more_info' );


### PR DESCRIPTION
Updated copy to help clarify where/when Ads will/can run.

**Module Info**
<img width="740" alt="screen shot 2016-12-15 at 12 09 03 pm" src="https://cloud.githubusercontent.com/assets/273708/21240255/534b916a-c2bf-11e6-815b-9eb8c9104dfb.png">

**Included Module Info after activation**
<img width="733" alt="screen shot 2016-12-15 at 12 29 04 pm" src="https://cloud.githubusercontent.com/assets/273708/21240908/2fadf042-c2c2-11e6-9cdd-b997764920e7.png">
