### PR TITLE
Settings UI: Add banner for WordAds feature

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -17,6 +17,7 @@ import {
 	FEATURE_SEO_TOOLS_JETPACK,
 	FEATURE_VIDEO_HOSTING_JETPACK,
 	FEATURE_GOOGLE_ANALYTICS_JETPACK,
+	FEATURE_WORDADS_JETPACK,
 	getPlanClass
 } from 'lib/plans/constants';
 import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
@@ -72,6 +73,24 @@ export const SettingsCard = props => {
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						href={ 'https://jetpack.com/redirect/?source=settings-video-premium&site=' + siteRawUrl }
+					/>
+				);
+
+			case FEATURE_WORDADS_JETPACK:
+				if (
+					'is-premium-plan' === planClass ||
+					'is-business-plan' === planClass
+				) {
+					return '';
+				}
+
+				return (
+					<Banner
+						title={ __( 'Generate income with high-quality ads.' ) }
+						callToAction={ upgradeLabel }
+						plan={ PLAN_JETPACK_PREMIUM }
+						feature={ feature }
+						href={ 'https://jetpack.com/redirect/?source=settings-ads&site=' + siteRawUrl }
 					/>
 				);
 
@@ -149,6 +168,16 @@ export const SettingsCard = props => {
 				if (
 					'is-free-plan' === planClass ||
 					'is-personal-plan' === planClass
+				) {
+					return false;
+				}
+
+				break;
+
+			case FEATURE_WORDADS_JETPACK:
+				if (
+					'is-premium-plan' !== planClass &&
+					'is-business-plan' !== planClass
 				) {
 					return false;
 				}

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -9,6 +9,7 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 /**
  * Internal dependencies
  */
+import { FEATURE_WORDADS_JETPACK } from 'lib/plans/constants';
 import { FormFieldset } from 'components/forms';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import { ModuleToggle } from 'components/module-toggle';
@@ -50,7 +51,7 @@ export const Ads = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Ads', { context: 'Ads header' } ) }
-					module="wordads"
+					feature={ FEATURE_WORDADS_JETPACK }
 					hideButton>
 					<SettingsGroup
 						disableInDevMode


### PR DESCRIPTION
Adds an upgrade banner and replaces the settings content when the site is on a free plan.  

![screen shot 2017-03-21 at 11 11 38 am](https://cloud.githubusercontent.com/assets/7129409/24154314/316e7be4-0e27-11e7-9bdc-8e4b133095c4.png)

