### PR TITLE
Extra Sidebar Widgets: update Twitter Timeline for sane limit

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -183,6 +183,9 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		}
 
 		$tweet_limit = (int) $new_instance['tweet-limit'];
+		if ( $tweet_limit > 20 ) {
+			$tweet_limit = 20;
+		}
 		$instance['tweet-limit'] = ( $tweet_limit ? $tweet_limit : null );
 
 		// If they entered something that might be a full URL, try to parse it out
@@ -323,7 +326,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 
 		<p>
 			<label for="<?php echo $this->get_field_id( 'tweet-limit' ); ?>">
-				<?php esc_html_e( '# of Tweets Shown:', 'jetpack' ); ?>
+				<?php esc_html_e( '# of Tweets Shown (1 to 20):', 'jetpack' ); ?>
 			</label>
 			<input
 				class="widefat"

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -183,10 +183,18 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		}
 
 		$tweet_limit = (int) $new_instance['tweet-limit'];
-		if ( $tweet_limit > 20 ) {
-			$tweet_limit = 20;
+		if ( $tweet_limit ) {
+			$instance['tweet-limit'] = min( max( $tweet_limit, 1 ), 20 );
+			/**
+			 * A timeline with a specified limit is expanded to the height of those Tweets.
+			 * The specified height value no longer applies, so reject the height value
+			 * when a valid limit is set: a widget attempting to save both limit 5 and
+			 * height 400 would be saved with just limit 5.
+			 */
+			$instance['height'] = '';
+		} else {
+			$instance['tweet-limit'] = null;
 		}
-		$instance['tweet-limit'] = ( $tweet_limit ? $tweet_limit : null );
 
 		// If they entered something that might be a full URL, try to parse it out
 		if ( is_string( $new_instance['widget-id'] ) ) {


### PR DESCRIPTION
Syncs (part of) r148193-wpcom

#### Changes proposed in this Pull Request:

Update the labeling of this widget to be obvious about 1 - 20 range of tweets for the widget display.

#### Testing instructions:

* Enable the Twitter Timeline widget.
* Check the form to make sure the `# of Tweets Shown (1 to 20):` text appears.
* Try adding more than 20; the form should reset back to 20 upon save.

Note: There is no lower limit. If empty Twitter decides the limit.