### PR TITLE
Always fire publicize if there are any connections

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -480,7 +480,7 @@ class Publicize extends Publicize_Base {
 			return $flags;
 		}
 
-		$connected_services = Jetpack_Options::get_option( 'publicize_connections' )
+		$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
 
 		if ( empty( $connected_services ) ) {
 			return $flags;

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -162,7 +162,7 @@ class Publicize extends Publicize_Base {
 					if ( is_wp_error( $verification ) ) {
 						$url = Jetpack::admin_url( 'jetpack#/settings' );
 						wp_die( sprintf( __( "Jetpack is not connected. Please connect Jetpack by visiting <a href='%s'>Settings</a>.", 'jetpack' ), $url ) );
-						
+
 					}
 					$stats_options = get_option( 'stats_options' );
 					$wpcom_blog_id = Jetpack_Options::get_option( 'id' );
@@ -454,7 +454,7 @@ class Publicize extends Publicize_Base {
 	function save_publicized( $post_ID, $post, $update ) {
 		// Only do this when a post transitions to being published
 		if ( get_post_meta( $post->ID, $this->PENDING ) && $this->post_type_is_publicizeable( $post->post_type ) ) {
-			$connected_services = $this->get_services( 'connected' );
+			$connected_services = Jetpack_Options::get_option( 'publicize_connections' );
 			if ( ! empty( $connected_services ) ) {
 				/**
 				 * Fires when a post is saved that has is marked as pending publicizing
@@ -480,7 +480,7 @@ class Publicize extends Publicize_Base {
 			return $flags;
 		}
 
-		$connected_services = $this->get_services( 'connected' );
+		$connected_services = Jetpack_Options::get_option( 'publicize_connections' )
 
 		if ( empty( $connected_services ) ) {
 			return $flags;

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -330,8 +330,8 @@ abstract class Publicize_Base {
 		// Did this request happen via wp-admin?
 		$from_web = isset( $_SERVER['REQUEST_METHOD'] )
 			&&
-			'post' == strtolower( $_SERVER['REQUEST_METHOD'] ) 
-			&& 
+			'post' == strtolower( $_SERVER['REQUEST_METHOD'] )
+			&&
 			isset( $_POST[$this->ADMIN_PAGE] );
 
 		if ( ( $from_web || defined( 'POST_BY_EMAIL' ) ) && isset( $_POST['wpas_title'] ) ) {


### PR DESCRIPTION
Fixes an issue where publicize wasn't being fired for scheduled posts in some instances.

- where the cron job didn't run with the same user ID as the post author, and
- there were no publicize connections shared with the cron user (if any)

