### PR TITLE
Carousel: allow to filter EXIF tags that will be displayed in lightbox

### DIFF
--- a/modules/carousel/jetpack-carousel.css
+++ b/modules/carousel/jetpack-carousel.css
@@ -552,7 +552,8 @@ div#carousel-reblog-box {
 
 .jp-carousel-image-meta li {
 	width: 48% !important;
-	float: left !important;
+	display: inline-block !important;
+	vertical-align: top !important;
 	margin: 0 2% 15px 0 !important;
 	color: #fff !important;
 	font-size:13px !important;

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1128,7 +1128,7 @@ jQuery(document).ready(function($) {
 			var $ul = $( '<ul class=\'jp-carousel-image-exif\'></ul>' );
 
 			$.each( meta, function( key, val ) {
-				if ( 0 === parseFloat(val) || !val.length || -1 === $.inArray( key, [ 'camera', 'aperture', 'shutter_speed', 'focal_length' ] ) ) {
+				if ( 0 === parseFloat(val) || !val.length || -1 === $.inArray( key, $.makeArray( jetpackCarouselStrings.meta_data ) ) ) {
 					return;
 				}
 

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -197,7 +197,7 @@ class Jetpack_Carousel {
 
 	function enqueue_assets() {
 		if ( $this->first_run ) {
-			wp_enqueue_script( 'jetpack-carousel', plugins_url( 'jetpack-carousel.js', __FILE__ ), array( 'jquery.spin' ), $this->asset_version( '20160325' ), true );
+			wp_enqueue_script( 'jetpack-carousel', plugins_url( 'jetpack-carousel.js', __FILE__ ), array( 'jquery.spin' ), $this->asset_version( '20170209' ), true );
 
 			// Note: using  home_url() instead of admin_url() for ajaxurl to be sure  to get same domain on wpcom when using mapped domains (also works on self-hosted)
 			// Also: not hardcoding path since there is no guarantee site is running on site root in self-hosted context.
@@ -231,11 +231,13 @@ class Jetpack_Carousel {
 				'aperture'             => __( 'Aperture', 'jetpack' ),
 				'shutter_speed'        => __( 'Shutter Speed', 'jetpack' ),
 				'focal_length'         => __( 'Focal Length', 'jetpack' ),
+				'copyright'            => __( 'Copyright', 'jetpack' ),
 				'comment_registration' => $comment_registration,
 				'require_name_email'   => $require_name_email,
 				/** This action is documented in core/src/wp-includes/link-template.php */
 				'login_url'            => wp_login_url( apply_filters( 'the_permalink', get_permalink() ) ),
 				'blog_id'              => (int) get_current_blog_id(),
+				'meta_data'            => array( 'camera', 'aperture', 'shutter_speed', 'focal_length', 'copyright' )
 			);
 
 			if ( ! isset( $localize_strings['jetpack_comments_iframe_src'] ) || empty( $localize_strings['jetpack_comments_iframe_src'] ) ) {


### PR DESCRIPTION
Fixes #861

#### Changes proposed in this Pull Request:
* display "Copyright" tag
* allow to filter the EXIF tags that will be included.
    They can be added now using something like this:
    ```php
    function jp_custom_exif_info( $js ) {
    	// Add tag to list
    	$js['meta_data'][] = 'credit';

    	// Add translation for tag
    	$js['credit'] = __( 'Credit', 'jetpack' );
    
    	return $js;
    } 
    add_filter( 'jp_carousel_localize_strings', 'jp_custom_exif_info');
    ```
    The filter also allows to redefine the tags that will be displayed by overwriting the list with a full array instead of appending an item like in the previous example:
    ```php
    function jp_custom_exif_info( $js ) {
    	// Overwrite with a new list
    	$js['meta_data'] = array( 'copyright', 'credit' );

    	// Add translation for tag
    	$js['credit'] = __( 'Credit', 'jetpack' );
    
    	return $js;
    } 
    add_filter( 'jp_carousel_localize_strings', 'jp_custom_exif_info');
    ```
* the styles will prevent the exif data blocks from being incorrectly stacked
    With previous styles, the last block is incorrectly floated towards right
    <img width="226" alt="captura de pantalla 2017-02-09 a las 22 05 36" src="https://cloud.githubusercontent.com/assets/1041600/22809903/0d7aa1ea-ef14-11e6-9778-5aef08354cb5.png">
    With the updated styles, the last block is correctly placed towards left
    <img width="223" alt="captura de pantalla 2017-02-09 a las 22 05 51" src="https://cloud.githubusercontent.com/assets/1041600/22809904/0d7fbd92-ef14-11e6-9679-9680234e028d.png">


#### Testing instructions:
* use an image with copyright field in the EXIF metadata

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Carousel: now displays copyright EXIF information if it's available and allows to define custom EXIF information to display.