### PR TITLE
Reverted part of the changes introduced in #6339.

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -548,9 +548,6 @@ function sharing_add_footer() {
 		);
 		wp_localize_script( 'sharing-js', 'sharing_js_options', $sharing_js_options);
 	}
-}
-
-function sharing_add_footer_scripts_inline() {
 	$sharer = new Sharing_Service();
 	$enabled = $sharer->get_blog_services();
 	foreach ( array_merge( $enabled['visible'], $enabled['hidden'] ) AS $service ) {
@@ -779,9 +776,6 @@ function sharing_display( $text = '', $echo = false ) {
 
 			// Enqueue scripts for the footer
 			add_action( 'wp_footer', 'sharing_add_footer' );
-
-			// Print inline scripts that depend on jQuery
-			add_action( 'wp_footer', 'sharing_add_footer_scripts_inline', 25 );
 		}
 	}
 


### PR DESCRIPTION
Fixes #6640 

#### Changes proposed in this Pull Request:
* Reverts part of the changes introduced in #6639: calls `display_footer` method of sharing service classes immediately instead of delegating to a later hook.

#### Testing instructions:
* Enable sharing buttons for your site.
* Ensure that clicking them opens a new smaller window instead of opening full new tab.