### PR TITLE
Admin: new general settings

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -5,6 +5,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
 import { translate as __ } from 'i18n-calypso';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import Modal from 'components/modal';
 
 /**
  * Internal dependencies
@@ -26,14 +29,68 @@ export const ConnectButton = React.createClass( {
 
 	propTypes: {
 		connectUser: React.PropTypes.bool,
-		from: React.PropTypes.string
+		from: React.PropTypes.string,
+		asLink: React.PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
 			connectUser: false,
-			from: ''
+			from: '',
+			asLink: false
 		};
+	},
+
+	getInitialState() {
+		return {
+			showModal: false
+		};
+	},
+
+	handleOpenModal( e ) {
+		e.preventDefault();
+		this.setState( { showModal: true } );
+	},
+
+	handleCloseModal() {
+		this.setState( { showModal: false } );
+	},
+
+	disconnectSite() {
+		this.handleCloseModal();
+		this.props.disconnectSite();
+	},
+
+	getModal() {
+		return this.state.showModal && (
+			<Modal title={ __( 'Manage Site Connection' ) } onRequestClose={ this.handleCloseModal } initialFocus="">
+				<SectionHeader label={ __( 'Manage Site Connection' ) } />
+				<Card className="jp-connection-settings__modal-body">
+					{
+						__( 'Disconnecting Jetpack means that most features will be disabled, including all security services, content delivery, related posts, promotion and SEO tools, and all features in paid plans.' )
+					}
+					<div className="jp-connection-settings__modal-actions">
+						<Button
+							borderless
+							className="jp-connection-settings__cancel"
+							onClick={ this.handleCloseModal }>
+							{
+								__( 'Cancel' )
+							}
+						</Button>
+						<Button
+							scary
+							primary
+							className="jp-connection-settings__disconnect"
+							onClick={ this.disconnectSite }>
+							{
+								__( 'Disconnect' )
+							}
+						</Button>
+					</div>
+				</Card>
+			</Modal>
+		);
 	},
 
 	renderUserButton: function() {
@@ -42,11 +99,11 @@ export const ConnectButton = React.createClass( {
 		if ( this.props.isLinked ) {
 			return (
 				<div>
-					<Button
+					<a
 						onClick={ this.props.unlinkUser }
 						disabled={ this.props.isUnlinking } >
 						{ __( 'Unlink me from WordPress.com' ) }
-					</Button>
+					</a>
 				</div>
 			);
 		}
@@ -57,20 +114,16 @@ export const ConnectButton = React.createClass( {
 			connectUrl += '&additional-user';
 		}
 
-		return (
-			<Button
-				className="is-primary jp-jetpack-connect__button"
-				href={ connectUrl }
-				disabled={ this.props.fetchingConnectUrl } >
-				{ __( 'Link to WordPress.com' ) }
-			</Button>
-		);
-	},
+		let buttonProps = {
+				className: 'is-primary jp-jetpack-connect__button',
+				href: connectUrl,
+				disabled: this.props.fetchingConnectUrl
+			},
+			connectLegend = __( 'Link to WordPress.com' );
 
-	disconnectSite() {
-		if ( window.confirm( __( 'Do you really want to disconnect your site from WordPress.com?' ) ) ) {
-			this.props.disconnectSite();
-		}
+		return this.props.asLink
+			? <a { ...buttonProps }>{ connectLegend }</a>
+			: <Button { ...buttonProps }>{ connectLegend }</Button>;
 	},
 
 	renderContent: function() {
@@ -80,11 +133,11 @@ export const ConnectButton = React.createClass( {
 
 		if ( this.props.isSiteConnected ) {
 			return (
-				<Button
-					onClick={ this.disconnectSite }
+				<a
+					onClick={ this.handleOpenModal }
 					disabled={ this.props.isDisconnecting }>
-					{ __( 'Disconnect Jetpack' ) }
-				</Button>
+					{ __( 'Manage site connection' ) }
+				</a>
 			);
 		}
 
@@ -93,14 +146,16 @@ export const ConnectButton = React.createClass( {
 			connectUrl += `&from=${ this.props.from }`;
 		}
 
-		return (
-			<Button
-				className="is-primary jp-jetpack-connect__button"
-				href={ connectUrl }
-				disabled={ this.props.fetchingConnectUrl }>
-				{ __( 'Connect Jetpack' ) }
-			</Button>
-		);
+		let buttonProps = {
+				className: 'is-primary jp-jetpack-connect__button',
+				href: connectUrl,
+				disabled: this.props.fetchingConnectUrl
+			},
+			connectLegend = __( 'Connect Jetpack' );
+
+		return this.props.asLink
+			? <a { ...buttonProps }>{ connectLegend }</a>
+			: <Button { ...buttonProps }>{ connectLegend }</Button>;
 	},
 
 	render() {
@@ -108,6 +163,7 @@ export const ConnectButton = React.createClass( {
 			<div>
 				<QueryConnectUrl />
 				{ this.renderContent() }
+				{ this.getModal() }
 			</div>
 		);
 	}

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -28,21 +28,68 @@
 }
 
 // Connection Settings styles
-.jp-connection-settings {
-	margin: rem( 24px ) 0;
-	text-align: center;
-	font-weight: 300;
+.jp-connections, .jp-connection-settings__info {
+	display: flex;
 }
+.jp-connection-type {
+	width: 50%;
+	flex-grow: 1;
+	display: flex;
+	flex-direction: column;
 
-.jp-connection-settings__headline {
-	font-size: rem( 21px );
+	&:first-child {
+		margin-right: rem( 16px );
+	}
+
+	& > .dops-section-header {
+		width: 100%;
+	}
+
+	& > .dops-card:last-child {
+		flex-grow: 1;
+		display: flex;
+		width: 100%;
+	}
+
+	.jp-connection-settings__actions {
+		margin: 1em 0 0;
+
+		a {
+			cursor: pointer;
+		}
+	}
+}
+@include breakpoint( "<660px" ) {
+	.jp-connections {
+		display: block;
+	}
+	.jp-connection-type {
+		width: 100%;
+	}
+}
+.jp-connection-settings__text {
+	width: 72%;
+	margin-left: rem( 16px );
+}
+.jp-connection-settings__info {
+	.gridicon {
+		opacity: .6;
+	}
+	.gridicon,
+	.jp-connection-settings__site-icon {
+		background: #c8d7e1;
+		color: #fff;
+	}
+	.jp-connection-settings__gravatar {
+		margin-bottom: 0;
+	}
 }
 
 .jp-connection-settings__gravatar {
 	display: inline-block;
 	margin-bottom: rem( 16px );
-	width: rem( 72px );
-	height: rem( 72px );
+	width: rem( 64px );
+	height: rem( 64px );
 	background: $gray;
 	border-radius: 50%;
 }
@@ -58,14 +105,22 @@
 	font-weight: 400;
 }
 
-.jp-connection-settings__actions {
-	margin-top: rem( 16px );
-	> div {
-		display: inline-block;
-		margin: 0 rem( 4px ) rem( 16px );
-	}
+.jp-connection-settings__cancel {
+	margin-right: 1em;
 }
 
+.jp-connection-settings__modal-body {
+	margin: 0;
+}
+
+.jp-connection-settings__modal-actions {
+	text-align: right;
+	margin-top: 1em;
+}
+
+.jp-connection-settings__cancel, .jp-connection-settings__disconnect {
+	vertical-align: middle;
+}
 
 // Related Posts Preview styles
 .jp-related-posts-preview {

--- a/_inc/client/general-settings/connection-settings.jsx
+++ b/_inc/client/general-settings/connection-settings.jsx
@@ -4,73 +4,141 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import Gridicon from 'components/gridicon';
+import SiteIcon from 'components/my-sites-navigation/site-icon';
 
 /**
  * Internal dependencies
  */
