### PR TITLE
Carousel: Check if image parent is not a link

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -445,7 +445,7 @@ jQuery(document).ready(function($) {
 				return;
 			}
 
-			// skip if the parent is not a link
+			// skip if the container is not a link
 			if ( 'undefined' === typeof( $( container ).attr( 'href' ) ) ) {
 				return;
 			}

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -445,6 +445,11 @@ jQuery(document).ready(function($) {
 				return;
 			}
 
+			// skip if the parent is not a link
+			if ( 'undefined' === typeof( $( container ).attr( 'href' ) ) ) {
+				return;
+			}
+
 			var valid = false;
 
 			// if link points to 'Media File' (ignoring GET parameters) and flag is set allow it


### PR DESCRIPTION
Fixes #6638

#### Changes proposed in this Pull Request:

* Add additional condition to check if the parent is not a link, to prevent javascript errors.

#### Testing instructions:

* Enable Carousel 
* Disable html5 support for captions
* Create new page and add a sample gallery
* Add two or more caption shortcodes wrapped in a custom `a` tag (you can use [the following code](https://gist.github.com/Stoyan0v/caa692e5e60149d27e3f4d40105068f3) )
* Open the page and make sure that there is no javascript error like the following :
`Uncaught TypeError: Cannot read property 'split' of undefined`
On line 451 of `modules/carousel/jetpack-carousel.js`

cc @jeherve 