### PR TITLE
JSON API: Use register_rest_route() consistently

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -288,11 +288,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return array|wp-error
 	 */
-	public static function dismiss_notice( $data ) {
-		$notice = $data['notice'];
-		$param = $data->get_json_params();
+	public static function dismiss_notice( $request ) {
+		$notice = $request['notice'];
 
-		if ( ! isset( $param['dismissed'] ) || $param['dismissed'] !== true ) {
+		if ( ! isset( $request['dismissed'] ) || $request['dismissed'] !== true ) {
 			return new WP_Error( 'invalid_param', esc_html__( 'Invalid parameter "dismissed".', 'jetpack' ), array( 'status' => 404 ) );
 		}
 
@@ -512,10 +511,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 * @return bool|WP_Error True if Jetpack successfully disconnected.
 	 */
-	public static function disconnect_site( $data ) {
-		$param = $data->get_json_params();
+	public static function disconnect_site( $request ) {
 
-		if ( ! isset( $param['isActive'] ) || $param['isActive'] !== false ) {
+		if ( ! isset( $request['isActive'] ) || $request['isActive'] !== false ) {
 			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
 		}
 
@@ -581,13 +579,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data
+	 * @param WP_REST_Request $request
 	 *
 	 * @return object Jetpack miscellaneous settings.
 	 */
-	public static function update_setting( $data ) {
+	public static function update_setting( $request ) {
 		// Get parameters to update the module.
-		$param = $data->get_json_params();
+		$param = $request->get_params();
 
 		// Exit if no parameters were passed.
 		if ( ! is_array( $param ) ) {
@@ -626,10 +624,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return bool|WP_Error True if user successfully unlinked.
 	 */
-	public static function unlink_user( $data ) {
-		$param = $data->get_json_params();
+	public static function unlink_user( $request ) {
 
-		if ( ! isset( $param['linked'] ) || $param['linked'] !== false ) {
+		if ( ! isset( $request['linked'] ) || $request['linked'] !== false ) {
 			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
 		}
 
@@ -752,7 +749,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $options Available options to reset are options|modules
@@ -760,15 +757,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return bool|WP_Error True if options were reset. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public static function reset_jetpack_options( $data ) {
-		$param = $data->get_json_params();
+	public static function reset_jetpack_options( $request ) {
 
-		if ( ! isset( $param['reset'] ) || $param['reset'] !== true ) {
+		if ( ! isset( $request['reset'] ) || $request['reset'] !== true ) {
 			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
 		}
 
-		if ( isset( $data['options'] ) ) {
-			$data = $data['options'];
+		if ( isset( $request['options'] ) ) {
+			$data = $request['options'];
 
 			switch( $data ) {
 				case ( 'options' ) :
@@ -830,19 +826,18 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 * }
 	 *
 	 * @return bool|WP_Error True if toggling Jumpstart succeeded. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public static function jumpstart_toggle( $data ) {
-		$param = $data->get_json_params();
+	public static function jumpstart_toggle( $request ) {
 
-		if ( $param[ 'active' ] ) {
-			return self::jumpstart_activate( $data );
+		if ( $request[ 'active' ] ) {
+			return self::jumpstart_activate( $request );
 		} else {
-			return self::jumpstart_deactivate( $data );
+			return self::jumpstart_deactivate( $request );
 		}
 	}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -281,29 +281,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 	}
 
-	public static function route( $path, $classname, $method,
-		$constructor_arguments = NULL,
-		$endpoint_arguments = NULL
-	) {
-		if ( ! empty( $constructor_arguments ) ) {
-			$endpoint = new $classname( $constructor_arguments );
-		} else {
-			$endpoint = new $classname();
-		}
-
-		$parameters = array(
-			'methods' => $method,
-			'callback' => array( $endpoint, 'process' ),
-			'permission_callback' => array( $endpoint, 'can_request' )
-		);
-
-		if ( ! empty( $endpoint_arguments ) ) {
-			$parameters['args'] = $endpoint_arguments;
-		}
-
-		register_rest_route( 'jetpack/v4', $path, $parameters );
-	}
-
 	/**
 	 * Handles dismissing of Jetpack Notices
 	 *

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -286,6 +286,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
 	 * @return array|wp-error
 	 */
 	public static function dismiss_notice( $request ) {
@@ -509,6 +511,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @uses Jetpack::disconnect();
 	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
 	 * @return bool|WP_Error True if Jetpack successfully disconnected.
 	 */
 	public static function disconnect_site( $request ) {
@@ -530,6 +535,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @uses Jetpack::disconnect();
 	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
 	 * @return string|WP_Error A raw URL if the connection URL could be built; error message otherwise.
 	 */
 	public static function build_connect_url() {
@@ -547,6 +555,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Information about the current user.
 	 *
 	 * @since 4.3.0
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return object
 	 */
@@ -579,7 +589,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return object Jetpack miscellaneous settings.
 	 */
@@ -621,6 +631,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 * @uses  Jetpack::unlink_user
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return bool|WP_Error True if user successfully unlinked.
 	 */
@@ -826,9 +838,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $request {
-	 *     Array of parameters received by request.
-	 * }
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return bool|WP_Error True if toggling Jumpstart succeeded. Otherwise, a WP_Error instance with the corresponding error.
 	 */
@@ -846,9 +856,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $request {
-	 *     Array of parameters received by request.
-	 * }
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return bool|WP_Error True if Jumpstart succeeded. Otherwise, a WP_Error instance with the corresponding error.
 	 */
@@ -930,9 +938,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $request {
-	 *     Array of parameters received by request.
-	 * }
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return bool|WP_Error True if Jumpstart was disabled or was nothing to dismiss. Otherwise, a WP_Error instance with a message.
 	 */
@@ -1650,7 +1656,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1668,7 +1674,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param int $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1686,7 +1692,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1717,7 +1723,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1742,7 +1748,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1760,7 +1766,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1781,7 +1787,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1811,7 +1817,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *     @type array $visible List of slug of services to share to that are displayed directly in the page.
 	 *     @type array $hidden  List of slug of services to share to that are concealed in a folding menu.
 	 * }
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1851,7 +1857,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string|bool $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1884,7 +1890,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool
@@ -1931,7 +1937,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 *
 	 * @param string $value Value to check.
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -846,13 +846,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 * }
 	 *
 	 * @return bool|WP_Error True if Jumpstart succeeded. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public static function jumpstart_activate( $data ) {
+	public static function jumpstart_activate( $request ) {
 		$modules = Jetpack::get_available_modules();
 		$activate_modules = array();
 		foreach ( $modules as $module ) {
@@ -930,13 +930,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 * }
 	 *
 	 * @return bool|WP_Error True if Jumpstart was disabled or was nothing to dismiss. Otherwise, a WP_Error instance with a message.
 	 */
-	public static function jumpstart_deactivate( $data ) {
+	public static function jumpstart_deactivate( $request ) {
 
 		// If dismissed, flag the jumpstart option as such.
 		if ( 'new_connection' === Jetpack_Options::get_option( 'jumpstart' ) ) {
@@ -2360,7 +2360,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.2.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Plugin slug with the syntax 'plugin-directory/plugin-main-file.php'.
@@ -2368,7 +2368,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public static function get_plugin( $data ) {
+	public static function get_plugin( $request ) {
 
 		$plugins = self::core_get_plugins();
 
@@ -2376,7 +2376,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error( 'no_plugins_found', esc_html__( 'This site has no plugins.', 'jetpack' ), array( 'status' => 404 ) );
 		}
 
-		$plugin = stripslashes( $data['plugin'] );
+		$plugin = stripslashes( $request['plugin'] );
 
 		if ( ! in_array( $plugin, array_keys( $plugins ) ) ) {
 			return new WP_Error( 'plugin_not_found', esc_html( sprintf( __( 'Plugin %s is not installed.', 'jetpack' ), $plugin ) ), array( 'status' => 404 ) );

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -852,15 +852,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		if ( ! is_array( $params ) ) {
 			return false;
 		}
-		$parsed = array_filter( $params, function( $key ) {
-			if ( is_int( $key ) ) {
-				return false;
-			}
-			if ( in_array( $key, array( 'slug', 'context' ) ) ) {
-				return false;
-			}
-			return true;
-		}, ARRAY_FILTER_USE_KEY );
+		$parsed = array_filter( $params, 'is_string' );
+		$parsed = array_diff_key( $parsed, array_flip( array( 'context', 'slug' ) ) );
 		return $parsed;
 	}
 }

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -12,7 +12,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Module slug.
@@ -21,11 +21,11 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @return WP_REST_Response|WP_Error A REST response if the request was served successfully, otherwise an error.
 	 */
-	public function process( $data ) {
-		if ( $data['active'] ) {
-			return $this->activate_module( $data );
+	public function process( $request ) {
+		if ( $request['active'] ) {
+			return $this->activate_module( $request );
 		} else {
-			return $this->deactivate_module( $data );
+			return $this->deactivate_module( $request );
 		}
 	}
 
@@ -34,7 +34,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param string|WP_REST_Request $data {
+	 * @param string|WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Module slug.
@@ -42,10 +42,10 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public function activate_module( $data ) {
-		$module_slug = isset( $data['slug'] )
-			? $data['slug']
-			: $data;
+	public function activate_module( $request ) {
+		$module_slug = isset( $request['slug'] )
+			? $request['slug']
+			: $request;
 
 		if ( ! Jetpack::is_module( $module_slug ) ) {
 			return new WP_Error(
@@ -74,7 +74,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param string|WP_REST_Request $data {
+	 * @param string|WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Module slug.
@@ -82,10 +82,10 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public function deactivate_module( $data ) {
-		$module_slug = isset( $data['slug'] )
-			? $data['slug']
-			: $data;
+	public function deactivate_module( $request ) {
+		$module_slug = isset( $request['slug'] )
+			? $request['slug']
+			: $request;
 
 		if ( ! Jetpack::is_module( $module_slug ) ) {
 			return new WP_Error(
@@ -292,19 +292,19 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data
+	 * @param WP_REST_Request $request
 	 *
 	 * @return bool|mixed|void|WP_Error
 	 */
-	public function process( $data ) {
-		if ( 'GET' === $data->get_method() ) {
-			if ( isset( $data['slug'] ) ) {
-				return $this->get_module( $data );
+	public function process( $request ) {
+		if ( 'GET' === $request->get_method() ) {
+			if ( isset( $request['slug'] ) ) {
+				return $this->get_module( $request );
 			}
 
-			return $this->get_all_options( $data );
+			return $this->get_all_options( $request );
 		} else {
-			return $this->update_data( $data );
+			return $this->update_data( $request );
 		}
 	}
 
@@ -313,7 +313,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Module slug.
@@ -321,12 +321,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @return mixed|void|WP_Error
 	 */
-	public function get_module( $data ) {
-		if ( Jetpack::is_module( $data['slug'] ) ) {
+	public function get_module( $request ) {
+		if ( Jetpack::is_module( $request['slug'] ) ) {
 
-			$module = Jetpack::get_module( $data['slug'] );
+			$module = Jetpack::get_module( $request['slug'] );
 
-			$module['options'] = Jetpack_Core_Json_Api_Endpoints::prepare_options_for_response( $data['slug'] );
+			$module['options'] = Jetpack_Core_Json_Api_Endpoints::prepare_options_for_response( $request['slug'] );
 
 			if (
 				isset( $module['requires_connection'] )
@@ -336,7 +336,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				$module['activated'] = false;
 			}
 
-			$i18n = jetpack_get_module_i18n( $data['slug'] );
+			$i18n = jetpack_get_module_i18n( $request['slug'] );
 			if ( isset( $module['name'] ) ) {
 				$module['name'] = $i18n['name'];
 			}
@@ -360,13 +360,13 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @since 4.6.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 * }
 	 *
 	 * @return array
 	 */
-	public function get_all_options( $data ) {
+	public function get_all_options( $request ) {
 		$response = array();
 
 		$modules = Jetpack::get_available_modules();
@@ -944,7 +944,7 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	 *
 	 * @since 4.1.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $date Date range to restrict results to.
@@ -952,9 +952,9 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	 *
 	 * @return int|string Number of spam blocked by Akismet. Otherwise, an error message.
 	 */
-	public function get_stats_data( WP_REST_Request $data ) {
+	public function get_stats_data( WP_REST_Request $request ) {
 		// Get parameters to fetch Stats data.
-		$range = $data->get_param( 'range' );
+		$range = $request->get_param( 'range' );
 
 		// If no parameters were passed.
 		if (
@@ -1166,8 +1166,6 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 	 * decides if the current user has enough privileges to act.
 	 *
 	 * @since 4.3.0
-	 *
-	 * @param WP_REST_Request $request
 	 *
 	 * @return bool does a current user have enough privileges.
 	 */

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -840,12 +840,13 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 * Allows the `settings` and `module/<slug>` EDITABLE endpoints to accept both JSON and multi-part POST bodies.
 	 *
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
-	 * 
+	 *
 	 * @return array|bool
 	 */
 	public function parse_settings_request_body( $request ) {
-		if ( is_array( $request->get_json_params() ) ) {
-			return $request->get_json_params();
+		$params = $request->get_json_params();
+		if ( is_array( $params ) ) {
+			return $params;
 		}
 		$params = $request->get_body_params();
 		if ( ! is_array( $params ) ) {

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -133,7 +133,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	/**
 	 * A WordPress REST API callback method that accepts a request object and decides what to do with it.
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @since 4.3.0
 	 *
@@ -262,7 +262,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return bool does the current user have enough privilege.
 	 */
@@ -360,9 +360,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @since 4.6.0
 	 *
-	 * @param WP_REST_Request $request {
-	 *     Array of parameters received by request.
-	 * }
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return array
 	 */
@@ -821,7 +819,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
 	 * @return bool
 	 */
@@ -841,7 +839,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	/**
 	 * Allows the `settings` and `module/<slug>` EDITABLE endpoints to accept both JSON and multi-part POST bodies.
 	 *
-	 * @param $request A WP REST API Request Object
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 * 
 	 * @return array|bool
 	 */
 	public function parse_settings_request_body( $request ) {

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -422,7 +422,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		// Get parameters to update the module.
-		$params = $request->get_params();
+		$params = $this->parse_settings_request_body( $request );
 
 		// Exit if no parameters were passed.
 		if ( ! is_array( $params ) ) {
@@ -836,6 +836,32 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			}
 			return current_user_can( 'jetpack_configure_modules' );
 		}
+	}
+
+	/**
+	 * Allows the `settings` and `module/<slug>` EDITABLE endpoints to accept both JSON and multi-part POST bodies.
+	 *
+	 * @param $request A WP REST API Request Object
+	 * @return array|bool
+	 */
+	public function parse_settings_request_body( $request ) {
+		if ( is_array( $request->get_json_params() ) ) {
+			return $request->get_json_params();
+		}
+		$params = $request->get_body_params();
+		if ( ! is_array( $params ) ) {
+			return false;
+		}
+		$parsed = array_filter( $params, function( $key ) {
+			if ( is_int( $key ) ) {
+				return false;
+			}
+			if ( in_array( $key, array( 'slug', 'context' ) ) ) {
+				return false;
+			}
+			return true;
+		}, ARRAY_FILTER_USE_KEY );
+		return $parsed;
 	}
 }
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -180,7 +180,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Module slug.
@@ -188,12 +188,11 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	 *
 	 * @return bool|WP_Error True if modules were activated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public static function activate_modules( $data ) {
-		$params = $data->get_json_params();
+	public static function activate_modules( $request ) {
 
 		if (
-			! isset( $params['modules'] )
-			|| ! is_array( $params['modules'] )
+			! isset( $request['modules'] )
+			|| ! is_array( $request['modules'] )
 		) {
 			return new WP_Error(
 				'not_found',
@@ -205,7 +204,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 		$activated = array();
 		$failed = array();
 
-		foreach ( $params['modules'] as $module ) {
+		foreach ( $request['modules'] as $module ) {
 			if ( Jetpack::activate_module( $module, false, false ) ) {
 				$activated[] = $module;
 			} else {
@@ -396,7 +395,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_REST_Request $data {
+	 * @param WP_REST_Request $request {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Module slug.
@@ -404,26 +403,26 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @return bool|WP_Error True if module was updated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
-	public function update_data( $data ) {
+	public function update_data( $request ) {
 
 		// If it's null, we're trying to update many module options from different modules.
-		if ( is_null( $data['slug'] ) ) {
+		if ( is_null( $request['slug'] ) ) {
 
 			// Value admitted by Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list that will make it return all module options.
 			// It will not be passed. It's just checked in this method to pass that method a string or array.
-			$data['slug'] = 'any';
+			$request['slug'] = 'any';
 		} else {
-			if ( ! Jetpack::is_module( $data['slug'] ) ) {
+			if ( ! Jetpack::is_module( $request['slug'] ) ) {
 				return new WP_Error( 'not_found', esc_html__( 'The requested Jetpack module was not found.', 'jetpack' ), array( 'status' => 404 ) );
 			}
 
-			if ( ! Jetpack::is_module_active( $data['slug'] ) ) {
+			if ( ! Jetpack::is_module_active( $request['slug'] ) ) {
 				return new WP_Error( 'inactive', esc_html__( 'The requested Jetpack module is inactive.', 'jetpack' ), array( 'status' => 409 ) );
 			}
 		}
 
 		// Get parameters to update the module.
-		$params = $data->get_json_params();
+		$params = $request->get_params();
 
 		// Exit if no parameters were passed.
 		if ( ! is_array( $params ) ) {
@@ -431,9 +430,9 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 		}
 
 		// Get available module options.
-		$options = Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list( 'any' === $data['slug']
+		$options = Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list( 'any' === $request['slug']
 			? $params
-			: $data['slug']
+			: $request['slug']
 		);
 
 		// Prepare to toggle module if needed

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -434,8 +434,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			return new WP_Error( 'missing_options', esc_html__( 'Missing options.', 'jetpack' ), array( 'status' => 404 ) );
 		}
 
+		// If $params was set via `get_body_params()` there may be some additional variables in the request that can
+		// cause validation to fail. This method verifies that each param was in fact updated and will throw a `some_updated`
+		// error if unused variables are included in the request.
 		$params = array_filter( $params, 'is_string' );
-		$params = array_diff_key( $params, array_flip( array( 'context', 'slug' ) ) );
+		unset( $params['context'], $params['slug'] );
 
 		// Get available module options.
 		$options = Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list( 'any' === $request['slug']

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -837,7 +837,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	}
 
 	/**
-	 * Allows the `settings` and `module/<slug>` EDITABLE endpoints to accept both JSON and multi-part POST bodies.
+	 * Allows the `settings` and `module/<slug>` EDITABLE endpoints to accept both JSON encoded and non-JSON encode POST bodies.
 	 *
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -711,6 +711,9 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$response = $this->create_and_get_request( 'settings', array( 'carousel_background_color' => 'black' ), 'POST' );
 		$this->assertResponseStatus( 200, $response );
 
+		// It should also save correctly with a multi-part POST body.
+		$response = $this->create_and_get_request( 'settings', array(), 'POST', array( 'carousel_background_color' => 'black' ) );
+		$this->assertResponseStatus( 200, $response );
 	}
 
 	/**
@@ -733,7 +736,13 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		$response = $this->create_and_get_request( 'settings', array( 'show' => array( 'post', 'page' ) ), 'POST' );
 		$this->assertResponseStatus( 200, $response );
+		
+		// It should also work correctly with a multi-part POST body.
+		$response = $this->create_and_get_request( 'settings', array(), 'POST',  array( 'show' => 'post' ) );
+		$this->assertResponseStatus( 400, $response );
 
+		$response = $this->create_and_get_request( 'settings', array(), 'POST', array( 'show' => array( 'post', 'page' ) ) );
+		$this->assertResponseStatus( 200, $response );
 	}
 
 	/**

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -711,7 +711,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$response = $this->create_and_get_request( 'settings', array( 'carousel_background_color' => 'black' ), 'POST' );
 		$this->assertResponseStatus( 200, $response );
 
-		// It should also save correctly with a multi-part POST body.
+		// It should also save correctly with a POST body that is not JSON encoded
 		$response = $this->create_and_get_request( 'settings', array(), 'POST', array( 'carousel_background_color' => 'black' ) );
 		$this->assertResponseStatus( 200, $response );
 	}
@@ -737,7 +737,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$response = $this->create_and_get_request( 'settings', array( 'show' => array( 'post', 'page' ) ), 'POST' );
 		$this->assertResponseStatus( 200, $response );
 		
-		// It should also work correctly with a multi-part POST body.
+		// It should also work correctly with a POST body that is not JSON encoded
 		$response = $this->create_and_get_request( 'settings', array(), 'POST',  array( 'show' => 'post' ) );
 		$this->assertResponseStatus( 400, $response );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR suggests that we use `register_rest_route()` consistently for registering JSON API endpoint routes. It also removes the now obsolete `Jetpack_Core_Json_Api_Endpoints::route()` method.

#### Testing instructions:

* Checkout this branch
* Verify there are no regressions in any of the affected JSON API endpoints.

#### Proposed changelog entry for your changes:
* Use `register_rest_route()` consistently for registering JSON API endpoint routes.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [x] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [x] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
