### PR TITLE
Upcoming Events: un-ignore from SVN

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -15,10 +15,7 @@ gulpfile.js
 node_modules
 languages/jetpack.pot
 LICENSE.txt
-_inc/lib/icalendar-reader.php
-modules/shortcodes/upcoming-events.php
 modules/widgets/follow-button.php
-modules/widgets/upcoming-events.php
 to-test.md
 .editorconfig
 _inc/client


### PR DESCRIPTION
We'll be shipping the upcoming events widget & shortcode (see #6059) in 4.5