### PR TITLE
Sync: CLI: First pass at adding sync CLI commands

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -670,7 +670,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 					Jetpack_Sync_Settings::update_settings( $original_settings );
 
 					if ( $modules ) {
-						WP_CLI::error( sprintf( __( 'Could not start a new full sync', 'jetpack' ), join( ', ', $modules ) ) );
+						WP_CLI::error( sprintf( __( 'Could not start a new full sync with modules: %s', 'jetpack' ), join( ', ', $modules ) ) );
 					} else {
 						WP_CLI::error( __( 'Could not start a new full sync', 'jetpack' ) );
 					}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -665,6 +665,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 						WP_CLI::log( __( 'Initialized a new full sync', 'jetpack' ) );
 					}
 				} else {
+
+					// Reset sync settings to original.
+					Jetpack_Sync_Settings::update_settings( $original_settings );
+
 					if ( $modules ) {
 						WP_CLI::error( sprintf( __( 'Could not start a new full sync', 'jetpack' ), join( ', ', $modules ) ) );
 					} else {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -684,9 +684,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * status : Print the current sync status
-	 * start  : Start a full sync from this site to WordPress.com
-	 * queue  : Print the current contents of a queue
+	 * peek : List the 100 front-most items on the queue.
 	 *
 	 * ## EXAMPLES
 	 *

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -561,8 +561,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 	}
 
 	public function sync( $args, $assoc_args ) {
-		if ( ! Jetpack::is_active() ) {
-			WP_CLI::error( __( 'Jetpack must be connected to WordPress.com to sync.', 'jetpack' ) );
+		if ( ! Jetpack_Sync_Actions::sync_allowed() ) {
+			WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site.', 'jetpack' ) );
 		}
 
 		$action = isset( $args[0] ) ? $args[0] : 'status';

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -579,30 +579,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		switch ( $action ) {
 			case 'status':
-				require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
-				require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
-
-				$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-				$sender      = Jetpack_Sync_Sender::get_instance();
-				$queue       = $sender->get_sync_queue();
-				$full_queue  = $sender->get_full_sync_queue();
-				$cron_timestamps = array_keys( _get_cron_array() );
-				$next_cron = $cron_timestamps[0] - time();
-
-				$status = array_merge(
-					$sync_module->get_status(),
-					array(
-						'cron_size'             => count( $cron_timestamps ),
-						'next_cron'             => $next_cron,
-						'queue_size'            => $queue->size(),
-						'queue_lag'             => $queue->lag(),
-						'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),
-						'full_queue_size'       => $full_queue->size(),
-						'full_queue_lag'        => $full_queue->lag(),
-						'full_queue_next_sync'  => ( $sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
-					)
-				);
-
+				$status = Jetpack_Sync_Actions::get_sync_status();
 				$collection = array();
 				foreach ( $status as $key => $item ) {
 					$collection[]  = array(

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -582,15 +582,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		$action = isset( $args[0] ) ? $args[0] : 'status';
 
-		$allowed_actions = array(
-			'status',
-			'start',
-		);
-
-		if ( ! in_array( $action, $allowed_actions ) ) {
-			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
-		}
-
 		switch ( $action ) {
 			case 'status':
 				$status = Jetpack_Sync_Actions::get_sync_status();
@@ -710,23 +701,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		$queue_name = isset( $args[0] ) ? $args[0] : 'sync';
 		$action = isset( $args[1] ) ? $args[1] : 'peek';
-
-		$allowed_queues = array(
-			'incremental',
-			'full',
-		);
-
-		if ( ! in_array( $queue_name, $allowed_queues ) ) {
-			WP_CLI::error( sprintf( __( '%s is not a valid queue.', 'jetpack' ), $queue_name ) );
-		}
-
-		$allowed_actions = array(
-			'peek',
-		);
-
-		if ( ! in_array( $action, $allowed_actions ) ) {
-			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
-		}
 
 		// We map the queue name that way we can support more friendly queue names in the commands, but still use
 		// the queue name that the code expects.

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -701,7 +701,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * wp jetpack sync_queue full_sync peek
 	 *
-	 * @synopsis <sync|full_sync> <peek>
+	 * @synopsis <incremental|full_sync> <peek>
 	 */
 	public function sync_queue( $args, $assoc_args ) {
 		if ( ! Jetpack_Sync_Actions::sync_allowed() ) {
@@ -712,8 +712,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 		$action = isset( $args[1] ) ? $args[1] : 'peek';
 
 		$allowed_queues = array(
-			'sync',
-			'full_sync',
+			'incremental',
+			'full',
 		);
 
 		if ( ! in_array( $queue_name, $allowed_queues ) ) {
@@ -728,10 +728,18 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
 		}
 
+		// We map the queue name that way we can support more friendly queue names in the commands, but still use
+		// the queue name that the code expects.
+		$queue_name_map = $allowed_queues = array(
+			'incremental' => 'sync',
+			'full'        => 'full_sync',
+		);
+		$mapped_queue_name = isset( $queue_name_map[ $queue_name ] ) ? $queue_name_map[ $queue_name ] : $queue_name;
+
 		switch( $action ) {
 			case 'peek':
 				require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-queue.php';
-				$queue = new Jetpack_Sync_Queue( $queue_name );
+				$queue = new Jetpack_Sync_Queue( $mapped_queue_name );
 				$items = $queue->peek( 100 );
 
 				if ( empty( $items ) ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -52,29 +52,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 // GET /sites/%s/sync/status
 class Jetpack_JSON_API_Sync_Status_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
-		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
-		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
-
-		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-		$sender      = Jetpack_Sync_Sender::get_instance();
-		$queue       = $sender->get_sync_queue();
-		$full_queue  = $sender->get_full_sync_queue();
-		$cron_timestamps = array_keys( _get_cron_array() );
-		$next_cron = $cron_timestamps[0] - time();
-
-		return array_merge(
-			$sync_module->get_status(),
-			array(
-				'cron_size'             => count( $cron_timestamps ),
-				'next_cron'             => $next_cron,
-				'queue_size'            => $queue->size(),
-				'queue_lag'             => $queue->lag(),
-				'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),
-				'full_queue_size'       => $full_queue->size(),
-				'full_queue_lag'        => $full_queue->lag(),
-				'full_queue_next_sync'  => ( $sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
-			)
-		);
+		return Jetpack_Sync_Actions::get_sync_status();
 	}
 }
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -342,6 +342,32 @@ class Jetpack_Sync_Actions {
 			wp_clear_scheduled_hook( 'jetpack_sync_send_db_checksum' );
 		}
 	}
+
+	static function get_sync_status() {
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
+		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
+
+		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$sender      = Jetpack_Sync_Sender::get_instance();
+		$queue       = $sender->get_sync_queue();
+		$full_queue  = $sender->get_full_sync_queue();
+		$cron_timestamps = array_keys( _get_cron_array() );
+		$next_cron = $cron_timestamps[0] - time();
+
+		return array_merge(
+			$sync_module->get_status(),
+			array(
+				'cron_size'             => count( $cron_timestamps ),
+				'next_cron'             => $next_cron,
+				'queue_size'            => $queue->size(),
+				'queue_lag'             => $queue->lag(),
+				'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),
+				'full_queue_size'       => $full_queue->size(),
+				'full_queue_lag'        => $full_queue->lag(),
+				'full_queue_next_sync'  => ( $sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
+			)
+		);
+	}
 }
 
 /**

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -344,13 +344,11 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function get_sync_status() {
-		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-modules.php';
-		require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
+		self::initialize_sender();
 
 		$sync_module = Jetpack_Sync_Modules::get_module( 'full-sync' );
-		$sender      = Jetpack_Sync_Sender::get_instance();
-		$queue       = $sender->get_sync_queue();
-		$full_queue  = $sender->get_full_sync_queue();
+		$queue       = self::$sender->get_sync_queue();
+		$full_queue  = self::$sender->get_full_sync_queue();
 		$cron_timestamps = array_keys( _get_cron_array() );
 		$next_cron = $cron_timestamps[0] - time();
 
@@ -361,10 +359,10 @@ class Jetpack_Sync_Actions {
 				'next_cron'             => $next_cron,
 				'queue_size'            => $queue->size(),
 				'queue_lag'             => $queue->lag(),
-				'queue_next_sync'       => ( $sender->get_next_sync_time( 'sync' ) - microtime( true ) ),
+				'queue_next_sync'       => ( self::$sender->get_next_sync_time( 'sync' ) - microtime( true ) ),
 				'full_queue_size'       => $full_queue->size(),
 				'full_queue_lag'        => $full_queue->lag(),
-				'full_queue_next_sync'  => ( $sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
+				'full_queue_next_sync'  => ( self::$sender->get_next_sync_time( 'full_sync' ) - microtime( true ) ),
 			)
 		);
 	}


### PR DESCRIPTION
For our ATAT work on WP.com, it is necessary that we have the ability to script a full sync. This PR introduces a handful of commands that should be useful to @seanosh for ATAT work.

Here are the commands to test:

- `wp jetpack sync status`
    - This command retrieves the current sync status. The best way to test this is:
        - Go to [REST api console](https://developer.wordpress.com/docs/api/console/) and make a request to `POST /sites/$site/sync`
        - Immediately run `wp jetpack sync status` on your site to make sure that the status updates
- `wp jetpack sync start`
    - Run this command on your host
    - Go to the REST api console, and run `GET /sites/$site/sync/status` a few times and verify that the status changes
- `wp jetpack sync start --modules=functions`
    - Run this command on your host
    - Go to the REST api console, and run `GET /sites/$site/sync/status` and verify that functions is the only thing in `config` property.
- `wp jetpack sync_queue incremental peek`
    - This command will likely return `Nothing is in the sync queue`
- `wp jetpack sync sync_queue full peek`
    - Go to REST API console and trigger a `POST /sites/$site/sync`
    - Immediately run `wp jetpack sync sync_queue full peek` and you should see things in the queue
    - Note: This command only shows the top 100 things. In the future we could perhaps add paging? But, I don't think that's necessary for this first pass