### PR TITLE
Sync: Update sync modules instantiation and set defaults

### DIFF
--- a/sync/class.jetpack-sync-module-wp-super-cache.php
+++ b/sync/class.jetpack-sync-module-wp-super-cache.php
@@ -2,6 +2,11 @@
 
 class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 
+	public function __construct() {
+		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_wp_super_cache_constants_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_callable_whitelist', array( $this, 'add_wp_super_cache_callable_whitelist' ), 10 );
+	}
+
 	static $wp_super_cache_constants = array(
 		'WPLOCKDOWN',
 		'WPSC_DISABLE_COMPRESSION',
@@ -62,19 +67,6 @@ class Jetpack_Sync_Module_WP_Super_Cache extends Jetpack_Sync_Module {
 			'cache_jetpack' => $cache_jetpack,
 			'cache_domain_mapping' => $cache_domain_mapping,
 		);
-	}
-
-	public function init_listeners( $callable ) {
-		$this->sync_wp_super_cache();
-	}
-
-	public function init_full_sync_listeners( $callable ) {
-		$this->sync_wp_super_cache();
-	}
-
-	public function sync_wp_super_cache() {
-		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_wp_super_cache_constants_whitelist' ), 10 );
-		add_filter( 'jetpack_sync_callable_whitelist', array( $this, 'add_wp_super_cache_callable_whitelist' ), 10 );
 	}
 
 	public function add_wp_super_cache_constants_whitelist( $list ) {

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -80,12 +80,12 @@ class Jetpack_Sync_Modules {
 		 */
 		$modules = apply_filters( 'jetpack_sync_modules', self::$default_sync_modules );
 
-		$modules = array_map( array( 'Jetpack_Sync_Modules', 'initialize_module' ), $modules );
+		$modules = array_map( array( 'Jetpack_Sync_Modules', 'load_module' ), $modules );
 
 		return array_map( array( 'Jetpack_Sync_Modules', 'set_module_defaults' ), $modules );
 	}
 
-	static function initialize_module( $module_name ) {
+	static function load_module( $module_name ) {
 		return new $module_name;
 	}
 

--- a/sync/class.jetpack-sync-modules.php
+++ b/sync/class.jetpack-sync-modules.php
@@ -80,16 +80,20 @@ class Jetpack_Sync_Modules {
 		 */
 		$modules = apply_filters( 'jetpack_sync_modules', self::$default_sync_modules );
 
-		return array_map( array( 'Jetpack_Sync_Modules', 'initialize_module' ), $modules );
+		$modules = array_map( array( 'Jetpack_Sync_Modules', 'initialize_module' ), $modules );
+
+		return array_map( array( 'Jetpack_Sync_Modules', 'set_module_defaults' ), $modules );
 	}
 
 	static function initialize_module( $module_name ) {
-		$module = new $module_name;
+		return new $module_name;
+	}
+
+	static function set_module_defaults( $module ) {
 		$module->set_defaults();
 		if ( method_exists( $module, 'set_late_default' ) ) {
 			add_action( 'init', array( $module, 'set_late_default' ), 90 );
 		}
-
 		return $module;
 	}
 


### PR DESCRIPTION
Woo and WP Super Cache modules set filters at the constructor.

`set_defaults` for callables and constants depends on those filters being set.

This PR instantiates the modules first so the filters are registerd, and calls `set_defaults` on a second step.