### PR TITLE
Only check services belonging or shared with user when deciding whether to publicize

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -450,7 +450,7 @@ class Publicize extends Publicize_Base {
 	function save_publicized( $post_ID, $post, $update ) {
 		// Only do this when a post transitions to being published
 		if ( get_post_meta( $post->ID, $this->PENDING ) && $this->post_type_is_publicizeable( $post->post_type ) ) {
-			$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
+			$connected_services = $this->get_services( 'connected' );
 			if ( ! empty( $connected_services ) ) {
 				/**
 				 * Fires when a post is saved that has is marked as pending publicizing


### PR DESCRIPTION
Fixes an issue where the publicize method was being sent based on all services available to the system, not just on whether services were enabled/available for the current user.