### PR TITLE
SSO: Pass $user_data to new user override filter

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -666,6 +666,11 @@ class Jetpack_SSO {
 			 * user, then we know that email is unused, so it's safe to add.
 			 */
 			if ( Jetpack_SSO_Helpers::match_by_email() || ! get_user_by( 'email', $user_data->email ) ) {
+				
+				if ( $new_user_override_role ) {
+					$user_data->role = $new_user_override_role;
+				}
+
 				$user = Jetpack_SSO_Helpers::generate_user( $user_data );
 				if ( ! $user ) {
 					JetpackTracking::record_user_event( 'sso_login_failed', array(
@@ -673,10 +678,6 @@ class Jetpack_SSO {
 					) );
 					add_filter( 'login_message', array( 'Jetpack_SSO_Notices', 'error_unable_to_create_user' ) );
 					return;
-				}
-
-				if ( $new_user_override_role ) {
-					$user->set_role( $new_user_override_role );
 				}
 
 				$user_found_with = $new_user_override_role

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -655,7 +655,8 @@ class Jetpack_SSO {
 		}
 
 		// If we've still got nothing, create the user.
-		if ( empty( $user ) && ( get_option( 'users_can_register' ) || ( $new_user_override = Jetpack_SSO_Helpers::new_user_override( $user_data ) ) ) ) {
+		$new_user_override_role = false;
+		if ( empty( $user ) && ( get_option( 'users_can_register' ) || ( $new_user_override_role = Jetpack_SSO_Helpers::new_user_override( $user_data ) ) ) ) {
 			/**
 			 * If not matching by email we still need to verify the email does not exist
 			 * or this blows up
@@ -674,7 +675,11 @@ class Jetpack_SSO {
 					return;
 				}
 
-				$user_found_with = $new_user_override
+				if ( $new_user_override_role ) {
+					$user->set_role( $new_user_override_role );
+				}
+
+				$user_found_with = $new_user_override_role
 					? 'user_created_new_user_override'
 					: 'user_created_users_can_register';
 			} else {

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -655,7 +655,7 @@ class Jetpack_SSO {
 		}
 
 		// If we've still got nothing, create the user.
-		if ( empty( $user ) && ( get_option( 'users_can_register' ) || Jetpack_SSO_Helpers::new_user_override( $user_data ) ) ) {
+		if ( empty( $user ) && ( get_option( 'users_can_register' ) || ( $new_user_override = Jetpack_SSO_Helpers::new_user_override( $user_data ) ) ) ) {
 			/**
 			 * If not matching by email we still need to verify the email does not exist
 			 * or this blows up
@@ -674,7 +674,7 @@ class Jetpack_SSO {
 					return;
 				}
 
-				$user_found_with = Jetpack_SSO_Helpers::new_user_override()
+				$user_found_with = $new_user_override
 					? 'user_created_new_user_override'
 					: 'user_created_users_can_register';
 			} else {

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -655,7 +655,7 @@ class Jetpack_SSO {
 		}
 
 		// If we've still got nothing, create the user.
-		if ( empty( $user ) && ( get_option( 'users_can_register' ) || Jetpack_SSO_Helpers::new_user_override() ) ) {
+		if ( empty( $user ) && ( get_option( 'users_can_register' ) || Jetpack_SSO_Helpers::new_user_override( $user_data ) ) ) {
 			/**
 			 * If not matching by email we still need to verify the email does not exist
 			 * or this blows up

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -234,6 +234,11 @@ class Jetpack_SSO_Helpers {
 		$user->last_name    = $user_data->last_name;
 		$user->url          = $user_data->url;
 		$user->description  = $user_data->description;
+
+		if ( isset( $user_data->role ) && $user_data->role ) {
+			$user->role     = $user_data->role;
+		}
+
 		wp_update_user( $user );
 
 		update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -54,7 +54,7 @@ class Jetpack_SSO_Helpers {
 	 *
 	 * @return bool
 	 */
-	static function new_user_override() {
+	static function new_user_override( $user_data = null ) {
 		$new_user_override = defined( 'WPCC_NEW_USER_OVERRIDE' ) ? WPCC_NEW_USER_OVERRIDE : false;
 
 		/**
@@ -63,10 +63,12 @@ class Jetpack_SSO_Helpers {
 		 * @module sso
 		 *
 		 * @since 2.6.0
+		 * @since 4.6   $user_data object is now passed to the jetpack_sso_new_user_override filter
 		 *
-		 * @param bool $new_user_override Allow users to register on your site with a WordPress.com account. Default to false.
+		 * @param bool        $new_user_override Allow users to register on your site with a WordPress.com account. Default to false.
+		 * @param object|null $user_data         An object containing the user data returned from WordPress.com.
 		 */
-		return (bool) apply_filters( 'jetpack_sso_new_user_override', $new_user_override );
+		return (bool) apply_filters( 'jetpack_sso_new_user_override', $new_user_override, $user_data );
 	}
 
 	/**

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -58,7 +58,8 @@ class Jetpack_SSO_Helpers {
 		$new_user_override = defined( 'WPCC_NEW_USER_OVERRIDE' ) ? WPCC_NEW_USER_OVERRIDE : false;
 
 		/**
-		 * Allow users to register on your site with a WordPress.com account, even though you disallow normal registrations.
+		 * Allow users to register on your site with a WordPress.com account, even though you disallow normal registrations. 
+		 * If you return a string that corresponds to a user role, the user will be given that role.
 		 *
 		 * @module sso
 		 *
@@ -68,7 +69,17 @@ class Jetpack_SSO_Helpers {
 		 * @param bool        $new_user_override Allow users to register on your site with a WordPress.com account. Default to false.
 		 * @param object|null $user_data         An object containing the user data returned from WordPress.com.
 		 */
-		return (bool) apply_filters( 'jetpack_sso_new_user_override', $new_user_override, $user_data );
+		$role = apply_filters( 'jetpack_sso_new_user_override', $new_user_override, $user_data );
+
+		if ( $role ) {
+			if ( is_string( $role ) && get_role( $role ) ) {
+				return $role;
+			} else {
+				return get_option( 'default_role' );
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -75,9 +75,11 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		remove_filter( 'jetpack_sso_match_by_email', '__return_false' );
 	}
 
-	function test_sso_helpers_new_user_override_filter_true() {
+	function test_sso_helpers_new_user_override_filter_true_returns_default_role() {
+		add_role( 'foo', 'Foo' );
+		update_option( 'default_role', 'foo' );
 		add_filter( 'jetpack_sso_new_user_override', '__return_true' );
-		$this->assertTrue( Jetpack_SSO_Helpers::new_user_override() );
+		$this->assertEquals( 'foo', Jetpack_SSO_Helpers::new_user_override() );
 		remove_filter( 'jetpack_sso_new_user_override', '__return_true' );
 	}
 
@@ -85,6 +87,20 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		add_filter( 'jetpack_sso_new_user_override', '__return_false' );
 		$this->assertFalse( Jetpack_SSO_Helpers::new_user_override() );
 		remove_filter( 'jetpack_sso_new_user_override', '__return_false' );
+	}
+
+	function test_sso_helpers_new_user_override_filter_rolename() {
+		add_filter( 'jetpack_sso_new_user_override', array( $this, 'return_administrator' ) );
+		$this->assertEquals( 'administrator', Jetpack_SSO_Helpers::new_user_override() );
+		remove_filter( 'jetpack_sso_new_user_override', array( $this, 'return_administrator' ) );
+	}
+
+	function test_sso_helpers_new_user_override_filter_bad_rolename_returns_default() {
+		add_role( 'foo', 'Foo' );
+		update_option( 'default_role', 'foo' );
+		add_filter( 'jetpack_sso_new_user_override', array( $this, 'return_foobarbaz' ) );
+		$this->assertEquals( 'foo', Jetpack_SSO_Helpers::new_user_override() );
+		remove_filter( 'jetpack_sso_new_user_override', array( $this, 'return_foobarbaz' ) );
 	}
 
 	function test_sso_helpers_sso_bypass_default_login_form_filter_true() {
@@ -207,5 +223,13 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 
 	function __return_string_value() {
 		return '1';
+	}
+
+	function return_administrator() {
+		return 'administrator';
+	}
+
+	function return_foobarbaz() {
+		return 'foobarbaz';
 	}
 }

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -211,6 +211,12 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_SSO_Helpers::generate_user( $this->user_data ) );
 	}
 
+	function test_generate_user_sets_user_role_when_provided() {
+		$this->user_data->role = 'administrator';
+		$user = Jetpack_SSO_Helpers::generate_user( $this->user_data );
+		$this->assertContains( 'administrator', get_userdata( $user->ID )->roles );
+	}
+
 	function test_extend_auth_cookie_casts_to_int() {
 		add_filter( 'jetpack_sso_auth_cookie_expirtation', array( $this, '__return_string_value' ) );
 		$this->assertSame( intval( $this->__return_string_value() ), Jetpack_SSO_Helpers::extend_auth_cookie_expiration_for_sso() );

--- a/tests/php/sync/test_class.jetpack-sync-sso.php
+++ b/tests/php/sync/test_class.jetpack-sync-sso.php
@@ -35,9 +35,10 @@ class WP_Test_Jetpack_Sync_SSO extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sync_sso_new_user_override_filter_true() {
 		add_filter( 'jetpack_sso_new_user_override', '__return_true' );
+		update_option( 'default_role', 'subscriber' );
 		$this->sender->do_sync();
 		$callableValue = $this->server_replica_storage->get_callable( 'sso_new_user_override' );
-		$this->assertTrue( $callableValue );
+		$this->assertEquals( 'subscriber', $callableValue );
 		remove_filter( 'jetpack_sso_new_user_override', '__return_true' );
 	}
 


### PR DESCRIPTION
To handle Jetpack invitations as well as helper plugins, such as allowing Automattician's access to a site for debugging, passing `$user_data` into the `new_user_override` method will be very handy.

We already store the `$user_data` information in user meta, so there are no added security concerns here since plugins could already access a user's meta.

With this change, we could do something like this:

```php
add_filter( 'jetpack_sso_new_user_override', 'sso_allow_a12s_override', 10, 2 );
function sso_allow_a12s_override( $override, $user_data ) {
	if ( false !== sso_ends_with( $user_data->email, '@automattic.com' ) ) {
		return true;
	}

	return $override;
}

function sso_ends_with( $haystack, $needle ) {
	$length = strlen( $needle );
	if ( $length == 0 ) {
		return true;
	}

	return ( substr( $haystack, -$length ) === $needle );
}
```

Note: This comes in handy for allowing a12s to login to Jetpack sites. For example, each others' test sites. But, this should also come in handy for invites for Jetpack sites. So, cc @nickdaugherty.