### PR TITLE
Settings UI: Add masterbar card

### DIFF
--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -322,3 +322,9 @@ export function maybeHideNavMenuItem( module, values ) {
 			return false;
 	}
 }
+
+export function maybeReloadAfterAction( module ) {
+	if ( 'masterbar' in module ) {
+		window.location.reload();
+	}
+}

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -105,6 +105,13 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 			newOptionValues = { post_by_email_address: 'regenerate' };
 		}
 
+		// Adapt message for masterbar toggle, since it needs to reload.
+		if ( 'object' === typeof newOptionValues && 'masterbar' in newOptionValues ) {
+			messages = {
+				success: __( 'Updated settings. Refreshing page…' )
+			};
+		}
+
 		dispatch( {
 			type: JETPACK_SETTINGS_UPDATE,
 			updatedOptions: newOptionValues

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -20,7 +20,10 @@ import {
 	JETPACK_SETTINGS_SET_UNSAVED_FLAG,
 	JETPACK_SETTINGS_CLEAR_UNSAVED_FLAG
 } from 'state/action-types';
-import { maybeHideNavMenuItem } from 'state/modules';
+import {
+	maybeHideNavMenuItem,
+	maybeReloadAfterAction
+} from 'state/modules';
 import restApi from 'rest-api';
 
 export const setUnsavedSettingsFlag = () => {
@@ -79,6 +82,7 @@ export const updateSetting = ( updatedOption ) => {
 };
 
 export const updateSettings = ( newOptionValues, type = '' ) => {
+
 	return ( dispatch ) => {
 
 		let messages = {
@@ -113,6 +117,7 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 				success: success
 			} );
 			maybeHideNavMenuItem( newOptionValues );
+			maybeReloadAfterAction( newOptionValues );
 
 			dispatch( removeNotice( `module-setting-update` ) );
 			dispatch( createNotice(

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -23,6 +23,7 @@ import Media from './media';
 import CustomContentTypes from './custom-content-types';
 import ThemeEnhancements from './theme-enhancements';
 import PostByEmail from './post-by-email';
+import { Masterbar } from './masterbar';
 
 export const Writing = React.createClass( {
 	displayName: 'WritingSettings',
@@ -36,6 +37,7 @@ export const Writing = React.createClass( {
 		};
 
 		const found = [
+			'masterbar',
 			'markdown',
 			'after-the-deadline',
 			'custom-content-types',
@@ -62,6 +64,7 @@ export const Writing = React.createClass( {
 		return (
 			<div>
 				<QuerySite />
+				<Masterbar { ...commonProps } />
 				{
 					showComposing && (
 						<Composing { ...commonProps } userCanManageModules={ this.props.userCanManageModules } />

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -33,7 +33,8 @@ export const Writing = React.createClass( {
 			settings: this.props.settings,
 			getModule: this.props.module,
 			isDevMode: this.props.isDevMode,
-			isUnavailableInDevMode: this.props.isUnavailableInDevMode
+			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
+			isLinked: this.props.isLinked
 		};
 
 		const found = [

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
@@ -21,7 +22,7 @@ export const Masterbar = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'WordPress.com Toolbar', { context: 'Settings header' } ) }
+					header={ __( 'WordPress.com toolbar', { context: 'Settings header' } ) }
 					module="masterbar"
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'masterbar' } } support="https://jetpack.com/support/masterbar/">
@@ -31,9 +32,22 @@ export const Masterbar = moduleSettingsForm(
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }>
-							{ __( 'Replaces the admin bar with a useful toolbar to quickly manage your site via WordPress.com.' ) }
+							{ __( 'Replace the admin bar with a useful toolbar to quickly manage your site via WordPress.com' ) }
 						</ModuleToggle>
 					</SettingsGroup>
+					{
+						( ! this.props.isUnavailableInDevMode( 'masterbar' ) && ! this.props.isLinked ) && (
+							<Card
+								compact
+								className="jp-settings-card__configure-link"
+								href={ `${ this.props.connectUrl }&from=unlinked-user-connect-masterbar` }
+							>
+								{
+									__( 'Link your existing WordPress.com account to use this feature.' )
+								}
+							</Card>
+						)
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -18,7 +18,10 @@ export const Masterbar = moduleSettingsForm(
 		render() {
 			const isActive = this.props.getOptionValue( 'masterbar' ),
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' ),
-				isLinked = this.props.isLinked;
+				isLinked = this.props.isLinked,
+				toggleHeader = isActive
+					? __( 'Disable the WordPress.com toolbar' )
+					: __( 'Enable the WordPress.com toolbar' );
 
 			return (
 				<SettingsCard
@@ -33,7 +36,14 @@ export const Masterbar = moduleSettingsForm(
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }>
-							{ __( 'Replace the admin bar with a useful toolbar to quickly manage your site via WordPress.com' ) }
+							{ toggleHeader }
+							<span className="jp-form-setting-explanation">
+							{
+								__( 'The WordPress.com toolbar replaces the default admin bar and offers quick links to' +
+									'the Reader, all your sites, your WordPress.com profile, and notifications. ' +
+									'Centralize your WordPress experience with a single global toolbar.' )
+							}
+						</span>
 						</ModuleToggle>
 					</SettingsGroup>
 					{
@@ -44,7 +54,7 @@ export const Masterbar = moduleSettingsForm(
 								href={ `${ this.props.connectUrl }&from=unlinked-user-connect-masterbar` }
 							>
 								{
-									__( 'Link your account to WordPress.com to use this feature.' )
+									__( 'Connect your user account to WordPress.com to use this feature.' )
 								}
 							</Card>
 						)

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -18,10 +18,7 @@ export const Masterbar = moduleSettingsForm(
 		render() {
 			const isActive = this.props.getOptionValue( 'masterbar' ),
 				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' ),
-				isLinked = this.props.isLinked,
-				toggleHeader = isActive
-					? __( 'Disable the WordPress.com toolbar' )
-					: __( 'Enable the WordPress.com toolbar' );
+				isLinked = this.props.isLinked;
 
 			return (
 				<SettingsCard
@@ -36,7 +33,7 @@ export const Masterbar = moduleSettingsForm(
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }>
-							{ toggleHeader }
+							{ __( 'Enable the WordPress.com toolbar' ) }
 							<span className="jp-form-setting-explanation">
 							{
 								__( 'The WordPress.com toolbar replaces the default admin bar and offers quick links to' +
@@ -54,7 +51,7 @@ export const Masterbar = moduleSettingsForm(
 								href={ `${ this.props.connectUrl }&from=unlinked-user-connect-masterbar` }
 							>
 								{
-									__( 'Connect your user account to WordPress.com to use this feature.' )
+									__( 'Connect your user account to WordPress.com to use this feature' )
 								}
 							</Card>
 						)

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -17,7 +17,8 @@ export const Masterbar = moduleSettingsForm(
 	class extends Component {
 		render() {
 			const isActive = this.props.getOptionValue( 'masterbar' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' );
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' ),
+				isLinked = this.props.isLinked;
 
 			return (
 				<SettingsCard
@@ -28,7 +29,7 @@ export const Masterbar = moduleSettingsForm(
 					<SettingsGroup disableInDevMode module={ { module: 'masterbar' } } support="https://jetpack.com/support/masterbar/">
 						<ModuleToggle
 							slug="masterbar"
-							disabled={ unavailableInDevMode }
+							disabled={ unavailableInDevMode || ! isLinked }
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }>
@@ -43,7 +44,7 @@ export const Masterbar = moduleSettingsForm(
 								href={ `${ this.props.connectUrl }&from=unlinked-user-connect-masterbar` }
 							>
 								{
-									__( 'Link your existing WordPress.com account to use this feature.' )
+									__( 'Link your account to WordPress.com to use this feature.' )
 								}
 							</Card>
 						)

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { ModuleToggle } from 'components/module-toggle';
+
+export const Masterbar = moduleSettingsForm(
+	class extends Component {
+		render() {
+			const isActive = this.props.getOptionValue( 'masterbar' ),
+				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' );
+
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'WordPress.com Toolbar', { context: 'Settings header' } ) }
+					module="masterbar"
+					hideButton>
+					<SettingsGroup disableInDevMode module={ { module: 'masterbar' } } support="https://jetpack.com/support/masterbar/">
+						<ModuleToggle
+							slug="masterbar"
+							disabled={ unavailableInDevMode }
+							activated={ isActive }
+							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
+							toggleModule={ this.props.toggleModuleNow }>
+							{ __( 'Replaces the admin bar with a useful toolbar to quickly manage your site via WordPress.com.' ) }
+						</ModuleToggle>
+					</SettingsGroup>
+				</SettingsCard>
+			);
+		}
+	}
+);

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -49,7 +49,7 @@ class A8C_WPCOM_Masterbar {
 		}
 	}
 
-	public function isAutomatedTransferSite() {
+	public function is_automated_transfer_site() {
 		$at_options = get_option( 'at_options', array() );
 
 		if ( ! empty( $at_options ) ) {
@@ -90,7 +90,7 @@ class A8C_WPCOM_Masterbar {
 
 		if ( ! Jetpack::is_module_active( 'notes ' ) ) {
 			// Masterbar is relying on some icons from noticons.css
-			wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK__VERSION . '-' . gmdate( 'oW' ) );
 		}
 
 		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
@@ -447,7 +447,7 @@ class A8C_WPCOM_Masterbar {
 
 		$help_link = 'https://jetpack.com/support/';
 
-		if ( $this->isAutomatedTransferSite() ) {
+		if ( $this->is_automated_transfer_site() ) {
 			$help_link = 'https://wordpress.com/help';
 		}
 
@@ -837,7 +837,7 @@ class A8C_WPCOM_Masterbar {
 				),
 			) );
 
-			if ( $this->isAutomatedTransferSite() ) {
+			if ( $this->is_automated_transfer_site() ) {
 				$domain_title = $this->create_menu_item_pair(
 					array(
 						'url'   => 'https://wordpress.com/domains/' . esc_attr( $this->primary_site_slug ),
@@ -872,7 +872,7 @@ class A8C_WPCOM_Masterbar {
 				),
 			) );
 
-			if ( $this->isAutomatedTransferSite() ) {
+			if ( $this->is_automated_transfer_site() ) {
 				$wp_admin_bar->add_menu( array(
 					'parent' => 'configuration',
 					'id'     => 'legacy-dashboard',

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -850,17 +850,17 @@ class A8C_WPCOM_Masterbar {
 						'label' => _x( 'Add', 'Label for the button on the Masterbar to add a new domain', 'jetpack' ),
 					)
 				);
+				$wp_admin_bar->add_menu( array(
+					'parent' => 'configuration',
+					'id'     => 'domains',
+					'title'  => $domain_title,
+					'href'   => false,
+					'meta'   => array(
+						'class' => 'inline-action',
+					),
+				) );
 			}
 
-			$wp_admin_bar->add_menu( array(
-				'parent' => 'configuration',
-				'id'     => 'domains',
-				'title'  => $domain_title,
-				'href'   => false,
-				'meta'   => array(
-					'class' => 'inline-action',
-				),
-			) );
 
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'configuration',


### PR DESCRIPTION
Adds the WordPress.com Masterbar module to the settings page, in the /writing tab.  

Currently using the copy from the module Header.  

It also adds a new function that will reload the page after activation/deactivation in the `updateSettings` function, since we're no longer using `activateModule` and `deactivateModule`.  

**Connected/linked Admin View**
![screen shot 2017-03-21 at 5 19 50 pm](https://cloud.githubusercontent.com/assets/7129409/24171467/f943f788-0e5a-11e7-834f-c652de471ee5.png)

**Unlinked admin view:**
Since the toolbar only works when the user is linked, I figured we should have something there to promote it.  The toggle will be disabled when the user is not linked.  
![screen shot 2017-03-21 at 6 41 20 pm](https://cloud.githubusercontent.com/assets/7129409/24174244/07eb35c0-0e66-11e7-82d3-d46a782eb816.png)



**Unlinked non-admin role (editor, for example)**
Do we need anything here?  Do we want to add a blurb to push them to link their account?  There are three scenarios here for non-admins: 
- Module is inactive: We don't show anything
- Module is active/user unlinked: We add a special promotion there to link? 
- Module is active/user linked: We show nothing?  

Alternatively, we ignore non-admins and if they're linked, then good for them?