### PR TITLE
Add Global Post Object Juggling

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -102,7 +102,17 @@ class Jetpack_PostImages {
 
 		$permalink = get_permalink( $post->ID );
 
+		/**
+		 *  Juggle global post object because the gallery shortcode uses the
+		 *  global object.
+		 *
+		 *  See core ticket:
+		 *  https://core.trac.wordpress.org/ticket/39304
+		 */
+		$juggle_post = $GLOBALS['post'];
+		$GLOBALS['post'] = $post;
 		$galleries = get_post_galleries( $post->ID, false );
+		$GLOBALS['post'] = $juggle_post;
 
 		foreach ( $galleries as $gallery ) {
 			if ( isset( $gallery['type'] ) && 'slideshow' === $gallery['type'] && ! empty( $gallery['ids'] ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The `[gallery]` shortcode needs the global post object set to the context of the shortcode so juggle the global object so we get the correct images back.

Also see r148733-wpcom

#### Testing instructions:

* Using wpsh or similar call `Jetpack_PostImages::from_gallery()` without a global post object to see the correct images are returned.

#### Proposed changelog entry for your changes:

Workaround for WordPress core bug (https://core.trac.wordpress.org/ticket/39304). Fixes images extracted from gallery shortcodes.