### PR TITLE
Jetpack WordPress.com Toolbar Accessibility improvements

### DIFF
--- a/_inc/accessible-focus.js
+++ b/_inc/accessible-focus.js
@@ -1,0 +1,19 @@
+var keyboardNavigation = false,
+	keyboardNavigationKeycodes = [ 9, 32, 37, 38, 39, 40 ]; // keyCodes for tab, space, left, up, right, down respectively
+
+document.addEventListener( 'keydown', function( event ) {
+	if ( keyboardNavigation ) {
+		return;
+	}
+	if ( keyboardNavigationKeycodes.indexOf( event.keyCode ) !== -1 ) {
+		keyboardNavigation = true;
+		document.documentElement.classList.add( 'accessible-focus' );
+	}
+} );
+document.addEventListener( 'mouseup', function() {
+	if ( ! keyboardNavigation ) {
+		return;
+	}
+	keyboardNavigation = false;
+	document.documentElement.classList.remove( 'accessible-focus' );
+} );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -162,9 +162,10 @@ class A8C_WPCOM_Masterbar {
 		$wp_admin_bar->add_node( array(
 			'id'     => 'notes',
 			'title'  => '<span id="wpnt-notes-unread-count" class="wpnt-loading wpn-read"></span>
+						 <span class="screen-reader-text">Notifications</span>
 						 <span class="noticon noticon-bell"></span>',
 			'meta'   => array(
-				'html'  => '<div id="wpnt-notes-panel2" style="display:none" lang="'. esc_attr( $this->locale ) . '" dir="' . ( $this->is_rtl() ? 'rtl' : 'ltr' ) . '">' .
+				'html'  => '<div id="wpnt-notes-panel2" aria-hidden="true" style="display:none" lang="'. esc_attr( $this->locale ) . '" dir="' . ( $this->is_rtl() ? 'rtl' : 'ltr' ) . '">' .
 				           '<div class="wpnt-notes-panel-header">' .
 				           '<span class="wpnt-notes-header">' .
 				           __( 'Notifications', 'jetpack' ) .

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -166,7 +166,7 @@ class A8C_WPCOM_Masterbar {
 						 <span class="screen-reader-text">Notifications</span>
 						 <span class="noticon noticon-bell"></span>',
 			'meta'   => array(
-				'html'  => '<div id="wpnt-notes-panel2" aria-hidden="true" style="display:none" lang="'. esc_attr( $this->locale ) . '" dir="' . ( $this->is_rtl() ? 'rtl' : 'ltr' ) . '">' .
+				'html'  => '<div id="wpnt-notes-panel2" style="display:none" lang="'. esc_attr( $this->locale ) . '" dir="' . ( $this->is_rtl() ? 'rtl' : 'ltr' ) . '">' .
 				           '<div class="wpnt-notes-panel-header">' .
 				           '<span class="wpnt-notes-header">' .
 				           __( 'Notifications', 'jetpack' ) .

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -93,6 +93,7 @@ class A8C_WPCOM_Masterbar {
 			wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		}
 
+		wp_enqueue_script( 'accessible-focus', plugins_url( '_inc/build/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ) );
 	}
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -93,7 +93,7 @@ class A8C_WPCOM_Masterbar {
 			wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		}
 
-		wp_enqueue_script( 'accessible-focus', plugins_url( '_inc/build/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+		wp_enqueue_script( 'accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ) );
 	}
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -182,6 +182,7 @@ class A8C_WPCOM_Masterbar {
 
 	public function add_reader_submenu( $wp_admin_bar ) {
 		$wp_admin_bar->add_menu( array(
+			'parent' => 'root-default',
 			'id'    => 'newdash',
 			'title' => __( 'Reader', 'jetpack' ),
 			'href'  => '#',
@@ -277,11 +278,10 @@ class A8C_WPCOM_Masterbar {
 	}
 
 	public function wpcom_adminbar_add_secondary_groups( $wp_admin_bar ) {
-		$class = 'ab-top-secondary';
 		$wp_admin_bar->add_group( array(
-			'id'     => 'top-secondary',
+			'id'     => 'root-default',
 			'meta'   => array(
-				'class' => $class,
+				'class' => 'ab-top-menu',
 			),
 		) );
 
@@ -290,6 +290,13 @@ class A8C_WPCOM_Masterbar {
 			'id'     => 'blog-secondary',
 			'meta'   => array(
 				'class' => 'ab-sub-secondary',
+			),
+		) );
+
+		$wp_admin_bar->add_group( array(
+			'id'     => 'top-secondary',
+			'meta'   => array(
+				'class' => 'ab-top-secondary',
 			),
 		) );
 	}
@@ -494,6 +501,7 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		$wp_admin_bar->add_menu( array(
+			'parent' => 'root-default',
 			'id'    => 'blog',
 			'title' => __( 'My Sites', 'jetpack' ),
 			'href'  => '#',

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -93,7 +93,7 @@ class A8C_WPCOM_Masterbar {
 			wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		}
 
-		wp_enqueue_script( 'accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ) );
 	}
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -163,7 +163,7 @@ class A8C_WPCOM_Masterbar {
 		$wp_admin_bar->add_node( array(
 			'id'     => 'notes',
 			'title'  => '<span id="wpnt-notes-unread-count" class="wpnt-loading wpn-read"></span>
-						 <span class="screen-reader-text">Notifications</span>
+						 <span class="screen-reader-text">' . __( 'Notifications', 'jetpack' ) . '</span>
 						 <span class="noticon noticon-bell"></span>',
 			'meta'   => array(
 				'html'  => '<div id="wpnt-notes-panel2" style="display:none" lang="'. esc_attr( $this->locale ) . '" dir="' . ( $this->is_rtl() ? 'rtl' : 'ltr' ) . '">' .

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -8,6 +8,28 @@
     content: none;
 }
 
+/* Add a focus style for menu items */
+.accessible-focus #wpadminbar li.menupop a.ab-item:focus,
+.accessible-focus #wpadminbar li#wp-admin-bar-notes.menupop .ab-item:focus,
+.accessible-focus #wpadminbar ul li#wp-admin-bar-ab-new-post a:focus {
+	-webkit-box-shadow: inset  2px  2px 0 #668eaa,
+	                    inset -2px -2px 0 #668eaa;
+	box-shadow: inset  2px  2px 0 #668eaa,
+	            inset -2px -2px 0 #668eaa;
+}
+
+/* Menu items in panels are inside `ab-empty-item` */
+.accessible-focus #wpadminbar li.menupop .ab-empty-item a.ab-item:focus {
+	-webkit-box-shadow: inset  2px  2px 0 #2e4354,
+						inset -2px -2px 0 #2e4354;
+	box-shadow: inset  2px  2px 0 #2e4354,
+				inset -2px -2px 0 #2e4354;
+}
+
+.accessible-focus #wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus {
+	background: transparent;
+}
+
 /* Change notification icon the match the one on WP.com */
 #wp-admin-bar-notes .noticon-bell:before {
     content: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cmVjdCB4PSIwIiBmaWxsPSJub25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiLz48Zz48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNNi4xNCAxNC45N2wyLjgyOCAyLjgyN2MtLjM2Mi4zNjItLjg2Mi41ODYtMS40MTQuNTg2LTEuMTA1IDAtMi0uODk1LTItMiAwLS41NTIuMjI0LTEuMDUyLjU4Ni0xLjQxNHptOC44NjcgNS4zMjRMMTQuMyAyMSAzIDkuN2wuNzA2LS43MDcgMS4xMDIuMTU3Yy43NTQuMTA4IDEuNjktLjEyMiAyLjA3Ny0uNTFsMy44ODUtMy44ODRjMi4zNC0yLjM0IDYuMTM1LTIuMzQgOC40NzUgMHMyLjM0IDYuMTM1IDAgOC40NzVsLTMuODg1IDMuODg2Yy0uMzg4LjM4OC0uNjE4IDEuMzIzLS41MSAyLjA3N2wuMTU3IDEuMXoiLz48L2c+PC9zdmc+") !important;

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -24,11 +24,20 @@
 }
 
 /* Menu items in panels are inside `ab-empty-item` */
-.accessible-focus #wpadminbar li.menupop .ab-empty-item a.ab-item:focus {
+.accessible-focus #wpadminbar li.menupop .ab-empty-item a.ab-item:focus,
+.accessible-focus #wpadminbar li.menupop .ab-empty-item a.ab-secondary:focus,
+.accessible-focus #wpadminbar li.menupop .ab-empty-item a.username:focus {
 	-webkit-box-shadow: inset  2px  2px 0 #2e4354,
 						inset -2px -2px 0 #2e4354;
 	box-shadow: inset  2px  2px 0 #2e4354,
 				inset -2px -2px 0 #2e4354;
+}
+
+.accessible-focus #wpadminbar .quicklinks li#wp-admin-bar-my-account #wp-admin-bar-user-info .ab-sign-out:focus {
+	-webkit-box-shadow: inset  2px  2px 0 #2e4354,
+						inset -2px -2px 0 #2e4354 !important;
+	box-shadow: inset  2px  2px 0 #2e4354,
+				inset -2px -2px 0 #2e4354 !important;
 }
 
 .accessible-focus #wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus {

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -30,6 +30,22 @@
 	background: transparent;
 }
 
+/* Hide the panels initially */
+#wpadminbar li#wp-admin-bar-blog.menupop > .ab-sub-wrapper, /* My Sites */
+#wpadminbar li#wp-admin-bar-newdash.menupop > .ab-sub-wrapper, /* Reader */
+#wpadminbar li#wp-admin-bar-my-account.menupop > .ab-sub-wrapper, /* Me */
+#wpadminbar li#wp-admin-bar-notes.menupop > #wpnt-notes-panel2 { /* Notifications */
+	display: none !important;
+}
+
+/* Show the panels when the item is active */
+#wpadminbar li#wp-admin-bar-blog.menupop.ab-active > .ab-sub-wrapper, /* My Sites */
+#wpadminbar li#wp-admin-bar-newdash.menupop.ab-active > .ab-sub-wrapper, /* Reader */
+#wpadminbar li#wp-admin-bar-my-account.menupop.ab-active > .ab-sub-wrapper, /* Me */
+#wpadminbar li#wp-admin-bar-notes.menupop.wpnt-show > #wpnt-notes-panel2 { /* Notifications */
+	display: block !important;
+}
+
 /* Change notification icon the match the one on WP.com */
 #wp-admin-bar-notes .noticon-bell:before {
     content: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cmVjdCB4PSIwIiBmaWxsPSJub25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiLz48Zz48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNNi4xNCAxNC45N2wyLjgyOCAyLjgyN2MtLjM2Mi4zNjItLjg2Mi41ODYtMS40MTQuNTg2LTEuMTA1IDAtMi0uODk1LTItMiAwLS41NTIuMjI0LTEuMDUyLjU4Ni0xLjQxNHptOC44NjcgNS4zMjRMMTQuMyAyMSAzIDkuN2wuNzA2LS43MDcgMS4xMDIuMTU3Yy43NTQuMTA4IDEuNjktLjEyMiAyLjA3Ny0uNTFsMy44ODUtMy44ODRjMi4zNC0yLjM0IDYuMTM1LTIuMzQgOC40NzUgMHMyLjM0IDYuMTM1IDAgOC40NzVsLTMuODg1IDMuODg2Yy0uMzg4LjM4OC0uNjE4IDEuMzIzLS41MSAyLjA3N2wuMTU3IDEuMXoiLz48L2c+PC9zdmc+") !important;

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -8,6 +8,11 @@
     content: none;
 }
 
+/* Overwrite a core style which breaks the overflow for .my-sites in Safari */
+#wpadminbar li.menupop.my-sites {
+	overflow: visible;
+}
+
 /* Add a focus style for menu items */
 .accessible-focus #wpadminbar li.menupop a.ab-item:focus,
 .accessible-focus #wpadminbar li#wp-admin-bar-notes.menupop .ab-item:focus,


### PR DESCRIPTION
**This PR is done against `add/masterbar-module`, in an effort to add accessibility before the toolbar is merged**

Improved the keyboard accessibility and screen reader experience when using the WordPress.com toolbar in Jetpack sites.

- Add screen reader text for the Notifications icon
- Added focus styling to all links
- Add default group explicitly so that the HTML menu order matches display (for more intuitive keyboard navigation)
- Add accessible-focus script from calypso

This PR also fixes a bug in Safari where the "My Sites" dropdown was hidden by a overzealous core style on `.my-sites`.

There are fixes that needed to happen in the WordPress.com code as well, so make sure to have D4639-code applied to your sandbox when testing.

**To test**

1. Check out this branch on your Jetpack site
2. Apply D4639-code to your sandbox
3. Make sure the WordPress.com Toolbar is enabled under Jetpack > Settings > General
4. Use your keyboard to navigate through the toolbar
5. Use a screen reader ([VoiceOver](https://href.li/?http://webaim.org/articles/voiceover/), [NVDA](https://href.li/?http://webaim.org/blog/testing-with-the-nvda-screen-reader/), [JAWS](https://href.li/?http://webaim.org/articles/jaws/)) to navigate through the toolbar

Getting into the notifications with VoiceOver was a little tricky, but I think it's an improvement from previously.

See #6413