### PR TITLE
JSON API: Add new `action_links` field to plugins endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -213,7 +213,15 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 
 				 $link_element = $link_elements->item( 0 );
 				 if ( $link_element->hasAttribute( 'href' ) && $link_element->nodeValue ) {
-					 $formatted_action_links[ $link_element->nodeValue ] = $link_element->getAttribute( 'href' );
+					 $link_url = trim( $link_element->getAttribute( 'href' ) );
+
+					 // Add the full admin path to the url if the plugin did not provide it
+					 $link_url_scheme = wp_parse_url( $link_url, PHP_URL_SCHEME );
+					 if ( empty( $link_url_scheme ) ) {
+						 $link_url = admin_url( $link_url );
+					 }
+
+					 $formatted_action_links[ $link_element->nodeValue ] = $link_url;
 				 }
 			 }
 		 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -29,6 +29,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		'next_autoupdate' => '(string) Y-m-d H:i:s for next scheduled update event',
 		'log'             => '(array:safehtml) An array of update log strings.',
 		'uninstallable'   => '(boolean) Whether the plugin is unistallable.',
+		'action_links'    => '(array) An array of action links that the plugins uses.',
 	);
 
 	protected function result() {
@@ -69,7 +70,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 			$this->bulk = false;
 			$this->plugins[] = urldecode( $plugin );
 		}
-		
+
 		if ( is_wp_error( $error = $this->validate_plugins() ) ) {
 			return $error;
 		};
@@ -113,10 +114,11 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		$plugin['network']         = $plugin_data['Network'];
 		$plugin['update']          = $this->get_plugin_updates( $plugin_file );
 		$plugin['next_autoupdate'] = date( 'Y-m-d H:i:s', wp_next_scheduled( 'wp_maybe_auto_update' ) );
+		$plugin['action_links']    = $this->get_plugin_action_links( $plugin_file );
 
 		$autoupdate = in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins', array() ) );
 		$plugin['autoupdate']      = $autoupdate;
-		
+
 		$autoupdate_translation = in_array( $plugin_file, Jetpack_Options::get_option( 'autoupdate_plugins_translations', array() ) );
 		$plugin['autoupdate_translation'] = $autoupdate || $autoupdate_translation || Jetpack_Options::get_option( 'autoupdate_translations', false );
 
@@ -183,4 +185,32 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		}
 		return null;
 	}
+
+	/**
+	 * Get custom action link tags that the plugin is using
+	 * Ref: https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)
+	 * @return array of plugin action links (key: link name value: url)
+	 */
+	 protected function get_plugin_action_links( $plugin_file ) {
+		 $formatted_action_links = array();
+
+		 $action_links = apply_filters( 'plugin_action_links', null, $plugin_file, null, 'all' );
+		 if ( count( $action_links ) > 0 ) {
+			 $dom_doc = new DOMDocument;
+			 foreach( $action_links as $action_link ) {
+				 $dom_doc->loadHTML( $action_link );
+				 $link_elements = $dom_doc->getElementsByTagName( 'a' );
+				 if ( $link_elements->length == 0 ) {
+					 continue;
+				 }
+
+				 $link_element = $link_elements->item( 0 );
+				 if ( $link_element->hasAttribute( 'href' ) && $link_element->nodeValue ) {
+					 $formatted_action_links[ $link_element->nodeValue ] = $link_element->getAttribute( 'href' );
+				 }
+			 }
+		 }
+
+		 return $formatted_action_links;
+	 }
 }

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -29,7 +29,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		'next_autoupdate' => '(string) Y-m-d H:i:s for next scheduled update event',
 		'log'             => '(array:safehtml) An array of update log strings.',
 		'uninstallable'   => '(boolean) Whether the plugin is unistallable.',
-		'action_links'    => '(array) An array of action links that the plugins uses.',
+		'action_links'    => '(array) An array of action links that the plugin uses.',
 	);
 
 	protected function result() {

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -194,6 +194,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	 protected function get_plugin_action_links( $plugin_file ) {
 		 $formatted_action_links = array();
 
+		 /** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
 		 $action_links = apply_filters( 'plugin_action_links', null, $plugin_file, null, 'all' );
 		 if ( count( $action_links ) > 0 ) {
 			 $dom_doc = new DOMDocument;

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -131,6 +131,9 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	}
 
 	protected function get_plugins() {
+		// Do the admin_init action in order to capture plugin action links.
+		// See get_plugin_action_links()
+		do_action( 'admin_init' );
 		$plugins = array();
 		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
 		$installed_plugins = apply_filters( 'all_plugins', get_plugins() );
@@ -194,8 +197,11 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	 protected function get_plugin_action_links( $plugin_file ) {
 		 $formatted_action_links = array();
 
+		 $action_links = array();
 		 /** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-		 $action_links = apply_filters( 'plugin_action_links', null, $plugin_file, null, 'all' );
+		 $action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, null, 'all' );
+		 /** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
+		 $action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, null, 'all' );
 		 if ( count( $action_links ) > 0 ) {
 			 $dom_doc = new DOMDocument;
 			 foreach( $action_links as $action_link ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -198,6 +198,11 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	 protected function get_plugin_action_links( $plugin_file ) {
 		 $formatted_action_links = array();
 
+		 // Some sites may have DOM disabled in PHP
+		 if ( ! class_exists( 'DOMDocument' ) ) {
+			 return $formatted_action_links;
+		 }
+
 		 $action_links = array();
 		 /** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
 		 $action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, null, 'all' );

--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -133,6 +133,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 	protected function get_plugins() {
 		// Do the admin_init action in order to capture plugin action links.
 		// See get_plugin_action_links()
+		/** This action is documented in wp-admin/admin.php */
 		do_action( 'admin_init' );
 		$plugins = array();
 		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */


### PR DESCRIPTION
Over in https://github.com/Automattic/wp-calypso/issues/82 we'd like to show any action links that the plugin uses in the Calypso plugins page. This PR adds support for returning these action links via the `/sites/example.com/plugins` endpoint.

The only way to get the links is in an HTML tag format, so this parses out the url and link name and returns them in an array. Because the plugin developer can return anything they want in these links, I used `DOMDocument` to handle the parsing to be safest. Other ideas are welcome!

**To test**
* Apply Diff `D4247` to your wp.com sandbox to whitelist the new field.
* Do a `get` to the `/sites/your-jetpack-dev-site/plugins` endpoint.
* You should see an empty `action_link` array if no action links were added, or an array of data if it exists for the plugin:

<img width="632" alt="screen shot 2017-02-02 at 11 46 30 am" src="https://cloud.githubusercontent.com/assets/789137/22566260/09be6c82-e940-11e6-975d-a1afdd2b3f70.png">

