### PR TITLE
Generate new module headers

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -51,7 +51,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'google-analytics' => array(
 				'name' => _x( 'Google Analytics', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Lets you use Google Analytics to track your WordPress site statistics.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Set up Google Analytics without touching a line of code.', 'Module Description', 'jetpack' ),
 			),
 
 			'gravatar-hovercards' => array(


### PR DESCRIPTION
`gulp php:module-headings` Needed to be run manually for changes in #6250 to take effect.