### PR TITLE
Settings: update highlight color for selected stats range

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -210,9 +210,11 @@
 	color: $gray;
 	text-decoration: underline;
 
-	&.is-current {
-		font-weight: 600;
-		text-decoration: none;
+	&.is-current,
+	&:visited.is-current,
+	&:focus.is-current {
+		color: #23282d;
+		text-decoration:none;
 	}
 }
 


### PR DESCRIPTION
Fixes #3871

#### Changes proposed in this Pull Request:

* updates the highlight color used for stats range
<img width="759" alt="captura de pantalla 2017-02-09 a las 15 58 50" src="https://cloud.githubusercontent.com/assets/1041600/22798412/b6581434-eee0-11e6-9f43-2a1e0f274266.png">

This is a change that doesn't depend on the new UI so can be merged at any point.

#### Testing instructions:

* go to At a Glance, the stats range tabs should highlight in black as go through them

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Stats: the highlight of the stats range was updated for easier spotting and to make it consistent with other areas of the dashboard.