### PR TITLE
Sync: Require Jetpack_Sync_Settings class before cleanup on upgrade

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -389,6 +389,7 @@ class Jetpack_Sync_Actions {
 
 		$is_new_sync_upgrade = version_compare( $old_version, '4.2', '>=' );
 		if ( ! empty( $old_version ) && $is_new_sync_upgrade && version_compare( $old_version, '4.5', '<' ) ) {
+			require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 			self::clear_sync_cron_jobs();
 			Jetpack_Sync_Settings::update_settings( array(
 				'render_filtered_content' => Jetpack_Sync_Defaults::$default_render_filtered_content


### PR DESCRIPTION
Fixes an issue that was introduced in #6099 where we were causing a fatal error when upgrading:

`Fatal error: Class 'Jetpack_Sync_Settings' not found in /wp-content/plugins/jetpack/sync/class.jetpack-sync-actions.php on line 393`

The issue here is that we didn't include the `Jetpack_Sync_Settings` class before updating a setting.