### PR TITLE
Widgets: set number 5 as default for input field so it matches what it's previewed in Customizer

### DIFF
--- a/modules/widgets/authors.php
+++ b/modules/widgets/authors.php
@@ -166,7 +166,7 @@ class Jetpack_Widget_Authors extends WP_Widget {
 	}
 
 	public function form( $instance ) {
-		$instance = wp_parse_args( $instance, array( 'title' => '', 'all' => false, 'avatar_size' => 48, 'number' => 0 ) );
+		$instance = wp_parse_args( $instance, array( 'title' => '', 'all' => false, 'avatar_size' => 48, 'number' => 5 ) );
 
 		?>
 		<p>


### PR DESCRIPTION
Fixes #5895

#### Changes proposed in this Pull Request:
- instead of 0, display 5 as default in input field labeled `Number of posts to show for each author:`

#### Testing instructions:
* add Authors widget to Customizer and verify number in field and number of posts displayed is the same.