### PR TITLE
Use HTTPS links for stats/devicepx

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -861,7 +861,7 @@ class Jetpack {
 	 */
 	function devicepx() {
 		if ( Jetpack::is_active() ) {
-			wp_enqueue_script( 'devicepx', set_url_scheme( 'http://s0.wp.com/wp-content/js/devicepx-jetpack.js' ), array(), gmdate( 'oW' ), true );
+			wp_enqueue_script( 'devicepx', 'https://s0.wp.com/wp-content/js/devicepx-jetpack.js', array(), gmdate( 'oW' ), true );
 		}
 	}
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -122,7 +122,7 @@ function stats_template_redirect() {
 	add_action( 'wp_footer', 'stats_footer', 101 );
 	add_action( 'wp_head', 'stats_add_shutdown_action' );
 
-	$script = 'https://stats.wp.com/e-' . gmdate( 'YW' ) . '.js'	;
+	$script = 'https://stats.wp.com/e-' . gmdate( 'YW' ) . '.js';
 	$data = stats_build_view_data();
 	$data_stats_array = stats_array( $data );
 

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -122,7 +122,7 @@ function stats_template_redirect() {
 	add_action( 'wp_footer', 'stats_footer', 101 );
 	add_action( 'wp_head', 'stats_add_shutdown_action' );
 
-	$script = set_url_scheme( '//stats.wp.com/e-' . gmdate( 'YW' ) . '.js' );
+	$script = 'https://stats.wp.com/e-' . gmdate( 'YW' ) . '.js'	;
 	$data = stats_build_view_data();
 	$data_stats_array = stats_array( $data );
 


### PR DESCRIPTION
Removes set_url_scheme call to always use https. Ran into a case in support of a misconfigured site not firing is_ssl() correctly. This would prevent that issue and secure all the things. 