### PR TITLE
Subscriptions - Fix already subscribed email notification

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -530,10 +530,10 @@ class Jetpack_Subscriptions {
 			case 'invalid_email':
 				$result = $error;
 				break;
-			case 'active':
 			case 'blocked_email':
 				$result = 'opted_out';
 				break;
+			case 'active':
 			case 'pending':
 				$result = 'already';
 				break;


### PR DESCRIPTION
Fixes #3110

#### Changes proposed in this Pull Request:

* Show the correct notification, when the email is already subscribed.

#### Testing instructions:

* Activate "Subscription" module.
* Add "Blog Subscription" widget to any sidebar.
* Subscribe to the blog.
* Refresh the page and make sure that `$_GET` params are removed from URL ( ?subscribe= )
* Subscribe again.
* You should see the following message:
"You have already subscribed to this site. Please check your inbox."
