### PR TITLE
Settings UI: add writing tab settings, optimistic toggles, fix state tree update

### DIFF
--- a/_inc/client/components/forms/index.jsx
+++ b/_inc/client/components/forms/index.jsx
@@ -8,6 +8,7 @@ import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 
 export const FormFieldset = React.createClass( {
 
@@ -16,6 +17,16 @@ export const FormFieldset = React.createClass( {
 	render: function() {
 		return (
 			<fieldset { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'jp-form-fieldset' ) } >
+				{
+					this.props.support
+						? <div className="jp-module-settings__learn-more">
+							<Button borderless compact href={ this.props.support }>
+								<Gridicon icon="help-outline" />
+								<span className="screen-reader-text">{ __( 'Learn More' ) }</span>
+							</Button>
+						  </div>
+						: ''
+				}
 				{ this.props.children }
 			</fieldset>
 		);

--- a/_inc/client/components/forms/index.jsx
+++ b/_inc/client/components/forms/index.jsx
@@ -5,10 +5,12 @@ var React = require( 'react' ),
 	classnames = require( 'classnames' );
 import classNames from 'classnames';
 import omit from 'lodash/omit';
+import forOwn from 'lodash/forown';
 import isEmpty from 'lodash/isEmpty';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import SelectDropdown from 'components/select-dropdown';
 
 export const FormFieldset = React.createClass( {
 
@@ -170,5 +172,25 @@ export const FormButton = React.createClass( {
 				{ isEmpty( this.props.children ) ? this.getDefaultButtonAction() : this.props.children }
 			</Button>
 		);
+	}
+} );
+
+export const FormSelect = React.createClass( {
+	handleOnSelect: function( option ) {
+		this.props.onOptionChange( {
+			target: {
+				type: 'select',
+				name: this.props.name,
+				value: option.value
+			}
+		} );
+	},
+
+	render() {
+		let validValues = [];
+		forOwn( this.props.validValues, ( label, value ) => {
+			validValues.push( { label: label, value: value } );
+		} );
+		return <SelectDropdown options={ validValues } onSelect={ this.handleOnSelect } initialSelected={ this.props.value } />;
 	}
 } );

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -63,6 +63,7 @@
 .jp-form-fieldset {
 
 	margin-bottom: 4em;
+	position: relative;
 
 	.jp-form-legend + .jp-form-setting-explanation {
 		margin-top: rem( 8px );

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -46,7 +46,7 @@ export function connectModuleOptions( Component ) {
 					return getModuleOptionValidValues( state, module_slug, option_name );
 				},
 				getOptionCurrentValue: ( module_slug, option_name ) => getModuleOption( state, module_slug, option_name ),
-				getSettingCurrentValue: ( setting_name ) => getSetting( state, setting_name ),
+				getSettingCurrentValue: ( setting_name, moduleName = '' ) => getSetting( state, setting_name, moduleName ),
 				getSiteRoles: () => getSiteRoles( state ),
 				isUpdating: () => isUpdatingSetting( state ),
 				adminEmailAddress: getAdminEmailAddress( state ),

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -10,15 +10,15 @@ import get from 'lodash/get';
 import {
 	updateModuleOptions,
 	getModuleOption,
-	getModuleOptionValidValues,
-	regeneratePostByEmailAddress
+	getModuleOptionValidValues
 } from 'state/modules';
 import {
 	getSetting,
 	updateSettings,
 	isUpdatingSetting,
 	setUnsavedSettingsFlag,
-	clearUnsavedSettingsFlag
+	clearUnsavedSettingsFlag,
+	regeneratePostByEmailAddress
 } from 'state/settings';
 import { getCurrentIp, getSiteAdminUrl } from 'state/initial-state';
 import {

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -48,7 +48,7 @@ export function connectModuleOptions( Component ) {
 				getOptionCurrentValue: ( module_slug, option_name ) => getModuleOption( state, module_slug, option_name ),
 				getSettingCurrentValue: ( setting_name, moduleName = '' ) => getSetting( state, setting_name, moduleName ),
 				getSiteRoles: () => getSiteRoles( state ),
-				isUpdating: () => isUpdatingSetting( state ),
+				isUpdating: settingName => isUpdatingSetting( state, settingName ),
 				adminEmailAddress: getAdminEmailAddress( state ),
 				currentIp: getCurrentIp( state ),
 				siteAdminUrl: getSiteAdminUrl( state ),

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -119,35 +119,6 @@ export let MonitorSettings = React.createClass( {
 
 MonitorSettings = moduleSettingsForm( MonitorSettings );
 
-export let CarouselSettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<FormLegend> { __( 'Mobile Promos' ) } </FormLegend>
-					<ModuleSettingCheckbox
-						name={ 'carousel_display_exif' }
-						{ ...this.props }
-						label={ __( 'Show photo metadata (Exif) in carousel, when available' ) } />
-				</FormFieldset>
-				<FormFieldset>
-					<FormLegend> { __( 'Background Color' ) }</FormLegend>
-					<ModuleSettingRadios
-						name={ 'carousel_background_color' }
-						{ ...this.props }
-						validValues={ this.props.validValues( 'carousel_background_color' ) } />
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-CarouselSettings = moduleSettingsForm( CarouselSettings );
-
 export let InfiniteScrollSettings = React.createClass( {
 	render() {
 		return (
@@ -208,27 +179,6 @@ export let MinilevenSettings = React.createClass( {
  } );
 
 MinilevenSettings = moduleSettingsForm( MinilevenSettings );
-
-export let TiledGallerySettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<ModuleSettingCheckbox
-						name={ 'tiled_galleries' }
-						{ ...this.props }
-						label={ __( 'Display all your gallery pictures in a cool mosaic' ) } />
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-TiledGallerySettings = moduleSettingsForm( TiledGallerySettings );
 
 export let PostByEmailSettings = React.createClass( {
 	regeneratePostByEmailAddress( event ) {

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
-import TextInput from 'components/text-input';
-import Textarea from 'components/textarea';
 import TagsInput from 'components/tags-input';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import ConnectButton from 'components/connect-button';
@@ -25,8 +23,7 @@ import {
 
 import {
 	ModuleSettingRadios,
-	ModuleSettingCheckbox,
-	ModuleSettingMultipleSelectCheckboxes
+	ModuleSettingCheckbox
 } from 'components/module-settings/form-components';
 
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
@@ -118,67 +115,6 @@ export let MonitorSettings = React.createClass( {
 } );
 
 MonitorSettings = moduleSettingsForm( MonitorSettings );
-
-export let InfiniteScrollSettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<ModuleSettingCheckbox
-						name={ 'infinite_scroll' }
-						{ ...this.props }
-						label={ __( 'Scroll infinitely (Shows 7 posts on each load)' ) } />
-					<ModuleSettingCheckbox
-						name={ 'infinite_scroll_google_analytics' }
-						{ ...this.props }
-						label={ __( 'Track each infinite Scroll post load as a page view in Google Analytics' ) } />
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-InfiniteScrollSettings = moduleSettingsForm( InfiniteScrollSettings );
-
-export let MinilevenSettings = React.createClass( {
-	render() {
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<FormLegend> { __( 'Excerpts' ) } </FormLegend>
-						<ModuleSettingRadios
-							name={ 'wp_mobile_excerpt' }
-							{ ...this.props }
-							validValues={ this.props.validValues( 'wp_mobile_excerpt' ) } />
-				</FormFieldset>
-				<FormFieldset>
-					<FormLegend> { __( 'Featured Images' ) } </FormLegend>
-						<ModuleSettingRadios
-							name={ 'wp_mobile_featured_images' }
-							{ ...this.props }
-							validValues={ this.props.validValues( 'wp_mobile_featured_images' ) } />
-				</FormFieldset>
-				<FormFieldset>
-					<FormLegend> { __( 'Mobile Promos' ) } </FormLegend>
-					<ModuleSettingCheckbox
-						name={ 'wp_mobile_app_promos' }
-						{ ...this.props }
-						label={ __( 'Show a promo for the WordPress mobile apps in the footer of the mobile theme' ) } />
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
- } );
-
-MinilevenSettings = moduleSettingsForm( MinilevenSettings );
 
 export let PostByEmailSettings = React.createClass( {
 	regeneratePostByEmailAddress( event ) {

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -285,62 +285,6 @@ PostByEmailSettings.propTypes = {
 
 PostByEmailSettings = moduleSettingsForm( PostByEmailSettings );
 
-export let CustomContentTypesSettings = React.createClass( {
-	render() {
-		let portfolioConfigure = () => {
-			return ! this.props.getOptionCurrentValue( this.props.module.module, 'jetpack_portfolio' ) ?
-				'' :
-				<Button
-					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
-					href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-portfolio' }
-					compact={ true }
-				>{ __( 'Configure Portfolios' ) }</Button>;
-		};
-
-		let testimonialConfigure = () => {
-			return ! this.props.getOptionCurrentValue( this.props.module.module, 'jetpack_testimonial' ) ?
-				'' :
-				<Button
-					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
-					href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-testimonial' }
-					compact={ true }
-				>{ __( 'Configure Testimonials' ) }</Button>;
-		};
-
-		return (
-			<form onSubmit={ this.props.onSubmit } >
-				<FormFieldset>
-					<ModuleSettingCheckbox
-						name={ 'jetpack_portfolio' }
-						{ ...this.props }
-						label={ __( 'Enable Portfolio Projects for this site.' ) }
-					/>
-					<ModuleSettingCheckbox
-						name={ 'jetpack_testimonial' }
-						{ ...this.props }
-						label={ __( 'Enable Testimonials for this site.' ) }
-					/>
-					<br/>
-					{ portfolioConfigure() }
-					{ testimonialConfigure() }
-					<FormButton
-						className="is-primary"
-						isSubmitting={ this.props.isSavingAnyOption() }
-						disabled={ this.props.shouldSaveButtonBeDisabled() } />
-				</FormFieldset>
-			</form>
-		)
-	}
-} );
-
-CustomContentTypesSettings.propTypes = {
-	siteAdminUrl: React.PropTypes.string.isRequired
-};
-
-CustomContentTypesSettings = moduleSettingsForm( CustomContentTypesSettings );
-
-;
-
 export let WordAdsSettings = React.createClass( {
 	render() {
 		return (

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -3,12 +3,7 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import TagsInput from 'components/tags-input';
-import ClipboardButtonInput from 'components/clipboard-button-input';
-import ConnectButton from 'components/connect-button';
 import get from 'lodash/get';
-import Button from 'components/button';
 
 /**
  * Internal dependencies
@@ -115,61 +110,6 @@ export let MonitorSettings = React.createClass( {
 } );
 
 MonitorSettings = moduleSettingsForm( MonitorSettings );
-
-export let PostByEmailSettings = React.createClass( {
-	regeneratePostByEmailAddress( event ) {
-		event.preventDefault();
-		this.props.regeneratePostByEmailAddress();
-	},
-	address() {
-		const currentValue = this.props.getOptionValue( 'post_by_email_address' );
-		// If the module Post-by-email is enabled BUT it's configured as disabled
-		// Its value is set to false
-		if ( currentValue === false ) {
-			return '';
-		}
-		return currentValue;
-	},
-	render() {
-		return (
-			this.props.isCurrentUserLinked ?
-				<form>
-					<FormFieldset>
-						<FormLabel>
-							<FormLegend>{ __( 'Email Address' ) }</FormLegend>
-							<ClipboardButtonInput
-								value={ this.address() }
-								copy={ __( 'Copy', { context: 'verb' } ) }
-								copied={ __( 'Copied!' ) }
-								prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
-							/>
-							<FormButton
-								onClick={ this.regeneratePostByEmailAddress } >
-								{ __( 'Regenerate address' ) }
-							</FormButton>
-						</FormLabel>
-					</FormFieldset>
-				</form>
-				:
-				<div>
-					{
-						<div className="jp-connection-settings">
-							<div className="jp-connection-settings__headline">{ __( 'Link your account to WordPress.com to start using this feature.' ) }</div>
-							<div className="jp-connection-settings__actions">
-								<ConnectButton connectUser={ true } from="post-by-email" />
-							</div>
-						</div>
-					}
-				</div>
-		)
-	}
-} );
-
-PostByEmailSettings.propTypes = {
-	isCurrentUserLinked: React.PropTypes.bool.isRequired
-};
-
-PostByEmailSettings = moduleSettingsForm( PostByEmailSettings );
 
 export let WordAdsSettings = React.createClass( {
 	render() {

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -106,8 +106,8 @@ export function ModuleSettingsForm( InnerComponent ) {
 		 * Retrieves an option from an existing module, or from an array of modules
 		 * if the form was initialized with an array
 		 */
-		getOptionValue( settingName ) {
-			const currentValue = this.props.getSettingCurrentValue( settingName );
+		getOptionValue( settingName, module = '' ) {
+			const currentValue = this.props.getSettingCurrentValue( settingName, module );
 			return typeof this.state.options[ settingName ] !== 'undefined'
 				 ? this.state.options[ settingName ]
 				 : currentValue;

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import assign from 'lodash/assign';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -112,10 +113,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 		 * if the form was initialized with an array
 		 */
 		getOptionValue( settingName, module = '' ) {
-			const currentValue = this.props.getSettingCurrentValue( settingName, module );
-			return typeof this.state.options[ settingName ] !== 'undefined'
-				 ? this.state.options[ settingName ]
-				 : currentValue;
+			return get( this.state.options, settingName, this.props.getSettingCurrentValue( settingName, module ) );
 		},
 
 		shouldSaveButtonBeDisabled() {

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -108,9 +108,13 @@ export function ModuleSettingsForm( InnerComponent ) {
 		},
 		onSubmit( event ) {
 			event.preventDefault();
-			this.props.updateOptions( assign( {}, this.state.options ) );
-			this.props.clearUnsavedSettingsFlag();
-			this.setState( { options: {} } )
+			this.props.updateOptions( this.state.options )
+				.then( () => {
+					this.setState( { options: {} } );
+				} )
+				.then( () => {
+					this.props.clearUnsavedSettingsFlag();
+				} );
 		},
 
 		/**

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -62,9 +62,9 @@ export function ModuleSettingsForm( InnerComponent ) {
 		 * If the module is active, only the option is added to the list of form values to send.
 		 * If it's inactive, an additional option stating that the module must be activated is added to the list.
 		 *
-		 * @param {string}  module
-		 * @param {string}  moduleOption
-		 * @param {boolean} deactivate
+		 * @param {String}  module
+		 * @param {String}  moduleOption
+		 * @param {Boolean} deactivate
 		 */
 		updateFormStateModuleOption( module, moduleOption, deactivate = false ) {
 
@@ -93,6 +93,11 @@ export function ModuleSettingsForm( InnerComponent ) {
 				} );
 			}
 		},
+		/**
+		 * Instantly activate or deactivate a module.
+		 *
+		 * @param {String} module
+		 */
 		toggleModuleNow( module ) {
 			this.props.updateOptions( { [ module ]: ! this.getOptionValue( module ) } );
 		},
@@ -123,9 +128,15 @@ export function ModuleSettingsForm( InnerComponent ) {
 		isDirty() {
 			return !! Object.keys( this.state.options ).length;
 		},
-		isSavingAnyOption() {
-			// Check if any of the updated options is still saving
-			return this.props.isUpdating();
+		/**
+		 * Checks if a setting is currently being saved.
+		 *
+		 * @param {String|Array} settings
+		 *
+		 * @returns {Boolean} True if specified settings are being saved, false otherwise.
+		 */
+		isSavingAnyOption( settings = '' ) {
+			return this.props.isUpdating( settings );
 		},
 		render() {
 			return (

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -125,6 +125,11 @@ export function ModuleSettingsForm( InnerComponent ) {
 			// Check if the form is not currently dirty
 			return this.isSavingAnyOption() || ! this.isDirty();
 		},
+		/**
+		 * Check if there are unsaved settings in the card.
+		 *
+		 * @returns {Boolean}
+		 */
 		isDirty() {
 			return !! Object.keys( this.state.options ).length;
 		},
@@ -149,6 +154,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 					updateFormStateModuleOption={ this.updateFormStateModuleOption }
 					shouldSaveButtonBeDisabled={ this.shouldSaveButtonBeDisabled }
 					isSavingAnyOption={ this.isSavingAnyOption }
+					isDirty={ this.isDirty }
 					{ ...this.props } />
 			);
 		}

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -90,6 +90,9 @@ export function ModuleSettingsForm( InnerComponent ) {
 				} );
 			}
 		},
+		toggleModuleNow( module ) {
+			this.props.updateOptions( { [ module ]: ! this.getOptionValue( module ) } );
+		},
 		componentDidUpdate() {
 			if ( this.isDirty() ) {
 				this.props.setUnsavedSettingsFlag();
@@ -131,6 +134,7 @@ export function ModuleSettingsForm( InnerComponent ) {
 					onSubmit={ this.onSubmit }
 					onOptionChange={ this.onOptionChange }
 					updateFormStateOptionValue={ this.updateFormStateOptionValue }
+					toggleModuleNow={ this.toggleModuleNow }
 					updateFormStateModuleOption={ this.updateFormStateModuleOption }
 					shouldSaveButtonBeDisabled={ this.shouldSaveButtonBeDisabled }
 					isSavingAnyOption={ this.isSavingAnyOption }

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -61,14 +61,26 @@ export function ModuleSettingsForm( InnerComponent ) {
 		 * If the module is active, only the option is added to the list of form values to send.
 		 * If it's inactive, an additional option stating that the module must be activated is added to the list.
 		 *
-		 * @param {string} module
-		 * @param {string} moduleOption
+		 * @param {string}  module
+		 * @param {string}  moduleOption
+		 * @param {boolean} deactivate
 		 */
-		updateFormStateModuleOption( module, moduleOption ) {
+		updateFormStateModuleOption( module, moduleOption, deactivate = false ) {
 
-			// If the module is active, we pass the value to set.
+			// If the module is active, check if we're going to update the option or update and deactivate.
 			if ( this.getOptionValue( module ) ) {
-				this.updateFormStateOptionValue( moduleOption, ! this.getOptionValue( moduleOption ) );
+				if ( deactivate ) {
+
+					// If after toggling the option the module is no longer needed to be active, deactivate it.
+					this.updateFormStateOptionValue( {
+						[ module ]: false,
+						[ moduleOption ]: ! this.getOptionValue( moduleOption )
+					} );
+				} else {
+
+					// We pass the value to set.
+					this.updateFormStateOptionValue( moduleOption, ! this.getOptionValue( moduleOption ) );
+				}
 			} else {
 
 				// If the module is inactive, we pass the module to activate and the value to set.

--- a/_inc/client/components/module-settings/module-settings-form.jsx
+++ b/_inc/client/components/module-settings/module-settings-form.jsx
@@ -72,19 +72,21 @@ export function ModuleSettingsForm( InnerComponent ) {
 				if ( deactivate ) {
 
 					// If after toggling the option the module is no longer needed to be active, deactivate it.
-					this.updateFormStateOptionValue( {
+					this.props.updateOptions( {
 						[ module ]: false,
 						[ moduleOption ]: ! this.getOptionValue( moduleOption )
 					} );
 				} else {
 
 					// We pass the value to set.
-					this.updateFormStateOptionValue( moduleOption, ! this.getOptionValue( moduleOption ) );
+					this.props.updateOptions( {
+						[ moduleOption ]: ! this.getOptionValue( moduleOption )
+					} );
 				}
 			} else {
 
 				// If the module is inactive, we pass the module to activate and the value to set.
-				this.updateFormStateOptionValue( {
+				this.props.updateOptions( {
 					[ module ]: true,
 					[ moduleOption ]: true
 				} );

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -13,8 +13,6 @@ import {
 	LikesSettings,
 	MonitorSettings,
 	SingleSignOnSettings,
-	MinilevenSettings,
-	InfiniteScrollSettings,
 	PostByEmailSettings,
 	VideoPressSettings,
 	WordAdsSettings
@@ -42,10 +40,6 @@ const AllModuleSettingsComponent = React.createClass( {
 				);
 			case 'post-by-email':
 				return ( <PostByEmailSettings module={ module }  /> );
-			case 'minileven':
-				return ( <MinilevenSettings module={ module }  /> );
-			case 'infinite-scroll':
-				return ( <InfiniteScrollSettings module={ module }  /> );
 			case 'monitor':
 				module.raw_url = this.props.siteRawUrl;
 				return ( <MonitorSettings module={ module }  /> );
@@ -91,7 +85,6 @@ const AllModuleSettingsComponent = React.createClass( {
 				return ( <LikesSettings module={ module }  /> );
 			case 'wordads':
 				return ( <WordAdsSettings module={ module } /> );
-			case 'gravatar-hovercards':
 			case 'contact-form':
 			case 'latex':
 			case 'shortlinks':

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -19,7 +19,6 @@ import {
 	TiledGallerySettings,
 	PostByEmailSettings,
 	CustomContentTypesSettings,
-	MarkdownSettings,
 	VideoPressSettings,
 	WordAdsSettings
 } from 'components/module-settings/';

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -18,7 +18,6 @@ import {
 	InfiniteScrollSettings,
 	TiledGallerySettings,
 	PostByEmailSettings,
-	CustomContentTypesSettings,
 	VideoPressSettings,
 	WordAdsSettings
 } from 'components/module-settings/';
@@ -45,8 +44,6 @@ const AllModuleSettingsComponent = React.createClass( {
 				);
 			case 'post-by-email':
 				return ( <PostByEmailSettings module={ module }  /> );
-			case 'custom-content-types':
-				return ( <CustomContentTypesSettings module={ module }  /> );
 			case 'tiled-gallery':
 				return ( <TiledGallerySettings module={ module }  /> );
 			case 'minileven':

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -14,9 +14,7 @@ import {
 	MonitorSettings,
 	SingleSignOnSettings,
 	MinilevenSettings,
-	CarouselSettings,
 	InfiniteScrollSettings,
-	TiledGallerySettings,
 	PostByEmailSettings,
 	VideoPressSettings,
 	WordAdsSettings
@@ -44,12 +42,8 @@ const AllModuleSettingsComponent = React.createClass( {
 				);
 			case 'post-by-email':
 				return ( <PostByEmailSettings module={ module }  /> );
-			case 'tiled-gallery':
-				return ( <TiledGallerySettings module={ module }  /> );
 			case 'minileven':
 				return ( <MinilevenSettings module={ module }  /> );
-			case 'carousel':
-				return ( <CarouselSettings module={ module }  /> );
 			case 'infinite-scroll':
 				return ( <InfiniteScrollSettings module={ module }  /> );
 			case 'monitor':
@@ -102,7 +96,6 @@ const AllModuleSettingsComponent = React.createClass( {
 			case 'latex':
 			case 'shortlinks':
 			case 'shortcodes':
-			case 'photon':
 			case 'widget-visibility':
 			case 'notifications':
 			case 'enhanced-distribution':

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -13,7 +13,6 @@ import {
 	LikesSettings,
 	MonitorSettings,
 	SingleSignOnSettings,
-	PostByEmailSettings,
 	VideoPressSettings,
 	WordAdsSettings
 } from 'components/module-settings/';
@@ -38,8 +37,6 @@ const AllModuleSettingsComponent = React.createClass( {
 						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href='/wp-admin/admin.php?page=omnisearch'>{ __( 'Search your content.' ) }</ExternalLink>
 					</div>
 				);
-			case 'post-by-email':
-				return ( <PostByEmailSettings module={ module }  /> );
 			case 'monitor':
 				module.raw_url = this.props.siteRawUrl;
 				return ( <MonitorSettings module={ module }  /> );

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -20,6 +20,11 @@
 	position: absolute;
 	top: 12px;
 	right: 17px;
+
+	.jp-form-fieldset & {
+		top: -12px;
+		right:-7px;
+	}
 }
 
 // Connection Settings styles

--- a/_inc/client/components/module-toggle/style.scss
+++ b/_inc/client/components/module-toggle/style.scss
@@ -1,0 +1,8 @@
+.form-toggle.is-compact.is-toggling + .form-toggle__label .form-toggle__switch:before,
+.form-toggle.is-compact.is-toggling + .form-toggle__label .form-toggle__switch:after {
+	left: 8px;
+}
+.form-toggle.is-compact.is-toggling:checked + .form-toggle__label .form-toggle__switch:before,
+.form-toggle.is-compact.is-toggling:checked + .form-toggle__label .form-toggle__switch:after {
+	left: 0;
+}

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -44,7 +44,7 @@ export const SettingsCard = props => {
 							compact
 							isSubmitting={ isSaving }
 							onClick={ isSaving ? () => {} : props.onSubmit }
-							disabled={ isSaving }>
+							disabled={ isSaving || ! props.isDirty() }>
 							{
 								isSaving
 									? __( 'Saving…', { context: 'Button caption' } )

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -12,11 +12,11 @@ import TextInput from 'components/text-input';
 import {
 	FormFieldset,
 	FormLegend,
-	FormLabel
+	FormLabel,
+	FormSelect
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingSelect } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 
 export const Comments = moduleSettingsForm(
@@ -55,7 +55,7 @@ export const Comments = moduleSettingsForm(
 								<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
 								<FormLabel>
 									<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
-									<ModuleSettingSelect
+									<FormSelect
 										name={ 'jetpack_comment_form_color_scheme' }
 										value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
 										onChange={ this.props.onOptionChange }

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -30,10 +30,10 @@ export const Comments = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="comments">
-					<ModuleToggle slug={ 'comments' }
+					<ModuleToggle slug="comments"
 								  compact
 								  activated={ this.props.getOptionValue( 'comments' ) }
-								  toggling={ this.props.isSavingAnyOption() }
+								  toggling={ this.props.isSavingAnyOption( 'comments' ) }
 								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
@@ -67,10 +67,10 @@ export const Comments = moduleSettingsForm(
 					}
 					<hr />
 					<FormFieldset support={ gravatar.learn_more_button }>
-						<ModuleToggle slug={ 'gravatar-hovercards' }
+						<ModuleToggle slug="gravatar-hovercards"
 									  compact
 									  activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
-									  toggling={ this.props.isSavingAnyOption() }
+									  toggling={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
 									  toggleModule={ this.props.toggleModuleNow }>
 							<span className="jp-form-toggle-explanation">
 								{
@@ -80,10 +80,10 @@ export const Comments = moduleSettingsForm(
 						</ModuleToggle>
 					</FormFieldset>
 					<FormFieldset support={ markdown.learn_more_button }>
-						<ModuleToggle slug={ 'markdown' }
+						<ModuleToggle slug="markdown"
 									  compact
 									  activated={ !!this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
-									  toggling={ this.props.isSavingAnyOption() }
+									  toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_comments_with_markdown' ] ) }
 									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'wpcom_publish_comments_with_markdown' ) }>
 							<span className="jp-form-toggle-explanation">
 								{

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -22,10 +22,6 @@ import SettingsCard from 'components/settings-card';
 export const Comments = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		render() {
 			let comments = this.props.getModule( 'comments' ),
 				gravatar = this.props.getModule( 'gravatar-hovercards' ),
@@ -38,40 +34,44 @@ export const Comments = moduleSettingsForm(
 								  compact
 								  activated={ this.props.getOptionValue( 'comments' ) }
 								  toggling={ this.props.isSavingAnyOption() }
-								  toggleModule={ this.toggleModule }>
+								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								comments.description
 							}
 						</span>
 					</ModuleToggle>
-					<FormFieldset>
-						<FormLabel>
-							<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
-							<TextInput
-								name={ 'highlander_comment_form_prompt' }
-								value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
-								disabled={ this.props.isUpdating( 'highlander_comment_form_prompt' ) }
-								onChange={ this.props.onOptionChange} />
-						</FormLabel>
-						<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
-						<FormLabel>
-							<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
-							<ModuleSettingSelect
-								name={ 'jetpack_comment_form_color_scheme' }
-								value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
-								onChange={ this.props.onOptionChange }
-								{ ...this.props }
-								validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
-						</FormLabel>
-					</FormFieldset>
+					{
+						this.props.getOptionValue( 'comments' )
+							? <FormFieldset>
+								<FormLabel>
+									<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
+									<TextInput
+										name={ 'highlander_comment_form_prompt' }
+										value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
+										disabled={ this.props.isUpdating( 'highlander_comment_form_prompt' ) }
+										onChange={ this.props.onOptionChange } />
+								</FormLabel>
+								<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
+								<FormLabel>
+									<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
+									<ModuleSettingSelect
+										name={ 'jetpack_comment_form_color_scheme' }
+										value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
+										onChange={ this.props.onOptionChange }
+										{ ...this.props }
+										validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
+								</FormLabel>
+							  </FormFieldset>
+							: ''
+					}
 					<hr />
 					<FormFieldset support={ gravatar.learn_more_button }>
 						<ModuleToggle slug={ 'gravatar-hovercards' }
 									  compact
 									  activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
 									  toggling={ this.props.isSavingAnyOption() }
-									  toggleModule={ this.toggleModule }>
+									  toggleModule={ this.props.toggleModuleNow }>
 							<span className="jp-form-toggle-explanation">
 								{
 									gravatar.description
@@ -82,7 +82,7 @@ export const Comments = moduleSettingsForm(
 					<FormFieldset support={ markdown.learn_more_button }>
 						<ModuleToggle slug={ 'markdown' }
 									  compact
-									  activated={ !!this.props.getOptionValue( 'wpcom_publish_comments_with_markdown' ) }
+									  activated={ !!this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
 									  toggling={ this.props.isSavingAnyOption() }
 									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'wpcom_publish_comments_with_markdown' ) }>
 							<span className="jp-form-toggle-explanation">

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -27,6 +27,9 @@ export const Comments = moduleSettingsForm(
 		},
 
 		render() {
+			let comments = this.props.getModule( 'comments' ),
+				gravatar = this.props.getModule( 'gravatar-hovercards' ),
+				markdown = this.props.getModule( 'markdown' );
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -38,7 +41,7 @@ export const Comments = moduleSettingsForm(
 								  toggleModule={ this.toggleModule }>
 						<span className="jp-form-toggle-explanation">
 							{
-								__( 'Use Jetpack comments. Let readers use their WordPress.com,	Twitter, Facebook or Google+ to leave comments on your posts and pages.' )
+								comments.description
 							}
 						</span>
 					</ModuleToggle>
@@ -63,7 +66,7 @@ export const Comments = moduleSettingsForm(
 						</FormLabel>
 					</FormFieldset>
 					<hr />
-					<FormFieldset>
+					<FormFieldset support={ gravatar.learn_more_button }>
 						<ModuleToggle slug={ 'gravatar-hovercards' }
 									  compact
 									  activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
@@ -71,11 +74,12 @@ export const Comments = moduleSettingsForm(
 									  toggleModule={ this.toggleModule }>
 							<span className="jp-form-toggle-explanation">
 								{
-									this.props.getModule( 'gravatar-hovercards' ).description
+									gravatar.description
 								}
 							</span>
 						</ModuleToggle>
-						<br />
+					</FormFieldset>
+					<FormFieldset support={ markdown.learn_more_button }>
 						<ModuleToggle slug={ 'markdown' }
 									  compact
 									  activated={ !!this.props.getOptionValue( 'wpcom_publish_comments_with_markdown' ) }
@@ -83,7 +87,7 @@ export const Comments = moduleSettingsForm(
 									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'wpcom_publish_comments_with_markdown' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
-									__( 'Use Markdown for comments.' )
+									__( 'Enable Markdown use for comments.' )
 								}
 							</span>
 						</ModuleToggle>

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -24,34 +24,39 @@ export const Subscriptions = moduleSettingsForm(
 		},
 
 		render() {
+			let isSubscriptionsActive = this.props.getOptionValue( 'subscriptions' );
 			return (
 				<SettingsCard
 					{ ...this.props }
 					module="subscriptions">
 					<ModuleToggle slug={ 'subscriptions' }
 								  compact
-								  activated={ this.props.getOptionValue( 'subscriptions' ) }
+								  activated={ isSubscriptionsActive }
 								  toggling={ this.props.isSavingAnyOption() }
 								  toggleModule={ this.toggleModule }>
 						<span className="jp-form-toggle-explanation">
 							{
-								__( 'Allow users to subscribe to your posts and comments and receive notifications via email.' )
+								this.props.getModule( 'subscriptions' ).description
 							}
 						</span>
 					</ModuleToggle>
-					<p>
-						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
-					</p>
-					<FormFieldset>
-						<ModuleSettingCheckbox
-							name={ 'stb_enabled' }
-							{ ...this.props }
-							label={ __( 'Show a "follow blog" options in the comment form' ) } />
-						<ModuleSettingCheckbox
-							name={ 'stc_enabled' }
-							{ ...this.props }
-							label={ __( 'Show a "follow comments" option in the comment form.' ) } />
-					</FormFieldset>
+					{
+						isSubscriptionsActive
+							? <FormFieldset>
+								<p>
+									<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
+								</p>
+								<ModuleSettingCheckbox
+									name={ 'stb_enabled' }
+									{ ...this.props }
+									label={ __( 'Show a "follow blog" option in the comment form' ) } />
+								<ModuleSettingCheckbox
+									name={ 'stc_enabled' }
+									{ ...this.props }
+									label={ __( 'Show a "follow comments" option in the comment form.' ) } />
+							  </FormFieldset>
+							: ''
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -19,10 +19,6 @@ import SettingsCard from 'components/settings-card';
 export const Subscriptions = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		render() {
 			let isSubscriptionsActive = this.props.getOptionValue( 'subscriptions' );
 			return (
@@ -33,7 +29,7 @@ export const Subscriptions = moduleSettingsForm(
 								  compact
 								  activated={ isSubscriptionsActive }
 								  toggling={ this.props.isSavingAnyOption() }
-								  toggleModule={ this.toggleModule }>
+								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'subscriptions' ).description

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -25,10 +25,10 @@ export const Subscriptions = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="subscriptions">
-					<ModuleToggle slug={ 'subscriptions' }
+					<ModuleToggle slug="subscriptions"
 								  compact
 								  activated={ isSubscriptionsActive }
-								  toggling={ this.props.isSavingAnyOption() }
+								  toggling={ this.props.isSavingAnyOption( 'subscriptions' ) }
 								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -275,10 +275,9 @@ window.wpNavMenuClassChange = function() {
 	const settingRoutes = [
 		'#/settings',
 		'#/general',
-		'#/engagement',
 		'#/discussion',
 		'#/security',
-		'#/appearance',
+		'#/traffic',
 		'#/writing',
 		'#/search'
 	],

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -38,6 +38,7 @@
 @import '../components/tags-input/style';
 @import '../components/admin-notices/style';
 @import '../components/inline-expand/style';
+@import '../components/module-toggle/style';
 
 
 // Page Templates

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -26,11 +26,11 @@ export const BackupsScan = moduleSettingsForm(
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 					support="https://vaultpress.com/jetpack/"
 					hideButton>
-					<span>
+					<p>
 						{
 							__( 'Your site is backed up and threat-free.' )
 						}
-					</span>
+					</p>
 					<p className="jp-form-setting-explanation">
 						{
 							__( 'You can see the information about your backups and security scanning in the "At a Glance" section.' )

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -69,10 +69,10 @@ export const Protect = moduleSettingsForm(
 					{ ...this.props }
 					module="protect"
 					header={ __( 'Brute force protection', { context: 'Settings header' } ) } >
-					<ModuleToggle slug={ 'protect' }
+					<ModuleToggle slug="protect"
 								  compact
 								  activated={ isProtectActive }
-								  toggling={ this.props.isSavingAnyOption() }
+								  toggling={ this.props.isSavingAnyOption( 'protect' ) }
 								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -4,7 +4,6 @@
 import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
 import Button from 'components/button';
 import Textarea from 'components/textarea';
 import includes from 'lodash/includes';
@@ -68,6 +67,7 @@ export const Protect = moduleSettingsForm(
 		},
 
 		render() {
+			let isProtectActive = this.props.getOptionValue( 'protect' );
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -75,7 +75,7 @@ export const Protect = moduleSettingsForm(
 					header={ __( 'Brute force protection', { context: 'Settings header' } ) } >
 					<ModuleToggle slug={ 'protect' }
 								  compact
-								  activated={ this.props.getOptionValue( 'protect' ) }
+								  activated={ isProtectActive }
 								  toggling={ this.props.isSavingAnyOption() }
 								  toggleModule={ this.toggleModule }>
 						<span className="jp-form-toggle-explanation">
@@ -90,40 +90,46 @@ export const Protect = moduleSettingsForm(
 						</p>
 					</ModuleToggle>
 					{
-						this.props.currentIp
-							? <p>
+						isProtectActive
+							? <div>
 								{
-									__( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
+									this.props.currentIp
+										? <p>
+										{
+											__( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
+										}
+										<br />
+										{
+											<Button
+												disabled={ this.currentIpIsWhitelisted() }
+												onClick={ this.addToWhitelist }
+												compact >{ __( 'Add to whitelist' ) }</Button>
+										}
+									</p>
+										: ''
 								}
-								<br />
-								{
-									<Button
-										disabled={ this.currentIpIsWhitelisted() }
-										onClick={ this.addToWhitelist }
-										compact >{ __( 'Add to whitelist' ) }</Button>
-								}
-							  </p>
+								<FormFieldset>
+									<FormLabel>
+										<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
+										<Textarea
+											name={ 'jetpack_protect_global_whitelist' }
+											placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
+											onChange={ this.updateText }
+											value={ this.state.whitelist } />
+											</FormLabel>
+									<span className="jp-form-setting-explanation">
+										{
+											__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
+												components: {
+													br: <br />
+												}
+											} )
+										}
+									</span>
+								</FormFieldset>
+							  </div>
 							: ''
 					}
-					<FormFieldset>
-						<FormLabel>
-							<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
-							<Textarea
-								name={ 'jetpack_protect_global_whitelist' }
-								placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
-								onChange={ this.updateText }
-								value={ this.state.whitelist } />
-						</FormLabel>
-						<span className="jp-form-setting-explanation">
-							{
-								__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
-									components: {
-										br: <br />
-									}
-								} )
-							}
-						</span>
-					</FormFieldset>
 				</SettingsCard>
 			)
 		}

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -24,10 +24,6 @@ import SettingsCard from 'components/settings-card';
 export const Protect = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		getInitialState() {
 			return {
 				whitelist: this.props.getOptionValue( 'jetpack_protect_global_whitelist' )
@@ -77,7 +73,7 @@ export const Protect = moduleSettingsForm(
 								  compact
 								  activated={ isProtectActive }
 								  toggling={ this.props.isSavingAnyOption() }
-								  toggleModule={ this.toggleModule }>
+								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'protect' ).description

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -25,10 +25,10 @@ export const SSO = moduleSettingsForm(
 					{ ...this.props }
 					module="sso"
 					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
-					<ModuleToggle slug={ 'sso' }
+					<ModuleToggle slug="sso"
 								  compact
 								  activated={ isSSOActive }
-								  toggling={ this.props.isSavingAnyOption() }
+								  toggling={ this.props.isSavingAnyOption( 'sso' ) }
 								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -23,37 +23,44 @@ export const SSO = moduleSettingsForm(
 		},
 
 		render() {
+			let isSSOActive = this.props.getOptionValue( 'sso' );
 			return (
 				<SettingsCard
 					{ ...this.props }
 					module="sso"
 					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
-					<ModuleToggle slug={ 'subscriptions' }
+					<ModuleToggle slug={ 'sso' }
 								  compact
-								  activated={ this.props.getOptionValue( 'subscriptions' ) }
+								  activated={ isSSOActive }
 								  toggling={ this.props.isSavingAnyOption() }
 								  toggleModule={ this.toggleModule }>
 						<span className="jp-form-toggle-explanation">
 							{
-								__( 'Allow log-in using WordPress.com accounts.' )
+								this.props.getModule( 'sso' ).description
 							}
 						</span>
 					</ModuleToggle>
-					<p className="jp-form-setting-explanation">
-						{
-							__( 'Use WordPress.com’s secure authentication.' )
-						}
-					</p>
-					<FormFieldset>
-						<ModuleSettingCheckbox
-							name={ 'jetpack_sso_match_by_email' }
-							{ ...this.props }
-							label={ __( 'Match By Email' ) } />
-						<ModuleSettingCheckbox
-							name={ 'jetpack_sso_require_two_step' }
-							{ ...this.props }
-							label={ __( 'Require Two-Step Authentication' ) } />
-					</FormFieldset>
+					{
+						isSSOActive
+							? <div>
+								<p className="jp-form-setting-explanation">
+									{
+										__( 'Use WordPress.com’s secure authentication.' )
+									}
+								</p>
+								<FormFieldset>
+									<ModuleSettingCheckbox
+										name={ 'jetpack_sso_match_by_email' }
+										{ ...this.props }
+										label={ __( 'Match accounts using email addresses.' ) } />
+									<ModuleSettingCheckbox
+										name={ 'jetpack_sso_require_two_step' }
+										{ ...this.props }
+										label={ __( 'Require two step authentication.' ) } />
+								</FormFieldset>
+							  </div>
+							: ''
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -18,10 +18,6 @@ import SettingsCard from 'components/settings-card';
 export const SSO = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		render() {
 			let isSSOActive = this.props.getOptionValue( 'sso' );
 			return (
@@ -33,7 +29,7 @@ export const SSO = moduleSettingsForm(
 								  compact
 								  activated={ isSSOActive }
 								  toggling={ this.props.isSavingAnyOption() }
-								  toggleModule={ this.toggleModule }>
+								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'sso' ).description

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -126,3 +126,57 @@ export const updateSettings = ( newOptionValues ) => {
 		} );
 	};
 };
+
+export const regeneratePostByEmailAddress = () => {
+	return ( dispatch, getState ) => {
+
+		const newOptionValues = {
+			post_by_email_address: 'regenerate'
+		};
+
+		dispatch( removeNotice( `module-setting-update` ) );
+		dispatch( createNotice(
+			'is-info',
+			__( 'Updating Post by Email address…' ),
+			{ id: `module-setting-update` }
+		) );
+		dispatch( {
+			type: JETPACK_SETTINGS_UPDATE
+		} );
+
+		return restApi.updateSettings( newOptionValues ).then( success => {
+			dispatch( {
+				type: JETPACK_SETTINGS_UPDATE_SUCCESS,
+				updatedOptions: {
+					post_by_email_address: success.post_by_email_address
+				},
+				success: success
+			} );
+
+			dispatch( removeNotice( `module-setting-update` ) );
+			dispatch( createNotice(
+				'is-success',
+				__( 'Regenerated Post by Email address.' ),
+				{ id: `module-setting-update` }
+			) );
+		} ).catch( error => {
+			dispatch( {
+				type: JETPACK_SETTINGS_UPDATE_FAIL,
+				success: false,
+				error: error,
+				updatedOptions: newOptionValues
+			} );
+
+			dispatch( removeNotice( `module-setting-update` ) );
+			dispatch( createNotice(
+				'is-error',
+				__( 'Error regenerating Post by Email address. %(error)s', {
+					args: {
+						error: error
+					}
+				} ),
+				{ id: `module-setting-update` }
+			) );
+		} );
+	};
+};

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -88,7 +88,8 @@ export const updateSettings = ( newOptionValues ) => {
 			{ id: `module-setting-update` }
 		) );
 		dispatch( {
-			type: JETPACK_SETTINGS_UPDATE
+			type: JETPACK_SETTINGS_UPDATE,
+			updatedOptions: newOptionValues
 		} );
 
 		return restApi.updateSettings( newOptionValues ).then( success => {

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -103,11 +103,15 @@ export function getSettings( state ) {
 
 /**
  * Returns a value of a certain setting
- * @param  {Object} state Global state tree
- * @param  {String} key   Setting name
- * @return {Mixed}       Settings value
+ * @param  {Object} state      Global state tree
+ * @param  {String} key        Name of setting or module option to return.
+ * @param  {String} moduleName If present, it will check if the module is active before returning it.
+ * @return {undefined|*}       Settings value or undefined if a module was specified and it wasn't active.
  */
-export function getSetting( state, key ) {
+export function getSetting( state, key, moduleName = '' ) {
+	if ( '' !== moduleName && ! get( state.jetpack.settings.items, moduleName, false ) ) {
+		return undefined;
+	}
 	return get( state.jetpack.settings.items, key, undefined );
 }
 

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -4,8 +4,11 @@
 import { combineReducers } from 'redux';
 import get from 'lodash/get';
 import assign from 'lodash/assign';
+import merge from 'lodash/merge';
 import includes from 'lodash/includes';
 import some from 'lodash/some';
+import filter from 'lodash/filter';
+import mapValues from 'lodash/mapvalues';
 
 /**
  * Internal dependencies
@@ -45,8 +48,7 @@ export const items = ( state = {}, action ) => {
 
 export const initialRequestsState = {
 	fetchingSettingsList: false,
-	updatingSetting: false,
-	settingsSent: []
+	settingsSent: {}
 };
 
 export const requests = ( state = initialRequestsState, action ) => {
@@ -63,17 +65,15 @@ export const requests = ( state = initialRequestsState, action ) => {
 
 		case JETPACK_SETTING_UPDATE:
 		case JETPACK_SETTINGS_UPDATE:
-			return assign( {}, state, {
-				updatingSetting: true,
-				settingsSent: Object.keys( action.updatedOptions )
+			return merge( {}, state, {
+				settingsSent: mapValues( action.updatedOptions, item => true )
 			} );
 		case JETPACK_SETTING_UPDATE_FAIL:
 		case JETPACK_SETTING_UPDATE_SUCCESS:
 		case JETPACK_SETTINGS_UPDATE_FAIL:
 		case JETPACK_SETTINGS_UPDATE_SUCCESS:
-			return assign( {}, state, {
-				updatingSetting: false,
-				settingsSent: []
+			return merge( {}, state, {
+				settingsSent: mapValues( action.updatedOptions, item => false )
 			} );
 		default:
 			return state;
@@ -140,9 +140,9 @@ export function isFetchingSettingsList( state ) {
  */
 export function isUpdatingSetting( state, settings = '' ) {
 	if ( 'object' === typeof settings ) {
-		return some( state.jetpack.settings.requests.settingsSent, item => includes( settings, item ) );
+		return some( filter( state.jetpack.settings.requests.settingsSent, ( item, key ) => includes( settings, key ) ), item => item );
 	}
-	return includes( state.jetpack.settings.requests.settingsSent, settings );
+	return state.jetpack.settings.requests.settingsSent[ settings ];
 }
 
 /**

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -4,6 +4,8 @@
 import { combineReducers } from 'redux';
 import get from 'lodash/get';
 import assign from 'lodash/assign';
+import includes from 'lodash/includes';
+import some from 'lodash/some';
 
 /**
  * Internal dependencies
@@ -43,7 +45,8 @@ export const items = ( state = {}, action ) => {
 
 export const initialRequestsState = {
 	fetchingSettingsList: false,
-	updatingSetting: false
+	updatingSetting: false,
+	settingsSent: []
 };
 
 export const requests = ( state = initialRequestsState, action ) => {
@@ -61,14 +64,16 @@ export const requests = ( state = initialRequestsState, action ) => {
 		case JETPACK_SETTING_UPDATE:
 		case JETPACK_SETTINGS_UPDATE:
 			return assign( {}, state, {
-				updatingSetting: true
+				updatingSetting: true,
+				settingsSent: Object.keys( action.updatedOptions )
 			} );
 		case JETPACK_SETTING_UPDATE_FAIL:
 		case JETPACK_SETTING_UPDATE_SUCCESS:
 		case JETPACK_SETTINGS_UPDATE_FAIL:
 		case JETPACK_SETTINGS_UPDATE_SUCCESS:
 			return assign( {}, state, {
-				updatingSetting: false
+				updatingSetting: false,
+				settingsSent: []
 			} );
 		default:
 			return state;
@@ -129,11 +134,15 @@ export function isFetchingSettingsList( state ) {
 /**
  * Returns true if we are currently making a request to update a setting's option
  *
- * @param  {Object}  state Global state tree
- * @return {Boolean}       Whether option is being updated on the setting
+ * @param  {Object}        state    Global state tree
+ * @param  {String|Array} settings Single or multiple settings to check if they're being saved or not.
+ * @return {Boolean}                Whether option is being updated on the setting
  */
-export function isUpdatingSetting( state ) {
-	return state.jetpack.settings.requests.updatingSetting;
+export function isUpdatingSetting( state, settings = '' ) {
+	if ( 'object' === typeof settings ) {
+		return some( state.jetpack.settings.requests.settingsSent, item => includes( settings, item ) );
+	}
+	return includes( state.jetpack.settings.requests.settingsSent, settings );
 }
 
 /**

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -20,10 +20,10 @@ export const RelatedPosts = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="related-posts">
-					<ModuleToggle slug={ 'related-posts' }
+					<ModuleToggle slug="related-posts"
 								  compact
 								  activated={ this.props.getOptionValue( 'related-posts' ) }
-								  toggling={ this.props.isSavingAnyOption() }
+								  toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
 								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -27,7 +27,7 @@ export const RelatedPosts = moduleSettingsForm(
 								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
-								__( 'Use Jetpack comments. Let readers use their WordPress.com,	Twitter, Facebook or Google+ to leave comments on your posts and pages.' )
+								__( 'Show related content after posts.' )
 							}
 						</span>
 					</ModuleToggle>

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -15,10 +15,6 @@ import SettingsCard from 'components/settings-card';
 export const RelatedPosts = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		render() {
 			return (
 				<SettingsCard
@@ -28,7 +24,7 @@ export const RelatedPosts = moduleSettingsForm(
 								  compact
 								  activated={ this.props.getOptionValue( 'related-posts' ) }
 								  toggling={ this.props.isSavingAnyOption() }
-								  toggleModule={ this.toggleModule }>
+								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Use Jetpack comments. Let readers use their WordPress.com,	Twitter, Facebook or Google+ to leave comments on your posts and pages.' )

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -15,10 +15,6 @@ import SettingsCard from 'components/settings-card';
 export const SEO = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		render() {
 			return (
 				<SettingsCard

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -32,10 +32,10 @@ export const SiteStats = moduleSettingsForm(
 					header={ __( 'Site stats' ) }
 					module="stats">
 					<FormFieldset>
-						<ModuleToggle slug={ 'stats' }
+						<ModuleToggle slug="stats"
 									  compact
 									  activated={ !!this.props.getOptionValue( 'admin_bar' ) }
-									  toggling={ this.props.isSavingAnyOption() }
+									  toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
 									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
@@ -44,10 +44,10 @@ export const SiteStats = moduleSettingsForm(
 							</span>
 						</ModuleToggle>
 						<br />
-						<ModuleToggle slug={ 'stats' }
+						<ModuleToggle slug="stats"
 									  compact
 									  activated={ !!this.props.getOptionValue( 'hide_smile' ) }
-									  toggling={ this.props.isSavingAnyOption() }
+									  toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
 									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }>
 							<span className="jp-form-toggle-explanation">
 								{

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -25,10 +25,6 @@ import InlineExpand from 'components/inline-expand';
 export const SiteStats = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		render() {
 			return (
 				<SettingsCard

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -23,10 +23,6 @@ import SettingsCard from 'components/settings-card';
 export const VerificationServices = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		render() {
 			let module = this.props.getModule( 'sitemaps' ),
 				sitemap_url = get( module, [ 'extra', 'sitemap_url' ], '' ),

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -76,22 +76,22 @@ export const VerificationServices = moduleSettingsForm(
 								{
 									id: 'google',
 									label: __( 'Google' ),
-									placeholder: 'Example: dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8'
+									placeholder: '<meta name="google-site-verification" content="1234" />'
 								},
 								{
 									id: 'bing',
 									label: __( 'Bing' ),
-									placeholder: 'Example: 12C1203B5086AECE94EB3A3D9830B2E'
+									placeholder: '<meta name="msvalidate.01" content="1234" />'
 								},
 								{
 									id: 'pinterest',
 									label: __( 'Pinterest' ),
-									placeholder: 'Example: f100679e6048d45e4a0b0b92dce1efce'
+									placeholder: '<meta name="p:domain_verify" content="1234" />'
 								},
 								{
 									id: 'yandex',
 									label: __( 'Yandex' ),
-									placeholder: 'Example: 44d68e1216009f40'
+									placeholder: '<meta name="yandex-verification" content="1234" />'
 								}
 							].map( item => (
 								<FormLabel

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -13,7 +13,7 @@ import {
 	FormLegend,
 	FormLabel
 } from 'components/forms';
-import { getModule as _getModule } from 'state/modules';
+import { getModule } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
@@ -23,14 +23,10 @@ import InlineExpand from 'components/inline-expand';
 
 export const Composing = moduleSettingsForm(
 	React.createClass( {
-		getCheckbox( setting, label, isAtd = true ) {
-			let markdown = this.props.getModule( 'markdown' );
-			let atd = this.props.getModule( 'after-the-deadline' );
-
+		getCheckbox( setting, label ) {
 			return(
 				<ModuleSettingCheckbox
 					name={ setting }
-					module={ isAtd ? atd : markdown }
 					label={ label }
 					{ ...this.props }
 				/>
@@ -42,6 +38,7 @@ export const Composing = moduleSettingsForm(
 		},
 
 		getAtdSettings() {
+			let ignoredPhrases = this.props.getOptionValue( 'ignored_phrases' );
 			return (
 				<div>
 					<FormFieldset>
@@ -56,8 +53,7 @@ export const Composing = moduleSettingsForm(
 						</FormLegend>
 						<span className="jp-form-setting-explanation">
 							{ __(
-								  'The proofreader supports English, French, ' +
-								  'German, Portuguese and Spanish.'
+								  'The proofreader supports English, French, German, Portuguese and Spanish.'
 							  ) }
 						</span>
 						{
@@ -91,13 +87,10 @@ export const Composing = moduleSettingsForm(
 							name="ignored_phrases"
 							placeholder={ __( 'Add a phrase' ) }
 							value={
-								(
-									'undefined' !== typeof this.props.getOptionValue( 'ignored_phrases' )
-									&& '' !== this.props.getOptionValue( 'ignored_phrases' )
-								)
-								 ? this.props.getOptionValue( 'ignored_phrases' ).split( ',' )
-								 : []
-								  }
+								'undefined' !== typeof ignoredPhrases && '' !== ignoredPhrases
+									 ? ignoredPhrases.split( ',' )
+									 : []
+							}
 							onChange={ this.props.onOptionChange } />
 					</FormFieldset>
 				</div>
@@ -105,8 +98,8 @@ export const Composing = moduleSettingsForm(
 		},
 
 		render() {
-			let markdown = this.props.getModule( 'markdown' );
-			let atd = this.props.getModule( 'after-the-deadline' );
+			let markdown = this.props.getModule( 'markdown' ),
+				atd = this.props.getModule( 'after-the-deadline' );
 
 			return (
 				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props }>

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -33,10 +33,6 @@ export const Composing = moduleSettingsForm(
 			);
 		},
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		getAtdSettings() {
 			let ignoredPhrases = this.props.getOptionValue( 'ignored_phrases' );
 			return (
@@ -108,7 +104,7 @@ export const Composing = moduleSettingsForm(
 									  compact
 									  activated={ this.props.getOptionValue( 'markdown' ) }
 									  toggling={ this.props.isSavingAnyOption() }
-									  toggleModule={ this.toggleModule }>
+									  toggleModule={ this.props.toggleModuleNow }>
 							<span className="jp-form-toggle-explanation">
 								{ markdown.description }
 							</span>
@@ -120,7 +116,7 @@ export const Composing = moduleSettingsForm(
 									  compact
 									  activated={ this.props.getOptionValue( 'after-the-deadline' ) }
 									  toggling={ this.props.isSavingAnyOption() }
-									  toggleModule={ this.toggleModule }>
+									  toggleModule={ this.props.toggleModuleNow }>
 							<span className="jp-form-toggle-explanation">
 								{ atd.description }
 							</span>

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -11,8 +11,7 @@ import { translate as __ } from 'i18n-calypso';
 import {
 	FormFieldset,
 	FormLegend,
-	FormLabel,
-	FormButton
+	FormLabel
 } from 'components/forms';
 import { getModule as _getModule } from 'state/modules';
 import { ModuleToggle } from 'components/module-toggle';
@@ -20,6 +19,7 @@ import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-sett
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import TagsInput from 'components/tags-input';
 import SettingsCard from 'components/settings-card';
+import InlineExpand from 'components/inline-expand';
 
 export const Composing = moduleSettingsForm(
 	React.createClass( {
@@ -110,7 +110,7 @@ export const Composing = moduleSettingsForm(
 
 			return (
 				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props }>
-					<FormFieldset>
+					<FormFieldset support={ markdown.learn_more_button }>
 						<ModuleToggle slug={ 'markdown' }
 									  compact
 									  activated={ this.props.getOptionValue( 'markdown' ) }
@@ -121,7 +121,8 @@ export const Composing = moduleSettingsForm(
 							</span>
 						</ModuleToggle>
 					</FormFieldset>
-					<FormFieldset>
+					<hr />
+					<FormFieldset support={ atd.learn_more_button }>
 						<ModuleToggle slug={ 'after-the-deadline' }
 									  compact
 									  activated={ this.props.getOptionValue( 'after-the-deadline' ) }
@@ -131,11 +132,12 @@ export const Composing = moduleSettingsForm(
 								{ atd.description }
 							</span>
 						</ModuleToggle>
+						{
+							this.props.getOptionValue( 'after-the-deadline' )
+								? <InlineExpand label={ __( 'Fancy options' ) }>{ this.getAtdSettings() }</InlineExpand>
+								: ''
+						}
 					</FormFieldset>
-					{ this.props.getOptionValue( 'after-the-deadline' )
-					  ? this.getAtdSettings()
-					  : ''
-					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -100,10 +100,10 @@ export const Composing = moduleSettingsForm(
 			return (
 				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props }>
 					<FormFieldset support={ markdown.learn_more_button }>
-						<ModuleToggle slug={ 'markdown' }
+						<ModuleToggle slug="markdown"
 									  compact
 									  activated={ this.props.getOptionValue( 'markdown' ) }
-									  toggling={ this.props.isSavingAnyOption() }
+									  toggling={ this.props.isSavingAnyOption( 'markdown' ) }
 									  toggleModule={ this.props.toggleModuleNow }>
 							<span className="jp-form-toggle-explanation">
 								{ markdown.description }
@@ -112,10 +112,10 @@ export const Composing = moduleSettingsForm(
 					</FormFieldset>
 					<hr />
 					<FormFieldset support={ atd.learn_more_button }>
-						<ModuleToggle slug={ 'after-the-deadline' }
+						<ModuleToggle slug="after-the-deadline"
 									  compact
 									  activated={ this.props.getOptionValue( 'after-the-deadline' ) }
-									  toggling={ this.props.isSavingAnyOption() }
+									  toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
 									  toggleModule={ this.props.toggleModuleNow }>
 							<span className="jp-form-toggle-explanation">
 								{ atd.description }

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import analytics from 'lib/analytics';
+import { translate as __ } from 'i18n-calypso';
+import Button from 'components/button';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLegend,
+	FormLabel
+} from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+
+export const CustomContentTypes = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		contentTypeConfigure( module, type, legend ) {
+			return ! this.props.getOptionCurrentValue( module, 'jetpack_' + type )
+				? ''
+				: <Button
+					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
+					href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type }
+					compact={ true }>
+					{
+						legend
+					}
+				  </Button>;
+		},
+
+		render() {
+			let module = this.props.getModule( 'custom-content-types' );
+			return (
+				<SettingsCard module="custom-content-types" { ...this.props }>
+					<FormFieldset>
+						<p>
+							{
+								module.description
+							}
+						</p>
+						<ModuleToggle slug={ 'custom-content-types' }
+									  compact
+									  activated={ this.props.getOptionValue( 'jetpack_testimonial' ) }
+									  toggling={ this.props.isSavingAnyOption() }
+									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'jetpack_testimonial' ) }>
+							<span className="jp-form-toggle-explanation">
+								{
+									__( 'Enable Testimonial custom content types.' )
+								}
+							</span>
+						</ModuleToggle>
+						<p>
+							{
+								__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
+							}
+						</p>
+						{
+							this.contentTypeConfigure( module.module, 'testimonial', __( 'Configure Testimonials' ) )
+						}
+						<br />
+						<ModuleToggle slug={ 'custom-content-types' }
+									  compact
+									  activated={ this.props.getOptionValue( 'jetpack_portfolio' ) }
+									  toggling={ this.props.isSavingAnyOption() }
+									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'jetpack_portfolio' ) }>
+							<span className="jp-form-toggle-explanation">
+								{
+									__( 'Enable Portfolio custom content types.' )
+								}
+							</span>
+						</ModuleToggle>
+						<p>
+							{
+								__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
+							}
+						</p>
+						{
+							this.contentTypeConfigure( module.module, 'portfolio', __( 'Configure Portfolios' ) )
+						}
+					</FormFieldset>
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -22,6 +22,9 @@ export const CustomContentTypes = moduleSettingsForm(
 	React.createClass( {
 
 		contentTypeConfigure( type, legend ) {
+			if ( ! this.state[ type ] ) {
+				return '';
+			}
 			return ! this.props.getSettingCurrentValue( 'jetpack_' + type, 'custom-content-types' )
 				? ''
 				: <Button compact href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type }>
@@ -70,11 +73,15 @@ export const CustomContentTypes = moduleSettingsForm(
 								}
 							</span>
 						</FormToggle>
-						<p>
-							{
-								__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
-							}
-						</p>
+						{
+							this.state.testimonial
+								? <p className="jp-form-setting-explanation">
+									{
+										__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
+									}
+								  </p>
+								: ''
+						}
 						{
 							this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
 						}
@@ -89,11 +96,15 @@ export const CustomContentTypes = moduleSettingsForm(
 								}
 							</span>
 						</FormToggle>
-						<p>
-							{
-								__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
-							}
-						</p>
+						{
+							this.state.portfolio
+								? <p className="jp-form-setting-explanation">
+									{
+										__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
+									}
+								  </p>
+								: ''
+						}
 						{
 							this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
 						}

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import analytics from 'lib/analytics';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
+import FormToggle from 'components/form/form-toggle';
 
 /**
  * Internal dependencies
@@ -14,28 +15,39 @@ import {
 	FormLegend,
 	FormLabel
 } from 'components/forms';
-import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 
 export const CustomContentTypes = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
-		contentTypeConfigure( module, type, legend ) {
-			return ! this.props.getOptionCurrentValue( module, 'jetpack_' + type )
+		contentTypeConfigure( type, legend ) {
+			return ! this.props.getSettingCurrentValue( 'jetpack_' + type, 'custom-content-types' )
 				? ''
-				: <Button
-					disabled={ ! this.props.shouldSaveButtonBeDisabled() }
-					href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type }
-					compact={ true }>
+				: <Button compact href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type }>
 					{
 						legend
 					}
 				  </Button>;
+		},
+
+		getInitialState() {
+			return {
+				testimonial: this.props.getOptionValue( 'jetpack_testimonial', 'custom-content-types' ),
+				portfolio: this.props.getOptionValue( 'jetpack_portfolio', 'custom-content-types' )
+			};
+		},
+
+		updateCPTs( type ) {
+			let deactivate = 'testimonial' === type
+				? ! ( ( ! this.state.testimonial ) || this.state.portfolio )
+				: ! ( ( ! this.state.portfolio ) || this.state.testimonial );
+
+			this.props.updateFormStateModuleOption( 'custom-content-types', 'jetpack_' + type, deactivate );
+
+			this.setState( {
+				[ type ]: ! this.state[ type ]
+			} );
 		},
 
 		render() {
@@ -48,44 +60,42 @@ export const CustomContentTypes = moduleSettingsForm(
 								module.description
 							}
 						</p>
-						<ModuleToggle slug={ 'custom-content-types' }
-									  compact
-									  activated={ this.props.getOptionValue( 'jetpack_testimonial' ) }
-									  toggling={ this.props.isSavingAnyOption() }
-									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'jetpack_testimonial' ) }>
+						<FormToggle compact
+									checked={ this.state.testimonial }
+									disabled={ this.props.isSavingAnyOption() }
+									onChange={ e => this.updateCPTs( 'testimonial' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
 									__( 'Enable Testimonial custom content types.' )
 								}
 							</span>
-						</ModuleToggle>
+						</FormToggle>
 						<p>
 							{
 								__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
 							}
 						</p>
 						{
-							this.contentTypeConfigure( module.module, 'testimonial', __( 'Configure Testimonials' ) )
+							this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
 						}
 						<br />
-						<ModuleToggle slug={ 'custom-content-types' }
-									  compact
-									  activated={ this.props.getOptionValue( 'jetpack_portfolio' ) }
-									  toggling={ this.props.isSavingAnyOption() }
-									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'jetpack_portfolio' ) }>
+						<FormToggle compact
+									checked={ this.state.portfolio }
+									disabled={ this.props.isSavingAnyOption() }
+									onChange={ e => this.updateCPTs( 'portfolio' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
 									__( 'Enable Portfolio custom content types.' )
 								}
 							</span>
-						</ModuleToggle>
+						</FormToggle>
 						<p>
 							{
 								__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
 							}
 						</p>
 						{
-							this.contentTypeConfigure( module.module, 'portfolio', __( 'Configure Portfolios' ) )
+							this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
 						}
 					</FormFieldset>
 				</SettingsCard>

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -56,7 +56,10 @@ export const CustomContentTypes = moduleSettingsForm(
 		render() {
 			let module = this.props.getModule( 'custom-content-types' );
 			return (
-				<SettingsCard module="custom-content-types" { ...this.props }>
+				<SettingsCard
+					{ ...this.props }
+					module="custom-content-types"
+					hideButton>
 					<FormFieldset>
 						<p>
 							{

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -13,6 +13,7 @@ import QuerySite from 'components/data/query-site';
 import { Composing } from './composing';
 import { Media } from './media';
 import { CustomContentTypes } from './custom-content-types';
+import { ThemeEnhancements } from './theme-enhancements';
 
 export const Writing = React.createClass( {
 	displayName: 'WritingSettings',
@@ -30,6 +31,10 @@ export const Writing = React.createClass( {
 					getModule={ this.props.module }
 				/>
 				<CustomContentTypes
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+				/>
+				<ThemeEnhancements
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 				/>

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -7,10 +7,11 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getModule as _getModule } from 'state/modules';
-import { getSettings as _getSettings } from 'state/settings';
+import { getModule } from 'state/modules';
+import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { Composing } from './composing';
+import { CustomContentTypes } from './custom-content-types';
 
 export const Writing = React.createClass( {
 	displayName: 'WritingSettings',
@@ -20,8 +21,12 @@ export const Writing = React.createClass( {
 			<div>
 				<QuerySite />
 				<Composing
-					settings={ this.props.getSettings() }
-					getModule={ this.props.getModule }
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+				/>
+				<CustomContentTypes
+					settings={ this.props.settings }
+					getModule={ this.props.module }
 				/>
 			</div>
 		);
@@ -31,8 +36,8 @@ export const Writing = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
-			getModule: ( module_name ) => _getModule( state, module_name ),
-			getSettings: () => _getSettings( state )
+			module: ( module_name ) => getModule( state, module_name ),
+			settings: getSettings( state )
 		}
 	},
 	( dispatch ) => {

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -14,6 +14,7 @@ import { Composing } from './composing';
 import { Media } from './media';
 import { CustomContentTypes } from './custom-content-types';
 import { ThemeEnhancements } from './theme-enhancements';
+import { PostByEmail } from './post-by-email';
 
 export const Writing = React.createClass( {
 	displayName: 'WritingSettings',
@@ -35,6 +36,10 @@ export const Writing = React.createClass( {
 					getModule={ this.props.module }
 				/>
 				<ThemeEnhancements
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+				/>
+				<PostByEmail
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 				/>

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -11,6 +11,7 @@ import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { Composing } from './composing';
+import { Media } from './media';
 import { CustomContentTypes } from './custom-content-types';
 
 export const Writing = React.createClass( {
@@ -21,6 +22,10 @@ export const Writing = React.createClass( {
 			<div>
 				<QuerySite />
 				<Composing
+					settings={ this.props.settings }
+					getModule={ this.props.module }
+				/>
+				<Media
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 				/>

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -25,10 +25,11 @@ export const Media = moduleSettingsForm(
 			if ( 'photon' === name ) {
 
 				// Carousel depends on Photon. Deactivate it if Photon is deactivated.
-				this.props.updateFormStateOptionValue( false === ! value
-					? { photon: false, 'tiled-gallery': false, tiled_galleries: false }
-					: { photon: true, 'tiled-gallery': true, tiled_galleries: true }
-				);
+				if ( false === ! value ) {
+					this.props.updateOptions( { photon: false, 'tiled-gallery': false, tiled_galleries: false } );
+				} else {
+					this.props.updateOptions( { photon: true, 'tiled-gallery': true, tiled_galleries: true } );
+				}
 			} else {
 				this.props.updateFormStateOptionValue( name, !value );
 			}
@@ -65,7 +66,7 @@ export const Media = moduleSettingsForm(
 					<ModuleToggle slug={ 'carousel' }
 								  compact
 								  activated={ isCarouselActive }
-								  toggleModule={ this.toggleModule }>
+								  toggleModule={ this.props.toggleModuleNow }>
 								<span className="jp-form-toggle-explanation">
 									{
 										carousel.description

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -11,11 +11,12 @@ import { translate as __ } from 'i18n-calypso';
 import {
 	FormFieldset,
 	FormLegend,
-	FormLabel
+	FormLabel,
+	FormSelect
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingSelect, ModuleSettingCheckbox } from 'components/module-settings/form-components';
+import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 
 export const Media = moduleSettingsForm(
@@ -83,10 +84,9 @@ export const Media = moduleSettingsForm(
 									label={ __( 'Show photo metadata (Exif) in carousel, when available' ) } />
 								<FormLabel>
 									<FormLegend className="jp-form-label-wide">{ __( 'Background color' ) }</FormLegend>
-									<ModuleSettingSelect
+									<FormSelect
 										name={ 'carousel_background_color' }
 										value={ this.props.getOptionValue( 'carousel_background_color' ) }
-										onChange={ this.props.onOptionChange }
 										{ ...this.props }
 										validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
 								</FormLabel>

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -4,7 +4,6 @@
 import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
 
 /**
  * Internal dependencies
@@ -37,7 +36,8 @@ export const Media = moduleSettingsForm(
 
 		render() {
 			let photon   = this.props.getModule( 'photon' ),
-				carousel = this.props.getModule( 'carousel' );
+				carousel = this.props.getModule( 'carousel' ),
+				isCarouselActive = this.props.getOptionValue( 'carousel' );
 
 			return (
 				<SettingsCard
@@ -64,7 +64,7 @@ export const Media = moduleSettingsForm(
 					<hr />
 					<ModuleToggle slug={ 'carousel' }
 								  compact
-								  activated={ this.props.getOptionValue( 'carousel' ) }
+								  activated={ isCarouselActive }
 								  toggleModule={ this.toggleModule }>
 								<span className="jp-form-toggle-explanation">
 									{
@@ -73,22 +73,22 @@ export const Media = moduleSettingsForm(
 								</span>
 					</ModuleToggle>
 					{
-						this.props.getSettingCurrentValue( 'carousel' )
+						isCarouselActive
 							? <FormFieldset support={ carousel.learn_more_button }>
-							<ModuleSettingCheckbox
-								name={ 'carousel_display_exif' }
-								{ ...this.props }
-								label={ __( 'Show photo metadata (Exif) in carousel, when available' ) } />
-							<FormLabel>
-								<span className="jp-form-label-wide">{ __( 'Background color' ) }</span>
-								<ModuleSettingSelect
-									name={ 'carousel_background_color' }
-									value={ this.props.getOptionValue( 'carousel_background_color' ) }
-									onChange={ this.props.onOptionChange }
+								<ModuleSettingCheckbox
+									name={ 'carousel_display_exif' }
 									{ ...this.props }
-									validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
-							</FormLabel>
-						</FormFieldset>
+									label={ __( 'Show photo metadata (Exif) in carousel, when available' ) } />
+								<FormLabel>
+									<FormLegend className="jp-form-label-wide">{ __( 'Background color' ) }</FormLegend>
+									<ModuleSettingSelect
+										name={ 'carousel_background_color' }
+										value={ this.props.getOptionValue( 'carousel_background_color' ) }
+										onChange={ this.props.onOptionChange }
+										{ ...this.props }
+										validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
+								</FormLabel>
+							  </FormFieldset>
 							: ''
 					}
 				</SettingsCard>

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -45,10 +45,10 @@ export const Media = moduleSettingsForm(
 					{ ...this.props }
 					header={ __( 'Media' ) }>
 					<FormFieldset support={ photon.learn_more_button }>
-						<ModuleToggle slug={ 'photon' }
+						<ModuleToggle slug="photon"
 									  compact
 									  activated={ this.props.getOptionValue( 'photon' ) }
-									  toggling={ this.props.isSavingAnyOption() }
+									  toggling={ this.props.isSavingAnyOption( 'photon' ) }
 									  toggleModule={ this.toggleModule }>
 							<span className="jp-form-toggle-explanation">
 								{
@@ -63,9 +63,10 @@ export const Media = moduleSettingsForm(
 						</ModuleToggle>
 					</FormFieldset>
 					<hr />
-					<ModuleToggle slug={ 'carousel' }
+					<ModuleToggle slug="carousel"
 								  compact
 								  activated={ isCarouselActive }
+								  toggling={ this.props.isSavingAnyOption( 'carousel' ) }
 								  toggleModule={ this.props.toggleModuleNow }>
 								<span className="jp-form-toggle-explanation">
 									{

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import TextInput from 'components/text-input';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLegend,
+	FormLabel
+} from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleSettingSelect, ModuleSettingCheckbox } from 'components/module-settings/form-components';
+import SettingsCard from 'components/settings-card';
+
+export const Media = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			if ( 'photon' === name ) {
+
+				// Carousel depends on Photon. Deactivate it if Photon is deactivated.
+				this.props.updateFormStateOptionValue( false === ! value
+					? { photon: false, 'tiled-gallery': false, tiled_galleries: false }
+					: { photon: true, 'tiled-gallery': true, tiled_galleries: true }
+				);
+			} else {
+				this.props.updateFormStateOptionValue( name, !value );
+			}
+		},
+
+		render() {
+			let photon   = this.props.getModule( 'photon' ),
+				carousel = this.props.getModule( 'carousel' );
+
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Media' ) }>
+					<FormFieldset support={ photon.learn_more_button }>
+						<ModuleToggle slug={ 'photon' }
+									  compact
+									  activated={ this.props.getOptionValue( 'photon' ) }
+									  toggling={ this.props.isSavingAnyOption() }
+									  toggleModule={ this.toggleModule }>
+							<span className="jp-form-toggle-explanation">
+								{
+									photon.description
+								}
+							</span>
+							<span className="jp-form-setting-explanation">
+								{
+									__( 'Enabling Photon is required to use Tiled Galleries.' )
+								}
+							</span>
+						</ModuleToggle>
+					</FormFieldset>
+					<hr />
+					<ModuleToggle slug={ 'carousel' }
+								  compact
+								  activated={ this.props.getOptionValue( 'carousel' ) }
+								  toggleModule={ this.toggleModule }>
+								<span className="jp-form-toggle-explanation">
+									{
+										carousel.description
+									}
+								</span>
+					</ModuleToggle>
+					{
+						this.props.getSettingCurrentValue( 'carousel' )
+							? <FormFieldset support={ carousel.learn_more_button }>
+							<ModuleSettingCheckbox
+								name={ 'carousel_display_exif' }
+								{ ...this.props }
+								label={ __( 'Show photo metadata (Exif) in carousel, when available' ) } />
+							<FormLabel>
+								<span className="jp-form-label-wide">{ __( 'Background color' ) }</span>
+								<ModuleSettingSelect
+									name={ 'carousel_background_color' }
+									value={ this.props.getOptionValue( 'carousel_background_color' ) }
+									onChange={ this.props.onOptionChange }
+									{ ...this.props }
+									validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
+							</FormLabel>
+						</FormFieldset>
+							: ''
+					}
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -42,7 +42,8 @@ export const PostByEmail = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					module="post-by-email">
+					module="post-by-email"
+					hideButton>
 					<ModuleToggle slug="post-by-email"
 								  compact
 								  activated={ isPbeActive }

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -47,7 +47,7 @@ export const PostByEmail = moduleSettingsForm(
 					<ModuleToggle slug="post-by-email"
 								  compact
 								  activated={ isPbeActive }
-								  toggling={ this.props.isSavingAnyOption() }
+								  toggling={ this.props.isSavingAnyOption( 'post-by-email' ) }
 								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -61,8 +61,8 @@ export const PostByEmail = moduleSettingsForm(
 					{
 						isPbeActive
 							? <FormFieldset>
-								<FormLabel className="jp-form-label-wide">
-									{ __( 'Email Address' ) }
+								<FormLabel>
+									<FormLegend>{ __( 'Email Address' ) }</FormLegend>
 									<ClipboardButtonInput
 										value={ this.address() }
 										copy={ __( 'Copy', { context: 'verb' } ) }

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import Button from 'components/button';
+import ClipboardButtonInput from 'components/clipboard-button-input';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset,
+	FormLegend,
+	FormLabel
+} from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+
+export const PostByEmail = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		regeneratePostByEmailAddress( event ) {
+			event.preventDefault();
+			this.props.regeneratePostByEmailAddress();
+		},
+
+		address() {
+			const currentValue = this.props.getOptionValue( 'post_by_email_address' );
+			// If the module Post-by-email is enabled BUT it's configured as disabled
+			// Its value is set to false
+			if ( currentValue === false ) {
+				return '';
+			}
+			return currentValue;
+		},
+
+		render() {
+			let isPbeActive = this.props.getOptionValue( 'post-by-email' );
+			return (
+				<SettingsCard
+					{ ...this.props }
+					module="post-by-email">
+					<ModuleToggle slug="post-by-email"
+								  compact
+								  activated={ isPbeActive }
+								  toggling={ this.props.isSavingAnyOption() }
+								  toggleModule={ this.toggleModule }>
+						<span className="jp-form-toggle-explanation">
+							{
+								this.props.getModule( 'post-by-email' ).description
+							}
+						</span>
+					</ModuleToggle>
+					{
+						isPbeActive
+							? <FormFieldset>
+								<FormLabel className="jp-form-label-wide">
+									{ __( 'Email Address' ) }
+									<ClipboardButtonInput
+										value={ this.address() }
+										copy={ __( 'Copy', { context: 'verb' } ) }
+										copied={ __( 'Copied!' ) }
+										prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+									/>
+								</FormLabel>
+								<Button
+									onClick={ this.regeneratePostByEmailAddress } >
+									{ __( 'Regenerate address' ) }
+								</Button>
+							  </FormFieldset>
+							: ''
+					}
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -22,10 +22,6 @@ import SettingsCard from 'components/settings-card';
 export const PostByEmail = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		regeneratePostByEmailAddress( event ) {
 			event.preventDefault();
 			this.props.regeneratePostByEmailAddress();
@@ -51,7 +47,7 @@ export const PostByEmail = moduleSettingsForm(
 								  compact
 								  activated={ isPbeActive }
 								  toggling={ this.props.isSavingAnyOption() }
-								  toggleModule={ this.toggleModule }>
+								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'post-by-email' ).description

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -17,10 +17,6 @@ import SettingsCard from 'components/settings-card';
 export const ThemeEnhancements = moduleSettingsForm(
 	React.createClass( {
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
-
 		render() {
 			return (
 				<SettingsCard
@@ -67,7 +63,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 													  compact
 													  activated={ this.props.getOptionValue( item.module ) }
 													  toggling={ this.props.isSavingAnyOption() }
-													  toggleModule={ this.toggleModule }>
+													  toggleModule={ this.props.toggleModuleNow }>
 										<span className="jp-form-toggle-explanation">
 										{
 											item.description

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -62,7 +62,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 										<ModuleToggle slug={ item.module }
 													  compact
 													  activated={ this.props.getOptionValue( item.module ) }
-													  toggling={ this.props.isSavingAnyOption() }
+													  toggling={ this.props.isSavingAnyOption( item.module ) }
 													  toggleModule={ this.props.toggleModuleNow }>
 										<span className="jp-form-toggle-explanation">
 										{

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import analytics from 'lib/analytics';
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { FormFieldset } from 'components/forms';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
+import SettingsCard from 'components/settings-card';
+
+export const ThemeEnhancements = moduleSettingsForm(
+	React.createClass( {
+
+		toggleModule( name, value ) {
+			this.props.updateFormStateOptionValue( name, !value );
+		},
+
+		render() {
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Theme enhancements' ) }>
+					{
+						[
+							{
+								...this.props.getModule( 'infinite-scroll' ),
+								checkboxes: [
+									{
+										key: 'infinite_scroll',
+										label: __( 'Scroll infinitely (Shows 7 posts on each load)' )
+									},
+									{
+										key: 'infinite_scroll_google_analytics',
+										label: __( 'Track each infinite Scroll post load as a page view in Google Analytics' )
+									}
+								],
+								separator: true
+							},
+							{
+								...this.props.getModule( 'minileven' ),
+								checkboxes: [
+									{
+										key: 'wp_mobile_excerpt',
+										label: __( 'Use excerpts instead of full posts on front page and archive pages' )
+									},
+									{
+										key: 'wp_mobile_featured_images',
+										label: __( 'Show featured images' )
+									},
+									{
+										key: 'wp_mobile_app_promos',
+										label: __( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' )
+									}
+								]
+							}
+						].map( item => {
+							return (
+								<div key={ `theme_enhancement_${ item.module }` }>
+									<FormFieldset support={ item.learn_more_button }>
+										<ModuleToggle slug={ item.module }
+													  compact
+													  activated={ this.props.getOptionValue( item.module ) }
+													  toggling={ this.props.isSavingAnyOption() }
+													  toggleModule={ this.toggleModule }>
+										<span className="jp-form-toggle-explanation">
+										{
+											item.description
+										}
+										</span>
+										</ModuleToggle>
+										{
+											this.props.getOptionValue( item.module )
+												? item.checkboxes.map( chkbx => {
+													return <ModuleSettingCheckbox
+														name={ chkbx.key }
+														{ ...this.props }
+														label={ chkbx.label }
+														key={ `${ item.module }_${ chkbx.key }`}
+													/>
+												  } )
+												: ''
+										}
+									</FormFieldset>
+									{
+										item.separator
+											? <hr />
+											: ''
+									}
+								</div>
+							);
+						} )
+					}
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1487,28 +1487,28 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'description'       => esc_html__( 'Google Search Console', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
-				'validate_callback' => __CLASS__ . '::validate_alphanum',
+				'validate_callback' => __CLASS__ . '::validate_verification_service',
 				'jp_group'          => 'verification-tools',
 			),
 			'bing' => array(
 				'description'       => esc_html__( 'Bing Webmaster Center', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
-				'validate_callback' => __CLASS__ . '::validate_alphanum',
+				'validate_callback' => __CLASS__ . '::validate_verification_service',
 				'jp_group'          => 'verification-tools',
 			),
 			'pinterest' => array(
 				'description'       => esc_html__( 'Pinterest Site Verification', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => '',
-				'validate_callback' => __CLASS__ . '::validate_alphanum',
+				'validate_callback' => __CLASS__ . '::validate_verification_service',
 				'jp_group'          => 'verification-tools',
 			),
 			'yandex' => array(
-				'description'        => esc_html__( 'Yandex Site Verification', 'jetpack' ),
-				'type'               => 'string',
-				'default'            => '',
-				'validate_callback'  => __CLASS__ . '::validate_alphanum',
+				'description'       => esc_html__( 'Yandex Site Verification', 'jetpack' ),
+				'type'              => 'string',
+				'default'           => '',
+				'validate_callback' => __CLASS__ . '::validate_verification_service',
 				'jp_group'          => 'verification-tools',
 			),
 			'enable_header_ad' => array(
@@ -1751,6 +1751,24 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function validate_alphanum( $value = '', $request, $param ) {
 		if ( ! empty( $value ) && ( ! is_string( $value ) || ! preg_match( '/^[a-z0-9]+$/i', $value ) ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be an alphanumeric string.', 'jetpack' ), $param ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Validates that the parameter is a tag or id for a verification service, or an empty string (to be able to clear the field).
+	 *
+	 * @since 4.6.0
+	 *
+	 * @param string $value Value to check.
+	 * @param WP_REST_Request $request
+	 * @param string $param Name of the parameter passed to endpoint holding $value.
+	 *
+	 * @return bool
+	 */
+	public static function validate_verification_service( $value = '', $request, $param ) {
+		if ( ! empty( $value ) && ! ( is_string( $value ) && ( preg_match( '/^[a-z0-9_-]+$/i', $value ) || preg_match( '#^<meta name="([a-z0-9_\-.:]+)?" content="([a-z0-9_-]+)?" />$#i', $value ) ) ) ) {
+			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be an alphanumeric string or a verification tag.', 'jetpack' ), $param ) );
 		}
 		return true;
 	}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1177,32 +1177,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 			// Mobile Theme
 			'wp_mobile_excerpt' => array(
 				'description'       => esc_html__( 'Excerpts', 'jetpack' ),
-				'type'              => 'string',
-				'default'           => 'disabled',
-				'enum'              => array(
-					'enabled',
-					'disabled',
-				),
-				'enum_labels' => array(
-					'enabled'  => esc_html__( 'Enable excerpts on front page and on archive pages', 'jetpack' ),
-					'disabled' => esc_html__( 'Show full posts on front page and on archive pages', 'jetpack' ),
-				),
-				'validate_callback' => __CLASS__ . '::validate_list_item',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'minileven',
 			),
 			'wp_mobile_featured_images' => array(
 				'description'       => esc_html__( 'Featured Images', 'jetpack' ),
-				'type'              => 'string',
-				'default'           => 'disabled',
-				'enum'              => array(
-					'enabled',
-					'disabled',
-				),
-				'enum_labels' => array(
-					'enabled'  => esc_html__( 'Display featured images', 'jetpack' ),
-					'disabled' => esc_html__( 'Hide all featured images', 'jetpack' ),
-				),
-				'validate_callback' => __CLASS__ . '::validate_list_item',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'minileven',
 			),
 			'wp_mobile_app_promos' => array(
@@ -2121,16 +2105,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 				$options['guess_lang']['current_value'] = self::cast_value( isset( $atd_options['true'] ), $options[ 'guess_lang' ] );
 				$options['ignored_phrases']['current_value'] = AtD_get_setting( get_current_user_id(), 'AtD_ignored_phrases' );
 				unset( $options['unignore_phrase'] );
-				break;
-
-			case 'minileven':
-				$options['wp_mobile_excerpt']['current_value'] =
-					1 === intval( $options['wp_mobile_excerpt']['current_value'] ) ?
-					'enabled' : 'disabled';
-
-				$options['wp_mobile_featured_images']['current_value'] =
-					1 === intval( $options['wp_mobile_featured_images']['current_value'] ) ?
-					'enabled' : 'disabled';
 				break;
 
 			case 'stats':

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1749,7 +1749,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool
 	 */
 	public static function validate_alphanum( $value = '', $request, $param ) {
-		if ( ! empty( $value ) && ( ! is_string( $value ) || ! preg_match( '/[a-z0-9]+/i', $value ) ) ) {
+		if ( ! empty( $value ) && ( ! is_string( $value ) || ! preg_match( '/^[a-z0-9]+$/i', $value ) ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be an alphanumeric string.', 'jetpack' ), $param ) );
 		}
 		return true;

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -695,10 +695,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$updated = get_option( $option ) != $value ? update_option( $option, (bool) $value ? '1' : '0' ) : true;
 					break;
 
-				case 'wp_mobile_featured_images':
-				case 'wp_mobile_excerpt':
-					$value = ( 'enabled' === $value ) ? '1' : '0';
-				// break intentionally omitted
 				default:
 					// If option value was the same, consider it done.
 					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Comments
- * Module Description: Allow comments with WordPress.com, Twitter, Facebook, or Google+.
+ * Module Description: Use Jetpack comments. Let readers use their WordPress.com, Twitter, Facebook or Google+ to leave comments on your posts and pages.
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes

--- a/modules/custom-content-types.php
+++ b/modules/custom-content-types.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Custom Content Types
- * Module Description: Organize and display different types of content on your site.
+ * Module Description: Display different types of content on your site with custom content types.
  * First Introduced: 3.1
  * Requires Connection: No
  * Auto Activate: Yes

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -4,7 +4,7 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' 
 
 /**
  * Module Name: Single Sign On
- * Module Description: Secure user authentication with WordPress.com.
+ * Module Description: Allow log-in using WordPress.com accounts.
  * Jumpstart Description: Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.
  * Sort Order: 30
  * Recommendation Order: 5

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Subscriptions
- * Module Description: Notify your readers of new posts and comments by email.
+ * Module Description: Allow users to subscribe to your posts and comments and receive notifications via email.
  * Jumpstart Description: Give visitors two easy subscription options — while commenting, or via a separate email subscription widget you can display.
  * Sort Order: 9
  * Recommendation Order: 8

--- a/modules/verification-tools/blog-verification-tools.php
+++ b/modules/verification-tools/blog-verification-tools.php
@@ -42,7 +42,12 @@ function jetpack_verification_print_meta() {
 		$ver_output = "<!-- Jetpack Site Verification Tags -->\n";
 		foreach ( jetpack_verification_services() as $name => $service ) {
 			if ( is_array( $service ) && !empty( $verification_services_codes["$name"] ) ) {
-				$ver_tag = sprintf( '<meta name="%s" content="%s" />', esc_attr( $service["key"] ), esc_attr( $verification_services_codes["$name"] ) );
+				if ( preg_match( '#^<meta name="([a-z0-9_\-.:]+)?" content="([a-z0-9_-]+)?" />$#i', $verification_services_codes["$name"], $matches ) ) {
+					$verification_code = $matches[2];
+				} else {
+					$verification_code = $verification_services_codes["$name"];
+				}
+				$ver_tag = sprintf( '<meta name="%s" content="%s" />', esc_attr( $service["key"] ), esc_attr( $verification_code ) );
 				/**
 				 * Filter the meta tag template used for all verification tools.
 				 *


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- introduce settings for Writing tab
- make instantaneous optimistic toggles, both for modules or for an option that relies on a module (module is activated and option is set)
- `updateFormStateModuleOption()` now accepts a third parameter to state if the module should be deactivated
- reveal options only after a module is enabled
- make FormFieldset able to display a help icon
- add all needed help links
- add inline link to toggle fancy atd options
- update some module descriptions to use them in JS
- Site Verification fields now accepts the entire meta tag

#### Testing instructions:
* build and check Jetpack > Settings. Make sure that:
- toggles work instantly
- Post by Email regeneration works and display the address
- all help links works
- site verification works both with full meta tags like `<meta name="google-site-verification" content="1234abcd-5678_efgh" />` and just the code like `1234abcd-5678_efgh`