### PR TITLE
Settings UI: allow to independently toggle Markdown for posts and for comments 

### DIFF
--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -21,6 +21,20 @@ import SettingsGroup from 'components/settings-group';
 export const Comments = moduleSettingsForm(
 	React.createClass( {
 
+		/**
+		 * If markdown module is inactive and this is toggling markdown for comments on, activate module.
+		 * If markdown for posts is off and this is toggling markdown for comments off, deactivate module.
+		 *
+		 * @param {string} module
+		 * @returns {*}
+		 */
+		updateFormStateByMarkdown( module ) {
+			if ( !! this.props.getSettingCurrentValue( 'wpcom_publish_posts_with_markdown', module ) ) {
+				return this.props.updateFormStateModuleOption( module, 'wpcom_publish_comments_with_markdown' );
+			}
+			return this.props.updateFormStateModuleOption( module, 'wpcom_publish_comments_with_markdown', true );
+		},
+
 		render() {
 			let comments = this.props.getModule( 'comments' ),
 				isCommentsActive = this.props.getOptionValue( 'comments' ),
@@ -88,9 +102,9 @@ export const Comments = moduleSettingsForm(
 							<ModuleToggle
 								slug="markdown"
 								compact
-								activated={ !!this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
+								activated={ !! this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
 								toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_comments_with_markdown' ] ) }
-								toggleModule={ m => this.props.updateFormStateModuleOption( m, 'wpcom_publish_comments_with_markdown' ) }
+								toggleModule={ this.updateFormStateByMarkdown }
 							>
 							<span className="jp-form-toggle-explanation">
 								{

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -157,6 +157,20 @@ const Composing = moduleSettingsForm(
 			);
 		},
 
+		/**
+		 * If markdown module is inactive and this is toggling markdown for posts on, activate module.
+		 * If markdown for comments is off and this is toggling markdown for posts off, deactivate module.
+		 *
+		 * @param {string} module
+		 * @returns {*}
+		 */
+		updateFormStateByMarkdown( module ) {
+			if ( !! this.props.getSettingCurrentValue( 'wpcom_publish_comments_with_markdown', module ) ) {
+				return this.props.updateFormStateModuleOption( module, 'wpcom_publish_posts_with_markdown' );
+			}
+			return this.props.updateFormStateModuleOption( module, 'wpcom_publish_posts_with_markdown', true );
+		},
+
 		render() {
 			// If we don't have any element to show, return early
 			if (
@@ -175,10 +189,9 @@ const Composing = moduleSettingsForm(
 						<ModuleToggle
 							slug="markdown"
 							compact
-							activated={ this.props.getOptionValue( 'markdown' ) }
-							toggling={ this.props.isSavingAnyOption( 'markdown' ) }
-							toggleModule={ this.props.toggleModuleNow }
-						>
+							activated={ !! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' ) }
+							toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
+							toggleModule={ this.updateFormStateByMarkdown }>
 							<span className="jp-form-toggle-explanation">
 								{ markdown.description }
 							</span>

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1178,6 +1178,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'markdown',
 			),
+			'wpcom_publish_posts_with_markdown' => array(
+				'description'       => esc_html__( 'Use Markdown for posts.', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'markdown',
+			),
 
 			// Mobile Theme
 			'wp_mobile_excerpt' => array(

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -13,15 +13,3 @@
  */
 
 include dirname( __FILE__ ) . '/markdown/easy-markdown.php';
-
-// If the module is active, let's make this active for posting, period.
-// Comments will still be optional.
-add_filter( 'pre_option_' . WPCom_Markdown::POST_OPTION, '__return_true' );
-function jetpack_markdown_posting_always_on() {
-	// why oh why isn't there a remove_settings_field?
-	global $wp_settings_fields;
-	if ( isset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] ) ) {
-		unset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] );
-	}
-}
-add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );


### PR DESCRIPTION
Fixes #6311

See p6TEKc-HQ-jpopdesignp2, comment-2128 by @tyxla 

#### Changes proposed in this Pull Request:

* allow to toggle Markdown for posts and for comments independent of each other
* whitelist option for Markdown for posts.
* remove code in `markdown.php` that forcefully enables Markdown for posts every time the option is attempted to be written.
* when both are toggled off, the Markdown module is disabled

🗒 the first commit won't be needed if it's merged in https://github.com/Automattic/jetpack/pull/6406

#### Testing instructions:

* test the markdown options for posts and comments in Writing and Discussion respectively. Each one should work correctly and independently.