### PR TITLE
WordAds: add TOS message in subheader when not active

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -108,7 +108,8 @@ export const Engagement = ( props ) => {
 			isModuleActive = isModuleActivated( element[0] ),
 			planLoaded = 'undefined' !== typeof props.sitePlan.product_slug,
 			hasBusiness = false,
-			hasPremiumOrBusiness = false;
+			hasPremiumOrBusiness = false,
+			wordAdsSubHeader = element[2];
 
 		hasBusiness =
 			planLoaded &&
@@ -135,6 +136,11 @@ export const Engagement = ( props ) => {
 						activated={ isModuleActive }
 						toggling={ isTogglingModule( element[0] ) }
 						toggleModule={ toggleModule } />;
+
+				// Add text about TOS if inactive
+				if ( 'wordads' === element[0] && ! isModuleActive ) {
+					wordAdsSubHeader = <WordAdsSubHeaderTos subheader={ element[2] } />
+				}
 			}
 
 			if ( isPro ) {
@@ -174,7 +180,7 @@ export const Engagement = ( props ) => {
 				className={ customClasses }
 				key={ `module-card_${element[0]}` /* https://fb.me/react-warning-keys */ }
 				header={ element[1] }
-				subheader={ element[2] }
+				subheader={ 'wordads' === element[0] ? wordAdsSubHeader : element[2] }
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }
@@ -247,6 +253,24 @@ export const Engagement = ( props ) => {
 		</div>
 	);
 };
+
+const WordAdsSubHeaderTos = React.createClass( {
+	render() {
+		return (
+			<div>
+				{ this.props.subheader }
+				<br/>
+				<small>
+					{ __( 'By activating ads, you agree to the Automattic Ads {{link}}Terms of Service{{/link}}.', {
+						components: {
+							link: <a href="https://wordpress.com/automattic-ads-tos/" target="_blank" />
+						}
+					} ) }
+				</small>
+			</div>
+		)
+	}
+} );
 
 function renderLongDescription( module ) {
 	// Rationale behind returning an object and not just the string

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -254,7 +254,7 @@ export const Engagement = ( props ) => {
 	);
 };
 
-const WordAdsSubHeaderTos = React.createClass( {
+export const WordAdsSubHeaderTos = React.createClass( {
 	render() {
 		return (
 			<div>

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -37,6 +37,7 @@ import {
 	isPluginActive
 } from 'state/site/plugins';
 import { getSiteRawUrl } from 'state/initial-state';
+import { WordAdsSubHeaderTos } from 'engagement'
 
 export const SearchResults = ( {
 	siteAdminUrl,
@@ -118,7 +119,12 @@ export const SearchResults = ( {
 					toggleModule={ toggleModule }
 				/>
 			),
-			customClasses = unavailableDevMode ? 'devmode-disabled' : '';
+			customClasses = unavailableDevMode ? 'devmode-disabled' : '',
+			wordAdsSubHeader = element[2];
+
+		if ( 'wordads' === element[0] && ! isModuleActivated( element[0] ) ) {
+			wordAdsSubHeader = <WordAdsSubHeaderTos subheader={ element[2] } />
+		}
 
 		if ( isPro ) {
 			proProps = {
@@ -181,7 +187,7 @@ export const SearchResults = ( {
 				className={ customClasses }
 				header={ element[1] }
 				searchTerms={ element.toString().replace( /<(?:.|\n)*?>/gm, '' ) }
-				subheader={ element[2] }
+				subheader={ 'wordads' === element[0] ? wordAdsSubHeader : element[2] }
 				summary={ toggle }
 				expandedSummary={ toggle }
 				clickableHeaderText={ true }


### PR DESCRIPTION
When WordAds is not active, we need to make sure the TOS is available to read and accept.  

Note: the TOS text should not show if the site is not on a pro/business plan, since they can't activate it anyway. 

This is what it looks like: 
![screen shot 2017-01-11 at 6 24 22 pm](https://cloud.githubusercontent.com/assets/7129409/21870610/34996428-d82b-11e6-8438-942b71edebca.png)

And it goes away when Ads is activated. 
![screen shot 2017-01-11 at 6 25 01 pm](https://cloud.githubusercontent.com/assets/7129409/21870628/4d6cbcd4-d82b-11e6-82eb-148f55df340a.png)

