### PR TITLE
Open Graph: do not return images smaller than required size.

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -368,14 +368,14 @@ class Jetpack_PostImages {
 				continue;
 			}
 
-			$meta['width']  = $image_tag->getAttribute( 'width' );
-			$meta['height'] = $image_tag->getAttribute( 'height' );
+			$meta['width']  = (int) $image_tag->getAttribute( 'width' );
+			$meta['height'] = (int) $image_tag->getAttribute( 'height' );
 
 			// Must be larger than 200x200 (or user-specified).
-			if ( ! isset( $meta['width'] ) || $meta['width'] < $width ) {
+			if ( ! empty( $meta['width'] ) || $meta['width'] < $width ) {
 				continue;
 			}
-			if ( ! isset( $meta['height'] ) || $meta['height'] < $height ) {
+			if ( ! empty( $meta['height'] ) || $meta['height'] < $height ) {
 				continue;
 			}
 

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -359,7 +359,7 @@ class Jetpack_PostImages {
 		foreach ( $image_tags as $image_tag ) {
 			$img_src = $image_tag->getAttribute( 'src' );
 
-			if ( ! isset( $img_src ) || empty( $img_src ) ) {
+			if ( empty( $img_src ) ) {
 				continue;
 			}
 

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -363,7 +363,8 @@ class Jetpack_PostImages {
 				continue;
 			}
 
-			if ( stristr( $img_src, '/smilies/' ) ) {
+			// Do not grab smiley images that were automatically created by WP when entering text smilies.
+			if ( stripos( $img_src, '/smilies/' ) ) {
 				continue;
 			}
 

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -372,10 +372,10 @@ class Jetpack_PostImages {
 			$meta['height'] = (int) $image_tag->getAttribute( 'height' );
 
 			// Must be larger than 200x200 (or user-specified).
-			if ( ! empty( $meta['width'] ) || $meta['width'] < $width ) {
+			if ( empty( $meta['width'] ) || $meta['width'] < $width ) {
 				continue;
 			}
-			if ( ! empty( $meta['height'] ) || $meta['height'] < $height ) {
+			if ( empty( $meta['height'] ) || $meta['height'] < $height ) {
 				continue;
 			}
 
@@ -620,7 +620,7 @@ class Jetpack_PostImages {
 		if( function_exists( 'jetpack_photon_url' ) ) {
 			return jetpack_photon_url( $src, array( 'resize' => "$width,$height" ) );
 		}
-		
+
 		// Arg... no way to resize image using WordPress.com infrastructure!
 		return $src;
 	}

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -317,10 +317,16 @@ class Jetpack_PostImages {
 
 	/**
 	 * Very raw -- just parse the HTML and pull out any/all img tags and return their src
-	 * @param  mixed $html_or_id The HTML string to parse for images, or a post id
+	 *
+	 * @param mixed $html_or_id The HTML string to parse for images, or a post id.
+	 * @param int   $width      Minimum Image width.
+	 * @param int   $height     Minimum Image height.
+	 *
+	 * @uses DOMDocument
+	 *
 	 * @return Array containing images
 	 */
-	static function from_html( $html_or_id ) {
+	static function from_html( $html_or_id, $width = 200, $height = 200 ) {
 		$images = array();
 
 		if ( is_numeric( $html_or_id ) ) {
@@ -330,7 +336,7 @@ class Jetpack_PostImages {
 				return $images;
 			}
 
-			$html = $post->post_content; // DO NOT apply the_content filters here, it will cause loops
+			$html = $post->post_content; // DO NOT apply the_content filters here, it will cause loops.
 		} else {
 			$html = $html_or_id;
 		}
@@ -339,21 +345,48 @@ class Jetpack_PostImages {
 			return $images;
 		}
 
-		preg_match_all( '!<img.*src=[\'"]([^"]+)[\'"].*/?>!iUs', $html, $matches );
-		if ( !empty( $matches[1] ) ) {
-			foreach ( $matches[1] as $match ) {
-				if ( stristr( $match, '/smilies/' ) )
-					continue;
-
-				$images[] = array(
-					'type'  => 'image',
-					'from'  => 'html',
-					'src'   => html_entity_decode( $match ),
-					'href'  => '', // No link to apply to these. Might potentially parse for that as well, but not for now
-				);
-			}
+		// Do not go any further if DOMDocument is disabled on the server.
+		if ( ! class_exists( 'DOMDocument' ) ) {
+			return $images;
 		}
 
+		// Let's grab all image tags from the HTML.
+		$dom_doc = new DOMDocument;
+		$dom_doc->loadHTML( $html );
+		$image_tags = $dom_doc->getElementsByTagName( 'img' );
+
+		// For each image Tag, make sure it can be added to the $images array, and add it.
+		foreach ( $image_tags as $image_tag ) {
+			$img_src = $image_tag->getAttribute( 'src' );
+
+			if ( ! isset( $img_src ) || empty( $img_src ) ) {
+				continue;
+			}
+
+			if ( stristr( $img_src, '/smilies/' ) ) {
+				continue;
+			}
+
+			$meta['width']  = $image_tag->getAttribute( 'width' );
+			$meta['height'] = $image_tag->getAttribute( 'height' );
+
+			// Must be larger than 200x200 (or user-specified).
+			if ( ! isset( $meta['width'] ) || $meta['width'] < $width ) {
+				continue;
+			}
+			if ( ! isset( $meta['height'] ) || $meta['height'] < $height ) {
+				continue;
+			}
+
+			$images[] = array(
+				'type'  => 'image',
+				'from'  => 'html',
+				'src'   => $img_src,
+				'src_width'  => $meta['width'],
+				'src_height' => $meta['height'],
+				'href'  => '', // No link to apply to these. Might potentially parse for that as well, but not for now.
+			);
+		}
 		return $images;
 	}
 

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -352,7 +352,13 @@ class Jetpack_PostImages {
 
 		// Let's grab all image tags from the HTML.
 		$dom_doc = new DOMDocument;
+
+		// The @ is not enough to suppress errors when dealing with libxml,
+		// we have to tell it directly how we want to handle errors.
+		libxml_use_internal_errors( true );
 		$dom_doc->loadHTML( $html );
+		libxml_use_internal_errors( false );
+
 		$image_tags = $dom_doc->getElementsByTagName( 'img' );
 
 		// For each image Tag, make sure it can be added to the $images array, and add it.

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -374,8 +374,10 @@ class Jetpack_PostImages {
 				continue;
 			}
 
-			$meta['width']  = (int) $image_tag->getAttribute( 'width' );
-			$meta['height'] = (int) $image_tag->getAttribute( 'height' );
+			$meta = array(
+				'width'  => (int) $image_tag->getAttribute( 'width' ),
+				'height' => (int) $image_tag->getAttribute( 'height' ),
+			);
 
 			// Must be larger than 200x200 (or user-specified).
 			if ( empty( $meta['width'] ) || $meta['width'] < $width ) {

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -356,7 +356,7 @@ class Jetpack_PostImages {
 		// The @ is not enough to suppress errors when dealing with libxml,
 		// we have to tell it directly how we want to handle errors.
 		libxml_use_internal_errors( true );
-		$dom_doc->loadHTML( $html );
+		@$dom_doc->loadHTML( $html );
 		libxml_use_internal_errors( false );
 
 		$image_tags = $dom_doc->getElementsByTagName( 'img' );

--- a/tests/php/_inc/lib/test_class.jetpack-media-extractor.php
+++ b/tests/php/_inc/lib/test_class.jetpack-media-extractor.php
@@ -31,7 +31,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 		$img_title = 'title.jpg';
 
 		$post_id = $this->factory->post->create( array(
-			'post_content' => "<img src='$img_title'>",
+			'post_content' => "<img src='$img_title' width='200' height='200'>",
 		) );
 
 		$extract = Jetpack_Media_Meta_Extractor::extract( Jetpack_Options::get_option( 'id' ), $post_id );
@@ -145,7 +145,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	 */
 	public function test_mediaextractor_extract_images_from_content_return_correct_image_struct() {
 		$img_name = 'image.jpg';
-		$content = "<img src='$img_name'>";
+		$content = "<img src='$img_name' width='200' height='200'>";
 
 		$image_struct = Jetpack_Media_Meta_Extractor::extract_images_from_content( $content, array() );
 
@@ -257,7 +257,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 
 			An Image:
 
-			<a href="http://mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png"><img class="alignnone size-medium wp-image-32" alt="Screen Shot 2013-03-15 at 1.27.05 PM" src="http://mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png?w=300" width="300" height="183" /></a>
+			<a href="http://mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png"><img class="alignnone size-full wp-image-32" alt="Screen Shot 2013-03-15 at 1.27.05 PM" src="http://mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png?w=519" width="519" height="317" /></a>
 
 			&nbsp;
 
@@ -336,7 +336,7 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 					'host' => 'mrwpsandbox.files.wordpress.com',
 				),
 				array(
-					'url' => 'mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png?w=300',
+					'url' => 'mrwpsandbox.files.wordpress.com/2013/03/screen-shot-2013-03-15-at-1-27-05-pm.png?w=519',
 					'host_reversed' => 'com.wordpress.files.mrwpsandbox',
 					'host' => 'mrwpsandbox.files.wordpress.com',
 				),
@@ -493,12 +493,12 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 	 */
 	function test_extract_image_from_html() {
 		$html = <<<EOT
-<p><a href="http://paulbernal.files.wordpress.com/2013/05/mr-gove-cover.jpeg"><img class="aligncenter size-full wp-image-1027" alt="Mr Gove Cover" src="http://paulbernal.files.wordpress.com/2013/05/mr-gove-cover.jpeg?w=640" /></a></p>
+<p><a href="http://paulbernal.files.wordpress.com/2013/05/mr-gove-cover.jpeg"><img class="aligncenter size-full wp-image-1027" alt="Mr Gove Cover" src="http://paulbernal.files.wordpress.com/2013/05/mr-gove-cover.jpeg" width="612" height="547" /></a></p>
 <p>Mr Gove was extraordinarily arrogant.</p>
 <p>Painfully arrogant.</p>
 <p>He believed that he knew how everything should be done. He believed that everyone else in the world was stupid and ignorant.</p>
 <p>The problem was, Mr Gove himself was the one who was ignorant.</p>
-<p><a href="http://paulbernal.files.wordpress.com/2013/05/mr-gove-close-up.jpeg"><img class="aligncenter size-full wp-image-1030" alt="Mr Gove Close up" src="http://paulbernal.files.wordpress.com/2013/05/mr-gove-close-up.jpeg?w=640" /></a></p>
+<p><a href="http://paulbernal.files.wordpress.com/2013/05/mr-gove-close-up.jpeg"><img class="aligncenter size-full wp-image-1030" alt="Mr Gove Close up" src="http://paulbernal.files.wordpress.com/2013/05/mr-gove-close-up.jpeg" width="612" height="542" /></a></p>
 <p>He got most of his information from his own, misty, memory.</p>
 <p>He thought he remembered what it had been like when he had been at school &#8211; and assumed that everyone else&#8217;s school should be the same.</p>
 <p>He remembered the good things about his own school days, and thought that everyone should have the same.</p>

--- a/tests/php/test_class.jetpack-post-images.php
+++ b/tests/php/test_class.jetpack-post-images.php
@@ -8,7 +8,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @since 2.7
 	 */
 	public function test_from_html_single_quotes() {
-		$s = '<imgANYTHINGATALLHEREsrc="bob.jpg"MOREANYTHINGHERE/>';
+		$s = '<img ANYTHINGATALLHERE src="bob.jpg" MOREANYTHINGHERE />';
 
 		$result = Jetpack_PostImages::from_html( $s );
 
@@ -22,7 +22,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @since 2.7
 	 */
 	public function test_from_html_double_quotes() {
-		$s = "<imgANYTHINGATALLHEREsrc='bob.jpg'MOREANYTHINGHERE/>";
+		$s = "<img ANYTHINGATALLHERE src='bob.jpg' MOREANYTHINGHERE />";
 
 		$result = Jetpack_PostImages::from_html( $s );
 

--- a/tests/php/test_class.jetpack-post-images.php
+++ b/tests/php/test_class.jetpack-post-images.php
@@ -8,7 +8,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @since 2.7
 	 */
 	public function test_from_html_single_quotes() {
-		$s = '<img ANYTHINGATALLHERE src="bob.jpg" MOREANYTHINGHERE />';
+		$s = '<img ANYTHINGATALLHERE src="bob.jpg" MOREANYTHINGHERE width="200" height="200" />';
 
 		$result = Jetpack_PostImages::from_html( $s );
 
@@ -22,7 +22,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	 * @since 2.7
 	 */
 	public function test_from_html_double_quotes() {
-		$s = "<img ANYTHINGATALLHERE src='bob.jpg' MOREANYTHINGHERE />";
+		$s = "<img ANYTHINGATALLHERE src='bob.jpg' MOREANYTHINGHERE width='200' height='200' />";
 
 		$result = Jetpack_PostImages::from_html( $s );
 
@@ -73,7 +73,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	public function test_from_attachment_is_correct_array() {
 		$img_name = 'image.jpg';
 		$img_url = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . $img_name;
-		$img_html = '<img src="' . $img_url . '"/>';
+		$img_html = '<img src="' . $img_url . '" width="250" height="250"/>';
 		$img_dimensions = array( 'width' => 250, 'height' => 250 );
 
 		$post_id = $this->factory->post->create( array(


### PR DESCRIPTION
Fixes #2284

When using `jetpack_og_get_image`, we specify a minimum width and height (200px).
Those 2 values are then used by `Jetpack_PostImages::get_images()`. `get_images` looks for images following different methods, and we
applied the minimum width and height to most of them, thus excluding images that were too small. However, we did not apply the values for
the last fallback used to look for images in a post: `from_html`.

This commit implements the 2 width and height requirements to `from_html`. To do so, I switched from a regex match to using `DOMDocument`
to fetch the different image tags and their width and height values.

#### Testing instructions:

1. Enable Sharing or Publicize on your Jetpack site.
2. Insert multiple small images (less than 200x200px) in a new post.
3. Publish post.
4. View post.
5. View source code and make sure the images do not appear in Jetpack OG tags.
6. Create a new post and insert large images (larger than 200x200px) in a new post.
7. Publish post.
8. View post.
9. View source code and make sure the images **do appear** in Jetpack OG tags.

#### Proposed changelog entry for your changes:
* Open Graph: do not display images smaller than Facebook's required size.