### PR TITLE
Fixed a condition to show SEO configuration link.

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -172,7 +172,10 @@ export const Engagement = ( props ) => {
 		if ( element[0] === 'seo-tools' ) {
 			if ( 'undefined' === typeof props.sitePlan.product_slug && ! unavailableInDevMode ) {
 				proProps.configure_url = 'checking';
-			} else if ( props.sitePlan.product_slug === 'jetpack_business' ) {
+			} else if (
+				props.sitePlan.product_slug === 'jetpack_business' ||
+				props.sitePlan.product_slug === 'jetpack_business_monthly'
+			) {
 				proProps.configure_url = isModuleActive
 					? 'https://wordpress.com/settings/seo/' + props.siteRawUrl
 					: 'inactive';


### PR DESCRIPTION
Fixes the configuration link condition for monthly Pro plans.

#### Testing instructions:
* Get the monthly pro plan.
* Observe that there is a configuration link in the SEO card.
