### PR TITLE
Related Posts - Theme Tools: remove colon forcefully added with CSS

### DIFF
--- a/modules/theme-tools/compat/twentyfourteen.css
+++ b/modules/theme-tools/compat/twentyfourteen.css
@@ -18,10 +18,6 @@
 	margin: 0;
 }
 
-div.jp-relatedposts .jp-relatedposts-headline em:after {
-	content: ":";
-}
-
 #page .entry-content div.sharedaddy h3,
 #page .entry-summary div.sharedaddy h3,
 #page .entry-content h3.sd-title,

--- a/modules/theme-tools/compat/twentysixteen.css
+++ b/modules/theme-tools/compat/twentysixteen.css
@@ -501,10 +501,6 @@ iframe[src^="http://api.mixcloud.com/"] {
 	font-weight: 400;
 }
 
-.entry-content #jp-relatedposts .jp-relatedposts-headline em:after {
-	content: ":";
-}
-
 .jp-relatedposts-items:before,
 .jp-relatedposts-items:after {
 	content: "";


### PR DESCRIPTION
Before this PR, in Twenty Fourteen and Twenty Sixteen, a colon will be added after the **Related** heading for related posts.

Adding Blocker tag because without this, what users enter in title field in Customizer and what users see in preview is different.

#### Changes proposed in this Pull Request:
This PR removes the colon since user should be free to remove the colon without having to add a CSS to override the previous one.

#### Testing instructions:
* Activate Twenty Fourteen and verify there's not a colon after **Related** heading. Do the same with Twenty Sixteen.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Related Posts: a colon is no longer added using CSS after "Related" heading when using Twenty Fourteen or Twenty Sixteen themes.
