### PR TITLE
Markdown: enable markdown on posts automatically on activation. 

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1192,3 +1192,15 @@ function jetpack_do_after_gravatar_hovercards_deactivation() {
 	update_option( 'gravatar_disable_hovercards', 'disabled' );
 }
 add_action( 'jetpack_deactivate_module_gravatar-hovercards', 'jetpack_do_after_gravatar_hovercards_deactivation' );
+
+/**
+ * Actions performed only when Markdown is activated through the endpoint call.
+ *
+ * @since 4.7.0
+ */
+function jetpack_do_after_markdown_activation() {
+
+	// When Markdown is activated, enable support for post editing automatically.
+	update_option( 'wpcom_publish_posts_with_markdown', true );
+}
+add_action( 'jetpack_activate_module_markdown', 'jetpack_do_after_markdown_activation' );


### PR DESCRIPTION
Fixes #6442

#### Changes proposed in this Pull Request:

* Enables markdown on posts and pages automatically if the module is active.  

This was a regression with the new UI, since there are no options to turn it on in the new UI.  