### PR TITLE
Settings: convert checkboxes to toggles. Fade toggle child settings when it's inactive.

### DIFF
--- a/_inc/client/components/forms/index.jsx
+++ b/_inc/client/components/forms/index.jsx
@@ -5,7 +5,7 @@ var React = require( 'react' ),
 	classnames = require( 'classnames' );
 import classNames from 'classnames';
 import omit from 'lodash/omit';
-import forOwn from 'lodash/forown';
+import forOwn from 'lodash/forOwn';
 import isEmpty from 'lodash/isEmpty';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -140,7 +140,7 @@
 	}
 }
 
-.jp-form-block-click {
+.jp-form-block-fade {
 	position: absolute;
 	top: 0;
 	left: 0;

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -35,7 +35,7 @@ export const SettingsGroup = props => {
 				'jp-form-settings-disable': disableInDevMode
 			} ) }>
 				{
-					disableInDevMode && <div className="jp-form-block-click"></div>
+					disableInDevMode && <div className="jp-form-block-fade"></div>
 				}
 				{
 					support && (

--- a/_inc/client/components/tags-input/index.jsx
+++ b/_inc/client/components/tags-input/index.jsx
@@ -9,7 +9,7 @@ const JetpackTagsInput = React.createClass( {
 	},
 
 	handleChange( tags ) {
-		this.setState( { tags } )
+		this.setState( { tags } );
 		if ( this.props.onChange ) {
 			this.props.onChange( {
 				target: {
@@ -21,10 +21,10 @@ const JetpackTagsInput = React.createClass( {
 	},
 
 	render() {
-		const props = this.props;
 		return (
 			<TagsInput
-				inputProps={ { placeholder: props.placeholder } }
+				disabled={ this.props.disabled }
+				inputProps={ { placeholder: this.props.placeholder } }
 				onChange={ this.handleChange }
 				value={ this.state.tags } />
 		);

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -25,6 +25,7 @@ export const Comments = moduleSettingsForm(
 
 		render() {
 			let comments = this.props.getModule( 'comments' ),
+				isCommentsActive = this.props.getOptionValue( 'comments' ),
 				commentsUnavailableInDevMode = this.props.isUnavailableInDevMode( 'comments' ),
 				gravatar = this.props.getModule( 'gravatar-hovercards' ),
 				markdown = this.props.getModule( 'markdown' );
@@ -45,31 +46,27 @@ export const Comments = moduleSettingsForm(
 							}
 						</span>
 						</ModuleToggle>
-						{
-							this.props.getOptionValue( 'comments' ) && (
-								<FormFieldset>
-									<FormLabel>
-										<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
-										<TextInput
-											name={ 'highlander_comment_form_prompt' }
-											value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
-											disabled={ commentsUnavailableInDevMode || this.props.isUpdating( 'highlander_comment_form_prompt' ) }
-											onChange={ this.props.onOptionChange } />
-									</FormLabel>
-									<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
-									<FormLabel>
-										<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
-										<FormSelect
-											name={ 'jetpack_comment_form_color_scheme' }
-											value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
-											disabled={ commentsUnavailableInDevMode }
-											onChange={ this.props.onOptionChange }
-											{ ...this.props }
-											validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
-									</FormLabel>
-								</FormFieldset>
-							)
-						}
+						<FormFieldset>
+							<FormLabel>
+								<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
+								<TextInput
+									name={ 'highlander_comment_form_prompt' }
+									value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
+									disabled={ ! isCommentsActive || commentsUnavailableInDevMode || this.props.isUpdating( 'highlander_comment_form_prompt' ) }
+									onChange={ this.props.onOptionChange } />
+							</FormLabel>
+							<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
+							<FormLabel>
+								<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
+								<FormSelect
+									name={ 'jetpack_comment_form_color_scheme' }
+									value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
+									disabled={ ! isCommentsActive || commentsUnavailableInDevMode }
+									onChange={ this.props.onOptionChange }
+									{ ...this.props }
+									validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
+							</FormLabel>
+						</FormFieldset>
 					</SettingsGroup>
 					<SettingsGroup>
 						<FormFieldset support={ gravatar.learn_more_button }>

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -68,39 +68,37 @@ export const Subscriptions = moduleSettingsForm(
 						</span>
 						</ModuleToggle>
 						{
-							isSubscriptionsActive && (
-								<FormFieldset>
-									<FormToggle
-										compact
-										checked={ this.state.stb_enabled }
-										disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
-										onChange={ e => this.updateOptions( 'stb_enabled' ) }>
-										<span className="jp-form-toggle-explanation">
-											{
-												__( 'Show a "follow blog" option in the comment form' )
-											}
-										</span>
-									</FormToggle>
-									<FormToggle
-										compact
-										checked={ this.state.stc_enabled }
-										disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
-										onChange={ e => this.updateOptions( 'stc_enabled' ) }>
-										<span className="jp-form-toggle-explanation">
-											{
-												__( 'Show a "follow comments" option in the comment form.' )
-											}
-										</span>
-									</FormToggle>
-									{
-										! unavailableInDevMode && (
-											<p>
-												<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
-											</p>
-										)
-									}
-								</FormFieldset>
-							)
+							<FormFieldset>
+								<FormToggle
+									compact
+									checked={ this.state.stb_enabled }
+									disabled={ ! isSubscriptionsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+									onChange={ e => this.updateOptions( 'stb_enabled' ) }>
+									<span className="jp-form-toggle-explanation">
+										{
+											__( 'Show a "follow blog" option in the comment form' )
+										}
+									</span>
+								</FormToggle>
+								<FormToggle
+									compact
+									checked={ this.state.stc_enabled }
+									disabled={ ! isSubscriptionsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+									onChange={ e => this.updateOptions( 'stc_enabled' ) }>
+									<span className="jp-form-toggle-explanation">
+										{
+											__( 'Show a "follow comments" option in the comment form.' )
+										}
+									</span>
+								</FormToggle>
+								{
+									( isSubscriptionsActive || ! unavailableInDevMode ) && (
+										<p>
+											<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
+										</p>
+									)
+								}
+							</FormFieldset>
 						}
 					</SettingsGroup>
 				</SettingsCard>

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -4,6 +4,7 @@
 import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
+import FormToggle from 'components/form/form-toggle';
 
 /**
  * Internal dependencies
@@ -12,12 +13,37 @@ import { FormFieldset } from 'components/forms';
 import ExternalLink from 'components/external-link';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const Subscriptions = moduleSettingsForm(
 	React.createClass( {
+
+		/**
+		 * Get options for initial state.
+		 *
+		 * @returns {{stb_enabled: *, stc_enabled: *}}
+		 */
+		getInitialState() {
+			return {
+				stb_enabled: this.props.getOptionValue( 'stb_enabled', 'subscriptions' ),
+				stc_enabled: this.props.getOptionValue( 'stc_enabled', 'subscriptions' )
+			};
+		},
+
+		/**
+		 * Update state so toggles are updated.
+		 *
+		 * @param {string} optionName
+		 */
+		updateOptions( optionName ) {
+			this.setState(
+				{
+					[ optionName ]: ! this.state[ optionName ]
+				},
+				this.props.updateFormStateModuleOption( 'subscriptions', optionName )
+			);
+		},
 
 		render() {
 			let subscriptions = this.props.getModule( 'subscriptions' ),
@@ -26,6 +52,7 @@ export const Subscriptions = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
+					hideButton
 					module="subscriptions">
 					<SettingsGroup hasChild disableInDevMode module={ subscriptions }>
 						<ModuleToggle slug="subscriptions"
@@ -43,18 +70,30 @@ export const Subscriptions = moduleSettingsForm(
 						{
 							isSubscriptionsActive && (
 								<FormFieldset>
-									<ModuleSettingCheckbox
-										name={ 'stb_enabled' }
-										{ ...this.props }
-										disabled={ unavailableInDevMode }
-										label={ __( 'Show a "follow blog" option in the comment form' ) } />
-									<ModuleSettingCheckbox
-										name={ 'stc_enabled' }
-										{ ...this.props }
-										disabled={ unavailableInDevMode }
-										label={ __( 'Show a "follow comments" option in the comment form.' ) } />
+									<FormToggle
+										compact
+										checked={ this.state.stb_enabled }
+										disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
+										onChange={ e => this.updateOptions( 'stb_enabled' ) }>
+										<span className="jp-form-toggle-explanation">
+											{
+												__( 'Show a "follow blog" option in the comment form' )
+											}
+										</span>
+									</FormToggle>
+									<FormToggle
+										compact
+										checked={ this.state.stc_enabled }
+										disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
+										onChange={ e => this.updateOptions( 'stc_enabled' ) }>
+										<span className="jp-form-toggle-explanation">
+											{
+												__( 'Show a "follow comments" option in the comment form.' )
+											}
+										</span>
+									</FormToggle>
 									{
-										unavailableInDevMode && (
+										! unavailableInDevMode && (
 											<p>
 												<ExternalLink className="jp-module-settings__external-link" icon={ true } iconSize={ 16 } href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
 											</p>

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -88,46 +88,42 @@ export const Protect = moduleSettingsForm(
 								__( 'Secure user authentication.' )
 							}
 						</p>
-						{
-							isProtectActive && (
-								<FormFieldset>
-									{
-										this.props.currentIp && (
-											<p>
-												{
-													__( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
-												}
-												<br />
-												{
-													<Button
-														disabled={ unavailableInDevMode || this.currentIpIsWhitelisted() }
-														onClick={ this.addToWhitelist }
-														compact >{ __( 'Add to whitelist' ) }</Button>
-												}
-											</p>
-										)
-									}
-									<FormLabel>
-										<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
-										<Textarea
-											disabled={ unavailableInDevMode }
-											name={ 'jetpack_protect_global_whitelist' }
-											placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
-											onChange={ this.updateText }
-											value={ this.state.whitelist } />
-									</FormLabel>
-									<span className="jp-form-setting-explanation">
+						<FormFieldset>
+							{
+								this.props.currentIp && (
+									<p>
 										{
-											__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
-												components: {
-													br: <br />
-												}
-											} )
+											__( 'Your Current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
 										}
-									</span>
-								</FormFieldset>
-							)
-						}
+										<br />
+										{
+											<Button
+												disabled={ ! isProtectActive || unavailableInDevMode || this.currentIpIsWhitelisted() }
+												onClick={ this.addToWhitelist }
+												compact>{ __( 'Add to whitelist' ) }</Button>
+										}
+									</p>
+								)
+							}
+							<FormLabel>
+								<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
+								<Textarea
+									disabled={ ! isProtectActive || unavailableInDevMode }
+									name={ 'jetpack_protect_global_whitelist' }
+									placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
+									onChange={ this.updateText }
+									value={ this.state.whitelist } />
+							</FormLabel>
+							<span className="jp-form-setting-explanation">
+								{
+									__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
+										components: {
+											br: <br />
+										}
+									} )
+								}
+							</span>
+						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>
 			)

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -66,39 +66,35 @@ export const SSO = moduleSettingsForm(
 							}
 						</span>
 						</ModuleToggle>
-						{
-							isSSOActive && (
-								<FormFieldset>
-									<p className="jp-form-setting-explanation">
-										{
-											__( 'Use WordPress.com’s secure authentication.' )
-										}
-									</p>
-									<FormToggle
-										compact
-										checked={ this.state.jetpack_sso_match_by_email }
-										disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
-										onChange={ e => this.updateOptions( 'jetpack_sso_match_by_email' ) }>
-										<span className="jp-form-toggle-explanation">
-											{
-												__( 'Match accounts using email addresses.' )
-											}
-										</span>
-									</FormToggle>
-									<FormToggle
-										compact
-										checked={ this.state.jetpack_sso_require_two_step }
-										disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
-										onChange={ e => this.updateOptions( 'jetpack_sso_require_two_step' ) }>
-										<span className="jp-form-toggle-explanation">
-											{
-												__( 'Require two step authentication.' )
-											}
-										</span>
-									</FormToggle>
-								</FormFieldset>
-							)
-						}
+						<FormFieldset>
+							<p className="jp-form-setting-explanation">
+								{
+									__( 'Use WordPress.com’s secure authentication.' )
+								}
+							</p>
+							<FormToggle
+								compact
+								checked={ this.state.jetpack_sso_match_by_email }
+								disabled={ ! isSSOActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+								onChange={ e => this.updateOptions( 'jetpack_sso_match_by_email' ) }>
+								<span className="jp-form-toggle-explanation">
+									{
+										__( 'Match accounts using email addresses.' )
+									}
+								</span>
+							</FormToggle>
+							<FormToggle
+								compact
+								checked={ this.state.jetpack_sso_require_two_step }
+								disabled={ ! isSSOActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+								onChange={ e => this.updateOptions( 'jetpack_sso_require_two_step' ) }>
+								<span className="jp-form-toggle-explanation">
+									{
+										__( 'Require two step authentication.' )
+									}
+								</span>
+							</FormToggle>
+						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>
 			);

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -4,6 +4,7 @@
 import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
+import FormToggle from 'components/form/form-toggle';
 
 /**
  * Internal dependencies
@@ -11,12 +12,37 @@ import { translate as __ } from 'i18n-calypso';
 import { FormFieldset } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const SSO = moduleSettingsForm(
 	React.createClass( {
+
+		/**
+		 * Get options for initial state.
+		 *
+		 * @returns {{jetpack_sso_match_by_email: *, jetpack_sso_require_two_step: *}}
+		 */
+		getInitialState() {
+			return {
+				jetpack_sso_match_by_email: this.props.getOptionValue( 'jetpack_sso_match_by_email', 'sso' ),
+				jetpack_sso_require_two_step: this.props.getOptionValue( 'jetpack_sso_require_two_step', 'sso' )
+			};
+		},
+
+		/**
+		 * Update state so toggles are updated.
+		 *
+		 * @param {string} optionName
+		 */
+		updateOptions( optionName ) {
+			this.setState(
+				{
+					[ optionName ]: ! this.state[ optionName ]
+				},
+				this.props.updateFormStateModuleOption( 'sso', optionName )
+			);
+		},
 
 		render() {
 			let isSSOActive = this.props.getOptionValue( 'sso' ),
@@ -24,6 +50,7 @@ export const SSO = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
+					hideButton
 					module="sso"
 					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
 					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'sso' ) }>
@@ -47,16 +74,28 @@ export const SSO = moduleSettingsForm(
 											__( 'Use WordPress.com’s secure authentication.' )
 										}
 									</p>
-									<ModuleSettingCheckbox
-										name={ 'jetpack_sso_match_by_email' }
-										{ ...this.props }
-										disabled={ unavailableInDevMode  }
-										label={ __( 'Match accounts using email addresses.' ) } />
-									<ModuleSettingCheckbox
-										name={ 'jetpack_sso_require_two_step' }
-										{ ...this.props }
-										disabled={ unavailableInDevMode  }
-										label={ __( 'Require two step authentication.' ) } />
+									<FormToggle
+										compact
+										checked={ this.state.jetpack_sso_match_by_email }
+										disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
+										onChange={ e => this.updateOptions( 'jetpack_sso_match_by_email' ) }>
+										<span className="jp-form-toggle-explanation">
+											{
+												__( 'Match accounts using email addresses.' )
+											}
+										</span>
+									</FormToggle>
+									<FormToggle
+										compact
+										checked={ this.state.jetpack_sso_require_two_step }
+										disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
+										onChange={ e => this.updateOptions( 'jetpack_sso_require_two_step' ) }>
+										<span className="jp-form-toggle-explanation">
+											{
+												__( 'Require two step authentication.' )
+											}
+										</span>
+									</FormToggle>
 								</FormFieldset>
 							)
 						}

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -8,7 +8,7 @@ import merge from 'lodash/merge';
 import includes from 'lodash/includes';
 import some from 'lodash/some';
 import filter from 'lodash/filter';
-import mapValues from 'lodash/mapvalues';
+import mapValues from 'lodash/mapValues';
 
 /**
  * Internal dependencies

--- a/_inc/client/state/settings/test/reducer.js
+++ b/_inc/client/state/settings/test/reducer.js
@@ -17,8 +17,8 @@ describe( 'items reducer', () => {
 			name: 'setting-a'
 		},
 		b: {
-			name: 'setting-b',
-		},
+			name: 'setting-b'
+		}
 	};
 
 	describe( '#settingsFetch', () => {
@@ -114,22 +114,32 @@ describe( 'requests reducer', () => {
 	} );
 
 	describe( '#settingUpdate', () => {
-		it( 'should set updatingSetting to true when updating a setting', () => {
+		it( 'should set settingsSent to true when updating a setting', () => {
 			const stateIn = {};
 			const action = {
-				type: 'JETPACK_SETTING_UPDATE'
+				type: 'JETPACK_SETTING_UPDATE',
+				updatedOptions: {
+					settingOne: 'new-value-one',
+					settingTwo: 'new-value-two'
+				}
 			};
 			let stateOut = requestsReducer( stateIn, action );
-			expect( stateOut.updatingSetting ).to.be.true;
+			expect( stateOut.settingsSent.settingOne ).to.be.true;
+			expect( stateOut.settingsSent.settingTwo ).to.be.true;
 		} );
 
-		it( 'should set updatingSetting to false when a setting was updated', () => {
+		it( 'should set settingsSent to false when a setting was updated', () => {
 			const stateIn = {};
 			const action = {
-				type: 'JETPACK_SETTING_UPDATE_SUCCESS'
+				type: 'JETPACK_SETTING_UPDATE_SUCCESS',
+				updatedOptions: {
+					settingOne: 'new-value-one',
+					settingTwo: 'new-value-two'
+				}
 			};
 			let stateOut = requestsReducer( stateIn, action );
-			expect( stateOut.updatingSetting ).to.be.false;
+			expect( stateOut.settingsSent.settingOne ).to.be.false;
+			expect( stateOut.settingsSent.settingTwo ).to.be.false;
 		} );
 	} );
 
@@ -138,27 +148,28 @@ describe( 'requests reducer', () => {
 			const stateIn = {};
 			const action = {
 				type: 'JETPACK_SETTINGS_UPDATE',
+				updatedOptions: {
+					settingOne: 'new-value-one',
+					settingTwo: 'new-value-two'
+				}
 			};
 			let stateOut = requestsReducer( stateIn, action );
-			expect( stateOut.updatingSetting ).to.be.true;
+			expect( stateOut.settingsSent.settingOne ).to.be.true;
+			expect( stateOut.settingsSent.settingTwo ).to.be.true;
 		} );
 
 		it( 'should set updatingSetting to false when settings were updated', () => {
 			const stateIn = {};
 			const action = {
-				type: 'JETPACK_SETTINGS_UPDATE_SUCCESS'
+				type: 'JETPACK_SETTINGS_UPDATE_SUCCESS',
+				updatedOptions: {
+					settingOne: 'new-value-one',
+					settingTwo: 'new-value-two'
+				}
 			};
 			let stateOut = requestsReducer( stateIn, action );
-			expect( stateOut.updatingSetting ).to.be.false;
-		} );
-
-		it( 'should set updatingSetting to false when settings update has failed', () => {
-			const stateIn = {};
-			const action = {
-				type: 'JETPACK_SETTINGS_UPDATE_SUCCESS'
-			};
-			let stateOut = requestsReducer( stateIn, action );
-			expect( stateOut.updatingSetting ).to.be.false;
+			expect( stateOut.settingsSent.settingOne ).to.be.false;
+			expect( stateOut.settingsSent.settingTwo ).to.be.false;
 		} );
 	} );
 } );

--- a/_inc/client/state/settings/test/selectors.js
+++ b/_inc/client/state/settings/test/selectors.js
@@ -19,7 +19,12 @@ let state = {
 			},
 			requests: {
 				fetchingSettingsList: true,
-				updatingSetting: true
+				settingsSent: {
+					'setting-a': true,
+					'setting-b': true,
+					'setting-numeric': true,
+					'setting-string': true
+				}
 			}
 		}
 	}
@@ -28,17 +33,15 @@ let state = {
 describe( 'requests selectors', () => {
 	describe( '#isFetchingSettingsList', () => {
 		it( 'should return state.jetpack.settings.requests.fetchingSettingsList', () => {
-			const stateIn = state;
-			const output = isFetchingSettingsList( stateIn );
+			const output = isFetchingSettingsList( state );
 			expect( output ).to.equal( state.jetpack.settings.requests.fetchingSettingsList );
 		} );
 	} );
 
 	describe( '#isUpdatingSetting', () => {
-		it( 'should return state.jetpack.settings.requests.updatingSetting', () => {
-			const stateIn = state;
-			const output = isUpdatingSetting( stateIn );
-			expect( output ).to.equal( state.jetpack.settings.requests.updatingSetting );
+		it( 'should return state.jetpack.settings.requests.settingsSent', () => {
+			const output = isUpdatingSetting( state, [ 'setting-a' ] );
+			expect( output ).to.equal( state.jetpack.settings.requests.settingsSent[ 'setting-a' ] );
 		} );
 	} );
 } );
@@ -46,28 +49,25 @@ describe( 'requests selectors', () => {
 describe( 'items selectors', () => {
 	describe( '#isSettingActivated', () => {
 		it( 'should return state.jetpack.settings.items[ setting-slug ]', () => {
-			const stateIn = state;
-			const output = isSettingActivated( stateIn, 'setting-a' );
+			const output = isSettingActivated( state, 'setting-a' );
 			expect( output ).to.equal( state.jetpack.settings.items[ 'setting-a' ] );
-			const output2 = isSettingActivated( stateIn, 'setting-b' );
+			const output2 = isSettingActivated( state, 'setting-b' );
 			expect( output2 ).to.equal( state.jetpack.settings.items[ 'setting-b' ] );
 		} );
 	} );
 
 	describe( '#getSettings', () => {
 		it( 'should return state.jetpack.settings.items', () => {
-			const stateIn = state;
-			const output2 = getSettings( stateIn );
+			const output2 = getSettings( state );
 			expect( output2 ).to.eql( state.jetpack.settings.items );
 		} );
 	} );
 
 	describe( '#getSetting', () => {
 		it( 'should return a setting by its key', () => {
-			const stateIn = state;
-			expect( getSetting( stateIn, 'setting-numeric' ) )
+			expect( getSetting( state, 'setting-numeric' ) )
 				.to.eql( state.jetpack.settings.items[ 'setting-numeric' ] );
-			expect( getSetting( stateIn, 'setting-string' ) )
+			expect( getSetting( state, 'setting-string' ) )
 				.to.eql( state.jetpack.settings.items[ 'setting-string' ] );
 		} );
 	} );

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -69,85 +69,77 @@ export const RelatedPosts = moduleSettingsForm(
 							}
 						</span>
 						</ModuleToggle>
-						{
-							// Only show controls if Related Posts module:
-							// - is active and it's not being toggled off
-							// - is inactive and it's being toggled on.
-							( ( isRelatedPostsActive && ! this.props.isSavingAnyOption( 'related-posts' ) ) ||
-							( ! isRelatedPostsActive && this.props.isSavingAnyOption( 'related-posts' ) ) ) && (
-								<FormFieldset>
-									<FormToggle compact
-												checked={ this.state.show_headline }
-												disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
-												onChange={ e => this.updateOptions( 'show_headline' ) }>
+						<FormFieldset>
+							<FormToggle compact
+										checked={ this.state.show_headline }
+										disabled={ ! isRelatedPostsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+										onChange={ e => this.updateOptions( 'show_headline' ) }>
 										<span className="jp-form-toggle-explanation">
 											{
 												__( 'Show a "Related" header to more clearly separate the related section from posts' )
 											}
 										</span>
-									</FormToggle>
-									<FormToggle compact
-												checked={ this.state.show_thumbnails }
-												disabled={ unavailableInDevMode || this.props.isSavingAnyOption() }
-												onChange={ e => this.updateOptions( 'show_thumbnails' ) }>
+							</FormToggle>
+							<FormToggle compact
+										checked={ this.state.show_thumbnails }
+										disabled={ ! isRelatedPostsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+										onChange={ e => this.updateOptions( 'show_thumbnails' ) }>
 										<span className="jp-form-toggle-explanation">
 											{
 												__( 'Use a large and visually striking layout' )
 											}
 										</span>
-									</FormToggle>
-									{
-										__( '{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}', {
-											components: {
-												span: <span className="jp-form-setting-explanation" />,
-												ExternalLink: <ExternalLink
-													className="jp-module-settings__external-link"
-													href={ this.props.configureUrl } />
-											}
-										} )
+							</FormToggle>
+							{
+								__( '{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}', {
+									components: {
+										span: <span className="jp-form-setting-explanation" />,
+										ExternalLink: <ExternalLink
+											className="jp-module-settings__external-link"
+											href={ this.props.configureUrl } />
 									}
-									<FormLabel className="jp-form-label-wide">{ __( 'Preview' ) }</FormLabel>
-									<Card className="jp-related-posts-preview">
+								} )
+							}
+							<FormLabel className="jp-form-label-wide">{ __( 'Preview' ) }</FormLabel>
+							<Card className="jp-related-posts-preview">
+								{
+									this.state.show_headline && (
+										<div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div>
+									)
+								}
+								{
+									[
 										{
-											this.state.show_headline && (
-												<div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div>
-											)
-										}
+											url : '1-wpios-ipad-3-1-viewsite.png',
+											text: __( 'Big iPhone/iPad Update Now Available' ),
+											context: __( 'In "Mobile"' )
+										},
 										{
-											[
-												{
-													url : '1-wpios-ipad-3-1-viewsite.png',
-													text: __( 'Big iPhone/iPad Update Now Available' ),
-													context: __( 'In "Mobile"' )
-												},
-												{
-													url : 'wordpress-com-news-wordpress-for-android-ui-update2.jpg',
-													text: __( 'The WordPress for Android App Gets a Big Facelift' ),
-													context: __( 'In "Mobile"' )
-												},
-												{
-													url : 'videopresswedding.jpg',
-													text: __( 'Upgrade Focus: VideoPress For Weddings' ),
-													context: __( 'In "Upgrade"' )
-												}
-											].map( ( item, index ) => (
-												<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
-													{
-														this.state.show_thumbnails && (
-															<img src={ `https://jetpackme.files.wordpress.com/2014/08/${ item.url }?w=350&h=200&crop=1` } />
-														)
-													}
-													<h4 className="jp-related-posts-preview__post-title"><a href="#/traffic">{ item.text }</a></h4>
-													<p  className="jp-related-posts-preview__post-context">
-														{ item.context }
-													</p>
-												</div>
-											) )
+											url : 'wordpress-com-news-wordpress-for-android-ui-update2.jpg',
+											text: __( 'The WordPress for Android App Gets a Big Facelift' ),
+											context: __( 'In "Mobile"' )
+										},
+										{
+											url : 'videopresswedding.jpg',
+											text: __( 'Upgrade Focus: VideoPress For Weddings' ),
+											context: __( 'In "Upgrade"' )
 										}
-									</Card>
-								</FormFieldset>
-							)
-						}
+									].map( ( item, index ) => (
+										<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
+											{
+												this.state.show_thumbnails && (
+													<img src={ `https://jetpackme.files.wordpress.com/2014/08/${ item.url }?w=350&h=200&crop=1` } />
+												)
+											}
+											<h4 className="jp-related-posts-preview__post-title"><a href="#/traffic">{ item.text }</a></h4>
+											<p  className="jp-related-posts-preview__post-context">
+												{ item.context }
+											</p>
+										</div>
+									) )
+								}
+							</Card>
+						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>
 			);

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -4,6 +4,9 @@
 import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
+import FormToggle from 'components/form/form-toggle';
+import includes from 'lodash/includes';
+import filter from 'lodash/filter';
 
 /**
  * Internal dependencies
@@ -14,7 +17,6 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingMultipleSelectCheckboxes } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import InlineExpand from 'components/inline-expand';
@@ -22,12 +24,72 @@ import InlineExpand from 'components/inline-expand';
 export const SiteStats = moduleSettingsForm(
 	React.createClass( {
 
+		/**
+		 * Get options for initial state.
+		 *
+		 * @returns {{count_roles: *, roles: *, count_roles_administrator, count_roles_editor, count_roles_author, count_roles_contributor, count_roles_subscriber, roles_administrator: boolean, roles_editor, roles_author, roles_contributor, roles_subscriber}}
+		 */
+		getInitialState() {
+			let countRoles = this.props.getOptionValue( 'count_roles', 'stats' ),
+				roles = this.props.getOptionValue( 'roles', 'stats' );
+			return {
+				count_roles: countRoles,
+				roles: roles,
+
+				count_roles_administrator: includes( countRoles, 'administrator', false ),
+				count_roles_editor: includes( countRoles, 'editor', false ),
+				count_roles_author: includes( countRoles, 'author', false ),
+				count_roles_contributor: includes( countRoles, 'contributor', false ),
+				count_roles_subscriber: includes( countRoles, 'subscriber', false ),
+
+				roles_administrator: true,
+				roles_editor: includes( roles, 'editor', false ),
+				roles_author: includes( roles, 'author', false ),
+				roles_contributor: includes( roles, 'contributor', false ),
+				roles_subscriber: includes( roles, 'subscriber', false )
+			};
+		},
+
+		/**
+		 * Update state so toggles are updated.
+		 *
+		 * @param {string} optionName
+		 * @param {string} optionSet
+		 */
+		updateOptions( optionName, optionSet ) {
+			let value = this.props.getOptionValue( optionSet, 'stats' );
+			if ( ! this.state[ `${optionSet}_${optionName}` ] ) {
+				if ( ! includes( value, optionName ) ) {
+					value.push( optionName );
+				}
+			} else {
+				if ( includes( value, optionName ) ) {
+					value = filter( value, item => {
+						return item !== optionName;
+					} );
+				}
+			}
+
+			this.setState(
+				{
+					[ `${optionSet}_${optionName}` ]: ! this.state[ `${optionSet}_${optionName}` ]
+				},
+				() => {
+					this.props.updateOptions( {
+						[ optionSet ]: value
+					} );
+				}
+			);
+		},
+
 		render() {
 			let stats = this.props.getModule( 'stats' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'stats' );
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'stats' ),
+				siteRoles = this.props.getSiteRoles();
 			return (
 				<SettingsCard
 					{ ...this.props }
+					hideButton
 					header={ __( 'Site stats' ) }
 					module="stats">
 					<SettingsGroup disableInDevMode module={ stats }>
@@ -65,18 +127,47 @@ export const SiteStats = moduleSettingsForm(
 									<div>
 										<FormFieldset>
 											<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
-											<ModuleSettingMultipleSelectCheckboxes
-												name={ 'count_roles' }
-												{ ...this.props }
-												validValues={ this.props.getSiteRoles() } />
+											{
+												Object.keys( siteRoles ).map( key => (
+													<FormToggle
+														compact
+														checked={ this.state[ `count_roles_${key}` ] }
+														disabled={ unavailableInDevMode || this.props.isSavingAnyOption( [ 'stats', 'count_roles' ] ) }
+														onChange={ e => this.updateOptions( key, 'count_roles' ) }
+														key={ `count_roles-${key}` }>
+														<span className="jp-form-toggle-explanation">
+															{ siteRoles[ key ].name }
+														</span>
+													</FormToggle>
+												) )
+											}
 										</FormFieldset>
 										<FormFieldset>
 											<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
-											<ModuleSettingMultipleSelectCheckboxes
-												always_checked={ [ 'administrator' ] }
-												name={ 'roles' }
-												{ ...this.props }
-												validValues={ this.props.getSiteRoles() } />
+											<FormToggle
+												compact
+												checked={ true }
+												disabled={ true }>
+													<span className="jp-form-toggle-explanation">
+														{ siteRoles.administrator.name }
+													</span>
+											</FormToggle>
+											{
+												Object.keys( siteRoles ).map( key => (
+													( 'administrator' !== key ) && (
+														<FormToggle
+															compact
+															checked={ this.state[ `roles_${key}` ] }
+															disabled={ unavailableInDevMode || this.props.isSavingAnyOption( [ 'stats', 'roles' ] ) }
+															onChange={ e => this.updateOptions( key, 'roles' ) }
+															key={ `roles-${key}` }>
+															<span className="jp-form-toggle-explanation">
+																{ siteRoles[ key ].name }
+															</span>
+														</FormToggle>
+													)
+												) )
+											}
 										</FormFieldset>
 									</div>
 								)

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -84,6 +84,7 @@ export const SiteStats = moduleSettingsForm(
 
 		render() {
 			let stats = this.props.getModule( 'stats' ),
+				isStatsActive = this.props.getOptionValue( 'stats' ),
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'stats' ),
 				siteRoles = this.props.getSiteRoles();
 			return (
@@ -96,82 +97,76 @@ export const SiteStats = moduleSettingsForm(
 						<FormFieldset>
 							<ModuleToggle slug="stats"
 										  compact
-										  disabled={ unavailableInDevMode }
+										  disabled={ ! isStatsActive || unavailableInDevMode }
 										  activated={ !!this.props.getOptionValue( 'admin_bar' ) }
 										  toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
 										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }>
-							<span className="jp-form-toggle-explanation">
-								{
-									__( 'Put a chart showing 48 hours of views in the admin bar.' )
-								}
-							</span>
+								<span className="jp-form-toggle-explanation">
+									{
+										__( 'Put a chart showing 48 hours of views in the admin bar.' )
+									}
+								</span>
 							</ModuleToggle>
 							<ModuleToggle slug="stats"
 										  compact
-										  disabled={ unavailableInDevMode }
+										  disabled={ ! isStatsActive || unavailableInDevMode }
 										  activated={ !!this.props.getOptionValue( 'hide_smile' ) }
 										  toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
 										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }>
-							<span className="jp-form-toggle-explanation">
-								{
-									__( 'Hide the stats smiley face image. The image helps collect stats, but should work when hidden.' )
-								}
-							</span>
+								<span className="jp-form-toggle-explanation">
+									{
+										__( 'Hide the stats smiley face image. The image helps collect stats, but should work when hidden.' )
+									}
+								</span>
 							</ModuleToggle>
 						</FormFieldset>
-						<InlineExpand
-							disabled={ unavailableInDevMode }
-							label={ __( 'Advanced Options' ) }>
-							{
-								! unavailableInDevMode && (
-									<div>
-										<FormFieldset>
-											<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
-											{
-												Object.keys( siteRoles ).map( key => (
-													<FormToggle
-														compact
-														checked={ this.state[ `count_roles_${key}` ] }
-														disabled={ unavailableInDevMode || this.props.isSavingAnyOption( [ 'stats', 'count_roles' ] ) }
-														onChange={ e => this.updateOptions( key, 'count_roles' ) }
-														key={ `count_roles-${key}` }>
-														<span className="jp-form-toggle-explanation">
-															{ siteRoles[ key ].name }
-														</span>
-													</FormToggle>
-												) )
-											}
-										</FormFieldset>
-										<FormFieldset>
-											<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
+						<InlineExpand label={ __( 'Advanced Options' ) }>
+							<div>
+								<FormFieldset>
+									<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
+									{
+										Object.keys( siteRoles ).map( key => (
 											<FormToggle
 												compact
-												checked={ true }
-												disabled={ true }>
-													<span className="jp-form-toggle-explanation">
-														{ siteRoles.administrator.name }
-													</span>
+												checked={ this.state[ `count_roles_${key}` ] }
+												disabled={ ! isStatsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'stats', 'count_roles' ] ) }
+												onChange={ e => this.updateOptions( key, 'count_roles' ) }
+												key={ `count_roles-${key}` }>
+												<span className="jp-form-toggle-explanation">
+													{ siteRoles[ key ].name }
+												</span>
 											</FormToggle>
-											{
-												Object.keys( siteRoles ).map( key => (
-													( 'administrator' !== key ) && (
-														<FormToggle
-															compact
-															checked={ this.state[ `roles_${key}` ] }
-															disabled={ unavailableInDevMode || this.props.isSavingAnyOption( [ 'stats', 'roles' ] ) }
-															onChange={ e => this.updateOptions( key, 'roles' ) }
-															key={ `roles-${key}` }>
-															<span className="jp-form-toggle-explanation">
-																{ siteRoles[ key ].name }
-															</span>
-														</FormToggle>
-													)
-												) )
-											}
-										</FormFieldset>
-									</div>
-								)
-							}
+										) )
+									}
+								</FormFieldset>
+								<FormFieldset>
+									<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
+									<FormToggle
+										compact
+										checked={ true }
+										disabled={ true }>
+										<span className="jp-form-toggle-explanation">
+											{ siteRoles.administrator.name }
+										</span>
+									</FormToggle>
+									{
+										Object.keys( siteRoles ).map( key => (
+											( 'administrator' !== key ) && (
+												<FormToggle
+													compact
+													checked={ this.state[ `roles_${key}` ] }
+													disabled={ ! isStatsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'stats', 'roles' ] ) }
+													onChange={ e => this.updateOptions( key, 'roles' ) }
+													key={ `roles-${key}` }>
+													<span className="jp-form-toggle-explanation">
+														{ siteRoles[ key ].name }
+													</span>
+												</FormToggle>
+											)
+										) )
+									}
+								</FormFieldset>
+							</div>
 						</InlineExpand>
 					</SettingsGroup>
 				</SettingsCard>

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -72,7 +72,7 @@ export const Composing = moduleSettingsForm(
 				<FormToggle
 					compact
 					checked={ this.state[ setting ] }
-					disabled={ this.props.isSavingAnyOption() }
+					disabled={ ! this.props.getOptionValue( 'after-the-deadline' ) || this.props.isUnavailableInDevMode( 'after-the-deadline' ) || this.props.isSavingAnyOption( setting ) }
 					onChange={ e => this.updateOptions( setting ) }>
 					<span className="jp-form-toggle-explanation">
 						{ label }
@@ -127,6 +127,7 @@ export const Composing = moduleSettingsForm(
 						</FormLegend>
 						<TagsInput
 							name="ignored_phrases"
+							disabled={ ! this.props.getOptionValue( 'after-the-deadline' ) }
 							placeholder={ __( 'Add a phrase' ) }
 							value={
 								'undefined' !== typeof ignoredPhrases && '' !== ignoredPhrases
@@ -173,11 +174,7 @@ export const Composing = moduleSettingsForm(
 							</span>
 						</ModuleToggle>
 						<FormFieldset>
-							{
-								! atdUnavailableInDevMode && this.props.getOptionValue( 'after-the-deadline' ) && (
-									<InlineExpand label={ __( 'Advanced Options' ) }>{ this.getAtdSettings() }</InlineExpand>
-								)
-							}
+							<InlineExpand label={ __( 'Advanced Options' ) }>{ this.getAtdSettings() }</InlineExpand>
 						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import analytics from 'lib/analytics';
 import { translate as __ } from 'i18n-calypso';
+import FormToggle from 'components/form/form-toggle';
 
 /**
  * Internal dependencies
@@ -14,7 +15,6 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import TagsInput from 'components/tags-input';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -22,13 +22,62 @@ import InlineExpand from 'components/inline-expand';
 
 export const Composing = moduleSettingsForm(
 	React.createClass( {
-		getCheckbox( setting, label ) {
+
+		/**
+		 * Get options for initial state.
+		 *
+		 * @returns {{onpublish: *, onupdate: *, guess_lang: *, Bias Language: *, Cliches: *, Complex Expression: *, Diacritical Marks: *, Double Negative: *, Hidden Verbs: *, Jargon Language: *, Passive voice: *, Phrases to Avoid: *, Redundant Expression: *}}
+		 */
+		getInitialState() {
+			return {
+				onpublish: this.props.getOptionValue( 'onpublish', 'after-the-deadline' ),
+				onupdate: this.props.getOptionValue( 'onupdate', 'after-the-deadline' ),
+				guess_lang: this.props.getOptionValue( 'guess_lang', 'after-the-deadline' ),
+				'Bias Language': this.props.getOptionValue( 'Bias Language', 'after-the-deadline' ),
+				'Cliches': this.props.getOptionValue( 'Cliches', 'after-the-deadline' ),
+				'Complex Expression': this.props.getOptionValue( 'Complex Expression', 'after-the-deadline' ),
+				'Diacritical Marks': this.props.getOptionValue( 'Diacritical Marks', 'after-the-deadline' ),
+				'Double Negative': this.props.getOptionValue( 'Double Negative', 'after-the-deadline' ),
+				'Hidden Verbs': this.props.getOptionValue( 'Hidden Verbs', 'after-the-deadline' ),
+				'Jargon Language': this.props.getOptionValue( 'Jargon Language', 'after-the-deadline' ),
+				'Passive voice': this.props.getOptionValue( 'Passive voice', 'after-the-deadline' ),
+				'Phrases to Avoid': this.props.getOptionValue( 'Phrases to Avoid', 'after-the-deadline' ),
+				'Redundant Expression': this.props.getOptionValue( 'Redundant Expression', 'after-the-deadline' )
+			};
+		},
+
+		/**
+		 * Update state so toggles are updated.
+		 *
+		 * @param {string} optionName
+		 */
+		updateOptions( optionName ) {
+			this.setState(
+				{
+					[ optionName ]: ! this.state[ optionName ]
+				},
+				this.props.updateFormStateModuleOption( 'after-the-deadline', optionName )
+			);
+		},
+
+		/**
+		 * Render a toggle for a single option.
+		 *
+		 * @param {string} setting
+		 * @param {string} label
+		 * @returns {object}
+		 */
+		getToggle( setting, label ) {
 			return(
-				<ModuleSettingCheckbox
-					name={ setting }
-					label={ label }
-					{ ...this.props }
-				/>
+				<FormToggle
+					compact
+					checked={ this.state[ setting ] }
+					disabled={ this.props.isSavingAnyOption() }
+					onChange={ e => this.updateOptions( setting ) }>
+					<span className="jp-form-toggle-explanation">
+						{ label }
+					</span>
+				</FormToggle>
 			);
 		},
 
@@ -40,8 +89,8 @@ export const Composing = moduleSettingsForm(
 						<span className="jp-form-setting-explanation">
 							{ __( 'Automatically proofread content when: ' ) }
 						</span>
-						{ this.getCheckbox( 'onpublish', __( 'A post or page is first published' ) ) }
-						{ this.getCheckbox( 'onupdate', __( 'A post or page is updated' ) ) }
+						{ this.getToggle( 'onpublish', __( 'A post or page is first published' ) ) }
+						{ this.getToggle( 'onupdate', __( 'A post or page is updated' ) ) }
 					</FormFieldset>
 					<FormFieldset>
 						<FormLegend> { __( 'Automatic Language Detection' ) }
@@ -50,7 +99,7 @@ export const Composing = moduleSettingsForm(
 							{ __( 'The proofreader supports English, French, German, Portuguese and Spanish.' ) }
 						</span>
 						{
-							this.getCheckbox(
+							this.getToggle(
 								'guess_lang',
 								__( 'Use automatically detected language to proofread posts and pages' )
 							)
@@ -61,16 +110,16 @@ export const Composing = moduleSettingsForm(
 						<span className="jp-form-setting-explanation">
 							{ __( 'Enable proofreading for the following grammar and style rules: ' ) }
 						</span>
-						{ this.getCheckbox( 'Bias Language', __( 'Bias Language' ) ) }
-						{ this.getCheckbox( 'Cliches', __( 'Clichés' ) ) }
-						{ this.getCheckbox( 'Complex Expression', __( 'Complex Phrases' ) ) }
-						{ this.getCheckbox( 'Diacritical Marks', __( 'Diacritical Marks' ) ) }
-						{ this.getCheckbox( 'Double Negative', __( 'Double Negatives' ) ) }
-						{ this.getCheckbox( 'Hidden Verbs', __( 'Hidden Verbs' ) ) }
-						{ this.getCheckbox( 'Jargon Language', __( 'Jargon' ) ) }
-						{ this.getCheckbox( 'Passive voice', __( 'Passive Voice' ) ) }
-						{ this.getCheckbox( 'Phrases to Avoid', __( 'Phrases to Avoid' ) ) }
-						{ this.getCheckbox( 'Redundant Expression', __( 'Redundant Phrases' ) ) }
+						{ this.getToggle( 'Bias Language', __( 'Bias Language' ) ) }
+						{ this.getToggle( 'Cliches', __( 'Clichés' ) ) }
+						{ this.getToggle( 'Complex Expression', __( 'Complex Phrases' ) ) }
+						{ this.getToggle( 'Diacritical Marks', __( 'Diacritical Marks' ) ) }
+						{ this.getToggle( 'Double Negative', __( 'Double Negatives' ) ) }
+						{ this.getToggle( 'Hidden Verbs', __( 'Hidden Verbs' ) ) }
+						{ this.getToggle( 'Jargon Language', __( 'Jargon' ) ) }
+						{ this.getToggle( 'Passive voice', __( 'Passive Voice' ) ) }
+						{ this.getToggle( 'Phrases to Avoid', __( 'Phrases to Avoid' ) ) }
+						{ this.getToggle( 'Redundant Expression', __( 'Redundant Phrases' ) ) }
 					</FormFieldset>
 					<FormFieldset>
 						<FormLegend>
@@ -92,7 +141,8 @@ export const Composing = moduleSettingsForm(
 
 		render() {
 			let markdown = this.props.getModule( 'markdown' ),
-				atd = this.props.getModule( 'after-the-deadline' );
+				atd = this.props.getModule( 'after-the-deadline' ),
+				atdUnavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' );
 
 			return (
 				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props }>
@@ -114,7 +164,7 @@ export const Composing = moduleSettingsForm(
 						<ModuleToggle
 							slug="after-the-deadline"
 							compact
-							disabled={ this.props.isUnavailableInDevMode( 'after-the-deadline' ) }
+							disabled={ atdUnavailableInDevMode }
 							activated={ this.props.getOptionValue( 'after-the-deadline' ) }
 							toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
 							toggleModule={ this.props.toggleModuleNow }>
@@ -124,7 +174,7 @@ export const Composing = moduleSettingsForm(
 						</ModuleToggle>
 						<FormFieldset>
 							{
-								this.props.getOptionValue( 'after-the-deadline' ) && (
+								! atdUnavailableInDevMode && this.props.getOptionValue( 'after-the-deadline' ) && (
 									<InlineExpand label={ __( 'Advanced Options' ) }>{ this.getAtdSettings() }</InlineExpand>
 								)
 							}

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -19,16 +19,14 @@ export const CustomContentTypes = moduleSettingsForm(
 	React.createClass( {
 
 		contentTypeConfigure( type, legend ) {
-			if ( ! this.state[ type ] ) {
-				return '';
-			}
-			return ! this.props.getSettingCurrentValue( 'jetpack_' + type, 'custom-content-types' )
-				? ''
-				: (
-					<Button compact href={ this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type }>
-						{ legend }
-					</Button>
-				);
+			let disabledOrHref = this.props.getSettingCurrentValue( 'jetpack_' + type, 'custom-content-types' )
+				? { href: this.props.siteAdminUrl + 'edit.php?post_type=jetpack-' + type }
+				: { disabled: true };
+			return (
+				<Button compact	{ ...disabledOrHref }>
+					{ legend }
+				</Button>
+			);
 		},
 
 		getInitialState() {
@@ -73,22 +71,18 @@ export const CustomContentTypes = moduleSettingsForm(
 								}
 							</span>
 						</FormToggle>
-						{
-							this.state.testimonial && (
-								<FormFieldset>
-									<p className="jp-form-setting-explanation">
-										{
-											__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
-										}
-									</p>
-									<p>
-										{
-											this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
-										}
-									</p>
-								</FormFieldset>
-							)
-						}
+						<FormFieldset>
+							<p className="jp-form-setting-explanation">
+								{
+									__( "The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the testimonial shortcode	( [testimonials] ) or you can view a full archive of your testimonials." )
+								}
+							</p>
+							<p>
+								{
+									this.contentTypeConfigure( 'testimonial', __( 'Configure Testimonials' ) )
+								}
+							</p>
+						</FormFieldset>
 						<FormToggle compact
 									checked={ this.state.portfolio }
 									disabled={ this.props.isSavingAnyOption() }
@@ -99,22 +93,18 @@ export const CustomContentTypes = moduleSettingsForm(
 								}
 							</span>
 						</FormToggle>
-						{
-							this.state.portfolio && (
-								<FormFieldset>
-									<p className="jp-form-setting-explanation">
-										{
-											__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
-										}
-									</p>
-									<p>
-										{
-											this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
-										}
-									</p>
-								</FormFieldset>
-							)
-						}
+						<FormFieldset>
+							<p className="jp-form-setting-explanation">
+								{
+									__( "The Portfolio custom content type allows you to add, organize, and display your portfolios. If your theme doesn’t support it yet, you can display portfolios using the portfolio shortcode ( [portfolios] ) or you can view a full archive of your portfolios." )
+								}
+							</p>
+							<p>
+								{
+									this.contentTypeConfigure( 'portfolio', __( 'Configure Portfolios' ) )
+								}
+							</p>
+						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>
 			);

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
+import FormToggle from 'components/form/form-toggle';
 
 /**
  * Internal dependencies
@@ -16,12 +16,36 @@ import {
 } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const Media = moduleSettingsForm(
 	React.createClass( {
+
+		/**
+		 * Get options for initial state.
+		 *
+		 * @returns {{carousel_display_exif: Boolean}}
+		 */
+		getInitialState() {
+			return {
+				carousel_display_exif: this.props.getOptionValue( 'carousel_display_exif', 'carousel' )
+			};
+		},
+
+		/**
+		 * Update state so toggles are updated.
+		 *
+		 * @param {string} optionName
+		 */
+		updateOptions( optionName ) {
+			this.setState(
+				{
+					[ optionName ]: ! this.state[ optionName ]
+				},
+				this.props.updateFormStateModuleOption( 'carousel', optionName )
+			);
+		},
 
 		toggleModule( name, value ) {
 			if ( 'photon' === name ) {
@@ -80,10 +104,17 @@ export const Media = moduleSettingsForm(
 						{
 							isCarouselActive && (
 								<FormFieldset>
-									<ModuleSettingCheckbox
-										name={ 'carousel_display_exif' }
-										{ ...this.props }
-										label={ __( 'Show photo metadata (Exif) in carousel, when available' ) } />
+									<FormToggle
+										compact
+										checked={ this.state.carousel_display_exif }
+										disabled={ this.props.isSavingAnyOption() }
+										onChange={ e => this.updateOptions( 'carousel_display_exif' ) }>
+										<span className="jp-form-toggle-explanation">
+											{
+												__( 'Show photo metadata (Exif) in carousel, when available' )
+											}
+										</span>
+									</FormToggle>
 									<FormLabel>
 										<FormLegend className="jp-form-label-wide">{ __( 'Background color' ) }</FormLegend>
 										<FormSelect

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -101,31 +101,28 @@ export const Media = moduleSettingsForm(
 									}
 								</span>
 						</ModuleToggle>
-						{
-							isCarouselActive && (
-								<FormFieldset>
-									<FormToggle
-										compact
-										checked={ this.state.carousel_display_exif }
-										disabled={ this.props.isSavingAnyOption() }
-										onChange={ e => this.updateOptions( 'carousel_display_exif' ) }>
-										<span className="jp-form-toggle-explanation">
-											{
-												__( 'Show photo metadata (Exif) in carousel, when available' )
-											}
-										</span>
-									</FormToggle>
-									<FormLabel>
-										<FormLegend className="jp-form-label-wide">{ __( 'Background color' ) }</FormLegend>
-										<FormSelect
-											name={ 'carousel_background_color' }
-											value={ this.props.getOptionValue( 'carousel_background_color' ) }
-											{ ...this.props }
-											validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
-									</FormLabel>
-								</FormFieldset>
-							)
-						}
+						<FormFieldset>
+							<FormToggle
+								compact
+								checked={ this.state.carousel_display_exif }
+								disabled={ ! isCarouselActive || this.props.isSavingAnyOption() }
+								onChange={ e => this.updateOptions( 'carousel_display_exif' ) }>
+									<span className="jp-form-toggle-explanation">
+										{
+											__( 'Show photo metadata (Exif) in carousel, when available' )
+										}
+									</span>
+							</FormToggle>
+							<FormLabel>
+								<FormLegend className="jp-form-label-wide">{ __( 'Background color' ) }</FormLegend>
+								<FormSelect
+									name={ 'carousel_background_color' }
+									value={ this.props.getOptionValue( 'carousel_background_color' ) }
+									disabled={ ! isCarouselActive || this.props.isSavingAnyOption( 'carousel_background_color' ) }
+									{ ...this.props }
+									validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
+							</FormLabel>
+						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>
 			);

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -40,7 +40,8 @@ export const PostByEmail = moduleSettingsForm(
 
 		render() {
 			let postByEmail = this.props.getModule( 'post-by-email' ),
-				isPbeActive = this.props.getOptionValue( 'post-by-email' );
+				isPbeActive = this.props.getOptionValue( 'post-by-email' ),
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'post-by-email' );
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -49,7 +50,7 @@ export const PostByEmail = moduleSettingsForm(
 					<SettingsGroup hasChild disableInDevMode module={ postByEmail }>
 						<ModuleToggle slug="post-by-email"
 									  compact
-									  disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
+									  disabled={ unavailableInDevMode }
 									  activated={ isPbeActive }
 									  toggling={ this.props.isSavingAnyOption( 'post-by-email' ) }
 									  toggleModule={ this.props.toggleModuleNow }>
@@ -59,25 +60,23 @@ export const PostByEmail = moduleSettingsForm(
 							}
 						</span>
 						</ModuleToggle>
-						{
-							isPbeActive && (
-								<FormFieldset>
-									<FormLabel>
-										<FormLegend>{ __( 'Email Address' ) }</FormLegend>
-										<ClipboardButtonInput
-											value={ this.address() }
-											copy={ __( 'Copy', { context: 'verb' } ) }
-											copied={ __( 'Copied!' ) }
-											prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
-										/>
-									</FormLabel>
-									<Button
-										onClick={ this.regeneratePostByEmailAddress } >
-										{ __( 'Regenerate address' ) }
-									</Button>
-								</FormFieldset>
-							)
-						}
+						<FormFieldset>
+							<FormLabel>
+								<FormLegend>{ __( 'Email Address' ) }</FormLegend>
+								<ClipboardButtonInput
+									value={ this.address() }
+									disabled={ ! isPbeActive || unavailableInDevMode }
+									copy={ __( 'Copy', { context: 'verb' } ) }
+									copied={ __( 'Copied!' ) }
+									prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+								/>
+							</FormLabel>
+							<Button
+								disabled={ ! isPbeActive || unavailableInDevMode }
+								onClick={ this.regeneratePostByEmailAddress } >
+								{ __( 'Regenerate address' ) }
+							</Button>
+						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>
 			);

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
+import FormToggle from 'components/form/form-toggle';
 
 /**
  * Internal dependencies
@@ -12,17 +11,47 @@ import Card from 'components/card';
 import { FormFieldset } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleSettingCheckbox } from 'components/module-settings/form-components';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const ThemeEnhancements = moduleSettingsForm(
 	React.createClass( {
 
+		/**
+		 * Get options for initial state.
+		 *
+		 * @returns {{infinite_scroll: *, infinite_scroll_google_analytics: *, wp_mobile_excerpt: *, wp_mobile_featured_images: *, wp_mobile_app_promos: *}}
+		 */
+		getInitialState() {
+			return {
+				infinite_scroll: this.props.getOptionValue( 'infinite_scroll', 'infinite-scroll' ),
+				infinite_scroll_google_analytics: this.props.getOptionValue( 'infinite_scroll_google_analytics', 'infinite-scroll' ),
+				wp_mobile_excerpt: this.props.getOptionValue( 'wp_mobile_excerpt', 'minileven' ),
+				wp_mobile_featured_images: this.props.getOptionValue( 'wp_mobile_featured_images', 'minileven' ),
+				wp_mobile_app_promos: this.props.getOptionValue( 'wp_mobile_app_promos', 'minileven' )
+			};
+		},
+
+		/**
+		 * Update state so toggles are updated.
+		 *
+		 * @param {string} optionName
+		 * @param {string} module
+		 */
+		updateOptions( optionName, module ) {
+			this.setState(
+				{
+					[ optionName ]: ! this.state[ optionName ]
+				},
+				this.props.updateFormStateModuleOption( module, optionName )
+			);
+		},
+
 		render() {
 			return (
 				<SettingsCard
 					{ ...this.props }
+					hideButton
 					header={ __( 'Theme enhancements' ) }>
 					{
 						[
@@ -74,12 +103,20 @@ export const ThemeEnhancements = moduleSettingsForm(
 										{
 											this.props.getOptionValue( item.module ) && (
 												item.checkboxes.map( chkbx => {
-													return <ModuleSettingCheckbox
-														name={ chkbx.key }
-														{ ...this.props }
-														label={ chkbx.label }
-														key={ `${ item.module }_${ chkbx.key }`}
-													/>
+													return (
+														<FormToggle
+															compact
+															checked={ this.state[ chkbx.key ] }
+															disabled={ this.props.isSavingAnyOption() }
+															onChange={ e => this.updateOptions( chkbx.key, item.module ) }
+															key={ `${ item.module }_${ chkbx.key }`}>
+															<span className="jp-form-toggle-explanation">
+																{
+																	chkbx.label
+																}
+															</span>
+														</FormToggle>
+													);
 												} )
 											)
 										}

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -86,11 +86,12 @@ export const ThemeEnhancements = moduleSettingsForm(
 								]
 							}
 						].map( item => {
+							let isItemActive = this.props.getOptionValue( item.module );
 							return (
 								<SettingsGroup hasChild key={ `theme_enhancement_${ item.module }` }>
 									<ModuleToggle slug={ item.module }
 												  compact
-												  activated={ this.props.getOptionValue( item.module ) }
+												  activated={ isItemActive }
 												  toggling={ this.props.isSavingAnyOption( item.module ) }
 												  toggleModule={ this.props.toggleModuleNow }>
 									<span className="jp-form-toggle-explanation">
@@ -101,24 +102,22 @@ export const ThemeEnhancements = moduleSettingsForm(
 									</ModuleToggle>
 									<FormFieldset support={ item.learn_more_button }>
 										{
-											this.props.getOptionValue( item.module ) && (
-												item.checkboxes.map( chkbx => {
-													return (
-														<FormToggle
-															compact
-															checked={ this.state[ chkbx.key ] }
-															disabled={ this.props.isSavingAnyOption() }
-															onChange={ e => this.updateOptions( chkbx.key, item.module ) }
-															key={ `${ item.module }_${ chkbx.key }`}>
-															<span className="jp-form-toggle-explanation">
-																{
-																	chkbx.label
-																}
-															</span>
-														</FormToggle>
-													);
-												} )
-											)
+											item.checkboxes.map( chkbx => {
+												return (
+													<FormToggle
+														compact
+														checked={ this.state[ chkbx.key ] }
+														disabled={ ! isItemActive }
+														onChange={ e => this.updateOptions( chkbx.key, item.module ) }
+														key={ `${ item.module }_${ chkbx.key }`}>
+														<span className="jp-form-toggle-explanation">
+															{
+																chkbx.label
+															}
+														</span>
+													</FormToggle>
+												);
+											} )
 										}
 									</FormFieldset>
 								</SettingsGroup>


### PR DESCRIPTION
Fixes #6173 Fixes #6193 

#### Changes proposed in this Pull Request:

## Convert checkboxes to toggles
- checkboxes in Subscriptions, Single Sign On, Stats, After the Deadline, Carousel, Infinite Scroll and Mobile Theme are to toggles
- the Save Settings button was removed in setting cards that have only toggles now

Note that due to the nature of the value saved by the role options in Stats, an array, they had to be disabled while they were toggled, because otherwise there was a race condition that would have allow the user to save erroneous values if the toggles were quickly tapped sequentially.
Due to this, maybe it would be better to leave this as checkboxes.

## Fade and disable child settings
- when a parent toggle is inactive, the child settings that depend on the toggle are faded and disabled

#### Testing instructions:
* Build and test the toggles in the features described above