### PR TITLE
Social Media Icons Widget: add LinkedIn company page support

### DIFF
--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -53,6 +53,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'instagram_username'  => '',
 			'pinterest_username'  => '',
 			'linkedin_username'   => '',
+			'linkedin_is_company' => false,
 			'github_username'     => '',
 			'youtube_username'    => '',
 			'vimeo_username'      => '',
@@ -67,7 +68,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			'twitter'    => array( 'Twitter', 'https://twitter.com/%s/' ),
 			'instagram'  => array( 'Instagram', 'https://instagram.com/%s/' ),
 			'pinterest'  => array( 'Pinterest', 'https://www.pinterest.com/%s/' ),
-			'linkedin'   => array( 'LinkedIn', 'https://www.linkedin.com/in/%s/' ),
+			'linkedin'   => array( 'LinkedIn', 'https://www.linkedin.com/%s/' ),
 			'github'     => array( 'GitHub', 'https://github.com/%s/' ),
 			'youtube'    => array( 'YouTube', 'https://www.youtube.com/%s/' ),
 			'vimeo'      => array( 'Vimeo', 'https://vimeo.com/%s/' ),
@@ -148,6 +149,14 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 				$link_username = 'channel/' . $username;
 			} else if ( 'youtube' === $service ) {
 				$link_username = 'user/' . $username;
+			}
+			if ( 'linkedin' === $service ) {
+				// Check if the name is a company name and change the URL
+				if ( ! empty( $instance[ $service . '_is_company' ] ) ) {
+					$link_username = 'company/' . $username;
+				} else {
+					$link_username = 'in/' . $username;
+				}
 			}
 			/**
 			 * Fires for each profile link in the social icons widget. Can be used
@@ -240,6 +249,15 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 						type="text"
 						value="<?php echo esc_attr( $instance[ $service . '_username' ] ); ?>"
 					/>
+					<?php if ( 'linkedin' === $service ): ?>
+						<input
+								class="checkbox"
+								type="checkbox"
+								name="<?php echo $this->get_field_name( $service . '_is_company' ); ?>"
+								<?php checked( $instance[ $service . '_is_company' ], 1 ); ?>
+							/>
+						<label for="<?php echo esc_attr( $this->get_field_id( $service . '_is_company' ) ); ?>">This is a company page.</label>
+					<?php endif ?>
 				</p>
 			<?php
 		}
@@ -258,6 +276,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		foreach ( $new_instance as $field => $value ) {
 			$instance[ $field ] = sanitize_text_field( $new_instance[ $field ] );
 		}
+		$instance['linkedin_is_company'] = isset( $new_instance['linkedin_is_company'] );
 		// Stats.
 		$stats = $instance;
 		unset( $stats['title'] );

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -256,7 +256,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 								name="<?php echo $this->get_field_name( $service . '_is_company' ); ?>"
 								<?php checked( $instance[ $service . '_is_company' ], 1 ); ?>
 							/>
-						<label for="<?php echo esc_attr( $this->get_field_id( $service . '_is_company' ) ); ?>">This is a company page.</label>
+						<label for="<?php echo esc_attr( $this->get_field_id( $service . '_is_company' ) ); ?>"><?php esc_html_e( 'This is a company page.', 'jetpack' ); ?></label>
 					<?php endif ?>
 				</p>
 			<?php


### PR DESCRIPTION
Fixes #6010

#### Changes proposed in this Pull Request:
Add support for company pages in "Social Media Icons" widget.

I think a checkbox below the LinkedIn username field will be a good solution to tell if you are using a company page.

#### Testing instructions:

* Add Social Media Icons widget to sidebar
* Add a company username and check the checkbox below the field.
* Check if the LinkedIn url is changed properly
