### PR TITLE
Infinite Scroll: apply the <body> CSS classes using JS

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -648,6 +648,8 @@ $( document ).ready( function() {
 	if ( 'object' != typeof infiniteScroll )
 		return;
 
+	$( document.body ).addClass( infiniteScroll.settings.body_class );
+
 	// Set ajaxurl (for brevity)
 	ajaxurl = infiniteScroll.settings.ajaxurl;
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -385,9 +385,6 @@ class The_Neverending_Home_Page {
 			return;
 		}
 
-		// Add a class to the body.
-		add_filter( 'body_class', array( $this, 'body_class' ) );
-
 		// Add our scripts.
 		wp_enqueue_script( 'the-neverending-homepage' );
 
@@ -411,16 +408,21 @@ class The_Neverending_Home_Page {
 	}
 
 	/**
-	 * Adds an 'infinite-scroll' class to the body.
+	 * Returns classes to be added to <body>. If it's enabled, 'infinite-scroll'. If set to continuous scroll, adds 'neverending' too.
+	 *
+	 * @since 4.7.0 No longer added as a 'body_class' filter but passed to JS environment and added using JS.
+	 *
+	 * @return string
 	 */
-	function body_class( $classes ) {
+	function body_class() {
+		$classes = '';
 		// Do not add infinity-scroll class if disabled through the Reading page
 		$disabled = '' === get_option( self::$option_name_enabled ) ? true : false;
 		if ( ! $disabled || 'click' == self::get_settings()->type ) {
-			$classes[] = 'infinite-scroll';
+			$classes = 'infinite-scroll';
 
 			if ( 'scroll' == self::get_settings()->type )
-				$classes[] = 'neverending';
+				$classes .= ' neverending';
 		}
 
 		return $classes;
@@ -776,6 +778,7 @@ class The_Neverending_Home_Page {
 			),
 			'query_args'      => self::get_query_vars(),
 			'last_post_date'  => self::get_last_post_date(),
+			'body_class'	  => self::body_class(),
 		);
 
 		// Optional order param

--- a/tests/php/modules/infinite-scroll/test_class.infinite-scroll.php
+++ b/tests/php/modules/infinite-scroll/test_class.infinite-scroll.php
@@ -6,39 +6,12 @@ class WP_Test_The_Neverending_Home_Page extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		add_theme_support( 'infinite-scroll' );
-		remove_action( 'init', 'the_neverending_home_page_init', 20 );
 		$this->infinite_scroll = new The_Neverending_Home_Page;
 	}
 
 	public function test_body_class() {
-		add_filter( 'body_class', array( $this->infinite_scroll, 'body_class' ) );
-
-		$classes = get_body_class();
+		$classes = $this->infinite_scroll->body_class();
 		$this->assertContains( 'infinite-scroll', $classes );
 		$this->assertContains( 'neverending', $classes );
-
-		// Disable Infinite Scroll.
-		update_option( The_Neverending_Home_Page::$option_name_enabled, '' );
-
-		$classes = get_body_class();
-		$this->assertNotContains( 'infinite-scroll', $classes );
-		$this->assertNotContains( 'neverending', $classes );
-	}
-
-	public function test_body_class_type_click() {
-		The_Neverending_Home_Page::$settings['type'] = 'click';
-		add_filter( 'body_class', array( $this->infinite_scroll, 'body_class' ) );
-
-		$classes = get_body_class();
-		$this->assertContains( 'infinite-scroll', $classes );
-		$this->assertNotContains( 'neverending', $classes );
-
-		// Disable Infinite Scroll.
-		update_option( The_Neverending_Home_Page::$option_name_enabled, '' );
-
-		$classes = get_body_class();
-		$this->assertContains( 'infinite-scroll', $classes );
-		$this->assertNotContains( 'neverending', $classes );
 	}
 }


### PR DESCRIPTION
Fixes #743

#### Changes proposed in this Pull Request:

* Infinite Scroll: apply the `<body>` CSS classes `infinite-scroll` and `neverending` using JS instead of PHP

#### Testing instructions:

* test Infinite Scroll in continuous scroll mode. The `<body>` should have the classes `infinite-scroll` and `neverending`.
* test when it displays a button to load more posts. The `<body>` should have the class `infinite-scroll`.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Infinite Scroll: the <body> classes `infinite-scroll` and `neverending` are now applied using JS instead of PHP.