### PR TITLE
Suppress CSS migration warning

### DIFF
--- a/modules/custom-css/migrate-to-core.php
+++ b/modules/custom-css/migrate-to-core.php
@@ -41,6 +41,11 @@ class Jetpack_Custom_CSS_Data_Migration {
 		$preprocessors      = apply_filters( 'jetpack_custom_css_preprocessors', array() );
 		$core_css_post      = wp_get_custom_css_post();
 		$jetpack_css_post   = self::get_post();
+
+		if ( ! $jetpack_css_post ) {
+			return;
+		}
+
 		$revisions          = self::get_all_revisions();
 
 		// Migrate the settings from revision meta to theme mod.


### PR DESCRIPTION
Fixes a loud warning when connecting Jetpack:

```
Notice: Trying to get property of non-object in !/public/wp-content/plugins/jetpack/modules/custom-css/migrate-to-core.php on line 47

Notice: Trying to get property of non-object in ~/wp-content/plugins/jetpack/modules/custom-css/migrate-to-core.php on line 217

Warning: Cannot modify header information - headers already sent by (output started at ~/wp-content/plugins/jetpack/modules/custom-css/migrate-to-core.php:47) in ~/wp-content/plugins/jetpack/class.jetpack.php on line 5043

Warning: Cannot modify header information - headers already sent by (output started at ~/wp-content/plugins/jetpack/modules/custom-css/migrate-to-core.php:47) in ~/wp-includes/option.php on line 828

Warning: Cannot modify header information - headers already sent by (output started at ~/wp-content/plugins/jetpack/modules/custom-css/migrate-to-core.php:47) in ~/wp-includes/option.php on line 829
```