### PR TITLE
Settings UI: remove notices after 2 secs

### DIFF
--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -17,8 +17,7 @@ import {
 	updateSettings,
 	isUpdatingSetting,
 	setUnsavedSettingsFlag,
-	clearUnsavedSettingsFlag,
-	regeneratePostByEmailAddress
+	clearUnsavedSettingsFlag
 } from 'state/settings';
 import { getCurrentIp, getSiteAdminUrl } from 'state/initial-state';
 import {
@@ -59,8 +58,8 @@ export function connectModuleOptions( Component ) {
 			updateOptions: ( newOptions ) => {
 				return dispatch( updateSettings( newOptions ) );
 			},
-			regeneratePostByEmailAddress: () => {
-				return dispatch( regeneratePostByEmailAddress() );
+			regeneratePostByEmailAddress: newOptions => {
+				return dispatch( updateSettings( newOptions, 'regeneratePbE' ) );
 			},
 			setUnsavedSettingsFlag: () => {
 				return dispatch( setUnsavedSettingsFlag() );

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -104,7 +104,7 @@ export const updateSettings = ( newOptionValues ) => {
 			dispatch( createNotice(
 				'is-success',
 				__( 'Updated settings.' ),
-				{ id: `module-setting-update` }
+				{ id: `module-setting-update`, duration: 2000 }
 			) );
 		} ).catch( error => {
 			dispatch( {

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -78,13 +78,35 @@ export const updateSetting = ( updatedOption ) => {
 	}
 };
 
-export const updateSettings = ( newOptionValues ) => {
+export const updateSettings = ( newOptionValues, type = '' ) => {
 	return ( dispatch, getState ) => {
+
+		let messages = {
+				progress: __( 'Updating settings…' ),
+				success: __( 'Updated settings.' ),
+				error: error => __( 'Error updating settings. %(error)s', { args: { error: error } } )
+			},
+			updatedOptionsSuccess = () => newOptionValues;
+
+		// Adapt messages and data when regenerating Post by Email address
+		if ( 'regeneratePbE' === type ) {
+			messages = {
+				progress: __( 'Updating Post by Email address…' ),
+				success: __( 'Regenerated Post by Email address.' ),
+				error: error => __( 'Error regenerating Post by Email address. %(error)s', { args: { error: error } } )
+			};
+			updatedOptionsSuccess = success => {
+				return {
+					post_by_email_address: success.post_by_email_address
+				};
+			};
+			newOptionValues = { post_by_email_address: 'regenerate' };
+		}
 
 		dispatch( removeNotice( `module-setting-update` ) );
 		dispatch( createNotice(
 			'is-info',
-			__( 'Updating settings…' ),
+			messages.progress,
 			{ id: `module-setting-update` }
 		) );
 		dispatch( {
@@ -95,7 +117,7 @@ export const updateSettings = ( newOptionValues ) => {
 		return restApi.updateSettings( newOptionValues ).then( success => {
 			dispatch( {
 				type: JETPACK_SETTINGS_UPDATE_SUCCESS,
-				updatedOptions: newOptionValues,
+				updatedOptions: updatedOptionsSuccess( success ),
 				success: success
 			} );
 			maybeHideNavMenuItem( newOptionValues );
@@ -103,7 +125,7 @@ export const updateSettings = ( newOptionValues ) => {
 			dispatch( removeNotice( `module-setting-update` ) );
 			dispatch( createNotice(
 				'is-success',
-				__( 'Updated settings.' ),
+				messages.success,
 				{ id: `module-setting-update`, duration: 2000 }
 			) );
 		} ).catch( error => {
@@ -117,65 +139,7 @@ export const updateSettings = ( newOptionValues ) => {
 			dispatch( removeNotice( `module-setting-update` ) );
 			dispatch( createNotice(
 				'is-error',
-				__( 'Error updating settings. %(error)s', {
-					args: {
-						error: error
-					}
-				} ),
-				{ id: `module-setting-update` }
-			) );
-		} );
-	};
-};
-
-export const regeneratePostByEmailAddress = () => {
-	return ( dispatch, getState ) => {
-
-		const newOptionValues = {
-			post_by_email_address: 'regenerate'
-		};
-
-		dispatch( removeNotice( `module-setting-update` ) );
-		dispatch( createNotice(
-			'is-info',
-			__( 'Updating Post by Email address…' ),
-			{ id: `module-setting-update` }
-		) );
-		dispatch( {
-			type: JETPACK_SETTINGS_UPDATE
-		} );
-
-		return restApi.updateSettings( newOptionValues ).then( success => {
-			dispatch( {
-				type: JETPACK_SETTINGS_UPDATE_SUCCESS,
-				updatedOptions: {
-					post_by_email_address: success.post_by_email_address
-				},
-				success: success
-			} );
-
-			dispatch( removeNotice( `module-setting-update` ) );
-			dispatch( createNotice(
-				'is-success',
-				__( 'Regenerated Post by Email address.' ),
-				{ id: `module-setting-update` }
-			) );
-		} ).catch( error => {
-			dispatch( {
-				type: JETPACK_SETTINGS_UPDATE_FAIL,
-				success: false,
-				error: error,
-				updatedOptions: newOptionValues
-			} );
-
-			dispatch( removeNotice( `module-setting-update` ) );
-			dispatch( createNotice(
-				'is-error',
-				__( 'Error regenerating Post by Email address. %(error)s', {
-					args: {
-						error: error
-					}
-				} ),
+				messages.error( error ),
 				{ id: `module-setting-update` }
 			) );
 		} );


### PR DESCRIPTION
Fixes #6204 

#### Changes proposed in this Pull Request:
- remove updated settings notice after 2 seconds
- refactor updateSettings action to consider when Post by Email address is regenerated. This allows to remove a large portion of code that is basically the same with only a few tweaks for PbE.

![autohide](https://cloud.githubusercontent.com/assets/1041600/22601627/7f7ddaf0-ea1e-11e6-8fc0-2785c630a810.gif)

#### Testing instructions:
* build and save or toggle options. The Updated settings notice should dissapear after 2 seconds.
* regenerate Post by Email address. The notice text should be different.
