### PR TITLE
Ads: Updated House Ads & "Advertisements" Notice

### DIFF
--- a/modules/wordads/css/style.css
+++ b/modules/wordads/css/style.css
@@ -44,11 +44,6 @@
 	box-shadow: none !important;
 }
 
-.wpa-about:hover, .wa_infobox a:hover {
-	text-decoration: underline !important;	/* !important necessary, since themes override this routinely */
-	color: #444;
-}
-
 /* ad unit wrapper */
 .wpa .u>div {	/* @todo: deprecate wpdvert */
 	display: block;

--- a/modules/wordads/php/widgets.php
+++ b/modules/wordads/php/widgets.php
@@ -64,7 +64,7 @@ HTML;
 		echo <<< HTML
 		<div class="wpcnt">
 			<div class="wpa">
-				<a class="wpa-about" href="https://en.wordpress.com/about-these-ads/" rel="nofollow">$about</a>
+				<span class="wpa-about">$about</span>
 				<div class="u {$instance['unit']}">
 					$snippet
 				</div>

--- a/modules/wordads/php/widgets.php
+++ b/modules/wordads/php/widgets.php
@@ -37,20 +37,14 @@ class WordAds_Sidebar_Widget extends WP_Widget {
 
 		$snippet = '';
 		if ( $wordads->option( 'wordads_house', true ) ) {
-			$ad_url = 'https://s0.wp.com/wp-content/blog-plugins/wordads/house/';
+			$unit = 'mrec';
 			if ( 'leaderboard' == $instance['unit'] && ! $this->params->mobile_device ) {
-				$ad_url .= 'leaderboard.png';
+				$unit = 'leaderboard';
 			} else if ( 'wideskyscraper' == $instance['unit'] ) {
-				$ad_url .= 'widesky.png';
-			} else {
-				$ad_url .= 'mrec.png';
+				$unit = 'widesky';
 			}
 
-			$snippet = <<<HTML
-			<a href="https://wordpress.com/create/" target="_blank">
-				<img src="$ad_url" alt="WordPress.com: Grow Your Business" width="$width" height="$height" />
-			</a>
-HTML;
+			$snippet = $wordads->get_house_ad( $unit );
 		} else {
 			$section_id = 0 === $wordads->params->blog_id ? WORDADS_API_TEST_ID : $wordads->params->blog_id . '3';
 			$data_tags = ( $wordads->params->cloudflare ) ? ' data-cfasync="false"' : '';

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -325,7 +325,7 @@ HTML;
 		return <<<HTML
 		<div class="wpcnt $header">
 			<div class="wpa">
-				<a class="wpa-about" href="https://en.wordpress.com/about-these-ads/" rel="nofollow">$about</a>
+				<span class="wpa-about">$about</span>
 				<div class="u $spot">
 					$snippet
 				</div>

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -302,22 +302,8 @@ HTML;
 			</script>
 HTML;
 		} else if ( 'house' == $type ) {
-			$width = 300;
-			$height = 250;
-			$ad_url = 'https://s0.wp.com/wp-content/blog-plugins/wordads/house/';
-			if ( 'top' == $spot && ! $this->params->mobile_device ) {
-				$width = 728;
-				$height = 90;
-				$ad_url .= 'leaderboard.png';
-			} else {
-				$ad_url .= 'mrec.png';
-			}
-
-			$snippet = <<<HTML
-			<a href="https://wordpress.com/create/" target="_blank">
-				<img src="$ad_url" alt="WordPress.com: Grow Your Business" width="$width" height="$height" />
-			</a>
-HTML;
+			$leaderboard = 'top' == $spot && ! $this->params->mobile_device;
+			$snippet = $this->get_house_ad( $leaderboard ? 'leaderboard' : 'mrec' );
 		}
 
 		$header = 'top' == $spot ? 'wpcnt-header' : '';
@@ -342,6 +328,41 @@ HTML;
 	 */
 	public function should_bail() {
 		return ! $this->option( 'wordads_approved' );
+	}
+
+	/**
+	 * Returns markup for HTML5 house ad base on unit
+	 * @param  string $unit mrec, widesky, or leaderboard
+	 * @return string       markup for HTML5 house ad
+	 *
+	 * @since 4.7.0
+	 */
+	public function get_house_ad( $unit = 'mrec' ) {
+		if ( ! in_array( $unit, array( 'mrec', 'widesky', 'leaderboard' ) ) ) {
+			$unit = 'mrec';
+		}
+
+		$width  = 300;
+		$height = 250;
+		if ( 'widesky' == $unit ) {
+			$width  = 160;
+			$height = 600;
+		} else if ( 'leaderboard' == $unit ) {
+			$width  = 728;
+			$height = 90;
+		}
+
+		return <<<HTML
+		<iframe
+			src="https://s0.wp.com/wp-content/blog-plugins/wordads/house/html5/$unit/index.html"
+			width="$width"
+			height="$height"
+			frameborder="0"
+			scrolling="no"
+			marginheight="0"
+			marginwidth="0">
+		</iframe>
+HTML;
 	}
 
 	/**


### PR DESCRIPTION
A bit of cleanup to update Jetpack Ads with the latest developments from the .com side. Notably:
* New HTML5 versions of the house ads.
* Removing the link to https://en.support.wordpress.com/about-these-ads/ from "Advertisements" notice. Per @kriskarkoski the link was generating too much spam and minimal actual contacts.

**To test:**
1. Turn on ads via settings
1. Set `'wordads_house'    => true,` on line 14 of `modules/wordads/params.php` to force house ads to appear.
1. Check to see link has been removed from "Advertisements"
1. Check your ad units look like this:

<img width="776" alt="screen shot 2017-02-22 at 10 07 31 am" src="https://cloud.githubusercontent.com/assets/273708/23225431/be35bcb4-f8e6-11e6-88a5-64adcd20099a.png">
