### PR TITLE
JITM: Detect when WooCommerce Services is installed, but not active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .DS_Store
 languages/messages.pot
 .idea
+*.iml
 npm-debug.log
 tests/php/files/jetpack-150x150.jpg
 *.unison.tmp

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -34,26 +34,43 @@ class WC_Services_Installer {
 	 * Verify the intent to install WooCommerce Services, and kick off installation.
 	 */
 	public function try_install() {
-		if ( isset( $_GET['wc-services-action'] ) && ( 'install' === $_GET['wc-services-action'] ) ) {
-			check_admin_referer( 'wc-services-install' );
-
-			if ( ! current_user_can( 'install_plugins' ) ) {
-				return;
-			}
-
-			$result   = $this->install();
-			$redirect = wp_get_referer();
-
-			if ( false === $result ) {
-				$redirect = add_query_arg( 'wc-services-install-error', true, $redirect );
-			} else {
-				$this->jetpack->stat( 'jitm', 'wooservices-activated-' . JETPACK__VERSION );
-			}
-
-			wp_safe_redirect( $redirect );
-
-			exit;
+		if ( ! isset( $_GET['wc-services-action'] ) ) {
+			return;
 		}
+		check_admin_referer( 'wc-services-install' );
+
+		$result = false;
+
+		switch ( $_GET['wc-services-action'] ) {
+			case 'install':
+				if ( current_user_can( 'install_plugins' ) ) {
+					$this->jetpack->stat( 'jitm', 'wooservices-install-' . JETPACK__VERSION );
+					$result = $this->install();
+					if ( $result ) {
+						$result = $this->activate();
+					}
+				}
+				break;
+
+			case 'activate':
+				if ( current_user_can( 'activate_plugins' ) ) {
+					$this->jetpack->stat( 'jitm', 'wooservices-activate-' . JETPACK__VERSION );
+					$result = $this->activate();
+				}
+				break;
+		}
+
+		$redirect = wp_get_referer();
+
+		if ( $result ) {
+			$this->jetpack->stat( 'jitm', 'wooservices-activated-' . JETPACK__VERSION );
+		} else {
+			$redirect = add_query_arg( 'wc-services-install-error', true, $redirect );
+		}
+
+		wp_safe_redirect( $redirect );
+
+		exit;
 	}
 
 	/**
@@ -77,13 +94,11 @@ class WC_Services_Installer {
 	}
 
 	/**
-	 * Download, install, and activate the WooCommerce Services plugin.
+	 * Download and install the WooCommerce Services plugin.
 	 *
-	 * @return bool result of installation/activation
+	 * @return bool result of installation
 	 */
 	private function install() {
-		$this->jetpack->stat( 'jitm', 'wooservices-install-' . JETPACK__VERSION );
-
 		include_once( ABSPATH . '/wp-admin/includes/admin.php' );
 		include_once( ABSPATH . '/wp-admin/includes/plugin-install.php' );
 		include_once( ABSPATH . '/wp-admin/includes/plugin.php' );
@@ -99,10 +114,15 @@ class WC_Services_Installer {
 		$upgrader = new Plugin_Upgrader( new Automatic_Upgrader_Skin() );
 		$result   = $upgrader->install( $api->download_link );
 
-		if ( true !== $result ) {
-			return false;
-		}
+		return true === $result;
+	}
 
+	/**
+	 * Activate the WooCommerce Services plugin.
+	 *
+	 * @return bool result of activation
+	 */
+	private function activate() {
 		$result = activate_plugin( 'woocommerce-services/woocommerce-services.php' );
 
 		// activate_plugin() returns null on success

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -457,7 +457,11 @@ class Jetpack_JITM {
 				return;
 		}
 
-		$install_url = wp_nonce_url( add_query_arg( array( 'wc-services-action' => 'install' ) ), 'wc-services-install' );
+		// If plugin dir exists, means it's installed but not activated
+		$all_plugins = get_plugins();
+		$already_installed = isset( $all_plugins[ 'woocommerce-services/woocommerce-services.php' ] );
+
+		$install_url = wp_nonce_url( add_query_arg( array( 'wc-services-action' => $already_installed ? 'activate' : 'install' ) ), 'wc-services-install' );
 
 		?>
 		<div class="jp-jitm woo-jitm">
@@ -471,7 +475,9 @@ class Jetpack_JITM {
 				<?php echo esc_html( $message ); ?>
 			</p>
 			<p>
-				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" class="button button-jetpack show-after-enable"><?php esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?></a>
+				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" class="button button-jetpack show-after-enable">
+					<?php $already_installed ? esc_html_e( 'Activate WooCommerce Services', 'jetpack' ) : esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?>
+				</a>
 			</p>
 		</div>
 		<?php

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -40,12 +40,12 @@ class Jetpack_JITM {
 		}
 		add_action( 'current_screen', array( $this, 'prepare_jitms' ) );
 	}
-	
+
 	function get_emblem()
 	{
 		return '<div class="jp-emblem">' . Jetpack::get_jp_emblem() . '</div>';
 	}
-	
+
 	/**
 	 * Prepare actions according to screen and post type.
 	 *
@@ -458,8 +458,7 @@ class Jetpack_JITM {
 		}
 
 		// If plugin dir exists, means it's installed but not activated
-		$all_plugins = get_plugins();
-		$already_installed = isset( $all_plugins[ 'woocommerce-services/woocommerce-services.php' ] );
+		$already_installed = ( 0 === validate_plugin( 'woocommerce-services/woocommerce-services.php' ) );
 
 		$install_url = wp_nonce_url( add_query_arg( array( 'wc-services-action' => $already_installed ? 'activate' : 'install' ) ), 'wc-services-install' );
 
@@ -475,7 +474,7 @@ class Jetpack_JITM {
 				<?php echo esc_html( $message ); ?>
 			</p>
 			<p>
-				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" class="button button-jetpack show-after-enable">
+				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php $already_installed ? esc_attr_e( 'Activate WooCommerce Services', 'jetpack' ) : esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" class="button button-jetpack show-after-enable">
 					<?php $already_installed ? esc_html_e( 'Activate WooCommerce Services', 'jetpack' ) : esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?>
 				</a>
 			</p>

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "clean-client": "rm -rf _inc/build/*.js _inc/build/*.css _inc/build/*.map _inc/build/*.html",
     "distclean": "rm -rf node_modules && yarn cache clean",
     "build": "yarn && yarn build-client",
-    "build-client": "./node_modules/.bin/gulp",
-    "build-production": "yarn clean-client && yarn build-languages && ./node_modules/.bin/gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build",
-    "build-languages": "./node_modules/.bin/gulp languages",
+    "build-client": "gulp",
+    "build-production": "yarn clean-client && yarn build-languages && gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build",
+    "build-languages": "gulp languages",
     "lint": "eslint _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
-    "add-textdomain": "./node_modules/.bin/grunt addtextdomain",
-    "build-pot": "./node_modules/.bin/grunt makepot",
+    "add-textdomain": "grunt addtextdomain",
+    "build-pot": "grunt makepot",
     "test-gui": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js gui"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #6283

#### Changes proposed in this Pull Request:

When the WooCommerce Services JITM is displayed and the user already has the plugin installed (but deactivated):
* Change the button label from "Install WooCommerce Services" to "Activate WooCommerce Services" (see screenshot).
* When clicking the button, the plugin will just be activated (not trying to installing it again).
* When clicking the button, a different stat will be bumped (`wooservices-activate-$version` as opposed to the regular `wooservices-install-$version`). I expect this use case to be very rare, but I don't want unexplained discrepancies in our numbers :)

![activate](https://cloud.githubusercontent.com/assets/1715800/22882884/43f6755e-f1e5-11e6-942a-8921cbc3b9d3.png)


#### Testing instructions:

* Install WooCommerce, configure your store to be in the US or Canada.
* Install WooCommerce Services, keep it deactivated.
* Go to `WooCommerce -> Settings` or any of the other pages that show the JITM.
* Note the JITM is prompting you to **activate** WooCommerce Services, not installing it.
* Click the button.
* The page will reload without errors.
* Check that now the WooCommerce Services plugin is activated.
* (Optional) Uninstall WooCommerce Services, then check the old behaviour of installing the plugin from the JITM still works as expected.
