### PR TITLE
Adjusts the masthead styles to center things and be mobile friendly

### DIFF
--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -39,9 +39,7 @@ export const Masthead = React.createClass( {
 						</a>
 						{ devNotice }
 					</div>
-
-					<ul className="jp-masthead__links">
-						<li className="jp-masthead__link-li">
+					<div className="jp-masthead__nav">
 							<ButtonGroup>
 								<Button
 									compact={ true }
@@ -58,8 +56,7 @@ export const Masthead = React.createClass( {
 									{ __( 'Settings' ) }
 								</Button>
 							</ButtonGroup>
-						</li>
-					</ul>
+					</div>
 				</div>
 			</div>
 		)

--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -10,16 +10,22 @@
 }
 
 .jp-masthead__inside-container {
-	padding: rem( 6px ) 0;
+	display: flex;
+	flex-wrap: wrap;
 	margin: 0 auto;
 	width: 100%;
 	max-width: rem( 720px );
-	display: flex;
-	flex-flow: row nowrap;
+	padding-bottom: rem( 6px );
 }
 
 .jp-masthead__logo-container {
-	padding: rem( 5px ) 0 0;
+	flex-grow: 0;
+	flex-shrink: 0;
+	padding: rem( 11px ) 0 0;
+
+	@include breakpoint( "<480px" ) {
+		margin-right: rem( 16px );
+	}
 }
 
 .jp-masthead__logo {
@@ -47,64 +53,20 @@
 	}
 }
 
-.jp-masthead__links {
+.jp-masthead__nav {
 	display: flex;
-	flex-flow: row wrap;
-	flex: 2 50%;
-	justify-content: flex-end;
-	margin: 0;
+	flex-wrap: nowrap;
+	flex-grow: 1;
+	flex-shrink: 0;
+	text-align: right;
+	margin-top: rem( 6px );
+	padding: rem( 4px ) 0;
 
+	.dops-button-group {
+		flex-grow: 1;
+		align-self: center;
+	}
 	@include breakpoint( "<480px" ) {
-		padding-right: rem( 10px );
-	}
-}
-
-.jp-masthead__link-li {
-	margin: 0;
-	padding: 0;
-}
-
-.jp-masthead__link {
-	font-style: normal;
-	color: $blue-wordpress;
-	padding: rem( 10px );
-	display: inline-block;
-
-	&:visited {
-		color: $blue-wordpress;
-	}
-
-	&:active,
-	&:hover {
-		color: $blue-medium;
-	}
-
-	&:hover {
-		text-decoration: underline;
-	}
-
-	.dashicons {
-		display: none;
-	}
-
-	@include breakpoint( "<480px" ) {
-
-		&:hover,
-		&:active {
-			text-decoration: none;
-		}
-		.dashicons {
-			display: block;
-			font-size: rem( 28px );
-		}
-		span + span {
-			display: none;
-		}
-	}
-}
-
-.jp-masthead__link-li {
-	&:last-of-type .jp-masthead__link {
-		padding-right: 0;
+		text-align: left;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Removed vestigial link styles and elements
* Made the header flexbox-y
* Vertically centered the dash/settings nav group
* did some fancy CSS footwork to make it look good on mobile

#### Testing instructions:
* Load up this branch and resize your browser a bunch.

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23477219/81439bd4-fe7a-11e6-8b8d-8b6e0cf3a9d8.png)
![image](https://cloud.githubusercontent.com/assets/1123119/23477227/8b0123bc-fe7a-11e6-8717-11489d4521cf.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23477143/4eb286b2-fe7a-11e6-889c-fdafe62bf77f.png)
![image](https://cloud.githubusercontent.com/assets/1123119/23477167/614a866c-fe7a-11e6-99cd-f5cc0031275c.png)
![image](https://cloud.githubusercontent.com/assets/1123119/23477177/691e35e6-fe7a-11e6-892a-a6d9753366bf.png)