-import { isCurrentUserLinked, isDevMode } from 'state/connection';
 import {
-	userCanDisconnectSite as _userCanDisconnectSite,
-	userIsMaster as _userIsMaster,
-	getUserWpComLogin as _getUserWpComLogin,
-	getUserWpComEmail as _getUserWpComEmail,
-	getUserWpComAvatar as _getUserWpComAvatar,
-	getUsername as _getUsername
+	getSiteConnectionStatus,
+	isCurrentUserLinked,
+	isDevMode
+} from 'state/connection';
+import {
+	userCanDisconnectSite,
+	userIsMaster,
+	getUserWpComLogin,
+	getUserWpComEmail,
+	getUserWpComAvatar,
+	getUsername,
+	getSiteIcon
 } from 'state/initial-state';
 import QueryUserConnectionData from 'components/data/query-user-connection';
 import ConnectButton from 'components/connect-button';
 
 const ConnectionSettings = React.createClass( {
-	renderContent: function() {
+	render() {
+
 		const maybeShowDisconnectBtn = this.props.userCanDisconnectSite
-			? <ConnectButton />
+			? <ConnectButton asLink />
 			: null;
 
 		const maybeShowLinkUnlinkBtn = this.props.userIsMaster
 			? null
-			: <ConnectButton connectUser={ true } from="connection-settings" />;
+			: <ConnectButton asLink connectUser={ true } from="connection-settings" />;
 
-		return this.props.isDevMode ?
-			(
-				<div>
-					{
-						__( 'The site is in Development Mode, so you can not connect to WordPress.com.' )
-					}
-				</div>
-			)	:
-			<div>
-				{
-					this.props.isLinked
-					? (
-						<div className="jp-connection-settings">
-							<img alt="gravatar" width="75" height="75" className="jp-connection-settings__gravatar" src={ this.props.userWpComAvatar } />
-							<div className="jp-connection-settings__headline">{ __( 'You are connected as ' ) }<span className="jp-connection-settings__username">{ this.props.userWpComLogin }</span></div>
-							<div className="jp-connection-settings__email">{ this.props.userWpComEmail }</div>
-							<div className="jp-connection-settings__actions">
-								{ maybeShowDisconnectBtn }
-								{ maybeShowLinkUnlinkBtn }
-							</div>
+		let cardContent = '';
+
+		if ( this.props.isDevMode ) {
+			if ( 'site' === this.props.type ) {
+				cardContent = (
+					<div className="jp-connection-settings__info">
+						{
+							this.props.siteIcon
+								? <img width="64" height="64" className="jp-connection-settings__site-icon" src={ this.props.siteIcon } />
+								: <Gridicon icon="globe" size={ 64 } />
+						}
+						<div className="jp-connection-settings__text">
+							{
+								__( 'Your site is in Development Mode, so it can not be connected to WordPress.com.' )
+							}
 						</div>
-					)
-					: (
-						<div className="jp-connection-settings">
-							<div className="jp-connection-settings__headline">{ __( 'Link your account to WordPress.com to get the most out of Jetpack.' ) }</div>
-							<div className="jp-connection-settings__actions">
-								{ maybeShowDisconnectBtn }
-								{ maybeShowLinkUnlinkBtn }
-							</div>
+					</div>
+				);
+			} else {
+				// return nothing if this is an account connection card
+				cardContent = (
+					<div className="jp-connection-settings__info">
+						<img alt="gravatar" width="64" height="64" className="jp-connection-settings__gravatar" src={ this.props.userWpComAvatar } />
+						<div className="jp-connection-settings__text">
+							{
+								__( 'The site is in Development Mode, so you can not connect to WordPress.com.' )
+							}
 						</div>
-					)
+					</div>
+				);
+			}
+		} else {
+			if ( 'site' === this.props.type ) {
+				if ( true === this.props.siteConnectionStatus ) {
+					cardContent = (
+						<div>
+							<div className="jp-connection-settings__info">
+								{
+									this.props.siteIcon
+										? <img width="64" height="64" className="jp-connection-settings__site-icon" src={ this.props.siteIcon } />
+										: <Gridicon icon="globe" size={ 64 } />
+								}
+								<div className="jp-connection-settings__text">
+									{
+										__( 'Your site is connected to WordPress.com.' )
+									}
+									{
+										this.props.userIsMaster
+											? <span><br /><em>{ __( 'You are the Jetpack owner.' ) }</em></span>
+											: ''
+									}
+								</div>
+							</div>
+							{
+								this.props.userCanDisconnectSite
+									? <div className="jp-connection-settings__actions">
+										{ maybeShowDisconnectBtn }
+									  </div>
+									: ''
+							}
+						</div>
+					);
 				}
-			</div>
-			;
-	},
+			} else {
+				cardContent = (
+					this.props.isLinked
+						? <div>
+							<div className="jp-connection-settings__info">
+								<img alt="gravatar" width="64" height="64" className="jp-connection-settings__gravatar" src={ this.props.userWpComAvatar } />
+								<div className="jp-connection-settings__text">
+									{ __( 'Connected as ' ) }<span className="jp-connection-settings__username">{ this.props.userWpComLogin }</span>
+									<div className="jp-connection-settings__email">{ this.props.userWpComEmail }</div>
+								</div>
+							</div>
+							<div className="jp-connection-settings__actions">
+								{ maybeShowLinkUnlinkBtn }
+							</div>
+						  </div>
+						: <div>
+							<div className="jp-connection-settings__info">
+								{
+									__( 'Link your account to WordPress.com to get the most out of Jetpack.' )
+								}
+							</div>
+							<div className="jp-connection-settings__actions">
+								{ maybeShowLinkUnlinkBtn }
+							</div>
+						  </div>
+				);
+			}
+		}
 
-	render() {
 		return(
-			<div>
-				{ this.renderContent() }
+			<div className="jp-connection-type">
 				<QueryUserConnectionData />
+				<SectionHeader label={ 'site' === this.props.type ? __( 'Site Connection' ) : __( 'Account Connection' ) } />
+				<Card>
+					{ cardContent }
+				</Card>
 			</div>
 		)
 	}
@@ -90,14 +158,16 @@ ConnectionSettings.propTypes = {
 export default connect(
 	( state ) => {
 		return {
+			siteConnectionStatus: getSiteConnectionStatus( state ),
 			isDevMode: isDevMode( state ),
-			userCanDisconnectSite: _userCanDisconnectSite( state ),
-			userIsMaster: _userIsMaster( state ),
-			userWpComLogin: _getUserWpComLogin( state ),
-			userWpComEmail: _getUserWpComEmail( state ),
-			userWpComAvatar: _getUserWpComAvatar( state ),
-			username: _getUsername( state ),
-			isLinked: isCurrentUserLinked( state )
+			userCanDisconnectSite: userCanDisconnectSite( state ),
+			userIsMaster: userIsMaster( state ),
+			userWpComLogin: getUserWpComLogin( state ),
+			userWpComEmail: getUserWpComEmail( state ),
+			userWpComAvatar: getUserWpComAvatar( state ),
+			username: getUsername( state ),
+			isLinked: isCurrentUserLinked( state ),
+			siteIcon: getSiteIcon( state )
 		}
 	}
 )( ConnectionSettings );

--- a/_inc/client/general-settings/index.jsx
+++ b/_inc/client/general-settings/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'i18n-calypso';
@@ -24,82 +23,19 @@ import {
 	getModule as _getModule,
 	getModules
 } from 'state/modules';
-import { ModuleToggle } from 'components/module-toggle';
 import { userCanManageModules } from 'state/initial-state';
 
 export const GeneralSettings = ( props ) => {
-	let {
-		toggleModule,
-		isModuleActivated,
-		isTogglingModule,
-		getModule
-	} = props,
-		isAdmin = props.userCanManageModules,
+	let	isAdmin = props.userCanManageModules,
 		moduleList = Object.keys( props.moduleList );
-
-	const moduleCard = ( module_slug ) => {
-		var unavailableInDevMode = props.isUnavailableInDevMode( module_slug ),
-			customClasses = unavailableInDevMode ? 'devmode-disabled' : '',
-			toggle = '';
-
-		if ( unavailableInDevMode ) {
-			toggle = () => __( 'Unavailable in Dev Mode' );
-		} else if ( isAdmin ) {
-			toggle = ( module_name ) =>
-				<ModuleToggle
-					slug={ module_name }
-					activated={ isModuleActivated( module_name ) }
-					toggling={ isTogglingModule( module_name ) }
-					toggleModule={ toggleModule }
-				/>;
-		}
-
-		if ( ! isAdmin || ! includes( moduleList, module_slug ) ) {
-			return null;
-		}
-
-		return (
-			<FoldableCard
-				className={ customClasses }
-				header={ getModule( module_slug ).name }
-				subheader={ getModule( module_slug ).description }
-				clickableHeaderText={ true }
-				disabled={ ! isAdmin }
-				summary={ isAdmin ? toggle( module_slug ) : '' }
-				expandedSummary={ isAdmin ? toggle( module_slug ) : '' }
-				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-					{
-						card: module_slug,
-						path: props.route.path
-					}
-				) }
-			>
-				<div className="jp-form-setting-explanation"><div dangerouslySetInnerHTML={ renderLongDescription( getModule( module_slug ) ) } /></div>
-				<div className="jp-module-settings__learn-more">
-					<Button borderless compact href={ getModule( module_slug ).learn_more_button }><Gridicon icon="help-outline" /><span className="screen-reader-text">{ __( 'Learn More' ) }</span></Button>
-				</div>
-			</FoldableCard>
-		);
-	};
 
 	return (
 		<div>
-			<FoldableCard
-				header={ __( 'Connection Settings' ) }
-				subheader={ __( 'Manage your Jetpack connection.' ) }
-				clickableHeaderText={ true }
-				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-					{
-						card: 'connection_settings',
-						path: props.route.path
-					}
-				) }
-			>
-				<ConnectionSettings { ...props } />
-			</FoldableCard>
-			{ isModuleActivated( 'manage' ) ? '' : moduleCard( 'manage' ) }
-			{ moduleCard( 'notes' ) }
-			{ moduleCard( 'json-api' ) }
+			<h3>{ __( 'Connections' ) }</h3>
+			<div className="jp-connections">
+				<ConnectionSettings { ...props } type="site" />
+				<ConnectionSettings { ...props } type="user" />
+			</div>
 		</div>
 	);
 };

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -137,6 +137,15 @@ export function userCanViewStats( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'view_stats', false );
 }
 
