### PR TITLE
Sync: Fix undefined variable when processing shortcodes

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -190,13 +190,14 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 * @param array of shortcode tags to remove.
 		 */
 		$shortcodes_to_remove = apply_filters( 'jetpack_sync_do_not_expand_shortcodes', array( 'gallery', 'slideshow' ) );
+		$removed_shortcode_callbacks = array();
 		foreach ( $shortcodes_to_remove as $shortcode ) {
 			if ( isset ( $shortcode_tags[ $shortcode ] )  ) {
-				$shortcodes_and_callbacks_to_remove[ $shortcode ] =  $shortcode_tags[ $shortcode ];
+				$removed_shortcode_callbacks[ $shortcode ] =  $shortcode_tags[ $shortcode ];
 			}
 		}
 
-		array_map( 'remove_shortcode' , array_keys( $shortcodes_and_callbacks_to_remove ) );
+		array_map( 'remove_shortcode' , array_keys( $removed_shortcode_callbacks ) );
 
 		/** This filter is already documented in core. wp-includes/post-template.php */
 		if ( Jetpack_Sync_Settings::get_setting( 'render_filtered_content' ) && $post_type->public  ) {
@@ -204,7 +205,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$post->post_excerpt_filtered   = apply_filters( 'the_excerpt', $post->post_excerpt );
 		}
 
-		foreach ( $shortcodes_and_callbacks_to_remove as $shortcode => $callback ) {
+		foreach ( $removed_shortcode_callbacks as $shortcode => $callback ) {
 			add_shortcode( $shortcode, $callback );
 		}
 


### PR DESCRIPTION
Fixes a warning like this when there are no shortcodes to remove and posts are being post-processed:

```
*E_WARNING: /home/foo/public_html/wp-content/plugins/jetpack/sync/class.jetpack-sync-module-posts.php:198 - array_keys() expects parameter 1 to be array, null given*
array_keys() expects parameter 1 to be array, null given
```