### PR TITLE
Capitalization fix for 'SEO Tools' module header.

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -139,7 +139,7 @@ function jetpack_get_module_i18n( $key ) {
 			),
 
 			'seo-tools' => array(
-				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
+				'name' => _x( 'SEO tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Better results on search engines and social media.', 'Jumpstart Description', 'jetpack' ),
 			),

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -139,7 +139,7 @@ function jetpack_get_module_i18n( $key ) {
 			),
 
 			'seo-tools' => array(
-				'name' => _x( 'SEO tools', 'Module Name', 'jetpack' ),
+				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Better results on search engines and social media.', 'Jumpstart Description', 'jetpack' ),
 			),

--- a/modules/seo-tools.php
+++ b/modules/seo-tools.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: SEO tools
+ * Module Name: SEO Tools
  * Module Description: Better results on search engines and social media.
  * Jumpstart Description: Better results on search engines and social media.
  * Sort Order: 35


### PR DESCRIPTION
Small copy fix. I noticed that the `SEO tools` module title wasn't capitalized properly like the rest of the titles.

Before:
<img width="731" alt="screen shot 2017-03-02 at 11 44 57 am" src="https://cloud.githubusercontent.com/assets/789137/23524088/13820ff8-ff3e-11e6-9ae1-aced9f15feee.png">

After:
<img width="732" alt="screen shot 2017-03-02 at 11 44 47 am" src="https://cloud.githubusercontent.com/assets/789137/23524096/196c608a-ff3e-11e6-900f-bd70496bd816.png">
