### PR TITLE
Infinite scroll: Namespace and refactor theme function

### DIFF
--- a/modules/infinite-scroll/themes/twentyeleven.php
+++ b/modules/infinite-scroll/themes/twentyeleven.php
@@ -8,35 +8,30 @@
 /**
  * Add theme support for infinity scroll
  */
-function jetpack_twenty_eleven_infinite_scroll_init() {
+function jetpack_twentyeleven_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
-		'container' => 'content',
-		'footer'    => 'page',
+		'container'      => 'content',
+		'footer'         => 'page',
+		'footer_widgets' => jetpack_twentyeleven_has_footer_widgets(),
 	) );
 }
-add_action( 'init', 'jetpack_twenty_eleven_infinite_scroll_init' );
+add_action( 'init', 'jetpack_twentyeleven_infinite_scroll_init' );
 
 /**
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
-function jetpack_twenty_eleven_infinite_scroll_enqueue_styles() {
+function jetpack_twentyeleven_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		// Add theme specific styles.
 		wp_enqueue_style( 'infinity-twentyeleven', plugins_url( 'twentyeleven.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'jetpack_twenty_eleven_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twentyeleven_infinite_scroll_enqueue_styles', 25 );
 
 /**
- * Have we any footer widgets?
- *
- * @param bool $has_widgets
- * @uses is_active_sidebar
- * @uses jetpack_is_mobile
- * @filter infinite_scroll_has_footer_widgets
- * @return bool
+ * Do we have footer widgets?
  */
-function jetpack_twenty_eleven_has_footer_widgets( $has_widgets ) {
+function jetpack_twentyeleven_has_footer_widgets() {
 	// Are any of the "Footer Area" sidebars active?
 	if ( is_active_sidebar( 'sidebar-3' ) || is_active_sidebar( 'sidebar-4' ) || is_active_sidebar( 'sidebar-5' ) )
 		return true;
@@ -45,6 +40,5 @@ function jetpack_twenty_eleven_has_footer_widgets( $has_widgets ) {
 	if ( function_exists( 'jetpack_is_mobile' ) && jetpack_is_mobile() && is_active_sidebar( 'sidebar-1' ) )
 		return true;
 
-	return $has_widgets;
+	return false;
 }
-add_filter( 'infinite_scroll_has_footer_widgets', 'jetpack_twenty_eleven_has_footer_widgets' );

--- a/modules/infinite-scroll/themes/twentyeleven.php
+++ b/modules/infinite-scroll/themes/twentyeleven.php
@@ -8,24 +8,24 @@
 /**
  * Add theme support for infinity scroll
  */
-function twenty_eleven_infinite_scroll_init() {
+function jetpack_twenty_eleven_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container' => 'content',
 		'footer'    => 'page',
 	) );
 }
-add_action( 'init', 'twenty_eleven_infinite_scroll_init' );
+add_action( 'init', 'jetpack_twenty_eleven_infinite_scroll_init' );
 
 /**
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
-function twenty_eleven_infinite_scroll_enqueue_styles() {
+function jetpack_twenty_eleven_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		// Add theme specific styles.
 		wp_enqueue_style( 'infinity-twentyeleven', plugins_url( 'twentyeleven.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'twenty_eleven_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twenty_eleven_infinite_scroll_enqueue_styles', 25 );
 
 /**
  * Have we any footer widgets?
@@ -36,7 +36,7 @@ add_action( 'wp_enqueue_scripts', 'twenty_eleven_infinite_scroll_enqueue_styles'
  * @filter infinite_scroll_has_footer_widgets
  * @return bool
  */
-function twenty_eleven_has_footer_widgets( $has_widgets ) {
+function jetpack_twenty_eleven_has_footer_widgets( $has_widgets ) {
 	// Are any of the "Footer Area" sidebars active?
 	if ( is_active_sidebar( 'sidebar-3' ) || is_active_sidebar( 'sidebar-4' ) || is_active_sidebar( 'sidebar-5' ) )
 		return true;
@@ -47,4 +47,4 @@ function twenty_eleven_has_footer_widgets( $has_widgets ) {
 
 	return $has_widgets;
 }
-add_filter( 'infinite_scroll_has_footer_widgets', 'twenty_eleven_has_footer_widgets' );
+add_filter( 'infinite_scroll_has_footer_widgets', 'jetpack_twenty_eleven_has_footer_widgets' );

--- a/modules/infinite-scroll/themes/twentyfifteen.php
+++ b/modules/infinite-scroll/themes/twentyfifteen.php
@@ -8,21 +8,21 @@
 /**
  * Add theme support for infinite scroll
  */
-function twentyfifteen_infinite_scroll_init() {
+function jetpack_twentyfifteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container' => 'main',
 		'footer'    => 'page',
 	) );
 }
