### PR TITLE
Settings UI: Add VideoPress settings card

### DIFF
--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -65,26 +65,26 @@ const Media = moduleSettingsForm(
 					this.props.updateOptions( { photon: true, 'tiled-gallery': true, tiled_galleries: true } );
 				}
 			} else {
-				this.props.updateFormStateOptionValue( name, !value );
+				this.props.updateFormStateOptionValue( name, ! value );
 			}
 		},
 
 		render() {
 			if (
-				! this.props.isModuleFound( 'photon' )
-				&& ! this.props.isModuleFound( 'carousel' )
+				! this.props.isModuleFound( 'photon' ) &&
+				! this.props.isModuleFound( 'carousel' )
 			) {
 				// Nothing to show here
 				return null;
 			}
 
-			let photon = this.props.module( 'photon' ),
+			const photon = this.props.module( 'photon' ),
 				carousel = this.props.module( 'carousel' ),
 				isCarouselActive = this.props.getOptionValue( 'carousel' ),
 				videoPress = this.props.module( 'videopress' ),
 				planClass = getPlanClass( this.props.sitePlan.product_slug );
 
-			let photonSettings = (
+			const photonSettings = (
 				<SettingsGroup
 					hasChild
 					disableInDevMode
@@ -110,7 +110,7 @@ const Media = moduleSettingsForm(
 				</SettingsGroup>
 			);
 
-			let carouselSettings = (
+			const carouselSettings = (
 				<SettingsGroup hasChild support={ carousel.learn_more_button }>
 					<ModuleToggle
 						slug="carousel"
@@ -144,7 +144,7 @@ const Media = moduleSettingsForm(
 								value={ this.props.getOptionValue( 'carousel_background_color' ) }
 								disabled={ ! isCarouselActive || this.props.isSavingAnyOption( 'carousel_background_color' ) }
 								{ ...this.props }
-								validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) }/>
+								validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) } />
 						</FormLabel>
 					</FormFieldset>
 				</SettingsGroup>
@@ -191,6 +191,6 @@ export default connect(
 			module: ( module_name ) => getModule( state, module_name ),
 			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
 			sitePlan: getSitePlan( state )
-		}
+		};
 	}
 )( Media );

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -160,7 +160,7 @@ const Media = moduleSettingsForm(
 						disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
 						activated={ this.props.getOptionValue( 'videopress' ) }
 						toggling={ this.props.isSavingAnyOption( 'videopress' ) }
-						toggleModule={ this.toggleModule }
+						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">
 							{

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -5,11 +5,15 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import CompactFormToggle from 'components/form/form-toggle/compact';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
  */
-import { FEATURE_VIDEO_HOSTING_JETPACK } from 'lib/plans/constants';
+import {
+	FEATURE_VIDEO_HOSTING_JETPACK,
+	getPlanClass
+} from 'lib/plans/constants';
 import {
 	FormFieldset,
 	FormLegend,
@@ -22,6 +26,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
+import { getSitePlan } from 'state/site';
 
 const Media = moduleSettingsForm(
 	React.createClass( {
@@ -75,7 +80,9 @@ const Media = moduleSettingsForm(
 
 			let photon = this.props.module( 'photon' ),
 				carousel = this.props.module( 'carousel' ),
-				isCarouselActive = this.props.getOptionValue( 'carousel' );
+				isCarouselActive = this.props.getOptionValue( 'carousel' ),
+				videoPress = this.props.module( 'videopress' ),
+				planClass = getPlanClass( this.props.sitePlan.product_slug );
 
 			let photonSettings = (
 				<SettingsGroup
@@ -143,6 +150,27 @@ const Media = moduleSettingsForm(
 				</SettingsGroup>
 			);
 
+			const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
+				<SettingsGroup
+					hasChild
+					disableInDevMode
+					module={ videoPress }>
+					<ModuleToggle
+						slug="videopress"
+						disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
+						activated={ this.props.getOptionValue( 'videopress' ) }
+						toggling={ this.props.isSavingAnyOption( 'videopress' ) }
+						toggleModule={ this.toggleModule }
+					>
+						<span className="jp-form-toggle-explanation">
+							{
+								videoPress.description
+							}
+						</span>
+					</ModuleToggle>
+				</SettingsGroup>
+			);
+
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -150,6 +178,7 @@ const Media = moduleSettingsForm(
 					feature={ FEATURE_VIDEO_HOSTING_JETPACK }>
 					{ this.props.isModuleFound( 'photon' ) && photonSettings }
 					{ this.props.isModuleFound( 'carousel' ) && carouselSettings }
+					{ this.props.isModuleFound( 'videopress' ) && videoPressSettings }
 				</SettingsCard>
 			);
 		}
@@ -160,7 +189,8 @@ export default connect(
 	( state ) => {
 		return {
 			module: ( module_name ) => getModule( state, module_name ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name )
+			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
+			sitePlan: getSitePlan( state )
 		}
 	}
 )( Media );

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -139,7 +139,7 @@ function jetpack_get_module_i18n( $key ) {
 			),
 
 			'seo-tools' => array(
-				'name' => _x( 'SEO tools', 'Module Name', 'jetpack' ),
+				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),
 				'recommended description' => _x( 'Better results on search engines and social media.', 'Jumpstart Description', 'jetpack' ),
 			),
@@ -199,7 +199,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'videopress' => array(
 				'name' => _x( 'VideoPress', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Powerful, simple video hosting for WordPress.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Fast, ad-free video hosting', 'Module Description', 'jetpack' ),
 			),
 
 			'widget-visibility' => array(

--- a/modules/videopress.php
+++ b/modules/videopress.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: VideoPress
- * Module Description: Powerful, simple video hosting for WordPress.
+ * Module Description: Fast, ad-free video hosting
  * First Introduced: 2.5
  * Free: false
  * Requires Connection: Yes


### PR DESCRIPTION
Adds a settings card in /writing in the media section to allow toggling of VideoPress.  

Will only show if on premium or business plan.  Otherwise, you should see a banner CTA.  

![screen shot 2017-03-14 at 5 26 36 pm](https://cloud.githubusercontent.com/assets/7129409/23923065/68925358-08db-11e7-8080-0e23adc1ef04.png)

![screen shot 2017-03-14 at 5 26 14 pm](https://cloud.githubusercontent.com/assets/7129409/23923068/6a2231c0-08db-11e7-98ae-8b2c53461f0a.png)
