### PR TITLE
Featured Content: Reword checkboxes for clarity

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -493,14 +493,14 @@ class Featured_Content {
 			'priority'       => 20,
 		) );
 		$wp_customize->add_control( 'featured-content[hide-tag]', array(
-			'label'          => __( 'Hide tag from displaying in post meta and tag clouds.', 'jetpack' ),
+			'label'          => __( 'Hide tag from displaying in post details and tag clouds.', 'jetpack' ),
 			'section'        => 'featured_content',
 			'theme_supports' => 'featured-content',
 			'type'           => 'checkbox',
 			'priority'       => 30,
 		) );
 		$wp_customize->add_control( 'featured-content[show-all]', array(
-			'label'          => __( 'Display tag content in all listings.', 'jetpack' ),
+			'label'          => __( 'Display tagged posts outside the Featured Content area.', 'jetpack' ),
 			'section'        => 'featured_content',
 			'theme_supports' => 'featured-content',
 			'type'           => 'checkbox',

--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -267,7 +267,7 @@ class Featured_Content {
 
 	/**
 	 * Exclude featured posts from the blog query when the blog is the front-page,
-	 * and user has not checked the "Display tag content in all listings" checkbox.
+	 * and user has not checked the "Also display tagged posts outside the Featured Content area" checkbox.
 	 *
 	 * Filter the home page posts, and remove any featured post ID's from it.
 	 * Hooked onto the 'pre_get_posts' action, this changes the parameters of the
@@ -493,14 +493,14 @@ class Featured_Content {
 			'priority'       => 20,
 		) );
 		$wp_customize->add_control( 'featured-content[hide-tag]', array(
-			'label'          => __( 'Hide tag from displaying in post details and tag clouds.', 'jetpack' ),
+			'label'          => __( 'Do not display tag in post details and tag clouds.', 'jetpack' ),
 			'section'        => 'featured_content',
 			'theme_supports' => 'featured-content',
 			'type'           => 'checkbox',
 			'priority'       => 30,
 		) );
 		$wp_customize->add_control( 'featured-content[show-all]', array(
-			'label'          => __( 'Display tagged posts outside the Featured Content area.', 'jetpack' ),
+			'label'          => __( 'Also display tagged posts outside the Featured Content area.', 'jetpack' ),
 			'section'        => 'featured_content',
 			'theme_supports' => 'featured-content',
 			'type'           => 'checkbox',


### PR DESCRIPTION
Fixes #6670

@kathrynwp I implemented the changes you suggested; I liked both of your suggestions. :) If I had to make one more change, I'd add "too" at the end of "Display tagged posts outside the Featured Content area", but I don't know if that would read well.

What do you think? 

#### Proposed changelog entry for your changes:
* Featured Content: Reword checkboxes for clarity