### PR TITLE
Reordered settings tabs to match mockups and Calypso

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -73,14 +73,14 @@ export const NavigationSettings = React.createClass( {
 						{ __( 'General', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
+						path="#writing"
+						selected={ this.props.route.path === '/writing' }>
+						{ __( 'Writing', { context: 'Navigation item.' } ) }
+					</NavItem>
+					<NavItem
 						path="#discussion"
 						selected={ this.props.route.path === '/discussion' }>
 						{ __( 'Discussion', { context: 'Navigation item.' } ) }
-					</NavItem>
-					<NavItem
-						path="#security"
-						selected={ this.props.route.path === '/security' }>
-						{ __( 'Security', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
 						path="#traffic"
@@ -88,9 +88,9 @@ export const NavigationSettings = React.createClass( {
 						{ __( 'Traffic', { context: 'Navigation item.' } ) }
 					</NavItem>
 					<NavItem
-						path="#writing"
-						selected={ this.props.route.path === '/writing' }>
-						{ __( 'Writing', { context: 'Navigation item.' } ) }
+						path="#security"
+						selected={ this.props.route.path === '/security' }>
+						{ __( 'Security', { context: 'Navigation item.' } ) }
 					</NavItem>
 				</NavTabs>
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Reorders Settings navigation tabs to match mockups & Calypso

#### Testing instructions:
* Go to settings and click around

#### Before:
![image](https://cloud.githubusercontent.com/assets/1123119/22296381/34e05ab6-e2d7-11e6-81ac-de8197943f63.png)

#### After:
![image](https://cloud.githubusercontent.com/assets/1123119/22296358/236e0d8c-e2d7-11e6-8c00-7f2691f89075.png)
