### PR TITLE
Switch to wp_json_encode to gracefully handle encoding issues

### DIFF
--- a/sync/class.jetpack-sync-json-deflate-array-codec.php
+++ b/sync/class.jetpack-sync-json-deflate-array-codec.php
@@ -23,7 +23,7 @@ class Jetpack_Sync_JSON_Deflate_Array_Codec implements iJetpack_Sync_Codec {
 
 	// @see https://gist.github.com/muhqu/820694
 	private function json_serialize( $any ) {
-		return json_encode( $this->json_wrap( $any ) );
+		return wp_json_encode( $this->json_wrap( $any ) );
 	}
 
 	private function json_unserialize( $str ) {


### PR DESCRIPTION
Attempts to fix issues with some sites failing to sync posts that have illegate multibyte characters in them. It was suggested that `wp_json_encode()` is better at dealing with this than regular `json_encode()`. This has yet to be verified.