### PR TITLE
Enhancing Footer Support Block

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import sample from 'lodash/sample';
+import Button from 'components/button';
 import { translate as __ } from 'i18n-calypso';
 
 /**
@@ -34,37 +35,10 @@ const SupportCard = React.createClass( {
 						<p className="jp-support-card__description">
 							{ __( 'We offer free, full support to all of our Jetpack users. Our support team is always around to help you.' ) }
 						</p>
-						<p className="jp-support-card__description">
-							{ __(
-								'{{supportLink}}View our support page{{/supportLink}}{{hideOnMobile}},{{/hideOnMobile}} ' +
-								'{{forumLink}}check the forums for answers{{/forumLink}}{{hideOnMobile}}, or{{/hideOnMobile}} ' +
-								'{{contactLink}}contact us directly{{/contactLink}}{{hideOnMobile}}.{{/hideOnMobile}}', {
-									components: {
-										hideOnMobile: <span className="jp-hidden-on-mobile" />,
-										supportLink: (
-											<a
-												className="jp-support-card__link"
-												href="https://jetpack.com/support/"
-												title={ __( 'Go to Jetpack.com/support' ) }
-											/>
-										),
-										forumLink: (
-											<a
-												className="jp-support-card__link"
-												href="https://wordpress.org/support/plugin/jetpack"
-												title={ __( 'Go to the WordPress.org support forums' ) }
-											/>
-										),
-										contactLink: (
-											<a
-												className="jp-support-card__link"
-												href="https://jetpack.com/contact-support/"
-												title={ __( 'Contact Jetpack support staff directly' ) }
-											/>
-										)
-									}
-								}
-							) }
+						<p className="jp-support-card__buttons">
+							<Button href="https://jetpack.com/contact-support/">
+								{ __( 'Contact Support' ) }
+							</Button>
 						</p>
 					</div>
 				</Card>

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -27,15 +27,6 @@ const SupportCard = React.createClass( {
 		return (
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
-					<div className="jp-support-card__happiness-engineer">
-						<img
-							src={ 'https://secure.gravatar.com/avatar/' + randomGravID }
-							alt={ __( 'Jetpack Happiness Engineer' ) }
-							className="jp-support-card__happiness-engineer-img"
-							width="72"
-							height="72"
-						/>
-					</div>
 					<div className="jp-support-card__happiness-contact">
 						<h4 className="jp-support-card__header">
 							{ __( 'Need help? The Jetpack team is here for you.' ) }

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -68,44 +68,6 @@ const SupportCard = React.createClass( {
 						</p>
 					</div>
 				</Card>
-				<Card className="jp-support-card__social">
-					<p className="jp-support-card__description">
-						{ __(
-							'{{hideOnMobile}}Enjoying Jetpack or have feedback?{{/hideOnMobile}} ' +
-							'{{reviewLink}}Leave us a review{{/reviewLink}}{{hideOnMobile}},{{/hideOnMobile}} ' +
-							'{{twitterLink}}follow us on Twitter{{/twitterLink}}{{hideOnMobile}}, and{{/hideOnMobile}} ' +
-							'{{facebookLink}}like us on Facebook{{/facebookLink}}{{hideOnMobile}}.{{/hideOnMobile}}', {
-								components: {
-									hideOnMobile: <span className="jp-hidden-on-mobile" />,
-									reviewLink: (
-										<a
-											className="jp-support-card__link"
-											href="https://wordpress.org/support/view/plugin-reviews/jetpack"
-											title={ __( 'Leave a Jetpack review' ) }
-											target="_blank"
-										/>
-									),
-									twitterLink: (
-										<a
-											className="jp-support-card__link"
-											href="http://twitter.com/jetpack"
-											title={ __( 'Follow Jetpack on Twitter' ) }
-											target="_blank"
-										/>
-									),
-									facebookLink: (
-										<a
-											className="jp-support-card__link"
-											href="https://www.facebook.com/jetpackme"
-											title={ __( 'Like us on Facebook' ) }
-											target="_blank"
-										/>
-									)
-								}
-							}
-						) }
-					</p>
-				</Card>
 			</div>
 		);
 	}

--- a/_inc/client/components/support-card/style.scss
+++ b/_inc/client/components/support-card/style.scss
@@ -52,11 +52,7 @@
 	margin: 0 0 rem( 16px ) 0;
 }
 
-.jp-support-card__happiness-contact {
-
-	@include breakpoint( ">660px" ) {
-		flex-basis: 85%;
-		flex-shrink: 1;
-		flex-grow: 1;
-	}
+.jp-support-card__buttons {
+	padding: rem( 6px ) 0 0;
+	margin-bottom: 0;
 }

--- a/_inc/client/components/support-card/style.scss
+++ b/_inc/client/components/support-card/style.scss
@@ -48,39 +48,8 @@
 
 }
 
-.jp-support-card__social {
-	background-color: lighten( $gray, 35% );
-	padding: rem( 16px );
-
-		@include breakpoint( "<660px" ) {
-			background: $white;
-			margin-top: rem( 16px );
-			padding: 0 rem( 16px );
-	}
-}
-
 .jp-support-card__header {
 	margin: 0 0 rem( 16px ) 0;
-}
-
-.jp-support-card__happiness-engineer {
-
-	@include breakpoint( ">660px" ) {
-		flex-basis: 15%;
-		flex-shrink: 1;
-		flex-grow: 1;
-	}
-
-	@include breakpoint( "<660px" ) {
-		display: none;
-	}
-}
-
-.jp-support-card__happiness-engineer-img {
-	width: rem( 72px );
-	height: rem( 72px );
-	margin-right: rem( 24px );
-	border-radius: 50%;
 }
 
 .jp-support-card__happiness-contact {


### PR DESCRIPTION
Per a p2 conversation, we'll be fixing up the design of the footer support block and tidying some things up.

**Before:**
![screen shot 2017-02-20 at 11 39 48 am](https://cloud.githubusercontent.com/assets/108942/23137789/4edb798e-f761-11e6-9b9b-bea0dff2cf77.png)

**After:**
_Paid_
![support_block_jetpack_settings_paid](https://cloud.githubusercontent.com/assets/22752103/23878415/ad6b8684-081d-11e7-80cf-c6f5008f202b.jpg)
_Language for ease of use:_
> Need help?
> Utilize your priority-speed Jetpack support whenever you need it thanks to your paid plan.
> [btn] Ask a question  [btn] Search our support site

_Unpaid_
![support_block_jetpack_settings_unpaid](https://cloud.githubusercontent.com/assets/22752103/23878420/b14cd3a2-081d-11e7-8fa6-1aeaccf05017.jpg)
After is styled to the most up-to-date Calypso styles. Reference components from the top-right HE block here: https://wordpress.com/plans/my-plan/jetpack.com
Settings as can be seen here: https://wordpress.com/settings/general/jetpack.com
_Language for ease of use:_
> Need help?
> Utilize your free Jetpack support whenever you need.
> [btn] Ask a question  [btn] Search our support site
> Need a fast response? Upgrade to a paid plan to get priority support.

---

To do:
- [ ] Add button to contact support directly: https://jetpack.com/contact-support/
- [ ] Add button to search support: https://jetpack.com/support/
- [ ] Add three names (chosen name and not necessarily first name) and gravatars for HE's (not clickable
- [ ] Distinguish between users with plans and those without to generate correct version of the support block

_Related P2: p6TEKc-11E-p2
_Note that the Settings in Calypso and Jetpack changed significantly from the start of that conversation and have influenced the design proposed here._
