### PR TITLE
Call the WP functions directly.

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -15,7 +15,7 @@ class Jetpack_Client_Server {
 		$role              = Jetpack::translate_current_user_to_role();
 		$redirect          = isset( $data['redirect'] ) ? esc_url_raw( (string) $data['redirect'] ) : '';
 
-		$this->check_admin_referer( "jetpack-authorize_{$role}_{$redirect}" );
+		check_admin_referer( "jetpack-authorize_{$role}_{$redirect}" );
 
 		$result = $this->authorize( $data );
 		if ( is_wp_error( $result ) ) {
@@ -23,9 +23,9 @@ class Jetpack_Client_Server {
 		}
 
 		if ( wp_validate_redirect( $redirect ) ) {
-			$this->wp_safe_redirect( $redirect );
+			wp_safe_redirect( $redirect );
 		} else {
-			$this->wp_safe_redirect( Jetpack::admin_url() );
+			wp_safe_redirect( Jetpack::admin_url() );
 		}
 
 		/**
@@ -267,14 +267,6 @@ class Jetpack_Client_Server {
 
 	public function get_jetpack() {
 		return Jetpack::init();
-	}
-
-	public function check_admin_referer( $action ) {
-		return check_admin_referer( $action );
-	}
-
-	public function wp_safe_redirect( $redirect ) {
-		return wp_safe_redirect( $redirect );
 	}
 
 	public function do_exit() {

--- a/tests/php/test_class.jetpack-client-server.php
+++ b/tests/php/test_class.jetpack-client-server.php
@@ -34,7 +34,7 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 		wp_set_current_user( $author_id );
 
 		$client_server = $this->getMockBuilder( 'Jetpack_Client_Server' )
-			->setMethods( array( 'check_admin_referer', 'wp_safe_redirect', 'do_exit' ) )
+			->setMethods( array( 'do_exit' ) )
 			->getMock();
 
 		$result = $client_server->authorize();
@@ -56,7 +56,7 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 		wp_set_current_user( $author_id );
 
 		$client_server = $this->getMockBuilder( 'Jetpack_Client_Server' )
-			->setMethods( array( 'check_admin_referer', 'wp_safe_redirect', 'do_exit' ) )
+			->setMethods( array( 'do_exit' ) )
 			->getMock();
 
 		$result = $client_server->authorize();
@@ -77,7 +77,7 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 		wp_set_current_user( $author_id );
 
 		$client_server = $this->getMockBuilder( 'Jetpack_Client_Server' )
-			->setMethods( array( 'check_admin_referer', 'wp_safe_redirect', 'do_exit' ) )
+			->setMethods( array( 'do_exit' ) )
 			->getMock();
 
 		$result = $client_server->authorize( array( 'error' => 'test_error' ) );


### PR DESCRIPTION
Fixes #3762.

#### Changes proposed in this Pull Request:

* Remove unnecessary methods

#### Testing instructions:

* Deactivate Jetpack
* Reactivate Jetpack
* Authorize Jetpack

I was also able to test using wp shell:
return Jetpack_Client_Server::client_authorize();

Before these changes, the above returned a PHP Fatal. After the changes were applied, no more PHP Fatals and a proper error message was returned.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
