### PR TITLE
Make sure the index is defined to solve a PHP notice and provide a fallback

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -230,9 +230,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 		// Get last post, to build the link to Customizer in the Related Posts module.
 		$last_post = get_posts( array( 'posts_per_page' => 1 ) );
-		if ( $last_post[0] instanceof WP_Post ) {
-			$last_post = get_permalink( $last_post[0]->ID );
-		}
+		$last_post = isset( $last_post[0] ) && $last_post[0] instanceof WP_Post
+			? get_permalink( $last_post[0]->ID )
+			: get_home_url();
 
 		// Add objects to be passed to the initial state of the app
 		wp_localize_script( 'react-plugin', 'Initial_State', array(


### PR DESCRIPTION
Fixes #6125

#### Changes proposed in this Pull Request:
- tests that a post is retured by `get_posts`
- if there's not a post returned, will add the link to home

#### Testing instructions:
* implementing this fix should solve the notice
Notice: Undefined offset: 0 in /home/XXXXXXXX/public_html/wp-content/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php on line 233 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Admin: fixes PHP notice regarding undefined offset 0 in array

cc @richardmtl 

