### PR TITLE
Fixes settings info popover collision with labels

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -102,6 +102,10 @@
 		position: relative;
 		margin-bottom: 0;
 
+		.dops-card  {
+			padding-right: rem( 40px );
+		}
+
 		.form-toggle__switch {
 			float: left;
 			margin-top: 2px;


### PR DESCRIPTION
Fixes #6195 

Follow up of https://github.com/Automattic/jetpack/pull/6359

#### Changes proposed in this Pull Request:
* Adds extra padding that prevents infopopover icon from colliding with text/labels/elements

NOTE: It does not work on these, but there is [an issue](https://github.com/Automattic/jetpack/issues/6273) to fix/move those anyway:
![image](https://cloud.githubusercontent.com/assets/1123119/22817496/ecc282fc-ef67-11e6-9629-46b016a5cc58.png)

#### Testing instructions:
* Go to each panel in settings and resize the window a bunch looking for text collisions

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/22817556/43bb249c-ef68-11e6-9f44-06a3a6221f79.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/22817542/2ab4ae00-ef68-11e6-8089-2284fd2f80fa.png)

