### PR TITLE
Settings UI: update VaultPress notice markup when it's moved into notices area

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -11,11 +11,12 @@ const AdminNotices = React.createClass( {
 		if ( $vpNotice.length > 0 ) {
 			$vpNotice.each( function () {
 				let $notice = jQuery( this ).addClass( 'dops-notice is-warning' ).removeClass( 'wrap vp-notice' );
+				$notice.wrapInner( '<div class="dops-notice__content">' );
 				$notice.find( 'a' ).addClass( 'dops-notice__action' ).appendTo( $notice );
 				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );
 				$notice.find( 'h3' ).replaceWith( function () { return jQuery( '<strong />', { html: this.innerHTML } ); } );
 				$notice.find( 'p' ).replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML } ); } );
-				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
+				$notice.prependTo( $adminNotices ).show();
 			} );
 		}
 

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -120,7 +120,7 @@ export const DevModeNotice = React.createClass( {
 			return (
 				<SimpleNotice
 					showDismiss={ false }
-					status="is-basic"
+					status="is-info"
 					text={ text }
 				>
 					<NoticeAction


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- updates the markup to match the new one in the dops notice
- restores 'is-info' status for dev mode notice

before

<img width="747" alt="captura de pantalla 2017-02-15 a las 16 06 25" src="https://cloud.githubusercontent.com/assets/1041600/22991236/6b230e10-f39a-11e6-8bc7-42d5da1c4d46.png">

after

<img width="767" alt="captura de pantalla 2017-02-15 a las 15 51 32" src="https://cloud.githubusercontent.com/assets/1041600/22991240/6ded57ea-f39a-11e6-8c90-bc8aaa7c0ac9.png">

#### Testing instructions:
* make sure there is no padding that separates the button from the edge of the notice