### PR TITLE
Remove Settings links and buttons from disconnected views.

### DIFF
--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -39,26 +39,27 @@ export const Masthead = React.createClass( {
 						</a>
 						{ devNotice }
 					</div>
-
 					{
 						this.props.userCanEditPosts && (
 							<div className="jp-masthead__nav">
-								<ButtonGroup>
-									<Button
-										compact={ true }
-										href="#/dashboard"
-										primary={ isDashboardView && ! isStatic }
-									>
-										{ __( 'Dashboard' ) }
-									</Button>
-									<Button
-										compact={ true }
-										href="#/settings"
-										primary={ ! isDashboardView && ! isStatic }
-									>
-										{ __( 'Settings' ) }
-									</Button>
-								</ButtonGroup>
+								{ ( ! isStatic && this.props.siteConnectionStatus ) &&
+									<ButtonGroup>
+										<Button
+											compact={ true }
+											href="#/dashboard"
+											primary={ isDashboardView && ! isStatic }
+										>
+											{ __( 'Dashboard' ) }
+										</Button>
+										<Button
+											compact={ true }
+											href="#/settings"
+											primary={ ! isDashboardView && ! isStatic }
+										>
+											{ __( 'Settings' ) }
+										</Button>
+									</ButtonGroup>
+								}
 							</div>
 						)
 					}

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -115,6 +115,23 @@ const Main = React.createClass( {
 			nextProps.searchTerm !== this.props.searchTerm;
 	},
 
+	componentDidUpdate( prevProps ) {
+		// Not taking into account development mode here because changing the connection
+		// status without reloading is possible only by disconnecting a live site not
+		// in development mode.
+		if ( prevProps.siteConnectionStatus !== this.props.siteConnectionStatus ) {
+			jQuery( '#toplevel_page_jetpack ul.wp-submenu li' )
+				.filter( function() {
+					const anchor = jQuery( this ).find( 'a' );
+					if ( ! anchor.length ) {
+						return false;
+					}
+					return -1 !== anchor.attr( 'href' ).indexOf( '#/settings' );
+				} )
+				.hide();
+		}
+	},
+
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.jumpStartStatus !== this.props.jumpStartStatus ||
 			nextProps.isJumpstarting !== this.props.isJumpstarting ) {

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -120,15 +120,9 @@ const Main = React.createClass( {
 		// status without reloading is possible only by disconnecting a live site not
 		// in development mode.
 		if ( prevProps.siteConnectionStatus !== this.props.siteConnectionStatus ) {
-			jQuery( '#toplevel_page_jetpack ul.wp-submenu li' )
-				.filter( function() {
-					const anchor = jQuery( this ).find( 'a' );
-					if ( ! anchor.length ) {
-						return false;
-					}
-					return -1 !== anchor.attr( 'href' ).indexOf( '#/settings' );
-				} )
-				.hide();
+			const $items = jQuery( '#toplevel_page_jetpack' ).find( 'ul.wp-submenu li' );
+			$items.find( 'a[href$="#/settings"]' ).hide();
+			$items.find( 'a[href$="admin.php?page=stats"]' ).hide();
 		}
 	},
 


### PR DESCRIPTION
Fixes #6461 

#### Changes proposed in this Pull Request:
* Removes the navigation button group from static loading placeholders.
* Removes the navigation button group from disconnected sites that are not in dev mode.
* Adds a page reload on site disconnection to refresh the sidebar navigation.

#### Testing instructions:
* Reload the admin page, observe the Masthead element. There should be no button group in loading state.
* Disconnect the site from the dashboard, you should observe a page being reloaded and scrolled back to top. Settings link shouldn't be there in the left sidebar.
* In disconnected mode observe that there are no buttons in the Masthead.
* Turn development mode on, observe the button group in the Masthead.