### PR TITLE
Follow Widget: load translation files using wpcom language codes.

### DIFF
--- a/modules/notes.php
+++ b/modules/notes.php
@@ -143,7 +143,7 @@ class Jetpack_Notifications {
 		}
 
 		if ( class_exists( 'GP_Locales' ) ) {
-			$wpcom_locale_object = GP_Locales::by_field( 'wp_locale', get_locale() );
+			$wpcom_locale_object = GP_Locales::by_field( 'wp_locale', $wpcom_locale );
 			if ( $wpcom_locale_object instanceof GP_Locale ) {
 				$wpcom_locale = $wpcom_locale_object->slug;
 			}

--- a/modules/widgets/follow-button.php
+++ b/modules/widgets/follow-button.php
@@ -35,7 +35,7 @@ class Follow_Button_Widget extends WP_Widget {
 		}
 
 		if ( class_exists( 'GP_Locales' ) ) {
-			$wpcom_locale_object = GP_Locales::by_field( 'wp_locale', get_locale() );
+			$wpcom_locale_object = GP_Locales::by_field( 'wp_locale', $wpcom_locale );
 			if ( $wpcom_locale_object instanceof GP_Locale ) {
 				$wpcom_locale = $wpcom_locale_object->slug;
 			}

--- a/modules/widgets/follow-button.php
+++ b/modules/widgets/follow-button.php
@@ -26,6 +26,21 @@ class Follow_Button_Widget extends WP_Widget {
 		$attributes = array();
 		$instance = wp_parse_args( (array) $instance, array( 'show_name' => 1, 'show_count' => 0 ) );
 
+		$wpcom_locale = get_locale();
+
+		if ( ! class_exists( 'GP_Locales' ) ) {
+			if ( defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) && file_exists( JETPACK__GLOTPRESS_LOCALES_PATH ) ) {
+				require JETPACK__GLOTPRESS_LOCALES_PATH;
+			}
+		}
+
+		if ( class_exists( 'GP_Locales' ) ) {
+			$wpcom_locale_object = GP_Locales::by_field( 'wp_locale', get_locale() );
+			if ( $wpcom_locale_object instanceof GP_Locale ) {
+				$wpcom_locale = $wpcom_locale_object->slug;
+			}
+		}
+
 		if ( empty( $instance['show_name'] ) ) {
 			$attributes[] = 'data-show-blog-name="false"';
 		}
@@ -41,7 +56,7 @@ class Follow_Button_Widget extends WP_Widget {
 			class="wordpress-follow-button"
 			href="<?php echo esc_url( home_url() ); ?>"
 			data-blog="<?php echo esc_url( home_url() ); ?>"
-			data-lang="<?php echo get_locale(); ?>" <?php if ( ! empty( $attributes ) ) echo implode( ' ', $attributes ); ?>
+			data-lang="<?php echo esc_attr( $wpcom_locale ); ?>" <?php if ( ! empty( $attributes ) ) echo implode( ' ', $attributes ); ?>
 		>
 			<?php sprintf( __( 'Follow %s on WordPress.com', 'jetpack' ), get_bloginfo( 'name' ) ); ?>
 		</a>


### PR DESCRIPTION
Related: #2698

The widget previously used the site's language code to populate the `data-lang` parameter.
that parameter is used to grab language files from WordPress.com, and should consequently use a language code that's available on
WordPress.com.

We consequently use the data available in locales.php to use the `slug` language code instead of `wp_locale` for each language.

cc @akirk 
