### PR TITLE
Removes trailing periods from settings labels

### DIFF
--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -90,7 +90,7 @@ export const Comments = moduleSettingsForm(
 										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'wpcom_publish_comments_with_markdown' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
-									__( 'Enable Markdown use for comments.' )
+									__( 'Enable Markdown use for comments' )
 								}
 							</span>
 							</ModuleToggle>

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -87,7 +87,7 @@ export const Subscriptions = moduleSettingsForm(
 									onChange={ e => this.updateOptions( 'stc_enabled' ) }>
 									<span className="jp-form-toggle-explanation">
 										{
-											__( 'Show a "follow comments" option in the comment form.' )
+											__( 'Show a "follow comments" option in the comment form' )
 										}
 									</span>
 								</FormToggle>

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -31,7 +31,7 @@ export const Antispam = moduleSettingsForm(
 							<ModuleSettingCheckbox
 								name={ 'akismet_show_user_comments_approved' }
 								{ ...this.props }
-								label={ __( 'Show the number of approved comments beside each comment author.' ) } />
+								label={ __( 'Show the number of approved comments beside each comment author' ) } />
 						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -79,7 +79,7 @@ export const SSO = moduleSettingsForm(
 								onChange={ e => this.updateOptions( 'jetpack_sso_match_by_email' ) }>
 								<span className="jp-form-toggle-explanation">
 									{
-										__( 'Match accounts using email addresses.' )
+										__( 'Match accounts using email addresses' )
 									}
 								</span>
 							</FormToggle>
@@ -90,7 +90,7 @@ export const SSO = moduleSettingsForm(
 								onChange={ e => this.updateOptions( 'jetpack_sso_require_two_step' ) }>
 								<span className="jp-form-toggle-explanation">
 									{
-										__( 'Require accounts to use WordPress.com Two-Step Authentication.' )
+										__( 'Require accounts to use WordPress.com Two-Step Authentication' )
 									}
 								</span>
 							</FormToggle>

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -65,7 +65,7 @@ export const RelatedPosts = moduleSettingsForm(
 									  toggleModule={ this.props.toggleModuleNow }>
 						<span className="jp-form-toggle-explanation">
 							{
-								__( 'Show related content after posts.' )
+								__( 'Show related content after posts' )
 							}
 						</span>
 						</ModuleToggle>

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -103,7 +103,7 @@ export const SiteStats = moduleSettingsForm(
 										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'admin_bar' ) }>
 								<span className="jp-form-toggle-explanation">
 									{
-										__( 'Put a chart showing 48 hours of views in the admin bar.' )
+										__( 'Put a chart showing 48 hours of views in the admin bar' )
 									}
 								</span>
 							</ModuleToggle>
@@ -115,7 +115,7 @@ export const SiteStats = moduleSettingsForm(
 										  toggleModule={ m => this.props.updateFormStateModuleOption( m, 'hide_smile' ) }>
 								<span className="jp-form-toggle-explanation">
 									{
-										__( 'Hide the stats smiley face image. The image helps collect stats, but should work when hidden.' )
+										__( 'Hide the stats smiley face image (The image helps collect stats, but should work when hidden.)' )
 									}
 								</span>
 							</ModuleToggle>

--- a/modules/after-the-deadline.php
+++ b/modules/after-the-deadline.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Spelling and Grammar
- * Module Description: Check your spelling, style, and grammar.
+ * Module Description: Check your spelling, style, and grammar
  * Sort Order: 6
  * First Introduced: 1.1
  * Requires Connection: Yes

--- a/modules/carousel.php
+++ b/modules/carousel.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Carousel
- * Module Description: Display images and galleries in a gorgeous, full-screen browsing experience.
+ * Module Description: Display images and galleries in a gorgeous, full-screen browsing experience
  * Jumpstart Description: Brings your photos and images to life as full-size, easily navigable galleries.
  * Sort Order: 22
  * Recommendation Order: 12

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Comments
- * Module Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment.
+ * Module Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Gravatar Hovercards
- * Module Description: Enable pop-up business cards over commenters’ Gravatars.
+ * Module Description: Enable pop-up business cards over commenters’ Gravatars
  * Jumpstart Description: Let commenters link their profiles to their Gravatar accounts, making it easy for your visitors to learn more about your community.
  * Sort Order: 11
  * Recommendation Order: 13

--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Infinite Scroll
- * Module Description: Automatically load new content when a visitor scrolls.
+ * Module Description: Automatically load new content when a visitor scrolls
  * Sort Order: 26
  * First Introduced: 2.0
  * Requires Connection: No

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Markdown
- * Module Description: Write posts or pages in plain-text Markdown syntax.
+ * Module Description: Write posts or pages in plain-text Markdown syntax
  * Sort Order: 31
  * First Introduced: 2.8
  * Requires Connection: No

--- a/modules/minileven.php
+++ b/modules/minileven.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Mobile Theme
- * Module Description: Optimize your site for smartphones and tablets.
+ * Module Description: Optimize your site for smartphones and tablets
  * Sort Order: 21
  * Recommendation Order: 11
  * First Introduced: 1.8

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -14,18 +14,18 @@ function jetpack_get_module_i18n( $key ) {
 		$modules = array(
 			'after-the-deadline' => array(
 				'name' => _x( 'Spelling and Grammar', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Check your spelling, style, and grammar.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Check your spelling, style, and grammar', 'Module Description', 'jetpack' ),
 			),
 
 			'carousel' => array(
 				'name' => _x( 'Carousel', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Display images and galleries in a gorgeous, full-screen browsing experience.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Display images and galleries in a gorgeous, full-screen browsing experience', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Brings your photos and images to life as full-size, easily navigable galleries.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'comments' => array(
 				'name' => _x( 'Comments', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Allow comments with WordPress.com, Twitter, Facebook, or Google+.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Use Jetpack comments. Let readers use their WordPress.com, Twitter, Facebook or Google+ to leave comments on your posts and pages', 'Module Description', 'jetpack' ),
 			),
 
 			'contact-form' => array(
@@ -36,7 +36,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'custom-content-types' => array(
 				'name' => _x( 'Custom Content Types', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Organize and display different types of content on your site.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Display different types of content on your site with custom content types.', 'Module Description', 'jetpack' ),
 			),
 
 			'custom-css' => array(
@@ -56,13 +56,13 @@ function jetpack_get_module_i18n( $key ) {
 
 			'gravatar-hovercards' => array(
 				'name' => _x( 'Gravatar Hovercards', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Enable pop-up business cards over commenters’ Gravatars.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Enable pop-up business cards over commenters’ Gravatars', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Let commenters link their profiles to their Gravatar accounts, making it easy for your visitors to learn more about your community.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'infinite-scroll' => array(
 				'name' => _x( 'Infinite Scroll', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Automatically load new content when a visitor scrolls.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Automatically load new content when a visitor scrolls', 'Module Description', 'jetpack' ),
 			),
 
 			'json-api' => array(
@@ -88,12 +88,12 @@ function jetpack_get_module_i18n( $key ) {
 
 			'markdown' => array(
 				'name' => _x( 'Markdown', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Write posts or pages in plain-text Markdown syntax.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Write posts or pages in plain-text Markdown syntax', 'Module Description', 'jetpack' ),
 			),
 
 			'minileven' => array(
 				'name' => _x( 'Mobile Theme', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Optimize your site for smartphones and tablets.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Optimize your site for smartphones and tablets', 'Module Description', 'jetpack' ),
 			),
 
 			'monitor' => array(
@@ -113,18 +113,18 @@ function jetpack_get_module_i18n( $key ) {
 
 			'photon' => array(
 				'name' => _x( 'Photon', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Speed up images and photos.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Speed up images and photos', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'post-by-email' => array(
 				'name' => _x( 'Post by Email', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Publish posts by sending an email.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Publish posts by sending an email', 'Module Description', 'jetpack' ),
 			),
 
 			'protect' => array(
 				'name' => _x( 'Protect', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Prevent and block malicious login attempts.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Prevent brute force attacks', 'Module Description', 'jetpack' ),
 			),
 
 			'publicize' => array(
@@ -167,7 +167,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'sso' => array(
 				'name' => _x( 'Single Sign On', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Secure user authentication with WordPress.com.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Allow log-in using WordPress.com accounts', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.', 'Jumpstart Description', 'jetpack' ),
 			),
 
@@ -178,7 +178,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'subscriptions' => array(
 				'name' => _x( 'Subscriptions', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Notify your readers of new posts and comments by email.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Allow users to subscribe to your posts and comments and receive notifications via email', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Give visitors two easy subscription options — while commenting, or via a separate email subscription widget you can display.', 'Jumpstart Description', 'jetpack' ),
 			),
 

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -14,18 +14,18 @@ function jetpack_get_module_i18n( $key ) {
 		$modules = array(
 			'after-the-deadline' => array(
 				'name' => _x( 'Spelling and Grammar', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Check your spelling, style, and grammar', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Check your spelling, style, and grammar.', 'Module Description', 'jetpack' ),
 			),
 
 			'carousel' => array(
 				'name' => _x( 'Carousel', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Display images and galleries in a gorgeous, full-screen browsing experience', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Display images and galleries in a gorgeous, full-screen browsing experience.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Brings your photos and images to life as full-size, easily navigable galleries.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'comments' => array(
 				'name' => _x( 'Comments', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Use Jetpack comments. Let readers use their WordPress.com, Twitter, Facebook or Google+ to leave comments on your posts and pages', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Allow comments with WordPress.com, Twitter, Facebook, or Google+.', 'Module Description', 'jetpack' ),
 			),
 
 			'contact-form' => array(
@@ -36,7 +36,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'custom-content-types' => array(
 				'name' => _x( 'Custom Content Types', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Display different types of content on your site with custom content types.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Organize and display different types of content on your site.', 'Module Description', 'jetpack' ),
 			),
 
 			'custom-css' => array(
@@ -56,13 +56,13 @@ function jetpack_get_module_i18n( $key ) {
 
 			'gravatar-hovercards' => array(
 				'name' => _x( 'Gravatar Hovercards', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Enable pop-up business cards over commenters’ Gravatars', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Enable pop-up business cards over commenters’ Gravatars.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Let commenters link their profiles to their Gravatar accounts, making it easy for your visitors to learn more about your community.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'infinite-scroll' => array(
 				'name' => _x( 'Infinite Scroll', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Automatically load new content when a visitor scrolls', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Automatically load new content when a visitor scrolls.', 'Module Description', 'jetpack' ),
 			),
 
 			'json-api' => array(
@@ -88,12 +88,12 @@ function jetpack_get_module_i18n( $key ) {
 
 			'markdown' => array(
 				'name' => _x( 'Markdown', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Write posts or pages in plain-text Markdown syntax', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Write posts or pages in plain-text Markdown syntax.', 'Module Description', 'jetpack' ),
 			),
 
 			'minileven' => array(
 				'name' => _x( 'Mobile Theme', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Optimize your site for smartphones and tablets', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Optimize your site for smartphones and tablets.', 'Module Description', 'jetpack' ),
 			),
 
 			'monitor' => array(
@@ -113,18 +113,18 @@ function jetpack_get_module_i18n( $key ) {
 
 			'photon' => array(
 				'name' => _x( 'Photon', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Speed up images and photos', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Speed up images and photos.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'post-by-email' => array(
 				'name' => _x( 'Post by Email', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Publish posts by sending an email', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Publish posts by sending an email.', 'Module Description', 'jetpack' ),
 			),
 
 			'protect' => array(
 				'name' => _x( 'Protect', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Prevent brute force attacks', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Prevent and block malicious login attempts.', 'Module Description', 'jetpack' ),
 			),
 
 			'publicize' => array(
@@ -167,7 +167,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'sso' => array(
 				'name' => _x( 'Single Sign On', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Allow log-in using WordPress.com accounts', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Secure user authentication with WordPress.com.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.', 'Jumpstart Description', 'jetpack' ),
 			),
 
@@ -178,7 +178,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'subscriptions' => array(
 				'name' => _x( 'Subscriptions', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Allow users to subscribe to your posts and comments and receive notifications via email', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Notify your readers of new posts and comments by email.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Give visitors two easy subscription options — while commenting, or via a separate email subscription widget you can display.', 'Jumpstart Description', 'jetpack' ),
 			),
 

--- a/modules/photon.php
+++ b/modules/photon.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Photon
- * Module Description: Speed up images and photos.
+ * Module Description: Speed up images and photos
  * Jumpstart Description: Mirrors and serves your images from our free and fast image CDN, improving your site’s performance with no additional load on your servers.
  * Sort Order: 25
  * Recommendation Order: 1

--- a/modules/post-by-email.php
+++ b/modules/post-by-email.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Post by Email
- * Module Description: Publish posts by sending an email.
+ * Module Description: Publish posts by sending an email
  * First Introduced: 2.0
  * Sort Order: 14
  * Requires Connection: Yes

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Protect
- * Module Description: Block suspicious-looking login activity from unknown IP addresses.
+ * Module Description: Block suspicious-looking login activity from unknown IP addresses
  * Sort Order: 1
  * Recommendation Order: 4
  * First Introduced: 3.4
@@ -433,9 +433,9 @@ class Jetpack_Protect_Module {
 			ob_end_clean();
 			return true;
 		}
-		
+
 		/**
-		 * Short-circuit check_login_ability. 
+		 * Short-circuit check_login_ability.
 		 *
 		 * If there is an alternate way to validate the current IP such as
 		 * a hard-coded list of IP addresses, we can short-circuit the rest
@@ -450,7 +450,7 @@ class Jetpack_Protect_Module {
 		if ( apply_filters( 'jpp_allow_login', false, $ip ) ) {
 			return true;
 		}
-		
+
 		$headers         = $this->get_headers();
 		$header_hash     = md5( json_encode( $headers ) );
 		$transient_name  = 'jpp_li_' . $header_hash;

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -4,7 +4,7 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-notices.php' 
 
 /**
  * Module Name: Single Sign On
- * Module Description: Allow users to log into this site using WordPress.com accounts.
+ * Module Description: Allow users to log into this site using WordPress.com accounts
  * Jumpstart Description: Lets you log in to all your Jetpack-enabled sites with one click using your WordPress.com account.
  * Sort Order: 30
  * Recommendation Order: 5
@@ -667,7 +667,7 @@ class Jetpack_SSO {
 			 * user, then we know that email is unused, so it's safe to add.
 			 */
 			if ( Jetpack_SSO_Helpers::match_by_email() || ! get_user_by( 'email', $user_data->email ) ) {
-				
+
 				if ( $new_user_override_role ) {
 					$user_data->role = $new_user_override_role;
 				}

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Subscriptions
- * Module Description: Allow users to subscribe to your posts and comments and receive notifications via email.
+ * Module Description: Allow users to subscribe to your posts and comments and receive notifications via email
  * Jumpstart Description: Give visitors two easy subscription options — while commenting, or via a separate email subscription widget you can display.
  * Sort Order: 9
  * Recommendation Order: 8


### PR DESCRIPTION
Fixes #6220

#### Changes proposed in this Pull Request:
* Removes all trailing periods from settings labels

#### Testing instructions:
* Go to all settings sections and look for any trailing periods on toggle/checkbox labels.

#### Example before:
![image](https://cloud.githubusercontent.com/assets/1123119/22531400/d5c957b8-e89d-11e6-90ab-2340d2f9aaed.png)


#### Example after:
![image](https://cloud.githubusercontent.com/assets/1123119/22531340/80d247a6-e89d-11e6-9ec6-82a6455f70c9.png)
