### PR TITLE
Sync: Fixes an issue where sync_wait_time was immediately overwritten

### DIFF
--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -333,7 +333,7 @@ class Jetpack_Sync_Sender {
 		$this->set_upload_max_bytes( $settings['upload_max_bytes'] );
 		$this->set_upload_max_rows( $settings['upload_max_rows'] );
 		$this->set_sync_wait_time( $settings['sync_wait_time'] );
-		$this->set_sync_wait_time( $settings['enqueue_wait_time'] );
+		$this->set_enqueue_wait_time( $settings['enqueue_wait_time'] );
 		$this->set_sync_wait_threshold( $settings['sync_wait_threshold'] );
 		$this->set_max_dequeue_time( Jetpack_Sync_Defaults::get_max_sync_execution_time() );
 	}


### PR DESCRIPTION
When looking through code with @lamosty today, I noticed some code in the sync sender where we were setting `sync_wait_time` back-to-back. 

This PR changes the second line so that we're setting `enqueue_wait_time` instead of overwriting `sync_wait_time`.

To test:

- Checkout branch
- Attempt a full sync
- Publish some posts and ensure they get synced

Anything else team Poseidon? @gravityrail @lezama @enejb 