### PR TITLE
Remove videopress local files

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -173,29 +173,17 @@ class Jetpack_VideoPress {
 	}
 
 	/**
-	 * An override for the attachment url, which returns back the WPCOM videopress original url,
-	 * if it is set to the the objects metadata. this allows us to show the original uploaded
-	 * file on the WPCOM architecture, instead of the locally uplodaded file,
-	 * which doeasn't exist.
+	 * An override for the attachment url, which returns back the WPCOM VideoPress processed url.
 	 *
-	 * TODO: Fix this so that it will return a VideoPress process url, to ensure that it is in MP4 format.
+	 * This is most a action proxy to the videopress_get_attachment_url() utility function.
 	 *
 	 * @param string $url
 	 * @param int $post_id
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function update_attachment_url_for_videopress( $url, $post_id ) {
-
-		if ( get_post_mime_type( $post_id ) === 'video/videopress' ) {
-			$meta = wp_get_attachment_metadata( $post_id );
-
-			if ( isset( $meta['original']['url'] ) ) {
-				$url = $meta['original']['url'];
-			}
-		}
-
-		return $url;
+		return videopress_get_attachment_url( $post_id );
 	}
 
 	/**

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -183,7 +183,11 @@ class Jetpack_VideoPress {
 	 * @return string
 	 */
 	public function update_attachment_url_for_videopress( $url, $post_id ) {
-		return videopress_get_attachment_url( $post_id );
+		if ( $videopress_url = videopress_get_attachment_url( $post_id ) ) {
+			return $videopress_url;
+		}
+
+		return $url;
 	}
 
 	/**

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -175,7 +175,7 @@ class Jetpack_VideoPress {
 	/**
 	 * An override for the attachment url, which returns back the WPCOM VideoPress processed url.
 	 *
-	 * This is most a action proxy to the videopress_get_attachment_url() utility function.
+	 * This is an action proxy to the videopress_get_attachment_url() utility function.
 	 *
 	 * @param string $url
 	 * @param int $post_id

--- a/modules/videopress/class.videopress-xmlrpc.php
+++ b/modules/videopress/class.videopress-xmlrpc.php
@@ -133,12 +133,6 @@ class VideoPress_XMLRPC {
 		// update the meta to tell us that we're processing or complete
 		update_post_meta( $id, 'videopress_status', videopress_is_finished_processing( $id ) ? 'complete' : 'processing' );
 
-		// Get the attached file and if there isn't one, then let's update it with the one from the server.
-		$file = get_attached_file( $id );
-		if ( ! $file && is_string( $info['original'] ) ) {
-			videopress_download_video( $info['original'], $id );
-		}
-
 		return true;
 	}
 

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -153,46 +153,6 @@ function videopress_download_poster_image( $url, $attachment_id ) {
 }
 
 /**
- * Downloads and sets a file to the given attachment.
- *
- * @param string $url
- * @param int $attachment_id
- * @return bool|WP_Error
- */
-function videopress_download_video( $url, $attachment_id ) {
-
-	if ( ! $attachment = get_post( $attachment_id ) )  {
-		return new WP_Error( 'invalid_attachment', __( 'Could not find video attachment', 'jetpack' ) );
-	}
-
-	$tmpfile   = download_url( $url );
-
-	$remote_file_path = parse_url( $url, PHP_URL_PATH );
-
-	$file_name =  pathinfo( $remote_file_path, PATHINFO_FILENAME ) . '.' . pathinfo( $remote_file_path, PATHINFO_EXTENSION );
-
-	$time = date( 'YYYY/MM', strtotime( $attachment->post_date ) );
-
-	if ( ! ( ( $uploads = wp_upload_dir( $time ) ) && false === $uploads['error'] ) ) {
-		return new WP_Error( 'video_save_failed', __( 'Could not save video', 'jetpack' ) );
-	}
-
-	$unique_filename = wp_unique_filename( $uploads['path'], $file_name );
-
-	$save_path = $uploads['path'] . DIRECTORY_SEPARATOR . $unique_filename;
-
-	if ( ! @ copy( $tmpfile, $save_path ) ) {
-		return new WP_Error( 'video_save_failed', __( 'Could not save video', 'jetpack' ) );
-	}
-
-	unlink( $tmpfile );
-
-	update_attached_file( $attachment_id, $save_path );
-
-	return true;
-}
-
-/**
  * Creates a local media library item of a remote VideoPress video.
  *
  * @param $guid

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -666,18 +666,22 @@ function video_get_post_by_guid( $guid ) {
  */
 function videopress_get_attachment_url( $post_id ) {
 
+	// We only handle VideoPress attachments.
 	if ( get_post_mime_type( $post_id ) !== 'video/videopress' ) {
 		return null;
 	}
 
 	$meta = wp_get_attachment_metadata( $post_id );
 
-	// If the video hasn't been transcoded to an HD mp4 yet, then don't continue, use the original url.
 	if ( ! isset( $meta['videopress']['files']['hd']['mp4'] ) ) {
+		// Use the original file as the url if it isn't transcoded yet.
+		if ( isset( $meta['original'] ) ) {
+			return $meta['original'];
+		}
+
+		// Otherwise, there isn't much we can do.
 		return null;
 	}
 
-	$filename = $meta['videopress']['files']['hd']['mp4'];
-
-	return $meta['videopress']['file_url_base']['https'] . $filename;
+	return $meta['videopress']['file_url_base']['https'] . $meta['videopress']['files']['hd']['mp4'];
 }

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -696,3 +696,28 @@ function video_get_post_by_guid( $guid ) {
 	return $post;
 }
 
+/**
+ * From the given VideoPress post_id, return back the appropriate attachment URL.
+ *
+ * When the MP4 hasn't been processed yet or this is not a VideoPress video, this will return null.
+ *
+ * @param int $post_id
+ * @return string|null
+ */
+function videopress_get_attachment_url( $post_id ) {
+
+	if ( get_post_mime_type( $post_id ) !== 'video/videopress' ) {
+		return null;
+	}
+
+	$meta = wp_get_attachment_metadata( $post_id );
+
+	// If the video hasn't been transcoded to an HD mp4 yet, then don't continue, use the original url.
+	if ( ! isset( $meta['videopress']['files']['hd']['mp4'] ) ) {
+		return null;
+	}
+
+	$filename = $meta['videopress']['files']['hd']['mp4'];
+
+	return $meta['videopress']['file_url_base']['https'] . $filename;
+}


### PR DESCRIPTION
This PR removes the use of locally downloaded (sideloaded) video files from the user's server and instead uses an attachment URL that points to the processed file for any video headers.

Fixes #6588

## To test

1) Upload a video
2) Test that it can be embedded in a post
3) Verify that it can be added as the Video header for the 2017 theme.