### PR TITLE
Add a build script to be used in automated builds.

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -4,6 +4,9 @@
 .jshintrc
 .jshintignore
 .travis.yml
+.npmrc
+.nvmrc
+.eslintrc
 readme.md
 .github
 phpunit.xml.dist

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "distclean": "rm -rf node_modules && yarn cache clean",
     "build": "yarn && yarn build-client",
     "build-client": "gulp",
-    "build-production": "yarn clean-client && yarn build-languages && gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build",
+    "build-production": "yarn clean-client && gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build",
     "build-languages": "gulp languages",
     "lint": "eslint _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -12,16 +12,20 @@ OPTIND=1         # Reset in case getopts has been used previously in the shell.
 
 # Initialize our own variables:
 CLEANUP=0
+ADD_BETA_VERSION=0
 
-while getopts "d" opt; do
+while getopts "db" opt; do
     case "$opt" in
     d)  CLEANUP=1
+        ;;
+    b)  ADD_BETA_VERSION=1
         ;;
     esac
 done
 
 shift $((OPTIND-1))
 
+GET_VERSION_SCRIPT="`pwd`/tools/get-version.sh"
 TARGET_BRANCH=${1:-master}
 TARGET_DIR=${2:-"/tmp/jetpack"}
 
@@ -33,9 +37,21 @@ if [[ $CLEANUP -eq 1 ]]; then
     echo "Done!"
 fi
 
-git clone --branch $TARGET_BRANCH --depth 1 git@github.com:Automattic/jetpack.git $TARGET_DIR
+git clone \
+    --branch $TARGET_BRANCH \
+    --depth 1000 \
+    https://github.com/Automattic/jetpack.git \
+    $TARGET_DIR
 
 cd $TARGET_DIR
+
+if [[ $ADD_BETA_VERSION -eq 1 ]]; then
+    echo "Changing version of the Jetpack to reflect the latest changes.."
+    CURRENT_VERSION="`$GET_VERSION_SCRIPT`"
+
+    sed -i -e 's/Version: .*$/Version: '$CURRENT_VERSION'/' jetpack.php
+    echo "Now at version $CURRENT_VERSION!"
+fi
 
 yarn
 yarn build-production

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+RED='\033[0;31m'
+trap 'exit_build' ERR
+
+function exit_build {
+    echo -e "${RED}Something went wrong and the build has stopped.  See error above for more details."
+    exit 1
+}
+
+# A POSIX variable
+OPTIND=1         # Reset in case getopts has been used previously in the shell.
+
+# Initialize our own variables:
+CLEANUP=0
+
+while getopts "d" opt; do
+    case "$opt" in
+    d)  CLEANUP=1
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+TARGET_BRANCH=${1:-master}
+TARGET_DIR=${2:-"/tmp/jetpack"}
+
+[ "$1" = "--" ] && shift
+
+if [[ $CLEANUP -eq 1 ]]; then
+    echo "Cleaning up existing paths.."
+    rm -rf $TARGET_DIR
+    echo "Done!"
+fi
+
+git clone --branch $TARGET_BRANCH --depth 1 git@github.com:Automattic/jetpack.git $TARGET_DIR
+
+cd $TARGET_DIR
+
+yarn
+yarn build
+
+echo "Purging paths included in .svnignore, .gitignore and .git itself"
+# check .git
+for file in $( cat "$TARGET_DIR/.gitignore" | grep -v '#' 2>/dev/null ); do
+    rm -rf $TARGET_DIR/$file
+done
+# check .svnignore
+for file in $( cat "$TARGET_DIR/.svnignore" 2>/dev/null ); do
+    rm -rf $TARGET_DIR/$file
+done
+echo "Done!"
+

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -50,6 +50,7 @@ if [[ $ADD_BETA_VERSION -eq 1 ]]; then
     CURRENT_VERSION="`$GET_VERSION_SCRIPT`"
 
     sed -i -e 's/Version: .*$/Version: '$CURRENT_VERSION'/' jetpack.php
+    echo $CURRENT_VERSION > version.txt
     echo "Now at version $CURRENT_VERSION!"
 fi
 
@@ -57,10 +58,6 @@ yarn --modules-folder=$TARGET_DIR/node_modules
 NODE_ENV=production BABEL_ENV=production $TARGET_DIR/node_modules/.bin/gulp
 
 echo "Purging paths included in .svnignore, .gitignore and .git itself"
