### PR TITLE
Add MailChimp Widget

### DIFF
--- a/modules/widgets/mailchimp.php
+++ b/modules/widgets/mailchimp.php
@@ -9,12 +9,88 @@ if ( ! class_exists( 'Jetpack_Mailchimp_Widget' ) ) {
 
 	add_action( 'widgets_init', 'jetpack_mailchimp_widget_init' );
 
+	/**
+	 * Add a Mailchimp embedcode
+	 *
+	 *
+	 */
 	class Jetpack_Mailchimp_Widget extends WP_Widget {
 
 		/**
 		 * Constructor
 		 */
-		function __construct() { }
+		function __construct() {
+			parent::__construct(
+				'widget_mailchimp',
+				/** This filter is documented in modules/widgets/facebook-likebox.php */
+				apply_filters( 'jetpack_widget_name', __( 'Mailchimp', 'jetpack' ) ),
+				array(
+					'classname'                   => 'widget_mailchimp',
+					'description'                 => __( 'Display a Mailchimp subscribe form.', 'jetpack' ),
+					'customize_selective_refresh' => true,
+				)
+			);
+			$this->alt_option_name = 'widget_mailchimp';
+		}
+
+		/**
+		 * Outputs the HTML for this widget.
+		 *
+		 * @param array $args     An array of standard parameters for widgets in this theme
+		 * @param array $instance An array of settings for this widget instance
+		 *
+		 * @return void Echoes it's output
+		 **/
+		function widget( $args, $instance ) {
+			$instance = wp_parse_args( $instance, array( 'code' ) );
+
+			echo $args['before_widget'];
+
+			if ( '' != $instance['code'] ) {
+				echo do_shortcode( $instance['code'] );
+			}
+
+			echo $args['after_widget'];
+
+			/** This action is documented in modules/widgets/gravatar-profile.php */
+			do_action( 'jetpack_stats_extra', 'widget_view', 'mailchimp' );
+		}
+
+
+		/**
+		 * Deals with the settings when they are saved by the admin.
+		 *
+		 * @param array $new_instance New configuration values
+		 * @param array $old_instance Old configuration values
+		 *
+		 * @return array
+		 */
+		function update( $new_instance, $old_instance ) {
+			$instance         = array();
+			$instance['code'] = wp_kses( $new_instance['code'], array() );
+
+			return $instance;
+		}
+
+
+		/**
+		 * Displays the form for this widget on the Widgets page of the WP Admin area.
+		 *
+		 * @param array $instance Instance configuration.
+		 *
+		 * @return void
+		 */
+		function form( $instance ) {
+			$instance = wp_parse_args( $instance, array( 'code' ) );
+			?>
+
+			<p>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'code' ) ); ?>"><?php esc_html_e( 'Code:', 'jetpack' ); ?></label>
+				<textarea class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'code' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'code' ) ); ?>"><?php echo esc_textarea( $instance['code'] ); ?></textarea>
+			</p>
+
+			<?php
+		}
 
 	}
 

--- a/modules/widgets/mailchimp.php
+++ b/modules/widgets/mailchimp.php
@@ -4,7 +4,9 @@ if ( ! class_exists( 'Jetpack_MailChimp_Subscriber_Popup_Widget' ) ) {
 
 	//register MailChimp Subscriber Popup widget
 	function jetpack_mailchimp_subscriber_popup_widget_init() {
-		register_widget( 'Jetpack_MailChimp_Subscriber_Popup_Widget' );
+		if ( class_exists( 'MailChimp_Subscriber_Popup' ) ) {
+			register_widget( 'Jetpack_MailChimp_Subscriber_Popup_Widget' );
+		}
 	}
 
 	add_action( 'widgets_init', 'jetpack_mailchimp_subscriber_popup_widget_init' );
@@ -85,7 +87,9 @@ if ( ! class_exists( 'Jetpack_MailChimp_Subscriber_Popup_Widget' ) ) {
 			?>
 
 			<p>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'code' ) ); ?>"><?php esc_html_e( 'Code:', 'jetpack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'code' ) ); ?>">
+					<?php printf( __( 'Code: <a href="%s" target="_blank">( ? )</a>', 'jetpack' ), 'https://en.support.wordpress.com/mailchimp/' ); ?>
+				</label>
 				<textarea class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'code' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'code' ) ); ?>" rows="3"><?php echo esc_textarea( $instance['code'] ); ?></textarea>
 			</p>
 

