### PR TITLE
VideoPress: Fix JITM links, break out of the loop. 

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -394,7 +394,7 @@ class Jetpack_JITM {
 	function videopress_media_upload_warning_msg() {
 		$jitm_stats_url = Jetpack::build_stats_url( array( 'x_jetpack-jitm' => 'videopress' ) );
 
-		$upload_url   = admin_url( 'upload.php' );
+		$upload_url   = add_query_arg( 'mode', 'grid', admin_url( 'upload.php' ) );
 		$new_post_url = admin_url( 'post-new.php' );
 
 		$msg = sprintf( __( 'Only videos uploaded from within the <a href="%s">media library</a> or while creating a <a href="%s">new post</a> will be fully hosted by WordPress.com.', 'jetpack' ), esc_url( $upload_url ), esc_url( $new_post_url ) );


### PR DESCRIPTION
![screen shot 2017-01-13 at 9 01 10 am](https://cloud.githubusercontent.com/assets/7129409/21933083/e8a9021a-d971-11e6-85cc-2027e84f92f5.png)

I noticed that this message https://cloudup.com/cxb1BE49-y8 takes you to `/wp-admin/upload.php`, but then when you click "Add New" there, you're taken back to `/wp-admin/media-new.php` where the message is... Stuck in a loop.  

This PR makes sure that we link to a place (`/wp-admin/upload.php?mode=grid`) that we have control over, and will be able to upload videos to.  

@dbtlr for review 