### PR TITLE
Settings UI: Related Posts controls and preview + indentation for controls after toggle

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -62,7 +62,7 @@
 
 .jp-form-fieldset {
 
-	margin-bottom: 4em;
+	margin-bottom: rem( 24px );
 	position: relative;
 
 	.jp-form-legend + .jp-form-setting-explanation {
@@ -71,6 +71,10 @@
 
 	.jp-form-setting-explanation + .jp-form-label {
 		margin-top: rem( 16px );
+	}
+
+	&:last-child {
+		margin-bottom: 0;
 	}
 }
 
@@ -96,7 +100,21 @@
 	}
 }
 
+.jp-form-settings-card {
+	margin-bottom: rem( 24px );
+
+	& > .jp-form-settings-group {
+		margin: 0;
+	}
+}
+
 .jp-form-has-child {
+	margin-bottom: rem( 24px );
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
 	& > .jp-form-fieldset,
 	& > .jp-form-setting-explanation {
 		margin-left: rem( 36px );

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -95,3 +95,10 @@
 		border-left: 0;
 	}
 }
+
+.jp-form-has-child {
+	& > .jp-form-fieldset,
+	& > .jp-form-setting-explanation {
+		margin-left: rem( 36px );
+	}
+}

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -68,6 +68,15 @@
 
 
 // Related Posts Preview styles
+.jp-related-posts-preview {
+	position: relative;
+	margin-top: rem( 8px );
+	padding: rem( 16px ) rem( 8px );
+	width: 100%;
+	background: #f3f6f8;
+	box-sizing: border-box;
+	box-shadow: none;
+}
 .jp-related-posts-settings__preview-label {
 	margin-bottom: rem( 8px );
 	margin-top: rem( 24px );
@@ -75,17 +84,22 @@
 	font-weight: 600;
 }
 
