### PR TITLE
Settings: Toggles will now toggle when you click their label

### DIFF
--- a/_inc/client/components/module-toggle/index.jsx
+++ b/_inc/client/components/module-toggle/index.jsx
@@ -32,7 +32,9 @@ export const ModuleToggle = React.createClass( {
 				id = { this.props.id }
 				compact = {	 this.props.compact }
 				onChange={ this.toggleModule }>
-				{ this.props.children }
+				<span onClick={ this.toggleModule }>
+					{ this.props.children }
+				</span>
 			</FormToggle>
 		);
 	}


### PR DESCRIPTION
Fixes #6200

This seems like the most straightforward way to make the settings labels click toggle.  

It works, but I feel like there might be something else that we're missing to make this possible.  I didn't see any special instructions in dops-components [readme](https://github.com/Automattic/dops-components/blob/master/client/components/form/form-toggle/README.md) or the form-toggle component itself.  

To test: 
- Click the settings labels with **toggles** to see the settings toggle.  
- Make sure correct setting gets saved.  