### PR TITLE
Settings: fix toggle indents and move stats smiley explanation

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -37,7 +37,6 @@
 		margin-bottom: rem( 24px );
 	}
 	.form-toggle__label {
-		display: block;
 		margin-top: 4px;
 		margin-bottom: 4px;
 	}

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -115,7 +115,12 @@ export const SiteStats = moduleSettingsForm(
 							>
 								<span className="jp-form-toggle-explanation">
 									{
-										__( 'Hide the stats smiley face image (The image helps collect stats, but should work when hidden.)' )
+										__( 'Hide the stats smiley face image' )
+									}
+								</span>
+								<span className="jp-form-setting-explanation">
+									{
+										__( 'The image helps collect stats, but should work when hidden.' )
 									}
 								</span>
 							</ModuleToggle>


### PR DESCRIPTION
This requires testing on https://github.com/Automattic/dops-components/pull/96

It moves the explanation text in parenthesis for the stats smiley into its own explanation text element. It also helps fix the toggle alignment issue.

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23381696/a0d34abe-fcfc-11e6-83ff-f8c5da08273c.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23381494/e6f5ef20-fcfb-11e6-8435-f569d7a86292.png)
