### PR TITLE
Settings UI: Fix behavior of Save buttons and children toggles

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -38,7 +38,7 @@ export const SettingsCard = props => {
 		return <span />;
 	}
 
-	const isSaving = props.isSavingAnyOption(),
+	const isSaving = props.saveDisabled,
 		feature = props.feature
 			? props.feature
 			: false,
@@ -165,6 +165,14 @@ export const SettingsCard = props => {
 			{ getBanner( feature ) }
 		</form>
 	);
+};
+
+SettingsCard.propTypes = {
+	saveDisabled: React.PropTypes.bool
+};
+
+SettingsCard.defaultProps = {
+	saveDisabled: false
 };
 
 export default connect(

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -44,7 +44,9 @@ export const Comments = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					module="comments">
+					module="comments"
+					saveDisabled={ this.props.isSavingAnyOption( [ 'highlander_comment_form_prompt', 'jetpack_comment_form_color_scheme' ] ) }
+				>
 					<SettingsGroup hasChild disableInDevMode module={ comments }>
 						<ModuleToggle
 							slug="comments"
@@ -66,7 +68,7 @@ export const Comments = moduleSettingsForm(
 								<TextInput
 									name={ 'highlander_comment_form_prompt' }
 									value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
-									disabled={ ! isCommentsActive || commentsUnavailableInDevMode || this.props.isUpdating( 'highlander_comment_form_prompt' ) }
+									disabled={ ! isCommentsActive || commentsUnavailableInDevMode || this.props.isSavingAnyOption( 'highlander_comment_form_prompt' ) }
 									onChange={ this.props.onOptionChange } />
 							</FormLabel>
 							<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
@@ -75,7 +77,7 @@ export const Comments = moduleSettingsForm(
 								<FormSelect
 									name={ 'jetpack_comment_form_color_scheme' }
 									value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
-									disabled={ ! isCommentsActive || commentsUnavailableInDevMode }
+									disabled={ ! isCommentsActive || commentsUnavailableInDevMode || this.props.isSavingAnyOption( 'jetpack_comment_form_color_scheme' ) }
 									onChange={ this.props.onOptionChange }
 									{ ...this.props }
 									validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -70,7 +70,7 @@ export const Subscriptions = moduleSettingsForm(
 							<FormFieldset>
 								<CompactFormToggle
 									checked={ this.state.stb_enabled }
-									disabled={ ! isSubscriptionsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+									disabled={ ! isSubscriptionsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'subscriptions', 'stb_enabled' ] ) }
 									onChange={ () => this.updateOptions( 'stb_enabled' ) }>
 									<span className="jp-form-toggle-explanation">
 										{
@@ -80,7 +80,7 @@ export const Subscriptions = moduleSettingsForm(
 								</CompactFormToggle>
 								<CompactFormToggle
 									checked={ this.state.stc_enabled }
-									disabled={ ! isSubscriptionsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+									disabled={ ! isSubscriptionsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'subscriptions', 'stc_enabled' ] ) }
 									onChange={ () => this.updateOptions( 'stc_enabled' ) }>
 									<span className="jp-form-toggle-explanation">
 										{

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -84,7 +84,9 @@ export const Protect = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="protect"
-					header={ __( 'Prevent brute force login attacks', { context: 'Settings header' } ) } >
+					header={ __( 'Prevent brute force login attacks', { context: 'Settings header' } ) }
+					saveDisabled={ this.props.isSavingAnyOption( 'jetpack_protect_global_whitelist' ) }
+				>
 					<FoldableCard
 						header={ toggle }
 						className={ classNames( { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
@@ -101,7 +103,7 @@ export const Protect = moduleSettingsForm(
 											</div>
 											{
 												<Button
-													disabled={ ! isProtectActive || unavailableInDevMode || this.currentIpIsWhitelisted() }
+													disabled={ ! isProtectActive || unavailableInDevMode || this.currentIpIsWhitelisted() || this.props.isSavingAnyOption( [ 'protect', 'jetpack_protect_global_whitelist' ] ) }
 													onClick={ this.addToWhitelist }
 													>{ __( 'Add to whitelist' ) }</Button>
 											}
@@ -111,10 +113,11 @@ export const Protect = moduleSettingsForm(
 								<FormLabel>
 									<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
 									<Textarea
-										disabled={ ! isProtectActive || unavailableInDevMode }
+										disabled={ ! isProtectActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'protect', 'jetpack_protect_global_whitelist' ] ) }
 										name={ 'jetpack_protect_global_whitelist' }
 										placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
 										onChange={ this.updateText }
+										disabled={ this.props.isSavingAnyOption( [ 'protect', 'jetpack_protect_global_whitelist' ] ) }
 										value={ this.state.whitelist } />
 								</FormLabel>
 								<span className="jp-form-setting-explanation">

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -69,7 +69,7 @@ export const SSO = moduleSettingsForm(
 						<FormFieldset>
 							<CompactFormToggle
 								checked={ this.state.jetpack_sso_match_by_email }
-								disabled={ ! isSSOActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+								disabled={ ! isSSOActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_match_by_email' ] ) }
 								onChange={ () => this.updateOptions( 'jetpack_sso_match_by_email' ) }>
 								<span className="jp-form-toggle-explanation">
 									{
@@ -79,7 +79,7 @@ export const SSO = moduleSettingsForm(
 							</CompactFormToggle>
 							<CompactFormToggle
 								checked={ this.state.jetpack_sso_require_two_step }
-								disabled={ ! isSSOActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+								disabled={ ! isSSOActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_require_two_step' ] ) }
 								onChange={ () => this.updateOptions( 'jetpack_sso_require_two_step' ) }>
 								<span className="jp-form-toggle-explanation">
 									{

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -82,7 +82,7 @@ export const Ads = moduleSettingsForm(
 						<FormFieldset>
 							<CompactFormToggle
 								checked={ this.state.enable_header_ad }
-								disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+								disabled={ ! isAdsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'wordads', 'enable_header_ad' ] ) }
 								onChange={ () => this.updateOptions( 'enable_header_ad' ) }>
 								<span className="jp-form-toggle-explanation">
 									{ __( 'Display an additional ad at the top of each page' ) }

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -73,7 +73,7 @@ export const RelatedPosts = moduleSettingsForm(
 						<FormFieldset>
 							<CompactFormToggle
 										checked={ this.state.show_headline }
-										disabled={ ! isRelatedPostsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+										disabled={ ! isRelatedPostsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'related-posts', 'show_headline' ] ) }
 										onChange={ () => this.updateOptions( 'show_headline' ) }>
 										<span className="jp-form-toggle-explanation">
 											{
@@ -83,7 +83,7 @@ export const RelatedPosts = moduleSettingsForm(
 							</CompactFormToggle>
 							<CompactFormToggle
 										checked={ this.state.show_thumbnails }
-										disabled={ ! isRelatedPostsActive || unavailableInDevMode || this.props.isSavingAnyOption() }
+										disabled={ ! isRelatedPostsActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'related-posts', 'show_thumbnails' ] ) }
 										onChange={ () => this.updateOptions( 'show_thumbnails' ) }>
 										<span className="jp-form-toggle-explanation">
 											{

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -29,7 +29,9 @@ export const VerificationServices = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					module="verification-tools">
+					module="verification-tools"
+					saveDisabled={ this.props.isSavingAnyOption( [ 'google', 'bing', 'pinterest', 'yandex' ] ) }
+				>
 					<SettingsGroup support={ verification.learn_more_button }>
 						<p>
 							{ __(

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -88,7 +88,7 @@ const Composing = moduleSettingsForm(
 			return (
 				<CompactFormToggle
 					checked={ this.state[ setting ] }
-					disabled={ ! this.props.getOptionValue( 'after-the-deadline' ) || this.props.isUnavailableInDevMode( 'after-the-deadline' ) || this.props.isSavingAnyOption( setting ) }
+					disabled={ ! this.props.getOptionValue( 'after-the-deadline' ) || this.props.isUnavailableInDevMode( 'after-the-deadline' ) || this.props.isSavingAnyOption( [ 'after-the-deadline', setting ] ) }
 					onChange={ () => this.updateOptions( setting ) }>
 					<span className="jp-form-toggle-explanation">
 						{ label }
@@ -190,6 +190,7 @@ const Composing = moduleSettingsForm(
 								slug="markdown"
 								activated={ !! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' ) }
 								toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
+								disabled={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
 								toggleModule={ this.updateFormStateByMarkdown }>
 								<span className="jp-form-toggle-explanation">
 									{ markdown.description }

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -229,7 +229,11 @@ const Composing = moduleSettingsForm(
 				);
 
 			return (
-				<SettingsCard header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props } module="composing">
+				<SettingsCard
+					header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props }
+					module="composing"
+					saveDisabled={ this.props.isSavingAnyOption( 'ignored_phrases' ) }
+				>
 					{ this.props.isModuleFound( 'markdown' ) && markdownSettings }
 					{ this.props.isModuleFound( 'after-the-deadline' ) && atdSettings }
 				</SettingsCard>

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -58,7 +58,7 @@ const CustomContentTypes = moduleSettingsForm(
 					<SettingsGroup hasChild support={ module.learn_more_button }>
 						<CompactFormToggle
 									checked={ this.state.testimonial }
-									disabled={ this.props.isSavingAnyOption() }
+									disabled={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) }
 									onChange={ () => this.updateCPTs( 'testimonial' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
@@ -81,7 +81,7 @@ const CustomContentTypes = moduleSettingsForm(
 						</FormFieldset>
 						<CompactFormToggle
 									checked={ this.state.portfolio }
-									disabled={ this.props.isSavingAnyOption() }
+									disabled={ this.props.isSavingAnyOption( 'jetpack_portfolio' ) }
 									onChange={ () => this.updateCPTs( 'portfolio' ) }>
 							<span className="jp-form-toggle-explanation">
 								{

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -175,7 +175,9 @@ const Media = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Media' ) }
-					feature={ FEATURE_VIDEO_HOSTING_JETPACK }>
+					feature={ FEATURE_VIDEO_HOSTING_JETPACK }
+					saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
+				>
 					{ this.props.isModuleFound( 'photon' ) && photonSettings }
 					{ this.props.isModuleFound( 'carousel' ) && carouselSettings }
 					{ this.props.isModuleFound( 'videopress' ) && videoPressSettings }

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -127,7 +127,7 @@ const Media = moduleSettingsForm(
 					<FormFieldset>
 						<CompactFormToggle
 							checked={ this.state.carousel_display_exif }
-							disabled={ ! isCarouselActive || this.props.isSavingAnyOption() }
+							disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_display_exif' ] ) }
 							onChange={ () => this.updateOptions( 'carousel_display_exif' ) }>
 							<span className="jp-form-toggle-explanation">
 								{
@@ -142,7 +142,7 @@ const Media = moduleSettingsForm(
 							<FormSelect
 								name={ 'carousel_background_color' }
 								value={ this.props.getOptionValue( 'carousel_background_color' ) }
-								disabled={ ! isCarouselActive || this.props.isSavingAnyOption( 'carousel_background_color' ) }
+								disabled={ ! isCarouselActive || this.props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] ) }
 								{ ...this.props }
 								validValues={ this.props.validValues( 'carousel_background_color', 'carousel' ) } />
 						</FormLabel>

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -129,7 +129,7 @@ const ThemeEnhancements = moduleSettingsForm(
 												return (
 													<CompactFormToggle
 														checked={ this.state[ chkbx.key ] }
-														disabled={ ! isItemActive }
+														disabled={ ! isItemActive || this.props.isSavingAnyOption( [ item.module, chkbx.key ] ) }
 														onChange={ () => this.updateOptions( chkbx.key, item.module ) }
 														key={ `${ item.module }_${ chkbx.key }`}>
 														<span className="jp-form-toggle-explanation">


### PR DESCRIPTION
Fixes #6653

This fixes the behavior of all toggles/settings areas while settings are being saved.  Previously toggles were not disabled as they were saving, so you could click multiple times which would break things.  

Now individual toggles should be disabled as that corresponding settings is being saved.  Related settings that depend on it should also be disabled, such as disabling the parent module should disable the children toggles during that save.  

This also changes the behavior of the `Save Settings` buttons in some cards.  During save, you should see a disabled `Saving...` button in place, and ONLY for that specific card.  To do this, I've introduced a new boolean prop `saveDisabled` that should be passed to the `SettingsCard` component.  

To Test: 
- Make sure all toggles and settings are behaving as you expect.  