### PR TITLE
Reverse permission check in REST API auth

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4840,22 +4840,23 @@ p {
 		}
 
 		if (
-			false === $verified ||
-			! isset( $verified['type'] ) ||
-			'user' !== $verified['type'] ||
-			empty( $verified['user_id'] )
+			$verified &&
+			isset( $verified['type'] ) &&
+			'user' === $verified['type'] &&
+			! empty( $verified['user_id'] )
 		) {
-			$this->rest_authentication_status = new WP_Error(
-				'rest_invalid_signature',
-				__( 'The request is not signed correctly.', 'jetpack' ),
-				array( 'status' => 400 )
-			);
-			return null;
+			// Authentication successful.
+			$this->rest_authentication_status = true;
+			return $verified['user_id'];
 		}
 
-		// Authentication successful.
-		$this->rest_authentication_status = true;
-		return $verified['user_id'];
+		// Something else went wrong.  Probably a signature error.
+		$this->rest_authentication_status = new WP_Error(
+			'rest_invalid_signature',
+			__( 'The request is not signed correctly.', 'jetpack' ),
+			array( 'status' => 400 )
+		);
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
There should be no change in logic, but in general permissions-related
functions should fall through to an error rather than success.

Follow-up to #5418.  cc: @roccotripaldi @oskosk 

#### Testing instructions:

* Make sure the test suite still passes.
* Make sure the REST API authentication mechanism still works from WP.com requests.