--- a/modules/widgets/mailchimp.php
+++ b/modules/widgets/mailchimp.php
@@ -1,0 +1,21 @@
+<?php
+
+if ( ! class_exists( 'Jetpack_Mailchimp_Widget' ) ) {
+
+	//register Mailchimp widget
+	function jetpack_mailchimp_widget_init() {
+		register_widget( 'Jetpack_Mailchimp_Widget' );
+	}
+
+	add_action( 'widgets_init', 'jetpack_mailchimp_widget_init' );
+
+	class Jetpack_Mailchimp_Widget extends WP_Widget {
+
+		/**
+		 * Constructor
+		 */
+		function __construct() { }
+
+	}
+
+}

--- a/modules/widgets/mailchimp.php
+++ b/modules/widgets/mailchimp.php
@@ -1,20 +1,20 @@
 <?php
 
-if ( ! class_exists( 'Jetpack_Mailchimp_Widget' ) ) {
+if ( ! class_exists( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' ) ) {
 
-	//register Mailchimp widget
+	//register MailChimp Subscriber Popup widget
 	function jetpack_mailchimp_widget_init() {
-		register_widget( 'Jetpack_Mailchimp_Widget' );
+		register_widget( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' );
 	}
 
 	add_action( 'widgets_init', 'jetpack_mailchimp_widget_init' );
 
 	/**
-	 * Add a Mailchimp embedcode
+	 * Add a MailChimp Subscriber Popup embedcode
 	 *
 	 *
 	 */
-	class Jetpack_Mailchimp_Widget extends WP_Widget {
+	class Jetpack_Mailchimp_Subscriber_Popup_Widget extends WP_Widget {
 
 		/**
 		 * Constructor
@@ -23,10 +23,10 @@ if ( ! class_exists( 'Jetpack_Mailchimp_Widget' ) ) {
 			parent::__construct(
 				'widget_mailchimp',
 				/** This filter is documented in modules/widgets/facebook-likebox.php */
-				apply_filters( 'jetpack_widget_name', __( 'Mailchimp', 'jetpack' ) ),
+				apply_filters( 'jetpack_widget_name', __( 'MailChimp Subscriber Popup', 'jetpack' ) ),
 				array(
 					'classname'                   => 'widget_mailchimp',
-					'description'                 => __( 'Display a Mailchimp subscribe form.', 'jetpack' ),
+					'description'                 => __( 'Allows displaying a popup subscription form to visitors.', 'jetpack' ),
 					'customize_selective_refresh' => true,
 				)
 			);
@@ -44,13 +44,9 @@ if ( ! class_exists( 'Jetpack_Mailchimp_Widget' ) ) {
 		function widget( $args, $instance ) {
 			$instance = wp_parse_args( $instance, array( 'code' ) );
 
-			echo $args['before_widget'];
-
 			if ( '' != $instance['code'] ) {
 				echo do_shortcode( $instance['code'] );
 			}
-
-			echo $args['after_widget'];
 
 			/** This action is documented in modules/widgets/gravatar-profile.php */
 			do_action( 'jetpack_stats_extra', 'widget_view', 'mailchimp' );

--- a/modules/widgets/mailchimp.php
+++ b/modules/widgets/mailchimp.php
@@ -1,36 +1,33 @@
 <?php
 
-if ( ! class_exists( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' ) ) {
+if ( ! class_exists( 'Jetpack_MailChimp_Subscriber_Popup_Widget' ) ) {
 
 	//register MailChimp Subscriber Popup widget
-	function jetpack_mailchimp_widget_init() {
-		register_widget( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' );
+	function jetpack_mailchimp_subscriber_popup_widget_init() {
+		register_widget( 'Jetpack_MailChimp_Subscriber_Popup_Widget' );
 	}
 
-	add_action( 'widgets_init', 'jetpack_mailchimp_widget_init' );
+	add_action( 'widgets_init', 'jetpack_mailchimp_subscriber_popup_widget_init' );
 
 	/**
-	 * Add a MailChimp Subscriber Popup embedcode
-	 *
-	 *
+	 * Add a MailChimp subscription form.
 	 */
-	class Jetpack_Mailchimp_Subscriber_Popup_Widget extends WP_Widget {
+	class Jetpack_MailChimp_Subscriber_Popup_Widget extends WP_Widget {
 
 		/**
 		 * Constructor
 		 */
 		function __construct() {
 			parent::__construct(
-				'widget_mailchimp',
+				'widget_mailchimp_subscriber_popup',
 				/** This filter is documented in modules/widgets/facebook-likebox.php */
 				apply_filters( 'jetpack_widget_name', __( 'MailChimp Subscriber Popup', 'jetpack' ) ),
 				array(
-					'classname'                   => 'widget_mailchimp',
+					'classname'                   => 'widget_mailchimp_subscriber_popup',
 					'description'                 => __( 'Allows displaying a popup subscription form to visitors.', 'jetpack' ),
 					'customize_selective_refresh' => true,
 				)
 			);
-			$this->alt_option_name = 'widget_mailchimp';
 		}
 
 		/**
@@ -44,12 +41,19 @@ if ( ! class_exists( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' ) ) {
 		function widget( $args, $instance ) {
 			$instance = wp_parse_args( $instance, array( 'code' => '' ) );
 
-			if ( has_shortcode( $instance['code'], 'mailchimp_subscriber_popup' ) ) {
-				echo do_shortcode( $instance['code'] );
+			// Regular expresion that will match maichimp shortcode.
+			$regex = "(\[mailchimp_subscriber_popup[^\]]+\])";
+
+			// Check if the shortcode exists.
+			preg_match( $regex, $instance['code'], $matches );
+
+			// Process the shortcode only, if exists.
+			if ( ! empty( $matches[0] ) ) {
+				echo do_shortcode( $matches[0] );
 			}
 
 			/** This action is documented in modules/widgets/gravatar-profile.php */
-			do_action( 'jetpack_stats_extra', 'widget_view', 'mailchimp' );
+			do_action( 'jetpack_stats_extra', 'widget_view', 'mailchimp_subscriber_popup' );
 		}
 
 
@@ -82,7 +86,7 @@ if ( ! class_exists( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' ) ) {
 
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'code' ) ); ?>"><?php esc_html_e( 'Code:', 'jetpack' ); ?></label>
-				<textarea class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'code' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'code' ) ); ?>"><?php echo esc_textarea( $instance['code'] ); ?></textarea>
+				<textarea class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'code' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'code' ) ); ?>" rows="3"><?php echo esc_textarea( $instance['code'] ); ?></textarea>
 			</p>
 
 			<?php

--- a/modules/widgets/mailchimp.php
+++ b/modules/widgets/mailchimp.php
@@ -42,9 +42,9 @@ if ( ! class_exists( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' ) ) {
 		 * @return void Echoes it's output
 		 **/
 		function widget( $args, $instance ) {
-			$instance = wp_parse_args( $instance, array( 'code' ) );
+			$instance = wp_parse_args( $instance, array( 'code' => '' ) );
 
-			if ( '' != $instance['code'] ) {
+			if ( has_shortcode( $instance['code'], 'mailchimp_subscriber_popup' ) ) {
 				echo do_shortcode( $instance['code'] );
 			}
 
@@ -63,7 +63,7 @@ if ( ! class_exists( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' ) ) {
 		 */
 		function update( $new_instance, $old_instance ) {
 			$instance         = array();
-			$instance['code'] = wp_kses( $new_instance['code'], array() );
+			$instance['code'] = wp_kses_post( stripslashes( $new_instance['code'] ) );
 
 			return $instance;
 		}
@@ -77,7 +77,7 @@ if ( ! class_exists( 'Jetpack_Mailchimp_Subscriber_Popup_Widget' ) ) {
 		 * @return void
 		 */
 		function form( $instance ) {
-			$instance = wp_parse_args( $instance, array( 'code' ) );
+			$instance = wp_parse_args( $instance, array( 'code' => '' ) );
 			?>
 
 			<p>


### PR DESCRIPTION
Fixes #5942 

Adds the MailChimp Subscribe Popup widget. It basically uses the `mailchimp_subscriber_popup` shortcode to add the script and I've tried to match the WordPress.com widget as much as possible.

#### Testing instructions:

* Go to Widgets
* Find "MailChimp Subscriber Popup" and add the widget to any sidebar
* Add the following embedcode in "Code" field:
```
<script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">require(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us11.list-manage.com","uuid":"1ca7856462585a934b8674c71","lid":"2d24f1898b"}) })</script>
```
* Open the front-end and you should see the popup
* If the popup doesn't appear for some reason, check if the code exists in the sidebar. It's easier if you add the widget between two others that have some content/html.

cc @jeherve, @eliorivero 