### PR TITLE
Fixes published-post autosave-previews in calypso

### DIFF
--- a/class.frame-nonce-preview.php
+++ b/class.frame-nonce-preview.php
@@ -104,13 +104,13 @@ class Jetpack_Frame_Nonce_Preview {
 
 	/**
 	 * Handle validation for autosave preview request
-         *
+	 *
 	 * @since 4.7.0
-         *
+	 *
 	 */
 	public function handle_autosave_nonce_validation() {
 		if ( ! $this->is_frame_nonce_valid() ) {
-			wp_die( __( 'Sorry, you are not allowed to preview drafts.' ) );
+			wp_die( __( 'Sorry, you are not allowed to preview drafts.', 'jetpack' ) );
 		}
 		add_filter( 'the_preview', '_set_preview' );
 	}

--- a/class.frame-nonce-preview.php
+++ b/class.frame-nonce-preview.php
@@ -25,6 +25,12 @@ class Jetpack_Frame_Nonce_Preview {
 		if ( isset( $_GET['frame-nonce'] ) && ! is_admin() ) {
 			add_filter( 'pre_get_posts', array( $this, 'maybe_display_post' ) );
 		}
+
+		// autosave previews are validated differently
+		if ( isset( $_GET[ 'frame-nonce' ] ) && isset( $_GET[ 'preview_id' ] ) && isset( $_GET[ 'preview_nonce' ] ) ) {
+			remove_action( 'init', '_show_post_preview' );
+			add_action( 'init', array( $this, 'handle_autosave_nonce_validation' ) );
+		}
 	}
 
 	/**
@@ -94,6 +100,19 @@ class Jetpack_Frame_Nonce_Preview {
 		add_filter( 'pings_open', '__return_false' );
 
 		return $posts;
+	}
+
+	/**
+	 * Handle validation for autosave preview request
+         *
+	 * @since 4.7.0
+         *
+	 */
+	public function handle_autosave_nonce_validation() {
+		if ( ! $this->is_frame_nonce_valid() ) {
+			wp_die( __( 'Sorry, you are not allowed to preview drafts.' ) );
+		}
+		add_filter( 'the_preview', '_set_preview' );
 	}
 }
 


### PR DESCRIPTION
The wpcom endpoint cannot predict whether the user is logged in or not on the remote site. So it cannot pass the appropriate nonce that gets verified in `/wp-includes/revision.php`. This patch detects the frame-nonce parameter for a caypso preview and falls back to the existing frame-nonce validation when it exists.

Fixes https://github.com/Automattic/wp-calypso/issues/5607

#### Testing instructions:

1. **Confirm the issue**: _Without this patch_, go to wordpress.com, select a jetpack site and go to `/posts/:site`, then start to "edit" a _published post_ (not a draft!) in Calypso. Now start typing, and without saving click the "view" button in the left sidebar. It will open a new tab that will resolve to a page that says you don't have permission to view drafts, whether you are logged-in to the remote site or not.
2. **Confirm the fix**: _Apply this patch_ and follow the above instructions. The new tab will resolve to a working post preview. This preview URL with the frame-nonce will work whether you are logged-in to the remote site or not.
3. **Confirm no regressions**: _With this patch_ follow the above instructions with an unpublished draft (the button will say preview instead of view). Confirm previews are working correctly. Now try the same with a published post and a draft from wp-admin.

#### Caveat
FWIW I am seeing an error in the preview page, but it seems unrelated. Still worth confirming.

![preview page error](http://cld.wthms.co/oQvg+)

/cc @ebinnion