### PR TITLE
Publicize: Add should publicize post on the publish action

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -27,6 +27,8 @@ class Publicize extends Publicize_Base {
 
 		add_filter( 'publicize_checkbox_default', array( $this, 'publicize_checkbox_default' ), 10, 4 );
 
+		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags' ), 10, 2 );
+
 		add_action( 'wp_insert_post', array( $this, 'save_publicized' ), 11, 3 );
 
 		add_filter( 'jetpack_twitter_cards_site_tag', array( $this, 'enhaced_twitter_cards_site_tag' ) );
@@ -440,6 +442,25 @@ class Publicize extends Publicize_Base {
 			delete_post_meta( $post->ID, $this->PENDING );
 			update_post_meta( $post->ID, $this->POST_DONE . 'all', true );
 		}
+	}
+
+	function set_post_flags( $flags, $post ) {
+		$flags[ 'publicize_post' ] = false;
+		if ( ! $this->post_type_is_publicizeable( $post->post_type ) ) {
+			return $flags;
+		}
+
+		if ( ! apply_filters( 'publicize_should_publicize_published_post', true, $post ) ) {
+			return $flags;
+		}
+
+		$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
+		if ( empty( $connected_services ) ) {
+			return $flags;
+		}
+
+		$flags[ 'publicize_post' ] = true;
+		return $flags;
 	}
 
 	/**

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -476,12 +476,11 @@ class Publicize extends Publicize_Base {
 			return $flags;
 		}
 
-		$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
+		$connected_services = $this->get_services( 'connected' );
+
 		if ( empty( $connected_services ) ) {
 			return $flags;
 		}
-
-		if( )
 
 		$flags['publicize_post'] = true;
 

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -38,17 +38,18 @@ class Publicize extends Publicize_Base {
 
 		add_filter( 'jetpack_sharing_twitter_via', array( $this, 'get_publicized_twitter_account' ), 10, 2 );
 
-		include_once ( JETPACK__PLUGIN_DIR . 'modules/publicize/enhanced-open-graph.php' );
+		include_once( JETPACK__PLUGIN_DIR . 'modules/publicize/enhanced-open-graph.php' );
 	}
 
 	function force_user_connection() {
 		global $current_user;
-		$user_token = Jetpack_Data::get_access_token( $current_user->ID );
-		$is_user_connected = $user_token && !is_wp_error( $user_token );
+		$user_token        = Jetpack_Data::get_access_token( $current_user->ID );
+		$is_user_connected = $user_token && ! is_wp_error( $user_token );
 
 		// If the user is already connected via Jetpack, then we're good
-		if ( $is_user_connected )
+		if ( $is_user_connected ) {
 			return;
+		}
 
 		// If they're not connected, then remove the Publicize UI and tell them they need to connect first
 		global $publicize_ui;
@@ -60,7 +61,7 @@ class Publicize extends Publicize_Base {
 	}
 
 	function admin_page_warning() {
-		$jetpack = Jetpack::init();
+		$jetpack   = Jetpack::init();
 		$blog_name = get_bloginfo( 'blogname' );
 		if ( empty( $blog_name ) ) {
 			$blog_name = home_url( '/' );
@@ -71,13 +72,17 @@ class Publicize extends Publicize_Base {
 			<div class="jetpack-wrap-container">
 				<div class="jetpack-text-container">
 					<p><?php printf(
-						esc_html( wptexturize( __( "To use Publicize, you'll need to link your %s account to your WordPress.com account using the link below.", 'jetpack' ) ) ),
-						'<strong>' . esc_html( $blog_name ) . '</strong>'
-					); ?></p>
+							esc_html( wptexturize( __( "To use Publicize, you'll need to link your %s account to your WordPress.com account using the link below.", 'jetpack' ) ) ),
+							'<strong>' . esc_html( $blog_name ) . '</strong>'
+						); ?></p>
 					<p><?php echo esc_html( wptexturize( __( "If you don't have a WordPress.com account yet, you can sign up for free in just a few seconds.", 'jetpack' ) ) ); ?></p>
 				</div>
 				<div class="jetpack-install-container">
-					<p class="submit"><a href="<?php echo $jetpack->build_connect_url( false, menu_page_url( 'sharing', false ) ); ?>" class="button-connector" id="wpcom-connect"><?php esc_html_e( 'Link account with WordPress.com', 'jetpack' ); ?></a></p>
+					<p class="submit"><a
+							href="<?php echo $jetpack->build_connect_url( false, menu_page_url( 'sharing', false ) ); ?>"
+							class="button-connector"
+							id="wpcom-connect"><?php esc_html_e( 'Link account with WordPress.com', 'jetpack' ); ?></a>
+					</p>
 				</div>
 			</div>
 		</div>
@@ -101,6 +106,7 @@ class Publicize extends Publicize_Base {
 
 	function receive_updated_publicize_connections( $publicize_connections ) {
 		Jetpack_Options::update_option( 'publicize_connections', $publicize_connections );
+
 		return true;
 	}
 
@@ -111,18 +117,20 @@ class Publicize extends Publicize_Base {
 	}
 
 	function get_connections( $service_name, $_blog_id = false, $_user_id = false ) {
-		$connections = Jetpack_Options::get_option( 'publicize_connections' );
+		$connections           = Jetpack_Options::get_option( 'publicize_connections' );
 		$connections_to_return = array();
-		if ( !empty( $connections ) && is_array( $connections ) ) {
-			if ( !empty( $connections[$service_name] ) ) {
-				foreach( $connections[$service_name] as $id => $connection ) {
+		if ( ! empty( $connections ) && is_array( $connections ) ) {
+			if ( ! empty( $connections[ $service_name ] ) ) {
+				foreach ( $connections[ $service_name ] as $id => $connection ) {
 					if ( 0 == $connection['connection_data']['user_id'] || $this->user_id() == $connection['connection_data']['user_id'] ) {
-						$connections_to_return[$id] = $connection;
+						$connections_to_return[ $id ] = $connection;
 					}
 				}
 			}
+
 			return $connections_to_return;
 		}
+
 		return false;
 	}
 
@@ -137,62 +145,64 @@ class Publicize extends Publicize_Base {
 
 	function admin_page_load() {
 		if ( isset( $_GET['action'] ) ) {
-			if ( isset( $_GET['service'] ) )
+			if ( isset( $_GET['service'] ) ) {
 				$service_name = $_GET['service'];
+			}
 
 			switch ( $_GET['action'] ) {
-			case 'error':
-				add_action( 'pre_admin_screen_sharing', array( $this, 'display_connection_error' ), 9 );
-				break;
+				case 'error':
+					add_action( 'pre_admin_screen_sharing', array( $this, 'display_connection_error' ), 9 );
+					break;
 
-			case 'request':
-				check_admin_referer( 'keyring-request', 'kr_nonce' );
-				check_admin_referer( "keyring-request-$service_name", 'nonce' );
+				case 'request':
+					check_admin_referer( 'keyring-request', 'kr_nonce' );
+					check_admin_referer( "keyring-request-$service_name", 'nonce' );
 
-				$verification = Jetpack::create_nonce( 'publicize' );
+					$verification = Jetpack::create_nonce( 'publicize' );
 
-				$stats_options = get_option( 'stats_options' );
-				$wpcom_blog_id = Jetpack_Options::get_option('id');
-				$wpcom_blog_id = !empty( $wpcom_blog_id ) ? $wpcom_blog_id : $stats_options['blog_id'];
+					$stats_options = get_option( 'stats_options' );
+					$wpcom_blog_id = Jetpack_Options::get_option( 'id' );
+					$wpcom_blog_id = ! empty( $wpcom_blog_id ) ? $wpcom_blog_id : $stats_options['blog_id'];
 
-				$user = wp_get_current_user();
-				$redirect = $this->api_url( $service_name, urlencode_deep( array(
-					'action'       => 'request',
-					'redirect_uri' => add_query_arg( array( 'action' => 'done' ), menu_page_url( 'sharing', false ) ),
-					'for'          => 'publicize', // required flag that says this connection is intended for publicize
-					'siteurl'      => site_url(),
-					'state'        => $user->ID,
-					'blog_id'      => $wpcom_blog_id,
-					'secret_1'	   => $verification['secret_1'],
-					'secret_2'     => $verification['secret_2'],
-					'eol'		   => $verification['eol'],
-				) ) );
-				wp_redirect( $redirect );
-				exit;
-				break;
+					$user     = wp_get_current_user();
+					$redirect = $this->api_url( $service_name, urlencode_deep( array(
+						'action'       => 'request',
+						'redirect_uri' => add_query_arg( array( 'action' => 'done' ), menu_page_url( 'sharing', false ) ),
+						'for'          => 'publicize',
+						// required flag that says this connection is intended for publicize
+						'siteurl'      => site_url(),
+						'state'        => $user->ID,
+						'blog_id'      => $wpcom_blog_id,
+						'secret_1'     => $verification['secret_1'],
+						'secret_2'     => $verification['secret_2'],
+						'eol'          => $verification['eol'],
+					) ) );
+					wp_redirect( $redirect );
+					exit;
+					break;
 
-			case 'completed':
-				Jetpack::load_xml_rpc_client();
-				$xml = new Jetpack_IXR_Client();
-				$xml->query( 'jetpack.fetchPublicizeConnections' );
+				case 'completed':
+					Jetpack::load_xml_rpc_client();
+					$xml = new Jetpack_IXR_Client();
+					$xml->query( 'jetpack.fetchPublicizeConnections' );
 
-				if ( ! $xml->isError() ) {
-					$response = $xml->getResponse();
-					Jetpack_Options::update_option( 'publicize_connections', $response );
-				}
+					if ( ! $xml->isError() ) {
+						$response = $xml->getResponse();
+						Jetpack_Options::update_option( 'publicize_connections', $response );
+					}
 
-				break;
+					break;
 
-			case 'delete':
-				$id = $_GET['id'];
+				case 'delete':
+					$id = $_GET['id'];
 
-				check_admin_referer( 'keyring-request', 'kr_nonce' );
-				check_admin_referer( "keyring-request-$service_name", 'nonce' );
+					check_admin_referer( 'keyring-request', 'kr_nonce' );
+					check_admin_referer( "keyring-request-$service_name", 'nonce' );
 
-				$this->disconnect( $service_name, $id );
+					$this->disconnect( $service_name, $id );
 
-				add_action( 'admin_notices', array( $this, 'display_disconnected' ) );
-				break;
+					add_action( 'admin_notices', array( $this, 'display_disconnected' ) );
+					break;
 			}
 		}
 
@@ -210,26 +220,26 @@ class Publicize extends Publicize_Base {
 		$code = false;
 		if ( isset( $_GET['service'] ) ) {
 			$service_name = $_GET['service'];
-			$error = sprintf( __( 'There was a problem connecting to %s to create an authorized connection. Please try again in a moment.', 'jetpack' ), Publicize::get_service_label( $service_name ) );
+			$error        = sprintf( __( 'There was a problem connecting to %s to create an authorized connection. Please try again in a moment.', 'jetpack' ), Publicize::get_service_label( $service_name ) );
 		} else {
 			if ( isset( $_GET['publicize_error'] ) ) {
 				$code = strtolower( $_GET['publicize_error'] );
 				switch ( $code ) {
-				case '400':
-					$error = __( 'An invalid request was made. This normally means that something intercepted or corrupted the request from your server to the Jetpack Server. Try again and see if it works this time.', 'jetpack' );
-					break;
-				case 'secret_mismatch':
-					$error = __( 'We could not verify that your server is making an authorized request. Please try again, and make sure there is nothing interfering with requests from your server to the Jetpack Server.', 'jetpack' );
-					break;
-				case 'empty_blog_id':
-					$error = __( 'No blog_id was included in your request. Please try disconnecting Jetpack from WordPress.com and then reconnecting it. Once you have done that, try connecting Publicize again.', 'jetpack' );
-					break;
-				case 'empty_state':
-					$error = sprintf( __( 'No user information was included in your request. Please make sure that your user account has connected to Jetpack. Connect your user account by going to the <a href="%s">Jetpack page</a> within wp-admin.', 'jetpack' ), Jetpack::admin_url() );
-					break;
-				default:
-					$error = __( 'Something which should never happen, happened. Sorry about that. If you try again, maybe it will work.', 'jetpack' );
-					break;
+					case '400':
+						$error = __( 'An invalid request was made. This normally means that something intercepted or corrupted the request from your server to the Jetpack Server. Try again and see if it works this time.', 'jetpack' );
+						break;
+					case 'secret_mismatch':
+						$error = __( 'We could not verify that your server is making an authorized request. Please try again, and make sure there is nothing interfering with requests from your server to the Jetpack Server.', 'jetpack' );
+						break;
+					case 'empty_blog_id':
+						$error = __( 'No blog_id was included in your request. Please try disconnecting Jetpack from WordPress.com and then reconnecting it. Once you have done that, try connecting Publicize again.', 'jetpack' );
+						break;
+					case 'empty_state':
+						$error = sprintf( __( 'No user information was included in your request. Please make sure that your user account has connected to Jetpack. Connect your user account by going to the <a href="%s">Jetpack page</a> within wp-admin.', 'jetpack' ), Jetpack::admin_url() );
+						break;
+					default:
+						$error = __( 'Something which should never happen, happened. Sorry about that. If you try again, maybe it will work.', 'jetpack' );
+						break;
 				}
 			} else {
 				$error = __( 'There was a problem connecting with Publicize. Please try again in a moment.', 'jetpack' );
@@ -239,9 +249,14 @@ class Publicize extends Publicize_Base {
 		?>
 		<div id="message" class="jetpack-message jetpack-err">
 			<div class="squeezer">
-				<h2><?php echo wp_kses( $error, array( 'a' => array( 'href' => true ), 'code' => true, 'strong' => true, 'br' => true, 'b' => true ) ); ?></h2>
+				<h2><?php echo wp_kses( $error, array( 'a'      => array( 'href' => true ),
+				                                       'code'   => true,
+				                                       'strong' => true,
+				                                       'br'     => true,
+				                                       'b'      => true
+					) ); ?></h2>
 				<?php if ( $code ) : ?>
-				<p><?php printf( __( 'Error code: %s', 'jetpack' ), esc_html( stripslashes( $code ) ) ); ?></p>
+					<p><?php printf( __( 'Error code: %s', 'jetpack' ), esc_html( stripslashes( $code ) ) ); ?></p>
 				<?php endif; ?>
 			</div>
 		</div>
@@ -258,14 +273,15 @@ class Publicize extends Publicize_Base {
 		if ( 'on' == $_REQUEST['global'] ) {
 			$id = $_REQUEST['connection'];
 
-			if ( !current_user_can( $this->GLOBAL_CAP ) )
+			if ( ! current_user_can( $this->GLOBAL_CAP ) ) {
 				return;
+			}
 
 			Jetpack::load_xml_rpc_client();
 			$xml = new Jetpack_IXR_Client();
 			$xml->query( 'jetpack.globalizePublicizeConnection', $id, 'globalize' );
 
-			if ( !$xml->isError() ) {
+			if ( ! $xml->isError() ) {
 				$response = $xml->getResponse();
 				Jetpack_Options::update_option( 'publicize_connections', $response );
 			}
@@ -273,11 +289,12 @@ class Publicize extends Publicize_Base {
 	}
 
 	/**
-	* Gets a URL to the public-api actions. Works like WP's admin_url
-	*
-	* @param string $service Shortname of a specific service.
-	* @return URL to specific public-api process
-	*/
+	 * Gets a URL to the public-api actions. Works like WP's admin_url
+	 *
+	 * @param string $service Shortname of a specific service.
+	 *
+	 * @return URL to specific public-api process
+	 */
 	// on WordPress.com this is/calls Keyring::admin_url
 	function api_url( $service = false, $params = array() ) {
 		/**
@@ -291,11 +308,13 @@ class Publicize extends Publicize_Base {
 		 */
 		$url = apply_filters( 'publicize_api_url', 'https://public-api.wordpress.com/connect/?jetpack=publicize' );
 
-		if ( $service )
+		if ( $service ) {
 			$url = add_query_arg( array( 'service' => $service ), $url );
+		}
 
-		if ( count ( $params ) )
+		if ( count( $params ) ) {
 			$url = add_query_arg( $params, $url );
+		}
 
 		return $url;
 	}
