### PR TITLE
JSON API: Add all module settings to the /settings readable endpoint

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -217,12 +217,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 			self::get_updateable_parameters()
 		);
 
-		// Return miscellaneous settings
-		register_rest_route( 'jetpack/v4', '/settings', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::get_settings',
-			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
-		) );
+		// Return all module settings
+		self::route(
+			'/settings',
+			'Jetpack_Core_API_Data',
+			WP_REST_Server::READABLE,
+			new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) )
+		);
 
 		// Reset all Jetpack options
 		register_rest_route( 'jetpack/v4', '/options/(?P<options>[a-z\-]+)', array(
@@ -556,24 +557,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return new WP_Error( 'build_connect_url_failed', esc_html__( 'Unable to build the connect URL.  Please reload the page and try again.', 'jetpack' ), array( 'status' => 400 ) );
-	}
-
-	/**
-	 * Get miscellaneous settings for this Jetpack installation, like Holiday Snow.
-	 *
-	 * @since 4.3.0
-	 *
-	 * @return object $response {
-	 *     Array of miscellaneous settings.
-	 *
-	 *     @type bool $holiday-snow Did Jack steal Christmas?
-	 * }
-	 */
-	public static function get_settings() {
-		$response = array(
-			self::holiday_snow_option_name() => get_option( self::holiday_snow_option_name() ) == 'letitsnow',
-		);
-		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -56,6 +56,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		self::$stats_roles = array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' );
 
+		Jetpack::load_xml_rpc_client();
+		$ixr_client = new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) );
+		$core_api_endpoint = new Jetpack_Core_API_Data( $ixr_client );
+
 		// Get current connection status of Jetpack
 		register_rest_route( 'jetpack/v4', '/connection', array(
 			'methods' => WP_REST_Server::READABLE,
@@ -147,8 +151,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 			)
 		);
 
-		Jetpack::load_xml_rpc_client();
-
 		// Return a single module and update it when needed
 		self::route(
 			'/module/(?P<slug>[a-z\-]+)',
@@ -200,30 +202,27 @@ class Jetpack_Core_Json_Api_Endpoints {
 		);
 
 		// Update any Jetpack module option or setting
-		self::route(
-			'/settings',
-			'Jetpack_Core_API_Data',
-			WP_REST_Server::EDITABLE,
-			new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) ),
-			self::get_updateable_parameters( 'any' )
-		);
+		register_rest_route( 'jetpack/v4', '/settings', array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => array( $core_api_endpoint, 'process' ),
+			'permission_callback' => array( $core_api_endpoint, 'can_request' ),
+			'args' => self::get_updateable_parameters( 'any' )
+		) );
 
 		// Update a module
-		self::route(
-			'/settings/(?P<slug>[a-z\-]+)',
-			'Jetpack_Core_API_Data',
-			WP_REST_Server::EDITABLE,
-			new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) ),
-			self::get_updateable_parameters()
-		);
+		register_rest_route( 'jetpack/v4', '/settings/(?P<slug>[a-z\-]+)', array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => array( $core_api_endpoint, 'process' ),
+			'permission_callback' => array( $core_api_endpoint, 'can_request' ),
+			'args' => self::get_updateable_parameters()
+		) );
 
 		// Return all module settings
