### PR TITLE
Adds vscode dir to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /node_modules
 /vendor/
 /wpcom-test-backup/
+/.vscode/
 
 
 ## FILES


### PR DESCRIPTION
Visual Studio Code can store per-project settings in a .vscode folder;
this updates .gitignore to ignore that, since it shouldn't be checked
in.