### PR TITLE
Brought back the compact toggle margin.

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -61,6 +61,7 @@
 }
 
 .jp-form-toggle-explanation {
+	margin-left: rem( 12px );
 	font-size: rem( 14px );
 	word-break: break-word;
 	vertical-align: middle;


### PR DESCRIPTION
This fixes the lack of the margin in the compact toggle. Before:
![before](https://cloud.githubusercontent.com/assets/374293/23064047/55bfc322-f527-11e6-8f08-d350fcea277d.png)

After:
![after](https://cloud.githubusercontent.com/assets/374293/23064054/5b3e7942-f527-11e6-9fd5-6761f9f0eed1.png)
