### PR TITLE
Updates banner styles and behaviour.

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -52,7 +52,8 @@ export const SettingsCard = props => {
 	}
 
 	const getBanner = () => {
-		const planClass = getPlanClass( props.sitePlan.product_slug );
+		const planClass = getPlanClass( props.sitePlan.product_slug ),
+			upgradeLabel = __( 'Upgrade', { context: 'A caption for a button to upgrade an existing paid feature to a higher tier.' } );
 
 		switch ( feature ) {
 			case FEATURE_VIDEO_HOSTING_JETPACK:
@@ -66,7 +67,7 @@ export const SettingsCard = props => {
 				return (
 					<Banner
 						title={ __( 'Host fast, high-quality, and ad-free video.' ) }
-						callToAction={ __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } ) }
+						callToAction={ upgradeLabel }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						href={ 'https://jetpack.com/redirect/?source=settings-video-premium&site=' + siteRawUrl }
@@ -85,7 +86,7 @@ export const SettingsCard = props => {
 						<Banner
 							title={ __( 'Real-time site backups and automated threat resolution.' ) }
 							plan={ PLAN_JETPACK_BUSINESS }
-							callToAction={ __( 'Upgrade', { context: 'A caption for a button to upgrade an existing paid feature to a higher tier.' } ) }
+							callToAction={ upgradeLabel }
 							feature={ feature }
 							href={ 'https://jetpack.com/redirect/?source=settings-security-pro&site=' + siteRawUrl }
 						/>
@@ -94,7 +95,7 @@ export const SettingsCard = props => {
 
 				return (
 					<Banner
-						callToAction={ __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } ) }
+						callToAction={ upgradeLabel }
 						title={ __( 'Protect against data loss, malware, and hacks.' ) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
@@ -108,7 +109,7 @@ export const SettingsCard = props => {
 				}
 				return (
 					<Banner
-						callToAction={ __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } ) }
+						callToAction={ upgradeLabel }
 						title={ __( 'Hassle-free Google Analytics installation.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }
@@ -122,7 +123,7 @@ export const SettingsCard = props => {
 
 				return (
 					<Banner
-						callToAction={ __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } ) }
+						callToAction={ upgradeLabel }
 						title={ __( 'SEO tools help your content get found and shared.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
 						feature={ feature }

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -87,7 +87,10 @@ export const SettingsCard = props => {
 					__( 'Comprehensive and automated scanning for any security vulnerabilites or threats' )
 				];
 
-				if ( 'is-premium-plan' !== planClass ) {
+				if (
+					'is-premium-plan' !== planClass &&
+					'is-personal-plan' !== planClass
+				) {
 					list.unshift(
 						__( 'State-of-the-art spam defence powered by Akismet' )
 					);

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -52,12 +52,7 @@ export const SettingsCard = props => {
 	}
 
 	const getBanner = () => {
-		const planClass = getPlanClass( props.sitePlan.product_slug ),
-			commonProps = {
-				feature: feature,
-				href: 'https://jetpack.com/redirect/?source=plans-compare-personal&site=' + siteRawUrl
-			};
-		let list;
+		const planClass = getPlanClass( props.sitePlan.product_slug );
 
 		switch ( feature ) {
 			case FEATURE_VIDEO_HOSTING_JETPACK:
@@ -70,10 +65,11 @@ export const SettingsCard = props => {
 
 				return (
 					<Banner
-						title={ __( 'Add premium video' ) }
-						description={ __( 'Upgrade to the Premium plan to easily upload videos to your website and display them using a fast, unbranded, customizable player.' ) }
+						title={ __( 'Host fast, high-quality, and ad-free video.' ) }
+						callToAction={ __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } ) }
 						plan={ PLAN_JETPACK_PREMIUM }
-						{ ...commonProps }
+						feature={ feature }
+						href={ 'https://jetpack.com/redirect/?source=settings-video-premium&site=' + siteRawUrl }
 					/>
 				);
 
@@ -82,60 +78,55 @@ export const SettingsCard = props => {
 					return '';
 				}
 
-				list = [
-					__( 'Automatic backups of every single aspect of your site' ),
-					__( 'Comprehensive and automated scanning for any security vulnerabilites or threats' )
-				];
-
 				if (
-					'is-premium-plan' !== planClass &&
-					'is-personal-plan' !== planClass
+					'is-premium-plan' === planClass
 				) {
-					list.unshift(
-						__( 'State-of-the-art spam defence powered by Akismet' )
+					return (
+						<Banner
+							title={ __( 'Real-time site backups and automated threat resolution.' ) }
+							plan={ PLAN_JETPACK_BUSINESS }
+							callToAction={ __( 'Upgrade', { context: 'A caption for a button to upgrade an existing paid feature to a higher tier.' } ) }
+							feature={ feature }
+							href={ 'https://jetpack.com/redirect/?source=settings-security-pro&site=' + siteRawUrl }
+						/>
 					);
 				}
 
 				return (
 					<Banner
-						title={ __( 'Upgrade to further protect your site' ) }
-						list={ list }
-						plan={
-							'is-premium-plan' !== planClass
-							? PLAN_JETPACK_PREMIUM
-							: PLAN_JETPACK_BUSINESS
-						}
-						{ ...commonProps }
+						callToAction={ __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } ) }
+						title={ __( 'Protect against data loss, malware, and hacks.' ) }
+						plan={ PLAN_JETPACK_PREMIUM }
+						feature={ feature }
+						href={ 'https://jetpack.com/redirect/?source=settings-security-premium&site=' + siteRawUrl }
 					/>
 				);
 
-			case FEATURE_SEO_TOOLS_JETPACK:
 			case FEATURE_GOOGLE_ANALYTICS_JETPACK:
 				if ( 'is-business-plan' === planClass ) {
 					return '';
 				}
-
-				list = [
-					__( 'SEO tools to optimize your site for search engines and social media sharing' ),
-					__( 'Google Analytics tracking settings to complement WordPress.com stats' )
-				];
-
-				if ( 'is-premium-plan' !== planClass ) {
-					list.unshift(
-						__( 'Enable advertisements on your site to earn money from impressions' )
-					);
+				return (
+					<Banner
+						callToAction={ __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } ) }
+						title={ __( 'Hassle-free Google Analytics installation.' ) }
+						plan={ PLAN_JETPACK_BUSINESS }
+						feature={ feature }
+						href={ 'https://jetpack.com/redirect/?source=settings-ga&site=' + siteRawUrl }
+					/>
+				);
+			case FEATURE_SEO_TOOLS_JETPACK:
+				if ( 'is-business-plan' === planClass ) {
+					return '';
 				}
 
 				return (
 					<Banner
-						title={ __( 'Upgrade to monetize your site and unlock more tools' ) }
-						list={ list }
-						plan={
-							'is-premium-plan' !== planClass
-							? PLAN_JETPACK_PREMIUM
-							: PLAN_JETPACK_BUSINESS
-						}
-						{ ...commonProps }
+						callToAction={ __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } ) }
+						title={ __( 'SEO tools help your content get found and shared.' ) }
+						plan={ PLAN_JETPACK_BUSINESS }
+						feature={ feature }
+						href={ 'https://jetpack.com/redirect/?source=settings-seo&site=' + siteRawUrl }
 					/>
 				);
 

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -162,7 +162,7 @@ export const SettingsCard = props => {
 				}
 			</SectionHeader>
 			{ props.children }
-			{ getBanner( feature ) }
+			{ ! props.fetchingSiteData && getBanner( feature ) }
 		</form>
 	);
 };

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -135,6 +135,42 @@ export const SettingsCard = props => {
 		}
 	};
 
+	const showChildren = () => {
+		if ( props.fetchingSiteData ) {
+			return true;
+		}
+
+		const planClass = getPlanClass( props.sitePlan.product_slug );
+
+		switch ( feature ) {
+			case FEATURE_SECURITY_SCANNING_JETPACK:
+				if (
+					'is-free-plan' === planClass ||
+					'is-personal-plan' === planClass
+				) {
+					return false;
+				}
+
+				break;
+
+			case FEATURE_GOOGLE_ANALYTICS_JETPACK:
+				if ( 'is-business-plan' !== planClass ) {
+					return false;
+				}
+
+				break;
+
+			case FEATURE_SEO_TOOLS_JETPACK:
+				if ( 'is-business-plan' !== planClass ) {
+					return false;
+				}
+
+				break;
+		}
+
+		return true;
+	};
+
 	return (
 		<form className="jp-form-settings-card">
 			<SectionHeader label={ header }>
@@ -155,7 +191,7 @@ export const SettingsCard = props => {
 					)
 				}
 			</SectionHeader>
-			{ props.children }
+			{ showChildren() && props.children }
 			{ ! props.fetchingSiteData && getBanner( feature ) }
 		</form>
 	);


### PR DESCRIPTION
Fixes #6449 

#### Changes proposed in this Pull Request:
* Made banners only appear when the site data is not being fetched.
* Used new styles for banners: one liners with call to action buttons.
* Added a condition to hide settings card children for cases when the plan doesn't allow configuration.
* Properly attached banner plan props to each feature's required plans.

### To test
* Make sure correct banners appear for correct plans.
* Make sure call to action is 'Activate' when it's not yet in the plan, and 'Upgrade' when it's in the plan but a higher tier is needed.
* Make sure the links have the right query parameters, like `settings-video-premium` for VideoPress on free and personal, and `settings-video-pro` on VideoPress for Premium.

![screen shot 2017-03-15 at 2 46 07 pm](https://cloud.githubusercontent.com/assets/7129409/23965438/5a023020-098e-11e7-93be-a241744a5bd4.png)
![screen shot 2017-03-15 at 2 45 20 pm](https://cloud.githubusercontent.com/assets/7129409/23965440/5b094de6-098e-11e7-8ee7-e73574fd35df.png)
![screen shot 2017-03-15 at 2 44 10 pm](https://cloud.githubusercontent.com/assets/7129409/23965442/5bf56e10-098e-11e7-9459-02539b2d21d1.png)
![screen shot 2017-03-15 at 2 43 48 pm](https://cloud.githubusercontent.com/assets/7129409/23965443/5d5d581c-098e-11e7-8b0a-1b0ad9403f4c.png)
![screen shot 2017-03-15 at 2 43 26 pm](https://cloud.githubusercontent.com/assets/7129409/23965444/5e6064c0-098e-11e7-9168-c439e16dfce1.png)

