### PR TITLE
Fix Media Extractor tests

### DIFF
--- a/tests/php/_inc/lib/test_class.jetpack-media-extractor.php
+++ b/tests/php/_inc/lib/test_class.jetpack-media-extractor.php
@@ -409,7 +409,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 		$post_id = $this->add_test_post();
 
 		$expected = array(
-			'has' => array( 'shortcode' => 10 ),
+			'has' => array( 'shortcode' => 8 ),
 			'shortcode' => array(
 				'youtube' => array(
 					'count' => 2,
@@ -466,10 +466,11 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 		$post_id = $this->add_test_post();
 
 		$expected = array(
-			'has' => array( 'embed' => 2 ),
+			'has' => array( 'embed' => 3 ),
 			'embed' => array( 'url' => array(
 				'www.youtube.com/watch?v=r0cN_bpLrxk',
 				'vimeo.com/44633289',
+				'twitter.com/mremy'
 			) ),
 		);
 


### PR DESCRIPTION
Media extractor tests are currently failing, (probably invisible, until #5937 is fixed).

#### Changes proposed in this Pull Request:
This PR fixes the failing tests, which only fail because of wrong expected values. I'm not sure why the values are wrong.

#### Testing instructions:

* `phpunit --testsuite=media`

