### PR TITLE
Fix empty Size box in attachment window

### DIFF
--- a/modules/videopress/js/videopress-uploader.js
+++ b/modules/videopress/js/videopress-uploader.js
@@ -53,7 +53,7 @@ window.wp = window.wp || {};
 					name: '',
 					nonces: { update: '', 'delete': '', edit: '' },
 					orientation: '',
-					sizes: {},
+					sizes: undefined,
 					status: '',
 					subtype: mimeParts[1] || '',
 					title: media.title || '',


### PR DESCRIPTION
Fixes #5901

When uploading a VideoPress video, the size box was showing up as empty. This is because we were defaulting the size element to an empty object. The core code however looks for `undefined` to decide when to hide this. Switching the default to `undefined` hides the box as expected.