### PR TITLE
Settings endpoint: fixed endpoint name typo

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-class WPCOM_JSON_API_Site_Settings_V1_2_endpoint extends WPCOM_JSON_API_Site_Settings_Endpoint {
+class WPCOM_JSON_API_Site_Settings_V1_2_Endpoint extends WPCOM_JSON_API_Site_Settings_Endpoint {
 
 	public static $site_format = array(
 		'ID'          => '(int) Site ID',


### PR DESCRIPTION
Capitalized "endpoint" to "Endpoint"

Not fixing any issue, just standartizing code.