-# check .git
-for file in $( cat "$TARGET_DIR/.gitignore" | grep -v '#' 2>/dev/null ); do
-    rm -rf $TARGET_DIR/$file
-done
 # check .svnignore
 for file in $( cat "$TARGET_DIR/.svnignore" 2>/dev/null ); do
     rm -rf $TARGET_DIR/$file

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -27,7 +27,8 @@ shift $((OPTIND-1))
 
 GET_VERSION_SCRIPT="`pwd`/tools/get-version.sh"
 TARGET_BRANCH=${1:-master}
-TARGET_DIR=${2:-"/tmp/jetpack"}
+TARGET_REPO=${2:-"Automattic/jetpack"}
+TARGET_DIR=${3:-"/tmp/jetpack"}
 
 [ "$1" = "--" ] && shift
 
@@ -40,7 +41,7 @@ fi
 git clone \
     --branch $TARGET_BRANCH \
     --depth 1000 \
-    https://github.com/Automattic/jetpack.git \
+    git://github.com/$TARGET_REPO.git \
     $TARGET_DIR
 
 cd $TARGET_DIR

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -38,7 +38,7 @@ git clone --branch $TARGET_BRANCH --depth 1 git@github.com:Automattic/jetpack.gi
 cd $TARGET_DIR
 
 yarn
-yarn build
+yarn build-production
 
 echo "Purging paths included in .svnignore, .gitignore and .git itself"
 # check .git

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -53,8 +53,8 @@ if [[ $ADD_BETA_VERSION -eq 1 ]]; then
     echo "Now at version $CURRENT_VERSION!"
 fi
 
-yarn
-yarn build-production
+yarn --modules-folder=$TARGET_DIR/node_modules
+NODE_ENV=production BABEL_ENV=production $TARGET_DIR/node_modules/.bin/gulp
 
 echo "Purging paths included in .svnignore, .gitignore and .git itself"
 # check .git

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -68,6 +68,9 @@ NODE_ENV=production BABEL_ENV=production $TARGET_DIR/node_modules/.bin/gulp
 echo "Purging paths included in .svnignore, .gitignore and .git itself"
 # check .svnignore
 for file in $( cat "$TARGET_DIR/.svnignore" 2>/dev/null ); do
+    if [[ $file == "to-test.md" ]]; then
+        continue
+    fi
     rm -rf $TARGET_DIR/$file
 done
 echo "Done!"

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -55,6 +55,13 @@ if [[ $ADD_BETA_VERSION -eq 1 ]]; then
     echo "Now at version $CURRENT_VERSION!"
 fi
 
+# Checking for yarn
+hash yarn 2>/dev/null || {
+    echo >&2 "This script requires you to have yarn package manager installed."
+    echo >&2 "Please install it following the instructions on https://yarnpkg.com. Aborting.";
+    exit 1;
+}
+
 yarn --modules-folder=$TARGET_DIR/node_modules
 NODE_ENV=production BABEL_ENV=production $TARGET_DIR/node_modules/.bin/gulp
 

--- a/tools/get-version.sh
+++ b/tools/get-version.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Retrieving the version from jetpack.php file
+PHP_VERSION=`cat jetpack.php | grep '* Version' | cut -d ':' -f2`
+
+# Getting a github prefix
+CLOSEST_TAG=`git describe --tags --abbrev=0`
+
+# Getting a git full version with the prefix and stripping away the prefix
+GIT_SUFFIX=$(git describe --tags | awk -F "$CLOSEST_TAG" '{ print $2; }')
+
+echo $PHP_VERSION$GIT_SUFFIX

--- a/tools/get-version.sh
+++ b/tools/get-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Retrieving the version from jetpack.php file
-PHP_VERSION=`cat jetpack.php | grep '* Version' | cut -d ':' -f2`
+PHP_VERSION=`head -15 jetpack.php | grep '* Version' | cut -d ':' -f2`
 
 # Getting a github prefix
 CLOSEST_TAG=`git describe --tags --abbrev=0`


### PR DESCRIPTION
This PR adds a script that we run to build PRs.

## To test ##
- [ ] Try running the build script from the Jetpack root dir: `./tools/build-jetpack.sh`. You should get a built ready to check in with SVN or uploaded to WordPress plugin folder in `/tmp/jetpack`.
- [ ] You can specify a target branch with the first parameter: `./tools/build-jetpack.sh branch-4.6`
- [ ] You can use the second parameter to specify a repository instead of the default choice: `./tools/build-jetpack.sh branch-4.6 zinigor/jetpack`
- [ ] You can select the output directory using the third parameter: `./tools/build-jetpack.sh branch-4.6 zinigor/jetpack ~/built-jetpack`
- [ ] In case the target directory is not empty, you can use the `-d` switch to clean it up first: `./tools/build-jetpack.sh -d branch-4.6 zinigor/jetpack ~/built-jetpack`
