### PR TITLE
AT: Add jetpack_sync_send_data_query_args

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -137,6 +137,8 @@ class Jetpack_Sync_Actions {
 
 		$query_args['timeout'] = Jetpack_Sync_Settings::is_doing_cron() ? 30 : 15;
 
+		$query_args = apply_filters( 'jetpack_sync_send_data_query_args', $query_args );
+
 		$url = add_query_arg( $query_args, Jetpack::xmlrpc_api_url() );
 
 		$rpc = new Jetpack_IXR_Client( array(

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -137,6 +137,13 @@ class Jetpack_Sync_Actions {
 
 		$query_args['timeout'] = Jetpack_Sync_Settings::is_doing_cron() ? 30 : 15;
 
+		/**
+		 * Filters query parameters appended to the Sync request URL sent to WordPress.com
+		 *
+		 * @since 4.7.0
+		 *
+		 * @param array associative array of query parameters
+		 */
 		$query_args = apply_filters( 'jetpack_sync_send_data_query_args', $query_args );
 
 		$url = add_query_arg( $query_args, Jetpack::xmlrpc_api_url() );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -52,7 +52,7 @@ class Jetpack_Sync_Actions {
 		if ( apply_filters( 'jetpack_sync_listener_should_load', true ) ) {
 			self::initialize_listener();
 		}
-		
+
 		add_action( 'init', array( __CLASS__, 'add_sender_shutdown' ), 90 );
 
 	}
@@ -138,11 +138,11 @@ class Jetpack_Sync_Actions {
 		$query_args['timeout'] = Jetpack_Sync_Settings::is_doing_cron() ? 30 : 15;
 
 		/**
-		 * Filters query parameters appended to the Sync request URL sent to WordPress.com
+		 * Filters query parameters appended to the Sync request URL sent to WordPress.com.
 		 *
 		 * @since 4.7.0
 		 *
-		 * @param array associative array of query parameters
+		 * @param array $query_args associative array of query parameters.
 		 */
 		$query_args = apply_filters( 'jetpack_sync_send_data_query_args', $query_args );
 


### PR DESCRIPTION
Adds a filter for query_args in `Jetpack_Sync_Actions::send_data`
We need this filter for changing timeout property while fast-Syncing big sites.

This is not a priority, we don't use it now, but our current solution is clunky.

CC @gravityrail @lamosty 