### PR TITLE
Holiday Snow: remove settings outside of Holiday Snow period

### DIFF
--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -90,29 +90,32 @@ export const Page = ( props ) => {
 		);
 	} );
 
+	let holidaySnowCard = Initial_State.showHolidaySnow ? (
+		<FoldableCard
+			header={ __( 'Holiday Snow' ) }
+			subheader={ __( 'Show falling snow in the holiday period.' ) }
+			clickableHeaderText={ true }
+			disabled={ ! isAdmin }
+			summary={ isAdmin ? <Settings slug="snow" /> : '' }
+			expandedSummary={ isAdmin ? <Settings slug="snow" /> : '' }
+			onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
+				{
+					card: 'holiday_snow',
+					path: props.route.path
+				}
+			) }
+		>
+			<span className="jp-form-setting-explanation">
+				{ __( 'Show falling snow on my blog from Dec 1st until Jan 4th.' ) }
+			</span>
+		</FoldableCard>
+	) : '';
+
 	return (
 		<div>
 			<QuerySite />
 			{ cards }
-
-			<FoldableCard
-				header={ __( 'Holiday Snow' ) }
-				subheader={ __( 'Show falling snow in the holiday period.' ) }
-				clickableHeaderText={ true }
-				disabled={ ! isAdmin }
-				summary={ isAdmin ? <Settings slug="snow" /> : '' }
-				expandedSummary={ isAdmin ? <Settings slug="snow" /> : '' }
-				onOpen={ () => analytics.tracks.recordEvent( 'jetpack_wpa_settings_card_open',
-					{
-						card: 'holiday_snow',
-						path: props.route.path
-					}
-				) }
-			>
-				<span className="jp-form-setting-explanation">
-					{ __( 'Show falling snow on my blog from Dec 1st until Jan 4th.' ) }
-				</span>
-			</FoldableCard>
+			{ holidaySnowCard }
 		</div>
 	);
 };

--- a/_inc/client/appearance/index.jsx
+++ b/_inc/client/appearance/index.jsx
@@ -23,6 +23,7 @@ import {
 	getModule as _getModule,
 	getModules
 } from 'state/modules';
+import { getShowHolidaySnow } from 'state/settings';
 import { ModuleToggle } from 'components/module-toggle';
 import { AllModuleSettings } from 'components/module-settings/modules-per-tab-page';
 import { isUnavailableInDevMode } from 'state/connection';
@@ -34,7 +35,8 @@ export const Page = ( props ) => {
 		toggleModule,
 		isModuleActivated,
 		isTogglingModule,
-		getModule
+		getModule,
+		showHolidaySnow
 	} = props,
 		isAdmin = props.userCanManageModules,
 		moduleList = Object.keys( props.moduleList );
@@ -90,7 +92,7 @@ export const Page = ( props ) => {
 		);
 	} );
 
-	let holidaySnowCard = Initial_State.showHolidaySnow ? (
+	let holidaySnowCard = showHolidaySnow ? (
 		<FoldableCard
 			header={ __( 'Holiday Snow' ) }
 			subheader={ __( 'Show falling snow in the holiday period.' ) }
@@ -135,7 +137,8 @@ export default connect(
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			isUnavailableInDevMode: ( module_name ) => isUnavailableInDevMode( state, module_name ),
 			userCanManageModules: userCanManageModules( state ),
-			moduleList: getModules( state )
+			moduleList: getModules( state ),
+			showHolidaySnow: getShowHolidaySnow( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -126,3 +126,12 @@ export function toggleSetting( state, name ) {
 export function getSettingName( state, name ) {
 	return get( state.jetpack.initialState.settingNames, [ name ] );
 }
+
+/**
+ * Returns whether or not the Holiday Snow setting should be displayed.
+ * @param  {Object}  state Global state tree
+ * @return {Boolean}       Whether the Holiday Snow setting should be displayed
+ */
+export function getShowHolidaySnow( state ) {
+	return state.jetpack.initialState.showHolidaySnow;
+}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -257,6 +257,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'happinessGravIds' => jetpack_get_happiness_gravatar_ids(),
 			'getModules' => $modules,
 			'showJumpstart' => jetpack_show_jumpstart(),
+			'showHolidaySnow' => function_exists( 'jetpack_show_holiday_snow_option' ) ? jetpack_show_holiday_snow_option() : false,
 			'rawUrl' => Jetpack::build_raw_urls( get_home_url() ),
 			'adminUrl' => esc_url( admin_url() ),
 			'stats' => array(

--- a/modules/holiday-snow.php
+++ b/modules/holiday-snow.php
@@ -116,7 +116,7 @@ function jetpack_show_holiday_snow_option() {
 
 	$today            = time();
 	$first_option_day = mktime( 0, 0, 0, 11, 24 ); // Nov 24
-	$last_option_day  = mktime( 0, 0, 0, 1, 11 );  // Jan 11
+	$last_option_day  = mktime( 0, 0, 0, 1, 4 );   // Jan 4
 
 	return ( $today >= $first_option_day || $today < $last_option_day );
 }

--- a/modules/holiday-snow.php
+++ b/modules/holiday-snow.php
@@ -108,6 +108,19 @@ function jetpack_holiday_snow_option_name() {
 	return apply_filters( 'jetpack_holiday_snow_option_name', 'jetpack_holiday_snow_enabled' );
 }
 
+function jetpack_show_holiday_snow_option() {
+	// Always show snow option if a custom snow season has been set.
+	if ( has_filter( 'jetpack_is_holiday_snow_season' ) ) {
+		return true;
+	}
+
+	$today            = time();
+	$first_option_day = mktime( 0, 0, 0, 11, 24 ); // Nov 24
+	$last_option_day  = mktime( 0, 0, 0, 1, 11 );  // Jan 11
+
+	return ( $today >= $first_option_day || $today < $last_option_day );
+}
+
 function jetpack_is_holiday_snow_season() {
 	$today          = time();
 	$first_snow_day = mktime( 0, 0, 0, 12, 1 );


### PR DESCRIPTION
Fixes #6090, #6065

#### Changes proposed in this Pull Request:

* Only show Holiday Snow options during holiday season
* Options are shown for 1 extra week before and after default Holiday Snow period
* Options are shown all the time if a custom holiday period has been set via the `jetpack_is_holiday_snow_season` filter
* Does not show a holiday snow setting if the holiday-snow module is not loaded.

#### Testing instructions:

* Set server time to November 10, view Jetpack > Settings > Appearance, and see the holiday option disabled
* Set server time to November 11, view Jetpack > Settings > Appearance, and see the holiday option enabled
* Repeat for Jan 10.
* Set a `jetpack_is_holiday_snow_season` filter, and confirm the settings are visible year-round.
* Force the holiday-snow module to not load (see #6065 for instructions), settings are no longer visible.