### PR TITLE
Add endpoint for verifying secrets even if XMLRPC is unavailable

### DIFF
--- a/class.jetpack-xmlrpc-fallback.php
+++ b/class.jetpack-xmlrpc-fallback.php
@@ -1,0 +1,42 @@
+<?php 
+
+/**
+ * A bridge between WP's built-in REST and Jetpack's XMLRPC server
+ */
+class Jetpack_XMLRPC_Fallback {
+    private $xmlrpc_server;
+
+    function init() {
+        register_rest_route( 'jetpack/v1', '/verify_registration', array(
+			'methods' => 'POST',
+			'callback' => array( $this, 'verify_registration' ),
+		) );
+
+        // fallback for anything not yet converted
+        register_rest_route( 'jetpack/v1', '/xmlrpc', array(
+			'methods' => 'POST',
+			'callback' => array( $this, 'xmlrpc_fallback' ),
+		) );
+    }
+
+    function verify_registration( $request ) {
+        $this->load_xmlrpc();
+		return $this->xmlrpc_server->verify_registration( array( $request['secret_1'], $request['state'] ) );
+	}
+
+    // allow invocation of Jetpack XMLRPC, and a handful of core XMLRPC methods, over REST
+    // does NOT allow random XMLRPC requests
+    function xmlrpc_fallback( $request ) {
+        $this->load_xmlrpc();
+        $methods = $this->xmlrpc->xmlrpc_methods();
+        error_log("xmlrpc fallback");
+        error_log(print_r($methods,1));
+    }
+
+    private function load_xmlrpc() {
+        if ( ! $this->xmlrpc_server ) {
+            require_once JETPACK__PLUGIN_DIR . 'class.jetpack-xmlrpc-server.php';
+            $this->xmlrpc_server = new Jetpack_XMLRPC_Server();
+        }
+    }
+}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -446,6 +446,15 @@ class Jetpack {
 		add_action( 'deleted_user', array( $this, 'unlink_user' ), 10, 1 );
 		add_action( 'remove_user_from_blog', array( $this, 'unlink_user' ), 10, 1 );
 
+		// define a few REST endpoints for getting through the connection process
+		// without XMLRPC
+		add_action( 'rest_api_init', function () {
+			register_rest_route( 'jetpack/v1', '/verify_registration', array(
+				'methods' => 'POST',
+				'callback' => array( $this, 'rest_verify_registration' ),
+			) );
+		} );
+
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
 			@ini_set( 'display_errors', false ); // Display errors can cause the XML to be not well formed.
 
@@ -558,6 +567,12 @@ class Jetpack {
 			add_action( 'wp_print_styles', array( $this, 'implode_frontend_css' ), -1 ); // Run first
 			add_action( 'wp_print_footer_scripts', array( $this, 'implode_frontend_css' ), -1 ); // Run first to trigger before `print_late_styles`
 		}
+	}
+
+	function rest_verify_registration( $request ) {
+		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-xmlrpc-server.php';
+		$xmlrpc_server = new Jetpack_XMLRPC_Server();
+		return $xmlrpc_server->verify_registration( array( $request['secret_1'], $request['state'] ) );
 	}
 
 	function jetpack_admin_ajax_tracks_callback() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -448,12 +448,7 @@ class Jetpack {
 
 		// define a few REST endpoints for getting through the connection process
 		// without XMLRPC
-		add_action( 'rest_api_init', function () {
-			register_rest_route( 'jetpack/v1', '/verify_registration', array(
-				'methods' => 'POST',
-				'callback' => array( $this, 'rest_verify_registration' ),
-			) );
-		} );
+		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
 
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST && isset( $_GET['for'] ) && 'jetpack' == $_GET['for'] ) {
 			@ini_set( 'display_errors', false ); // Display errors can cause the XML to be not well formed.
@@ -567,6 +562,13 @@ class Jetpack {
 			add_action( 'wp_print_styles', array( $this, 'implode_frontend_css' ), -1 ); // Run first
 			add_action( 'wp_print_footer_scripts', array( $this, 'implode_frontend_css' ), -1 ); // Run first to trigger before `print_late_styles`
 		}
+	}
+
+	function rest_api_init() {
+		register_rest_route( 'jetpack/v1', '/verify_registration', array(
+			'methods' => 'POST',
+			'callback' => array( $this, 'rest_verify_registration' ),
+		) );
 	}
 
 	function rest_verify_registration( $request ) {


### PR DESCRIPTION
Often sites protect their XMLRPC files with aggressive .htaccess rules that prevent Jetpack from working completely.

This is somewhat understandable as XMLRPC is a vector for many kinds of attacks, and the only reasonable solution available to us until now was to have users implement obscure rules that permit Jetpack requests but not others.

This PR begins extracting the most important requests to WP's new REST layer, so that we have a backup in case XMLRPC doesn't work.

It is envisioned that ultimately we may end up with some XMLRPC-over-REST type compatibility layer, while increasingly migrating endpoints to pure REST.

For starters, this will allow sites to complete the registration flow without error.

The WPCOM piece is implemented in D4437-code.