### PR TITLE
Remove jetpack_publicize_post action

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -464,7 +464,7 @@ class Publicize extends Publicize_Base {
 				 *
 				 * @param int The post ID
 				 */
-				do_action( 'jetpack_publicize_post', $post->ID );
+				do_action_deprecated( 'jetpack_publicize_post', $post->ID, '4.8.0', 'jetpack_published_post_flags' );
 			}
 			delete_post_meta( $post->ID, $this->PENDING );
 			update_post_meta( $post->ID, $this->POST_DONE . 'all', true );

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -32,7 +32,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		add_action( 'wp_insert_post', array( $this, 'wp_insert_post' ), $priority, 3 );
 
 		add_action( 'deleted_post', $callable, 10 );
-		add_action( 'jetpack_publicize_post', $callable );
 		add_action( 'jetpack_published_post', $callable, 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'save_published' ), 10, 3 );
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'filter_blacklisted_post_types' ) );

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -3,7 +3,7 @@ require dirname( __FILE__ ) . '/../../../../modules/publicize.php';
 
 class WP_Test_Publicize extends WP_UnitTestCase {
 
-	private $fired_publicized_post = false;
+
 	private $in_publish_filter = false;
 	private $publicized_post_id = null;
 	private $post;
@@ -12,7 +12,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->publicize = publicize_init();
-		$this->fired_publicized_post = false;
 		$this->publicized_post_id = null;
 
 		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
@@ -20,7 +19,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 
 		Jetpack_Options::update_options( array( 'publicize_connections' => array( 'facebook' => array( 'id_number' => array( 'connection_data' => array( 'user_id' => 0 ) ) ) ) ) );
 
-		add_action( 'jetpack_publicize_post', array( $this, 'publicized_post' ), 10, 1 );
 		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags_check' ), 20, 2 );
 	}
 
@@ -74,26 +72,22 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 
 	function assertPublicized( $should_have_publicized, $post ) {
 		if ( $should_have_publicized ) {
-			$this->assertTrue( $this->fired_publicized_post, 'Not Fired on publicize post' );
 			$this->assertEquals( $post->ID, $this->publicized_post_id, 'Is not the same post ID' );
 			$this->assertTrue( $this->in_publish_filter, 'Not in filter' );
 		} else {
-			$this->assertFalse( $this->fired_publicized_post, 'Fired publicize post' );
 			$this->assertNull( $this->publicized_post_id, 'Not Null' );
 			$this->assertFalse( $this->in_publish_filter, 'in filter' );
 		}
 	}
 
 	function set_post_flags_check( $flags, $post ) {
+		if ( $flags['publicize_post'] ) {
+			$this->publicized_post_id = $post->ID;
+		}
 		$this->in_publish_filter = $flags['publicize_post'];
 		return $flags;
 	}
-
-	function publicized_post( $post_id ) {
-		$this->fired_publicized_post = true;
-		$this->publicized_post_id = $post_id;
-	}
-
+	
 	function prevent_publicize_post( $should_publicize, $post ) {
 		return false;
 	}

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -9,12 +9,11 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEmpty( $this->sender->get_sync_queue()->get_all() );
 	}
 
-	function test_sends_publicize_action() {
+	function test_sends_publish_post_action() {
 		$post_id = $this->factory->post->create();
-		do_action( 'jetpack_publicize_post', $post_id );
 		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_publicize_post' );
+		$event = $this->server_event_storage->get_most_recent_event();
+		$this->assertEquals( 'jetpack_published_post', $event->action );
 		$this->assertEquals( $post_id, $event->args[0] );
 	}
 


### PR DESCRIPTION
Since we are using jetpack_published_post instead instead.
- deprecate the action.
- remove listeners
- update tests

This PR is mostly clean up.

#### Testing instructions:
* Publicize should work as expected. 
