### PR TITLE
Admin - Dev Mode: update 'Compare plans' link

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -313,7 +313,9 @@ const PlanBody = React.createClass( {
 						</div>
 
 						<p>
-							<Button href={ 'https://jetpack.com/redirect/?source=plans-main-bottom&site=' + this.props.siteRawUrl } className="is-primary">
+							<Button href={ 'jetpack_free' === this.props.plans
+								? 'https://jetpack.com/redirect/?source=plans-main-bottom&site=' + this.props.siteRawUrl
+								: 'https://jetpack.com/redirect/?source=plans-main-bottom-dev-mode' } className="is-primary">
 								{ __( 'Compare Plans' ) }
 							</Button>
 						</p>

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -25,6 +25,16 @@ import {
 import QuerySitePlugins from 'components/data/query-site-plugins';
 
 const PlanBody = React.createClass( {
+	propTypes: {
+		plan: React.PropTypes.string
+	},
+
+	getDefaultProps: function() {
+		return {
+			plan: ''
+		};
+	},
+
 	render() {
 		let planCard = '';
 		switch ( this.props.plan ) {


### PR DESCRIPTION
When site is in dev mode, there's a button 'Compare Plans' in Plans tab that goes to a blank page in wpcom.

#### Changes proposed in this Pull Request:

* Update the link @richardmuscat comment in following https://github.com/Automattic/jetpack/pull/6189#issuecomment-281052431

#### Testing instructions:

* Put the site in dev mode and verify it goes to the correct link.
