### PR TITLE
JSON API: Remove PHP Notice 

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1169,7 +1169,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		$file = basename( wp_get_attachment_url( $media_item->ID ) );
 		$file_info = pathinfo( $file );
-		$ext  = $file_info['extension'];
+		$ext  = isset( $file_info['extension'] ) ? $file_info['extension'] : null;
 
 		$response = array(
 			'ID'           => $media_item->ID,


### PR DESCRIPTION
Fixes #4423

#### Changes proposed in this Pull Request:
- Check if the `extension` exists if that is not the case. We are probably not dealing with a valid file so return null in that case.

