### PR TITLE
Add checkout and preprocess time to sync requests

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -113,7 +113,7 @@ class Jetpack_Sync_Actions {
 		Jetpack_Sync_Settings::set_importing( true );
 	}
 
-	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id ) {
+	static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration ) {
 		Jetpack::load_xml_rpc_client();
 
 		$query_args = array(
@@ -123,6 +123,8 @@ class Jetpack_Sync_Actions {
 			'queue'     => $queue_id,       // sync or full_sync
 			'home'      => get_home_url(),  // Send home url option to check for Identity Crisis server-side
 			'siteurl'   => get_site_url(),  // Send siteurl option to check for Identity Crisis server-side
+			'cd'        => sprintf( '%.4f', $checkout_duration),   // Time spent retrieving queue items from the DB
+			'pd'        => sprintf( '%.4f', $preprocess_duration), // Time spent converting queue items into data to send
 		);
 
 		// Has the site opted in to IDC mitigation?
@@ -275,7 +277,7 @@ class Jetpack_Sync_Actions {
 		self::$sender = Jetpack_Sync_Sender::get_instance();
 
 		// bind the sending process
-		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 4 );
+		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 6 );
 	}
 
 	static function sanitize_filtered_sync_cron_schedule( $schedule ) {


### PR DESCRIPTION
Sites sometimes report issues with resource use of sync. Some of this is send time, and some is preprocessing time.

This PR adds the time spent checking out and preprocessing queue items as parameters to the sync request.