### PR TITLE
Remove infinite loop for cron sync

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -225,26 +225,7 @@ class Jetpack_Sync_Actions {
 		}
 
 		self::initialize_sender();
-
-		do {
-			$next_sync_time = self::$sender->get_next_sync_time( 'sync' );
-
-			if ( $next_sync_time ) {
-				$delay = $next_sync_time - time() + 1;
-				if ( $delay > 15 ) {
-					break;
-				} elseif ( $delay > 0 ) {
-					sleep( $delay );
-				}
-			}
-
-			$result = self::$sender->do_sync();
-
-			// if we are time-limited, only do one cycle
-			if ( !! ini_get('max_execution_time') ) {
-				return;
-			}
-		} while ( $result );
+		self::$sender->do_sync();
 	}
 
 	static function do_cron_full_sync() {
@@ -253,26 +234,7 @@ class Jetpack_Sync_Actions {
 		}
 
 		self::initialize_sender();
-
-		do {
-			$next_sync_time = self::$sender->get_next_sync_time( 'full_sync' );
-
-			if ( $next_sync_time ) {
-				$delay = $next_sync_time - time() + 1;
-				if ( $delay > 15 ) {
-					break;
-				} elseif ( $delay > 0 ) {
-					sleep( $delay );
-				}
-			}
-
-			$result = self::$sender->do_full_sync();
-
-			// if we are time-limited, only do one cycle
-			if ( !! ini_get('max_execution_time') ) {
-				return;
-			}
-		} while ( $result );
+		self::$sender->do_full_sync();
 	}
 
 	static function initialize_listener() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -239,6 +239,11 @@ class Jetpack_Sync_Actions {
 			}
 
 			$result = self::$sender->do_sync();
+
+			// if we are time-limited, only do one cycle
+			if ( !! ini_get('max_execution_time') ) {
+				return;
+			}
 		} while ( $result );
 	}
 
@@ -262,6 +267,11 @@ class Jetpack_Sync_Actions {
 			}
 
 			$result = self::$sender->do_full_sync();
+
+			// if we are time-limited, only do one cycle
+			if ( !! ini_get('max_execution_time') ) {
+				return;
+			}
 		} while ( $result );
 	}
 


### PR DESCRIPTION
We've had some reports of our cron jobs exceeding timeouts and causing errors on WP Engine (and possibly other sites).

On reflection, having a loop which just tries to send stuff until it runs out of time is probably bad behaviour. In addition, we already have code in there which tries to allow more time to do sending if there's no `max_execution_time` set. 

This PR removes the loop that sends from cron, and just executed a single send. This may greatly slow down full sync on larger sites - perhaps - but should be sufficient for periodically syncing constants and callables. 

It's probably worth it in order to be a better plugin citizen.