### PR TITLE
Sync: Sanitize taxonomies on the jetpack side

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -36,6 +36,10 @@ class Jetpack_Sync_Functions {
 		// Lets clone the taxonomy object instead of modifing the global one.
 		$cloned_taxonomy = json_decode( json_encode( $taxonomy ) );
 
+		// recursive taxonomies are no fun.
+		if ( is_null( $cloned_taxonomy ) ) {
+			return null;
+		}
 		// Remove any meta_box_cb if they are not the default wp ones.
 		if ( isset( $cloned_taxonomy->meta_box_cb ) &&
 		     ! in_array( $cloned_taxonomy->meta_box_cb, array( 'post_tags_meta_box', 'post_categories_meta_box' ) ) ) {

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -18,11 +18,11 @@ class Jetpack_Sync_Functions {
 		global $wp_taxonomies;
 		$wp_taxonomies_without_callbacks = array();
 		foreach ( $wp_taxonomies as $taxonomy_name => $taxonomy ) {
-			$sanatized_taxonomy = self::sanitize_taxonomy( $taxonomy );
-			if ( ! empty( $sanatized_taxonomy ) ) {
-				$wp_taxonomies_without_callbacks[ $taxonomy_name ] = $sanatized_taxonomy;
+			$sanitized_taxonomy = self::sanitize_taxonomy( $taxonomy );
+			if ( ! empty( $sanitized_taxonomy ) ) {
+				$wp_taxonomies_without_callbacks[ $taxonomy_name ] = $sanitized_taxonomy;
 	 		} else {
-				error_log( 'Jepack encountered a recusive taxobomy:' . $taxonomy_name );
+				error_log( 'Jetpack: Encountered a recusive taxonomy:' . $taxonomy_name );
 			}
 		}
 		return $wp_taxonomies_without_callbacks;
@@ -34,7 +34,7 @@ class Jetpack_Sync_Functions {
 	public static function sanitize_taxonomy( $taxonomy ) {
 
 		// Lets clone the taxonomy object instead of modifing the global one.
-		$cloned_taxonomy = json_decode( json_encode( $taxonomy ) );
+		$cloned_taxonomy = json_decode( wp_json_encode( $taxonomy ) );
 
 		// recursive taxonomies are no fun.
 		if ( is_null( $cloned_taxonomy ) ) {
@@ -45,7 +45,6 @@ class Jetpack_Sync_Functions {
 		     ! in_array( $cloned_taxonomy->meta_box_cb, array( 'post_tags_meta_box', 'post_categories_meta_box' ) ) ) {
 			$cloned_taxonomy->meta_box_cb = null;
 		}
-
 		// Remove update call back
 		if ( isset( $cloned_taxonomy->update_count_callback ) &&
 		     ! is_null( $cloned_taxonomy->update_count_callback ) ) {
@@ -56,7 +55,6 @@ class Jetpack_Sync_Functions {
 		     'WP_REST_Terms_Controller' !== $cloned_taxonomy->rest_controller_class ) {
 			$cloned_taxonomy->rest_controller_class = null;
 		}
-
 		return $cloned_taxonomy;
 	}
 

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -18,7 +18,12 @@ class Jetpack_Sync_Functions {
 		global $wp_taxonomies;
 		$wp_taxonomies_without_callbacks = array();
 		foreach ( $wp_taxonomies as $taxonomy_name => $taxonomy ) {
-			$wp_taxonomies_without_callbacks[ $taxonomy_name ] = self::sanitize_taxonomie( $taxonomy);
+			$sanatized_taxonomy = self::sanitize_taxonomy( $taxonomy );
+			if ( ! empty( $sanatized_taxonomy ) ) {
+				$wp_taxonomies_without_callbacks[ $taxonomy_name ] = $sanatized_taxonomy;
+	 		} else {
+				error_log( 'Jepack encountered a recusive taxobomy:' . $taxonomy_name );
+			}
 		}
 		return $wp_taxonomies_without_callbacks;
 	}
@@ -26,7 +31,7 @@ class Jetpack_Sync_Functions {
 	/**
 	 * Removes any callback data since we will not be able to process it on our side anyways.
 	 */
-	public static function sanitize_taxonomie( $taxonomy ) {
+	public static function sanitize_taxonomy( $taxonomy ) {
 
 		// Lets clone the taxonomy object instead of modifing the global one.
 		$cloned_taxonomy = json_decode( json_encode( $taxonomy ) );

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -494,22 +494,22 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sanitize_sync_taxonomies_method() {
 		
-		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomie( (object) array( 'meta_box_cb' => 'post_tags_meta_box' ) );
+		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomy( (object) array( 'meta_box_cb' => 'post_tags_meta_box' ) );
 		$this->assertEquals( $sanitized->meta_box_cb, 'post_tags_meta_box' );
 
-		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomie( (object) array( 'meta_box_cb' => 'post_categories_meta_box' ) );
+		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomy( (object) array( 'meta_box_cb' => 'post_categories_meta_box' ) );
 		$this->assertEquals( $sanitized->meta_box_cb, 'post_categories_meta_box' );
 
-		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomie( (object) array( 'meta_box_cb' => 'banana' ) );
+		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomy( (object) array( 'meta_box_cb' => 'banana' ) );
 		$this->assertEquals( $sanitized->meta_box_cb, null );
 
-		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomie( (object) array( 'update_count_callback' => 'banana' ) );
+		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomy( (object) array( 'update_count_callback' => 'banana' ) );
 		$this->assertFalse( isset( $sanitized->update_count_callback ) );
 
-		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomie( (object) array( 'rest_controller_class' => 'banana' ) );
+		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomy( (object) array( 'rest_controller_class' => 'banana' ) );
 		$this->assertEquals( $sanitized->rest_controller_class, null );
 
-		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomie( (object) array( 'rest_controller_class' => 'WP_REST_Terms_Controller' ) );
+		$sanitized = Jetpack_Sync_Functions::sanitize_taxonomy( (object) array( 'rest_controller_class' => 'WP_REST_Terms_Controller' ) );
 
 		$this->assertEquals( $sanitized->rest_controller_class, 'WP_REST_Terms_Controller' );
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -555,7 +555,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 }
 
-
+/* Example Test Taxonomy */
 class ABC_FOO_TEST_Taxonomy_Example {
 	function __construct() {
 


### PR DESCRIPTION
This fixes #5858 by removing taxonomy callbacks before we send the data .com

#### Changes proposed in this Pull Request:
Remove callbacks that are not found by default in WP. 

#### Testing instructions:
* Do the test pass. Try to replicate the issue found in #5858. 
