### PR TITLE
Sync: Add rssap-feedand wp_automatic to the post type black list

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -214,7 +214,7 @@ class Jetpack_Sync_Defaults {
 		'postman_sent_mail',
 		'rssmi_feed_item',
 		'rssap-feed',
-		'wp_automatic'
+		'wp_automatic',
 	);
 
 	static $default_post_checksum_columns = array(

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -213,6 +213,8 @@ class Jetpack_Sync_Defaults {
 		'idx_page',
 		'postman_sent_mail',
 		'rssmi_feed_item',
+		'rssap-feed',
+		'wp_automatic'
 	);
 
 	static $default_post_checksum_columns = array(


### PR DESCRIPTION
Adds 2 post types that are generated by auto post plugins. (rssap-feed and wp_automatic)

https://codecanyon.net/item/wordpress-automatic-plugin/1904470
and 
https://codecanyon.net/item/rss-autopilot-unique-content-extractor/12041946

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Stop syncing more post types by blacklisting them