### PR TITLE
Add vip-go to hosting provider detection

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -88,6 +88,9 @@ class Jetpack_Sync_Functions {
 		if ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ) {
 			return 'wpe';
 		}
+		if ( defined( 'VIP_GO_ENV' ) && false !== VIP_GO_ENV ) {
+			return 'vip-go';
+		}
 		return 'unknown';
 	}
 


### PR DESCRIPTION
Adds `vip-go` to the list of known hosting providers in Jetpack Sync.