### PR TITLE
Fix bug where wrong xmlrpc url was being sent to Jetpack Debugger

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -163,7 +163,7 @@ class Jetpack_Debugger {
 		$tests['IDENTITY_CRISIS']['result'] = $identity_crisis;
 		$tests['IDENTITY_CRISIS']['fail_message'] = esc_html__( 'Something has gotten mixed up in your Jetpack Connection!', 'jetpack' );
 
-		$self_xml_rpc_url = home_url( 'xmlrpc.php' );
+		$self_xml_rpc_url = site_url( 'xmlrpc.php' );
 
 		$testsite_url = Jetpack::fix_url_for_bad_hosts( JETPACK__API_BASE . 'testsite/1/?url=' );
 


### PR DESCRIPTION
This change fixes an issue where the Jetpack Debugger would report a broken connection if you had a custom Site Address that is different from the WordPress Address.

To reproduce:

- Head to the "general settings" page and add a path component to the "Site Address (URL)" field, e.g. `http://example.com/home`
- Go to the Jetpack Debugger page at /wp-admin/admin.php?page=jetpack-debugger

What happens:

- Error due to "site connection" being broken

What should happen:

- Everything is fine