### PR TITLE
Add image caching to jetpack_og_get_image()

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -313,7 +313,13 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 			$img_width  = '';
 			$img_height = '';
-			$image_id = attachment_url_to_postid( $image_url );
+			$cached_image_id = get_transient( 'jp_' . $image_url )
+			if ( false !== $cached_image_id ){
+				$image_id = $cached_image_id;
+			}else{
+				$image_id = attachment_url_to_postid( $image_url );
+				set_transient( 'jp_' . $image_url, $image_id );
+			}
 			$image_size = wp_get_attachment_image_src( $image_id, $width >= 512
 				? 'full'
 				: array( $width, $width ) );
@@ -351,7 +357,15 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 		$img_width  = '';
 		$img_height = '';
-		$image_id = get_option( 'site_icon' );
+
+		$cached_image_id = get_transient( 'jp_' . $image_url )
+		if ( false !== $cached_image_id ){
+			$image_id = $cached_image_id;
+		}else{
+			$image_id = attachment_url_to_postid( $image_url );
+			set_transient( 'jp_' . $image_url, $image_id );
+		}
+
 		$image_size = wp_get_attachment_image_src( $image_id, $max_side >= 512
 			? 'full'
 			: array( $max_side, $max_side ) );

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -313,7 +313,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 			$img_width  = '';
 			$img_height = '';
-			$cached_image_id = get_transient( 'jp_' . $image_url )
+			$cached_image_id = get_transient( 'jp_' . $image_url );
 			if ( false !== $cached_image_id ){
 				$image_id = $cached_image_id;
 			}else{
@@ -357,8 +357,8 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 		$img_width  = '';
 		$img_height = '';
+		$cached_image_id = get_transient( 'jp_' . $image_url );
 
-		$cached_image_id = get_transient( 'jp_' . $image_url )
 		if ( false !== $cached_image_id ){
 			$image_id = $cached_image_id;
 		}else{

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -314,9 +314,9 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 			$img_width  = '';
 			$img_height = '';
 			$cached_image_id = get_transient( 'jp_' . $image_url );
-			if ( false !== $cached_image_id ){
+			if ( false !== $cached_image_id ) {
 				$image_id = $cached_image_id;
-			}else{
+			} else {
 				$image_id = attachment_url_to_postid( $image_url );
 				set_transient( 'jp_' . $image_url, $image_id );
 			}
@@ -359,9 +359,9 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 		$img_height = '';
 		$cached_image_id = get_transient( 'jp_' . $image_url );
 
-		if ( false !== $cached_image_id ){
+		if ( false !== $cached_image_id ) {
 			$image_id = $cached_image_id;
-		}else{
+		} else {
 			$image_id = attachment_url_to_postid( $image_url );
 			set_transient( 'jp_' . $image_url, $image_id );
 		}


### PR DESCRIPTION
This adds a transient to store the value of the $image_id to "speed up"  the function to fix #6017

Fixes #6017

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Open Graph: Avoid slow queries on sites with thousands of images
