### PR TITLE
Connection Banner: Remove tests for connection banner; Ship banner to all

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -22,43 +22,14 @@ class Jetpack_Connection_Banner {
 	 */
 	private function __construct() {
 		add_action( 'current_screen', array( $this, 'maybe_initialize_hooks' ) );
+		add_action( 'updating_jetpack_version', array( $this, 'cleanup_on_upgrade' ), 10, 2 );
 	}
 
-	/**
-	 * Checks whether the connection banner A/B test should be ran.
-	 *
-	 * @since 4.4.0
-	 *
-	 * @param null $now
-	 *
-	 * @return bool
-	 */
-	static function check_ab_test_not_expired( $now = null ) {
-		// Get the current timestamp in GMT
-		$now = empty( $now ) ? current_time( 'timestamp', 1 ) : $now;
-
-		// Arguments are hour, minute, second, month, day, year. So, we are getting the timestamp for GMT timestamp
-		// for the 15th of December 2016.
-		$expiration = gmmktime( 0, 0, 0, 12, 15, 2016 );
-
-		return $expiration >= $now;
-	}
-
-	/**
-	 * Gets the value for which connection banner to show, and initializes if not set.
-	 *
-	 * @since 4.4.0
-	 *
-	 * @return int
-	 */
-	static function get_random_connection_banner_value() {
-		$random_connection_banner = Jetpack_Options::get_option( 'connection_banner_ab' );
-		if ( ! $random_connection_banner ) {
-			$random_connection_banner = mt_rand( 1, 2 );
-			Jetpack_Options::update_option( 'connection_banner_ab', $random_connection_banner );
+	function cleanup_on_upgrade( $new_version = null, $old_version = null ) {
+		if ( version_compare( $old_version, '4.4', '>=' ) && version_compare( $old_version, '4.5', '<' ) ) {
+			// We don't use `Jetpack_Options` here since the option is no longer in that class.
+			delete_option( 'jetpack_connection_banner_ab' );
 		}
-
-		return $random_connection_banner;
 	}
 
 	/**

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -62,12 +62,13 @@ class Jetpack_Connection_Banner {
 	}
 
 	/**
-	 * Will initialize hooks to display the new and legacy connection banners if the current user can
+	 * Will initialize hooks to display the new (as of 4.4) connection banner if the current user can
 	 * connect Jetpack, if Jetpack has not been deactivated, and if the current page is the plugins page.
 	 *
 	 * This method should not be called if the site is connected to WordPress.com or if the site is in development mode.
 	 *
 	 * @since 4.4.0
+	 * @since 4.5.0 Made the new (as of 4.4) connection banner display to everyone by default.
 	 *
 	 * @param $current_screen
 	 */
@@ -81,13 +82,8 @@ class Jetpack_Connection_Banner {
 			return;
 		}
 
-		if ( self::check_ab_test_not_expired() && 2 == self::get_random_connection_banner_value() ) {
-			add_action( 'admin_notices', array( $this, 'render_banner' ) );
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_banner_scripts' ) );
-		} else {
-			add_action( 'admin_notices', array( $this, 'render_legacy_banner' ) );
-
-		}
+		add_action( 'admin_notices', array( $this, 'render_banner' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_banner_scripts' ) );
 
 		add_action( 'admin_print_styles', array( Jetpack::init(), 'admin_banner_styles' ) );
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -51,7 +51,6 @@ class Jetpack_Options {
 				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
 				'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
-				'connection_banner_ab',        // (int) 1 or 2, which will represent which connection banner to show.
 			);
 
 		case 'private' :

--- a/tests/php/test_class.jetpack-connection-banner.php
+++ b/tests/php/test_class.jetpack-connection-banner.php
@@ -8,10 +8,4 @@ class WP_Test_Jetpack_Connection_Banner extends WP_UnitTestCase {
 	function test_ab_test_expiration_after_12_15() {
 		$this->assertFalse( Jetpack_Connection_Banner::check_ab_test_not_expired( strtotime( '17 December 2016' ) ) );
 	}
-
-	function test_get_random_connection_banner_value_if_not_set() {
-		Jetpack_Options::delete_option( 'connection_banner_ab' );
-		$this->assertNotEquals( false, Jetpack_Connection_Banner::get_random_connection_banner_value() );
-		$this->assertNotEquals( false, Jetpack_Options::get_option( 'connection_banner_ab' ) );
-	}
 }

--- a/tests/php/test_class.jetpack-connection-banner.php
+++ b/tests/php/test_class.jetpack-connection-banner.php
@@ -1,11 +1,15 @@
 <?php
 
 class WP_Test_Jetpack_Connection_Banner extends WP_UnitTestCase {
-	function test_ab_test_expiration_before_12_15() {
-		$this->assertTrue( Jetpack_Connection_Banner::check_ab_test_not_expired( strtotime( '10 November 2016' ) ) );
-	}
+	function test_connection_banner_cleans_up_on_upgrade() {
+		Jetpack_Connection_Banner::init();
+		$this->assertTrue( update_option( 'jetpack_connection_banner_ab', 2 ) );
 
-	function test_ab_test_expiration_after_12_15() {
-		$this->assertFalse( Jetpack_Connection_Banner::check_ab_test_not_expired( strtotime( '17 December 2016' ) ) );
+		$this->assertEquals( 2, get_option( 'jetpack_connection_banner_ab' ) );
+
+		/** This action is documented in class.jetpack.php */
+		do_action( 'updating_jetpack_version', '4.5', '4.4.1' );
+
+		$this->assertFalse( get_option( 'jetpack_connection_banner_ab' ) );
 	}
 }


### PR DESCRIPTION
@jeffgolenski and @rickybanister requested that we ship the connection banner to all users in 4.5 since the tests in 4.4 seemed to be in favor of the new connection banner. This PR makes that happen.

To test:

- Checkout branch
- Deactivate Jetpack
- Go to plugins page
- You should see something that looks like this:
    <img width="1076" alt="screen shot 2017-01-12 at 10 20 23 am" src="https://cloud.githubusercontent.com/assets/1126811/21902429/bff6aad2-d8b0-11e6-9567-54c4440f5439.png">
