### PR TITLE
Settings UI: Google Analytics Settings Card

### DIFF
--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -7,26 +7,61 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import {
+	FormFieldset,
+	FormLegend,
+	FormLabel
+} from 'components/forms';
+import TextInput from 'components/text-input';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { ModuleToggle } from 'components/module-toggle';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 
-const GoogleAnalytics = moduleSettingsForm(
-	React.createClass( {
-		render() {
-			const translate = this.props.translate;
+const GoogleAnalytics = React.createClass( {
+	render() {
+		const translate = this.props.translate;
 
-			return (
-				<SettingsCard
-					{ ...this.props }
-					header={ translate( 'Google Analytics', { context: 'Settings Header' } ) }
-					hideButton >
-					<SettingsGroup support="https://support.wordpress.com/google-analytics/">
-					</SettingsGroup>
-				</SettingsCard>
-			);
-		}
-	} )
-);
+		const isModuleActive = true; // this.props.getOptionValue( 'google_analytics_tracking_id' )
 
-export default localize( GoogleAnalytics );
+		return (
+			<SettingsCard
+				{ ...this.props }
+				header={ translate( 'Google Analytics', { context: 'Settings Header' } ) } >
+				<SettingsGroup hasChild support="https://support.wordpress.com/google-analytics/">
+					<ModuleToggle slug="google-analytics"
+						compact
+						activated={ isModuleActive }
+						toggling={ this.props.isSavingAnyOption( 'google-analytics' ) }
+						toggleModule={ this.props.toggleModuleNow } >
+					<span className="jp-form-toggle-explanation">{ this.props.getModule( 'google-analytics' ).description }</span>
+					</ModuleToggle>
+					<p className="jp-form-setting-explanation">{ translate( 'lorem ipsum dolor' ) }</p>
+						<p className="jp-form-setting-explanation">
+							{
+								translate( 'Enter your tracking Id value to track your blog with {{a}}Google Analytics{{/a}}.', {
+									components: {
+										a: <a href="https://www.google.com/analytics/" target="_blank" />
+									}
+								} )
+							}
+						</p>
+					<FormFieldset>
+						<FormLabel>
+							<FormLegend>{ translate( 'Google Analytics Tracking Id' ) }</FormLegend>
+							<TextInput
+								name={ 'google_analytics_tracking_id' }
+								value={ this.props.getOptionValue( 'google_analytics_tracking_id' ) }
+								placeholder={ translate( 'Example: UA-11111111-1' ) }
+								className="widefat code"
+								disabled={ this.props.isUpdating( 'google_analytics_tracking_id' ) }
+								onChange={ this.props.onOptionChange } />
+						</FormLabel>
+					</FormFieldset>
+				</SettingsGroup>
+			</SettingsCard>
+		);
+	}
+} );
+
+export default localize( moduleSettingsForm( GoogleAnalytics ) );

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+
+const GoogleAnalytics = moduleSettingsForm(
+	React.createClass( {
+		render() {
+			const translate = this.props.translate;
+
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ translate( 'Google Analytics', { context: 'Settings Header' } ) }
+					hideButton >
+					<SettingsGroup support="https://support.wordpress.com/google-analytics/">
+					</SettingsGroup>
+				</SettingsCard>
+			);
+		}
+	} )
+);
+
+export default localize( GoogleAnalytics );

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -11,6 +11,7 @@ import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import QuerySite from 'components/data/query-site';
 import { SEO } from './seo';
+import GoogleAnalytics from './google-analytics';
 import { SiteStats } from './site-stats';
 import { RelatedPosts } from './related-posts';
 import { VerificationServices } from './verification-services';
@@ -44,6 +45,7 @@ export const Traffic = React.createClass( {
 					settings={ this.props.settings }
 					getModule={ this.props.module }
 				/>
+				<GoogleAnalytics settings={ this.props.settings } getModule={ this.props.module } />
 			</div>
 		);
 	}


### PR DESCRIPTION
Adds setting card for Google Analytics to the Settings UI new traffic tab.

Fixes #

#### Changes proposed in this Pull Request:


#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
