### PR TITLE
OG Tags: Do not convert to an array silently

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -290,7 +290,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		$author = get_queried_object();
 		if ( function_exists( 'get_avatar_url' ) ) {
 			// Prefer the core function get_avatar_url() if available, WP 4.2+
-			$image['src'] = get_avatar_url( $author->user_email, array( 'size' => $width ) );
+			$image = get_avatar_url( $author->user_email, array( 'size' => $width ) );
 		}
 		else {
 			$has_filter = has_filter( 'pre_option_show_avatars', '__return_true' );
@@ -304,7 +304,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 			if ( ! empty( $avatar ) && ! is_wp_error( $avatar ) ) {
 				if ( preg_match( '/src=["\']([^"\']+)["\']/', $avatar, $matches ) );
-					$image['src'] = wp_specialchars_decode( $matches[1], ENT_QUOTES );
+					$image = wp_specialchars_decode( $matches[1], ENT_QUOTES );
 			}
 		}
 	}


### PR DESCRIPTION
`$image` is a string when, previously, we try to assign it a `$image['src']` value. This causes a PHP warning in 7.1: `PHP Warning:  Illegal string offset 'src' in /srv/www/master/html/wp-content/plugins/jetpack/functions.opengraph.php on line 293`

To test:
Visit an author archive page before and after.