### PR TITLE
Support Jetpack Photon for Text Widgets

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -271,3 +271,20 @@ function jetpack_photon_banned_domains( $skip, $image_url, $args, $scheme ) {
 
 	return $skip;
 }
+
+
+/**
+ * Jetpack Photon - Support Text Widgets.
+ * 
+ * @access public
+ * @param mixed $content Content from text widget.
+ * @return void
+ */
+function jetpack_photon_support_text_widgets( $content ) {
+    if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+        $content = Jetpack_Photon::filter_the_content( $content );
+    }
+ 
+    return $content;
+}
+add_filter( 'widget_text', 'jetpack_photon_support_text_widgets' );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -284,6 +284,6 @@ function jetpack_photon_support_text_widgets( $content ) {
     if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
         return Jetpack_Photon::filter_the_content( $content );
     }
-
+	return $content;
 }
 add_filter( 'widget_text', 'jetpack_photon_support_text_widgets' );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -282,9 +282,8 @@ function jetpack_photon_banned_domains( $skip, $image_url, $args, $scheme ) {
  */
 function jetpack_photon_support_text_widgets( $content ) {
     if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
-        $content = Jetpack_Photon::filter_the_content( $content );
+        return Jetpack_Photon::filter_the_content( $content );
     }
- 
-    return $content;
+
 }
 add_filter( 'widget_text', 'jetpack_photon_support_text_widgets' );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -277,8 +277,8 @@ function jetpack_photon_banned_domains( $skip, $image_url, $args, $scheme ) {
  * Jetpack Photon - Support Text Widgets.
  * 
  * @access public
- * @param mixed $content Content from text widget.
- * @return void
+ * @param string $content Content from text widget.
+ * @return string
  */
 function jetpack_photon_support_text_widgets( $content ) {
     if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {


### PR DESCRIPTION
Support Jetpack Photon for Text Widgets only when Photon module is enabled.

Fixes #4724