### PR TITLE
Fixes toggle spacing and removes br elements that caused gaps

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -1,9 +1,5 @@
 .jp-form-fieldset {
 	clear: both;
-
-	+ .jp-form-fieldset {
-		margin-top: rem( 24px );
-	}
 }
 
 .jp-form-legend, .jp-form-label-wide {
@@ -53,6 +49,11 @@
 }
 
 .jp-form-settings-group {
+	.form-toggle__label {
+		display: block;
+		margin-top: 4px;
+		margin-bottom: 4px;
+	}
 	.form-toggle__switch {
 		float: left;
 		margin-top: 2px;
@@ -68,8 +69,6 @@
 }
 
 .jp-form-fieldset {
-
-	margin-bottom: rem( 24px );
 	position: relative;
 
 	.jp-form-legend + .jp-form-setting-explanation {

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -87,7 +87,6 @@ export const RelatedPosts = moduleSettingsForm(
 											}
 										</span>
 									</FormToggle>
-									<br />
 									<FormToggle compact
 												checked={ this.state.show_thumbnails }
 												disabled={ this.props.isSavingAnyOption() }

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -48,7 +48,6 @@ export const SiteStats = moduleSettingsForm(
 								}
 							</span>
 							</ModuleToggle>
-							<br />
 							<ModuleToggle slug="stats"
 										  compact
 										  activated={ !!this.props.getOptionValue( 'hide_smile' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds spacing to `form-toggle__label` when in new settings groups
* no more need for `br` elements

#### Testing instructions:
* go through settings sections

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/22299657/34b5bd64-e2e2-11e6-973b-7d8e791c222b.png)


#### After
![image](https://cloud.githubusercontent.com/assets/1123119/22299608/02c4e92e-e2e2-11e6-9ca7-af33e72a3717.png)
