### PR TITLE
Use Title Case consistently in card titles, to match Calypso

### DIFF
--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -1,16 +1,13 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
 
 /**
  * Internal dependencies
  */
 import { FormFieldset } from 'components/forms';
-import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import {
@@ -29,7 +26,7 @@ export const Antispam = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Antispam', { context: 'Settings header' } ) }>
+					header={ __( 'Spam Filtering', { context: 'Settings header' } ) }>
 					<SettingsGroup support="https://akismet.com/jetpack/">
 						<FormFieldset>
 							<ModuleSettingCheckbox

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 
@@ -26,7 +25,7 @@ export const BackupsScan = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+					header={ __( 'Backups and Security Scanning', { context: 'Settings header' } ) }
 					hideButton>
 					<SettingsGroup support="https://vaultpress.com/jetpack/">
 						<p>

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -1,13 +1,11 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
 import Textarea from 'components/textarea';
 import includes from 'lodash/includes';
-import ExternalLink from 'components/external-link';
 
 /**
  * Internal dependencies
@@ -71,13 +69,13 @@ export const Protect = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="protect"
-					header={ __( 'Brute force protection', { context: 'Settings header' } ) } >
+					header={ __( 'Brute Force Protection', { context: 'Settings header' } ) } >
 					<SettingsGroup hasChild support={ this.props.getModule( 'protect' ).learn_more_button }>
 						<ModuleToggle slug="protect"
-									  compact
-									  activated={ isProtectActive }
-									  toggling={ this.props.isSavingAnyOption( 'protect' ) }
-									  toggleModule={ this.props.toggleModuleNow }>
+							compact
+							activated={ isProtectActive }
+							toggling={ this.props.isSavingAnyOption( 'protect' ) }
+							toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'protect' ).description
@@ -125,7 +123,7 @@ export const Protect = moduleSettingsForm(
 											} )
 										}
 									</span>
-								  </FormFieldset>
+								</FormFieldset>
 								: ''
 						}
 					</SettingsGroup>

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
 
 /**
  * Internal dependencies
@@ -27,13 +25,13 @@ export const SSO = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="sso"
-					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
+					header={ __( 'WordPress.com Log In', { context: 'Settings header' } ) }>
 					<SettingsGroup hasChild support={ this.props.getModule( 'sso' ).learn_more_button }>
 						<ModuleToggle slug="sso"
-									  compact
-									  activated={ isSSOActive }
-									  toggling={ this.props.isSavingAnyOption( 'sso' ) }
-									  toggleModule={ this.props.toggleModuleNow }>
+							compact
+							activated={ isSSOActive }
+							toggling={ this.props.isSavingAnyOption( 'sso' ) }
+							toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
 								this.props.getModule( 'sso' ).description
@@ -56,7 +54,7 @@ export const SSO = moduleSettingsForm(
 										name={ 'jetpack_sso_require_two_step' }
 										{ ...this.props }
 										label={ __( 'Require two step authentication.' ) } />
-								  </FormFieldset>
+								</FormFieldset>
 								: ''
 						}
 					</SettingsGroup>

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -22,7 +22,7 @@ export const SEO = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Search Engine Optimization', { context: 'Settings header' } ) }
+					header={ __( 'Search engine optimization', { context: 'Settings header' } ) }
 					hideButton>
 					<SettingsGroup support="https://jetpack.com/support/seo-tools/">
 						<p>

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import ExternalLink from 'components/external-link';
@@ -22,7 +21,7 @@ export const SEO = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Search engine optimization', { context: 'Settings header' } ) }
+					header={ __( 'Search Engine Optimization', { context: 'Settings header' } ) }
 					hideButton>
 					<SettingsGroup support="https://jetpack.com/support/seo-tools/">
 						<p>

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 
@@ -10,13 +9,11 @@ import { translate as __ } from 'i18n-calypso';
  */
 import {
 	FormFieldset,
-	FormLegend,
-	FormLabel
+	FormLegend
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import {
-	ModuleSettingSelect,
 	ModuleSettingMultipleSelectCheckboxes
 } from 'components/module-settings/form-components';
 import {
@@ -33,15 +30,15 @@ export const SiteStats = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Site stats' ) }
+					header={ __( 'Site Stats' ) }
 					module="stats">
 					<SettingsGroup support={ stats.learn_more_button }>
 						<FormFieldset>
 							<ModuleToggle slug="stats"
-										  compact
-										  activated={ !!this.props.getOptionValue( 'admin_bar' ) }
-										  toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
-										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }>
+											compact
+											activated={ !!this.props.getOptionValue( 'admin_bar' ) }
+											toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
+											toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
 									__( 'Put a chart showing 48 hours of views in the admin bar.' )
@@ -50,10 +47,10 @@ export const SiteStats = moduleSettingsForm(
 							</ModuleToggle>
 							<br />
 							<ModuleToggle slug="stats"
-										  compact
-										  activated={ !!this.props.getOptionValue( 'hide_smile' ) }
-										  toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
-										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }>
+											compact
+											activated={ !!this.props.getOptionValue( 'hide_smile' ) }
+											toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
+											toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
 									__( 'Hide the stats smiley face image. The image helps collect stats, but should work when hidden.' )

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
 
 /**
  * Internal dependencies
@@ -12,8 +11,8 @@ import { FormFieldset } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
-import { SettingsCard } from 'components/settings-card';
-import { SettingsGroup } from 'components/settings-group';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
 
 export const ThemeEnhancements = moduleSettingsForm(
 	React.createClass( {
@@ -57,7 +56,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 							}
 						].map( item => {
 							return (
-								<Card compact className="jp-form-has-child jp-form-settings-group" key={ `theme_enhancement_${ item.module }` }>
+								<SettingsGroup compact hasChild key={ `theme_enhancement_${ item.module }` }>
 									<ModuleToggle slug={ item.module }
 										compact
 										activated={ this.props.getOptionValue( item.module ) }
@@ -83,7 +82,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 												: ''
 										}
 									</FormFieldset>
-								</Card>
+								</SettingsGroup>
 							);
 						} )
 					}

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
@@ -14,8 +13,7 @@ import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import {
-	SettingsCard,
-	SettingsGroup
+	SettingsCard
 } from 'components/settings-card';
 
 export const ThemeEnhancements = moduleSettingsForm(
@@ -25,7 +23,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Theme enhancements' ) }>
+					header={ __( 'Theme Enhancements' ) }>
 					{
 						[
 							{
@@ -62,10 +60,10 @@ export const ThemeEnhancements = moduleSettingsForm(
 							return (
 								<Card compact className="jp-form-has-child jp-form-settings-group" key={ `theme_enhancement_${ item.module }` }>
 									<ModuleToggle slug={ item.module }
-												  compact
-												  activated={ this.props.getOptionValue( item.module ) }
-												  toggling={ this.props.isSavingAnyOption( item.module ) }
-												  toggleModule={ this.props.toggleModuleNow }>
+										compact
+										activated={ this.props.getOptionValue( item.module ) }
+										toggling={ this.props.isSavingAnyOption( item.module ) }
+										toggleModule={ this.props.toggleModuleNow }>
 									<span className="jp-form-toggle-explanation">
 									{
 										item.description
@@ -82,7 +80,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 														label={ chkbx.label }
 														key={ `${ item.module }_${ chkbx.key }`}
 													/>
-												  } )
+												} )
 												: ''
 										}
 									</FormFieldset>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* removes title case in settings headings

#### Testing instructions:
* Go to Settings and check all the headings to make sure they are not using Title Case

@zinigor @eliorivero or @georgestephanis I couldn't figure out how to change it for all of them. Can one of you fix these:
- [ ] Custom Content Types > Custom content types
- [ ] Related Posts > Related posts
- [ ] Site Verification > Site verification

