### PR TITLE
Updates deprecated and no longer relevant ESLint rules.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,7 @@
 		"no-mixed-spaces-and-tabs": 1,
 		"no-multiple-empty-lines": [ 1, { "max": 1 } ],
 		"no-multi-spaces": 1,
-		"no-nested-ternary": 1,
+		"no-nested-ternary": 0,
 		"no-new": 1,
 		"no-process-exit": 1,
 		"no-shadow": 1,
@@ -56,7 +56,7 @@
 		// We split external, internal, module variables
 		"one-var": 0,
 		"operator-linebreak": [ 1, "after", { "overrides": { "?": "ignore", ":": "ignore" } } ],
-		"padded-blocks": [ 1, "never" ],
+		"padded-blocks": 0,
 		"quote-props": [ 1, "as-needed" ],
 		"quotes": [ 1, "single", "avoid-escape" ],
 		"semi-spacing": 1,

--- a/.eslintrc
+++ b/.eslintrc
@@ -60,7 +60,7 @@
 		"quote-props": [ 1, "as-needed" ],
 		"quotes": [ 1, "single", "avoid-escape" ],
 		"semi-spacing": 1,
-		"space-after-keywords": [ 1, "always" ],
+		"keyword-spacing": [ 1, { "after": true } ],
 		"space-before-blocks": [ 1, "always" ],
 		"space-before-function-paren": [ 1, "never" ],
 		// Our array literal index exception violates this rule


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fixes a warning about unused `space-after-keywords` rule by using a newer rule with the same effect.

Feel free to add changes to .eslint here if you feel like something annoys you too much.

@eliorivero perhaps we can make the new "Calypso" ternary format the default by changing the rules?