### PR TITLE
Content Options: Always load Featured Images functionality if we are in the Customizer but not on the front end if all the options are ticked.

### DIFF
--- a/modules/theme-tools/content-options.php
+++ b/modules/theme-tools/content-options.php
@@ -85,9 +85,9 @@ function jetpack_featured_images_get_settings() {
 function jetpack_featured_images_should_load() {
 	$opts = jetpack_featured_images_get_settings();
 
-	// If the theme doesn't support archive, post and page or if all the options are ticked, don't continue.
+	// If the theme doesn't support archive, post and page or if all the options are ticked and we aren't in the customizer, don't continue.
 	if ( ( true !== $opts['archive'] && true !== $opts['post'] && true !== $opts['page'] )
-		|| ( 1 === $opts['archive-option'] && 1 === $opts['post-option'] && 1 === $opts['page-option'] ) ) {
+		|| ( 1 === $opts['archive-option'] && 1 === $opts['post-option'] && 1 === $opts['page-option'] && ! is_customize_preview() ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
In order to trigger the filtering function on first unclick in the
Customizer we need `( 1 === $opts['archive-option'] && 1 ===
$opts['post-option'] && 1 === $opts['page-option'] )` to return `true`.