### PR TITLE
Sync: Only schedule initial full sync on JP install

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -180,16 +180,17 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function do_initial_sync( $new_version = null, $old_version = null ) {
-		$initial_sync_config = array(
-			'options' => true,
-			'network_options' => true,
-			'functions' => true,
-			'constants' => true,
-		);
-
-		if ( $old_version && ( version_compare( $old_version, '4.2', '<' ) ) ) {
-			$initial_sync_config['users'] = 'initial';
+		if ( ! empty( $old_version ) && version_compare( $old_version, '4.2', '>=' ) ) {
+			return;
 		}
+
+		$initial_sync_config = array(
+			'options'         => true,
+			'network_options' => true,
+			'functions'       => true,
+			'constants'       => true,
+			'users'           => 'initial',
+		);
 
 		self::do_full_sync( $initial_sync_config );
 	}
@@ -403,4 +404,3 @@ add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_woocomm
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ) );
-

--- a/sync/class.jetpack-sync-module-full-sync.php
+++ b/sync/class.jetpack-sync-module-full-sync.php
@@ -239,7 +239,6 @@ class Jetpack_Sync_Module_Full_Sync extends Jetpack_Sync_Module {
 		);
 
 		$enqueue_status = $this->get_enqueue_status();
-		$module_config = $this->get_config();
 
 		foreach ( Jetpack_Sync_Modules::get_modules() as $module ) {
 			$name = $module->name();

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -37,16 +37,15 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $sync_status['config'], $expected_sync_config );
 	}
 
-	function test_upgrading_from_42_plus_does_not_includes_users_in_initial_sync() {
+	function test_upgrading_from_42_plus_does_not_start_an_initial_sync() {
 
-		$initial_sync_without_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'network_options' => true );
 		$initial_sync_with_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'network_options' => true, 'users' => 'initial' );
 
 		do_action( 'updating_jetpack_version', '4.3', '4.2' );
 		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
 		$sync_config = $sync_status[ 'config' ];
 
-		$this->assertEquals( $initial_sync_without_users_config, $sync_config );
+		$this->assertNull( $sync_config );
 		$this->assertNotEquals( $initial_sync_with_users_config, $sync_config );
 
 		do_action( 'updating_jetpack_version', '4.2', '4.1' );


### PR DESCRIPTION
Alternative or complementary? to #5865

Tries to only start an initial Sync if we haven't done one before.

What do you think friends?