### PR TITLE
Related Posts: get user profile locale before translating the headline

### DIFF
--- a/modules/related-posts/class.related-posts-customize.php
+++ b/modules/related-posts/class.related-posts-customize.php
@@ -146,6 +146,16 @@ class Jetpack_Related_Posts_Customize {
 	 */
 	function get_options( $wp_customize ) {
 		$transport = isset( $wp_customize->selective_refresh ) ? 'postMessage' : 'refresh';
+
+		// Get the correct translated string for preview in WP 4.7 and later.
+		$switched_locale = function_exists( 'switch_to_locale' )
+			? switch_to_locale( get_user_locale() )
+			: false;
+		$headline = __( 'Related', 'jetpack' );
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+
 		return apply_filters(
 			'jetpack_related_posts_customize_options', array(
 				'enabled'       => array(
@@ -166,7 +176,7 @@ class Jetpack_Related_Posts_Customize {
 					'label'        => '',
 					'description'  => esc_html__( 'Enter text to use as headline.', 'jetpack' ),
 					'control_type' => 'text',
-					'default'      => esc_html__( 'Related', 'jetpack' ),
+					'default'      => esc_html( $headline ),
 					'setting_type' => 'option',
 					'transport'    => $transport,
 				),


### PR DESCRIPTION
Fixes #5886

#### Changes proposed in this Pull Request:
- switch to the user profile locale before translating the "Related" string, since this is the string that will be in the headline input field. Switching like this allows to get the right translation, if one is meant to be applied.

This allows to have the same string in the preview than in the input field.

#### Testing instructions:
1. do `wp option delete jetpack_relatedposts` 
2. go to Settings > General. Set the **Site Language** to **Español de Argentina**. Save.
3. go to Users > Your Profile. Set the **Language** to **English (United States)**. Save.
4. go to Jetpack > Settings > Related Posts. Expand the card and click the link to load the Customizer.

- Without this PR, the field labeled **Enter text to use as headline.** in Customizer controls would have **Related** but in the preview you would see **Relacionado**.
- With this PR, both texts say **Related**.
- When you change the text in the input field, the change should be reflected in preview.