### PR TITLE
Shortcodes: update how a tweet is fetch when only the numeric Id is set as attribute

### DIFF
--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -53,36 +53,15 @@ class Jetpack_Tweet {
 		}
 
 		if ( ctype_digit( $attr['tweet'] ) ) {
-			$transient = "jpt_{$attr['tweet']}";
-			if ( false === $cached_url = get_transient( $transient ) ) {
-				$response = wp_remote_get( "https://twitter.com/statuses/{$attr['tweet']}" );
-				if ( 200 !== wp_remote_retrieve_response_code( $response ) || ! isset( $response['http_response'] ) ) {
-
-					// Cache for 15 minutes to avoid making the request over and over.
-					set_transient( $transient, '', 60 * 15 );
-					return '';
-				}
-				$http_response = $response['http_response'];
-				$http_response_object = $http_response->get_response_object();
-				if ( empty( $http_response_object->url ) ) {
-
-					// Cache for 15 minutes to avoid making the request over and over.
-					set_transient( $transient, '', 60 * 15 );
-					return '';
-				}
-				$cached_url = isset( $http_response_object->url ) && ! empty( $http_response_object->url )
-					? $http_response_object->url
-					: '';
-				set_transient( $transient, $cached_url, DAY_IN_SECONDS );
-			}
-			$attr['tweet'] = $cached_url;
-		}
-
-		preg_match( '/^http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)$/', $attr['tweet'], $urlbits );
-		if ( isset( $urlbits[5] ) && intval( $urlbits[5] ) ) {
-			$id = 'https://twitter.com/' . $urlbits[3] . '/status/' . intval( $urlbits[5] );
+			$id = 'https://twitter.com/jetpack/status/' . $attr['tweet'];
 		} else {
-			return '<!-- Invalid tweet id -->';
+			preg_match( '/^http(s|):\/\/twitter\.com(\/\#\!\/|\/)([a-zA-Z0-9_]{1,20})\/status(es)*\/(\d+)$/', $attr['tweet'], $urlbits );
+
+			if ( isset( $urlbits[5] ) && intval( $urlbits[5] ) ) {
+				$id = 'https://twitter.com/' . $urlbits[3] . '/status/' . intval( $urlbits[5] );
+			} else {
+				return '<!-- Invalid tweet id -->';
+			}
 		}
 
 		// Add shortcode arguments to provider URL


### PR DESCRIPTION
Fixes #5936

Props @niallkennedy for the trick on using a fixed base url.

#### Changes proposed in this Pull Request:
- use a fixed url `https://twitter.com/jetpack/status/` to resolve tweets.

#### Testing instructions:
* Add the `[tweet 804373035700678657]` in the post editor. Make sure it renders the tweet.
Note: the tweet is from my account, but since we're using as base the `jetpack` username, I'm using it to verify it correctly resolves the right tweet.
* Run the tests
