### PR TITLE
Remove PHP error on uninstall, by making sure that jetpack includes all the required files.

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -3,6 +3,7 @@
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-queue.php';
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-modules.php';
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-actions.php';
 
 /**
  * This class monitors actions and logs them to the queue to be sent


### PR DESCRIPTION
Fixes the following error: 
```
PHP Fatal error:  Uncaught Error: Class 'Jetpack_Sync_Actions' not found in /srv/www/wordpress-default/wp-content/plugins/jetpack/sync/class.jetpack-sync-listener.php:208
Stack trace:
#0 /srv/www/wordpress-default/wp-content/plugins/jetpack/sync/class.jetpack-sync-listener.php(115): Jetpack_Sync_Listener->enqueue_action('deleted_plugin', Array, Object(Jetpack_Sync_Queue))
#1 /srv/www/wordpress-default/wp-includes/class-wp-hook.php(298): Jetpack_Sync_Listener->action_handler('jetpack/jetpack...', true)
#2 /srv/www/wordpress-default/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters('', Array)
#3 /srv/www/wordpress-default/wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#4 /srv/www/wordpress-default/wp-admin/includes/plugin.php(865): do_action('deleted_plugin', 'jetpack/jetpack...', true)
#5 /srv/www/wordpress-default/wp-admin/includes/ajax-actions.php(3806): delete_plugins(Array)
#6 /srv/www/wordpress-default/wp-includes/class-wp-hook.php(298): wp_ajax_delete_plugin('')
#7 /srv/www/wordpress-default/wp-includes/c in /srv/www/wordpress-default/wp-content/plugins/jetpack/sync/class.jetpack-sync-listener.php on line 208
```
#### Testing instructions:
Uninstalling jetpack produced no errors. 
