### PR TITLE
Infinite Scroll: remove load more button when there are no posts

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -49,52 +49,55 @@ Scroller = function( settings ) {
 
 	// We have two type of infinite scroll
 	// cases 'scroll' and 'click'
+	
+	if ( settings.have_posts ) {
+		
+		if ( type == 'scroll' ) {
+			// Bind refresh to the scroll event
+			// Throttle to check for such case every 300ms
 
-	if ( type == 'scroll' ) {
-		// Bind refresh to the scroll event
-		// Throttle to check for such case every 300ms
+			// On event the case becomes a fact
+			this.window.bind( 'scroll.infinity', function() {
+				this.throttle = true;
+			});
 
-		// On event the case becomes a fact
-		this.window.bind( 'scroll.infinity', function() {
-			this.throttle = true;
-		});
+			// Go back top method
+			self.gotop();
 
-		// Go back top method
-		self.gotop();
+			setInterval( function() {
+				if ( this.throttle ) {
+					// Once the case is the case, the action occurs and the fact is no more
+					this.throttle = false;
+					// Reveal or hide footer
+					self.thefooter();
+					// Fire the refresh
+					self.refresh();
+	                self.determineURL(); // determine the url 
+				}
+			}, 250 );
 
-		setInterval( function() {
-			if ( this.throttle ) {
-				// Once the case is the case, the action occurs and the fact is no more
-				this.throttle = false;
-				// Reveal or hide footer
-				self.thefooter();
+			// Ensure that enough posts are loaded to fill the initial viewport, to compensate for short posts and large displays.
+			self.ensureFilledViewport();
+			this.body.bind( 'post-load', { self: self }, self.checkViewportOnLoad );
+		} else if ( type == 'click' ) {
+			if ( this.click_handle ) {
+				this.element.append( this.handle );
+			}
+
+			this.body.delegate( '#infinite-handle', 'click.infinity', function() {
+				// Handle the handle
+				if ( self.click_handle ) {
+					$( '#infinite-handle' ).remove();
+				}
+
 				// Fire the refresh
 				self.refresh();
-                self.determineURL(); // determine the url 
-			}
-		}, 250 );
-
-		// Ensure that enough posts are loaded to fill the initial viewport, to compensate for short posts and large displays.
-		self.ensureFilledViewport();
-		this.body.bind( 'post-load', { self: self }, self.checkViewportOnLoad );
-	} else if ( type == 'click' ) {
-		if ( this.click_handle ) {
-			this.element.append( this.handle );
+			});
 		}
 
-		this.body.delegate( '#infinite-handle', 'click.infinity', function() {
-			// Handle the handle
-			if ( self.click_handle ) {
-				$( '#infinite-handle' ).remove();
-			}
-
-			// Fire the refresh
-			self.refresh();
-		});
+		// Initialize any Core audio or video players loaded via IS
+		this.body.bind( 'post-load', { self: self }, self.initializeMejs );
 	}
-
-	// Initialize any Core audio or video players loaded via IS
-	this.body.bind( 'post-load', { self: self }, self.initializeMejs );
 };
 
 /**

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -775,6 +775,7 @@ class The_Neverending_Home_Page {
 			),
 			'query_args'      => self::get_query_vars(),
 			'last_post_date'  => self::get_last_post_date(),
+			'have_posts'      => self::wp_query()->have_posts(),
 		);
 
 		// Optional order param


### PR DESCRIPTION
Fixes #5550

#### Changes proposed in this Pull Request:

remove "Load more" button when there are no posts
#### Testing instructions:

* Search for something that doesn't exists. For example "asdasdasd". The "Load more" button should not be displayed
