### PR TITLE
Extra Sidebar Widgets: Facebook Page Plugin: better UX for min/max height and width

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -10,7 +10,7 @@ function jetpack_facebook_likebox_init() {
 }
 
 /**
- * Facebook Page Plugin (formely known as the Like Box)
+ * Facebook Page Plugin (formerly known as the Like Box)
  * Display a Facebook Page Plugin as a widget (replaces the old like box plugin)
  * https://developers.facebook.com/docs/plugins/page-plugin
  */
@@ -165,15 +165,17 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'width' ); ?>">
-				<?php _e( 'Width', 'jetpack' ); ?>
-				<input type="number" class="smalltext" min="1" max="999" maxlength="3" name="<?php echo $this->get_field_name( 'width' ); ?>" id="<?php echo $this->get_field_id( 'width' ); ?>" value="<?php echo esc_attr( $like_args['width'] ); ?>" style="text-align: center;" />px
+				<?php _e( 'Width in pixels', 'jetpack' ); ?>
+				<input type="number" class="smalltext" min="<?php echo esc_attr( $this->min_width ); ?>" max="<?php echo esc_attr( $this->max_width ); ?>" maxlength="3" name="<?php echo $this->get_field_name( 'width' ); ?>" id="<?php echo $this->get_field_id( 'width' ); ?>" value="<?php echo esc_attr( $like_args['width'] ); ?>" style="text-align: center;" />
+				<small><?php echo sprintf( __( 'Minimum: %s', 'jetpack' ), $this->min_width ); ?> / <?php echo sprintf( __( 'Maximum: %s', 'jetpack' ), $this->max_width ); ?></small>
 			</label>
 		</p>
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'height' ); ?>">
-				<?php _e( 'Height', 'jetpack' ); ?>
-				<input type="number" class="smalltext" min="1" max="999" maxlength="3" name="<?php echo $this->get_field_name( 'height' ); ?>" id="<?php echo $this->get_field_id( 'height' ); ?>" value="<?php echo esc_attr( $like_args['height'] ); ?>" style="text-align: center;" />px
+				<?php _e( 'Height in pixels', 'jetpack' ); ?>
+				<input type="number" class="smalltext" min="<?php echo esc_attr( $this->min_height ); ?>" max="<?php echo esc_attr( $this->max_height ); ?>" maxlength="3" name="<?php echo $this->get_field_name( 'height' ); ?>" id="<?php echo $this->get_field_id( 'height' ); ?>" value="<?php echo esc_attr( $like_args['height'] ); ?>" style="text-align: center;" />
+				<small><?php echo sprintf( __( 'Minimum: %s', 'jetpack' ), $this->min_height ); ?> / <?php echo sprintf( __( 'Maximum: %s', 'jetpack' ), $this->max_height ); ?></small>
 			</label>
 		</p>
 
@@ -262,14 +264,17 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 	}
 
 	function is_valid_facebook_url( $url ) {
-		return ( FALSE !== strpos( $url, 'facebook.com' ) ) ? TRUE : FALSE;
+		return ( false !== strpos( $url, 'facebook.com' ) ) ? true : false;
 	}
 
 	function normalize_int_value( $value, $default = 0, $max = 0, $min = 0 ) {
 		$value = (int) $value;
 
-		if ( $max < $value || $min > $value )
-			$value = $default;
+		if ( $value > $max ) {
+			$value = $max;
+		} else if ( $value < $min ) {
+			$value = $min;
+		}
 
 		return (int) $value;
 	}


### PR DESCRIPTION
Improves how minimum and maximum height and width values are communicated to authors, and how they are validated if incorrect (out of range) values are saved in the form.

Includes minor code and comments cleanup.

Syncs r148069-wpcom and r148071-wpcom

#### Testing instructions:

* Enable the Facebook Page Plugin widget, try various combinations of height and width values, and save the widget.
* The settings should reset to the stated max and min.
 