### PR TITLE
API Endpoint: API Request should behave in the same way as when we sync filtered content.

### DIFF
--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -162,7 +162,7 @@ class Jetpack_Sync_Settings {
 	}
 
 	static function is_syncing() {
-		return (bool) self::$is_syncing;
+		return (bool) self::$is_syncing || ( defined( 'DOING_CRON' ) && REST_API_REQUEST );
 	}
 
 	static function set_is_syncing( $is_syncing ) {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -162,7 +162,7 @@ class Jetpack_Sync_Settings {
 	}
 
 	static function is_syncing() {
-		return (bool) self::$is_syncing || ( defined( 'DOING_CRON' ) && REST_API_REQUEST );
+		return (bool) self::$is_syncing || ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST );
 	}
 
 	static function set_is_syncing( $is_syncing ) {


### PR DESCRIPTION
Fixes #4601

#### Changes proposed in this Pull Request:
Treat Rest api the same as when data is being synced to .com. 

#### Testing instructions:
* Enable Sharing module, make sure that the posts api endpoint is coming from the Jetpack site. ( not the shadow site)

Notice that you do not see the sharing buttons code in the content of the post.

#### Proposed changelog entry for your changes:
Bug fix: Posts API Endpoint does not contain the appended html of share buttons.

