### PR TITLE
Likes: Prevent a PHP notice when there is no $post object

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -760,9 +760,9 @@ class Jetpack_Likes {
 	}
 
 	function post_likes( $content ) {
-		global $post;
+		$post_id = get_the_ID();
 
-		if ( ! $post instanceof WP_Post || ! $this->is_likes_visible() )
+		if ( ! is_numeric( $post_id ) || ! $this->is_likes_visible() )
 			return $content;
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -784,9 +784,9 @@ class Jetpack_Likes {
 		*/
 		$uniqid = uniqid();
 
-		$src = sprintf( '//widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s', $blog_id, $post->ID, $domain, $uniqid );
-		$name = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post->ID, $uniqid );
-		$wrapper = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post->ID, $uniqid );
+		$src = sprintf( '//widgets.wp.com/likes/#blog_id=%1$d&amp;post_id=%2$d&amp;origin=%3$s&amp;obj_id=%1$d-%2$d-%4$s', $blog_id, $post_id, $domain, $uniqid );
+		$name = sprintf( 'like-post-frame-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
+		$wrapper = sprintf( 'like-post-wrapper-%1$d-%2$d-%3$s', $blog_id, $post_id, $uniqid );
 		$headline = sprintf(
 			/** This filter is already documented in modules/sharedaddy/sharing-service.php */
 			apply_filters( 'jetpack_sharing_headline_html', '<h3 class="sd-title">%s</h3>', esc_html__( 'Like this:', 'jetpack' ), 'likes' ),
@@ -845,9 +845,11 @@ class Jetpack_Likes {
 	}
 
 	function admin_bar_likes() {
-		global $wp_admin_bar, $post;
+		global $wp_admin_bar;
 
-		if ( ! $this->is_admin_bar_button_visible() ) {
+		$post_id = get_the_ID();
+
+		if ( ! is_numeric( $post_id ) || ! $this->is_admin_bar_button_visible() ) {
 			return;
 		}
 
@@ -868,7 +870,7 @@ class Jetpack_Likes {
 		// make sure to include the scripts before the iframe otherwise weird things happen
 		add_action( 'wp_footer', array( $this, 'likes_master' ), 21 );
 
-		$src = sprintf( '%1$s://widgets.wp.com/likes/#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%1$s://%4$s', $protocol, $blog_id, $post->ID, $domain );
+		$src = sprintf( '%1$s://widgets.wp.com/likes/#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%1$s://%4$s', $protocol, $blog_id, $post_id, $domain );
 
 		$html = "<iframe class='admin-bar-likes-widget jetpack-likes-widget' scrolling='no' frameBorder='0' name='admin-bar-likes-widget' src='$src'></iframe>";
 
@@ -979,7 +981,9 @@ class Jetpack_Likes {
 			return false;
 		}
 
-		global $post, $wp_current_filter; // Used to apply 'sharing_show' filter
+		global $wp_current_filter; // Used to apply 'sharing_show' filter
+
+		$post = get_post();
 
 		// @todo: Remove this block when 4.5 is the minimum
 		global $wp_version;
@@ -1037,7 +1041,7 @@ class Jetpack_Likes {
 			}
 		}
 
-		if( is_object( $post ) ) {
+		if ( $post instanceof WP_Post ) {
 			// Check that the post is a public, published post.
 			if ( 'attachment' == $post->post_type ) {
 				$post_status = get_post_status( $post->post_parent );

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -762,7 +762,7 @@ class Jetpack_Likes {
 	function post_likes( $content ) {
 		global $post;
 
-		if ( ! $this->is_likes_visible() )
+		if ( ! $post instanceof WP_Post || ! $this->is_likes_visible() )
 			return $content;
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,6 +37,9 @@
 		<testsuite name="infinite-scroll">
 			<directory prefix="test_" suffix=".php">tests/php/modules/infinite-scroll</directory>
 		</testsuite>
+		<testsuite name="likes">
+			<directory prefix="test_" suffix=".php">tests/php/modules/likes</directory>
+		</testsuite>
 		<testsuite name="publicize">
 			<directory prefix="test_" suffix=".php">tests/php/modules/publicize</directory>
 		</testsuite>

--- a/tests/php/modules/likes/test_class.likes.php
+++ b/tests/php/modules/likes/test_class.likes.php
@@ -1,0 +1,88 @@
+<?php
+require dirname( __FILE__ ) . '/../../../../modules/likes.php';
+
+class WP_Test_Likes extends WP_UnitTestCase {
+
+	/**
+	 * Test if likes are rendered correctly.
+	 *
+	 * @since 4.6.0
+	 */
+	public function test_post_likes() {
+
+		// Enable Likes
+		add_filter( 'wpl_is_likes_visible', '__return_true' );
+
+		$content = 'Some content.';
+
+		// There's no post set so return the same.
+		$this->assertEquals( 'Some content.', Jetpack_Likes::init()->post_likes( $content ) );
+
+		// Create and set a global post
+		$post_id = $this->factory->post->create( array() );
+		global $post;
+		$post = get_post( $post_id );
+
+		// This time there's a post set so return the HTML.
+		$this->assertContains( "<div class='sharedaddy sd-block", Jetpack_Likes::init()->post_likes( $content ) );
+
+		// Disable likes
+		remove_filter( 'wpl_is_likes_visible', '__return_true' );
+
+		// Likes are disabled this time so return the same content.
+		$this->assertContains( 'Some content.', Jetpack_Likes::init()->post_likes( $content ) );
+	}
+
+	/**
+	 * Test Likes visibility.
+	 *
+	 * @since 4.6.0
+	 */
+	public function test_is_likes_visible() {
+		$post_id = self::factory()->post->create( array( 'post_content' => 'Some content.' ) );
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Are we on a single post?
+		$this->assertQueryTrue( 'is_single', 'is_singular' );
+
+		// Disable support for 'post' type
+		add_filter( 'wpl_is_single_post_disabled', '__return_false' );
+
+		// Likes should not be visible where they're not supported
+		$this->assertEquals( false, Jetpack_Likes::init()->is_likes_visible() );
+
+		// Reenable support
+		remove_filter( 'wpl_is_single_post_disabled', '__return_false' );
+
+		$GLOBALS['post']->post_status = 'draft';
+
+		// Likes should not be visible in draft posts
+		$this->assertEquals( false, Jetpack_Likes::init()->is_likes_visible() );
+
+		$GLOBALS['post']->post_status = 'publish';
+
+		// Likes should be visible
+		$this->assertEquals( true, Jetpack_Likes::init()->is_likes_visible() );
+	}
+
+	/**
+	 * Check that Likes are properly added to admin bar.
+	 *
+	 * @since 4.6.0
+	 */
+	public function test_admin_bar_likes() {
+		$post_id = self::factory()->post->create( array( 'post_content' => 'Some content.' ) );
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Initialize admin bar
+		add_filter( 'show_admin_bar', '__return_true' );
+		_wp_admin_bar_init();
+
+		// Add Likes to admin bar
+		Jetpack_Likes::init()->admin_bar_likes();
+
+		// The widget must be added to admin bar now.
+		global $wp_admin_bar;
+		$this->assertArrayHasKey( 'admin-bar-likes-widget', $wp_admin_bar->get_nodes() );
+	}
+}


### PR DESCRIPTION
Prevents PHP notices when the filter is running without a global `$post` for whatever reasons.