### PR TITLE
Never return WP_Error from Tonesque::imagecreatefromurl()

### DIFF
--- a/_inc/lib/tonesque.php
+++ b/_inc/lib/tonesque.php
@@ -61,7 +61,7 @@ class Tonesque {
 			if ( empty( $data ) ) {
 				$response = wp_remote_get( $image_url );
 				if ( is_wp_error( $response ) ) {
-					return $response;
+					return false;
 				}
 				$data = wp_remote_retrieve_body( $response );
 			}


### PR DESCRIPTION
Currently Tonesque expects the result from Tonesque::imagecreatefromurl() to be either false-y or an image object, but it can also return a WP_Error as of #4924.
This can cause it to try to use a WP_Error as an image object later causing PHP Warnings.

#### Changes proposed in this Pull Request:
 - make the return values of `Tonesque::imagecreatefromurl()` match the PHP function `imagecreatefromstring()` 

#### Testing instructions:
* Attempt to use Tonesque against an invalid image:
```
include_once WP_PLUGIN_DIR . '/jetpack/_inc/lib/tonesque.php';
error_reporting( E_ALL );
ini_set( 'display_errors', 'on' );

$ton = new Tonesque( 'http://404.wordpress/404.jpg' );
var_dump( $ton->grab_color() );
```
* You should NOT see PHP warnings such as `Warning: imagesy() expects parameter 1 to be resource, object given in ..lib/tonesque.php on line 119`