### PR TITLE
Photon: Force only Photon URLs to HTTPS

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -96,12 +96,10 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
-	if (
-		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
-		|| $image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST )
-	) {
+	$is_wpcom_host = in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) );
+	if ( $is_wpcom_host || $image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST ) ) {
 		$photon_url = add_query_arg( $args, $image_url );
-		return jetpack_photon_url_scheme( $photon_url, $scheme );
+		return jetpack_photon_url_scheme( $photon_url, $is_wpcom_host ? 'https' : $scheme );
 	}
 
 	/**
@@ -235,7 +233,11 @@ add_filter( 'jetpack_photon_any_extension_for_domain',   'jetpack_photon_allow_f
 
 function jetpack_photon_url_scheme( $url, $scheme ) {
 	if ( ! in_array( $scheme, array( 'http', 'https', 'network_path' ) ) ) {
-		$scheme = 'https';
+		if ( preg_match( '#^(https?:)?//#', $url ) ) {
+			return $url;
+		}
+
+		$scheme = 'http';
 	}
 
 	if ( 'network_path' == $scheme ) {

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -71,7 +71,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	if ( empty( $image_url ) )
 		return $image_url;
 
-	$image_url_parts = @parse_url( $image_url );
+	$image_url_parts = @jetpack_photon_parse_url( $image_url );
 
 	// Unable to parse
 	if ( ! is_array( $image_url_parts ) || empty( $image_url_parts['host'] ) || empty( $image_url_parts['path'] ) )
@@ -98,7 +98,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
 	if (
 		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
-		|| $image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST )
+		|| $image_url_parts['host'] === jetpack_photon_parse_url( $custom_photon_url, PHP_URL_HOST )
 	) {
 		$photon_url = add_query_arg( $args, $image_url );
 		return jetpack_photon_url_scheme( $photon_url, $scheme );
@@ -258,6 +258,24 @@ function jetpack_photon_allow_facebook_graph_domain( $allow = false, $domain ) {
 	}
 
 	return $allow;
+}
+
+/**
+ * A wrapper for PHP's parse_url, prepending assumed scheme for network path
+ * URLs. PHP versions 5.4.6 and earlier do not correctly parse without scheme.
+ *
+ * @see http://php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-changelog
+ *
+ * @param string $url The URL to parse
+ * @param integer $component Retrieve specific URL component
+ * @return mixed Result of parse_url
+ */
+function jetpack_photon_parse_url( $url, $component = -1 ) {
+	if ( 0 === strpos( $url, '//' ) ) {
+		$url = ( is_ssl() ? 'https:' : 'http:' ) . $url;
+	}
+
+	return parse_url( $url, $component );
 }
 
 add_filter( 'jetpack_photon_skip_for_url', 'jetpack_photon_banned_domains', 9, 4 );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -96,8 +96,10 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
-	if ( in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
-			|| $image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST ) ) {
+	if (
+		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
+		|| $image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST )
+	) {
 		$photon_url = add_query_arg( $args, $image_url );
 		return jetpack_photon_url_scheme( $photon_url, $scheme );
 	}

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -246,7 +246,7 @@ function jetpack_photon_url_scheme( $url, $scheme ) {
 		$scheme_slashes = "$scheme://";
 	}
 
