### PR TITLE
Verbiage: Changing 'pro' labels to say 'paid' to prevent plan confusion

### DIFF
--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -95,7 +95,7 @@ export const DashItem = React.createClass( {
 					compact={ true }
 					href="#/plans"
 				>
-					{ __( 'Pro' ) }
+					{ __( 'Paid' ) }
 				</Button>
 			;
 

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -143,7 +143,7 @@ export const Engagement = ( props ) => {
 					<span>
 						{ element[1] }
 						<Button compact={ true } href="#/plans">
-							{ __( 'Pro' ) }
+							{ __( 'Paid' ) }
 						</Button>
 					</span>;
 			}

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -145,7 +145,7 @@ export const SearchResults = ( {
 					compact={ true }
 					href="#/plans"
 				>
-					{ __( 'Pro' ) }
+					{ __( 'Paid' ) }
 				</Button>
 			</span>;
 

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -79,7 +79,7 @@ export const Page = ( props ) => {
 					compact={ true }
 					href="#/plans"
 				>
-					{ __( 'Pro' ) }
+					{ __( 'Paid' ) }
 				</Button>
 			</span>;
 

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -114,7 +114,7 @@ export const Writing = ( props ) => {
 					compact={ true }
 					href="#/plans"
 				>
-					{ __( 'Pro' ) }
+					{ __( 'Paid' ) }
 				</Button>
 			</span>;
 		}


### PR DESCRIPTION
Fixes some of: https://github.com/Automattic/jetpack/issues/5949

Changing "Pro" labels to say "Paid"

Question for devs: Do we need to change the `jetpack.strings.php` file in any way as well?

Before:
<img width="375" alt="pro-label" src="https://cloud.githubusercontent.com/assets/214813/21327996/b5bce13a-c5ff-11e6-9588-1be177d7a8d4.png">

After: 
![screen shot 2017-01-03 at 4 02 11 pm](https://cloud.githubusercontent.com/assets/214813/21623029/7aa55fd4-d1ce-11e6-9047-893fde0a376f.png)

![screen shot 2017-01-03 at 4 01 37 pm](https://cloud.githubusercontent.com/assets/214813/21623033/818f2866-d1ce-11e6-941c-c8498ba25840.png)

