### PR TITLE
Widgets - Image: use code like the one that adds support for Text widget

### DIFF
--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -69,14 +69,7 @@ class Jetpack_Image_Widget extends WP_Widget {
 
 		if ( '' != $instance['img_url'] ) {
 
-			$image_url = Jetpack::is_module_active( 'photon' )
-				? jetpack_photon_url( $instance['img_url'], array(
-                                        'w' => $instance['img_width'],
-                                        'h' => $instance['img_height'],
-                                  ) )
-				: $instance['img_url'];
-
-			$output = '<img src="' . esc_url( $image_url ) . '" ';
+			$output = '<img src="' . esc_url( $instance['img_url'] ) . '" ';
 
 			if ( '' != $instance['alt_text'] ) {
 				$output .= 'alt="' . esc_attr( $instance['alt_text'] ) .'" ';
@@ -94,6 +87,11 @@ class Jetpack_Image_Widget extends WP_Widget {
 				$output .= 'height="' . esc_attr( $instance['img_height'] ) .'" ';
 			}
 			$output .= '/>';
+
+			if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+				$output = Jetpack_Photon::filter_the_content( $output );
+			}
+
 			if ( '' != $instance['link'] ) {
 				$target = ! empty( $instance['link_target_blank'] )
 					? 'target="_blank"'


### PR DESCRIPTION
Related #6599

#### Changes proposed in this Pull Request:

* make routines for photonization similar to those to enable support in Text widget. Unlike before, where the URL was built, this will parse a `<img />` tag just like it would do in content or Text widget and use the `resize` mode which is more reliable.

Note that this doesn't solve the issue of the poor resampling experienced in Firefox. This seems to be a common occurrence since it also happens with images placed in the Text widget.
The difference between Blink and Gecko is that the `zoom` parameter isn't sent from Gecko. The `srcset` attribute isn't built, so the image served is a non-hidpi one.

To the left, you can see how Image and Text widget render in Chrome, and to the right how Firefox does
<img width="1113" alt="photon" src="https://cloud.githubusercontent.com/assets/1041600/23809781/c178a1e2-05ad-11e7-9ec9-69c6b39703df.png">

#### Testing instructions:

1. Add a Image widget. Use an image around 1000x1000 for better results. Set image URL and Width/Height to 200/150 respectively.
2. Add a Text widget and introduce `<img src="URL TO SOME IMAGE" width="200" height="150" />` in it.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Widgets - Image: improve rendering of image.
