### PR TITLE
Settings UI: introduce actions for scan settings card

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -25,7 +25,7 @@ import { isDevMode } from 'state/connection';
 const DashBackups = React.createClass( {
 	getContent: function() {
 		const labelName = __( 'Backups' ),
-			hasSitePlan = false !== this.props.sitePlan,
+			hasSitePlan = false !== this.props.sitePlan && 'jetpack_free' !== this.props.sitePlan.product_slug,
 			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled';
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
@@ -74,7 +74,7 @@ const DashBackups = React.createClass( {
 				);
 			} else {
 				return (
-					__( 'To automatically back up your entire site, please {{a}}upgrade!{{/a}}.', {
+					__( 'To automatically back up your entire site, please {{a}}upgrade your account.{{/a}}.', {
 						components: {
 							a: <a href={ 'https://jetpack.com/redirect/?source=aag-backups&site=' + this.props.siteRawUrl } target="_blank" rel="noopener noreferrer" />
 						}

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -31,12 +31,9 @@ const DashScan = React.createClass( {
 			vpData = this.props.vaultPressData,
 			inactiveOrUninstalled = this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) ? 'pro-inactive' : 'pro-uninstalled',
 			scanEnabled = (
-				'undefined' !== typeof vpData.data
-				&&
-				'undefined' !== typeof vpData.data.features
-				&&
-				'undefined' !== typeof vpData.data.features.security
-				&&
+				'undefined' !== typeof vpData.data &&
+				'undefined' !== typeof vpData.data.features &&
+				'undefined' !== typeof vpData.data.features.security &&
 				vpData.data.features.security
 			),
 			hasPremium = /jetpack_premium*/.test( this.props.sitePlan.product_slug ),

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -261,6 +261,13 @@
 		}
 		.dops-card.is-compact {
 			flex-grow: 0;
+			a.dops-notice__action {
+				margin-left: 0;
+				padding-left: 0;
+				@include breakpoint( "<480px" ) {
+					text-transform: none;
+				}
+			}
 		}
 	}
 	.jp-dash-item__card {

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import includes from 'lodash/includes';
+import ProStatus from 'pro-status';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ import {
 	FEATURE_GOOGLE_ANALYTICS_JETPACK,
 	getPlanClass
 } from 'lib/plans/constants';
-import { getSiteRawUrl, userCanManageModules } from 'state/initial-state';
+import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
 import {
 	getSitePlan,
 	isFetchingSiteData
@@ -191,6 +192,9 @@ export const SettingsCard = props => {
 						</Button>
 					)
 				}
+				{
+					props.action && <ProStatus proFeature={ props.action } siteAdminUrl={ props.siteAdminUrl } isCompact={ false } />
+				}
 			</SectionHeader>
 			{ showChildren() && props.children }
 			{ ! props.fetchingSiteData && getBanner( feature ) }
@@ -199,10 +203,12 @@ export const SettingsCard = props => {
 };
 
 SettingsCard.propTypes = {
+	action: React.PropTypes.string,
 	saveDisabled: React.PropTypes.bool
 };
 
 SettingsCard.defaultProps = {
+	action: '',
 	saveDisabled: false
 };
 
@@ -212,6 +218,7 @@ export default connect(
 			sitePlan: getSitePlan( state ),
 			fetchingSiteData: isFetchingSiteData( state ),
 			siteRawUrl: getSiteRawUrl( state ),
+			siteAdminUrl: getSiteAdminUrl( state ),
 			userCanManageModules: userCanManageModules( state )
 		};
 	}

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -106,6 +106,15 @@ const ProStatus = React.createClass( {
 			if ( this.props.isDevMode ) {
 				return '';
 			}
+
+			if ( 'backups' === feature ) {
+				if ( hasFree ) {
+					if ( this.props.isCompact ) {
+						return this.getScanActions( 'free' );
+					}
+				}
+			}
+
 			if ( 'scan' === feature ) {
 				if ( hasFree || hasPersonal ) {
 					if ( this.props.isCompact ) {

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -7,6 +7,7 @@ import { translate as __ } from 'i18n-calypso';
 import includes from 'lodash/includes';
 import Button from 'components/button';
 import SimpleNotice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 /**
  * Internal dependencies
@@ -44,32 +45,84 @@ const ProStatus = React.createClass( {
 		}
 	},
 
+	getScanActions( type ) {
+		let status = '',
+			message = false,
+			action = false,
+			actionUrl = '';
+		switch ( type ) {
+			case 'threats':
+				status = 'is-error';
+				if ( this.props.isCompact ) {
+					action = __( 'FIX THREATS', { context: 'A caption for a small button to fix security issues.' } );
+				} else {
+					message = __( 'Threats found!', { context: 'Short warning message about new threats found.' } );
+					action = __( 'FIX', { context: 'A caption for a small button to fix security issues.' } );
+				}
+				actionUrl = 'https://dashboard.vaultpress.com/';
+				break;
+			case 'free':
+			case 'personal':
+				status = 'is-warning';
+				if ( ! this.props.isCompact ) {
+					message = __( 'No scanning', { context: 'Short warning message about site having no security scan.' } );
+				}
+				action = __( 'Upgrade', { context: 'Caption for a button to purchase a paid feature.' } );
+				actionUrl = 'https://jetpack.com/redirect/?source=upgrade&site=' + this.props.siteRawUrl;
+				break;
+			case 'secure':
+				status = 'is-success';
+				message = __( 'Secure', { context: 'Short message informing user that the site is secure.' } );
+				break;
+		}
+		return (
+			<SimpleNotice
+				showDismiss={ false }
+				status={ status }
+				isCompact={ true }
+			>
+				{
+					message
+				}
+				{
+					action && <NoticeAction href={ actionUrl }>{ action }</NoticeAction>
+				}
+			</SimpleNotice>
+		);
+	},
+
 	render() {
-		let sitePlan = this.props.sitePlan(),
-			pluginSlug = 'scan' === this.props.proFeature || 'backups' === this.props.proFeature || 'vaultpress' === this.props.proFeature ?
-			'vaultpress/vaultpress.php' :
-			'akismet/akismet.php';
+		const sitePlan = this.props.sitePlan(),
+			pluginSlug = 'scan' === this.props.proFeature || 'backups' === this.props.proFeature || 'vaultpress' === this.props.proFeature
+				? 'vaultpress/vaultpress.php'
+				: 'akismet/akismet.php';
 
 		const hasPremium = /jetpack_premium*/.test( sitePlan.product_slug ),
-			hasBusiness = /jetpack_business*/.test( sitePlan.product_slug );
+			hasBusiness = /jetpack_business*/.test( sitePlan.product_slug ),
+			hasPersonal = /jetpack_personal*/.test( sitePlan.product_slug ),
+			hasFree = /jetpack_free*/.test( sitePlan.product_slug );
 
-		let getStatus = ( feature, active, installed ) => {
-			let vpData = this.props.getVaultPressData();
-
+		const getStatus = ( feature, active, installed ) => {
 			if ( this.props.isDevMode ) {
-				return __( 'Unavailable in Dev Mode' );
+				return '';
 			}
-
-			if ( 'N/A' !== vpData && 'scan' === feature && 0 !== this.props.getScanThreats() ) {
-				return(
-					<SimpleNotice
-						showDismiss={ false }
-						status='is-error'
-						isCompact={ true }
-					>
-						{ __( 'Threats found!', { context: 'Short warning message about new threats found.' } ) }
-					</SimpleNotice>
-				);
+			if ( 'scan' === feature ) {
+				if ( hasFree || hasPersonal ) {
+					if ( this.props.isCompact ) {
+						return this.getScanActions( 'free' );
+					}
+					return '';
+				}
+				const vpData = this.props.getVaultPressData();
+				if ( 'N/A' !== vpData ) {
+					const threatsCount = this.props.getScanThreats();
+					if ( 0 !== threatsCount ) {
+						return this.getScanActions( 'threats' );
+					}
+					if ( 0 === threatsCount ) {
+						return this.getScanActions( 'secure' );
+					}
+				}
 			}
 
 			if ( 'akismet' === feature ) {

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -42,7 +42,7 @@ const ProStatus = React.createClass( {
 		return {
 			isCompact: true,
 			proFeature: ''
-		}
+		};
 	},
 
 	getScanActions( type ) {
@@ -93,6 +93,7 @@ const ProStatus = React.createClass( {
 
 	render() {
 		const sitePlan = this.props.sitePlan(),
+			vpData = this.props.getVaultPressData(),
 			pluginSlug = 'scan' === this.props.proFeature || 'backups' === this.props.proFeature || 'vaultpress' === this.props.proFeature
 				? 'vaultpress/vaultpress.php'
 				: 'akismet/akismet.php';
@@ -100,15 +101,27 @@ const ProStatus = React.createClass( {
 		const hasPremium = /jetpack_premium*/.test( sitePlan.product_slug ),
 			hasBusiness = /jetpack_business*/.test( sitePlan.product_slug ),
 			hasPersonal = /jetpack_personal*/.test( sitePlan.product_slug ),
-			hasFree = /jetpack_free*/.test( sitePlan.product_slug );
-
+			hasFree = /jetpack_free*/.test( sitePlan.product_slug ),
+			hasBackups = (
+				'undefined' !== typeof vpData.data &&
+				'undefined' !== typeof vpData.data.features &&
+				'undefined' !== typeof vpData.data.features.backups &&
+				vpData.data.features.backups
+			),
+			hasScan = (
+				'undefined' !== typeof vpData.data &&
+				'undefined' !== typeof vpData.data.features &&
+				'undefined' !== typeof vpData.data.features.security &&
+				vpData.data.features.security
+			);
+		
 		const getStatus = ( feature, active, installed ) => {
 			if ( this.props.isDevMode ) {
 				return '';
 			}
 
 			if ( 'backups' === feature ) {
-				if ( hasFree ) {
+				if ( hasFree && ! hasBackups ) {
 					if ( this.props.isCompact ) {
 						return this.getScanActions( 'free' );
 					}
@@ -116,13 +129,12 @@ const ProStatus = React.createClass( {
 			}
 
 			if ( 'scan' === feature ) {
-				if ( hasFree || hasPersonal ) {
+				if ( ( hasFree || hasPersonal ) && ! hasScan ) {
 					if ( this.props.isCompact ) {
 						return this.getScanActions( 'free' );
 					}
 					return '';
 				}
-				const vpData = this.props.getVaultPressData();
 				if ( 'N/A' !== vpData ) {
 					const threatsCount = this.props.getScanThreats();
 					if ( 0 !== threatsCount ) {

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -26,6 +26,7 @@ export const BackupsScan = moduleSettingsForm(
 					feature={ FEATURE_SECURITY_SCANNING_JETPACK }
 					{ ...this.props }
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+					action="scan"
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://vaultpress.com/jetpack/">
 						{


### PR DESCRIPTION
Fixes #6405 

#### Changes proposed in this Pull Request:

* if site has a free plan, prompt to upgrade. This is done only in dashboard item

<img width="369" alt="captura de pantalla 2017-03-16 a las 16 31 47" src="https://cloud.githubusercontent.com/assets/1041600/24015118/2fd96c54-0a66-11e7-9b92-dfeeee7390ef.png">

* if there are threats, prompt to fix them

<img width="735" alt="captura de pantalla 2017-03-16 a las 16 25 20" src="https://cloud.githubusercontent.com/assets/1041600/24015124/3bb123a0-0a66-11e7-9bc7-a4e712502c22.png">
<img width="369" alt="captura de pantalla 2017-03-16 a las 16 27 54" src="https://cloud.githubusercontent.com/assets/1041600/24015125/3bb6e7ae-0a66-11e7-91ef-d0b9786c23bb.png">

* if site is secure, display a success badge

<img width="739" alt="captura de pantalla 2017-03-16 a las 16 24 07" src="https://cloud.githubusercontent.com/assets/1041600/24015114/2b2d4b62-0a66-11e7-9183-d07c53b5e4b0.png">
<img width="369" alt="captura de pantalla 2017-03-16 a las 16 24 53" src="https://cloud.githubusercontent.com/assets/1041600/24015113/2b2516ae-0a66-11e7-92a7-b499f327a0a9.png">

* action text is not uppercased in mobile size

<img width="441" alt="captura de pantalla 2017-03-16 a las 19 28 41" src="https://cloud.githubusercontent.com/assets/1041600/24021478/edf840c0-0a7f-11e7-9dd2-fc8a2caa2353.png">

#### Testing instructions:

* test switching plans
* the threats badge can be tested by, standing on this branch in your local Git, cherry picking the commit from #6688 `git cherry-pick bd607587539c3c05c62476003a4f41d8fa822bb0`