### PR TITLE
Settings UI: align and space elements

### DIFF
--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -10,6 +10,16 @@
 			background: $white;
 		}
 	}
+	.dops-section-header__actions {
+		.form-toggle__label {
+			position: relative;
+			top: 6px;
+			right: 0;
+		}
+		.form-toggle__label-content {
+			margin: 0;
+		}
+	}
 }
 
 .jp-dash-item__card {
@@ -54,7 +64,6 @@
 	.dops-section-header__actions {
 		.dops-notice {
 			margin-top: rem( 2px );
-			margin-right: rem( -10px );
 		}
 	}
 }

--- a/_inc/client/components/foldable-card/style.scss
+++ b/_inc/client/components/foldable-card/style.scss
@@ -41,7 +41,6 @@
 
 	@include breakpoint( "<480px" ) {
 		font-size: rem( 14px );
-		line-height: 1.8;
 	}
 
 	.dops-button {

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -33,7 +33,7 @@
 .jp-form-toggle-explanation {
 	font-size: rem( 14px );
 	word-break: break-word;
-	vertical-align: middle;
+	vertical-align: baseline;
 }
 
 .jp-form-fieldset {

--- a/_inc/client/components/module-settings/style.scss
+++ b/_inc/client/components/module-settings/style.scss
@@ -18,8 +18,8 @@
 
 .jp-module-settings__learn-more {
 	position: absolute;
-	top: 12px;
-	right: 17px;
+	top: rem( 27px );
+	right: rem( 25px );
 	z-index: 1;
 
 	.jp-form-fieldset & {

--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -53,18 +53,26 @@
 		font-size: rem( 14px );
 	}
 
-	.dops-foldable-card__header,
-	&.dops-card.is-expanded .dops-foldable-card__content {
-		padding-left: rem( 24px );
-		padding-right: rem( 24px );
+	@include breakpoint( ">480px" ) {
+		.dops-foldable-card__header,
+		&.dops-card.is-expanded .dops-foldable-card__content {
+			padding-left: rem( 24px );
+			padding-right: rem( 24px );
+		}
+
+		.dops-foldable-card__action {
+			right: rem( 10px );
+		}
+		.jp-form-settings-group .jp-module-settings__learn-more {
+			right: rem( 2px );
+			top: 0;
+		}
 	}
 
-	.dops-foldable-card__action {
-		right: rem( 10px );
-	}
-
-	.jp-form-settings-group .jp-module-settings__learn-more {
-		right: 2px;
-		top: 0;
+	@include breakpoint( "<480px" ) {
+		.jp-form-settings-group .jp-module-settings__learn-more {
+			right: rem( -31px );
+			top: rem( 6px );
+		}
 	}
 }

--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -10,8 +10,9 @@
 	.dops-foldable-card {
 		.dops-foldable-card__header {
 			color: #444;
-			padding-left: rem( 24px );
-			padding-right: rem( 24px );
+			@include  breakpoint( ">480px" ) {
+				padding-left: rem( 24px );
+			}
 		}
 
 		.form-toggle__switch {
@@ -21,10 +22,6 @@
 
 		.dops-foldable-card__header-text {
 			font-size: rem( 14px );
-		}
-
-		&.is-expanded .dops-foldable-card__content {
-			padding-right: rem( 24px );
 		}
 
 		&.jp-foldable-settings-disable .dops-foldable-card__header {
@@ -39,10 +36,22 @@
 
 		.dops-foldable-card__action {
 			right: rem( 10px );
+			@include breakpoint( "<480px" ) {
+				right: rem( 1px );
+			}
 		}
 
 		.jp-module-settings__learn-more {
-			right: rem( 2px );
+			right: rem( -21px );
+			top: rem( 7px );
+			@include breakpoint( "<480px" ) {
+				right: rem( -30px );
+			}
+		}
+
+		.jp-form-legend:first-child,
+		.jp-form-label-wide:first-child {
+			padding-top: rem( 7px );
 		}
 	}
 }

--- a/_inc/client/components/settings-group/style.scss
+++ b/_inc/client/components/settings-group/style.scss
@@ -32,7 +32,13 @@
 		padding-bottom: 16px;
 	}
 	.dops-card  {
-		padding-right: rem( 40px );
+		padding-right: rem( 48px );
+	}
+
+	@include breakpoint( "<480px" ) {
+		.jp-module-settings__learn-more {
+			right: rem( 16px );
+		}
 	}
 
 	.form-toggle__switch {

--- a/_inc/client/components/settings-group/style.scss
+++ b/_inc/client/components/settings-group/style.scss
@@ -18,7 +18,7 @@
 	.jp-form-setting-explanation {
 		color: $gray-text-min;
 		display: block;
-		margin: rem( 5px ) rem( 14px ) 0 0;
+		margin: rem( 5px ) rem( 14px ) rem( 5px ) 0;
 		font-size: rem( 13px );
 		font-style: italic;
 		font-weight: 400;

--- a/_inc/client/components/settings-group/style.scss
+++ b/_inc/client/components/settings-group/style.scss
@@ -35,9 +35,17 @@
 		padding-right: rem( 48px );
 	}
 
-	@include breakpoint( "<480px" ) {
-		.jp-module-settings__learn-more {
+	.jp-module-settings__learn-more {
+		@include breakpoint( "<480px" ) {
 			right: rem( 16px );
+			top: rem( 20px );
+		}
+		& + p {
+			margin-top: 2px;
+		}
+		& + span {
+			margin-top: 2px;
+			display: inline-block;
 		}
 	}
 

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -35,7 +35,7 @@ export const Protect = moduleSettingsForm(
 
 		currentIpIsWhitelisted() {
 			// get current whitelist in textarea from this.state.whitelist;
-			return !!includes( this.state.whitelist, this.props.currentIp );
+			return !! includes( this.state.whitelist, this.props.currentIp );
 		},
 
 		updateText( event ) {
@@ -52,7 +52,7 @@ export const Protect = moduleSettingsForm(
 		},
 
 		addToWhitelist() {
-			let newWhitelist = this.state.whitelist + ( 0 >= this.state.whitelist.length ? '' : '\n' ) + this.props.currentIp;
+			const newWhitelist = this.state.whitelist + ( 0 >= this.state.whitelist.length ? '' : '\n' ) + this.props.currentIp;
 
 			// Update form value manually
 			this.props.updateFormStateOptionValue( 'jetpack_protect_global_whitelist', newWhitelist );
@@ -132,7 +132,7 @@ export const Protect = moduleSettingsForm(
 						</SettingsGroup>
 					</FoldableCard>
 				</SettingsCard>
-			)
+			);
 		}
 	} )
 );

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -102,11 +102,13 @@ const Media = moduleSettingsForm(
 							}
 						</span>
 					</ModuleToggle>
-					<span className="jp-form-setting-explanation">
-						{
-							__( 'Must be enabled to use tiled galleries.' )
-						}
-					</span>
+					<FormFieldset>
+						<span className="jp-form-setting-explanation">
+							{
+								__( 'Must be enabled to use tiled galleries.' )
+							}
+						</span>
+					</FormFieldset>
 				</SettingsGroup>
 			);
 

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -124,7 +124,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'protect' => array(
 				'name' => _x( 'Protect', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Block suspicious-looking sign in activity from unknown IP addresses', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Block suspicious-looking sign in activity', 'Module Description', 'jetpack' ),
 			),
 
 			'publicize' => array(

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Protect
- * Module Description: Block suspicious-looking sign in activity from unknown IP addresses
+ * Module Description: Block suspicious-looking sign in activity
  * Sort Order: 1
  * Recommendation Order: 4
  * First Introduced: 3.4


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

fixes #6554

* **align learn more icons, mobile and desktop**

    <img width="746" alt="captura de pantalla 2017-03-15 a las 12 04 03" src="https://cloud.githubusercontent.com/assets/1041600/23956024/5900cdb2-097a-11e7-8faf-83e45c96e391.png">
    <img width="156" alt="captura de pantalla 2017-03-15 a las 11 25 47" src="https://cloud.githubusercontent.com/assets/1041600/23956025/59053316-097a-11e7-95a0-3cf0a15a996b.png">

* **evenly space toggle explanation**
    Before

    <img width="370" alt="captura de pantalla 2017-03-15 a las 12 25 19" src="https://cloud.githubusercontent.com/assets/1041600/23956481/8362eb52-097b-11e7-8d91-3c2e21803e0f.png">
    <img width="355" alt="captura de pantalla 2017-03-15 a las 12 44 31" src="https://cloud.githubusercontent.com/assets/1041600/23957049/2dcceefc-097d-11e7-9f0c-96df52a33662.png">

    After

    <img width="423" alt="captura de pantalla 2017-03-15 a las 12 25 40" src="https://cloud.githubusercontent.com/assets/1041600/23956480/83609fb4-097b-11e7-9c63-e754c706820b.png">
    <img width="345" alt="captura de pantalla 2017-03-15 a las 12 44 16" src="https://cloud.githubusercontent.com/assets/1041600/23957051/30517c92-097d-11e7-8ea3-6d5e50e4279d.png">

* **vertically align text with toggle**
    Before
    <img width="150" alt="captura de pantalla 2017-03-15 a las 12 37 25" src="https://cloud.githubusercontent.com/assets/1041600/23956763/482a58d0-097c-11e7-93e6-04b6a5cc2c11.png">
    <img width="593" alt="captura de pantalla 2017-03-15 a las 12 40 55" src="https://cloud.githubusercontent.com/assets/1041600/23956943/cafbc4ba-097c-11e7-956e-5eb61aab1995.png">

    After
    <img width="148" alt="captura de pantalla 2017-03-15 a las 12 37 43" src="https://cloud.githubusercontent.com/assets/1041600/23956764/482e0bd8-097c-11e7-8b78-9cfe619804a1.png">
    <img width="589" alt="captura de pantalla 2017-03-15 a las 12 41 06" src="https://cloud.githubusercontent.com/assets/1041600/23956947/cd1fe276-097c-11e7-9ae9-0d0c194d7f7a.png">

* **align toggles and notice in dash items, also solves bad positioning issue for notice in dash item on mobile**
<img width="368" alt="captura de pantalla 2017-03-15 a las 16 57 51" src="https://cloud.githubusercontent.com/assets/1041600/23968431/6eb40ae4-09a1-11e7-9879-2e11bbe7edb1.png">
<img width="74" alt="captura de pantalla 2017-03-15 a las 17 01 34" src="https://cloud.githubusercontent.com/assets/1041600/23968427/696c3b74-09a1-11e7-9076-09b51e716a6f.png"><img width="92" alt="captura de pantalla 2017-03-15 a las 17 01 50" src="https://cloud.githubusercontent.com/assets/1041600/23968428/69cd3a8c-09a1-11e7-8d5b-68f9daa5f800.png">

* **indent explanation for Photon toggle**
    <img width="306" alt="captura de pantalla 2017-03-15 a las 18 10 24" src="https://cloud.githubusercontent.com/assets/1041600/23970990/c44b46da-09aa-11e7-9488-cad480dc81f2.png">

* **update texts for Protect settings card, "Brute force login blocking" for header and "Block suspicious-looking login activity" for toggle description**