### PR TITLE
Revert "Update CSV call to https"

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -1194,7 +1194,7 @@ function stats_get_csv( $table, $args = null ) {
 	$args['table'] = $table;
 	$args['blog_id'] = Jetpack_Options::get_option( 'id' );
 
-	$stats_csv_url = add_query_arg( $args, 'https://stats.wordpress.com/csv.php' );
+	$stats_csv_url = add_query_arg( $args, 'http://stats.wordpress.com/csv.php' );
 
 	$key = md5( $stats_csv_url );
 


### PR DESCRIPTION
This reverts commit da8d091a31a459616a6b325a8d6c2873a7393200.

On some hosts, this change was resulting in the remote requests to fail, which led to no posts being returned for top posts, subscribers, and other things that relied on the stats csv.  

The response body returned by `stats_get_remote_csv()` does not return data, but instead `Error: api_key is a required parameter...`.  It seems as if wpcom does not validate the current user?  

I could not reproduce on two separate hosts, nor get my site to talk to my sandboxed stats csv API, so debugging was futile.  Since the original change here only sought to avoid a redirect in the request, we're not losing/breaking anything by reverting the change.  