### PR TITLE
REST API: Add support for HTTP_CONTENT_TYPE in authentication

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4812,10 +4812,17 @@ p {
 			);
 			return null;
 		}
+
+		if ( ! empty( $_SERVER['CONTENT_TYPE'] ) ) {
+			$content_type = $_SERVER['CONTENT_TYPE'];
+		} elseif ( ! empty( $_SERVER['HTTP_CONTENT_TYPE'] ) ) {
+			$content_type = $_SERVER['HTTP_CONTENT_TYPE'];
+		}
+
 		if (
-			isset( $_SERVER['CONTENT_TYPE'] ) &&
-			$_SERVER['CONTENT_TYPE'] !== 'application/x-www-form-urlencoded' &&
-			$_SERVER['CONTENT_TYPE'] !== 'application/json'
+			isset( $content_type ) &&
+			$content_type !== 'application/x-www-form-urlencoded' &&
+			$content_type !== 'application/json'
 		) {
 			$this->rest_authentication_status = new WP_Error(
 				'rest_invalid_request',


### PR DESCRIPTION
In #5418 we introduced an alternative authentication method that allows us to authenticate with Jetpack Signatures. 

However while testing together with @oskosk we discovered that there's a bug with the `Content-Type`. Specifically, we're reading it only from `$_SERVER['CONTENT_TYPE']`, but  some servers might pass it as `$_SERVER['HTTP_CONTENT_TYPE']`. This PR adds support for `HTTP_CONTENT_TYPE` in addition to `CONTENT_TYPE`. In addition, we're making sure that the content type is actually specified (by using `! empty()` instead of `isset()`).

Thanks @oskosk for finding this one.

#### Testing instructions

Please review the code. The fix here appears to be a common practice with PHP development, as we always need to consider BOTH keys under `$_SERVER` for correct content type detection. 

#### Proposed changelog entry for your changes:

Fixes detection of request content type, based on available headers passed down by the web server. 