### PR TITLE
Infinite Scroll: When we're displaying the last page, don't display both footers.

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -300,12 +300,22 @@ class The_Neverending_Home_Page {
 	 * Is this guaranteed to be the last batch of posts?
 	 */
 	static function is_last_batch() {
-		$post_type = get_post_type();
-		$entries = wp_count_posts( empty( $post_type ) ? 'post' : $post_type )->publish;
-		if ( self::wp_query()->get( 'paged' ) && self::wp_query()->get( 'paged' ) > 1 ) {
-			$entries -= self::get_settings()->posts_per_page * self::wp_query()->get( 'paged' );
+		$entries = (int) self::wp_query()->found_posts;
+		$posts_per_page = self::get_settings()->posts_per_page;
+		$paged = self::wp_query()->get( 'paged' );
+
+		// Are there enough posts for more than the first page?
+		if ( $entries <= $posts_per_page ) {
+			return true;
 		}
-		return $entries <= self::get_settings()->posts_per_page;
+
+		// Calculate entries left after a certain number of pages
+		if ( $paged && $paged > 1 ) {
+			$entries -= $posts_per_page * $paged;
+		}
+
+		// Are there some entries left to display?
+		return $entries <= 0;
 	}
 
 	/**

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1429,6 +1429,10 @@ class The_Neverending_Home_Page {
 		if ( 'scroll' != self::get_settings()->type || ! self::archive_supports_infinity() )
 			return;
 
+		if ( self::is_last_batch() ) {
+			return;
+		}
+
 		// Display a footer, either user-specified or a default
 		if ( false !== self::get_settings()->footer_callback && is_callable( self::get_settings()->footer_callback ) )
 			call_user_func( self::get_settings()->footer_callback, self::get_settings() );


### PR DESCRIPTION
When we're displaying the last page, don't display both footers.

Fixes #5268
Fixes #5267
Fixes #282
Fixes #5550

Fixes #4345-wpcom-themes
Reviewed at D4291 in Phabricator

Merges r150547-wpcom.