### PR TITLE
correct twitter character limit

### DIFF
--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -326,7 +326,7 @@ jQuery( function($) {
 		wpasTitle = $('#wpas-title').keyup( function() {
 		var length = wpasTitle.val().length;
 		wpasTitleCounter.text( length );
-		if ( wpasTwitterCheckbox && length > 140 ) {
+		if ( wpasTwitterCheckbox && length > 117 ) {
 			wpasTitleCounter.addClass( 'wpas-twitter-length-limit' );
 		} else {
 			wpasTitleCounter.removeClass( 'wpas-twitter-length-limit' );

--- a/modules/publicize/ui.php
+++ b/modules/publicize/ui.php
@@ -326,7 +326,7 @@ jQuery( function($) {
 		wpasTitle = $('#wpas-title').keyup( function() {
 		var length = wpasTitle.val().length;
 		wpasTitleCounter.text( length );
-		if ( wpasTwitterCheckbox && length > 117 ) {
+		if ( wpasTwitterCheckbox && length > 116 ) {
 			wpasTitleCounter.addClass( 'wpas-twitter-length-limit' );
 		} else {
 			wpasTitleCounter.removeClass( 'wpas-twitter-length-limit' );


### PR DESCRIPTION
Correct Twitter character count limit to account for url length
i.e. 140 - 23(url) - 1 (space) = 116

Fixes #

#### Changes proposed in this Pull Request:

* change character limit for custom text

#### Testing instructions:

* wpas-twitter-length-limit class will be added to wpas-title counter at 118 characters 