### PR TITLE
Widget Visibility - Fix broken dropdowns after updating to 4.7

### DIFF
--- a/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -200,7 +200,10 @@ jQuery( function( $ ) {
 			select = condition.find( '.conditions-rule-minor' ).html( '' ),
 			major = condition.data( 'rule-major' );
 
-		if ( ! major ) {
+		// Disable the select, if major rule is empty or if it's a `post_type`.
+		// "Post Type" rule has been removed in Jetpack 4.7, and
+		// because it breaks all other rules we should `return`.
+		if ( ! major || 'post_type' === major ) {
 			select.attr( 'disabled', 'disabled' );
 			return;
 		}


### PR DESCRIPTION
Fixes #6596 #6595

#### Changes proposed in this Pull Request:

* Fix broken dropdowns after updating to 4.7

Since "Post Type" option has been removed in 4.7, there is an js error when you open the widget visibility after updating from 4.6 to 4.7. The `majorData` variable is empty and it prevents other conditions to be shown. This PR adds a check that the `major` rule is not `post_type` and additional check that `widget_conditions_data` has the property, before we make anything.

![visibility-options-error](https://cldup.com/gC8o7M3SyF-3000x3000.png)

#### Testing instructions:

* Install Jetpack 4.6
* Add a widget to any sidebar
* Add a Post Type rule in the beginning 
* Add other rule/rules ( it doesn't matter which one )
* Update to Jetpack 4.7
* Check that all other rules except the "Post type" one are displayed ( similar to the following image )
![visibility-options](https://cldup.com/fM1puzTOlC-3000x3000.png)
