### PR TITLE
Jetpack Debug: add category dropdown to contact form.

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -294,6 +294,29 @@ class Jetpack_Debugger {
 							$subject_line
 						);
 					?>
+					<div id="category_div" class="formbox">
+						<label class="h" for="category"><?php esc_html_e( 'What do you need help with?', 'jetpack' ); ?></label>
+						<select name="category" id="category">
+						<?php
+						/**
+						 * Set up an array of ticket categories.
+						 * (reasons why a user would contact us.)
+						 */
+						$categories = array(
+							'Connection' => esc_html__( "I'm having trouble connecting Jetpack to WordPress.com", 'jetpack' ),
+							'Billing'    => esc_html__( 'I have a billing or plans question', 'jetpack' ),
+							'Backups'    => esc_html__( 'I need help with backing up or restoring my site', 'jetpack' ),
+							'Security'   => esc_html__( 'I have security concerns / my site is hacked', 'jetpack' ),
+							'Priority'   => esc_html__( "My site is down / I can't access my site", 'jetpack' ),
+							'Other'      => esc_html__( 'Something Else' ),
+						);
+
+						foreach ( $categories as $value => $label ) { ?>
+							<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value ); ?>><?php echo esc_html( $label ); ?></option>
+						<?php } ?>
+						</select>
+					</div>
+
 					<div class="formbox">
 						<label for="message" class="h"><?php esc_html_e( 'Please describe the problem you are having.', 'jetpack' ); ?></label>
 						<textarea name="message" cols="40" rows="7" id="did"></textarea>

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -308,7 +308,8 @@ class Jetpack_Debugger {
 							'Backups'    => esc_html__( 'I need help with backing up or restoring my site', 'jetpack' ),
 							'Security'   => esc_html__( 'I have security concerns / my site is hacked', 'jetpack' ),
 							'Priority'   => esc_html__( "My site is down / I can't access my site", 'jetpack' ),
-							'Other'      => esc_html__( 'Something Else' ),
+							/* translators: Last item in a list of reasons to contact Jetpack support. */
+							'Other'      => esc_html__( 'Something Else', 'jetpack' ),
 						);
 
 						foreach ( $categories as $value => $label ) { ?>

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -296,7 +296,7 @@ class Jetpack_Debugger {
 					?>
 					<div id="category_div" class="formbox">
 						<label class="h" for="category"><?php esc_html_e( 'What do you need help with?', 'jetpack' ); ?></label>
-						<select name="category" id="category">
+						<ul>
 						<?php
 						/**
 						 * Set up an array of ticket categories.
@@ -313,9 +313,18 @@ class Jetpack_Debugger {
 						);
 
 						foreach ( $categories as $value => $label ) { ?>
-							<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value ); ?>><?php echo esc_html( $label ); ?></option>
+							<li><label for="<?php echo esc_attr( $value ); ?>">
+								<input
+									id="<?php echo esc_attr( $value ); ?>"
+									name="category"
+									type="radio"
+									value="<?php echo esc_attr( $value ); ?>"
+									<?php checked( esc_attr( $value ), 'Other' ); ?>
+								/>
+								<?php echo esc_html( $label ); ?>
+							</label></li>
 						<?php } ?>
-						</select>
+						</ul>
 					</div>
 
 					<div class="formbox">
@@ -487,6 +496,10 @@ class Jetpack_Debugger {
 
 			#debug_info_div, #toggle_debug_info, #debug_info_div p {
 				font-size: 12px;
+			}
+
+			#category_div ul li {
+				list-style-type: none;
 			}
 
 		</style>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

It allows users to specify why they're contacting us. The form was modified on WordPress.com to support the new field. See more information in p7pQDF-1gx-p2

#### Testing instructions:

1. Go to Jetpack > Debug in your dashboard.
2. Click on the link to contact the Jetpack support team.
3. Pick a reason why you're contacting the Jetpack support team.
4. Submit the form.
5. A prefix should be added to your support email's subject line to indicate the ticket category. No prefix will be added if you picked "Something Else" as reason to contact the support team.

#### Proposed changelog entry for your changes:
* Debug: include more information in the built-in contact form to help prioritizing your requests for support.