### PR TITLE
Fix WooCommerce Services JITM Stats

### DIFF
--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -73,6 +73,9 @@ class WC_Services_Installer {
 	 * @return bool result of installation/activation
 	 */
 	private function install() {
+		$jetpack = Jetpack::init();
+		$jetpack->stat( 'jitm', 'wooservices-activated-' . JETPACK__VERSION );
+
 		include_once( ABSPATH . '/wp-admin/includes/admin.php' );
 		include_once( ABSPATH . '/wp-admin/includes/plugin-install.php' );
 		include_once( ABSPATH . '/wp-admin/includes/plugin.php' );

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -7,6 +7,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Services_Installer {
 
 	/**
+	 * @var Jetpack
+	 **/
+	private $jetpack;
+
+	/**
 	 * @var WC_Services_Installer
 	 **/
 	private static $instance = null;
@@ -19,6 +24,8 @@ class WC_Services_Installer {
 	}
 
 	public function __construct() {
+		$this->jetpack = Jetpack::init();
+
 		add_action( 'admin_init', array( $this, 'add_error_notice' ) );
 		add_action( 'admin_init', array( $this, 'try_install' ) );
 	}
@@ -39,6 +46,8 @@ class WC_Services_Installer {
 
 			if ( false === $result ) {
 				$redirect = add_query_arg( 'wc-services-install-error', true, $redirect );
+			} else {
+				$this->jetpack->stat( 'jitm', 'wooservices-activated-' . JETPACK__VERSION );
 			}
 
 			wp_safe_redirect( $redirect );
@@ -73,8 +82,7 @@ class WC_Services_Installer {
 	 * @return bool result of installation/activation
 	 */
 	private function install() {
-		$jetpack = Jetpack::init();
-		$jetpack->stat( 'jitm', 'wooservices-activated-' . JETPACK__VERSION );
+		$this->jetpack->stat( 'jitm', 'wooservices-install-' . JETPACK__VERSION );
 
 		include_once( ABSPATH . '/wp-admin/includes/admin.php' );
 		include_once( ABSPATH . '/wp-admin/includes/plugin-install.php' );

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -471,7 +471,7 @@ class Jetpack_JITM {
 				<?php echo esc_html( $message ); ?>
 			</p>
 			<p>
-				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
+				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" class="button button-jetpack show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
 			</p>
 		</div>
 		<?php

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -461,7 +461,7 @@ class Jetpack_JITM {
 
 		?>
 		<div class="jp-jitm woo-jitm">
-			<a href="#"  data-module="woocommerce_services" class="dismiss"><span class="genericon genericon-close"></span></a>
+			<a href="#"  data-module="wooservices" class="dismiss"><span class="genericon genericon-close"></span></a>
 			<div class="jp-emblem">
 				<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
 					<path d="M18,8h-2V7c0-1.105-0.895-2-2-2H4C2.895,5,2,5.895,2,7v10h2c0,1.657,1.343,3,3,3s3-1.343,3-3h4c0,1.657,1.343,3,3,3s3-1.343,3-3h2v-5L18,8z M7,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S7.828,18.5,7,18.5z M4,14V7h10v7H4z M17,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S17.828,18.5,17,18.5z" />
@@ -471,13 +471,13 @@ class Jetpack_JITM {
 				<?php echo esc_html( $message ); ?>
 			</p>
 			<p>
-				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="woocommerce_services" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
+				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" class="button button-jetpack launch show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
 			</p>
 		</div>
 		<?php
 		//jitm is being viewed, track it
 		$jetpack = Jetpack::init();
-		$jetpack->stat( 'jitm', 'woocommerce_services-viewed-' . JETPACK__VERSION );
+		$jetpack->stat( 'jitm', 'wooservices-viewed-' . JETPACK__VERSION );
 	}
 
 	/*


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Rename `woocommerce_services` MC stat to `wooservices` (was hitting char limit)
* Don't bump activation stat as `launch` type, record as module activation

#### Testing instructions:

* Verify that view, dismissal, and activation stats are bumped using the `wooservices` group, and that `jitmActionToTake` is not `launch` for WooCommerce Services.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
