### PR TITLE
Fix undefined variable during registration

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4655,7 +4655,7 @@ p {
 		 * @param string $json->jetpack_secret Jetpack Blog Token.
 		 * @param int|bool $jetpack_public Is the site public.
 		 */
-		do_action( 'jetpack_site_registered', $json->jetpack_id, $json->jetpack_secret, $jetpack_public );
+		do_action( 'jetpack_site_registered', $registration_details->jetpack_id, $registration_details->jetpack_secret, $jetpack_public );
 
 		// Initialize Jump Start for the first and only time.
 		if ( ! Jetpack_Options::get_option( 'jumpstart' ) ) {


### PR DESCRIPTION
Some vars were renamed in #6322, but this one seems to have been missed.  

Make sure you're able to connect/register properly.  