### PR TITLE
Custom CSS: update configuration link to new Core CSS editor.

### DIFF
--- a/modules/custom-css.php
+++ b/modules/custom-css.php
@@ -52,7 +52,9 @@ function custom_css_loaded() {
 }
 
 function custom_css_configuration_load() {
-	wp_safe_redirect( admin_url( 'themes.php?page=editcss#settingsdiv' ) );
+	wp_safe_redirect( Jetpack_Custom_CSS_Enhancements::customizer_link( array(
+		'return_url' => wp_get_referer(),
+	) ) );
 	exit;
 }
 

--- a/modules/custom-css.php
+++ b/modules/custom-css.php
@@ -52,9 +52,18 @@ function custom_css_loaded() {
 }
 
 function custom_css_configuration_load() {
-	wp_safe_redirect( Jetpack_Custom_CSS_Enhancements::customizer_link( array(
-		'return_url' => wp_get_referer(),
-	) ) );
+	// Redirect to Core's CSS editor in the customizer if the feature is available.
+	if ( function_exists( 'wp_get_custom_css' ) ) {
+		$configuration_link = Jetpack_Custom_CSS_Enhancements::customizer_link(
+			array(
+				'return_url' => wp_get_referer(),
+			)
+		);
+	} else {
+		$configuration_link = admin_url( 'themes.php?page=editcss#settingsdiv' );
+	}
+
+	wp_safe_redirect( $configuration_link );
 	exit;
 }
 


### PR DESCRIPTION
Fixes #6089

#### Testing instructions:

1. Go to Jetpack > Settings > Appearance
2. Activate the Custom CSS module.
3. Click on the link to configure Custom CSS in the card settings.
4. You should be redirected to the new Core CSS editor in the customizer.