### PR TITLE
WooCommerce Services JITM

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -13,3 +13,4 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
 
 // We can't load this conditionally since polldaddy add the call in class constuctor.
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce-services.php' );

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -12,9 +12,7 @@ class WC_Services_Installer {
 	}
 
 	public function try_install() {
-		$action = filter_input( INPUT_GET, 'wc-services-action' );
-
-		if ( 'install' === $action ) {
+		if ( isset( $_GET['wc-services-action'] ) && ( 'install' === $_GET['wc-services-action'] ) ) {
 			check_admin_referer( 'wc-services-install' );
 
 			$result = $this->install();
@@ -30,9 +28,7 @@ class WC_Services_Installer {
 	}
 
 	public function add_error_notice() {
-		$error = filter_input( INPUT_GET, 'wc-services-install-error' );
-
-		if ( $error ) {
+		if ( ! empty( $_GET['wc-services-install-error'] ) ) {
 			add_action( 'admin_notices', array( $this, 'error_notice' ) );
 		}
 	}

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -6,18 +6,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Services_Installer {
 
+	public function init() {
+		$this->add_error_notice();
+		$this->try_install();
+	}
+
 	public function try_install() {
 		$action = filter_input( INPUT_GET, 'wc-services-action' );
 
 		if ( 'install' === $action ) {
 			check_admin_referer( 'wc-services-install' );
 
-			$this->install();
+			$result = $this->install();
 
-			wp_safe_redirect( remove_query_arg( array( 'wc-services-action', '_wpnonce' ) ) );
+			wp_safe_redirect( add_query_arg( array(
+				'wc-services-action'        => false,
+				'_wpnonce'                  => false,
+				'wc-services-install-error' => ( false === $result ),
+			) ) );
 
 			exit;
 		}
+	}
+
+	public function add_error_notice() {
+		$error = filter_input( INPUT_GET, 'wc-services-install-error' );
+
+		if ( $error ) {
+			add_action( 'admin_notices', array( $this, 'error_notice' ) );
+		}
+	}
+
+	public function error_notice() {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php _e( 'There was an error installing WooCommerce Services.', 'jetpack' ); ?></p>
+		</div>
+		<?php
 	}
 
 	private function install() {
@@ -27,29 +52,27 @@ class WC_Services_Installer {
 		include_once( ABSPATH . '/wp-admin/includes/class-wp-upgrader.php' );
 		include_once( ABSPATH . '/wp-admin/includes/class-plugin-upgrader.php' );
 
-		$api = plugins_api( 'plugin_information', array(
-			'slug'   => 'connect-for-woocommerce',
-		) );
+		$api = plugins_api( 'plugin_information', array( 'slug' => 'connect-for-woocommerce' ) );
 
 		if ( is_wp_error( $api ) ) {
-			wp_die( $api );
+			return false;
 		}
 
 		$upgrader = new Plugin_Upgrader( new Automatic_Upgrader_Skin() );
 		$result   = $upgrader->install( $api->download_link );
 
-		if ( is_wp_error( $result ) ) {
-			wp_die( $result );
+		if ( true !== $result ) {
+			return false;
 		}
 
 		$result = activate_plugin( 'connect-for-woocommerce/woocommerce-connect-client.php' );
 
 		if ( is_wp_error( $result ) ) {
-			wp_die( $result );
+			return false;
 		}
 	}
 }
 
 $wc_services_installer = new WC_Services_Installer();
 
-add_action( 'init', array( $wc_services_installer, 'try_install' ) );
+add_action( 'admin_init', array( $wc_services_installer, 'init' ) );

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -31,13 +31,14 @@ class WC_Services_Installer {
 				return;
 			}
 
-			$result = $this->install();
+			$result   = $this->install();
+			$redirect = wp_get_referer();
 
-			wp_safe_redirect( add_query_arg( array(
-				'wc-services-action'        => false,
-				'_wpnonce'                  => false,
-				'wc-services-install-error' => ( false === $result ),
-			) ) );
+			if ( false === $result ) {
+				$redirect = add_query_arg( 'wc-services-install-error', true, $redirect );
+			}
+
+			wp_safe_redirect( $redirect );
 
 			exit;
 		}

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -6,9 +6,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Services_Installer {
 
-	public function init() {
-		$this->add_error_notice();
-		$this->try_install();
+	/**
+	 * @var WC_Services_Installer
+	 **/
+	private static $instance = null;
+
+	static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new WC_Services_Installer();
+		}
+		return self::$instance;
+	}
+
+	public function __construct() {
+		add_action( 'admin_init', array( $this, 'add_error_notice' ) );
+		add_action( 'admin_init', array( $this, 'try_install' ) );
 	}
 
 	public function try_install() {
@@ -72,6 +84,4 @@ class WC_Services_Installer {
 	}
 }
 
-$wc_services_installer = new WC_Services_Installer();
-
-add_action( 'admin_init', array( $wc_services_installer, 'init' ) );
+WC_Services_Installer::init();

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -4,8 +4,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! class_exists( 'WC_Connect_Admin_Setup_Wizard' ) ) :
-
 class WC_Services_Installer {
 
 	public function notice() {
@@ -63,5 +61,3 @@ $wc_services_installer = new WC_Services_Installer();
 
 add_action( 'init', array( $wc_services_installer, 'try_install' ) );
 add_action( 'admin_notices', array( $wc_services_installer, 'notice' ) );
-
-endif;

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -7,11 +7,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Services_Installer {
 
 	public function try_install() {
-		$install = filter_input( INPUT_GET, 'wc-services-action' );
+		$action = filter_input( INPUT_GET, 'wc-services-action' );
 
-		if ( 'install' === $install ) {
+		if ( 'install' === $action ) {
+			check_admin_referer( 'wc-services-install' );
+
 			$this->install();
-			wp_redirect( esc_url_raw( remove_query_arg( array( 'wc-services-action' ) ) ) );
+
+			wp_safe_redirect( remove_query_arg( array( 'wc-services-action', '_wpnonce' ) ) );
+
 			exit;
 		}
 	}

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -23,6 +23,9 @@ class WC_Services_Installer {
 		add_action( 'admin_init', array( $this, 'try_install' ) );
 	}
 
+	/**
+	 * Verify the intent to install WooCommerce Services, and kick off installation.
+	 */
 	public function try_install() {
 		if ( isset( $_GET['wc-services-action'] ) && ( 'install' === $_GET['wc-services-action'] ) ) {
 			check_admin_referer( 'wc-services-install' );
@@ -44,12 +47,18 @@ class WC_Services_Installer {
 		}
 	}
 
+	/**
+	 * Set up installation error admin notice.
+	 */
 	public function add_error_notice() {
 		if ( ! empty( $_GET['wc-services-install-error'] ) ) {
 			add_action( 'admin_notices', array( $this, 'error_notice' ) );
 		}
 	}
 
+	/**
+	 * Notify the user that the installation of WooCommerce Services failed.
+	 */
 	public function error_notice() {
 		?>
 		<div class="notice notice-error is-dismissible">
@@ -58,6 +67,11 @@ class WC_Services_Installer {
 		<?php
 	}
 
+	/**
+	 * Download, install, and activate the WooCommerce Services plugin.
+	 *
+	 * @return bool result of installation/activation
+	 */
 	private function install() {
 		include_once( ABSPATH . '/wp-admin/includes/admin.php' );
 		include_once( ABSPATH . '/wp-admin/includes/plugin-install.php' );

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -15,6 +15,10 @@ class WC_Services_Installer {
 		if ( isset( $_GET['wc-services-action'] ) && ( 'install' === $_GET['wc-services-action'] ) ) {
 			check_admin_referer( 'wc-services-install' );
 
+			if ( ! current_user_can( 'install_plugins' ) ) {
+				return;
+			}
+
 			$result = $this->install();
 
 			wp_safe_redirect( add_query_arg( array(

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -6,20 +6,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Services_Installer {
 
-	public function notice() {
-		$this->try_install();
-		$link = add_query_arg( array( 'wc-services-action' => 'install' ) );
-?>
-		<div class="notice notice-warning">
-			<p>
-				Hello World. <a href="<?php echo $link; ?>">install</a>
-			</p>
-		</div>
-<?php
-	}
-
 	public function try_install() {
 		$install = filter_input( INPUT_GET, 'wc-services-action' );
+
 		if ( 'install' === $install ) {
 			$this->install();
 			wp_redirect( esc_url_raw( remove_query_arg( array( 'wc-services-action' ) ) ) );
@@ -60,4 +49,3 @@ class WC_Services_Installer {
 $wc_services_installer = new WC_Services_Installer();
 
 add_action( 'init', array( $wc_services_installer, 'try_install' ) );
-add_action( 'admin_notices', array( $wc_services_installer, 'notice' ) );

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -65,7 +65,7 @@ class WC_Services_Installer {
 		include_once( ABSPATH . '/wp-admin/includes/class-wp-upgrader.php' );
 		include_once( ABSPATH . '/wp-admin/includes/class-plugin-upgrader.php' );
 
-		$api = plugins_api( 'plugin_information', array( 'slug' => 'connect-for-woocommerce' ) );
+		$api = plugins_api( 'plugin_information', array( 'slug' => 'woocommerce-services' ) );
 
 		if ( is_wp_error( $api ) ) {
 			return false;
@@ -78,7 +78,7 @@ class WC_Services_Installer {
 			return false;
 		}
 
-		$result = activate_plugin( 'connect-for-woocommerce/woocommerce-connect-client.php' );
+		$result = activate_plugin( 'woocommerce-services/woocommerce-services.php' );
 
 		// activate_plugin() returns null on success
 		return is_null( $result );

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -67,9 +67,8 @@ class WC_Services_Installer {
 
 		$result = activate_plugin( 'connect-for-woocommerce/woocommerce-connect-client.php' );
 
-		if ( is_wp_error( $result ) ) {
-			return false;
-		}
+		// activate_plugin() returns null on success
+		return is_null( $result );
 	}
 }
 

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -1,0 +1,67 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Connect_Admin_Setup_Wizard' ) ) :
+
+class WC_Services_Installer {
+
+	public function notice() {
+		$this->try_install();
+		$link = add_query_arg( array( 'wc-services-action' => 'install' ) );
+?>
+		<div class="notice notice-warning">
+			<p>
+				Hello World. <a href="<?php echo $link; ?>">install</a>
+			</p>
+		</div>
+<?php
+	}
+
+	public function try_install() {
+		$install = filter_input( INPUT_GET, 'wc-services-action' );
+		if ( 'install' === $install ) {
+			$this->install();
+			wp_redirect( esc_url_raw( remove_query_arg( array( 'wc-services-action' ) ) ) );
+			exit;
+		}
+	}
+
+	private function install() {
+		include_once( ABSPATH . '/wp-admin/includes/admin.php' );
+		include_once( ABSPATH . '/wp-admin/includes/plugin-install.php' );
+		include_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+		include_once( ABSPATH . '/wp-admin/includes/class-wp-upgrader.php' );
+		include_once( ABSPATH . '/wp-admin/includes/class-plugin-upgrader.php' );
+
+		$api = plugins_api( 'plugin_information', array(
+			'slug'   => 'connect-for-woocommerce',
+		) );
+
+		if ( is_wp_error( $api ) ) {
+			wp_die( $api );
+		}
+
+		$upgrader = new Plugin_Upgrader( new Automatic_Upgrader_Skin() );
+		$result   = $upgrader->install( $api->download_link );
+
+		if ( is_wp_error( $result ) ) {
+			wp_die( $result );
+		}
+
+		$result = activate_plugin( 'connect-for-woocommerce/woocommerce-connect-client.php' );
+
+		if ( is_wp_error( $result ) ) {
+			wp_die( $result );
+		}
+	}
+}
+
+$wc_services_installer = new WC_Services_Installer();
+
+add_action( 'init', array( $wc_services_installer, 'try_install' ) );
+add_action( 'admin_notices', array( $wc_services_installer, 'notice' ) );
+
+endif;

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -446,12 +446,15 @@ class Jetpack_JITM {
 
 		$base_location = wc_get_base_location();
 
-		if ( 'US' === $base_location['country'] ) {
-			$message = __( 'Try our new service for USPS shipping & label-printing.', 'jetpack' );
-		} elseif ( 'CA' === $base_location['country'] ) {
-			$message = __( 'Try our new Canada Post shipping service.', 'jetpack' );
-		} else {
-			return;
+		switch ( $base_location['country'] ) {
+			case 'US':
+				$message = __( 'Try our new service for USPS shipping & label-printing.', 'jetpack' );
+				break;
+			case 'CA':
+				$message = __( 'Try our new Canada Post shipping service.', 'jetpack' );
+				break;
+			default:
+				return;
 		}
 
 		$install_url = wp_nonce_url( add_query_arg( array( 'wc-services-action' => 'install' ) ), 'wc-services-install' );

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -472,7 +472,7 @@ class Jetpack_JITM {
 				<?php echo esc_html( $message ); ?>
 			</p>
 			<p>
-				<a href="<?php echo esc_url( $install_url ); ?>" target="_blank" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="woocommerce_services" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
+				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="woocommerce_services" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
 			</p>
 		</div>
 		<?php

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -444,17 +444,13 @@ class Jetpack_JITM {
 			return;
 		}
 
-		$base_location   = wc_get_base_location();
-		$store_in_usa    = ( 'US' == $base_location['country'] );
-		$store_in_canada = ( 'CA' == $base_location['country'] );
+		$base_location = wc_get_base_location();
 
-		if ( $store_in_usa ) {
+		if ( 'US' === $base_location['country'] ) {
 			$message = __( 'Try our new service for USPS shipping & label-printing.', 'jetpack' );
-		}
-		elseif ( $store_in_canada ) {
+		} elseif ( 'CA' === $base_location['country'] ) {
 			$message = __( 'Try our new Canada Post shipping service.', 'jetpack' );
-		}
-		else {
+		} else {
 			return;
 		}
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -459,9 +459,13 @@ class Jetpack_JITM {
 		}
 
 		?>
-		<div class="jp-jitm">
+		<div class="jp-jitm woo-jitm">
 			<a href="#"  data-module="woocommerce_services" class="dismiss"><span class="genericon genericon-close"></span></a>
-			<?php echo self::get_emblem(); ?>
+			<div class="jp-emblem">
+				<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+					<path d="M18,8h-2V7c0-1.105-0.895-2-2-2H4C2.895,5,2,5.895,2,7v10h2c0,1.657,1.343,3,3,3s3-1.343,3-3h4c0,1.657,1.343,3,3,3s3-1.343,3-3h2v-5L18,8z M7,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S7.828,18.5,7,18.5z M4,14V7h10v7H4z M17,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S17.828,18.5,17,18.5z" />
+				</svg>
+			</div>
 			<p class="msg">
 				<?php echo esc_html( $message ); ?>
 			</p>

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -432,7 +432,7 @@ class Jetpack_JITM {
 	 * @since 4.6
 	 */
 	function woocommerce_services_msg() {
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) || ! current_user_can( 'install_plugins' ) ) {
 			return;
 		}
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -458,6 +458,8 @@ class Jetpack_JITM {
 			return;
 		}
 
+		$install_url = wp_nonce_url( add_query_arg( array( 'wc-services-action' => 'install' ) ), 'wc-services-install' );
+
 		?>
 		<div class="jp-jitm woo-jitm">
 			<a href="#"  data-module="woocommerce_services" class="dismiss"><span class="genericon genericon-close"></span></a>
@@ -470,7 +472,7 @@ class Jetpack_JITM {
 				<?php echo esc_html( $message ); ?>
 			</p>
 			<p>
-				<a href="<?php echo esc_url( add_query_arg( array( 'wc-services-action' => 'install' ) ) ); ?>" target="_blank" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="woocommerce_services" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
+				<a href="<?php echo esc_url( $install_url ); ?>" target="_blank" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="woocommerce_services" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
 			</p>
 		</div>
 		<?php

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -475,7 +475,6 @@ class Jetpack_JITM {
 		//jitm is being viewed, track it
 		$jetpack = Jetpack::init();
 		$jetpack->stat( 'jitm', 'woocommerce_services-viewed-' . JETPACK__VERSION );
-		$jetpack->do_stats( 'server_side' );
 	}
 
 	/*

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -466,7 +466,7 @@ class Jetpack_JITM {
 				<?php echo esc_html( $message ); ?>
 			</p>
 			<p>
-				<a href="#" target="_blank" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="woocommerce_services" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
+				<a href="<?php echo esc_url( add_query_arg( array( 'wc-services-action' => 'install' ) ) ); ?>" target="_blank" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="woocommerce_services" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
 			</p>
 		</div>
 		<?php

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -40,6 +40,11 @@
 		fill: #8cc258;
 	}
 
+  	// WooCommerce jitm
+  	&.woo-jitm path {
+	  fill: #96588a;
+	}
+
 	.dismiss {
 		margin: 0;
 		text-decoration: none;


### PR DESCRIPTION
Fixes #4659 

_Note: this will remain "in progress" until our WordPress.org plugin slug has been finalized. This PR was opened to start the code review process._

#### Changes proposed in this Pull Request:

![screen shot 2017-01-26 at 9 00 07 am](https://cloud.githubusercontent.com/assets/63922/22349025/2038c9aa-e3cb-11e6-9f45-87241bda2b82.png)

Add JITMs for WooCommerce Services.

USA and Canada-based WooCommerce merchants will be shown messages informing them of new USPS or CanadaPost shipping functionality available through WooCommerce Services.

The call to action button on these messages will handle automatic installation and activation of the plugin from the WordPress.org repository.

Messages will be displayed on the following WooCommerce pages:
* WooCommerce > Orders
* WooCommerce > Edit Order
* WooCommerce > Settings

#### Testing instructions:

On a site with WooCommerce active, but without WooCommerce Services, with a store location in the USA or Canada:

* Visit one of the pages described above
* Verify that the JITM is displayed (with relevant USPS or CanadaPost copy)
* Click "install" button
* Verify that the JITM no longer displays
* Verify that the plugin has been installed and activated
