### PR TITLE
Settings UI: Add Google Analytics settings card

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -14,6 +14,7 @@ import {
 	FEATURE_SECURITY_SCANNING_JETPACK,
 	FEATURE_SEO_TOOLS_JETPACK,
 	FEATURE_VIDEO_HOSTING_JETPACK,
+	FEATURE_GOOGLE_ANALYTICS_JETPACK,
 	getPlanClass
 } from 'lib/plans/constants';
 import { getSiteRawUrl } from 'state/initial-state';
@@ -98,6 +99,7 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SEO_TOOLS_JETPACK:
+			case FEATURE_GOOGLE_ANALYTICS_JETPACK:
 				if ( 'is-business-plan' === planClass ) {
 					return '';
 				}

--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -1,4 +1,4 @@
 .jp-settings-card__configure-link {
-  display: flex;
-  margin-bottom: 0px;
+	display: flex;
+	margin-bottom: 0;
 }

--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -1,0 +1,4 @@
+.jp-settings-card__configure-link {
+  display: flex;
+  margin-bottom: 0px;
+}

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -41,6 +41,7 @@
 @import '../components/inline-expand/style';
 @import '../components/module-toggle/style';
 @import '../components/navigation-settings/style';
+@import '../components/settings-card/style';
 
 
 // Page Templates

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import ExternalLink from 'components/external-link';
+
+/**
+ * Internal dependencies
+ */
+import { FEATURE_GOOGLE_ANALYTICS_JETPACK } from 'lib/plans/constants';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+
+export const GoogleAnalytics = moduleSettingsForm(
+	React.createClass( {
+
+		render() {
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Analytics Settings', { context: 'Settings header' } ) }
+					feature={ FEATURE_GOOGLE_ANALYTICS_JETPACK }
+					hideButton>
+					<SettingsGroup disableInDevMode module={ { module: 'google-analytics' } } support="https://jetpack.com/support/google-analytics/">
+						<p>
+							{ __(
+								'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
+								' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
+								'normally show slightly different totals for your visits, views, etc.',
+								{
+									components: {
+										a: <a href={ 'https://wordpress.com/stats/day/' + this.props.siteRawUrl } />
+									}
+								}
+							) }
+						</p>
+						{
+							! this.props.isUnavailableInDevMode( 'seo-tools' ) && (
+								<span>
+									<ExternalLink className="jp-module-settings__external-link" href={ this.props.configureUrl }>{ __( 'Configure Google Analytics settings.' ) }</ExternalLink>
+								</span>
+							)
+						}
+					</SettingsGroup>
+				</SettingsCard>
+			);
+		}
+	} )
+);

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -39,7 +39,7 @@ export const GoogleAnalytics = moduleSettingsForm(
 					</SettingsGroup>
 					{
 						! this.props.isUnavailableInDevMode( 'google-analytics' ) && (
-							<Card className="jp-settings-card__configure-link" href={ this.props.configureUrl }>{ __( 'Configure Google Analytics settings.' ) }</Card>
+							<Card compact className="jp-settings-card__configure-link" href={ this.props.configureUrl }>{ __( 'Configure Google Analytics settings.' ) }</Card>
 						)
 					}
 				</SettingsCard>

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import ExternalLink from 'components/external-link';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
@@ -36,14 +36,12 @@ export const GoogleAnalytics = moduleSettingsForm(
 								}
 							) }
 						</p>
-						{
-							! this.props.isUnavailableInDevMode( 'google-analytics' ) && (
-								<span>
-									<ExternalLink className="jp-module-settings__external-link" href={ this.props.configureUrl }>{ __( 'Configure Google Analytics settings.' ) }</ExternalLink>
-								</span>
-							)
-						}
 					</SettingsGroup>
