### PR TITLE
Add shortcode handler for embedding geogebra widgets

### DIFF
--- a/modules/shortcodes/geogebra.php
+++ b/modules/shortcodes/geogebra.php
@@ -104,7 +104,7 @@ function geogebra_shortcode_handler( $attr ) {
  * @return string String with iframes replaced.
  */
 function geogebra_embed_to_shortcode( $content ) {
-	if ( ! is_string( $content ) || false === stripos( $content, 'geogebra.org/materials' ) ) {
+	if ( ! is_string( $content ) || false === stripos( $content, 'geogebra.org/material' ) ) {
 		return $content;
 	}
 
@@ -118,60 +118,60 @@ function geogebra_embed_to_shortcode( $content ) {
 
 		$shortcode = '[geogebra';
 
-		$id_regex = '%/id/([^/])*/%';
-		if ( ! preg_match( $id_regex, $match, $id_match ) ) {
+		$id_regex = '%/id/([^/]*)/%';
+		if ( ! preg_match( $id_regex, $match[0], $id_match ) ) {
 			return $content;
 		} else {
 			$shortcode .= ' id="' . $id_match[1] . '"';
 		}
 
-		$height_regex = '%/height/([0-9])*/%';
-		if ( ! preg_match( $height_regex, $match, $height_match ) ) {
+		$height_regex = '%/height/([0-9]*)/%';
+		if ( ! preg_match( $height_regex, $match[0], $height_match ) ) {
 			return $content;
 		} else {
 			$shortcode .= ' height="' . $height_match[1] . '"';
 		}
 
-		$width_regex = '%/width/([0-9])*/%';
-		if ( ! preg_match( $width_regex, $match, $width_match ) ) {
+		$width_regex = '%/width/([0-9]*)/%';
+		if ( ! preg_match( $width_regex, $match[0], $width_match ) ) {
 			return $content;
 		} else {
 			$shortcode .= ' width="' . $width_match[1] . '"';
 		}
 
-		if ( false !== strpos( $match, '/ai/true' ) ) {
+		if ( false !== strpos( $match[0], '/ai/true' ) ) {
 			$shortcode .= ' input-bar="true"';
 		}
 
-		if ( false !== strpos( $match, '/asb/true' ) ) {
+		if ( false !== strpos( $match[0], '/asb/true' ) ) {
 			$shortcode .= ' style-bar="true"';
 		}
 
-		if ( false !== strpos( $match, '/smb/true' ) ) {
+		if ( false !== strpos( $match[0], '/smb/true' ) ) {
 			$shortcode .= ' menu-bar="true"';
 		}
 
-		if ( false !== strpos( $match, '/stb/true' ) ) {
+		if ( false !== strpos( $match[0], '/stb/true' ) ) {
 			$shortcode .= ' tool-bar="true"';
 
-			if ( false !== strpos( $match, '/stbh/true' ) ) {
+			if ( false !== strpos( $match[0], '/stbh/true' ) ) {
 				$shortcode .= ' tool-help="true"';
 			}
 		}
 
-		if ( false !== strpos( $match, '/sri/true' ) ) {
+		if ( false !== strpos( $match[0], '/sri/true' ) ) {
 			$shortcode .= ' reset-icon="true"';
 		}
 
-		if ( false !== strpos( $match, '/rc/true' ) ) {
+		if ( false !== strpos( $match[0], '/rc/true' ) ) {
 			$shortcode .= ' right-click="true"';
 		}
 
-		if ( false !== strpos( $match, '/ld/true' ) ) {
+		if ( false !== strpos( $match[0], '/ld/true' ) ) {
 			$shortcode .= ' drag-labels="true"';
 		}
 
-		if ( false !== strpos( $match, '/sdz/true' ) ) {
+		if ( false !== strpos( $match[0], '/sdz/true' ) ) {
 			$shortcode .= ' pan-zoom="true"';
 		}
 

--- a/modules/shortcodes/geogebra.php
+++ b/modules/shortcodes/geogebra.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Geogebra embeds
+ *
+ * @link https://www.geogebra.org/
+ */
+
+add_shortcode( 'geogebra', 'geogebra_shortcode_handler' );
+
+function geogebra_shortcode_handler( $attr ) {
+
+	if ( ! isset( $attr['id'] ) ) {
+		return 'Geogebra shortcode: must provide an id!';
+	}
+
+	$keyval = shortcode_atts(
+		array(
+			'id'          => null,
+			'height'      => 480,
+			'width'       => 640,
+			'border'      => "888888",
+			'input-bar'   => null,
+			'style-bar'   => null,
+			'menu-bar'    => null,
+			'tool-bar'    => null,
+			'tool-help'   => null,
+			'reset-icon'  => null,
+			'right-click' => null,
+			'drag-labels' => null,
+			'pan-zoom'    => null,
+		),
+		$attr
+	);
+
+	$embed_url  = 'http://www.geogebra.org/material/iframe/id/' . $keyval['id'];
+	$embed_url .= '/height/' . $keyval['height'];
+	$embed_url .= '/width/' . $keyval['width'];
+	$embed_url .= '/border/' . $keyval['border'];
+
+	if ( 'true' === $keyval['input-bar'] ) {
+		$embed_url .= '/ai/true';
+	}
+
+	if ( 'true' === $keyval['style-bar'] ) {
+		$embed_url .= '/asb/true';
+	}
+
+	if ( 'true' === $keyval['menu-bar'] ) {
+		$embed_url .= '/smb/true';
+	}
+
+	if ( 'true' === $keyval['tool-bar'] ) {
+		$embed_url .= '/stb/true';
+
+		if ( 'true' === $keyval['tool-help'] ) {
+			$embed_url .= '/stbh/true';
+		}
+	}
+
+	if ( 'true' === $keyval['reset-icon'] ) {
+		$embed_url .= '/sri/true';
+	}
+
+	if ( 'true' === $keyval['right-click'] ) {
+		$embed_url .= '/rc/true';
+	}
+
+	if ( 'true' === $keyval['drag-labels'] ) {
+		$embed_url .= '/ld/true';
+	}
+
+	if ( 'true' === $keyval['pan-zoom'] ) {
+		$embed_url .= '/sdz/true';
+	}
+
+	$content  = '<iframe';
+	$content .= ' scrolling="no"';
+	$content .= ' src="' . $embed_url . '"';
+	$content .= ' height="' . $keyval['height'] . 'px"';
+	$content .= ' width="' . $keyval['width'] . 'px"';
+	$content .= '></iframe>';
+
+	return $content;
+}

--- a/modules/shortcodes/geogebra.php
+++ b/modules/shortcodes/geogebra.php
@@ -93,3 +93,94 @@ function geogebra_shortcode_handler( $attr ) {
 
 	return $content;
 }
+
+/**
+ * Replace embedded geogebra iframes with shortcodes.
+ *
+ * @since TODO
+ *
+ * @param string $content String to replace iframes in.
+ *
+ * @return string String with iframes replaced.
+ */
+function geogebra_embed_to_shortcode( $content ) {
+	if ( ! is_string( $content ) || false === stripos( $content, 'geogebra.org/materials' ) ) {
+		return $content;
+	}
+
+	$regex = '%(<iframe[^>]*?src="https://www.geogebra.org/material/[^>]*>[^<]*<\/iframe>)%';
+
+	if ( ! preg_match_all( $regex, $content, $matches, PREG_SET_ORDER ) ) {
+		return $content;
+	}
+
+	foreach ( $matches as $match ) {
+
+		$shortcode = '[geogebra';
+
+		$id_regex = '%/id/([^/])*/%';
+		if ( ! preg_match( $id_regex, $match, $id_match ) ) {
+			return $content;
+		} else {
+			$shortcode .= ' id="' . $id_match[1] . '"';
+		}
+
+		$height_regex = '%/height/([0-9])*/%';
+		if ( ! preg_match( $height_regex, $match, $height_match ) ) {
+			return $content;
+		} else {
+			$shortcode .= ' height="' . $height_match[1] . '"';
+		}
+
+		$width_regex = '%/width/([0-9])*/%';
+		if ( ! preg_match( $width_regex, $match, $width_match ) ) {
+			return $content;
+		} else {
+			$shortcode .= ' width="' . $width_match[1] . '"';
+		}
+
+		if ( false !== strpos( $match, '/ai/true' ) ) {
+			$shortcode .= ' input-bar="true"';
+		}
+
+		if ( false !== strpos( $match, '/asb/true' ) ) {
+			$shortcode .= ' style-bar="true"';
+		}
+
+		if ( false !== strpos( $match, '/smb/true' ) ) {
+			$shortcode .= ' menu-bar="true"';
+		}
+
+		if ( false !== strpos( $match, '/stb/true' ) ) {
+			$shortcode .= ' tool-bar="true"';
+
+			if ( false !== strpos( $match, '/stbh/true' ) ) {
+				$shortcode .= ' tool-help="true"';
+			}
+		}
+
+		if ( false !== strpos( $match, '/sri/true' ) ) {
+			$shortcode .= ' reset-icon="true"';
+		}
+
+		if ( false !== strpos( $match, '/rc/true' ) ) {
+			$shortcode .= ' right-click="true"';
+		}
+
+		if ( false !== strpos( $match, '/ld/true' ) ) {
+			$shortcode .= ' drag-labels="true"';
+		}
+
+		if ( false !== strpos( $match, '/sdz/true' ) ) {
+			$shortcode .= ' pan-zoom="true"';
+		}
+
+		$shortcode .= ']';
+
+		$content = str_replace( $match[0], $shortcode, $content );
+	}
+
+	return $content;
+}
+
+add_filter( 'pre_kses', 'geogebra_embed_to_shortcode' );

--- a/modules/shortcodes/geogebra.php
+++ b/modules/shortcodes/geogebra.php
@@ -3,10 +3,21 @@
  * Geogebra embeds
  *
  * @link https://www.geogebra.org/
+ *
+ * @package Jetpack
  */
 
 add_shortcode( 'geogebra', 'geogebra_shortcode_handler' );
 
+/**
+ * Constructs a GeoGebra embed iframe. There is no official API doc for this,
+ * but the URL format is simple to reverse engineer from the embed code generated
+ * by tube.geogebra.org.
+ *
+ * @param array $attr Array of shortcode attributes.
+ *
+ * @return string The iframe element.
+ */
 function geogebra_shortcode_handler( $attr ) {
 
 	if ( ! isset( $attr['id'] ) ) {
@@ -18,7 +29,7 @@ function geogebra_shortcode_handler( $attr ) {
 			'id'          => null,
 			'height'      => 480,
 			'width'       => 640,
-			'border'      => "888888",
+			'border'      => '888888',
 			'input-bar'   => null,
 			'style-bar'   => null,
 			'menu-bar'    => null,

--- a/modules/shortcodes/geogebra.php
+++ b/modules/shortcodes/geogebra.php
@@ -21,7 +21,7 @@ add_shortcode( 'geogebra', 'geogebra_shortcode_handler' );
 function geogebra_shortcode_handler( $attr ) {
 
 	if ( ! isset( $attr['id'] ) ) {
-		return 'Geogebra shortcode: must provide an id!';
+		return '<!-- Missing GeoGebra Applet ID -->';
 	}
 
 	$keyval = shortcode_atts(
@@ -43,7 +43,7 @@ function geogebra_shortcode_handler( $attr ) {
 		$attr
 	);
 
-	$embed_url  = 'http://www.geogebra.org/material/iframe/id/' . $keyval['id'];
+	$embed_url  = 'https://www.geogebra.org/material/iframe/id/' . $keyval['id'];
 	$embed_url .= '/height/' . $keyval['height'];
 	$embed_url .= '/width/' . $keyval['width'];
 	$embed_url .= '/border/' . $keyval['border'];

--- a/modules/shortcodes/geogebra.php
+++ b/modules/shortcodes/geogebra.php
@@ -5,6 +5,8 @@
  * @link https://www.geogebra.org/
  *
  * @package Jetpack
+ * @module shortcodes
+ * @since TODO
  */
 
 add_shortcode( 'geogebra', 'geogebra_shortcode_handler' );
@@ -13,6 +15,9 @@ add_shortcode( 'geogebra', 'geogebra_shortcode_handler' );
  * Constructs a GeoGebra embed iframe. There is no official API doc for this,
  * but the URL format is simple to reverse engineer from the embed code generated
  * by tube.geogebra.org.
+ *
+ * @module shortcodes
+ * @since TODO
  *
  * @param array $attr Array of shortcode attributes.
  *
@@ -97,6 +102,7 @@ function geogebra_shortcode_handler( $attr ) {
 /**
  * Replace embedded geogebra iframes with shortcodes.
  *
+ * @module shortcodes
  * @since TODO
  *
  * @param string $content String to replace iframes in.

--- a/tests/php/modules/shortcodes/test_class.geogebra.php
+++ b/tests/php/modules/shortcodes/test_class.geogebra.php
@@ -100,4 +100,20 @@ class WP_Test_Jetpack_Shortcodes_GeoGebra extends WP_UnitTestCase {
 			do_shortcode( '[geogebra id="0" pan-zoom="true"]' )
 		);
 	}
+
+	/**
+	 * Verify that toolbar help only renders if toolbar also renders.
+	 *
+	 * @since TODO
+	 */
+	public function test_shortcodes_geogebra_tool_bar_help() {
+		$this->assertNotContains(
+			'/stbh/true',
+			do_shortcode( '[geogebra id="0" tool-help="true"]' )
+		);
+		$this->assertContains(
+			'/stbh/true',
+			do_shortcode( '[geogebra id="0" tool-bar="true" tool-help="true"]' )
+		);
+	}
 }

--- a/tests/php/modules/shortcodes/test_class.geogebra.php
+++ b/tests/php/modules/shortcodes/test_class.geogebra.php
@@ -1,0 +1,103 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_GeoGebra extends WP_UnitTestCase {
+
+	/**
+	 * Verify that [geogebra] exists.
+	 *
+	 * @since TODO
+	 */
+	public function test_shortcodes_geogebra_exists() {
+		$this->assertEquals( shortcode_exists( 'geogebra' ), true );
+	}
+
+	/**
+	 * Verify that rendering a geogebra shortcode with no ID attribute
+	 * returns an error comment.
+	 *
+	 * @since TODO
+	 */
+	public function test_shortcodes_geogebra_no_id() {
+		$content = '[geogebra]';
+
+		$rendered_shortcode = do_shortcode( $content );
+
+		$this->assertEquals(
+			'<!-- Missing GeoGebra Applet ID -->',
+			$rendered_shortcode
+		);
+	}
+
+	/**
+	 * Verify that rendering the shortcode returns a GeoGebra iframe.
+	 *
+	 * @since TODO
+	 */
+	public function test_shortcodes_geogebra_widget_url() {
+		$widget_id = '1234567';
+		$content = "[geogebra id='$widget_id']";
+
+		$rendered_shortcode = do_shortcode( $content );
+
+		$this->assertContains(
+			'<iframe',
+			$rendered_shortcode
+		);
+		$this->assertContains(
+			'src="https://www.geogebra.org/material/iframe',
+			$rendered_shortcode
+		);
+		$this->assertContains(
+			'/id/' . $widget_id,
+			$rendered_shortcode
+		);
+	}
+
+	/**
+	 * Verify that optional shortcode attributes are rendered.
+	 *
+	 * @since TODO
+	 */
+	public function test_shortcodes_geogebra_optional_attributes() {
+		$this->assertContains(
+			'/height/100',
+			do_shortcode( '[geogebra id="0" height="100"]' )
+		);
+		$this->assertContains(
+			'/width/100',
+			do_shortcode( '[geogebra id="0" width="100"]' )
+		);
+		$this->assertContains(
+			'/ai/true',
+			do_shortcode( '[geogebra id="0" input-bar="true"]' )
+		);
+		$this->assertContains(
+			'/asb/true',
+			do_shortcode( '[geogebra id="0" style-bar="true"]' )
+		);
+		$this->assertContains(
+			'/smb/true',
+			do_shortcode( '[geogebra id="0" menu-bar="true"]' )
+		);
+		$this->assertContains(
+			'/stb/true',
+			do_shortcode( '[geogebra id="0" tool-bar="true"]' )
+		);
+		$this->assertContains(
+			'/sri/true',
+			do_shortcode( '[geogebra id="0" reset-icon="true"]' )
+		);
+		$this->assertContains(
+			'/rc/true',
+			do_shortcode( '[geogebra id="0" right-click="true"]' )
+		);
+		$this->assertContains(
+			'/ld/true',
+			do_shortcode( '[geogebra id="0" drag-labels="true"]' )
+		);
+		$this->assertContains(
+			'/sdz/true',
+			do_shortcode( '[geogebra id="0" pan-zoom="true"]' )
+		);
+	}
+}

--- a/tests/php/modules/shortcodes/test_class.geogebra.php
+++ b/tests/php/modules/shortcodes/test_class.geogebra.php
@@ -3,7 +3,7 @@
 class WP_Test_Jetpack_Shortcodes_GeoGebra extends WP_UnitTestCase {
 
 	/**
-	 * Verify that [geogebra] exists.
+	 * Check that [geogebra] shortcode exists.
 	 *
 	 * @since TODO
 	 */
@@ -12,7 +12,7 @@ class WP_Test_Jetpack_Shortcodes_GeoGebra extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that rendering a geogebra shortcode with no ID attribute
+	 * Check that rendering a geogebra shortcode with no ID attribute
 	 * returns an error comment.
 	 *
 	 * @since TODO
@@ -29,7 +29,7 @@ class WP_Test_Jetpack_Shortcodes_GeoGebra extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that rendering the shortcode returns a GeoGebra iframe.
+	 * Check that rendering the shortcode returns a GeoGebra iframe.
 	 *
 	 * @since TODO
 	 */
@@ -54,7 +54,7 @@ class WP_Test_Jetpack_Shortcodes_GeoGebra extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that optional shortcode attributes are rendered.
+	 * Check that optional shortcode attributes are rendered.
 	 *
 	 * @since TODO
 	 */
@@ -102,7 +102,7 @@ class WP_Test_Jetpack_Shortcodes_GeoGebra extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that toolbar help only renders if toolbar also renders.
+	 * Check that toolbar help only renders if toolbar also renders.
 	 *
 	 * @since TODO
 	 */
@@ -115,5 +115,41 @@ class WP_Test_Jetpack_Shortcodes_GeoGebra extends WP_UnitTestCase {
 			'/stbh/true',
 			do_shortcode( '[geogebra id="0" tool-bar="true" tool-help="true"]' )
 		);
+	}
+
+	/**
+	 * Check that plain geogebra iframes are converted to shortcodes.
+	 *
+	 * @covers geogebra_embed_to_shortcode
+	 * @since TODO
+	 */
+	public function test_shortcodes_geogebra_from_isolated_iframe() {
+		$iframe = '<iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/m3Zgkq9g/width/567/height/496/border/888888" width="567px" height="496px" style="border:0px;"> </iframe>';
+
+		$shortcode = '[geogebra id="m3Zgkq9g" height="496" width="567"]';
+
+		$this->assertEquals( $shortcode, geogebra_embed_to_shortcode( $iframe ) );
+	}
+
+	/**
+	 * Check that geogebra iframes with path parameters are converted to shortcodes.
+	 *
+	 * @covers geogebra_embed_to_shortcode
+	 * @since TODO
+	 */
+	public function test_shortcodes_geogebra_from_isolated_iframe_with_params() {
+		// Check some parameters.
+		$iframe_1 = '<iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/DpseMPzu/width/662/height/394/border/888888/smb/true/ai/true" width="662px" height="394px" style="border:0px;"> </iframe>';
+
+		$shortcode_1 = '[geogebra id="DpseMPzu" height="394" width="662" input-bar="true" menu-bar="true"]';
+
+		$this->assertEquals( $shortcode_1, geogebra_embed_to_shortcode( $iframe_1 ) );
+
+		// Check some more parameters.
+		$iframe_2 = '<iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/DpseMPzu/width/662/height/394/border/888888/stb/true/sri/true/ld/true" width="662px" height="394px" style="border:0px;"> </iframe>';
+
+		$shortcode_2 = '[geogebra id="DpseMPzu" height="394" width="662" tool-bar="true" reset-icon="true" drag-labels="true"]';
+
+		$this->assertEquals( $shortcode_2, geogebra_embed_to_shortcode( $iframe_2 ) );
 	}
 }


### PR DESCRIPTION
Just like it says on the tin.

[GeoGebra](www.geogebra.org) is a tool for building interactive geometry demonstrations. It is mature, open source, and widely used in math education. This PR adds a shortcode for embedding GeoGebra applets uploaded to the project's [online library](tube.geogebra.org). It also hooks into ``pre_kses`` so that geogebra iframes in comments are converted to shortcodes.

#### Changes proposed in this Pull Request:

Add a new shortcode handler.

#### Testing instructions:

1. Make sure the Shortcodes module is enabled.
2. Create a new post with a shortcode of the following form: ``[geogebra id="vnRmvGCx"]`` (arbitrary example)
3. Save and view the post.
4. Try out the optional shortcode attributes: ``height``, ``width``, ``input-bar``, ``style-bar``, ``menu-bar``, ``tool-bar``, ``tool-help``, ``reset-icon``, ``right-click``, ``drag-labels``, and ``pan-zoom``. All but height and width expect to be "true" or "false".
5. Try using the shortcode without an ``id`` attribute. (This is an error)
6. Comment on a post with the following scary HTML: ``<iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/DpseMPzu/width/662/height/394/border/888888" width="662px" height="394px" style="border:0px;"> </iframe>``

You can get more iframes for testing at [https://tube.geogebra.org](https://tube.geogebra.org); open an applet page, click on the Share icon at the top of the page (it looks like a sideways V) and click on the "Embed" tab. Click "show more" to see the embed options.

### Changelog:

The ``geogebra`` shortcode has one required attribute, ``id``; this is the ID code of the applet to be embedded. It has several optional attributes as follows:

* ``height`` (integer): The height of the embedded applet.
* ``width`` (integer): The width of the embedded applet.
* ``input-bar`` (true/false): Show or don't show.
* ``style-bar`` (true/false): Show or don't show.
* ``menu-bar`` (true/false): Show or don't show.
* ``tool-bar`` (true/false): Show or don't show.
* ``tool-help`` (true/false): Show or don't show.
* ``reset-icon`` (true/false): Show or don't show.
* ``right-click`` (true/false): Allow or don't allow.
* ``drag-labels`` (true/false): Allow or don't allow.
* ``pan-zoom`` (true/false): Allow or don't allow.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
