### PR TITLE
Fix: Use the site_icon id instead of the url

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -351,7 +351,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 		$img_width  = '';
 		$img_height = '';
-		$image_id = attachment_url_to_postid( $image_url );
+		$image_id = get_option( 'site_icon' );
 		$image_size = wp_get_attachment_image_src( $image_id, $max_side >= 512
 			? 'full'
 			: array( $max_side, $max_side ) );


### PR DESCRIPTION
When $image_url is set to a photon image we are not able to deremine
the $image_id. Instead we should use the option that stores the ID
instead.

This fixes the issue when we show the default image instead of the
site icon as the open graph main image. When photon is enabled and the
site icon is set.

Before:
![image](https://cloud.githubusercontent.com/assets/115071/22659335/2011ec38-ec52-11e6-8735-304dcd6a363b.png)

After:
![screen shot 2017-02-06 at 09 54 00](https://cloud.githubusercontent.com/assets/115071/22659371/3d4daecc-ec52-11e6-8d70-ef643be77a90.png)


