### PR TITLE
Sync Queue: Prevent Fatal Errors when syncing SimpleXMLElement object

### DIFF
--- a/sync/class.jetpack-sync-queue.php
+++ b/sync/class.jetpack-sync-queue.php
@@ -50,11 +50,18 @@ class Jetpack_Sync_Queue {
 			$rows_added = $wpdb->query( $wpdb->prepare(
 				"INSERT INTO $wpdb->options (option_name, option_value, autoload) VALUES (%s, %s,%s)",
 				$this->get_next_data_row_option_name(),
-				serialize( $item ),
+				$this->serialize( $item ),
 				'no'
 			) );
 			$added      = ( 0 !== $rows_added );
 		}
+	}
+
+	function serialize( $item ) {
+		if ( $item instanceof SimpleXMLElement ) {
+			$item = $item->asXML();
+		}
+		return serialize( $item );
 	}
 
 	// Attempts to insert all the items in a single SQL query. May be subject to query size limits!
@@ -68,7 +75,7 @@ class Jetpack_Sync_Queue {
 
 		for ( $i = 0; $i < count( $items ); $i += 1 ) {
 			$option_name  = esc_sql( $base_option_name . '-' . $i );
-			$option_value = esc_sql( serialize( $items[ $i ] ) );
+			$option_value = esc_sql( $this->serialize( $items[ $i ] ) );
 			$rows[]       = "('$option_name', '$option_value', 'no')";
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-queue.php
+++ b/tests/php/sync/test_class.jetpack-sync-queue.php
@@ -254,6 +254,22 @@ class WP_Test_Jetpack_Sync_Queue extends WP_UnitTestCase {
 		$this->assertEquals( array( 'foo' ), $other_queue->checkout( 5 )->get_item_values() );
 	}
 
+	function test_add_simple_xml_object() {
+		// lag is the difference in time between the age of the oldest item and the current time
+		$this->queue->reset();
+		$xml = simplexml_load_string( '<x>hello</x>');
+		$this->queue->add( $xml );
+		
+		$buffer = $this->queue->checkout( 1 );
+		$this->assertNotEquals( false, $buffer );
+		$this->queue->close( $buffer );
+
+		$this->queue->add_all( array( $xml ) );
+		$buffer = $this->queue->checkout( 1 );
+		$this->assertNotEquals( false, $buffer );
+		$this->queue->close( $buffer );
+	}
+
 	function test_benchmark() {
 		$this->markTestIncomplete( "We don't want to run this every time" );
 		$iterations  = 100;


### PR DESCRIPTION
Added support because a user was seeing fatal errors when syncing
SimpleXMLElements that were added by a plugin.

Fixes #6373

#### Changes proposed in this Pull Request:
* Check for SimpleXML object before trying to searlize it into the DB. 

#### Testing instructions:
* Do the test pass? 
