### PR TITLE
Social Links: Still fire hooks outside of admin

### DIFF
--- a/modules/theme-tools/social-links.php
+++ b/modules/theme-tools/social-links.php
@@ -78,14 +78,6 @@ class Social_Links {
 	}
 
 	public function admin_setup() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
-		if ( ! is_admin() && ! $this->is_customize_preview() ) {
-			return;
-		}
-
 		$this->publicize = publicize_init();
 		$publicize_services = $this->publicize->get_services( 'connected' );
 		$this->services  = array_intersect( array_keys( $publicize_services ), $this->theme_supported_services );


### PR DESCRIPTION
On WP.com, these actions should always be added since Calypso hits outside of admin through the API.

WIP: Jetpack needs better hooks since the publicize_connect/disconnect don't fire on Jetpack.