### PR TITLE
Contact Form: Add display names to addresses in the `To` header

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2002,14 +2002,16 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 * @param string|array $to Array of valid email addresses, or single email address.
 		 */
 		$to = (array) apply_filters( 'contact_form_to', $to );
+		$reply_to_addr = $to[0]; // get just the address part before the name part is added
+
 		foreach ( $to as $to_key => $to_value ) {
 			$to[ $to_key ] = Grunion_Contact_Form_Plugin::strip_tags( $to_value );
+			$to[ $to_key ] = self::add_name_to_address( $to_value );
 		}
 
 		$blog_url = parse_url( site_url() );
 		$from_email_addr = 'wordpress@' . $blog_url['host'];
 
-		$reply_to_addr = $to[0];
 		if ( ! empty( $comment_author_email ) ) {
 			$reply_to_addr = $comment_author_email;
 		}
@@ -2219,6 +2221,25 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		wp_safe_redirect( $redirect );
 		exit;
+	}
+
+	/**
+	 * Add a display name part to an email address
+	 *
+	 * SpamAssassin doesn't like addresses in HTML messages that are missing display names (e.g., `foo@bar.org`
+	 * instead of `"Foo Bar" <foo@bar.org>`.
+	 *
+	 * @param string $address
+	 *
+	 * @return string
+	 */
+	function add_name_to_address( $address ) {
+		// If it's just the address, without a display name
+		if ( is_email( $address ) ) {
+			$address = sprintf( '"%s" <%s>', $address, $address );
+		}
+
+		return $address;
 	}
 
 	/**

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -86,7 +86,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		// Default metadata should be saved
 		$submission = $feedback[0];
 		$email = get_post_meta( $submission->ID, '_feedback_email', true );
-		$this->assertEquals( 'john@example.com', $email['to'][0] );
+		$this->assertEquals( '"john@example.com" <john@example.com>', $email['to'][0] );
 		$this->assertContains( 'IP Address: 127.0.0.1', $email['message'] );
 	}
 
@@ -323,12 +323,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Initialize a form with name, dropdown and radiobutton (first, second
 		// and third option), text field
-		$form = new Grunion_Contact_Form( array( 'to' => 'john@example.com', 'subject' => 'Hello there!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
+		$form = new Grunion_Contact_Form( array( 'to' => '"john@example.com" <john@example.com>', 'subject' => 'Hello there!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
 		$form->process_submission();
 	}
 
 	public function pre_test_process_submission_sends_correct_single_email( $args ){
-		$this->assertContains( 'john@example.com', $args['to'] );
+		$this->assertContains( '"john@example.com" <john@example.com>', $args['to'] );
 		$this->assertEquals( 'Hello there!', $args['subject'] );
 
 		$expected = '<b>Name:</b> John Doe<br /><br />';
@@ -365,7 +365,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	public function pre_test_process_submission_sends_correct_multiple_email( $args ){
-		$this->assertEquals( array( 'john@example.com','jane@example.com'), $args['to'] );
+		$this->assertEquals( array( '"john@example.com" <john@example.com>','"jane@example.com" <jane@example.com>'), $args['to'] );
 	}
 
 	/**


### PR DESCRIPTION
This avoids SpamAssassin's `TO_NO_BRKTS_HTML_ONLY` rule.

See #6114

#### Testing instructions:

* From `master`, fill out a `[contact-form]` and copy the email source to http://spamcheck.postmarkapp.com/
* Note the triggered `TO_NO_BRKTS_HTML_ONLY` rule
* Check out this branch, and re-run the test. The rule should no longer be triggered.