### PR TITLE
Change the token check to use the passed user_id

### DIFF
--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -300,7 +300,7 @@ class Jetpack_XMLRPC_Server {
 		error_log( "VERIFY: $verify" );
 		*/
 
-		$jetpack_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+		$jetpack_token = Jetpack_Data::get_access_token( $user_id );
 
 		$api_user_code = get_user_meta( $user_id, "jetpack_json_api_$client_id", true );
 		if ( !$api_user_code ) {
@@ -326,7 +326,7 @@ class Jetpack_XMLRPC_Server {
 	* @return boolean
 	*/
 	function disconnect_blog() {
-		
+
 		// For tracking
 		if ( ! empty( $this->user->ID ) ) {
 			wp_set_current_user( $this->user->ID );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5273,7 +5273,8 @@ p {
 			? $_REQUEST
 			: $environment;
 
-		$token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+		list( $envToken, $envVersion, $envUserId ) = explode( ':', $environment['token'] );
+		$token = Jetpack_Data::get_access_token( $envUserId );
 		if ( ! $token || empty( $token->secret ) ) {
 			wp_die( __( 'You must connect your Jetpack plugin to WordPress.com to use this feature.' , 'jetpack' ) );
 		}


### PR DESCRIPTION
The wpcom servers do not always retrieve the master user_id when signing requests. When the wrong user_id is sent over, the request will fail. During the oauth connection flow, this would result 

This change uses the user_id that is encoded in the token format to check requests.

Fixes #5847

#### Changes proposed in this Pull Request:

* Update wpcom token checks to use user_id encoded in the token instead of the `master_user` token

#### Testing instructions:

* Find a blog where the `Jetpack_Options::get_option( 'master_user' );` is not the same as the id returned by public-api's `Jetpack_Data::get_access_token_by_blog_id_user_id( $someBlogId, JETPACK__ANY_USER_TOKEN )`
* Attempt to connect an Oauth application to that blog
* Confirm that the Oauth flow is successful

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