-add_action( 'after_setup_theme', 'twentyfifteen_infinite_scroll_init' );
+add_action( 'after_setup_theme', 'jetpack_twentyfifteen_infinite_scroll_init' );
 
 /**
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
-function twentyfifteen_infinite_scroll_enqueue_styles() {
+function jetpack_twentyfifteen_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		wp_enqueue_style( 'infinity-twentyfifteen', plugins_url( 'twentyfifteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20141022' );
 		wp_style_add_data( 'infinity-twentyfifteen', 'rtl', 'replace' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'twentyfifteen_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twentyfifteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/infinite-scroll/themes/twentyfourteen.php
+++ b/modules/infinite-scroll/themes/twentyfourteen.php
@@ -8,13 +8,13 @@
 /**
  * Add theme support for infinite scroll
  */
-function twentyfourteen_infinite_scroll_init() {
+function jetpack_twentyfourteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container' => 'content',
 		'footer'    => 'page'
 	) );
 }
-add_action( 'after_setup_theme', 'twentyfourteen_infinite_scroll_init' );
+add_action( 'after_setup_theme', 'jetpack_twentyfourteen_infinite_scroll_init' );
 
 /**
  * Switch to the "click to load" type IS with the following cases
@@ -26,7 +26,7 @@ add_action( 'after_setup_theme', 'twentyfourteen_infinite_scroll_init' );
  */
 
 if ( function_exists( 'jetpack_is_mobile' ) ) {
-	function twentyfourteen_has_footer_widgets( $has_widgets ) {
+	function jetpack_twentyfourteen_has_footer_widgets( $has_widgets ) {
 		if ( ( Jetpack_User_Agent_Info::is_ipad() && is_active_sidebar( 'sidebar-1' ) )
 			|| ( jetpack_is_mobile( '', true ) && ( is_active_sidebar( 'sidebar-1' ) || is_active_sidebar( 'sidebar-2' ) ) )
 			|| is_active_sidebar( 'sidebar-3' ) )
@@ -35,15 +35,15 @@ if ( function_exists( 'jetpack_is_mobile' ) ) {
 
 		return $has_widgets;
 	}
-	add_filter( 'infinite_scroll_has_footer_widgets', 'twentyfourteen_has_footer_widgets' );
+	add_filter( 'infinite_scroll_has_footer_widgets', 'jetpack_twentyfourteen_has_footer_widgets' );
 }
 
 /**
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
-function twentyfourteen_infinite_scroll_enqueue_styles() {
+function jetpack_twentyfourteen_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		wp_enqueue_style( 'infinity-twentyfourteen', plugins_url( 'twentyfourteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20131118' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'twentyfourteen_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twentyfourteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/infinite-scroll/themes/twentyfourteen.php
+++ b/modules/infinite-scroll/themes/twentyfourteen.php
@@ -10,8 +10,9 @@
  */
 function jetpack_twentyfourteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
-		'container' => 'content',
-		'footer'    => 'page'
+		'container'      => 'content',
+		'footer'         => 'page',
+		'footer_widgets' => jetpack_twentyfourteen_has_footer_widgets(),
 	) );
 }
 add_action( 'after_setup_theme', 'jetpack_twentyfourteen_infinite_scroll_init' );
@@ -19,23 +20,21 @@ add_action( 'after_setup_theme', 'jetpack_twentyfourteen_infinite_scroll_init' )
 /**
  * Switch to the "click to load" type IS with the following cases
  * 1. Viewed from iPad and the primary sidebar is active.
- * 2. Viewed from mobile and either the primary or the content sudebar is active.
+ * 2. Viewed from mobile and either the primary or the content sidebar is active.
  * 3. The footer widget is active.
  *
  * @return bool
  */
