### PR TITLE
Widget Visibility: Fix select option in Customizer

### DIFF
--- a/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -162,7 +162,10 @@ jQuery( function( $ ) {
 	$( document ).on( 'change.widgetconditions', 'select.conditions-rule-minor', function() {
 		var $conditionsRuleMinor = $( this ),
 			$conditionsRuleMajor = $conditionsRuleMinor.siblings( 'select.conditions-rule-major' ),
-			$conditionsRuleHasChildren = $conditionsRuleMinor.siblings( 'span.conditions-rule-has-children' );
+			$conditionsRuleHasChildren = $conditionsRuleMinor.siblings( 'span.conditions-rule-has-children' ),
+			$condition = $conditionsRuleMinor.closest( '.condition' );
+
+		$condition.data( 'rule-minor', $conditionsRuleMinor.val() );
 
 		if ( $conditionsRuleMajor.val() === 'page' ) {
 			if ( $conditionsRuleMinor.val() in widget_conditions_parent_pages ) {


### PR DESCRIPTION
Fixes #6574

#### Changes proposed in this Pull Request:

* Change the `.condition` holder `data-rule-minor` attribute when the minor select is changed.

It appears that `.condition` data attribute is not updated when minor rules select is changed. Then when `buildMinorConditions` function is called the `minor` data is empty and the select looks broken.

#### Testing instructions:

* Install Jetpack 4.7 Beta.
* Go to Appearance > Customize > Widgets
* Select a Widget.
* Try to apply any option
* Make sure that the minor option doesn't disappear

