### PR TITLE
Updated the security card notice design.

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -175,7 +175,7 @@ SettingsCard.propTypes = {
 SettingsCard.defaultProps = {
 	module: null,
 	header: '',
-	feature: false,
+	feature: '',
 	notice: null,
 	hideButton: false,
 	isDirty: () => false,

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -28,9 +28,10 @@ import Banner from 'components/banner';
 import Button from 'components/button';
 
 export const SettingsCard = props => {
-	const module = props.module
-			? props.getModule( props.module )
-			: false;
+
+	let header = props.header;
+
+	const isSaving = props.isSavingAnyOption();
 
 	// Non admin users only get Publicize, After the Deadline, and Post by Email settings. The UI doesn't have settings for Publicize.
 	// composing is not a module slug but it's used so the Composing card is rendered to show AtD.
@@ -38,25 +39,13 @@ export const SettingsCard = props => {
 		return <span />;
 	}
 
-	const isSaving = props.isSavingAnyOption(),
-		feature = props.feature
-			? props.feature
-			: false,
-		siteRawUrl = props.siteRawUrl;
-	let header = props.header
-			? props.header
-			: '';
-
-	if ( '' === header && module ) {
-		header = module.name;
-	}
-
-	const getBanner = () => {
+	const getBanner = ( feature, siteRawUrl ) => {
 		const planClass = getPlanClass( props.sitePlan.product_slug ),
 			commonProps = {
 				feature: feature,
 				href: 'https://jetpack.com/redirect/?source=plans-compare-personal&site=' + siteRawUrl
 			};
+
 		let list;
 
 		switch ( feature ) {
@@ -141,9 +130,14 @@ export const SettingsCard = props => {
 		}
 	};
 
+	if ( ! header && props.module ) {
+		header = props.module.name;
+	}
+
 	return (
 		<form className="jp-form-settings-card">
 			<SectionHeader label={ header }>
+				{ props.notice }
 				{
 					! props.hideButton && (
 						<Button
@@ -162,9 +156,30 @@ export const SettingsCard = props => {
 				}
 			</SectionHeader>
 			{ props.children }
-			{ getBanner( feature ) }
+			{ getBanner( props.feature, props.siteRawUrl ) }
 		</form>
 	);
+};
+
+SettingsCard.propTypes = {
+	module: React.PropTypes.object,
+	header: React.PropTypes.string,
+	feature: React.PropTypes.string,
+	notice: React.PropTypes.element,
+	hideButton: React.PropTypes.bool,
+	isSavingAnyOption: React.PropTypes.func.isRequired,
+	isDirty: React.PropTypes.func,
+	onSubmit: React.PropTypes.func
+};
+
+SettingsCard.defaultProps = {
+	module: null,
+	header: '',
+	feature: false,
+	notice: null,
+	hideButton: false,
+	isDirty: () => false,
+	onSubmit: () => {}
 };
 
 export default connect(

--- a/_inc/client/components/settings-card/test/component.js
+++ b/_inc/client/components/settings-card/test/component.js
@@ -14,14 +14,11 @@ import { SettingsCard } from '../index';
 describe( 'SettingsCard', () => {
 
 	let testProps = {
-		module: 'comments',
 		hideButton: false,
-		getModule: () => (
-			{
-				name: 'Comments',
-				learn_more_button: 'https://jetpack.com/support/protect'
-			}
-		),
+		module: {
+			name: 'Comments',
+			learn_more_button: 'https://jetpack.com/support/protect'
+		},
 		isSavingAnyOption: () => false,
 		isDirty: () => true,
 		header: '',

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -43,8 +43,8 @@ export const Comments = moduleSettingsForm(
 				markdown = this.props.getModule( 'markdown' );
 			return (
 				<SettingsCard
-					{ ...this.props }
-					module="comments">
+					isSavingAnyOption={ this.props.isSavingAnyOption }
+					module={ comments }>
 					<SettingsGroup hasChild disableInDevMode module={ comments }>
 						<ModuleToggle
 							slug="comments"

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -50,9 +50,9 @@ export const Subscriptions = moduleSettingsForm(
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'subscriptions' );
 			return (
 				<SettingsCard
-					{ ...this.props }
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					hideButton
-					module="subscriptions">
+					module={ subscriptions }>
 					<SettingsGroup hasChild disableInDevMode module={ subscriptions }>
 						<ModuleToggle
 							slug="subscriptions"

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -4,10 +4,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import includes from 'lodash/includes';
 import Button from 'components/button';
 import SimpleNotice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { getPlanClass } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
@@ -35,171 +35,192 @@ import {
 const ProStatus = React.createClass( {
 	propTypes: {
 		isCompact: React.PropTypes.bool,
-		proFeature: React.PropTypes.string
+		proFeature: React.PropTypes.string,
+		forceNotice: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
 		return {
 			isCompact: true,
-			proFeature: ''
-		}
+			proFeature: '',
+			forceNotice: false
+		};
 	},
 
 	render() {
-		let sitePlan = this.props.sitePlan(),
-			pluginSlug = 'scan' === this.props.proFeature || 'backups' === this.props.proFeature || 'vaultpress' === this.props.proFeature ?
-			'vaultpress/vaultpress.php' :
-			'akismet/akismet.php';
+		const pluginSlug = 'scan' === this.props.proFeature || 'backups' === this.props.proFeature || 'vaultpress' === this.props.proFeature
+			? 'vaultpress/vaultpress.php'
+			: 'akismet/akismet.php';
 
-		const hasPremium = /jetpack_premium*/.test( sitePlan.product_slug ),
-			hasBusiness = /jetpack_business*/.test( sitePlan.product_slug );
-
-		let getStatus = ( feature, active, installed ) => {
-			let vpData = this.props.getVaultPressData();
-
-			if ( this.props.isDevMode ) {
-				return __( 'Unavailable in Dev Mode' );
-			}
-
-			if ( 'N/A' !== vpData && 'scan' === feature && 0 !== this.props.getScanThreats() ) {
-				return(
-					<SimpleNotice
-						showDismiss={ false }
-						status="is-error"
-						isCompact={ true }
-					>
-						{ __( 'Threats found!', { context: 'Short warning message about new threats found.' } ) }
-						<NoticeAction href="https://dashboard.vaultpress.com/">
-							{ __( 'FIX IT', { context: 'A caption for a small button to fix security issues.' } ) }
-						</NoticeAction>
-					</SimpleNotice>
-				);
-			}
-
-			if ( 'akismet' === feature ) {
-				const akismetData = this.props.getAkismetData();
-				if ( 'invalid_key' === akismetData ) {
-					return (
-						<a href={ this.props.siteAdminUrl + 'admin.php?page=akismet-key-config' } >
-							<SimpleNotice
-								showDismiss={ false }
-								status='is-warning'
-								isCompact={ true }
-							>
-								{ __( 'Invalid key', { context: 'Short warning message about an invalid key being used for Akismet.' } ) }
-							</SimpleNotice>
-						</a>
-					);
-				}
-			}
-
-			if ( 'seo-tools' === feature ) {
-				if ( this.props.fetchingSiteData ) {
-					return '';
-				}
-
-				return (
-					<Button
-						compact={ true }
-						primary={ true }
-						href={ 'https://jetpack.com/redirect/?source=upgrade-seo&site=' + this.props.siteRawUrl + '&feature=advanced-seo' }
-					>
-						{ __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } ) }
-					</Button>
-				);
-			}
-
-			if ( 'wordads' === feature ) {
-				if ( this.props.fetchingSiteData ) {
-					return '';
-				}
-
-				return (
-					<Button
-						compact={ true }
-						primary={ true }
-						href={ 'https://jetpack.com/redirect/?source=upgrade-ads&site=' + this.props.siteRawUrl + '&feature=jetpack-ads' }
-					>
-						{ __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } ) }
-					</Button>
-				);
-			}
-
-			if ( 'google-analytics' === feature && ! includes( [ 'jetpack_business', 'jetpack_business_monthly' ], sitePlan.product_slug ) ) {
-				if ( this.props.fetchingSiteData ) {
-					return '';
-				}
-
-				return (
-					<Button
-						compact={ true }
-						primary={ true }
-						href={ 'https://jetpack.com/redirect/?source=upgrade-google-analytics&site=' + this.props.siteRawUrl + '&feature=google-analytics' }
-					>
-						{ __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } ) }
-					</Button>
-				);
-			}
-
-			if ( sitePlan.product_slug ) {
-				let btnVals = {};
-				if ( 'jetpack_free' !== sitePlan.product_slug ) {
-					btnVals = {
-						href: `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }`,
-						text: __( 'Set up', { context: 'Caption for a button to set up a feature.' } )
-					}
-
-					if ( 'scan' === feature && ! hasBusiness && ! hasPremium ) {
-						return (
-							<Button
-								compact={ true }
-								primary={ true }
-								href={ 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl }
-							>
-								{ __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } ) }
-							</Button>
-						);
-					}
-				} else {
-					btnVals = {
-						href: 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl,
-						text: __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } )
-					}
-				}
-
-				if ( active && installed ) {
-					return <span className="jp-dash-item__active-label">{ __( 'ACTIVE' ) }</span>;
-				}
-
-				return (
-					<Button
-						compact={ true }
-						primary={ true }
-						href={ btnVals.href }
-					>
-						{ btnVals.text }
-					</Button>
-				);
-			}
-
-			return active && installed && sitePlan.product_slug ?
-				<span className="jp-dash-item__active-label">{ __( 'ACTIVE' ) }</span>
-				: '';
-		};
-
-		return(
+		return (
 			<div>
 				<QuerySitePlugins />
 				<QueryAkismetData />
 				<QueryVaultPressData />
-				{ getStatus(
+				{ this.getStatus(
 					this.props.proFeature,
 					this.props.pluginActive( pluginSlug ),
-					this.props.pluginInstalled( pluginSlug )
+					this.props.pluginInstalled( pluginSlug ),
+					this.props.forceNotice
 				) }
 			</div>
-		)
+		);
+	},
+
+	getStatusNotice( status, text, action, href ) {
+		const notice = (
+			<SimpleNotice showDismiss={ false } status={ status } isCompact={ true }>
+				{ text }
+				{ action }
+			</SimpleNotice>
+		);
+
+		if ( href ) {
+			return ( <a href={ href }>{ notice }</a> );
+		}
+		return notice;
+	},
+
+	getStatusButton( href, text ) {
+		return (
+			<Button compact={ true } primary={ true } href={ href }>
+				{ text }
+			</Button>
+		);
+	},
+
+	getStatus( feature, active, installed, forceNotice ) {
+		const vpData = this.props.getVaultPressData(),
+			sitePlan = this.props.sitePlan(),
+			planClass = getPlanClass( sitePlan.product_slug ),
+			hasPremium = 'is-premium-plan' === planClass,
+			hasBusiness = 'is-business-plan' === planClass;
+
+		if ( this.props.isDevMode ) {
+			return __( 'Unavailable in Dev Mode' );
+		}
+
+		if ( 'N/A' !== vpData && 'scan' === feature && 0 !== this.props.getScanThreats() ) {
+			return this.getStatusNotice(
+				'is-error',
+				__( 'Threats found!', { context: 'Short warning message about new threats found.' } ),
+				(
+					<NoticeAction href="https://dashboard.vaultpress.com/">
+						{ __(
+							'FIX IT',
+							{ context: 'A caption for a small button to fix security issues.' }
+						) }
+					</NoticeAction>
+				)
+			);
+		}
+
+		if ( 'akismet' === feature ) {
+			const akismetData = this.props.getAkismetData();
+			if ( 'invalid_key' === akismetData ) {
+				return this.getStatusNotice(
+					'is-warning',
+					__(
+						'Invalid key',
+						{ context: 'Short warning message about an invalid key being used for Akismet.' }
+					),
+					null,
+					this.props.siteAdminUrl + 'admin.php?page=akismet-key-config'
+				);
+			}
+		}
+
+		if ( 'seo-tools' === feature ) {
+			if ( this.props.fetchingSiteData ) {
+				return '';
+			}
+
+			return this.getStatusButton(
+				'https://jetpack.com/redirect/?source=upgrade-seo&site=' + this.props.siteRawUrl + '&feature=advanced-seo',
+				__( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } )
+			);
+		}
+
+		if ( 'wordads' === feature ) {
+			if ( this.props.fetchingSiteData ) {
+				return '';
+			}
+
+			return this.getStatusButton(
+				'https://jetpack.com/redirect/?source=upgrade-ads&site=' + this.props.siteRawUrl + '&feature=jetpack-ads',
+				__( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } )
+			);
+		}
+
+		if ( 'google-analytics' === feature && ! hasBusiness ) {
+			if ( this.props.fetchingSiteData ) {
+				return '';
+			}
+
+			return this.getStatusButton(
+				'https://jetpack.com/redirect/?source=upgrade-google-analytics&site=' + this.props.siteRawUrl + '&feature=google-analytics',
+				__( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } )
+			);
+		}
+
+		if ( sitePlan.product_slug ) {
+			let btnVals = {};
+			if ( 'is_free' !== planClass ) {
+				btnVals = {
+					href: `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }`,
+					text: __( 'Set up', { context: 'Caption for a button to set up a feature.' } )
+				};
+
+				if ( 'scan' === feature && ! hasBusiness && ! hasPremium ) {
+					if ( forceNotice ) {
+						return this.getStatusNotice(
+							'is-warning',
+							__( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } ),
+							(
+								<NoticeAction href={ 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl }>
+									{ __(
+										'FIX IT',
+										{ context: 'A caption for a small button to fix security issues.' }
+									) }
+								</NoticeAction>
+							)
+						);
+					} else {
+						return this.getStatusButton(
+							'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl,
+							__( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } )
+						);
+					}
+				}
+			} else {
+				btnVals = {
+					href: 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl,
+					text: __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } )
+				};
+			}
+
+			if ( active && installed ) {
+				if ( forceNotice && 'scan' === feature ) {
+					return this.getStatusNotice(
+						'is-success',
+						__( 'Secure', { context: 'Noun, a small message informing the user that their site is secure.' } )
+					);
+				}
+				return (
+					<span className="jp-dash-item__active-label">
+						{ __( 'ACTIVE' ) }
+					</span>
+				);
+			}
+
+			return this.getStatusButton( btnVals.href, btnVals.text );
+		}
+
+		return active && installed && sitePlan.product_slug
+			? <span className="jp-dash-item__active-label">{ __( 'ACTIVE' ) }</span>
+			: '';
 	}
