### PR TITLE
Sync: Re add active_plugins option and test since they were removed f…

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -104,6 +104,7 @@ class Jetpack_Sync_Defaults {
 		'jetpack_relatedposts',
 		'verification_services_codes',
 		'users_can_register',
+		'active_plugins',
 		'uninstall_plugins',
 		'advanced_seo_front_page_description', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -164,6 +164,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_relatedposts'                 => 'pineapple',
 			'verification_services_codes'          => 'pineapple',
 			'users_can_register'                   => '1',
+			'active_plugins'                       => array( 'pineapple' ),
 			'uninstall_plugins'                    => 'banana',
 			'advanced_seo_front_page_description'  => 'banana', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 			'advanced_seo_title_formats'           => array( 'posts' => array( 'type' => 'string', 'value' => 'test' ) ), // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -95,6 +95,22 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 
 	}
 
+	public function test_activate_and_deactivating_plugin_is_synced() {
+		activate_plugin( 'hello.php' );
+		$this->sender->do_sync();
+
+		$active_plugins = $this->server_replica_storage->get_option( 'active_plugins' );
+		$this->assertEquals( get_option( 'active_plugins' ), $active_plugins );
+		$this->assertTrue( in_array( 'hello.php', $active_plugins ) );
+
+		deactivate_plugins( 'hello.php' );
+		$this->sender->do_sync();
+
+		$active_plugins = $this->server_replica_storage->get_option( 'active_plugins' );
+		$this->assertEquals( get_option( 'active_plugins' ), $active_plugins );
+		$this->assertFalse( in_array( 'hello.php', $active_plugins ) );
+	}
+
 	function test_plugin_activation_action_is_synced() {
 		activate_plugin( 'hello.php' );
 		$this->sender->do_sync();


### PR DESCRIPTION
Remved in https://github.com/Automattic/jetpack/pull/6395.
But we still need the info for the plugins api endpoint. 


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
