### PR TITLE
Admin: remove ellipsis from Learn More button

### DIFF
--- a/_inc/client/plans/plan-header.jsx
+++ b/_inc/client/plans/plan-header.jsx
@@ -34,7 +34,7 @@ const PlanHeader = React.createClass( {
 								</p>
 								<p className="jp-landing-plans__header-btn-container">
 									<Button href={ 'https://jetpack.com/redirect/?source=plans-main-top&site=' + this.props.siteRawUrl } className="is-primary">
-										{ __( 'Learn more...' ) }
+										{ __( 'Learn more' ) }
 									</Button>
 								</p>
 							</div>


### PR DESCRIPTION
Fixes #5946

#### Changes proposed in this Pull Request:
- remove ellipsis from Learn More button displayed in plan header when site is in Free plan

#### Testing instructions:
* in a Jetpack site with a Free plan, go to Plans tab. Make sure the Learn more blue button doesn't have an ellipsis at the end.
