### PR TITLE
Remove unused rule for saving mobile theme options

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -819,10 +819,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$updated = $grouped_options_current != $grouped_options ? update_option( 'jetpack_wga', $grouped_options ) : true;
 					break;
 
-				case 'wp_mobile_featured_images':
-				case 'wp_mobile_excerpt':
-					$value = ( 'enabled' === $value ) ? '1' : '0';
-				// break intentionally omitted
 				default:
 					// If option value was the same, consider it done.
 					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;


### PR DESCRIPTION
Fixes a bug where saving either of these options would not actually work: 
![screen shot 2017-03-21 at 7 37 34 pm](https://cloud.githubusercontent.com/assets/7129409/24175672/db804dc4-0e6d-11e7-8e25-15c0aadd752d.png)

It's not clear to me why we were checking for the `enabled` string for the value.  Maybe we were passing this before through the request?  Anyway, saving should work now and to test you should toggle these settings and make sure they're working properly.  