### PR TITLE
Add Autoupdate Translations

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -52,6 +52,11 @@ class Jetpack_Autoupdate {
 	}
 
 	public function autoupdate_translation( $update, $item ) {
+		// Autoupdate all translations
+		if ( Jetpack_Options::get_option( 'autoupdate_translations', false ) ) {
+			return true;
+		}
+		
 		// Themes
 		$autoupdate_themes_translations = Jetpack_Options::get_option( 'autoupdate_themes_translations', array() );
 		$autoupdate_theme_list          = Jetpack_Options::get_option( 'autoupdate_themes', array() );

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -39,6 +39,7 @@ class Jetpack_Options {
 				'autoupdate_themes',           // (array)  An array of theme ids ( eg. twentyfourteen ) that should be autoupdated
 				'autoupdate_themes_translations', // (array)  An array of theme ids ( eg. twentyfourteen ) that should autoupdated translation files.
 				'autoupdate_core',             // (bool)   Whether or not to autoupdate core
+				'autoupdate_translations',     // (bool)   Whether or not to autoupdate all translations
 				'json_api_full_management',    // (bool)   Allow full management (eg. Activate, Upgrade plugins) of the site via the JSON API.
 				'sync_non_public_post_stati',  // (bool)   Allow synchronisation of posts and pages with non-public status.
 				'site_icon_url',               // (string) url to the full site icon

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -118,7 +118,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		$plugin['autoupdate']      = $autoupdate;
 		
 		$autoupdate_translation = in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins_translations', array() ) );
-		$plugin['autoupdate_translation'] = $autoupdate || $autoupdate_translation;
+		$plugin['autoupdate_translation'] = $autoupdate || $autoupdate_translation || Jetpack_Options::get_option( 'autoupdate_translations', false );
 
 		$plugin['uninstallable']   = is_uninstallable_plugin( $plugin_file );
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
@@ -123,7 +123,7 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 		$formatted_theme['autoupdate'] =  $autoupdate;
 
 		$autoupdate_translation = in_array( $id, Jetpack_Options::get_option( 'autoupdate_themes_translations', array() ) );
-		$formatted_theme['autoupdate_translation'] = $autoupdate || $autoupdate_translation;
+		$formatted_theme['autoupdate_translation'] = $autoupdate || $autoupdate_translation || Jetpack_Options::get_option( 'autoupdate_translations', false );
 
 		if ( isset( $this->log[ $id ] ) ) {
 			$formatted_theme['log'] = $this->log[ $id ];

--- a/json-endpoints/jetpack/class.jetpack-json-api-translations-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-translations-endpoint.php
@@ -3,12 +3,12 @@
 // Translations
 class Jetpack_JSON_API_Translations_Endpoint extends Jetpack_JSON_API_Endpoint {
 	// GET /sites/%s/translations
+	// POST /sites/%s/translations
 	// POST /sites/%s/translations/update
 	protected $needed_capabilities = array( 'update_core', 'update_plugins', 'update_themes' );
 	protected $log;
 
 	public function result() {
-		error_log( 'show resulsts...' );
 		return array(
 			'translations' => wp_get_translation_updates(),
 			'autoupdate' => Jetpack_Options::get_option( 'autoupdate_translations', false ),
@@ -16,4 +16,3 @@ class Jetpack_JSON_API_Translations_Endpoint extends Jetpack_JSON_API_Endpoint {
 		);
 	}
 }
-

--- a/json-endpoints/jetpack/class.jetpack-json-api-translations-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-translations-endpoint.php
@@ -7,12 +7,14 @@ class Jetpack_JSON_API_Translations_Endpoint extends Jetpack_JSON_API_Endpoint {
 	// POST /sites/%s/translations/update
 	protected $needed_capabilities = array( 'update_core', 'update_plugins', 'update_themes' );
 	protected $log;
+	protected $success;
 
 	public function result() {
 		return array(
-			'translations' => wp_get_translation_updates(),
-			'autoupdate' => Jetpack_Options::get_option( 'autoupdate_translations', false ),
-			'log'        => $this->log,
+			'translations'  => wp_get_translation_updates(),
+			'autoupdate'    => Jetpack_Options::get_option( 'autoupdate_translations', false ),
+			'log'           => $this->log,
+			'success'       => $this->success,
 		);
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-translations-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-translations-endpoint.php
@@ -1,0 +1,19 @@
+<?php
+
+// Translations
+class Jetpack_JSON_API_Translations_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// GET /sites/%s/translations
+	// POST /sites/%s/translations/update
+	protected $needed_capabilities = array( 'update_core', 'update_plugins', 'update_themes' );
+	protected $log;
+
+	public function result() {
+		error_log( 'show resulsts...' );
+		return array(
+			'translations' => wp_get_translation_updates(),
+			'autoupdate' => Jetpack_Options::get_option( 'autoupdate_translations', false ),
+			'log'        => $this->log,
+		);
+	}
+}
+

--- a/json-endpoints/jetpack/class.jetpack-json-api-translations-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-translations-modify-endpoint.php
@@ -18,15 +18,12 @@ class Jetpack_JSON_API_Translations_Modify_Endpoint extends Jetpack_JSON_API_Tra
 	}
 
 	protected function update() {
-		$args = $this->input();
-
 		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 		$upgrader = new Language_Pack_Upgrader( new Automatic_Upgrader_Skin() );
 		$result = $upgrader->bulk_upgrade();
 
 		$this->log = $upgrader->skin->get_upgrade_messages();
-		
-		return $result;
+		$this->success = ( ! is_wp_error( $result ) ) ? (bool) $result : false;
 	}
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-translations-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-translations-modify-endpoint.php
@@ -1,0 +1,32 @@
+<?php
+
+class Jetpack_JSON_API_Translations_Modify_Endpoint extends Jetpack_JSON_API_Translations_Endpoint {
+	// POST /sites/%s/translations
+	// POST /sites/%s/translations/update
+	protected $action              = 'default_action';
+	protected $new_version;
+	protected $log;
+
+	public function default_action() {
+		$args = $this->input();
+
+		if ( isset( $args['autoupdate'] ) && is_bool( $args['autoupdate'] ) ) {
+			Jetpack_Options::update_option( 'autoupdate_translations', $args['autoupdate'] );
+		}
+
+		return true;
+	}
+
+	protected function update() {
+		$args = $this->input();
+
+		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		$upgrader = new Language_Pack_Upgrader( new Automatic_Upgrader_Skin() );
+		$result = $upgrader->bulk_upgrade();
+
+		$this->log = $upgrader->skin->get_upgrade_messages();
+		
+		return $result;
+	}
+}

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -909,7 +909,8 @@ new Jetpack_JSON_API_Translations_Endpoint( array(
 	),
 	'response_format' => array(
 		'translations' => '(array) A list of translations that are available',
-		'autoupdate' => '(bool) Whether or not we automatically update translations'
+		'autoupdate' => '(bool) Whether or not we automatically update translations',
+		'log'     => '(array:safehtml) An array of log strings.',
 	),
 	'example_request_data' => array(
 		'headers' => array(
@@ -932,7 +933,7 @@ new Jetpack_JSON_API_Translations_Modify_Endpoint( array(
 	),
 	'response_format' => array(
 		'translations' => '(array) A list of translations that are available',
-		'autoupdate' => '(bool) Whether or not we automatically update translations'
+		'autoupdate' => '(bool) Whether or not we automatically update translations',
 	),
 	'example_request_data' => array(
 		'headers' => array(
@@ -953,11 +954,9 @@ new Jetpack_JSON_API_Translations_Modify_Endpoint( array(
 	'path_labels' => array(
 		'$site' => '(int|string) The site ID, The site domain'
 	),
-	'request_format' => array(
-		'version'   => '(string) The core version to update',
-	),
 	'response_format' => array(
 		'log'     => '(array:safehtml) An array of log strings.',
+		'success' => '(bool) Was the operation successful'
 	),
 	'example_request_data' => array(
 		'headers' => array(

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -896,6 +896,77 @@ new Jetpack_JSON_API_Maybe_Auto_Update_Endpoint( array(
 
 ) );
 
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-translations-endpoint.php' );
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-translations-modify-endpoint.php' );
+
+new Jetpack_JSON_API_Translations_Endpoint( array(
+	'description'     => 'Gets info about a Jetpack blog\'s core installation',
+	'method'          => 'GET',
+	'path'            => '/sites/%s/translations',
+	'stat'            => 'translations',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'response_format' => array(
+		'translations' => '(array) A list of translations that are available',
+		'autoupdate' => '(bool) Whether or not we automatically update translations'
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/translations'
+) );
+
+new Jetpack_JSON_API_Translations_Modify_Endpoint( array(
+	'description'     => 'Toggle automatic core updates for a Jetpack blog',
+	'method'          => 'POST',
+	'path'            => '/sites/%s/translations',
+	'stat'            => 'translations',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'request_format' => array(
+		'autoupdate'   => '(bool) Whether or not we automatically update translations',
+	),
+	'response_format' => array(
+		'translations' => '(array) A list of translations that are available',
+		'autoupdate' => '(bool) Whether or not we automatically update translations'
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+		'body' => array(
+			'autoupdate' => true,
+		),
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/translations'
+) );
+
+new Jetpack_JSON_API_Translations_Modify_Endpoint( array(
+	'description'     => 'Update All Translations installation on a Jetpack blog',
+	'method'          => 'POST',
+	'path'            => '/sites/%s/translations/update',
+	'stat'            => 'translations:update',
+	'path_labels' => array(
+		'$site' => '(int|string) The site ID, The site domain'
+	),
+	'request_format' => array(
+		'version'   => '(string) The core version to update',
+	),
+	'response_format' => array(
+		'log'     => '(array:safehtml) An array of log strings.',
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/translations/update'
+) );
+
 // Options
 require_once( $json_jetpack_endpoints_dir . 'class.wpcom-json-api-get-option-endpoint.php' );
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -82,6 +82,7 @@ class Jetpack_Sync_Defaults {
 		'jetpack_autoupdate_themes',
 		'jetpack_autoupdate_themes_translations',
 		'jetpack_autoupdate_core',
+		'jetpack_autoupdate_translations',
 		'carousel_background_color',
 		'carousel_display_exif',
 		'jetpack_portfolio',

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -142,6 +142,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_autoupdate_themes'            => 'pineapple',
 			'jetpack_autoupdate_themes_translations' => 'pineapple',
 			'jetpack_autoupdate_core'              => 'pineapple',
+			'jetpack_autoupdate_translations'      => 'pineapple',
 			'carousel_background_color'            => 'pineapple',
 			'carousel_display_exif'                => 'pineapple',
 			'jetpack_portfolio'                    => 'pineapple',


### PR DESCRIPTION
Add a new api endpoint that will allow us to enable translation autoupdates.  
As well as update all translations.


**To Test:**
Go to https://developer.wordpress.com/docs/api/console/
Try the following endpoints 
GET /sites/yoursite/translations
POST  /sites/yoursite/translations/ 
in the body autoupdate=true

POST  /sites/yoursite/translations/update

To get a new item that needs translating to show up in case you don't have any 
go to wp-content/languages/plugins/ and delete jetpack-* files 

To test that auto update works as expected go to 
Set items to autoupdate the translations. 

run the cron wp_version_check which should trigger the autoupdate mechanism.
