### PR TITLE
Add Jetpack sync module to sync WP Super Cache constants and global variables

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -296,7 +296,7 @@ class Jetpack_Sync_Actions {
 
 	static function initialize_wp_super_cache() {
 		//WPCACHEHOME looks like a reasonable constant to test for the plugin's presence as per https://github.com/Automattic/wp-super-cache/blob/master/wp-cache.php
-		if ( false === defined( 'WPCACHEHOME' ) ) {
+		if ( false === function_exists( 'wp_cache_is_enabled' ) ) {
 			return;
 		}
 		add_filter( 'jetpack_sync_modules', array( 'Jetpack_Sync_Actions', 'add_wp_super_cache_sync_module' ) );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -282,14 +282,29 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function initialize_woocommerce() {
-		if ( class_exists( 'WooCommerce' ) ) {
-			add_filter( 'jetpack_sync_modules', array( 'Jetpack_Sync_Actions', 'add_woocommerce_sync_module' ) );
+		if ( false === class_exists( 'WooCommerce' ) ) {
+			return;
 		}
+		add_filter( 'jetpack_sync_modules', array( 'Jetpack_Sync_Actions', 'add_woocommerce_sync_module' ) );
 	}
 
 	static function add_woocommerce_sync_module( $sync_modules ) {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-woocommerce.php';
 		$sync_modules[] = 'Jetpack_Sync_Module_WooCommerce';
+		return $sync_modules;
+	}
+
+	static function initialize_wp_super_cache() {
+		//WPCACHEHOME looks like a reasonable constant to test for the plugin's presence as per https://github.com/Automattic/wp-super-cache/blob/master/wp-cache.php
+		if ( false === defined( 'WPCACHEHOME' ) ) {
+			return;
+		}
+		add_filter( 'jetpack_sync_modules', array( 'Jetpack_Sync_Actions', 'add_wp_super_cache_sync_module' ) );
+	}
+
+	static function add_wp_super_cache_sync_module( $sync_modules ) {
+		require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-wp-super-cache.php';
+		$sync_modules[] = 'Jetpack_Sync_Module_WPSuperCache';
 		return $sync_modules;
 	}
 
@@ -425,6 +440,9 @@ add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
 
 // Check for WooCommerce support
 add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
+
+// Check for WP Super Cache
+add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_wp_super_cache' ), 5 );
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -431,17 +431,19 @@ class Jetpack_Sync_Actions {
 	}
 }
 
+// Check for WooCommerce support
+add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
+
+// Check for WP Super Cache
+add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_wp_super_cache' ), 5 );
+
 /*
  * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
  * with a high priority or sites that use alternate cron.
  */
 add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
 
-// Check for WooCommerce support
-add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_woocommerce' ), 5 );
 
-// Check for WP Super Cache
-add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'initialize_wp_super_cache' ), 5 );
 
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -304,7 +304,7 @@ class Jetpack_Sync_Actions {
 
 	static function add_wp_super_cache_sync_module( $sync_modules ) {
 		require_once dirname( __FILE__ ) . '/class.jetpack-sync-module-wp-super-cache.php';
-		$sync_modules[] = 'Jetpack_Sync_Module_WPSuperCache';
+		$sync_modules[] = 'Jetpack_Sync_Module_WP_Super_Cache';
 		return $sync_modules;
 	}
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -295,7 +295,6 @@ class Jetpack_Sync_Actions {
 	}
 
 	static function initialize_wp_super_cache() {
-		//WPCACHEHOME looks like a reasonable constant to test for the plugin's presence as per https://github.com/Automattic/wp-super-cache/blob/master/wp-cache.php
 		if ( false === function_exists( 'wp_cache_is_enabled' ) ) {
 			return;
 		}

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -119,21 +119,18 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_options_whitelist() {
-		if ( ! self::$initialized_options_whitelist ) {
-			/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
-			$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
-			/**
-			 * Filter the list of WordPress options that are manageable via the JSON API.
-			 *
-			 * @module sync
-			 *
-			 * @since 4.7
-			 *
-			 * @param array The default list of options.
-			 */
-			self::$initialized_options_whitelist = apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
-		}
-		return self::$initialized_options_whitelist;
+		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
+		$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
+		/**
+		 * Filter the list of WordPress options that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.7
+		 *
+		 * @param array The default list of options.
+		 */
+		return apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
 	}
 
 	static $default_constants_whitelist = array(
@@ -157,19 +154,7 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_constants_whitelist() {
-		if ( ! self::$initialized_constants_whitelist ) {
-			/**
-			 * Filter the list of PHP constants that are manageable via the JSON API.
-			 *
-			 * @module sync
-			 *
-			 * @since 4.7
-			 *
-			 * @param array The default list of constants options.
-			 */
-			self::$initialized_constants_whitelist = apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
-		}
-		return self::$initialized_constants_whitelist;
+		return apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
 	}
 
 	static $default_callable_whitelist = array(

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -5,6 +5,13 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' 
  * Just some defaults that we share with the server
  */
 class Jetpack_Sync_Defaults {
+
+	static $initialized_options_whitelist;
+	static $initialized_constants_whitelist;
+	static $initialized_callable_whitelist;
+	static $initialized_multisite_callable_whitelist;
+	static $initialized_post_meta_whitelist;
+
 	static $default_options_whitelist = array(
 		'stylesheet',
 		'blogname',
@@ -112,18 +119,21 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_options_whitelist() {
-		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
-		$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
-		/**
-		 * Filter the list of WordPress options that are manageable via the JSON API.
-		 *
-		 * @module sync
-		 *
-		 * @since 4.7
-		 *
-		 * @param array The default list of options.
-		 */
-		return apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
+		if ( ! self::$initialized_options_whitelist ) {
+			/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
+			$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
+			/**
+			 * Filter the list of WordPress options that are manageable via the JSON API.
+			 *
+			 * @module sync
+			 *
+			 * @since 4.7
+			 *
+			 * @param array The default list of options.
+			 */
+			self::$initialized_options_whitelist = apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
+		}
+		return self::$initialized_options_whitelist;
 	}
 
 	static $default_constants_whitelist = array(
@@ -147,16 +157,19 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_constants_whitelist() {
-		/**
-		 * Filter the list of PHP constants that are manageable via the JSON API.
-		 *
-		 * @module sync
-		 *
-		 * @since 4.7
-		 *
-		 * @param array The default list of constants options.
-		 */
-		return apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
+		if ( ! self::$initialized_constants_whitelist ) {
+			/**
+			 * Filter the list of PHP constants that are manageable via the JSON API.
+			 *
+			 * @module sync
+			 *
+			 * @since 4.7
+			 *
+			 * @param array The default list of constants options.
+			 */
+			self::$initialized_constants_whitelist = apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
+		}
+		return self::$initialized_constants_whitelist;
 	}
 
 	static $default_callable_whitelist = array(
@@ -188,6 +201,22 @@ class Jetpack_Sync_Defaults {
 		'locale'                           => 'get_locale',
 		'site_icon_url'                    => array( 'Jetpack_Sync_Functions', 'site_icon_url' ),
 	);
+
+	public static function get_callable_whitelist() {
+		if ( ! self::$initialized_callable_whitelist ) {
+			/**
+			 * Filter the list of callables that are manageable via the JSON API.
+			 *
+			 * @module sync
+			 *
+			 * @since 4.7
+			 *
+			 * @param array The default list of callables.
+			 */
+			self::$initialized_callable_whitelist = apply_filters( 'jetpack_sync_callable_whitelist', self::$default_callable_whitelist );
+		}
+		return self::$initialized_callable_whitelist;
+	}
 
 	static $blacklisted_post_types = array(
 		'ai1ec_event',
@@ -235,6 +264,22 @@ class Jetpack_Sync_Defaults {
 		'network_enable_administration_menus' => array( 'Jetpack', 'network_enable_administration_menus' ),
 	);
 
+	public static function get_multisite_callable_whitelist() {
+		if ( ! self::$initialized_multisite_callable_whitelist ) {
+			/**
+			 * Filter the list of multisite callables that are manageable via the JSON API.
+			 *
+			 * @module sync
+			 *
+			 * @since 4.7
+			 *
+			 * @param array The default list of multisite callables.
+			 */
+			self::$initialized_multisite_callable_whitelist = apply_filters( 'jetpack_sync_multisite_callable_whitelist', self::$default_multisite_callable_whitelist );
+		}
+		return self::$initialized_multisite_callable_whitelist;
+	}
+
 	static $post_meta_whitelist = array(
 		'_feedback_akismet_values',
 		'_feedback_email',
@@ -276,16 +321,19 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_post_meta_whitelist() {
-		/**
-		 * Filter the list of post meta data that are manageable via the JSON API.
-		 *
-		 * @module sync
-		 *
-		 * @since 4.7
-		 *
-		 * @param array The default list of meta data keys.
-		 */
-		return apply_filters( 'jetpack_sync_post_meta_whitelist', self::$post_meta_whitelist );
+		if ( ! self::$initialized_post_meta_whitelist ) {
+			/**
+			 * Filter the list of post meta data that are manageable via the JSON API.
+			 *
+			 * @module sync
+			 *
+			 * @since 4.7
+			 *
+			 * @param array The default list of meta data keys.
+			 */
+			self::$initialized_post_meta_whitelist = apply_filters( 'jetpack_sync_post_meta_whitelist', self::$post_meta_whitelist );
+		}
+		return self::$initialized_post_meta_whitelist;
 	}
 
 	static $comment_meta_whitelist = array(

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -6,12 +6,6 @@ require_once( JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-helpers.php' 
  */
 class Jetpack_Sync_Defaults {
 
-	static $initialized_options_whitelist;
-	static $initialized_constants_whitelist;
-	static $initialized_callable_whitelist;
-	static $initialized_multisite_callable_whitelist;
-	static $initialized_post_meta_whitelist;
-
 	static $default_options_whitelist = array(
 		'stylesheet',
 		'blogname',

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -119,18 +119,18 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_options_whitelist() {
-		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
-		$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
-		/**
-		 * Filter the list of WordPress options that are manageable via the JSON API.
-		 *
-		 * @module sync
-		 *
-		 * @since 4.7
-		 *
-		 * @param array The default list of options.
-		 */
-		return apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
+			/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
+			$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
+			/**
+			 * Filter the list of WordPress options that are manageable via the JSON API.
+			 *
+			 * @module sync
+			 *
+			 * @since 4.7
+			 *
+			 * @param array The default list of options.
+			 */
+			return apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
 	}
 
 	static $default_constants_whitelist = array(
@@ -154,7 +154,16 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_constants_whitelist() {
-		return apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
+			/**
+			 * Filter the list of PHP constants that are manageable via the JSON API.
+			 *
+			 * @module sync
+			 *
+			 * @since 4.7
+			 *
+			 * @param array The default list of constants options.
+			 */
+			return apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
 	}
 
 	static $default_callable_whitelist = array(
@@ -188,7 +197,6 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_callable_whitelist() {
-		if ( ! self::$initialized_callable_whitelist ) {
 			/**
 			 * Filter the list of callables that are manageable via the JSON API.
 			 *
@@ -198,9 +206,7 @@ class Jetpack_Sync_Defaults {
 			 *
 			 * @param array The default list of callables.
 			 */
-			self::$initialized_callable_whitelist = apply_filters( 'jetpack_sync_callable_whitelist', self::$default_callable_whitelist );
-		}
-		return self::$initialized_callable_whitelist;
+			return apply_filters( 'jetpack_sync_callable_whitelist', self::$default_callable_whitelist );
 	}
 
 	static $blacklisted_post_types = array(
@@ -250,7 +256,6 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_multisite_callable_whitelist() {
-		if ( ! self::$initialized_multisite_callable_whitelist ) {
 			/**
 			 * Filter the list of multisite callables that are manageable via the JSON API.
 			 *
@@ -260,9 +265,7 @@ class Jetpack_Sync_Defaults {
 			 *
 			 * @param array The default list of multisite callables.
 			 */
-			self::$initialized_multisite_callable_whitelist = apply_filters( 'jetpack_sync_multisite_callable_whitelist', self::$default_multisite_callable_whitelist );
-		}
-		return self::$initialized_multisite_callable_whitelist;
+			return apply_filters( 'jetpack_sync_multisite_callable_whitelist', self::$default_multisite_callable_whitelist );
 	}
 
 	static $post_meta_whitelist = array(
@@ -306,7 +309,6 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_post_meta_whitelist() {
-		if ( ! self::$initialized_post_meta_whitelist ) {
 			/**
 			 * Filter the list of post meta data that are manageable via the JSON API.
 			 *
@@ -316,9 +318,7 @@ class Jetpack_Sync_Defaults {
 			 *
 			 * @param array The default list of meta data keys.
 			 */
-			self::$initialized_post_meta_whitelist = apply_filters( 'jetpack_sync_post_meta_whitelist', self::$post_meta_whitelist );
-		}
-		return self::$initialized_post_meta_whitelist;
+			return apply_filters( 'jetpack_sync_post_meta_whitelist', self::$post_meta_whitelist );
 	}
 
 	static $comment_meta_whitelist = array(

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -119,18 +119,18 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_options_whitelist() {
-			/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
-			$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
-			/**
-			 * Filter the list of WordPress options that are manageable via the JSON API.
-			 *
-			 * @module sync
-			 *
-			 * @since 4.7
-			 *
-			 * @param array The default list of options.
-			 */
-			return apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
+		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
+		$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
+		/**
+		 * Filter the list of WordPress options that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.8
+		 *
+		 * @param array The default list of options.
+		 */
+		return apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
 	}
 
 	static $default_constants_whitelist = array(
@@ -154,16 +154,16 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_constants_whitelist() {
-			/**
-			 * Filter the list of PHP constants that are manageable via the JSON API.
-			 *
-			 * @module sync
-			 *
-			 * @since 4.7
-			 *
-			 * @param array The default list of constants options.
-			 */
-			return apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
+		/**
+		 * Filter the list of PHP constants that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.8
+		 *
+		 * @param array The default list of constants options.
+		 */
+		return apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
 	}
 
 	static $default_callable_whitelist = array(
@@ -197,16 +197,16 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_callable_whitelist() {
-			/**
-			 * Filter the list of callables that are manageable via the JSON API.
-			 *
-			 * @module sync
-			 *
-			 * @since 4.7
-			 *
-			 * @param array The default list of callables.
-			 */
-			return apply_filters( 'jetpack_sync_callable_whitelist', self::$default_callable_whitelist );
+		/**
+		 * Filter the list of callables that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.8
+		 *
+		 * @param array The default list of callables.
+		 */
+		return apply_filters( 'jetpack_sync_callable_whitelist', self::$default_callable_whitelist );
 	}
 
 	static $blacklisted_post_types = array(
@@ -256,16 +256,16 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_multisite_callable_whitelist() {
-			/**
-			 * Filter the list of multisite callables that are manageable via the JSON API.
-			 *
-			 * @module sync
-			 *
-			 * @since 4.7
-			 *
-			 * @param array The default list of multisite callables.
-			 */
-			return apply_filters( 'jetpack_sync_multisite_callable_whitelist', self::$default_multisite_callable_whitelist );
+		/**
+		 * Filter the list of multisite callables that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.8
+		 *
+		 * @param array The default list of multisite callables.
+		 */
+		return apply_filters( 'jetpack_sync_multisite_callable_whitelist', self::$default_multisite_callable_whitelist );
 	}
 
 	static $post_meta_whitelist = array(
@@ -309,16 +309,16 @@ class Jetpack_Sync_Defaults {
 	);
 
 	public static function get_post_meta_whitelist() {
-			/**
-			 * Filter the list of post meta data that are manageable via the JSON API.
-			 *
-			 * @module sync
-			 *
-			 * @since 4.7
-			 *
-			 * @param array The default list of meta data keys.
-			 */
-			return apply_filters( 'jetpack_sync_post_meta_whitelist', self::$post_meta_whitelist );
+		/**
+		 * Filter the list of post meta data that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since 4.8
+		 *
+		 * @param array The default list of meta data keys.
+		 */
+		return apply_filters( 'jetpack_sync_post_meta_whitelist', self::$post_meta_whitelist );
 	}
 
 	static $comment_meta_whitelist = array(

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -12,6 +12,14 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		return 'functions';
 	}
 
+	public function set_defaults() {
+		if ( is_multisite() ) {
+			$this->callable_whitelist = array_merge( Jetpack_Sync_Defaults::get_callable_whitelist(), Jetpack_Sync_Defaults::get_multisite_callable_whitelist() );
+		} else {
+			$this->callable_whitelist = Jetpack_Sync_Defaults::get_callable_whitelist();
+		}
+	}
+
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
 
@@ -61,13 +69,6 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	}
 
 	function get_callable_whitelist() {
-		if ( ! $this->callable_whitelist ) {
-			if ( is_multisite() ) {
-				$this->callable_whitelist = array_merge( Jetpack_Sync_Defaults::get_callable_whitelist(), Jetpack_Sync_Defaults::get_multisite_callable_whitelist() );
-			} else {
-				$this->callable_whitelist = Jetpack_Sync_Defaults::get_callable_whitelist();
-			}
-		}
 		return $this->callable_whitelist;
 	}
 

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -12,14 +12,6 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		return 'functions';
 	}
 
-	public function set_defaults() {
-		if ( is_multisite() ) {
-			$this->callable_whitelist = array_merge( Jetpack_Sync_Defaults::$default_callable_whitelist, Jetpack_Sync_Defaults::$default_multisite_callable_whitelist );
-		} else {
-			$this->callable_whitelist = Jetpack_Sync_Defaults::$default_callable_whitelist;
-		}
-	}
-
 	public function init_listeners( $callable ) {
 		add_action( 'jetpack_sync_callable', $callable, 10, 2 );
 
@@ -69,6 +61,13 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 	}
 
 	function get_callable_whitelist() {
+		if ( ! $this->callable_whitelist ) {
+			if ( is_multisite() ) {
+				$this->callable_whitelist = array_merge( Jetpack_Sync_Defaults::get_callable_whitelist(), Jetpack_Sync_Defaults::get_multisite_callable_whitelist() );
+			} else {
+				$this->callable_whitelist = Jetpack_Sync_Defaults::get_callable_whitelist();
+			}
+		}
 		return $this->callable_whitelist;
 	}
 
@@ -77,8 +76,8 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 		$current_user_id = get_current_user_id();
 		wp_set_current_user( Jetpack_Options::get_option( 'master_user' ) );
 		$callables = array_combine(
-			array_keys( $this->callable_whitelist ),
-			array_map( array( $this, 'get_callable' ), array_values( $this->callable_whitelist ) )
+			array_keys( $this->get_callable_whitelist() ),
+			array_map( array( $this, 'get_callable' ), array_values( $this->get_callable_whitelist() ) )
 		);
 		wp_set_current_user( $current_user_id );
 

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -117,4 +117,11 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 
 		return $args;
 	}
+
+	/**
+	 * @param $additional_constants Array of names of additional constants that should be synced
+	 */
+	public function add_constants( $additional_constants ) {
+		$this->constants_whitelist = array_merge( $this->constants_whitelist, $additional_constants );
+	}
 }

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -117,11 +117,4 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 
 		return $args;
 	}
-
-	/**
-	 * @param $additional_constants Array of names of additional constants that should be synced
-	 */
-	public function add_constants( $additional_constants ) {
-		$this->constants_whitelist = array_merge( $this->constants_whitelist, $additional_constants );
-	}
 }

--- a/sync/class.jetpack-sync-module-wp-super-cache.php
+++ b/sync/class.jetpack-sync-module-wp-super-cache.php
@@ -1,0 +1,36 @@
+<?php
+
+class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
+
+	public function name() {
+		return 'wp-super-cache';
+	}
+
+	public function init_listeners( $callable ) {
+		add_action( 'jetpack_sync_wp_super_cache', $callable, 10, 1 );
+	}
+
+	public function init_full_sync_listeners( $callable ) {
+		add_action('jetpack_sync_wp_super_cache', $callable, 10, 1);
+	}
+
+	public function init_before_send() {
+		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'trigger_enqueue' ) );
+
+		// full sync
+		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_constants', array( $this, 'trigger_enqueue' ) );
+	}
+
+	public function trigger_enqueue() {
+		$values = array(); //array of values containing WP Super Cache variables and constants
+
+/*
+		$wp_cache_mod_rewrite, $cache_enabled, $super_cache_enabled, $ossdlcdn, $cache_rebuild_files, $wp_cache_mobile, $wp_super_cache_late_init, $wp_cache_anon_only, $wp_cache_not_logged_in, $wp_cache_clear_on_post_edit, $wp_cache_mobile_enabled, $wp_super_cache_debug, $cache_max_time, $wp_cache_refresh_single_only, $wp_cache_mfunc_enabled, $wp_supercache_304, $wp_cache_no_cache_for_get, $wp_cache_mutex_disabled, $cache_jetpack, $cache_domain_mapping
+
+Constants:
+WPLOCKDOWN, WPSC_DISABLE_COMPRESSION, WPSC_DISABLE_LOCKING, WPSC_DISABLE_HTACCESS_UPDATE, ADVANCEDCACHEPROBLEM
+*/
+		do_action('jetpack_sync_wp_super_cache', $values);
+	}
+
+}

--- a/sync/class.jetpack-sync-module-wp-super-cache.php
+++ b/sync/class.jetpack-sync-module-wp-super-cache.php
@@ -2,6 +2,8 @@
 
 class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 
+	static $wp_super_cache_globals = array();
+
 	static $wp_super_cache_constants = array(
 		'WPLOCKDOWN',
 		'WPSC_DISABLE_COMPRESSION',
@@ -12,6 +14,62 @@ class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 
 	public function name() {
 		return 'wp-super-cache';
+	}
+
+	public function set_defaults() {
+		global $wp_cache_mod_rewrite;
+		global $cache_enabled;
+		global $super_cache_enabled;
+		global $ossdlcdn;
+		global $cache_rebuild_files;
+		global $wp_cache_mobile;
+		global $wp_super_cache_late_init;
+		global $wp_cache_anon_only;
+		global $wp_cache_not_logged_in;
+		global $wp_cache_clear_on_post_edit;
+		global $wp_cache_mobile_enabled;
+		global $wp_super_cache_debug;
+		global $cache_max_time;
+		global $wp_cache_refresh_single_only;
+		global $wp_cache_mfunc_enabled;
+		global $wp_supercache_304;
+		global $wp_cache_no_cache_for_get;
+		global $wp_cache_mutex_disabled;
+		global $cache_jetpack;
+		global $cache_domain_mapping;
+
+		self::$wp_super_cache_globals = array (
+			'wp_cache_mod_rewrite' => $wp_cache_mod_rewrite,
+			'cache_enabled' => $cache_enabled,
+			'super_cache_enabled' => $super_cache_enabled,
+			'ossdlcdn' => $ossdlcdn,
+			'cache_rebuild_files' => $cache_rebuild_files,
+			'wp_cache_mobile' => $wp_cache_mobile,
+			'wp_super_cache_late_init' => $wp_super_cache_late_init,
+			'wp_cache_anon_only' => $wp_cache_anon_only,
+			'wp_cache_not_logged_in' => $wp_cache_not_logged_in,
+			'wp_cache_clear_on_post_edit' => $wp_cache_clear_on_post_edit,
+			'wp_cache_mobile_enabled' => $wp_cache_mobile_enabled,
+			'wp_super_cache_debug' => $wp_super_cache_debug,
+			'cache_max_time' => $cache_max_time,
+			'wp_cache_refresh_single_only' => $wp_cache_refresh_single_only,
+			'wp_cache_mfunc_enabled' => $wp_cache_mfunc_enabled,
+			'wp_supercache_304' => $wp_supercache_304,
+			'wp_cache_no_cache_for_get' => $wp_cache_no_cache_for_get,
+			'wp_cache_mutex_disabled' => $wp_cache_mutex_disabled,
+			'cache_jetpack' => $cache_jetpack,
+			'cache_domain_mapping' => $cache_domain_mapping,
+		);
+	}
+
+	public function init_listeners( $callable ) {
+		add_action( 'enqueue_wp_super_cache_globals', $callable, 10, 1 );
+		do_action( 'enqueue_wp_super_cache_globals', self::$wp_super_cache_globals );
+	}
+
+	public function init_full_sync_listeners( $callable ) {
+		add_action( 'enqueue_wp_super_cache_globals', $callable, 10, 1 );
+		do_action( 'enqueue_wp_super_cache_globals', self::$wp_super_cache_globals );
 	}
 
 	/**

--- a/sync/class.jetpack-sync-module-wp-super-cache.php
+++ b/sync/class.jetpack-sync-module-wp-super-cache.php
@@ -19,6 +19,6 @@ class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 	 */
 	public function set_late_default() {
 		$constants_module = Jetpack_Sync_Modules::get_module( 'constants' );
-		$constants_module->add_constants( self::WP_SUPER_CACHE_CONSTANTS );
+		$constants_module->add_constants( self::$wp_super_cache_constants);
 	}
 }

--- a/sync/class.jetpack-sync-module-wp-super-cache.php
+++ b/sync/class.jetpack-sync-module-wp-super-cache.php
@@ -19,6 +19,6 @@ class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 	 */
 	public function set_late_default() {
 		$constants_module = Jetpack_Sync_Modules::get_module( 'constants' );
-		$constants_module->add_constants( self::$wp_super_cache_constants);
+		$constants_module->add_constants( self::$wp_super_cache_constants );
 	}
 }

--- a/sync/class.jetpack-sync-module-wp-super-cache.php
+++ b/sync/class.jetpack-sync-module-wp-super-cache.php
@@ -2,35 +2,23 @@
 
 class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 
+	static $wp_super_cache_constants = array(
+		'WPLOCKDOWN',
+		'WPSC_DISABLE_COMPRESSION',
+		'WPSC_DISABLE_LOCKING',
+		'WPSC_DISABLE_HTACCESS_UPDATE',
+		'ADVANCEDCACHEPROBLEM',
+	);
+
 	public function name() {
 		return 'wp-super-cache';
 	}
 
-	public function init_listeners( $callable ) {
-		add_action( 'jetpack_sync_wp_super_cache', $callable, 10, 1 );
+	/**
+	 * Using set_late_default to ensure constants module is already initialized, then add WP Super Cache constants to it for syncing via existing mechanism
+	 */
+	public function set_late_default() {
+		$constants_module = Jetpack_Sync_Modules::get_module( 'constants' );
+		$constants_module->add_constants( self::WP_SUPER_CACHE_CONSTANTS );
 	}
-
-	public function init_full_sync_listeners( $callable ) {
-		add_action('jetpack_sync_wp_super_cache', $callable, 10, 1);
-	}
-
-	public function init_before_send() {
-		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'trigger_enqueue' ) );
-
-		// full sync
-		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_constants', array( $this, 'trigger_enqueue' ) );
-	}
-
-	public function trigger_enqueue() {
-		$values = array(); //array of values containing WP Super Cache variables and constants
-
-/*
-		$wp_cache_mod_rewrite, $cache_enabled, $super_cache_enabled, $ossdlcdn, $cache_rebuild_files, $wp_cache_mobile, $wp_super_cache_late_init, $wp_cache_anon_only, $wp_cache_not_logged_in, $wp_cache_clear_on_post_edit, $wp_cache_mobile_enabled, $wp_super_cache_debug, $cache_max_time, $wp_cache_refresh_single_only, $wp_cache_mfunc_enabled, $wp_supercache_304, $wp_cache_no_cache_for_get, $wp_cache_mutex_disabled, $cache_jetpack, $cache_domain_mapping
-
-Constants:
-WPLOCKDOWN, WPSC_DISABLE_COMPRESSION, WPSC_DISABLE_LOCKING, WPSC_DISABLE_HTACCESS_UPDATE, ADVANCEDCACHEPROBLEM
-*/
-		do_action('jetpack_sync_wp_super_cache', $values);
-	}
-
 }

--- a/sync/class.jetpack-sync-module-wp-super-cache.php
+++ b/sync/class.jetpack-sync-module-wp-super-cache.php
@@ -18,7 +18,7 @@ class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 		return 'wp-super-cache';
 	}
 
-	public function get_wp_super_cache_globals() {
+	public static function get_wp_super_cache_globals() {
 		global $wp_cache_mod_rewrite;
 		global $cache_enabled;
 		global $super_cache_enabled;
@@ -81,7 +81,7 @@ class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 		return array_merge( $list, self::$wp_super_cache_constants );
 	}
 
-	public function add_wp_super_cache_callables_whitelist( $list ) {
+	public function add_wp_super_cache_callable_whitelist( $list ) {
 		return array_merge( $list, self::$wp_super_cache_callables );
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -33,7 +33,7 @@ if ( "1" != getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 
 if ( "1" != getenv( 'JETPACK_TEST_WP_SUPER_CACHE' ) ) {
 	echo "To run Jetpack WP Super Cache tests, prefix phpunit with JETPACK_TEST_WP_SUPER_CACHE=1" . PHP_EOL;
-} else {
+} else if ( false === function_exists( 'wp_cache_is_enabled' ) ) {
 	/**
 	 * "Mocking" function so that it exists and Jetpack_Sync_Actions will load Jetpack_Sync_Module_WP_Super_Cache
 	 */

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -31,6 +31,17 @@ if ( "1" != getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 	define( 'JETPACK_WOOCOMMERCE_INSTALL_DIR', dirname( __FILE__ ) . '/../../../woocommerce' );
 }
 
+if ( "1" != getenv( 'JETPACK_TEST_WP_SUPER_CACHE' ) ) {
+	echo "To run Jetpack WP Super Cache tests, prefix phpunit with JETPACK_TEST_WP_SUPER_CACHE=1" . PHP_EOL;
+} else {
+	/**
+	 * "Mocking" function so that it exists and Jetpack_Sync_Actions will load Jetpack_Sync_Module_WP_Super_Cache
+	 */
+	function wp_cache_is_enabled() {
+
+	}
+}
+
 require $test_root . '/includes/functions.php';
 
 // Activates this plugin in WordPress so it can be tested.

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -31,9 +31,7 @@ if ( '1' != getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 	define( 'JETPACK_WOOCOMMERCE_INSTALL_DIR', dirname( __FILE__ ) . '/../../../woocommerce' );
 }
 
-if ( '1' != getenv( 'JETPACK_TEST_WP_SUPER_CACHE' ) ) {
-	echo "To run Jetpack WP Super Cache tests, prefix phpunit with JETPACK_TEST_WP_SUPER_CACHE=1" . PHP_EOL;
-} else if ( false === function_exists( 'wp_cache_is_enabled' ) ) {
+if ( false === function_exists( 'wp_cache_is_enabled' ) ) {
 	/**
 	 * "Mocking" function so that it exists and Jetpack_Sync_Actions will load Jetpack_Sync_Module_WP_Super_Cache
 	 */

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -19,19 +19,19 @@ if( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	$test_root = '/tmp/wordpress-tests-lib';
 }
 
-if ( "1" != getenv( 'WP_MULTISITE' ) &&
+if ( '1' != getenv( 'WP_MULTISITE' ) &&
  ( defined( 'WP_TESTS_MULTISITE') && ! WP_TESTS_MULTISITE ) ) {
  echo "To run Jetpack multisite, use -c tests/php.multisite.xml" . PHP_EOL;
  echo "Disregard Core's -c tests/phpunit/multisite.xml notice below." . PHP_EOL;
 }
 
-if ( "1" != getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
+if ( '1' != getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
  echo "To run Jetpack woocommerce tests, prefix phpunit with JETPACK_TEST_WOOCOMMERCE=1" . PHP_EOL;
 } else {
 	define( 'JETPACK_WOOCOMMERCE_INSTALL_DIR', dirname( __FILE__ ) . '/../../../woocommerce' );
 }
 
-if ( "1" != getenv( 'JETPACK_TEST_WP_SUPER_CACHE' ) ) {
+if ( '1' != getenv( 'JETPACK_TEST_WP_SUPER_CACHE' ) ) {
 	echo "To run Jetpack WP Super Cache tests, prefix phpunit with JETPACK_TEST_WP_SUPER_CACHE=1" . PHP_EOL;
 } else if ( false === function_exists( 'wp_cache_is_enabled' ) ) {
 	/**
@@ -46,7 +46,7 @@ require $test_root . '/includes/functions.php';
 
 // Activates this plugin in WordPress so it can be tested.
 function _manually_load_plugin() {
-	if ( "1" == getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
+	if ( '1' == getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 		require JETPACK_WOOCOMMERCE_INSTALL_DIR . '/woocommerce.php';
 	}
 	require dirname( __FILE__ ) . '/../../jetpack.php';
@@ -74,7 +74,7 @@ function _manually_install_woocommerce() {
 // If we are running the uninstall tests don't load jepack.
 if ( ! ( in_running_uninstall_group() ) ) {
 	tests_add_filter( 'plugins_loaded', '_manually_load_plugin', 1 );
-	if ( "1" == getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
+	if ( '1' == getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 		tests_add_filter( 'setup_theme', '_manually_install_woocommerce' );	
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -81,6 +81,10 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'shortcodes'                       => Jetpack_Sync_Functions::get_shortcodes(),
 		);
 
+		if ( function_exists( 'wp_cache_is_enabled' ) ) {
+			$callables['wp_super_cache_globals'] = Jetpack_Sync_Module_WP_Super_Cache::get_wp_super_cache_globals();
+		}
+
 		if ( is_multisite() ) {
 			$callables['network_name']                        = Jetpack::network_name();
 			$callables['network_allow_new_registrations']     = Jetpack::network_allow_new_registrations();

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Testing WP Super Cache Sync
+ */
+class WP_Test_Jetpack_Sync_WP_Super_Cache extends WP_Test_Jetpack_Sync_Base {
+	protected $post;
+	protected $callable_module;
+	protected $full_sync;
+	static $woo_enabled;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		if ( "1" != getenv( 'JETPACK_TEST_WP_SUPER_CACHE' ) ) {
+			return; 
+		} 
+		
+		self::$wp_super_cache_enabled = true;
+	}
+
+	public function setUp() {
+		if ( ! self::$wp_super_cache_enabled ) {
+			$this->markTestSkipped();
+			return;
+		}
+		parent::setUp();
+		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
+	}
+
+	function test_module_is_enabled() {
+		$this->assertTrue( !! Jetpack_Sync_Modules::get_module( "wp-super-cache" ) );
+	}
+
+	//@todo test functionality
+}
+

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -5,6 +5,8 @@
  */
 class WP_Test_Jetpack_Sync_WP_Super_Cache extends WP_Test_Jetpack_Sync_Base {
 
+	static $wp_super_cache_enabled;
+
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -4,10 +4,6 @@
  * Testing WP Super Cache Sync
  */
 class WP_Test_Jetpack_Sync_WP_Super_Cache extends WP_Test_Jetpack_Sync_Base {
-	protected $post;
-	protected $callable_module;
-	protected $full_sync;
-	static $woo_enabled;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -30,6 +30,32 @@ class WP_Test_Jetpack_Sync_WP_Super_Cache extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( !! Jetpack_Sync_Modules::get_module( "wp-super-cache" ) );
 	}
 
-	//@todo test functionality
+	function test_constants_are_synced() {
+		$this->sender->do_sync();
+
+		//Confirm that constants that aren't synced return null
+		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'WP_SUPER_CACHE_NON_EXISTENT_CONSTANT' ) );
+
+		$this->server_replica_storage->reset();
+		$this->sender->do_sync();
+
+		foreach ( Jetpack_Sync_Module_WP_Super_Cache::$wp_super_cache_constants as $constant ) {
+			$this->assertNotEquals( null, $this->server_replica_storage->get_constant( $constant ) );
+		}
+	}
+
+	function test_globals_are_synced() {
+		$wp_super_cache_globals = Jetpack_Sync_Module_WP_Super_Cache::get_wp_super_cache_globals();
+		foreach ( $wp_super_cache_globals as $key => $value ) {
+			$GLOBALS[$key] = $key;
+		}
+		$this->sender->do_sync();
+
+		$synced_values = $this->server_replica_storage->get_callable( 'wp_super_cache_globals' );
+
+		foreach ( $wp_super_cache_globals as $key => $value ) {
+			$this->assertEquals( $key, $synced_values[$key] );
+		}
+	}
 }
 

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -1,5 +1,5 @@
 <?php
-
+require_once dirname( __FILE__ ) . '/../../../sync/class.jetpack-sync-module-wp-super-cache.php';
 /**
  * Testing WP Super Cache Sync
  */

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -1,5 +1,4 @@
 <?php
-require_once dirname( __FILE__ ) . '/../../../sync/class.jetpack-sync-module-wp-super-cache.php';
 /**
  * Testing WP Super Cache Sync
  */

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -23,7 +23,16 @@ class WP_Test_Jetpack_Sync_WP_Super_Cache extends WP_Test_Jetpack_Sync_Base {
 			return;
 		}
 		parent::setUp();
-		$this->full_sync = Jetpack_Sync_Modules::get_module( 'full-sync' );
+		$this->resetCallableAndConstantTimeouts();
+		set_current_screen( 'post_user' );
+	}
+
+	function define_constants() {
+		foreach ( Jetpack_Sync_Module_WP_Super_Cache::$wp_super_cache_constants as $constant ) {
+			if ( false === defined( $constant ) ) {
+				define( $constant, $constant );
+			}
+		}
 	}
 
 	function test_module_is_enabled() {
@@ -31,16 +40,10 @@ class WP_Test_Jetpack_Sync_WP_Super_Cache extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_constants_are_synced() {
+		$this->define_constants();
 		$this->sender->do_sync();
-
-		//Confirm that constants that aren't synced return null
-		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'WP_SUPER_CACHE_NON_EXISTENT_CONSTANT' ) );
-
-		$this->server_replica_storage->reset();
-		$this->sender->do_sync();
-
 		foreach ( Jetpack_Sync_Module_WP_Super_Cache::$wp_super_cache_constants as $constant ) {
-			$this->assertNotEquals( null, $this->server_replica_storage->get_constant( $constant ) );
+			$this->assertEquals( constant( $constant ), $this->server_replica_storage->get_constant( $constant ) );
 		}
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
+++ b/tests/php/sync/test_class.jetpack-sync-wp_super_cache.php
@@ -9,10 +9,6 @@ class WP_Test_Jetpack_Sync_WP_Super_Cache extends WP_Test_Jetpack_Sync_Base {
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-
-		if ( "1" != getenv( 'JETPACK_TEST_WP_SUPER_CACHE' ) ) {
-			return; 
-		} 
 		
 		self::$wp_super_cache_enabled = true;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds Jetpack Sync module for syncing WP Super Cache globals and constants

#### Testing instructions:

* Tests have been added to the test suite for the new sync module. Additionally, you can test manually by installing WP Super Cache, changing values, and confirming that the changes values are reflected on WordPress.com.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
This change syncs constants and globals used by WP Super Cache. You can now whitelist additional callables for sync by adding them to the whitelist via the jetpack_sync_callable_whitelist filter.