### PR TITLE
Add in the ability to get thumbnails for VideoPress via media endpoint.

### DIFF
--- a/modules/videopress/class.videopress-xmlrpc.php
+++ b/modules/videopress/class.videopress-xmlrpc.php
@@ -155,18 +155,25 @@ class VideoPress_XMLRPC {
 			return false;
 		}
 
+		// Switch to photon if needed.
+		$poster = str_replace(
+			'https://videos.files.wordpress.com',
+			'https://i0.wp.com/videos.files.wordpress.com',
+			$poster
+		);
+
+		$meta = wp_get_attachment_metadata( $post_id );
+		$meta['videopress']['poster'] = $poster;
+		wp_update_attachment_metadata( $post_id, $meta );
+
 		// Update the poster in the VideoPress info.
 		$thumbnail_id = videopress_download_poster_image( $poster, $post_id );
 
-		if ( !is_int( $thumbnail_id ) ) {
+		if ( ! is_int( $thumbnail_id ) ) {
 			return false;
 		}
 
 		update_post_meta( $post_id, '_thumbnail_id', $thumbnail_id );
-		$meta = wp_get_attachment_metadata( $post_id );
-
-		$meta['videopress']['poster'] = $poster;
-		wp_update_attachment_metadata( $post_id, $meta );
 
 		return true;
 	}

--- a/modules/videopress/class.videopress-xmlrpc.php
+++ b/modules/videopress/class.videopress-xmlrpc.php
@@ -155,12 +155,8 @@ class VideoPress_XMLRPC {
 			return false;
 		}
 
