### PR TITLE
JSON API: Fixes remaining PHP errors when editing items in Calypso

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php
@@ -56,7 +56,7 @@ class WPCOM_JSON_API_Update_Taxonomy_Endpoint extends WPCOM_JSON_API_Taxonomy_En
 
 		$data = wp_insert_term( addslashes( $input['name'] ), $taxonomy_type,
 			array(
-		  		'description' => addslashes( $input['description'] ),
+		  		'description' => isset( $input['description'] ) ? addslashes( $input['description'] ) : '',
 		  		'parent'      => $input['parent']
 			)
 		);

--- a/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
@@ -63,7 +63,7 @@ class WPCOM_JSON_API_Update_Term_Endpoint extends WPCOM_JSON_API_Taxonomy_Endpoi
 		}
 
 		$data = wp_insert_term( addslashes( $input['name'] ), $taxonomy, array(
-	  		'description' => addslashes( $input['description'] ),
+	  		'description' => isset( $input['description'] ) ? addslashes( $input['description'] ) : '',
 	  		'parent'      => $input['parent']
 		) );
 


### PR DESCRIPTION
Fixes #4424 
Fixes #5943 

Closes #5566 (master issue)

#### Changes proposed in this Pull Request:
When creating a new term or taxonomy in the JSON API, pass `description` attribute from input to `wp_insert_term()`when provided, otherwise provide attribute's default value (''). 

#### Testing instructions:

* Follow steps outlined in #4424 and #5943 and make sure no error is logged.