### PR TITLE
Extra Sidebar Widgets: improve error message for Display WordPress Posts

### DIFF
--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -269,7 +269,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 		if ( isset( $parsed_data->error ) ) {
 			return new WP_Error(
 				'remote_error',
-				__( 'We cannot display information for this blog.', 'jetpack' ),
+				__( 'It looks like the WordPress site URL is incorrectly configured. Please check it in your widget settings.', 'jetpack' ),
 				$parsed_data->error
 			);
 		}

--- a/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -121,7 +121,7 @@ class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 		$this->assertTrue( is_wp_error( $result ) );
 
 		$this->assertEquals( array( 'remote_error' ), $result->get_error_codes() );
-		$this->assertEquals( array( 'We cannot display information for this blog.' ), $result->get_error_messages() );
+		$this->assertEquals( array( 'It looks like the WordPress site URL is incorrectly configured. Please check it in your widget settings.' ), $result->get_error_messages() );
 		$this->assertEquals( 'test error', $result->get_error_data() );
 
 	}


### PR DESCRIPTION
Syncs r148149-wpcom

#### Testing instructions:

* Enable Display WordPress Posts widget.
* Enter a bad or empty value for the URL.
* Ensure the error message is as expected.