-
-if ( function_exists( 'jetpack_is_mobile' ) ) {
-	function jetpack_twentyfourteen_has_footer_widgets( $has_widgets ) {
+function jetpack_twentyfourteen_has_footer_widgets() {
+	if ( function_exists( 'jetpack_is_mobile' ) ) {
 		if ( ( Jetpack_User_Agent_Info::is_ipad() && is_active_sidebar( 'sidebar-1' ) )
 			|| ( jetpack_is_mobile( '', true ) && ( is_active_sidebar( 'sidebar-1' ) || is_active_sidebar( 'sidebar-2' ) ) )
 			|| is_active_sidebar( 'sidebar-3' ) )
 
 			return true;
-
-		return $has_widgets;
 	}
-	add_filter( 'infinite_scroll_has_footer_widgets', 'jetpack_twentyfourteen_has_footer_widgets' );
+
+	return false;
 }
 
 /**

--- a/modules/infinite-scroll/themes/twentyseventeen.php
+++ b/modules/infinite-scroll/themes/twentyseventeen.php
@@ -39,10 +39,11 @@ function jetpack_twentyseventeen_has_footer_widgets() {
 	if ( is_active_sidebar( 'sidebar-2' ) ||
 		 is_active_sidebar( 'sidebar-3' ) ||
 		 has_nav_menu( 'social' ) ) {
+
 		return true;
-	} else {
-		return false;
 	}
+
+	return false;
 }
 
 /**

--- a/modules/infinite-scroll/themes/twentysixteen.php
+++ b/modules/infinite-scroll/themes/twentysixteen.php
@@ -8,19 +8,19 @@
 /**
  * Add theme support for infinite scroll
  */
-function twentysixteen_infinite_scroll_init() {
+function jetpack_twentysixteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container' => 'main',
-		'render'    => 'twentysixteen_infinite_scroll_render',
+		'render'    => 'jetpack_twentysixteen_infinite_scroll_render',
 		'footer'    => 'content',
 	) );
 }
-add_action( 'after_setup_theme', 'twentysixteen_infinite_scroll_init' );
+add_action( 'after_setup_theme', 'jetpack_twentysixteen_infinite_scroll_init' );
 
 /**
  * Custom render function for Infinite Scroll.
  */
