### PR TITLE
Stats settings: update label text for advanced options

### DIFF
--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -124,7 +124,7 @@ export const SiteStats = moduleSettingsForm(
 						<InlineExpand label={ __( 'Advanced Options' ) }>
 							<div>
 								<FormFieldset>
-									<FormLegend>{ __( 'Registered Users: Count the page views of registered users who are logged in' ) }</FormLegend>
+									<FormLegend>{ __( 'Count logged in page views from' ) }</FormLegend>
 									{
 										Object.keys( siteRoles ).map( key => (
 											<FormToggle
@@ -141,7 +141,7 @@ export const SiteStats = moduleSettingsForm(
 									}
 								</FormFieldset>
 								<FormFieldset>
-									<FormLegend>{ __( 'Report Visibility: Select the roles that will be able to view stats reports' ) }</FormLegend>
+									<FormLegend>{ __( 'Allow stats reports to be viewed by' ) }</FormLegend>
 									<FormToggle
 										compact
 										checked={ true }


### PR DESCRIPTION
Fixes #6211 

Follow up of https://github.com/Automattic/jetpack/pull/6357

#### Changes proposed in this Pull Request:
* Updates label text

#### Testing instructions:
* Go to Settings > Stats > Advanced

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/22816731/f2a7058e-ef63-11e6-8505-1af8f78ed9fa.png)


#### After
![image](https://cloud.githubusercontent.com/assets/1123119/22816702/d3a8d19e-ef63-11e6-8564-fb281d0611c5.png)
