### PR TITLE
Admin - Settings: add Discussion, Security, and Traffic

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -62,6 +62,7 @@ function render() {
 					<Route path='/engagement' name={ i18n.translate( 'Engagement', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/discussion' name={ i18n.translate( 'Discussion', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/security' name={ i18n.translate( 'Security', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/traffic' name={ i18n.translate( 'Traffic', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/appearance' name={ i18n.translate( 'Appearance', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/writing' name={ i18n.translate( 'Writing', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/search' component={ Main } />

--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -60,6 +60,7 @@ function render() {
 					<Route path='/settings' name={ i18n.translate( 'General', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/general' name={ i18n.translate( 'General', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/engagement' name={ i18n.translate( 'Engagement', { context: 'Navigation item.' } ) } component={ Main } />
+					<Route path='/discussion' name={ i18n.translate( 'Discussion', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/security' name={ i18n.translate( 'Security', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/appearance' name={ i18n.translate( 'Appearance', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/writing' name={ i18n.translate( 'Writing', { context: 'Navigation item.' } ) } component={ Main } />

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -6,7 +6,7 @@
 	}
 }
 
-.jp-form-legend {
+.jp-form-legend, .jp-form-label-wide {
 	padding: 0;
 	margin-bottom: rem( 5px );
 	font-size: rem( 14px );
@@ -18,6 +18,10 @@
 	font-size: rem( 14px );
 	line-height: 1.5;
 	margin-bottom: rem( 5px );
+}
+
+.jp-form-label-wide {
+	display: block;
 }
 
 .jp-form-label input[type="radio"] + span {

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -72,3 +72,25 @@
 		margin-top: rem( 16px );
 	}
 }
+
+.jp-form-input-with-prefix {
+
+	display: inline-flex;
+	width: 100%;
+	margin-bottom: rem( 24px );
+
+	span:first-child {
+		min-width: rem( 60px );
+		text-align: center;
+		background: #f3f6f8;
+		border: 1px solid #c8d7e1;
+		color: #4f748e;
+		padding: rem( 8px ) rem( 14px );
+		white-space: nowrap;
+	}
+
+	input[type="text"] {
+		width: 100%;
+		border-left: 0;
+	}
+}

--- a/_inc/client/components/inline-expand/README.md
+++ b/_inc/client/components/inline-expand/README.md
@@ -1,0 +1,35 @@
+InlineExpand
+=========
+
+This component is used to slide down a inline block with text or elements. When it's rendered, it displays a clickable link. When it's clicked the block slides down. When clicked again, it slides up.
+
+#### Usage
+
+```js
+var InlineExpand = require( 'components/inline-expand' );
+
+render: function() {
+	return (
+		<InlineExpand label={ __( 'More options' ) }>
+			// elements
+		</InlineExpand>
+	);
+}
+```
+
+#### Properties
+
+* `label` — The title of the card. If it's not present but `module` attribute is, it will fetch the module and use its name property as title.
+* `onOpen`/`onClose` - Pass functions that will be executed when the block is revealed/concealed respectively.
+```js
+<InlineExpand
+	label={ __( 'More options' ) }
+	onOpen={
+		() => {
+			// do something
+		}
+	}>
+	// elements
+</InlineExpand>
+```
+* `icon` - To show an icon, pass an icon name like 'chevron-down'. Check list in dops-components/client/components/gridicon.

--- a/_inc/client/components/inline-expand/index.jsx
+++ b/_inc/client/components/inline-expand/index.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Gridicon from 'components/gridicon';
+
+export const InlineExpand = React.createClass( {
+
+	propTypes: {
+		label: React.PropTypes.string.isRequired,
+		icon: React.PropTypes.string,
+		cardKey: React.PropTypes.string,
+		expanded: React.PropTypes.bool,
+		onClick: React.PropTypes.func,
+		onClose: React.PropTypes.func,
+		onOpen: React.PropTypes.func
+	},
+
+	getInitialState: function() {
+		return {
+			expanded: this.props.expanded
+		};
+	},
+
+	getDefaultProps: function() {
+		return {
+			icon: '',
+			onOpen: () => false,
+			onClose: () => false,
+			cardKey: '',
+			expanded: false
+		};
+	},
+
+	onClick: function() {
+		if ( this.props.children ) {
+			this.setState( { expanded: ! this.state.expanded } );
+		}
+
+		if ( this.props.onClick ) {
+			this.props.onClick();
+		}
+
+		if ( this.state.expanded ) {
+			this.props.onClose( this.props.cardKey );
+		} else {
+			this.props.onOpen( this.props.cardKey );
+		}
+	},
+
+	render: function() {
+		let isExpanded = this.state.expanded
+				? ' is-expanded'
+				: '',
+			extraClasses = this.props.className
+				? ' ' + this.props.className
+				: '';
+		return (
+			<div className={ 'jp-inline-expand' + extraClasses + isExpanded }>
+				{
+					<a className="jp-inline-expand-action" onClick={ this.onClick }>
+						{
+							this.props.label
+						}
+						{
+							this.props.icon
+								? <Gridicon icon={ this.props.icon } size={ 16 } />
+								: ''
+						}
+					</a>
+				}
+				{
+					this.state.expanded
+						? <div className="jp-inline-expand-content">
+							{ this.props.children }
+						  </div>
+						: ''
+				}
+			</div>
+		);
+	}
+} );
+
+export default InlineExpand;

--- a/_inc/client/components/inline-expand/index.jsx
+++ b/_inc/client/components/inline-expand/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import Gridicon from 'components/gridicon';
+import classNames from 'classnames';
 
 export const InlineExpand = React.createClass( {
 
@@ -49,14 +50,8 @@ export const InlineExpand = React.createClass( {
 	},
 
 	render: function() {
-		let isExpanded = this.state.expanded
-				? ' is-expanded'
-				: '',
-			extraClasses = this.props.className
-				? ' ' + this.props.className
-				: '';
 		return (
-			<div className={ 'jp-inline-expand' + extraClasses + isExpanded }>
+			<div className={ classNames( 'jp-inline-expand', this.props.className, { 'is-expanded': this.state.expanded } ) }>
 				{
 					<a className="jp-inline-expand-action" onClick={ this.onClick }>
 						{

--- a/_inc/client/components/inline-expand/style.scss
+++ b/_inc/client/components/inline-expand/style.scss
@@ -1,0 +1,32 @@
+// Styles for a FoldableCard that looks like a link
+
+.jp-inline-expand {
+
+	&.dops-card {
+		box-shadow: none;
+		padding: 0;
+	}
+
+	.jp-inline-expand-action {
+		font-size: rem( 14px );
+		cursor: pointer;
+
+		.gridicon {
+			transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.5s ease-in;
+			vertical-align: text-bottom;
+			display: inline-block;
+			margin: 0 5px;
+		}
+	}
+
+	&.is-expanded {
+
+		.jp-inline-expand-action .gridicon {
+			transform: rotate(180deg);
+		}
+
+		.jp-inline-expand-content {
+			padding: 16px 0 0;
+		}
+	}
+}

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -39,7 +40,7 @@ export function connectModuleOptions( Component ) {
 		( state, ownProps ) => {
 			return {
 				validValues: ( option_name, module_slug = '' ) => {
-					if ( 'object' === typeof ownProps.module && 'undefined' !== typeof ownProps.module.module ) {
+					if ( 'string' === typeof get( ownProps, [ 'module', 'module' ] ) ) {
 						module_slug = ownProps.module.module;
 					}
 					return getModuleOptionValidValues( state, module_slug, option_name );

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -38,7 +38,12 @@ export function connectModuleOptions( Component ) {
 	return connect(
 		( state, ownProps ) => {
 			return {
-				validValues: ( option_name ) => getModuleOptionValidValues( state, ownProps.module.module, option_name ),
+				validValues: ( option_name, module_slug = '' ) => {
+					if ( 'object' === typeof ownProps.module && 'undefined' !== typeof ownProps.module.module ) {
+						module_slug = ownProps.module.module;
+					}
+					return getModuleOptionValidValues( state, module_slug, option_name );
+				},
 				getOptionCurrentValue: ( module_slug, option_name ) => getModuleOption( state, module_slug, option_name ),
 				getSettingCurrentValue: ( setting_name ) => getSetting( state, setting_name ),
 				getSiteRoles: () => getSiteRoles( state ),

--- a/_inc/client/components/module-settings/form-components.jsx
+++ b/_inc/client/components/module-settings/form-components.jsx
@@ -55,6 +55,21 @@ export const ModuleSettingRadios = React.createClass( {
 	}
 } );
 
+export const ModuleSettingSelect = React.createClass( {
+	render() {
+		let validValues = this.props.validValues;
+		return (
+			<select name={ this.props.name } value={ this.props.value } onChange={ this.props.onOptionChange }>
+				{
+					Object.keys( validValues ).map( key => {
+						return <option value={ key } key={ `option-${ this.props.option_name }-${key}` } >{ validValues[ key ] }</option>;
+					} )
+				}
+			</select>
+		);
+	}
+} );
+
 export const ModuleSettingMultipleSelectCheckboxes = React.createClass( {
 	getDefaultProps() {
 		return {

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -170,47 +170,6 @@ export let StatsSettings = React.createClass( {
 
 StatsSettings = moduleSettingsForm( StatsSettings );
 
-export let ProtectSettings = React.createClass( {
-	render() {
-		const maybeShowIp = this.props.currentIp ?
-			<p>{ __( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } ) }</p> :
-			'';
-
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<FormLegend>{ __( 'Whitelist Management' ) }</FormLegend>
-					<p>{ __( 'Whitelisting an IP address prevents it from ever being blocked by Jetpack.' ) }</p>
-					<small>{ __( 'Make sure to add your most frequently used IP addresses as they can change between your home, office or other locations. Removing an IP address from the list below will remove it from your whitelist.' ) }</small>
-					{ maybeShowIp }
-					<FormLabel>
-						<Textarea
-							name={ 'jetpack_protect_global_whitelist' }
-							placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
-							onChange={ this.props.onOptionChange }
-							value={ this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local } />
-					</FormLabel>
-					<span className="jp-form-setting-explanation">{ __( 'IPv4 and IPv6 are acceptable. {{br/}} To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
-						components: {
-							br: <br/>
-						}
-					} ) }</span>
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-ProtectSettings.propTypes = {
-	currentIp: React.PropTypes.string.isRequired
-};
-
-ProtectSettings = moduleSettingsForm( ProtectSettings );
-
 export let MonitorSettings = React.createClass( {
 	render() {
 		return (

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -100,39 +100,6 @@ export let LikesSettings = React.createClass( {
 
 LikesSettings = moduleSettingsForm( LikesSettings );
 
-export let CommentsSettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<FormLegend>{ __( 'Comments headline' ) }</FormLegend>
-					<FormLabel>
-						<TextInput
-							name={ 'highlander_comment_form_prompt' }
-							value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
-							disabled={ this.props.isUpdating( 'highlander_comment_form_prompt' ) }
-							onChange={ this.props.onOptionChange} />
-					</FormLabel>
-					<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
-				</FormFieldset>
-				<FormFieldset>
-					<FormLegend>{ __( 'Color Scheme' ) }</FormLegend>
-					<ModuleSettingRadios
-						name={ 'jetpack_comment_form_color_scheme' }
-						{ ...this.props }
-						validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme' ) } />
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-CommentsSettings = moduleSettingsForm( CommentsSettings );
-
 export let SubscriptionsSettings = React.createClass( {
 	render() {
 		return (

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -100,32 +100,6 @@ export let LikesSettings = React.createClass( {
 
 LikesSettings = moduleSettingsForm( LikesSettings );
 
-export let SubscriptionsSettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormLegend>{ __( 'Can readers subscribe to your posts, comments or both?' ) }</FormLegend>
-				<FormFieldset>
-					<ModuleSettingCheckbox
-						name={ "stb_enabled" }
-						{ ...this.props }
-						label={ __( 'Show a "follow blog" options in the comment form' ) } />
-					<ModuleSettingCheckbox
-						name={ 'stc_enabled' }
-						{ ...this.props }
-						label={ __( 'Show a "follow comments" option in the comment form.' ) } />
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-SubscriptionsSettings = moduleSettingsForm( SubscriptionsSettings );
-
 export let MonitorSettings = React.createClass( {
 	render() {
 		return (
@@ -144,31 +118,6 @@ export let MonitorSettings = React.createClass( {
 } );
 
 MonitorSettings = moduleSettingsForm( MonitorSettings );
-
-export let SingleSignOnSettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<ModuleSettingCheckbox
-						name={ 'jetpack_sso_match_by_email' }
-						{ ...this.props }
-						label={ __( 'Match By Email' ) } />
-					<ModuleSettingCheckbox
-						name={ 'jetpack_sso_require_two_step' }
-						{ ...this.props }
-						label={ __( 'Require Two-Step Authentication' ) } />
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-SingleSignOnSettings = moduleSettingsForm( SingleSignOnSettings );
 
 export let CarouselSettings = React.createClass( {
 	render() {
@@ -259,103 +208,6 @@ export let MinilevenSettings = React.createClass( {
  } );
 
 MinilevenSettings = moduleSettingsForm( MinilevenSettings );
-
-export let VerificationToolsSettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<p className="jp-form-setting-explanation">
-						{
-							__( 'Enter your meta key "content" value to verify your blog with {{a}}Google Search Console{{/a}}, {{a1}}Bing Webmaster Center{{/a1}} and {{a2}}Pinterest Site Verification{{/a2}}.', {
-								components: {
-									a: <a href="https://www.google.com/webmasters/tools/" target="_blank" />,
-									a1: <a href="http://www.bing.com/webmaster/" target="_blank" />,
-									a2: <a href="https://pinterest.com/website/verify/" target="_blank" />
-								}
-							} )
-						}
-					</p>
-
-					<div className="dops-card">
-						<FormLabel>
-							<FormLegend>Google</FormLegend>
-							<TextInput
-								name={ 'google' }
-								value={ this.props.getOptionValue( 'google' ) }
-								placeholder={ 'Example: dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8' }
-								className="widefat code"
-								disabled={ this.props.isUpdating( 'google' ) }
-								onChange={ this.props.onOptionChange} />
-						</FormLabel>
-						<span className="jp-form-setting-explanation">
-							{ __( 'Meta key example:' ) }
-							&nbsp;&lt;meta name='google-site-verification' content='<strong className="code">dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8</strong>'&gt;
-						</span>
-					</div>
-
-					<div className="dops-card">
-						<FormLabel>
-							<FormLegend>Bing</FormLegend>
-							<TextInput
-								name={ 'bing' }
-								value={ this.props.getOptionValue( 'bing' ) }
-								placeholder={ 'Example: 12C1203B5086AECE94EB3A3D9830B2E' }
-								className="widefat code"
-								disabled={ this.props.isUpdating( 'bing' ) }
-								onChange={ this.props.onOptionChange} />
-						</FormLabel>
-						<span className="jp-form-setting-explanation">
-							{ __( 'Meta key example:' ) }
-							&nbsp;&lt;meta name='msvalidate.01' content='<strong>12C1203B5086AECE94EB3A3D9830B2E</strong>'&gt;
-						</span>
-					</div>
-
-					<div className="dops-card">
-						<FormLabel>
-							<FormLegend>Pinterest</FormLegend>
-							<TextInput
-								name={ 'pinterest' }
-								value={ this.props.getOptionValue( 'pinterest' ) }
-								placeholder={ 'Example: f100679e6048d45e4a0b0b92dce1efce' }
-								className="widefat code"
-								disabled={ this.props.isUpdating( 'pinterest' ) }
-								onChange={ this.props.onOptionChange} />
-						</FormLabel>
-						<span className="jp-form-setting-explanation">
-							{ __( 'Meta key example:' ) }
-							&nbsp;&lt;meta name='p:domain_verify' content='<strong>f100679e6048d45e4a0b0b92dce1efce</strong>'&gt;
-						</span>
-					</div>
-
-					<div className="dops-card">
-						<FormLabel>
-							<FormLegend>Yandex</FormLegend>
-							<TextInput
-								name={ 'yandex' }
-								value={ this.props.getOptionValue( 'yandex' ) }
-								placeholder={ 'Example: 44d68e1216009f40' }
-								className="widefat code"
-								disabled={ this.props.isUpdating( 'yandex' ) }
-								onChange={ this.props.onOptionChange} />
-						</FormLabel>
-						<span className="jp-form-setting-explanation">
-							{ __( 'Meta key example:' ) }
-							&nbsp;&lt;meta name='yandex-verification' content='<strong>44d68e1216009f40</strong>'&gt;
-						</span>
-					</div>
-
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-VerificationToolsSettings = moduleSettingsForm( VerificationToolsSettings );
 
 export let TiledGallerySettings = React.createClass( {
 	render() {
@@ -487,39 +339,7 @@ CustomContentTypesSettings.propTypes = {
 
 CustomContentTypesSettings = moduleSettingsForm( CustomContentTypesSettings );
 
-export let SitemapsSettings = React.createClass( {
-	render() {
-		let sitemap_url = get( this.props, [ 'module', 'extra', 'sitemap_url' ], '' ),
-			news_sitemap_url = get( this.props, [ 'module', 'extra', 'news_sitemap_url' ], '' );
-		return (
-			<div>
-				<p>{ __( 'Search engines will find the sitemaps at these locations:' ) }</p>
-				<p>{
-					__( 'Sitemap: {{a}}%(url)s{{/a}}', {
-						components: {
-							a: <a href={ sitemap_url } target="_blank" />
-						},
-						args: {
-							url: sitemap_url
-						}
-					} )
-				}</p>
-				<p>{
-					__( 'News Sitemap: {{a}}%(url)s{{/a}}', {
-						components: {
-							a: <a href={ news_sitemap_url } target="_blank" />
-						},
-						args: {
-							url: news_sitemap_url
-						}
-					} )
-				}</p>
-			</div>
-		)
-	}
-} );
-
-SitemapsSettings = moduleSettingsForm( SitemapsSettings );
+;
 
 export let WordAdsSettings = React.createClass( {
 	render() {

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -126,50 +126,6 @@ export let SubscriptionsSettings = React.createClass( {
 
 SubscriptionsSettings = moduleSettingsForm( SubscriptionsSettings );
 
-export let StatsSettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<FormLegend>{ __( 'Admin Bar' ) }</FormLegend>
-					<ModuleSettingCheckbox
-						name={ 'admin_bar' }
-						{ ...this.props }
-						label={ __( 'Put a chart showing 48 hours of views in the admin bar' ) } />
-				</FormFieldset>
-				<FormFieldset>
-					<FormLegend>{ __( 'Smiley' ) }</FormLegend>
-					<ModuleSettingCheckbox
-						name={ 'hide_smile' }
-						{ ...this.props }
-						label={ __( 'Hide the stats smiley face image. The image helps collect stats but should still work when hidden.' ) } />
-				</FormFieldset>
-				<FormFieldset>
-					<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
-					<ModuleSettingMultipleSelectCheckboxes
-						name={ 'count_roles' }
-						{ ...this.props }
-						validValues={ this.props.getSiteRoles() } />
-				</FormFieldset>
-				<FormFieldset>
-					<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
-					<ModuleSettingMultipleSelectCheckboxes
-						always_checked={ [ 'administrator' ] }
-						name={ 'roles' }
-						{ ...this.props }
-						validValues={ this.props.getSiteRoles() } />
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		);
-	}
-} );
-
-StatsSettings = moduleSettingsForm( StatsSettings );
-
 export let MonitorSettings = React.createClass( {
 	render() {
 		return (

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -13,7 +13,7 @@ import { connectModuleOptions } from 'components/module-settings/connect-module-
  * High order component that provides a <form> with functionality
  * to handle input values on the forms' own React component state.
  *
- * @param  {React.Component} Component The component with a top level form element
+ * @param  {React.Component} InnerComponent The component with a top level form element
  * @return {[React.Component]}	The component with new functionality
  */
 export function ModuleSettingsForm( InnerComponent ) {
@@ -69,10 +69,8 @@ export function ModuleSettingsForm( InnerComponent ) {
 		},
 
 		shouldSaveButtonBeDisabled() {
-			let shouldItBeEnabled = false;
 			// Check if the form is not currently dirty
-			shouldItBeEnabled = ! this.isSavingAnyOption() && this.isDirty();
-			return ! shouldItBeEnabled;
+			return this.isSavingAnyOption() || ! this.isDirty();
 		},
 		isDirty() {
 			return !! Object.keys( this.state.options ).length;

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -56,6 +56,28 @@ export function ModuleSettingsForm( InnerComponent ) {
 			this.setState( { options: newOptions } );
 			return true;
 		},
+		/**
+		 * Receives an option and the module it depends on.
+		 * If the module is active, only the option is added to the list of form values to send.
+		 * If it's inactive, an additional option stating that the module must be activated is added to the list.
+		 *
+		 * @param {string} module
+		 * @param {string} moduleOption
+		 */
+		updateFormStateModuleOption( module, moduleOption ) {
+
+			// If the module is active, we pass the value to set.
+			if ( this.getOptionValue( module ) ) {
+				this.updateFormStateOptionValue( moduleOption, ! this.getOptionValue( moduleOption ) );
+			} else {
+
+				// If the module is inactive, we pass the module to activate and the value to set.
+				this.updateFormStateOptionValue( {
+					[ module ]: true,
+					[ moduleOption ]: true
+				} );
+			}
+		},
 		componentDidUpdate() {
 			if ( this.isDirty() ) {
 				this.props.setUnsavedSettingsFlag();
@@ -97,6 +119,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 					onSubmit={ this.onSubmit }
 					onOptionChange={ this.onOptionChange }
 					updateFormStateOptionValue={ this.updateFormStateOptionValue }
+					updateFormStateModuleOption={ this.updateFormStateModuleOption }
 					shouldSaveButtonBeDisabled={ this.shouldSaveButtonBeDisabled }
 					isSavingAnyOption={ this.isSavingAnyOption }
 					{ ...this.props } />

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -37,10 +37,21 @@ export function ModuleSettingsForm( InnerComponent ) {
 
 			this.updateFormStateOptionValue( optionName, optionValue );
 		},
-		updateFormStateOptionValue( optionName, optionValue ) {
+		/**
+		 * Updates the list of form values to save, usually options to set or modules to activate.
+		 * Receives an object with key => value pairs to set multiple options or a string and a value to set a single option.
+		 *
+		 * @param   {string|object} optionMaybeOptions
+		 * @param   {*}             optionValue
+		 * @returns {boolean}
+		 */
+		updateFormStateOptionValue( optionMaybeOptions, optionValue = undefined ) {
+			if ( 'string' === typeof optionMaybeOptions ) {
+				optionMaybeOptions = { [ optionMaybeOptions ]: optionValue };
+			}
 			const newOptions = {
 				...this.state.options,
-				[ optionName ]: optionValue
+				...optionMaybeOptions
 			};
 			this.setState( { options: newOptions } );
 			return true;

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -156,7 +156,6 @@ const AllModuleSettingsComponent = React.createClass( {
 						}
 					</div>
 				);
-			case 'related-posts':
 			case 'custom-css':
 			case 'widgets':
 			case 'publicize':
@@ -164,12 +163,6 @@ const AllModuleSettingsComponent = React.createClass( {
 			default:
 				if ( 'publicize' === module.module ) {
 					module.configure_url = this.props.adminUrl + 'options-general.php?page=sharing';
-				}
-				if ( 'related-posts' === module.module ) {
-					module.configure_url = this.props.adminUrl +
-						'customize.php?autofocus[section]=jetpack_relatedposts' +
-						'&return=' + encodeURIComponent( this.props.adminUrl + 'admin.php?page=jetpack#/engagement' ) +
-						'&url=' + encodeURIComponent( this.props.lastPostUrl );
 				}
 				return (
 					<div>

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -10,10 +10,7 @@ import { connect } from 'react-redux';
  */
 import {
 	StatsSettings,
-	CommentsSettings,
 	LikesSettings,
-	SubscriptionsSettings,
-	ProtectSettings,
 	MonitorSettings,
 	SingleSignOnSettings,
 	MinilevenSettings,
@@ -23,8 +20,6 @@ import {
 	PostByEmailSettings,
 	CustomContentTypesSettings,
 	MarkdownSettings,
-	VerificationToolsSettings,
-	SitemapsSettings,
 	VideoPressSettings,
 	WordAdsSettings
 } from 'components/module-settings/';
@@ -61,8 +56,6 @@ const AllModuleSettingsComponent = React.createClass( {
 				return ( <CarouselSettings module={ module }  /> );
 			case 'infinite-scroll':
 				return ( <InfiniteScrollSettings module={ module }  /> );
-			case 'protect':
-				return ( <ProtectSettings module={ module }  /> );
 			case 'monitor':
 				module.raw_url = this.props.siteRawUrl;
 				return ( <MonitorSettings module={ module }  /> );
@@ -82,8 +75,6 @@ const AllModuleSettingsComponent = React.createClass( {
 						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ module.configure_url }>{ __( 'Configure your Security Scans' ) }</ExternalLink>
 					</div>
 				);
-			case 'sso':
-				return ( <SingleSignOnSettings module={ module }  /> );
 			case 'seo-tools':
 				if ( '' === module.configure_url ) {
 					return (
@@ -106,18 +97,8 @@ const AllModuleSettingsComponent = React.createClass( {
 						</div>
 					);
 				}
-			case 'stats':
-				return ( <StatsSettings module={ module }  /> );
-			case 'comments':
-				return ( <CommentsSettings module={ module }  /> );
-			case 'subscriptions':
-				return ( <SubscriptionsSettings module={ module } { ...this.props } /> );
 			case 'likes':
 				return ( <LikesSettings module={ module }  /> );
-			case 'verification-tools':
-				return ( <VerificationToolsSettings module={ module }  /> );
-			case 'sitemaps':
-				return ( <SitemapsSettings module={ module } { ...this.props } /> );
 			case 'wordads':
 				return ( <WordAdsSettings module={ module } /> );
 			case 'gravatar-hovercards':

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -73,11 +73,6 @@ export const NavigationSettings = React.createClass( {
 						{ __( 'General', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
-						path="#engagement"
-						selected={ this.props.route.path === '/engagement' }>
-						{ __( 'Engagement', { context: 'Navigation item.' } ) }
-					</NavItem>
-					<NavItem
 						path="#discussion"
 						selected={ this.props.route.path === '/discussion' }>
 						{ __( 'Discussion', { context: 'Navigation item.' } ) }
@@ -88,9 +83,9 @@ export const NavigationSettings = React.createClass( {
 						{ __( 'Security', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
-						path="#appearance"
-						selected={ this.props.route.path === '/appearance' }>
-						{ __( 'Appearance', { context: 'Navigation item.' } ) }
+						path="#traffic"
+						selected={ this.props.route.path === '/traffic' }>
+						{ __( 'Traffic', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
 						path="#writing"
@@ -116,11 +111,6 @@ export const NavigationSettings = React.createClass( {
 						path="#general"
 						selected={ ( this.props.route.path === '/general' || this.props.route.path === '/settings' ) }>
 						{ __( 'General', { context: 'Navigation item.' } ) }
-					</NavItem>
-					<NavItem
-						path="#engagement"
-						selected={ this.props.route.path === '/engagement' }>
-						{ __( 'Engagement', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
 						path="#writing"

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -78,6 +78,11 @@ export const NavigationSettings = React.createClass( {
 						{ __( 'Engagement', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
+						path="#discussion"
+						selected={ this.props.route.path === '/discussion' }>
+						{ __( 'Discussion', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
 						path="#security"
 						selected={ this.props.route.path === '/security' }>
 						{ __( 'Security', { context: 'Navigation item.' } ) }

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -71,8 +71,8 @@ describe( 'NavigationSettings', () => {
 
 		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
 
-		it( 'renders tabs with General, Engagement, Writing', () => {
-			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Engagement,Writing' );
+		it( 'renders tabs with General, Writing', () => {
+			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Writing' );
 		} );
 
 		it( 'does not display Search', () => {
@@ -90,8 +90,8 @@ describe( 'NavigationSettings', () => {
 
 		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
 
-		it( 'renders tabs with General, Engagement, Security, Appearance, Writing', () => {
-			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Engagement,Discussion,Security,Appearance,Writing' );
+		it( 'renders tabs with General, Discussion, Security, Traffic, Writing', () => {
+			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Discussion,Security,Traffic,Writing' );
 		} );
 
 		it( 'displays Search', () => {

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -91,7 +91,7 @@ describe( 'NavigationSettings', () => {
 		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
 
 		it( 'renders tabs with General, Engagement, Security, Appearance, Writing', () => {
-			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Engagement,Security,Appearance,Writing' );
+			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'General,Engagement,Discussion,Security,Appearance,Writing' );
 		} );
 
 		it( 'displays Search', () => {

--- a/_inc/client/components/settings-card/README.md
+++ b/_inc/client/components/settings-card/README.md
@@ -1,22 +1,39 @@
 SettingsCard
 =========
 
-This component is used to display a card with header and button to save settings.
+This component is used to display a card with header, button to save settings and help link.
 Its children are all the form elements used to compose the settings.
 Uses isSavingAnyOption and onSubmit defined in components/module-settings/module-settings-form.jsx
 
-#### How to use:
+#### Usage
 
 ```js
 var SettingsCard = require( 'components/settings-card' );
 
 render: function() {
 	return (
-		<SettingsCard header={ __( 'The card header', { context: 'Settings header' } ) } { ...this.props }>
+		<SettingsCard { ...this.props } header={ __( 'The card header', { context: 'Settings header' } ) }>
 			<FormFieldset>
 				// form elements
 			</FormFieldset>
 		</SettingsCard>
 	);
 }
+```
+
+#### Properties
+
+* `module` - A Jetpack module. If it's not present, the `header` and `support` attributes must be explicitly passed if it's intended to display them.
+* `header` — The title of the card. If it's not present but `module` attribute is, it will fetch the module and use its name property as title.
+* `hideButton` - When this attribute is present, the saving button will not be rendered:
+```js
+<SettingsCard { ...this.props } header={ __( 'The card header', { context: 'Settings header' } ) } hideButton>
+	// form elements
+</SettingsCard>
+```
+* `support` - A custom URL to a support resource. Will be used to render an icon linked to the URL. If no URL is passed but `module` is present, it will fetch the module and use its learn_more_button property as URL.
+```js
+<SettingsCard { ...this.props } header={ __( 'The card header', { context: 'Settings header' } ) } help="https://jetpack.com/support/sso">
+	// form elements
+</SettingsCard>
 ```

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -15,29 +15,49 @@ import {
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 
 export const SettingsCard = props => {
+	let module = props.module
+			? props.getModule( props.module )
+			: false,
+		header = props.header
+			? props.header
+			: module
+				? module.name
+				: '',
+		support = props.support
+			? props.support
+			: module && '' !== module.learn_more_button
+				? module.learn_more_button
+				: false;
+
 	return (
 		<form>
-			<SectionHeader label={ props.header }>
+			<SectionHeader label={ header }>
 				{
-					! props.hideButton
-						? <Button
-								primary
-								compact
-								isSubmitting={ props.isSavingAnyOption() }
-								onClick={ props.onSubmit }
-							>
-								{
-									props.isSavingAnyOption() ?
-										__( 'Saving…', { context: 'Button caption' } ) :
-										__( 'Save settings', { context: 'Button caption' } )
-								}
+					props.hideButton
+						? ''
+						: <Button primary compact isSubmitting={ props.isSavingAnyOption() } onClick={ props.onSubmit }>
+							{
+								props.isSavingAnyOption()
+									? __( 'Saving…', { context: 'Button caption' } )
+									: __( 'Save settings', { context: 'Button caption' } )
+							}
 						  </Button>
-						: ''
 				}
 			</SectionHeader>
 			<Card>
+				{
+					support
+						? <div className="jp-module-settings__learn-more">
+							<Button borderless compact href={ support }>
+								<Gridicon icon="help-outline" />
+								<span className="screen-reader-text">{ __( 'Learn More' ) }</span>
+							</Button>
+						  </div>
+						: ''
+				}
 				{ props.children }
 			</Card>
 		</form>

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -22,7 +22,7 @@ export const SettingsCard = props => {
 			<SectionHeader label={ props.header }>
 				{
 					! props.hideButton
-						?	<Button
+						? <Button
 								primary
 								compact
 								isSubmitting={ props.isSavingAnyOption() }
@@ -33,8 +33,8 @@ export const SettingsCard = props => {
 										__( 'Saving…', { context: 'Button caption' } ) :
 										__( 'Save settings', { context: 'Button caption' } )
 								}
-							</Button>
-						:	''
+						  </Button>
+						: ''
 				}
 			</SectionHeader>
 			<Card>

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -30,7 +30,8 @@ export const SettingsCard = props => {
 			? props.support
 			: module && '' !== module.learn_more_button
 				? module.learn_more_button
-				: false;
+				: false,
+		isSaving = props.isSavingAnyOption();
 
 	return (
 		<form>
@@ -38,9 +39,14 @@ export const SettingsCard = props => {
 				{
 					props.hideButton
 						? ''
-						: <Button primary compact isSubmitting={ props.isSavingAnyOption() } onClick={ props.onSubmit }>
+						: <Button
+							primary
+							compact
+							isSubmitting={ isSaving }
+							onClick={ isSaving ? () => {} : props.onSubmit }
+							disabled={ isSaving }>
 							{
-								props.isSavingAnyOption()
+								isSaving
 									? __( 'Saving…', { context: 'Button caption' } )
 									: __( 'Save settings', { context: 'Button caption' } )
 							}

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -20,18 +20,22 @@ export const SettingsCard = props => {
 	return (
 		<form>
 			<SectionHeader label={ props.header }>
-				<Button
-					primary
-					compact
-					isSubmitting={ props.isSavingAnyOption() }
-					onClick={ props.onSubmit }
-				>
-					{
-						props.isSavingAnyOption() ?
-							__( 'Saving…', { context: 'Button caption' } ) :
-							__( 'Save settings', { context: 'Button caption' } )
-					}
-				</Button>
+				{
+					! props.hideButton
+						?	<Button
+								primary
+								compact
+								isSubmitting={ props.isSavingAnyOption() }
+								onClick={ props.onSubmit }
+							>
+								{
+									props.isSavingAnyOption() ?
+										__( 'Saving…', { context: 'Button caption' } ) :
+										__( 'Save settings', { context: 'Button caption' } )
+								}
+							</Button>
+						:	''
+				}
 			</SectionHeader>
 			<Card>
 				{ props.children }

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 
 /**

--- a/_inc/client/components/settings-card/test/component.js
+++ b/_inc/client/components/settings-card/test/component.js
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsCard } from '../index';
+
+describe( 'SettingsCard', () => {
+
+	let testProps = {
+		module: 'comments',
+		hideButton: false,
+		getModule: () => (
+			{
+				name: 'Comments',
+				learn_more_button: 'https://jetpack.com/support/protect'
+			}
+		),
+		isSavingAnyOption: () => false,
+		header: '',
+		support: ''
+	};
+
+	const wrapper = shallow( <SettingsCard { ...testProps } /> );
+
+	it( 'renders a heading', () => {
+		expect( wrapper.find( 'SectionHeader' ) ).to.have.length( 1 );
+	} );
+
+	it( 'the heading has the right text', () => {
+		expect( wrapper.find( 'SectionHeader' ).props().label ).to.be.equal( 'Comments' );
+	} );
+
+	it( 'the learn more icon is linked to the correct URL', () => {
+		expect( wrapper.find( 'Button' ).get(1).props.href ).to.be.equal( 'https://jetpack.com/support/protect' );
+	} );
+
+	it( "when not saving, it's enabled", () => {
+		expect( wrapper.find( 'Button' ).get(0).props.disabled ).to.be.false;
+	} );
+
+	describe( 'When a custom header or support URL are passed', () => {
+
+		Object.assign( testProps, {
+			header: 'A custom header',
+			support: 'https://jetpack.com/'
+		} );
+
+		const wrapper = shallow( <SettingsCard { ...testProps } /> );
+
+		it( 'the header has priority over module.name', () => {
+			expect( wrapper.find( 'SectionHeader' ).props().label ).to.be.equal( 'A custom header' );
+		} );
+
+		it( 'the learn more icon will be linked to the custom URL', () => {
+			expect( wrapper.find( 'Button' ).get(1).props.href ).to.be.equal( 'https://jetpack.com/' );
+		} );
+
+	} );
+
+	describe( 'When a custom header or support URL are passed', () => {
+
+		Object.assign( testProps, {
+			isSavingAnyOption: () => true
+		} );
+
+		const wrapper = shallow( <SettingsCard { ...testProps } /> );
+
+		it( "when saving, it's disabled", () => {
+			expect( wrapper.find( 'Button' ).get(0).props.disabled ).to.be.true;
+		} );
+
+	} );
+
+	describe( "If the support attribute and module doesn't have a support link", () => {
+
+		Object.assign( testProps, {
+			isSavingAnyOption: () => false,
+			support: '',
+			getModule: () => (
+				{
+					name: 'Comments',
+					learn_more_button: ''
+				}
+			)
+		} );
+
+		const wrapper = shallow( <SettingsCard { ...testProps } /> );
+
+		it( 'the support icon is not rendered', () => {
+			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
+		} );
+
+	} );
+
+	describe( 'When save button is clicked three times', () => {
+
+		const onSave = sinon.spy();
+		const wasSaving = sinon.spy();
+
+		Object.assign( testProps, {
+			onSubmit: onSave,
+			isSavingAnyOption: wasSaving
+		} );
+
+		const saveButton = shallow( <SettingsCard { ...testProps } /> ).find( 'SectionHeader' ).find( 'Button' );
+
+		saveButton.simulate( 'click' );
+		saveButton.simulate( 'click' );
+		saveButton.simulate( 'click' );
+
+		it( 'onSubmit() was triggered once', () => {
+			expect( onSave ).to.have.property( 'callCount', 3 );
+		} );
+
+		it( 'isSavingAnyOption() is called once', () => {
+			expect( wasSaving.calledOnce ).to.be.true;
+		} );
+
+	} );
+
+} );

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -16,7 +16,7 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingCheckbox, ModuleSettingRadios } from 'components/module-settings/form-components';
+import { ModuleSettingCheckbox, ModuleSettingRadios, ModuleSettingSelect } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 
 export const Comments = moduleSettingsForm(
@@ -55,10 +55,12 @@ export const Comments = moduleSettingsForm(
 					</FormFieldset>
 					<FormFieldset>
 						<FormLegend>{ __( 'Color Scheme' ) }</FormLegend>
-						<ModuleSettingRadios
+						<ModuleSettingSelect
 							name={ 'jetpack_comment_form_color_scheme' }
+							value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
+							onChange={ this.props.onOptionChange }
 							{ ...this.props }
-							validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) } />
+							validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
 					</FormFieldset>
 				</SettingsCard>
 			);

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -28,7 +28,9 @@ export const Comments = moduleSettingsForm(
 
 		render() {
 			return (
-				<SettingsCard header={ __( 'Comments', { context: 'Settings header' } ) } { ...this.props } >
+				<SettingsCard
+					{ ...this.props }
+					module="comments">
 					<ModuleToggle slug={ 'comments' }
 								  compact
 								  activated={ this.props.getOptionValue( 'comments' ) }

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -43,8 +43,8 @@ export const Comments = moduleSettingsForm(
 						</span>
 					</ModuleToggle>
 					<FormFieldset>
-						<FormLegend>{ __( 'Comments headline' ) }</FormLegend>
 						<FormLabel>
+							<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
 							<TextInput
 								name={ 'highlander_comment_form_prompt' }
 								value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
@@ -52,15 +52,15 @@ export const Comments = moduleSettingsForm(
 								onChange={ this.props.onOptionChange} />
 						</FormLabel>
 						<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
-					</FormFieldset>
-					<FormFieldset>
-						<FormLegend>{ __( 'Color Scheme' ) }</FormLegend>
-						<ModuleSettingSelect
-							name={ 'jetpack_comment_form_color_scheme' }
-							value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
-							onChange={ this.props.onOptionChange }
-							{ ...this.props }
-							validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
+						<FormLabel>
+							<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
+							<ModuleSettingSelect
+								name={ 'jetpack_comment_form_color_scheme' }
+								value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
+								onChange={ this.props.onOptionChange }
+								{ ...this.props }
+								validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
+						</FormLabel>
 					</FormFieldset>
 					<hr />
 					<FormFieldset>

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import TextInput from 'components/text-input';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLegend,
+	FormLabel
+} from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleSettingCheckbox, ModuleSettingRadios } from 'components/module-settings/form-components';
+import SettingsCard from 'components/settings-card';
+
+export const Comments = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			let comments = this.props.getModule( 'comments' );
+
+			return (
+				<SettingsCard header={ __( 'Comments', { context: 'Settings header' } ) } { ...this.props } >
+					<ModuleToggle slug={ 'comments' }
+								  compact
+								  activated={ this.props.getOptionValue( 'comments' ) }
+								  toggling={ this.props.isSavingAnyOption() }
+								  toggleModule={ this.toggleModule }>
+						<span className="jp-form-toggle-explanation">
+							{
+								__( 'Use Jetpack comments. Let readers use their WordPress.com,	Twitter, Facebook or Google+ to leave comments on your posts and pages.' )
+							}
+						</span>
+					</ModuleToggle>
+					<FormFieldset>
+						<FormLegend>{ __( 'Comments headline' ) }</FormLegend>
+						<FormLabel>
+							<TextInput
+								name={ 'highlander_comment_form_prompt' }
+								value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
+								disabled={ this.props.isUpdating( 'highlander_comment_form_prompt' ) }
+								onChange={ this.props.onOptionChange} />
+						</FormLabel>
+						<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
+					</FormFieldset>
+					<FormFieldset>
+						<FormLegend>{ __( 'Color Scheme' ) }</FormLegend>
+						<ModuleSettingRadios
+							name={ 'jetpack_comment_form_color_scheme' }
+							{ ...this.props }
+							validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) } />
+					</FormFieldset>
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -27,8 +27,6 @@ export const Comments = moduleSettingsForm(
 		},
 
 		render() {
-			let comments = this.props.getModule( 'comments' );
-
 			return (
 				<SettingsCard header={ __( 'Comments', { context: 'Settings header' } ) } { ...this.props } >
 					<ModuleToggle slug={ 'comments' }
@@ -61,6 +59,20 @@ export const Comments = moduleSettingsForm(
 							onChange={ this.props.onOptionChange }
 							{ ...this.props }
 							validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
+					</FormFieldset>
+					<hr />
+					<FormFieldset>
+						<ModuleToggle slug={ 'gravatar-hovercards' }
+									  compact
+									  activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
+									  toggling={ this.props.isSavingAnyOption() }
+									  toggleModule={ this.toggleModule }>
+							<span className="jp-form-toggle-explanation">
+								{
+									this.props.getModule( 'gravatar-hovercards' ).description
+								}
+							</span>
+						</ModuleToggle>
 					</FormFieldset>
 				</SettingsCard>
 			);

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -16,7 +16,7 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingCheckbox, ModuleSettingRadios, ModuleSettingSelect } from 'components/module-settings/form-components';
+import { ModuleSettingSelect } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 
 export const Comments = moduleSettingsForm(
@@ -70,6 +70,18 @@ export const Comments = moduleSettingsForm(
 							<span className="jp-form-toggle-explanation">
 								{
 									this.props.getModule( 'gravatar-hovercards' ).description
+								}
+							</span>
+						</ModuleToggle>
+						<br />
+						<ModuleToggle slug={ 'markdown' }
+									  compact
+									  activated={ !!this.props.getOptionValue( 'wpcom_publish_comments_with_markdown' ) }
+									  toggling={ this.props.isSavingAnyOption() }
+									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'wpcom_publish_comments_with_markdown' ) }>
+							<span className="jp-form-toggle-explanation">
+								{
+									__( 'Use Markdown for comments.' )
 								}
 							</span>
 						</ModuleToggle>

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -11,6 +11,7 @@ import { getModule as _getModule } from 'state/modules';
 import { getSettings as _getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { Comments } from './comments';
+import { Subscriptions } from './subscriptions';
 
 export const Discussion = React.createClass( {
 	displayName: 'DiscussionSettings',
@@ -22,6 +23,11 @@ export const Discussion = React.createClass( {
 				<Comments
 					settings={ this.props.getSettings() }
 					getModule={ this.props.getModule }
+				/>
+				<Subscriptions
+					settings={ this.props.getSettings() }
+					getModule={ this.props.getModule }
+					siteRawUrl={ this.props.siteRawUrl }
 				/>
 			</div>
 		);

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -7,8 +7,8 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getModule as _getModule } from 'state/modules';
-import { getSettings as _getSettings } from 'state/settings';
+import { getModule } from 'state/modules';
+import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { Comments } from './comments';
 import { Subscriptions } from './subscriptions';
@@ -21,12 +21,12 @@ export const Discussion = React.createClass( {
 			<div>
 				<QuerySite />
 				<Comments
-					settings={ this.props.getSettings() }
-					getModule={ this.props.getModule }
+					settings={ this.props.settings }
+					getModule={ this.props.module }
 				/>
 				<Subscriptions
-					settings={ this.props.getSettings() }
-					getModule={ this.props.getModule }
+					settings={ this.props.settings }
+					getModule={ this.props.module }
 					siteRawUrl={ this.props.siteRawUrl }
 				/>
 			</div>
@@ -37,11 +37,8 @@ export const Discussion = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			getModule: ( module_name ) => _getModule( state, module_name ),
-			getSettings: () => _getSettings( state )
+			module: ( module_name ) => getModule( state, module_name ),
+			settings: getSettings( state )
 		}
-	},
-	( dispatch ) => {
-		return {};
 	}
 )( Discussion );

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getModule as _getModule } from 'state/modules';
+import { getSettings as _getSettings } from 'state/settings';
+import QuerySite from 'components/data/query-site';
+import { Comments } from './comments';
+
+export const Discussion = React.createClass( {
+	displayName: 'DiscussionSettings',
+
+	render() {
+		return (
+			<div>
+				<QuerySite />
+				<Comments
+					settings={ this.props.getSettings() }
+					getModule={ this.props.getModule }
+				/>
+			</div>
+		);
+	}
+} );
+
+export default connect(
+	( state ) => {
+		return {
+			getModule: ( module_name ) => _getModule( state, module_name ),
+			getSettings: () => _getSettings( state )
+		}
+	},
+	( dispatch ) => {
+		return {};
+	}
+)( Discussion );

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -58,7 +58,6 @@ export const Subscriptions = moduleSettingsForm(
 							{ ...this.props }
 							label={ __( 'Show a "follow comments" option in the comment form.' ) } />
 					</FormFieldset>
-
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -25,7 +25,9 @@ export const Subscriptions = moduleSettingsForm(
 
 		render() {
 			return (
-				<SettingsCard header={ __( 'Subscriptions', { context: 'Settings header' } ) } { ...this.props } >
+				<SettingsCard
+					{ ...this.props }
+					module="subscriptions">
 					<ModuleToggle slug={ 'subscriptions' }
 								  compact
 								  activated={ this.props.getOptionValue( 'subscriptions' ) }

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import TextInput from 'components/text-input';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLabel
+} from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
+import SettingsCard from 'components/settings-card';
+
+export const Subscriptions = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			return (
+				<SettingsCard header={ __( 'Subscriptions', { context: 'Settings header' } ) } { ...this.props } >
+					<ModuleToggle slug={ 'subscriptions' }
+								  compact
+								  activated={ this.props.getOptionValue( 'subscriptions' ) }
+								  toggling={ this.props.isSavingAnyOption() }
+								  toggleModule={ this.toggleModule }>
+						<span className="jp-form-toggle-explanation">
+							{
+								__( 'Allow users to subscribe to your posts and comments and receive notifications via email.' )
+							}
+						</span>
+					</ModuleToggle>
+					<p>
+						{
+							__( 'View your {{a}}Email Followers{{/a}}', {
+								components: {
+									a: <a href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl } />
+								}
+							} )
+						}
+					</p>
+					<FormFieldset>
+						<ModuleSettingCheckbox
+							name={ 'stb_enabled' }
+							{ ...this.props }
+							label={ __( 'Show a "follow blog" options in the comment form' ) } />
+						<ModuleSettingCheckbox
+							name={ 'stc_enabled' }
+							{ ...this.props }
+							label={ __( 'Show a "follow comments" option in the comment form.' ) } />
+					</FormFieldset>
+
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -13,6 +13,7 @@ import {
 	FormFieldset,
 	FormLabel
 } from 'components/forms';
+import ExternalLink from 'components/external-link';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
@@ -40,13 +41,7 @@ export const Subscriptions = moduleSettingsForm(
 						</span>
 					</ModuleToggle>
 					<p>
-						{
-							__( 'View your {{a}}Email Followers{{/a}}', {
-								components: {
-									a: <a href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl } />
-								}
-							} )
-						}
+						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
 					</p>
 					<FormFieldset>
 						<ModuleSettingCheckbox

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -72,7 +72,6 @@ export const Engagement = ( props ) => {
 		[ 'sharedaddy', getModule( 'sharedaddy' ).name, getModule( 'sharedaddy' ).description, getModule( 'sharedaddy' ).learn_more_button ],
 		[ 'publicize', getModule( 'publicize' ).name, getModule( 'publicize' ).description, getModule( 'publicize' ).learn_more_button ],
 		[ 'related-posts', getModule( 'related-posts' ).name, getModule( 'related-posts' ).description, getModule( 'related-posts' ).learn_more_button ],
-		[ 'comments', getModule( 'comments' ).name, getModule( 'comments' ).description, getModule( 'comments' ).learn_more_button ],
 		[ 'likes', getModule( 'likes' ).name, getModule( 'likes' ).description, getModule( 'likes' ).learn_more_button ],
 		[ 'subscriptions', getModule( 'subscriptions' ).name, getModule( 'subscriptions' ).description, getModule( 'subscriptions' ).learn_more_button ],
 		[ 'gravatar-hovercards', getModule( 'gravatar-hovercards' ).name, getModule( 'gravatar-hovercards' ).description, getModule( 'gravatar-hovercards' ).learn_more_button ],

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -189,7 +189,7 @@ const Main = React.createClass( {
 				break;
 			case '/discussion':
 				navComponent = <NavigationSettings route={ this.props.route } />;
-				pageComponent = <Discussion route={ this.props.route } />;
+				pageComponent = <Discussion route={ this.props.route } siteRawUrl={ this.props.siteRawUrl } />;
 				break;
 			case '/security':
 				navComponent = <NavigationSettings route={ this.props.route } />;

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -32,6 +32,7 @@ import { areThereUnsavedSettings, clearUnsavedSettingsFlag } from 'state/setting
 
 import AtAGlance from 'at-a-glance/index.jsx';
 import Engagement from 'engagement/index.jsx';
+import Discussion from 'discussion';
 import Security from 'security/index.jsx';
 import Appearance from 'appearance/index.jsx';
 import GeneralSettings from 'general-settings/index.jsx';
@@ -186,6 +187,10 @@ const Main = React.createClass( {
 				navComponent = <NavigationSettings route={ this.props.route } />;
 				pageComponent = <Engagement route={ this.props.route } />;
 				break;
+			case '/discussion':
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <Discussion route={ this.props.route } />;
+				break;
 			case '/security':
 				navComponent = <NavigationSettings route={ this.props.route } />;
 				pageComponent = <Security route={ this.props.route } siteAdminUrl={ this.props.siteAdminUrl } />;
@@ -266,6 +271,7 @@ window.wpNavMenuClassChange = function() {
 		'#/settings',
 		'#/general',
 		'#/engagement',
+		'#/discussion',
 		'#/security',
 		'#/appearance',
 		'#/writing',

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -34,6 +34,7 @@ import AtAGlance from 'at-a-glance/index.jsx';
 import Engagement from 'engagement/index.jsx';
 import Discussion from 'discussion';
 import Security from 'security/index.jsx';
+import Traffic from 'traffic';
 import Appearance from 'appearance/index.jsx';
 import GeneralSettings from 'general-settings/index.jsx';
 import Writing from 'writing/index.jsx';
@@ -194,6 +195,10 @@ const Main = React.createClass( {
 			case '/security':
 				navComponent = <NavigationSettings route={ this.props.route } />;
 				pageComponent = <Security route={ this.props.route } siteAdminUrl={ this.props.siteAdminUrl } />;
+				break;
+			case '/traffic':
+				navComponent = <NavigationSettings route={ this.props.route } />;
+				pageComponent = <Traffic route={ this.props.route } siteRawUrl={ this.props.siteRawUrl } />;
 				break;
 			case '/appearance':
 				navComponent = <NavigationSettings route={ this.props.route } />;

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -198,7 +198,7 @@ const Main = React.createClass( {
 				break;
 			case '/traffic':
 				navComponent = <NavigationSettings route={ this.props.route } />;
-				pageComponent = <Traffic route={ this.props.route } siteRawUrl={ this.props.siteRawUrl } />;
+				pageComponent = <Traffic route={ this.props.route } siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/appearance':
 				navComponent = <NavigationSettings route={ this.props.route } />;

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -37,6 +37,7 @@
 @import '../components/forms/styles';
 @import '../components/tags-input/style';
 @import '../components/admin-notices/style';
+@import '../components/inline-expand/style';
 
 
 // Page Templates

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import TextInput from 'components/text-input';
+
+/**
+ * Internal dependencies
+ */
+import { FormFieldset } from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
+import SettingsCard from 'components/settings-card';
+
+export const Antispam = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Antispam', { context: 'Settings header' } ) }
+					support="https://akismet.com/jetpack/">
+					<FormFieldset>
+						<ModuleSettingCheckbox
+							name={ 'akismet_show_user_comments_approved' }
+							{ ...this.props }
+							label={ __( 'Show the number of approved comments beside each comment author.' ) } />
+					</FormFieldset>
+					<p>
+						<a href="javascript:alert( 'Needs coding' );">
+							{
+								__( 'Reveal API key (needs coding)' )
+							}
+						</a>
+					</p>
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -34,13 +34,6 @@ export const Antispam = moduleSettingsForm(
 							{ ...this.props }
 							label={ __( 'Show the number of approved comments beside each comment author.' ) } />
 					</FormFieldset>
-					<p>
-						<a href="javascript:alert( 'Needs coding' );">
-							{
-								__( 'Reveal API key (needs coding)' )
-							}
-						</a>
-					</p>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -4,17 +4,11 @@
 import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
 
 /**
  * Internal dependencies
  */
-import {
-	FormFieldset,
-	FormLabel
-} from 'components/forms';
 import ExternalLink from 'components/external-link';
-import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -45,13 +45,6 @@ export const BackupsScan = moduleSettingsForm(
 					<p>
 						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
 					</p>
-					<p>
-						<a href="javascript:alert( 'Needs coding' );">
-						{
-							__( 'Reveal API key (needs coding)' )
-						}
-						</a>
-					</p>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -27,7 +27,11 @@ export const BackupsScan = moduleSettingsForm(
 
 		render() {
 			return (
-				<SettingsCard header={ __( 'Backups and security scanning', { context: 'Settings header' } ) } { ...this.props } hideButton={ true } >
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+					support="https://vaultpress.com/jetpack/"
+					hideButton>
 					<span>
 						{
 							__( 'Your site is backed up and threat-free.' )

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import TextInput from 'components/text-input';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLabel
+} from 'components/forms';
+import ExternalLink from 'components/external-link';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+
+export const BackupsScan = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			return (
+				<SettingsCard header={ __( 'Backups and security scanning', { context: 'Settings header' } ) } { ...this.props } hideButton={ true } >
+					<span>
+						{
+							__( 'Your site is backed up and threat-free.' )
+						}
+					</span>
+					<p className="jp-form-setting-explanation">
+						{
+							__( 'You can see the information about your backups and security scanning in the "At a Glance" section.' )
+						}
+					</p>
+					<p>
+						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
+					</p>
+					<p>
+						<a href="javascript:alert( 'Needs coding' );">
+						{
+							__( 'Reveal API key (needs coding)' )
+						}
+						</a>
+					</p>
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -3,160 +3,36 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import FoldableCard from 'components/foldable-card';
-import Button from 'components/button';
-import Gridicon from 'components/gridicon';
-import { translate as __ } from 'i18n-calypso';
-import SimpleNotice from 'components/notice';
-import includes from 'lodash/includes';
-import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
  */
+import { getModule } from 'state/modules';
+import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
-import ProStatus from 'pro-status';
-import {
-	isModuleActivated as _isModuleActivated,
-	activateModule,
-	deactivateModule,
-	isActivatingModule,
-	isDeactivatingModule,
-	getModule as _getModule,
-	getModules
-} from 'state/modules';
-import { ModuleToggle } from 'components/module-toggle';
-import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
-import { isUnavailableInDevMode } from 'state/connection';
-import {
-	isFetchingPluginsData,
-	isPluginActive
-} from 'state/site/plugins';
-import { getSiteAdminUrl } from 'state/initial-state';
+import { BackupsScan } from './backups-scan';
 
-export const Page = ( props ) => {
-	let {
-		toggleModule,
-		isModuleActivated,
-		isTogglingModule,
-		getModule
-	} = props,
-		moduleList = Object.keys( props.moduleList );
-	var cards = [
-		[ 'scan', __( 'Security Scanning' ), __( 'Automated, comprehensive protection from threats and attacks.' ), 'https://vaultpress.com/jetpack/' ],
-		[ 'protect', getModule( 'protect' ).name, getModule( 'protect' ).description, getModule( 'protect' ).learn_more_button ],
-		[ 'monitor', getModule( 'monitor' ).name, getModule( 'monitor' ).description, getModule( 'monitor' ).learn_more_button ],
-		[ 'akismet', 'Akismet', __( 'State-of-the-art spam defense.' ), 'https://akismet.com/jetpack/' ],
-		[ 'backups', __( 'Site Backups' ), __( 'Automatically backup your entire site.' ), 'https://vaultpress.com/jetpack/' ],
-		[ 'sso', getModule( 'sso' ).name, getModule( 'sso' ).description, getModule( 'sso' ).learn_more_button ]
-	].map( ( element ) => {
-		var unavailableInDevMode = props.isUnavailableInDevMode( element[0] ),
-			toggle = (
-				unavailableInDevMode ? __( 'Unavailable in Dev Mode' ) :
-				<ModuleToggle slug={ element[0] } activated={ isModuleActivated( element[0] ) }
-					toggling={ isTogglingModule( element[0] ) }
-					toggleModule={ toggleModule } />
-			),
-			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
-			isPro = 'scan' === element[0] || 'akismet' === element[0] || 'backups' === element[0],
-			proProps = {};
+export const Security = React.createClass( {
+	displayName: 'SecuritySettings',
 
-		if ( ! includes( moduleList, element[0] ) && ! isPro ) {
-			return null;
-		}
-
-		if ( isPro ) {
-			proProps = {
-				module: element[0],
-				configure_url: ''
-			};
-			toggle = <ProStatus proFeature={ element[0] } siteAdminUrl={ props.siteAdminUrl } />;
-
-			// Add a "pro" button next to the header title
-			element[1] = <span>
-				{ element[1] }
-				<Button
-					compact={ true }
-					href="#/plans"
-				>
-					{ __( 'Pro' ) }
-				</Button>
-			</span>;
-
-			// Set proper .configure_url
-			if ( ! props.isFetchingPluginsData ) {
-				if ( 'akismet' === element[0] && props.isPluginActive( 'akismet/akismet.php' ) ) {
-					proProps.configure_url = props.siteAdminUrl + 'admin.php?page=akismet-key-config';
-				} else if ( ( 'scan' === element[0] || 'backups' === element[0] ) && props.isPluginActive( 'vaultpress/vaultpress.php' ) ) {
-					proProps.configure_url = 'https://dashboard.vaultpress.com/';
-				}
-			}
-		}
-
+	render() {
 		return (
-			<FoldableCard
-				className={ customClasses }
-				key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
-				header={ element[1] }
-				subheader={ element[2] }
-				summary={ toggle }
-				expandedSummary={ toggle }
-				clickableHeaderText={ true }
-				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-					{
-						card: element[0],
-						path: props.route.path
-					}
-				) }
-			>
-				{
-					isModuleActivated( element[0] ) || isPro ?
-						<AllModuleSettings module={ isPro ? proProps : getModule( element[ 0 ] ) } /> :
-						// Render the long_description if module is deactivated
-						<div dangerouslySetInnerHTML={ renderLongDescription( getModule( element[0] ) ) } />
-				}
-				<div className="jp-module-settings__learn-more">
-					<Button borderless compact href={ element[3] }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
-				</div>
-			</FoldableCard>
+			<div>
+				<QuerySite />
+				<BackupsScan
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+				/>
+			</div>
 		);
-	} );
-
-	return (
-		<div>
-			<QuerySite />
-			{ cards }
-		</div>
-	);
-};
-
-function renderLongDescription( module ) {
-	// Rationale behind returning an object and not just the string
-	// https://facebook.github.io/react/tips/dangerously-set-inner-html.html
-	return { __html: module.long_description };
-}
+	}
+} );
 
 export default connect(
 	( state ) => {
 		return {
-			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
-			isTogglingModule: ( module_name ) =>
-				isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
-			getModule: ( module_name ) => _getModule( state, module_name ),
-			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
-			isFetchingPluginsData: isFetchingPluginsData( state ),
-			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
-			moduleList: getModules( state ),
-			siteAdminUrl: getSiteAdminUrl( state )
-		};
-	},
-	( dispatch ) => {
-		return {
-			toggleModule: ( module_name, activated ) => {
-				return ( activated )
-					? dispatch( deactivateModule( module_name ) )
-					: dispatch( activateModule( module_name ) );
-			}
-		};
+			module: ( module_name ) => getModule( state, module_name ),
+			settings: getSettings( state )
+		}
 	}
-)( Page );
+)( Security );

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -12,6 +12,7 @@ import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { BackupsScan } from './backups-scan';
 import { Protect } from './protect';
+import { SSO } from './sso';
 
 export const Security = React.createClass( {
 	displayName: 'SecuritySettings',
@@ -25,6 +26,10 @@ export const Security = React.createClass( {
 					getModule={ this.props.module }
 				/>
 				<Protect
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+				/>
+				<SSO
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 				/>

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -11,6 +11,7 @@ import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { BackupsScan } from './backups-scan';
+import { Antispam } from './antispam';
 import { Protect } from './protect';
 import { SSO } from './sso';
 
@@ -22,6 +23,10 @@ export const Security = React.createClass( {
 			<div>
 				<QuerySite />
 				<BackupsScan
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+				/>
+				<Antispam
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 				/>

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -11,6 +11,7 @@ import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { BackupsScan } from './backups-scan';
+import { Protect } from './protect';
 
 export const Security = React.createClass( {
 	displayName: 'SecuritySettings',
@@ -20,6 +21,10 @@ export const Security = React.createClass( {
 			<div>
 				<QuerySite />
 				<BackupsScan
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+				/>
+				<Protect
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 				/>

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -69,7 +69,10 @@ export const Protect = moduleSettingsForm(
 
 		render() {
 			return (
-				<SettingsCard header={ __( 'Brute force protection', { context: 'Settings header' } ) } { ...this.props } >
+				<SettingsCard
+					{ ...this.props }
+					module="protect"
+					header={ __( 'Brute force protection', { context: 'Settings header' } ) } >
 					<ModuleToggle slug={ 'protect' }
 								  compact
 								  activated={ this.props.getOptionValue( 'protect' ) }

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import TextInput from 'components/text-input';
+import Button from 'components/button';
+import Textarea from 'components/textarea';
+import includes from 'lodash/includes';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLegend,
+	FormLabel
+} from 'components/forms';
+import ExternalLink from 'components/external-link';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+
+export const Protect = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		getInitialState() {
+			return {
+				whitelist: this.props.getOptionValue( 'jetpack_protect_global_whitelist' )
+					? this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local
+					: ''
+			};
+		},
+
+		currentIpIsWhitelisted() {
+			// get current whitelist in textarea from this.state.whitelist;
+			return !!includes( this.state.whitelist, this.props.currentIp );
+		},
+
+		updateText( event ) {
+			// Enable button if IP is not in the textarea
+			this.currentIpIsWhitelisted();
+
+			// Update textarea value
+			this.setState( {
+				whitelist: event.target.value
+			} );
+
+			// Add textarea content to form values to save
+			this.props.onOptionChange( event );
+		},
+
+		addToWhitelist() {
+			let newWhitelist = this.state.whitelist + ( 0 >= this.state.whitelist.length ? '' : '\n' ) + this.props.currentIp;
+
+			// Update form value manually
+			this.props.updateFormStateOptionValue( 'jetpack_protect_global_whitelist', newWhitelist );
+
+			// add to current state this.state.whitelist;
+			this.setState( {
+				whitelist: newWhitelist
+			} );
+		},
+
+		render() {
+			return (
+				<SettingsCard header={ __( 'Brute force protection', { context: 'Settings header' } ) } { ...this.props } >
+					<ModuleToggle slug={ 'protect' }
+								  compact
+								  activated={ this.props.getOptionValue( 'protect' ) }
+								  toggling={ this.props.isSavingAnyOption() }
+								  toggleModule={ this.toggleModule }>
+						<span className="jp-form-toggle-explanation">
+							{
+								this.props.getModule( 'protect' ).description
+							}
+						</span>
+						<p className="jp-form-setting-explanation">
+							{
+								__( 'Secure user authentication.' )
+							}
+						</p>
+					</ModuleToggle>
+					{
+						this.props.currentIp
+							? <p>
+								{
+									__( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
+								}
+								<br />
+								{
+									<Button
+										disabled={ this.currentIpIsWhitelisted() }
+										onClick={ this.addToWhitelist }
+										compact >{ __( 'Add to whitelist' ) }</Button>
+								}
+							  </p>
+							: ''
+					}
+					<FormFieldset>
+						<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
+						<FormLabel>
+						<Textarea
+							name={ 'jetpack_protect_global_whitelist' }
+							placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
+							onChange={ this.updateText }
+							value={ this.state.whitelist } />
+						</FormLabel>
+						<span className="jp-form-setting-explanation">
+							{
+								__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
+									components: {
+										br: <br />
+									}
+								} )
+							}
+						</span>
+					</FormFieldset>
+				</SettingsCard>
+			)
+		}
+	} )
+);

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -106,13 +106,13 @@ export const Protect = moduleSettingsForm(
 							: ''
 					}
 					<FormFieldset>
-						<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
 						<FormLabel>
-						<Textarea
-							name={ 'jetpack_protect_global_whitelist' }
-							placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
-							onChange={ this.updateText }
-							value={ this.state.whitelist } />
+							<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
+							<Textarea
+								name={ 'jetpack_protect_global_whitelist' }
+								placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
+								onChange={ this.updateText }
+								value={ this.state.whitelist } />
 						</FormLabel>
 						<span className="jp-form-setting-explanation">
 							{

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -8,6 +8,7 @@ import TextInput from 'components/text-input';
 import Button from 'components/button';
 import Textarea from 'components/textarea';
 import includes from 'lodash/includes';
+import ExternalLink from 'components/external-link';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import {
 	FormLegend,
 	FormLabel
 } from 'components/forms';
-import ExternalLink from 'components/external-link';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -24,7 +24,10 @@ export const SSO = moduleSettingsForm(
 
 		render() {
 			return (
-				<SettingsCard header={ __( 'WordPress.com log in', { context: 'Settings header' } ) } { ...this.props } >
+				<SettingsCard
+					{ ...this.props }
+					module="sso"
+					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
 					<ModuleToggle slug={ 'subscriptions' }
 								  compact
 								  activated={ this.props.getOptionValue( 'subscriptions' ) }

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -10,13 +10,12 @@ import TextInput from 'components/text-input';
  * Internal dependencies
  */
 import { FormFieldset } from 'components/forms';
-import ExternalLink from 'components/external-link';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 
-export const Subscriptions = moduleSettingsForm(
+export const SSO = moduleSettingsForm(
 	React.createClass( {
 
 		toggleModule( name, value ) {
@@ -25,7 +24,7 @@ export const Subscriptions = moduleSettingsForm(
 
 		render() {
 			return (
-				<SettingsCard header={ __( 'Subscriptions', { context: 'Settings header' } ) } { ...this.props } >
+				<SettingsCard header={ __( 'WordPress.com log in', { context: 'Settings header' } ) } { ...this.props } >
 					<ModuleToggle slug={ 'subscriptions' }
 								  compact
 								  activated={ this.props.getOptionValue( 'subscriptions' ) }
@@ -33,22 +32,24 @@ export const Subscriptions = moduleSettingsForm(
 								  toggleModule={ this.toggleModule }>
 						<span className="jp-form-toggle-explanation">
 							{
-								__( 'Allow users to subscribe to your posts and comments and receive notifications via email.' )
+								__( 'Allow log-in using WordPress.com accounts.' )
 							}
 						</span>
 					</ModuleToggle>
-					<p>
-						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
+					<p className="jp-form-setting-explanation">
+						{
+							__( 'Use WordPress.com’s secure authentication.' )
+						}
 					</p>
 					<FormFieldset>
 						<ModuleSettingCheckbox
-							name={ 'stb_enabled' }
+							name={ 'jetpack_sso_match_by_email' }
 							{ ...this.props }
-							label={ __( 'Show a "follow blog" options in the comment form' ) } />
+							label={ __( 'Match By Email' ) } />
 						<ModuleSettingCheckbox
-							name={ 'stc_enabled' }
+							name={ 'jetpack_sso_require_two_step' }
 							{ ...this.props }
-							label={ __( 'Show a "follow comments" option in the comment form.' ) } />
+							label={ __( 'Require Two-Step Authentication' ) } />
 					</FormFieldset>
 				</SettingsCard>
 			);

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -13,6 +13,7 @@ import QuerySite from 'components/data/query-site';
 import { SEO } from './seo';
 import { SiteStats } from './site-stats';
 import { RelatedPosts } from './related-posts';
+import { VerificationServices } from './verification-services';
 import { getLastPostUrl } from 'state/initial-state';
 
 export const Traffic = React.createClass( {
@@ -38,6 +39,10 @@ export const Traffic = React.createClass( {
 						'customize.php?autofocus[section]=jetpack_relatedposts' +
 						'&return=' + encodeURIComponent( this.props.siteAdminUrl + 'admin.php?page=jetpack#/traffic' ) +
 						'&url=' + encodeURIComponent( this.props.lastPostUrl ) }
+				/>
+				<VerificationServices
+					settings={ this.props.settings }
+					getModule={ this.props.module }
 				/>
 			</div>
 		);

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -12,6 +12,8 @@ import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { SEO } from './seo';
 import { SiteStats } from './site-stats';
+import { RelatedPosts } from './related-posts';
+import { getLastPostUrl } from 'state/initial-state';
 
 export const Traffic = React.createClass( {
 	displayName: 'TrafficSettings',
@@ -29,6 +31,14 @@ export const Traffic = React.createClass( {
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 				/>
+				<RelatedPosts
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+					configureUrl={ this.props.siteAdminUrl +
+						'customize.php?autofocus[section]=jetpack_relatedposts' +
+						'&return=' + encodeURIComponent( this.props.siteAdminUrl + 'admin.php?page=jetpack#/traffic' ) +
+						'&url=' + encodeURIComponent( this.props.lastPostUrl ) }
+				/>
 			</div>
 		);
 	}
@@ -38,7 +48,8 @@ export default connect(
 	( state ) => {
 		return {
 			module: ( module_name ) => getModule( state, module_name ),
-			settings: getSettings( state )
+			settings: getSettings( state ),
+			lastPostUrl: getLastPostUrl( state )
 		}
 	}
 )( Traffic );

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getModule } from 'state/modules';
+import { getSettings } from 'state/settings';
+import QuerySite from 'components/data/query-site';
+import { SEO } from './seo';
+
+export const Traffic = React.createClass( {
+	displayName: 'TrafficSettings',
+
+	render() {
+		return (
+			<div>
+				<QuerySite />
+				<SEO
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+					configureUrl={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl }
+				/>
+			</div>
+		);
+	}
+} );
+
+export default connect(
+	( state ) => {
+		return {
+			module: ( module_name ) => getModule( state, module_name ),
+			settings: getSettings( state )
+		}
+	}
+)( Traffic );

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -11,6 +11,7 @@ import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { SEO } from './seo';
+import { SiteStats } from './site-stats';
 
 export const Traffic = React.createClass( {
 	displayName: 'TrafficSettings',
@@ -23,6 +24,10 @@ export const Traffic = React.createClass( {
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 					configureUrl={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl }
+				/>
+				<SiteStats
+					settings={ this.props.settings }
+					getModule={ this.props.module }
 				/>
 			</div>
 		);

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import ExternalLink from 'components/external-link';
+
+/**
+ * Internal dependencies
+ */
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+
+export const RelatedPosts = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			return (
+				<SettingsCard
+					{ ...this.props }
+					module="related-posts">
+					<ModuleToggle slug={ 'related-posts' }
+								  compact
+								  activated={ this.props.getOptionValue( 'related-posts' ) }
+								  toggling={ this.props.isSavingAnyOption() }
+								  toggleModule={ this.toggleModule }>
+						<span className="jp-form-toggle-explanation">
+							{
+								__( 'Use Jetpack comments. Let readers use their WordPress.com,	Twitter, Facebook or Google+ to leave comments on your posts and pages.' )
+							}
+						</span>
+					</ModuleToggle>
+					{
+						this.props.getOptionValue( 'related-posts' )
+							? (
+								<p>
+									<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ this.props.configureUrl }>{ __( 'Configure your Related Posts settings.' ) }</ExternalLink>
+								</p>
+							  )
+							: ''
+					}
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import ExternalLink from 'components/external-link';
+
+/**
+ * Internal dependencies
+ */
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+
+export const SEO = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Search Engine Optimization', { context: 'Settings header' } ) }
+					support="https://jetpack.com/support/seo-tools/"
+					hideButton>
+					<p>
+						{
+							__( "You can tweak these settings if you'd like more advanced control. Read more about what you can do to {{a}}optimize your site's SEO{{/a}}.",
+								{
+									components: {
+										a: <a href="https://jetpack.com/support/seo-tools/" />
+									}
+								}
+							)
+						}
+					</p>
+					<p>
+						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ this.props.configureUrl }>{ __( 'Configure your SEO settings.' ) }</ExternalLink>
+					</p>
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLegend,
+	FormLabel
+} from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleSettingSelect } from 'components/module-settings/form-components';
+import SettingsCard from 'components/settings-card';
+
+export const SiteStats = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Site stats' ) }
+					module="stats">
+					<FormFieldset>
+						<ModuleToggle slug={ 'stats' }
+									  compact
+									  activated={ !!this.props.getOptionValue( 'admin_bar' ) }
+									  toggling={ this.props.isSavingAnyOption() }
+									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }>
+							<span className="jp-form-toggle-explanation">
+								{
+									__( 'Put a chart showing 48 hours of views in the admin bar.' )
+								}
+							</span>
+						</ModuleToggle>
+						<br />
+						<ModuleToggle slug={ 'stats' }
+									  compact
+									  activated={ !!this.props.getOptionValue( 'hide_smile' ) }
+									  toggling={ this.props.isSavingAnyOption() }
+									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }>
+							<span className="jp-form-toggle-explanation">
+								{
+									__( 'Hide the stats smiley face image. The image helps collect stats, but should work when hidden.' )
+								}
+							</span>
+						</ModuleToggle>
+					</FormFieldset>
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -15,8 +15,12 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingSelect } from 'components/module-settings/form-components';
+import {
+	ModuleSettingSelect,
+	ModuleSettingMultipleSelectCheckboxes
+} from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
+import InlineExpand from 'components/inline-expand';
 
 export const SiteStats = moduleSettingsForm(
 	React.createClass( {
@@ -56,6 +60,23 @@ export const SiteStats = moduleSettingsForm(
 							</span>
 						</ModuleToggle>
 					</FormFieldset>
+					<InlineExpand label={ __( 'Serious options' ) }>
+						<FormFieldset>
+							<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
+							<ModuleSettingMultipleSelectCheckboxes
+								name={ 'count_roles' }
+								{ ...this.props }
+								validValues={ this.props.getSiteRoles() } />
+						</FormFieldset>
+						<FormFieldset>
+							<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
+							<ModuleSettingMultipleSelectCheckboxes
+								always_checked={ [ 'administrator' ] }
+								name={ 'roles' }
+								{ ...this.props }
+								validValues={ this.props.getSiteRoles() } />
+						</FormFieldset>
+					</InlineExpand>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -100,7 +100,7 @@ export const VerificationServices = moduleSettingsForm(
 							].map( item => (
 								<FormLabel
 									className="jp-form-input-with-prefix"
-									key={ `verification_service_${ item.id }` /* https://fb.me/react-warning-keys */ }>
+									key={ `verification_service_${ item.id }` }>
 									<span>{ item.label }</span>
 									<TextInput
 										name={ item.id }
@@ -121,15 +121,17 @@ export const VerificationServices = moduleSettingsForm(
 								{
 									[
 										{
+											id: 'sitemap',
 											label: __( 'Sitemaps' ),
 											url: sitemap_url
 										},
 										{
+											id: 'news_sitemap',
 											label: __( 'News Sitemaps' ),
 											url: news_sitemap_url
 										}
 									].map( item => (
-										<li>
+										<li key={ `xml_${ item.id }` }>
 											<strong>{ item.label }</strong>
 											<br />
 											<ExternalLink icon={ true } target="_blank" href={ item.url }>{ item.url }</ExternalLink>

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import TextInput from 'components/text-input';
+import ExternalLink from 'components/external-link';
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLegend,
+	FormLabel
+} from 'components/forms';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleSettingSelect } from 'components/module-settings/form-components';
+import SettingsCard from 'components/settings-card';
+
+export const VerificationServices = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			let module = this.props.getModule( 'sitemaps' ),
+				sitemap_url = get( module, [ 'extra', 'sitemap_url' ], '' ),
+				news_sitemap_url = get( module, [ 'extra', 'news_sitemap_url' ], '' );
+			return (
+				<SettingsCard
+					{ ...this.props }
+					module="verification-tools">
+					<p>
+						{ __(
+							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order for your site to be indexed by search engines. To use these advanced search engine tools and verify your site with a service, paste the HTML Tag code below. Read the {{support}}full instructions{{/support}} if you are having trouble. Supported verification services: {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}}, {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
+							{
+								components: {
+									b: <strong />,
+									support: <a href="https://support.wordpress.com/webmaster-tools/" />,
+									google: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://www.google.com/webmasters/tools/"
+										/>
+									),
+									bing: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://www.bing.com/webmaster/"
+										/>
+									),
+									pinterest: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://pinterest.com/website/verify/"
+										/>
+									),
+									yandex: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://webmaster.yandex.com/sites/"
+										/>
+									)
+								}
+							}
+						) }
+					</p>
+					<FormFieldset>
+						{
+							[
+								{
+									id: 'google',
+									label: __( 'Google' ),
+									placeholder: 'Example: dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8'
+								},
+								{
+									id: 'bing',
+									label: __( 'Bing' ),
+									placeholder: 'Example: 12C1203B5086AECE94EB3A3D9830B2E'
+								},
+								{
+									id: 'pinterest',
+									label: __( 'Pinterest' ),
+									placeholder: 'Example: f100679e6048d45e4a0b0b92dce1efce'
+								},
+								{
+									id: 'yandex',
+									label: __( 'Yandex' ),
+									placeholder: 'Example: 44d68e1216009f40'
+								}
+							].map( item => (
+								<FormLabel
+									className="jp-form-input-with-prefix"
+									key={ `verification_service_${ item.id }` /* https://fb.me/react-warning-keys */ }>
+									<span>{ item.label }</span>
+									<TextInput
+										name={ item.id }
+										value={ this.props.getOptionValue( item.id ) }
+										placeholder={ item.placeholder }
+										className="code"
+										disabled={ this.props.isUpdating( item.id ) }
+										onChange={ this.props.onOptionChange} />
+								</FormLabel>
+							) )
+						}
+					</FormFieldset>
+					<FormFieldset>
+						<FormLegend>{ __( 'XML Sitemaps' ) }</FormLegend>
+						<div>
+							<p>{ __( 'Search engines will find the sitemaps at these locations:' ) }</p>
+							<ul>
+								{
+									[
+										{
+											label: __( 'Sitemaps' ),
+											url: sitemap_url
+										},
+										{
+											label: __( 'News Sitemaps' ),
+											url: news_sitemap_url
+										}
+									].map( item => (
+										<li>
+											<strong>{ item.label }</strong>
+											<br />
+											<ExternalLink icon={ true } target="_blank" href={ item.url }>{ item.url }</ExternalLink>
+										</li>
+									) )
+								}
+							</ul>
+						</div>
+					</FormFieldset>
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1608,6 +1608,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
+			// Akismet - Not a module, but a plugin. The options can be passed and handled differently.
+			'akismet_show_user_comments_approved' => array(
+				'description'       => '',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'settings',
+			),
+
 		);
 
 		// Add modules to list so they can be toggled

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -689,6 +689,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$updated = get_option( $option ) != $value ? update_option( $option, (bool) $value ? 'letitsnow' : '' ) : true;
 					break;
 
+				case 'akismet_show_user_comments_approved':
+
+					// Save Akismet option '1' or '0' like it's done in akismet/class.akismet-admin.php
+					$updated = get_option( $option ) != $value ? update_option( $option, (bool) $value ? '1' : '0' ) : true;
+					break;
+
 				case 'wp_mobile_featured_images':
 				case 'wp_mobile_excerpt':
 					$value = ( 'enabled' === $value ) ? '1' : '0';

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Protect
- * Module Description: Prevent and block malicious login attempts.
+ * Module Description: Prevent brute force attacks.
  * Sort Order: 1
  * Recommendation Order: 4
  * First Introduced: 3.4


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- removes Engagement and Appearance tabs and clears the settings in Security
- adds Discussion and Traffic tabs
- adds settings in Discussion, Security and Traffic tabs 

#### Testing instructions:
- build and go to Jetpack > Settings

In addition to adding the settings in each tab, this PR also introduces 2 new components:

SettingsCard
=========

This component is used to display a card with header, button to save settings and help link.
Its children are all the form elements used to compose the settings.
Uses `isSavingAnyOption` and `onSubmit` defined in `components/module-settings/module-settings-form.jsx`.

#### Usage

```js
var SettingsCard = require( 'components/settings-card' );

render: function() {
	return (
		<SettingsCard { ...this.props } header={ __( 'The card header', { context: 'Settings header' } ) }>
			<FormFieldset>
				// form elements
			</FormFieldset>
		</SettingsCard>
	);
}
```

#### Properties

* `module` - A Jetpack module. If it's not present, the `header` and `support` attributes must be explicitly passed if it's intended to display them.
* `header` — The title of the card. If it's not present but `module` attribute is, it will fetch the module and use its name property as title.
* `hideButton` - When this attribute is present, the saving button will not be rendered:
```js
<SettingsCard { ...this.props } header={ __( 'The card header', { context: 'Settings header' } ) } hideButton>
	// form elements
</SettingsCard>
```
* `support` - A custom URL to a support resource. Will be used to render an icon linked to the URL. If no URL is passed but `module` is present, it will fetch the module and use its learn_more_button property as URL.
```js
<SettingsCard { ...this.props } header={ __( 'The card header', { context: 'Settings header' } ) } help="https://jetpack.com/support/sso">
	// form elements
</SettingsCard>
```

InlineExpand
=========

This component is used to slide down a inline block with text or elements. When it's rendered, it displays a clickable link. When it's clicked the block slides down. When clicked again, it slides up.

#### Usage

```js
var InlineExpand = require( 'components/inline-expand' );

render: function() {
	return (
		<InlineExpand label={ __( 'More options' ) }>
			// elements
		</InlineExpand>
	);
}
```

#### Properties

* `label` — The title of the card. If it's not present but `module` attribute is, it will fetch the module and use its name property as title.
* `onOpen`/`onClose` - Pass functions that will be executed when the block is revealed/concealed respectively.
```js
<InlineExpand
	label={ __( 'More options' ) }
	onOpen={
		() => {
			// do something
		}
	}>
	// elements
</InlineExpand>
```
* `icon` - To show an icon, pass an icon name like 'chevron-down'. Check list in dops-components/client/components/gridicon.

