### PR TITLE
Comments: fix validation errors

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -3,7 +3,7 @@
 require dirname( __FILE__ ) . '/base.php';
 
 /**
- * Main Jetpack Comments class
+ * Main Comments class
  *
  * @package JetpackComments
  * @version 1.4
@@ -17,20 +17,20 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * Possible comment form sources
 	 * @var array
 	 */
-	var $id_sources = array();
+	public $id_sources = array();
 
 	/**
 	 * URL
 	 * @var string
 	 */
-	var $signed_url = '';
+	public $signed_url = '';
 
 	/**
 	 * The default comment form color scheme
 	 * @var string
 	 * @see ::set_default_color_theme_based_on_theme_settings()
 	 */
-	var $default_color_scheme =  'light';
+	public $default_color_scheme =  'light';
 
 	/** Methods ***************************************************************/
 
@@ -45,14 +45,14 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	}
 
 	/**
-	 * Main constructor for Jetpack Comments
+	 * Main constructor for Comments
 	 *
 	 * @since JetpackComments (1.4)
 	 */
 	public function __construct() {
 		parent::__construct();
 
-		// Jetpack Comments is loaded
+		// Comments is loaded
 
 		/**
 		 * Fires after the Jetpack_Comments object has been instantiated

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -291,17 +291,16 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		<div id="respond" class="comment-respond">
 			<h3 id="reply-title" class="comment-reply-title"><?php comment_form_title( esc_html( $params['greeting'] ), esc_html( $params['greeting_reply'] ) ); ?> <small><?php cancel_comment_reply_link( esc_html__( 'Cancel reply' , 'jetpack') ); ?></small></h3>
 			<form id="commentform" class="comment-form">
-				<iframe src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0; overflow:hidden;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment"></iframe>			
+				<iframe src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment"></iframe>
 				<!--[if !IE]><!-->
 				<script>
-				r(function(){
-					//document.getElementById("jetpack_remote_comment").allowTransparency = <?php echo $transparent; ?>;
-					var comment_form_elements = document.getElementsByClassName("jetpack_remote_comment");
-					for (var i = 0; i < comment_form_elements.length; i++) {
-					    comment_form_elements[i].allowTransparency = <?php echo $transparent; ?>;
-					}
-				});
-				function r(f){/in/.test(document.readyState)?setTimeout('r('+f+')',9):f()}
+					document.addEventListener( 'DOMContentLoaded', function () {
+						var commentForms = document.getElementsByClassName( 'jetpack_remote_comment' );
+						for ( var i = 0; i < commentForms.length; i++ ) {
+							commentForms[i].allowTransparency = <?php echo $transparent; ?>;
+							commentForms[i].scrolling = 'no';
+						}
+					} );
 				</script>
 				<!--<![endif]-->
 			</form>
@@ -322,6 +321,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	public function watch_comment_parent() {
 		$url_origin = 'https://jetpack.wordpress.com';
 	?>
+
 		<!--[if IE]>
 		<script type="text/javascript">
 		if ( 0 === window.location.hash.indexOf( '#comment-' ) ) {

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -291,11 +291,15 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		<div id="respond" class="comment-respond">
 			<h3 id="reply-title" class="comment-reply-title"><?php comment_form_title( esc_html( $params['greeting'] ), esc_html( $params['greeting_reply'] ) ); ?> <small><?php cancel_comment_reply_link( esc_html__( 'Cancel reply' , 'jetpack') ); ?></small></h3>
 			<form id="commentform" class="comment-form">
-				<iframe src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0; overflow:hidden;" name="jetpack_remote_comment" id="jetpack_remote_comment"></iframe>			
+				<iframe src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0; overflow:hidden;" name="jetpack_remote_comment" class="jetpack_remote_comment" id="jetpack_remote_comment"></iframe>			
 				<!--[if !IE]><!-->
 				<script>
 				r(function(){
-					document.getElementById("jetpack_remote_comment").allowTransparency = <?php echo $transparent; ?>;
+					//document.getElementById("jetpack_remote_comment").allowTransparency = <?php echo $transparent; ?>;
+					var comment_form_elements = document.getElementsByClassName("jetpack_remote_comment");
+					for (var i = 0; i < comment_form_elements.length; i++) {
+					    comment_form_elements[i].allowTransparency = <?php echo $transparent; ?>;
+					}
 				});
 				function r(f){/in/.test(document.readyState)?setTimeout('r('+f+')',9):f()}
 				</script>

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -3,7 +3,7 @@
 require dirname( __FILE__ ) . '/base.php';
 
 /**
- * Main Comments class
+ * Main Jetpack Comments class
  *
  * @package JetpackComments
  * @version 1.4
@@ -17,20 +17,20 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * Possible comment form sources
 	 * @var array
 	 */
-	public $id_sources = array();
+	var $id_sources = array();
 
 	/**
 	 * URL
 	 * @var string
 	 */
-	public $signed_url = '';
+	var $signed_url = '';
 
 	/**
 	 * The default comment form color scheme
 	 * @var string
 	 * @see ::set_default_color_theme_based_on_theme_settings()
 	 */
-	public $default_color_scheme =  'light';
+	var $default_color_scheme =  'light';
 
 	/** Methods ***************************************************************/
 
@@ -45,14 +45,14 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	}
 
 	/**
-	 * Main constructor for Comments
+	 * Main constructor for Jetpack Comments
 	 *
 	 * @since JetpackComments (1.4)
 	 */
 	public function __construct() {
 		parent::__construct();
 
-		// Comments is loaded
+		// Jetpack Comments is loaded
 
 		/**
 		 * Fires after the Jetpack_Comments object has been instantiated
@@ -291,7 +291,15 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		<div id="respond" class="comment-respond">
 			<h3 id="reply-title" class="comment-reply-title"><?php comment_form_title( esc_html( $params['greeting'] ), esc_html( $params['greeting_reply'] ) ); ?> <small><?php cancel_comment_reply_link( esc_html__( 'Cancel reply' , 'jetpack') ); ?></small></h3>
 			<form id="commentform" class="comment-form">
-				<iframe src="<?php echo esc_url( $url ); ?>" allowtransparency="<?php echo $transparent; ?>" style="width:100%; height: <?php echo $height; ?>px;border:0;" frameBorder="0" scrolling="no" name="jetpack_remote_comment" id="jetpack_remote_comment"></iframe>
+				<iframe src="<?php echo esc_url( $url ); ?>" style="width:100%; height: <?php echo $height; ?>px; border:0; overflow:hidden;" name="jetpack_remote_comment" id="jetpack_remote_comment"></iframe>			
+				<!--[if !IE]><!-->
+				<script>
+				r(function(){
+					document.getElementById("jetpack_remote_comment").allowTransparency = <?php echo $transparent; ?>;
+				});
+				function r(f){/in/.test(document.readyState)?setTimeout('r('+f+')',9):f()}
+				</script>
+				<!--<![endif]-->
 			</form>
 		</div>
 
@@ -310,7 +318,6 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	public function watch_comment_parent() {
 		$url_origin = 'https://jetpack.wordpress.com';
 	?>
-
 		<!--[if IE]>
 		<script type="text/javascript">
 		if ( 0 === window.location.hash.indexOf( '#comment-' ) ) {


### PR DESCRIPTION
Follow up of #2683

> Fixes the issue reported here. https://wordpress.org/support/topic/please-fix-w3-validation-errors?replies=1&view=all

props @shahthepro

#### Changes proposed in this Pull Request:
* apply properties that are no longer valid in HTML 5 using JavaScript.

#### Testing instructions:
* Test the Comments form. It should look and behave the same before and after this PR.
* Feel free to check validation if you want, but with `allowTransparency`, `frameborder` and `scrolling` removed, this validates well (at least what is the scope of this PR).

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Comments: fix W3 validation errors regarding `allowTransparency`, `frameborder` and `scrolling`.