### PR TITLE
Protect: Add instructions for entering multiple IPs on separate lines

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -299,7 +299,7 @@ export let ProtectSettings = React.createClass( {
 							onChange={ this.props.onOptionChange }
 							value={ this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local } />
 					</FormLabel>
-					<span className="jp-form-setting-explanation">{ __( 'IPv4 and IPv6 are acceptable. {{br/}} To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
+					<span className="jp-form-setting-explanation">{ __( 'IPv4 and IPv6 are acceptable. Enter multiple IPs on separate lines. {{br/}} To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
 						components: {
 							br: <br/>
 						}

--- a/_inc/jetpack-strings.php
+++ b/_inc/jetpack-strings.php
@@ -365,7 +365,7 @@ __( "Match By Email", "jetpack" ), // _inc/client/components/module-settings/ind
 __( "{{a}}Edit{{/a}}", "jetpack" ), // _inc/client/components/module-settings/index.jsx:303
 __( "Emails will be sent to ", "jetpack" ), // _inc/client/components/module-settings/index.jsx:300
 __( "Receive Monitor Email Notifications", "jetpack" ), // _inc/client/components/module-settings/index.jsx:299
-__( "IPv4 and IPv6 are acceptable. {{br/}} To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100", "jetpack" ), // _inc/client/components/module-settings/index.jsx:270
+__( "IPv4 and IPv6 are acceptable. Enter multiple IPs on separate lines. {{br/}} To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100", "jetpack" ), // _inc/client/components/module-settings/index.jsx:270
 __( "Make sure to add your most frequently used IP addresses as they can change between your home, office or other locations. Removing an IP address from the list below will remove it from your whitelist.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:261
 __( "Whitelisting an IP address prevents it from ever being blocked by Jetpack.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:260
 __( "Whitelist Management", "jetpack" ), // _inc/client/components/module-settings/index.jsx:259

--- a/_inc/jetpack-strings.php
+++ b/_inc/jetpack-strings.php
@@ -365,7 +365,7 @@ __( "Match By Email", "jetpack" ), // _inc/client/components/module-settings/ind
 __( "{{a}}Edit{{/a}}", "jetpack" ), // _inc/client/components/module-settings/index.jsx:303
 __( "Emails will be sent to ", "jetpack" ), // _inc/client/components/module-settings/index.jsx:300
 __( "Receive Monitor Email Notifications", "jetpack" ), // _inc/client/components/module-settings/index.jsx:299
-__( "IPv4 and IPv6 are acceptable. Enter multiple IPs on separate lines. {{br/}} To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100", "jetpack" ), // _inc/client/components/module-settings/index.jsx:270
+__( "IPv4 and IPv6 are acceptable. {{br/}} To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100", "jetpack" ), // _inc/client/components/module-settings/index.jsx:270
 __( "Make sure to add your most frequently used IP addresses as they can change between your home, office or other locations. Removing an IP address from the list below will remove it from your whitelist.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:261
 __( "Whitelisting an IP address prevents it from ever being blocked by Jetpack.", "jetpack" ), // _inc/client/components/module-settings/index.jsx:260
 __( "Whitelist Management", "jetpack" ), // _inc/client/components/module-settings/index.jsx:259

--- a/modules/protect/config-ui.php
+++ b/modules/protect/config-ui.php
@@ -58,7 +58,7 @@
 			<input type='hidden' name='action' value='jetpack_protect_save_whitelist' />
 			<textarea name="whitelist"><?php echo implode( PHP_EOL, $whitelist['local'] ); ?></textarea>
 			<p>
-				<em><?php _e('IPv4 and IPv6 are acceptable. <br />To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', 'jetpack' ); ?></em>
+				<em><?php _e('IPv4 and IPv6 are acceptable. Enter multiple IPs on separate lines. <br />To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', 'jetpack' ); ?></em>
 			</p>
 			<p>
 				<input type='submit' class='button-primary' value='<?php echo esc_attr( __( 'Save', 'jetpack' ) ); ?>' />

--- a/views/admin/network-settings.php
+++ b/views/admin/network-settings.php
@@ -37,7 +37,7 @@
 				<td>
 					<p><strong><?php printf( __( 'Your current IP: %s', 'jetpack' ), jetpack_protect_get_ip() ); ?></strong></p>
 					<textarea name="global-whitelist" style="width: 100%;" rows="8"><?php echo implode( PHP_EOL, $jetpack_protect_whitelist['global'] ); ?></textarea> <br />
-					<label for="global-whitelist"><?php _e('IPv4 and IPv6 are acceptable. <br />To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', 'jetpack' ); ?></label>
+					<label for="global-whitelist"><?php _e('IPv4 and IPv6 are acceptable. Enter multiple IPs on separate lines. <br />To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', 'jetpack' ); ?></label>
 				</td>
 			</tr>
 <?php /* Remove the toggles for 2.9, re-evaluate how they're done and added for a 3.0 release. They don't feel quite right yet.


### PR DESCRIPTION
Added `Enter multiple IPs on separate lines.` to Protect's Whitelist setting instructions .

Fixes #5760

#### Changes proposed in this Pull Request:
Before: 
<img width="682" alt="screen shot 2017-01-06 at 02 26 48" src="https://cloud.githubusercontent.com/assets/68693/21705451/e9453b9a-d3b7-11e6-96a6-22961723e029.png">

After:
<img width="670" alt="screen shot 2017-01-06 at 02 27 22" src="https://cloud.githubusercontent.com/assets/68693/21705453/eb1dc5f4-d3b7-11e6-89d7-2ee68be9ed61.png">


