### PR TITLE
Google Analytics: hook tracking code into wp_footer.

### DIFF
--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -35,7 +35,7 @@ class Jetpack_Google_Analytics {
 	 * @return void
 	 */
 	private function __construct() {
-		add_action( 'get_footer', array( $this, 'insert_code' ) );
+		add_action( 'wp_footer', array( $this, 'insert_code' ) );
 	}
 
 	/**


### PR DESCRIPTION
`get_footer` might not be compatible with every theme out there.