### PR TITLE
Removed a carriage return character from module headings builder.

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -19,7 +19,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'carousel' => array(
 				'name' => _x( 'Carousel', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Transform image galleries into gorgeous, full-screen slideshows.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Display images and galleries in a gorgeous, full-screen browsing experience.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Brings your photos and images to life as full-size, easily navigable galleries.', 'Jumpstart Description', 'jetpack' ),
 			),
 
@@ -194,7 +194,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'videopress' => array(
 				'name' => _x( 'VideoPress', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Powerful, simple video hosting for WordPress', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Powerful, simple video hosting for WordPress.', 'Module Description', 'jetpack' ),
 			),
 
 			'widget-visibility' => array(
@@ -209,7 +209,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'wordads' => array(
 				'name' => _x( 'Ads', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Earn income by allowing Jetpack to insert high quality ads.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Earn income by allowing Jetpack to display high quality ads.', 'Module Description', 'jetpack' ),
 			),
 		);
 	}

--- a/tools/build-module-headings-translations.php
+++ b/tools/build-module-headings-translations.php
@@ -49,7 +49,7 @@ foreach ( $files as $file ) {
 					$tags[ $tag ][] = $relative_path;
 				}
 			} else {
-				$_file_contents .= "\t\t\t\t'{$field}' => _x( '{$string}', '{$regex}', 'jetpack' ),\r\n";
+				$_file_contents .= "\t\t\t\t'{$field}' => _x( '{$string}', '{$regex}', 'jetpack' ),\n";
 			}
 		}
 	}


### PR DESCRIPTION
Makes the builder script generate lines without carriage return symbols on the end, making it compatible with what we have in the editor config file.
