### PR TITLE
Settings: removed stray green focus style

### DIFF
--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -4,7 +4,7 @@
 }
 
 .react-tagsinput--focused {
-	border-color: #a5d24a;
+	border-color: $blue-medium;
 }
 
 .react-tagsinput-tag {


### PR DESCRIPTION
This isn't the prettiest, but it's temporary until we can spend some time to get #4719 in.

#### Testing
* go to Settings > Writing > spelling > Advanced options > select the input

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23382995/a91c7a38-fd01-11e6-82cf-8ce84e1980dd.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23382963/849061e8-fd01-11e6-9dce-cccae486ddec.png)
