### PR TITLE
Related Posts: use posts from site for Customizer preview

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -873,8 +873,12 @@ EOT;
 
 			$current_post = get_post();
 
-			/** This filter is already documented in modules/related-posts/jetpack-related-posts.php */
-			$excluded_posts = apply_filters( 'jetpack_relatedposts_filter_exclude_post_ids', array( $current_post->ID ) );
+			// Exclude current post after filtering to make sure it's excluded and not lost during filtering.
+			$excluded_posts = array_merge(
+				/** This filter is already documented in modules/related-posts/jetpack-related-posts.php */
+				apply_filters( 'jetpack_relatedposts_filter_exclude_post_ids', array() ),
+				array( $current_post->ID )
+			);
 
 			// Fetch posts with featured image.
 			$with_post_thumbnails = get_posts( array(

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -866,7 +866,52 @@ EOT;
 					'classes'  => array()
 				),
 			);
-			$options['size'] = 3;
+
+			for ( $total = 0; $total < $options['size'] - 3; $total++ ) {
+				$related_posts[] = $related_posts[ $total ];
+			}
+
+			$current_post = get_post();
+
+			/** This filter is already documented in modules/related-posts/jetpack-related-posts.php */
+			$excluded_posts = apply_filters( 'jetpack_relatedposts_filter_exclude_post_ids', array( $current_post->ID ) );
+
+			// Fetch posts with featured image.
+			$with_post_thumbnails = get_posts( array(
+				'posts_per_page'   => $options['size'],
+				'post__not_in'     => $excluded_posts,
+				'post_type'        => $current_post->post_type,
+				'meta_key'         => '_thumbnail_id',
+				'suppress_filters' => false,
+			) );
+
+			// If we don't have enough, fetch posts without featured image.
+			if ( 0 < ( $more = $options['size'] - count( $with_post_thumbnails ) ) ) {
+				$no_post_thumbnails = get_posts( array(
+					'posts_per_page'  => $more,
+					'post__not_in'    => $excluded_posts,
+					'post_type'       => $current_post->post_type,
+					'meta_query' => array(
+						array(
+							'key'     => '_thumbnail_id',
+							'compare' => 'NOT EXISTS',
+						),
+					),
+					'suppress_filters' => false,
+				) );
+			} else {
+				$no_post_thumbnails = array();
+			}
+
+			foreach ( array_merge( $with_post_thumbnails, $no_post_thumbnails ) as $index => $real_post ) {
+				$related_posts[ $index ]['id']      = $real_post->ID;
+				$related_posts[ $index ]['url']     = esc_url( get_permalink( $real_post ) );
+				$related_posts[ $index ]['title']   = $this->_to_utf8( $this->_get_title( $real_post->post_title, $real_post->post_content ) );
+				$related_posts[ $index ]['date']    = get_the_date( '', $real_post );
+				$related_posts[ $index ]['excerpt'] = html_entity_decode( $this->_to_utf8( $this->_get_excerpt( $real_post->post_excerpt, $real_post->post_content ) ), ENT_QUOTES, 'UTF-8' );
+				$related_posts[ $index ]['img']     = $this->_generate_related_post_image_params( $real_post->ID );
+				$related_posts[ $index ]['context'] = $this->_generate_related_post_context( $real_post->ID );
+			}
 		} else {
 			$related_posts = $this->get_for_post_id(
 				get_the_ID(),


### PR DESCRIPTION
Fixes #5897

#### Changes proposed in this Pull Request:
- after building the usual list of mockup posts, it will look for entries with featured images. If it falls short, it will look for the necessary entries to complete the number of related posts displayed. If it still falls short, that is, there are no more posts in the site, will complete the number of related posts to display using one of the mock up posts.

By default the number of related posts to display is 3 but can be modified using the filter `jetpack_relatedposts_filter_options` which receives an associative array where one of the elements has the key `size` and indicates the number of posts to display. This is another enhancement to RP, since the usual preview displayed only 3 posts regardless if user had used the filter to show more.

#### Testing instructions:
* go to Jetpack > Engagement > Related Posts. Expand the card and click the link to launch the Customizer:
- make sure you have posts in the Related Posts area
- if you're displaying 3 posts, and you have less than 3 published posts, for example, 2, make sure the last one is one of the mockup posts

cc @beaulebens since he suggested this originally in a p2 post comment
