### PR TITLE
Used the more standard "Advanced Options" for the labels for extra options

### DIFF
--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -58,7 +58,7 @@ export const SiteStats = moduleSettingsForm(
 							</span>
 							</ModuleToggle>
 						</FormFieldset>
-						<InlineExpand label={ __( 'Serious options' ) }>
+						<InlineExpand label={ __( 'Advanced Options' ) }>
 							<FormFieldset>
 								<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
 								<ModuleSettingMultipleSelectCheckboxes

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -49,9 +49,7 @@ export const Composing = moduleSettingsForm(
 						<FormLegend> { __( 'Automatic Language Detection' ) }
 						</FormLegend>
 						<span className="jp-form-setting-explanation">
-							{ __(
-								  'The proofreader supports English, French, German, Portuguese and Spanish.'
-							  ) }
+							{ __( 'The proofreader supports English, French, German, Portuguese and Spanish.' ) }
 						</span>
 						{
 							this.getCheckbox(
@@ -85,8 +83,8 @@ export const Composing = moduleSettingsForm(
 							placeholder={ __( 'Add a phrase' ) }
 							value={
 								'undefined' !== typeof ignoredPhrases && '' !== ignoredPhrases
-									 ? ignoredPhrases.split( ',' )
-									 : []
+								? ignoredPhrases.split( ',' )
+								: []
 							}
 							onChange={ this.props.onOptionChange } />
 					</FormFieldset>
@@ -103,10 +101,10 @@ export const Composing = moduleSettingsForm(
 					<SettingsGroup support={ markdown.learn_more_button }>
 						<FormFieldset>
 							<ModuleToggle slug="markdown"
-										  compact
-										  activated={ this.props.getOptionValue( 'markdown' ) }
-										  toggling={ this.props.isSavingAnyOption( 'markdown' ) }
-										  toggleModule={ this.props.toggleModuleNow }>
+								compact
+								activated={ this.props.getOptionValue( 'markdown' ) }
+								toggling={ this.props.isSavingAnyOption( 'markdown' ) }
+								toggleModule={ this.props.toggleModuleNow }>
 								<span className="jp-form-toggle-explanation">
 									{ markdown.description }
 								</span>
@@ -115,10 +113,10 @@ export const Composing = moduleSettingsForm(
 					</SettingsGroup>
 					<SettingsGroup hasChild support={ atd.learn_more_button }>
 						<ModuleToggle slug="after-the-deadline"
-									  compact
-									  activated={ this.props.getOptionValue( 'after-the-deadline' ) }
-									  toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
-									  toggleModule={ this.props.toggleModuleNow }>
+							compact
+							activated={ this.props.getOptionValue( 'after-the-deadline' ) }
+							toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
+							toggleModule={ this.props.toggleModuleNow }>
 							<span className="jp-form-toggle-explanation">
 								{ atd.description }
 							</span>
@@ -126,7 +124,7 @@ export const Composing = moduleSettingsForm(
 						<FormFieldset>
 							{
 								this.props.getOptionValue( 'after-the-deadline' )
-									? <InlineExpand label={ __( 'Fancy options' ) }>{ this.getAtdSettings() }</InlineExpand>
+									? <InlineExpand label={ __( 'Advanced Options' ) }>{ this.getAtdSettings() }</InlineExpand>
 									: ''
 							}
 						</FormFieldset>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Rather than using ambiguous and non-standard terms like "fancy" and "serious", just use "Advanced Options" to hide/show more detailed options for features.

Cleans up some linting errors in the touched files as well.

#### Testing instructions:
* Look under Discussion > Site Stats and Writing > Composing
* Confirm there are text links saying "Advanced Options", and that clicking them shows additional options

![screen shot 2017-01-26 at 6 34 26 pm](https://cloud.githubusercontent.com/assets/108942/22357540/17431fb4-e3f6-11e6-98e8-946bc8c86f61.png)

Note this clearly needs some more spacing; that can be addressed separately.