### PR TITLE
Settings UI: remove disconnect link in footer. Add it in Debugger page.

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -12,26 +12,14 @@ import { translate as __ } from 'i18n-calypso';
 import {
 	isDevVersion as _isDevVersion,
 	getCurrentVersion,
-	userCanManageOptions,
-	userCanDisconnectSite
+	userCanManageOptions
 } from 'state/initial-state';
 import { resetOptions } from 'state/dev-version';
-import { disconnectSite } from 'state/connection';
-import { getSiteConnectionStatus, isInIdentityCrisis } from 'state/connection';
-import { isDevMode as _isDevMode } from 'state/connection';
+import { isInIdentityCrisis } from 'state/connection';
 import { getSiteAdminUrl } from 'state/initial-state';
 
 export const Footer = React.createClass( {
 	displayName: 'Footer',
-
-	disconnectSite() {
-		if (
-			this.props.isInIdentityCrisis ||
-			window.confirm( __( 'Do you really want to disconnect your site from WordPress.com?' ) )
-		) {
-			this.props.disconnectSite();
-		}
-	},
 
 	resetOnClick() {
 		if ( window.confirm( __( 'This will reset all Jetpack options, are you sure?' ) ) ) {
@@ -76,21 +64,6 @@ export const Footer = React.createClass( {
 			}
 		};
 
-		const maybeShowDisconnect = () => {
-			if ( this.props.userCanDisconnectSite && this.props.siteConnectionStatus && ! this.props.isDevMode ) {
-				return (
-					<li className="jp-footer__link-item">
-						<a
-							onClick={ this.disconnectSite }
-							title={ __( 'Disconnect from WordPress.com' ) }
-							className="jp-footer__link">
-							{ __( 'Disconnect Jetpack' ) }
-						</a>
-					</li>
-				);
-			}
-		};
-
 		return (
 			<div className={ classes }>
 				<div className="jp-footer__a8c-attr-container">
@@ -128,7 +101,6 @@ export const Footer = React.createClass( {
 					</li>
 					{ maybeShowDebug() }
 					{ maybeShowReset() }
-					{ maybeShowDisconnect() }
 				</ul>
 			</div>
 		);
@@ -140,19 +112,13 @@ export default connect(
 		return {
 			currentVersion: getCurrentVersion( state ),
 			userCanManageOptions: userCanManageOptions( state ),
-			userCanDisconnectSite: userCanDisconnectSite( state ),
 			isDevVersion: _isDevVersion( state ),
-			isDevMode: _isDevMode( state ),
-			siteConnectionStatus: getSiteConnectionStatus( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
 			isInIdentityCrisis: isInIdentityCrisis( state )
 		}
 	},
 	( dispatch ) => {
 		return {
-			disconnectSite: () => {
-				return dispatch( disconnectSite() );
-			},
 			resetOptions: () => {
 				return dispatch( resetOptions( 'options' ) );
 			}

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -236,6 +236,7 @@ class Jetpack_Admin {
 	}
 
 	function admin_menu_debugger() {
+		Jetpack_Debugger::disconnect_and_redirect();
 		$debugger_hook = add_submenu_page( null, __( 'Jetpack Debugging Center', 'jetpack' ), '', 'manage_options', 'jetpack-debugger', array( $this, 'debugger_page' ) );
 		add_action( "admin_head-$debugger_hook", array( 'Jetpack_Debugger', 'jetpack_debug_admin_head' ) );
 	}

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -261,7 +261,7 @@ class Jetpack_Debugger {
 							<?php
 							echo wp_kses(
 								sprintf(
-									__( 'Jetpack works by connecting to WordPress.com for a lot of features. Sometimes that connection gets messed up, and you need to disconnect and reconnect to get things working again. <a href="%s" class="jetpack-disconnect-site">Disconnect from WordPress.com</a>, then reconnect and see if that helps.', 'jetpack' ),
+									__( 'Jetpack works by connecting to WordPress.com for a lot of features. Sometimes, when the connection gets messed up, you need to disconnect and reconnect to get things working properly. <a href="%s">Disconnect from WordPress.com</a>', 'jetpack' ),
 									wp_nonce_url(
 										Jetpack::admin_url( array( 'page' => 'jetpack-debugger', 'disconnect' => true ) ),
 										'jp_disconnect',

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -43,16 +43,19 @@ class Jetpack_Debugger {
 		return 30; // seconds
 	}
 
-	public static function jetpack_debug_display_handler() {
-		if ( ! current_user_can( 'manage_options' ) )
-			wp_die( esc_html__('You do not have sufficient permissions to access this page.', 'jetpack' ) );
-
+	public static function disconnect_and_redirect() {
 		$can_disconnect = isset( $_GET['disconnect'] ) && $_GET['disconnect'] && isset( $_GET['nonce'] ) && wp_verify_nonce( $_GET['nonce'], 'jp_disconnect' );
 		if ( $can_disconnect ) {
 			if ( Jetpack::is_active() ) {
 				Jetpack::disconnect();
+				wp_redirect( Jetpack::admin_url() );
 			}
 		}
+	}
+
+	public static function jetpack_debug_display_handler() {
+		if ( ! current_user_can( 'manage_options' ) )
+			wp_die( esc_html__('You do not have sufficient permissions to access this page.', 'jetpack' ) );
 
 		$current_user = wp_get_current_user();
 

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -47,6 +47,13 @@ class Jetpack_Debugger {
 		if ( ! current_user_can( 'manage_options' ) )
 			wp_die( esc_html__('You do not have sufficient permissions to access this page.', 'jetpack' ) );
 
+		$can_disconnect = isset( $_GET['disconnect'] ) && $_GET['disconnect'] && isset( $_GET['nonce'] ) && wp_verify_nonce( $_GET['nonce'], 'jp_disconnect' );
+		if ( $can_disconnect ) {
+			if ( Jetpack::is_active() ) {
+				Jetpack::disconnect();
+			}
+		}
+
 		$current_user = wp_get_current_user();
 
 		$user_id = get_current_user_id();
@@ -181,43 +188,48 @@ class Jetpack_Debugger {
 		?>
 		<div class="wrap">
 			<h2><?php esc_html_e( 'Jetpack Debugging Center', 'jetpack' ); ?></h2>
-			<h3><?php _e( "Testing your site's compatibility with Jetpack...", 'jetpack' ); ?></h3>
-			<div class="jetpack-debug-test-container">
-			<?php
-			ob_start();
-			foreach ( $tests as $test_name => $test_info ) :
-				if ( 'PASS' !== $test_info['result'] && ( is_wp_error( $test_info['result'] ) ||
-					false == ( $response_code = wp_remote_retrieve_response_code( $test_info['result'] ) )  ||
-					'200' != $response_code ) ) {
-					$debug_info .= $test_name . ": FAIL\r\n";
-					?>
-					<div class="jetpack-test-error">
-						<p>
-							<a class="jetpack-test-heading" href="#"><?php echo $test_info['fail_message']; ?>
-							<span class="noticon noticon-collapse"></span>
-							</a>
-						</p>
+			<?php if ( $can_disconnect ) : ?>
+				<div id="message" class="updated notice notice-success is-dismissible"><p><?php esc_html_e( 'This site was successfully disconnected.', 'jetpack' ) ?> <a href="<?php echo esc_url( Jetpack::admin_url() ); ?>"><?php esc_html_e( 'Go to connection screen.', 'jetpack' ); ?></a></p>
+					<button type="button" class="notice-dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'jetpack' ); ?></span></button></div>
+			<?php else: ?>
+				<h3><?php _e( "Testing your site's compatibility with Jetpack...", 'jetpack' ); ?></h3>
+				<div class="jetpack-debug-test-container">
+					<?php
+					ob_start();
+					foreach ( $tests as $test_name => $test_info ) :
+						if ( 'PASS' !== $test_info['result'] && ( is_wp_error( $test_info['result'] ) ||
+								false == ( $response_code = wp_remote_retrieve_response_code( $test_info['result'] ) )  ||
+								'200' != $response_code ) ) {
+							$debug_info .= $test_name . ": FAIL\r\n";
+							?>
+							<div class="jetpack-test-error">
+							<p>
+								<a class="jetpack-test-heading" href="#"><?php echo $test_info['fail_message']; ?>
+									<span class="noticon noticon-collapse"></span>
+								</a>
+							</p>
 						<pre class="jetpack-test-details"><?php echo esc_html( $test_name ); ?>:
-	<?php echo esc_html( is_wp_error( $test_info['result'] ) ? $test_info['result']->get_error_message() : print_r( $test_info['result'], 1 ) ); ?></pre>
-					</div><?php
-				} else {
-					$debug_info .= $test_name . ": PASS\r\n";
-				}
-				$debug_raw_info .= "\r\n\r\n" . $test_name . "\r\n" . esc_html( is_wp_error( $test_info['result'] ) ? $test_info['result']->get_error_message() : print_r( $test_info['result'], 1 ) );
-				?>
-			<?php endforeach;
-			$html = ob_get_clean();
+							<?php echo esc_html( is_wp_error( $test_info['result'] ) ? $test_info['result']->get_error_message() : print_r( $test_info['result'], 1 ) ); ?></pre>
+							</div><?php
+						} else {
+							$debug_info .= $test_name . ": PASS\r\n";
+						}
+						$debug_raw_info .= "\r\n\r\n" . $test_name . "\r\n" . esc_html( is_wp_error( $test_info['result'] ) ? $test_info['result']->get_error_message() : print_r( $test_info['result'], 1 ) );
+						?>
+					<?php endforeach;
+					$html = ob_get_clean();
 
-			if ( '' == trim( $html ) ) {
-				echo '<div class="jetpack-tests-succed">' . esc_html__( 'Your Jetpack setup looks a-okay!', 'jetpack' ) . '</div>';
-			}
-			else {
-				echo '<h3>' . esc_html__( 'There seems to be a problem with your site’s ability to communicate with Jetpack!', 'jetpack' ) . '</h3>';
-				echo $html;
-			}
-			$debug_info .= "\r\n\r\nRAW TEST RESULTS:" . $debug_raw_info ."\r\n";
-			?>
-			</div>
+					if ( '' == trim( $html ) ) {
+						echo '<div class="jetpack-tests-succed">' . esc_html__( 'Your Jetpack setup looks a-okay!', 'jetpack' ) . '</div>';
+					} else {
+						echo '<h3>' . esc_html__( 'There seems to be a problem with your site’s ability to communicate with Jetpack!', 'jetpack' ) . '</h3>';
+						echo $html;
+					}
+					$debug_info .= "\r\n\r\nRAW TEST RESULTS:" . $debug_raw_info ."\r\n";
+					?>
+				</div>
+			<?php endif; ?>
+
 			<div class="entry-content">
 				<h3><?php esc_html_e( 'Trouble with Jetpack?', 'jetpack' ); ?></h3>
 				<h4><?php esc_html_e( 'It may be caused by one of these issues, which you can diagnose yourself:', 'jetpack' ); ?></h4>
@@ -243,6 +255,24 @@ class Jetpack_Debugger {
 							<li>- <?php esc_html_e( "If you get a 404 message, contact your web host. Their security may block XMLRPC.", 'jetpack' ); ?></li>
 						</ul>
 					</li>
+					<?php if ( current_user_can( 'jetpack_disconnect' ) && Jetpack::is_active() ) : ?>
+						<li>
+							<strong><em><?php esc_html_e( 'A connection problem with WordPress.com.', 'jetpack' ); ?></em></strong>
+							<?php
+							echo wp_kses(
+								sprintf(
+									__( 'Jetpack works by connecting to WordPress.com for a lot of features. Sometimes that connection gets messed up, and you need to disconnect and reconnect to get things working again. <a href="%s" class="jetpack-disconnect-site">Disconnect from WordPress.com</a>, then reconnect and see if that helps.', 'jetpack' ),
+									wp_nonce_url(
+										Jetpack::admin_url( array( 'page' => 'jetpack-debugger', 'disconnect' => true ) ),
+										'jp_disconnect',
+										'nonce'
+									)
+								),
+								array( 'a' => array( 'href'  => array(), 'class' => array() ) )
+							);
+							?>
+						</li>
+					<?php endif; ?>
 				</ol>
 				<?php if ( self::is_jetpack_support_open() ): ?>
 				<p class="jetpack-show-contact-form"><?php echo sprintf( __( 'If none of these help you find a solution, <a href="%s">click here to contact Jetpack support</a>. Tell us as much as you can about the issue and what steps you\'ve tried to resolve it, and one of our Happiness Engineers will be in touch to help.', 'jetpack' ), Jetpack::admin_url( array( 'page' => 'jetpack-debugger', 'contact' => true ) ) ); ?>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4140,15 +4140,6 @@ p {
 		}
 	}
 
-	function debugger_page() {
-		nocache_headers();
-		if ( ! current_user_can( 'manage_options' ) ) {
-			die( '-1' );
-		}
-		Jetpack_Debugger::jetpack_debug_display_handler();
-		exit;
-	}
-
 	public static function admin_screen_configure_module( $module_id ) {
 
 		// User that doesn't have 'jetpack_configure_modules' will never end up here since Jetpack Landing Page woun't let them.


### PR DESCRIPTION
Fixes #6219 

#### Changes proposed in this Pull Request:
- Settings: remove disconnect link in footer.
- Debug: add text about connection and link to disconnect Jetpack.

After the disconnection a notice shows up stating that the site was successfully disconnected and prompting user to go to connection screen.

#### Testing instructions:
* verify that there is no link to disconnect Jetpack in the footer of the settings page
* verify that there's a link in the `admin.php?page=jetpack-debugger` page and that it disconnects Jetpack