-	return preg_replace( '#^[a-z:]+//#i', $scheme_slashes, $url );
+	return preg_replace( '#^([a-z:]+)?//#i', $scheme_slashes, $url );
 }
 
 function jetpack_photon_allow_facebook_graph_domain( $allow = false, $domain ) {

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -96,10 +96,10 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
-	$is_wpcom_host = in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) );
-	if ( $is_wpcom_host || $image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST ) ) {
+	if ( in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
+			|| $image_url_parts['host'] === parse_url( $custom_photon_url, PHP_URL_HOST ) ) {
 		$photon_url = add_query_arg( $args, $image_url );
-		return jetpack_photon_url_scheme( $photon_url, $is_wpcom_host ? 'https' : $scheme );
+		return jetpack_photon_url_scheme( $photon_url, $scheme );
 	}
 
 	/**

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -322,4 +322,58 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 		$this->assertEquals( 'https://i0.wp.com/example.com/img.jpg', $url );
 	}
 
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_parse_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_parse_url
+	 */
+	public function test_jetpack_photon_parse_url_with_scheme() {
+		$parsed = jetpack_photon_parse_url( 'https://i0.wp.com/example.com/img.jpg' );
+
+		$this->assertEquals( array(
+			'scheme' => 'https',
+			'host' => 'i0.wp.com',
+			'path' => '/example.com/img.jpg'
+		), $parsed );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_parse_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_parse_url
+	 */
+	public function test_jetpack_photon_parse_url_without_scheme() {
+		$parsed = jetpack_photon_parse_url( '//i0.wp.com/example.com/img.jpg' );
+
+		$this->assertArrayHasKey( 'scheme', $parsed );
+		$this->assertEquals( 'i0.wp.com', $parsed['host'] );
+		$this->assertEquals( '/example.com/img.jpg', $parsed['path'] );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_parse_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_parse_url
+	 */
+	public function test_jetpack_photon_parse_url_with_scheme_specifying_component() {
+		$host = jetpack_photon_parse_url( 'https://i0.wp.com/example.com/img.jpg', PHP_URL_HOST );
+
+		$this->assertEquals( 'i0.wp.com', $host );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_parse_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_parse_url
+	 */
+	public function test_jetpack_photon_parse_url_without_scheme_specifying_component() {
+		$host = jetpack_photon_parse_url( '//i0.wp.com/example.com/img.jpg', PHP_URL_HOST );
+
+		$this->assertEquals( 'i0.wp.com', $host );
+	}
+
 }

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -2,6 +2,24 @@
 
 class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
+	public function tearDown() {
+		remove_filter( 'jetpack_photon_domain', array( $this, 'apply_custom_domain' ) );
+		unset( $this->custom_photon_domain );
+	}
+
+	public function apply_custom_domain( $domain ) {
+		if ( 'jetpack_photon_domain' === current_filter() ) {
+			return $this->custom_photon_domain;
+		}
+
+		$this->custom_photon_domain = $domain;
+		add_filter( 'jetpack_photon_domain', array( $this, 'apply_custom_domain' ) );
+	}
+
+	protected function assertMatchesPhotonHost( $host ) {
+		$this->assertRegExp( '/^i[0-2]\.wp\.com$/', $host );
+	}
+
 	/**
 	 * @author kraftbj
 	 * @covers jetpack_photon_url
@@ -23,4 +41,285 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 		parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
 		$this->assertArrayNotHasKey( 'ssl', $args, 'HTTP image source should not have an ssl query string.' );
 	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_no_filter
+	 */
+	public function test_photon_url_no_filter_http() {
+		$url = jetpack_photon_url( 'http://example.com/img.jpg' );
+		$parsed_url = parse_url( $url );
+
+		$this->assertEquals( 'https', $parsed_url['scheme'] );
+		$this->assertMatchesPhotonHost( $parsed_url['host'] );
+		$this->assertEquals( '/example.com/img.jpg', $parsed_url['path'] );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_no_filter
+	 */
+	public function test_photon_url_no_filter_http_to_http() {
+		$url = jetpack_photon_url( 'http://example.com/img.jpg', array(), 'http' );
+		$parsed_url = parse_url( $url );
+
+		$this->assertEquals( 'http', $parsed_url['scheme'] );
+		$this->assertMatchesPhotonHost( $parsed_url['host'] );
+		$this->assertEquals( '/example.com/img.jpg', $parsed_url['path'] );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_no_filter
+	 */
+	public function test_photon_url_no_filter_photonized_https() {
+		$url = jetpack_photon_url( 'https://i0.wp.com/example.com/img.jpg' );
+
+		$this->assertEquals( 'https://i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_no_filter
+	 */
+	public function test_photon_url_no_filter_photonized_http() {
+		$url = jetpack_photon_url( 'http://i0.wp.com/example.com/img.jpg' );
+
+		$this->assertEquals( 'http://i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_no_filter
+	 */
+	public function test_photon_url_no_filter_photonized_https_to_http() {
+		$url = jetpack_photon_url( 'https://i0.wp.com/example.com/img.jpg', array(), 'http' );
+
+		$this->assertEquals( 'http://i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_http
+	 */
+	public function test_photon_url_filter_http_http() {
+		$this->apply_custom_domain( 'http://photon.dev' );
+		$url = jetpack_photon_url( 'http://example.com/img.jpg' );
+
+		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_http
+	 */
+	public function test_photon_url_filter_http_http_to_http() {
+		$this->apply_custom_domain( 'http://photon.dev' );
+		$url = jetpack_photon_url( 'http://example.com/img.jpg', array(), 'http' );
+
+		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_http
+	 */
+	public function test_photon_url_filter_http_photonized_http() {
+		$this->apply_custom_domain( 'http://photon.dev' );
+		$url = jetpack_photon_url( 'http://photon.dev/example.com/img.jpg' );
+
+		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_http
+	 */
+	public function test_photon_url_filter_http_photonized_https() {
+		$this->apply_custom_domain( 'http://photon.dev' );
+		$url = jetpack_photon_url( 'https://photon.dev/example.com/img.jpg' );
+
+		$this->assertEquals( 'https://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_http
+	 */
+	public function test_photon_url_filter_http_photonized_http_to_https() {
+		$this->apply_custom_domain( 'http://photon.dev' );
+		$url = jetpack_photon_url( 'http://photon.dev/example.com/img.jpg', array(), 'https' );
+
+		$this->assertEquals( 'https://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_network_path
+	 */
+	public function test_photon_url_filter_network_path_http() {
+		$this->apply_custom_domain( '//photon.dev' );
+		$url = jetpack_photon_url( 'http://example.com/img.jpg' );
+
+		$this->assertEquals( '//photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_network_path
+	 */
+	public function test_photon_url_filter_network_path_http_to_http() {
+		$this->apply_custom_domain( '//photon.dev' );
+		$url = jetpack_photon_url( 'http://example.com/img.jpg', array(), 'http' );
+
+		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_network_path
+	 */
+	public function test_photon_url_filter_network_path_photonized_http() {
+		$this->apply_custom_domain( '//photon.dev' );
+		$url = jetpack_photon_url( 'http://photon.dev/example.com/img.jpg' );
+
+		$this->assertEquals( 'http://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_network_path
+	 */
+	public function test_photon_url_filter_network_path_photonized_https() {
+		$this->apply_custom_domain( '//photon.dev' );
+		$url = jetpack_photon_url( 'https://photon.dev/example.com/img.jpg' );
+
+		$this->assertEquals( 'https://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url
+	 * @since  4.5.0
+	 * @group  jetpack_photon_filter_network_path
+	 */
+	public function test_photon_url_filter_network_path_photonized_to_https() {
+		$this->apply_custom_domain( '//photon.dev' );
+		$url = jetpack_photon_url( '//photon.dev/example.com/img.jpg', array(), 'https' );
+
+		$this->assertEquals( 'https://photon.dev/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url_scheme
+	 * @since  4.5.0
+	 * @group  jetpack_photon_url_scheme
+	 */
+	public function test_photon_url_scheme_valid_url_null_scheme() {
+		$url = jetpack_photon_url_scheme( 'https://i0.wp.com/example.com/img.jpg', null );
+
+		$this->assertEquals( 'https://i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url_scheme
+	 * @since  4.5.0
+	 * @group  jetpack_photon_url_scheme
+	 */
+	public function test_photon_url_scheme_valid_url_invalid_scheme() {
+		$url = jetpack_photon_url_scheme( 'https://i0.wp.com/example.com/img.jpg', 'ftp' );
+
+		$this->assertEquals( 'https://i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url_scheme
+	 * @since  4.5.0
+	 * @group  jetpack_photon_url_scheme
+	 */
+	public function test_photon_url_scheme_valid_url_valid_scheme() {
+		$url = jetpack_photon_url_scheme( 'https://i0.wp.com/example.com/img.jpg', 'http' );
+
+		$this->assertEquals( 'http://i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url_scheme
+	 * @since  4.5.0
+	 * @group  jetpack_photon_url_scheme
+	 */
+	public function test_photon_url_scheme_valid_url_network_path_scheme() {
+		$url = jetpack_photon_url_scheme( 'https://i0.wp.com/example.com/img.jpg', 'network_path' );
+
+		$this->assertEquals( '//i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url_scheme
+	 * @since  4.5.0
+	 * @group  jetpack_photon_url_scheme
+	 */
+	public function test_photon_url_scheme_invalid_url_null_scheme() {
+		$url = jetpack_photon_url_scheme( 'ftp://i0.wp.com/example.com/img.jpg', null );
+
+		$this->assertEquals( 'http://i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url_scheme
+	 * @since  4.5.0
+	 * @group  jetpack_photon_url_scheme
+	 */
+	public function test_photon_url_scheme_invalid_url_invalid_scheme() {
+		$url = jetpack_photon_url_scheme( 'ftp://i0.wp.com/example.com/img.jpg', 'ftp' );
+
+		$this->assertEquals( 'http://i0.wp.com/example.com/img.jpg', $url );
+	}
+
+	/**
+	 * @author aduth
+	 * @covers jetpack_photon_url_scheme
+	 * @since  4.5.0
+	 * @group  jetpack_photon_url_scheme
+	 */
+	public function test_photon_url_scheme_invalid_url_valid_scheme() {
+		$url = jetpack_photon_url_scheme( 'ftp://i0.wp.com/example.com/img.jpg', 'https' );
+
+		$this->assertEquals( 'https://i0.wp.com/example.com/img.jpg', $url );
+	}
+
 }


### PR DESCRIPTION
Fixes #6073

#### Changes proposed in this Pull Request:

This pull request seeks to resolve an issue where providing one's own Photon domain via the `jetpack_photon_domain` would not have its scheme respected and instead forced to HTTPS, regardless of whether the custom domain is capable of supporting it.

The changes here force only those URLs we detect to be Photon to HTTPS. Combined with previous changes in 0fa10d4, this should ensure all Photon URLs use HTTPS while still respecting custom domains provided through the filter.

Further, it resolves an issue where if a custom domain is provided for Photon that is already "network_path" and a valid scheme is provided, that scheme should be reflected in the return value.

#### Testing instructions:

Verify newly added unit tests are passing:

```
WP_DEVELOP_DIR=/path/to/wordpress-develop/tests/phpunit phpunit tests/php/test_functions.photon.php 
```

Replace `WP_DEVELOP_DIR` with a path to a checkout of the [WordPress develop repository](https://wordpress.org/download/source/).

[_(See original testing instructions)_](https://gist.github.com/aduth/87e319476ae6ecf21233dc860b891d1c)

cc @danielbachhuber @jeherve 