### PR TITLE
SAL: Move icon logic to Jetpack base, leverage core site icon option consistently

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -92,7 +92,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION,
 	);
 
-	protected static $jetpack_response_field_additions = array( 
+	protected static $jetpack_response_field_additions = array(
 		'subscribers_count',
 	);
 
@@ -101,7 +101,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'plan',
 	);
 
-	protected static $jetpack_response_option_additions = array( 
+	protected static $jetpack_response_option_additions = array(
 		'publicize_permanently_disabled',
 		'ak_vp_bundle_enabled'
 	);
@@ -128,7 +128,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return $blog_id;
 		}
 
-		// TODO: enable this when we can do so without being interfered with by 
+		// TODO: enable this when we can do so without being interfered with by
 		// other endpoints that might be wrapping this one.
 		// Uncomment and see failing test: test_jetpack_site_should_have_true_jetpack_property_via_site_meta
 		// $this->filter_fields_and_options();
@@ -243,7 +243,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[ $key ] = $this->site->is_following();
 				break;
 			case 'options':
-				// small optimisation - don't recalculate 
+				// small optimisation - don't recalculate
 				$all_options = apply_filters( 'sites_site_options_format', self::$site_options_format );
 
 				$options_response_keys = is_array( $this->options_to_include ) ?
@@ -268,16 +268,16 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'jetpack' :
 				$response[ $key ] = $this->site->is_jetpack();
 				break;
-			case 'single_user_site' : 
+			case 'single_user_site' :
 				$response[ $key ] = $this->site->is_single_user_site();
 				break;
-			case 'is_vip' : 
+			case 'is_vip' :
 				$response[ $key ] = $this->site->is_vip();
 				break;
 			case 'is_multisite' :
 				$response[ $key ] = $this->site->is_multisite();
 				break;
-			case 'capabilities' : 
+			case 'capabilities' :
 				$response[ $key ] = $this->site->get_capabilities();
 				break;
 			case 'jetpack_modules':
@@ -303,7 +303,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$site = $this->site;
 
 		$custom_front_page = $site->is_custom_front_page();
-		
+
 
 		foreach ( $options_response_keys as $key ) {
 			switch ( $key ) {
@@ -368,7 +368,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$options[ $key ] = $site->get_image_large_width();
 					break;
 				case 'image_large_height' :
-					$options[ $key ] = $site->get_image_large_height(); 
+					$options[ $key ] = $site->get_image_large_height();
 					break;
 				case 'permalink_structure' :
 					$options[ $key ] = $site->get_permalink_structure();

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -448,14 +448,21 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	}
 
 	protected function build_meta_response( &$response ) {
+		$links = array(
+			'self'     => (string) $this->links->get_site_link( $this->site->blog_id ),
+			'help'     => (string) $this->links->get_site_link( $this->site->blog_id, 'help'      ),
+			'posts'    => (string) $this->links->get_site_link( $this->site->blog_id, 'posts/'    ),
+			'comments' => (string) $this->links->get_site_link( $this->site->blog_id, 'comments/' ),
+			'xmlrpc'   => (string) $this->site->get_xmlrpc_url(),
+		);
+
+		$icon = $this->site->get_icon();
+		if ( ! empty( $icon ) && ! empty( $icon['media_id'] ) ) {
+			$links['site_icon'] = (string) $this->links->get_site_link( $this->site->blog_id, 'media/' . $icon['media_id'] );
+		}
+
 		$response['meta'] = (object) array(
-			'links' => (object) array(
-				'self'     => (string) $this->links->get_site_link( $this->site->blog_id ),
-				'help'     => (string) $this->links->get_site_link( $this->site->blog_id, 'help'      ),
-				'posts'    => (string) $this->links->get_site_link( $this->site->blog_id, 'posts/'    ),
-				'comments' => (string) $this->links->get_site_link( $this->site->blog_id, 'comments/' ),
-				'xmlrpc'   => (string) $this->site->get_xmlrpc_url(),
-			),
+			'links' => (object) $links
 		);
 	}
 

--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -129,10 +129,14 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 			return null;
 		}
 
-		$icon = array(
+		$icon = array_filter( array(
 			'img' => wp_get_attachment_image_url( $icon_id, 'full' ),
 			'ico' => wp_get_attachment_image_url( $icon_id, array( 16, 16 ) )
-		);
+		) );
+
+		if ( empty( $icon ) ) {
+			return null;
+		}
 
 		if ( current_user_can( 'edit_posts', $icon_id ) ) {
 			$icon['media_id'] = (int) $icon_id;

--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -119,6 +119,28 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 		return $supported_formats;
 	}
 
+	function get_icon() {
+		$icon_id = get_option( 'site_icon' );
+		if ( empty( $icon_id ) ) {
+			$icon_id = Jetpack_Options::get_option( 'site_icon_id' );
+		}
+
+		if ( empty( $icon_id ) ) {
+			return null;
+		}
+
+		$icon = array(
+			'img' => wp_get_attachment_image_url( $icon_id, 'full' ),
+			'ico' => wp_get_attachment_image_url( $icon_id, array( 16, 16 ) )
+		);
+
+		if ( current_user_can( 'edit_posts', $icon_id ) ) {
+			$icon['media_id'] = (int) $icon_id;
+		}
+
+		return $icon;
+	}
+
 	/**
 	 * Private methods
 	 **/

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -128,17 +128,6 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return get_bloginfo( 'language' );
 	}
 
-	function get_icon() {
-		if ( function_exists( 'get_site_icon_url' ) && function_exists( 'jetpack_photon_url' ) ) {
-			return array(
-				'img' => (string) jetpack_photon_url( get_site_icon_url( 80, '', get_current_blog_id() ), array( 'w' => 80 ), 'https' ),
-				'ico' => (string) jetpack_photon_url( get_site_icon_url( 16, '', get_current_blog_id() ), array( 'w' => 16 ), 'https' ),
-			);
-		}
-
-		return null;
-	}
-
 	function is_jetpack() {
 		return true;
 	}

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -55,7 +55,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function get_id() {
-		return $this->platform->token->blog_id;	
+		return $this->platform->token->blog_id;
 	}
 
 	function has_videopress() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The Jetpack Site Icon module was [deprecated in 3.6.1](https://github.com/Automattic/jetpack/pull/2402). The transition logic deactivates the module for most sites, so the `jetpack_site_icon_url` function usually does not pass the existence check for most Jetpack sites.

In any case, we plan toward moving to treating Site Icon as the canonical source of site's icon. The changes herein check for this option, falling back to the Jetpack-defined icon option if unset.

This improves consistency between Jetpack shadow sites and the remote site. Previously, `/me/sites` (shadow site) will show the icon property for my Jetpack site, whereas `/sites/%s` does not (because the module is not active on the site).

#### Testing instructions:

With changes applied to your Jetpack site, ensure that an icon property is consistently returned for Jetpack sites between `/me/sites` and `/sites/%s`. Authenticated requests can be issued using the [Developer Site console](https://developer.wordpress.com/docs/api/console/) to verify presence of `icon.media_id` when user has REST API media editing capabilities.

#### Related:

- D2940-code
- r148273-wpcom