### PR TITLE
Retain hashes for current AND current-1 versions

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2312,7 +2312,7 @@ class Jetpack {
 			krsort( $file_data_option );
 			foreach ( $file_data_option as $version => $values ) {
 				$count++;
-				if( $count > 2 ) {
+				if( $count > 2 && JETPACK__VERSION != $version ) {
 					unset( $file_data_option[ $version ] );
 				}
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2307,12 +2307,12 @@ class Jetpack {
 		
 		$file_data_option[ JETPACK__VERSION ][ $key ] = $data;
 		
-		if( count( $file_data_option ) > 2 ) {
+		if ( count( $file_data_option ) > 2 ) {
 			$count = 0;
 			krsort( $file_data_option );
 			foreach ( $file_data_option as $version => $values ) {
 				$count++;
-				if( $count > 2 && JETPACK__VERSION != $version ) {
+				if ( $count > 2 && JETPACK__VERSION != $version ) {
 					unset( $file_data_option[ $version ] );
 				}
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2300,12 +2300,29 @@ class Jetpack {
 		$data = get_file_data( $file, $headers );
 
 		// Strip out any old Jetpack versions that are cluttering the option.
-		$file_data_option = array_intersect_key( (array) $file_data_option, array( JETPACK__VERSION => null ) );
+		//
+		// We maintain the data for the current version of Jetpack plus the previous version
+		// to prevent repeated DB hits on large sites hosted with multiple web servers
+		// on a single database (since all web servers might not be updated simultaneously)
+		
 		$file_data_option[ JETPACK__VERSION ][ $key ] = $data;
+		
+		if( count( $file_data_option ) > 2 ) {
+			$count = 0;
+			krsort( $file_data_option );
+			foreach ( $file_data_option as $version => $values ) {
+				$count++;
+				if( $count > 2 ) {
+					unset( $file_data_option[ $version ] );
+				}
+			}
+		}
+		
 		Jetpack_Options::update_option( 'file_data', $file_data_option );
 
 		return $data;
 	}
+	
 
 	/**
 	 * Return translated module tag.


### PR DESCRIPTION
This addresses an issue on large sites which have multiple web servers accessing a single database.  In that scenario, if updates are applied as a roll out rather than simultaneously, it will cause excessive database load as the versions "fight" over this option.