### PR TITLE
Properly set the admin language based on user language

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -149,7 +149,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 	function get_i18n_data() {
 
-		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . jetpack_get_locale() . '.json';
+		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . jetpack_get_user_locale() . '.json';
 
 		if ( is_file( $i18n_json ) && is_readable( $i18n_json ) ) {
 			$locale_data = @file_get_contents( $i18n_json );
@@ -203,7 +203,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 
-		$localeSlug = explode( '_', jetpack_get_locale() );
+		$localeSlug = explode( '_', jetpack_get_user_locale() );
 		$localeSlug = $localeSlug[0];
 
 		// Collecting roles that can view site stats
@@ -429,9 +429,9 @@ function jetpack_current_user_data() {
  * @return string
  *
  * @todo Remove this function when WordPress 4.8 is released
- * and replace `jetpack_get_locale()` in this file with `get_user_locale()`.
+ * and replace `jetpack_get_user_locale()` in this file with `get_user_locale()`.
  */
-function jetpack_get_locale() {
+function jetpack_get_user_locale() {
 	$locale = get_locale();
 
 	if ( function_exists( 'get_user_locale' ) ) {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -149,7 +149,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 	function get_i18n_data() {
 
-		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . get_locale() . '.json';
+		$i18n_json = JETPACK__PLUGIN_DIR . 'languages/json/jetpack-' . jetpack_get_locale() . '.json';
 
 		if ( is_file( $i18n_json ) && is_readable( $i18n_json ) ) {
 			$locale_data = @file_get_contents( $i18n_json );
@@ -203,7 +203,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 
-		$localeSlug = explode( '_', get_locale() );
+		$localeSlug = explode( '_', jetpack_get_locale() );
 		$localeSlug = $localeSlug[0];
 
 		// Collecting roles that can view site stats
@@ -419,4 +419,25 @@ function jetpack_current_user_data() {
 	);
 
 	return $current_user_data;
+}
+
+/**
+ * Set the admin language, based on user language.
+ *
+ * @since 4.5.0
+ *
+ * @return string
+ *
+ * @todo Remove this function when WordPress 4.8 is released
+ * and replace `jetpack_get_locale()` in this file with `get_user_locale()`.
+ */
+function jetpack_get_locale() {
+	global $wp_version;
+	$locale = get_locale();
+
+	if ( version_compare( $wp_version , '4.6.1', '>') ) {
+
+		$locale = get_user_locale();
+	}
+	return $locale;
 }

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -432,10 +432,9 @@ function jetpack_current_user_data() {
  * and replace `jetpack_get_locale()` in this file with `get_user_locale()`.
  */
 function jetpack_get_locale() {
-	global $wp_version;
 	$locale = get_locale();
 
-	if ( version_compare( $wp_version , '4.6.1', '>') ) {
+	if ( function_exists( 'get_user_locale' ) ) {
 		$locale = get_user_locale();
 	}
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -436,8 +436,8 @@ function jetpack_get_locale() {
 	$locale = get_locale();
 
 	if ( version_compare( $wp_version , '4.6.1', '>') ) {
-
 		$locale = get_user_locale();
 	}
+
 	return $locale;
 }

--- a/tests/prepare-wordpress.sh
+++ b/tests/prepare-wordpress.sh
@@ -32,6 +32,12 @@ for WP_SLUG in 'latest' 'previous'; do
 	cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_SLUG/src/wp-content/plugins/$PLUGIN_SLUG"
 	cd /tmp/wordpress-$WP_SLUG
 
+	if [ $WP_SLUG != previous ]; then
+		echo 'Unprops @pento ...'
+		curl 'https://core.trac.wordpress.org/changeset/39626?format=diff&new=39626' | patch -R -p2
+		echo 'Unprops complete'
+	fi
+
 	cp wp-tests-config-sample.php wp-tests-config.php
 	sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
 	sed -i "s/yourusernamehere/root/" wp-tests-config.php

--- a/tests/prepare-wordpress.sh
+++ b/tests/prepare-wordpress.sh
@@ -32,12 +32,6 @@ for WP_SLUG in 'latest' 'previous'; do
 	cp -r $PLUGIN_SLUG "/tmp/wordpress-$WP_SLUG/src/wp-content/plugins/$PLUGIN_SLUG"
 	cd /tmp/wordpress-$WP_SLUG
 
-	if [ $WP_SLUG != previous ]; then
-		echo 'Unprops @pento ...'
-		curl 'https://core.trac.wordpress.org/changeset/39626?format=diff&new=39626' | patch -R -p2
-		echo 'Unprops complete'
-	fi
-
 	cp wp-tests-config-sample.php wp-tests-config.php
 	sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
 	sed -i "s/yourusernamehere/root/" wp-tests-config.php


### PR DESCRIPTION
Fixes #5956 #5535

#### Changes proposed in this Pull Request:
Check if the user has set admin language and set Jetpack Settings and Jetpack Notifications panels to use this language 

#### Testing instructions:

* Install WordPress 4.7 in English
* Change the site language in Settings > General to French or other language 
* Go to Users > My Profile, and switch your user language to English.
* Install, activate, and connect Jetpack to WordPress.com.
* Go to Jetpack > Dashboard, or open the notifications panel
* Everything should be in English.
