### PR TITLE
Make sure override happens after wp-plupload

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -155,7 +155,8 @@ class Jetpack_VideoPress {
 				'videopress-plupload',
 				plugins_url( 'js/videopress-plupload.js', __FILE__ ),
 				array(
-					'jquery'
+					'jquery',
+					'wp-plupload'
 				),
 				$this->version
 			);

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -144,13 +144,6 @@ class Jetpack_VideoPress {
 		}
 
 		if ( $this->should_override_media_uploader() ) {
-			// We're going to replace the standard wp-plupload with our own ... messy, I know, but as of now the
-			// hooks in it are not good enough for us to be able to override / add in just the code we need.
-			// P.S. Please don't take this as an example of good behavior, this is a temporary fix until I
-			// can get a more permanent action / filter system added into the core wp-plupload.js to make this
-			// type of override unnecessary.
-			wp_dequeue_script( 'wp-plupload' );
-
 			wp_enqueue_script(
 				'videopress-plupload',
 				plugins_url( 'js/videopress-plupload.js', __FILE__ ),


### PR DESCRIPTION
It appears that in some circumstances, plugins will forcefully add in the wp-plupload script, which we dequeue and replace with our own. Doing this causes our uploader to get overridden by it, instead of the other way around.

To combat this, we need to make sure that VideoPress adds wp-plupload as a dependency, to make sure that it always loads after.

## Testing

To test, simply make sure the VideoPress uploader still works. 