### PR TITLE
Tracks: don't allow Travis CI/unit tests to fire tracks events 

### DIFF
--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -114,6 +114,12 @@ function jetpack_tracks_get_identity( $user_id ) {
  * @return bool true for success | \WP_Error if the event pixel could not be fired
  */
 function jetpack_tracks_record_event( $user, $event_name, $properties = array(), $event_timestamp_millis = false ) {
+
+	// We don't want to track user events during unit tests/CI runs.
+	if ( $user instanceof WP_User && 'wptests_capabilities' === $user->cap_key ) {
+		return false;
+	}
+
 	$event_obj = jetpack_tracks_build_event_obj( $user, $event_name, $properties, $event_timestamp_millis );
 
 	if ( is_wp_error( $event_obj->error ) ) {


### PR DESCRIPTION
#6248 was generating a tracks event for every travis test.  Let's put a stop to sending events for automated testing.  

To Test: 
- Put some error_logging below the changeset here. 
- run `phpunit --testsuite "restapi"`
- No logs should appear, nor tracks.  

This doesn't necessarily have to go into 4.6, but it should go into master to stop the fake events from being fired on builds.  