### PR TITLE
Remove "login" from Jetpack

### DIFF
--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -62,7 +62,7 @@ const DashProtect = React.createClass( {
 			>
 				<p className="jp-dash-item__description">{
 					this.props.isDevMode ? __( 'Unavailable in Dev Mode' ) :
-					__( '{{a}}Activate Protect{{/a}} to keep your site protected from malicious login attempts.', {
+					__( '{{a}}Activate Protect{{/a}} to keep your site protected from malicious sign in attempts.', {
 						components: {
 							a: <a href="javascript:void(0)" onClick={ this.props.activateProtect } />
 						}

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -84,7 +84,7 @@ export const Protect = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="protect"
-					header={ __( 'Prevent brute force login attacks', { context: 'Settings header' } ) }
+					header={ __( 'Brute force attack blocking', { context: 'Settings header' } ) }
 					saveDisabled={ this.props.isSavingAnyOption( 'jetpack_protect_global_whitelist' ) }
 				>
 					<FoldableCard

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -84,7 +84,7 @@ export const Protect = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					module="protect"
-					header={ __( 'Brute force attack blocking', { context: 'Settings header' } ) }
+					header={ __( 'Brute force attack protection', { context: 'Settings header' } ) }
 					saveDisabled={ this.props.isSavingAnyOption( 'jetpack_protect_global_whitelist' ) }
 				>
 					<FoldableCard

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -124,7 +124,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'protect' => array(
 				'name' => _x( 'Protect', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Block suspicious-looking login activity from unknown IP addresses', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Block suspicious-looking sign in activity from unknown IP addresses', 'Module Description', 'jetpack' ),
 			),
 
 			'publicize' => array(

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Protect
- * Module Description: Block suspicious-looking login activity from unknown IP addresses
+ * Module Description: Block suspicious-looking sign in activity from unknown IP addresses
  * Sort Order: 1
  * Recommendation Order: 4
  * First Introduced: 3.4


### PR DESCRIPTION
Removes "login" from Jetpack.

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23973557/4a9e3620-099c-11e7-9f3c-ec499e9b94cd.png)

![image](https://cloud.githubusercontent.com/assets/1123119/23973574/5d9d5f76-099c-11e7-9cf6-6cb8877bd3e1.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23973619/8108c39c-099c-11e7-9efb-ddec9e85c698.png)

![image](https://cloud.githubusercontent.com/assets/1123119/23973632/8c2e7096-099c-11e7-971f-cd64ab59a4da.png)


