### PR TITLE
Fix `jp_carousel_load_for_images_linked_to_file` filter when Photon is activated

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1429,8 +1429,8 @@ jQuery(document).ready(function($) {
 
 			var valid = false;
 
-			// if link points to 'Media File' and flag is set allow it
-			if ( $( container ).attr( 'href' ) === $( this ).attr( 'data-orig-file' ) &&
+			// if link points to 'Media File' (ignoring GET parameters) and flag is set allow it
+			if ( $( container ).attr( 'href' ).split( '?' )[0] === $( this ).attr( 'data-orig-file' ).split( '?' )[0] &&
 				1 === Number( jetpackCarouselStrings.single_image_gallery_media_file )
 			) {
 				valid = true;


### PR DESCRIPTION
Fixes #6054

#### Changes proposed in this Pull Request:

- Strip GET parameters when comparing image URLs between `data-orig-file` and containing element href

#### Testing instructions:

1. Set add_filter( 'jp_carousel_load_for_images_linked_to_file', '__return_true' );
2. Activate Photon and Carousel
3. Create a post with an image that is linked to its' full size file
4. Click on the image on the frontend
5. See that the full size image is displayed in a lightbox.

#### Proposed changelog entry for your changes:

- Bugfix: `jp_carousel_load_for_images_linked_to_file` filter now works when Photon is activated
