### PR TITLE
Contact Form: Add a plain-text alternative to outbound messages

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2007,9 +2007,16 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$reply_to_addr = $comment_author_email;
 		}
 
+		/*
+		 * Build the message headers
+		 *
+		 * We don't need to specify a Content-Type header, because PHPMailer will automatically generate the
+		 * proper content-type for each part of the message once it detects that an AltBody is added.
+		 *
+		 * wp_mail() automatically sets the Charset to the site's charset, so we don't need to do that either.
+		 */
 		$headers = 'From: "' . $comment_author . '" <' . $from_email_addr . ">\r\n" .
-					'Reply-To: "' . $comment_author . '" <' . $reply_to_addr . ">\r\n" .
-					'Content-Type: text/html; charset="' . get_option( 'blog_charset' ) . '"';
+					'Reply-To: "' . $comment_author . '" <' . $reply_to_addr . ">\r\n";
 
 		// Build feedback reference
 		$feedback_time  = current_time( 'mysql' );
@@ -2139,6 +2146,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			wp_schedule_event( time() + 250, 'daily', 'grunion_scheduled_delete' );
 		}
 
+		add_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
 		if (
 			$is_spam !== true &&
 			/**
@@ -2169,6 +2177,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		) { // don't send spam by default.  Filterable.
 			wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 		}
+		remove_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return self::success_message( $post_id, $this );
@@ -2200,6 +2209,18 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		wp_safe_redirect( $redirect );
 		exit;
+	}
+
+	/**
+	 * Add a plain-text alternative part to an outbound email
+	 *
+	 * This makes the message more accessible to mail clients that aren't HTML-aware, and decreases the likelihood
+	 * that the message will be flagged as spam.
+	 *
+	 * @param PHPMailer $phpmailer
+	 */
+	static function add_plain_text_alternative( $phpmailer ) {
+		$phpmailer->AltBody = strip_tags( $phpmailer->Body );
 	}
 
 	function addslashes_deep( $value ) {


### PR DESCRIPTION
This avoid's SpamAssassin's `MIME_HTML_ONLY` rule.

See #6114

#### Testing instructions:

1. From `master`, fill out a `[contact-form]` and copy the email source to http://spamcheck.postmarkapp.com/
1. Note the triggered `MIME_HTML_ONLY` rule
1. Check out this branch, and re-run the test. The rule should no longer be triggered.