### PR TITLE
Show all reasons for dev mode

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -87,6 +87,7 @@ export const DevModeNotice = React.createClass( {
 	render() {
 		if ( this.props.siteConnectionStatus === 'dev' ) {
 			const devMode = this.props.siteDevMode;
+			const text = __( 'Currently in {{a}}Development Mode{{/a}} (some features are disabled) because:',
 				{
 					components: {
 						a: <a href="https://jetpack.com/support/development-mode/" target="_blank"/>,

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -87,34 +87,39 @@ export const DevModeNotice = React.createClass( {
 	render() {
 		if ( this.props.siteConnectionStatus === 'dev' ) {
 			const devMode = this.props.siteDevMode;
-			let text;
+				{
+					components: {
+						a: <a href="https://jetpack.com/support/development-mode/" target="_blank"/>,
+					}
+				}
+			);
+			const reasons = [];
 			if ( devMode.filter ) {
-				text = __( 'Currently in {{a}}Development Mode{{/a}} via the jetpack_development_mode filter.{{br/}}Some features are disabled.',
+				reasons.push( __( '{{li}}The jetpack_development_mode filter is active{{/li}}',
 					{
 						components: {
-							a: <a href="https://jetpack.com/support/development-mode/" target="_blank"/>,
-							br: <br />
+							li: <li />,
 						}
 					}
-				);
-			} else if ( devMode.constant ) {
-				text = __( 'Currently in {{a}}Development Mode{{/a}} via the JETPACK_DEV_DEBUG constant.{{br/}}Some features are disabled.',
+				) );
+			}
+			if ( devMode.constant ) {
+				reasons.push( __( '{{li}}The JETPACK_DEV_DEBUG constant is defined{{/li}}',
 					{
 						components: {
-							a: <a href="https://jetpack.com/support/development-mode/" target="_blank"/>,
-							br: <br />
+							li: <li />,
 						}
 					}
-				);
-			} else if ( devMode.url ) {
-				text = __( 'Currently in {{a}}Development Mode{{/a}} because your site URL lacks a dot (e.g. http://localhost).{{br/}}Some features are disabled.',
+				) );
+			}
+			if ( devMode.url ) {
+				reasons.push( __( '{{li}}Your site URL lacks a dot (e.g. http://localhost){{/li}}',
 					{
 						components: {
-							a: <a href="https://jetpack.com/support/development-mode/" target="_blank"/>,
-							br: <br />
+							li: <li />,
 						}
 					}
-				);
+				) );
 			}
 
 			return (
@@ -123,6 +128,7 @@ export const DevModeNotice = React.createClass( {
 					status="is-basic"
 				>
 					{ text }
+					<ul>{ reasons }</ul>
 				</SimpleNotice>
 			);
 		}


### PR DESCRIPTION
Fixes #4558

Instead of only showing one reason for dev mode, this shows a list of
reasons, since more than one could apply.

## Testing Plan

- Place site in dev mode via each reason and examine the notice
- Place site in dev mode via 2-3 reasons and examine the notice
- (for above, can just hard-code the `const devMode = ...` line for
easier testing, especially for the URL reason)

## Design

Someone should take a look at this, will ping for it. Do we want bullets
or similar on the list? Despite what the issue says, I'm not seeing any
problems with the notice box becoming slightly taller, but maybe I've
missed something.