### PR TITLE
API: Add a filter for theme info results

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
@@ -129,7 +129,16 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 			$formatted_theme['log'] = $this->log[ $id ];
 		}
 
-		return $formatted_theme;
+		/**
+		 * Filter the array of theme information that will be returned
+		 * per theme by the Jetpack theme APIs.
+		 *
+		 * @module json-api
+		 * @since 4.7
+		 * @param array $formatted_theme The theme info array
+		 * @returns array The filtered theme info array
+		 */
+		return apply_filters( 'jetpack_format_theme_details', $formatted_theme );
 	}
 
 	/**

--- a/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
@@ -136,7 +136,7 @@ abstract class Jetpack_JSON_API_Themes_Endpoint extends Jetpack_JSON_API_Endpoin
 		 * @module json-api
 		 * @since 4.7
 		 * @param array $formatted_theme The theme info array
-		 * @returns array The filtered theme info array
+		 * @return array The filtered theme info array
 		 */
 		return apply_filters( 'jetpack_format_theme_details', $formatted_theme );
 	}


### PR DESCRIPTION
Adds a filter that allows modification of the array of information returned for a theme by any of the Jetpack theme endpoints.

Will be used by `wpcomsh` plugin to tweak one of the fields to indicate whether or not a given theme is a wpcom theme.


