### PR TITLE
Settings: updated Learn more links

### DIFF
--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -95,7 +95,7 @@ export const Comments = moduleSettingsForm(
 									{
 										gravatar.description + ' '
 									}
-									<a href={ gravatar.learn_more_button }>{ __( 'Learn more about Gravatar' ) }</a>
+									<a href={ gravatar.learn_more_button }>{ __( 'Learn more' ) }</a>
 								</span>
 							</ModuleToggle>
 						</FormFieldset>
@@ -109,9 +109,9 @@ export const Comments = moduleSettingsForm(
 								>
 								<span className="jp-form-toggle-explanation">
 									{
-										__( 'Enable Markdown use for comments' ) + ' '
+										__( 'Enable Markdown use for comments.' ) + ' '
 									}
-									<a href={ markdown.learn_more_button }>{ __( 'Learn more about Markdown' ) }</a>
+									<a href={ markdown.learn_more_button }>{ __( 'Learn more' ) }</a>
 								</span>
 							</ModuleToggle>
 						</FormFieldset>

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Gravatar Hovercards
- * Module Description: Enable pop-up business cards over commenters’ Gravatars
+ * Module Description: Enable pop-up business cards over commenters’ Gravatars.
  * Jumpstart Description: Let commenters link their profiles to their Gravatar accounts, making it easy for your visitors to learn more about your community.
  * Sort Order: 11
  * Recommendation Order: 13

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -56,7 +56,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'gravatar-hovercards' => array(
 				'name' => _x( 'Gravatar Hovercards', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Enable pop-up business cards over commenters’ Gravatars', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Enable pop-up business cards over commenters’ Gravatars.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Let commenters link their profiles to their Gravatar accounts, making it easy for your visitors to learn more about your community.', 'Jumpstart Description', 'jetpack' ),
 			),
 


### PR DESCRIPTION
Now the Gravatar and Markdown settings have correct punctuation (little as possible punctuation) and the learn more links are a bit less. After all, less is more.
#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23385641/6c1ffc9c-fd0e-11e6-9988-52c230c9deff.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23385609/21be2106-fd0e-11e6-9ea8-a8f7560a5121.png)
