### PR TITLE
Tiled gallery: do not vertically stretch a lone image in a row

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/templates/square-layout.php
+++ b/modules/tiled-gallery/tiled-gallery/templates/square-layout.php
@@ -1,6 +1,6 @@
 <?php
 foreach ( $rows as $row ): ?>
-	<div class="gallery-row"
+	<div class="gallery-row<?php if ( 1 === count( $row->images ) ) echo ' gallery-singleton-row' ?>"
 		style="width: <?php echo esc_attr( $row->width ); ?>px; height: <?php echo esc_attr( $row->height ); ?>px;"
 		data-original-width="<?php echo esc_attr( $row->width ); ?>"
 		data-original-height="<?php echo esc_attr( $row->height ); ?>"

--- a/modules/tiled-gallery/tiled-gallery/templates/square-layout.php
+++ b/modules/tiled-gallery/tiled-gallery/templates/square-layout.php
@@ -1,12 +1,12 @@
 <?php
-foreach ( $rows as $row ): ?>
-	<div class="gallery-row<?php if ( 1 === count( $row->images ) ) echo ' gallery-singleton-row' ?>"
+foreach ( $rows as $row ) : ?>
+	<div class="gallery-row<?php if ( 1 === count( $row->images ) ) { echo ' gallery-singleton-row'; } ?>"
 		style="width: <?php echo esc_attr( $row->width ); ?>px; height: <?php echo esc_attr( $row->height ); ?>px;"
 		data-original-width="<?php echo esc_attr( $row->width ); ?>"
 		data-original-height="<?php echo esc_attr( $row->height ); ?>"
 	>
 		<?php $add_link = 'none' !== $link; ?>
-		<?php foreach ( $row->images as $item ): ?>
+		<?php foreach ( $row->images as $item ) : ?>
 			<div class="gallery-group"
 				style="width: <?php echo esc_attr( $row->group_size ); ?>px; height: <?php echo esc_attr( $row->group_size ); ?>px;"
 				data-original-width="<?php echo esc_attr( $row->group_size ); ?>"

--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery.css
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery.css
@@ -92,3 +92,14 @@
 	opacity: 0;
 }
 
+
+/* =Square Layout
+-------------------------------------------------------------- */
+
+.gallery-row.gallery-singleton-row,
+.gallery-row.gallery-singleton-row .gallery-group,
+.tiled-gallery.type-square .gallery-row.gallery-singleton-row:first-child .gallery-group .tiled-gallery-item img {
+	/* Do not vertically stretch an image if it's the only one in the row. */
+	height: auto !important;
+}
+


### PR DESCRIPTION
Fixes #5975

#### Changes proposed in this Pull Request:

Add a new CSS class, ``gallery-singleton-row``, and a rule which prevents vertical stretching on images in rows of length 1 in square tile galleries.

#### Testing instructions:

1. Create a post with two galleries, both of "square" type. One with 4 images and one with 5. Make the first image in each gallery shorter than it is wide and shorter than the second image (so the effect is more noticeable).
2. Note that without this change applied, the sole image in the first row of the 4 image gallery is stretched vertically.
3. Note that with this change applied, the sole image in the first row of the 4 image gallery is not stretched vertically, but the first image in the first row of the 5 image gallery is stretched.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
