### PR TITLE
Give users guidance when PHP's XML module is missing.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4470,7 +4470,12 @@ p {
 		} elseif ( 408 == $code ) {
 			return new Jetpack_Error( 'wpcom_408', sprintf( __( 'Error Details: %s', 'jetpack' ), $code ), $code );
 		} elseif ( ! empty( $json->error ) ) {
-			$error_description = isset( $json->error_description ) ? sprintf( __( 'Error Details: %s', 'jetpack' ), (string) $json->error_description ) : '';
+			if ( 'xml_rpc-32700' == $json->error && ! function_exists( 'xml_parser_create' ) ) {
+				$error_description = __( "PHP's XML extension is not available. Jetpack requires the XML extension to communicate with WordPress.com. Please contact your hosting provider to enable PHP's XML extension.", 'jetpack' );
+			} else {
+				$error_description = isset( $json->error_description ) ? sprintf( __( 'Error Details: %s', 'jetpack' ), (string) $json->error_description ) : '';
+			}
+			
 			return new Jetpack_Error( (string) $json->error, $error_description, $code );
 		} elseif ( 200 != $code ) {
 			return new Jetpack_Error( 'wpcom_bad_response', sprintf( __( 'Error Details: %s', 'jetpack' ), $code ), $code );


### PR DESCRIPTION
#### Fixes #5925

#### Changes proposed in this Pull Request:
Give users some more guidance when setting up a new Jetpack site on a server without PHP's XML module installed. Currently users are given an unhelpful message regarding potential extra whitespace in XMLRPC responses, whereas detecting the missing module is easy.

#### Testing instructions:
* Remove PHP-XML (and/or PHP7.0-XML) from your testing server
* Try to connect a Jetpack site
* Observe the error popup. It should read: "PHP's XML extension is not available. Jetpack requires the XML extension to communicate with WordPress.com. Please contact your hosting provider to enable PHP's XML extension."