### PR TITLE
Endpoints: allow to save Akismet key

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -304,17 +304,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @return array flattened settings with modules.
 	 */
 	function get_flattened_settings( $modules ) {
-		$settings = array();
-
-		foreach ( $modules as $slug => $data ) {
-			$settings[ $slug ] = $data['activated'] ? true : false;
-
-			foreach ( $data['options'] as $name => $option ) {
-				$settings[ $name ] = $option['current_value'];
-			}
-		}
-
-		return $settings;
+		$core_api_endpoint = new Jetpack_Core_API_Data();
+		$settings = $core_api_endpoint->get_all_options();
+		return $settings->data;
 	}
 }
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1600,6 +1600,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
+			'wordpress_api_key' => array(
+				'description'       => '',
+				'type'              => 'string',
+				'default'           => '',
+				'validate_callback' => __CLASS__ . '::validate_alphanum',
+				'jp_group'          => 'settings',
+			),
+
 		);
 
 		// Add modules to list so they can be toggled

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2347,7 +2347,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool
 	 */
 	private static function core_is_plugin_active( $plugin ) {
-		if ( ! function_exists( 'get_plugins' ) ) {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -403,6 +403,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			}
 		}
 
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$response['akismet'] = is_plugin_active( 'akismet/akismet.php' );
+
 		return rest_ensure_response( $response );
 	}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -19,7 +19,7 @@ abstract class Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 *
 	 * @param Jetpack_IXR_Client $xmlrpc
 	 */
-	public function __construct( $xmlrpc ) {
+	public function __construct( $xmlrpc = null ) {
 		$this->xmlrpc = $xmlrpc;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* whitelist the 'wordpress_api_key' option: an alphanumerical string that can be saved as the Akismet key

* returns data for Holiday Snow and Akismet on Initial_State. This fixes the Akismet checkbox that until now wasn't ticked.

* adds a key `akismet` to list of settings returned by `/settings` endpoint. Value is `true` if Akismet plugin is active, otherwise is `false`.

Fixes #6695
Related #6206