### PR TITLE
DashItem: fix disabled overflow text shadow

### DIFF
--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -79,7 +79,8 @@
 	}
 	.dops-section-header__label {
 		padding-right: rem( 8px );
-
+	}
+	.dops-section-header__label-text {
 		&:before {
 			@include long-content-fade( $size: 8px, $color : $gray-light );
 		}


### PR DESCRIPTION
Before

<img width="734" alt="captura de pantalla 2017-02-28 a las 09 22 34" src="https://cloud.githubusercontent.com/assets/1041600/23405117/7fb46106-fd97-11e6-87ae-4a6de7105ba1.png">

After

<img width="736" alt="captura de pantalla 2017-02-28 a las 09 21 58" src="https://cloud.githubusercontent.com/assets/1041600/23405118/7fb5302c-fd97-11e6-883c-f3df24473894.png">