### PR TITLE
Settings UI: Replace some settings external links with clickable cards 

### DIFF
--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -4,12 +4,12 @@
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import CompactFormToggle from 'components/form/form-toggle/compact';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
  */
 import { FormFieldset } from 'components/forms';
-import ExternalLink from 'components/external-link';
 import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
@@ -88,16 +88,14 @@ export const Subscriptions = moduleSettingsForm(
 										}
 									</span>
 								</CompactFormToggle>
-								{
-									( isSubscriptionsActive || ! unavailableInDevMode ) && (
-										<p>
-											<ExternalLink className="jp-module-settings__external-link" href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</ExternalLink>
-										</p>
-									)
-								}
 							</FormFieldset>
 						}
 					</SettingsGroup>
+					{
+						! unavailableInDevMode && isSubscriptionsActive && (
+							<Card compact className="jp-settings-card__configure-link" href={ 'https://wordpress.com/people/email-followers/' + this.props.siteRawUrl }>{ __( 'View your Email Followers' ) }</Card>
+						)
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -3,12 +3,12 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
  */
 import { FEATURE_SECURITY_SCANNING_JETPACK } from 'lib/plans/constants';
-import ExternalLink from 'components/external-link';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -28,19 +28,15 @@ export const BackupsScan = moduleSettingsForm(
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://vaultpress.com/jetpack/">
-						<p>
-							{
-								__( 'Your site is backed up and threat-free.' )
-							}
-						</p>
 						{
-							! this.props.isUnavailableInDevMode( 'backups' ) && (
-								<span>
-									<ExternalLink className="jp-module-settings__external-link" href="https://dashboard.vaultpress.com/" >{ __( 'Configure your Security Scans' ) }</ExternalLink>
-								</span>
-							)
+							__( 'Your site is backed up and threat-free.' )
 						}
 					</SettingsGroup>
+					{
+						! this.props.isUnavailableInDevMode( 'backups' ) && (
+							<Card compact className="jp-settings-card__configure-link" href="https://dashboard.vaultpress.com/">{ __( 'Configure your Security Scans' ) }</Card>
+						)
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import ExternalLink from 'components/external-link';
+import Card from 'components/card';
 import CompactFormToggle from 'components/form/form-toggle/compact';
 
 /**
@@ -88,17 +88,13 @@ export const Ads = moduleSettingsForm(
 									{ __( 'Display an additional ad at the top of each page' ) }
 								</span>
 							</CompactFormToggle>
-							{ ! unavailableInDevMode && (
-								<p>
-									<ExternalLink
-										className="jp-module-settings__external-link"
-										href={ this.props.configureUrl }>
-										{ __( 'View your earnings' ) }
-									</ExternalLink>
-								</p>
-							) }
 						</FormFieldset>
 					</SettingsGroup>
+					{
+						! unavailableInDevMode && isAdsActive && (
+							<Card compact className="jp-settings-card__configure-link" href={ this.props.configureUrl }>{ __( 'View your earnings' ) }</Card>
+						)
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -19,7 +19,7 @@ export const GoogleAnalytics = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Analytics Settings', { context: 'Settings header' } ) }
+					header={ __( 'Google Analytics', { context: 'Settings header' } ) }
 					feature={ FEATURE_GOOGLE_ANALYTICS_JETPACK }
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'google-analytics' } } support="https://jetpack.com/support/google-analytics/">
@@ -36,7 +36,7 @@ export const GoogleAnalytics = moduleSettingsForm(
 					</SettingsGroup>
 					{
 						! this.props.isUnavailableInDevMode( 'google-analytics' ) && (
-							<Card compact className="jp-settings-card__configure-link" href={ this.props.configureUrl }>{ __( 'Configure Google Analytics settings.' ) }</Card>
+							<Card compact className="jp-settings-card__configure-link" href={ this.props.configureUrl }>{ __( 'Configure your Google Analytics settings' ) }</Card>
 						)
 					}
 				</SettingsCard>

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -23,18 +23,16 @@ export const GoogleAnalytics = moduleSettingsForm(
 					feature={ FEATURE_GOOGLE_ANALYTICS_JETPACK }
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'google-analytics' } } support="https://jetpack.com/support/google-analytics/">
-						<p>
-							{ __(
-								'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
-								' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
-								'normally show slightly different totals for your visits, views, etc.',
-								{
-									components: {
-										a: <a href={ 'https://wordpress.com/stats/day/' + this.props.siteRawUrl } />
-									}
+						{ __(
+							'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
+							' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
+							'normally show slightly different totals for your visits, views, etc.',
+							{
+								components: {
+									a: <a href={ 'https://wordpress.com/stats/day/' + this.props.siteRawUrl } />
 								}
-							) }
-						</p>
+							}
+						) }
 					</SettingsGroup>
 					{
 						! this.props.isUnavailableInDevMode( 'google-analytics' ) && (

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
-import ExternalLink from 'components/external-link';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
@@ -24,25 +24,21 @@ export const SEO = moduleSettingsForm(
 					feature={ FEATURE_SEO_TOOLS_JETPACK }
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'seo-tools' } } support="https://jetpack.com/support/seo-tools/">
-						<p>
-							{
-								__( "You can tweak these settings if you'd like more advanced control. Read more about what you can do to {{a}}optimize your site's SEO{{/a}}.",
-									{
-										components: {
-											a: <a href="https://jetpack.com/support/seo-tools/" />
-										}
-									}
-								)
-							}
-						</p>
 						{
-							! this.props.isUnavailableInDevMode( 'seo-tools' ) && (
-								<span>
-									<ExternalLink className="jp-module-settings__external-link" href={ this.props.configureUrl }>{ __( 'Configure your SEO settings' ) }</ExternalLink>
-								</span>
+							__( "You can tweak these settings if you'd like more advanced control. Read more about what you can do to {{a}}optimize your site's SEO{{/a}}.",
+								{
+									components: {
+										a: <a href="https://jetpack.com/support/seo-tools/" />
+									}
+								}
 							)
 						}
 					</SettingsGroup>
+					{
+						! this.props.isUnavailableInDevMode( 'seo-tools' ) && (
+							<Card compact className="jp-settings-card__configure-link" href={ this.props.configureUrl }>{ __( 'Configure your SEO settings' ) }</Card>
+						)
+					}
 				</SettingsCard>
 			);
 		}


### PR DESCRIPTION
Fixes #6651

Uses clickable compact cards for external links for some settings cards.  Also removed some `p` tags to remove some crazy padding.  

Some of the cards won't show if the module isn't active, like ads and subscriptions.  

![screen shot 2017-03-15 at 12 15 27 pm](https://cloud.githubusercontent.com/assets/7129409/23958794/92a5044e-0979-11e7-9c19-c21659384169.png)
![screen shot 2017-03-15 at 12 15 43 pm](https://cloud.githubusercontent.com/assets/7129409/23958852/c2379334-0979-11e7-87c8-1693780e7093.png)
![screen shot 2017-03-15 at 12 15 54 pm](https://cloud.githubusercontent.com/assets/7129409/23958798/965792c8-0979-11e7-9df0-2ab0f4b93328.png)
![screen shot 2017-03-15 at 12 16 03 pm](https://cloud.githubusercontent.com/assets/7129409/23958800/97a89852-0979-11e7-8728-db5d1e053c00.png)
