### PR TITLE
Settings UI: Routes that aren't defined will take you to the /dashboard

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -70,7 +70,7 @@ function render() {
 					<Route path='/writing' name={ i18n.translate( 'Writing', { context: 'Navigation item.' } ) } component={ Main } />
 					<Route path='/wpbody-content' component={ Main } />
 					<Route path='/wp-toolbar' component={ Main } />
-					<Route path="*" />
+					<Route path="*" component={ Main } />
 				</Router>
 			</Provider>
 		</div>,

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -197,6 +197,9 @@ const Main = React.createClass( {
 				break;
 
 			default:
+				// If no route found, kick them to the dashboard and do some url/history trickery
+				const history = createHistory();
+				history.replace( window.location.pathname + '?page=jetpack#/dashboard' );
 				pageComponent = <AtAGlance siteRawUrl={ this.props.siteRawUrl } siteAdminUrl={ this.props.siteAdminUrl } />;
 		}
 


### PR DESCRIPTION
Fixes #6610

This ensures that if any route is navigated that is not registered, we will show them the AAG Dashboard rather than a blank page.  This is increasingly important as we're about to change/remove a lot of the routes.  

To test: 
- Navigate the UI as you normally would, click around a couple times
- manually change the route to something like `/wp-admin/admin.php?page=jetpack#/whatever`
- observe that you're taken to the /dashboard route
- observe that the URL changed
- observe that the `back` button takes you to the route you were at before.  