### PR TITLE
SSO: Add integration with JSON API authorization

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5254,9 +5254,21 @@ p {
 		);
 	}
 
-	// Verifies the request by checking the signature
-	function verify_json_api_authorization_request() {
+
+	/**
+	 * Verifies the request by checking the signature
+	 *
+	 * @since 4.6.0 Method was updated to use `$_REQUEST` instead of `$_GET` and `$_POST`. Method also updated to allow
+	 * passing in an `$environment` argument that overrides `$_REQUEST`. This was useful for integrating with SSO.
+	 *
+	 * @param null|array $environment
+	 */
+	function verify_json_api_authorization_request( $environment = null ) {
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-signature.php';
+
+		$environment = is_null( $environment )
+			? $_REQUEST
+			: $environment;
 
 		$token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 		if ( ! $token || empty( $token->secret ) ) {
@@ -5267,8 +5279,17 @@ p {
 
 		$jetpack_signature = new Jetpack_Signature( $token->secret, (int) Jetpack_Options::get_option( 'time_diff' ) );
 
-		if ( isset( $_POST['jetpack_json_api_original_query'] ) ) {
-			$signature = $jetpack_signature->sign_request( $_GET['token'], $_GET['timestamp'], $_GET['nonce'], '', 'GET', $_POST['jetpack_json_api_original_query'], null, true );
+		if ( isset( $environment['jetpack_json_api_original_query'] ) ) {
+			$signature = $jetpack_signature->sign_request(
+				$environment['token'],
+				$environment['timestamp'],
+				$environment['nonce'],
+				'',
+				'GET',
+				$environment['jetpack_json_api_original_query'],
+				null,
+				true
+			);
 		} else {
 			$signature = $jetpack_signature->sign_current_request( array( 'body' => null, 'method' => 'GET' ) );
 		}
@@ -5277,11 +5298,11 @@ p {
 			wp_die( $die_error );
 		} else if ( is_wp_error( $signature ) ) {
 			wp_die( $die_error );
-		} else if ( ! hash_equals( $signature, $_GET['signature'] ) ) {
+		} else if ( ! hash_equals( $signature, $environment['signature'] ) ) {
 			if ( is_ssl() ) {
 				// If we signed an HTTP request on the Jetpack Servers, but got redirected to HTTPS by the local blog, check the HTTP signature as well
 				$signature = $jetpack_signature->sign_current_request( array( 'scheme' => 'http', 'body' => null, 'method' => 'GET' ) );
-				if ( ! $signature || is_wp_error( $signature ) || ! hash_equals( $signature, $_GET['signature'] ) ) {
+				if ( ! $signature || is_wp_error( $signature ) || ! hash_equals( $signature, $environment['signature'] ) ) {
 					wp_die( $die_error );
 				}
 			} else {
@@ -5289,8 +5310,8 @@ p {
 			}
 		}
 
-		$timestamp = (int) $_GET['timestamp'];
-		$nonce     = stripslashes( (string) $_GET['nonce'] );
+		$timestamp = (int) $environment['timestamp'];
+		$nonce     = stripslashes( (string) $environment['nonce'] );
 
 		if ( ! $this->add_nonce( $timestamp, $nonce ) ) {
 			// De-nonce the nonce, at least for 5 minutes.
@@ -5301,7 +5322,7 @@ p {
 			}
 		}
 
-		$data = json_decode( base64_decode( stripslashes( $_GET['data'] ) ) );
+		$data = json_decode( base64_decode( stripslashes( $environment['data'] ) ) );
 		$data_filters = array(
 			'state'        => 'opaque',
 			'client_id'    => 'int',

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -731,11 +731,9 @@ class Jetpack_SSO {
 				setcookie( 'jetpack_sso_redirect_to', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
 			}
 
-			$original_request = ! empty( $_COOKIE['jetpack_sso_original_request'] )
-				? esc_url_raw( $_COOKIE['jetpack_sso_original_request'] )
-				: false;
+			$json_api_auth_environment = Jetpack_SSO_Helpers::get_json_api_auth_environment();
 
-			$is_json_api_auth = Jetpack_SSO_Helpers::is_sso_for_json_api_auth( $original_request );
+			$is_json_api_auth = ! empty( $json_api_auth_environment );
 			$is_user_connected = Jetpack::is_user_connected( $user->ID );
 			JetpackTracking::record_user_event( 'sso_user_logged_in', array(
 				'user_found_with'  => $user_found_with,
@@ -746,10 +744,7 @@ class Jetpack_SSO {
 
 			if ( $is_json_api_auth ) {
 				add_filter( 'login_redirect', array( Jetpack::init(), 'add_token_to_login_redirect_json_api_authorization' ), 10, 3 );
-
-				Jetpack_SSO_Helpers::set_superglobal_values_for_json_api_auth( $original_request );
-				Jetpack::init()->verify_json_api_authorization_request();
-				Jetpack_SSO_Helpers::reset_superglobal_values_after_json_api_auth();
+				Jetpack::init()->verify_json_api_authorization_request( $json_api_auth_environment );
 			} else if ( ! $is_user_connected ) {
 				$calypso_env = ! empty( $_GET['calypso_env'] )
 					? sanitize_key( $_GET['calypso_env'] )

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -372,14 +372,9 @@ class Jetpack_SSO {
 			// Save cookies so we can handle redirects after SSO
 			$this->save_cookies();
 
-			if ( 'jetpack_json_api_authorization' == $action ) {
-				Jetpack::init()->verify_json_api_authorization_request();
-			}
-
 			/**
 			 * Check to see if the site admin wants to automagically forward the user
-			 * to the WordPress.com login page AND  that the request to wp-login.php
-			 * is not something other than login (Like logout!)
+			 * to the WordPress.com login page.
 			 */
 			if ( Jetpack_SSO_Helpers::bypass_login_forward_wpcom() ) {
 				add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );
@@ -857,11 +852,6 @@ class Jetpack_SSO {
 	 * @return string            The WordPress.com SSO URL.
 	 */
 	function get_sso_url_or_die( $reauth = false, $args = array() ) {
-		global $action;
-		if ( 'jetpack_json_api_authorization' == $action ) {
-			Jetpack::init()->verify_json_api_authorization_request();
-		}
-
 		if ( empty( $reauth ) ) {
 			$sso_redirect = $this->build_sso_url( $args );
 		} else {

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -384,16 +384,17 @@ class Jetpack_SSO {
 					exit;
 				}
 			}
-		} else if ( $this->wants_to_login() ) {
+		} else if ( Jetpack_SSO_Helpers::display_sso_form_for_action( $action ) ) {
 
 			// Save cookies so we can handle redirects after SSO
 			$this->save_cookies();
 
 			/**
 			 * Check to see if the site admin wants to automagically forward the user
-			 * to the WordPress.com login page.
+			 * to the WordPress.com login page AND  that the request to wp-login.php
+			 * is not something other than login (Like logout!)
 			 */
-			if ( Jetpack_SSO_Helpers::bypass_login_forward_wpcom() ) {
+			if ( Jetpack_SSO_Helpers::bypass_login_forward_wpcom() && $this->wants_to_login() ) {
 				add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );
 				$reauth = ! empty( $_GET['force_reauth'] );
 				$sso_url = $this->get_sso_url_or_die( $reauth );

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -743,8 +743,9 @@ class Jetpack_SSO {
 			) );
 
 			if ( $is_json_api_auth ) {
-				add_filter( 'login_redirect', array( Jetpack::init(), 'add_token_to_login_redirect_json_api_authorization' ), 10, 3 );
 				Jetpack::init()->verify_json_api_authorization_request( $json_api_auth_environment );
+				Jetpack::init()->store_json_api_authorization_token( $user->user_login, $user );
+
 			} else if ( ! $is_user_connected ) {
 				$calypso_env = ! empty( $_GET['calypso_env'] )
 					? sanitize_key( $_GET['calypso_env'] )

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -132,7 +132,7 @@ class Jetpack_SSO {
 	public function login_enqueue_scripts() {
 		global $action;
 
-		if ( ! in_array( $action, array( 'jetpack-sso', 'login' ) ) ) {
+		if ( ! Jetpack_SSO_Helpers::display_sso_form_for_action( $action ) ) {
 			return;
 		}
 
@@ -154,7 +154,7 @@ class Jetpack_SSO {
 	public function login_body_class( $classes ) {
 		global $action;
 
-		if ( ! in_array( $action, array( 'jetpack-sso', 'login' ) ) ) {
+		if ( ! Jetpack_SSO_Helpers::display_sso_form_for_action( $action ) ) {
 			return $classes;
 		}
 
@@ -385,7 +385,7 @@ class Jetpack_SSO {
 			exit;
 		}
 
-		if ( Jetpack_SSO_Helpers::display_sso_form_for_action( $action ) ) {
+		if ( $this->wants_to_login() ) {
 			$this->display_sso_login_form();
 		} elseif ( 'jetpack-sso' === $action ) {
 			if ( isset( $_GET['result'], $_GET['user_id'], $_GET['sso_nonce'] ) && 'success' == $_GET['result'] ) {

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -756,6 +756,7 @@ class Jetpack_SSO {
 				exit;
 			}
 
+			add_filter( 'allowed_redirect_hosts', array( 'Jetpack_SSO_Helpers', 'allowed_redirect_hosts' ) );
 			wp_safe_redirect(
 				/** This filter is documented in core/src/wp-login.php */
 				apply_filters( 'login_redirect', $redirect_to, $_request_redirect_to, $user )

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -358,15 +358,6 @@ class Jetpack_SSO {
 			}
 		}
 
-		/**
-		 * If the user is attempting to logout AND the auto-forward to WordPress.com
-		 * login is set then we need to ensure we do not auto-forward the user and get
-		 * them stuck in an infinite logout loop.
-		 */
-		if ( isset( $_GET['loggedout'] ) && Jetpack_SSO_Helpers::bypass_login_forward_wpcom() ) {
-			add_filter( 'jetpack_remove_login_form', '__return_true' );
-		}
-
 		 if ( 'jetpack-sso' === $action ) {
 			if ( isset( $_GET['result'], $_GET['user_id'], $_GET['sso_nonce'] ) && 'success' == $_GET['result'] ) {
 				$this->handle_login();

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -325,7 +325,7 @@ class Jetpack_SSO {
 		// And now the exceptions
 		$action = isset( $_GET['loggedout'] ) ? 'loggedout' : $action;
 
-		if ( 'login' == $action ) {
+		if ( Jetpack_SSO_Helpers::display_sso_form_for_action( $action ) ) {
 			$wants_to_login = true;
 		}
 
@@ -385,7 +385,7 @@ class Jetpack_SSO {
 			exit;
 		}
 
-		if ( 'login' === $action ) {
+		if ( Jetpack_SSO_Helpers::display_sso_form_for_action( $action ) ) {
 			$this->display_sso_login_form();
 		} elseif ( 'jetpack-sso' === $action ) {
 			if ( isset( $_GET['result'], $_GET['user_id'], $_GET['sso_nonce'] ) && 'success' == $_GET['result'] ) {

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -292,6 +292,7 @@ class Jetpack_SSO_Helpers {
 		 */
 		$allowed_actions_for_sso = (array) apply_filters( 'jetpack_sso_allowed_actions', array(
 			'login',
+			'jetpack-sso',
 			'jetpack_json_api_authorization',
 		) );
 		return in_array( $action, $allowed_actions_for_sso );

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -8,7 +8,16 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
  * @since 4.1.0
  */
 class Jetpack_SSO_Helpers {
+	/**
+	 * An array used to store the contents of $_GET before overriding $_GET.
+	 * @var array
+	 */
 	static $stashed_get_params = array();
+
+	/**
+	 * An array used to store the content of $_POST before overriding $_POST.
+	 * @var array
+	 */
 	static $stashed_post_params = array();
 
 	/**
@@ -285,9 +294,17 @@ class Jetpack_SSO_Helpers {
 			'login',
 			'jetpack_json_api_authorization',
 		) );
-	    return in_array( $action, $allowed_actions_for_sso );
+		return in_array( $action, $allowed_actions_for_sso );
 	}
 
+	/**
+	 * Given a URL that is the original request which kicked off the SSO flow, this function returns whether
+	 * the request was for Jetpack JSON API authorization by checking the value of `$action`.
+	 *
+	 * @param string $original_request
+	 *
+	 * @return bool Was the original request for JSON API authorization?
+	 */
 	static function is_sso_for_json_api_auth( $original_request ) {
 		$original_request = esc_url_raw( $original_request );
 
@@ -306,6 +323,15 @@ class Jetpack_SSO_Helpers {
 		return 'jetpack_json_api_authorization' === $args['action'];
 	}
 
+	/**
+	 * Given a URL that is the original request which kicked off the SSO flow, this function stores the contents of
+	 * $_GET and $_POST into static variables of this class and then updates $_GET and $_POST to match the original
+	 * request. This is done so that we can verify the JSON API authorization request.
+	 *
+	 * @param string $original_request
+	 *
+	 * @return bool Were the superglobal values updated to mathch the original request?
+	 */
 	static function set_superglobal_values_for_json_api_auth( $original_request ) {
 		$original_request = esc_url_raw( $original_request );
 
@@ -319,8 +345,14 @@ class Jetpack_SSO_Helpers {
 
 		wp_parse_str( $parsed_url['query'], $_GET );
 		$_POST['jetpack_json_api_original_query'] = $original_request;
+
+		return true;
 	}
 
+	/**
+	 * This function is meant to be run after calling self::set_superglobal_values_for_json_api_auth( $original_request)
+	 * and resets the superglobals back to their original values.
+	 */
 	static function reset_superglobal_values_after_json_api_auth() {
 		$_POST = self::$stashed_post_params;
 		$_GET = self::$stashed_get_params;

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -188,6 +188,7 @@ class Jetpack_SSO_Helpers {
 
 		$hosts[] = 'wordpress.com';
 		$hosts[] = 'jetpack.wordpress.com';
+		$hosts[] = 'public-api.wordpress.com';
 
 		if (
 			( Jetpack::is_development_mode() || Jetpack::is_development_version() ) &&

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -258,6 +258,30 @@ class Jetpack_SSO_Helpers {
 		 */
 		return intval( apply_filters( 'jetpack_sso_auth_cookie_expirtation', YEAR_IN_SECONDS ) );
 	}
+
+	/**
+	 * Determines if the SSO form should be displayed for the current action.
+	 *
+	 * @param string $action
+	 *
+	 * @return bool  Is SSO allowed for the current action?
+	 */
+	static function display_sso_form_for_action( $action ) {
+		/**
+		 * Allows plugins the ability to overwrite actions where the SSO form is allowed to be used.
+		 *
+		 * @module sso
+		 *
+		 * @since 4.6.0
+		 *
+		 * @param array $allowed_actions_for_sso
+		 */
+		$allowed_actions_for_sso = (array) apply_filters( 'jetpack_sso_allowed_actions', array(
+			'login',
+			'jetpack_json_api_authorization',
+		) );
+	    return in_array( $action, $allowed_actions_for_sso );
+	}
 }
 
 endif;

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -340,10 +340,21 @@ class Jetpack_SSO_Helpers {
 			return false;
 		}
 
+		$args = array();
+		wp_parse_str( $parsed_url['query'], $args );
+
+		if ( empty( $args ) || empty( $args['action'] ) ) {
+			return false;
+		}
+
+		if ( 'jetpack_json_api_authorization' !== $args['action'] ) {
+			return false;
+		}
+
 		self::$stashed_get_params = $_GET;
 		self::$stashed_post_params = $_POST;
 
-		wp_parse_str( $parsed_url['query'], $_GET );
+		$_GET = $args;
 		$_POST['jetpack_json_api_original_query'] = $original_request;
 
 		return true;

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -150,7 +150,7 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 			'http://fakesite.com/jetpack.'
 		);
 		$this->assertInternalType( 'array', $hosts );
-		$this->assertCount( 3, $hosts );
+		$this->assertCount( 4, $hosts );
 		$this->assertContains( 'test.com', $hosts );
 		$this->assertContains( 'wordpress.com', $hosts );
 		$this->assertContains( 'jetpack.wordpress.com', $hosts );
@@ -165,7 +165,7 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 			'http://fakesite.com/jetpack.'
 		);
 		$this->assertInternalType( 'array', $hosts );
-		$this->assertCount( 4, $hosts );
+		$this->assertCount( 5, $hosts );
 		$this->assertContains( 'fakesite.com', $hosts );
 		remove_filter( 'jetpack_development_mode', '__return_true' );
 	}
@@ -177,7 +177,7 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 			'http://fakesite.com/jetpack.'
 		);
 		$this->assertInternalType( 'array', $hosts );
-		$this->assertCount( 4, $hosts );
+		$this->assertCount( 5, $hosts );
 		$this->assertContains( 'fakesite.com', $hosts );
 		remove_filter( 'jetpack_development_version', '__return_true' );
 	}

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -234,6 +234,8 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_SSO_Helpers::display_sso_form_for_action( 'hello_world' ) );
 
 		add_filter( 'jetpack_sso_allowed_actions', array( $this, 'allow_hello_world_login_action_for_sso' ) );
+		$this->assertTrue( Jetpack_SSO_Helpers::display_sso_form_for_action( 'hello_world' ) );
+		remove_filter( 'jetpack_sso_allowed_actions', array( $this, 'allow_hello_world_login_action_for_sso' ) );
 	}
 
 	function test_get_json_api_auth_environment() {

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -236,6 +236,12 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		add_filter( 'jetpack_sso_allowed_actions', array( $this, 'allow_hello_world_login_action_for_sso' ) );
 	}
 
+	function test_is_sso_for_json_api_auth() {
+		$this->assertTrue( Jetpack_SSO_Helpers::is_sso_for_json_api_auth( 'http://website.com/wordpress/wp-login.php?action=jetpack_json_api_authorization' ) );
+		$this->assertFalse( Jetpack_SSO_Helpers::is_sso_for_json_api_auth( 'http://website.com/wordpress/wp-login.php?action=loggedout' ) );
+		$this->assertFalse( Jetpack_SSO_Helpers::is_sso_for_json_api_auth( 'http://website.com/wordpress/wp-login.php' ) );
+	}
+
 	function __return_string_value() {
 		return '1';
 	}

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -242,6 +242,50 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_SSO_Helpers::is_sso_for_json_api_auth( 'http://website.com/wordpress/wp-login.php' ) );
 	}
 
+	function test_set_superglobal_values_for_json_api_auth_false() {
+		$this->assertFalse( Jetpack_SSO_Helpers::set_superglobal_values_for_json_api_auth( 'http://website.com/wordpress/wp-login.php?action=loggedout' ) );
+		$this->assertFalse( Jetpack_SSO_Helpers::set_superglobal_values_for_json_api_auth( 'http://website.com' ) );
+		$this->assertFalse( Jetpack_SSO_Helpers::set_superglobal_values_for_json_api_auth( '' ) );
+	}
+
+	function test_set_superglobal_values_for_json_api_auth_stashes_superglobals() {
+		Jetpack_SSO_Helpers::$stashed_get_params = Jetpack_SSO_Helpers::$stashed_post_params = array();
+
+		$_POST = $_GET = array(
+			'foo' => 'bar'
+		);
+
+		$this->assertTrue( Jetpack_SSO_Helpers::set_superglobal_values_for_json_api_auth(
+			'http://website.com/wordpress/wp-login.php?action=jetpack_json_api_authorization&token=my-special-token'
+		) );
+
+		$this->assertSame( array( 'foo' => 'bar' ), Jetpack_SSO_Helpers::$stashed_get_params );
+		$this->assertSame( array( 'foo' => 'bar' ), Jetpack_SSO_Helpers::$stashed_post_params );
+
+		$this->assertTrue( isset( $_GET['token'] ) );
+		$this->assertTrue( isset( $_GET['action'] ) );
+
+		$this->assertSame( $_GET['token'], 'my-special-token' );
+		$this->assertSame( $_GET['action'], 'jetpack_json_api_authorization' );
+	}
+
+	function test_reset_superglobal_values_after_json_api_auth() {
+		Jetpack_SSO_Helpers::$stashed_get_params = Jetpack_SSO_Helpers::$stashed_post_params = array(
+			'foo' => 'bar'
+		);
+
+		$_GET = array(
+			'action' => 'jetpack_json_api_authorization',
+			'token'  => 'my-special-token'
+		);
+		$_POST = array();
+
+		Jetpack_SSO_Helpers::reset_superglobal_values_after_json_api_auth();
+
+		$this->assertSame( array( 'foo' => 'bar' ), $_GET );
+		$this->assertSame( array( 'foo' => 'bar' ), $_POST );
+	}
+
 	function __return_string_value() {
 		return '1';
 	}

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -227,6 +227,15 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertGreaterThan( 2 * DAY_IN_SECONDS, Jetpack_SSO_Helpers::extend_auth_cookie_expiration_for_sso() );
 	}
 
+	function test_display_sso_form_for_action() {
+		// Let's test the default cases
+		$this->assertTrue( Jetpack_SSO_Helpers::display_sso_form_for_action( 'login' ) );
+		$this->assertTrue( Jetpack_SSO_Helpers::display_sso_form_for_action( 'jetpack_json_api_authorization' ) );
+		$this->assertFalse( Jetpack_SSO_Helpers::display_sso_form_for_action( 'hello_world' ) );
+
+		add_filter( 'jetpack_sso_allowed_actions', array( $this, 'allow_hello_world_login_action_for_sso' ) );
+	}
+
 	function __return_string_value() {
 		return '1';
 	}
@@ -237,5 +246,10 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 
 	function return_foobarbaz() {
 		return 'foobarbaz';
+	}
+
+	function allow_hello_world_login_action_for_sso( $actions ) {
+		$actions[] = 'hello_world';
+		return $actions;
 	}
 }


### PR DESCRIPTION
It was reported by @m and @beaulebens that the SSO form was not displaying when using Jetpack JSON API authorization. This seems to be because the action used was not `login`. 

This patch adds the `jetpack_json_api_authorization` action and provides a mechanism so plugins can add extra actions where the SSO form would show.

This PR also adds integration for SSO and JSON API authorization. From what I could tell, the two never worked well together since they use separate values for the `$action` global.

To test:
- Install Google Docs addon: https://chrome.google.com/webstore/detail/wordpresscom-for-google-d/baibkfjlahbcogbckhjljjenalhamjbp
- Go to "Add-ons > WordPress.com for Google Docs > Open"
- Authorize a Jetpack site that has this PR applied and SSO enabled
- Ensure that clicking the "Login with WordPress.com" button allows you to connect your site to Google Docs
- Do lots of regression testing. Make sure that bypassing the login form works as expected, that the SSO form displays when logging out, etc.

Here is an example of the various filters I use to test:

```php
//add_filter( 'jetpack_sso_require_two_step', '__return_true' );
//add_filter( 'jetpack_remove_login_form', '__return_true' );
//add_filter( 'jetpack_sso_display_disclaimer', '__return_false' );
//add_filter( 'jetpack_sso_match_by_email', '__return_false' );
//add_filter( 'jetpack_sso_new_user_override', '__return_true' );
//add_filter( 'jetpack_sso_allowed_username_generate_retries', '__return_zero' );
//add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
```