### PR TITLE
Dashboard: link scan notice to VP dashboard when threats detected 

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -61,7 +61,7 @@ const DashScan = React.createClass( {
 							module="scan"
 							status="is-error"
 							statusText={ __( 'Threats found' ) }
-							pro={ true } >
+						>
 							<h3>{
 								__(
 									'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.',

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -87,6 +87,20 @@ export const DashItem = React.createClass( {
 					toggle = <span className="jp-dash-item__active-label">{ __( 'Active' ) }</span>
 				}
 			}
+
+			if ( 'scan' === this.props.module && 'is-error' === this.props.status ) {
+				toggle = (
+					<a href="https://dashboard.vaultpress.com/" >
+						<SimpleNotice
+							showDismiss={ false }
+							status={ this.props.status }
+							isCompact={ true }
+						>
+							{ this.props.statusText }
+						</SimpleNotice>
+					</a>
+				);
+			}
 		}
 
 		if ( this.props.pro && ! this.props.isDevMode ) {


### PR DESCRIPTION
Closes #5714

This links the compact notice to `https://dashboard.vaultpress.com/` when there are threats detected, so that they can view more details there.  

To Test: 
- Change [this line](https://github.com/Automattic/jetpack/blob/a38c6aa247a0b5fe638811c6bca942e5d3c87f6e/_inc/client/at-a-glance/scan.jsx#L57) to `const threats = 3;`
- Build and click the notice, should take you to your VP Dashboard. 

![screen shot 2017-02-14 at 10 40 42 am](https://cloud.githubusercontent.com/assets/7129409/22935989/2692c216-f2a2-11e6-8da9-65486de9537d.png)
