### PR TITLE
Media Summary: improve performance with single page load caching

### DIFF
--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -6,7 +6,10 @@
  */
 class Jetpack_Media_Summary {
 
+	static $cache = array();
+
 	static function get( $post_id, $blog_id = 0, $args = array() ) {
+
 		$defaults = array(
 			'max_words' => 16,
 			'max_chars' => 256,
@@ -19,6 +22,11 @@ class Jetpack_Media_Summary {
 			$switched = true;
 		} else {
 			$blog_id = get_current_blog_id();
+		}
+
+		$cache_key = md5( "{$blog_id}_{$post_id}_{$args['max_words']}_{$args['max_chars']}" );
+		if ( isset( self::$cache[ $cache_key ] ) ){
+			return self::$cache[ $cache_key ];
 		}
 
 		if ( ! class_exists( 'Jetpack_Media_Meta_Extractor' ) ) {
@@ -241,6 +249,8 @@ class Jetpack_Media_Summary {
 		 * @param int $post_id The id of the post this data applies to.
 		 */
 		$return = apply_filters( 'jetpack_media_summary_output', $return, $post_id );
+
+		self::$cache[ $cache_key ] = $return;
 
 		return $return;
 	}

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -25,7 +25,7 @@ class Jetpack_Media_Summary {
 		}
 
 		$cache_key = md5( "{$blog_id}_{$post_id}_{$args['max_words']}_{$args['max_chars']}" );
-		if ( isset( self::$cache[ $cache_key ] ) ){
+		if ( isset( self::$cache[ $cache_key ] ) ) {
 			return self::$cache[ $cache_key ];
 		}
 

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -6,7 +6,7 @@
  */
 class Jetpack_Media_Summary {
 
-	static $cache = array();
+	private static $cache = array();
 
 	static function get( $post_id, $blog_id = 0, $args = array() ) {
 
@@ -24,7 +24,7 @@ class Jetpack_Media_Summary {
 			$blog_id = get_current_blog_id();
 		}
 
-		$cache_key = md5( "{$blog_id}_{$post_id}_{$args['max_words']}_{$args['max_chars']}" );
+		$cache_key = "{$blog_id}_{$post_id}_{$args['max_words']}_{$args['max_chars']}";
 		if ( isset( self::$cache[ $cache_key ] ) ) {
 			return self::$cache[ $cache_key ];
 		}


### PR DESCRIPTION
`Jetpack_Media_Summary::get()` runs up to 4 times on a single post. On a very large post with multiple media items, this can actually take a little while

#### Changes proposed in this Pull Request:
Use a class static var to cache the result, saving 3 runs per page load.
