### PR TITLE
Bump version number to 4.8-alpha, and minumim JP version to 4.7

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -5,16 +5,16 @@
  * Plugin URI: http://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
- * Version: 4.7-alpha
+ * Version: 4.8-alpha
  * Author URI: http://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
  * Domain Path: /languages/
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '4.6' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '4.7' );
 
-define( 'JETPACK__VERSION',            '4.7-alpha' );
+define( 'JETPACK__VERSION',            '4.8-alpha' );
 define( 'JETPACK_MASTER_USER',         true );
 define( 'JETPACK__API_VERSION',        1 );
 define( 'JETPACK__PLUGIN_DIR',         plugin_dir_path( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Jetpack",
-  "version": "4.7.0-alpha",
+  "version": "4.8.0-alpha",
   "description": "[Jetpack](http://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
   "homepage": "http://jetpack.com",
   "author": "Automattic",


### PR DESCRIPTION
With 4.7-beta now tagged and [branched](https://github.com/Automattic/jetpack/tree/branch-4.7), master will now act as 4.8-alpha.  