### PR TITLE
Use the `accessible-focus` library to enable keyboard focus styling

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -11,9 +11,13 @@ import { createHashHistory } from 'history'
 /**
  * Internal dependencies
  */
+import accessibleFocus from 'lib/accessible-focus';
 import store from 'state/redux-store';
 import i18n from 'i18n-calypso';
 import Main from 'main';
+
+// Initialize the accessibile focus to allow styling specifically for keyboard navigation
+accessibleFocus();
 
 Initial_State.locale = JSON.parse( Initial_State.locale );
 
@@ -71,4 +75,3 @@ function render() {
 		container
 	);
 }
-


### PR DESCRIPTION
See https://github.com/Automattic/dops-components/pull/87

dops-components has support for keyboard focus style using a library called `accessible-focus`, which only toggles the focus style when keyboard navigation is used. A handful of components already have this styling built in by default, but it isn't enabled because the accessible-focus library was not initialized. It's a quick accessibility win to turn on this functionality, so here's a PR 😄  

To test:

1. Link up the dops-components PR: https://github.com/Automattic/dops-components/pull/87
2. Build Jetpack
3. Visit your dashboard, and use the keyboard to navigate through items. You should see a border around each item you land on, for example:

![screen shot 2017-02-06 at 12 08 48 pm](https://cloud.githubusercontent.com/assets/541093/22657771/a8d40ee4-ec65-11e6-8b3a-a7f6bf459c0b.png)

You can verify that this only applied to keyboard nav by clicking on the items.