-		// Switch to photon if needed.
-		$poster = str_replace(
-			'https://videos.files.wordpress.com',
-			'https://i0.wp.com/videos.files.wordpress.com',
-			$poster
-		);
+		// We add ssl => 1 to make sure that the videos.files.wordpress.com domain is parsed as photon.
+		$poster = apply_filters( 'jetpack_photon_url', $poster, array( 'ssl' => 1 ), 'https' );
 
 		$meta = wp_get_attachment_metadata( $post_id );
 		$meta['videopress']['poster'] = $poster;

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -558,17 +558,22 @@ function videopress_make_media_upload_path( $blog_id ) {
 function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$post = get_post( $post_id );
 
+	$video_info = new stdClass();
+	$video_info->post_id = $post_id;
+	$video_info->blog_id = $blog_id;
+	$video_info->guid = null;
+	$video_info->finish_date_gmt = '0000-00-00 00:00:00';
+
 	if ( is_wp_error( $post ) ) {
-		return false;
+		return $video_info;
 	}
 
 	if ( 'video/videopress' !== $post->post_mime_type ) {
-		return false;
+		return $video_info;
 	}
 
-	$video_info = new stdClass();
+	// Since this is a VideoPress post, lt's fill out the rest of the object.
 	$video_info->guid = get_post_meta( $post_id, 'videopress_guid', true );
-	$video_info->finish_date_gmt = '0000-00-00 00:00:00';
 
 	if ( videopress_is_finished_processing( $post_id ) ) {
 		$video_info->finish_date_gmt = date( 'Y-m-d H:i:s' );
@@ -576,3 +581,122 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 
 	return $video_info;
 }
+
+
+/**
+ * Check that a VideoPress video format has finished processing.
+ *
+ * This uses the info object, because that is what the WPCOM endpoint
+ * uses, however we don't have a complete info object in the same way
+ * WPCOM does, so we pull the meta information out of the post
+ * options instead.
+ *
+ * Note: This mimics the WPCOM function of the same name and helps the media
+ * API endpoint add all needed VideoPress data.
+ *
+ * @param stdClass $info
+ * @param string $format
+ * @return bool
+ */
+function video_format_done( $info, $format ) {
+
+	// Avoids notice when a non-videopress item is found.
+	if ( ! is_object( $info ) ) {
+		return false;
+	}
+
+	$post_id = $info->post_id;
+
+	if ( get_post_mime_type( $post_id ) !== 'video/videopress' ) {
+		return false;
+	}
+
+	$post = get_post( $post_id );
+
+	if ( is_wp_error( $post ) ) {
+		return false;
+	}
+
+	$meta = wp_get_attachment_metadata( $post->ID );
+
+	switch ( $format ) {
+		case 'fmt_hd':
+			return isset( $meta['videopress']['files']['hd']['mp4'] );
+			break;
+
+		case 'fmt_dvd':
+			return isset( $meta['videopress']['files']['dvd']['mp4'] );
+			break;
+
+		case 'fmt_std':
+			return isset( $meta['videopress']['files']['std']['mp4'] );
+			break;
+
+		case 'fmt_ogg':
+			return isset( $meta['videopress']['files']['std']['ogg'] );
+			break;
+	}
+
+	return false;
+}
+
+/**
+ * Get the image URL for the given VideoPress GUID
+ *
+ * We look up by GUID, because that is what WPCOM does and this needs to be
+ * parameter compatible with that.
+ *
+ * Note: This mimics the WPCOM function of the same name and helps the media
+ * API endpoint add all needed VideoPress data.
+ *
+ * @param string $guid
+ * @param string $format
+ * @return string
+ */
+function video_image_url_by_guid( $guid, $format ) {
+
+	$post = video_get_post_by_guid( $guid );
+
+	if ( is_wp_error( $post ) ) {
+		return null;
+	}
+
+	$meta = wp_get_attachment_metadata( $post->ID );
+
+	// Switch to photon if needed.
+	$poster = str_replace(
+		'https://videos.files.wordpress.com',
+		'https://i0.wp.com/videos.files.wordpress.com',
+		$meta['videopress']['poster']
+	);
+
+	return $poster;
+}
+
+/**
+ * Using a GUID, find a post.
+ *
+ * @param string $guid
+ * @return WP_Post
+ */
+function video_get_post_by_guid( $guid ) {
+	$args = array(
+		'post_type' 	 => 'attachment',
+		'post_mime_type' => 'video/videopress',
+		'post_status' 	 => 'inherit',
+		'meta_query' 	 => array(
+			array(
+				'key' 	  => 'videopress_guid',
+				'value'   => $guid,
+				'compare' => '=',
+			)
+		)
+	);
+
+	$query = new WP_Query( $args );
+
+	$post = $query->next_post();
+
+	return $post;
+}
+

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -663,12 +663,8 @@ function video_image_url_by_guid( $guid, $format ) {
 
 	$meta = wp_get_attachment_metadata( $post->ID );
 
-	// Switch to photon if needed.
-	$poster = str_replace(
-		'https://videos.files.wordpress.com',
-		'https://i0.wp.com/videos.files.wordpress.com',
-		$meta['videopress']['poster']
-	);
+	// We add ssl => 1 to make sure that the videos.files.wordpress.com domain is parsed as photon.
+	$poster = apply_filters( 'jetpack_photon_url', $meta['videopress']['poster'], array( 'ssl' => 1 ), 'https' );
 
 	return $poster;
 }


### PR DESCRIPTION
When we pushed out VideoPress, it was missing poster thumbnails. This is needed to make Calypso work correctly with Jetpack sites.

This PR seeks to add thumbnails by adding the wpcom functions that the API tries to call, to add in the images.

Request: Can we get this in the next point release for Jetpack, to make sure we get Calypso working ASAP?

## Testing

Simply check the media library in Calypso and make sure thumbnails are loading.

If checking the output for the media API for a Jetpack site, you should see the thumbnails reporting in there like this:

<img width="786" alt="screen shot 2017-03-10 at 11 49 22 pm" src="https://cloud.githubusercontent.com/assets/195095/23804386/4b58b472-05ec-11e7-9b17-8a8343c53a30.png">
