### PR TITLE
Contact Form: Prevent PHP notices when processing contact form in widget

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -273,10 +273,17 @@ class Grunion_Contact_Form_Plugin {
 			$widget = isset( $GLOBALS['wp_registered_widgets'][ $this->current_widget_id ] ) ? $GLOBALS['wp_registered_widgets'][ $this->current_widget_id ] : false;
 
 			if ( $sidebar && $widget && isset( $widget['callback'] ) ) {
+				// prevent PHP notices by populating widget args
+				$widget_args = array(
+					'before_widget' => '',
+					'after_widget' => '',
+					'before_title' => '',
+					'after_title' => '',
+				);
 				// This is lamer - no API for outputting a given widget by ID
 				ob_start();
 				// Process the widget to populate Grunion_Contact_Form::$last
-				call_user_func( $widget['callback'], array(), $widget['params'][0] );
+				call_user_func( $widget['callback'], $widget_args, $widget['params'][0] );
 				ob_end_clean();
 			}
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* When a Contact Form is placed in a text widget, submissions generate PHP notices, e.g.:

```
[08-Mar-2017 15:00:41 UTC] PHP Notice:  Undefined index: before_widget in /path/to/wp-includes/widgets/class-wp-widget-text.php on line 75
[08-Mar-2017 15:00:41 UTC] PHP Notice:  Undefined index: before_title in /path/to/wp-includes/widgets/class-wp-widget-text.php on line 77
[08-Mar-2017 15:00:41 UTC] PHP Notice:  Undefined index: after_title in /path/to/wp-includes/widgets/class-wp-widget-text.php on line 77
[08-Mar-2017 15:00:41 UTC] PHP Notice:  Undefined index: after_widget in /path/to/wp-includes/widgets/class-wp-widget-text.php on line 81
```

This PR pre-populates the widget callback's `$args` array with dummy items that prevent these PHP notices.

#### Testing instructions:

Before:

* Place a Contact Form in a text widget
* Submit the Contact Form one or more times
* Watch your logs fill up with notices

After:

* Place a Contact Form in a text widget
* Submit the Contact Form one or more times
* Smile!