### PR TITLE
Fix the search component exit behaviour.

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -68,7 +68,6 @@ function render() {
 					<Route path='/security' name={ i18n.translate( 'Security', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/traffic' name={ i18n.translate( 'Traffic', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/writing' name={ i18n.translate( 'Writing', { context: 'Navigation item.' } ) } component={ Main } />
-					<Route path='/search' component={ Main } />
 					<Route path='/wpbody-content' component={ Main } />
 					<Route path='/wp-toolbar' component={ Main } />
 					<Route path="*" />

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -31,14 +31,12 @@ import { isModuleActivated } from 'state/modules';
 
 export const NavigationSettings = React.createClass( {
 	openSearch: function() {
-		let currentHash = window.location.hash;
-		if ( currentHash.indexOf( 'search' ) === -1 ) {
-			window.location.hash = 'search';
-		}
 		this.props.onSearchFocus && this.props.onSearchFocus( true );
 	},
 
 	onSearch( term ) {
+		let currentHash = window.location.hash;
+
 		if ( term.length >= 3 ) {
 			analytics.tracks.recordEvent( 'jetpack_wpa_search_term', { term: term.toLowerCase() } );
 		}
@@ -50,6 +48,10 @@ export const NavigationSettings = React.createClass( {
 			// Calling close handler to show what was previously shown to the user
 			this.onClose();
 		} else {
+
+			if ( currentHash.indexOf( 'search' ) === -1 ) {
+				window.location.hash = 'search';
+			}
 
 			// Calling open handler in case the search was previously closed due to zero
 			// length search term

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -18,8 +18,7 @@ import UrlSearch from 'mixins/url-search';
  */
 import {
 	filterSearch,
-	focusSearch,
-	getSearchFocus as _getSearchFocus
+	getSearchTerm
 } from 'state/search';
 import {
 	userCanManageModules as _userCanManageModules,
@@ -61,10 +60,8 @@ export const NavigationSettings = React.createClass( {
 					delaySearch={ true }
 					delayTimeout={ 500 }
 					onSearch={ this.doSearch }
-					isOpen={
-						'/search' === this.props.route.path
-						|| this.props.searchHasFocus
-					}
+					isOpen={ false !== this.props.searchTerm }
+					initialValue={ this.props.searchTerm }
 				/>
 			);
 		}
@@ -165,13 +162,12 @@ export default connect(
 			isSubscriber: _userIsSubscriber( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 			isModuleActivated: module => isModuleActivated( state, module ),
-			searchHasFocus: _getSearchFocus( state )
+			searchTerm: getSearchTerm( state )
 		};
 	},
 	( dispatch ) => {
 		return {
-			searchForTerm: ( term ) => dispatch( filterSearch( term ) ),
-			onSearchFocus: ( hasFocus ) => dispatch( focusSearch( hasFocus ) )
+			searchForTerm: ( term ) => dispatch( filterSearch( term ) )
 		};
 	}
 )( NavigationSettings );

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -41,7 +41,7 @@ export const NavigationSettings = React.createClass( {
 				return 0 === item.indexOf( 'term=' );
 			} );
 
-		let keyword = false;
+		let keyword = '';
 
 		if ( term.length > 0 ) {
 			keyword = term[ 0 ].split( '=' )[ 1 ];
@@ -60,7 +60,7 @@ export const NavigationSettings = React.createClass( {
 					delaySearch={ true }
 					delayTimeout={ 500 }
 					onSearch={ this.doSearch }
-					isOpen={ false !== this.props.searchTerm }
+					isOpen={ !! this.props.searchTerm }
 					initialValue={ this.props.searchTerm }
 				/>
 			);

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -81,6 +81,7 @@ export const NavigationSettings = React.createClass( {
 			return (
 				<Search
 					pinned={ true }
+					fitsContainer={ true }
 					placeholder={ __( 'Search for a Jetpack feature.' ) }
 					delaySearch={ true }
 					delayTimeout={ 500 }

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -35,7 +35,7 @@ export const NavigationSettings = React.createClass( {
 	},
 
 	onSearch( term ) {
-		let currentHash = window.location.hash;
+		const currentHash = window.location.hash;
 
 		if ( term.length >= 3 ) {
 			analytics.tracks.recordEvent( 'jetpack_wpa_search_term', { term: term.toLowerCase() } );
@@ -48,7 +48,6 @@ export const NavigationSettings = React.createClass( {
 			// Calling close handler to show what was previously shown to the user
 			this.onClose();
 		} else {
-
 			if ( currentHash.indexOf( 'search' ) === -1 ) {
 				window.location.hash = 'search';
 			}
@@ -60,14 +59,14 @@ export const NavigationSettings = React.createClass( {
 	},
 
 	onClose: function() {
-		let currentHash = window.location.hash;
+		const currentHash = window.location.hash;
 		if ( currentHash.indexOf( 'search' ) > -1 ) {
 			this.context.router.goBack();
 		}
 	},
 
 	onBlur: function() {
-		let currentHash = window.location.hash;
+		const currentHash = window.location.hash;
 		this.props.onSearchFocus( false );
 
 		// If the user has navigated back a page, we discard the search term
@@ -157,13 +156,13 @@ export const NavigationSettings = React.createClass( {
 		}
 
 		return (
-			<div className='dops-navigation'>
+			<div className="dops-navigation">
 				<SectionNav selectedText={ this.props.route.name }>
 					{ navItems }
 					{ this.maybeShowSearch() }
 				</SectionNav>
 			</div>
-		)
+		);
 	}
 } );
 

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -11,35 +11,39 @@ import { shallow } from 'enzyme';
 import { NavigationSettings } from '../index';
 
 describe( 'NavigationSettings', () => {
+	let wrapper,
+		testProps;
 
-	// Mock the required context type
-	NavigationSettings.contextTypes = {
-		router: () => {
-			return {
-				goBack: () => {}
+	before( () => {
+		// Mock the required context type
+		NavigationSettings.contextTypes = {
+			router: () => {
+				return {
+					goBack: () => {}
+				}
 			}
-		}
-	};
+		};
 
-	let testProps = {
-		userCanManageModules: false,
-		isSubscriber: true,
-		route: {
-			name: 'General',
-			path: '/settings'
-		},
-		router: {
-			goBack: () => {}
-		},
-		isModuleActivated: () => true,
-		siteConnectionStatus: true,
-		siteRawUrl: 'example.org',
-		siteAdminUrl: 'https://example.org/wp-admin/'
-	};
+		testProps = {
+			userCanManageModules: false,
+			isSubscriber: true,
+			route: {
+				name: 'General',
+				path: '/settings'
+			},
+			router: {
+				goBack: () => {}
+			},
+			isModuleActivated: () => true,
+			siteConnectionStatus: true,
+			siteRawUrl: 'example.org',
+			siteAdminUrl: 'https://example.org/wp-admin/'
+		};
+
+		wrapper = shallow( <NavigationSettings { ...testProps } /> );
+	} );
 
 	describe( 'initially', () => {
-		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
-
 		it( 'renders a div with a className of "dops-navigation"', () => {
 			expect( wrapper.find( '.dops-navigation' ) ).to.have.length( 1 );
 		} );
@@ -52,8 +56,6 @@ describe( 'NavigationSettings', () => {
 	} );
 
 	describe( 'for a Subscriber user', () => {
-		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
-
 		it( 'does not render Settings tabs', () => {
 			expect( wrapper.find( 'NavItem' ) ).to.have.length( 0 );
 		} );
@@ -65,12 +67,14 @@ describe( 'NavigationSettings', () => {
 
 	describe( 'for Editor, Author and Contributor users', () => {
 
-		Object.assign( testProps, {
-			userCanManageModules: false,
-			isSubscriber: false
-		} );
+		before( () => {
+			Object.assign( testProps, {
+				userCanManageModules: false,
+				isSubscriber: false
+			} );
 
-		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
+			wrapper = shallow( <NavigationSettings { ...testProps } /> );
+		} );
 
 		it( 'renders tabs with Writing', () => {
 			expect( wrapper.find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
@@ -87,25 +91,48 @@ describe( 'NavigationSettings', () => {
 	} );
 
 	describe( 'for an Admin user', () => {
+		before( () => {
+			Object.assign( testProps, {
+				userCanManageModules: true,
+				isSubscriber: false
+			} );
 
-		Object.assign( testProps, {
-			userCanManageModules: true,
-			isSubscriber: false
+			wrapper = shallow( <NavigationSettings { ...testProps } /> );
+
 		} );
 
-		const wrapper = shallow( <NavigationSettings { ...testProps } /> );
-
 		it( 'renders tabs with Discussion, Security, Traffic, Writing, Sharing', () => {
-			expect( wrapper.find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing', 'Discussion', 'Traffic', 'Security', 'Sharing' ].includes( item ) ) ).to.be.true;
+			expect(
+				wrapper
+					.find( 'NavItem' )
+					.children()
+					.nodes
+					.filter( item => 'string' === typeof item )
+					.every(
+						item => [
+							'Writing',
+							'Discussion',
+							'Traffic',
+							'Security',
+							'Sharing'
+						].includes( item )
+					)
+			).to.be.true;
 		} );
 
 		it( 'displays Search', () => {
 			expect( wrapper.find( 'Search' ) ).to.have.length( 1 );
 		} );
 
-		it( 'changes hash to #search when Search is invoked', () => {
-			wrapper.instance().openSearch();
-			expect( window.location.hash ).to.be.equal( '#search' );
+		describe( 'when Search is opened', () => {
+			before( () => {
+				wrapper.instance().openSearch();
+			} );
+
+			it( 'changes hash to #search', () => {
+				expect( window.location.hash ).to.be.equal( '#search' );
+			} );
+
 		} );
 
 		it( 'switches to Security when the tab is clicked', () => {
@@ -115,7 +142,7 @@ describe( 'NavigationSettings', () => {
 					path: '/security'
 				}
 			} );
-			const wrapper = shallow( <NavigationSettings { ...testProps } /> );
+			wrapper = shallow( <NavigationSettings { ...testProps } /> );
 			expect( wrapper.find( 'SectionNav' ).props().selectedText ).to.be.equal( 'Security' );
 		} );
 	} );
@@ -123,23 +150,87 @@ describe( 'NavigationSettings', () => {
 	describe( 'the Sharing link', () => {
 
 		it( 'is rendered if Publicize is active', () => {
-			const wrapper = shallow( <NavigationSettings { ...testProps } isModuleActivated={ m => 'publicize' === m } /> );
-			expect( wrapper.find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'General', 'Writing', 'Discussion', 'Traffic', 'Security', 'Sharing' ].includes( item ) ) ).to.be.true;
+			wrapper = shallow(
+				<NavigationSettings
+					{ ...testProps }
+					isModuleActivated={ m => 'publicize' === m }
+				/>
+			);
+			expect(
+				wrapper
+					.find( 'NavItem' )
+					.children()
+					.nodes
+					.filter( item => 'string' === typeof item )
+					.every(
+						item => [
+							'General',
+							'Writing',
+							'Discussion',
+							'Traffic',
+							'Security',
+							'Sharing'
+						].includes( item )
+					)
+			).to.be.true;
 		} );
 
 		it( 'is rendered if Sharing is active', () => {
-			const wrapper = shallow( <NavigationSettings { ...testProps } isModuleActivated={ m => 'sharing' === m } /> );
-			expect( wrapper.find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'General', 'Writing', 'Discussion', 'Traffic', 'Security', 'Sharing' ].includes( item ) ) ).to.be.true;
+			wrapper = shallow(
+				<NavigationSettings
+					{ ...testProps }
+					isModuleActivated={ m => 'sharing' === m }
+				/>
+			);
+			expect(
+				wrapper
+					.find( 'NavItem' )
+					.children()
+					.nodes
+					.filter( item => 'string' === typeof item )
+					.every(
+						item => [
+							'General',
+							'Writing',
+							'Discussion',
+							'Traffic',
+							'Security',
+							'Sharing'
+						].includes( item )
+					)
+			).to.be.true;
 		} );
 
 		it( 'is not rendered if Publicize and Sharing are inactive', () => {
-			const wrapper = shallow( <NavigationSettings { ...testProps } isModuleActivated={ () => false } /> );
-			expect( wrapper.find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'General', 'Writing', 'Discussion', 'Traffic', 'Security' ].includes( item ) ) ).to.be.true;
+			const wrapper = shallow(
+				<NavigationSettings
+					{ ...testProps }
+					isModuleActivated={ () => false }
+				/>
+			);
+			expect(
+				wrapper
+					.find( 'NavItem' )
+					.children()
+					.nodes
+					.filter( item => 'string' === typeof item )
+					.every(
+						item => [
+							'General',
+							'Writing',
+							'Discussion',
+							'Traffic',
+							'Security'
+						].includes( item )
+					)
+			).to.be.true;
 		} );
 
 		describe( 'if site is connected', () => {
 
-			const wrapper = shallow( <NavigationSettings { ...testProps } /> );
+			before( () => {
+				wrapper = shallow( <NavigationSettings { ...testProps } /> );
+			} );
 
 			it( 'points to Calypso', () => {
 				expect( wrapper.find( 'NavItem' ).nodes.pop().props.path ).to.be.equal( 'https://wordpress.com/sharing/example.org' );
@@ -152,7 +243,9 @@ describe( 'NavigationSettings', () => {
 
 		describe( 'if site is in dev mode', () => {
 
-			const wrapper = shallow( <NavigationSettings { ...testProps } siteConnectionStatus={ false } /> );
+			before( () => {
+				wrapper = shallow( <NavigationSettings { ...testProps } siteConnectionStatus={ false } /> );
+			} );
 
 			it( 'points to WP Admin', () => {
 				expect( wrapper.find( 'NavItem' ).nodes.pop().props.path ).to.be.equal( 'https://example.org/wp-admin/options-general.php?page=sharing' );

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -40,6 +41,7 @@ describe( 'NavigationSettings', () => {
 			siteAdminUrl: 'https://example.org/wp-admin/'
 		};
 
+		window.location.hash = '#settings';
 		wrapper = shallow( <NavigationSettings { ...testProps } /> );
 	} );
 
@@ -98,7 +100,6 @@ describe( 'NavigationSettings', () => {
 			} );
 
 			wrapper = shallow( <NavigationSettings { ...testProps } /> );
-
 		} );
 
 		it( 'renders tabs with Discussion, Security, Traffic, Writing, Sharing', () => {
@@ -125,12 +126,35 @@ describe( 'NavigationSettings', () => {
 		} );
 
 		describe( 'when Search is opened', () => {
+			let instance;
+
 			before( () => {
-				wrapper.instance().openSearch();
+				instance = wrapper.instance();
+				instance.props = {
+					...instance.props,
+					searchForTerm: sinon.stub(),
+					onSearchFocus: sinon.stub()
+				};
+
+				instance.context.router = { goBack: sinon.stub() };
 			} );
 
-			it( 'changes hash to #search', () => {
-				expect( window.location.hash ).to.be.equal( '#search' );
+			it( 'does not change hash to #search', () => {
+				expect( window.location.hash ).to.be.equal( '#settings' );
+			} );
+
+			describe( 'and a search term is opened', () => {
+				it( 'changes hash to #search', () => {
+					instance.onSearch( 'search term' );
+					expect( window.location.hash ).to.be.equal( '#search' );
+				} );
+
+				describe( 'and a search term is deleted', () => {
+					it( 'changes hash back to #settings', () => {
+						instance.onSearch( '' );
+						expect( instance.context.router.goBack.calledOnce ).to.be.true;
+					} );
+				} );
 			} );
 
 		} );

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -13,15 +13,17 @@ import { NavigationSettings } from '../index';
 
 describe( 'NavigationSettings', () => {
 	let wrapper,
-		testProps;
+		testProps,
+		options;
 
 	before( () => {
 		// Mock the required context type
 		NavigationSettings.contextTypes = {
 			router: () => {
 				return {
-					goBack: () => {}
-				}
+					goBack: () => {},
+					listen: () => {}
+				};
 			}
 		};
 
@@ -33,16 +35,24 @@ describe( 'NavigationSettings', () => {
 				path: '/settings'
 			},
 			router: {
-				goBack: () => {}
+				goBack: () => {},
+				listen: () => {}
 			},
 			isModuleActivated: () => true,
 			siteConnectionStatus: true,
 			siteRawUrl: 'example.org',
-			siteAdminUrl: 'https://example.org/wp-admin/'
+			siteAdminUrl: 'https://example.org/wp-admin/',
+			searchForTerm: () => {}
+		};
+
+		options = {
+			context: {
+				router: NavigationSettings.contextTypes.router()
+			}
 		};
 
 		window.location.hash = '#settings';
-		wrapper = shallow( <NavigationSettings { ...testProps } /> );
+		wrapper = shallow( <NavigationSettings { ...testProps } />, options );
 	} );
 
 	describe( 'initially', () => {
@@ -75,7 +85,7 @@ describe( 'NavigationSettings', () => {
 				isSubscriber: false
 			} );
 
-			wrapper = shallow( <NavigationSettings { ...testProps } /> );
+			wrapper = shallow( <NavigationSettings { ...testProps } />, options );
 		} );
 
 		it( 'renders tabs with Writing', () => {
@@ -99,7 +109,7 @@ describe( 'NavigationSettings', () => {
 				isSubscriber: false
 			} );
 
-			wrapper = shallow( <NavigationSettings { ...testProps } /> );
+			wrapper = shallow( <NavigationSettings { ...testProps } />, options );
 		} );
 
 		it( 'renders tabs with Discussion, Security, Traffic, Writing, Sharing', () => {
@@ -130,13 +140,6 @@ describe( 'NavigationSettings', () => {
 
 			before( () => {
 				instance = wrapper.instance();
-				instance.props = {
-					...instance.props,
-					searchForTerm: sinon.stub(),
-					onSearchFocus: sinon.stub()
-				};
-
-				instance.context.router = { goBack: sinon.stub() };
 			} );
 
 			it( 'does not change hash to #search', () => {
@@ -144,15 +147,15 @@ describe( 'NavigationSettings', () => {
 			} );
 
 			describe( 'and a search term is opened', () => {
-				it( 'changes hash to #search', () => {
-					instance.onSearch( 'search term' );
-					expect( window.location.hash ).to.be.equal( '#search' );
+				it( 'adds a search term in a query string', () => {
+					instance.doSearch( 'search term' );
+					expect( window.location.hash ).to.be.equal( '#settings?term=search term' );
 				} );
 
 				describe( 'and a search term is deleted', () => {
 					it( 'changes hash back to #settings', () => {
-						instance.onSearch( '' );
-						expect( instance.context.router.goBack.calledOnce ).to.be.true;
+						instance.doSearch( '' );
+						expect( window.location.hash ).to.be.equal( '#settings' );
 					} );
 				} );
 			} );
@@ -166,7 +169,7 @@ describe( 'NavigationSettings', () => {
 					path: '/security'
 				}
 			} );
-			wrapper = shallow( <NavigationSettings { ...testProps } /> );
+			wrapper = shallow( <NavigationSettings { ...testProps } />, options );
 			expect( wrapper.find( 'SectionNav' ).props().selectedText ).to.be.equal( 'Security' );
 		} );
 	} );
@@ -178,7 +181,8 @@ describe( 'NavigationSettings', () => {
 				<NavigationSettings
 					{ ...testProps }
 					isModuleActivated={ m => 'publicize' === m }
-				/>
+				/>,
+				options
 			);
 			expect(
 				wrapper
@@ -204,7 +208,8 @@ describe( 'NavigationSettings', () => {
 				<NavigationSettings
 					{ ...testProps }
 					isModuleActivated={ m => 'sharing' === m }
-				/>
+				/>,
+				options
 			);
 			expect(
 				wrapper
@@ -230,7 +235,8 @@ describe( 'NavigationSettings', () => {
 				<NavigationSettings
 					{ ...testProps }
 					isModuleActivated={ () => false }
-				/>
+				/>,
+				options
 			);
 			expect(
 				wrapper
@@ -253,7 +259,7 @@ describe( 'NavigationSettings', () => {
 		describe( 'if site is connected', () => {
 
 			before( () => {
-				wrapper = shallow( <NavigationSettings { ...testProps } /> );
+				wrapper = shallow( <NavigationSettings { ...testProps } />, options );
 			} );
 
 			it( 'points to Calypso', () => {
@@ -268,7 +274,7 @@ describe( 'NavigationSettings', () => {
 		describe( 'if site is in dev mode', () => {
 
 			before( () => {
-				wrapper = shallow( <NavigationSettings { ...testProps } siteConnectionStatus={ false } /> );
+				wrapper = shallow( <NavigationSettings { ...testProps } siteConnectionStatus={ false } />, options );
 			} );
 
 			it( 'points to WP Admin', () => {

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -144,12 +144,6 @@ const Main = React.createClass( {
 	},
 
 	renderMainContent: function( route ) {
-		if ( '/search' === route && false === this.props.searchTerm ) {
-			window.location.hash = 'settings';
-			const history = createHistory();
-			history.push( window.location.pathname + '?page=jetpack#/settings' );
-		}
-
 		// Track page views
 		analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: route } );
 
@@ -194,7 +188,6 @@ const Main = React.createClass( {
 			case '/traffic':
 			case '/discussion':
 			case '/writing':
-			case '/search':
 				navComponent = settingsNav;
 				pageComponent = <SearchableSettings
 					route={ this.props.route }
@@ -270,8 +263,7 @@ window.wpNavMenuClassChange = function() {
 		'#/discussion',
 		'#/security',
 		'#/traffic',
-		'#/writing',
-		'#/search'
+		'#/writing'
 	],
 	dashboardRoutes = [
 		'#/',

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -103,17 +103,6 @@ const Main = React.createClass( {
 	},
 
 	shouldComponentUpdate: function( nextProps ) {
-
-		// A special case when user has just entered search mode and has not yet
-		// entered a search term
-		if (
-			nextProps.route.path !== this.props.route.path
-			&& '/search' === nextProps.route.path
-			&& ! nextProps.searchTerm
-		) {
-			return false;
-		}
-
 		// If user triggers Skip to main content or Skip to toolbar with keyboard navigation, stay in the same tab.
 		if ( includes( [ '/wpbody-content', '/wp-toolbar' ], nextProps.route.path ) ) {
 			return false;

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -125,7 +125,7 @@ const Main = React.createClass( {
 	/**
 	 *
 	 * Takes care of redirection when
-	 *  - jumpstarting ( resseting options )
+	 * - jumpstarting ( resseting options )
 	 * - the jumpstart is complete
 	 * @param  {Object} nextProps The next props as received by componentWillReceiveProps
 	 */
@@ -144,6 +144,11 @@ const Main = React.createClass( {
 	},
 
 	renderMainContent: function( route ) {
+		if ( '/search' === route && false === this.props.searchTerm ) {
+			window.location.hash = 'settings';
+			const history = createHistory();
+			history.push( window.location.pathname + '?page=jetpack#/settings' );
+		}
 
 		// Track page views
 		analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: route } );

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -16,7 +16,7 @@ export default React.createClass( {
 	displayName: 'SearchableSettings',
 
 	render() {
-		var commonProps = {
+		const commonProps = {
 			route: this.props.route,
 			searchTerm: this.props.searchTerm
 		};
@@ -64,4 +64,3 @@ export default React.createClass( {
 		);
 	}
 } );
-

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -24,7 +24,7 @@ export default React.createClass( {
 		return (
 			<div className="jp-settings-container">
 				<div className="jp-no-results">
-					{ false !== commonProps.searchTerm
+					{ commonProps.searchTerm
 						? __(
 							'No search results found for %(term)s',
 							{

--- a/_inc/client/state/search/actions.js
+++ b/_inc/client/state/search/actions.js
@@ -2,9 +2,7 @@
  * Internal dependencies
  */
 import {
-	JETPACK_SEARCH_TERM,
-	JETPACK_SEARCH_FOCUS,
-	JETPACK_SEARCH_BLUR
+	JETPACK_SEARCH_TERM
 } from 'state/action-types';
 
 export const filterSearch = ( term ) => {
@@ -13,19 +11,5 @@ export const filterSearch = ( term ) => {
 			type: JETPACK_SEARCH_TERM,
 			term: term
 		} );
-	}
-};
-
-export const focusSearch = ( hasFocus ) => {
-	return ( dispatch ) => {
-		if ( hasFocus ) {
-			dispatch( {
-				type: JETPACK_SEARCH_FOCUS
-			} );
-		} else {
-			dispatch( {
-				type: JETPACK_SEARCH_BLUR
-			} );
-		}
-	}
+	};
 };

--- a/_inc/client/state/search/reducer.js
+++ b/_inc/client/state/search/reducer.js
@@ -10,9 +10,7 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import {
-	JETPACK_SEARCH_TERM,
-	JETPACK_SEARCH_FOCUS,
-	JETPACK_SEARCH_BLUR
+	JETPACK_SEARCH_TERM
 } from 'state/action-types';
 
 const searchTerm = ( state = false, action ) => {
@@ -25,22 +23,8 @@ const searchTerm = ( state = false, action ) => {
 	}
 };
 
-const searchFocus = ( state = false, action ) => {
-	switch ( action.type ) {
-		case JETPACK_SEARCH_FOCUS:
-			return true;
-
-		case JETPACK_SEARCH_BLUR:
-			return false;
-
-		default:
-			return state;
-	}
-};
-
 export const reducer = combineReducers( {
-	searchTerm,
-	searchFocus
+	searchTerm
 } );
 
 /**
@@ -51,16 +35,6 @@ export const reducer = combineReducers( {
  */
 export function getSearchTerm( state ) {
 	return state.jetpack.search.searchTerm;
-}
-
-/**
- * Returns the Search Focus state
- *
- * @param  {Object} state  Global state tree
- * @return {Boolean}       Whether the search input has focus
- */
-export function getSearchFocus( state ) {
-	return state.jetpack.search.searchFocus;
 }
 
 /**

--- a/_inc/client/state/search/reducer.js
+++ b/_inc/client/state/search/reducer.js
@@ -13,7 +13,7 @@ import {
 	JETPACK_SEARCH_TERM
 } from 'state/action-types';
 
-const searchTerm = ( state = false, action ) => {
+const searchTerm = ( state = '', action ) => {
 	switch ( action.type ) {
 		case JETPACK_SEARCH_TERM:
 			return action.term;

--- a/_inc/client/state/search/test/reducer.js
+++ b/_inc/client/state/search/test/reducer.js
@@ -30,34 +30,4 @@ describe( 'Search reducer', () => {
 			expect( stateOut.searchTerm ).to.equal( stateIn.searchTerm );
 		} );
 	} );
-
-	describe( 'focus property', () => {
-		it( 'should get set on the respective event', () => {
-			const stateIn = {};
-			const action = {
-				type: 'JETPACK_SEARCH_FOCUS',
-			};
-			let stateOut = searchReducer( stateIn, action );
-			expect( stateOut.searchFocus ).to.be.true;
-		} );
-
-		it( 'should get unset on the respective event', () => {
-			const stateIn = {};
-			const action = {
-				type: 'JETPACK_SEARCH_BLUR',
-			};
-			let stateOut = searchReducer( stateIn, action );
-			expect( stateOut.searchFocus ).to.be.false;
-		} );
-
-		it( 'should not change on any other events', () => {
-			const stateIn = {};
-
-			const action =  {
-				type: 'JETPACK_SOME_EVENT'
-			};
-			let stateOut = searchReducer( stateIn, action );
-			expect( stateOut.searchFocus ).to.be.false;
-		} );
-	} );
 } );

--- a/_inc/client/state/search/test/selectors.js
+++ b/_inc/client/state/search/test/selectors.js
@@ -24,7 +24,7 @@ describe( 'Module found selector', () => {
 					}
 				},
 				search: {
-					searchTerm: false
+					searchTerm: ''
 				}
 			}
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8111,13 +8111,13 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1, which@^1.2.12, which@^1.2.9, which@~1.2.10:
+which@1, which@^1.0.5, which@^1.2.12, which@^1.2.9, which@~1.2.10:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:
     isexe "^1.1.1"
 
-which@^1.0.5, which@~1.0.5:
+which@~1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/which/-/which-1.0.9.tgz#460c1da0f810103d0321a9b633af9e575e64486f"
 


### PR DESCRIPTION
Fixes #6414 

#### Changes proposed in this Pull Request:
* Updates tests to use the `before` functionality of the testing framework.
* Modifies the way search handles the query fragment - only sets it to `search` when there is actually a search term present.
* Fixes some eslint warnings.

This PR is waiting for https://github.com/Automattic/dops-components/pull/93 to get completed and merged.