### PR TITLE
Jetpack Footer: shortened margin

### DIFF
--- a/_inc/client/components/footer/style.scss
+++ b/_inc/client/components/footer/style.scss
@@ -1,9 +1,9 @@
 .jp-footer {
 	text-align: center;
-	margin: rem( 16px ) 0 rem( 64px );
+	margin: rem( 16px ) 0 rem( 32px );
 
 	@include breakpoint( "<1040px" ) {
-		margin: rem( 32px ) 0 rem( 48px );
+		margin: rem( 32px ) 0 rem( 24px );
 	}
 	@include breakpoint( "<660px" ) {
 		margin: rem( 24px ) 0 rem( 16px );


### PR DESCRIPTION
Reduced the footer bottom margin from 4 to 2rems at the two largest
breakpoints. Fixes: https://github.com/Automattic/jetpack/issues/5977

Before:
<img width="1370" alt="screen shot 2016-12-21 at 5 07 23 pm" src="https://cloud.githubusercontent.com/assets/22752103/21407956/2b4244e4-c7a0-11e6-91c9-3987cf86ac64.png">

After:
<img width="1402" alt="screen shot 2016-12-21 at 5 37 30 pm" src="https://cloud.githubusercontent.com/assets/22752103/21408651/332b5034-c7a4-11e6-8e02-4c3775c26094.png">

