### PR TITLE
CLI: Update translated string for sync queue

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -715,7 +715,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				$items = $queue->peek( 100 );
 
 				if ( empty( $items ) ) {
-					/* translators: %s is the ame of the queue, either 'incremental' or 'full' */
+					/* translators: %s is the name of the queue, either 'incremental' or 'full' */
 					WP_CLI::log( sprintf( __( 'Nothing is in the queue: %s', 'jetpack' ), $queue_name  ) );
 				} else {
 					$collection = array();

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -715,7 +715,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 				$items = $queue->peek( 100 );
 
 				if ( empty( $items ) ) {
-					WP_CLI::log( sprintf( __( 'Nothing is in the %s queue', 'jetpack' ), $queue_name  ) );
+					/* translators: %s is the ame of the queue, either 'incremental' or 'full' */
+					WP_CLI::log( sprintf( __( 'Nothing is in the queue: %s', 'jetpack' ), $queue_name  ) );
 				} else {
 					$collection = array();
 					foreach ( $items as $item ) {


### PR DESCRIPTION
In [this comment](https://github.com/Automattic/jetpack/pull/5933#pullrequestreview-19070545) @akirk pointed out an improper string in the `jetpack sync_queue` command. This PR aims to fix that by using the @akirk's suggestion.
