### PR TITLE
Settings UI: Fix Jumpstart

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -178,7 +178,8 @@ const Main = React.createClass( {
 		}
 
 		if ( this.props.jumpStartStatus ) {
-			if ( '/' === route ) {
+			if ( includes( [ '/', '/dashboard' ], route ) ) {
+				window.location.hash = 'jumpstart';
 				const history = createHistory();
 				history.push( window.location.pathname + '?page=jetpack#/jumpstart' );
 			} else if ( '/jumpstart' === route ) {


### PR DESCRIPTION
Jumpstart was broken in the Settings UI. 

To Test: 
- Disconnect the site
- Either `Reset options` in the Jetpack footer or reset just the jumpstart option with 
`wp jetpack options update jumpstart new_connection`
- Connect the site, choose any plan or free plan
- When you land back in jetpack admin you should see Jumpstart