### PR TITLE
Fix: Ads + Infinite Scroll

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -101,9 +101,7 @@ class WordAds {
 	 * @since 4.5.0
 	 */
 	public static function is_infinite_scroll() {
-		return current_theme_supports( 'infinite-scroll' ) &&
-				class_exists( 'The_Neverending_Home_Page' ) &&
-				The_Neverending_Home_Page::got_infinity();
+		return class_exists( 'The_Neverending_Home_Page' ) && The_Neverending_Home_Page::got_infinity();
 	}
 
 	/**


### PR DESCRIPTION
This fixes an issue in Twenty Seventeen and other themes that don't appropriately declare support for infinite scroll (but actually do). Previously check for `current_theme_supports( 'infinite-scroll' )` would return false for entire infinite scroll check because it doesn't appropriately declare support.

Fortunately a check for `class_exists( 'The_Neverending_Home_Page' ) && The_Neverending_Home_Page::got_infinity();` is sufficient.

**To Test**
1. Activate Jetpack ads on your site
1. Activate Infinite scroll on your site
1. Activate Twenty Seventeen as your theme
1. Scroll down your front page such that you kick off a call to infinite scroll
1. More posts should load as expected (no blank white screen)