### PR TITLE
Shortcodes: Infinite Scroll: Fixes issues where Instagram embeds would not load after IS

### DIFF
--- a/modules/shortcodes/js/instagram.js
+++ b/modules/shortcodes/js/instagram.js
@@ -1,7 +1,9 @@
-(function( instgrm ) {
+/* global window */
+
+(function() {
 	var instagramEmbed = function() {
-		if ( 'undefined' !== typeof instgrm && instgrm.Embeds && instgrm.Embeds.process ) {
-			instgrm.Embeds.process();
+		if ( 'undefined' !== typeof window.instgrm && window.instgrm.Embeds && 'function' === typeof instgrm.Embeds.process ) {
+			window.instgrm.Embeds.process();
 		} else {
 			var s = document.createElement( 'script' );
 			s.async = true;


### PR DESCRIPTION
Earlier today, I noticed an issue where an Instagram video embed would not load if the post was loaded through infinite scroll.

After looking, it seems like this is because we were passing the `instgrm` when first parsing the `instagram.js` file, but this never got updated after loading the Instagram embed. 😱 This led to multiple embeds of the Instagram embeds JS file.


<img width="574" alt="screen shot 2016-12-20 at 12 56 19 pm" src="https://cloud.githubusercontent.com/assets/1126811/21364179/579f621a-c6b5-11e6-849d-b9ec982d3da4.png">

To test:

- Checkout branch
- Create a post with Instagram video embed
- Create many more posts
- Create another post with video embed
- Ensure first video loads
- Scroll and ensure second video loads