### PR TITLE
Scan: Don't show prompt to set up if not on correct plan

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -22,13 +22,25 @@ import {
 	getVaultPressData as _getVaultPressData
 } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
+import { isFetchingSiteData } from 'state/site';
 
 const DashScan = React.createClass( {
 	getContent: function() {
 		const labelName = __( 'Security Scanning' ),
 			hasSitePlan = false !== this.props.sitePlan,
 			vpData = this.props.vaultPressData,
-			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
+			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled',
+			scanEnabled = (
+				'undefined' !== typeof vpData.data
+				&&
+				'undefined' !== typeof vpData.data.features
+				&&
+				'undefined' !== typeof vpData.data.features.security
+				&&
+				vpData.data.features.security
+			),
+			hasPremium = /jetpack_premium*/.test( this.props.sitePlan.product_slug ),
+			hasBusiness = /jetpack_business*/.test( this.props.sitePlan.product_slug );
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {
@@ -39,53 +51,59 @@ const DashScan = React.createClass( {
 				);
 			}
 
-			// Check for threats
-			const threats = this.props.scanThreats;
-			if ( threats !== 0 ) {
-				return (
-					<DashItem
-						label={ labelName }
-						module="scan"
-						status="is-error"
-						statusText={ __( 'Threats found' ) }
-						pro={ true } >
-						<h3>{
-							__(
-								'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.',
-								{
-									count: threats,
-									args: {
-										number: numberFormat( threats )
-									}
-								} )
-						}</h3>
-						<p className="jp-dash-item__description">
-							{ __( '{{a}}View details at VaultPress.com{{/a}}', { components: { a: <a href="https://dashboard.vaultpress.com/" /> } } ) }
-							<br/>
-							{ __( '{{a}}Contact Support{{/a}}', { components: { a: <a href='https://jetpack.com/support' /> } } ) }
-						</p>
-					</DashItem>
-				);
-			}
+			if ( scanEnabled ) {
+				// Check for threats
+				const threats = this.props.scanThreats;
+				if ( threats !== 0 ) {
+					return (
+						<DashItem
+							label={ labelName }
+							module="scan"
+							status="is-error"
+							statusText={ __( 'Threats found' ) }
+							pro={ true } >
+							<h3>{
+								__(
+									'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.',
+									{
+										count: threats,
+										args: {
+											number: numberFormat( threats )
+										}
+									} )
+							}</h3>
+							<p className="jp-dash-item__description">
+								{ __( '{{a}}View details at VaultPress.com{{/a}}', { components: { a: <a href="https://dashboard.vaultpress.com/" /> } } ) }
+								<br/>
+								{ __( '{{a}}Contact Support{{/a}}', { components: { a: <a href='https://jetpack.com/support' /> } } ) }
+							</p>
+						</DashItem>
+					);
+				}
 
-			// All good
-			if ( vpData.code === 'success' ) {
-				return (
-					<DashItem
-						label={ labelName }
-						module="scan"
-						status="is-working"
-						pro={ true } >
-						<p className="jp-dash-item__description">
-							{ __( "No threats found, you're good to go!" ) }
-						</p>
-					</DashItem>
-				);
+				// All good
+				if ( vpData.code === 'success' ) {
+					return (
+						<DashItem
+							label={ labelName }
+							module="scan"
+							status="is-working"
+							pro={ true } >
+							<p className="jp-dash-item__description">
+								{ __( "No threats found, you're good to go!" ) }
+							</p>
+						</DashItem>
+					);
+				}
 			}
 		}
 
 		const upgradeOrActivateText = () => {
-			if ( hasSitePlan ) {
+			if ( this.props.fetchingSiteData ) {
+				return __( 'Loading…' );
+			}
+
+			if ( hasPremium || hasBusiness || scanEnabled ) {
 				return (
 					__( 'For automated, comprehensive scanning of security threats, please {{a}}install and activate{{/a}} VaultPress.', {
 						components: {
@@ -148,7 +166,8 @@ export default connect(
 			scanThreats: _getVaultPressScanThreatCount( state ),
 			sitePlan: getSitePlan( state ),
 			isDevMode: isDevMode( state ),
-			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
+			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug ),
+			fetchingSiteData: isFetchingSiteData( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -130,10 +130,15 @@ const ProStatus = React.createClass( {
 					}
 
 					if ( 'scan' === feature && ! hasBusiness && ! hasPremium ) {
-						btnVals = {
-							href: 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl,
-							text: __( 'Upgrade' )
-						}
+						return (
+							<Button
+								compact={ true }
+								primary={ true }
+								href={ 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl }
+							>
+								{ __( 'Upgrade' ) }
+							</Button>
+						);
 					}
 				} else {
 					btnVals = {
@@ -157,7 +162,7 @@ const ProStatus = React.createClass( {
 				);
 			}
 
-			return active && installed ?
+			return active && installed && sitePlan.product_slug ?
 				<span className="jp-dash-item__active-label">{ __( 'ACTIVE' ) }</span>
 				: '';
 		};

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -49,6 +49,10 @@ const ProStatus = React.createClass( {
 			'vaultpress/vaultpress.php' :
 			'akismet/akismet.php';
 
+		const hasPersonal = /jetpack_personal*/.test( sitePlan.product_slug ),
+			hasPremium = /jetpack_premium*/.test( sitePlan.product_slug ),
+			hasBusiness = /jetpack_business*/.test( sitePlan.product_slug );
+
 		let getStatus = ( feature, active, installed ) => {
 			let vpData = this.props.getVaultPressData();
 
@@ -123,6 +127,13 @@ const ProStatus = React.createClass( {
 					btnVals = {
 						href: `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }`,
 						text: __( 'Set up' )
+					}
+
+					if ( 'scan' === feature && ! hasBusiness && ! hasPremium ) {
+						btnVals = {
+							href: 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl,
+							text: __( 'Upgrade' )
+						}
 					}
 				} else {
 					btnVals = {


### PR DESCRIPTION
Fixes #6008

The Scan feature requires minimum Premium plan.  Make sure to show prompt to upgrade in the scan cards.  

While on a Personal plan, Make sure the `Upgrade` buttons shows for all scan cards: 
- /security tab
- /search page
- /dashboard card