### PR TITLE
Photon: Use array_replace instead of array_merge for filter_srcset_array.

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -720,7 +720,7 @@ class Jetpack_Photon {
 					);
 			} // foreach ( $multipliers as $multiplier )
 			if ( is_array( $newsources ) ) {
-				$sources = array_merge( $sources, $newsources );
+				$sources = array_replace( $sources, $newsources );
 			}
 		} // if ( isset( $image_meta['width'] ) && isset( $image_meta['file'] ) )
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Before this array_merge, the $sources index is based on the image width. After, it's 0 based. This is causing issues with plugins that do srcset CDN replacement, similar to this: 

https://github.com/2aces/wordpress-srcset-cdn

The array_replace resolves this by preserving the original array index and replacing the duplicates in the original array. 

#### Testing instructions:

* Add the above plugin to your site. 
* Enable Photon.
* Enable WP_DEBUG. 
* Watch for notices like: 

```
Notice: Undefined offset: 688 in wordpress-srcset-cdn/wordpress-srcset-cdn.php on line 19
```


cc: @kraftbj
Related: #3748