### PR TITLE
Update xml sitemaps layout

### DIFF
--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -12,7 +12,6 @@ import get from 'lodash/get';
  */
 import {
 	FormFieldset,
-	FormLegend,
 	FormLabel
 } from 'components/forms';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
@@ -112,33 +111,14 @@ export const VerificationServices = moduleSettingsForm(
 						</FormFieldset>
 					</SettingsGroup>
 					<SettingsGroup support={ sitemaps.learn_more_button }>
+						<span className="jp-form-label-wide">{ __( 'XML Sitemaps' ) }</span>
 						<FormFieldset>
-							<FormLegend>{ __( 'XML Sitemaps' ) }</FormLegend>
-							<div>
-								<p>{ __( 'Search engines will find the sitemaps at these locations:' ) }</p>
-								<ul>
-									{
-										[
-											{
-												id: 'sitemap',
-												label: __( 'Sitemaps' ),
-												url: sitemap_url
-											},
-											{
-												id: 'news_sitemap',
-												label: __( 'News Sitemaps' ),
-												url: news_sitemap_url
-											}
-										].map( item => (
-											<li key={ `xml_${ item.id }` }>
-												<strong>{ item.label }</strong>
-												<br />
-												<ExternalLink icon={ true } target="_blank" href={ item.url }>{ item.url }</ExternalLink>
-											</li>
-										) )
-									}
-								</ul>
-							</div>
+							<p>
+								<ExternalLink icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
+								<br />
+								<ExternalLink icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+							</p>
+							<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
 						</FormFieldset>
 					</SettingsGroup>
 				</SettingsCard>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Rearranges and simplifies XML sitemaps group

#### Testing instructions:
* Go to Settings > Traffic and scroll to the bottom

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/22852315/9685f4f0-f039-11e6-80ff-5807fbd525b8.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/22852311/86ad0320-f039-11e6-8b57-371b6c389cca.png)

#### NOTE
It will look like this after https://github.com/Automattic/jetpack/pull/6377 is merged in:
![image](https://cloud.githubusercontent.com/assets/1123119/22852310/7ca61ad8-f039-11e6-97eb-e9ccccdf4622.png)
