### PR TITLE
Settings: fixes remaining font size and spacing issues

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -30,21 +30,12 @@
 	}
 }
 
-.jp-form-setting-explanation {
-	color: darken( $gray, 20% );
-	display: block;
-	margin: rem( 5px ) rem( 14px ) 0 0;
-	font-size: rem( 13px );
-	font-style: italic;
-	font-weight: 400;
-	word-break: break-word;
-
-	+ .dops-card {
-		margin-top: rem( 16px );
-	}
-}
-
 .jp-form-settings-group {
+	p {
+		font-size: rem( 15px );
+		margin-top: 0;
+		margin-bottom: rem( 24px );
+	}
 	.form-toggle__label {
 		display: block;
 		margin-top: 4px;
@@ -53,6 +44,19 @@
 	.form-toggle__switch {
 		float: left;
 		margin-top: 2px;
+	}
+	.jp-form-setting-explanation {
+		color: darken( $gray, 20% );
+		display: block;
+		margin: rem( 5px ) rem( 14px ) 0 0;
+		font-size: rem( 13px );
+		font-style: italic;
+		font-weight: 400;
+		word-break: break-word;
+
+		+ .dops-card {
+			margin-top: rem( 16px );
+		}
 	}
 }
 
@@ -77,7 +81,11 @@
 .jp-form-input-with-prefix {
 	display: inline-flex;
 	width: 100%;
-	margin-bottom: rem( 24px );
+	margin-top: rem( 24px );
+
+	&:first-of-type {
+		margin-top: 0;
+	}
 
 	span:first-child {
 		min-width: rem( 60px );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -31,16 +31,11 @@ export const BackupsScan = moduleSettingsForm(
 								__( 'Your site is backed up and threat-free.' )
 							}
 						</p>
-						<p className="jp-form-setting-explanation">
-							{
-								__( 'You can see the information about your backups and security scanning in the "At a Glance" section.' )
-							}
-						</p>
 						{
 							! this.props.isUnavailableInDevMode( 'backups' ) && (
-								<p>
+								<span>
 									<ExternalLink className="jp-module-settings__external-link" href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
-								</p>
+								</span>
 							)
 						}
 					</SettingsGroup>

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -35,9 +35,9 @@ export const SEO = moduleSettingsForm(
 						</p>
 						{
 							! this.props.isUnavailableInDevMode( 'seo-tools' ) && (
-								<p>
+								<span>
 									<ExternalLink className="jp-module-settings__external-link" href={ this.props.configureUrl }>{ __( 'Configure your SEO settings' ) }</ExternalLink>
-								</p>
+								</span>
 							)
 						}
 					</SettingsGroup>

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -121,6 +121,7 @@ export const SiteStats = moduleSettingsForm(
 								</span>
 							</ModuleToggle>
 						</FormFieldset>
+						<br />
 						<InlineExpand label={ __( 'Advanced Options' ) }>
 							<div>
 								<FormFieldset>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* makes `p` font size in settings `15px` to match Calypso (for now)
* resolves some remaining spacing issues

#### Testing instructions:
* go to settings and look at
  * Traffic > SEO
  * Traffic > Site Stats (added a `br`)
  * Traffic > Site Verification
  * Security > Backups & Security (also removed grey text)

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/22852047/37163778-f034-11e6-9fdd-03d7e596530c.png)
![image](https://cloud.githubusercontent.com/assets/1123119/22852049/3dff2572-f034-11e6-8fe2-37c5256edd0d.png)
![image](https://cloud.githubusercontent.com/assets/1123119/22852050/442deeba-f034-11e6-8200-300e8fd53e1b.png)


#### After
![image](https://cloud.githubusercontent.com/assets/1123119/22852035/141fa204-f034-11e6-88be-ade9d1ec0ef9.png)
![image](https://cloud.githubusercontent.com/assets/1123119/22852040/1be94aee-f034-11e6-9d46-8149b1ab8b86.png)
![image](https://cloud.githubusercontent.com/assets/1123119/22852044/23711a62-f034-11e6-9b75-74f2d114c360.png)
