### PR TITLE
Settings UI: Adds a toggle for sitemaps feature

### DIFF
--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -15,6 +15,7 @@ import {
 	FormLabel
 } from 'components/forms';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
@@ -113,15 +114,26 @@ export const VerificationServices = moduleSettingsForm(
 						</FormFieldset>
 					</SettingsGroup>
 					<SettingsGroup support={ sitemaps.learn_more_button }>
-						<span className="jp-form-label-wide">{ __( 'XML Sitemaps' ) }</span>
-						<FormFieldset>
-							<p>
-								<ExternalLink icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
-								<br />
-								<ExternalLink icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
-							</p>
-							<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
-						</FormFieldset>
+						<ModuleToggle
+							slug="sitemaps"
+							compact
+							activated={ this.props.getOptionValue( 'sitemaps' ) }
+							toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
+							toggleModule={ this.props.toggleModuleNow }>
+							{ __( 'Generate XML sitemaps' ) }
+						</ModuleToggle>
+						{
+							this.props.getOptionValue( 'sitemaps' ) && (
+								<FormFieldset>
+									<p>
+										<ExternalLink icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
+										<br />
+										<ExternalLink icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+									</p>
+									<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
+								</FormFieldset>
+							)
+						}
 					</SettingsGroup>
 				</SettingsCard>
 			);


### PR DESCRIPTION
This is my attempt at allowing people to turn on the feature if it is for whatever reason disabled.  

Currently when it's disabled we still show the links to non-existent sitemap URLs. 

**This PR hides the links when the module is inactive.**  

Active Feature: 
![screen shot 2017-03-21 at 8 26 20 pm](https://cloud.githubusercontent.com/assets/7129409/24176983/f1c081b4-0e75-11e7-869e-40ecb41f4fef.png)

Inactive: 
![screen shot 2017-03-21 at 8 26 11 pm](https://cloud.githubusercontent.com/assets/7129409/24176990/f7de7704-0e75-11e7-89fa-f09c66386e90.png)

