### PR TITLE
Top Posts Widget: make sure an image size is always provided.

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -250,6 +250,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 				'fallback_to_avatars' => true,
 				/** This filter is documented in modules/stats.php */
 				'gravatar_default' => apply_filters( 'jetpack_static_url', set_url_scheme( 'https://en.wordpress.com/i/logo/white-gray-80.png' ) ),
+				'avatar_size' => 40,
 			);
 			if ( 'grid' == $display ) {
 				$get_image_options['avatar_size'] = 200;


### PR DESCRIPTION
Ports the second part of r148090-wpcom

#6014 brought over some changes from WordPress.com, but not all of the commit. As a result, when someone uses the `list` layout in the Top Posts Widget, no image size is provided and the widget ends up serving the full size image.

cc @lancewillett 

#### Testing instructions:

1. Activate Jetpack, Stats, Extra Sidebar Widgets.
2. In Appearance > Widgets, create a new Top Posts Widget, choose the list layout.
3. Save.
4. View your site.
5. In a browser inspector, check the widget's image URLs. They should use Photon and should include `resize=40,40` at the end of the URL.

#### Proposed changelog entry for your changes:

* Top Posts Widget: fix image size when using the List Layout.

Reported here:
https://wordpress.org/support/topic/new-jetpack-update-not-resizing-image-in-top-posts-page-widget-image-list/