### PR TITLE
Admin: remove empty fieldset left when testimonial or portfolio CCTs …

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -80,7 +80,8 @@
 		margin-top: rem( 16px );
 	}
 
-	&:last-child {
+	&:last-child,
+	& > p:last-child {
 		margin-bottom: 0;
 	}
 }

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -31,10 +31,10 @@ export const CustomContentTypes = moduleSettingsForm(
 			return ! this.props.getSettingCurrentValue( 'jetpack_' + type, 'custom-content-types' )
 				? ''
 				: <Button compact href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type }>
-					{
-						legend
-					}
-				  </Button>;
+				{
+					legend
+				}
+			</Button>;
 		},
 
 		getInitialState() {
@@ -79,22 +79,22 @@ export const CustomContentTypes = moduleSettingsForm(
 								}
 							</span>
 						</FormToggle>
-						<FormFieldset>
-							{
-								this.state.testimonial
-									? <p className="jp-form-setting-explanation">
-									{
-										__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
-									}
-								</p>
-									: ''
-							}
-							<p>
-								{
-									this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
-								}
-							</p>
-						</FormFieldset>
+						{
+							this.state.testimonial
+								? <FormFieldset>
+									<p className="jp-form-setting-explanation">
+										{
+											__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
+										}
+									</p>
+									<p>
+										{
+											this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
+										}
+									</p>
+								  </FormFieldset>
+								: ''
+						}
 						<FormToggle compact
 									checked={ this.state.portfolio }
 									disabled={ this.props.isSavingAnyOption() }
@@ -105,22 +105,22 @@ export const CustomContentTypes = moduleSettingsForm(
 								}
 							</span>
 						</FormToggle>
-						<FormFieldset>
-							{
-								this.state.portfolio
-									? <p className="jp-form-setting-explanation">
-									{
-										__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
-									}
-								</p>
-									: ''
-							}
-							<p>
-								{
-									this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
-								}
-							</p>
-						</FormFieldset>
+						{
+							this.state.portfolio
+								? <FormFieldset>
+									<p className="jp-form-setting-explanation">
+										{
+											__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
+										}
+									</p>
+									<p>
+										{
+											this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
+										}
+									</p>
+								  </FormFieldset>
+								: ''
+						}
 					</SettingsGroup>
 				</SettingsCard>
 			);


### PR DESCRIPTION
Fixes #6174

#### Changes proposed in this Pull Request:
- remove empty fieldset left when testimonial or portfolio CCTs are inactive
- remove bottom margin of last paragraph inside a fieldset since fieldset already has a bottom margin.

NOTE: the spacing between toggles when both are deactivated will be fixed once this PR is merged https://github.com/Automattic/jetpack/pull/6167

