### PR TITLE
Google Analytics: add HTML comment before the script output.

### DIFF
--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -131,7 +131,8 @@ class Jetpack_Google_Analytics {
 			$custom_vars[] = "_gaq.push(['_trackPageview']);";
 		}
 
-		$async_code = "<script type='text/javascript'>
+		$async_code = "<!-- Jetpack Google Analytics -->
+		<script type='text/javascript'>
 							var _gaq = _gaq || [];
 							%custom_vars%
 


### PR DESCRIPTION
> It would be worth adding a comment tag in front the code saying it was added through Jetpack’s Google Analytics module – in case anyone was ever trying to remember how it got there or how to edit it when they were viewing source