### PR TITLE
Updated color variables and explanation text class

### DIFF
--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -43,13 +43,13 @@
 	}
 
 	.dops-section-header__label {
-		color: darken( $gray, 20% );
+		color: $gray-text-min;
 	}
 
 	&.is-working,
 	&.is-premium-inactive {
 		.dops-section-header__actions {
-			color: lighten( $gray, 20% );
+			color: $gray-text-min;
 		}
 	}
 }

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -46,7 +46,7 @@
 		margin-top: 2px;
 	}
 	.jp-form-setting-explanation {
-		color: darken( $gray, 20% );
+		color: $gray-text-min;
 		display: block;
 		margin: rem( 5px ) rem( 14px ) 0 0;
 		font-size: rem( 13px );

--- a/_inc/client/scss/variables/_colors.scss
+++ b/_inc/client/scss/variables/_colors.scss
@@ -4,7 +4,7 @@
 // WordPress.com Colors
 // ==========================================================================
 
-// Blues
+// Primary Accent (Blues)
 $blue-wordpress:         #0087be;
 $blue-light:             #78dcfa;
 $blue-medium:            #00aadc;
@@ -12,9 +12,15 @@ $blue-dark:              #005082;
 
 // Grays
 $gray:                   #87a6bc;
+$gray-light:             lighten( $gray, 33% ); //#f3f6f8
+$gray-dark:              darken( $gray, 38% ); //#2e4453
+
+// $gray-text: ideal for standard, non placeholder text
+// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
+$gray-text:              $gray-dark;
+$gray-text-min:          darken( $gray, 18% ); //#537994
 
 // $gray color functions:
-//
 // lighten( $gray, 10% )
 // lighten( $gray, 20% )
 // lighten( $gray, 30% )
@@ -24,10 +30,7 @@ $gray:                   #87a6bc;
 //
 // See wordpress.com/design-handbook/colors/ for more info.
 
-$gray-light:             lighten( $gray, 33% ); //#f3f6f8
-$gray-dark:              darken( $gray, 38% ); //#2e4453
-
-// Oranges
+// Secondary Accent (Oranges)
 $orange-jazzy:           #f0821e;
 $orange-fire:            #d54e21;
 
@@ -35,6 +38,7 @@ $orange-fire:            #d54e21;
 $alert-yellow:           #f0b849;
 $alert-red:              #d94f4f;
 $alert-green:            #4ab866;
+$alert-purple:           #855DA6;
 
 // Link hovers
 $link-highlight:         tint($blue-medium, 20%);
@@ -43,7 +47,35 @@ $link-highlight:         tint($blue-medium, 20%);
 $white:                  rgba(255,255,255,1);
 $transparent:            rgba(255,255,255,0);
 
+// Uncommon
 $border-ultra-light-gray: #e8f0f5;
+
+// Layout
+$masterbar-color:          $blue-wordpress;
+$sidebar-bg-color:         lighten( $gray, 30% );
+$sidebar-text-color:       $gray-dark;
+$sidebar-selected-color:   $gray;
+
+
+//Social media colors
+$color-facebook: #39579a;
+$color-twitter: #55ACEE;
+$color-gplus: #df4a32;
+$color-tumblr: #35465c;
+$color-linkedin: #0976b4;
+$color-path: #df3b2f;
+$color-instagram: #e12f67;
+$color-eventbrite: #ff8000;
+$color-stumbleupon: #eb4924;
+$color-reddit: #5f99cf;
+$color-pinterest: #cc2127;
+$color-pocket: #ee4256;
+$color-email: #f8f8f8;
+$color-print: #f8f8f8;
+$color-skype: #00AFF0;
+$color-telegram: #0088cc;
+$color-whatsapp: #43d854;
+
 
 // ==========================================================================
 // Jetpack Specific Colors


### PR DESCRIPTION
Updated our color variables to the latest on Calypso. One of the benefits is we now have the `$gray-text-min` variable which is the lightest a gray can be while still meeting accessibility guidelines. In that light, I updated the `jp-form-setting-explanation` class to use the `$gray-text-min` variable to match Calypso. There's almost no discernible difference. 

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23385820/ada811ee-fd0f-11e6-8e65-039fdf311fb7.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23385811/9c5f43a8-fd0f-11e6-8e0c-c4f6420fa556.png)
