### PR TITLE
Settings UI - At a Glance: add link to wpcom in Monitor card

### DIFF
--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -100,7 +100,6 @@ const DashAkismet = React.createClass( {
 					status="is-warning"
 					statusText={ __( 'Invalid key' ) }
 					pro={ true }
-					siteAdminUrl={ this.props.siteAdminUrl }
 				>
 					<p className="jp-dash-item__description">
 						{

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -57,8 +57,6 @@ const DashPluginUpdates = React.createClass( {
 					label={ labelName }
 					module="manage"
 					status="is-warning"
-					siteRawUrl={ this.props.siteRawUrl }
-					siteAdminUrl={ this.props.siteAdminUrl }
 				>
 					<h2 className="jp-dash-item__count">
 						{

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -25,7 +25,11 @@ import {
 	getModule as _getModule
 } from 'state/modules';
 import ProStatus from 'pro-status';
-import { userCanManageModules } from 'state/initial-state';
+import {
+	getSiteRawUrl,
+	getSiteAdminUrl,
+	userCanManageModules
+} from 'state/initial-state';
 
 export const DashItem = React.createClass( {
 	displayName: 'DashItem',
@@ -101,6 +105,27 @@ export const DashItem = React.createClass( {
 					</a>
 				);
 			}
+
+			if ( 'monitor' === this.props.module && ! this.props.isDevMode ) {
+				toggle = (
+					<div>
+						{
+							this.props.isModuleActivated( this.props.module ) && (
+								<Button
+									href={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
+									compact>
+									{
+										__( 'Settings' )
+									}
+								</Button>
+							)
+						}
+						{
+							toggle
+						}
+					</div>
+				);
+			}
 		}
 
 		if ( this.props.pro && ! this.props.isDevMode ) {
@@ -141,7 +166,9 @@ export default connect(
 			isTogglingModule: ( module_name ) => isActivatingModule( state, module_name ) || isDeactivatingModule( state, module_name ),
 			getModule: ( module_name ) => _getModule( state, module_name ),
 			isDevMode: isDevMode( state ),
-			userCanToggle: userCanManageModules( state )
+			userCanToggle: userCanManageModules( state ),
+			siteRawUrl: getSiteRawUrl( state ),
+			siteAdminUrl: getSiteAdminUrl( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -61,7 +61,7 @@ export const DashItem = React.createClass( {
 		);
 
 		if ( '' !== this.props.module ) {
-			toggle = ( includes( [ 'protect', 'monitor', 'photon', 'vaultpress', 'scan', 'backups', 'akismet' ], this.props.module ) && this.props.isDevMode ) ? '' : (
+			toggle = ( includes( [ 'protect', 'photon', 'vaultpress', 'scan', 'backups', 'akismet' ], this.props.module ) && this.props.isDevMode ) ? '' : (
 				<ModuleToggle
 					slug={ this.props.module }
 					activated={ this.props.isModuleActivated( this.props.module ) }
@@ -88,7 +88,7 @@ export const DashItem = React.createClass( {
 					);
 				}
 				if ( 'is-working' === this.props.status ) {
-					toggle = <span className="jp-dash-item__active-label">{ __( 'Active' ) }</span>
+					toggle = <span className="jp-dash-item__active-label">{ __( 'Active' ) }</span>;
 				}
 			}
 
@@ -106,24 +106,15 @@ export const DashItem = React.createClass( {
 				);
 			}
 
-			if ( 'monitor' === this.props.module && ! this.props.isDevMode ) {
-				toggle = (
-					<div>
+			if ( 'monitor' === this.props.module ) {
+				toggle = ! this.props.isDevMode && this.props.isModuleActivated( this.props.module ) && (
+					<Button
+						href={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
+						compact>
 						{
-							this.props.isModuleActivated( this.props.module ) && (
-								<Button
-									href={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
-									compact>
-									{
-										__( 'Settings' )
-									}
-								</Button>
-							)
+							__( 'Settings' )
 						}
-						{
-							toggle
-						}
-					</div>
+					</Button>
 				);
 			}
 		}

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -40,7 +40,6 @@
 
 	.dops-button {
 		font-style: normal;
-		margin-right: rem( 8px );
 	}
 
 	.dops-section-header__label {

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -40,6 +40,7 @@
 
 	.dops-button {
 		font-style: normal;
+		margin-right: rem( 8px );
 	}
 
 	.dops-section-header__label {

--- a/_inc/client/components/dash-item/test/component.js
+++ b/_inc/client/components/dash-item/test/component.js
@@ -26,7 +26,7 @@ describe( 'DashItem', () => {
 		isTogglingModule: () => true,
 		toggleModule: () => false,
 		siteAdminUrl: 'https://example.org/wp-admin/',
-		siteRawUrl: 'https://example.org/'
+		siteRawUrl: 'example.org'
 	};
 
 	const wrapper = shallow( <DashItem { ...testProps } /> );
@@ -122,6 +122,25 @@ describe( 'DashItem', () => {
 
 		it( 'if user can not toggle, it does not display a toggle', () => {
 			expect( wrapper.find( 'ModuleToggle' ) ).to.have.length( 0 );
+		} );
+
+	} );
+
+	describe( 'when site is connected and user can toggle, the Monitor dash item', () => {
+
+		testProps = Object.assign( testProps, {
+			userCanToggle: true
+		} );
+
+		const wrapper = shallow( <DashItem { ...testProps } /> );
+
+		it( 'has a toggle', () => {
+			expect( wrapper.find( 'ModuleToggle' ) ).to.have.length( 1 );
+		} );
+
+		it( 'and a link to Calypso settings', () => {
+			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
+			expect( wrapper.find( 'Button' ).props().href ).to.contain( 'https://wordpress.com/settings/security/' + testProps.siteRawUrl );
 		} );
 
 	} );

--- a/_inc/client/components/dash-item/test/component.js
+++ b/_inc/client/components/dash-item/test/component.js
@@ -13,8 +13,8 @@ import { DashItem } from '../index';
 describe( 'DashItem', () => {
 
 	let testProps = {
-		label: 'Monitor',
-		module: 'monitor',
+		label: 'Protect',
+		module: 'protect',
 		status: '',
 		statusText: '',
 		disabled: true,
@@ -33,7 +33,7 @@ describe( 'DashItem', () => {
 
 	it( 'has the right label for header', () => {
 		expect( wrapper.find( 'SectionHeader' ) ).to.have.length( 1 );
-		expect( wrapper.find( 'SectionHeader' ).props().label ).to.be.equal( 'Monitor' );
+		expect( wrapper.find( 'SectionHeader' ).props().label ).to.be.equal( 'Protect' );
 	} );
 
 	it( 'the card body is built and has its href property correctly set', () => {
@@ -70,7 +70,7 @@ describe( 'DashItem', () => {
 		} );
 
 		it( 'the badge references the module', () => {
-			expect( proStatus.props().proFeature ).to.be.equal( 'monitor' );
+			expect( proStatus.props().proFeature ).to.be.equal( 'protect' );
 		} );
 
 		it( 'the admin URL is correct', () => {
@@ -107,7 +107,7 @@ describe( 'DashItem', () => {
 		} );
 
 		it( 'the toggle references the module this card belongs to', () => {
-			expect( wrapper.find( 'ModuleToggle' ).props().slug ).to.be.equal( 'monitor' );
+			expect( wrapper.find( 'ModuleToggle' ).props().slug ).to.be.equal( 'protect' );
 		} );
 
 	} );
@@ -138,11 +138,6 @@ describe( 'DashItem', () => {
 			expect( wrapper.find( 'ModuleToggle' ) ).to.have.length( 1 );
 		} );
 
-		it( 'and a link to Calypso settings', () => {
-			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
-			expect( wrapper.find( 'Button' ).props().href ).to.contain( 'https://wordpress.com/settings/security/' + testProps.siteRawUrl );
-		} );
-
 	} );
 
 	describe( 'when site is in Dev Mode, not a PRO module, user can not toggle', () => {
@@ -165,29 +160,65 @@ describe( 'DashItem', () => {
 
 	describe( 'if this is the DashItem for Manage module', () => {
 
-		testProps = Object.assign( testProps, {
-			module: 'manage',
+		let manageProps = {
 			label: 'Manage',
+			module: 'manage',
 			status: 'is-warning',
-			userCanToggle: true
-		} );
+			pro: false,
+			isDevMode: false,
+			userCanToggle: true,
+			isModuleActivated: () => true,
+			isTogglingModule: () => true,
+			toggleModule: () => false,
+			siteAdminUrl: 'https://example.org/wp-admin/',
+			siteRawUrl: 'example.org'
+		};
 
-		const wrapper = shallow( <DashItem { ...testProps } /> );
+		const wrapper = shallow( <DashItem { ...manageProps } /> );
 
 		it( "shows a warning badge when status is 'is-warning'", () => {
 			expect( wrapper.find( 'SimpleNotice' ) ).to.have.length( 1 );
 		} );
 
-		it( 'when Manage is deactivated, the warning badge is linked to Plugins screen in WordPress.com', () => {
-			expect( wrapper.find( 'SectionHeader' ).find( 'a' ).props().href ).to.be.equal( 'https://wordpress.com/plugins/' + testProps.siteRawUrl );
+		it( 'when it is activated, the warning badge is linked to Plugins screen in WordPress.com', () => {
+			expect( wrapper.find( 'SectionHeader' ).find( 'a' ).props().href ).to.be.equal( 'https://wordpress.com/plugins/' + manageProps.siteRawUrl );
 		} );
 
 		it( 'when Manage is deactivated, the warning badge is linked to Plugins screen in WP Admin', () => {
-			expect( shallow( <DashItem { ...testProps } isModuleActivated={ () => false } /> ).find( 'SectionHeader' ).find( 'a' ).props().href ).to.be.equal( testProps.siteAdminUrl + 'plugins.php' );
+			expect( shallow( <DashItem { ...manageProps } isModuleActivated={ () => false } /> ).find( 'SectionHeader' ).find( 'a' ).props().href ).to.be.equal( manageProps.siteAdminUrl + 'plugins.php' );
 		} );
 
 		it( "when status is 'is-working', the warning badge has an 'active' label", () => {
-			expect( shallow( <DashItem { ...testProps } status="is-working" /> ).find( 'SectionHeader' ).find( '.jp-dash-item__active-label' ) ).to.have.length( 1 );
+			expect( shallow( <DashItem { ...manageProps } status="is-working" /> ).find( 'SectionHeader' ).find( '.jp-dash-item__active-label' ) ).to.have.length( 1 );
+		} );
+
+	} );
+
+	describe( 'if this is the DashItem for Monitor module', () => {
+
+		const monitorProps = {
+			module: 'monitor',
+			label: 'Monitor',
+			status: '',
+			pro: false,
+			isDevMode: false,
+			userCanToggle: true,
+			isModuleActivated: () => true,
+			isTogglingModule: () => true,
+			toggleModule: () => false,
+			siteAdminUrl: 'https://example.org/wp-admin/',
+			siteRawUrl: 'example.org'
+		};
+
+		const wrapper = shallow( <DashItem { ...monitorProps } /> );
+
+		it( 'shows a button to configure settings in wpcom', () => {
+			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
+		} );
+
+		it( 'has a link to Calypso settings', () => {
+			expect( wrapper.find( 'Button' ) ).to.have.length( 1 );
+			expect( wrapper.find( 'Button' ).props().href ).to.contain( 'https://wordpress.com/settings/security/' + monitorProps.siteRawUrl );
 		} );
 
 	} );


### PR DESCRIPTION
Fixes #6226 

#### Changes proposed in this Pull Request:

* add link in Monitor card in At a Glance pointing to Security settings in Calypso where user will be able to manage notifications.

This _is how it looks in this PR_, which is what @MichaelArestad suggested in #6226

<img width="364" alt="captura de pantalla 2017-02-16 a las 19 32 28" src="https://cloud.githubusercontent.com/assets/1041600/23045026/96b1e226-f481-11e6-991f-90c2deec1237.png">
<img width="368" alt="captura de pantalla 2017-02-16 a las 19 32 39" src="https://cloud.githubusercontent.com/assets/1041600/23045027/96b6ce26-f481-11e6-8d33-ca635f898304.png">

Since this card also has a toggle and there were no instructions about what to do with the toggle, I assumed we should leave it and tested adding a cog icon

<img width="760" alt="captura de pantalla 2017-02-16 a las 19 37 18" src="https://cloud.githubusercontent.com/assets/1041600/23045062/cc937238-f481-11e6-9f27-ff8fe791db14.png">

This is _not_ in this PR but it's trivial to implement it.

* the link is pointed to `https://wordpress.com/settings/security/%site%`. @beaulebens pointed in #6226 that it should point to `https://wordpress.com/me/notifications` but the referenced issue wasn't implemented so far https://github.com/Automattic/wp-calypso/issues/11021 and if it was implemented, it would also need a way to go straight into the relevant site, instead of the list of sites. So for now, it's pointed to security.

If we keep this, it would be good to have an `id` in the card Jetpack Monitor in Calypso so we can add it to the link and scroll the view straight to that card.

<img width="688" alt="captura de pantalla 2017-02-16 a las 20 01 10" src="https://cloud.githubusercontent.com/assets/1041600/23045250/b2cd2640-f482-11e6-8985-08286dfa1098.png">

* removes props siteAdminUrl and siteRawUrl that were passed in cascade (and unused in intermediate components) and instead fetches them in DashItem where they're used.

* updates test to reflect that Monitor now has a button in addition to the toggle

#### Testing instructions:

* should not be visible in dev mode
* should not be visible when card is toggled off
* should be visible when card is toggled on and point to `https://wordpress.com/settings/security/%site%`