### PR TITLE
Sync: Fixes a fatal error when we update jetpack to the latest version

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -34,7 +34,6 @@ class Jetpack_Sync_Listener {
 	}
 
 	private function init() {
-
 		$handler = array( $this, 'action_handler' );
 		$full_sync_handler = array( $this, 'full_sync_action_handler' );
 
@@ -208,7 +207,9 @@ class Jetpack_Sync_Listener {
 		// since we've added some items, let's try to load the sender so we can send them as quickly as possible
 		if ( ! Jetpack_Sync_Actions::$sender ) {
 			add_filter( 'jetpack_sync_sender_should_load', '__return_true' );
-			Jetpack_Sync_Actions::add_sender_shutdown();
+			if ( did_action( 'init' ) ) {
+				Jetpack_Sync_Actions::add_sender_shutdown();
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes a fatal error when Jetpack updates to the latest version. 

#### Changes proposed in this Pull Request:
- Do not call `Jetpack_Sync_Actions::add_sender_shutdown();` if the init action didn't happen already. 

The fatal error is caused when Jetpack runs though the update jetpack action before plugins_loaded is called. 

The fatal error is caused because function `wp_get_current_user()` is not even loaded yet. Jetpack tries to update the plugin before that is even set. 

The fatal is fixed by making sure that we do not call Jetpack_Sync_Actions::add_sender_shutdown(); unless the init has already happened. 

This make the action more full proof. 


#### Testing instructions:
Be logged into the admin. bump the version number. 
Notice that there is no more fatal error. 

The fatal error that I was is 
```
PHP Fatal error:  Uncaught Error: Call to undefined function wp_get_current_user() in /home/enej/public_html/aaa/wp-includes/capabilities.php:522
Stack trace:
#0 /home/enej/public_html/aaa/wp-content/plugins/jetpack/sync/class.jetpack-sync-actions.php(78): current_user_can('manage_options')
#1 /home/enej/public_html/aaa/wp-content/plugins/jetpack/sync/class.jetpack-sync-listener.php(211): Jetpack_Sync_Actions::add_sender_shutdown()
#2 /home/enej/public_html/aaa/wp-content/plugins/jetpack/sync/class.jetpack-sync-listener.php(111): Jetpack_Sync_Listener->enqueue_action('jetpack_full_sy...', Array, Object(Jetpack_Sync_Queue))
#3 /home/enej/public_html/aaa/wp-includes/class-wp-hook.php(298): Jetpack_Sync_Listener->full_sync_action_handler(Array)
#4 /home/enej/public_html/aaa/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters('', Array)
#5 /home/enej/public_html/aaa/wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#6 /home/enej/public_html/aaa/wp-content/plugins/jetpack/sync/class.jetpack-sync-module-full-sync.php(103 in /home/enej/public_html/aaa/wp-includes/capabilities.php on line 522
```

And was introduced by https://github.com/Automattic/jetpack/pull/5875 

