### PR TITLE
Settings: removed status prop from the beta banner

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -26,7 +26,6 @@ export const DevVersionNotice = React.createClass( {
 			return (
 				<SimpleNotice
 					showDismiss={ false }
-					status="is-basic"
 					text={ __( 'You are currently running a development version of Jetpack.' ) }
 				>
 					<NoticeAction


### PR DESCRIPTION
#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23379024/87fe39cc-fcf2-11e6-8b91-5a5e5cc5cdb2.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23378988/69086312-fcf2-11e6-8d46-ebfba2bccd8d.png)
