### PR TITLE
Open Graph: make sure transients are used to save image IDs.

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -302,10 +302,9 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 			if ( $image_url ) {
 				/**
 				 * Transient names are 45 chars max.
-				 * Let's generate a hash that's 41 chars max:
-				 * We will add 'jp_' in front of it later, so 45 chars minus those 3, and a one-off char just in in case.
+				 * Let's generate a hash that's never more than 40 chars long.
 				 */
-				$image_hash = substr( md5( $image_url ), 0, 41 );
+				$image_hash = sha1( $image_url );
 			}
 
 			// Look for data in our transient. If nothing, let's get an attachment ID.

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -298,14 +298,13 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 			$image_url = blavatar_url( $blavatar_domain, 'img', $width, false, true );
 
-			// Build a hash of the Image URL. We'll use it later when building the transient.
-			if ( $image_url ) {
-				/**
-				 * Transient names are 45 chars max.
-				 * Let's generate a hash that's never more than 40 chars long.
-				 */
-				$image_hash = sha1( $image_url );
-			}
+			/**
+			 * Build a hash of the Image URL. We'll use it later when building the transient.
+			 *
+			 * Transient names are 45 chars max.
+			 * Let's generate a hash that's never more than 40 chars long.
+			 */
+			$image_hash = sha1( $image_url );
 
 			// Look for data in our transient. If nothing, let's get an attachment ID.
 			$cached_image_id = get_transient( 'jp_' . $image_hash );

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -354,27 +354,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 
 		$max_side = max( $width, $height );
 		$image_url = get_site_icon_url( $max_side );
-
-		// Build a hash of the Image URL. We'll use it later when building the transient.
-		if ( $image_url ) {
-			/**
-			 * Transient names are 45 chars max.
-			 * Let's generate a hash that's 41 chars max:
-			 * We will add 'jp_' in front of it later, so 45 chars minus those 3, and a one-off char just in case.
-			 */
-			$image_hash = substr( md5( $image_url ), 0, 41 );
-		}
-
-		// Look for data in our transient. If nothing, let's get an attachment ID.
-		$cached_image_id = get_transient( 'jp_' . $image_hash );
-		if ( ! is_int( $cached_image_id ) ) {
-			$image_id = get_option( 'site_icon' );
-			set_transient( 'jp_' . $image_hash, $image_id );
-		} else {
-			// We have data in the transient. Use it.
-			$image_id = $cached_image_id;
-		}
-
+		$image_id = get_option( 'site_icon' );
 		$image_size = wp_get_attachment_image_src( $image_id, $max_side >= 512
 			? 'full'
 			: array( $max_side, $max_side ) );
@@ -412,7 +392,7 @@ function jetpack_og_get_image( $width = 200, $height = 200, $max_images = 4 ) { 
 * @param $width      int  Width of the image
 * @param $height     int  Height of the image
 * @param $req_width  int  Required width to pass validation
-* @param $req_height int  Required height to pass validation 
+* @param $req_height int  Required height to pass validation
 * @return bool - True if the image passed the required size validation
 */
 function _jetpack_og_get_image_validate_size($width, $height, $req_width, $req_height) {


### PR DESCRIPTION
In #6297, we added transients to cache some of the fallback images in jetpack_og_get_image().
However, transients can only be 45 chars maximum.
To work around that limitation, we now create a 44-char string using md5, based on the image URL.

Also added back changes to Site Icon brought in #6303, and accidentally reverted in #6297.

Fixes 144-gh-jpop-issues

#### Proposed changelog entry for your changes:
* Open Graph: make sure transients are used to save image IDs.
* Open Graph: make sure Site Icons are used as fallback Open Graph Image tags.