### PR TITLE
Fix broken shortcode post embeds.

### DIFF
--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -230,7 +230,10 @@ class Filter_Embedded_HTML_Objects {
 
 		foreach ( self::$failed_embeds as $entry ) {
 			$html   = sprintf( '<a href="%s">%s</a>', esc_url( $entry['src'] ), esc_url( $entry['src'] ) );
-			$string = str_replace( $entry['match'], $html, $string );
+			// Check if the string doesn't contain iframe, before replace.
+			if ( ! preg_match( '/<iframe /', $string ) ) {
+				$string = str_replace( $entry['match'], $html, $string );
+			}
 		}
 
 		self::$failed_embeds = array();

--- a/tests/php/modules/shortcodes/test_class.filter-embedded-html-objects.php
+++ b/tests/php/modules/shortcodes/test_class.filter-embedded-html-objects.php
@@ -1,0 +1,23 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Embedded_HTML_Objects extends WP_UnitTestCase {
+
+	/**
+	 * @author Toro_Unit
+	 */
+	public function test_wp_kses() {
+		$string = '<iframe src="https://wordpress.org"></iframe>';
+
+		$allowed_html = array(
+			'a'      => array(
+				'href' => true,
+			),
+			'iframe' => array(
+				'src' => true,
+			),
+		);
+		$actual = wp_kses( $string, $allowed_html );
+		$this->assertEquals( $string, $actual );
+	}
+
+}


### PR DESCRIPTION
Fixes #6380. Combines #6381 by @Stoyan0v and #6402 by @torounit , thank you both!

#### Changes proposed in this Pull Request:
* Fix posts preview when Shortcode Embeds is enabled. For some reason the iframe code is replaced by link on the following line.
* I am not sure that the changes I've made are the best way to fix this, so I will be happy if @eliorivero can take a look, since he was made this module and is familiar with it.
* add test for modules/shortcodes/class.filter-embedded-html-objects.php.

#### Testing instructions:
* Enable Shortcode embeds
* Add new post, paste URL for an already published post into visual editor
* Make sure that it's converted to embedded preview
