### PR TITLE
SSO: rename module to Secure Sign On

### DIFF
--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -339,7 +339,7 @@ export let MonitorSettings = React.createClass( {
 
 MonitorSettings = moduleSettingsForm( MonitorSettings );
 
-export let SingleSignOnSettings = React.createClass( {
+export let SecureSignOnSettings = React.createClass( {
 	render() {
 		return (
 			<form onSubmit={ this.props.onSubmit } >
@@ -362,7 +362,7 @@ export let SingleSignOnSettings = React.createClass( {
 	}
 } );
 
-SingleSignOnSettings = moduleSettingsForm( SingleSignOnSettings );
+SecureSignOnSettings = moduleSettingsForm( SecureSignOnSettings );
 
 export let CarouselSettings = React.createClass( {
 	render() {

--- a/_inc/client/components/module-settings/modules-per-tab-page.jsx
+++ b/_inc/client/components/module-settings/modules-per-tab-page.jsx
@@ -16,7 +16,7 @@ import {
 	SubscriptionsSettings,
 	ProtectSettings,
 	MonitorSettings,
-	SingleSignOnSettings,
+	SecureSignOnSettings,
 	MinilevenSettings,
 	CarouselSettings,
 	InfiniteScrollSettings,
@@ -89,7 +89,7 @@ const AllModuleSettingsComponent = React.createClass( {
 					</div>
 				);
 			case 'sso':
-				return ( <SingleSignOnSettings module={ module }  /> );
+				return ( <SecureSignOnSettings module={ module }  /> );
 			case 'seo-tools':
 				if ( '' === module.configure_url ) {
 					return (

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -3,7 +3,7 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' 
 require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' );
 
 /**
- * Module Name: Single Sign On
+ * Module Name: Secure Sign On
  * Module Description: Secure user authentication with WordPress.com.
  * Jumpstart Description: Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.
  * Sort Order: 30
@@ -195,7 +195,7 @@ class Jetpack_SSO {
 	}
 
 	/**
-	 * Adds settings fields to Settings > General > Single Sign On that allows users to
+	 * Adds settings fields to Settings > General > Secure Sign On that allows users to
 	 * turn off the login form on wp-login.php
 	 *
 	 * @since 2.7
@@ -204,13 +204,13 @@ class Jetpack_SSO {
 
 		add_settings_section(
 			'jetpack_sso_settings',
-			__( 'Single Sign On' , 'jetpack' ),
+			__( 'Secure Sign On' , 'jetpack' ),
 			'__return_false',
 			'jetpack-sso'
 		);
 
 		/*
-		 * Settings > General > Single Sign On
+		 * Settings > General > Secure Sign On
 		 * Require two step authentication
 		 */
 		register_setting(
@@ -228,7 +228,7 @@ class Jetpack_SSO {
 		);
 
 		/*
-		 * Settings > General > Single Sign On
+		 * Settings > General > Secure Sign On
 		 */
 		register_setting(
 			'jetpack-sso',

--- a/modules/sso/class.jetpack-sso-notices.php
+++ b/modules/sso/class.jetpack-sso-notices.php
@@ -135,7 +135,7 @@ class Jetpack_SSO_Notices {
 
 	/**
 	 * Message displayed when the site admin has disabled the default WordPress
-	 * login form in Settings > General > Single Sign On
+	 * login form in Settings > General > Secure Sign On
 	 *
 	 * @since 2.7
 	 * @param string $message


### PR DESCRIPTION
Fixes #5957

#### Changes proposed in this Pull Request:
Rename **Single Sign On** to **Secure Sign On**

#### Testing instructions:

* Verify all instances of "Single Sign On" have been properly renamed

#### Proposed changelog entry for your changes:
Renamed 'Single Sign On' module to 'Secure Sign On'