### PR TITLE
Sharing: force get sharing options when saved options are incorrect

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -170,6 +170,11 @@ class Sharing_Service {
 		$enabled  = get_option( 'sharing-services' );
 		$services = $this->get_all_services();
 
+		/**
+		 * Check if options exist and are well formatted.
+		 * This avoids issues on sites with corrupted options.
+		 * @see https://github.com/Automattic/jetpack/issues/6121
+		 */
 		if ( ! is_array( $options ) || ! isset( $options['button_style'] ) ) {
 			$options = array( 'global' => $this->get_global_options() );
 		}

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -175,7 +175,7 @@ class Sharing_Service {
 		 * This avoids issues on sites with corrupted options.
 		 * @see https://github.com/Automattic/jetpack/issues/6121
 		 */
-		if ( ! is_array( $options ) || ! isset( $options['button_style'] ) ) {
+		if ( ! is_array( $options ) || ! isset( $options['button_style'], $options['global'] ) ) {
 			$options = array( 'global' => $this->get_global_options() );
 		}
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -170,8 +170,9 @@ class Sharing_Service {
 		$enabled  = get_option( 'sharing-services' );
 		$services = $this->get_all_services();
 
-		if ( !is_array( $options ) )
+		if ( ! is_array( $options ) || ! isset( $options['button_style'] ) ) {
 			$options = array( 'global' => $this->get_global_options() );
+		}
 
 		$global = $options['global'];
 


### PR DESCRIPTION
Fixes #6121

When testing on one of the sites mentioned in #6121, `get_option( 'sharing-options' );` would return data saved from another plugin, Yoast SEO. On a regular site, Yoast SEO saves that data in `get_option( 'wpseo_social' );`, but on that particular site, `get_option( 'sharing-options' );` always returned data from the `wpseo_social` option.

One way to work around this was to add an additional check when checking for the integrity of the data we got from `get_option( 'sharing-options' );`.

That's what I came up with, but I'd be happy to consider other alternatives, though :)

Since Yoast SEO wasn't even installed on the other site, I guess the original problem may be linked to database configuration or caching issues.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Sharing: force get sharing options when saved options are incorrect due to site configuration issues. Avoids potential fatal errors.