### PR TITLE
Ads: Deactivate module if plan changes

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -216,11 +216,11 @@ abstract class Jetpack_Admin_Page {
 				$active = Jetpack::get_active_modules();
 				switch ( $current->plan->product_slug ) {
 					case 'jetpack_free':
-						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics' );
+						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads' );
 						break;
 					case 'jetpack_personal':
 					case 'jetpack_personal_monthly':
-						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics' );
+						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads' );
 						break;
 					case 'jetpack_premium':
 					case 'jetpack_premium_monthly':

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1246,6 +1246,7 @@ class Jetpack {
 				'videopress',
 				'akismet',
 				'vaultpress',
+				'wordads',
 			);
 		}
 
@@ -1262,6 +1263,7 @@ class Jetpack {
 				'vaultpress',
 				'seo-tools',
 				'google-analytics',
+				'wordads',
 			);
 		}
 

--- a/modules/wordads.php
+++ b/modules/wordads.php
@@ -11,11 +11,7 @@
  */
 
 function jetpack_load_wordads() {
-	if ( Jetpack::active_plan_supports( 'wordads' ) ) {
-		require_once( dirname( __FILE__ ) . "/wordads/wordads.php" );
-	} else {
-		Jetpack::deactivate_module( 'wordads' );
-	}
+	require_once( dirname( __FILE__ ) . "/wordads/wordads.php" );
 }
 
 jetpack_load_wordads();

--- a/modules/wordads.php
+++ b/modules/wordads.php
@@ -11,7 +11,11 @@
  */
 
 function jetpack_load_wordads() {
-	require_once( dirname( __FILE__ ) . "/wordads/wordads.php" );
+	if ( Jetpack::active_plan_supports( 'wordads' ) ) {
+		require_once( dirname( __FILE__ ) . "/wordads/wordads.php" );
+	} else {
+		Jetpack::deactivate_module( 'wordads' );
+	}
 }
 
 jetpack_load_wordads();


### PR DESCRIPTION
Check if active plan supports WordAds, otherwise disable it. This should ensure user doesn't get suck with activated module if plan changes.

**To Test**
1. On Jetpack site with Premium/Business plan activate Ads module.
1. Go to https://wordpress.com/me/purchases and remove the Premium upgrade for the Jetpack site.
1. Once Jetpack pulls new status data check that WordAds module is deactivated (ads should no longer be below posts).