### PR TITLE
Admin Page: Make sure Gravatar is always displayed in Settings.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -400,7 +400,7 @@ function jetpack_current_user_data() {
 		'isMaster'    => $is_master_user,
 		'username'    => $current_user->user_login,
 		'wpcomUser'   => $dotcom_data,
-		'gravatar'    => get_avatar( $current_user->ID, 40 ),
+		'gravatar'    => get_avatar( $current_user->ID, 40, 'mm', '', array( 'force_display' => true ) ),
 		'permissions' => array(
 			'admin_page'         => current_user_can( 'jetpack_admin_page' ),
 			'connect'            => current_user_can( 'jetpack_connect' ),


### PR DESCRIPTION
Fixes #6545

#### Changes proposed in this Pull Request:

* Always display the Gravatar on Jetpack's Connection settings page, even when avatars are deactivated under Settings > Discussion.

#### Testing instructions:

1. Visit wp-admin > Settings > Discussion
2. Disable the Show Avatars setting
3. Connect Jetpack
4. Visit Jetpack > Settings > Connection Settings

cc @alexjgustafson @danjjohnson 

Make sure the Gravatar is properly displayed.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Admin Page: Make sure Gravatar is always displayed in Settings.