### PR TITLE
Add Twitter partner ID for Twitter shortcodes and timeline widget

### DIFF
--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -111,6 +111,12 @@ class Jetpack_Tweet {
 		// Twitter doesn't support maxheight so don't send it
 		$provider = remove_query_arg( 'maxheight', $provider );
 
+		// Add Twitter partner ID to track embeds from Jetpack
+		$partner = apply_filters( 'jetpack_twitter_partner_id', 'jetpack' );
+		if ( false !== $partner ) {
+			$provider = add_query_arg( 'partner', $partner, $provider );
+		}
+
 		return $provider;
 	}
 

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -111,8 +111,18 @@ class Jetpack_Tweet {
 		// Twitter doesn't support maxheight so don't send it
 		$provider = remove_query_arg( 'maxheight', $provider );
 
-		// Add Twitter partner ID to track embeds from Jetpack
+		/**
+		 * Filter the Twitter Partner ID.
+		 *
+		 * @module shortcodes
+		 *
+		 * @since 4.6.0
+		 *
+		 * @param string $partner_id Twitter partner ID.
+		 */
 		$partner = apply_filters( 'jetpack_twitter_partner_id', 'jetpack' );
+
+		// Add Twitter partner ID to track embeds from Jetpack
 		if ( ! empty( $partner ) ) {
 			$provider = add_query_arg( 'partner', $partner, $provider );
 		}

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -113,7 +113,7 @@ class Jetpack_Tweet {
 
 		// Add Twitter partner ID to track embeds from Jetpack
 		$partner = apply_filters( 'jetpack_twitter_partner_id', 'jetpack' );
-		if ( false !== $partner ) {
+		if ( ! empty( $partner ) ) {
 			$provider = add_query_arg( 'partner', $partner, $provider );
 		}
 

--- a/modules/shortcodes/twitter-timeline.php
+++ b/modules/shortcodes/twitter-timeline.php
@@ -19,6 +19,10 @@ function twitter_timeline_shortcode( $atts ) {
 
 	$output = '<a class="twitter-timeline"';
 
+	$partner = apply_filters( 'jetpack_twitter_partner_id', 'jetpack' );
+	if ( false !== $partner ) {
+		$output .= ' data-partner="' . esc_attr( $partner ) . '"';
+	}
 	if ( is_numeric( $atts['width'] ) ) {
 		$output .= ' data-width="' . esc_attr( $atts['width'] ) . '"';
 	}

--- a/modules/shortcodes/twitter-timeline.php
+++ b/modules/shortcodes/twitter-timeline.php
@@ -20,7 +20,7 @@ function twitter_timeline_shortcode( $atts ) {
 	$output = '<a class="twitter-timeline"';
 
 	$partner = apply_filters( 'jetpack_twitter_partner_id', 'jetpack' );
-	if ( false !== $partner ) {
+	if ( ! empty( $partner ) ) {
 		$output .= ' data-partner="' . esc_attr( $partner ) . '"';
 	}
 	if ( is_numeric( $atts['width'] ) ) {

--- a/modules/shortcodes/twitter-timeline.php
+++ b/modules/shortcodes/twitter-timeline.php
@@ -19,6 +19,7 @@ function twitter_timeline_shortcode( $atts ) {
 
 	$output = '<a class="twitter-timeline"';
 
+	/** This filter is documented in modules/shortcodes/tweet.php */
 	$partner = apply_filters( 'jetpack_twitter_partner_id', 'jetpack' );
 	if ( ! empty( $partner ) ) {
 		$output .= ' data-partner="' . esc_attr( $partner ) . '"';

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -108,6 +108,12 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			}
 		}
 
+		/** This filter is documented in modules/shortcodes/tweet.php */
+		$partner = apply_filters( 'jetpack_twitter_partner_id', 'jetpack' );
+		if ( ! empty( $partner ) ) {
+			echo ' data-partner="' . esc_attr( $partner ) . '"';
+		}
+
 		if ( ! empty( $instance['chrome'] ) && is_array( $instance['chrome'] ) ) {
 			echo ' data-chrome="' . esc_attr( join( ' ', $instance['chrome'] ) ) . '"';
 		}

--- a/tests/php/modules/shortcodes/test_class.tweet.php
+++ b/tests/php/modules/shortcodes/test_class.tweet.php
@@ -67,4 +67,16 @@ class WP_Test_Jetpack_Shortcodes_Tweet extends WP_UnitTestCase {
 		$this->assertContains( '<a href="https://twitter.com/jetpack/status/759034293385502721">', $shortcode_content );
 	}
 
+	/**
+	 * Verify that rendering the shortcode contains Jetpack's partner ID
+	 *
+	 * @since 4.6.0
+	 */
+	public function test_shortcode_tweet_partner_id() {
+		$content = "[tweet 759034293385502721]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( 'data-partner="jetpack"', $shortcode_content );
+	}
 }

--- a/tests/php/modules/shortcodes/test_class.twitter-timeline.php
+++ b/tests/php/modules/shortcodes/test_class.twitter-timeline.php
@@ -24,4 +24,16 @@ class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 		$this->assertNotEquals( $content, $shortcode_content );
 	}
 
+	/**
+	 * Verify that rendering the shortcode contains Jetpack's partner ID
+	 *
+	 * @since 4.6.0
+	 */
+	public function test_shortcode_tweet_partner_id() {
+		$content = "[twitter-timeline username=automattic]";
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( 'data-partner="jetpack"', $shortcode_content );
+	}
 }


### PR DESCRIPTION
Enables Twitter partner tracking discovery in Jetpack’s Twitter `[tweet]` and `[twitter-timeline]` shortcodes and timeline widget. 

Fixes #5984

#### Changes proposed in this Pull Request:
Adds Twitter's partner ID to `[tweet]` and `[twitter-timeline]` shortcodes to enable Jetpack embed use tracking.

Adds `jetpack_twitter_partner_id` filter to allow overriding the default partner ID (jetpack) used in Twitter embeds.

#### Testing instructions:

Shortcodes:
* Add valid `[tweet]` and `[twitter-timeline]` shortcode to post
* Disable Javascript in browser
* Preview or publish and view post 
* Verify translated shortcode's blockquote tag has the additional attribute `data-partner="jetpack"` (for `[tweet]` the resulting blockquote tag comes from background call to Twitter via `wp_oembed_get()`)

Widget:
* Add Twitter Timeline widget to visible widget area and set up with valid Twitter username
* Disable Javascript in browser
* View page where widget area is visible and verify widget's anchor tag contains `data-partner="jetpack"`

#### Proposed changelog entry for your changes:
Twitter shortcodes and timeline widget now pass Jetpack's partner ID to track usage.
