### PR TITLE
General: Update WordPress.com SEO and Analytics URLs

### DIFF
--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -177,14 +177,14 @@ export const Engagement = ( props ) => {
 				props.sitePlan.product_slug === 'jetpack_business_monthly'
 			) {
 				proProps.configure_url = isModuleActive
-					? 'https://wordpress.com/settings/seo/' + props.siteRawUrl
+					? 'https://wordpress.com/settings/traffic/' + props.siteRawUrl
 					: 'inactive';
 			}
 
 			moduleDescription = <AllModuleSettings module={ proProps } />;
 		} else if ( element[0] === 'google-analytics' ) {
 			proProps.configure_url = isModuleActive
-				? 'https://wordpress.com/settings/analytics/' + props.siteRawUrl
+				? 'https://wordpress.com/settings/traffic/' + props.siteRawUrl
 				: 'inactive';
 
 			moduleDescription = <AllModuleSettings module={ proProps } />;

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -218,7 +218,7 @@ const PlanBody = React.createClass( {
 								{
 									this.props.isFetchingPluginsData ? '' :
 									this.props.isModuleActivated( 'seo-tools' ) ? (
-										<Button href={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl } className="is-primary">
+										<Button href={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl } className="is-primary">
 											{ __( 'Configure Site SEO' ) }
 										</Button>
 									)
@@ -244,7 +244,7 @@ const PlanBody = React.createClass( {
 								{
 									this.props.isFetchingPluginsData ? '' :
 									this.props.isModuleActivated( 'google-analytics' ) ? (
-										<Button href={ 'https://wordpress.com/settings/analytics/' + this.props.siteRawUrl } className="is-primary">
+										<Button href={ 'https://wordpress.com/settings/traffic/' + this.props.siteRawUrl } className="is-primary">
 											{ __( 'Configure Google Analytics' ) }
 										</Button>
 									)


### PR DESCRIPTION
After introducing the new Traffic tab in WordPress.com, `/settings/seo/:site_id` and `/settings/analytics/:site_id` are no longer valid, and we use `/settings/traffic/:site_id` instead.

https://github.com/Automattic/wp-calypso/pull/12309 introduces redirects, but this PR updates these URLs in Jetpack as well, so we can avoid the extra redirect.