### PR TITLE
Add postman_send_mail and rssmi_feed_item to post type blacklist

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -169,6 +169,8 @@ class Jetpack_Sync_Defaults {
 		'bwg_gallery',
 		'bwg_album',
 		'idx_page',
+		'postman_sent_mail',
+		'rssmi_feed_item',
 	);
 
 	static $default_post_checksum_columns = array(


### PR DESCRIPTION
- rssmi_feed_item are items that are saved from other sites rss feeds.
Plugin found here: https://github.com/wp-plugins/wp-rss-multi-importer 
- postman_send_mail are email logs when email went out. https://en-ca.wordpress.org/plugins/postman-smtp