@@ -303,7 +322,7 @@ class Publicize extends Publicize_Base {
 	function connect_url( $service_name ) {
 		return add_query_arg( array(
 			'action'   => 'request',
-			'service'  =>  $service_name,
+			'service'  => $service_name,
 			'kr_nonce' => wp_create_nonce( 'keyring-request' ),
 			'nonce'    => wp_create_nonce( "keyring-request-$service_name" ),
 		), menu_page_url( 'sharing', false ) );
@@ -321,7 +340,7 @@ class Publicize extends Publicize_Base {
 	}
 
 	function disconnect_url( $service_name, $id ) {
-		return add_query_arg( array (
+		return add_query_arg( array(
 			'action'   => 'delete',
 			'service'  => $service_name,
 			'id'       => $id,
@@ -331,16 +350,17 @@ class Publicize extends Publicize_Base {
 	}
 
 	function get_services( $filter ) {
-		if ( !in_array( $filter, array( 'all', 'connected' ) ) )
+		if ( ! in_array( $filter, array( 'all', 'connected' ) ) ) {
 			$filter = 'all';
+		}
 
 		$services = array(
-				'facebook'        => array(),
-				'twitter'         => array(),
-				'linkedin'        => array(),
-				'tumblr'          => array(),
-				'path'            => array(),
-				'google_plus'     => array(),
+			'facebook'    => array(),
+			'twitter'     => array(),
+			'linkedin'    => array(),
+			'tumblr'      => array(),
+			'path'        => array(),
+			'google_plus' => array(),
 		);
 
 		if ( 'all' == $filter ) {
@@ -349,9 +369,11 @@ class Publicize extends Publicize_Base {
 			$connected_services = array();
 			foreach ( $services as $service => $empty ) {
 				$connections = $this->get_connections( $service );
-				if ( $connections )
-					$connected_services[$service] = $connections;
+				if ( $connections ) {
+					$connected_services[ $service ] = $connections;
+				}
 			}
+
 			return $connected_services;
 		}
 	}
@@ -383,9 +405,9 @@ class Publicize extends Publicize_Base {
 	}
 
 	function test_connection( $service_name, $connection ) {
-		$connection_test_passed = true;
+		$connection_test_passed  = true;
 		$connection_test_message = '';
-		$user_can_refresh = false;
+		$user_can_refresh        = false;
 
 		$id = $this->get_connection_id( $connection );
 
@@ -394,9 +416,9 @@ class Publicize extends Publicize_Base {
 		$xml->query( 'jetpack.testPublicizeConnection', $id );
 
 		if ( $xml->isError() ) {
-			$xml_response = $xml->getResponse();
+			$xml_response            = $xml->getResponse();
 			$connection_test_message = $xml_response['faultString'];
-			$connection_test_passed = false;
+			$connection_test_passed  = false;
 		}
 
 		// Bail if all is well
@@ -407,15 +429,15 @@ class Publicize extends Publicize_Base {
 		// Set up refresh if the user can
 		$user_can_refresh = current_user_can( $this->GLOBAL_CAP );
 		if ( $user_can_refresh ) {
-			$nonce = wp_create_nonce( "keyring-request-" . $service_name );
+			$nonce        = wp_create_nonce( "keyring-request-" . $service_name );
 			$refresh_text = sprintf( _x( 'Refresh connection with %s', 'Refresh connection with {social media service}', 'jetpack' ), $this->get_service_label( $service_name ) );
-			$refresh_url = $this->refresh_url( $service_name );
+			$refresh_url  = $this->refresh_url( $service_name );
 		}
 
 		$error_data = array(
 			'user_can_refresh' => $user_can_refresh,
-			'refresh_text' => $refresh_text,
-			'refresh_url' => $refresh_url
+			'refresh_text'     => $refresh_text,
+			'refresh_url'      => $refresh_url
 		);
 
 		return new WP_Error( 'pub_conn_test_failed', $connection_test_message, $error_data );
@@ -445,11 +467,11 @@ class Publicize extends Publicize_Base {
 	}
 
 	function set_post_flags( $flags, $post ) {
-		$flags[ 'publicize_post' ] = false;
+		$flags['publicize_post'] = false;
 		if ( ! $this->post_type_is_publicizeable( $post->post_type ) ) {
 			return $flags;
 		}
-
+		/** This filter is already documented in modules/publicize/publicize-jetpack.php */
 		if ( ! apply_filters( 'publicize_should_publicize_published_post', true, $post ) ) {
 			return $flags;
 		}
@@ -459,29 +481,32 @@ class Publicize extends Publicize_Base {
 			return $flags;
 		}
 
-		$flags[ 'publicize_post' ] = true;
+		if( )
+
+		$flags['publicize_post'] = true;
+
 		return $flags;
 	}
 
 	/**
-	* Options Code
-	*/
+	 * Options Code
+	 */
 
 	function options_page_facebook() {
 		$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
-		$connection = $connected_services['facebook'][$_REQUEST['connection']];
-		$options_to_show = ( ! empty( $connection['connection_data']['meta']['options_responses'] ) ? $connection['connection_data']['meta']['options_responses'] : false );
+		$connection         = $connected_services['facebook'][ $_REQUEST['connection'] ];
+		$options_to_show    = ( ! empty( $connection['connection_data']['meta']['options_responses'] ) ? $connection['connection_data']['meta']['options_responses'] : false );
 
 		// Nonce check
 		check_admin_referer( 'options_page_facebook_' . $_REQUEST['connection'] );
 
-		$me    = ( ! empty( $options_to_show[0] )         ? $options_to_show[0]         : false );
+		$me    = ( ! empty( $options_to_show[0] ) ? $options_to_show[0] : false );
 		$pages = ( ! empty( $options_to_show[1]['data'] ) ? $options_to_show[1]['data'] : false );
 
 		$profile_checked = true;
-		$page_selected = false;
+		$page_selected   = false;
 
-		if ( !empty( $connection['connection_data']['meta']['facebook_page'] ) ) {
+		if ( ! empty( $connection['connection_data']['meta']['facebook_page'] ) ) {
 			$found = false;
 			if ( is_array( $pages->data ) ) {
 				foreach ( $pages->data as $page ) {
@@ -494,7 +519,7 @@ class Publicize extends Publicize_Base {
 
 			if ( $found ) {
 				$profile_checked = false;
-				$page_selected = $connection['connection_data']['meta']['facebook_page'];
+				$page_selected   = $connection['connection_data']['meta']['facebook_page'];
 			}
 		}
 
@@ -507,51 +532,63 @@ class Publicize extends Publicize_Base {
 			Publicize_UI::connected_notice( 'Facebook' );
 			$update_notice = ob_get_clean();
 
-			if ( ! empty( $update_notice ) )
+			if ( ! empty( $update_notice ) ) {
 				echo $update_notice;
+			}
 			?>
 
-			<?php if ( !empty( $me['name'] ) ) : ?>
-			<p><?php printf(
-				esc_html__( 'Publicize to my %s:', 'jetpack' ),
-				'<strong>' . esc_html__( 'Facebook Wall', 'jetpack' ) . '</strong>'
-			); ?></p>
-			<table id="option-profile">
-				<tbody>
+			<?php if ( ! empty( $me['name'] ) ) : ?>
+				<p><?php printf(
+						esc_html__( 'Publicize to my %s:', 'jetpack' ),
+						'<strong>' . esc_html__( 'Facebook Wall', 'jetpack' ) . '</strong>'
+					); ?></p>
+				<table id="option-profile">
+					<tbody>
 					<tr>
-						<td class="radio"><input type="radio" name="option" data-type="profile" id="<?php echo esc_attr( $me['id'] ) ?>" value="" <?php checked( $profile_checked, true ); ?> /></td>
-						<td class="thumbnail"><label for="<?php echo esc_attr( $me['id'] ) ?>"><img src="<?php echo esc_url( $me['picture']['data']['url'] ) ?>" width="50" height="50" /></label></td>
-						<td class="details"><label for="<?php echo esc_attr( $me['id'] ) ?>"><?php echo esc_html( $me['name'] ) ?></label></td>
+						<td class="radio"><input type="radio" name="option" data-type="profile"
+						                         id="<?php echo esc_attr( $me['id'] ) ?>"
+						                         value="" <?php checked( $profile_checked, true ); ?> /></td>
+						<td class="thumbnail"><label for="<?php echo esc_attr( $me['id'] ) ?>"><img
+									src="<?php echo esc_url( $me['picture']['data']['url'] ) ?>" width="50"
+									height="50"/></label></td>
+						<td class="details"><label
+								for="<?php echo esc_attr( $me['id'] ) ?>"><?php echo esc_html( $me['name'] ) ?></label>
+						</td>
 					</tr>
-				</tbody>
-			</table>
+					</tbody>
+				</table>
 			<?php endif; ?>
 
 			<?php if ( $pages ) : ?>
 
 				<p><?php printf(
-					esc_html__( 'Publicize to my %s:', 'jetpack' ),
-					'<strong>' . esc_html__( 'Facebook Page', 'jetpack' ) . '</strong>'
-				); ?></p>
+						esc_html__( 'Publicize to my %s:', 'jetpack' ),
+						'<strong>' . esc_html__( 'Facebook Page', 'jetpack' ) . '</strong>'
+					); ?></p>
 				<table id="option-fb-fanpage">
 					<tbody>
 
-						<?php foreach ( $pages as $i => $page ) : ?>
-							<?php if ( ! ( $i % 2 ) ) : ?>
-								<tr>
-							<?php endif; ?>
-									<td class="radio"><input type="radio" name="option" data-type="page" id="<?php echo esc_attr( $page['id'] ) ?>" value="<?php echo esc_attr( $page['id'] ) ?>" <?php checked( $page_selected && $page_selected == $page['id'], true ); ?> /></td>
-									<td class="thumbnail"><label for="<?php echo esc_attr( $page['id'] ) ?>"><img src="<?php echo esc_url( str_replace( '_s', '_q', $page['picture']['data']['url'] ) ) ?>" width="50" height="50" /></label></td>
-									<td class="details">
-										<label for="<?php echo esc_attr( $page['id'] ) ?>">
-											<span class="name"><?php echo esc_html( $page['name'] ) ?></span><br/>
-											<span class="category"><?php echo esc_html( $page['category'] ) ?></span>
-										</label>
-									</td>
-							<?php if ( ( $i % 2 ) || ( $i == count( $pages ) - 1 ) ): ?>
-								</tr>
-							<?php endif; ?>
-						<?php endforeach; ?>
+					<?php foreach ( $pages as $i => $page ) : ?>
+						<?php if ( ! ( $i % 2 ) ) : ?>
+							<tr>
+						<?php endif; ?>
+						<td class="radio"><input type="radio" name="option" data-type="page"
+						                         id="<?php echo esc_attr( $page['id'] ) ?>"
+						                         value="<?php echo esc_attr( $page['id'] ) ?>" <?php checked( $page_selected && $page_selected == $page['id'], true ); ?> />
+						</td>
+						<td class="thumbnail"><label for="<?php echo esc_attr( $page['id'] ) ?>"><img
+									src="<?php echo esc_url( str_replace( '_s', '_q', $page['picture']['data']['url'] ) ) ?>"
+									width="50" height="50"/></label></td>
+						<td class="details">
+							<label for="<?php echo esc_attr( $page['id'] ) ?>">
+								<span class="name"><?php echo esc_html( $page['name'] ) ?></span><br/>
+								<span class="category"><?php echo esc_html( $page['category'] ) ?></span>
+							</label>
+						</td>
+						<?php if ( ( $i % 2 ) || ( $i == count( $pages ) - 1 ) ): ?>
+							</tr>
+						<?php endif; ?>
+					<?php endforeach; ?>
 
 					</tbody>
 				</table>
@@ -561,7 +598,10 @@ class Publicize extends Publicize_Base {
 			<?php Publicize_UI::global_checkbox( 'facebook', $_REQUEST['connection'] ); ?>
 
 			<p style="text-align: center;">
-				<input type="submit" value="<?php esc_attr_e( 'OK', 'jetpack' ) ?>" class="button fb-options save-options" name="save" data-connection="<?php echo esc_attr( $_REQUEST['connection'] ); ?>" rel="<?php echo wp_create_nonce('save_fb_token_' . $_REQUEST['connection'] ) ?>" />
+				<input type="submit" value="<?php esc_attr_e( 'OK', 'jetpack' ) ?>"
+				       class="button fb-options save-options" name="save"
+				       data-connection="<?php echo esc_attr( $_REQUEST['connection'] ); ?>"
+				       rel="<?php echo wp_create_nonce( 'save_fb_token_' . $_REQUEST['connection'] ) ?>"/>
 			</p><br/>
 		</div>
 
@@ -576,25 +616,26 @@ class Publicize extends Publicize_Base {
 
 		// Check for a numeric page ID
 		$page_id = $_POST['selected_id'];
-		if ( !ctype_digit( $page_id ) )
+		if ( ! ctype_digit( $page_id ) ) {
 			die( 'Security check' );
+		}
 
 		if ( isset( $_POST['selected_id'] ) && 'profile' == $_POST['type'] ) {
 			// Publish to User Wall/Profile
 			$options = array(
-				'facebook_page'       => null,
-				'facebook_profile'    => true
+				'facebook_page'    => null,
+				'facebook_profile' => true
 			);
 
 		} else {
-			if ( 'page' != $_POST['type'] || !isset( $_POST['selected_id'] ) ) {
+			if ( 'page' != $_POST['type'] || ! isset( $_POST['selected_id'] ) ) {
 				return;
 			}
 
 			// Publish to Page
 			$options = array(
-				'facebook_page'       => $page_id,
-				'facebook_profile'    => null
+				'facebook_page'    => $page_id,
+				'facebook_profile' => null
 			);
 		}
 
@@ -602,7 +643,7 @@ class Publicize extends Publicize_Base {
 		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.setPublicizeOptions', $id, $options );
 
-		if ( !$xml->isError() ) {
+		if ( ! $xml->isError() ) {
 			$response = $xml->getResponse();
 			Jetpack_Options::update_option( 'publicize_connections', $response );
 		}
@@ -615,15 +656,15 @@ class Publicize extends Publicize_Base {
 		check_admin_referer( 'options_page_tumblr_' . $_REQUEST['connection'] );
 
 		$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
-		$connection = $connected_services['tumblr'][$_POST['connection']];
-		$options_to_show = $connection['connection_data']['meta']['options_responses'];
-		$request = $options_to_show[0];
+		$connection         = $connected_services['tumblr'][ $_POST['connection'] ];
+		$options_to_show    = $connection['connection_data']['meta']['options_responses'];
+		$request            = $options_to_show[0];
 
 		$blogs = $request['response']['user']['blogs'];
 
 		$blog_selected = false;
 
-		if ( !empty( $connection['connection_data']['meta']['tumblr_base_hostname'] ) ) {
+		if ( ! empty( $connection['connection_data']['meta']['tumblr_base_hostname'] ) ) {
 			foreach ( $blogs as $blog ) {
 				if ( $connection['connection_data']['meta']['tumblr_base_hostname'] == $this->get_basehostname( $blog['url'] ) ) {
 					$blog_selected = $connection['connection_data']['meta']['tumblr_base_hostname'];
@@ -634,10 +675,11 @@ class Publicize extends Publicize_Base {
 		}
 
 		// Use their Primary blog if they haven't selected one yet
-		if ( !$blog_selected ) {
+		if ( ! $blog_selected ) {
 			foreach ( $blogs as $blog ) {
-				if ( $blog['primary'] )
+				if ( $blog['primary'] ) {
 					$blog_selected = $this->get_basehostname( $blog['url'] );
+				}
 			}
 		} ?>
 
@@ -648,33 +690,39 @@ class Publicize extends Publicize_Base {
 			Publicize_UI::connected_notice( 'Tumblr' );
 			$update_notice = ob_get_clean();
 
-			if ( ! empty( $update_notice ) )
+			if ( ! empty( $update_notice ) ) {
 				echo $update_notice;
+			}
 			?>
 
 			<p><?php printf(
-				esc_html__( 'Publicize to my %s:', 'jetpack' ),
-				'<strong>' . esc_html__( 'Tumblr blog', 'jetpack' ) . '</strong>'
-			); ?></p>
+					esc_html__( 'Publicize to my %s:', 'jetpack' ),
+					'<strong>' . esc_html__( 'Tumblr blog', 'jetpack' ) . '</strong>'
+				); ?></p>
 
 			<ul id="option-tumblr-blog">
 
-			<?php
-			foreach ( $blogs as $blog ) {
-				$url = $this->get_basehostname( $blog['url'] ); ?>
-				<li>
-					<input type="radio" name="option" data-type="blog" id="<?php echo esc_attr( $url ) ?>" value="<?php echo esc_attr( $url ) ?>" <?php checked( $blog_selected == $url, true ); ?> />
-					<label for="<?php echo esc_attr( $url ) ?>"><span class="name"><?php echo esc_html( $blog['title'] ) ?></span></label>
-				</li>
-			<?php } ?>
+				<?php
+				foreach ( $blogs as $blog ) {
+					$url = $this->get_basehostname( $blog['url'] ); ?>
+					<li>
+						<input type="radio" name="option" data-type="blog" id="<?php echo esc_attr( $url ) ?>"
+						       value="<?php echo esc_attr( $url ) ?>" <?php checked( $blog_selected == $url, true ); ?> />
+						<label for="<?php echo esc_attr( $url ) ?>"><span
+								class="name"><?php echo esc_html( $blog['title'] ) ?></span></label>
+					</li>
+				<?php } ?>
 
 			</ul>
 
 			<?php Publicize_UI::global_checkbox( 'tumblr', $_REQUEST['connection'] ); ?>
 
 			<p style="text-align: center;">
-				<input type="submit" value="<?php esc_attr_e( 'OK', 'jetpack' ) ?>" class="button tumblr-options save-options" name="save" data-connection="<?php echo esc_attr( $_REQUEST['connection'] ); ?>" rel="<?php echo wp_create_nonce( 'save_tumblr_blog_' . $_REQUEST['connection'] ) ?>" />
-			</p> <br />
+				<input type="submit" value="<?php esc_attr_e( 'OK', 'jetpack' ) ?>"
+				       class="button tumblr-options save-options" name="save"
+				       data-connection="<?php echo esc_attr( $_REQUEST['connection'] ); ?>"
+				       rel="<?php echo wp_create_nonce( 'save_tumblr_blog_' . $_REQUEST['connection'] ) ?>"/>
+			</p> <br/>
 		</div>
 
 		<?php
@@ -696,7 +744,7 @@ class Publicize extends Publicize_Base {
 		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.setPublicizeOptions', $id, $options );
 
-		if ( !$xml->isError() ) {
+		if ( ! $xml->isError() ) {
 			$response = $xml->getResponse();
 			Jetpack_Options::update_option( 'publicize_connections', $response );
 		}
@@ -704,15 +752,37 @@ class Publicize extends Publicize_Base {
 		$this->globalization();
 	}
 
-	function options_page_twitter() { Publicize_UI::options_page_other( 'twitter' ); }
-	function options_page_linkedin() { Publicize_UI::options_page_other( 'linkedin' ); }
-	function options_page_path() { Publicize_UI::options_page_other( 'path' ); }
-	function options_page_google_plus() { Publicize_UI::options_page_other( 'google_plus' ); }
+	function options_page_twitter() {
+		Publicize_UI::options_page_other( 'twitter' );
+	}
 
-	function options_save_twitter() { $this->options_save_other( 'twitter' ); }
-	function options_save_linkedin() { $this->options_save_other( 'linkedin' ); }
-	function options_save_path() { $this->options_save_other( 'path' ); }
-	function options_save_google_plus() { $this->options_save_other( 'google_plus' ); }
+	function options_page_linkedin() {
+		Publicize_UI::options_page_other( 'linkedin' );
+	}
+
+	function options_page_path() {
+		Publicize_UI::options_page_other( 'path' );
+	}
+
+	function options_page_google_plus() {
+		Publicize_UI::options_page_other( 'google_plus' );
+	}
+
+	function options_save_twitter() {
+		$this->options_save_other( 'twitter' );
+	}
+
+	function options_save_linkedin() {
+		$this->options_save_other( 'linkedin' );
+	}
+
+	function options_save_path() {
+		$this->options_save_other( 'path' );
+	}
+
+	function options_save_google_plus() {
+		$this->options_save_other( 'google_plus' );
+	}
 
 	function options_save_other( $service_name ) {
 		// Nonce check
@@ -721,25 +791,28 @@ class Publicize extends Publicize_Base {
 	}
 
 	/**
-	* Already-published posts should not be Publicized by default. This filter sets checked to
-	* false if a post has already been published.
-	*/
+	 * Already-published posts should not be Publicized by default. This filter sets checked to
+	 * false if a post has already been published.
+	 */
 	function publicize_checkbox_default( $checked, $post_id, $name, $connection ) {
-		if ( 'publish' == get_post_status( $post_id ) )
+		if ( 'publish' == get_post_status( $post_id ) ) {
 			return false;
+		}
 
 		return $checked;
 	}
 
 	/**
-	* If there's only one shared connection to Twitter set it as twitter:site tag.
-	*/
+	 * If there's only one shared connection to Twitter set it as twitter:site tag.
+	 */
 	function enhaced_twitter_cards_site_tag( $tag ) {
 		$custom_site_tag = get_option( 'jetpack-twitter-cards-site-tag' );
-		if( ! empty( $custom_site_tag ) )
+		if ( ! empty( $custom_site_tag ) ) {
 			return $tag;
-		if ( ! $this->is_enabled('twitter') )
+		}
+		if ( ! $this->is_enabled( 'twitter' ) ) {
 			return $tag;
+		}
 		$connections = $this->get_connections( 'twitter' );
 		foreach ( $connections as $connection ) {
 			$connection_meta = $this->get_connection_meta( $connection );
@@ -748,12 +821,13 @@ class Publicize extends Publicize_Base {
 				return $this->get_display_name( 'twitter', $connection );
 			}
 		}
+
 		return $tag;
 	}
 
 	function save_publicized_twitter_account( $submit_post, $post_id, $service_name, $connection ) {
 		if ( 'twitter' == $service_name && $submit_post ) {
-			$connection_meta = $this->get_connection_meta( $connection );
+			$connection_meta        = $this->get_connection_meta( $connection );
 			$publicize_twitter_user = get_post_meta( $post_id, '_publicize_twitter_user' );
 			if ( empty( $publicize_twitter_user ) || 0 != $connection_meta['connection_data']['user_id'] ) {
 				update_post_meta( $post_id, '_publicize_twitter_user', $this->get_display_name( 'twitter', $connection ) );
@@ -769,13 +843,14 @@ class Publicize extends Publicize_Base {
 		if ( ! empty( $account ) ) {
 			return $account;
 		}
+
 		return '';
 	}
 
 	/**
-	* Save the Publicized Facebook account when publishing a post
-	* Use only Personal accounts, not Facebook Pages
-	*/
+	 * Save the Publicized Facebook account when publishing a post
+	 * Use only Personal accounts, not Facebook Pages
+	 */
 	function save_publicized_facebook_account( $submit_post, $post_id, $service_name, $connection ) {
 		$connection_meta = $this->get_connection_meta( $connection );
 		if ( 'facebook' == $service_name && isset( $connection_meta['connection_data']['meta']['facebook_profile'] ) && $submit_post ) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,9 +31,6 @@
 		<testsuite name="json-api">
 			<file>tests/php/test_class.json-api-jetpack-endpoints.php</file>
 		</testsuite>
-		<testsuite name="contact-form">
-			<directory prefix="test_" suffix=".php">tests/php/modules/contact-form</directory>
-		</testsuite>
 		<testsuite name="infinite-scroll">
 			<directory prefix="test_" suffix=".php">tests/php/modules/infinite-scroll</directory>
 		</testsuite>
@@ -69,6 +66,9 @@
 		</testsuite>
 		<testsuite name="idc">
 			<file>tests/php/test_class.jetpack-idc.php</file>
+		</testsuite>
+		<testsuite name="contact-form">
+			<directory prefix="test_" suffix=".php">tests/php/modules/contact-form</directory>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -55,6 +55,9 @@
 		<testsuite name="subscriptions">
 			<directory prefix="test_" suffix=".php">tests/php/modules/subscriptions</directory>
 		</testsuite>
+		<testsuite name="contact-form">
+			<directory prefix="test_" suffix=".php">tests/php/modules/contact-form</directory>
+		</testsuite>
 		<testsuite name="sync">
 			<directory prefix="test_" suffix=".php">tests/php/sync</directory>
 		</testsuite>
@@ -66,9 +69,6 @@
 		</testsuite>
 		<testsuite name="idc">
 			<file>tests/php/test_class.jetpack-idc.php</file>
-		</testsuite>
-		<testsuite name="contact-form">
-			<directory prefix="test_" suffix=".php">tests/php/modules/contact-form</directory>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/tests/php.multisite.xml
+++ b/tests/php.multisite.xml
@@ -29,9 +29,7 @@
         <testsuite name="json-api">
             <file>php/test_class.json-api-jetpack-endpoints.php</file>
         </testsuite>
-        <testsuite name="contact-form">
-            <directory prefix="test_" suffix=".php">php/modules/contact-form</directory>
-        </testsuite>
+
         <testsuite name="infinite-scroll">
             <directory prefix="test_" suffix=".php">php/modules/infinite-scroll</directory>
         </testsuite>
@@ -52,6 +50,9 @@
         </testsuite>
         <testsuite name="sso">
             <directory prefix="test_" suffix=".php">php/modules/sso</directory>
+        </testsuite>
+        <testsuite name="contact-form">
+            <directory prefix="test_" suffix=".php">php/modules/contact-form</directory>
         </testsuite>
         <testsuite name="sync">
             <directory prefix="test_" suffix=".php">php/sync</directory>

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -75,13 +75,13 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 
 	function assertPublicized( $should_have_publicized, $post ) {
 		if ( $should_have_publicized ) {
-			$this->assertTrue( $this->fired_publicized_post );
-			$this->assertEquals( $post->ID, $this->publicized_post_id );
-			$this->assertTrue( $this->in_publish_filter );
+			$this->assertTrue( $this->fired_publicized_post, 'Not Fired on publicize post' );
+			$this->assertEquals( $post->ID, $this->publicized_post_id, 'Is not the same post ID' );
+			$this->assertTrue( $this->in_publish_filter, 'Not in filter' );
 		} else {
-			$this->assertFalse( $this->fired_publicized_post );
-			$this->assertNull( $this->publicized_post_id );
-			$this->assertFalse( $this->in_publish_filter );
+			$this->assertFalse( $this->fired_publicized_post, 'Fired publicize post' );
+			$this->assertNull( $this->publicized_post_id, 'Not Null' );
+			$this->assertFalse( $this->in_publish_filter, 'in filter' );
 		}
 	}
 

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -18,7 +18,7 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
 		$this->post = get_post( $post_id );
 
-		Jetpack_Options::update_options( array( 'publicize_connections' => array( 'not_empty' ) ) );
+		Jetpack_Options::update_options( array( 'publicize_connections' => array( 'facebook' => array( 'id_number' => array( 'connection_data' => array( 'user_id' => 0 ) ) ) ) ) );
 
 		add_action( 'jetpack_publicize_post', array( $this, 'publicized_post' ), 10, 1 );
 		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags_check' ), 20, 2 );


### PR DESCRIPTION
This makes the publicise work the same way as subscriptions. 
We set a publicize_post flag on the jetpack_publish_post action. That would trigger the publicize if the flag is set to true. 

I didn't remove the current implementation. Since we could run them in parallel and if we find that it doesn't perform better then we can switch back to the previous way. 

#### Testing instructions:
* Do the tests pass?
