### PR TITLE
Settings  UI: allow non admins to use AtD, PbE and Publicize

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -24,18 +24,18 @@ import QuerySitePlugins from 'components/data/query-site-plugins';
 import QuerySite from 'components/data/query-site';
 import {
 	userCanManageModules,
-	userCanViewStats
+	userCanViewStats,
+	userIsSubscriber
 } from 'state/initial-state';
 import { isDevMode } from 'state/connection';
 
 const AtAGlance = React.createClass( {
 	render() {
 		const urls = {
-			siteAdminUrl: this.props.siteAdminUrl,
-			siteRawUrl: this.props.siteRawUrl
-		};
-
-		let securityHeader =
+				siteAdminUrl: this.props.siteAdminUrl,
+				siteRawUrl: this.props.siteRawUrl
+			},
+			securityHeader =
 				<DashSectionHeader
 					label={ __( 'Security' ) }
 					settingsPath="#security"
@@ -123,7 +123,16 @@ const AtAGlance = React.createClass( {
 
 			let nonAdminAAG = '';
 			if ( '' !== stats || '' !== protect ) {
-				nonAdminAAG = (
+				nonAdminAAG = this.props.userIsSubscriber
+				? (
+					<div>
+						{ stats	}
+						{
+							connections
+						}
+					</div>
+				)
+				: (
 					<div>
 						{ stats	}
 						{
@@ -149,6 +158,7 @@ export default connect(
 			isModuleActivated: ( module_name ) => _isModuleActivated( state, module_name ),
 			userCanManageModules: userCanManageModules( state ),
 			userCanViewStats: userCanViewStats( state ),
+			userIsSubscriber: userIsSubscriber( state ),
 			isDevMode: isDevMode( state )
 		};
 	}

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -13,7 +13,7 @@ import NoticesList from 'components/global-notices';
  */
 import JetpackStateNotices from './state-notices';
 import { getSiteConnectionStatus, getSiteDevMode, isStaging, isInIdentityCrisis, isCurrentUserLinked } from 'state/connection';
-import { isDevVersion, userCanManageModules, getUsername } from 'state/initial-state';
+import { isDevVersion, userCanManageModules, getUsername, userIsSubscriber } from 'state/initial-state';
 import DismissableNotices from './dismissable';
 import { getConnectUrl as _getConnectUrl } from 'state/connection';
 import QueryConnectUrl from 'components/data/query-connect-url';
@@ -22,7 +22,7 @@ export const DevVersionNotice = React.createClass( {
 	displayName: 'DevVersionNotice',
 
 	render() {
-		if ( this.props.isDevVersion ) {
+		if ( this.props.isDevVersion && ! this.props.userIsSubscriber ) {
 			return (
 				<SimpleNotice
 					showDismiss={ false }
@@ -43,7 +43,8 @@ export const DevVersionNotice = React.createClass( {
 } );
 
 DevVersionNotice.propTypes = {
-	isDevVersion: React.PropTypes.bool.isRequired
+	isDevVersion: React.PropTypes.bool.isRequired,
+	userIsSubscriber: React.PropTypes.bool.isRequired
 };
 
 export const StagingSiteNotice = React.createClass( {
@@ -51,13 +52,12 @@ export const StagingSiteNotice = React.createClass( {
 
 	render() {
 		if ( this.props.isStaging && ! this.props.isInIdentityCrisis ) {
-			let stagingSiteSupportLink = 'https://jetpack.com/support/staging-sites/';
-
-			let props = {
-				text: 	__( 'You are running Jetpack on a staging server.' ),
-				status: 'is-basic',
-				showDismiss: false
-			};
+			const stagingSiteSupportLink = 'https://jetpack.com/support/staging-sites/',
+				props = {
+					text: 	__( 'You are running Jetpack on a staging server.' ),
+					status: 'is-basic',
+					showDismiss: false
+				};
 
 			return (
 				<SimpleNotice { ... props }>
@@ -85,15 +85,13 @@ export const DevModeNotice = React.createClass( {
 
 	render() {
 		if ( this.props.siteConnectionStatus === 'dev' ) {
-			const devMode = this.props.siteDevMode;
-			const text = __( 'Currently in {{a}}Development Mode{{/a}} (some features are disabled) because:',
-				{
+			const devMode = this.props.siteDevMode,
+				text = __( 'Currently in {{a}}Development Mode{{/a}} (some features are disabled) because:', {
 					components: {
-						a: <a href="https://jetpack.com/support/development-mode/" target="_blank" rel="noopener noreferrer"/>
+						a: <a href="https://jetpack.com/support/development-mode/" target="_blank" rel="noopener noreferrer" />
 					}
-				}
-			);
-			const reasons = [];
+				} ),
+				reasons = [];
 			if ( devMode.filter ) {
 				reasons.push( __( '{{li}}The jetpack_development_mode filter is active{{/li}}',
 					{
@@ -202,7 +200,7 @@ const JetpackNotices = React.createClass( {
 				<QueryConnectUrl />
 				<NoticesList />
 				<JetpackStateNotices />
-				<DevVersionNotice isDevVersion={ this.props.isDevVersion } />
+				<DevVersionNotice isDevVersion={ this.props.isDevVersion } userIsSubscriber={ this.props.userIsSubscriber } />
 				<DevModeNotice
 					siteConnectionStatus={ this.props.siteConnectionStatus }
 					siteDevMode={ this.props.siteDevMode } />
@@ -235,6 +233,7 @@ export default connect(
 			connectUrl: _getConnectUrl( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 			userCanManageModules: userCanManageModules( state ),
+			userIsSubscriber: userIsSubscriber( state ),
 			username: getUsername( state ),
 			isLinked: isCurrentUserLinked( state ),
 			isDevVersion: isDevVersion( state ),

--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -12,7 +12,7 @@ import ButtonGroup from 'components/button-group';
  * Internal dependencies
  */
 import { getSiteConnectionStatus } from 'state/connection';
-import { getCurrentVersion } from 'state/initial-state';
+import { getCurrentVersion, userCanEditPosts } from 'state/initial-state';
 
 export const Masthead = React.createClass( {
 	getDefaultProps: function() {
@@ -22,7 +22,7 @@ export const Masthead = React.createClass( {
 	},
 
 	render: function() {
-		let devNotice = this.props.siteConnectionStatus === 'dev'
+		const devNotice = this.props.siteConnectionStatus === 'dev'
 			? <code>Dev Mode</code>
 			: '',
 			isDashboardView = includes( [ '/', '/dashboard', '/apps', '/plans' ], this.props.route.path ),
@@ -34,32 +34,37 @@ export const Masthead = React.createClass( {
 					<div className="jp-masthead__logo-container">
 						<a className="jp-masthead__logo-link" href="#dashboard">
 							<svg className="jp-masthead__logo" x="0" y="0" viewBox="0 0 183 32" enable-background="new 0 0 183 32">
-								<path d="M54 10.9v4.8 2.6c0 2.2-0.5 4.3-1.5 5.4 -1.3 1.4-3.3 1.9-5.5 1.9 -3.4 0-5.9-2.6-6-2.7l2-4c0.2 0.2 0.7 1.1 2 1.7 1.2 0.6 2.2 0.8 3 0.3 0.8-0.5 1-2 1-3v-6.1L44 7h6C52.2 7 54 8.7 54 10.9zM81 10.9h5V25h5V10.9h5V7H81V10.9zM115 8.9c1.1 1.1 2 2.8 2 4.6 0 2.1-1 3.8-2.2 4.9 -1.2 1.1-3 1.6-5.1 1.6h-2.6v5H102V7h7.8C112.1 7 113.8 7.7 115 8.9zM112.4 13.4c0-0.9-0.6-1.5-1-1.9 -0.6-0.5-1.4-0.6-2.1-0.6h-2.3V16h2.3c0.7 0 1.4-0.1 2-0.5C111.8 15.1 112.4 14.4 112.4 13.4zM135.8 8.9c1.4 1.4 2.1 3.5 2.1 5.4V25h-5v-5h-6v5h-5V14.3c0-1.9 0.7-4 2.1-5.4 1.3-1.3 3.4-2.4 5.9-2.4C132.5 6.5 134.6 7.7 135.8 8.9zM132.5 12c-0.7-0.7-1.6-1-2.5-1 -0.9 0-1.9 0.3-2.5 1 -0.5 0.6-0.5 1.5-0.5 2.6V16h6v-1.4C132.9 13.5 133 12.6 132.5 12zM61.1 25H75v-3.9h-9v-3.2h7V14h-7v-3.1h9V7H61.1V25zM157.6 20c-0.1 0-0.2 0.1-0.3 0.1 0 0 0 0 0 0 -1 0.5-2.1 0.8-3.4 0.8 -1.5 0-2.9-0.5-3.8-1.5 -1-0.9-1.5-2.2-1.5-3.8 0-1.3 0.5-2.5 1.2-3.4 0.9-1.1 2.3-1.8 4.1-1.8 1 0 1.8 0.2 2.7 0.5 0 0 0.1 0 0.2 0.1 0.1 0 0.2 0.1 0.3 0.1 0 0 0.1 0 0.1 0.1 0.1 0 0.1 0.1 0.2 0.1 0.2 0.1 0.4 0.2 0.6 0.3l1.7-3.6c-0.3-0.2-0.7-0.4-1.1-0.6 -1.3-0.6-2.8-1-4.9-1 -2.8 0-5.5 1.2-7.3 3.1 -1.5 1.6-2.4 3.7-2.4 6.1 0 2.9 1.1 5.2 2.8 6.8 1.7 1.6 4.1 2.5 6.9 2.5 2.3 0 4-0.5 5.4-1.3 0 0 0.1 0 0.1 0 0 0 0 0 0 0 0.2-0.1 0.5-0.3 0.7-0.4l-1.8-3.6C157.9 19.8 157.7 19.9 157.6 20zM182 7h-5.8l-5.2 5.7V7h-3v0h-2v18h2 2.4 0.6v-6.5l0.5-0.5 5.3 7h5.2l-7.5-10.1L182 7zM32 16c0 8.8-7.2 16-16 16S0 24.8 0 16C0 7.2 7.2 0 16 0S32 7.2 32 16zM15 4.7L8.7 15.5c-0.7 1.1 0 2.6 1.2 2.9l5 1.3V4.7zM22 13.5l-5-1.3v15l6.3-10.8C23.9 15.3 23.3 13.9 22 13.5z"/>
+								<path d="M54 10.9v4.8 2.6c0 2.2-0.5 4.3-1.5 5.4 -1.3 1.4-3.3 1.9-5.5 1.9 -3.4 0-5.9-2.6-6-2.7l2-4c0.2 0.2 0.7 1.1 2 1.7 1.2 0.6 2.2 0.8 3 0.3 0.8-0.5 1-2 1-3v-6.1L44 7h6C52.2 7 54 8.7 54 10.9zM81 10.9h5V25h5V10.9h5V7H81V10.9zM115 8.9c1.1 1.1 2 2.8 2 4.6 0 2.1-1 3.8-2.2 4.9 -1.2 1.1-3 1.6-5.1 1.6h-2.6v5H102V7h7.8C112.1 7 113.8 7.7 115 8.9zM112.4 13.4c0-0.9-0.6-1.5-1-1.9 -0.6-0.5-1.4-0.6-2.1-0.6h-2.3V16h2.3c0.7 0 1.4-0.1 2-0.5C111.8 15.1 112.4 14.4 112.4 13.4zM135.8 8.9c1.4 1.4 2.1 3.5 2.1 5.4V25h-5v-5h-6v5h-5V14.3c0-1.9 0.7-4 2.1-5.4 1.3-1.3 3.4-2.4 5.9-2.4C132.5 6.5 134.6 7.7 135.8 8.9zM132.5 12c-0.7-0.7-1.6-1-2.5-1 -0.9 0-1.9 0.3-2.5 1 -0.5 0.6-0.5 1.5-0.5 2.6V16h6v-1.4C132.9 13.5 133 12.6 132.5 12zM61.1 25H75v-3.9h-9v-3.2h7V14h-7v-3.1h9V7H61.1V25zM157.6 20c-0.1 0-0.2 0.1-0.3 0.1 0 0 0 0 0 0 -1 0.5-2.1 0.8-3.4 0.8 -1.5 0-2.9-0.5-3.8-1.5 -1-0.9-1.5-2.2-1.5-3.8 0-1.3 0.5-2.5 1.2-3.4 0.9-1.1 2.3-1.8 4.1-1.8 1 0 1.8 0.2 2.7 0.5 0 0 0.1 0 0.2 0.1 0.1 0 0.2 0.1 0.3 0.1 0 0 0.1 0 0.1 0.1 0.1 0 0.1 0.1 0.2 0.1 0.2 0.1 0.4 0.2 0.6 0.3l1.7-3.6c-0.3-0.2-0.7-0.4-1.1-0.6 -1.3-0.6-2.8-1-4.9-1 -2.8 0-5.5 1.2-7.3 3.1 -1.5 1.6-2.4 3.7-2.4 6.1 0 2.9 1.1 5.2 2.8 6.8 1.7 1.6 4.1 2.5 6.9 2.5 2.3 0 4-0.5 5.4-1.3 0 0 0.1 0 0.1 0 0 0 0 0 0 0 0.2-0.1 0.5-0.3 0.7-0.4l-1.8-3.6C157.9 19.8 157.7 19.9 157.6 20zM182 7h-5.8l-5.2 5.7V7h-3v0h-2v18h2 2.4 0.6v-6.5l0.5-0.5 5.3 7h5.2l-7.5-10.1L182 7zM32 16c0 8.8-7.2 16-16 16S0 24.8 0 16C0 7.2 7.2 0 16 0S32 7.2 32 16zM15 4.7L8.7 15.5c-0.7 1.1 0 2.6 1.2 2.9l5 1.3V4.7zM22 13.5l-5-1.3v15l6.3-10.8C23.9 15.3 23.3 13.9 22 13.5z" />
 							</svg>
 						</a>
 						{ devNotice }
 					</div>
-					<div className="jp-masthead__nav">
-							<ButtonGroup>
-								<Button
-									compact={ true }
-									href="#/dashboard"
-									primary={ isDashboardView && ! isStatic }
-								>
-									{ __( 'Dashboard' ) }
-								</Button>
-								<Button
-									compact={ true }
-									href="#/settings"
-									primary={ ! isDashboardView && ! isStatic }
-								>
-									{ __( 'Settings' ) }
-								</Button>
-							</ButtonGroup>
-					</div>
+
+					{
+						this.props.userCanEditPosts && (
+							<div className="jp-masthead__nav">
+								<ButtonGroup>
+									<Button
+										compact={ true }
+										href="#/dashboard"
+										primary={ isDashboardView && ! isStatic }
+									>
+										{ __( 'Dashboard' ) }
+									</Button>
+									<Button
+										compact={ true }
+										href="#/settings"
+										primary={ ! isDashboardView && ! isStatic }
+									>
+										{ __( 'Settings' ) }
+									</Button>
+								</ButtonGroup>
+							</div>
+						)
+					}
 				</div>
 			</div>
-		)
+		);
 	}
 } );
 
@@ -67,7 +72,8 @@ export default connect(
 	state => {
 		return {
 			siteConnectionStatus: getSiteConnectionStatus( state ),
-			currentVersion: getCurrentVersion( state )
+			currentVersion: getCurrentVersion( state ),
+			userCanEditPosts: userCanEditPosts( state )
 		};
 	}
 )( Masthead );

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -22,7 +22,8 @@ import {
 } from 'state/search';
 import {
 	userCanManageModules as _userCanManageModules,
-	userIsSubscriber as _userIsSubscriber
+	userIsSubscriber as _userIsSubscriber,
+	userIsContributor
 } from 'state/initial-state';
 import { getSiteConnectionStatus } from 'state/connection';
 import { isModuleActivated } from 'state/modules';
@@ -85,6 +86,23 @@ export const NavigationSettings = React.createClass( {
 	render: function() {
 		let navItems;
 
+		const publicizeTab = (
+			( this.props.isModuleActivated( 'publicize' ) || this.props.isModuleActivated( 'sharedaddy' ) ) && (
+				<NavItem
+					path={ true === this.props.siteConnectionStatus
+										? 'https://wordpress.com/sharing/' + this.props.siteRawUrl
+										: this.props.siteAdminUrl + 'options-general.php?page=sharing'
+										}>
+					{ __( 'Sharing', { context: 'Navigation item.' } ) }
+					{
+						true === this.props.siteConnectionStatus && (
+							<Gridicon icon="external" size={ 13 } />
+						)
+					}
+				</NavItem>
+			)
+		);
+
 		if ( this.props.userCanManageModules ) {
 			navItems = (
 				<NavTabs selectedText={ this.props.route.name }>
@@ -109,20 +127,7 @@ export const NavigationSettings = React.createClass( {
 						{ __( 'Security', { context: 'Navigation item.' } ) }
 					</NavItem>
 					{
-						( this.props.isModuleActivated( 'publicize' ) || this.props.isModuleActivated( 'sharedaddy' ) ) && (
-							<NavItem
-								path={ true === this.props.siteConnectionStatus
-									? 'https://wordpress.com/sharing/' + this.props.siteRawUrl
-									: this.props.siteAdminUrl + 'options-general.php?page=sharing'
-									}>
-								{ __( 'Sharing', { context: 'Navigation item.' } ) }
-								{
-									true === this.props.siteConnectionStatus && (
-										<Gridicon icon="external" size={ 13 } />
-									)
-								}
-							</NavItem>
-						)
+						publicizeTab
 					}
 				</NavTabs>
 			);
@@ -136,6 +141,10 @@ export const NavigationSettings = React.createClass( {
 						selected={ this.props.route.path === '/writing' || this.props.route.path === '/settings' }>
 						{ __( 'Writing', { context: 'Navigation item.' } ) }
 					</NavItem>
+					{
+						// Give only Publicize to non admin users
+						this.props.isModuleActivated( 'publicize' ) && ! this.props.isContributor && publicizeTab
+					}
 				</NavTabs>
 			);
 		}
@@ -160,6 +169,7 @@ export default connect(
 		return {
 			userCanManageModules: _userCanManageModules( state ),
 			isSubscriber: _userIsSubscriber( state ),
+			isContributor: userIsContributor( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 			isModuleActivated: module => isModuleActivated( state, module ),
 			searchTerm: getSearchTerm( state )

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -88,8 +88,28 @@ describe( 'NavigationSettings', () => {
 			wrapper = shallow( <NavigationSettings { ...testProps } />, options );
 		} );
 
-		it( 'renders tabs with Writing', () => {
-			expect( wrapper.find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
+		it( 'renders tabs with Writing and Sharing', () => {
+			expect( wrapper.find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing', 'Sharing' ].includes( item ) ) ).to.be.true;
+		} );
+
+		it( 'show only Writing if Publicize is disabled', () => {
+			const publicizeProps = Object.assign( {}, testProps, {
+				userCanManageModules: false,
+				isSubscriber: false,
+				isContributor: false,
+				isModuleActivated: m => 'sharedaddy' === m
+			} );
+			expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
+		} );
+
+		it( 'do not show Sharing to contributors', () => {
+			const publicizeProps = Object.assign( {}, testProps, {
+				userCanManageModules: false,
+				isSubscriber: false,
+				isContributor: true,
+				isModuleActivated: m => 'sharedaddy' === m
+			} );
+			expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
 		} );
 
 		it( 'has /writing as selected navigation item, accessing through /settings', () => {
@@ -100,6 +120,7 @@ describe( 'NavigationSettings', () => {
 		it( 'does not display Search', () => {
 			expect( wrapper.find( 'Search' ) ).to.have.length( 0 );
 		} );
+
 	} );
 
 	describe( 'for an Admin user', () => {
@@ -207,7 +228,7 @@ describe( 'NavigationSettings', () => {
 			wrapper = shallow(
 				<NavigationSettings
 					{ ...testProps }
-					isModuleActivated={ m => 'sharing' === m }
+					isModuleActivated={ m => 'sharedaddy' === m }
 				/>,
 				options
 			);

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -100,7 +100,7 @@ describe( 'NavigationSettings', () => {
 				userCanPublish: true,
 				isModuleActivated: m => 'sharedaddy' === m
 			} );
-			expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
+			expect( shallow( <NavigationSettings { ...publicizeProps } />, options ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
 		} );
 
 		it( 'has /writing as selected navigation item, accessing through /settings', () => {
@@ -119,7 +119,7 @@ describe( 'NavigationSettings', () => {
 				isContributor: true,
 				isModuleActivated: m => 'sharedaddy' === m
 			} );
-			expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
+			expect( shallow( <NavigationSettings { ...publicizeProps } />, options ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
 		} );
 
 		describe( 'if Publicize is active', () => {
@@ -128,15 +128,19 @@ describe( 'NavigationSettings', () => {
 				userCanManageModules: false,
 				isSubscriber: false,
 				userCanPublish: true,
+				route: {
+					name: 'General',
+					path: '/settings'
+				},
 				isModuleActivated: m => 'publicize' === m
 			} );
 			it( 'show Sharing if user is linked', () => {
-				expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing', 'Sharing' ].includes( item ) ) ).to.be.true;
+				expect( shallow( <NavigationSettings { ...publicizeProps } />, options ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing', 'Sharing' ].includes( item ) ) ).to.be.true;
 			} );
 
 			it( 'do not show Sharing if user is unlinked', () => {
 				publicizeProps.isLinked = false;
-				expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
+				expect( shallow( <NavigationSettings { ...publicizeProps } />, options ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
 			} );
 
 		} );

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -42,7 +42,8 @@ describe( 'NavigationSettings', () => {
 			siteConnectionStatus: true,
 			siteRawUrl: 'example.org',
 			siteAdminUrl: 'https://example.org/wp-admin/',
-			searchForTerm: () => {}
+			searchForTerm: () => {},
+			isLinked: true
 		};
 
 		options = {
@@ -96,17 +97,7 @@ describe( 'NavigationSettings', () => {
 			const publicizeProps = Object.assign( {}, testProps, {
 				userCanManageModules: false,
 				isSubscriber: false,
-				isContributor: false,
-				isModuleActivated: m => 'sharedaddy' === m
-			} );
-			expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
-		} );
-
-		it( 'do not show Sharing to contributors', () => {
-			const publicizeProps = Object.assign( {}, testProps, {
-				userCanManageModules: false,
-				isSubscriber: false,
-				isContributor: true,
+				userCanPublish: true,
 				isModuleActivated: m => 'sharedaddy' === m
 			} );
 			expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
@@ -119,6 +110,35 @@ describe( 'NavigationSettings', () => {
 
 		it( 'does not display Search', () => {
 			expect( wrapper.find( 'Search' ) ).to.have.length( 0 );
+		} );
+
+		it( 'do not show Sharing to contributors', () => {
+			const publicizeProps = Object.assign( {}, testProps, {
+				userCanManageModules: false,
+				isSubscriber: false,
+				isContributor: true,
+				isModuleActivated: m => 'sharedaddy' === m
+			} );
+			expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
+		} );
+
+		describe( 'if Publicize is active', () => {
+
+			let publicizeProps = Object.assign( {}, testProps, {
+				userCanManageModules: false,
+				isSubscriber: false,
+				userCanPublish: true,
+				isModuleActivated: m => 'publicize' === m
+			} );
+			it( 'show Sharing if user is linked', () => {
+				expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing', 'Sharing' ].includes( item ) ) ).to.be.true;
+			} );
+
+			it( 'do not show Sharing if user is unlinked', () => {
+				publicizeProps.isLinked = false;
+				expect( shallow( <NavigationSettings { ...publicizeProps } /> ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing' ].includes( item ) ) ).to.be.true;
+			} );
+
 		} );
 
 	} );

--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -15,7 +15,7 @@ import { isModuleActivated as _isModuleActivated } from 'state/modules';
 import Navigation from 'components/navigation';
 import NavigationSettings from 'components/navigation-settings';
 import AtAGlance from 'at-a-glance/index.jsx';
-import Writing from 'writing/index.jsx';
+import SearchableSettings from 'settings/index.jsx';
 import Apps from 'apps/index.jsx';
 import { getSiteConnectionStatus } from 'state/connection';
 
@@ -45,7 +45,11 @@ const NonAdminView = React.createClass( {
 			case '/writing':
 				if ( ! this.props.isSubscriber ) {
 					navComponent = <NavigationSettings { ...this.props } />;
-					pageComponent = <Writing { ...this.props } />;
+					pageComponent = <SearchableSettings
+						route={ this.props.route }
+						siteAdminUrl={ this.props.siteAdminUrl }
+						siteRawUrl={ this.props.siteRawUrl }
+						searchTerm={ this.props.searchTerm } />;
 				}
 				break;
 		}

--- a/_inc/client/components/settings-card/test/component.js
+++ b/_inc/client/components/settings-card/test/component.js
@@ -28,8 +28,52 @@ describe( 'SettingsCard', () => {
 		support: '',
 		sitePlan: {
 			product_slug: 'jetpack_free'
-		}
+		},
+		userCanManageModules: true
 	};
+
+	const allCardsNonAdminCantAccess = [
+			'widget-visibility',
+			'minileven',
+			'contact-form',
+			'sitemaps',
+			'latex',
+			'carousel',
+			'tiled-gallery',
+			'custom-content-types',
+			'verification-tools',
+			'markdown',
+			'infinite-scroll',
+			'gravatar-hovercards',
+			'omnisearch',
+			'custom-css',
+			'sharedaddy',
+			'widgets',
+			'shortcodes',
+			'related-posts',
+			'videopress',
+			'monitor',
+			'sso',
+			'vaultpress',
+			'google-analytics',
+			'seo-tools',
+			'stats',
+			'wordads',
+			'manage',
+			'likes',
+			'shortlinks',
+			'notes',
+			'subscriptions',
+			'protect',
+			'enhanced-distribution',
+			'comments',
+			'json-api',
+			'photon'
+		],
+		allCardsForNonAdmin = [
+			'composing',
+			'post-by-email'
+		];
 
 	const wrapper = shallow( <SettingsCard { ...testProps } /> );
 
@@ -117,6 +161,26 @@ describe( 'SettingsCard', () => {
 
 		it( 'isSavingAnyOption() is called once', () => {
 			expect( wasSaving.calledOnce ).to.be.true;
+		} );
+
+	} );
+
+	describe( 'When user is not an admin', () => {
+
+		Object.assign( testProps, {
+			userCanManageModules: false
+		} );
+
+		it( 'does not render cards that are not Composing or Post by Email', () => {
+			allCardsNonAdminCantAccess.forEach( item => {
+				expect( shallow( <SettingsCard { ...testProps } module={ item } /> ).find( 'form' ) ).to.have.length( 0 );
+			} );
+		} );
+
+		it( 'renders Composing and Post by Email cards', () => {
+			allCardsForNonAdmin.forEach( item => {
+				expect( shallow( <SettingsCard { ...testProps } module={ item } /> ).find( 'form' ) ).to.have.length( 1 );
+			} );
 		} );
 
 	} );

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -15,7 +15,8 @@ import noop from 'lodash/noop';
  * Internal dependencies
  */
 import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
-import { userCanManageModules, isSitePublic } from 'state/initial-state';
+import { userCanManageModules, isSitePublic, userCanEditPosts } from 'state/initial-state';
+import { isModuleActivated } from 'state/modules';
 
 export const SettingsGroup = props => {
 	const module = props.module;
@@ -32,7 +33,8 @@ export const SettingsGroup = props => {
 			: props.support;
 	let displayFadeBlock = disableInDevMode;
 
-	if ( 'post-by-email' === module.module && ! props.isLinked ) {
+	if ( ( 'post-by-email' === module.module && ! props.isLinked ) ||
+		( 'after-the-deadline' === module.module && ( ! props.userCanManageModules && props.userCanEditPosts && ! props.isModuleActivated( 'after-the-deadline' ) ) ) ) {
 		displayFadeBlock = true;
 	}
 
@@ -95,7 +97,9 @@ export default connect(
 			isDevMode: isDevMode( state ),
 			isSitePublic: isSitePublic( state ),
 			userCanManageModules: userCanManageModules( state ),
+			userCanEditPosts: userCanEditPosts( state ),
 			isLinked: isCurrentUserLinked( state ),
+			isModuleActivated: module => isModuleActivated( state, module ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name )
 		};
 	}

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -17,8 +17,15 @@ import { userCanManageModules, isSitePublic } from 'state/initial-state';
 import { getSitePlan } from 'state/site';
 
 export const SettingsGroup = props => {
-	const module = props.module,
-		disableInDevMode = props.disableInDevMode && props.isUnavailableInDevMode( module.module ),
+	const module = props.module;
+
+	// Non admin users only get Publicize, After the Deadline, and Post by Email settings. The UI doesn't have settings for Publicize.
+	// composing is not a module slug but it's used so the Composing card is rendered to show AtD.
+	if ( module.module && ! props.userCanManageModules && 'post-by-email' === module.module ) {
+		return <span />;
+	}
+
+	const disableInDevMode = props.disableInDevMode && props.isUnavailableInDevMode( module.module ),
 		support = ! props.support && module && '' !== module.learn_more_button
 			? module.learn_more_button
 			: props.support;
@@ -55,11 +62,13 @@ export const SettingsGroup = props => {
 };
 
 SettingsGroup.propTypes = {
-	support: React.PropTypes.string
+	support: React.PropTypes.string,
+	module: React.PropTypes.object
 };
 
 SettingsGroup.defaultProps = {
-	support: ''
+	support: '',
+	module: {}
 };
 
 export default connect(

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -8,6 +8,7 @@ import Card from 'components/card';
 import classNames from 'classnames';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
+import includes from 'lodash/includes';
 import noop from 'lodash/noop';
 
 /**
@@ -21,7 +22,7 @@ export const SettingsGroup = props => {
 
 	// Non admin users only get Publicize, After the Deadline, and Post by Email settings. The UI doesn't have settings for Publicize.
 	// composing is not a module slug but it's used so the Composing card is rendered to show AtD.
-	if ( module.module && ! props.userCanManageModules && 'post-by-email' === module.module ) {
+	if ( module.module && ! props.userCanManageModules && ! includes( [ 'after-the-deadline', 'post-by-email' ], module.module ) ) {
 		return <span />;
 	}
 

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -8,13 +8,13 @@ import Card from 'components/card';
 import classNames from 'classnames';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
+import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
-import { isDevMode, isUnavailableInDevMode } from 'state/connection';
+import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
 import { userCanManageModules, isSitePublic } from 'state/initial-state';
-import { getSitePlan } from 'state/site';
 
 export const SettingsGroup = props => {
 	const module = props.module;
@@ -29,6 +29,11 @@ export const SettingsGroup = props => {
 		support = ! props.support && module && '' !== module.learn_more_button
 			? module.learn_more_button
 			: props.support;
+	let displayFadeBlock = disableInDevMode;
+
+	if ( 'post-by-email' === module.module && ! props.isLinked ) {
+		displayFadeBlock = true;
+	}
 
 	return (
 		<div className="jp-form-settings-group">
@@ -37,7 +42,7 @@ export const SettingsGroup = props => {
 				'jp-form-settings-disable': disableInDevMode
 			} ) }>
 				{
-					disableInDevMode && <div className="jp-form-block-fade"></div>
+					displayFadeBlock && <div className="jp-form-block-fade"></div>
 				}
 				{
 					support && (
@@ -63,21 +68,33 @@ export const SettingsGroup = props => {
 
 SettingsGroup.propTypes = {
 	support: React.PropTypes.string,
-	module: React.PropTypes.object
+	module: React.PropTypes.object,
+	disableInDevMode: React.PropTypes.bool.isRequired,
+	isDevMode: React.PropTypes.bool.isRequired,
+	isSitePublic: React.PropTypes.bool.isRequired,
+	userCanManageModules: React.PropTypes.bool.isRequired,
+	isLinked: React.PropTypes.bool.isRequired,
+	isUnavailableInDevMode: React.PropTypes.func.isRequired
 };
 
 SettingsGroup.defaultProps = {
 	support: '',
-	module: {}
+	module: {},
+	disableInDevMode: false,
+	isDevMode: false,
+	isSitePublic: true,
+	userCanManageModules: false,
+	isLinked: false,
+	isUnavailableInDevMode: noop
 };
 
 export default connect(
 	state => {
 		return {
 			isDevMode: isDevMode( state ),
-			sitePlan: getSitePlan( state ),
 			isSitePublic: isSitePublic( state ),
 			userCanManageModules: userCanManageModules( state ),
+			isLinked: isCurrentUserLinked( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name )
 		};
 	}

--- a/_inc/client/components/settings-group/test/component.js
+++ b/_inc/client/components/settings-group/test/component.js
@@ -58,7 +58,11 @@ describe( 'SettingsGroup', () => {
 
 	let testProps = {
 		learn_more_button: 'https://jetpack.com/support/protect',
-		userCanManageModules: true
+		isDevMode: false,
+		isSitePublic: true,
+		userCanManageModules: true,
+		isLinked: true,
+		isUnavailableInDevMode: () => false
 	};
 
 	const settingsGroup = shallow( <SettingsGroup support={ testProps.learn_more_button } hasChild /> );
@@ -78,6 +82,38 @@ describe( 'SettingsGroup', () => {
 
 	it( 'does not have a learn more icon if there is no link or module are passed', () => {
 		expect( shallow( <SettingsGroup /> ).find( 'InfoPopover' ) ).to.have.length( 0 );
+	} );
+
+	describe( 'has a fading layer', () => {
+
+		it( 'visible in in Dev Mode', () => {
+			const disabled = {
+				disableInDevMode: true,
+				isUnavailableInDevMode: () => true
+			};
+			expect( shallow( <SettingsGroup { ...disabled } /> ).find( '.jp-form-block-fade' ) ).to.have.length( 1 );
+		} );
+
+		it( 'visible in Post by Email when user is unlinked', () => {
+			const disabled = {
+				module: {
+					module: 'post-by-email'
+				},
+				isLinked: false
+			};
+			expect( shallow( <SettingsGroup { ...disabled } /> ).find( '.jp-form-block-fade' ) ).to.have.length( 1 );
+		} );
+
+		it( 'not visible in Post by Email when user is linked', () => {
+			const disabled = {
+				module: {
+					module: 'post-by-email'
+				},
+				isLinked: true
+			};
+			expect( shallow( <SettingsGroup { ...disabled } /> ).find( '.jp-form-block-fade' ) ).to.have.length( 0 );
+		} );
+
 	} );
 
 	describe( 'When user is not an admin', () => {

--- a/_inc/client/components/settings-group/test/component.js
+++ b/_inc/client/components/settings-group/test/component.js
@@ -13,8 +13,52 @@ import { SettingsGroup } from '../index';
 
 describe( 'SettingsGroup', () => {
 
+	const allGroupsNonAdminCantAccess = [
+			'widget-visibility',
+			'minileven',
+			'contact-form',
+			'sitemaps',
+			'latex',
+			'carousel',
+			'tiled-gallery',
+			'custom-content-types',
+			'verification-tools',
+			'markdown',
+			'infinite-scroll',
+			'gravatar-hovercards',
+			'omnisearch',
+			'custom-css',
+			'sharedaddy',
+			'widgets',
+			'shortcodes',
+			'related-posts',
+			'videopress',
+			'monitor',
+			'sso',
+			'vaultpress',
+			'google-analytics',
+			'seo-tools',
+			'stats',
+			'wordads',
+			'manage',
+			'likes',
+			'shortlinks',
+			'notes',
+			'subscriptions',
+			'protect',
+			'enhanced-distribution',
+			'comments',
+			'json-api',
+			'photon'
+		],
+		allGroupsForNonAdmin = [
+			'after-the-deadline',
+			'post-by-email'
+		];
+
 	let testProps = {
-		learn_more_button: 'https://jetpack.com/support/protect'
+		learn_more_button: 'https://jetpack.com/support/protect',
+		userCanManageModules: true
 	};
 
 	const settingsGroup = shallow( <SettingsGroup support={ testProps.learn_more_button } hasChild /> );
@@ -35,4 +79,27 @@ describe( 'SettingsGroup', () => {
 	it( 'does not have a learn more icon if there is no link or module are passed', () => {
 		expect( shallow( <SettingsGroup /> ).find( 'InfoPopover' ) ).to.have.length( 0 );
 	} );
+
+	describe( 'When user is not an admin', () => {
+
+		Object.assign( testProps, {
+			userCanManageModules: false
+		} );
+
+		it( 'does not render groups that are not After the Deadline or Post by Email', () => {
+			allGroupsNonAdminCantAccess.forEach( item => {
+				testProps.module = item;
+				expect( shallow( <SettingsGroup module={ testProps } /> ).find( '.jp-form-settings-group' ) ).to.have.length( 0 );
+			} );
+		} );
+
+		it( 'renders After the Deadline and Post by Email groups', () => {
+			allGroupsForNonAdmin.forEach( item => {
+				testProps.module = item;
+				expect( shallow( <SettingsGroup module={ testProps } /> ).find( '.jp-form-settings-group' ) ).to.have.length( 1 );
+			} );
+		} );
+
+	} );
+
 } );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -86,6 +86,11 @@ export function userIsSubscriber( state ) {
 	return ! get( state.jetpack.initialState.userData.currentUser.permissions, 'edit_posts', false );
 }
 
+export function userIsContributor( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'edit_posts', false ) &&
+		! get( state.jetpack.initialState.userData.currentUser.permissions, 'publish_posts', false );
+}
+
 export function userCanManageModules( state ) {
 	return get( state.jetpack.initialState.userData.currentUser.permissions, 'manage_modules', false );
 }

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -86,9 +86,8 @@ export function userIsSubscriber( state ) {
 	return ! get( state.jetpack.initialState.userData.currentUser.permissions, 'edit_posts', false );
 }
 
-export function userIsContributor( state ) {
-	return get( state.jetpack.initialState.userData.currentUser.permissions, 'edit_posts', false ) &&
-		! get( state.jetpack.initialState.userData.currentUser.permissions, 'publish_posts', false );
+export function userCanPublish( state ) {
+	return get( state.jetpack.initialState.userData.currentUser.permissions, 'publish_posts', false );
 }
 
 export function userCanManageModules( state ) {

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -202,25 +202,32 @@ const Composing = moduleSettingsForm(
 				</SettingsGroup>
 			);
 
-			if ( this.props.userCanEditPosts ) {
+			if ( this.props.userCanManageModules || ( this.props.userCanEditPosts && this.props.getOptionValue( 'after-the-deadline' ) ) ) {
 				atdSettings = (
 					<div>
 						<FoldableCard
 							className={ classNames( 'jp-foldable-card__main-settings', { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
 							header={
+						this.props.userCanManageModules
+							? (
 								<ModuleToggle
 									slug="after-the-deadline"
 									compact
 									disabled={ unavailableInDevMode }
 									activated={ this.props.getOptionValue( 'after-the-deadline' ) }
 									toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
-									toggleModule={ this.props.toggleModuleNow }
-								>
+									toggleModule={ this.props.toggleModuleNow }>
 									<span className="jp-form-toggle-explanation">
 										{ atd.description }
 									</span>
 								</ModuleToggle>
-							}
+							)
+							: (
+								<span className="jp-form-toggle-explanation">
+									{ atd.description }
+								</span>
+							)
+						}
 						>
 							{ this.getAtdSettings() }
 						</FoldableCard>

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -182,58 +182,51 @@ const Composing = moduleSettingsForm(
 
 			const markdown = this.props.module( 'markdown' ),
 				atd = this.props.module( 'after-the-deadline' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' );
-
-			let atdSettings = false;
-
-			const markdownSettings = (
-				<SettingsGroup module={ markdown }>
-					<FormFieldset>
-						<ModuleToggle
-							slug="markdown"
-							activated={ !! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' ) }
-							toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
-							toggleModule={ this.updateFormStateByMarkdown }>
-							<span className="jp-form-toggle-explanation">
-								{ markdown.description }
-							</span>
-						</ModuleToggle>
-					</FormFieldset>
-				</SettingsGroup>
-			);
-
-			if ( this.props.userCanManageModules || ( this.props.userCanEditPosts && this.props.getOptionValue( 'after-the-deadline' ) ) ) {
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' ),
+				markdownSettings = (
+					<SettingsGroup module={ markdown }>
+						<FormFieldset>
+							<ModuleToggle
+								slug="markdown"
+								activated={ !! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' ) }
+								toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
+								toggleModule={ this.updateFormStateByMarkdown }>
+								<span className="jp-form-toggle-explanation">
+									{ markdown.description }
+								</span>
+							</ModuleToggle>
+						</FormFieldset>
+					</SettingsGroup>
+				),
 				atdSettings = (
-					<div>
-						<FoldableCard
-							className={ classNames( 'jp-foldable-card__main-settings', { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
-							header={
-						this.props.userCanManageModules
-							? (
-								<ModuleToggle
-									slug="after-the-deadline"
-									compact
-									disabled={ unavailableInDevMode }
-									activated={ this.props.getOptionValue( 'after-the-deadline' ) }
-									toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
-									toggleModule={ this.props.toggleModuleNow }>
-									<span className="jp-form-toggle-explanation">
-										{ atd.description }
-									</span>
-								</ModuleToggle>
-							)
-							: (
+					<FoldableCard
+						className={ classNames( 'jp-foldable-card__main-settings', {
+							'jp-foldable-settings-disable': unavailableInDevMode || ( ! this.props.userCanManageModules && this.props.userCanEditPosts && ! this.props.getOptionValue( 'after-the-deadline' ) ) } ) }
+						header={
+					this.props.userCanManageModules
+						? (
+							<ModuleToggle
+								slug="after-the-deadline"
+								compact
+								disabled={ unavailableInDevMode }
+								activated={ this.props.getOptionValue( 'after-the-deadline' ) }
+								toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
+								toggleModule={ this.props.toggleModuleNow }>
 								<span className="jp-form-toggle-explanation">
 									{ atd.description }
 								</span>
-							)
-						}
-						>
-							{ this.getAtdSettings() }
-						</FoldableCard>
-					</div>
+							</ModuleToggle>
+						)
+						: (
+							<span className="jp-form-toggle-explanation">
+								{ atd.description }
+							</span>
+						)
+					}
+					>
+						{ this.getAtdSettings() }
+					</FoldableCard>
 				);
-			}
 
 			return (
 				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props } module="composing">

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -184,8 +184,10 @@ const Composing = moduleSettingsForm(
 				atd = this.props.module( 'after-the-deadline' ),
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' );
 
+			let atdSettings = false;
+
 			const markdownSettings = (
-				<SettingsGroup support={ markdown.learn_more_button }>
+				<SettingsGroup module={ markdown }>
 					<FormFieldset>
 						<ModuleToggle
 							slug="markdown"
@@ -200,34 +202,34 @@ const Composing = moduleSettingsForm(
 				</SettingsGroup>
 			);
 
-			const atdHeader = (
-				<ModuleToggle
-					slug="after-the-deadline"
-					compact
-					disabled={ unavailableInDevMode }
-					activated={ this.props.getOptionValue( 'after-the-deadline' ) }
-					toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
-					toggleModule={ this.props.toggleModuleNow }
-				>
-					<span className="jp-form-toggle-explanation">
-						{ atd.description }
-					</span>
-				</ModuleToggle>
-			);
-
-			const atdSettings = (
-				<div>
-					<FoldableCard
-						className={ classNames( 'jp-foldable-card__main-settings', { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
-						header={ atdHeader }
-					>
-						{ this.getAtdSettings() }
-					</FoldableCard>
-				</div>
-			);
+			if ( this.props.userCanEditPosts ) {
+				atdSettings = (
+					<div>
+						<FoldableCard
+							className={ classNames( 'jp-foldable-card__main-settings', { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
+							header={
+								<ModuleToggle
+									slug="after-the-deadline"
+									compact
+									disabled={ unavailableInDevMode }
+									activated={ this.props.getOptionValue( 'after-the-deadline' ) }
+									toggling={ this.props.isSavingAnyOption( 'after-the-deadline' ) }
+									toggleModule={ this.props.toggleModuleNow }
+								>
+									<span className="jp-form-toggle-explanation">
+										{ atd.description }
+									</span>
+								</ModuleToggle>
+							}
+						>
+							{ this.getAtdSettings() }
+						</FoldableCard>
+					</div>
+				);
+			}
 
 			return (
-				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props }>
+				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props } module="composing">
 					{ this.props.isModuleFound( 'markdown' ) && markdownSettings }
 					{ this.props.isModuleFound( 'after-the-deadline' ) && atdSettings }
 				</SettingsCard>

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -200,8 +200,7 @@ const Composing = moduleSettingsForm(
 				),
 				atdSettings = (
 					<FoldableCard
-						className={ classNames( 'jp-foldable-card__main-settings', {
-							'jp-foldable-settings-disable': unavailableInDevMode || ( ! this.props.userCanManageModules && this.props.userCanEditPosts && ! this.props.getOptionValue( 'after-the-deadline' ) ) } ) }
+						className={ classNames( 'jp-foldable-card__main-settings', { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
 						header={
 					this.props.userCanManageModules
 						? (

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
-import { isDevMode, isUnavailableInDevMode } from 'state/connection';
+import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
 import { userCanEditPosts } from 'state/initial-state';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import QuerySite from 'components/data/query-site';
@@ -30,7 +30,7 @@ export const Writing = React.createClass( {
 			isUnavailableInDevMode: this.props.isUnavailableInDevMode
 		};
 
-		let found = [
+		const found = [
 			'markdown',
 			'after-the-deadline',
 			'custom-content-types',
@@ -56,7 +56,7 @@ export const Writing = React.createClass( {
 				<Media { ...commonProps } />
 				<CustomContentTypes { ...commonProps } />
 				<ThemeEnhancements { ...commonProps } />
-				<PostByEmail { ...commonProps } />
+				<PostByEmail { ...commonProps } isLinked={ this.props.isLinked } />
 			</div>
 		);
 	}
@@ -70,7 +70,8 @@ export default connect(
 			isDevMode: isDevMode( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
 			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
-			userCanEditPosts: userCanEditPosts( state )
+			userCanEditPosts: userCanEditPosts( state ),
+			isLinked: isCurrentUserLinked( state )
 		};
 	}
 )( Writing );

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  */
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
+import { userCanManageModules } from 'state/initial-state';
 import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
 import { userCanEditPosts } from 'state/initial-state';
 import { isModuleFound as _isModuleFound } from 'state/search';
@@ -52,11 +53,11 @@ export const Writing = React.createClass( {
 		return (
 			<div>
 				<QuerySite />
-				<Composing { ...commonProps } userCanEditPosts={ this.props.userCanEditPosts } />
+				<Composing { ...commonProps } userCanManageModules={ this.props.userCanManageModules } userCanEditPosts={ this.props.userCanEditPosts } />
 				<Media { ...commonProps } />
 				<CustomContentTypes { ...commonProps } />
 				<ThemeEnhancements { ...commonProps } />
-				<PostByEmail { ...commonProps } isLinked={ this.props.isLinked } />
+				<PostByEmail { ...commonProps } isLinked={ this.props.isLinked } userCanManageModules={ this.props.userCanManageModules } />
 			</div>
 		);
 	}
@@ -69,9 +70,10 @@ export default connect(
 			settings: getSettings( state ),
 			isDevMode: isDevMode( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
 			userCanEditPosts: userCanEditPosts( state ),
-			isLinked: isCurrentUserLinked( state )
+			isLinked: isCurrentUserLinked( state ),
+			userCanManageModules: userCanManageModules( state ),
+			isModuleFound: ( module_name ) => _isModuleFound( state, module_name )
 		};
 	}
 )( Writing );

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode } from 'state/connection';
+import { userCanEditPosts } from 'state/initial-state';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import QuerySite from 'components/data/query-site';
 import Composing from './composing';
@@ -51,7 +52,7 @@ export const Writing = React.createClass( {
 		return (
 			<div>
 				<QuerySite />
-				<Composing { ...commonProps } />
+				<Composing { ...commonProps } userCanEditPosts={ this.props.userCanEditPosts } />
 				<Media { ...commonProps } />
 				<CustomContentTypes { ...commonProps } />
 				<ThemeEnhancements { ...commonProps } />
@@ -68,7 +69,8 @@ export default connect(
 			settings: getSettings( state ),
 			isDevMode: isDevMode( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name )
-		}
+			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
+			userCanEditPosts: userCanEditPosts( state )
+		};
 	}
 )( Writing );

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
@@ -12,7 +14,8 @@ import { getSettings } from 'state/settings';
 import { userCanManageModules } from 'state/initial-state';
 import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
 import { userCanEditPosts } from 'state/initial-state';
-import { isModuleFound as _isModuleFound } from 'state/search';
+import { isModuleActivated } from 'state/modules';
+import { isModuleFound } from 'state/search';
 import QuerySite from 'components/data/query-site';
 import Composing from './composing';
 import Media from './media';
@@ -50,14 +53,34 @@ export const Writing = React.createClass( {
 			return null;
 		}
 
+		const showComposing = this.props.userCanManageModules ||
+				( this.props.userCanEditPosts && this.props.isModuleActivated( 'after-the-deadline' ) ),
+			showPostByEmail = this.props.userCanManageModules ||
+				( this.props.userCanEditPosts && this.props.isModuleActivated( 'post-by-email' ) );
+
 		return (
 			<div>
 				<QuerySite />
-				<Composing { ...commonProps } userCanManageModules={ this.props.userCanManageModules } userCanEditPosts={ this.props.userCanEditPosts } />
+				{
+					showComposing && (
+						<Composing { ...commonProps } userCanManageModules={ this.props.userCanManageModules } />
+					)
+				}
 				<Media { ...commonProps } />
 				<CustomContentTypes { ...commonProps } />
 				<ThemeEnhancements { ...commonProps } />
-				<PostByEmail { ...commonProps } isLinked={ this.props.isLinked } userCanManageModules={ this.props.userCanManageModules } />
+				{
+					showPostByEmail && (
+						<PostByEmail { ...commonProps } isLinked={ this.props.isLinked } userCanManageModules={ this.props.userCanManageModules } />
+					)
+				}
+				{
+					( ! showComposing && ! showPostByEmail ) && (
+						<Card>
+							{ __( 'Writing tools available to you will be shown here when an administrator enables them.' ) }
+						</Card>
+					)
+				}
 			</div>
 		);
 	}
@@ -71,9 +94,10 @@ export default connect(
 			isDevMode: isDevMode( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
 			userCanEditPosts: userCanEditPosts( state ),
+			isModuleActivated: module_name => isModuleActivated( state, module_name ),
 			isLinked: isCurrentUserLinked( state ),
 			userCanManageModules: userCanManageModules( state ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name )
+			isModuleFound: module_name => isModuleFound( state, module_name )
 		};
 	}
 )( Writing );

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -16,6 +16,7 @@ import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/co
 import { userCanEditPosts } from 'state/initial-state';
 import { isModuleActivated } from 'state/modules';
 import { isModuleFound } from 'state/search';
+import { getConnectUrl } from 'state/connection';
 import QuerySite from 'components/data/query-site';
 import Composing from './composing';
 import Media from './media';
@@ -71,7 +72,10 @@ export const Writing = React.createClass( {
 				<ThemeEnhancements { ...commonProps } />
 				{
 					showPostByEmail && (
-						<PostByEmail { ...commonProps } isLinked={ this.props.isLinked } userCanManageModules={ this.props.userCanManageModules } />
+						<PostByEmail { ...commonProps }
+							connectUrl={ this.props.connectUrl }
+							isLinked={ this.props.isLinked }
+							userCanManageModules={ this.props.userCanManageModules } />
 					)
 				}
 				{
@@ -97,7 +101,8 @@ export default connect(
 			isModuleActivated: module_name => isModuleActivated( state, module_name ),
 			isLinked: isCurrentUserLinked( state ),
 			userCanManageModules: userCanManageModules( state ),
-			isModuleFound: module_name => isModuleFound( state, module_name )
+			isModuleFound: module_name => isModuleFound( state, module_name ),
+			connectUrl: getConnectUrl( state )
 		};
 	}
 )( Writing );

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -41,9 +41,9 @@ const PostByEmail = moduleSettingsForm(
 		},
 
 		render() {
-			let postByEmail = this.props.getModule( 'post-by-email' ),
+			const postByEmail = this.props.getModule( 'post-by-email' ),
 				isPbeActive = this.props.getOptionValue( 'post-by-email' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'post-by-email' );
+				disabledControls = this.props.isUnavailableInDevMode( 'post-by-email' ) || ! this.props.isLinked;
 
 			if ( ! this.props.isModuleFound( 'post-by-email' ) ) {
 				return null;
@@ -58,7 +58,7 @@ const PostByEmail = moduleSettingsForm(
 						<ModuleToggle
 							slug="post-by-email"
 							compact
-							disabled={ unavailableInDevMode }
+							disabled={ disabledControls }
 							activated={ isPbeActive }
 							toggling={ this.props.isSavingAnyOption( 'post-by-email' ) }
 							toggleModule={ this.props.toggleModuleNow }
@@ -74,14 +74,14 @@ const PostByEmail = moduleSettingsForm(
 								<FormLegend>{ __( 'Email Address' ) }</FormLegend>
 								<ClipboardButtonInput
 									value={ this.address() }
-									disabled={ ! isPbeActive || unavailableInDevMode }
+									disabled={ ! isPbeActive || disabledControls }
 									copy={ __( 'Copy', { context: 'verb' } ) }
 									copied={ __( 'Copied!' ) }
 									prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
 								/>
 							</FormLabel>
 							<Button
-								disabled={ ! isPbeActive || unavailableInDevMode }
+								disabled={ ! isPbeActive || disabledControls }
 								onClick={ this.regeneratePostByEmailAddress } >
 								{ __( 'Regenerate address' ) }
 							</Button>
@@ -98,6 +98,6 @@ export default connect(
 		return {
 			module: ( module_name ) => getModule( state, module_name ),
 			isModuleFound: ( module_name ) => _isModuleFound( state, module_name )
-		}
+		};
 	}
 )( PostByEmail );

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -55,20 +55,27 @@ const PostByEmail = moduleSettingsForm(
 					module="post-by-email"
 					hideButton>
 					<SettingsGroup hasChild disableInDevMode module={ postByEmail }>
-						<ModuleToggle
-							slug="post-by-email"
-							compact
-							disabled={ disabledControls }
-							activated={ isPbeActive }
-							toggling={ this.props.isSavingAnyOption( 'post-by-email' ) }
-							toggleModule={ this.props.toggleModuleNow }
-						>
-						<span className="jp-form-toggle-explanation">
-							{
-								this.props.module( 'post-by-email' ).description
-							}
-						</span>
-						</ModuleToggle>
+						{
+							this.props.userCanManageModules
+								? (
+									<ModuleToggle
+										slug="post-by-email"
+										compact
+										disabled={ disabledControls }
+										activated={ isPbeActive }
+										toggling={ this.props.isSavingAnyOption( 'post-by-email' ) }
+										toggleModule={ this.props.toggleModuleNow }>
+										<span className="jp-form-toggle-explanation">
+											{ this.props.module( 'post-by-email' ).description }
+										</span>
+									</ModuleToggle>
+								)
+								: (
+									<span className="jp-form-toggle-explanation">
+										{ this.props.module( 'post-by-email' ).description }
+									</span>
+								)
+						}
 						<FormFieldset>
 							<FormLabel>
 								<FormLegend>{ __( 'Email Address' ) }</FormLegend>

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
 import ClipboardButtonInput from 'components/clipboard-button-input';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
@@ -94,6 +95,19 @@ const PostByEmail = moduleSettingsForm(
 							</Button>
 						</FormFieldset>
 					</SettingsGroup>
+					{
+						( ! this.props.isUnavailableInDevMode( 'post-by-email' ) && ! this.props.isLinked ) && (
+							<Card
+								compact
+								className="jp-settings-card__configure-link"
+								href={ `${ this.props.connectUrl }&from=unlinked-user-connect` }
+							>
+								{
+									__( 'Link your existing WordPress.com account to use Post by Email or create and link one for free.' )
+								}
+							</Card>
+						)
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -65,7 +65,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	function jetpack_add_settings_sub_nav_item() {
-		if ( ( Jetpack::is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) ) {
+		if ( ( Jetpack::is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) && current_user_can( 'edit_posts' ) ) {
 			global $submenu;
 			$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', Jetpack::admin_url( 'page=jetpack#/settings' ) );
 		}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -410,6 +410,7 @@ function jetpack_current_user_data() {
 			'network_admin'      => current_user_can( 'jetpack_network_admin_page' ),
 			'network_sites_page' => current_user_can( 'jetpack_network_sites_page' ),
 			'edit_posts'         => current_user_can( 'edit_posts' ),
+			'publish_posts'      => current_user_can( 'publish_posts' ),
 			'manage_options'     => current_user_can( 'manage_options' ),
 			'view_stats'		 => current_user_can( 'view_stats' ),
 			'manage_plugins'	 => current_user_can( 'install_plugins' )

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -858,6 +858,19 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			return current_user_can( 'jetpack_admin_page' );
 		} else {
 			$module = Jetpack_Core_Json_Api_Endpoints::get_module_requested();
+			if ( empty( $module ) ) {
+				$params = $request->get_json_params();
+				if ( ! is_array( $params ) ) {
+					$params = $request->get_body_params();
+				}
+				$options = Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list( $params );
+				foreach ( $options as $option => $definition ) {
+					if ( in_array( $options[ $option ]['jp_group'], array( 'after-the-deadline', 'post-by-email' ) ) ) {
+						$module = $options[ $option ]['jp_group'];
+						break;
+					}
+				}
+			}
 			// User is trying to create, regenerate or delete its PbE || ATD settings.
 			if ( 'post-by-email' === $module || 'after-the-deadline' === $module ) {
 				return current_user_can( 'edit_posts' ) && current_user_can( 'jetpack_admin_page' );


### PR DESCRIPTION
Fixes #6475

#### Changes proposed in this Pull Request:

* allow non admin to use After the Deadline, Post by Email, and, if Publicize is active, display the Sharing tab. This tab is not visible when only Sharing is active because it gives non admins the ability to change the appearance of the site and that's only something admins should do.

* extend GUI tests to verify that a non admin can access After the Deadline settings group, the Post by Email settings card. If Publicize is active, display the Sharing tab.

* if  user is unlinked, hide Sharing tab and block PbE settings card

* don't show main toggles when user can't manage modules

* the `/settings` endpoint was updated. There was an issue where it wasn't allowing non-admins to set AtD options or regenerate PbE address.

* if user is subscriber, don't show the notice "You are currently running a development version of Jetpack"

* when AtD or PbE are disabled don't show their card in settings available to non admins.

* if AtD and PbE are disabled, a message explaining why the tab is empty will be shown to non admins.

* if non admin is unlinked, display a clickable card explaining that PbE is disabled because the account needs to be linked

#### Testing instructions:

* log in as a non-admin and make sure you can see AtD and PbE. If Publicize is active, you should see the Sharing tab.
* contributors must not have the Sharing tab available
* disable AtD or PbE (not both), the disabled feature should no longer display a card for non admins
* disable both AtD and PbE, cards should not be displayed for non admins and instead a message should be displayed
* with PbE active, if user is unlinked, a message should be displayed below the card prompting user to link.