+					{
+						! this.props.isUnavailableInDevMode( 'google-analytics' ) && (
+							<Card className="jp-settings-card__configure-link" href={ this.props.configureUrl }>{ __( 'Configure Google Analytics settings.' ) }</Card>
+						)
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -37,7 +37,7 @@ export const GoogleAnalytics = moduleSettingsForm(
 							) }
 						</p>
 						{
-							! this.props.isUnavailableInDevMode( 'seo-tools' ) && (
+							! this.props.isUnavailableInDevMode( 'google-analytics' ) && (
 								<span>
 									<ExternalLink className="jp-module-settings__external-link" href={ this.props.configureUrl }>{ __( 'Configure Google Analytics settings.' ) }</ExternalLink>
 								</span>

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 
@@ -14,8 +14,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const GoogleAnalytics = moduleSettingsForm(
-	React.createClass( {
-
+	class extends Component {
 		render() {
 			return (
 				<SettingsCard
@@ -45,5 +44,5 @@ export const GoogleAnalytics = moduleSettingsForm(
 				</SettingsCard>
 			);
 		}
-	} )
+	}
 );

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -31,7 +31,7 @@ export const Traffic = React.createClass( {
 			isUnavailableInDevMode: this.props.isUnavailableInDevMode
 		};
 
-		let found = {
+		const found = {
 			seo: this.props.isModuleFound( 'seo-tools' ),
 			ads: this.props.isModuleFound( 'wordads' ),
 			stats: this.props.isModuleFound( 'stats' ),
@@ -57,24 +57,24 @@ export const Traffic = React.createClass( {
 			return null;
 		}
 
-		let seoSettings = (
+		const seoSettings = (
 			<SEO
 				{ ...commonProps }
 				configureUrl={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl }
 			/>
 		);
-		let adSettings = (
+		const adSettings = (
 			<Ads
 				{ ...commonProps }
 				configureUrl={ 'https://wordpress.com/ads/earnings/' + this.props.siteRawUrl }
 			/>
 		);
-		let statsSettings = (
+		const statsSettings = (
 			<SiteStats
 				{ ...commonProps }
 			/>
 		);
-		let relatedPostsSettings = (
+		const relatedPostsSettings = (
 			<RelatedPosts
 				{ ...commonProps }
 				configureUrl={ this.props.siteAdminUrl +
@@ -83,7 +83,7 @@ export const Traffic = React.createClass( {
 					'&url=' + encodeURIComponent( this.props.lastPostUrl ) }
 			/>
 		);
-		let verificationSettings = (
+		const verificationSettings = (
 			<VerificationServices
 				{ ...commonProps }
 			/>
@@ -118,6 +118,6 @@ export default connect(
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
 			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
 			lastPostUrl: getLastPostUrl( state )
-		}
+		};
 	}
 )( Traffic );

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -91,6 +91,7 @@ export const Traffic = React.createClass( {
 		const googleAnalyticsSettings = (
 			<GoogleAnalytics
 				{ ...commonProps }
+				configureUrl={ 'https://wordpress.com/settings/analytics/' + this.props.siteRawUrl }
 			/>
 		);
 

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -98,11 +98,11 @@ export const Traffic = React.createClass( {
 		return (
 			<div>
 				<QuerySite />
-				{ found.analytics && googleAnalyticsSettings }
 				{ found.seo && seoSettings }
 				{ found.ads && adSettings }
 				{ found.stats && statsSettings }
 				{ found.related && relatedPostsSettings }
+				{ found.analytics && googleAnalyticsSettings }
 				{ ( found.verification || found.sitemaps ) && verificationSettings }
 			</div>
 		);

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -13,6 +13,7 @@ import { isDevMode, isUnavailableInDevMode } from 'state/connection';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import QuerySite from 'components/data/query-site';
 import { SEO } from './seo';
+import { GoogleAnalytics } from './google-analytics';
 import { Ads } from './ads';
 import { SiteStats } from './site-stats';
 import { RelatedPosts } from './related-posts';
@@ -36,7 +37,8 @@ export const Traffic = React.createClass( {
 			stats: this.props.isModuleFound( 'stats' ),
 			related: this.props.isModuleFound( 'related-posts' ),
 			verification: this.props.isModuleFound( 'verification-tools' ),
-			sitemaps: this.props.isModuleFound( 'sitemaps' )
+			sitemaps: this.props.isModuleFound( 'sitemaps' ),
+			analytics: this.props.isModuleFound( 'google-analytics' )
 		};
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
@@ -44,12 +46,13 @@ export const Traffic = React.createClass( {
 		}
 
 		if (
-			! found.seo
-			&& ! found.ads
-			&& ! found.stats
-			&& ! found.related
-			&& ! found.verification
-			&& ! found.sitemaps
+			! found.seo &&
+			! found.ads &&
+			! found.stats &&
+			! found.related &&
+			! found.verification &&
+			! found.sitemaps &&
+			! found.analytics
 		) {
 			return null;
 		}
@@ -85,10 +88,16 @@ export const Traffic = React.createClass( {
 				{ ...commonProps }
 			/>
 		);
+		const googleAnalyticsSettings = (
+			<GoogleAnalytics
+				{ ...commonProps }
+			/>
+		);
 
 		return (
 			<div>
 				<QuerySite />
+				{ found.analytics && googleAnalyticsSettings }
 				{ found.seo && seoSettings }
 				{ found.ads && adSettings }
 				{ found.stats && statsSettings }


### PR DESCRIPTION
Fixes #6187 

This adds the settings card for the Google Analytics module in the `/traffic` tab.  
It behaves the same way as the SEO feature, and should be showing the same banners as that.  
The banners should disappear when you're on the PRO version.

We're also experimenting with using a `linked card` as the configure link instead of a regular one.  To do this, I had to apply a little bit of CSS to the card to make it fit properly, so I've introduced a new stylesheet to the `settings-card` components.  

<img width="753" alt="screen shot 2017-03-01 at 4 18 53 pm" src="https://cloud.githubusercontent.com/assets/7129409/23481880/26cf91dc-fe9b-11e6-845e-0608cd7297f0.png">
