### PR TITLE
Comment form: add filter to allow removing the Comment Form title.

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -285,11 +285,24 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			$url .= '&replytocom=' . (int) $_GET['replytocom'];
 		}
 
+		/**
+		 * Filter whether the comment title can be displayed.
+		 *
+		 * @module comments
+		 *
+		 * @since 4.7.0
+		 *
+		 * @param bool $show Can the comment be displayed? Default to true.
+		 */
+		$show_greeting = apply_filters( 'jetpack_comment_form_display_greeting', true );
+
 		// The actual iframe (loads comment form from Jetpack server)
 		?>
 
 		<div id="respond" class="comment-respond">
-			<h3 id="reply-title" class="comment-reply-title"><?php comment_form_title( esc_html( $params['greeting'] ), esc_html( $params['greeting_reply'] ) ); ?> <small><?php cancel_comment_reply_link( esc_html__( 'Cancel reply' , 'jetpack') ); ?></small></h3>
+			<?php if ( true === $show_greeting ) : ?>
+				<h3 id="reply-title" class="comment-reply-title"><?php comment_form_title( esc_html( $params['greeting'] ), esc_html( $params['greeting_reply'] ) ); ?> <small><?php cancel_comment_reply_link( esc_html__( 'Cancel reply' , 'jetpack') ); ?></small></h3>
+			<?php endif; ?>
 			<form id="commentform" class="comment-form">
 				<iframe src="<?php echo esc_url( $url ); ?>" allowtransparency="<?php echo $transparent; ?>" style="width:100%; height: <?php echo $height; ?>px;border:0;" frameBorder="0" scrolling="no" name="jetpack_remote_comment" id="jetpack_remote_comment"></iframe>
 			</form>


### PR DESCRIPTION
The filter can then be used like so:
`add_filter( 'jetpack_comment_form_display_greeting', '__return_false' );`

This allows removing the title like when using the core comment form and providing empty strings for
`title_reply`, `title_reply_before`, and `title_reply_after` as arguments to the `comment_form` function.
Unfortunately that is not possible with Jetpack's Comment form since the form lives in an iFrame.

Suggested here:
https://wordpress.org/support/topic/leave-a-reply-text-and-so-much-vertical-spacing-how-to-remove/

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Comments: add a filter to allow removing the Comment Form title.