### PR TITLE
Add aria-live attributes to dashboard containers for Main and notices

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -39,7 +39,7 @@ const AdminNotices = React.createClass( {
 	},
 
 	render() {
-		return ( <div ref="adminNotices"></div> )
+		return ( <div ref="adminNotices" aria-live="polite"></div> )
 	}
 } );
 

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -196,7 +196,7 @@ const JetpackNotices = React.createClass( {
 
 	render() {
 		return (
-			<div>
+			<div aria-live="polite">
 				<QueryConnectUrl />
 				<NoticesList />
 				<JetpackStateNotices />

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -162,11 +162,19 @@ const Main = React.createClass( {
 			if ( ! this.props.siteConnectionStatus ) {
 				return false;
 			}
-			return <NonAdminView { ...this.props } />;
+			return (
+				<div aria-live="assertive">
+					<NonAdminView { ...this.props } />
+				</div>
+			);
 		}
 
 		if ( ! this.props.siteConnectionStatus ) {
-			return <JetpackConnect />;
+			return (
+				<div aria-live="assertive">
+					<JetpackConnect />
+				</div>
+			);
 		}
 
 		if ( this.props.jumpStartStatus ) {
@@ -174,7 +182,11 @@ const Main = React.createClass( {
 				const history = createHistory();
 				history.push( window.location.pathname + '?page=jetpack#/jumpstart' );
 			} else if ( '/jumpstart' === route ) {
-				return <JumpStart />;
+				return (
+					<div aria-live="assertive">
+						<JumpStart />
+					</div>
+				);
 			}
 		}
 
@@ -217,7 +229,7 @@ const Main = React.createClass( {
 		window.wpNavMenuClassChange();
 
 		return (
-			<div>
+			<div aria-live="assertive">
 				{ navComponent }
 				{ pageComponent }
 			</div>


### PR DESCRIPTION
[`aria-live`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) is used to tell screen readers that the content in a section will be changed without a page reload. There are two levels of "politeness", polite and assertive.

This PR turns on aria-live=assertive for the Main component, which will interrupt the user when the page content changes (like for a navigation change, or reading out the content of an opened card).

The notices are set as "polite", so they're only read when the user pauses (this _sounds_ like it's not what we want, but it actually works very smoothly in testing).

Fixes #6534

**To test**

1. Turn on a screen reader — VoiceOver (mac), Narrator (windows), ChromeVox (chrome extension), or JAWS (windows).
2. Navigate through the dashboard, click on Apps for example, and you won't be told that the content changed.
3. Check out this branch onto your Jetpack site
4. Turn on a screen reader — VoiceOver (mac), Narrator (windows), ChromeVox (chrome extension), or JAWS (windows).
5. Navigate through the dashboard, and you'll be told of navigation changes.