### PR TITLE
Widgets: Prepend widgets with Jetpack_ to minimize conflicts

### DIFF
--- a/modules/widgets/follow-button.php
+++ b/modules/widgets/follow-button.php
@@ -4,11 +4,11 @@
 //add_action( 'widgets_init', 'follow_button_register_widget' );
 function follow_button_register_widget() {
 	if ( Jetpack::is_active() ) {
-		register_widget( 'Follow_Button_Widget' );
+		register_widget( 'Jetpack_Follow_Button_Widget' );
 	}
 }
 
-class Follow_Button_Widget extends WP_Widget {
+class Jetpack_Follow_Button_Widget extends WP_Widget {
 
 	public function __construct() {
 		parent::__construct(

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class Google_Translate_Widget extends WP_Widget {
+class Jetpack_Google_Translate_Widget extends WP_Widget {
 	static $instance = null;
 
 	/**
@@ -136,6 +136,6 @@ class Google_Translate_Widget extends WP_Widget {
  * Register the widget for use in Appearance -> Widgets.
  */
 function jetpack_google_translate_widget_init() {
-	register_widget( 'Google_Translate_Widget' );
+	register_widget( 'Jetpack_Google_Translate_Widget' );
 }
 add_action( 'widgets_init', 'jetpack_google_translate_widget_init' );

--- a/modules/widgets/upcoming-events.php
+++ b/modules/widgets/upcoming-events.php
@@ -1,6 +1,6 @@
 <?php
 
-class Upcoming_Events_Widget extends WP_Widget {
+class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 	function __construct() {
 		parent::__construct(
 			'upcoming_events_widget',
@@ -153,7 +153,7 @@ class Upcoming_Events_Widget extends WP_Widget {
 }
 
 function upcoming_events_register_widgets() {
-	register_widget( 'Upcoming_Events_Widget' );
+	register_widget( 'Jetpack_Upcoming_Events_Widget' );
 }
 
 add_action( 'widgets_init', 'upcoming_events_register_widgets' );


### PR DESCRIPTION
Fixes #6145.

In 3016571-t, a user reported a conflict with this plugin.

To fix this issue, and avoid conflicts in the future, this PR seeks to rename widgets which do not have `Jetpack_` or `WPCOM_` at the beginning of their class name.

To test:

- Checkout branch
- Go to Customize
- Add an `Upcoming Events` widget
- Add a `Google Translate` widget
- There should be no errors

Note: The follow button widget is not currently functional due to performance concerns.
