### PR TITLE
Enable using full URLs in social widget services.

### DIFF
--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -139,13 +139,12 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			$index += 10;
 
 			/** Check if full URL entered in configuration, use it instead of tinkering **/
-			if ( substr( $username, 0, 5 ) === "http:"
-				|| substr( $username, 0, 6 ) === "https:"
-			   ) {			
+			if ( preg_match( '#^https?://#', $username ) ) {		
 				$html[ $index ] =
 					'<a href="' . $username
 					. '" class="genericon genericon-' . $service . '" target="_blank"><span class="screen-reader-text">'
-					. 'View our profile on '. $service_name 
+					/* Translators: the placeholder is a social network name. */
+					. esc_html( sprintf( __( 'View our profile on %s', 'jetpack' ), $service_name ) )
 					. '</span></a>';
 
 				continue;

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -137,8 +137,22 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 				continue;
 			}
 			$index += 10;
-			if (
-				'googleplus' === $service
+
+			/** Check if full URL entered in configuration, use it instead of tinkering **/
+			if ( substr( $username, 0, 5 ) === "http:"
+				|| substr( $username, 0, 6 ) === "https:"
+			   ) {			
+				$html[ $index ] =
+					'<a href="' . $username
+					. '" class="genericon genericon-' . $service . '" target="_blank"><span class="screen-reader-text">'
+					. 'View our profile on '. $service_name 
+					. '</span></a>';
+
+				continue;
+			}
+
+
+			if ( 'googleplus' === $service
 				&& ! is_numeric( $username )
 				&& substr( $username, 0, 1 ) !== '+'
 			) {


### PR DESCRIPTION
Replay of #6016 by @howtoaddict with several additions.

#### Changes proposed in this Pull Request:
* Allows pasting the complete URL into a service to use it instead of composing, props @howtoaddict.
* Uses `parse_url` to detect URLs.
* Constructs screen reader text differently in case a full URL is supplied.
* Escapes URLs as late as possible.