-function twentysixteen_infinite_scroll_render() {
+function jetpack_twentysixteen_infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
 		if ( is_search() ) {
@@ -34,10 +34,10 @@ function twentysixteen_infinite_scroll_render() {
 /**
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
-function twentysixteen_infinite_scroll_enqueue_styles() {
+function jetpack_twentysixteen_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		wp_enqueue_style( 'infinity-twentysixteen', plugins_url( 'twentysixteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20151102' );
 		wp_style_add_data( 'infinity-twentysixteen', 'rtl', 'replace' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'twentysixteen_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twentysixteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/infinite-scroll/themes/twentyten.php
+++ b/modules/infinite-scroll/themes/twentyten.php
@@ -13,7 +13,12 @@ function jetpack_twentyten_infinite_scroll_init() {
 		'container'      => 'content',
 		'render'         => 'jetpack_twentyten_infinite_scroll_render',
 		'footer'         => 'wrapper',
-		'footer_widgets' => jetpack_twentyten_has_footer_widgets(),
+		'footer_widgets' => array(
+			'first-footer-widget-area',
+			'second-footer-widget-area',
+			'third-footer-widget-area',
+			'fourth-footer-widget-area',
+		),
 	) );
 }
 add_action( 'init', 'jetpack_twentyten_infinite_scroll_init' );
@@ -38,18 +43,3 @@ function jetpack_twentyten_infinite_scroll_enqueue_styles() {
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentyten_infinite_scroll_enqueue_styles', 25 );
-
-/**
- * Do we have footer widgets?
- */
-function jetpack_twentyten_has_footer_widgets() {
-	if ( is_active_sidebar( 'first-footer-widget-area' ) ||
-		is_active_sidebar( 'second-footer-widget-area' ) ||
-		is_active_sidebar( 'third-footer-widget-area'  ) ||
-		is_active_sidebar( 'fourth-footer-widget-area' ) ) {
-
-		return true;
-	}
-
-	return false;
-}

--- a/modules/infinite-scroll/themes/twentyten.php
+++ b/modules/infinite-scroll/themes/twentyten.php
@@ -8,14 +8,14 @@
 /**
  * Add theme support for infinity scroll
  */
-function twenty_ten_infinite_scroll_init() {
+function jetpack_twenty_ten_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container' => 'content',
-		'render'    => 'twenty_ten_infinite_scroll_render',
+		'render'    => 'jetpack_twenty_ten_infinite_scroll_render',
 		'footer'    => 'wrapper',
 	) );
 }
-add_action( 'init', 'twenty_ten_infinite_scroll_init' );
+add_action( 'init', 'jetpack_twenty_ten_infinite_scroll_init' );
 
 /**
  * Set the code to be rendered on for calling posts,
@@ -23,28 +23,28 @@ add_action( 'init', 'twenty_ten_infinite_scroll_init' );
  *
  * Note: must define a loop.
  */
-function twenty_ten_infinite_scroll_render() {
+function jetpack_twenty_ten_infinite_scroll_render() {
 	get_template_part( 'loop' );
 }
 
 /**
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
-function twenty_ten_infinite_scroll_enqueue_styles() {
+function jetpack_twenty_ten_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		// Add theme specific styles.
 		wp_enqueue_style( 'infinity-twentyten', plugins_url( 'twentyten.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'twenty_ten_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twenty_ten_infinite_scroll_enqueue_styles', 25 );
 
 /**
  * Do we have footer widgets?
  */
-function twenty_ten_has_footer_widgets( $has_widgets ) {
+function jetpack_twenty_ten_has_footer_widgets( $has_widgets ) {
 	if ( is_active_sidebar( 'first-footer-widget-area' ) || is_active_sidebar( 'second-footer-widget-area' ) || is_active_sidebar( 'third-footer-widget-area'  ) || is_active_sidebar( 'fourth-footer-widget-area' ) )
 		$has_widgets = true;
 
 	return $has_widgets;
 }
-add_filter( 'infinite_scroll_has_footer_widgets', 'twenty_ten_has_footer_widgets' );
+add_filter( 'infinite_scroll_has_footer_widgets', 'jetpack_twenty_ten_has_footer_widgets' );

--- a/modules/infinite-scroll/themes/twentyten.php
+++ b/modules/infinite-scroll/themes/twentyten.php
@@ -13,12 +13,7 @@ function jetpack_twentyten_infinite_scroll_init() {
 		'container'      => 'content',
 		'render'         => 'jetpack_twentyten_infinite_scroll_render',
 		'footer'         => 'wrapper',
-		'footer_widgets' => array(
-			'first-footer-widget-area',
-			'second-footer-widget-area',
-			'third-footer-widget-area',
-			'fourth-footer-widget-area',
-		),
+		'footer_widgets' => jetpack_twentyten_has_footer_widgets(),
 	) );
 }
 add_action( 'init', 'jetpack_twentyten_infinite_scroll_init' );
@@ -43,3 +38,18 @@ function jetpack_twentyten_infinite_scroll_enqueue_styles() {
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentyten_infinite_scroll_enqueue_styles', 25 );
+
+/**
+ * Do we have footer widgets?
+ */
+function jetpack_twentyten_has_footer_widgets() {
+	if ( is_active_sidebar( 'first-footer-widget-area' ) ||
+		is_active_sidebar( 'second-footer-widget-area' ) ||
+		is_active_sidebar( 'third-footer-widget-area'  ) ||
+		is_active_sidebar( 'fourth-footer-widget-area' ) ) {
+
+		return true;
+	}
+
+	return false;
+}

--- a/modules/infinite-scroll/themes/twentyten.php
+++ b/modules/infinite-scroll/themes/twentyten.php
@@ -8,14 +8,15 @@
 /**
  * Add theme support for infinity scroll
  */
-function jetpack_twenty_ten_infinite_scroll_init() {
+function jetpack_twentyten_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
-		'container' => 'content',
-		'render'    => 'jetpack_twenty_ten_infinite_scroll_render',
-		'footer'    => 'wrapper',
+		'container'      => 'content',
+		'render'         => 'jetpack_twentyten_infinite_scroll_render',
+		'footer'         => 'wrapper',
+		'footer_widgets' => jetpack_twentyten_has_footer_widgets(),
 	) );
 }
-add_action( 'init', 'jetpack_twenty_ten_infinite_scroll_init' );
+add_action( 'init', 'jetpack_twentyten_infinite_scroll_init' );
 
 /**
  * Set the code to be rendered on for calling posts,
@@ -23,28 +24,32 @@ add_action( 'init', 'jetpack_twenty_ten_infinite_scroll_init' );
  *
  * Note: must define a loop.
  */
