### PR TITLE
Settings UI: solve JS warning due to a mixed value

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -26,7 +26,7 @@ import {
 	userIsSubscriber as _userIsSubscriber,
 	userCanPublish
 } from 'state/initial-state';
-import { getSiteConnectionStatus, isCurrentUserLinked } from 'state/connection';
+import { isSiteConnected, isCurrentUserLinked } from 'state/connection';
 import { isModuleActivated } from 'state/modules';
 
 export const NavigationSettings = React.createClass( {
@@ -89,13 +89,13 @@ export const NavigationSettings = React.createClass( {
 			publicizeTab = (
 			( this.props.isModuleActivated( 'publicize' ) || this.props.isModuleActivated( 'sharedaddy' ) ) && (
 				<NavItem
-					path={ true === this.props.siteConnectionStatus
+					path={ true === this.props.isSiteConnected
 										? 'https://wordpress.com/sharing/' + this.props.siteRawUrl
 										: this.props.siteAdminUrl + 'options-general.php?page=sharing'
 										}>
 					{ __( 'Sharing', { context: 'Navigation item.' } ) }
 					{
-						true === this.props.siteConnectionStatus && (
+						true === this.props.isSiteConnected && (
 							<Gridicon icon="external" size={ 13 } />
 						)
 					}
@@ -172,7 +172,7 @@ NavigationSettings.propTypes = {
 	isSubscriber: React.PropTypes.bool.isRequired,
 	userCanPublish: React.PropTypes.bool.isRequired,
 	isLinked: React.PropTypes.bool.isRequired,
-	siteConnectionStatus: React.PropTypes.bool.isRequired,
+	isSiteConnected: React.PropTypes.bool.isRequired,
 	isModuleActivated: React.PropTypes.func.isRequired,
 	searchHasFocus: React.PropTypes.bool.isRequired
 };
@@ -182,7 +182,7 @@ NavigationSettings.defaultProps = {
 	isSubscriber: false,
 	userCanPublish: false,
 	isLinked: false,
-	siteConnectionStatus: false,
+	isSiteConnected: false,
 	isModuleActivated: noop,
 	searchHasFocus: false
 };
@@ -194,7 +194,7 @@ export default connect(
 			isSubscriber: _userIsSubscriber( state ),
 			userCanPublish: userCanPublish( state ),
 			isLinked: isCurrentUserLinked( state ),
-			siteConnectionStatus: getSiteConnectionStatus( state ),
+			isSiteConnected: isSiteConnected( state ),
 			isModuleActivated: module => isModuleActivated( state, module ),
 			searchTerm: getSearchTerm( state )
 		};

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -39,7 +39,7 @@ describe( 'NavigationSettings', () => {
 				listen: () => {}
 			},
 			isModuleActivated: () => true,
-			siteConnectionStatus: true,
+			isSiteConnected: true,
 			siteRawUrl: 'example.org',
 			siteAdminUrl: 'https://example.org/wp-admin/',
 			searchForTerm: () => {},
@@ -319,7 +319,7 @@ describe( 'NavigationSettings', () => {
 		describe( 'if site is in dev mode', () => {
 
 			before( () => {
-				wrapper = shallow( <NavigationSettings { ...testProps } siteConnectionStatus={ false } />, options );
+				wrapper = shallow( <NavigationSettings { ...testProps } isSiteConnected={ false } />, options );
 			} );
 
 			it( 'points to WP Admin', () => {

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -130,6 +130,20 @@ export function getSiteConnectionStatus( state ) {
 }
 
 /**
+ * Checks if the site is connected to WordPress.com. Unlike getSiteConnectionStatus, this one returns only a boolean.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {boolean} True if site is connected to WordPress.com. False if site is in Dev Mode or there's no connection data.
+ */
+export function isSiteConnected( state ) {
+	if ( ( 'object' !== typeof state.jetpack.connection.status.siteConnected ) ||
+		true === state.jetpack.connection.status.siteConnected.devMode.isActive ) {
+		return false;
+	}
+	return state.jetpack.connection.status.siteConnected.isActive;
+}
+
+/**
  * Returns an object with information about the Dev Mode.
  *
  * @param  {Object}      state Global state tree


### PR DESCRIPTION

Fixes #6660

#### Changes proposed in this Pull Request:

* introduce new reducer `isSiteConnected` that returns only a boolean
* fixes issue with JS warning regarding a mixed type value passed to `NavigationSettings` component
* updated GUI tests

#### Testing instructions:

* make sure Sharing is working properly in connected and Dev Mode 
