### PR TITLE
Carousel: update verbiage to include mention of simgle images

### DIFF
--- a/modules/carousel.php
+++ b/modules/carousel.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Carousel
- * Module Description: Transform image galleries into gorgeous, full-screen slideshows.
+ * Module Description: Display images and galleries in a gorgeous, full-screen browsing experience.
  * Jumpstart Description: Brings your photos and images to life as full-size, easily navigable galleries.
  * Sort Order: 22
  * Recommendation Order: 12

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -312,7 +312,7 @@ add_action( 'jetpack_learn_more_button_carousel', 'jetpack_carousel_learn_more_b
 
 function jetpack_carousel_more_info() { ?>
 	<?php esc_html_e(
-		'With Carousel active, any standard WordPress galleries you have embedded in posts or pages will
+		'With Carousel active, any standard WordPress galleries or single images you have embedded in posts or pages will
 		launch a full-screen photo browsing experience with comments and EXIF metadata.'
 		, 'jetpack' ); ?>
 <?php


### PR DESCRIPTION
We will add detailed instructions and more information about single image lightbox displays in the jetpack.com/support/carousel docs.  