### PR TITLE
Ads: Fix for header unit on Twenty (Seven|Fif|Four)teen.

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -119,7 +119,16 @@ class WordAds {
 		add_filter( 'the_excerpt', array( $this, 'insert_ad' ) );
 
 		if ( $this->option( 'enable_header_ad' ) ) {
-			add_action( 'wp_head', array( $this, 'insert_header_ad' ), 100 );
+			switch ( get_stylesheet() ) {
+				case 'twentyseventeen':
+				case 'twentyfifteen':
+				case 'twentyfourteen':
+					add_action( 'wp_footer', array( $this, 'insert_header_ad_special' ) );
+					break;
+				default:
+					add_action( 'wp_head', array( $this, 'insert_header_ad' ), 100 );
+					break;
+			}
 		}
 	}
 
@@ -225,6 +234,47 @@ HTML;
 	}
 
 	/**
+	 * Special cases for inserting header unit via jQuery
+	 *
+	 * @since 4.5.0
+	 */
+	function insert_header_ad_special() {
+		/**
+		 * Allow third-party tools to disable the display of header ads.
+		 *
+		 * @module wordads
+		 *
+		 * @since 4.5.0
+		 *
+		 * @param bool true Should the header unit be disabled. Default to false.
+		 */
+		if ( apply_filters( 'wordads_header_disable', false ) ) {
+			return;
+		}
+
+		$selector = '#content';
+		switch ( get_stylesheet() ) {
+			case 'twentyseventeen':
+				$selector = '#content';
+				break;
+			case 'twentyfifteen':
+				$selector = '#main';
+				break;
+			case 'twentyfourteen':
+				$selector = 'article:first';
+				break;
+		}
+
+		$ad_type = $this->option( 'wordads_house' ) ? 'house' : 'iponweb';
+		echo $this->get_ad( 'top', $ad_type );
+		echo <<<HTML
+		<script type="text/javascript">
+			jQuery('.wpcnt-header').insertBefore('$selector');
+		</script>
+HTML;
+	}
+
+	/**
 	 * Get the ad for the spot and type.
 	 * @param  string $spot top, side, or belowpost
 	 * @param  string $type iponweb or adsense
@@ -270,9 +320,10 @@ HTML;
 HTML;
 		}
 
+		$header = 'top' == $spot ? 'wpcnt-header' : '';
 		$about = __( 'About these ads', 'jetpack' );
 		return <<<HTML
-		<div class="wpcnt">
+		<div class="wpcnt $header">
 			<div class="wpa">
 				<a class="wpa-about" href="https://en.wordpress.com/about-these-ads/" rel="nofollow">$about</a>
 				<div class="u $spot">


### PR DESCRIPTION
WP default themes `Twenty Seventeen`, `Twenty Fifteen`, and `Twenty Fourteen` do "interesting" things with their headers and require special treatment. To solve this I'm manually inserting the header unit via jQuery before the page content.

**Twenty Seventeen**
<img width="1036" alt="screen shot 2016-12-15 at 7 43 38 pm" src="https://cloud.githubusercontent.com/assets/273708/21251071/66555f94-c2ff-11e6-8d3c-3e8b9ddcfbdd.png">

**Twenty Fifteen**
<img width="1238" alt="screen shot 2016-12-15 at 7 45 11 pm" src="https://cloud.githubusercontent.com/assets/273708/21251072/6929ea46-c2ff-11e6-890e-2e3eda9cc2eb.png">

**Twenty Fourteen**
<img width="1272" alt="screen shot 2016-12-15 at 7 45 44 pm" src="https://cloud.githubusercontent.com/assets/273708/21251077/704706c4-c2ff-11e6-93f8-ea86bd3f0c3f.png">

**To test**
1. Activate Ads module and select 'Display an ad unit at the top of each page.'
2. Activate either Twenty Seventeen, Fifteen, or Fourteen.