### PR TITLE
Settings UI: update dash items header text color to match Calypso

### DIFF
--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -42,10 +42,6 @@
 		font-style: normal;
 	}
 
-	.dops-section-header__label {
-		color: $gray-text-min;
-	}
-
 	&.is-working,
 	&.is-premium-inactive {
 		.dops-section-header__actions {


### PR DESCRIPTION
Companion to https://github.com/Automattic/dops-components/pull/99

#### Changes proposed in this Pull Request:

* remove color overriding and use color from dops component which follows Calypso

Before

<img width="366" alt="captura de pantalla 2017-03-09 a las 18 18 25" src="https://cloud.githubusercontent.com/assets/1041600/23771190/d0c420c2-04f4-11e7-9e97-7f8d17cbc650.png">

After

<img width="362" alt="captura de pantalla 2017-03-09 a las 18 13 24" src="https://cloud.githubusercontent.com/assets/1041600/23771171/bff408a2-04f4-11e7-9f17-c5a94a3c22c2.png">


#### Testing instructions:

* check that the text color of the dash item headers are dark

