### PR TITLE
Settings UI: place Protect settings into foldable card

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -57,6 +57,9 @@
 			margin-top: rem( 16px );
 		}
 	}
+	.dops-foldable-card & {
+		padding-bottom: 16px;
+	}
 }
 
 .jp-form-toggle-explanation {
@@ -132,6 +135,11 @@
 	& > .jp-form-fieldset,
 	& > .jp-form-setting-explanation {
 		margin-left: rem( 36px );
+	}
+
+	.dops-foldable-card & > .jp-form-fieldset,
+	.dops-foldable-card & > .jp-form-setting-explanation {
+		margin-left: rem( 44px );
 	}
 }
 

--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -2,3 +2,47 @@
 	display: flex;
 	margin-bottom: 0;
 }
+
+.jp-form-settings-card .dops-foldable-card {
+	.dops-foldable-card__header {
+		color: #444;
+		padding-left: rem( 24px );
+		padding-right: rem( 24px );
+	}
+
+	.form-toggle__switch {
+		float: left;
+		margin-top: 2px;
+	}
+
+	.dops-foldable-card__header-text {
+		font-size: rem( 14px );
+	}
+
+	&.is-expanded .dops-foldable-card__content {
+		padding-right: rem( 24px );
+	}
+
+	&.jp-foldable-settings-disable .dops-foldable-card__header {
+		color: #dadada;
+	}
+
+	.dops-foldable-card__main {
+		@include breakpoint( ">480px" ) {
+			max-width: 85%;
+		}
+	}
+
+	.jp-form-settings-group .dops-card {
+		padding: 0;
+		box-shadow: none;
+	}
+
+	.dops-foldable-card__action {
+		right: rem( 10px );
+	}
+
+	.jp-module-settings__learn-more {
+		right: 2px;
+	}
+}

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -6,6 +6,8 @@ import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
 import Textarea from 'components/textarea';
 import includes from 'lodash/includes';
+import FoldableCard from 'components/foldable-card';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -62,66 +64,71 @@ export const Protect = moduleSettingsForm(
 		},
 
 		render() {
-			let isProtectActive = this.props.getOptionValue( 'protect' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'protect' );
+			const isProtectActive = this.props.getOptionValue( 'protect' ),
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'protect' ),
+				toggle = (
+					<ModuleToggle
+						slug="protect"
+						compact
+						disabled={ unavailableInDevMode }
+						activated={ isProtectActive }
+						toggling={ this.props.isSavingAnyOption( 'protect' ) }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						<span className="jp-form-toggle-explanation">
+							{ this.props.getModule( 'protect' ).description }
+						</span>
+					</ModuleToggle>
+				);
 			return (
 				<SettingsCard
 					{ ...this.props }
 					module="protect"
 					header={ __( 'Prevent brute force login attacks', { context: 'Settings header' } ) } >
-					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'protect' ) }>
-						<ModuleToggle
-							slug="protect"
-							compact
-							disabled={ unavailableInDevMode }
-							activated={ isProtectActive }
-							toggling={ this.props.isSavingAnyOption( 'protect' ) }
-							toggleModule={ this.props.toggleModuleNow }
-						>
-						<span className="jp-form-toggle-explanation">
-							{
-								this.props.getModule( 'protect' ).description
-							}
-						</span>
-						</ModuleToggle>
-						<FormFieldset>
-							{
-								this.props.currentIp && (
-									<div>
-										<div className="jp-form-label-wide">
+					<FoldableCard
+						header={ toggle }
+						className={ classNames( { 'jp-foldable-settings-disable': this.props.isUnavailableInDevMode( 'protect' ) } ) }
+					>
+						<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'protect' ) }>
+							<FormFieldset>
+								{
+									this.props.currentIp && (
+										<div>
+											<div className="jp-form-label-wide">
+												{
+													__( 'Your current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
+												}
+											</div>
 											{
-												__( 'Your current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
+												<Button
+													disabled={ ! isProtectActive || unavailableInDevMode || this.currentIpIsWhitelisted() }
+													onClick={ this.addToWhitelist }
+													>{ __( 'Add to whitelist' ) }</Button>
 											}
 										</div>
-										{
-											<Button
-												disabled={ ! isProtectActive || unavailableInDevMode || this.currentIpIsWhitelisted() }
-												onClick={ this.addToWhitelist }
-												>{ __( 'Add to whitelist' ) }</Button>
-										}
-									</div>
-								)
-							}
-							<FormLabel>
-								<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
-								<Textarea
-									disabled={ ! isProtectActive || unavailableInDevMode }
-									name={ 'jetpack_protect_global_whitelist' }
-									placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
-									onChange={ this.updateText }
-									value={ this.state.whitelist } />
-							</FormLabel>
-							<span className="jp-form-setting-explanation">
-								{
-									__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
-										components: {
-											br: <br />
-										}
-									} )
+									)
 								}
-							</span>
-						</FormFieldset>
-					</SettingsGroup>
+								<FormLabel>
+									<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
+									<Textarea
+										disabled={ ! isProtectActive || unavailableInDevMode }
+										name={ 'jetpack_protect_global_whitelist' }
+										placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
+										onChange={ this.updateText }
+										value={ this.state.whitelist } />
+								</FormLabel>
+								<span className="jp-form-setting-explanation">
+									{
+										__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
+											components: {
+												br: <br />
+											}
+										} )
+									}
+								</span>
+							</FormFieldset>
+						</SettingsGroup>
+					</FoldableCard>
 				</SettingsCard>
 			)
 		}


### PR DESCRIPTION
Fixes #6504

#### Changes proposed in this Pull Request:

* the options for Protect have been placed into a foldable card

#### Connected

<img width="733" alt="captura de pantalla 2017-03-07 a las 19 03 45" src="https://cloud.githubusercontent.com/assets/1041600/23680123/dfba875c-0368-11e7-8d7a-b1419f773af7.png">

<img width="731" alt="captura de pantalla 2017-03-07 a las 19 03 28" src="https://cloud.githubusercontent.com/assets/1041600/23680122/dfb5dffe-0368-11e7-974b-a4b6500f01af.png">

##### Inactive

<img width="731" alt="captura de pantalla 2017-03-07 a las 19 06 46" src="https://cloud.githubusercontent.com/assets/1041600/23680246/47e347c4-0369-11e7-86fc-e6cf6cc85420.png">

#### Dev Mode

<img width="733" alt="captura de pantalla 2017-03-07 a las 18 25 49" src="https://cloud.githubusercontent.com/assets/1041600/23679904/1b2423ee-0368-11e7-8412-b1ae9259e060.png">

<img width="738" alt="captura de pantalla 2017-03-07 a las 18 45 16" src="https://cloud.githubusercontent.com/assets/1041600/23679903/1b1d3af2-0368-11e7-803a-dda32c59521f.png">

#### Testing instructions:

❗️ Do `yarn distclean` && `yarn build` before testing❗️

* go to Security tab and make sure Protect looks and works fine.