### PR TITLE
Milestone Widget: Make the widget take the full sidebar width

### DIFF
--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -95,7 +95,7 @@ class Milestone_Widget extends WP_Widget {
 .milestone-content {
 	line-height: 2;
 	margin-top: 5px;
-	max-width: 17em;
+	max-width: 100%;
 	padding: 0;
 	text-align: center;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR updates the Milestone widget to take the entire width of the sidebar, instead of being limited to just `17em`.

#### Screenshots

**Before**
![](https://cldup.com/afXKJMEt8v.png)

**After**
![](https://cldup.com/mGJX49fwXD.png)

#### Testing instructions:

* Checkout this branch
* Use the Twenty Sixteen on one of your test sites.
* Insert a Milestone Widget in your sidebar.
* Verify it takes the entire width of the sidebar.