### PR TITLE
fix PHP warnings about non-string

### DIFF
--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -89,6 +89,10 @@ class Filter_Embedded_HTML_Objects {
 		foreach ( $regexps as $element => $regexp ) {
 			self::$current_element = $element;
 
+			if ( ! is_string( $html )  || ! is_string( $element ) ) {
+				continue;
+			}
+
 			if ( false !== stripos( $html, "<$element" ) ) {
 				if ( $new_html = preg_replace_callback( $regexp, array( __CLASS__, 'dispatch' ), $html ) ) {
 					$html = $new_html;

--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -89,7 +89,7 @@ class Filter_Embedded_HTML_Objects {
 		foreach ( $regexps as $element => $regexp ) {
 			self::$current_element = $element;
 
-			if ( ! is_string( $html )  || ! is_string( $element ) ) {
+			if ( ! is_string( $html ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Stops the generation of these WP_DEBUG messages (https://gist.github.com/cliffordp/42b277d0321c78f59cd2d57faeb0a93d) with the Community Events plugin by Modern Tribe (https://theeventscalendar.com/product/wordpress-community-events/) when Shortcode Embeds is active (https://central.tri.be/issues/72412) and Community Events reCAPTCHA is in use (e.g. anonymous submissions)

Fixes #

#### Changes proposed in this Pull Request:


#### Testing instructions:

* 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
