### PR TITLE
Make sure the media API returns the VideoPress GUID

### DIFF
--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -546,3 +546,33 @@ function videopress_make_media_upload_path( $blog_id ) {
 		$blog_id
 	);
 }
+
+/**
+ * This is a mock of the internal VideoPress method, which is meant to duplicate the functionality
+ * of the WPCOM API, so that the Jetpack REST API returns the same data with no modifications.
+ *
+ * @param int $blog_id
+ * @param int $post_id
+ * @return bool|stdClass
+ */
+function video_get_info_by_blogpostid( $blog_id, $post_id ) {
+	$post = get_post( $post_id );
+
+	if ( is_wp_error( $post ) ) {
+		return false;
+	}
+
+	if ( $post->post_mime_type !== 'video/videopress' ) {
+		return false;
+	}
+
+	$video_info = new stdClass();
+	$video_info->guid = get_post_meta( $post_id, 'videopress_guid', true );
+	$video_info->finish_date_gmt = '0000-00-00 00:00:00';
+
+	if ( videopress_is_finished_processing( $post_id ) ) {
+		$video_info->finish_date_gmt = date( 'Y-m-d H:i:s' );
+	}
+
+	return $video_info;
+}

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -551,8 +551,8 @@ function videopress_make_media_upload_path( $blog_id ) {
  * This is a mock of the internal VideoPress method, which is meant to duplicate the functionality
  * of the WPCOM API, so that the Jetpack REST API returns the same data with no modifications.
  *
- * @param int $blog_id
- * @param int $post_id
+ * @param int $blog_id Blog ID.
+ * @param int $post_id Post ID.
  * @return bool|stdClass
  */
 function video_get_info_by_blogpostid( $blog_id, $post_id ) {
@@ -562,7 +562,7 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 		return false;
 	}
 
-	if ( $post->post_mime_type !== 'video/videopress' ) {
+	if ( 'video/videopress' !== $post->post_mime_type ) {
 		return false;
 	}
 


### PR DESCRIPTION
In creating parity of features between Jetpack and Calypso, we've run into an issue where Jetpack sites are not returning the VideoPress GUID as expected. This change adds in a stub of the similar function that WordPress.com uses in its API, so that the API endpoint will return the GUID as expected.

## Note

This is currently a pretty large blocker for the VideoPress thumbnail picker in Calypso. The sooner we can get this tested and merged the better.

## To test

1. Upload a Video w/ VideoPress enabled.
2. Go https://developer.wordpress.com/docs/api/console/
3. Enter the URL: `/sites/$site_id/media/` w/ the jetpack site domain name as the $site_id
4. Check the response and verify that it contains the `videopress_guid` for any VideoPress posts that were uploaded.