### PR TITLE
Custom CSS: Prevent KSES from running during migration

### DIFF
--- a/modules/custom-css/migrate-to-core.php
+++ b/modules/custom-css/migrate-to-core.php
@@ -50,7 +50,9 @@ class Jetpack_Custom_CSS_Data_Migration {
 		if ( empty( $revisions ) || ! is_array( $revisions ) ) {
 			if ( $jetpack_css_post instanceof WP_Post ) {
 				// Feed in the raw, if the current setting is Sass/LESS, it'll filter it inside.
+				kses_remove_filters();
 				wp_update_custom_css_post( $jetpack_css_post->post_content );
+				kses_init();
 				return 1;
 			}
 			return null;
@@ -79,11 +81,12 @@ class Jetpack_Custom_CSS_Data_Migration {
 				$css = call_user_func( $preprocessors[ $preprocessor ]['callback'], $pre );
 			}
 
-			// Do we need to remove any filters here for users without `unfiltered_html` ?
+			kses_remove_filters();
 			wp_update_custom_css_post( $css, array(
 				'stylesheet'   => $stylesheet,
 				'preprocessed' => $pre,
 			) );
+			kses_init();
 		}
 
 		// If we've migrated some CSS for the current theme and there was already something there in the Core dataset ...


### PR DESCRIPTION
If the user that triggers the migration doesn't have `unfiltered_html`, then the CSS will get mangled by KSES. For example,

`.main-navigation .current-menu-item > a,`

...becomes:

`.main-navigation .current-menu-item &gt; a,`

Some sites have `DISALLOW_UNFILTERED_HTML` defined, so no users (not even Super Admins) will have `unfiltered_html`.

See #5843