### PR TITLE
Update/sync user language choice

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -75,7 +75,10 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	public function add_to_user( $user ) {
 		$user->allowed_mime_types = get_allowed_mime_types( $user );
-
+		if ( function_exists( 'get_user_locale' ) ) {
+			$user->locale = get_user_locale( $user->ID );
+		}
+		
 		return $user;
 	}
 

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -162,8 +162,24 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	function maybe_save_user_meta( $meta_id, $user_id, $meta_key, $value ) {
 		if ( $meta_key === 'locale' ) {
 			if ( current_filter() === 'deleted_user_meta' ) {
+				/**
+				 * Allow listeners to listen for user local delete changes
+				 *
+				 * @since 4.8
+				 *
+				 * @param int $user_id - The ID of the user whos locale is being deleted
+				 */
 				do_action( 'jetpack_sync_user_locale_delete', $user_id );
 			} else {
+				/**
+				 * Allow listeners to listen for user local changes
+				 *
+				 * @since 4.8
+				 *
+				 * @param int $user_id - The ID of the user whos locale is being changed
+				 * @param int $value - The value of the new locale
+				 *
+				 */
 				do_action( 'jetpack_sync_user_locale', $user_id, $value );
 			}
 		}

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -23,6 +23,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'add_user_to_blog', array( $this, 'save_user_handler' ) );
 		add_action( 'jetpack_sync_save_user', $callable, 10, 2 );
 		add_action( 'jetpack_sync_user_locale', $callable, 10, 2 );
+		add_action( 'jetpack_sync_user_locale_delete', $callable, 10, 1 );
 
 		add_action( 'deleted_user', $callable, 10, 2 );
 		add_action( 'remove_user_from_blog', $callable, 10, 2 );
@@ -159,17 +160,15 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	function maybe_save_user_meta( $meta_id, $user_id, $meta_key, $value ) {
-		
 		if ( $meta_key === 'locale' ) {
-				do_action( 'jetpack_sync_user_locale', $user_id, '' );
 			if ( current_filter() === 'deleted_user_meta' ) {
+				do_action( 'jetpack_sync_user_locale_delete', $user_id );
 			} else {
 				do_action( 'jetpack_sync_user_locale', $user_id, $value );
 			}
 		}
 		$this->save_user_cap_handler( $meta_id, $user_id, $meta_key, $value );
 	}
-
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
 		// if a user is currently being removed as a member of this blog, we don't fire the event

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -75,10 +75,14 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	public function add_to_user( $user ) {
 		$user->allowed_mime_types = get_allowed_mime_types( $user );
-		if ( function_exists( 'get_user_locale' ) ) {
-			$user->locale = get_user_locale( $user->ID );
-		}
 		
+		if ( function_exists( 'get_user_locale' ) ) {
+
+			// Only set the user locale if it is different from the site local
+			if ( get_locale() !== get_user_locale( $user->ID ) ) {
+				$user->locale = get_user_locale( $user->ID );
+			}
+		}
 		return $user;
 	}
 
