### PR TITLE
Fix display of enabled custom share services

### DIFF
--- a/modules/sharedaddy/admin-sharing.js
+++ b/modules/sharedaddy/admin-sharing.js
@@ -402,7 +402,7 @@
 						$( '#new-service-form input[type=submit]' ).prop( 'disabled', false );
 					}
 					else {
-						document.location = document.location.href.replace( /&create_new_service=true/i, '' );
+						document.location.reload();
 					}
 				}
 			}

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -176,7 +176,8 @@ class Sharing_Service {
 		 * @see https://github.com/Automattic/jetpack/issues/6121
 		 */
 		if ( ! is_array( $options ) || ! isset( $options['button_style'], $options['global'] ) ) {
-			$options = array( 'global' => $this->get_global_options() );
+			$global_options = $this->get_global_options();
+			$options = array_merge( is_array( $options ) ? $options : array(), $global_options );
 		}
 
 		$global = $options['global'];


### PR DESCRIPTION
Fixes #6348

#### Changes proposed in this Pull Request:

* When a missing `button_style` option is detected, don't clobber all options with global defaults. Merge the current options with the global defaults to ensure `button_style` exists, while preserving share options. This prevents the custom share details from getting deleted.
* When closing the "Add new service" modal, reload the page directly rather than relying on regexp-based URL changes which appear to fail.

#### Testing instructions:

* Follow the instructions in #6348
* The new share button should render correctly, and send users to the appropriate URL when clicked.

#### Proposed changelog entry for your changes:
* Bugfix: custom sharing services are now rendered correctly when enabled.