### PR TITLE
If there is no post, return an empty array instead of querying revisions

### DIFF
--- a/modules/custom-css/migrate-to-core.php
+++ b/modules/custom-css/migrate-to-core.php
@@ -188,6 +188,11 @@ class Jetpack_Custom_CSS_Data_Migration {
 	 */
 	public static function get_all_revisions() {
 		$post = self::get_post();
+
+		if ( ! $post ) {
+			return array();
+		}
+
 		$revisions = wp_get_post_revisions( $post->ID, array(
 			'posts_per_page' => -1,
 			'orderby'        => 'date',


### PR DESCRIPTION
Fixes #5868

#### Changes proposed in this Pull Request:

get_post can return `false` and cause a notice here. This patch returns
an empty array if we get `false`.

#### Testing

Install Jetpack for the first time and connect it to your blog. Visit the front page of your blog so that posts get displayed. This will trigger the code in migrate-to-core.php.

It must be a fresh install of Jetpack for the notice to show.