### PR TITLE
Sync / WooCommerce: Add Product visibility to post meta whitelist.

### DIFF
--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -4,7 +4,7 @@ require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-module.php';
 
 class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 
-	private $meta_whitelist = array( 
+	private $meta_whitelist = array(
 		'_product_id',
 		'_variation_id',
 		'_qty',
@@ -14,6 +14,7 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_line_total',
 		'_line_tax',
 		'_line_tax_data',
+		'_visibility',
 	);
 
 	private $order_item_table_name;
@@ -68,7 +69,7 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 
 		$order_item_ids_sql = implode( ', ', array_map( 'intval', $order_item_ids ) );
 
-		$order_items = $wpdb->get_results( 
+		$order_items = $wpdb->get_results(
 			"SELECT * FROM $this->order_item_table_name WHERE order_item_id IN ( $order_item_ids_sql )"
 		);
 


### PR DESCRIPTION
See #6354 for more information.

Once `_visibility` is available for each shadow site using WooCommerce,
we will be able to use that post meta value to decide whether a post should be included in Related Posts or not.

#### Proposed changelog entry for your changes:
* Sync / WooCommerce: Add Product visibility to post meta whitelist, for better control of products displayed in Related Posts.