### PR TITLE
Remove unused JS logic in email sharing

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -547,7 +547,9 @@ function sharing_add_footer() {
 		);
 		wp_localize_script( 'sharing-js', 'sharing_js_options', $sharing_js_options);
 	}
+}
 
+function sharing_add_footer_scripts_inline() {
 	$sharer = new Sharing_Service();
 	$enabled = $sharer->get_blog_services();
 	foreach ( array_merge( $enabled['visible'], $enabled['hidden'] ) AS $service ) {
@@ -773,7 +775,12 @@ function sharing_display( $text = '', $echo = false ) {
 				$ver = '20141212';
 			}
 			wp_register_script( 'sharing-js', plugin_dir_url( __FILE__ ).'sharing.js', array( 'jquery' ), $ver );
+
+			// Enqueue scripts for the footer
 			add_action( 'wp_footer', 'sharing_add_footer' );
+
+			// Print inline scripts that depend on jQuery
+			add_action( 'wp_footer', 'sharing_add_footer_scripts_inline', 25 );
 		}
 	}
 

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -515,7 +515,6 @@ class Share_Email extends Sharing_Source {
 
 			<?php endif; ?>
 			<input type="text" id="jetpack-source_f_name" name="source_f_name" class="input" value="" size="25" autocomplete="off" />
-			<script>jQuery( document ).ready( function(){ document.getElementById('jetpack-source_f_name').value = '' });</script>
 			<?php
 				/**
 				 * Fires when the Email sharing dialog is loaded.


### PR DESCRIPTION
Fixes #1223

#### Changes proposed in this Pull Request:

* Remove the JS that was previously [removing a dummy input field value](https://github.com/Automattic/jetpack/commit/10cc7c924febca6eccb27a5a1064af01331c2865) for spam protection.
* Print inline scripts that depend on jQuery after WP core is done with `print_footer_scripts()`. We are not using `wp_add_inline_script()` because all the `display_footer()` methods echo instead of return their output.

#### Testing instructions:

* Share a post via email. Ensure that the email was sent.