### PR TITLE
Settings: updates size of p text to be 14px

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -32,7 +32,7 @@
 
 .jp-form-settings-group {
 	p {
-		font-size: rem( 15px );
+		font-size: rem( 14px );
 		margin-top: 0;
 		margin-bottom: rem( 24px );
 	}


### PR DESCRIPTION
After brief discussion with @rickybanister, we're making the majority of text 14px including links, settings, and descriptions (not explanation text)