### PR TITLE
Fix settings font size issues

### DIFF
--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -5,6 +5,7 @@
 
 .jp-form-settings-card {
 	margin-bottom: rem(24px);
+	font-size: rem( 14px );
 
 	.dops-foldable-card {
 		.dops-foldable-card__header {


### PR DESCRIPTION
Fixes clickable card font size and various text bits that hadn't been reset.

#### Before
![image](https://cloud.githubusercontent.com/assets/1123119/23974563/7ea0dcde-09a1-11e7-98a9-90150dd5bbb6.png)

#### After
![image](https://cloud.githubusercontent.com/assets/1123119/23974550/6bf78024-09a1-11e7-99ff-e2a7dcb21417.png)
