### PR TITLE
Infinite Scroll: Change button text on taxonomy page

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -748,6 +748,22 @@ class The_Neverending_Home_Page {
 		// Could be empty (posts) or an array of multiple post types.
 		// In the latter two cases cases, the default text is used, leaving the `infinite_scroll_js_settings` filter for further customization.
 		$post_type = self::wp_query()->get( 'post_type' );
+
+		// If it's a taxonomy, try to change the button text.
+		if ( is_tax() ) {
+			// Get current taxonomy slug.
+			$taxonomy_slug = self::wp_query()->get( 'taxonomy' );
+
+			// Get taxonomy settings.
+			$taxonomy = get_taxonomy( $taxonomy_slug );
+
+			// Check if the taxonomy is attached to one post type only and use its plural name.
+			// If not, use "Posts" without confusing the users.
+			if ( count( $taxonomy->object_type ) < 2 ) {
+				$post_type = $taxonomy->object_type[0];
+			}
+		}
+
 		if ( is_string( $post_type ) && ! empty( $post_type ) ) {
 			$post_type = get_post_type_object( $post_type );
 


### PR DESCRIPTION
Fixes #6568 

#### Changes proposed in this Pull Request:

* Change "Older Posts" button text, when we are on taxonomy page.
* If a taxonomy is attached to more that one post type, leave the text "Older Posts", without confusing the users.

#### Testing instructions:
* Enable Portfolio post type
* Change posts per page to 1 ( Settings -> Reading )
* Create at least two projects
* Create sample Project type ( Portfolio -> Project Types -> Add New )
* Assign the projects to that type
* Open that Project type archive
* Make sure that the button text is "Older Projects"
