### PR TITLE
Detect and remove double encoded redirects

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5364,7 +5364,7 @@ p {
 	}
 
 	static function is_redirect_encoded( $redirect_url ) {
-		return wp_startswith( $redirect_url, 'https%3A%2F%2F' );
+		return preg_match( '/https?%3A%2F%2F/i', $redirect_url ) > 0;
 	}
 
 	static function remove_double_encoding( $str ) {


### PR DESCRIPTION
When WordPress.com starts authenticating with a Jetpack site it accesses the site via http (I assume because it doesn't know if the site supports SSL).

Some hosts redirect http to https, but are somehow misconfigured so that query parameters are re-encoded. This causes signature matching to fail, and this message to be shown:

`Someone may be trying to trick you into giving them access to your site`

I'm currently unsure as to the exact cause of the problem - it's possibly a misconfiguration with Apache, or maybe even a plugin.

**Added**: [Really Simple SSL](https://en-gb.wordpress.org/plugins/really-simple-ssl/) adds this to `.htaccess` which is known to cause the problem on some (but not all) hosts.

```
RewriteCond %{HTTPS} !=on [NC]
RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
```

Adding `NE` to the list of options on the rewrite rule fixes it.

#### Testing the problem

You can check the problem with this:

`curl -v http://lireo.com/?s=%40`

The server incorrectly redirects you to:

`https://www.lireo.com/?s=%2540`

Note that the `%40` has been double-encoded to `%2540`. The correct target should be:

`https://www.lireo.com/?s=%40`

I created this [plugin that fakes the problem](https://gist.github.com/johngodley/d910240796e5dc76408ad7b790931174) to make it easier to test fixes with.

#### Changes proposed in this Pull Request:

This PR checks the `redirect_to` query param and if it detects a double-encoded value removes one level of encoding. This means that the signature matching succeeds, and the `redirect_to` goes to the right place.

This also has to be performed with the details saved to cookies in the SSO code.

Ideally the best solution is that the problem is removed from the server and we don't need this somewhat hacky solution. This PR silently removes the problem, but doesn't prevent the same problem occurring elsewhere.

An alternative to silently fixing the problem is that we change the 'someone may be trying to trick you' message to a full explanation of the problem, hoping that the user will be able to fix it properly - I don't know how realistic this is.

Also, maybe Jetpack could check for this and show an error in the dashboard. We may even be able to track statistics for how many people are affected.

Also it should be noted that I'm not familiar with the auth process, and there may be a better way of doing it. This is more to start the conversation. If a root cause can be discovered then it may help towards a better fix.

#### Testing instructions:

Requires a host that double-encodes the redirect (real or via above mentioned plugin):

- Use an app that goes through the wpcom auth process to connect to the Jetpack site (postbot.co or [Google Docs add on](https://chrome.google.com/webstore/detail/wordpresscom-for-google-d/baibkfjlahbcogbckhjljjenalhamjbp))
- At some point during the auth process you will see a `Someone may be trying to trick you into giving them access to your site` error

Try the same with this PR and the auth process should complete (SSO and normal login).

@georgeh 