### PR TITLE
Limit cron jobs to 30 seconds

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -226,6 +226,9 @@ class Jetpack_Sync_Actions {
 
 		self::initialize_sender();
 
+		$time_limit = Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
+		$start_time = time();
+
 		do {
 			$next_sync_time = self::$sender->get_next_sync_time( 'sync' );
 
@@ -239,7 +242,7 @@ class Jetpack_Sync_Actions {
 			}
 
 			$result = self::$sender->do_sync();
-		} while ( $result );
+		} while ( $result && ( $start_time + $time_limit ) > time() );
 	}
 
 	static function do_cron_full_sync() {
@@ -248,6 +251,9 @@ class Jetpack_Sync_Actions {
 		}
 
 		self::initialize_sender();
+
+		$time_limit = Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
+		$start_time = time();
 
 		do {
 			$next_sync_time = self::$sender->get_next_sync_time( 'full_sync' );
@@ -262,7 +268,7 @@ class Jetpack_Sync_Actions {
 			}
 
 			$result = self::$sender->do_full_sync();
-		} while ( $result );
+		} while ( $result && ( $start_time + $time_limit ) > time() );
 	}
 
 	static function initialize_listener() {

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -319,4 +319,5 @@ class Jetpack_Sync_Defaults {
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
 	static $default_sync_queue_lock_timeout = 120; // 2 minutes
+	static $default_cron_sync_time_limit = 30; // 30 seconds
 }

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -23,6 +23,7 @@ class Jetpack_Sync_Settings {
 		'max_enqueue_full_sync'   => true,
 		'max_queue_size_full_sync'=> true,
 		'sync_via_cron'           => true,
+		'cron_sync_time_limit'    => true,
 	);
 
 	static $is_importing;


### PR DESCRIPTION
An alternative, less aggressive approach to #5995

Sets a default time limit of 30 seconds when sending sync requests via Cron, per (incremental / full) sync type.

This is designed to alleviate reported cases where sync is timing out under certain cron configurations on really large DBs. This is part of trying to make Jetpack Sync a better plugin citizen :)

For sites which want to move faster, the 30 seconds is configurable as a setting called `cron_sync_time_limit`