### PR TITLE
Update tonesque to not assume content dir location

### DIFF
--- a/_inc/lib/tonesque.php
+++ b/_inc/lib/tonesque.php
@@ -46,7 +46,7 @@ class Tonesque {
 			$content_url = content_url();
 			$_image_url  = set_url_scheme( $image_url );
 			if ( wp_startswith( $_image_url, $content_url ) ) {
-				$_image_path = str_replace( $content_url, ABSPATH . 'wp-content', $_image_url );
+				$_image_path = str_replace( $content_url, WP_CONTENT_DIR, $_image_url );
 				if ( file_exists( $_image_path ) ) {
 					$filetype = wp_check_filetype( $_image_path );
 					$ext = $filetype['ext'];


### PR DESCRIPTION
Fixes #6056

The content dir is not neccesarily at `ABSPATH/wp-content`; the
`WP_CONTENT_DIR` constant is a better indicator of the location. The
existing path didn't end with a slash, and according to the docs
`WP_CONTENT_DIR` doesn't either, so this is a drop-in replacement.