### PR TITLE
Admin Page: always use relative links for submenu items.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -52,9 +52,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		if ( Jetpack::is_development_mode() || Jetpack::is_active() ) {
 			global $submenu;
 			if ( current_user_can( 'jetpack_manage_modules' ) || Jetpack::is_module_active( 'protect' ) || current_user_can( 'view_stats' ) ) {
-				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', Jetpack::admin_url( 'page=jetpack#/dashboard' ) );
+				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/dashboard' );
 			} elseif ( current_user_can( 'jetpack_admin_page' ) ) {
-				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', Jetpack::admin_url( 'page=jetpack#/apps' ) );
+				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/apps' );
 			}
 		}
 	}
@@ -67,7 +67,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	function jetpack_add_settings_sub_nav_item() {
 		if ( ( Jetpack::is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) ) {
 			global $submenu;
-			$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', Jetpack::admin_url( 'page=jetpack#/settings' ) );
+			$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/settings' );
 		}
 	}
 


### PR DESCRIPTION
cc @richardmtl

All other links in the WordPress admin menu list are relative links.
While absolute links do not usually cause any issues, it can cause notices on systems with `open_basedir` restrictions.

#### Changes proposed in this Pull Request:

* Here is `$submenu` right now:
https://gist.github.com/jeherve/aa3789294b597ed29e6fc8083e1ec592

* Here it is after this PR:
https://gist.github.com/jeherve/e10ec43d74f6a5247d7257bd14e8a8ca

#### Testing instructions:

* Apply this PR, and make sure all Jetpack menu items link to the right page.

#### Proposed changelog entry for your changes:
* Admin Page: always use relative links for submenu items to account for servers with specific restrictions.