### PR TITLE
Custom CSS: fix a PHP notice

### DIFF
--- a/modules/custom-css/custom-css-4.7.php
+++ b/modules/custom-css/custom-css-4.7.php
@@ -149,6 +149,11 @@ class Jetpack_Custom_CSS_Enhancements {
 	 * @return array $fields Modified array to include post_content_filtered.
 	 */
 	public static function _wp_post_revision_fields( $fields, $post ) {
+		// None of the fields in $post are required to be passed in this filter.
+		if( ! isset( $post['post_type'] ) || ! isset( $post['ID'] ) ) {
+			return $fields;
+		}
+
 		// If we're passed in a revision, go get the main post instead.
 		if ( 'revision' === $post['post_type'] ) {
 			$main_post_id = wp_is_post_revision( $post['ID'] );

--- a/modules/custom-css/custom-css-4.7.php
+++ b/modules/custom-css/custom-css-4.7.php
@@ -150,7 +150,7 @@ class Jetpack_Custom_CSS_Enhancements {
 	 */
 	public static function _wp_post_revision_fields( $fields, $post ) {
 		// None of the fields in $post are required to be passed in this filter.
-		if( ! isset( $post['post_type'] ) || ! isset( $post['ID'] ) ) {
+		if ( ! isset( $post['post_type'], $post['ID'] ) ) {
 			return $fields;
 		}
 


### PR DESCRIPTION
The `$post` parameter for the `_wp_post_revision_fields` filter doesn’t
necessarily have any of the fields set that this function requires.

If they’re not set, bail early.

Fixes #6128
