### PR TITLE
Settings UI: fix Dev Mode mobile spacing

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -98,7 +98,7 @@ export const DevModeNotice = React.createClass( {
 				reasons.push( __( '{{li}}The jetpack_development_mode filter is active{{/li}}',
 					{
 						components: {
-							li: <li />,
+							li: <li />
 						}
 					}
 				) );
@@ -107,7 +107,7 @@ export const DevModeNotice = React.createClass( {
 				reasons.push( __( '{{li}}The JETPACK_DEV_DEBUG constant is defined{{/li}}',
 					{
 						components: {
-							li: <li />,
+							li: <li />
 						}
 					}
 				) );
@@ -116,7 +116,7 @@ export const DevModeNotice = React.createClass( {
 				reasons.push( __( '{{li}}Your site URL lacks a dot (e.g. http://localhost){{/li}}',
 					{
 						components: {
-							li: <li />,
+							li: <li />
 						}
 					}
 				) );

--- a/_inc/client/components/jetpack-notices/style.scss
+++ b/_inc/client/components/jetpack-notices/style.scss
@@ -1,1 +1,8 @@
-// Nothing here yet. 
+.dops-notice {
+	ul {
+		@include breakpoint( "<480px" ) {
+			margin: 0 rem( 48px ) rem( 8px );
+			font-size: rem( 12px );
+		}
+	}
+}

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -31,6 +31,7 @@
 @import '../components/dev-card/style';
 @import '../components/loading-placeholder/style';
 @import '../components/jetpack-connect/style';
+@import '../components/jetpack-notices/style';
 @import '../components/jumpstart/style';
 @import '../components/masthead/style';
 @import '../components/module-settings/style';


### PR DESCRIPTION
Fixes #6551

While we might revisit this later, I'm just adding the minimum so it doesn't look broken right now.

#### Changes proposed in this Pull Request:

Before

<img width="405" alt="captura de pantalla 2017-03-09 a las 13 47 08" src="https://cloud.githubusercontent.com/assets/1041600/23760885/d79db766-04cf-11e7-9914-7390a907b38a.png">

After

<img width="424" alt="captura de pantalla 2017-03-09 a las 13 57 24" src="https://cloud.githubusercontent.com/assets/1041600/23761051/5bd60da8-04d0-11e7-9176-fb1e8ded51c8.png">

#### Testing instructions:

* Put site in Dev Mode and reduce screen size.