-function jetpack_twenty_ten_infinite_scroll_render() {
+function jetpack_twentyten_infinite_scroll_render() {
 	get_template_part( 'loop' );
 }
 
 /**
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
-function jetpack_twenty_ten_infinite_scroll_enqueue_styles() {
+function jetpack_twentyten_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		// Add theme specific styles.
 		wp_enqueue_style( 'infinity-twentyten', plugins_url( 'twentyten.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'jetpack_twenty_ten_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twentyten_infinite_scroll_enqueue_styles', 25 );
 
 /**
  * Do we have footer widgets?
  */
-function jetpack_twenty_ten_has_footer_widgets( $has_widgets ) {
-	if ( is_active_sidebar( 'first-footer-widget-area' ) || is_active_sidebar( 'second-footer-widget-area' ) || is_active_sidebar( 'third-footer-widget-area'  ) || is_active_sidebar( 'fourth-footer-widget-area' ) )
-		$has_widgets = true;
+function jetpack_twentyten_has_footer_widgets() {
+	if ( is_active_sidebar( 'first-footer-widget-area' ) ||
+		is_active_sidebar( 'second-footer-widget-area' ) ||
+		is_active_sidebar( 'third-footer-widget-area'  ) ||
+		is_active_sidebar( 'fourth-footer-widget-area' ) ) {
 
-	return $has_widgets;
+		return true;
+	}
+
+	return false;
 }
-add_filter( 'infinite_scroll_has_footer_widgets', 'jetpack_twenty_ten_has_footer_widgets' );

--- a/modules/infinite-scroll/themes/twentythirteen.php
+++ b/modules/infinite-scroll/themes/twentythirteen.php
@@ -8,21 +8,21 @@
 /**
  * Add theme support for infinite scroll
  */
-function twentythirteen_infinite_scroll_init() {
+function jetpack_twentythirteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container' => 'content',
 		'footer'    => 'page',
 		'footer_widgets' => array( 'sidebar-1' )
 	) );
 }
-add_action( 'after_setup_theme', 'twentythirteen_infinite_scroll_init' );
+add_action( 'after_setup_theme', 'jetpack_twentythirteen_infinite_scroll_init' );
 
 /**
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
-function twentythirteen_infinite_scroll_enqueue_styles() {
+function jetpack_twentythirteen_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		wp_enqueue_style( 'infinity-twentythirteen', plugins_url( 'twentythirteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20130409' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'twentythirteen_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twentythirteen_infinite_scroll_enqueue_styles', 25 );

--- a/modules/infinite-scroll/themes/twentythirteen.php
+++ b/modules/infinite-scroll/themes/twentythirteen.php
@@ -10,9 +10,9 @@
  */
 function jetpack_twentythirteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
-		'container' => 'content',
-		'footer'    => 'page',
-		'footer_widgets' => array( 'sidebar-1' )
+		'container'      => 'content',
+		'footer'         => 'page',
+		'footer_widgets' => array( 'sidebar-1' ),
 	) );
 }
 add_action( 'after_setup_theme', 'jetpack_twentythirteen_infinite_scroll_init' );

--- a/modules/infinite-scroll/themes/twentytwelve.php
+++ b/modules/infinite-scroll/themes/twentytwelve.php
@@ -8,24 +8,24 @@
 /**
  * Add theme support for infinite scroll
  */
-function twenty_twelve_infinite_scroll_init() {
+function jetpack_twenty_twelve_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container'      => 'content',
 		'footer'         => 'page'
 	) );
 }
-add_action( 'after_setup_theme', 'twenty_twelve_infinite_scroll_init' );
+add_action( 'after_setup_theme', 'jetpack_twenty_twelve_infinite_scroll_init' );
 
 /**
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
-function twenty_twelve_infinite_scroll_enqueue_styles() {
+function jetpack_twenty_twelve_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		// Add theme specific styles.
 		wp_enqueue_style( 'infinity-twentytwelve', plugins_url( 'twentytwelve.css', __FILE__ ), array( 'the-neverending-homepage' ), '20120817' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'twenty_twelve_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twenty_twelve_infinite_scroll_enqueue_styles', 25 );
 
 /**
  * Handle `footer_widgets` argument for mobile devices
@@ -35,7 +35,7 @@ add_action( 'wp_enqueue_scripts', 'twenty_twelve_infinite_scroll_enqueue_styles'
  * @filter infinite_scroll_has_footer_widgets
  * @return bool
  */
