### PR TITLE
Make `jp_carousel_load_for_images_linked_to_file` filter works when Photon is activated

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1428,9 +1428,10 @@ jQuery(document).ready(function($) {
 			}
 
 			var valid = false;
+			var dataOrigFile = $( this ).attr( 'data-orig-file' ).split('?fit')[0];
 
 			// if link points to 'Media File' and flag is set allow it
-			if ( $( container ).attr( 'href' ) === $( this ).attr( 'data-orig-file' ) &&
+			if ( $( container ).attr( 'href' ) === dataOrigFile &&
 				1 === Number( jetpackCarouselStrings.single_image_gallery_media_file )
 			) {
 				valid = true;


### PR DESCRIPTION
Fixes #6054

If we have `add_filter( 'jp_carousel_load_for_images_linked_to_file', '__return_true' );` and Photon activated, single image carousel doesn't work.

There is a check, that fails because Photon adds `?fit=` parameter to image URL in `data-orig-file` attribute.
 A variable that contains the URL, with omitted attributes, used in the if statement fix the problem.

#### Testing instructions:

* Set add_filter( 'jp_carousel_load_for_images_linked_to_file', '__return_true' );
* Activate Photon and Carousel
* Create a post with an image that is linked to its' full size file
* Click on the image on the frontend
* It should be open in lightbox 
