### PR TITLE
Jetpack Sync: Consolidate nearly duplicate sync and full_sync methods

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -228,11 +228,11 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function do_cron_sync() {
-        self::do_cron_sync_by_type('sync');
+        self::do_cron_sync_by_type( 'sync' );
 	}
 
 	static function do_cron_full_sync() {
-        self::do_cron_sync_by_type('full_sync');
+        self::do_cron_sync_by_type( 'full_sync' );
 	}
 
     // try to send actions until we run out of things to send,

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -235,34 +235,38 @@ class Jetpack_Sync_Actions {
 		self::do_cron_sync_by_type( 'full_sync' );
 	}
 
-    // try to send actions until we run out of things to send,
-    // or have to wait more than 15s before sending again,
-    // or we hit a lock or some other sending issue
-    static function do_cron_sync_by_type( $type ) {
-        if ( ! self::sync_allowed() || ( 'sync' !== $type && 'full_sync' !== $type ) ) {
-            return;
-        }
+	/**
+	 * Try to send actions until we run out of things to send,
+	 * or have to wait more than 15s before sending again,
+	 * or we hit a lock or some other sending issue
+	 *
+	 * @param string $type Sync type. Can be `sync` or `full_sync`.
+	 */
+	static function do_cron_sync_by_type( $type ) {
+		if ( ! self::sync_allowed() || ( 'sync' !== $type && 'full_sync' !== $type ) ) {
+			return;
+		}
 
-        self::initialize_sender();
+		self::initialize_sender();
 
-        $time_limit = Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
-        $start_time = time();
+		$time_limit = Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
+		$start_time = time();
 
-        do {
-            $next_sync_time = self::$sender->get_next_sync_time( $type );
+		do {
+			$next_sync_time = self::$sender->get_next_sync_time( $type );
 
-            if ( $next_sync_time ) {
-                $delay = $next_sync_time - time() + 1;
-                if ( $delay > 15 ) {
-                    break;
-                } elseif ( $delay > 0 ) {
-                    sleep( $delay );
-                }
-            }
+			if ( $next_sync_time ) {
+				$delay = $next_sync_time - time() + 1;
+				if ( $delay > 15 ) {
+					break;
+				} elseif ( $delay > 0 ) {
+					sleep( $delay );
+				}
+			}
 
-            $result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync();
-        } while ( $result && ( $start_time + $time_limit ) > time() );
-    }
+			$result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync();
+		} while ( $result && ( $start_time + $time_limit ) > time() );
+	}
 
 	static function initialize_listener() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -227,60 +227,42 @@ class Jetpack_Sync_Actions {
 		return $schedules;
 	}
 
-	// try to send actions until we run out of things to send,
-	// or have to wait more than 15s before sending again,
-	// or we hit a lock or some other sending issue
 	static function do_cron_sync() {
-		if ( ! self::sync_allowed() ) {
-			return;
-		}
-
-		self::initialize_sender();
-
-		$time_limit = Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
-		$start_time = time();
-
-		do {
-			$next_sync_time = self::$sender->get_next_sync_time( 'sync' );
-
-			if ( $next_sync_time ) {
-				$delay = $next_sync_time - time() + 1;
-				if ( $delay > 15 ) {
-					break;
-				} elseif ( $delay > 0 ) {
-					sleep( $delay );
-				}
-			}
-
-			$result = self::$sender->do_sync();
-		} while ( $result && ( $start_time + $time_limit ) > time() );
+        self::do_cron_sync_by_type('sync');
 	}
 
 	static function do_cron_full_sync() {
-		if ( ! self::sync_allowed() ) {
-			return;
-		}
-
-		self::initialize_sender();
-
-		$time_limit = Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
-		$start_time = time();
-
-		do {
-			$next_sync_time = self::$sender->get_next_sync_time( 'full_sync' );
-
-			if ( $next_sync_time ) {
-				$delay = $next_sync_time - time() + 1;
-				if ( $delay > 15 ) {
-					break;
-				} elseif ( $delay > 0 ) {
-					sleep( $delay );
-				}
-			}
-
-			$result = self::$sender->do_full_sync();
-		} while ( $result && ( $start_time + $time_limit ) > time() );
+        self::do_cron_sync_by_type('full_sync');
 	}
+
+    // try to send actions until we run out of things to send,
+    // or have to wait more than 15s before sending again,
+    // or we hit a lock or some other sending issue
+    static function do_cron_sync_by_type( $type ) {
+        if ( ! self::sync_allowed() || ( 'sync' !== $type && 'full_sync' !== $type ) ) {
+            return;
+        }
+
+        self::initialize_sender();
+
+        $time_limit = Jetpack_Sync_Settings::get_setting( 'cron_sync_time_limit' );
+        $start_time = time();
+
+        do {
+            $next_sync_time = self::$sender->get_next_sync_time( $type );
+
+            if ( $next_sync_time ) {
+                $delay = $next_sync_time - time() + 1;
+                if ( $delay > 15 ) {
+                    break;
+                } elseif ( $delay > 0 ) {
+                    sleep( $delay );
+                }
+            }
+
+            $result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync();
+        } while ( $result && ( $start_time + $time_limit ) > time() );
+    }
 
 	static function initialize_listener() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-listener.php';

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -228,11 +228,11 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function do_cron_sync() {
-        self::do_cron_sync_by_type( 'sync' );
+		self::do_cron_sync_by_type( 'sync' );
 	}
 
 	static function do_cron_full_sync() {
-        self::do_cron_sync_by_type( 'full_sync' );
+		self::do_cron_sync_by_type( 'full_sync' );
 	}
 
     // try to send actions until we run out of things to send,


### PR DESCRIPTION
The Jetpack sync and full_sync methods were nearly exact duplicates of each other, so I kept the "interface" to the two methods for the sake of any clients calling them, but delegated to a single helper method that behaves one way or the other depending on the identifying parameter passed to it by one of the original methods. Less duplicate code means less to grok, less to maintain, and less opportunity for oversights keeping the methods in sync if there are any changes to them.

Fixes #

#### Changes proposed in this Pull Request:

*

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
