### PR TITLE
Stats Verbiage: Removing "old" stats

### DIFF
--- a/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -92,7 +92,7 @@ const DashStatsBottom = React.createClass( {
 				<div className="jp-at-a-glance__stats-cta-description">
 				</div>
 				<div className="jp-at-a-glance__stats-cta-buttons">
-					{ __( '{{button}}View Old Stats{{/button}}', {
+					{ __( '{{button}}View Detailed Stats{{/button}}', {
 						components: {
 							button:
 								<Button


### PR DESCRIPTION
Stats Verbiage: Removing "old stats”. Changing to “detailed stats” -
using the term “old” may signify “outdated” stats, which doesn’t make
sense.


*Before*
![screen shot 2017-03-21 at 12 24 17 pm](https://cloud.githubusercontent.com/assets/214813/24160894/5177fc32-0e39-11e7-80a6-eca7b0376cf7.png)


*After*
![screen shot 2017-03-21 at 1 19 22 pm](https://cloud.githubusercontent.com/assets/214813/24160901/59ce773a-0e39-11e7-980a-e4481c327a54.png)
