### PR TITLE
Endpoints: allow to toggle Markdown for posts independent of comments

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1178,6 +1178,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'markdown',
 			),
+			'wpcom_publish_posts_with_markdown' => array(
+				'description'       => esc_html__( 'Use Markdown for posts.', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'markdown',
+			),
 
 			// Mobile Theme
 			'wp_mobile_excerpt' => array(

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -13,15 +13,3 @@
  */
 
 include dirname( __FILE__ ) . '/markdown/easy-markdown.php';
-
-// If the module is active, let's make this active for posting, period.
-// Comments will still be optional.
-add_filter( 'pre_option_' . WPCom_Markdown::POST_OPTION, '__return_true' );
-function jetpack_markdown_posting_always_on() {
-	// why oh why isn't there a remove_settings_field?
-	global $wp_settings_fields;
-	if ( isset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] ) ) {
-		unset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] );
-	}
-}
-add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* whitelist option for Markdown for posts.
* remove code in `markdown.php` that forcefully enables Markdown for posts every time the option is attempted to be written.

#### Testing instructions:
* Calls to `wp-json/jetpack/v4/settings` passing `true` or `false` for `wpcom_publish_posts_with_markdown` should succeed in toggling it on and off.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Endpoints: allow to independently toggle Markdown for posts