### PR TITLE
SSO: Modify new user override to return $user_data instead of role

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -656,8 +656,12 @@ class Jetpack_SSO {
 		}
 
 		// If we've still got nothing, create the user.
-		$new_user_override_role = false;
-		if ( empty( $user ) && ( get_option( 'users_can_register' ) || ( $new_user_override_role = Jetpack_SSO_Helpers::new_user_override( $user_data ) ) ) ) {
+		$new_user_override = Jetpack_SSO_Helpers::new_user_override( $user_data );
+		if ( empty( $user ) && ( get_option( 'users_can_register' ) || $new_user_override ) ) {
+			if ( is_object( $new_user_override ) ) {
+				$user_data = $new_user_override;
+			}
+
 			/**
 			 * If not matching by email we still need to verify the email does not exist
 			 * or this blows up
@@ -667,11 +671,6 @@ class Jetpack_SSO {
 			 * user, then we know that email is unused, so it's safe to add.
 			 */
 			if ( Jetpack_SSO_Helpers::match_by_email() || ! get_user_by( 'email', $user_data->email ) ) {
-				
-				if ( $new_user_override_role ) {
-					$user_data->role = $new_user_override_role;
-				}
-
 				$user = Jetpack_SSO_Helpers::generate_user( $user_data );
 				if ( ! $user ) {
 					JetpackTracking::record_user_event( 'sso_login_failed', array(
@@ -681,7 +680,7 @@ class Jetpack_SSO {
 					return;
 				}
 
-				$user_found_with = $new_user_override_role
+				$user_found_with = $new_user_override
 					? 'user_created_new_user_override'
 					: 'user_created_users_can_register';
 			} else {

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -49,14 +49,11 @@ class Jetpack_SSO_Helpers {
 	}
 
 	/**
-	 * Returns a boolean for whether users are allowed to register on the Jetpack site with SSO,
-	 * even though the site disallows normal registrations.
+	 * Returns an object if the user should be added to the site, even though the site disallows normal registrations.
 	 *
-	 * @return bool
+	 * @return object
 	 */
 	static function new_user_override( $user_data = null ) {
-		$new_user_override = defined( 'WPCC_NEW_USER_OVERRIDE' ) ? WPCC_NEW_USER_OVERRIDE : false;
-
 		/**
 		 * Allow users to register on your site with a WordPress.com account, even though you disallow normal registrations. 
 		 * If you return a string that corresponds to a user role, the user will be given that role.
@@ -66,20 +63,21 @@ class Jetpack_SSO_Helpers {
 		 * @since 2.6.0
 		 * @since 4.6   $user_data object is now passed to the jetpack_sso_new_user_override filter
 		 *
-		 * @param bool        $new_user_override Allow users to register on your site with a WordPress.com account. Default to false.
-		 * @param object|null $user_data         An object containing the user data returned from WordPress.com.
+		 * @param bool        false
+		 * @param object|null $user_data An object containing the user data returned from WordPress.com.
 		 */
-		$role = apply_filters( 'jetpack_sso_new_user_override', $new_user_override, $user_data );
+		$override = apply_filters( 'jetpack_sso_new_user_override', false, $user_data );
 
-		if ( $role ) {
-			if ( is_string( $role ) && get_role( $role ) ) {
-				return $role;
-			} else {
-				return get_option( 'default_role' );
-			}
+		// Handle legacy functionality of this method by returning the $user_data when the WPCC_NEW_USER_OVERRIDE constant
+		// or jetpack_sso_new_user_override filter are being used as previously expected.
+		if ( true === $override || (
+			Jetpack_Constants::is_defined( 'WPCC_NEW_USER_OVERRIDE' ) &&
+		    Jetpack_Constants::get_constant( 'WPCC_NEW_USER_OVERRIDE' )
+		) ) {
+			$override = $user_data;
 		}
 
-		return false;
+		return $override;
 	}
 
 	/**

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -75,32 +75,10 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		remove_filter( 'jetpack_sso_match_by_email', '__return_false' );
 	}
 
-	function test_sso_helpers_new_user_override_filter_true_returns_default_role() {
-		add_role( 'foo', 'Foo' );
-		update_option( 'default_role', 'foo' );
-		add_filter( 'jetpack_sso_new_user_override', '__return_true' );
-		$this->assertEquals( 'foo', Jetpack_SSO_Helpers::new_user_override() );
-		remove_filter( 'jetpack_sso_new_user_override', '__return_true' );
-	}
-
 	function test_sso_helpers_new_user_override_filter_false() {
 		add_filter( 'jetpack_sso_new_user_override', '__return_false' );
 		$this->assertFalse( Jetpack_SSO_Helpers::new_user_override() );
 		remove_filter( 'jetpack_sso_new_user_override', '__return_false' );
-	}
-
-	function test_sso_helpers_new_user_override_filter_rolename() {
-		add_filter( 'jetpack_sso_new_user_override', array( $this, 'return_administrator' ) );
-		$this->assertEquals( 'administrator', Jetpack_SSO_Helpers::new_user_override() );
-		remove_filter( 'jetpack_sso_new_user_override', array( $this, 'return_administrator' ) );
-	}
-
-	function test_sso_helpers_new_user_override_filter_bad_rolename_returns_default() {
-		add_role( 'foo', 'Foo' );
-		update_option( 'default_role', 'foo' );
-		add_filter( 'jetpack_sso_new_user_override', array( $this, 'return_foobarbaz' ) );
-		$this->assertEquals( 'foo', Jetpack_SSO_Helpers::new_user_override() );
-		remove_filter( 'jetpack_sso_new_user_override', array( $this, 'return_foobarbaz' ) );
 	}
 
 	function test_sso_helpers_sso_bypass_default_login_form_filter_true() {
@@ -265,6 +243,23 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 			'token'  => 'my-token',
 			'jetpack_json_api_original_query' => $original_request,
 		) );
+	}
+
+	function test_new_user_override_returns_user_data_for_legacy() {
+		$user_data = (object) array(
+			'username' => 'testuser',
+			'email'    => 'test@test.com',
+		);
+
+		$this->assertFalse( Jetpack_SSO_Helpers::new_user_override( $user_data ) );
+
+		Jetpack_Constants::set_constant( 'WPCC_NEW_USER_OVERRIDE', true );
+		$this->assertSame( $user_data, Jetpack_SSO_Helpers::new_user_override( $user_data ) );
+		Jetpack_Constants::clear_constants();
+
+		add_filter( 'jetpack_sso_new_user_override', '__return_true' );
+		$this->assertSame( $user_data, Jetpack_SSO_Helpers::new_user_override( $user_data ) );
+		remove_filter( 'jetpack_sso_new_user_override', '__return_true' );
 	}
 
 	function __return_string_value() {

--- a/tests/php/sync/test_class.jetpack-sync-sso.php
+++ b/tests/php/sync/test_class.jetpack-sync-sso.php
@@ -33,15 +33,6 @@ class WP_Test_Jetpack_Sync_SSO extends WP_Test_Jetpack_Sync_Base {
 		remove_filter( 'jetpack_sso_match_by_email', '__return_true' );
 	}
 
-	function test_sync_sso_new_user_override_filter_true() {
-		add_filter( 'jetpack_sso_new_user_override', '__return_true' );
-		update_option( 'default_role', 'subscriber' );
-		$this->sender->do_sync();
-		$callableValue = $this->server_replica_storage->get_callable( 'sso_new_user_override' );
-		$this->assertEquals( 'subscriber', $callableValue );
-		remove_filter( 'jetpack_sso_new_user_override', '__return_true' );
-	}
-
 	function test_sync_sso_sso_bypass_default_login_form_filter_true() {
 		add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
 		$this->sender->do_sync();


### PR DESCRIPTION
This PR modifies the `Jetpack_SSO_Helpers::new_user_override()` method to return an object with user data for when we should override and create the user. This is useful for automated transfer purposes.

I have added a test to make sure that we're still working properly with legacy usage of the `WPCC_NEW_USER_OVERRIDE` constant and the `jetpack_sso_new_user_override` filter.

To test, you'll want to hook on to the filter and add whatever conditional you'd like to the user_data, then if return $user_data to log the user in.

I have sample code that I'll share for reviewers.