### PR TITLE
Shortcode Instagram: fix jshint error

### DIFF
--- a/modules/shortcodes/js/instagram.js
+++ b/modules/shortcodes/js/instagram.js
@@ -2,7 +2,7 @@
 
 (function() {
 	var instagramEmbed = function() {
-		if ( 'undefined' !== typeof window.instgrm && window.instgrm.Embeds && 'function' === typeof instgrm.Embeds.process ) {
+		if ( 'undefined' !== typeof window.instgrm && window.instgrm.Embeds && 'function' === typeof window.instgrm.Embeds.process ) {
 			window.instgrm.Embeds.process();
 		} else {
 			var s = document.createElement( 'script' );


### PR DESCRIPTION
Fixes undefined object in the instagram js.  

to test: 
- `gulp js:hint` should pass
- No console errors, and infinite scroll with multiple insta video shortcode embeds should work properly.  