### PR TITLE
Remove 'header-footer' from conflicting plugins

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -223,7 +223,6 @@ class Jetpack {
 		'facebook-thumb-fixer/_facebook-thumb-fixer.php',        // Facebook Thumb Fixer
 		'facebook-and-digg-thumbnail-generator/facebook-and-digg-thumbnail-generator.php',
 		                                                         // Fedmich's Facebook Open Graph Meta
-		'header-footer/plugin.php',                              // Header and Footer
 		'network-publisher/networkpub.php',                      // Network Publisher
 		'nextgen-facebook/nextgen-facebook.php',                 // NextGEN Facebook OG
 		'social-networks-auto-poster-facebook-twitter-g/NextScripts_SNAP.php',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* [header-footer](https://wordpress.org/plugins/header-footer/) plugin no longer supports facebook open graph metatag, so it's not conflicting now:

https://plugins.svn.wordpress.org/header-footer/3.0.3/options.php
> The Facebook open graph metatag are no more supported. Please install a specialized plugin, you can find many on wordpress.org/plugins.
> The configuration panel is kept so you can get the original configurations.

#### Testing instructions:

* Install header-footer plugin
* Check if the open graph meta tag is working

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Remove 'header-footer' from conflicting plugins