### PR TITLE
Sync WooCommerce Data

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -111,6 +111,11 @@ class Jetpack_Sync_Defaults {
 		'jetpack_api_cache_enabled',
 	);
 
+	public static function get_options_whitelist() {
+		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
+		return apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
+	}
+
 	static $default_constants_whitelist = array(
 		'EMPTY_TRASH_DAYS',
 		'WP_POST_REVISIONS',
@@ -128,8 +133,21 @@ class Jetpack_Sync_Defaults {
 		'DISABLE_WP_CRON',
 		'ALTERNATE_WP_CRON',
 		'WP_CRON_LOCK_TIMEOUT',
-		'PHP_VERSION'
+		'PHP_VERSION',
 	);
+
+	public static function get_constants_whitelist() {
+		/**
+		 * Filter the list of PHP constants that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.7
+		 *
+		 * @param array The default list of constants options.
+		 */
+		return apply_filters( 'jetpack_constants_whitelist', self::$default_constants_whitelist );
+	}
 
 	static $default_callable_whitelist = array(
 		'wp_max_upload_size'               => 'wp_max_upload_size',
@@ -246,6 +264,19 @@ class Jetpack_Sync_Defaults {
 		'vimeo_poster_image',
 		'advanced_seo_description', // Jetpack_SEO_Posts::DESCRIPTION_META_KEY
 	);
+
+	public static function get_post_meta_whitelist() {
+		/**
+		 * Filter the list of post meta data that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.7
+		 *
+		 * @param array The default list of meta data keys.
+		 */
+		return apply_filters( 'jetpack_post_meta_whitelist', self::$post_meta_whitelist );
+	}
 
 	static $comment_meta_whitelist = array(
 		'hc_avatar',

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -113,7 +113,17 @@ class Jetpack_Sync_Defaults {
 
 	public static function get_options_whitelist() {
 		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
-		return apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
+		$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
+		/**
+		 * Filter the list of WordPress options that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.7
+		 *
+		 * @param array The default list of options.
+		 */
+		return apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
 	}
 
 	static $default_constants_whitelist = array(
@@ -146,7 +156,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @param array The default list of constants options.
 		 */
-		return apply_filters( 'jetpack_constants_whitelist', self::$default_constants_whitelist );
+		return apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
 	}
 
 	static $default_callable_whitelist = array(
@@ -275,7 +285,7 @@ class Jetpack_Sync_Defaults {
 		 *
 		 * @param array The default list of meta data keys.
 		 */
-		return apply_filters( 'jetpack_post_meta_whitelist', self::$post_meta_whitelist );
+		return apply_filters( 'jetpack_sync_post_meta_whitelist', self::$post_meta_whitelist );
 	}
 
 	static $comment_meta_whitelist = array(

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -10,12 +10,6 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 		return 'constants';
 	}
 
-	private $constants_whitelist;
-
-	public function set_defaults() {
-		$this->constants_whitelist = Jetpack_Sync_Defaults::$default_constants_whitelist;
-	}
-
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_constant', $callable, 10, 2 );
 	}
@@ -41,7 +35,7 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 	}
 
 	function get_constants_whitelist() {
-		return $this->constants_whitelist;
+		return Jetpack_Sync_Defaults::get_constants_whitelist();
 	}
 
 	function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
@@ -103,9 +97,10 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 
 	// public so that we don't have to store an option for each constant
 	function get_all_constants() {
+		$constants_whitelist = $this->get_constants_whitelist();
 		return array_combine(
-			$this->constants_whitelist,
-			array_map( array( $this, 'get_constant' ), $this->constants_whitelist )
+			$constants_whitelist,
+			array_map( array( $this, 'get_constant' ), $constants_whitelist )
 		);
 	}
 

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -85,8 +85,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 	}
 
 	function update_options_whitelist() {
-		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
-		$this->options_whitelist = apply_filters( 'jetpack_options_whitelist', Jetpack_Sync_Defaults::$default_options_whitelist );
+		$this->options_whitelist = Jetpack_Sync_Defaults::get_options_whitelist();
 	}
 
 	function set_options_whitelist( $options ) {

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -42,6 +42,11 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 
 		// order item meta
 		$this->init_listeners_for_meta_type( 'order_item', $callable );
+
+		// options, constants and post meta whitelists
+		add_filter( 'jetpack_options_whitelist', array( $this, 'add_woocommerce_options_whitelist' ), 10 );
+		add_filter( 'jetpack_constants_whitelist', array( $this, 'add_woocommerce_constants_whitelist' ), 10 );
+		add_filter( 'jetpack_post_meta_whitelist', array( $this, 'add_woocommerce_post_meta_whitelist' ), 10 );
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -113,4 +118,111 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 	private function get_where_sql( $config ) {
 		return '1=1';
 	}
+
+	public function add_woocommerce_options_whitelist( $list ) {
+		return array_merge( $list, self::$wc_options_whitelist );
+	}
+
+	public function add_woocommerce_constants_whitelist( $list ) {
+		return array_merge( $list, self::$wc_constants_whitelist );
+	}
+
+	public function add_woocommerce_post_meta_whitelist( $list ) {
+		return array_merge( $list, self::$wc_post_meta_whitelist );
+	}
+
+	private static $wc_options_whitelist = array(
+		'woocommerce_currency',
+		'woocommerce_db_version',
+		'woocommerce_weight_unit',
+		'woocommerce_version',
+		'woocommerce_unforce_ssl_checkout',
+		'woocommerce_tax_total_display',
+		'woocommerce_tax_round_at_subtotal',
+		'woocommerce_tax_display_shop',
+		'woocommerce_tax_display_cart',
+		'woocommerce_prices_include_tax',
+		'woocommerce_price_thousand_sep',
+		'woocommerce_price_num_decimals',
+		'woocommerce_price_decimal_sep',
+		'woocommerce_notify_low_stock',
+		'woocommerce_notify_low_stock_amount',
+		'woocommerce_notify_no_stock',
+		'woocommerce_notify_no_stock_amount',
+		'woocommerce_manage_stock',
+		'woocommerce_force_ssl_checkout',
+		'woocommerce_hide_out_of_stock_items',
+		'woocommerce_file_download_method',
+		'woocommerce_enable_signup_and_login_from_checkout',
+		'woocommerce_enable_shipping_calc',
+		'woocommerce_enable_review_rating',
+		'woocommerce_enable_guest_checkout',
+		'woocommerce_enable_coupons',
+		'woocommerce_enable_checkout_login_reminder',
+		'woocommerce_enable_ajax_add_to_cart',
+		'woocommerce_dimension_unit',
+		'woocommerce_default_country',
+		'woocommerce_default_customer_address',
+		'woocommerce_currency_pos',
+		'woocommerce_api_enabled',
+		'woocommerce_allow_tracking',
+	);
+
+	private static $wc_constants_whitelist = array(
+		//woocommerce options
+		'WC_PLUGIN_FILE',
+		'WC_ABSPATH',
+		'WC_PLUGIN_BASENAME',
+		'WC_VERSION',
+		'WOOCOMMERCE_VERSION',
+		'WC_ROUNDING_PRECISION',
+		'WC_DISCOUNT_ROUNDING_MODE',
+		'WC_TAX_ROUNDING_MODE',
+		'WC_DELIMITER',
+		'WC_LOG_DIR',
+		'WC_SESSION_CACHE_GROUP',
+		'WC_TEMPLATE_DEBUG_MODE',
+	);
+
+	private static $wc_post_meta_whitelist = array(
+		//woocommerce products
+		'_stock_status',
+		'_visibility',
+		'total_sales',
+		'_downloadable',
+		'_virtual',
+		'_regular_price',
+		'_sale_price',
+		'_tax_status',
+		'_tax_class',
+		'_featured',
+		'_price',
+		'_stock',
+		'_backorders',
+		'_manage_stock',
+
+		//woocommerce orders
+		'_order_currency',
+		'_prices_include_tax',
+		'_created_via',
+		'_billing_country',
+		'_billing_city',
+		'_billing_state',
+		'_billing_postcode',
+		'_shipping_country',
+		'_shipping_city',
+		'_shipping_state',
+		'_shipping_postcode',
+		'_payment_method',
+		'_payment_method_title',
+		'_order_shipping',
+		'_cart_discount',
+		'_cart_discount_tax',
+		'_order_tax',
+		'_order_shipping_tax',
+		'_order_total',
+		'_download_permissions_granted',
+		'_recorded_sales',
+		'_order_stock_reduced',
+	);
 }

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -44,9 +44,9 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		$this->init_listeners_for_meta_type( 'order_item', $callable );
 
 		// options, constants and post meta whitelists
-		add_filter( 'jetpack_options_whitelist', array( $this, 'add_woocommerce_options_whitelist' ), 10 );
-		add_filter( 'jetpack_constants_whitelist', array( $this, 'add_woocommerce_constants_whitelist' ), 10 );
-		add_filter( 'jetpack_post_meta_whitelist', array( $this, 'add_woocommerce_post_meta_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_options_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_woocommerce_constants_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_woocommerce_post_meta_whitelist' ), 10 );
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -70,7 +70,7 @@ class Jetpack_Sync_Settings {
 				$default_array_value = Jetpack_Sync_Defaults::$blacklisted_post_types;
 				break;
 			case 'post_meta_whitelist':
-				$default_array_value = Jetpack_Sync_Defaults::$post_meta_whitelist;
+				$default_array_value = Jetpack_Sync_Defaults::get_post_meta_whitelist();
 				break;
 			case 'comment_meta_whitelist':
 				$default_array_value = Jetpack_Sync_Defaults::$comment_meta_whitelist;

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -42,6 +42,7 @@ function _manually_load_plugin() {
 }
 
 function _manually_install_woocommerce() {
+	global $wp_version;
 	// clean existing install first
 	define( 'WP_UNINSTALL_PLUGIN', true );
 	define( 'WC_REMOVE_ALL_DATA', true );
@@ -49,6 +50,12 @@ function _manually_install_woocommerce() {
 
 	WC_Install::install();
 
+
+	if ( version_compare( $wp_version, '4.7.0!', '>=' ) ) {
+		$GLOBALS['wp_roles'] = new WP_Roles();
+	} else {
+		$GLOBALS['wp_roles']->reinit();
+	}
 	// reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374
 	$GLOBALS['wp_roles']->reinit();
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -50,15 +50,13 @@ function _manually_install_woocommerce() {
 
 	WC_Install::install();
 
-
-	if ( version_compare( $wp_version, '4.7.0!', '>=' ) ) {
+	// reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374
+	if ( version_compare( $wp_version, '4.7.0' ) >= 0 ) {
 		$GLOBALS['wp_roles'] = new WP_Roles();
 	} else {
 		$GLOBALS['wp_roles']->reinit();
 	}
-	// reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374
-	$GLOBALS['wp_roles']->reinit();
-
+	
 	echo "Installing WooCommerce..." . PHP_EOL;
 }
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -57,7 +57,7 @@ function _manually_install_woocommerce() {
 
 // If we are running the uninstall tests don't load jepack.
 if ( ! ( in_running_uninstall_group() ) ) {
-	tests_add_filter( 'plugins_loaded', '_manually_load_plugin' );
+	tests_add_filter( 'plugins_loaded', '_manually_load_plugin', 1 );
 	if ( "1" == getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 		tests_add_filter( 'setup_theme', '_manually_install_woocommerce' );	
 	}

--- a/tests/php/sync/server/class.jetpack-sync-test-helper.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-helper.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Class Jetpack_Sync_Test_Helper
+ *
+ * Provides utilities and hooks needed for testing
+ */
+
+class Jetpack_Sync_Test_Helper {
+	public $array_override;
+
+	public function filter_override_array() {
+		return $this->array_override;
+	}
+}

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -12,6 +12,7 @@ require_once $sync_dir . 'class.jetpack-sync-wp-replicastore.php';
 require_once $sync_server_dir . 'class.jetpack-sync-test-replicastore.php';
 require_once $sync_server_dir . 'class.jetpack-sync-server-replicator.php';
 require_once $sync_server_dir . 'class.jetpack-sync-server-eventstore.php';
+require_once $sync_server_dir . 'class.jetpack-sync-test-helper.php';
 
 /*
  * Base class for Sync tests - establishes connection between local

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -21,7 +21,7 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 	function test_white_listed_constant_is_synced() {
 		$helper = new Jetpack_Sync_Test_Helper();
 		$helper->array_override = array( 'TEST_FOO' );
-		add_filter( 'jetpack_constants_whitelist', array( $helper, 'filter_override_array' ) );
+		add_filter( 'jetpack_sync_constants_whitelist', array( $helper, 'filter_override_array' ) );
 
 		define( 'TEST_FOO', sprintf( "%.8f", microtime( true ) ) );
 		define( 'TEST_BAR', sprintf( "%.8f", microtime( true ) ) );
@@ -59,7 +59,7 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 	function test_white_listed_constant_doesnt_get_synced_twice() {
 		$helper = new Jetpack_Sync_Test_Helper();
 		$helper->array_override = array( 'TEST_ABC' );
-		add_filter( 'jetpack_constants_whitelist', array( $helper, 'filter_override_array' ) );
+		add_filter( 'jetpack_sync_constants_whitelist', array( $helper, 'filter_override_array' ) );
 
 		define( 'TEST_ABC', 'FOO' );
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -19,8 +19,9 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 	// Add tests for Syncing data on shutdown
 	// Add tests that prove that we know constants change
 	function test_white_listed_constant_is_synced() {
-
-		$this->constant_module->set_constants_whitelist( array( 'TEST_FOO' ) );
+		$helper = new Jetpack_Sync_Test_Helper();
+		$helper->array_override = array( 'TEST_FOO' );
+		add_filter( 'jetpack_constants_whitelist', array( $helper, 'filter_override_array' ) );
 
 		define( 'TEST_FOO', sprintf( "%.8f", microtime( true ) ) );
 		define( 'TEST_BAR', sprintf( "%.8f", microtime( true ) ) );
@@ -56,7 +57,10 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_white_listed_constant_doesnt_get_synced_twice() {
-		$this->constant_module->set_constants_whitelist( array( 'TEST_ABC' ) );
+		$helper = new Jetpack_Sync_Test_Helper();
+		$helper->array_override = array( 'TEST_ABC' );
+		add_filter( 'jetpack_constants_whitelist', array( $helper, 'filter_override_array' ) );
+
 		define( 'TEST_ABC', 'FOO' );
 		$this->sender->do_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -277,7 +277,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$helper = new Jetpack_Sync_Test_Helper();
 		$helper->array_override = array( 'TEST_SYNC_ALL_CONSTANTS' );
-		add_filter( 'jetpack_constants_whitelist', array( $helper, 'filter_override_array' ) );
+		add_filter( 'jetpack_sync_constants_whitelist', array( $helper, 'filter_override_array' ) );
 
 		$this->sender->do_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -275,7 +275,10 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	function test_full_sync_sends_all_constants() {
 		define( 'TEST_SYNC_ALL_CONSTANTS', 'foo' );
 
-		Jetpack_Sync_Modules::get_module( "constants" )->set_constants_whitelist( array( 'TEST_SYNC_ALL_CONSTANTS' ) );
+		$helper = new Jetpack_Sync_Test_Helper();
+		$helper->array_override = array( 'TEST_SYNC_ALL_CONSTANTS' );
+		add_filter( 'jetpack_constants_whitelist', array( $helper, 'filter_override_array' ) );
+
 		$this->sender->do_sync();
 
 		// reset the storage, check value, and do full sync - storage should be set!

--- a/tests/php/sync/test_class.jetpack-sync-woocommerce.php
+++ b/tests/php/sync/test_class.jetpack-sync-woocommerce.php
@@ -105,7 +105,7 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 		$order->payment_complete( '12345' );
 		
 		// just for fun
-		$this->assertEquals( 'processing', $order->get_status() );
+		$this->assertEquals( 'completed', $order->get_status() );
 		$this->assertEquals( '12345', $order->get_transaction_id() );
 
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-woocommerce.php
+++ b/tests/php/sync/test_class.jetpack-sync-woocommerce.php
@@ -20,6 +20,11 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 
 		$woo_tests_dir = dirname( __FILE__ ) . '/../../../../woocommerce/tests';
 
+		if( ! file_exists( $woo_tests_dir ) ) {
+			error_log('PLEASE RUN THE GIT VERSION OF WooCommerce that has the tests folder. Found at github.com/WooCommerce/woocommerce' );
+			self::$woo_enabled = false;
+		}
+
 		// This is taken from WooCommerce's bootstrap.php file
 
 		// factories


### PR DESCRIPTION
The main goal of this PR is to add support for WooCommerce specific data in the Jetpack Sync modules.

- Add filters on the whitelist arrays needed to acheive this
- Refactor the constants module to avoid race condition on filtered whitelist
- Add WooCommerce constants
- Add WooCommerce WordPress options
- Add Post Metadata for WooCommerce Orders and Products

#### Changes proposed in this Pull Request:

* Add new filter on default constant whitelist
* Add new filter on default post metadata whitelist
* Add WooCommerce specific whitelist data (constants, options, post metadata)
* Refactor sync constants module to correctly apply filtered whitelist

#### Testing instructions:

* Setup a test site with WooCommerce and test products, settings and orders
* Install this version of the plugin
* Run sync to observe that new data is included

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

- Better support for WooCommerce data sync and backup
