### PR TITLE
Open Graph: Grab site icon ID directly

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -360,10 +360,10 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 	if ( empty( $image ) && ( function_exists( 'has_site_icon') && has_site_icon() ) ) {
 		$max_side = max( $width, $height );
 		$image_url = get_site_icon_url( $max_side );
+		$image_id = get_option( 'site_icon' );
 
 		$img_width  = '';
 		$img_height = '';
-		$image_id = attachment_url_to_postid( $image_url );
 		$image_size = wp_get_attachment_image_src( $image_id, $max_side >= 512
 			? 'full'
 			: array( $max_side, $max_side ) );


### PR DESCRIPTION
When checking for optimal sizing for our open graph image, instead of using `attachment_url_to_postid` for the reverse lookup of our site icon, we can just grab the icon id directly via options. This is much faster as `attachment_url_to_postid` can be very slow on large sites.

See #6061

#### Testing instructions:

* Add core site icon to your site that meets the required dimensions.
* Go to the homepage and view source.
* Make sure that `og:image` displays the site icon you selected.
