### PR TITLE
Settings UI - Non admin: refresh view after unlink. Don't show features if site disconnected

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -116,6 +116,7 @@ const Main = React.createClass( {
 
 		return nextProps.siteConnectionStatus !== this.props.siteConnectionStatus ||
 			nextProps.jumpStartStatus !== this.props.jumpStartStatus ||
+			nextProps.isLinked !== this.props.isLinked ||
 			nextProps.route.path !== this.props.route.path ||
 			nextProps.searchTerm !== this.props.searchTerm;
 	},

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -19,7 +19,7 @@ import SearchableSettings from 'settings/index.jsx';
 import JetpackConnect from 'components/jetpack-connect';
 import JumpStart from 'components/jumpstart';
 import { getJumpStartStatus, isJumpstarting } from 'state/jumpstart';
-import { getSiteConnectionStatus } from 'state/connection';
+import { getSiteConnectionStatus, isCurrentUserLinked } from 'state/connection';
 import {
 	setInitialState,
 	getSiteRawUrl,
@@ -154,11 +154,14 @@ const Main = React.createClass( {
 		analytics.tracks.recordEvent( 'jetpack_wpa_page_view', { path: route } );
 
 		if ( ! this.props.userCanManageModules ) {
-			return <NonAdminView { ...this.props } />
+			if ( ! this.props.siteConnectionStatus ) {
+				return false;
+			}
+			return <NonAdminView { ...this.props } />;
 		}
 
 		if ( ! this.props.siteConnectionStatus ) {
-			return <JetpackConnect />
+			return <JetpackConnect />;
 		}
 
 		if ( this.props.jumpStartStatus ) {
@@ -166,7 +169,7 @@ const Main = React.createClass( {
 				const history = createHistory();
 				history.push( window.location.pathname + '?page=jetpack#/jumpstart' );
 			} else if ( '/jumpstart' === route ) {
-				return <JumpStart />
+				return <JumpStart />;
 			}
 		}
 
@@ -241,6 +244,7 @@ export default connect(
 			jumpStartStatus: getJumpStartStatus( state ),
 			isJumpstarting: isJumpstarting( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
+			isLinked: isCurrentUserLinked( state ),
 			siteRawUrl: getSiteRawUrl( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
 			searchTerm: getSearchTerm( state ),


### PR DESCRIPTION
Fixes #6464
Fixes #6466 props @oskosk 

#### Changes proposed in this Pull Request:

* remove usage of `window.Initial_State`.
* if non admin users unlink their accounts, the view is refreshed.
* if site is not connected and user can't do it, show notice prompting user to ask an admin to connect and don't show link button.

<img width="739" alt="captura de pantalla 2017-02-23 a las 18 49 07" src="https://cloud.githubusercontent.com/assets/1041600/23280652/d1f26230-f9f8-11e6-893c-c459725ffc1d.png">

#### Testing instructions:

* Disconnect site and log with non admin: it should display a notice prompting to ask admin to connect the site.
* Disconnect site, the view should be refreshed