### PR TITLE
Avoid .ashx files that serve images from being mishosted on Photon.

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -142,7 +142,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		// However some source images are served via PHP so check the no-query-string extension.
 		// For future proofing, this is a blacklist of common issues rather than a whitelist.
 		$extension = pathinfo( $image_url_parts['path'], PATHINFO_EXTENSION );
-		if ( empty( $extension ) || in_array( $extension, array( 'php' ) ) )
+		if ( empty( $extension ) || in_array( $extension, array( 'php', 'ashx' ) ) )
 			return $image_url;
 	}
 


### PR DESCRIPTION
Some images like  `http://img.domain.com/imageX.ashx?id=356` were being photon-ized to `http://i2.wp.com/img.nova-future.com/imageX.ashx`

This is a sync from wpcom.