### PR TITLE
Fix posts preview when Shortcode Embeds is enabled

### DIFF
--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -230,7 +230,10 @@ class Filter_Embedded_HTML_Objects {
 
 		foreach ( self::$failed_embeds as $entry ) {
 			$html   = sprintf( '<a href="%s">%s</a>', esc_url( $entry['src'] ), esc_url( $entry['src'] ) );
-			$string = str_replace( $entry['match'], $html, $string );
+			// Check if the string doesn't contain iframe, before replace.
+			if ( ! preg_match( '/<iframe /', $string ) ) {
+				$string = str_replace( $entry['match'], $html, $string );
+			}
 		}
 
 		self::$failed_embeds = array();


### PR DESCRIPTION
Fixes #6380

#### Changes proposed in this Pull Request:

* Fix posts preview when Shortcode Embeds is enabled. For some reason the iframe code is replaced by link on the [following line](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/class.filter-embedded-html-objects.php#L233
).
I am not sure that the changes I've made are the best way to fix this, so I will be happy if @eliorivero can take a look, since he was made this module and is familiar with it.
#### Testing instructions:

* Enable Shortcode embeds
* Add new post, paste URL for an already published post into visual editor
* Make sure that it's converted to embedded preview
