### PR TITLE
Patch Grunion for PHP 7.1

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1282,6 +1282,9 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 	function __construct( $attributes, $content = null ) {
 		global $post;
+		
+		// Force attributes to be an array to work on PHP 7.1
+		$attributes = (array) $attributes;
 
 		// Set up the default subject and recipient for this form
 		$default_to = '';


### PR DESCRIPTION
Force attributes to be an array for the contact form so they actually show on PHP 7.1

Fixes #5810

#### Changes proposed in this Pull Request:

Force attributes to be an array in `class Grunion_Contact_Form` via `$attributes = (array) $attributes;` for support on PHP 7.1

#### Testing instructions:

* Install PHP 7.1
* Make a contact form
* See it broken
* Apply this patch
* Rejoice!

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Add support for PHP 7.1 and Grunion

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If [Gulp](http://gulpjs.com/) is installed on your testing environment, run `gulp js:hint` before to commit your changes. It will allow you to [detect errors in Javascript files](http://jshint.com/about/).
- [ ] Did you create a **new action or filter**? [Add inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters) to help others understand how to use the action or the filter.
- [ ] Create **[unit tests](https://github.com/Automattic/jetpack/tree/master/tests)** if you can. If you're not familiar with Unit Testing, you can check [this tutorial](https://pippinsplugins.com/series/unit-tests-wordpress-plugins/).