### PR TITLE
Related Posts: bring jetpack_sharing_headline_html back.

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -154,7 +154,8 @@ class Jetpack_RelatedPosts {
 
 		if ( $options['show_headline'] ) {
 			$headline = sprintf(
-				'<h3 class="jp-relatedposts-headline"><em>%s</em></h3>',
+				/** This filter is already documented in modules/sharedaddy/sharing-service.php */
+				apply_filters( 'jetpack_sharing_headline_html', '<h3 class="jp-relatedposts-headline"><em>%s</em></h3>', esc_html( $options['headline'] ), 'related-posts' ),
 				esc_html( $options['headline'] )
 			);
 		} else {


### PR DESCRIPTION
It was removed by mistake in edbc449bca266b4ff4d63f658aed5b97409fe1ab

