### PR TITLE
Sync shortcode tags

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -145,6 +145,7 @@ class Jetpack_Sync_Defaults {
 		'taxonomies'                       => array( 'Jetpack_Sync_Functions', 'get_taxonomies' ),
 		'post_types'                       => array( 'Jetpack_Sync_Functions', 'get_post_types' ),
 		'post_type_features'               => array( 'Jetpack_Sync_Functions', 'get_post_type_features' ),
+		'shortcodes'                       => array( 'Jetpack_Sync_Functions', 'get_shortcodes' ),
 		'rest_api_allowed_post_types'      => array( 'Jetpack_Sync_Functions', 'rest_api_allowed_post_types' ),
 		'rest_api_allowed_public_metadata' => array( 'Jetpack_Sync_Functions', 'rest_api_allowed_public_metadata' ),
 		'sso_is_two_step_required'         => array( 'Jetpack_SSO_Helpers', 'is_two_step_required' ),

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -28,6 +28,11 @@ class Jetpack_Sync_Functions {
 		return $wp_taxonomies_without_callbacks;
 	}
 
+	public static function get_shortcodes() {
+		global $shortcode_tags;
+		return array_keys( $shortcode_tags );
+	}
+
 	/**
 	 * Removes any callback data since we will not be able to process it on our side anyways.
 	 */

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -78,6 +78,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'hosting_provider'                 => Jetpack_Sync_Functions::get_hosting_provider(),
 			'locale'                           => get_locale(),
 			'site_icon_url'                    => Jetpack_Sync_Functions::site_icon_url(),
+			'shortcodes'                       => Jetpack_Sync_Functions::get_shortcodes(),
 		);
 
 		if ( is_multisite() ) {


### PR DESCRIPTION
Helps address #869 by syncing the supported shortcodes for a site, so we can distinguish between `[foo id="1]` and `the [president elect] said`