### PR TITLE
Stop Sharding Photon Domains

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -128,11 +128,18 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	$image_host_path = $image_url_parts['host'] . $image_url_parts['path'];
 
 	// Figure out which CDN subdomain to use for this site
-	$subdomain_seed = (int) Jetpack_Options::get_option( 'id' );
-	if ( empty( $subdomain_seed ) && !empty( $_SERVER['HTTP_HOST'] ) ) {
-		$subdomain_seed = crc32( $_SERVER['HTTP_HOST'] ); // Fallback to site domain
+	if ( class_exists( 'Jetpack_Server' ) ) {
+		// Is WordPress.com
+		$subdomain = get_current_blog_id();
+	} elseif ( (int) Jetpack_Options::get_option( 'id' ) > 0 ) {
+		// Is connected Jetpack
+		$subdomain = Jetpack_Options::get_option( 'id' );
+	} else {
+		// Fallback to site domain
+		$subdomain = crc32( (string) $_SERVER['HTTP_HOST'] );
 	}
-	$subdomain = abs( $subdomain_seed % 3 ); // abs() for 32bit system crc
+	// abs() for 32bit system CRCs
+	$subdomain = abs( (int) $subdomain % 3 );
 
 	/**
 	 * Filters the domain used by the Photon module.

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -127,10 +127,12 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	$image_host_path = $image_url_parts['host'] . $image_url_parts['path'];
 
-	// Figure out which CDN subdomain to use
-	srand( crc32( $image_host_path ) );
-	$subdomain = rand( 0, 2 );
-	srand();
+	// Figure out which CDN subdomain to use for this site
+	$subdomain_seed = (int) Jetpack_Options::get_option( 'id' );
+	if ( empty( $subdomain_seed ) && !empty( $_SERVER['HTTP_HOST'] ) ) {
+		$subdomain_seed = crc32( $_SERVER['HTTP_HOST'] ); // Fallback to site domain
+	}
+	$subdomain = abs( $subdomain_seed % 3 ); // abs() for 32bit system crc
 
 	/**
 	 * Filters the domain used by the Photon module.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The Photon domains, `i[0-2].wp.com`, all support HTTP/2.0 and according to http://caniuse.com/#feat=http2 global browser support is getting pretty good at 78%.

Sharding domains in HTTP/2.0 is now an anti-pattern because requests for assets can be multiplexed over the same connection negating the need for sharding. If we have Photon select subdomains based the current blog_id or HTTP host header we can save some extraneous DNS and TCP connection times.

#### Testing instructions:

* Load a site and see all Photon requests go to the same domain.

#### Proposed changelog entry for your changes:

Take better advantage of HTTP/2.0 multiplexing and get rid of domain sharding or Photon requests.
