### PR TITLE
Remove some sync defaults

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -100,7 +100,6 @@ class Jetpack_Sync_Defaults {
 		'post_by_email_address',
 		'jetpack_protect_key',
 		'jetpack_protect_global_whitelist',
-		'sharing_services',
 		'jetpack_sso_require_two_step',
 		'jetpack_relatedposts',
 		'verification_services_codes',

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -105,7 +105,6 @@ class Jetpack_Sync_Defaults {
 		'jetpack_relatedposts',
 		'verification_services_codes',
 		'users_can_register',
-		'active_plugins',
 		'uninstall_plugins',
 		'advanced_seo_front_page_description', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -160,7 +160,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'post_by_email_address'                => 'pineapple',
 			'jetpack_protect_key'                  => 'pineapple',
 			'jetpack_protect_global_whitelist'     => 'pineapple',
-			'sharing_services'                     => 'pineapple',
 			'jetpack_sso_require_two_step'         => 'pineapple',
 			'jetpack_relatedposts'                 => 'pineapple',
 			'verification_services_codes'          => 'pineapple',

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -164,7 +164,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_relatedposts'                 => 'pineapple',
 			'verification_services_codes'          => 'pineapple',
 			'users_can_register'                   => '1',
-			'active_plugins'                       => array( 'pineapple' ),
 			'uninstall_plugins'                    => 'banana',
 			'advanced_seo_front_page_description'  => 'banana', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 			'advanced_seo_title_formats'           => array( 'posts' => array( 'type' => 'string', 'value' => 'test' ) ), // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -38,22 +38,6 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 
 	}
 
-	public function test_activate_and_deactivating_plugin_is_synced() {
-		activate_plugin( 'hello.php' );
-		$this->sender->do_sync();
-
-		$active_plugins = $this->server_replica_storage->get_option( 'active_plugins' );
-		$this->assertEquals( get_option( 'active_plugins' ), $active_plugins );
-		$this->assertTrue( in_array( 'hello.php', $active_plugins ) );
-
-		deactivate_plugins( 'hello.php' );
-		$this->sender->do_sync();
-
-		$active_plugins = $this->server_replica_storage->get_option( 'active_plugins' );
-		$this->assertEquals( get_option( 'active_plugins' ), $active_plugins );
-		$this->assertFalse( in_array( 'hello.php', $active_plugins ) );
-	}
-
 	public function test_autoupdate_enabled_and_disabled_is_synced() {
 		// enable autoupdates
 		$autoupdate_plugins = Jetpack_Options::get_option( 'autoupdate_plugins', array() );


### PR DESCRIPTION
We don't use these on WPCOM, and this should also save some RAM during sync.