### PR TITLE
Remove old get_avatar_url implementations post 4.2

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -392,9 +392,8 @@ function jetpack_current_user_data() {
 	global $current_user;
 	$is_master_user = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
 	$dotcom_data    = Jetpack::get_connected_user_data();
-	// Add connected user gravatar to the returned dotcom_data
-	$avatar_data = Jetpack::get_avatar_url( $dotcom_data[ 'email' ] );
-	$dotcom_data[ 'avatar'] = $avatar_data[ 0 ];
+	// Add connected user gravatar to the returned dotcom_data.
+	$dotcom_data['avatar'] = get_avatar_url( $dotcom_data['email'] );
 
 	$current_user_data = array(
 		'isConnected' => Jetpack::is_user_connected( $current_user->ID ),

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -380,8 +380,10 @@ class Jetpack_PostImages {
 	}
 
 	/**
-	 * @param    int $post_id The post ID to check
-	 * @param    int $size
+	 * Gets a post image from the author avatar.
+	 *
+	 * @param int    $post_id The post ID to check.
+	 * @param int    $size The size of the avatar to get.
 	 * @param string $default The default image to use.
 	 * @return Array containing details of the image, or empty array if none.
 	 */
@@ -395,34 +397,22 @@ class Jetpack_PostImages {
 				$url = $url[0];
 			}
 		} else {
-			$has_filter = has_filter( 'pre_option_show_avatars', '__return_true' );
-			if ( !$has_filter ) {
-				add_filter( 'pre_option_show_avatars', '__return_true' );
-			}
-			$avatar = get_avatar( $post->post_author, $size, $default );
-			if ( !$has_filter ) {
-				remove_filter( 'pre_option_show_avatars', '__return_true' );
-			}
-
-			if ( !$avatar ) {
-				return array();
-			}
-
-			if ( !preg_match( '/src=["\']([^"\']+)["\']/', $avatar, $matches ) ) {
-				return array();
-			}
-
-			$url = wp_specialchars_decode( $matches[1], ENT_QUOTES );
+			$url = get_avatar_url( $post->post_author, array(
+				'size' => $size,
+				'default' => $default,
+			) );
 		}
 
-		return array( array(
-			'type'       => 'image',
-			'from'       => 'gravatar',
-			'src'        => $url,
-			'src_width'  => $size,
-			'src_height' => $size,
-			'href'       => $permalink,
-		) );
+		return array(
+			array(
+				'type'       => 'image',
+				'from'       => 'gravatar',
+				'src'        => $url,
+				'src_width'  => $size,
+				'src_height' => $size,
+				'href'       => $permalink,
+			),
+		);
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5382,45 +5382,6 @@ p {
 	}
 
 	/**
-	 * Centralize the function here until it gets added to core.
-	 *
-	 * @param int|string|object $id_or_email A user ID,  email address, or comment object
-	 * @param int $size Size of the avatar image
-	 * @param string $default URL to a default image to use if no avatar is available
-	 * @param bool $force_display Whether to force it to return an avatar even if show_avatars is disabled
-	 *
-	 * @return array First element is the URL, second is the class.
-	 */
-	public static function get_avatar_url( $id_or_email, $size = 96, $default = '', $force_display = false ) {
-		// Don't bother adding the __return_true filter if it's already there.
-		$has_filter = has_filter( 'pre_option_show_avatars', '__return_true' );
-
-		if ( $force_display && ! $has_filter )
-			add_filter( 'pre_option_show_avatars', '__return_true' );
-
-		$avatar = get_avatar( $id_or_email, $size, $default );
-
-		if ( $force_display && ! $has_filter )
-			remove_filter( 'pre_option_show_avatars', '__return_true' );
-
-		// If no data, fail out.
-		if ( is_wp_error( $avatar ) || ! $avatar )
-			return array( null, null );
-
-		// Pull out the URL.  If it's not there, fail out.
-		if ( ! preg_match( '/src=["\']([^"\']+)["\']/', $avatar, $url_matches ) )
-			return array( null, null );
-		$url = wp_specialchars_decode( $url_matches[1], ENT_QUOTES );
-
-		// Pull out the class, but it's not a big deal if it's missing.
-		$class = '';
-		if ( preg_match( '/class=["\']([^"\']+)["\']/', $avatar, $class_matches ) )
-			$class = wp_specialchars_decode( $class_matches[1], ENT_QUOTES );
-
-		return array( $url, $class );
-	}
-
-	/**
 	 * Pings the WordPress.com Mirror Site for the specified options.
 	 *
 	 * @param string|array $option_names The option names to request from the WordPress.com Mirror Site

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1032,7 +1032,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$first_name  = '';
 			$last_name   = '';
 			$URL         = $author->comment_author_url;
-			$avatar_URL  = $this->api->get_avatar_url( $author );
+			$avatar_URL  = get_avatar_url( $author );
 			$profile_URL = 'https://en.gravatar.com/' . md5( strtolower( trim( $email ) ) );
 			$nice        = '';
 			$site_id     = -1;
@@ -1102,7 +1102,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$site_id     = -1;
 			}
 
-			$avatar_URL = $this->api->get_avatar_url( $email );
+			$avatar_URL = get_avatar_url( $email );
 		}
 
 		$email = $show_email ? (string) $email : false;

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -587,35 +587,11 @@ class WPCOM_JSON_API {
 		return '';
 	}
 
-	function get_avatar_url( $email, $avatar_size = 96 ) {
-		add_filter( 'pre_option_show_avatars', '__return_true', 999 );
-		$_SERVER['HTTPS'] = 'off';
-
-		$avatar_img_element = get_avatar( $email, $avatar_size, '' );
-
-		if ( !$avatar_img_element || is_wp_error( $avatar_img_element ) ) {
-			$return = '';
-		} elseif ( !preg_match( '#src=([\'"])?(.*?)(?(1)\\1|\s)#', $avatar_img_element, $matches ) ) {
-			$return = '';
-		} else {
-			$return = esc_url_raw( htmlspecialchars_decode( $matches[2] ) );
-		}
-
-		remove_filter( 'pre_option_show_avatars', '__return_true', 999 );
-		if ( '--UNset--' === $this->_server_https ) {
-			unset( $_SERVER['HTTPS'] );
-		} else {
-			$_SERVER['HTTPS'] = $this->_server_https;
-		}
-
-		return $return;
-	}
-
 	/**
 	 * Traps `wp_die()` calls and outputs a JSON response instead.
 	 * The result is always output, never returned.
 	 *
-	 * @param string|null $error_code.  Call with string to start the trapping.  Call with null to stop.
+	 * @param string|null $error_code  Call with string to start the trapping.  Call with null to stop.
 	 */
 	function trap_wp_die( $error_code = null ) {
 		// Stop trapping

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -282,27 +282,11 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 				}
 			}
 		}