+
 } );
 
 export default connect(

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -7,6 +7,7 @@ import { translate as __ } from 'i18n-calypso';
 import includes from 'lodash/includes';
 import Button from 'components/button';
 import SimpleNotice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 /**
  * Internal dependencies
@@ -64,10 +65,13 @@ const ProStatus = React.createClass( {
 				return(
 					<SimpleNotice
 						showDismiss={ false }
-						status='is-error'
+						status="is-error"
 						isCompact={ true }
 					>
 						{ __( 'Threats found!', { context: 'Short warning message about new threats found.' } ) }
+						<NoticeAction href="https://dashboard.vaultpress.com/">
+							{ __( 'FIX IT', { context: 'A caption for a small button to fix security issues.' } ) }
+						</NoticeAction>
 					</SimpleNotice>
 				);
 			}

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -23,7 +23,7 @@ export const Antispam = moduleSettingsForm(
 		render() {
 			return (
 				<SettingsCard
-					{ ...this.props }
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					header={ __( 'Spam filtering', { context: 'Settings header' } ) }>
 					<SettingsGroup support="https://akismet.com/jetpack/">
 						<FormFieldset>

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -26,7 +26,10 @@ export const BackupsScan = React.createClass( {
 				feature={ FEATURE_SECURITY_SCANNING_JETPACK }
 				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 				hideButton
-				notice={ <ProStatus proFeature={ 'scan' } /> }>
+				notice={
+					! this.props.isUnavailableInDevMode( 'backups' ) &&
+						<ProStatus proFeature={ 'scan' } forceNotice={ true } />
+				}>
 				<SettingsGroup
 					disableInDevMode
 					module={ { module: 'backups' } }

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -49,17 +49,17 @@ const BackupsScan = React.createClass( {
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {
-				status = 'is-simple';
+				status = 'is-info';
 				text = __( 'Loading…' );
 				link = false;
 			} else if ( scanEnabled ) {
 				if ( 0 !== this.props.scanThreats ) {
-					status = 'is-working';
+					status = 'is-warning';
 					text = __( 'Threats found!', { context: 'A message about security threats found.' } );
 					link = 'https://dashboard.vaultpress.com/';
 					icon = 'notice';
 				} else if ( vpData.code === 'success' ) {
-					status = 'is-working';
+					status = 'is-success';
 					text = __( 'All clean!', { context: 'A message about no security threats found.' } );
 					link = false;
 					icon = 'checkmark';
@@ -70,16 +70,16 @@ const BackupsScan = React.createClass( {
 				icon = 'notice';
 			}
 		} else if ( hasPremium || hasBusiness ) {
-			status = 'pro-inactive';
+			status = 'is-warning';
 			text = __( 'Inactive', { context: 'A message about the security plugin not activated yet.' } );
 			link = 'https://wordpress.com/plugins/vaultpress';
 			icon = 'notice';
 		} else if ( this.props.fetchingSiteData ) {
-			status = 'is-simple';
+			status = 'is-info';
 			text = __( 'Loading…' );
 			link = false;
 		} else {
-			status = 'no-pro-uninstalled-or-inactive';
+			status = 'is-warning';
 			text = __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } );
 			link = 'https://jetpack.com/redirect/?source=security-scan&site=' + this.props.siteRawUrl;
 			icon = 'notice';

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -14,93 +12,11 @@ import ExternalLink from 'components/external-link';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import SimpleNotice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import {
-	isModuleActivated as _isModuleActivated,
-	isFetchingModulesList as _isFetchingModulesList
-} from 'state/modules';
-import { getSitePlan } from 'state/site';
-import { isPluginInstalled } from 'state/site/plugins';
-import {
-	getVaultPressScanThreatCount as _getVaultPressScanThreatCount,
-	getVaultPressData as _getVaultPressData
-} from 'state/at-a-glance';
-import { isFetchingSiteData } from 'state/site';
-import QueryVaultPressData from 'components/data/query-vaultpress-data';
+import ProStatus from 'pro-status';
 
-const BackupsScan = React.createClass( {
+export const BackupsScan = React.createClass( {
 	toggleModule( name, value ) {
-		this.props.updateFormStateOptionValue( name, !value );
-	},
-
-	getNotice() {
-		const vpData = this.props.vaultPressData,
-			scanEnabled = get( vpData, [ 'data', 'features', 'security' ], false ),
-			hasPremium = /jetpack_premium*/.test( this.props.sitePlan.product_slug ),
-			hasBusiness = /jetpack_business*/.test( this.props.sitePlan.product_slug );
-
-		let status,
-			text,
-			link,
-			icon = '';
-
-		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
-			if ( vpData === 'N/A' ) {
-				status = 'is-info';
-				text = __( 'Loading…' );
-				link = false;
-			} else if ( scanEnabled ) {
-				if ( 0 !== this.props.scanThreats ) {
-					status = 'is-error';
-					text = __( 'Threats found!', { context: 'A message about security threats found.' } );
-					link = 'https://dashboard.vaultpress.com/';
-				} else if ( vpData.code === 'success' ) {
-					status = 'is-success';
-					text = __( 'All clean!', { context: 'A message about no security threats found.' } );
-					link = false;
-					icon = 'checkmark';
-				}
-			} else {
-				status = 'no-pro-uninstalled-or-inactive';
-				text = __( 'Inactive', { context: 'A message about the security plugin not activated yet.' } );
-				icon = 'notice';
-			}
-		} else if ( hasPremium || hasBusiness ) {
-			status = 'is-warning';
-			text = __( 'Inactive', { context: 'A message about the security plugin not activated yet.' } );
-			link = 'https://wordpress.com/plugins/vaultpress';
-			icon = 'notice';
-		} else if ( this.props.fetchingSiteData ) {
-			status = 'is-info';
-			text = __( 'Loading…' );
-			link = false;
-		} else {
-			status = 'is-warning';
-			text = __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } );
-			link = 'https://jetpack.com/redirect/?source=security-scan&site=' + this.props.siteRawUrl;
-			icon = 'notice';
-		}
-
-		if ( ! status ) {
-			return null;
-		}
-
-		return (
-			<SimpleNotice
-				icon={ icon }
-				showDismiss={ false }
-				isCompact={ true }
-				status={ status }
-				text={ text }>
-				<QueryVaultPressData />
-				{ link &&
-					<NoticeAction href={ link }>
-						{ __( 'FIX IT', { context: 'A caption for a small button to fix security issues.' } ) }
-					</NoticeAction>
-				}
-			</SimpleNotice>
-		);
+		this.props.updateFormStateOptionValue( name, ! value );
 	},
 
 	render() {
@@ -110,12 +26,19 @@ const BackupsScan = React.createClass( {
 				feature={ FEATURE_SECURITY_SCANNING_JETPACK }
 				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 				hideButton
-				notice={ this.getNotice() }>
-				<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://vaultpress.com/jetpack/">
+				notice={ <ProStatus proFeature={ 'scan' } /> }>
+				<SettingsGroup
+					disableInDevMode
+					module={ { module: 'backups' } }
+					support="https://vaultpress.com/jetpack/">
 					{
 						! this.props.isUnavailableInDevMode( 'backups' ) && (
 							<span>
-								<ExternalLink className="jp-module-settings__external-link" href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
+								<ExternalLink
+									className="jp-module-settings__external-link"
+									href="https://dashboard.vaultpress.com/" >
+									{ __( 'Configure your Security Scans' ) }
+								</ExternalLink>
 							</span>
 						)
 					}
@@ -125,16 +48,4 @@ const BackupsScan = React.createClass( {
 	}
 } );
 
-export default connect(
-	( state ) => {
-		return {
-			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
-			isFetchingModulesList: () => _isFetchingModulesList( state ),
-			vaultPressData: _getVaultPressData( state ),
-			scanThreats: _getVaultPressScanThreatCount( state ),
-			sitePlan: getSitePlan( state ),
-			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug ),
-			fetchingSiteData: isFetchingSiteData( state )
-		};
-	}
-)( moduleSettingsForm( BackupsScan ) );
+export default moduleSettingsForm( BackupsScan );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -106,8 +106,8 @@ const BackupsScan = React.createClass( {
 	render() {
 		return (
 			<SettingsCard
+				isSavingAnyOption={ this.props.isSavingAnyOption }
 				feature={ FEATURE_SECURITY_SCANNING_JETPACK }
-				{ ...this.props }
 				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 				hideButton
 				notice={ this.getNotice() }>

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -54,10 +54,9 @@ const BackupsScan = React.createClass( {
 				link = false;
 			} else if ( scanEnabled ) {
 				if ( 0 !== this.props.scanThreats ) {
-					status = 'is-warning';
+					status = 'is-error';
 					text = __( 'Threats found!', { context: 'A message about security threats found.' } );
 					link = 'https://dashboard.vaultpress.com/';
-					icon = 'notice';
 				} else if ( vpData.code === 'success' ) {
 					status = 'is-success';
 					text = __( 'All clean!', { context: 'A message about no security threats found.' } );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -27,8 +27,9 @@ export const BackupsScan = React.createClass( {
 				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 				hideButton
 				notice={
-					! this.props.isUnavailableInDevMode( 'backups' ) &&
-						<ProStatus proFeature={ 'scan' } forceNotice={ true } />
+					! this.props.isUnavailableInDevMode( 'backups' )
+						? <ProStatus proFeature={ 'scan' } forceNotice={ true } />
+						: null
 				}>
 				<SettingsGroup
 					disableInDevMode

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -35,9 +35,7 @@ const BackupsScan = React.createClass( {
 	},
 
 	getNotice() {
-		const hasSitePlan = false !== this.props.sitePlan,
-			vpData = this.props.vaultPressData,
-			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled',
+		const vpData = this.props.vaultPressData,
 			scanEnabled = get( vpData, [ 'data', 'features', 'security' ], false ),
 			hasPremium = /jetpack_premium*/.test( this.props.sitePlan.product_slug ),
 			hasBusiness = /jetpack_business*/.test( this.props.sitePlan.product_slug );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -12,37 +14,130 @@ import ExternalLink from 'components/external-link';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import SimpleNotice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import {
+	isModuleActivated as _isModuleActivated,
+	isFetchingModulesList as _isFetchingModulesList
+} from 'state/modules';
+import { getSitePlan } from 'state/site';
+import { isPluginInstalled } from 'state/site/plugins';
+import {
+	getVaultPressScanThreatCount as _getVaultPressScanThreatCount,
+	getVaultPressData as _getVaultPressData
+} from 'state/at-a-glance';
+import { isFetchingSiteData } from 'state/site';
+import QueryVaultPressData from 'components/data/query-vaultpress-data';
 
-export const BackupsScan = moduleSettingsForm(
-	React.createClass( {
+const BackupsScan = React.createClass( {
+	toggleModule( name, value ) {
+		this.props.updateFormStateOptionValue( name, !value );
+	},
 
-		toggleModule( name, value ) {
-			this.props.updateFormStateOptionValue( name, !value );
-		},
+	getNotice() {
+		const hasSitePlan = false !== this.props.sitePlan,
+			vpData = this.props.vaultPressData,
+			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled',
+			scanEnabled = get( vpData, [ 'data', 'features', 'security' ], false ),
+			hasPremium = /jetpack_premium*/.test( this.props.sitePlan.product_slug ),
+			hasBusiness = /jetpack_business*/.test( this.props.sitePlan.product_slug );
 
-		render() {
-			return (
-				<SettingsCard
-					feature={ FEATURE_SECURITY_SCANNING_JETPACK }
-					{ ...this.props }
-					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
-					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://vaultpress.com/jetpack/">
-						<p>
-							{
-								__( 'Your site is backed up and threat-free.' )
-							}
-						</p>
-						{
-							! this.props.isUnavailableInDevMode( 'backups' ) && (
-								<span>
-									<ExternalLink className="jp-module-settings__external-link" href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
-								</span>
-							)
-						}
-					</SettingsGroup>
-				</SettingsCard>
-			);
+		let status,
+			text,
+			link,
+			icon = '';
+
+		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
+			if ( vpData === 'N/A' ) {
+				status = 'is-simple';
+				text = __( 'Loading…' );
+				link = false;
+			} else if ( scanEnabled ) {
+				if ( 0 !== this.props.scanThreats ) {
+					status = 'is-working';
+					text = __( 'Threats found!', { context: 'A message about security threats found.' } );
+					link = 'https://dashboard.vaultpress.com/';
+					icon = 'notice';
+				} else if ( vpData.code === 'success' ) {
+					status = 'is-working';
+					text = __( 'All clean!', { context: 'A message about no security threats found.' } );
+					link = false;
+					icon = 'checkmark';
+				}
+			} else {
+				status = 'no-pro-uninstalled-or-inactive';
+				text = __( 'Inactive', { context: 'A message about the security plugin not activated yet.' } );
+				icon = 'notice';
+			}
+		} else if ( hasPremium || hasBusiness ) {
+			status = 'pro-inactive';
+			text = __( 'Inactive', { context: 'A message about the security plugin not activated yet.' } );
+			link = 'https://wordpress.com/plugins/vaultpress';
+			icon = 'notice';
+		} else if ( this.props.fetchingSiteData ) {
+			status = 'is-simple';
+			text = __( 'Loading…' );
+			link = false;
+		} else {
+			status = 'no-pro-uninstalled-or-inactive';
+			text = __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } );
+			link = 'https://jetpack.com/redirect/?source=security-scan&site=' + this.props.siteRawUrl;
+			icon = 'notice';
 		}
-	} )
-);
+
+		if ( ! status ) {
+			return null;
+		}
+
+		return (
+			<SimpleNotice
+				icon={ icon }
+				showDismiss={ false }
+				isCompact={ true }
+				status={ status }
+				text={ text }>
+				<QueryVaultPressData />
+				{ link &&
+					<NoticeAction href={ link }>
+						{ __( 'FIX IT', { context: 'A caption for a small button to fix security issues.' } ) }
+					</NoticeAction>
+				}
+			</SimpleNotice>
+		);
+	},
+
+	render() {
+		return (
+			<SettingsCard
+				feature={ FEATURE_SECURITY_SCANNING_JETPACK }
+				{ ...this.props }
+				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+				hideButton
+				notice={ this.getNotice() }>
+				<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://vaultpress.com/jetpack/">
+					{
+						! this.props.isUnavailableInDevMode( 'backups' ) && (
+							<span>
+								<ExternalLink className="jp-module-settings__external-link" href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
+							</span>
+						)
+					}
+				</SettingsGroup>
+			</SettingsCard>
+		);
+	}
+} );
+
+export default connect(
+	( state ) => {
+		return {
+			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
+			isFetchingModulesList: () => _isFetchingModulesList( state ),
+			vaultPressData: _getVaultPressData( state ),
+			scanThreats: _getVaultPressScanThreatCount( state ),
+			sitePlan: getSitePlan( state ),
+			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug ),
+			fetchingSiteData: isFetchingSiteData( state )
+		};
+	}
+)( moduleSettingsForm( BackupsScan ) );

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -43,6 +43,7 @@ export const Security = React.createClass( {
 
 		let backupSettings = (
 			<BackupsScan
+				siteRawUrl={ this.props.siteRawUrl }
 				{ ...commonProps }
 			/>
 		);

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -12,7 +12,7 @@ import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode } from 'state/connection';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import QuerySite from 'components/data/query-site';
-import { BackupsScan } from './backups-scan';
+import BackupsScan from './backups-scan';
 import { Antispam } from './antispam';
 import { Protect } from './protect';
 import { SSO } from './sso';

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -82,8 +82,7 @@ export const Protect = moduleSettingsForm(
 				);
 			return (
 				<SettingsCard
-					{ ...this.props }
-					module="protect"
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					header={ __( 'Prevent brute force login attacks', { context: 'Settings header' } ) } >
 					<FoldableCard
 						header={ toggle }

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -48,9 +48,8 @@ export const SSO = moduleSettingsForm(
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'sso' );
 			return (
 				<SettingsCard
-					{ ...this.props }
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					hideButton
-					module="sso"
 					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
 					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'sso' ) }>
 						<ModuleToggle

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -42,6 +42,7 @@ export default React.createClass( {
 					{ ...commonProps }
 				/>
 				<Security
+					siteRawUrl={ this.props.siteRawUrl }
 					siteAdminUrl={ this.props.siteAdminUrl }
 					active={ ( '/security' === this.props.route.path ) }
 					{ ...commonProps }

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -48,9 +48,8 @@ export const Ads = moduleSettingsForm(
 			const unavailableInDevMode = this.props.isUnavailableInDevMode( 'wordads' );
 			return (
 				<SettingsCard
-					{ ...this.props }
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					header={ __( 'Ads', { context: 'Ads header' } ) }
-					module="wordads"
 					hideButton>
 					<SettingsGroup
 						disableInDevMode

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -53,9 +53,9 @@ export const RelatedPosts = moduleSettingsForm(
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'related-posts' );
 			return (
 				<SettingsCard
-					{ ...this.props }
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					hideButton
-					module="related-posts">
+					module={ this.props.getModule( 'related-posts' ) }>
 					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'related-posts' ) }>
 						<ModuleToggle
 							slug="related-posts"

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -19,7 +19,7 @@ export const SEO = moduleSettingsForm(
 		render() {
 			return (
 				<SettingsCard
-					{ ...this.props }
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					header={ __( 'Search engine optimization', { context: 'Settings header' } ) }
 					feature={ FEATURE_SEO_TOOLS_JETPACK }
 					hideButton>

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -28,8 +28,8 @@ export const VerificationServices = moduleSettingsForm(
 				news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' );
 			return (
 				<SettingsCard
-					{ ...this.props }
-					module="verification-tools">
+					isSavingAnyOption={ this.props.isSavingAnyOption }
+					module={ verification }>
 					<SettingsGroup support={ verification.learn_more_button }>
 						<p>
 							{ __(

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -228,7 +228,10 @@ const Composing = moduleSettingsForm(
 				);
 
 			return (
-				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props } module="composing">
+				<SettingsCard
+					module="composing"
+					isSavingAnyOption={ this.props.isSavingAnyOption }
+					header={ __( 'Composing', { context: 'Settings header' } ) }>
 					{ this.props.isModuleFound( 'markdown' ) && markdownSettings }
 					{ this.props.isModuleFound( 'after-the-deadline' ) && atdSettings }
 				</SettingsCard>

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -52,8 +52,8 @@ const CustomContentTypes = moduleSettingsForm(
 			let module = this.props.module( 'custom-content-types' );
 			return (
 				<SettingsCard
-					{ ...this.props }
-					module="custom-content-types"
+					isSavingAnyOption={ this.props.isSavingAnyOption }
+					module={ module }
 					hideButton>
 					<SettingsGroup hasChild support={ module.learn_more_button }>
 						<CompactFormToggle

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -88,6 +88,7 @@ const Media = moduleSettingsForm(
 				<SettingsGroup
 					hasChild
 					disableInDevMode
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					module={ photon }>
 					<ModuleToggle
 						slug="photon"
@@ -173,7 +174,7 @@ const Media = moduleSettingsForm(
 
 			return (
 				<SettingsCard
-					{ ...this.props }
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					header={ __( 'Media' ) }
 					feature={ FEATURE_VIDEO_HOSTING_JETPACK }>
 					{ this.props.isModuleFound( 'photon' ) && photonSettings }

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -52,8 +52,8 @@ const PostByEmail = moduleSettingsForm(
 
 			return (
 				<SettingsCard
-					{ ...this.props }
-					module="post-by-email"
+					isSavingAnyOption={ this.props.isSavingAnyOption }
+					module={ postByEmail }
 					hideButton>
 					<SettingsGroup hasChild disableInDevMode module={ postByEmail }>
 						{

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -66,7 +66,7 @@ const ThemeEnhancements = moduleSettingsForm(
 
 			return (
 				<SettingsCard
-					{ ...this.props }
+					isSavingAnyOption={ this.props.isSavingAnyOption }
 					hideButton
 					header={ __( 'Theme enhancements' ) }>
 					{


### PR DESCRIPTION
Fixes #6405.

#### Changes proposed in this Pull Request:
* Adds a property to the SettingsCard element to allow passing a notice in.
* Adds a notice when the user has no plan, leading them to ugrade:
![upgrade](https://cloud.githubusercontent.com/assets/374293/23082873/afaecbc4-f574-11e6-80fb-6d7fb626379e.png)
* Adds a notice when the user has a plan but the scanning is not active:
![activate](https://cloud.githubusercontent.com/assets/374293/23082895/ce097c40-f574-11e6-9f40-13b8f5c09d4a.png)
* Adds a notice when the user has a plan, has scan active and has threats:
![threats](https://cloud.githubusercontent.com/assets/374293/23082929/e7479142-f574-11e6-988a-5710ad291660.png)
* Adds a notice when the user has a plan, has scan active and no threats:
![ok](https://cloud.githubusercontent.com/assets/374293/23082966/0da0cf02-f575-11e6-9d49-45b1c03f1c06.png)

This PR copies a lot of logic that is already used by the At a Glance widget. Once this is merged I will create an issue about refactoring both of them and using a memoized selector to get rid of code duplication and simplify data retrieval.