### PR TITLE
Shortcode Embeds: test for modules/shortcodes/class.filter-embedded-html-objects.php

### DIFF
--- a/tests/php/modules/shortcodes/test_class.filter-embedded-html-objects.php
+++ b/tests/php/modules/shortcodes/test_class.filter-embedded-html-objects.php
@@ -1,0 +1,23 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Embedded_HTML_Objects extends WP_UnitTestCase {
+
+	/**
+	 * @author Toro_Unit
+	 */
+	public function test_wp_kses() {
+		$string = '<iframe src="https://wordpress.org"></iframe>';
+
+		$allowed_html = array(
+			'a'      => array(
+				'href' => true,
+			),
+			'iframe' => array(
+				'src' => true,
+			),
+		);
+		$actual = wp_kses( $string, $allowed_html );
+		$this->assertEquals( $string, $actual );
+	}
+
+}


### PR DESCRIPTION
Related #6381

Add Test code for iframe pass through wp_keses.

Fixes #

#### Changes proposed in this Pull Request:

* add test for modules/shortcodes/class.filter-embedded-html-objects.php.

#### Testing instructions:

* checkout pull request #6381 

