### PR TITLE
Widgets: trim spaces in the URLs entered in Image and Display WordPress Posts

### DIFF
--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -148,12 +148,12 @@ class Jetpack_Image_Widget extends WP_Widget {
 		$instance = $old_instance;
 
 		$instance['title']             = strip_tags( $new_instance['title'] );
-		$instance['img_url']           = esc_url( $new_instance['img_url'], null, 'display' );
+		$instance['img_url']           = esc_url( trim( $new_instance['img_url'] ) );
 		$instance['alt_text']          = strip_tags( $new_instance['alt_text'] );
 		$instance['img_title']         = strip_tags( $new_instance['img_title'] );
 		$instance['caption']           = wp_kses( stripslashes($new_instance['caption'] ), $allowed_caption_html );
 		$instance['align']             = $new_instance['align'];
-		$instance['link']              = esc_url( $new_instance['link'], null, 'display' );
+		$instance['link']              = esc_url( trim( $new_instance['link'] ) );
 		$instance['link_target_blank'] = isset( $new_instance['link_target_blank'] ) ? (bool) $new_instance['link_target_blank'] : false;
 
 		$new_img_width  = absint( $new_instance['img_width'] );

--- a/modules/widgets/wordpress-post-widget.php
+++ b/modules/widgets/wordpress-post-widget.php
@@ -1063,7 +1063,7 @@ class Jetpack_Display_Posts_Widget extends WP_Widget {
 
 		$instance          = array();
 		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
-		$instance['url']   = ( ! empty( $new_instance['url'] ) ) ? strip_tags( $new_instance['url'] ) : '';
+		$instance['url']   = ( ! empty( $new_instance['url'] ) ) ? strip_tags( trim( $new_instance['url'] ) ) : '';
 		$instance['url']   = preg_replace( "!^https?://!is", "", $instance['url'] );
 		$instance['url']   = untrailingslashit( $instance['url'] );
 


### PR DESCRIPTION
Fixes #6328

#### Changes proposed in this Pull Request:

* Image: trim spaces before escaping the URL so esc_url doesn't convert it to %20 and fail the regexp that checks the formatting.
* Display WordPress Posts: trim spaces so the preg_replace doesn't remove the URL due to the wrong start

#### Testing instructions:
* Add an Image widget and enter a URL that has a space at the beginning so it's invalid. It should be stripped and the URL should be correct.
* Add an Display WordPress Posts widget and enter a URL that has a space at the beginning so it's invalid. It should be stripped and the URL should be correct.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Widgets: if URLs are entered in Image and Display WordPress Posts widgets with spaces inadvertently added at the beginning, remove them so the URL begins correctly and is not rejected.