-	} else if ( is_author() ) {
+	} elseif ( is_author() ) {
 		$author = get_queried_object();
-		if ( function_exists( 'get_avatar_url' ) ) {
-			// Prefer the core function get_avatar_url() if available, WP 4.2+
-			$image['src'] = get_avatar_url( $author->user_email, array( 'size' => $width ) );
-		}
-		else {
-			$has_filter = has_filter( 'pre_option_show_avatars', '__return_true' );
-			if ( ! $has_filter ) {
-				add_filter( 'pre_option_show_avatars', '__return_true' );
-			}
-			$avatar = get_avatar( $author->user_email, $width );
-			if ( ! $has_filter ) {
-				remove_filter( 'pre_option_show_avatars', '__return_true' );
-			}
-
-			if ( ! empty( $avatar ) && ! is_wp_error( $avatar ) ) {
-				if ( preg_match( '/src=["\']([^"\']+)["\']/', $avatar, $matches ) );
-					$image['src'] = wp_specialchars_decode( $matches[1], ENT_QUOTES );
-			}
-		}
+		$image['src'] = get_avatar_url( $author->user_email, array(
+			'size' => $width,
+		) );
 	}
 
 	// First fall back, blavatar
@@ -418,36 +402,14 @@ function _jetpack_og_get_image_validate_size($width, $height, $req_width, $req_h
 }
 
 /**
-* @param $email
-* @param $width
-* @return array|bool|mixed|string
-*/
+ * Gets a gravatar URL of the specified size.
+ *
+ * @param string $email E-mail address to get gravatar for.
+ * @param int    $width Size of returned gravatar.
+ * @return array|bool|mixed|string
+ */
 function jetpack_og_get_image_gravatar( $email, $width ) {
-	$image = '';
-	if ( function_exists( 'get_avatar_url' ) ) {
-		$avatar = get_avatar_url( $email, $width );
-		if ( ! empty( $avatar ) ) {
-			if ( is_array( $avatar ) )
-				$image = $avatar[0];
-			else
-				$image = $avatar;
-		}
-	} else {
-		$has_filter = has_filter( 'pre_option_show_avatars', '__return_true' );
-		if ( !$has_filter ) {
-			add_filter( 'pre_option_show_avatars', '__return_true' );
-		}
-		$avatar = get_avatar( $email, $width );
-
-		if ( !$has_filter ) {
-			remove_filter( 'pre_option_show_avatars', '__return_true' );
-		}
-
-		if ( !empty( $avatar ) && !is_wp_error( $avatar ) ) {
-			if ( preg_match( '/src=["\']([^"\']+)["\']/', $avatar, $matches ) )
-				$image = wp_specialchars_decode($matches[1], ENT_QUOTES);
-		}
-	}
-
-	return $image;
+	return get_avatar_url( $email, array(
+		'size' => $width,
+	) );
 }

--- a/sal/class.json-api-post-base.php
+++ b/sal/class.json-api-post-base.php
@@ -497,7 +497,7 @@ abstract class SAL_Post {
 
 	protected function get_avatar_url( $email, $avatar_size = 96 ) {
 		$avatar_url = wpcom_get_avatar_url( $email, $avatar_size, '', true );
-		if ( !$avatar_url || is_wp_error( $avatar_url ) ) {
+		if ( ! $avatar_url || is_wp_error( $avatar_url ) ) {
 			return '';
 		}
 

--- a/sal/class.json-api-post-jetpack.php
+++ b/sal/class.json-api-post-jetpack.php
@@ -23,12 +23,15 @@ class Jetpack_Post extends SAL_Post {
 	public function get_geo() {
 		return false;
 	}
-	
+
 	protected function get_avatar_url( $email, $avatar_size = 96 ) {
-		$avatar_url = get_avatar_url( $email, array( 'size' => $avatar_size ) );
-        	if ( !$avatar_url || is_wp_error( $avatar_url ) ) {
-	            return '';
-       		}
+		$avatar_url = get_avatar_url( $email, array(
+			'size' => $avatar_size,
+		) );
+
+		if ( ! $avatar_url || is_wp_error( $avatar_url ) ) {
+			return '';
+		}
 		return $avatar_url;
 	}
 }


### PR DESCRIPTION
Fixes #2035

Since 4.2 is well outside our supported range now, we can remove our old
get_avatar_url implmentations in favor of the core function.

Not super clear on testing for this, but the core function should be a
drop-in replacement for ours.