### PR TITLE
Settings: update text in two places to "Color scheme"

### DIFF
--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -71,7 +71,7 @@ export const Comments = moduleSettingsForm(
 							</FormLabel>
 							<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
 							<FormLabel>
-								<span className="jp-form-label-wide">{ __( 'Color Scheme' ) }</span>
+								<span className="jp-form-label-wide">{ __( 'Color scheme' ) }</span>
 								<FormSelect
 									name={ 'jetpack_comment_form_color_scheme' }
 									value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -130,7 +130,7 @@ const Media = moduleSettingsForm(
 						</CompactFormToggle>
 						<FormLabel>
 							<FormLegend className="jp-form-label-wide">
-								{ __( 'Background color' ) }
+								{ __( 'Color scheme' ) }
 							</FormLegend>
 							<FormSelect
 								name={ 'carousel_background_color' }

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1026,7 +1026,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 			// Carousel
 			'carousel_background_color' => array(
-				'description'       => esc_html__( 'Background color.', 'jetpack' ),
+				'description'       => esc_html__( 'Color scheme.', 'jetpack' ),
 				'type'              => 'string',
 				'default'           => 'black',
 				'enum'              => array(
@@ -1057,7 +1057,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'comments',
 			),
 			'jetpack_comment_form_color_scheme' => array(
-				'description'       => esc_html__( "Color Scheme", 'jetpack' ),
+				'description'       => esc_html__( "Color scheme", 'jetpack' ),
 				'type'              => 'string',
 				'default'           => 'light',
 				'enum'              => array(


### PR DESCRIPTION
Before, it was in title case instead of sentence case. Also, in the media group, the label said "Background color." I changed it to "Color scheme" for consistence.

You can test it in Writing > Media and Discussion > Comments.