### PR TITLE
Settings UI: add a link to Sharing in settings navigation

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -12,6 +12,7 @@ import trim from 'lodash/trim';
 import analytics from 'lib/analytics';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -21,6 +22,8 @@ import {
 	userCanManageModules as _userCanManageModules,
 	userIsSubscriber as _userIsSubscriber
 } from 'state/initial-state';
+import { getSiteConnectionStatus } from 'state/connection';
+import { isModuleActivated } from 'state/modules';
 
 export const NavigationSettings = React.createClass( {
 	openSearch: function() {
@@ -92,6 +95,18 @@ export const NavigationSettings = React.createClass( {
 						selected={ this.props.route.path === '/security' }>
 						{ __( 'Security', { context: 'Navigation item.' } ) }
 					</NavItem>
+					{
+						( this.props.isModuleActivated( 'publicize' ) || this.props.isModuleActivated( 'sharedaddy' ) ) && (
+							<NavItem
+								path={ true === this.props.siteConnectionStatus
+									? 'https://wordpress.com/sharing/' + this.props.siteRawUrl
+									: this.props.siteAdminUrl + 'options-general.php?page=sharing'
+									}>
+								{ __( 'Sharing' ) }
+								<Gridicon icon="external" size={ 13 } />
+							</NavItem>
+						)
+					}
 				</NavTabs>
 			);
 		} else if ( this.props.isSubscriber ) {
@@ -140,7 +155,9 @@ export default connect(
 	( state ) => {
 		return {
 			userCanManageModules: _userCanManageModules( state ),
-			isSubscriber: _userIsSubscriber( state )
+			isSubscriber: _userIsSubscriber( state ),
+			siteConnectionStatus: getSiteConnectionStatus( state ),
+			isModuleActivated: module => isModuleActivated( state, module )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -103,7 +103,11 @@ export const NavigationSettings = React.createClass( {
 									: this.props.siteAdminUrl + 'options-general.php?page=sharing'
 									}>
 								{ __( 'Sharing' ) }
-								<Gridicon icon="external" size={ 13 } />
+								{
+									true === this.props.siteConnectionStatus && (
+										<Gridicon icon="external" size={ 13 } />
+									)
+								}
 							</NavItem>
 						)
 					}

--- a/_inc/client/components/navigation-settings/style.scss
+++ b/_inc/client/components/navigation-settings/style.scss
@@ -1,0 +1,4 @@
+.dops-section-nav-tab__text .gridicon {
+	vertical-align: middle;
+	margin: 0 0 2px 5px;
+}

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -165,7 +165,8 @@ const Main = React.createClass( {
 		}
 
 		let pageComponent,
-			navComponent = <Navigation route={ this.props.route }/>;
+			navComponent = <Navigation route={ this.props.route }/>,
+			settingsNav = <NavigationSettings route={ this.props.route } siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 		switch ( route ) {
 			case '/dashboard':
 				pageComponent = <AtAGlance siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
@@ -177,39 +178,39 @@ const Main = React.createClass( {
 				pageComponent = <Plans siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/settings':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <GeneralSettings route={ this.props.route } />;
 				break;
 			case '/general':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <GeneralSettings route={ this.props.route } />;
 				break;
 			case '/engagement':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <Engagement route={ this.props.route } />;
 				break;
 			case '/discussion':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <Discussion route={ this.props.route } siteRawUrl={ this.props.siteRawUrl } />;
 				break;
 			case '/security':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <Security route={ this.props.route } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/traffic':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <Traffic route={ this.props.route } siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/appearance':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <Appearance route={ this.props.route } />;
 				break;
 			case '/writing':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <Writing route={ this.props.route } siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 			case '/search':
-				navComponent = <NavigationSettings route={ this.props.route } />;
+				navComponent = settingsNav;
 				pageComponent = <SearchPage siteAdminUrl={ this.props.siteAdminUrl } />;
 				break;
 

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -39,6 +39,7 @@
 @import '../components/admin-notices/style';
 @import '../components/inline-expand/style';
 @import '../components/module-toggle/style';
+@import '../components/navigation-settings/style';
 
 
 // Page Templates


### PR DESCRIPTION
Fixes #6228

#### Changes proposed in this Pull Request:
- adds a Sharing link with icon to the Settings navigation bar:
    - if site is connected, it goes to Sharing section in Calypso
    - if site isn't connected, it goes to Settings > Sharing in WP Admin.
- the link is displayed if Publicize or Sharing modules are active

#### Testing instructions:
* build and make sure the link goes to the correct location when site it's connected and when it's in dev mode.

