### PR TITLE
Rename Quiz shortcode class names

### DIFF
--- a/modules/shortcodes/css/quiz.css
+++ b/modules/shortcodes/css/quiz.css
@@ -1,4 +1,4 @@
-div.quiz {
+div.jetpack-quiz {
 	border: 1px solid #deede3;
 	background-color: #f3f3f3;
 	padding: 1em;
@@ -7,47 +7,47 @@ div.quiz {
 	border-radius: .2em;
 }
 
-div.quiz div.question {
+div.jetpack-quiz div.jetpack-quiz-question {
 	margin-bottom: .5em;
 	font-weight: bold;
 }
 
-div.quiz div.answer {
+div.jetpack-quiz div.jetpack-quiz-answer {
 	cursor: pointer;
 	margin-bottom: .5em;
 	padding: 1em 0 1em 1em;
 	border-bottom: 1px dotted #999;
 }
-div.quiz div.answer.last {
+div.jetpack-quiz div.jetpack-quiz-answer.last {
 	padding-bottom: 0;
 	margin-bottom: 0;
 	border-bottom: 0;
 }
 
-div.quiz div.answer.correct {
+div.jetpack-quiz div.jetpack-quiz-answer.correct {
 	color: green;
 }
 
-div.quiz div.answer.wrong {
+div.jetpack-quiz div.jetpack-quiz-answer.wrong {
 	color: red;
 }
 
-div.quiz div.answer div.explanation {
+div.jetpack-quiz div.jetpack-quiz-answer div.jetpack-quiz-explanation {
 	display: none;
 }
 
-div.quiz div.answer.correct div.explanation, div.quiz div.answer.wrong div.explanation {
+div.jetpack-quiz div.jetpack-quiz-answer.correct div.jetpack-quiz-explanation, div.jetpack-quiz div.jetpack-quiz-answer.wrong div.jetpack-quiz-explanation {
 	display: block;
 	color: black;
 	font-size: 90%;
 	margin-top: 1em;
 }
 
-div.quiz div.answer.correct div.explanation tt, div.quiz div.answer.wrong div.explanation tt {
+div.jetpack-quiz div.jetpack-quiz-answer.correct div.jetpack-quiz-explanation tt, div.jetpack-quiz div.jetpack-quiz-answer.wrong div.jetpack-quiz-explanation tt {
 	font-size: 85%;
 }
 
-div.quiz pre {
+div.jetpack-quiz pre {
 	font: 15px Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 	background: transparent;
 	margin: 0;

--- a/modules/shortcodes/js/quiz.js
+++ b/modules/shortcodes/js/quiz.js
@@ -20,16 +20,16 @@
 })(jQuery);
 
 jQuery( function( $ ) {
-	$( '.quiz' ).each( function() {
+	$( '.jetpack-quiz' ).each( function() {
 		var quiz = $(this);
-		quiz.find( 'div.answer' ).shuffleQuiz();
+		quiz.find( 'div.jetpack-quiz-answer' ).shuffleQuiz();
 		quiz.find( 'div[data-correct]' ).removeAttr( 'data-correct' ).data( 'correct', 1 );
-		quiz.find( 'div.answer:last' ).addClass( 'last' );
+		quiz.find( 'div.jetpack-quiz-answer:last' ).addClass( 'last' );
 	});
 
-	$( 'div.quiz' ).on( 'click', 'div.answer', function() {
+	$( 'div.jetpack-quiz' ).on( 'click', 'div.jetpack-quiz-answer', function() {
 		var trackid, answer = $( this ),
-			quiz = answer.closest( 'div.quiz' );
+			quiz = answer.closest( 'div.jetpack-quiz' );
 
 		if  ( quiz.data( 'a8ctraining' ) ) {
 			new Image().src = '//pixel.wp.com/b.gif?v=wpcom-no-pv&x_trainingchaos-' + quiz.data( 'username' ) + '=' + quiz.data( 'a8ctraining' ) + '&rand=' + Math.random();

--- a/modules/shortcodes/quiz.php
+++ b/modules/shortcodes/quiz.php
@@ -181,7 +181,7 @@ class Quiz_Shortcode {
 		}
 
 		$quiz = self::do_shortcode( $content );
-		return '<div class="quiz"' . $id . '>' . $quiz . '</div>';
+		return '<div class="jetpack-quiz quiz"' . $id . '>' . $quiz . '</div>';
 	}
 
 	/**
@@ -224,7 +224,7 @@ class Quiz_Shortcode {
 	 */
 	public static function question_shortcode( $atts, $content = null ) {
 		return isset( $atts['quiz_item'] )
-			? '<div class="question">' . self::do_shortcode( $content ) . '</div>'
+			? '<div class="jetpack-quiz-question question">' . self::do_shortcode( $content ) . '</div>'
 			: '';
 	}
 
@@ -244,7 +244,7 @@ class Quiz_Shortcode {
 		}
 
 		return isset( $atts['quiz_item'] )
-			? '<div class="answer" data-correct="1">' . self::do_shortcode( $content ) . '</div>'
+			? '<div class="jetpack-quiz-answer answer" data-correct="1">' . self::do_shortcode( $content ) . '</div>'
 			: '';
 	}
 
@@ -264,7 +264,7 @@ class Quiz_Shortcode {
 		}
 
 		return isset( $atts['quiz_item'] )
-			? '<div class="answer">' . self::do_shortcode( $content ) . '</div>'
+			? '<div class="jetpack-quiz-answer answer">' . self::do_shortcode( $content ) . '</div>'
 			: '';
 	}
 
@@ -284,7 +284,7 @@ class Quiz_Shortcode {
 		}
 
 		return isset( $atts['quiz_item'] )
-			? '<div class="explanation">' . self::do_shortcode( $content ) . '</div>'
+			? '<div class="jetpack-quiz-explanation explanation">' . self::do_shortcode( $content ) . '</div>'
 			: '';
 	}
 }

--- a/tests/php/modules/shortcodes/test_class.quiz.php
+++ b/tests/php/modules/shortcodes/test_class.quiz.php
@@ -32,7 +32,7 @@ class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_quiz_id() {
 		$shortcode_content = do_shortcode( '[quiz trackid="the-quiz"][question]What is the right answer?[/question][/quiz]' );
-		$this->assertEquals( '<div class="quiz" data-trackid="the-quiz"><div class="question">What is the right answer?</div></div>', $shortcode_content );
+		$this->assertEquals( '<div class="jetpack-quiz quiz" data-trackid="the-quiz"><div class="jetpack-quiz-question question">What is the right answer?</div></div>', $shortcode_content );
 	}
 
 	/**
@@ -45,7 +45,7 @@ class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
 		$this->assertEquals( '', $shortcode_content );
 
 		$shortcode_content = do_shortcode( '[quiz][question]What is the right answer?[/question][/quiz]' );
-		$this->assertEquals( '<div class="quiz"><div class="question">What is the right answer?</div></div>', $shortcode_content );
+		$this->assertEquals( '<div class="jetpack-quiz quiz"><div class="jetpack-quiz-question question">What is the right answer?</div></div>', $shortcode_content );
 	}
 
 	/**
@@ -58,7 +58,7 @@ class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
 		$this->assertEquals( '', $shortcode_content );
 
 		$shortcode_content = do_shortcode( '[quiz][answer]This is the right answer![/answer][/quiz]' );
-		$this->assertEquals( '<div class="quiz"><div class="answer" data-correct="1">This is the right answer!</div></div>', $shortcode_content );
+		$this->assertEquals( '<div class="jetpack-quiz quiz"><div class="jetpack-quiz-answer answer" data-correct="1">This is the right answer!</div></div>', $shortcode_content );
 	}
 
 	/**
@@ -71,7 +71,7 @@ class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
 		$this->assertEquals( '', $shortcode_content );
 
 		$shortcode_content = do_shortcode( '[quiz][wrong]This is so wrong...[/wrong][/quiz]' );
-		$this->assertEquals( '<div class="quiz"><div class="answer">This is so wrong...</div></div>', $shortcode_content );
+		$this->assertEquals( '<div class="jetpack-quiz quiz"><div class="jetpack-quiz-answer answer">This is so wrong...</div></div>', $shortcode_content );
 	}
 
 	/**
@@ -84,7 +84,7 @@ class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
 		$this->assertEquals( '', $shortcode_content );
 
 		$shortcode_content = do_shortcode( '[quiz][explanation]This is why this is right or wrong.[/explanation][/quiz]' );
-		$this->assertEquals( '<div class="quiz"><div class="explanation">This is why this is right or wrong.</div></div>', $shortcode_content );
+		$this->assertEquals( '<div class="jetpack-quiz quiz"><div class="jetpack-quiz-explanation explanation">This is why this is right or wrong.</div></div>', $shortcode_content );
 	}
 
 	/**
@@ -94,7 +94,7 @@ class WP_Test_Jetpack_Shortcodes_Quiz extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_complete() {
 		$shortcode_content = do_shortcode( '[quiz][question]What is the right answer?[/question][wrong]This is so wrong...[explanation]This is why this is wrong.[/explanation][/wrong][answer]Yes, this is right![explanation]Yay![/explanation][/answer][/quiz]' );
-		$this->assertEquals( '<div class="quiz"><div class="question">What is the right answer?</div><div class="answer">This is so wrong...<div class="explanation">This is why this is wrong.</div></div><div class="answer" data-correct="1">Yes, this is right!<div class="explanation">Yay!</div></div></div>', $shortcode_content );
+		$this->assertEquals( '<div class="jetpack-quiz quiz"><div class="jetpack-quiz-question question">What is the right answer?</div><div class="jetpack-quiz-answer answer">This is so wrong...<div class="jetpack-quiz-explanation explanation">This is why this is wrong.</div></div><div class="jetpack-quiz-answer answer" data-correct="1">Yes, this is right!<div class="jetpack-quiz-explanation explanation">Yay!</div></div></div>', $shortcode_content );
 	}
 
 


### PR DESCRIPTION
Fixes #6191

#### Changes proposed in this Pull Request:
Change the Quiz shortcode class names, to prevent conflict with other styles if there are any other `.quiz` elements.

 I've also change the other element class names, to ensure that they will not cause a conflict too.

`.answer` to `.jetpack-quiz-answer`
`.question` to `.jetpack-quiz-question`
`.explanation` to `.jetpack-quiz-explanation`

I agree, that `jetpack-quiz-` prefix is quite long and can be changed to `jetpack-` only, but `jetpack-quiz-` is more specific