-function twenty_twelve_has_footer_widgets( $has_widgets ) {
+function jetpack_twenty_twelve_has_footer_widgets( $has_widgets ) {
 	if ( function_exists( 'jetpack_is_mobile' ) && jetpack_is_mobile() ) {
 		if ( is_front_page() && ( is_active_sidebar( 'sidebar-2' ) || is_active_sidebar( 'sidebar-3' ) ) )
 			$has_widgets = true;
@@ -45,4 +45,4 @@ function twenty_twelve_has_footer_widgets( $has_widgets ) {
 
 	return $has_widgets;
 }
-add_filter( 'infinite_scroll_has_footer_widgets', 'twenty_twelve_has_footer_widgets' );
+add_filter( 'infinite_scroll_has_footer_widgets', 'jetpack_twenty_twelve_has_footer_widgets' );

--- a/modules/infinite-scroll/themes/twentytwelve.php
+++ b/modules/infinite-scroll/themes/twentytwelve.php
@@ -8,41 +8,36 @@
 /**
  * Add theme support for infinite scroll
  */
-function jetpack_twenty_twelve_infinite_scroll_init() {
+function jetpack_twentytwelve_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container'      => 'content',
-		'footer'         => 'page'
+		'footer'         => 'page',
+		'footer_widgets' => jetpack_twentytwelve_has_footer_widgets(),
 	) );
 }
-add_action( 'after_setup_theme', 'jetpack_twenty_twelve_infinite_scroll_init' );
+add_action( 'after_setup_theme', 'jetpack_twentytwelve_infinite_scroll_init' );
 
 /**
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
-function jetpack_twenty_twelve_infinite_scroll_enqueue_styles() {
+function jetpack_twentytwelve_infinite_scroll_enqueue_styles() {
 	if ( wp_script_is( 'the-neverending-homepage' ) ) {
 		// Add theme specific styles.
 		wp_enqueue_style( 'infinity-twentytwelve', plugins_url( 'twentytwelve.css', __FILE__ ), array( 'the-neverending-homepage' ), '20120817' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'jetpack_twenty_twelve_infinite_scroll_enqueue_styles', 25 );
+add_action( 'wp_enqueue_scripts', 'jetpack_twentytwelve_infinite_scroll_enqueue_styles', 25 );
 
 /**
- * Handle `footer_widgets` argument for mobile devices
- *
- * @param bool $has_widgets
- * @uses jetpack_is_mobile, is_front_page, is_active_sidebar
- * @filter infinite_scroll_has_footer_widgets
- * @return bool
+ * Do we have footer widgets?
  */
-function jetpack_twenty_twelve_has_footer_widgets( $has_widgets ) {
+function jetpack_twentytwelve_has_footer_widgets() {
 	if ( function_exists( 'jetpack_is_mobile' ) && jetpack_is_mobile() ) {
 		if ( is_front_page() && ( is_active_sidebar( 'sidebar-2' ) || is_active_sidebar( 'sidebar-3' ) ) )
-			$has_widgets = true;
+			return true;
 		elseif ( is_active_sidebar( 'sidebar-1' ) )
-			$has_widgets = true;
+			return true;
 	}
 
-	return $has_widgets;
+	return false;
 }
-add_filter( 'infinite_scroll_has_footer_widgets', 'jetpack_twenty_twelve_has_footer_widgets' );


### PR DESCRIPTION
Yesterday @dereksmart requested me to namespace all functions here: #5940. 
He has agreed that since we are going to namespace the functions in twentyseventeen.php file, we should definitely namespace the functions in other theme files too ( twentyten.php, twentytwelve.php etc ). Meanwhile I found few more issues that I think will be nice to be addressed too.

#### Changes proposed in this Pull Request:
* Added `jetpack_` prefix to all Infinite Scroll theme functions.
* Changed the function names, so they will be consistent with the themes. For example:
   * twenty_ten -> twentyten
   * twenty_eleven -> twentyeleven

* Removed usage of `infinite_scroll_has_footer_widgets `, and change it to use `footer_widgets` setting instead.
* Changed several comments, so they will be consistent in all files.
* Added new line at the end of the files, where there is no such.

#### Proposed changelog entry for your changes:

Namespace with jetpack_ all of Infinite Scroll theme functions.