### PR TITLE
Make close notice icon clickable

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -59,6 +59,10 @@
 	box-sizing: border-box;
 }
 
+.jp-wpcom-connect__inner-container > a:first-child {
+	z-index: 1;
+}
+
 .jp-wpcom-connect__inner-container {
 	display: flex;
 	flex-direction: row;
@@ -70,6 +74,7 @@
 	max-width: rem( 1200px );
 	position: relative;
 	padding: rem( 32px );
+	z-index: 0;
 
 	@include minbreakpoint(tablet) {
 		padding: rem( 32px ) rem( 32px ) rem( 96px ) rem( 32px );

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -71,7 +71,7 @@
 }
 
 .jp-wpcom-connect__content-container {
-	max-width: rem( 1200px );
+	max-width: 800px;
 	position: relative;
 	padding: rem( 32px );
 	z-index: 0;


### PR DESCRIPTION
Bump the z-index of the x close link to make sure that the connect
banner is closable. Since currently you can't click on the link to
close the banner.

<img width="1190" alt="screen_shot_2017-01-26_at_10_06_07" src="https://cloud.githubusercontent.com/assets/115071/22348307/4e4bcb60-e3af-11e6-9cb4-577b6f072e32.png">