-		self::route(
-			'/settings',
-			'Jetpack_Core_API_Data',
-			WP_REST_Server::READABLE,
-			new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) )
-		);
+		register_rest_route( 'jetpack/v4', '/settings/', array(
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => array( $core_api_endpoint, 'process' ),
+			'permission_callback' => array( $core_api_endpoint, 'can_request' ),
+		) );
 
 		// Reset all Jetpack options
 		register_rest_route( 'jetpack/v4', '/options/(?P<options>[a-z\-]+)', array(

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -278,6 +278,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 
 /**
  * Class that manages updating of Jetpack module options and general Jetpack settings or retrieving module data.
+ * If no module is specified, all module settings are retrieved/updated.
  *
  * @since 4.3.0
  * @since 4.4.0 Renamed Jetpack_Core_API_Module_Endpoint from to Jetpack_Core_API_Data.
@@ -288,6 +289,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 	/**
 	 * Process request by returning the module or updating it.
+	 * If no module is specified, settings for all modules are assumed.
 	 *
 	 * @since 4.3.0
 	 *
@@ -297,7 +299,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 */
 	public function process( $data ) {
 		if ( 'GET' === $data->get_method() ) {
-			return $this->get_module( $data );
+			if ( isset( $data['slug'] ) && Jetpack::is_module( $data['slug'] ) ) {
+				return $this->get_module( $data );
+			}
+
+			return $this->get_all_options( $data );
 		} else {
 			return $this->update_data( $data );
 		}
@@ -348,6 +354,41 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ),
 			array( 'status' => 404 )
 		);
+	}
+
+	/**
+	 * Get information about all Jetpack module settings.
+	 *
+	 * @since 4.6.0
+	 *
+	 * @param WP_REST_Request $data {
+	 *     Array of parameters received by request.
+	 * }
+	 *
+	 * @return mixed|void|WP_Error
+	 */
+	public function get_all_options( $data ) {
+		$response = array();
+
+		$modules = Jetpack::get_available_modules();
+		if ( is_array( $modules ) && ! empty( $modules ) ) {
+			foreach ( $modules as $module ) {
+				// Add all module options
+				$options = Jetpack_Core_Json_Api_Endpoints::prepare_options_for_response( $module );
+				foreach ( $options as $option_name => $option ) {
+					$response[ $option_name ] = $option['current_value'];
+				}
+
+				// Add the module activation state
+				$response[ $module ] = Jetpack::is_module_active( $module );
+			}
+		}
+
+		// Add the Holiday snow current value
+		$holiday_snow_option_name = Jetpack_Core_Json_Api_Endpoints::holiday_snow_option_name();
+		$response[ $holiday_snow_option_name ] = get_option( $holiday_snow_option_name ) === 'letitsnow';
+
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -299,7 +299,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 */
 	public function process( $data ) {
 		if ( 'GET' === $data->get_method() ) {
-			if ( isset( $data['slug'] ) && Jetpack::is_module( $data['slug'] ) ) {
+			if ( isset( $data['slug'] ) ) {
 				return $this->get_module( $data );
 			}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -365,7 +365,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *     Array of parameters received by request.
 	 * }
 	 *
-	 * @return mixed|void|WP_Error
+	 * @return array
 	 */
 	public function get_all_options( $data ) {
 		$response = array();

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -732,7 +732,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertTrue( $response_data['carousel'] );
 
 		$this->assertArrayHasKey( 'jetpack_holiday_snow_enabled', $response_data );
-		$this->assertEquals( 'letitsnow', $response_data['jetpack_holiday_snow_enabled'] );
+		$this->assertTrue( $response_data['jetpack_holiday_snow_enabled'] );
 
 	}
 

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -700,4 +700,40 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Test that a setting is retrieved correctly.
+	 * Here we test three types of settings:
+	 * - module settings
+	 * - module activation state
+	 * - misc setting (holiday snow)
+	 *
+	 * @since 4.6.0
+	 */
+	public function test_settings_retrieve() {
+
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_activate_modules' );
+		wp_set_current_user( $user->ID );
+
+		Jetpack::update_active_modules( array( 'carousel' ) );
+		update_option( 'carousel_background_color', 'white' );
+		update_option( 'jetpack_holiday_snow_enabled', 'letitsnow' );
+
+		$response = $this->create_and_get_request( 'settings', array(), 'GET' );
+		$response_data = $response->get_data();
+
+		$this->assertResponseStatus( 200, $response );
+
+		$this->assertArrayHasKey( 'carousel_background_color', $response_data );
+		$this->assertEquals( 'white', $response_data['carousel_background_color'] );
+
+		$this->assertArrayHasKey( 'carousel', $response_data );
+		$this->assertTrue( $response_data['carousel'] );
+
+		$this->assertArrayHasKey( 'jetpack_holiday_snow_enabled', $response_data );
+		$this->assertEquals( 'letitsnow', $response_data['jetpack_holiday_snow_enabled'] );
+
+	}
+
 } // class end

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -47,6 +47,9 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_REST_Con
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)', 'POST', 'Jetpack_Core_API_Data' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/data', 'GET', 'Jetpack_Core_API_Module_Data_Endpoint' ),
 			array( '/jetpack/v4/module/(?P<slug>[a-z\-]+)/active', 'POST', 'Jetpack_Core_API_Module_Toggle_Endpoint' ),
+			array( '/jetpack/v4/settings', 'GET', 'Jetpack_Core_API_Data' ),
+			array( '/jetpack/v4/settings', 'POST', 'Jetpack_Core_API_Data' ),
+			array( '/jetpack/v4/settings/(?P<slug>[a-z\-]+)', 'POST', 'Jetpack_Core_API_Data' ),
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR suggests that all module settings are being retrieved by the readable `/settings` endpoint. The rationale behind this is to:
* achieve consistency with the editable `/settings` endpoint (which currently allows any module option to be updated), and currently the readable endpoint retrieves only the holiday snow value;
* allow a way to bulk change settings from Calypso (which will make it easy to implement Jetpack Settings into Calypso - https://github.com/Automattic/wp-calypso/issues/9171, related Calypso Redux PR is here: https://github.com/Automattic/wp-calypso/pull/10123)

#### Testing instructions:

* Get this branch going on your Jetpack site.
* Verify all tests pass.
* Manual testing is possible by checking out https://github.com/Automattic/wp-calypso/pull/10123 on your Calypso installation, then inserting the `QueryJetpackSettings` query component somewhere and verifying the network GET requests to /settings contain all expected settings. Ping me for more info.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
JSON API: Retrieve all module settings in the readable `/settings` endpoint

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
