### PR TITLE
Fix theme enhancement support button location

### DIFF
--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -88,7 +88,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 						].map( item => {
 							let isItemActive = this.props.getOptionValue( item.module );
 							return (
-								<SettingsGroup hasChild key={ `theme_enhancement_${ item.module }` }>
+								<SettingsGroup hasChild key={ `theme_enhancement_${ item.module }` }  support={ item.learn_more_button }>
 									<ModuleToggle slug={ item.module }
 												  compact
 												  activated={ isItemActive }
@@ -100,7 +100,7 @@ export const ThemeEnhancements = moduleSettingsForm(
 									}
 									</span>
 									</ModuleToggle>
-									<FormFieldset support={ item.learn_more_button }>
+									<FormFieldset>
 										{
 											item.checkboxes.map( chkbx => {
 												return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* moved support link into proper container to display in the correct position

#### Testing instructions:
* Go to Settings > Writing
* take a look at the support icons in the Theme enhancements section
* make sure both go to the correct place

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/22569310/533329d4-e954-11e6-8e32-503ad4538c2c.png)


#### After
![image](https://cloud.githubusercontent.com/assets/1123119/22569291/40de65dc-e954-11e6-8ed0-67244ba74c7b.png)
