### PR TITLE
Remove markdown card, autoactivate it

### DIFF
--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -157,16 +157,48 @@ const Composing = moduleSettingsForm(
 			);
 		},
 
+		/**
+		 * If markdown module is inactive and this is toggling markdown for posts on, activate module.
+		 * If markdown for comments is off and this is toggling markdown for posts off, deactivate module.
+		 *
+		 * @param {string} module
+		 * @returns {*}
+		 */
+		updateFormStateByMarkdown( module ) {
+			if ( !! this.props.getSettingCurrentValue( 'wpcom_publish_comments_with_markdown', module ) ) {
+				return this.props.updateFormStateModuleOption( module, 'wpcom_publish_posts_with_markdown' );
+			}
+			return this.props.updateFormStateModuleOption( module, 'wpcom_publish_posts_with_markdown', true );
+		},
+
 		render() {
 			// If we don't have any element to show, return early
 			if (
+				! this.props.isModuleFound( 'markdown' ) &&
 				! this.props.isModuleFound( 'after-the-deadline' )
 			) {
 				return null;
 			}
 
-			const atd = this.props.module( 'after-the-deadline' ),
+			const markdown = this.props.module( 'markdown' ),
+				atd = this.props.module( 'after-the-deadline' ),
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' ),
+				markdownSettings = (
+					<SettingsGroup module={ markdown }>
+						<FormFieldset>
+							<ModuleToggle
+								slug="markdown"
+								activated={ !! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' ) }
+								toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
+								disabled={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
+								toggleModule={ this.updateFormStateByMarkdown }>
+								<span className="jp-form-toggle-explanation">
+									{ markdown.description }
+								</span>
+							</ModuleToggle>
+						</FormFieldset>
+					</SettingsGroup>
+				),
 				atdSettings = (
 					<FoldableCard
 						className={ classNames( 'jp-foldable-card__main-settings', { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
@@ -202,6 +234,7 @@ const Composing = moduleSettingsForm(
 					module="composing"
 					saveDisabled={ this.props.isSavingAnyOption( 'ignored_phrases' ) }
 				>
+					{ this.props.isModuleFound( 'markdown' ) && markdownSettings }
 					{ this.props.isModuleFound( 'after-the-deadline' ) && atdSettings }
 				</SettingsCard>
 			);

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -157,48 +157,16 @@ const Composing = moduleSettingsForm(
 			);
 		},
 
-		/**
-		 * If markdown module is inactive and this is toggling markdown for posts on, activate module.
-		 * If markdown for comments is off and this is toggling markdown for posts off, deactivate module.
-		 *
-		 * @param {string} module
-		 * @returns {*}
-		 */
-		updateFormStateByMarkdown( module ) {
-			if ( !! this.props.getSettingCurrentValue( 'wpcom_publish_comments_with_markdown', module ) ) {
-				return this.props.updateFormStateModuleOption( module, 'wpcom_publish_posts_with_markdown' );
-			}
-			return this.props.updateFormStateModuleOption( module, 'wpcom_publish_posts_with_markdown', true );
-		},
-
 		render() {
 			// If we don't have any element to show, return early
 			if (
-				! this.props.isModuleFound( 'markdown' ) &&
 				! this.props.isModuleFound( 'after-the-deadline' )
 			) {
 				return null;
 			}
 
-			const markdown = this.props.module( 'markdown' ),
-				atd = this.props.module( 'after-the-deadline' ),
+			const atd = this.props.module( 'after-the-deadline' ),
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'after-the-deadline' ),
-				markdownSettings = (
-					<SettingsGroup module={ markdown }>
-						<FormFieldset>
-							<ModuleToggle
-								slug="markdown"
-								activated={ !! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' ) }
-								toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
-								disabled={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_posts_with_markdown' ] ) }
-								toggleModule={ this.updateFormStateByMarkdown }>
-								<span className="jp-form-toggle-explanation">
-									{ markdown.description }
-								</span>
-							</ModuleToggle>
-						</FormFieldset>
-					</SettingsGroup>
-				),
 				atdSettings = (
 					<FoldableCard
 						className={ classNames( 'jp-foldable-card__main-settings', { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
@@ -234,7 +202,6 @@ const Composing = moduleSettingsForm(
 					module="composing"
 					saveDisabled={ this.props.isSavingAnyOption( 'ignored_phrases' ) }
 				>
-					{ this.props.isModuleFound( 'markdown' ) && markdownSettings }
 					{ this.props.isModuleFound( 'after-the-deadline' ) && atdSettings }
 				</SettingsCard>
 			);

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -393,18 +393,6 @@ class Jetpack {
 		}
 	}
 
-	/**
-	 * Markdown is now a default, always-on feature of Jetpack
-	 * Since: 4.8
-	 */
-	static function activate_markdown( ) {
-		if ( did_action( 'init' ) || current_filter() == 'init' ) {
-			self::activate_module( 'markdown', false, false );
-		} else if ( !  has_action( 'init' , array( __CLASS__, 'activate_markdown' ) ) ) {
-			add_action( 'init', array( __CLASS__, 'activate_markdown' ) );
-		}
-	}
-
 	static function update_active_modules( $modules ) {
 		$current_modules = Jetpack_Options::get_option( 'active_modules', array() );
 
@@ -2794,9 +2782,7 @@ p {
 			// Setting up jetpack manage
 			Jetpack::activate_manage();
 		}
-
-		Jetpack::activate_markdown();
-
+		
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2793,8 +2793,10 @@ p {
 		if ( ! $old_version ) { // For new sites
 			// Setting up jetpack manage
 			Jetpack::activate_manage();
-			Jetpack::activate_markdown();
 		}
+
+		Jetpack::activate_markdown();
+
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -393,6 +393,18 @@ class Jetpack {
 		}
 	}
 
+	/**
+	 * Markdown is now a default, always-on feature of Jetpack
+	 * Since: 4.8
+	 */
+	static function activate_markdown( ) {
+		if ( did_action( 'init' ) || current_filter() == 'init' ) {
+			self::activate_module( 'markdown', false, false );
+		} else if ( !  has_action( 'init' , array( __CLASS__, 'activate_markdown' ) ) ) {
+			add_action( 'init', array( __CLASS__, 'activate_markdown' ) );
+		}
+	}
+
 	static function update_active_modules( $modules ) {
 		$current_modules = Jetpack_Options::get_option( 'active_modules', array() );
 
@@ -2781,6 +2793,7 @@ p {
 		if ( ! $old_version ) { // For new sites
 			// Setting up jetpack manage
 			Jetpack::activate_manage();
+			Jetpack::activate_markdown();
 		}
 	}
 
@@ -3278,7 +3291,7 @@ p {
 	 * If `$update_media_item` is true and `post_id` is defined
 	 * the attachment file of the media item (gotten through of the post_id)
 	 * will be updated instead of add a new one.
-	 * 
+	 *
 	 * @param  boolean $update_media_item - update media attachment
 	 * @return array - An array describing the uploadind files process
 	 */
@@ -3345,10 +3358,10 @@ p {
 
 				$media_array = $_FILES['media'];
 
-				$file_array['name'] = $media_array['name'][0]; 
-				$file_array['type'] = $media_array['type'][0]; 
-				$file_array['tmp_name'] = $media_array['tmp_name'][0]; 
-				$file_array['error'] = $media_array['error'][0]; 
+				$file_array['name'] = $media_array['name'][0];
+				$file_array['type'] = $media_array['type'][0];
+				$file_array['tmp_name'] = $media_array['tmp_name'][0];
+				$file_array['error'] = $media_array['error'][0];
 				$file_array['size'] = $media_array['size'][0];
 
 				$edited_media_item = Jetpack_Media::edit_media_file( $post_id, $file_array );

--- a/modules/markdown.php
+++ b/modules/markdown.php
@@ -6,7 +6,7 @@
  * Sort Order: 31
  * First Introduced: 2.8
  * Requires Connection: No
- * Auto Activate: No
+ * Auto Activate: Yes
  * Module Tags: Writing
  * Feature: Writing
  * Additional Search Queries: md, markdown


### PR DESCRIPTION
Fixes #6669

#### Changes proposed in this Pull Request:

* Remove Markdown and auto-activate it.

#### Testing instructions:

* Check to see if markdown options show up in settings.  They should be gone.

#### Proposed changelog entry for your changes:

Markdown is now auto-activated and no longer included in the settings interface.