### PR TITLE
Fix clickable card text size

### DIFF
--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -6,6 +6,9 @@
 .jp-form-settings-card {
 	margin-bottom: rem(24px);
 
+	.dops-card.is-card-link {
+		font-size: rem( 14px );
+	}
 	.dops-foldable-card {
 		.dops-foldable-card__header {
 			color: #444;


### PR DESCRIPTION
#### Testing
* switch to this branch
* go to settings
* switch to Professional
* check font size of clickable cards. They should be 14px

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23973396/a1bbb5a0-099b-11e7-8c85-e6aaec475d6b.png)


#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23973388/948ee7d0-099b-11e7-9268-b6c5e90fcefd.png)
