### PR TITLE
Fix VaultPress VP08 notice text so that the resulting Jetpack notice is not malformed.

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -7,11 +7,16 @@ const AdminNotices = React.createClass( {
 		let $vpNotice = jQuery( '.vp-notice' );
 		if ( $vpNotice.length > 0 ) {
 			$vpNotice.each( function () {
+				if ( jQuery( this ).children( '.vp-message' ).children( 'p' ).html().includes( 'VP08' ) ) {
+					jQuery( this ).children( '.vp-message' ).children( 'p' ).html( 'Your VaultPress subscription is no longer active. Please confirm the status of your account. <a href="https://dashboard.vaultpress.com/account/">View account</a>' );
+				}
+
 				let $notice = jQuery( this ).addClass( 'dops-notice is-warning' ).removeClass( 'wrap vp-notice' );
 				$notice.find( 'a' ).addClass( 'dops-notice__action' ).appendTo( $notice );
 				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );
 				$notice.find( 'h3' ).replaceWith( function () { return jQuery( '<strong />', { html: this.innerHTML } ); } );
 				$notice.find( 'p' ).replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML } ); } );
+
 				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
 			} );
 		}


### PR DESCRIPTION
Fix VaultPress VP08 notice text so that the resulting Jetpack notice is not malformed.

Fixes #

#### Changes proposed in this Pull Request:

* Change the text in the VaultPress notice so that it makes sense in the context of Jetpack.
* Remove the second hyperlink, as it's redundant and causes the notice to be malformed.

Before:
<img width="776" alt="before" src="https://cloud.githubusercontent.com/assets/5528445/24165049/cf4945f6-0e45-11e7-9a9d-7525a38a1247.png">

After:
![after](https://cloud.githubusercontent.com/assets/5528445/24165060/d6c8313e-0e45-11e7-95d7-8107934f80ea.png)

#### Testing instructions:

1. Activate Jetpack and VaultPress.
2. Cancel the VaultPress plan only.
3. View the malformed notice at the top of your Jetpack dashboard.
4. Apply this patch.
5. The notice should now be well formed and the text should more clearly explain the problem. The notice link should now send you to the VaultPress dashboard.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
