### PR TITLE
Twitter Widget: add noscrollbar option back.

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -81,7 +81,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		echo $args['before_widget'];
 
 		$title = isset( $instance['title'] ) ? $instance['title'] : '';
-		
+
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title );
 		if ( ! empty( $title ) ) {
@@ -222,7 +222,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			'noheader',
 			'nofooter',
 			'noborders',
-			'transparent'
+			'transparent',
+			'noscrollbar',
 		);
 		if ( isset( $new_instance['chrome'] ) ) {
 			foreach ( $new_instance['chrome'] as $chrome ) {
@@ -412,6 +413,16 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			/>
 			<label for="<?php echo $this->get_field_id( 'chrome-noborders' ); ?>">
 				<?php esc_html_e( 'No Borders', 'jetpack' ); ?>
+			</label>
+			<br />
+			<input
+				type="checkbox"<?php checked( in_array( 'noscrollbar', $instance['chrome'] ) ); ?>
+				id="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>"
+				name="<?php echo $this->get_field_name( 'chrome' ); ?>[]"
+				value="noscrollbar"
+			/>
+			<label for="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>">
+				<?php esc_html_e( 'No Scrollbar', 'jetpack' ); ?>
 			</label>
 			<br />
 			<input


### PR DESCRIPTION
The option was removed in #4198, but it is still supported by Twitter:
https://dev.twitter.com/web/embedded-timelines#customization

To be be able to hide the scrollbar, you should not specify a number of tweets in the widget.
If you do, the `data-tweet-limit` attribute will be added to the widget and the timeline will automatically adjust its height to fit the
specified number of Tweets. That's most likely why we thought the option didn't work when testing in #4198.

Reported here:
https://twitter.com/LorrieW_Art/status/822005258096406529

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Twitter Widget: add noscrollbar option back.