### PR TITLE
Publiclize: Show a WP_DIE message in case Jetpack is not connected properly.

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -159,7 +159,11 @@ class Publicize extends Publicize_Base {
 					check_admin_referer( "keyring-request-$service_name", 'nonce' );
 
 					$verification = Jetpack::create_nonce( 'publicize' );
-
+					if ( is_wp_error( $verification ) ) {
+						$url = Jetpack::admin_url( 'jetpack#/settings' );
+						wp_die( sprintf( __( "Jetpack is not connected. Please connect Jetpack by visiting <a href='%s'>Settings</a>.", 'jetpack' ), $url ) );
+						
+					}
 					$stats_options = get_option( 'stats_options' );
 					$wpcom_blog_id = Jetpack_Options::get_option( 'id' );
 					$wpcom_blog_id = ! empty( $wpcom_blog_id ) ? $wpcom_blog_id : $stats_options['blog_id'];


### PR DESCRIPTION
Shows a wp_die message asking the user to reconnect Jetpack
Instead of a fatal error.
Fixes #5630

#### Changes proposed in this Pull Request:
- end early if we know that the Jetpack:create_nonce() retrurns an error and display a wp_die message asking the user to reconnect. 


#### Testing instructions:
* Replace the line Jetpack::create_nonce( 'publicize' ); with new Jetpack_Error(); 

Go to the admin and try reconnecting Linked in. Instead of seeing a fatal error. You see a wp_die() notice that tells you to connect jetpack with a link to Jetpack settings. 
