### PR TITLE
Import specific lodash function instead of the whole library

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import { includes } from 'lodash';
+import includes from 'lodash/includes';
 import Button from 'components/button';
 import SimpleNotice from 'components/notice';
 


### PR DESCRIPTION
Fixes #6294

Introduced with GA in #5603. 

We should be importing specific lodash functions anyway so we're not loading the entire lodash library and potentially causing conflicts like the one reported in the issue.  

To Test: 
- Activate notifications module and check if console is free of errors on the react pages. 