### PR TITLE
Scope wp_user query to specific user level

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -51,7 +51,15 @@ class Jetpack_Widget_Conditions {
 		$widget_conditions_data['author'] = array();
 		$widget_conditions_data['author'][] = array( '', __( 'All author pages', 'jetpack' ) );
 
-		$authors = get_users( array( 'orderby' => 'name', 'exclude_admin' => true ) );
+		// Only users with publish caps (user level 2 minimum)
+		$authors = get_users(
+			array(
+				'orderby' => 'name',
+				'meta_key'     => 'wp_user_level',
+				'meta_value'   => '1',
+				'meta_compare' => '>',
+			)
+		);
 
 		foreach ( $authors as $author ) {
 			$widget_conditions_data['author'][] = array( (string) $author->ID, $author->display_name );

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -55,7 +55,7 @@ class Jetpack_Widget_Conditions {
 		$authors = get_users(
 			array(
 				'orderby' => 'name',
-				'who'     => 'authors'
+				'who'     => 'authors',
 			)
 		);
 

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -51,7 +51,7 @@ class Jetpack_Widget_Conditions {
 		$widget_conditions_data['author'] = array();
 		$widget_conditions_data['author'][] = array( '', __( 'All author pages', 'jetpack' ) );
 
-		// Only users with publish caps (user level 2 minimum)
+		// Only users with publish caps
 		$authors = get_users(
 			array(
 				'orderby' => 'name',

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -55,9 +55,7 @@ class Jetpack_Widget_Conditions {
 		$authors = get_users(
 			array(
 				'orderby' => 'name',
-				'meta_key'     => 'wp_user_level',
-				'meta_value'   => '1',
-				'meta_compare' => '>',
+				'who'     => 'authors'
 			)
 		);
 


### PR DESCRIPTION
Fixes #6698

Scope the WP_User query to only include those with publishing abilities.  Some sites were breaking since we were trying to get all subscribers as well.  This will only get the users with minimum user level of 2, which grants the ability to publish posts.  

https://codex.wordpress.org/User_Levels

To test: 
- Make sure the `authors` rule only lists those who can publish posts.  