### PR TITLE
Fix the build

### DIFF
--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -9,7 +9,8 @@ require_once( dirname( __FILE__ ) . '/../../../../modules/sso/class.jetpack-sso-
 class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 	protected $user_data;
 
-	function setUp() {
+	public function setUp() {
+		parent::setUp();
 		$this->user_data = (object) array(
 			'ID'           => 123456789,
 			'email'        => 'ssouser@testautomattic.com',

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -11,7 +11,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	private $full_sync_start_config;
 	private $synced_user_ids;
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-sso.php
+++ b/tests/php/sync/test_class.jetpack-sync-sso.php
@@ -4,7 +4,7 @@
  * Testing sync of values for SSO.
  */
 class WP_Test_Jetpack_Sync_SSO extends WP_Test_Jetpack_Sync_Base {
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 		$this->resetCallableAndConstantTimeouts();
 	}

--- a/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -32,7 +32,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		self::$factory = new JetpackSyncTestObjectFactory();
 	}
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 
 		if ( version_compare( phpversion(), '5.3.0', '<' ) ) {
@@ -57,7 +57,7 @@ class WP_Test_iJetpack_Sync_Replicastore extends PHPUnit_Framework_TestCase {
 		}
 	}
 
-	function tearDown() {
+	public function tearDown() {
 		parent::tearDown();
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/tests/php/test_class.functions.opengraph.php
+++ b/tests/php/test_class.functions.opengraph.php
@@ -12,6 +12,7 @@ class WP_Test_Functions_OpenGraph extends Jetpack_Attachment_Test_Case {
 	 * @since 3.9.2
 	 */
 	public function setUp() {
+		parent::setUp();
 		$this->icon_id = self::_create_upload_object( dirname( __FILE__ ) . '/jetpack-icon.jpg' ); // 150 x 150
 		require_once JETPACK__PLUGIN_DIR . 'functions.opengraph.php';
 	}
@@ -20,6 +21,7 @@ class WP_Test_Functions_OpenGraph extends Jetpack_Attachment_Test_Case {
 	 * Include Open Graph functions after each test.
 	 */
 	public function tearDown() {
+		parent::tearDown();
 		wp_delete_attachment( $this->icon_id );
 	}
 

--- a/tests/php/test_class.jetpack-client-server.php
+++ b/tests/php/test_class.jetpack-client-server.php
@@ -3,6 +3,7 @@
 class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 
 	static public function setUpBeforeClass() {
+		parent::setUpBeforeClass();
 		self::$ignore_files = TRUE;
 	}
 

--- a/tests/php/test_class.jetpack-constants.php
+++ b/tests/php/test_class.jetpack-constants.php
@@ -1,7 +1,8 @@
 <?php
 
 class WP_Test_Jetpack_Constants extends WP_UnitTestCase {
-	function tearDown() {
+	public function tearDown() {
+		parent::tearDown();
 		Jetpack_Constants::$set_constants = array();
 	}
 

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -11,7 +11,8 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 	static $activated_modules = array();
 	static $deactivated_modules = array();
 
-	function tearDown() {
+	public function tearDown() {
+		parent::tearDown();
 		Jetpack_Constants::clear_constants();
 	}
 


### PR DESCRIPTION
After https://core.trac.wordpress.org/changeset/39626 the Jetpack build is broken with errors like the following:

> mysqli_query(): Couldn't fetch mysqli
PHP Warning:  mysqli_errno(): Couldn't fetch mysqli in /tmp/wordpress-latest/src/wp-includes/wp-db.php on line 1772
> No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
> PHP Warning:  mysqli_query(): Couldn't fetch mysqli in /tmp/wordpress-latest/src/wp-includes/wp-db.php on line 1877

However, it's not the core changeset's (or Gary's) fault:  we need to add a call to `parent::setUpBeforeClass()` in one of the test suites, and this shuffling in the core test suite exposed that issue.

Originally discovered/investigated at https://github.com/Automattic/jetpack/pull/5418#issuecomment-268447491.  See also [discussion in core Slack](https://wordpress.slack.com/archives/core/p1482304077002800).

There are some missing `parent::setUp()` and `parent::tearDown()` calls; let's go ahead and fix those too.