### PR TITLE
Add user tracking for disconnecting site

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -10,6 +10,11 @@ class Jetpack_XMLRPC_Server {
 	public $error = null;
 
 	/**
+	 * The current user
+	 */
+	public $user = null;
+
+	/**
 	 * Whitelist of the XML-RPC methods available to the Jetpack Server. If the
 	 * user is not authenticated (->login()) then the methods are never added,
 	 * so they will get a "does not exist" error.
@@ -20,9 +25,9 @@ class Jetpack_XMLRPC_Server {
 			'jetpack.verifyAction' => array( $this, 'verify_action' ),
 		);
 
-		$user = $this->login();
+		$this->user = $this->login();
 
-		if ( $user ) {
+		if ( $this->user ) {
 			$jetpack_methods = array_merge( $jetpack_methods, array(
 				'jetpack.testConnection'    => array( $this, 'test_connection' ),
 				'jetpack.testAPIUserCode'   => array( $this, 'test_api_user_code' ),
@@ -48,7 +53,7 @@ class Jetpack_XMLRPC_Server {
 			 * @param array $core_methods Available core XML-RPC methods.
 			 * @param WP_User $user Information about a given WordPress user.
 			 */
-			$jetpack_methods = apply_filters( 'jetpack_xmlrpc_methods', $jetpack_methods, $core_methods, $user );
+			$jetpack_methods = apply_filters( 'jetpack_xmlrpc_methods', $jetpack_methods, $core_methods, $this->user );
 		}
 
 		/**
@@ -321,6 +326,12 @@ class Jetpack_XMLRPC_Server {
 	* @return boolean
 	*/
 	function disconnect_blog() {
+		
+		// For tracking
+		if ( ! empty( $this->user->ID ) ) {
+			wp_set_current_user( $this->user->ID );
+		}
+
 		Jetpack::log( 'disconnect' );
 		Jetpack::disconnect();
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2753,6 +2753,7 @@ p {
 		// If the site is in an IDC because sync is not allowed,
 		// let's make sure to not disconnect the production site.
 		if ( ! self::validate_sync_error_idc_option() ) {
+			JetpackTracking::record_user_event( 'disconnect_site', array() );
 			Jetpack::load_xml_rpc_client();
 			$xml = new Jetpack_IXR_Client();
 			$xml->query( 'jetpack.deregister' );


### PR DESCRIPTION
This will send a user event any time the site is disconnected.  Since all methods of disconnecting the site eventually calls this method (calypso and plugin deactivation as well), we're able to track all instances from here.  

Worth noting we're now making sure to pass the correct user token when disconnecting from calypso since r150226-wpcom props @roccotripaldi

To test: 
- Disconnect via admin UI 
- Disconnect via deactivating plugin 
- Disconnect via calypso 
- Do all of those things as a secondary admin 

Check the live tracks feed for the correct user.  Event name `jetpack_disconnect_site`