+/**
+ * Returns the site icon as an image URL
+ *
+ * @param state
+ */
+export function getSiteIcon( state ) {
+	return get( state.jetpack.initialState.siteData, [ 'icon' ] );
+}
+
 export function getApiNonce( state ) {
 	return get( state.jetpack.initialState, 'WP_API_nonce' );
 }

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -277,6 +277,11 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 //				'othersLinked' => Jetpack::get_other_linked_admins(),
 				'currentUser'  => jetpack_current_user_data(),
 			),
+			'siteData' => array(
+				'icon' => has_site_icon()
+					? apply_filters( 'jetpack_photon_url', get_site_icon_url(), array( 'w' => 64 ) )
+					: '',
+			),
 			'locale' => $this->get_i18n_data(),
 			'localeSlug' => $localeSlug,
 			'jetpackStateNotices' => array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- build new cards for site and account connection
- cover cases when site is connected and in dev mode.
- Remove JSON API, Manage and Notifications cards.
- introduce a modal to be displayed when user manages the Jetpack connection

<img width="745" alt="connections" src="https://cloud.githubusercontent.com/assets/1041600/22298215/817fdaaa-e2fe-11e6-9cba-182ba84663ee.png">

<img width="568" alt="captura de pantalla 2017-01-25 a las 14 39 35" src="https://cloud.githubusercontent.com/assets/1041600/22302618/45977cfe-e30e-11e6-8733-662d49b6a343.png">

#### Testing instructions:
* build and check Jetpack > Settings > General tab. Test with disconnected site, master user, user who can't disconnect Jetpack.