@@ -157,15 +161,15 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	function maybe_save_user_meta( $meta_id, $user_id, $meta_key, $value ) {
 		
 		if ( $meta_key === 'locale' ) {
-			if( current_filter() === 'deleted_user_meta' ) {
 				do_action( 'jetpack_sync_user_locale', $user_id, '' );
+			if ( current_filter() === 'deleted_user_meta' ) {
 			} else {
 				do_action( 'jetpack_sync_user_locale', $user_id, $value );
 			}
 		}
-
 		$this->save_user_cap_handler( $meta_id, $user_id, $meta_key, $value );
 	}
+
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
 		// if a user is currently being removed as a member of this blog, we don't fire the event

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -587,6 +587,10 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 	public function upsert_user_locale( $user_id, $local ) {
 		$this->invalid_call();
 	}
+
+	public function delete_user_locale( $user_id ) {
+		$this->invalid_call();
+	}
 	
 	public function get_user_locale( $user_id ) {
 		return jetpack_get_user_locale( $user_id );

--- a/sync/class.jetpack-sync-wp-replicastore.php
+++ b/sync/class.jetpack-sync-wp-replicastore.php
@@ -584,6 +584,14 @@ class Jetpack_Sync_WP_Replicastore implements iJetpack_Sync_Replicastore {
 		$this->invalid_call();
 	}
 
+	public function upsert_user_locale( $user_id, $local ) {
+		$this->invalid_call();
+	}
+	
+	public function get_user_locale( $user_id ) {
+		return jetpack_get_user_locale( $user_id );
+	}
+
 	public function get_allowed_mime_types( $user_id ) {
 
 	}

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -120,6 +120,10 @@ interface iJetpack_Sync_Replicastore {
 
 	public function delete_user( $user_id );
 
+	public function upsert_user_locale( $user_id, $locale );
+
+	public function get_user_locale( $user_id );
+
 	public function get_allowed_mime_types( $user_id );
 
 

--- a/sync/interface.jetpack-sync-replicastore.php
+++ b/sync/interface.jetpack-sync-replicastore.php
@@ -122,6 +122,8 @@ interface iJetpack_Sync_Replicastore {
 
 	public function upsert_user_locale( $user_id, $locale );
 
+	public function delete_user_locale( $user_id );
+
 	public function get_user_locale( $user_id );
 
 	public function get_allowed_mime_types( $user_id );

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -254,6 +254,11 @@ class Jetpack_Sync_Server_Replicator {
 				$this->store->delete_user( $user_id );
 				break;
 
+			case 'jetpack_sync_user_locale':
+				list( $user_id, $locale ) = $args;
+				$this->store->upsert_user_locale( $user_id, $locale );
+				break;
+
 			// plugins
 			case 'deleted_plugin':
 				list( $plugin_file, $deleted ) = $args;

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -259,6 +259,11 @@ class Jetpack_Sync_Server_Replicator {
 				$this->store->upsert_user_locale( $user_id, $locale );
 				break;
 
+			case 'jetpack_sync_user_locale_delete':
+				list( $user_id ) = $args;
+				$this->store->delete_user_locale( $user_id );
+				break;
+
 			// plugins
 			case 'deleted_plugin':
 				list( $plugin_file, $deleted ) = $args;

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -21,6 +21,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 	private $terms;
 	private $object_terms;
 	private $users;
+	private $users_locale;
 	private $allowed_mime_types;
 	private $checksum_fields;
 
@@ -41,6 +42,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		$this->terms           = array();
 		$this->object_terms    = array();
 		$this->users           = array();
+		$this->users_locale     = array();
 	}
 
 	function full_sync_start( $config ) {
@@ -505,6 +507,14 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 
 	function get_user( $user_id ) {
 		return isset( $this->users[ $user_id ] ) ? $this->users[ $user_id ] : null;
+	}
+
+	function upsert_user_locale( $user_id, $user_locale ) {
+		$this->users_locale[ $user_id ] = $user_locale;
+	}
+
+	function get_user_locale( $user_id ) {
+		return isset( $this->users_locale[ $user_id ] ) ? $this->users_locale[ $user_id ] : null;
 	}
 
 	function get_allowed_mime_types( $user_id ) {

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -513,6 +513,10 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		$this->users_locale[ $user_id ] = $user_locale;
 	}
 
+	function delete_user_locale( $user_id ) {
+		unset( $this->users_locale[ $user_id ] );
+	}
+
 	function get_user_locale( $user_id ) {
 		return isset( $this->users_locale[ $user_id ] ) ? $this->users_locale[ $user_id ] : null;
 	}

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -42,7 +42,7 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 		$this->terms           = array();
 		$this->object_terms    = array();
 		$this->users           = array();
-		$this->users_locale     = array();
+		$this->users_locale    = array();
 	}
 
 	function full_sync_start( $config ) {

--- a/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -531,6 +531,11 @@ class Jetpack_Sync_Test_Replicastore implements iJetpack_Sync_Replicastore {
 			$this->allowed_mime_types[ $user->ID ] = $user->data->allowed_mime_types;
 			unset( $user->data->allowed_mime_types );
 		}
+
+		if ( isset( $user->data->locale ) ) {
+			$this->users_locale[ $user->ID ] = $user->data->locale;
+			unset( $user->data->locale );
+		}
 		$this->users[ $user->ID ] = $user;
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -171,20 +171,21 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_users() {
-		for ( $i = 0; $i < 10; $i += 1 ) {
+		$first_user_id = $this->factory->user->create();
+		for ( $i = 0; $i < 9; $i += 1 ) {
 			$user_id = $this->factory->user->create();
 		}
 
+		update_user_meta( $user_id, 'locale', 'en_GB' );
 		// simulate emptying the server storage
 		$this->server_replica_storage->reset();
 		$this->sender->reset_data();
-
+		
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
 
 		$users = get_users();
 		// 10 + 1 = 1 users gets always created.
-
 
 		$this->assertEquals( 11, $this->server_replica_storage->user_count() );
 		$user = $this->server_replica_storage->get_user( $user_id );
@@ -192,6 +193,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		if ( function_exists( 'get_user_locale' ) ) {
 			$this->assertEquals( get_user_locale( $user_id ), $this->server_replica_storage->get_user_locale( $user_id ) );
+			$this->assertNull( $this->server_replica_storage->get_user_locale( $first_user_id ) );
 		}
 		// Lets make sure that we don't send users passwords around.
 		$this->assertFalse( isset( $user->data->user_pass ) );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -189,6 +189,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 11, $this->server_replica_storage->user_count() );
 		$user = $this->server_replica_storage->get_user( $user_id );
 		$this->assertEquals( get_allowed_mime_types( $user_id ), $this->server_replica_storage->get_allowed_mime_types( $user_id ) );
+
+		if ( function_exists( 'get_user_locale' ) ) {
+			$this->assertEquals( get_user_locale( $user_id ), $this->server_replica_storage->get_user_locale( $user_id ) );
+		}
 		// Lets make sure that we don't send users passwords around.
 		$this->assertFalse( isset( $user->data->user_pass ) );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -184,9 +184,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
 
-		$users = get_users();
 		// 10 + 1 = 1 users gets always created.
-
 		$this->assertEquals( 11, $this->server_replica_storage->user_count() );
 		$user = $this->server_replica_storage->get_user( $user_id );
 		$this->assertEquals( get_allowed_mime_types( $user_id ), $this->server_replica_storage->get_allowed_mime_types( $user_id ) );
@@ -672,7 +670,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// reset the data before the full sync
 		$this->sender->reset_data();
-
 	}
 
 	function test_full_sync_status_should_be_not_started_after_reset() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -180,7 +180,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// simulate emptying the server storage
 		$this->server_replica_storage->reset();
 		$this->sender->reset_data();
-		
+
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -415,7 +415,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	public function test_update_user_locale_is_synced() {
 		global $wp_version;
 		if ( version_compare( $wp_version, 4.7, '<' ) ) {
-			$this->markTestSkipped( 'WP 4.7 and up supports user local' );
+			$this->markTestSkipped( 'WP 4.7 and up supports user locale' );
 			return;
 		}
 
@@ -432,7 +432,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 	public function test_delete_user_locale_is_synced() {
 		global $wp_version;
 		if ( version_compare( $wp_version, 4.7, '<' ) ) {
-			$this->markTestSkipped( 'WP 4.7 and up supports user local' );
+			$this->markTestSkipped( 'WP 4.7 and up supports user locale' );
 			return;
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -412,6 +412,40 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $synced_user, $retrieved_user );
 	}
 
+	public function test_update_user_locale_is_synced() {
+		global $wp_version;
+		if ( version_compare( $wp_version, 4.7, '<' ) ) {
+			$this->markTestSkipped( 'WP 4.7 and up supports user local' );
+			return;
+		}
+
+		update_user_meta( $this->user_id, 'locale', 'en_GB' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_user_locale' );
+		$this->assertNotEmpty( $event );
+
+		$server_user_local = $this->server_replica_storage->get_user_locale( $this->user_id );
+		$this->assertEquals( get_user_locale( $this->user_id ), $server_user_local );
+	}
+
+	public function test_delete_user_locale_is_synced() {
+		global $wp_version;
+		if ( version_compare( $wp_version, 4.7, '<' ) ) {
+			$this->markTestSkipped( 'WP 4.7 and up supports user local' );
+			return;
+		}
+
+		delete_user_meta( $this->user_id, 'locale' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_user_locale' );
+		$this->assertNotEmpty( $event );
+
+		$server_user_local = $this->server_replica_storage->get_user_locale( $this->user_id );
+		$this->assertEquals( '', $server_user_local );
+	}
+
 	protected function assertUsersEqual( $user1, $user2 ) {
 		// order-independent comparison
 		$user1_array = get_object_vars( $user1->data );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -439,7 +439,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		delete_user_meta( $this->user_id, 'locale' );
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_user_locale' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_user_locale_delete' );
 		$this->assertNotEmpty( $event );
 
 		$server_user_local = $this->server_replica_storage->get_user_locale( $this->user_id );


### PR DESCRIPTION
Fixes #5535 

Sync the user local if it is different from the sites or if the user sets it. 

#### Changes proposed in this Pull Request:
Add sync event when the user local changes.
Full Sync doesn't send user local if it is the same as the sites. 

#### Testing instructions:
* Do the test pass?

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).
