### PR TITLE
Extra Sidebar Widgets: fix grid layout for Top Posts and Pages

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -253,8 +253,6 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			);
 			if ( 'grid' == $display ) {
 				$get_image_options['avatar_size'] = 200;
-			} else {
-				$get_image_options['avatar_size'] = 40;
 			}
 			/**
 			 * Top Posts Widget Image options.
@@ -312,7 +310,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		case 'list' :
 		case 'grid' :
 			foreach ( $posts as &$post ) {
-				$image = Jetpack_PostImages::get_image( $post['post_id'], array( 'fallback_to_avatars' => true ) );
+				$image = Jetpack_PostImages::get_image( $post['post_id'], array( 'fallback_to_avatars' => true, 'avatar_size' => (int) $get_image_options['avatar_size'] ) );
 				$post['image'] = $image['src'];
 				if ( 'blavatar' != $image['from'] && 'gravatar' != $image['from'] ) {
 					$size = (int) $get_image_options['avatar_size'];


### PR DESCRIPTION
... to show correct avatar fallback image size of 200 pixels square.

Syncs r148090-wpcom

When using Visual and a Top Pages and Posts widget in Image Grid mode, you can get a broken grid if one of the posts has no image to be featured.

#### Testing instructions:

* Enable the Top Posts and Pages widget.
* View the widget with a post that has no image in it — it should instead use the author's Gravatar image at 200 by 200 pixels.

