### PR TITLE
Settings UI: use sentence case for all setting cards

### DIFF
--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -24,7 +24,7 @@ export const Antispam = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Antispam', { context: 'Settings header' } ) }>
+					header={ __( 'Spam filtering', { context: 'Settings header' } ) }>
 					<SettingsGroup support="https://akismet.com/jetpack/">
 						<FormFieldset>
 							<ModuleSettingCheckbox

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -19,7 +19,7 @@ export const SEO = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Search Engine Optimization', { context: 'Settings header' } ) }
+					header={ __( 'Search engine optimization', { context: 'Settings header' } ) }
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'seo-tools' } } support="https://jetpack.com/support/seo-tools/">
 						<p>

--- a/modules/custom-content-types.php
+++ b/modules/custom-content-types.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Module Name: Custom Content Types
+ * Module Name: Custom content types
  * Module Description: Display different types of content on your site with custom content types.
  * First Introduced: 3.1
  * Requires Connection: No

--- a/modules/post-by-email.php
+++ b/modules/post-by-email.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Module Name: Post by Email
+ * Module Name: Post by email
  * Module Description: Publish posts by sending an email
  * First Introduced: 2.0
  * Sort Order: 14

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Related Posts
+ * Module Name: Related posts
  * Module Description: Increase page views by showing related content to your visitors.
  * Jumpstart Description: Keep visitors engaged on your blog by highlighting relevant and new content at the bottom of each published post.
  * First Introduced: 2.9

--- a/modules/verification-tools.php
+++ b/modules/verification-tools.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Module Name: Site Verification
+ * Module Name: Site verification
  * Module Description: Establish your site's authenticity with external services.
  * First Introduced: 3.0
  * Sort Order: 33


### PR DESCRIPTION
See [comment](https://github.com/Automattic/jetpack/pull/6172#issuecomment-275767145) by @MichaelArestad 
> It looks like after a discussion in Slack, we should be using sentence case for all of these headings as per our branding guidelines: https://dotcombrand.wordpress.com/brand-voice/#style
> Calypso will need to be updated eventually to match.

#### Changes proposed in this Pull Request:

* Settings UI: use sentence case for the setting cards that were using title case.
* Updates "Antispam" to "Spam fitlering" props @beaulebens 

#### Testing instructions:
* Make sure all setting cards have their headers written in sentence case instead of title case.