### PR TITLE
Theme Tools: add Twenty Seventeen Compat files.

### DIFF
--- a/modules/theme-tools.php
+++ b/modules/theme-tools.php
@@ -35,9 +35,10 @@ function jetpack_load_theme_compat() {
 	 * @param array Associative array of theme compat files to load.
 	 */
 	$compat_files = apply_filters( 'jetpack_theme_compat_files', array(
-		'twentyfourteen' => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfourteen.php',
-		'twentyfifteen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfifteen.php',
-		'twentysixteen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentysixteen.php',
+		'twentyfourteen'   => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfourteen.php',
+		'twentyfifteen'    => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfifteen.php',
+		'twentysixteen'    => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentysixteen.php',
+		'twentyseventeen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyseventeen.php',
 	) );
 
 	_jetpack_require_compat_file( get_stylesheet(), $compat_files );

--- a/modules/theme-tools/compat/twentyseventeen.css
+++ b/modules/theme-tools/compat/twentyseventeen.css
@@ -2,7 +2,8 @@
  * Tiled Galleries
  */
 
-.tiled-gallery .tiled-gallery-item a {
+.tiled-gallery .tiled-gallery-item a,
+.tiled-gallery .tiled-gallery-item a:hover {
 	-webkit-box-shadow: none;
 	-moz-box-shadow: none;
 	box-shadow: none;

--- a/modules/theme-tools/compat/twentyseventeen.css
+++ b/modules/theme-tools/compat/twentyseventeen.css
@@ -1,0 +1,9 @@
+/**
+ * Tiled Galleries
+ */
+
+.tiled-gallery .tiled-gallery-item a {
+	-webkit-box-shadow: none;
+	-moz-box-shadow: none;
+	box-shadow: none;
+}

--- a/modules/theme-tools/compat/twentyseventeen.php
+++ b/modules/theme-tools/compat/twentyseventeen.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Jetpack Compatibility File
+ * See: http://jetpack.com/
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Add support for Jetpack Theme features.
+ */
+function twentyseventeen_jetpack_setup() {
+	/**
+	 * Add theme support for Responsive Videos.
+	 */
+	add_theme_support( 'jetpack-responsive-videos' );
+}
+add_action( 'after_setup_theme', 'twentyseventeen_jetpack_setup' );
+
+/**
+ * Enqueue our compatibility stylesheet.
+ */
+function twentyseventeen_init_jetpack() {
+	/**
+	 * Add our compat CSS file for custom widget stylings and such.
+	 * Set the version equal to filemtime for development builds, and the JETPACK__VERSION for production
+	 * or skip it entirely for wpcom.
+	 */
+	if ( ! is_admin() ) {
+		$version = false;
+		if ( method_exists( 'Jetpack', 'is_development_version' ) ) {
+			$version = Jetpack::is_development_version() ? filemtime( plugin_dir_path( __FILE__ ) . 'twentyseventeen.css' ) : JETPACK__VERSION;
+		}
+		wp_enqueue_style( 'twentyseventeen-jetpack', plugins_url( 'twentyseventeen.css', __FILE__ ), array(), $version );
+		wp_style_add_data( 'twentyseventeen-jetpack', 'rtl', 'replace' );
+	}
+}
+add_action( 'init', 'twentyseventeen_init_jetpack' );


### PR DESCRIPTION
- Avoid horizontal lines appearing under Tiled Gallery rows.

Before:

![hr](https://cloud.githubusercontent.com/assets/426388/23033584/ec950ac8-f478-11e6-8d71-48a577d54860.png)

After:

![no-hr](https://cloud.githubusercontent.com/assets/426388/23033592/f10934ee-f478-11e6-9949-4c4469d18c59.png)

We will also need to address the widget layout issues described in #5809

#### Proposed changelog entry for your changes:
* Add Twenty Seventeen Compatibility files to ensure that all Jetpack features work well with the latest default theme.