### PR TITLE
Admin: bring Related Posts settings back to their foldable card

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -68,6 +68,82 @@ export let SharedaddySettings = React.createClass( {
 
 SharedaddySettings = moduleSettingsForm( SharedaddySettings );
 
+export let RelatedPostsSettings = React.createClass( {
+	renderPreviews() {
+		const show_headline = this.props.getOptionValue( 'show_headline' );
+		const show_thumbnails = this.props.getOptionValue( 'show_thumbnails' );
+		const previews = [ {
+			url: 'https://jetpackme.files.wordpress.com/2014/08/1-wpios-ipad-3-1-viewsite.png?w=350&h=200&crop=1',
+			text: __( 'Big iPhone/iPad Update Now Available' )
+		}, {
+			url: 'https://jetpackme.files.wordpress.com/2014/08/wordpress-com-news-wordpress-for-android-ui-update2.jpg?w=350&h=200&crop=1',
+			text: __( 'The WordPress for Android App Gets a Big Facelift' )
+		}, {
+			url: 'https://jetpackme.files.wordpress.com/2014/08/videopresswedding.jpg?w=350&h=200&crop=1',
+			text: __( 'Upgrade Focus: VideoPress For Weddings' )
+		} ];
+
+		return (
+			<div className="jp-related-posts-preview">
+				{
+					show_headline ?
+						<div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div> :
+						''
+				}
+				{
+					previews.map( ( preview, i ) => (
+						<span key={ `preview_${ i }` } className="jp-related-posts-preview__item" >
+  							{
+								show_thumbnails ? <img src={ preview.url } /> : ''
+							}
+							<span><a href="#/engagement"> { preview.text } </a></span>
+  						</span>
+					) )
+				}
+			</div>
+		);
+	},
+	render() {
+		return (
+			<form onSubmit={ this.props.onSubmit } >
+				<FormFieldset>
+					{
+						__( '{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}', {
+							components: {
+								span: <span className="jp-form-setting-explanation" />,
+								ExternalLink: <ExternalLink
+									className="jp-module-settings__external-link"
+									href={ this.props.siteAdminUrl +
+									'customize.php?autofocus[section]=jetpack_relatedposts' +
+									'&return=' + encodeURIComponent( this.props.siteAdminUrl + 'admin.php?page=jetpack#/engagement' ) +
+									'&url=' + encodeURIComponent( this.props.lastPostUrl ) } />
+							}
+						} )
+					}
+					<ModuleSettingCheckbox
+						name={ 'show_headline' }
+						label={ __( 'Show a "Related" header to more clearly separate the related section from posts' ) }
+						{ ...this.props } />
+					<ModuleSettingCheckbox
+						name={ 'show_thumbnails' }
+						label={ __( 'Use a large and visually striking layout' ) }
+						{ ...this.props } />
+					<div className="jp-related-posts-settings__preview-label">{ __( 'Preview' ) }</div>
+					<Card>
+						{ this.renderPreviews() }
+					</Card>
+					<FormButton
+						className="is-primary"
+						isSubmitting={ this.props.isSavingAnyOption() }
+						disabled={ this.props.shouldSaveButtonBeDisabled() } />
+				</FormFieldset>
+			</form>
+		);
+	}
+} );
+
+RelatedPostsSettings = moduleSettingsForm( RelatedPostsSettings );
+
 export let LikesSettings = React.createClass( {
 	render() {
 		const old_sharing_settings_url = this.props.module.configure_url;

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import {
 	StatsSettings,
+	RelatedPostsSettings,
 	CommentsSettings,
 	LikesSettings,
 	SubscriptionsSettings,
@@ -113,6 +114,8 @@ const AllModuleSettingsComponent = React.createClass( {
 				}
 			case 'stats':
 				return ( <StatsSettings module={ module }  /> );
+			case 'related-posts':
+				return ( <RelatedPostsSettings module={ module } lastPostUrl={ this.props.lastPostUrl } /> );
 			case 'comments':
 				return ( <CommentsSettings module={ module }  /> );
 			case 'subscriptions':
@@ -161,7 +164,6 @@ const AllModuleSettingsComponent = React.createClass( {
 						}
 					</div>
 				);
-			case 'related-posts':
 			case 'custom-css':
 			case 'widgets':
 			case 'publicize':
@@ -169,12 +171,6 @@ const AllModuleSettingsComponent = React.createClass( {
 			default:
 				if ( 'publicize' === module.module ) {
 					module.configure_url = this.props.adminUrl + 'options-general.php?page=sharing';
-				}
-				if ( 'related-posts' === module.module ) {
-					module.configure_url = this.props.adminUrl +
-						'customize.php?autofocus[section]=jetpack_relatedposts' +
-						'&return=' + encodeURIComponent( this.props.adminUrl + 'admin.php?page=jetpack#/engagement' ) +
-						'&url=' + encodeURIComponent( this.props.lastPostUrl );
 				}
 				return (
 					<div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- reinstates the usual settings for Related Posts and adds a link to go to the Customizer.

#### Testing instructions:
* build and go to Jetpack > Settings > Enhancements and expand the Related Posts card. The settings should be there.
* saving both in Jetpack Settings and in the Customizer should work fine.

cc @MichaelArestad for review