### PR TITLE
Insert videopress.com URLs instead of shortcodes when inserting a video into the post editor

### DIFF
--- a/modules/videopress/editor-media-view.php
+++ b/modules/videopress/editor-media-view.php
@@ -201,12 +201,12 @@ function videopress_media_send_to_editor( $html, $id, $attachment ) {
 	$videopress_guid = get_post_meta( $id, 'videopress_guid', true );
 	if ( $videopress_guid && videopress_is_valid_guid( $videopress_guid ) ) {
 		if ( '[video ' === substr( $html, 0, 7 ) ) {
-			$html = sprintf( '[videopress %1$s]', esc_attr( $videopress_guid ) );
+			$html = sprintf( 'https://videopress.com/v/%1$s/', esc_attr( $videopress_guid ) );
 
 		} elseif ( '<a href=' === substr( $html, 0, 8 ) ) {
 			// We got here because `wp_attachment_is()` returned false for
 			// video, because there isn't a local copy of the file.
-			$html = sprintf( '[videopress %1$s]', esc_attr( $videopress_guid ) );
+			$html = sprintf( 'https://videopress.com/v/%1$s/', esc_attr( $videopress_guid ) );
 		}
 	} elseif ( videopress_is_attachment_without_guid( $id ) ) {
 		$html = sprintf( '[videopress postid=%d]', $id );


### PR DESCRIPTION
Insert videopress.com URLs instead of shortcodes when inserting a video into the post editor.

Fixes #6587 

#### Changes proposed in this Pull Request:

* Instead of inserting a shortcode into the post editor when a video is selected, insert the videopress.com URL.
* There are several reasons to do this, outlined in #6587.

#### Testing instructions:

* Insert a video and see that the VideoPress.com URL is inserted instead of the `[videopress abc123]` shortcode.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
