### PR TITLE
Follow Button: disable and remove from SVN

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -17,6 +17,7 @@ languages/jetpack.pot
 LICENSE.txt
 _inc/lib/icalendar-reader.php
 modules/shortcodes/upcoming-events.php
+modules/widgets/follow-button.php
 modules/widgets/upcoming-events.php
 to-test.md
 .editorconfig

--- a/modules/widgets/follow-button.php
+++ b/modules/widgets/follow-button.php
@@ -1,6 +1,7 @@
 <?php
 
-add_action( 'widgets_init', 'follow_button_register_widget' );
+// @todo Fix performance issues before shipping.
+//add_action( 'widgets_init', 'follow_button_register_widget' );
 function follow_button_register_widget() {
 	if ( Jetpack::is_active() ) {
 		register_widget( 'Follow_Button_Widget' );

--- a/to-test.md
+++ b/to-test.md
@@ -66,7 +66,6 @@ We ported existing shortcodes from WordPress.com to Jetpack. Give them a try in 
 
 We've added quite a few new widgets, so make sure you try them all:
 
-- **Follow Button**: allow people to follow your site from a widget.
 - **Authors**: display your authors on the front end of your site. *Note: it does not come with much styling, so it is up to the theme/user to style as desired.*
 - **Blog Stats**: A simple stat counter that will display the page views on the front end of your site.
 - **Milestone**: display a countdown to an upcoming event or milestone that you set.


### PR DESCRIPTION
@gravityrail noticed a pretty significant performance issue with this Widget: 

> I noticed that the follow button was rendering pretty slowly, so I did a trace on the call to /v1/batch and found that one of the batched requests is /sites/http://foo.com, which actually calls through to the Jetpack site in order to retrieve the site info.
> 
> This is pretty bad from a performance point of view (adds an extra second or two on my Dreamhost blog).  The call is NOT cached by the site (why??) and generates a call from WPCOM to the site for every single pageload.

We're going to pull it from 4.5 and will enable again pending performance updates.  