### PR TITLE
Markdown: enable for posts whenever the module is active.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -349,6 +349,11 @@ class Jetpack {
 					Jetpack_Options::delete_option( 'identity_crisis_whitelist' );
 				}
 
+				// Make sure Markdown for posts gets turned back on
+				if ( ! get_option( 'wpcom_publish_posts_with_markdown' ) ) {
+					update_option( 'wpcom_publish_posts_with_markdown', true );
+				}
+
 				Jetpack::maybe_set_version_option();
 			}
 		}

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -13,3 +13,17 @@
  */
 
 include dirname( __FILE__ ) . '/markdown/easy-markdown.php';
+
+/**
+ * Remove checkbox set in modules/markdown/easy-markdown.php.
+ * We don't just remove the register_setting call there because the checkbox is
+ * needed on WordPress.com, where the file is sync'ed verbatim.
+ */
+function jetpack_markdown_posting_always_on() {
+	// why oh why isn't there a remove_settings_field?
+	global $wp_settings_fields;
+	if ( isset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] ) ) {
+		unset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] );
+	}
+}
+add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -13,30 +13,3 @@
  */
 
 include dirname( __FILE__ ) . '/markdown/easy-markdown.php';
-
-/**
- * Markdown should be enabled for posts whenever the module is active.
- * We don't need any additional checkbox in Settings > Writing for that option.
- *
- * In addition to the filter above, the option is also automatically set when
- * the Markdown module is activated, thanks to the jetpack_activate_module_markdown filter.
- *
- * @see https://github.com/Automattic/jetpack/pull/6548
- */
-
-// Step 1. Force the option on whenever this file is loaded (i.e. when the module is acive).
-add_filter( 'pre_option_' . WPCom_Markdown::POST_OPTION, '__return_true' );
-
-/**
- * Step 2: remove checkbox set in modules/markdown/easy-markdown.php.
- * We don't just remove the register_setting call there because the checkbox is
- * needed on WordPress.com, where the file is sync'ed verbatim.
- */
-function jetpack_markdown_posting_always_on() {
-	// why oh why isn't there a remove_settings_field?
-	global $wp_settings_fields;
-	if ( isset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] ) ) {
-		unset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] );
-	}
-}
-add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -13,3 +13,30 @@
  */
 
 include dirname( __FILE__ ) . '/markdown/easy-markdown.php';
+
+/**
+ * Markdown should be enabled for posts whenever the module is active.
+ * We don't need any additional checkbox in Settings > Writing for that option.
+ *
+ * In addition to the filter above, the option is also automatically set when
+ * the Markdown module is activated, thanks to the jetpack_activate_module_markdown filter.
+ *
+ * @see https://github.com/Automattic/jetpack/pull/6548
+ */
+
+// Step 1. Force the option on whenever this file is loaded (i.e. when the module is acive).
+add_filter( 'pre_option_' . WPCom_Markdown::POST_OPTION, '__return_true' );
+
+/**
+ * Step 2: remove checkbox set in modules/markdown/easy-markdown.php.
+ * We don't just remove the register_setting call there because the checkbox is
+ * needed on WordPress.com, where the file is sync'ed verbatim.
+ */
+function jetpack_markdown_posting_always_on() {
+	// why oh why isn't there a remove_settings_field?
+	global $wp_settings_fields;
+	if ( isset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] ) ) {
+		unset( $wp_settings_fields['writing']['default'][ WPCom_Markdown::POST_OPTION ] );
+	}
+}
+add_action( 'admin_init', 'jetpack_markdown_posting_always_on', 11 );


### PR DESCRIPTION
Enable markdown for posts on plugin upgrade.  

The filter that forcefully enabled this when markdown was enabled was removed in #6406.  On plugin upgrade it will be re-enabled.

Fixes #6605

Related:
- https://github.com/Automattic/jetpack/pull/6406
- https://github.com/Automattic/jetpack/pull/6548

#### Proposed changelog entry for your changes:
* Markdown: always enable for posts whenever the module is active.