### PR TITLE
Build tools: Add `yarn cache clean` to the `distclean` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "watch": "./node_modules/.bin/gulp watch",
     "clean-client": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html",
-    "distclean": "rm -rf node_modules",
+    "distclean": "rm -rf node_modules && yarn cache clean",
     "build": "yarn && yarn build-client",
     "build-client": "./node_modules/.bin/gulp",
     "build-production": "yarn clean-client && yarn build-languages && ./node_modules/.bin/gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build",


### PR DESCRIPTION
This came up in slack: the addition of `lib/accessible-focus` to dops-components wasn't picked up because of yarn caching, and `distclean` alone wasn't enough to refresh the cached modules. Since `distclean` should reset the environment back to "new", we should also clear the yarn caches.

To test:

1. Run `npm run distclean`
2. You should see that it's running `rm -rf node_modules && yarn cache clean`
3. The `node_modules` folder is removed, and you should see `success Cleared cache.` at the end of the terminal output.