### PR TITLE
Widgets - Top Posts: use the WP.com REST API endpoint

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -17,7 +17,7 @@ function jetpack_top_posts_widget_init() {
 	if (
 		( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM )
 	&&
-		! function_exists( 'stats_get_csv' )
+		! function_exists( 'stats_get_from_restapi' )
 	) {
 		return;
 	}
@@ -488,12 +488,14 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			$days = 2;
 		}
 
-		$post_view_posts = stats_get_csv( 'postviews', array( 'days' => absint( $days ), 'limit' => 11 ) );
-		if ( ! $post_view_posts ) {
+		$post_view_posts = stats_get_from_restapi( array(), 'top-posts?max=11&summarize=1&num=' . absint( $days ) );
+
+		if ( ! isset( $post_view_posts->summary ) || empty( $post_view_posts->summary->postviews ) ) {
 			return array();
 		}
 
-		$post_view_ids = array_filter( wp_list_pluck( $post_view_posts, 'post_id' ) );
+		$post_view_ids = array_filter( wp_list_pluck( $post_view_posts->summary->postviews, 'id' ) );
+
 		if ( ! $post_view_ids ) {
 			return array();
 		}


### PR DESCRIPTION
Fixes #2196

#### Changes proposed in this Pull Request:
* stop fetching a CSV with posts stats and use the `/sites/%site%/stats/top-posts` endpoint in wpcom.

#### Testing instructions:
* add the widget, it should correctly display the top posts

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Widgets: the Top Posts widget now uses an endpoint from WP.com REST API which allows better performance and is more flexible for future updates.