### PR TITLE
Social Media Icons Widget: update Instagram base URL.

### DIFF
--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -65,7 +65,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 		$this->services = array(
 			'facebook'   => array( 'Facebook', 'https://www.facebook.com/%s/' ),
 			'twitter'    => array( 'Twitter', 'https://twitter.com/%s/' ),
-			'instagram'  => array( 'Instagram', 'https://instagram.com/%s/' ),
+			'instagram'  => array( 'Instagram', 'https://www.instagram.com/%s/' ),
 			'pinterest'  => array( 'Pinterest', 'https://www.pinterest.com/%s/' ),
 			'linkedin'   => array( 'LinkedIn', 'https://www.linkedin.com/in/%s/' ),
 			'github'     => array( 'GitHub', 'https://github.com/%s/' ),


### PR DESCRIPTION
Instagram now uses www. in all its URLs.

#### Proposed changelog entry for your changes:
* Social Media Icons Widget: update Instagram base URL to use `www`.