### PR TITLE
Pass the permalink through the sharing_permalink filter

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -68,7 +68,7 @@ function sharing_email_send_post_content( $data ) {
 	$content  = sprintf( __( '%1$s (%2$s) thinks you may be interested in the following post:', 'jetpack' ), $data['name'], $data['source'] );
 	$content .= "\n\n";
 	$content .= $data['post']->post_title."\n";
-	$content .= get_permalink( $data['post']->ID )."\n";
+	$content .= apply_filters( 'sharing_permalink', get_permalink( $data['post']->ID ) ) . "\n";
 	return $content;
 }
 


### PR DESCRIPTION
Fixes issue #5989.

#### Changes proposed in this Pull Request:

* Pass the permalink through the sharing_permalink filter.

#### Testing instructions:

* Add a filter to 'sharing_permalink' similar to this:
function test_sharing_permalink( $url ) {
	return add_query_arg( 'key', 'test', $url );
}
add_filter( 'sharing_permalink', 'test_sharing_permalink', 10, 2 );

* Load up wp shell
* Execute the sharing_email_send_post_content() function similar to this:
return sharing_email_send_post_content( array( 'name' => 'Brian', 'source' => 'brian@automattic.com', 'post' => (object) array( 'ID' => 1178, 'post_title' => 'Markup: HTML Tags and Formatting' ) ) );

* You should see ?key=test appended to the end of the permalink.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
