### PR TITLE
Travis: New test to check for eslint rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+_inc/client/**/test/*.js

--- a/.svnignore
+++ b/.svnignore
@@ -1,3 +1,5 @@
+.eslintrc
+.eslintignore
 .git
 .gitignore
 .sass-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ cache:
 matrix:
   include:
   - php: "5.6"
+    env: WP_TRAVISCI="npm run lint"
+  - php: "5.6"
     env: WP_TRAVISCI="npm run test-client"
   - php: "5.6"
     env: WP_TRAVISCI="npm run test-gui"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build-client": "./node_modules/.bin/gulp",
     "build-production": "yarn clean-client && yarn build-languages && ./node_modules/.bin/gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build",
     "build-languages": "./node_modules/.bin/gulp languages",
-    "lint": "eslint _inc/client -c .eslintrc",
+    "lint": "eslint --ext .js --ext .jsx _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "./node_modules/.bin/grunt addtextdomain",
     "build-pot": "./node_modules/.bin/grunt makepot",


### PR DESCRIPTION
Any `errors` reported by eslint (`yarn lint`) will now fail Travis in this new test suite.  

To test: 
- Verify that tests pass 
- You should still see the `warnings` in the test suite in the travis UI 