### PR TITLE
Top Posts Widget: allow non-square image sizes

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -251,6 +251,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 				/** This filter is documented in modules/stats.php */
 				'gravatar_default' => apply_filters( 'jetpack_static_url', set_url_scheme( 'https://en.wordpress.com/i/logo/white-gray-80.png' ) ),
 				'avatar_size' => 40,
+				'width' => null,
+				'height' => null,
 			);
 			if ( 'grid' == $display ) {
 				$get_image_options['avatar_size'] = 200;
@@ -310,12 +312,31 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		switch ( $display ) {
 		case 'list' :
 		case 'grid' :
+			// Keep the avatar_size as default dimensions for backward compatibility.
+			$width  = (int) $get_image_options['avatar_size'];
+			$height = (int) $get_image_options['avatar_size'];
+
+			// Check if the user has changed the width.
+			if ( ! empty( $get_image_options['width'] ) ) {
+				$width  = (int) $get_image_options['width'];
+			}
+
+			// Check if the user has changed the height.
+			if ( ! empty( $get_image_options['height'] ) ) {
+				$height = (int) $get_image_options['height'];
+			}
+
 			foreach ( $posts as &$post ) {
-				$image = Jetpack_PostImages::get_image( $post['post_id'], array( 'fallback_to_avatars' => true, 'avatar_size' => (int) $get_image_options['avatar_size'] ) );
+				$image = Jetpack_PostImages::get_image(
+					$post['post_id'],
+					array(
+						'fallback_to_avatars' => true,
+						'avatar_size'         => (int) $get_image_options['avatar_size']
+					)
+				);
 				$post['image'] = $image['src'];
 				if ( 'blavatar' != $image['from'] && 'gravatar' != $image['from'] ) {
-					$size = (int) $get_image_options['avatar_size'];
-					$post['image'] = jetpack_photon_url( $post['image'], array( 'resize' => "$size,$size" ) );
+					$post['image'] = jetpack_photon_url( $post['image'], array( 'resize' => "$width,$height" ) );
 				}
 			}
 
@@ -352,8 +373,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 
 						?>
 						<a href="<?php echo esc_url( $filtered_permalink ); ?>" title="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" class="bump-view" data-bump-view="tp">
-							<?php $size = (int) $get_image_options['avatar_size']; ?>
-							<img width="<?php echo absint( $size ); ?>" height="<?php echo absint( $size ); ?>" src="<?php echo esc_url( $post['image'] ); ?>" alt="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" data-pin-nopin="true" />
+							<img width="<?php echo absint( $width ); ?>" height="<?php echo absint( $height ); ?>" src="<?php echo esc_url( $post['image'] ); ?>" alt="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" data-pin-nopin="true" />
 						</a>
 						<?php
 						/**
@@ -384,8 +404,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 						$filtered_permalink = apply_filters( 'jetpack_top_posts_widget_permalink', $post['permalink'], $post );
 						?>
 						<a href="<?php echo esc_url( $filtered_permalink ); ?>" title="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" class="bump-view" data-bump-view="tp">
-							<?php $size = (int) $get_image_options['avatar_size']; ?>
-							<img width="<?php echo absint( $size ); ?>" height="<?php echo absint( $size ); ?>" src="<?php echo esc_url( $post['image'] ); ?>" class='widgets-list-layout-blavatar' alt="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" data-pin-nopin="true" />
+							<img width="<?php echo absint( $width ); ?>" height="<?php echo absint( $height ); ?>" src="<?php echo esc_url( $post['image'] ); ?>" class='widgets-list-layout-blavatar' alt="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" data-pin-nopin="true" />
 						</a>
 						<div class="widgets-list-layout-links">
 							<a href="<?php echo esc_url( $filtered_permalink ); ?>" class="bump-view" data-bump-view="tp">

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -269,6 +269,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			 * @type bool true Should we default to Gravatars when no image is found? Default is true.
 			 * @type string $gravatar_default Default Image URL if no Gravatar is found.
 			 * @type int $avatar_size Default Image size.
+			 * @type mixed $width Image width, not set by default and $avatar_size is used instead.
+			 * @type mixed $height Image height, not set by default and $avatar_size is used instead.
 			 * }
 			 */
 			$get_image_options = apply_filters( 'jetpack_top_posts_widget_image_options', $get_image_options );
@@ -331,7 +333,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 					$post['post_id'],
 					array(
 						'fallback_to_avatars' => true,
-						'avatar_size'         => (int) $get_image_options['avatar_size']
+						'avatar_size'         => (int) $get_image_options['avatar_size'],
 					)
 				);
 				$post['image'] = $image['src'];


### PR DESCRIPTION
Fixes #3682

#### Changes proposed in this Pull Request:
 * Add width and height options to `$get_image_options`, that will allow users to change the size of the image used in Top Posts Widget.

#### Testing instructions:
* Used to following code to change the image size.
```
function custom_thumb_size( $get_image_options ) {
        $get_image_options['width'] = 500;
        $get_image_options['height'] = 600;
 
        return $get_image_options;
}
add_filter( 'jetpack_top_posts_widget_image_options', 'custom_thumb_size' );
```

Is should also work, if you provide only `$get_image_options['avatar_size']`, but only if you want square images.
