### PR TITLE
ES - updated related posts for excluding terms to use terms instead of term

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -294,14 +294,14 @@ EOT;
 
 		return $this->_options;
 	}
-	
+
 	public function get_option( $option_name ) {
 		$options = $this->get_options();
-		
+
 		if ( isset( $options[ $option_name ] ) ) {
 			return $options[ $option_name ];
 		}
-		
+
 		return false;
 	}
 
@@ -770,10 +770,11 @@ EOT;
 		if ( !empty( $args['exclude_post_ids'] ) && is_array( $args['exclude_post_ids'] ) ) {
 			foreach ( $args['exclude_post_ids'] as $exclude_post_id) {
 				$exclude_post_id = (int)$exclude_post_id;
-
+				$excluded_post_ids = array();
 				if ( $exclude_post_id > 0 )
-					$filters[] = array( 'not' => array( 'term' => array( 'post_id' => $exclude_post_id ) ) );
+					$excluded_post_ids[] = $exclude_post_id;
 			}
+			$filters[] = array( 'not' => array( 'terms' => array( 'post_id' => $excluded_post_ids ) ) );
 		}
 
 		return $filters;
@@ -1404,7 +1405,7 @@ EOT;
 	 * @return bool
 	 */
 	protected function _enabled_for_request() {
-		$enabled = is_single() 
+		$enabled = is_single()
 			&&
 				! is_admin()
 			&&


### PR DESCRIPTION
Fixes #6706 

#### Changes proposed in this Pull Request:

* change the list of term queries into a single terms query that is an array of all of the post_ids to exclude

#### Testing instructions:

* make a related post request with over 1024 excluded post_ids and verify that the related post query returns a list of related posts

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
