### PR TITLE
Sync: Return expected response on Jetpack side

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -34,7 +34,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 			$modules = null;
 		}
 
-		return array( 'started' => Jetpack_Sync_Actions::do_full_sync( $modules ) );
+		return array( 'scheduled' => Jetpack_Sync_Actions::do_full_sync( $modules ) );
 	}
 
 	protected function validate_queue( $query ) {

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -629,7 +629,7 @@ new Jetpack_JSON_API_Sync_Endpoint( array(
 		'users'    => '(string) Comma-delimited list of user IDs to sync',
 	),
 	'response_format' => array(
-		'started' => '(bool) Whether or not the synchronisation was started'
+		'scheduled' => '(bool) Whether or not the synchronisation was started'
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync'
 ) );


### PR DESCRIPTION
Prior to bc192674c1b4307a8fbd4bbf2bc9cc82c10b5f96, we returned 'scheduled in the `POST /sites/$site/sync` response. With that commit, that endpoint began returning nothing since it didn't fit the `response_format` and was thus filtered out.

I thought about updating the WPCOM side to also use `started`, but that could cause jankiness for sites running Jetpack that was released between 4.2 and mid-October.

To be clear, the wording probably should be `started` instead of `scheduled` since we no longer schedule a cron job to start sync. But, we should also have versioned that change.

Because of this, I think the best move is to continue using `scheduled` for now.

It would be ideal to get this into 4.6 since this is contributing to some weirdness with the sync panel at `/settings/general/$site` in Calypso.

To test:

- Go to API console: https://developer.wordpress.com/docs/api/console/
- Make API request to `POST /sites/$site/sync`
- See that there is no response
- Checkout branch
- Make same request
- See response