### PR TITLE
Add build step to linting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,7 @@ env:
   global:
     - WP_TRAVISCI=phpunit
 
-cache:
-  directories:
-    - ~/.yarn
-    - ~/.nvm
+cache: yarn
 
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,
@@ -32,11 +29,11 @@ cache:
 matrix:
   include:
   - php: "5.6"
-    env: WP_TRAVISCI="npm run lint"
+    env: WP_TRAVISCI="yarn lint"
   - php: "5.6"
-    env: WP_TRAVISCI="npm run test-client"
+    env: WP_TRAVISCI="yarn test-client"
   - php: "5.6"
-    env: WP_TRAVISCI="npm run test-gui"
+    env: WP_TRAVISCI="yarn test-gui"
   - php: "5.2"
   - php: "5.3"
   - php: "5.5"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build-client": "gulp",
     "build-production": "yarn clean-client && gulp languages:extract && NODE_ENV=production BABEL_ENV=production yarn build",
     "build-languages": "gulp languages",
-    "lint": "eslint --ext .js --ext .jsx _inc/client -c .eslintrc",
+    "lint": "yarn build && eslint --ext .js --ext .jsx _inc/client -c .eslintrc",
     "test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client:node_modules/@automattic/dops-components/client tests/runner.js",
     "add-textdomain": "grunt addtextdomain",
     "build-pot": "grunt makepot",

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -40,9 +40,8 @@ else
 
     gem install sass
     gem install compass
-    npm install -g npm
-    npm install -g gulp-cli
-    npm install
+    curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.20.3
+    yarn
 
     if $WP_TRAVISCI; then
 	# Everything is fine

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -40,6 +40,7 @@ else
 
     gem install sass
     gem install compass
+    rm -rf ~/.yarn
     curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.20.3
     yarn
 


### PR DESCRIPTION
Sometimes it happens that the Travis build passes when the build actually fails. It happens because we weren't building the actual bundle before, but this commit introduces a build command before actual linting. That will make sure that Travis builds fail if the project doesn't build successfully or that jshint fails.
