### PR TITLE
Add an API Cache setting that is synced

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -2500,6 +2500,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'verification_services_codes'          => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex',
 		Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
 		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
+		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache'
 
 	),
 
@@ -2575,6 +2576,7 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'verification_services_codes'  => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex',
 		Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
 		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
+		'api_cache'                    => '(bool) Turn on/off the Jetpack JSON API cache'
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -423,6 +423,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 					break;
 
+				case 'api_cache':
+					if ( empty( $value ) || WPCOM_JSON_API::is_falsy( $value ) ) {
+						if ( delete_option( 'jetpack_api_cache_enabled' ) ) {
+							$updated[ $key ] = false;
+						}
+					} else if ( update_option( 'jetpack_api_cache_enabled', true ) ) {
+						$updated[ $key ] = true;
+					}
+					break;
+
 				case 'timezone_string':
 					// Map UTC+- timezones to gmt_offsets and set timezone_string to empty
 					// https://github.com/WordPress/WordPress/blob/4.4.2/wp-admin/options.php#L175

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -158,6 +158,8 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$holiday_snow = (bool) get_option( jetpack_holiday_snow_option_name() );
 				}
 
+				$api_cache = $is_jetpack ? get_option( 'jetpack_api_cache_enabled' ) : true;
+
 				$response[ $key ] = array(
 
 					// also exists as "options"
@@ -214,6 +216,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'site_icon'               => $this->get_cast_option_value_or_null( 'site_icon', 'intval' ),
 					Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => get_option( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION, '' ),
 					Jetpack_SEO_Titles::TITLE_FORMATS_OPTION => get_option( Jetpack_SEO_Titles::TITLE_FORMATS_OPTION, array() ),
+					'api_cache'               => $api_cache,
 				);
 
 				//allow future versions of this endpoint to support additional settings keys

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -158,7 +158,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$holiday_snow = (bool) get_option( jetpack_holiday_snow_option_name() );
 				}
 
-				$api_cache = $is_jetpack ? get_option( 'jetpack_api_cache_enabled' ) : true;
+				$api_cache = $is_jetpack ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
 
 				$response[ $key ] = array(
 

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -108,6 +108,7 @@ class Jetpack_Sync_Defaults {
 		'uninstall_plugins',
 		'advanced_seo_front_page_description', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
+		'jetpack_api_cache_enabled',
 	);
 
 	static $default_constants_whitelist = array(

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -168,6 +168,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'uninstall_plugins'                    => 'banana',
 			'advanced_seo_front_page_description'  => 'banana', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 			'advanced_seo_title_formats'           => array( 'posts' => array( 'type' => 'string', 'value' => 'test' ) ), // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
+			'jetpack_api_cache_enabled'            => '1',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
In the future, it will be possible to return some API calls directly from WPCOM using synced data, which helps to greatly accelerate some operations (particularly Calypso use) and also enables new kinds of APIs that can select across multiple sites, or multiple endpoints, simultaneously. 

This PR is the first supporting piece of that, and perhaps the only piece that needs to be included in Jetpack.