### PR TITLE
Related Posts: add a hidden field in Customizer for 'enabled' option

### DIFF
--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -148,6 +148,12 @@ class Jetpack_Related_Posts_Customize {
 		$transport = isset( $wp_customize->selective_refresh ) ? 'postMessage' : 'refresh';
 		return apply_filters(
 			'jetpack_related_posts_customize_options', array(
+				'enabled'       => array(
+					'control_type' => 'hidden',
+					'default'      => 1,
+					'setting_type' => 'option',
+					'transport'    => $transport,
+				),
 				'show_headline'       => array(
 					'label'        => esc_html__( 'Show a headline', 'jetpack' ),
 					'description'  => esc_html__( 'This helps to clearly separate the related posts from post content.', 'jetpack' ),


### PR DESCRIPTION
There was an `enabled` option in previous WP Admin settings that isn't available by default, only after setting the filter `jetpack_relatedposts_filter_allow_feature_toggle` to `true`. Since this wasn't included in the Customizer options, saving in the Customizer caused it to be undefined and set to `false` which disabled the Related Posts.

#### Changes proposed in this Pull Request:
- adds a hidden field named 'enabled' always set to true.

#### Testing instructions:
1. if you currently don't see Related Posts, go to Settings > Reading and save, no need to change anything. This will set the `enabled` option back to `true`.
2. verify that you see Related Posts
3. go to Jetpack > Settings > Engagement > Related Posts and access the Customizer.
4. make some changes and save
5. verify that you still see Related Posts

cc @cfinke @bubel @jeherve 

