### PR TITLE
Fixes legend and form label spacing in settings groups

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -8,7 +8,7 @@
 
 .jp-form-legend,
 .jp-form-label-wide {
-	margin-top: 8px;
+	margin-top: rem( 8px );
 	padding: 0;
 	margin-bottom: rem( 5px );
 	font-size: rem( 14px );

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -6,7 +6,9 @@
 	}
 }
 
-.jp-form-legend, .jp-form-label-wide {
+.jp-form-legend,
+.jp-form-label-wide {
+	margin-top: 8px;
 	padding: 0;
 	margin-bottom: rem( 5px );
 	font-size: rem( 14px );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* adds top margin to legends/labels

#### Testing instructions:
* open settings groups and take a look at the spacing

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/22298820/1ea5dc8c-e2df-11e6-85fa-211ef364550a.png)


#### After
![image](https://cloud.githubusercontent.com/assets/1123119/22298775/fb257dd0-e2de-11e6-8cc5-567059be45d2.png)
