### PR TITLE
Don't call site_url() twice

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1303,11 +1303,10 @@ class Jetpack {
 
 		if ( defined( 'JETPACK_DEV_DEBUG' ) ) {
 			$development_mode = JETPACK_DEV_DEBUG;
+		} elseif ( $site_url = site_url() ) {
+			$development_mode = false === strpos( $site_url, '.' );
 		}
 
-		elseif ( site_url() && false === strpos( site_url(), '.' ) ) {
-			$development_mode = true;
-		}
 		/**
 		 * Filters Jetpack's development mode.
 		 *


### PR DESCRIPTION
In `Jetpack::is_development_mode`, we current call the `site_url()` function twice on the same line. This is a waste since the value is unlikely to change between those two calls. 

#### Changes proposed in this Pull Request:

Assign the value of `site_url()` to a variable and uses that value to check whether we're on a tld-less domain or not.

#### Testing instructions:

* Make sure `JETPACK_DEV_DEBUG` constant is not set.
* With Jetpack on a domain like `localhost`, verify that the value of `Jetpack::is_development_mode()` is `true`.
* With Jetpack on a domain like `localhost.dev`, verify that the value of `Jetpack::is_development_mode()` is `false`.