### PR TITLE
Sync: Update the sync api endpoint to support the missing options. 

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -723,6 +723,8 @@ $sync_settings_response = array(
 	'max_enqueue_full_sync'    => '(int|bool=false) Maximum number of rows to enqueue during each full sync process',
 	'max_queue_size_full_sync' => '(int|bool=false) Maximum queue size that full sync is allowed to use',
 	'sync_via_cron'            => '(int|bool=false) Set to 1 or true to avoid using cron for sync.',
+	'cron_sync_time_limit'	   => '(int|bool=false) Limit cron jobs to number of seconds',
+	'enqueue_wait_time'		   => '(int|bool=false) Wait time in seconds between attempting to continue a full sync, via requests',
 );
 
 // GET /sites/%s/sync/settings

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -724,7 +724,7 @@ $sync_settings_response = array(
 	'max_queue_size_full_sync' => '(int|bool=false) Maximum queue size that full sync is allowed to use',
 	'sync_via_cron'            => '(int|bool=false) Set to 1 or true to avoid using cron for sync.',
 	'cron_sync_time_limit'	   => '(int|bool=false) Limit cron jobs to number of seconds',
-	'enqueue_wait_time'		   => '(int|bool=false) Wait time in seconds between attempting to continue a full sync, via requests',
+	'enqueue_wait_time'        => '(int|bool=false) Wait time in seconds between attempting to continue a full sync, via requests',
 );
 
 // GET /sites/%s/sync/settings


### PR DESCRIPTION
Missing settings in the api sync_time_limit, enqueue_wait_time

#### Changes proposed in this Pull Request:
* Add sync_time_limit, enqueue_wait_time to the api so that they can be updated via the api.

#### Testing instructions:
* Are you able to update the new settings via the jetpack debugger? 
