### PR TITLE
DashItem: fix dashboard title overflows

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -233,6 +233,7 @@
 .jp-at-a-glance__left,
 .jp-at-a-glance__right {
 	display: flex;
+	min-width: 0;
 
 	@include breakpoint( ">660px" ) {
 		flex-basis: 50%;
@@ -244,6 +245,7 @@
 
 	> div, // Sorry. not sure how to class this. Thanks, React.
 	.jp-dash-item {
+		min-width: 0; // weird fix for overflowing items
 		flex-grow: 1;
 		display: flex;
 		flex-direction: column;

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -46,10 +46,6 @@
 		color: darken( $gray, 20% );
 	}
 
-	.dops-section-header__label:before {
-		@include long-content-fade( $color : $white );
-	}
-
 	&.is-working,
 	&.is-premium-inactive {
 		.dops-section-header__actions {
@@ -78,14 +74,14 @@
 
 // conditional styles for content when items are inactive
 .jp-dash-item__is-inactive {
-	.dops-section-header .dops-section-header__label:before {
-		@include long-content-fade( $color : $gray-light );
-	}
-
 	.dops-card {
 		background-color: $gray-light;
 	}
-
+	.dops-section-header__label-text {
+		&:before {
+			@include long-content-fade( $color : $gray-light );
+		}
+	}
 	.jp-dash-item__description {
 		font-style: italic;
 		color: darken( $gray, 20% );

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -78,8 +78,10 @@
 		background-color: $gray-light;
 	}
 	.dops-section-header__label-text {
+		padding-right: rem( 8px );
+
 		&:before {
-			@include long-content-fade( $color : $gray-light );
+			@include long-content-fade( $size: 8px, $color : $gray-light );
 		}
 	}
 	.jp-dash-item__description {


### PR DESCRIPTION
Fixes #5565 

#### Changes proposed in this Pull Request:
Adds some minor style tweaks

#### Testing instructions:

* switch to `fix/5565` branch on dops-components
* go to dashboard
* change a dashboard title to be really long or switch to Russian
* resize the window a bunch

#### Before
<img width="753" alt="screen shot 2017-01-02 at 4 45 45 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597646/00da1a00-d10b-11e6-8c27-9d952ddaecfd.png">
<img width="410" alt="screen shot 2017-01-02 at 4 46 07 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597647/01169c8c-d10b-11e6-890e-8f8bb7602b51.png">


#### After
<img width="597" alt="screen shot 2017-01-02 at 4 40 46 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597599/6037f90a-d10a-11e6-960a-7bf75df76175.png">
<img width="427" alt="screen shot 2017-01-02 at 4 41 02 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597601/60943620-d10a-11e6-92bf-9875b338ae83.png">
<img width="785" alt="screen shot 2017-01-02 at 4 41 32 pm" src="https://cloud.githubusercontent.com/assets/1123119/21597600/60936f6a-d10a-11e6-8d2e-e105cf28547d.png">
