### PR TITLE
Use the sharing filters in e-mail too

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -25,7 +25,10 @@ function sharing_email_send_post( $data ) {
 	$headers[] = sprintf( 'From: %1$s <%2$s>', $data['name'], $from_email );
 	$headers[] = sprintf( 'Reply-To: %1$s <%2$s>', $data['name'], $data['source'] );
 
-	wp_mail( $data['target'], '['.__( 'Shared Post', 'jetpack' ).'] '.$data['post']->post_title, $content, $headers );
+	// Make sure to pass the title through the normal sharing filters.
+	$title = $data['sharing_source']->get_share_title( $data['post']->ID );
+
+	wp_mail( $data['target'], '[' . __( 'Shared Post', 'jetpack' ) . '] ' . $title, $content, $headers );
 }
 
 
@@ -39,7 +42,7 @@ function sharing_email_check_for_spam_via_akismet( $data ) {
 	// Prepare the body_request for akismet
 	$body_request = array(
 		'blog'                  => get_option( 'home' ),
-		'permalink'             => get_permalink( $data['post']->ID ),
+		'permalink'             => $data['sharing_source']->get_share_url( $data['post']->ID ),
 		'comment_type'          => 'share',
 		'comment_author'        => $data['name'],
 		'comment_author_email'  => $data['source'],
@@ -67,8 +70,9 @@ function sharing_email_send_post_content( $data ) {
 	/* translators: included in email when post is shared via email. First item is sender's name. Second is sender's email address. */
 	$content  = sprintf( __( '%1$s (%2$s) thinks you may be interested in the following post:', 'jetpack' ), $data['name'], $data['source'] );
 	$content .= "\n\n";
-	$content .= $data['post']->post_title."\n";
-	$content .= get_permalink( $data['post']->ID )."\n";
+	// Make sure to pass the title and URL through the normal sharing filters.
+	$content .= $data['sharing_source']->get_share_title( $data['post']->ID ) . "\n";
+	$content .= $data['sharing_source']->get_share_url( $data['post']->ID ) . "\n";
 	return $content;
 }
 

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -426,10 +426,11 @@ class Share_Email extends Sharing_Source {
 			 */
 			if ( apply_filters( 'sharing_email_check', true, $post, $post_data ) ) {
 				$data = array(
-					'post'	 => $post,
-					'source' => $source_email,
-					'target' => $target_email,
-					'name'	 => $source_name,
+					'post'           => $post,
+					'source'         => $source_email,
+					'target'         => $target_email,
+					'name'           => $source_name,
+					'sharing_source' => $this,
 				);
 				// todo: implement an error message when email doesn't get sent.
 				/**


### PR DESCRIPTION
Fixes #5989 

Per the issue, the URL and title shared are filterable for the other sharing types, but not e-mail. This change makes sure to call the same functions when sharing via e-mail.

Test plan:

- Have a server where e-mail sharing works and apply patch
- Share a post via e-mail, verify it looks normal
- Add `sharing_permalink` and `sharing_title` filters and share a post again; verify you get the new values