### PR TITLE
Settings UI: fix keyboard navigation to main content and toolbar

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -69,6 +69,8 @@ function render() {
 					<Route path='/traffic' name={ i18n.translate( 'Traffic', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/writing' name={ i18n.translate( 'Writing', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/search' component={ Main } />
+					<Route path='/wpbody-content' component={ Main } />
+					<Route path='/wp-toolbar' component={ Main } />
 					<Route path="*" />
 				</Router>
 			</Provider>

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -114,6 +114,11 @@ const Main = React.createClass( {
 			return false;
 		}
 
+		// If user triggers Skip to main content or Skip to toolbar with keyboard navigation, stay in the same tab.
+		if ( includes( [ '/wpbody-content', '/wp-toolbar' ], nextProps.route.path ) ) {
+			return false;
+		}
+
 		return nextProps.siteConnectionStatus !== this.props.siteConnectionStatus ||
 			nextProps.jumpStartStatus !== this.props.jumpStartStatus ||
 			nextProps.isLinked !== this.props.isLinked ||


### PR DESCRIPTION
Fixes #6634

Previously as noted in the issue, if you used keyboard navigation and went to "Skip to main content" or "Skip to toolbar", you ended up with a blank page. This PR fixes this by whitelisting the routes for Main component and by not refreshing the Main component when such action is taken.

#### Changes proposed in this Pull Request:

* add `'/wpbody-content'` and `'/wp-toolbar'` as recognized routes.
* if user goes to that routes, don't update the view

#### Testing instructions:

* use keyboard navigation and trigger these actions 
<img width="239" alt="captura de pantalla 2017-03-13 a las 15 15 02" src="https://cloud.githubusercontent.com/assets/1041600/23868876/e099b6ca-07ff-11e7-868f-cf92ae225748.png">
<img width="238" alt="captura de pantalla 2017-03-13 a las 15 15 11" src="https://cloud.githubusercontent.com/assets/1041600/23868877/e09d2896-07ff-11e7-9bab-38825064ec41.png">

You must continue seeing the same view and if you start pressing tab, you should see the logo gain focus, then Dashboard and then Settings in split button and so on
