### PR TITLE
Don't photonize wpcom images that don't need to be.

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -118,7 +118,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	if (
 		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
 		|| $image_url_parts['host'] === jetpack_photon_parse_url( $custom_photon_url, PHP_URL_HOST )
-		|| $is_wpcom_image_with_safe_args
+		|| $is_wpcom_image_with_safe_args // Keep the domain for *.files.wordpress.com domains with whitelisted args.
 	) {
 		$photon_url = add_query_arg( $args, $image_url );
 		return jetpack_photon_url_scheme( $photon_url, $scheme );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -91,7 +91,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	}
 
 	/* Don't photon-ize WPCOM hosted images with only the following url args:
-	 *  `w`, `h`, `fit`, `crop`, `resize`
+	 *  `w`, `h`, `fit`, `crop`, `zoom`, `strip`, `resize`, `quality`
 	 * These args can just be added to the wpcom-version of the image, and save on latency.
 	 */
 	$is_wpcom_image_with_safe_args = false;

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -96,11 +96,14 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	 */
 	$is_wpcom_image_with_safe_args = false;
 	$allowed_wpcom_keys = array(
-		'w'      => true,
-		'h'      => true,
-		'fit'    => true,
-		'crop'   => true,
-		'resize' => true,
+		'w'       => true,
+		'h'       => true,
+		'fit'     => true,
+		'crop'    => true,
+		'zoom'    => true,
+		'strip'   => true,
+		'resize'  => true,
+		'quality' => true,
 	);
 	if ( wp_endswith( '.files.wordpress.com', strtolower( $image_url_parts['host'] ) ) && array_diff_key( $args, $allowed_wpcom_keys ) ) {
 		$is_wpcom_image_with_safe_args = true;

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -105,7 +105,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		'resize'  => true,
 		'quality' => true,
 	);
-	if ( wp_endswith( '.files.wordpress.com', strtolower( $image_url_parts['host'] ) ) && array_diff_key( $args, $allowed_wpcom_keys ) ) {
+	if ( wp_endswith( strtolower( $image_url_parts['host'] ), '.files.wordpress.com' ) && ! array_diff_key( $args, $allowed_wpcom_keys ) ) {
 		$is_wpcom_image_with_safe_args = true;
 	}
 

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -115,10 +115,11 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	// You can't run a Photon URL through Photon again because query strings are stripped.
 	// So if the image is already a Photon URL, append the new arguments to the existing URL.
+	// Alternately, if it's a *.files.wordpress.com url, and the arguments are supported, keep the domain.
 	if (
 		in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ) )
 		|| $image_url_parts['host'] === jetpack_photon_parse_url( $custom_photon_url, PHP_URL_HOST )
-		|| $is_wpcom_image_with_safe_args // Keep the domain for *.files.wordpress.com domains with whitelisted args.
+		|| $is_wpcom_image_with_safe_args
 	) {
 		$photon_url = add_query_arg( $args, $image_url );
 		return jetpack_photon_url_scheme( $photon_url, $scheme );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -102,7 +102,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		'crop'   => true,
 		'resize' => true,
 	);
-	if ( wp_endswith( '.files.wordpress.com', $image_url_parts['host'] ) && array_diff_key( $args, $allowed_wpcom_keys ) ) {
+	if ( wp_endswith( '.files.wordpress.com', strtolower( $image_url_parts['host'] ) ) && array_diff_key( $args, $allowed_wpcom_keys ) ) {
 		$is_wpcom_image_with_safe_args = true;
 	}
 

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -123,8 +123,8 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 		// `filter` is not whitelisted, so this should remap to photon.
 		$url = jetpack_photon_url( $source, array( 'filter' => 'edgedetect' ) );
-		$expected = 'https://i1.wp.com/jetpackme.files.wordpress.com/2015/06/sec-11.png?filter=edgedetect&ssl=1';
-		$this->assertEquals( $expected, $url );
+		$suffix = '.wp.com/jetpackme.files.wordpress.com/2015/06/sec-11.png?filter=edgedetect&ssl=1';
+		$this->assertStringEndsWith( $suffix, $url );
 	}
 
 	/**

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -109,6 +109,25 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @author georgestephanis
+	 * @covers jetpack_photon_url()
+	 * @since 4.?.0
+	 * @group jetpack_photon_no_filter
+	 */
+	public function test_wpcom_files_to_photon_urls() {
+		$source = 'https://jetpackme.files.wordpress.com/2015/06/sec-11.png';
+
+		// This uses only the whitelisted attributes, so it should stay on jetpackme.files.wordpress.com
+		$url = jetpack_photon_url( $source, array( 'w' => 300 ) );
+		$this->assertEquals( add_query_arg( 'w', 300, $source ), $url );
+
+		// `filter` is not whitelisted, so this should remap to photon.
+		$url = jetpack_photon_url( $source, array( 'filter' => 'edgedetect' ) );
+		$expected = 'https://i1.wp.com/jetpackme.files.wordpress.com/2015/06/sec-11.png?filter=edgedetect&ssl=1';
+		$this->assertEquals( $expected, $url );
+	}
+
+	/**
 	 * @author aduth
 	 * @covers jetpack_photon_url
 	 * @since  4.5.0


### PR DESCRIPTION
Don't photon-ize WPCOM hosted images with only the following url args:

> `w`, `h`, `fit`, `crop`, `resize`

These args can just be added to the wpcom-version of the image, and save
on latency as the images don't need to be loaded into and cached on the
Photon CDN.