-.jp-related-posts-preview {
-	text-align: center;
+.jp-related-posts-preview__title {
+	margin: 0 0 rem( 11px ) rem( 8px );
+	font-size: rem( 11px );
+	font-weight: 600;
 }
 
-.jp-related-posts-preview__title {
-	text-align: left;
-	color: $gray;
-	font-weight: 600;
-	margin-left: rem( 8px );
-	margin-bottom: rem( 16px );
-	text-transform: uppercase;
+.jp-related-posts-preview__post-title {
+	font-size: rem( 15px );
+	font-weight: 400;
+	margin: 0;
+}
+
+.jp-related-posts-preview__post-context {
+	font-size: rem( 15px );
+	opacity: .6;
+	margin: 0;
 }
 
 .jp-related-posts-preview__item {
@@ -93,7 +107,7 @@
 	display: inline-block;
 	width: 33.33%;
 	padding: rem( 8px );
-	text-align: left;
+	vertical-align: top;
 
 	@include breakpoint( "<480px" ) {
 		width: 100%;

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
+import Card from 'components/card';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -13,7 +15,6 @@ import {
 	FormButton
 } from 'components/forms';
 import SectionHeader from 'components/section-header';
-import Card from 'components/card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
@@ -26,15 +27,10 @@ export const SettingsCard = props => {
 			: module
 				? module.name
 				: '',
-		support = props.support
-			? props.support
-			: module && '' !== module.learn_more_button
-				? module.learn_more_button
-				: false,
 		isSaving = props.isSavingAnyOption();
 
 	return (
-		<form>
+		<form className="jp-form-settings-card">
 			<SectionHeader label={ header }>
 				{
 					props.hideButton
@@ -53,21 +49,31 @@ export const SettingsCard = props => {
 						  </Button>
 				}
 			</SectionHeader>
-			<Card>
-				{
-					support
-						? <div className="jp-module-settings__learn-more">
-							<Button borderless compact href={ support }>
-								<Gridicon icon="help-outline" />
-								<span className="screen-reader-text">{ __( 'Learn More' ) }</span>
-							</Button>
-						  </div>
-						: ''
-				}
-				{ props.children }
-			</Card>
+			{ props.children }
 		</form>
 	);
 };
 
-export default SettingsCard;
+export const SettingsGroup = props => {
+	let support = props.support
+		? props.support
+		: module && '' !== module.learn_more_button
+			? module.learn_more_button
+			: false;
+
+	return (
+		<Card className={ classNames( 'jp-form-settings-group', { 'jp-form-has-child': props.hasChild } ) }>
+			{
+				support
+					? <div className="jp-module-settings__learn-more">
+						<Button borderless compact href={ support }>
+							<Gridicon icon="help-outline" />
+							<span className="screen-reader-text">{ __( 'Learn More' ) }</span>
+						</Button>
+					  </div>
+					: ''
+			}
+			{ props.children }
+		</Card>
+	);
+};

--- a/_inc/client/components/settings-card/test/component.js
+++ b/_inc/client/components/settings-card/test/component.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 /**
  * Internal dependencies
  */
-import { SettingsCard } from '../index';
+import { SettingsCard, SettingsGroup } from '../index';
 
 describe( 'SettingsCard', () => {
 
@@ -23,11 +23,13 @@ describe( 'SettingsCard', () => {
 			}
 		),
 		isSavingAnyOption: () => false,
+		isDirty: () => true,
 		header: '',
 		support: ''
 	};
 
-	const wrapper = shallow( <SettingsCard { ...testProps } /> );
+	const wrapper = shallow( <SettingsCard { ...testProps } /> ),
+		  settingsGroup = shallow( <SettingsGroup support={ testProps.getModule().learn_more_button } /> );
 
 	it( 'renders a heading', () => {
 		expect( wrapper.find( 'SectionHeader' ) ).to.have.length( 1 );
@@ -38,10 +40,10 @@ describe( 'SettingsCard', () => {
 	} );
 
 	it( 'the learn more icon is linked to the correct URL', () => {
-		expect( wrapper.find( 'Button' ).get(1).props.href ).to.be.equal( 'https://jetpack.com/support/protect' );
+		expect( settingsGroup.find( 'Button' ).get(0).props.href ).to.be.equal( 'https://jetpack.com/support/protect' );
 	} );
 
-	it( "when not saving, it's enabled", () => {
+	it( "when not saving and has settings to save, it's enabled", () => {
 		expect( wrapper.find( 'Button' ).get(0).props.disabled ).to.be.false;
 	} );
 
@@ -52,14 +54,15 @@ describe( 'SettingsCard', () => {
 			support: 'https://jetpack.com/'
 		} );
 
-		const wrapper = shallow( <SettingsCard { ...testProps } /> );
+		const wrapper = shallow( <SettingsCard { ...testProps } /> ),
+			  settingsGroup = shallow( <SettingsGroup support={ testProps.support } /> );
 
 		it( 'the header has priority over module.name', () => {
 			expect( wrapper.find( 'SectionHeader' ).props().label ).to.be.equal( 'A custom header' );
 		} );
 
 		it( 'the learn more icon will be linked to the custom URL', () => {
-			expect( wrapper.find( 'Button' ).get(1).props.href ).to.be.equal( 'https://jetpack.com/' );
+			expect( settingsGroup.find( 'Button' ).get(0).props.href ).to.be.equal( 'https://jetpack.com/' );
 		} );
 
 	} );

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -17,7 +17,10 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const Comments = moduleSettingsForm(
 	React.createClass( {
@@ -30,7 +33,7 @@ export const Comments = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="comments">
-					<div className="jp-form-has-child">
+					<SettingsGroup hasChild support={ comments.learn_more_button }>
 						<ModuleToggle slug="comments"
 									  compact
 									  activated={ this.props.getOptionValue( 'comments' ) }
@@ -66,34 +69,35 @@ export const Comments = moduleSettingsForm(
 								  </FormFieldset>
 								: ''
 						}
-					</div>
-					<hr />
-					<FormFieldset support={ gravatar.learn_more_button }>
-						<ModuleToggle slug="gravatar-hovercards"
-									  compact
-									  activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
-									  toggling={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
-									  toggleModule={ this.props.toggleModuleNow }>
+					</SettingsGroup>
+					<SettingsGroup>
+						<FormFieldset support={ gravatar.learn_more_button }>
+							<ModuleToggle slug="gravatar-hovercards"
+										  compact
+										  activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
+										  toggling={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
+										  toggleModule={ this.props.toggleModuleNow }>
 							<span className="jp-form-toggle-explanation">
 								{
 									gravatar.description
 								}
 							</span>
-						</ModuleToggle>
-					</FormFieldset>
-					<FormFieldset support={ markdown.learn_more_button }>
-						<ModuleToggle slug="markdown"
-									  compact
-									  activated={ !!this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
-									  toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_comments_with_markdown' ] ) }
-									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'wpcom_publish_comments_with_markdown' ) }>
+							</ModuleToggle>
+						</FormFieldset>
+						<FormFieldset support={ markdown.learn_more_button }>
+							<ModuleToggle slug="markdown"
+										  compact
+										  activated={ !!this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
+										  toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_comments_with_markdown' ] ) }
+										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'wpcom_publish_comments_with_markdown' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
 									__( 'Enable Markdown use for comments.' )
 								}
 							</span>
-						</ModuleToggle>
-					</FormFieldset>
+							</ModuleToggle>
+						</FormFieldset>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -30,41 +30,43 @@ export const Comments = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="comments">
-					<ModuleToggle slug="comments"
-								  compact
-								  activated={ this.props.getOptionValue( 'comments' ) }
-								  toggling={ this.props.isSavingAnyOption( 'comments' ) }
-								  toggleModule={ this.props.toggleModuleNow }>
+					<div className="jp-form-has-child">
+						<ModuleToggle slug="comments"
+									  compact
+									  activated={ this.props.getOptionValue( 'comments' ) }
+									  toggling={ this.props.isSavingAnyOption( 'comments' ) }
+									  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								comments.description
 							}
 						</span>
-					</ModuleToggle>
-					{
-						this.props.getOptionValue( 'comments' )
-							? <FormFieldset>
-								<FormLabel>
-									<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
-									<TextInput
-										name={ 'highlander_comment_form_prompt' }
-										value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
-										disabled={ this.props.isUpdating( 'highlander_comment_form_prompt' ) }
-										onChange={ this.props.onOptionChange } />
-								</FormLabel>
-								<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
-								<FormLabel>
-									<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
-									<FormSelect
-										name={ 'jetpack_comment_form_color_scheme' }
-										value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
-										onChange={ this.props.onOptionChange }
-										{ ...this.props }
-										validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
-								</FormLabel>
-							  </FormFieldset>
-							: ''
-					}
+						</ModuleToggle>
+						{
+							this.props.getOptionValue( 'comments' )
+								? <FormFieldset>
+									<FormLabel>
+										<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
+										<TextInput
+											name={ 'highlander_comment_form_prompt' }
+											value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
+											disabled={ this.props.isUpdating( 'highlander_comment_form_prompt' ) }
+											onChange={ this.props.onOptionChange } />
+									</FormLabel>
+									<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
+									<FormLabel>
+										<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
+										<FormSelect
+											name={ 'jetpack_comment_form_color_scheme' }
+											value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
+											onChange={ this.props.onOptionChange }
+											{ ...this.props }
+											validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
+									</FormLabel>
+								  </FormFieldset>
+								: ''
+						}
+					</div>
 					<hr />
 					<FormFieldset support={ gravatar.learn_more_button }>
 						<ModuleToggle slug="gravatar-hovercards"

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -25,20 +25,21 @@ export const Subscriptions = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="subscriptions">
-					<ModuleToggle slug="subscriptions"
-								  compact
-								  activated={ isSubscriptionsActive }
-								  toggling={ this.props.isSavingAnyOption( 'subscriptions' ) }
-								  toggleModule={ this.props.toggleModuleNow }>
+					<div className="jp-form-has-child">
+						<ModuleToggle slug="subscriptions"
+									  compact
+									  activated={ isSubscriptionsActive }
+									  toggling={ this.props.isSavingAnyOption( 'subscriptions' ) }
+									  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'subscriptions' ).description
 							}
 						</span>
-					</ModuleToggle>
-					{
-						isSubscriptionsActive
-							? <FormFieldset>
+						</ModuleToggle>
+						{
+							isSubscriptionsActive
+								? <FormFieldset>
 								<p>
 									<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
 								</p>
@@ -50,9 +51,10 @@ export const Subscriptions = moduleSettingsForm(
 									name={ 'stc_enabled' }
 									{ ...this.props }
 									label={ __( 'Show a "follow comments" option in the comment form.' ) } />
-							  </FormFieldset>
-							: ''
-					}
+							</FormFieldset>
+								: ''
+						}
+					</div>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -14,18 +14,22 @@ import ExternalLink from 'components/external-link';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const Subscriptions = moduleSettingsForm(
 	React.createClass( {
 
 		render() {
-			let isSubscriptionsActive = this.props.getOptionValue( 'subscriptions' );
+			let subscriptions = this.props.getModule( 'subscriptions' ),
+				isSubscriptionsActive = this.props.getOptionValue( 'subscriptions' );
 			return (
 				<SettingsCard
 					{ ...this.props }
 					module="subscriptions">
-					<div className="jp-form-has-child">
+					<SettingsGroup hasChild support={ subscriptions.learn_more_button }>
 						<ModuleToggle slug="subscriptions"
 									  compact
 									  activated={ isSubscriptionsActive }
@@ -33,28 +37,28 @@ export const Subscriptions = moduleSettingsForm(
 									  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
-								this.props.getModule( 'subscriptions' ).description
+								subscriptions.description
 							}
 						</span>
 						</ModuleToggle>
 						{
 							isSubscriptionsActive
 								? <FormFieldset>
-								<p>
-									<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
-								</p>
-								<ModuleSettingCheckbox
-									name={ 'stb_enabled' }
-									{ ...this.props }
-									label={ __( 'Show a "follow blog" option in the comment form' ) } />
-								<ModuleSettingCheckbox
-									name={ 'stc_enabled' }
-									{ ...this.props }
-									label={ __( 'Show a "follow comments" option in the comment form.' ) } />
-							</FormFieldset>
+									<p>
+										<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
+									</p>
+									<ModuleSettingCheckbox
+										name={ 'stb_enabled' }
+										{ ...this.props }
+										label={ __( 'Show a "follow blog" option in the comment form' ) } />
+									<ModuleSettingCheckbox
+										name={ 'stc_enabled' }
+										{ ...this.props }
+										label={ __( 'Show a "follow comments" option in the comment form.' ) } />
+								  </FormFieldset>
 								: ''
 						}
-					</div>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -13,7 +13,10 @@ import { FormFieldset } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const Antispam = moduleSettingsForm(
 	React.createClass( {
@@ -26,14 +29,15 @@ export const Antispam = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Antispam', { context: 'Settings header' } ) }
-					support="https://akismet.com/jetpack/">
-					<FormFieldset>
-						<ModuleSettingCheckbox
-							name={ 'akismet_show_user_comments_approved' }
-							{ ...this.props }
-							label={ __( 'Show the number of approved comments beside each comment author.' ) } />
-					</FormFieldset>
+					header={ __( 'Antispam', { context: 'Settings header' } ) }>
+					<SettingsGroup support="https://akismet.com/jetpack/">
+						<FormFieldset>
+							<ModuleSettingCheckbox
+								name={ 'akismet_show_user_comments_approved' }
+								{ ...this.props }
+								label={ __( 'Show the number of approved comments beside each comment author.' ) } />
+						</FormFieldset>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -10,7 +10,10 @@ import { translate as __ } from 'i18n-calypso';
  */
 import ExternalLink from 'components/external-link';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const BackupsScan = moduleSettingsForm(
 	React.createClass( {
@@ -24,21 +27,22 @@ export const BackupsScan = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
-					support="https://vaultpress.com/jetpack/"
 					hideButton>
-					<p>
-						{
-							__( 'Your site is backed up and threat-free.' )
-						}
-					</p>
-					<p className="jp-form-setting-explanation">
-						{
-							__( 'You can see the information about your backups and security scanning in the "At a Glance" section.' )
-						}
-					</p>
-					<p>
-						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
-					</p>
+					<SettingsGroup support="https://vaultpress.com/jetpack/">
+						<p>
+							{
+								__( 'Your site is backed up and threat-free.' )
+							}
+						</p>
+						<p className="jp-form-setting-explanation">
+							{
+								__( 'You can see the information about your backups and security scanning in the "At a Glance" section.' )
+							}
+						</p>
+						<p>
+							<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
+						</p>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -79,12 +79,12 @@ export const Protect = moduleSettingsForm(
 								this.props.getModule( 'protect' ).description
 							}
 						</span>
-						<p className="jp-form-setting-explanation">
-							{
-								__( 'Secure user authentication.' )
-							}
-						</p>
 					</ModuleToggle>
+					<p className="jp-form-setting-explanation">
+						{
+							__( 'Secure user authentication.' )
+						}
+					</p>
 					{
 						isProtectActive
 							? <div>

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -19,7 +19,10 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const Protect = moduleSettingsForm(
 	React.createClass( {
@@ -69,7 +72,7 @@ export const Protect = moduleSettingsForm(
 					{ ...this.props }
 					module="protect"
 					header={ __( 'Brute force protection', { context: 'Settings header' } ) } >
-					<div className="jp-form-has-child">
+					<SettingsGroup hasChild support={ this.props.getModule( 'protect' ).learn_more_button }>
 						<ModuleToggle slug="protect"
 									  compact
 									  activated={ isProtectActive }
@@ -125,7 +128,7 @@ export const Protect = moduleSettingsForm(
 								  </FormFieldset>
 								: ''
 						}
-					</div>
+					</SettingsGroup>
 				</SettingsCard>
 			)
 		}

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -69,42 +69,42 @@ export const Protect = moduleSettingsForm(
 					{ ...this.props }
 					module="protect"
 					header={ __( 'Brute force protection', { context: 'Settings header' } ) } >
-					<ModuleToggle slug="protect"
-								  compact
-								  activated={ isProtectActive }
-								  toggling={ this.props.isSavingAnyOption( 'protect' ) }
-								  toggleModule={ this.props.toggleModuleNow }>
+					<div className="jp-form-has-child">
+						<ModuleToggle slug="protect"
+									  compact
+									  activated={ isProtectActive }
+									  toggling={ this.props.isSavingAnyOption( 'protect' ) }
+									  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'protect' ).description
 							}
 						</span>
-					</ModuleToggle>
-					<p className="jp-form-setting-explanation">
+						</ModuleToggle>
+						<p className="jp-form-setting-explanation">
+							{
+								__( 'Secure user authentication.' )
+							}
+						</p>
 						{
-							__( 'Secure user authentication.' )
-						}
-					</p>
-					{
-						isProtectActive
-							? <div>
-								{
-									this.props.currentIp
-										? <p>
-										{
-											__( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
-										}
-										<br />
-										{
-											<Button
-												disabled={ this.currentIpIsWhitelisted() }
-												onClick={ this.addToWhitelist }
-												compact >{ __( 'Add to whitelist' ) }</Button>
-										}
-									</p>
-										: ''
-								}
-								<FormFieldset>
+							isProtectActive
+								? <FormFieldset>
+									{
+										this.props.currentIp
+											? <p>
+											{
+												__( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
+											}
+											<br />
+											{
+												<Button
+													disabled={ this.currentIpIsWhitelisted() }
+													onClick={ this.addToWhitelist }
+													compact >{ __( 'Add to whitelist' ) }</Button>
+											}
+										</p>
+											: ''
+									}
 									<FormLabel>
 										<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
 										<Textarea
@@ -112,7 +112,7 @@ export const Protect = moduleSettingsForm(
 											placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
 											onChange={ this.updateText }
 											value={ this.state.whitelist } />
-											</FormLabel>
+									</FormLabel>
 									<span className="jp-form-setting-explanation">
 										{
 											__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
@@ -122,10 +122,10 @@ export const Protect = moduleSettingsForm(
 											} )
 										}
 									</span>
-								</FormFieldset>
-							  </div>
-							: ''
-					}
+								  </FormFieldset>
+								: ''
+						}
+					</div>
 				</SettingsCard>
 			)
 		}

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -25,26 +25,26 @@ export const SSO = moduleSettingsForm(
 					{ ...this.props }
 					module="sso"
 					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
-					<ModuleToggle slug="sso"
-								  compact
-								  activated={ isSSOActive }
-								  toggling={ this.props.isSavingAnyOption( 'sso' ) }
-								  toggleModule={ this.props.toggleModuleNow }>
+					<div className="jp-form-has-child">
+						<ModuleToggle slug="sso"
+									  compact
+									  activated={ isSSOActive }
+									  toggling={ this.props.isSavingAnyOption( 'sso' ) }
+									  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'sso' ).description
 							}
 						</span>
-					</ModuleToggle>
-					{
-						isSSOActive
-							? <div>
-								<p className="jp-form-setting-explanation">
-									{
-										__( 'Use WordPress.com’s secure authentication.' )
-									}
-								</p>
-								<FormFieldset>
+						</ModuleToggle>
+						{
+							isSSOActive
+								? <FormFieldset>
+									<p className="jp-form-setting-explanation">
+										{
+											__( 'Use WordPress.com’s secure authentication.' )
+										}
+									</p>
 									<ModuleSettingCheckbox
 										name={ 'jetpack_sso_match_by_email' }
 										{ ...this.props }
@@ -53,10 +53,10 @@ export const SSO = moduleSettingsForm(
 										name={ 'jetpack_sso_require_two_step' }
 										{ ...this.props }
 										label={ __( 'Require two step authentication.' ) } />
-								</FormFieldset>
-							  </div>
-							: ''
-					}
+								  </FormFieldset>
+								: ''
+						}
+					</div>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -13,7 +13,10 @@ import { FormFieldset } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const SSO = moduleSettingsForm(
 	React.createClass( {
@@ -25,7 +28,7 @@ export const SSO = moduleSettingsForm(
 					{ ...this.props }
 					module="sso"
 					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
-					<div className="jp-form-has-child">
+					<SettingsGroup hasChild support={ this.props.getModule( 'sso' ).learn_more_button }>
 						<ModuleToggle slug="sso"
 									  compact
 									  activated={ isSSOActive }
@@ -56,7 +59,7 @@ export const SSO = moduleSettingsForm(
 								  </FormFieldset>
 								: ''
 						}
-					</div>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -4,10 +4,16 @@
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import ExternalLink from 'components/external-link';
+import Card from 'components/card';
+import FormToggle from 'components/form/form-toggle';
 
 /**
  * Internal dependencies
  */
+import {
+	FormFieldset
+} from 'components/forms';
+import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
@@ -15,14 +21,42 @@ import SettingsCard from 'components/settings-card';
 export const RelatedPosts = moduleSettingsForm(
 	React.createClass( {
 
+		/**
+		 * Get options for initial state.
+		 *
+		 * @returns {{show_headline: Boolean, show_thumbnails: Boolean}}
+		 */
+		getInitialState() {
+			return {
+				show_headline:   this.props.getOptionValue( 'show_headline', 'related-posts' ),
+				show_thumbnails: this.props.getOptionValue( 'show_thumbnails', 'related-posts' )
+			};
+		},
+
+		/**
+		 * Update state so preview is updated instantly and toggle options.
+		 *
+		 * @param optionName
+		 */
+		updateOptions( optionName ) {
+			this.setState(
+				{
+					[ optionName ]: ! this.state[ optionName ]
+				},
+				this.props.updateFormStateModuleOption( 'related-posts', optionName )
+			);
+		},
+
 		render() {
+			let isRelatedPostsActive = this.props.getOptionValue( 'related-posts' );
 			return (
 				<SettingsCard
 					{ ...this.props }
+					hideButton
 					module="related-posts">
 					<ModuleToggle slug="related-posts"
 								  compact
-								  activated={ this.props.getOptionValue( 'related-posts' ) }
+								  activated={ isRelatedPostsActive }
 								  toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
 								  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
@@ -32,12 +66,76 @@ export const RelatedPosts = moduleSettingsForm(
 						</span>
 					</ModuleToggle>
 					{
-						this.props.getOptionValue( 'related-posts' )
-							? (
-								<p>
-									<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ this.props.configureUrl }>{ __( 'Configure your Related Posts settings.' ) }</ExternalLink>
-								</p>
-							  )
+						// Only show controls if Related Posts module:
+						// - is active and it's not being toggled off
+						// - is inactive and it's being toggled on.
+						( isRelatedPostsActive && ! this.props.isSavingAnyOption( 'related-posts' ) ) ||
+						( ! isRelatedPostsActive && this.props.isSavingAnyOption( 'related-posts' ) )
+							? <FormFieldset>
+								{
+									__( '{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}', {
+										components: {
+											span: <span className="jp-form-setting-explanation" />,
+											ExternalLink: <ExternalLink
+												className="jp-module-settings__external-link"
+												href={ this.props.configureUrl } />
+										}
+									} )
+								}
+								<FormToggle compact
+											checked={ this.state.show_headline }
+											disabled={ this.props.isSavingAnyOption() }
+											onChange={ e => this.updateOptions( 'show_headline' ) }>
+									<span className="jp-form-toggle-explanation">
+										{
+											__( 'Show a "Related" header to more clearly separate the related section from posts' )
+										}
+									</span>
+								</FormToggle>
+								<br />
+								<FormToggle compact
+											checked={ this.state.show_thumbnails }
+											disabled={ this.props.isSavingAnyOption() }
+											onChange={ e => this.updateOptions( 'show_thumbnails' ) }>
+									<span className="jp-form-toggle-explanation">
+										{
+											__( 'Use a large and visually striking layout' )
+										}
+									</span>
+								</FormToggle>
+								<Card className="jp-related-posts-preview">
+									{
+										this.state.show_headline
+											? <div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div>
+											: ''
+									}
+									{
+										[
+											{
+												url : '1-wpios-ipad-3-1-viewsite.png',
+												text: __( 'Big iPhone/iPad Update Now Available' )
+											},
+											{
+												url : 'wordpress-com-news-wordpress-for-android-ui-update2.jpg',
+												text: __( 'The WordPress for Android App Gets a Big Facelift' )
+											},
+											{
+												url : 'videopresswedding.jpg',
+												text: __( 'Upgrade Focus: VideoPress For Weddings' )
+											}
+										].map( ( item, index ) => (
+											<span key={ `preview_${ index }` } className="jp-related-posts-preview__item">
+												{
+													this.state.show_thumbnails
+														? <img src={ `https://jetpackme.files.wordpress.com/2014/08/${ item.url }?w=350&h=200&crop=1` } />
+														: ''
+												}
+												<span><a href="#/traffic">{ item.text }</a></span>
+											</span>
+										) )
+									}
+								</Card>
+							  </FormFieldset>
 							: ''
 					}
 				</SettingsCard>

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -11,7 +11,8 @@ import FormToggle from 'components/form/form-toggle';
  * Internal dependencies
  */
 import {
-	FormFieldset
+	FormFieldset,
+	FormLabel
 } from 'components/forms';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import { ModuleToggle } from 'components/module-toggle';
@@ -76,70 +77,77 @@ export const RelatedPosts = moduleSettingsForm(
 							( isRelatedPostsActive && ! this.props.isSavingAnyOption( 'related-posts' ) ) ||
 							( ! isRelatedPostsActive && this.props.isSavingAnyOption( 'related-posts' ) )
 								? <FormFieldset>
-								{
-									__( '{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}', {
-										components: {
-											span: <span className="jp-form-setting-explanation" />,
-											ExternalLink: <ExternalLink
-												className="jp-module-settings__external-link"
-												href={ this.props.configureUrl } />
-										}
-									} )
-								}
-								<FormToggle compact
-											checked={ this.state.show_headline }
-											disabled={ this.props.isSavingAnyOption() }
-											onChange={ e => this.updateOptions( 'show_headline' ) }>
-									<span className="jp-form-toggle-explanation">
-										{
-											__( 'Show a "Related" header to more clearly separate the related section from posts' )
-										}
-									</span>
-								</FormToggle>
-								<br />
-								<FormToggle compact
-											checked={ this.state.show_thumbnails }
-											disabled={ this.props.isSavingAnyOption() }
-											onChange={ e => this.updateOptions( 'show_thumbnails' ) }>
-									<span className="jp-form-toggle-explanation">
-										{
-											__( 'Use a large and visually striking layout' )
-										}
-									</span>
-								</FormToggle>
-								<Card className="jp-related-posts-preview">
-									{
-										this.state.show_headline
-											? <div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div>
-											: ''
-									}
-									{
-										[
+									<FormToggle compact
+												checked={ this.state.show_headline }
+												disabled={ this.props.isSavingAnyOption() }
+												onChange={ e => this.updateOptions( 'show_headline' ) }>
+										<span className="jp-form-toggle-explanation">
 											{
-												url : '1-wpios-ipad-3-1-viewsite.png',
-												text: __( 'Big iPhone/iPad Update Now Available' )
-											},
-											{
-												url : 'wordpress-com-news-wordpress-for-android-ui-update2.jpg',
-												text: __( 'The WordPress for Android App Gets a Big Facelift' )
-											},
-											{
-												url : 'videopresswedding.jpg',
-												text: __( 'Upgrade Focus: VideoPress For Weddings' )
+												__( 'Show a "Related" header to more clearly separate the related section from posts' )
 											}
-										].map( ( item, index ) => (
-											<span key={ `preview_${ index }` } className="jp-related-posts-preview__item">
-												{
-													this.state.show_thumbnails
-														? <img src={ `https://jetpackme.files.wordpress.com/2014/08/${ item.url }?w=350&h=200&crop=1` } />
-														: ''
-												}
-												<span><a href="#/traffic">{ item.text }</a></span>
-											</span>
-										) )
+										</span>
+									</FormToggle>
+									<br />
+									<FormToggle compact
+												checked={ this.state.show_thumbnails }
+												disabled={ this.props.isSavingAnyOption() }
+												onChange={ e => this.updateOptions( 'show_thumbnails' ) }>
+										<span className="jp-form-toggle-explanation">
+											{
+												__( 'Use a large and visually striking layout' )
+											}
+										</span>
+									</FormToggle>
+									{
+										__( '{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}', {
+											components: {
+												span: <span className="jp-form-setting-explanation" />,
+												ExternalLink: <ExternalLink
+													className="jp-module-settings__external-link"
+													href={ this.props.configureUrl } />
+											}
+										} )
 									}
-								</Card>
-							</FormFieldset>
+									<FormLabel className="jp-form-label-wide">{ __( 'Preview' ) }</FormLabel>
+									<Card className="jp-related-posts-preview">
+										{
+											this.state.show_headline
+												? <div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div>
+												: ''
+										}
+										{
+											[
+												{
+													url : '1-wpios-ipad-3-1-viewsite.png',
+													text: __( 'Big iPhone/iPad Update Now Available' ),
+													context: __( 'In "Mobile"' )
+												},
+												{
+													url : 'wordpress-com-news-wordpress-for-android-ui-update2.jpg',
+													text: __( 'The WordPress for Android App Gets a Big Facelift' ),
+													context: __( 'In "Mobile"' )
+												},
+												{
+													url : 'videopresswedding.jpg',
+													text: __( 'Upgrade Focus: VideoPress For Weddings' ),
+													context: __( 'In "Upgrade"' )
+												}
+											].map( ( item, index ) => (
+												<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
+													{
+														this.state.show_thumbnails
+															? <img src={ `https://jetpackme.files.wordpress.com/2014/08/${ item.url }?w=350&h=200&crop=1` } />
+															: ''
+													}
+													<h4 className="jp-related-posts-preview__post-title"><a href="#/traffic">{ item.text }</a></h4>
+													<p  className="jp-related-posts-preview__post-context">
+														{ item.context }
+													</p>
+												</div>
+											) )
+										}
+									</Card>
+								 </FormFieldset>
 								: ''
 						}
 					</SettingsGroup>

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -16,7 +16,10 @@ import {
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const RelatedPosts = moduleSettingsForm(
 	React.createClass( {
@@ -54,7 +57,7 @@ export const RelatedPosts = moduleSettingsForm(
 					{ ...this.props }
 					hideButton
 					module="related-posts">
-					<div className="jp-form-has-child">
+					<SettingsGroup hasChild support={ this.props.getModule( 'related-posts' ).learn_more_button }>
 						<ModuleToggle slug="related-posts"
 									  compact
 									  activated={ isRelatedPostsActive }
@@ -139,7 +142,7 @@ export const RelatedPosts = moduleSettingsForm(
 							</FormFieldset>
 								: ''
 						}
-					</div>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -54,24 +54,25 @@ export const RelatedPosts = moduleSettingsForm(
 					{ ...this.props }
 					hideButton
 					module="related-posts">
-					<ModuleToggle slug="related-posts"
-								  compact
-								  activated={ isRelatedPostsActive }
-								  toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
-								  toggleModule={ this.props.toggleModuleNow }>
+					<div className="jp-form-has-child">
+						<ModuleToggle slug="related-posts"
+									  compact
+									  activated={ isRelatedPostsActive }
+									  toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
+									  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Show related content after posts.' )
 							}
 						</span>
-					</ModuleToggle>
-					{
-						// Only show controls if Related Posts module:
-						// - is active and it's not being toggled off
-						// - is inactive and it's being toggled on.
-						( isRelatedPostsActive && ! this.props.isSavingAnyOption( 'related-posts' ) ) ||
-						( ! isRelatedPostsActive && this.props.isSavingAnyOption( 'related-posts' ) )
-							? <FormFieldset>
+						</ModuleToggle>
+						{
+							// Only show controls if Related Posts module:
+							// - is active and it's not being toggled off
+							// - is inactive and it's being toggled on.
+							( isRelatedPostsActive && ! this.props.isSavingAnyOption( 'related-posts' ) ) ||
+							( ! isRelatedPostsActive && this.props.isSavingAnyOption( 'related-posts' ) )
+								? <FormFieldset>
 								{
 									__( '{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}', {
 										components: {
@@ -135,9 +136,10 @@ export const RelatedPosts = moduleSettingsForm(
 										) )
 									}
 								</Card>
-							  </FormFieldset>
-							: ''
-					}
+							</FormFieldset>
+								: ''
+						}
+					</div>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -10,7 +10,10 @@ import ExternalLink from 'components/external-link';
  * Internal dependencies
  */
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const SEO = moduleSettingsForm(
 	React.createClass( {
@@ -20,22 +23,23 @@ export const SEO = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Search Engine Optimization', { context: 'Settings header' } ) }
-					support="https://jetpack.com/support/seo-tools/"
 					hideButton>
-					<p>
-						{
-							__( "You can tweak these settings if you'd like more advanced control. Read more about what you can do to {{a}}optimize your site's SEO{{/a}}.",
-								{
-									components: {
-										a: <a href="https://jetpack.com/support/seo-tools/" />
+					<SettingsGroup support="https://jetpack.com/support/seo-tools/">
+						<p>
+							{
+								__( "You can tweak these settings if you'd like more advanced control. Read more about what you can do to {{a}}optimize your site's SEO{{/a}}.",
+									{
+										components: {
+											a: <a href="https://jetpack.com/support/seo-tools/" />
+										}
 									}
-								}
-							)
-						}
-					</p>
-					<p>
-						<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ this.props.configureUrl }>{ __( 'Configure your SEO settings.' ) }</ExternalLink>
-					</p>
+								)
+							}
+						</p>
+						<p>
+							<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ this.props.configureUrl }>{ __( 'Configure your SEO settings.' ) }</ExternalLink>
+						</p>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -19,60 +19,66 @@ import {
 	ModuleSettingSelect,
 	ModuleSettingMultipleSelectCheckboxes
 } from 'components/module-settings/form-components';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 import InlineExpand from 'components/inline-expand';
 
 export const SiteStats = moduleSettingsForm(
 	React.createClass( {
 
 		render() {
+			let stats = this.props.getModule( 'stats' );
 			return (
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Site stats' ) }
 					module="stats">
-					<FormFieldset>
-						<ModuleToggle slug="stats"
-									  compact
-									  activated={ !!this.props.getOptionValue( 'admin_bar' ) }
-									  toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
-									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }>
+					<SettingsGroup support={ stats.learn_more_button }>
+						<FormFieldset>
+							<ModuleToggle slug="stats"
+										  compact
+										  activated={ !!this.props.getOptionValue( 'admin_bar' ) }
+										  toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
+										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
 									__( 'Put a chart showing 48 hours of views in the admin bar.' )
 								}
 							</span>
-						</ModuleToggle>
-						<br />
-						<ModuleToggle slug="stats"
-									  compact
-									  activated={ !!this.props.getOptionValue( 'hide_smile' ) }
-									  toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
-									  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }>
+							</ModuleToggle>
+							<br />
+							<ModuleToggle slug="stats"
+										  compact
+										  activated={ !!this.props.getOptionValue( 'hide_smile' ) }
+										  toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
+										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
 									__( 'Hide the stats smiley face image. The image helps collect stats, but should work when hidden.' )
 								}
 							</span>
-						</ModuleToggle>
-					</FormFieldset>
-					<InlineExpand label={ __( 'Serious options' ) }>
-						<FormFieldset>
-							<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
-							<ModuleSettingMultipleSelectCheckboxes
-								name={ 'count_roles' }
-								{ ...this.props }
-								validValues={ this.props.getSiteRoles() } />
+							</ModuleToggle>
 						</FormFieldset>
-						<FormFieldset>
-							<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
-							<ModuleSettingMultipleSelectCheckboxes
-								always_checked={ [ 'administrator' ] }
-								name={ 'roles' }
-								{ ...this.props }
-								validValues={ this.props.getSiteRoles() } />
-						</FormFieldset>
-					</InlineExpand>
+						<InlineExpand label={ __( 'Serious options' ) }>
+							<FormFieldset>
+								<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
+								<ModuleSettingMultipleSelectCheckboxes
+									name={ 'count_roles' }
+									{ ...this.props }
+									validValues={ this.props.getSiteRoles() } />
+							</FormFieldset>
+							<FormFieldset>
+								<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
+								<ModuleSettingMultipleSelectCheckboxes
+									always_checked={ [ 'administrator' ] }
+									name={ 'roles' }
+									{ ...this.props }
+									validValues={ this.props.getSiteRoles() } />
+							</FormFieldset>
+						</InlineExpand>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -18,125 +18,133 @@ import {
 } from 'components/forms';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingSelect } from 'components/module-settings/form-components';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const VerificationServices = moduleSettingsForm(
 	React.createClass( {
 
 		render() {
-			let module = this.props.getModule( 'sitemaps' ),
-				sitemap_url = get( module, [ 'extra', 'sitemap_url' ], '' ),
-				news_sitemap_url = get( module, [ 'extra', 'news_sitemap_url' ], '' );
+			let verification     = this.props.getModule( 'verification-tools' ),
+				sitemaps         = this.props.getModule( 'sitemaps' ),
+				sitemap_url      = get( sitemaps, [ 'extra', 'sitemap_url' ], '' ),
+				news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' );
 			return (
 				<SettingsCard
 					{ ...this.props }
 					module="verification-tools">
-					<p>
-						{ __(
-							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order for your site to be indexed by search engines. To use these advanced search engine tools and verify your site with a service, paste the HTML Tag code below. Read the {{support}}full instructions{{/support}} if you are having trouble. Supported verification services: {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}}, {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
+					<SettingsGroup support={ verification.learn_more_button }>
+						<p>
+							{ __(
+								'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order for your site to be indexed by search engines. To use these advanced search engine tools and verify your site with a service, paste the HTML Tag code below. Read the {{support}}full instructions{{/support}} if you are having trouble. Supported verification services: {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}}, {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
+								{
+									components: {
+										b: <strong />,
+										support: <a href="https://support.wordpress.com/webmaster-tools/" />,
+										google: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="https://www.google.com/webmasters/tools/"
+											/>
+										),
+										bing: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="https://www.bing.com/webmaster/"
+											/>
+										),
+										pinterest: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="https://pinterest.com/website/verify/"
+											/>
+										),
+										yandex: (
+											<ExternalLink
+												icon={ true }
+												target="_blank"
+												href="https://webmaster.yandex.com/sites/"
+											/>
+										)
+									}
+								}
+							) }
+						</p>
+						<FormFieldset>
 							{
-								components: {
-									b: <strong />,
-									support: <a href="https://support.wordpress.com/webmaster-tools/" />,
-									google: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://www.google.com/webmasters/tools/"
-										/>
-									),
-									bing: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://www.bing.com/webmaster/"
-										/>
-									),
-									pinterest: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://pinterest.com/website/verify/"
-										/>
-									),
-									yandex: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											href="https://webmaster.yandex.com/sites/"
-										/>
-									)
-								}
+								[
+									{
+										id: 'google',
+										label: __( 'Google' ),
+										placeholder: '<meta name="google-site-verification" content="1234" />'
+									},
+									{
+										id: 'bing',
+										label: __( 'Bing' ),
+										placeholder: '<meta name="msvalidate.01" content="1234" />'
+									},
+									{
+										id: 'pinterest',
+										label: __( 'Pinterest' ),
+										placeholder: '<meta name="p:domain_verify" content="1234" />'
+									},
+									{
+										id: 'yandex',
+										label: __( 'Yandex' ),
+										placeholder: '<meta name="yandex-verification" content="1234" />'
+									}
+								].map( item => (
+									<FormLabel
+										className="jp-form-input-with-prefix"
+										key={ `verification_service_${ item.id }` }>
+										<span>{ item.label }</span>
+										<TextInput
+											name={ item.id }
+											value={ this.props.getOptionValue( item.id ) }
+											placeholder={ item.placeholder }
+											className="code"
+											disabled={ this.props.isUpdating( item.id ) }
+											onChange={ this.props.onOptionChange} />
+									</FormLabel>
+								) )
 							}
-						) }
-					</p>
-					<FormFieldset>
-						{
-							[
-								{
-									id: 'google',
-									label: __( 'Google' ),
-									placeholder: '<meta name="google-site-verification" content="1234" />'
-								},
-								{
-									id: 'bing',
-									label: __( 'Bing' ),
-									placeholder: '<meta name="msvalidate.01" content="1234" />'
-								},
-								{
-									id: 'pinterest',
-									label: __( 'Pinterest' ),
-									placeholder: '<meta name="p:domain_verify" content="1234" />'
-								},
-								{
-									id: 'yandex',
-									label: __( 'Yandex' ),
-									placeholder: '<meta name="yandex-verification" content="1234" />'
-								}
-							].map( item => (
-								<FormLabel
-									className="jp-form-input-with-prefix"
-									key={ `verification_service_${ item.id }` }>
-									<span>{ item.label }</span>
-									<TextInput
-										name={ item.id }
-										value={ this.props.getOptionValue( item.id ) }
-										placeholder={ item.placeholder }
-										className="code"
-										disabled={ this.props.isUpdating( item.id ) }
-										onChange={ this.props.onOptionChange} />
-								</FormLabel>
-							) )
-						}
-					</FormFieldset>
-					<FormFieldset>
-						<FormLegend>{ __( 'XML Sitemaps' ) }</FormLegend>
-						<div>
-							<p>{ __( 'Search engines will find the sitemaps at these locations:' ) }</p>
-							<ul>
-								{
-									[
-										{
-											id: 'sitemap',
-											label: __( 'Sitemaps' ),
-											url: sitemap_url
-										},
-										{
-											id: 'news_sitemap',
-											label: __( 'News Sitemaps' ),
-											url: news_sitemap_url
-										}
-									].map( item => (
-										<li key={ `xml_${ item.id }` }>
-											<strong>{ item.label }</strong>
-											<br />
-											<ExternalLink icon={ true } target="_blank" href={ item.url }>{ item.url }</ExternalLink>
-										</li>
-									) )
-								}
-							</ul>
-						</div>
-					</FormFieldset>
+						</FormFieldset>
+					</SettingsGroup>
+					<SettingsGroup support={ sitemaps.learn_more_button }>
+						<FormFieldset>
+							<FormLegend>{ __( 'XML Sitemaps' ) }</FormLegend>
+							<div>
+								<p>{ __( 'Search engines will find the sitemaps at these locations:' ) }</p>
+								<ul>
+									{
+										[
+											{
+												id: 'sitemap',
+												label: __( 'Sitemaps' ),
+												url: sitemap_url
+											},
+											{
+												id: 'news_sitemap',
+												label: __( 'News Sitemaps' ),
+												url: news_sitemap_url
+											}
+										].map( item => (
+											<li key={ `xml_${ item.id }` }>
+												<strong>{ item.label }</strong>
+												<br />
+												<ExternalLink icon={ true } target="_blank" href={ item.url }>{ item.url }</ExternalLink>
+											</li>
+										) )
+									}
+								</ul>
+							</div>
+						</FormFieldset>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -18,7 +18,10 @@ import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import TagsInput from 'components/tags-input';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 import InlineExpand from 'components/inline-expand';
 
 export const Composing = moduleSettingsForm(
@@ -99,36 +102,37 @@ export const Composing = moduleSettingsForm(
 
 			return (
 				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props }>
-					<FormFieldset support={ markdown.learn_more_button }>
-						<ModuleToggle slug="markdown"
-									  compact
-									  activated={ this.props.getOptionValue( 'markdown' ) }
-									  toggling={ this.props.isSavingAnyOption( 'markdown' ) }
-									  toggleModule={ this.props.toggleModuleNow }>
-							<span className="jp-form-toggle-explanation">
-								{ markdown.description }
-							</span>
-						</ModuleToggle>
-					</FormFieldset>
-					<hr />
-					<div className="jp-form-has-child">
+					<SettingsGroup support={ markdown.learn_more_button }>
+						<FormFieldset>
+							<ModuleToggle slug="markdown"
+										  compact
+										  activated={ this.props.getOptionValue( 'markdown' ) }
+										  toggling={ this.props.isSavingAnyOption( 'markdown' ) }
+										  toggleModule={ this.props.toggleModuleNow }>
+								<span className="jp-form-toggle-explanation">
+									{ markdown.description }
+								</span>
+							</ModuleToggle>
+						</FormFieldset>
+					</SettingsGroup>
+					<SettingsGroup hasChild support={ atd.learn_more_button }>
 						<ModuleToggle slug="after-the-deadline"
 									  compact
 									  activated={ this.props.getOptionValue( 'after-the-deadline' ) }
 									  toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
 									  toggleModule={ this.props.toggleModuleNow }>
-						<span className="jp-form-toggle-explanation">
-							{ atd.description }
-						</span>
+							<span className="jp-form-toggle-explanation">
+								{ atd.description }
+							</span>
 						</ModuleToggle>
-						<FormFieldset support={ atd.learn_more_button }>
+						<FormFieldset>
 							{
 								this.props.getOptionValue( 'after-the-deadline' )
 									? <InlineExpand label={ __( 'Fancy options' ) }>{ this.getAtdSettings() }</InlineExpand>
 									: ''
 							}
 						</FormFieldset>
-					</div>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -111,22 +111,24 @@ export const Composing = moduleSettingsForm(
 						</ModuleToggle>
 					</FormFieldset>
 					<hr />
-					<FormFieldset support={ atd.learn_more_button }>
+					<div className="jp-form-has-child">
 						<ModuleToggle slug="after-the-deadline"
 									  compact
 									  activated={ this.props.getOptionValue( 'after-the-deadline' ) }
 									  toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
 									  toggleModule={ this.props.toggleModuleNow }>
-							<span className="jp-form-toggle-explanation">
-								{ atd.description }
-							</span>
+						<span className="jp-form-toggle-explanation">
+							{ atd.description }
+						</span>
 						</ModuleToggle>
-						{
-							this.props.getOptionValue( 'after-the-deadline' )
-								? <InlineExpand label={ __( 'Fancy options' ) }>{ this.getAtdSettings() }</InlineExpand>
-								: ''
-						}
-					</FormFieldset>
+						<FormFieldset support={ atd.learn_more_button }>
+							{
+								this.props.getOptionValue( 'after-the-deadline' )
+									? <InlineExpand label={ __( 'Fancy options' ) }>{ this.getAtdSettings() }</InlineExpand>
+									: ''
+							}
+						</FormFieldset>
+					</div>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -60,22 +60,22 @@ export const CustomContentTypes = moduleSettingsForm(
 					{ ...this.props }
 					module="custom-content-types"
 					hideButton>
-					<FormFieldset>
-						<p>
+					<p>
+						{
+							module.description
+						}
+					</p>
+					<FormToggle compact
+								checked={ this.state.testimonial }
+								disabled={ this.props.isSavingAnyOption() }
+								onChange={ e => this.updateCPTs( 'testimonial' ) }>
+						<span className="jp-form-toggle-explanation">
 							{
-								module.description
+								__( 'Enable Testimonial custom content types.' )
 							}
-						</p>
-						<FormToggle compact
-									checked={ this.state.testimonial }
-									disabled={ this.props.isSavingAnyOption() }
-									onChange={ e => this.updateCPTs( 'testimonial' ) }>
-							<span className="jp-form-toggle-explanation">
-								{
-									__( 'Enable Testimonial custom content types.' )
-								}
-							</span>
-						</FormToggle>
+						</span>
+					</FormToggle>
+					<FormFieldset>
 						{
 							this.state.testimonial
 								? <p className="jp-form-setting-explanation">
@@ -88,17 +88,18 @@ export const CustomContentTypes = moduleSettingsForm(
 						{
 							this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
 						}
-						<br />
-						<FormToggle compact
-									checked={ this.state.portfolio }
-									disabled={ this.props.isSavingAnyOption() }
-									onChange={ e => this.updateCPTs( 'portfolio' ) }>
-							<span className="jp-form-toggle-explanation">
-								{
-									__( 'Enable Portfolio custom content types.' )
-								}
-							</span>
-						</FormToggle>
+					</FormFieldset>
+					<FormToggle compact
+								checked={ this.state.portfolio }
+								disabled={ this.props.isSavingAnyOption() }
+								onChange={ e => this.updateCPTs( 'portfolio' ) }>
+						<span className="jp-form-toggle-explanation">
+							{
+								__( 'Enable Portfolio custom content types.' )
+							}
+						</span>
+					</FormToggle>
+					<FormFieldset>
 						{
 							this.state.portfolio
 								? <p className="jp-form-setting-explanation">

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -16,7 +16,10 @@ import {
 	FormLabel
 } from 'components/forms';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const CustomContentTypes = moduleSettingsForm(
 	React.createClass( {
@@ -60,21 +63,21 @@ export const CustomContentTypes = moduleSettingsForm(
 					{ ...this.props }
 					module="custom-content-types"
 					hideButton>
-					<p>
-						{
-							module.description
-						}
-					</p>
-					<div className="jp-form-has-child">
+					<SettingsGroup hasChild support={ module.learn_more_button }>
+						<p>
+							{
+								module.description
+							}
+						</p>
 						<FormToggle compact
 									checked={ this.state.testimonial }
 									disabled={ this.props.isSavingAnyOption() }
 									onChange={ e => this.updateCPTs( 'testimonial' ) }>
-						<span className="jp-form-toggle-explanation">
-							{
-								__( 'Enable Testimonial custom content types.' )
-							}
-						</span>
+							<span className="jp-form-toggle-explanation">
+								{
+									__( 'Enable Testimonial custom content types.' )
+								}
+							</span>
 						</FormToggle>
 						<FormFieldset>
 							{
@@ -86,21 +89,21 @@ export const CustomContentTypes = moduleSettingsForm(
 								</p>
 									: ''
 							}
-							{
-								this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
-							}
+							<p>
+								{
+									this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
+								}
+							</p>
 						</FormFieldset>
-					</div>
-					<div className="jp-form-has-child">
 						<FormToggle compact
 									checked={ this.state.portfolio }
 									disabled={ this.props.isSavingAnyOption() }
 									onChange={ e => this.updateCPTs( 'portfolio' ) }>
-						<span className="jp-form-toggle-explanation">
-							{
-								__( 'Enable Portfolio custom content types.' )
-							}
-						</span>
+							<span className="jp-form-toggle-explanation">
+								{
+									__( 'Enable Portfolio custom content types.' )
+								}
+							</span>
 						</FormToggle>
 						<FormFieldset>
 							{
@@ -112,11 +115,13 @@ export const CustomContentTypes = moduleSettingsForm(
 								</p>
 									: ''
 							}
-							{
-								this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
-							}
+							<p>
+								{
+									this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
+								}
+							</p>
 						</FormFieldset>
-					</div>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -65,54 +65,58 @@ export const CustomContentTypes = moduleSettingsForm(
 							module.description
 						}
 					</p>
-					<FormToggle compact
-								checked={ this.state.testimonial }
-								disabled={ this.props.isSavingAnyOption() }
-								onChange={ e => this.updateCPTs( 'testimonial' ) }>
+					<div className="jp-form-has-child">
+						<FormToggle compact
+									checked={ this.state.testimonial }
+									disabled={ this.props.isSavingAnyOption() }
+									onChange={ e => this.updateCPTs( 'testimonial' ) }>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Enable Testimonial custom content types.' )
 							}
 						</span>
-					</FormToggle>
-					<FormFieldset>
-						{
-							this.state.testimonial
-								? <p className="jp-form-setting-explanation">
+						</FormToggle>
+						<FormFieldset>
+							{
+								this.state.testimonial
+									? <p className="jp-form-setting-explanation">
 									{
 										__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
 									}
-								  </p>
-								: ''
-						}
-						{
-							this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
-						}
-					</FormFieldset>
-					<FormToggle compact
-								checked={ this.state.portfolio }
-								disabled={ this.props.isSavingAnyOption() }
-								onChange={ e => this.updateCPTs( 'portfolio' ) }>
+								</p>
+									: ''
+							}
+							{
+								this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
+							}
+						</FormFieldset>
+					</div>
+					<div className="jp-form-has-child">
+						<FormToggle compact
+									checked={ this.state.portfolio }
+									disabled={ this.props.isSavingAnyOption() }
+									onChange={ e => this.updateCPTs( 'portfolio' ) }>
 						<span className="jp-form-toggle-explanation">
 							{
 								__( 'Enable Portfolio custom content types.' )
 							}
 						</span>
-					</FormToggle>
-					<FormFieldset>
-						{
-							this.state.portfolio
-								? <p className="jp-form-setting-explanation">
+						</FormToggle>
+						<FormFieldset>
+							{
+								this.state.portfolio
+									? <p className="jp-form-setting-explanation">
 									{
 										__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
 									}
-								  </p>
-								: ''
-						}
-						{
-							this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
-						}
-					</FormFieldset>
+								</p>
+									: ''
+							}
+							{
+								this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
+							}
+						</FormFieldset>
+					</div>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -45,25 +45,22 @@ export const Media = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Media' ) }>
-					<FormFieldset support={ photon.learn_more_button }>
-						<ModuleToggle slug="photon"
-									  compact
-									  activated={ this.props.getOptionValue( 'photon' ) }
-									  toggling={ this.props.isSavingAnyOption( 'photon' ) }
-									  toggleModule={ this.toggleModule }>
-							<span className="jp-form-toggle-explanation">
-								{
-									photon.description
-								}
-							</span>
-							<span className="jp-form-setting-explanation">
-								{
-									__( 'Enabling Photon is required to use Tiled Galleries.' )
-								}
-							</span>
-						</ModuleToggle>
-					</FormFieldset>
-					<hr />
+					<ModuleToggle slug="photon"
+								  compact
+								  activated={ this.props.getOptionValue( 'photon' ) }
+								  toggling={ this.props.isSavingAnyOption( 'photon' ) }
+								  toggleModule={ this.toggleModule }>
+						<span className="jp-form-toggle-explanation">
+							{
+								photon.description
+							}
+						</span>
+					</ModuleToggle>
+					<span className="jp-form-setting-explanation">
+						{
+							__( 'Enabling Photon is required to use Tiled Galleries.' )
+						}
+					</span>
 					<ModuleToggle slug="carousel"
 								  compact
 								  activated={ isCarouselActive }

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -45,36 +45,39 @@ export const Media = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Media' ) }>
-					<ModuleToggle slug="photon"
-								  compact
-								  activated={ this.props.getOptionValue( 'photon' ) }
-								  toggling={ this.props.isSavingAnyOption( 'photon' ) }
-								  toggleModule={ this.toggleModule }>
+					<div className="jp-form-has-child">
+						<ModuleToggle slug="photon"
+									  compact
+									  activated={ this.props.getOptionValue( 'photon' ) }
+									  toggling={ this.props.isSavingAnyOption( 'photon' ) }
+									  toggleModule={ this.toggleModule }>
 						<span className="jp-form-toggle-explanation">
 							{
 								photon.description
 							}
 						</span>
-					</ModuleToggle>
-					<span className="jp-form-setting-explanation">
-						{
-							__( 'Enabling Photon is required to use Tiled Galleries.' )
-						}
-					</span>
-					<ModuleToggle slug="carousel"
-								  compact
-								  activated={ isCarouselActive }
-								  toggling={ this.props.isSavingAnyOption( 'carousel' ) }
-								  toggleModule={ this.props.toggleModuleNow }>
+						</ModuleToggle>
+						<span className="jp-form-setting-explanation">
+							{
+								__( 'Enabling Photon is required to use Tiled Galleries.' )
+							}
+						</span>
+					</div>
+					<div className="jp-form-has-child">
+						<ModuleToggle slug="carousel"
+									  compact
+									  activated={ isCarouselActive }
+									  toggling={ this.props.isSavingAnyOption( 'carousel' ) }
+									  toggleModule={ this.props.toggleModuleNow }>
 								<span className="jp-form-toggle-explanation">
 									{
 										carousel.description
 									}
 								</span>
-					</ModuleToggle>
-					{
-						isCarouselActive
-							? <FormFieldset support={ carousel.learn_more_button }>
+						</ModuleToggle>
+						{
+							isCarouselActive
+								? <FormFieldset support={ carousel.learn_more_button }>
 								<ModuleSettingCheckbox
 									name={ 'carousel_display_exif' }
 									{ ...this.props }
@@ -87,9 +90,10 @@ export const Media = moduleSettingsForm(
 										{ ...this.props }
 										validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
 								</FormLabel>
-							  </FormFieldset>
-							: ''
-					}
+							</FormFieldset>
+								: ''
+						}
+					</div>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -17,7 +17,10 @@ import {
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const Media = moduleSettingsForm(
 	React.createClass( {
@@ -45,7 +48,7 @@ export const Media = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Media' ) }>
-					<div className="jp-form-has-child">
+					<SettingsGroup hasChild support={ photon.learn_more_button }>
 						<ModuleToggle slug="photon"
 									  compact
 									  activated={ this.props.getOptionValue( 'photon' ) }
@@ -62,8 +65,8 @@ export const Media = moduleSettingsForm(
 								__( 'Enabling Photon is required to use Tiled Galleries.' )
 							}
 						</span>
-					</div>
-					<div className="jp-form-has-child">
+					</SettingsGroup>
+					<SettingsGroup hasChild support={ carousel.learn_more_button }>
 						<ModuleToggle slug="carousel"
 									  compact
 									  activated={ isCarouselActive }
@@ -77,23 +80,23 @@ export const Media = moduleSettingsForm(
 						</ModuleToggle>
 						{
 							isCarouselActive
-								? <FormFieldset support={ carousel.learn_more_button }>
-								<ModuleSettingCheckbox
-									name={ 'carousel_display_exif' }
-									{ ...this.props }
-									label={ __( 'Show photo metadata (Exif) in carousel, when available' ) } />
-								<FormLabel>
-									<FormLegend className="jp-form-label-wide">{ __( 'Background color' ) }</FormLegend>
-									<FormSelect
-										name={ 'carousel_background_color' }
-										value={ this.props.getOptionValue( 'carousel_background_color' ) }
+								? <FormFieldset>
+									<ModuleSettingCheckbox
+										name={ 'carousel_display_exif' }
 										{ ...this.props }
-										validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
-								</FormLabel>
-							</FormFieldset>
+										label={ __( 'Show photo metadata (Exif) in carousel, when available' ) } />
+									<FormLabel>
+										<FormLegend className="jp-form-label-wide">{ __( 'Background color' ) }</FormLegend>
+										<FormSelect
+											name={ 'carousel_background_color' }
+											value={ this.props.getOptionValue( 'carousel_background_color' ) }
+											{ ...this.props }
+											validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
+									</FormLabel>
+								  </FormFieldset>
 								: ''
 						}
-					</div>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -44,20 +44,21 @@ export const PostByEmail = moduleSettingsForm(
 					{ ...this.props }
 					module="post-by-email"
 					hideButton>
-					<ModuleToggle slug="post-by-email"
-								  compact
-								  activated={ isPbeActive }
-								  toggling={ this.props.isSavingAnyOption( 'post-by-email' ) }
-								  toggleModule={ this.props.toggleModuleNow }>
+					<div className="jp-form-has-child">
+						<ModuleToggle slug="post-by-email"
+									  compact
+									  activated={ isPbeActive }
+									  toggling={ this.props.isSavingAnyOption( 'post-by-email' ) }
+									  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'post-by-email' ).description
 							}
 						</span>
-					</ModuleToggle>
-					{
-						isPbeActive
-							? <FormFieldset>
+						</ModuleToggle>
+						{
+							isPbeActive
+								? <FormFieldset>
 								<FormLabel>
 									<FormLegend>{ __( 'Email Address' ) }</FormLegend>
 									<ClipboardButtonInput
@@ -71,9 +72,10 @@ export const PostByEmail = moduleSettingsForm(
 									onClick={ this.regeneratePostByEmailAddress } >
 									{ __( 'Regenerate address' ) }
 								</Button>
-							  </FormFieldset>
-							: ''
-					}
+							</FormFieldset>
+								: ''
+						}
+					</div>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -17,7 +17,10 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const PostByEmail = moduleSettingsForm(
 	React.createClass( {
@@ -38,13 +41,14 @@ export const PostByEmail = moduleSettingsForm(
 		},
 
 		render() {
-			let isPbeActive = this.props.getOptionValue( 'post-by-email' );
+			let postByEmail = this.props.getModule( 'post-by-email' ),
+				isPbeActive = this.props.getOptionValue( 'post-by-email' );
 			return (
 				<SettingsCard
 					{ ...this.props }
 					module="post-by-email"
 					hideButton>
-					<div className="jp-form-has-child">
+					<SettingsGroup hasChild support={ postByEmail.learn_more_button }>
 						<ModuleToggle slug="post-by-email"
 									  compact
 									  activated={ isPbeActive }
@@ -59,23 +63,23 @@ export const PostByEmail = moduleSettingsForm(
 						{
 							isPbeActive
 								? <FormFieldset>
-								<FormLabel>
-									<FormLegend>{ __( 'Email Address' ) }</FormLegend>
-									<ClipboardButtonInput
-										value={ this.address() }
-										copy={ __( 'Copy', { context: 'verb' } ) }
-										copied={ __( 'Copied!' ) }
-										prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
-									/>
-								</FormLabel>
-								<Button
-									onClick={ this.regeneratePostByEmailAddress } >
-									{ __( 'Regenerate address' ) }
-								</Button>
-							</FormFieldset>
+									<FormLabel>
+										<FormLegend>{ __( 'Email Address' ) }</FormLegend>
+										<ClipboardButtonInput
+											value={ this.address() }
+											copy={ __( 'Copy', { context: 'verb' } ) }
+											copied={ __( 'Copied!' ) }
+											prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+										/>
+									</FormLabel>
+									<Button
+										onClick={ this.regeneratePostByEmailAddress } >
+										{ __( 'Regenerate address' ) }
+									</Button>
+								  </FormFieldset>
 								: ''
 						}
-					</div>
+					</SettingsGroup>
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -58,18 +58,18 @@ export const ThemeEnhancements = moduleSettingsForm(
 						].map( item => {
 							return (
 								<div key={ `theme_enhancement_${ item.module }` }>
+									<ModuleToggle slug={ item.module }
+												  compact
+												  activated={ this.props.getOptionValue( item.module ) }
+												  toggling={ this.props.isSavingAnyOption( item.module ) }
+												  toggleModule={ this.props.toggleModuleNow }>
+									<span className="jp-form-toggle-explanation">
+									{
+										item.description
+									}
+									</span>
+									</ModuleToggle>
 									<FormFieldset support={ item.learn_more_button }>
-										<ModuleToggle slug={ item.module }
-													  compact
-													  activated={ this.props.getOptionValue( item.module ) }
-													  toggling={ this.props.isSavingAnyOption( item.module ) }
-													  toggleModule={ this.props.toggleModuleNow }>
-										<span className="jp-form-toggle-explanation">
-										{
-											item.description
-										}
-										</span>
-										</ModuleToggle>
 										{
 											this.props.getOptionValue( item.module )
 												? item.checkboxes.map( chkbx => {

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -4,6 +4,7 @@
 import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
@@ -12,7 +13,10 @@ import { FormFieldset } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
-import SettingsCard from 'components/settings-card';
+import {
+	SettingsCard,
+	SettingsGroup
+} from 'components/settings-card';
 
 export const ThemeEnhancements = moduleSettingsForm(
 	React.createClass( {
@@ -35,8 +39,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 										key: 'infinite_scroll_google_analytics',
 										label: __( 'Track each infinite Scroll post load as a page view in Google Analytics' )
 									}
-								],
-								separator: true
+								]
 							},
 							{
 								...this.props.getModule( 'minileven' ),
@@ -57,7 +60,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 							}
 						].map( item => {
 							return (
-								<div className="jp-form-has-child" key={ `theme_enhancement_${ item.module }` }>
+								<Card compact className="jp-form-has-child" key={ `theme_enhancement_${ item.module }` }>
 									<ModuleToggle slug={ item.module }
 												  compact
 												  activated={ this.props.getOptionValue( item.module ) }
@@ -83,12 +86,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 												: ''
 										}
 									</FormFieldset>
-									{
-										item.separator
-											? <hr />
-											: ''
-									}
-								</div>
+								</Card>
 							);
 						} )
 					}

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -57,7 +57,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 							}
 						].map( item => {
 							return (
-								<div key={ `theme_enhancement_${ item.module }` }>
+								<div className="jp-form-has-child" key={ `theme_enhancement_${ item.module }` }>
 									<ModuleToggle slug={ item.module }
 												  compact
 												  activated={ this.props.getOptionValue( item.module ) }


### PR DESCRIPTION
Fixes #6037

#### Changes proposed in this Pull Request:

## Indentation
- All settings that are child of a toggle will be indented, as well as explanation related to a toggle immediately above.
- They're wrapped with `div.jp-form-has-child` that doesn't add margin on its own but delegates to the first `.jp-form-fieldset` and `.jp-form-setting-explanation` inside it.

Related conversation in Slack p1485210196000238-slack-jetpack-settings-ui

This is how Related Posts look like this with the indentation and the updated styling
<img width="732" alt="captura de pantalla 2017-01-24 a las 16 44 12" src="https://cloud.githubusercontent.com/assets/1041600/22263781/60eb225e-e254-11e6-9123-a18cad7e6096.png">

## Related Posts
- add the traditional controls to manage headline and thumbnails
- toggles for headline and thumbnail work instantly and the preview is updated instantly
![related](https://cloud.githubusercontent.com/assets/1041600/21656171/ceedab64-d29b-11e6-80d7-368bada82e25.gif)

#### Testing instructions:
* go to Jetpack > Traffic > Related posts and click on the toggles.

cc @rickybanister @MichaelArestad 