### PR TITLE
Settings UI: convert Infinite scroll options to radio buttons

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -13,11 +13,13 @@
 }
 
 .jp-form-label-wide {
+	padding: rem( 8px ) 0;
 	display: block;
 }
 
 .jp-form-label input[type="radio"] + span {
 	font-weight: normal;
+	margin-left: 8px;
 }
 
 .jp-form-button {

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -9,7 +9,7 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 /**
  * Internal dependencies
  */
-import { FormFieldset } from 'components/forms';
+import { FormFieldset, FormLabel, FormLegend } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
@@ -24,21 +24,62 @@ const ThemeEnhancements = moduleSettingsForm(
 		 * Get options for initial state.
 		 *
 		 * @returns {Object} {{
-		 * infinite_scroll: *,
-		*		infinite_scroll_google_analytics: *,
-		*		wp_mobile_excerpt: *,
-		*		wp_mobile_featured_images: *,
-		*		wp_mobile_app_promos: *
+		 * 		infinite_scroll: *,
+		 *		wp_mobile_excerpt: *,
+		 *		wp_mobile_featured_images: *,
+		 *		wp_mobile_app_promos: *
 		 * }}
 		 */
 		getInitialState() {
 			return {
-				infinite_scroll: this.props.getOptionValue( 'infinite_scroll', 'infinite-scroll' ),
-				infinite_scroll_google_analytics: this.props.getOptionValue( 'infinite_scroll_google_analytics', 'infinite-scroll' ),
+				infinite_mode: this.getInfiniteMode(),
 				wp_mobile_excerpt: this.props.getOptionValue( 'wp_mobile_excerpt', 'minileven' ),
 				wp_mobile_featured_images: this.props.getOptionValue( 'wp_mobile_featured_images', 'minileven' ),
 				wp_mobile_app_promos: this.props.getOptionValue( 'wp_mobile_app_promos', 'minileven' )
 			};
+		},
+
+		/**
+		 * Translate Infinite Scroll module and option status into our three values for the options.
+		 *
+		 * @returns {string}
+		 */
+		getInfiniteMode() {
+			if ( ! this.props.getOptionValue( 'infinite-scroll' ) ) {
+				return 'infinite_default';
+			}
+			if ( this.props.getOptionValue( 'infinite_scroll', 'infinite-scroll' ) ) {
+				return 'infinite_scroll';
+			}
+			return 'infinite_button';
+		},
+
+		/**
+		 * Update the state for infinite scroll options and prepare options to submit
+		 *
+		 * @param {string} radio
+		 */
+		updateInfiniteMode( radio ) {
+			this.setState(
+				{
+					infinite_mode: radio
+				},
+				this.prepareOptionsToUpdate
+			);
+		},
+
+		/**
+		 * Update the options that will be submitted to translate from the three radios to the module and option status.
+		 */
+		prepareOptionsToUpdate() {
+			if ( 'infinite_default' === this.state.infinite_mode ) {
+				this.props.updateFormStateOptionValue( 'infinite-scroll', false );
+			} else if ( 'infinite_scroll' === this.state.infinite_mode || 'infinite_button' === this.state.infinite_mode ) {
+				this.props.updateFormStateOptionValue( {
+					'infinite-scroll': true,
+					infinite_scroll: 'infinite_scroll' === this.state.infinite_mode
+				} );
+			}
 		},
 
 		/**
@@ -57,53 +98,87 @@ const ThemeEnhancements = moduleSettingsForm(
 		},
 
 		render() {
-			if (
-				! this.props.isModuleFound( 'infinite-scroll' )
-				&& ! this.props.isModuleFound( 'minileven' )
-			) {
+			if ( ! this.props.isModuleFound( 'infinite-scroll' ) && ! this.props.isModuleFound( 'minileven' ) ) {
 				return null;
 			}
 
 			return (
 				<SettingsCard
 					{ ...this.props }
-					hideButton
 					header={ __( 'Theme enhancements' ) }>
 					{
-
-						[
-							{
-								...this.props.getModule( 'infinite-scroll' ),
-								checkboxes: [
-									{
-										key: 'infinite_scroll',
-										label: __( 'Scroll infinitely (Shows 7 posts on each load)' )
-									},
-									{
-										key: 'infinite_scroll_google_analytics',
-										label: __( 'Track each scroll load (7 posts by default) as a page view in Google Analytics' )
-									}
-								]
-							},
-							{
-								...this.props.getModule( 'minileven' ),
-								checkboxes: [
-									{
-										key: 'wp_mobile_excerpt',
-										label: __( 'Use excerpts instead of full posts on front page and archive pages' )
-									},
-									{
-										key: 'wp_mobile_featured_images',
-										label: __( 'Show featured images' )
-									},
-									{
-										key: 'wp_mobile_app_promos',
-										label: __( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' )
-									}
-								]
+						[ {
+							...this.props.getModule( 'infinite-scroll' ),
+							radios: [
+								{
+									key: 'infinite_default',
+									label: __( 'Load more posts using the default theme behavior' )
+								},
+								{
+									key: 'infinite_button',
+									label: __( 'Load more posts in page with a button' )
+								},
+								{
+									key: 'infinite_scroll',
+									label: __( 'Load more posts as the reader scrolls down' )
+								}
+							]
+						} ].map( item => {
+							if ( ! this.props.isModuleFound( item.module ) ) {
+								return null;
 							}
-						].map( item => {
-							let isItemActive = this.props.getOptionValue( item.module );
+
+							return (
+								<SettingsGroup hasChild key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
+									<FormLegend className="jp-form-label-wide">
+										{
+											item.name
+										}
+									</FormLegend>
+									{
+										item.radios.map( radio => {
+											return (
+												<FormLabel key={ `${ item.module }_${ radio.key }` }>
+													<input
+														type="radio"
+														name="infinite_mode"
+														value={ radio.key }
+														checked={ radio.key === this.state.infinite_mode }
+														disabled={ this.props.isSavingAnyOption( [ item.module, radio.key ] ) }
+														onChange={ () => this.updateInfiniteMode( radio.key ) }
+													/>
+													<span className="jp-form-toggle-explanation">
+														{
+															radio.label
+														}
+													</span>
+												</FormLabel>
+											);
+										} )
+									}
+								</SettingsGroup>
+							);
+						} )
+					}
+					{
+						[ {
+							...this.props.getModule( 'minileven' ),
+							checkboxes: [
+								{
+									key: 'wp_mobile_excerpt',
+									label: __( 'Use excerpts instead of full posts on front page and archive pages' )
+								},
+								{
+									key: 'wp_mobile_featured_images',
+									label: __( 'Show featured images' )
+								},
+								{
+									key: 'wp_mobile_app_promos',
+									label: __( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' )
+								}
+							]
+						} ].map( item => {
+							const isItemActive = this.props.getOptionValue( item.module );
 
 							if ( ! this.props.isModuleFound( item.module ) ) {
 								return null;
@@ -111,18 +186,20 @@ const ThemeEnhancements = moduleSettingsForm(
 
 							return (
 								<SettingsGroup hasChild key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
-									<ModuleToggle
-										slug={ item.module }
-										activated={ isItemActive }
-										toggling={ this.props.isSavingAnyOption( item.module ) }
-										toggleModule={ this.props.toggleModuleNow }
-									>
-									<span className="jp-form-toggle-explanation">
 									{
-										item.description
+										<ModuleToggle
+											slug={ item.module }
+											activated={ isItemActive }
+											toggling={ this.props.isSavingAnyOption( item.module ) }
+											toggleModule={ this.props.toggleModuleNow }
+										>
+											<span className="jp-form-toggle-explanation">
+												{
+													item.description
+												}
+											</span>
+										</ModuleToggle>
 									}
-									</span>
-									</ModuleToggle>
 									<FormFieldset>
 										{
 											item.checkboxes.map( chkbx => {
@@ -131,7 +208,7 @@ const ThemeEnhancements = moduleSettingsForm(
 														checked={ this.state[ chkbx.key ] }
 														disabled={ ! isItemActive || this.props.isSavingAnyOption( [ item.module, chkbx.key ] ) }
 														onChange={ () => this.updateOptions( chkbx.key, item.module ) }
-														key={ `${ item.module }_${ chkbx.key }`}>
+														key={ `${ item.module }_${ chkbx.key }` }>
 														<span className="jp-form-toggle-explanation">
 															{
 																chkbx.label
@@ -157,6 +234,6 @@ export default connect(
 		return {
 			module: ( module_name ) => getModule( state, module_name ),
 			isModuleFound: ( module_name ) => _isModuleFound( state, module_name )
-		}
+		};
 	}
 )( ThemeEnhancements );


### PR DESCRIPTION
Fixes #6218

#### Changes proposed in this Pull Request:

* convert Infinite Scroll toggles into radio options updating its labels so it's more clear to end user

#### Testing instructions:

* make sure all options work. The first option will deactivate the module. The other two activate it and the second one sets `infinite_scroll` option to false while the third sets it to true.

cc @tyxla since you were going to implement this in Calypso.