### PR TITLE
SSO: Store initial nonce in cookie so that we are not requesting multiple nonces

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -32,6 +32,7 @@ class Jetpack_SSO {
 		add_action( 'jetpack_modules_loaded', array( $this, 'module_configure_button' ) );
 		add_action( 'login_form_logout',      array( $this, 'store_wpcom_profile_cookies_on_logout' ) );
 		add_action( 'jetpack_unlinked_user',  array( $this, 'delete_connection_for_user') );
+		add_action( 'wp_login',               array( 'Jetpack_SSO', 'clear_cookies_after_login' ) );
 
 		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
 		add_action( 'login_form_jetpack-sso', '__return_true' );
@@ -781,8 +782,6 @@ class Jetpack_SSO {
 				// Set that as the requested redirect to
 				$redirect_to = $_request_redirect_to = esc_url_raw( $_COOKIE['jetpack_sso_redirect_to'] );
 			}
-
-			self::clear_cookies_after_login();
 
 			$json_api_auth_environment = Jetpack_SSO_Helpers::get_json_api_auth_environment();
 

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -31,7 +31,6 @@ class Jetpack_SSO {
 		add_action( 'init',                   array( $this, 'maybe_logout_user' ), 5 );
 		add_action( 'jetpack_modules_loaded', array( $this, 'module_configure_button' ) );
 		add_action( 'login_form_logout',      array( $this, 'store_wpcom_profile_cookies_on_logout' ) );
-		add_action( 'wp_login',               array( 'Jetpack_SSO', 'clear_wpcom_profile_cookies' ) );
 		add_action( 'jetpack_unlinked_user',  array( $this, 'delete_connection_for_user') );
 
 		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
@@ -554,6 +553,44 @@ class Jetpack_SSO {
 		}
 	}
 
+	/**
+	 * Clear cookies that are no longer needed once the user has logged in.
+	 *
+	 * @since 4.8.0
+	 */
+	static function clear_cookies_after_login() {
+		self::clear_wpcom_profile_cookies();
+		if ( isset( $_COOKIE[ 'jetpack_sso_nonce' ] ) ) {
+			setcookie(
+				'jetpack_sso_nonce',
+				' ',
+				time() - YEAR_IN_SECONDS,
+				COOKIEPATH,
+				COOKIE_DOMAIN
+			);
+		}
+
+		if ( isset( $_COOKIE[ 'jetpack_sso_original_request' ] ) ) {
+			setcookie(
+				'jetpack_sso_original_request',
+				' ',
+				time() - YEAR_IN_SECONDS,
+				COOKIEPATH,
+				COOKIE_DOMAIN
+			);
+		}
+
+		if ( isset( $_COOKIE[ 'jetpack_sso_redirect_to' ] ) ) {
+			setcookie(
+				'jetpack_sso_redirect_to',
+				' ',
+				time() - YEAR_IN_SECONDS,
+				COOKIEPATH,
+				COOKIE_DOMAIN
+			);
+		}
+	}
+
 	static function delete_connection_for_user( $user_id ) {
 		if ( ! $wpcom_user_id = get_user_meta( $user_id, 'wpcom_user_id', true ) ) {
 			return;
@@ -577,17 +614,33 @@ class Jetpack_SSO {
 	}
 
 	static function request_initial_nonce() {
-		Jetpack::load_xml_rpc_client();
-		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => get_current_user_id(),
-		) );
-		$xml->query( 'jetpack.sso.requestNonce' );
+		$nonce = ! empty( $_COOKIE[ 'jetpack_sso_nonce' ] )
+			? $_COOKIE[ 'jetpack_sso_nonce' ]
+			: false;
 
-		if ( $xml->isError() ) {
-			return new WP_Error( $xml->getErrorCode(), $xml->getErrorMessage() );
+		if ( ! $nonce ) {
+			Jetpack::load_xml_rpc_client();
+			$xml = new Jetpack_IXR_Client( array(
+				'user_id' => get_current_user_id(),
+			) );
+			$xml->query( 'jetpack.sso.requestNonce' );
+
+			if ( $xml->isError() ) {
+				return new WP_Error( $xml->getErrorCode(), $xml->getErrorMessage() );
+			}
+
+			$nonce = $xml->getResponse();
+
+			setcookie(
+				'jetpack_sso_nonce',
+				$nonce,
+				time() + ( 10 * MINUTE_IN_SECONDS ),
+				COOKIEPATH,
+				COOKIE_DOMAIN
+			);
 		}
 
-		return $xml->getResponse();
+		return sanitize_key( $nonce );
 	}
 
 	/**
@@ -727,9 +780,9 @@ class Jetpack_SSO {
 			if ( ! empty( $_COOKIE['jetpack_sso_redirect_to'] ) ) {
 				// Set that as the requested redirect to
 				$redirect_to = $_request_redirect_to = esc_url_raw( $_COOKIE['jetpack_sso_redirect_to'] );
-				// And then purge it
-				setcookie( 'jetpack_sso_redirect_to', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
 			}
+
+			self::clear_cookies_after_login();
 
 			$json_api_auth_environment = Jetpack_SSO_Helpers::get_json_api_auth_environment();
 


### PR DESCRIPTION
Possible fix to #6388.

After adding some debug code on the WordPress.com side, as best as I can tell so far, this seems to be a cache issue. 

I added logging for when the nonces are created, and if I verify the nonce right after it is created, the nonce is valid.

I also added logging where we validate nonces, and I can see where it is failing. But, if I manually check through the terminal, the nonce returns valid.

So, for now, I'd like suggest this PR as a potential fix. Regardless of whether it fixes the issue as reported in #6388, it should get merged anyways since we don't need to make 2 nonce requests every time a user attempts to log in via SSO.

To test:

- Ensure site is connected to WP.com
- Turn on SSO
-Login, then logout
- Check cookies
- Ensure you see:
    - `jetpack_sso_nonce`
    - `jetpack_sso_original_request`
    - `jetpack_sso_redirect_to`
    - `jetpack_sso_wpcom_name_*`
    - `jetpack_sso_wpcom_gravatar_*`
- Log in with WP.com
- Ensure those cookies disappear after logging in via WP.com or with username and password