### PR TITLE
Only disable Related Posts if it's possible to re-enable it

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1397,7 +1397,7 @@ EOT;
 			&&
 				! is_admin()
 			&&
-				( $this->_allow_feature_toggle() && $this->get_option( 'enabled' ) );
+				( !$this->_allow_feature_toggle() || $this->get_option( 'enabled' ) );
 
 		/**
 		 * Filter the Enabled value to allow related posts to be shown on pages as well.

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -293,6 +293,16 @@ EOT;
 
 		return $this->_options;
 	}
+	
+	public function get_option( $option_name ) {
+		$options = $this->get_options();
+		
+		if ( isset( $options[ $option_name ] ) ) {
+			return $options[ $option_name ];
+		}
+		
+		return false;
+	}
 
 	/**
 	 * Parses input and returns normalized options array.
@@ -1383,24 +1393,11 @@ EOT;
 	 * @return bool
 	 */
 	protected function _enabled_for_request() {
-		// Default to enabled
-		$enabled = true;
-
-		// Must have feature enabled
-		$options = $this->get_options();
-		if ( ! $options['enabled'] ) {
-			$enabled = false;
-		}
-
-		// Only run for frontend pages
-		if ( is_admin() ) {
-			$enabled = false;
-		}
-
-		// Only run for standalone posts
-		if ( ! is_single() ) {
-			$enabled = false;
-		}
+		$enabled = is_single() 
+			&&
+				! is_admin()
+			&&
+				( $this->_allow_feature_toggle() && $this->get_option( 'enabled' ) );
 
 		/**
 		 * Filter the Enabled value to allow related posts to be shown on pages as well.

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -317,7 +317,17 @@ EOT;
 		if ( !is_array( $input ) )
 			$input = array();
 
-		if ( isset( $input['enabled'] ) && '1' == $input['enabled'] ) {
+		if (
+			! isset( $input['enabled'] )
+			|| isset( $input['show_date'] )
+			|| isset( $input['show_context'] )
+			|| isset( $input['layout'] )
+			|| isset( $input['headline'] )
+			) {
+			$input['enabled'] = '1';
+		}
+
+		if ( '1' == $input['enabled'] ) {
 			$current['enabled'] = true;
 			$current['show_headline'] = ( isset( $input['show_headline'] ) && '1' == $input['show_headline'] );
 			$current['show_thumbnails'] = ( isset( $input['show_thumbnails'] ) && '1' == $input['show_thumbnails'] );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -40,6 +40,9 @@
 		<testsuite name="publicize">
 			<directory prefix="test_" suffix=".php">tests/php/modules/publicize</directory>
 		</testsuite>
+		<testsuite name="related-posts">
+			<directory prefix="test_" suffix=".php">tests/php/modules/related-posts</directory>
+		</testsuite>
 		<testsuite name="sharedaddy">
 			<directory prefix="test_" suffix=".php">tests/php/modules/sharedaddy</directory>
 		</testsuite>

--- a/tests/php/modules/related-posts/test_class_related_posts.php
+++ b/tests/php/modules/related-posts/test_class_related_posts.php
@@ -1,0 +1,106 @@
+<?php
+
+require dirname( __FILE__ ) . '/../../../../modules/related-posts.php';
+
+class WP_Test_Jetpack_RelatedPosts extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		Jetpack_RelatedPosts_Module::instance()->action_on_load();
+		add_filter( 'jetpack_relatedposts_filter_options', '__return_null' );
+	}
+
+	/**
+	 * Verify that 'enabled' remains the same if it's true.
+	 *
+	 * @since  4.7.0
+	 */
+	public function test_options_ok() {
+		$options = $options_after_parse = array(
+			'enabled'         => true,
+			'show_headline'   => true,
+			'show_thumbnails' => true,
+			'show_date'       => true,
+			'show_context'    => true,
+			'layout'          => 'grid',
+			'headline'        => 'Related',
+			'size'            => null,
+		);
+
+		$this->assertEquals( $options_after_parse, Jetpack_RelatedPosts::init()->parse_options( $options ) );
+	}
+
+	/**
+	 * Verify that if 'enabled' is somehow not passed to saving request, it's set to true.
+	 *
+	 * @since  4.7.0
+	 */
+	public function test_options_enabled_true_if_not_set() {
+		$options = $options_after_parse = array(
+			// The option 'enabled' isn't passed if it's saved in Customizer
+			'show_headline'   => true,
+			'show_thumbnails' => true,
+			'show_date'       => true,
+			'show_context'    => true,
+			'layout'          => 'grid',
+			'headline'        => 'Related',
+			'size'            => null,
+		);
+
+		// Must be true after saving in Customizer
+		$options_after_parse['enabled'] = true;
+
+		$this->assertEquals( $options_after_parse, Jetpack_RelatedPosts::init()->parse_options( $options ) );
+	}
+
+	/**
+	 * Verify that 'enabled' is set to true if one of the keys saved by Customizer are passed.
+	 *
+	 * @since  4.7.0
+	 */
+	public function test_options_enabled_false_if_has_customizer_key() {
+		$options_after_parse = array(
+			'enabled'         => true,
+			'show_headline'   => false,
+			'show_thumbnails' => false,
+			'show_date'       => true,
+			'show_context'    => false,
+			'layout'          => 'grid',
+			'headline'        => 'Related',
+			'size'            => null,
+		);
+
+		$this->assertEquals( $options_after_parse, Jetpack_RelatedPosts::init()->parse_options( array(
+			'enabled'   => false,
+			'show_date' => true,
+		) ) );
+
+		$options_after_parse['show_date'] = false;
+		$this->assertEquals( $options_after_parse, Jetpack_RelatedPosts::init()->parse_options( array(
+			'show_date' => false,
+		) ) );
+	}
+
+	/**
+	 * Verify that 'enabled' can be saved as false if it's explicitly set to false.
+	 *
+	 * @since  4.7.0
+	 */
+	public function test_options_enabled_false_if_not_customizer_key() {
+		$options = $options_after_parse = array(
+			'enabled'         => false, // set to false
+			'show_headline'   => true,
+			'show_thumbnails' => true,
+			'size'            => null,
+		);
+
+		// When enabled is false, the other options are cleared.
+		$empty_options = array(
+			'enabled' => false,
+			'size'    => null,
+		);
+
+		$this->assertEquals( $empty_options, Jetpack_RelatedPosts::init()->parse_options( $options ) );
+	}
+}


### PR DESCRIPTION
Fixes #6323

#### Changes proposed in this Pull Request:

* Only respect "enabled" flag of `jetpack_relatedposts` option if the ability to actually change it is enabled.

#### Testing instructions:

* On a fresh install (or with freshly-deleted jetpack_relatedposts options), enable the Related Posts module
* Go into the customizer and edit Related Posts settings (e.g. disable show date)
* Save
* This will trigger a bug which disables Related Posts
* However, they should still appear since the "toggle UI" is not enabled via the `jetpack_relatedposts_filter_allow_feature_toggle` filter

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Always enables Related Posts unless disabled by filter or toggle UI is enabled.