### PR TITLE
Settings UI: force mysteryman as avatar in Connections

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -420,7 +420,7 @@ function jetpack_current_user_data() {
 	$is_master_user = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
 	$dotcom_data    = Jetpack::get_connected_user_data();
 	// Add connected user gravatar to the returned dotcom_data.
-	$dotcom_data['avatar'] = get_avatar_url( $dotcom_data['email'] );
+	$dotcom_data['avatar'] = get_avatar_url( $dotcom_data['email'], array( 'size' => 64, 'default' => 'mysteryman' ) );
 
 	$current_user_data = array(
 		'isConnected' => Jetpack::is_user_connected( $current_user->ID ),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -299,9 +299,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	/**
 	 * Returns an array of modules and settings both as first class members of the object.
 	 *
-	 * @param Array $modules the result of an API request to get all modules.
+	 * @param array $modules the result of an API request to get all modules.
 	 *
-	 * @return Array flattened settings with modules.
+	 * @return array flattened settings with modules.
 	 */
 	function get_flattened_settings( $modules ) {
 		$settings = array();
@@ -380,32 +380,6 @@ function jetpack_show_jumpstart() {
 	}
 
 	return true;
-}
-
-/*
- * Gather data about the master user.
- *
- * @since 4.1.0
- *
- * @return array
- */
-function jetpack_master_user_data() {
-	$masterID = Jetpack_Options::get_option( 'master_user' );
-	if ( ! get_user_by( 'id', $masterID ) ) {
-		return false;
-	}
-
-	$jetpack_user = get_userdata( $masterID );
-	$wpcom_user   = Jetpack::get_connected_user_data( $jetpack_user->ID );
-	$gravatar     = get_avatar( $jetpack_user->ID, 40 );
-
-	$master_user_data = array(
-		'jetpackUser' => $jetpack_user,
-		'wpcomUser'   => $wpcom_user,
-		'gravatar'    => $gravatar,
-	);
-
-	return $master_user_data;
 }
 
 /**

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -416,7 +416,7 @@ function jetpack_master_user_data() {
  * @return array
  */
 function jetpack_current_user_data() {
-	global $current_user;
+	$current_user = wp_get_current_user();
 	$is_master_user = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
 	$dotcom_data    = Jetpack::get_connected_user_data();
 	// Add connected user gravatar to the returned dotcom_data.


### PR DESCRIPTION
The main change in this PR was [previously introduced](https://github.com/Automattic/jetpack/pull/6287/commits/b7fe648fc0613fdbeecc0e9b80e3362b54905686#diff-d8d5ed819214c3890a8dbe9ddceef2c7) but at some point [it got overwritten](https://github.com/Automattic/jetpack/blame/feature/settings-overhaul/_inc/lib/admin-pages/class.jetpack-react-page.php#L400), maybe during some merge.

#### Changes proposed in this Pull Request:

* Always use mystery man as avatar default.
* Fix user avatar dimensions.
* replace global `$current_user` with `wp_get_current_user()`
* remove unused function `jetpack_master_user_data()`

#### Testing instructions:

Easier way is to test with site in Dev Mode
* In Settings > Discussion, set **Default Avatar** to anything other than Mystery Person and save
* go to Jetpack > Dashboard, scroll down, the avatar in Connections should still be Mystery Person
* In Settings > Discussion, untick **Show Avatars** and save
* go to Jetpack > Dashboard, scroll down, and again, the avatar in Connections should still be Mystery Person