### PR TITLE
Masterbar: Fix unstyled flash bug in WP Admin

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -37,8 +37,8 @@ class A8C_WPCOM_Masterbar {
 
 		add_action( 'wp_before_admin_bar_render', array( $this, 'replace_core_masterbar' ), 99999 );
 
-		add_action( 'wp_head', array( $this, 'add_styles_and_scripts' ) );
-		add_action( 'admin_head', array( $this, 'add_styles_and_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'add_styles_and_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_styles_and_scripts' ) );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'remove_core_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'remove_core_styles' ) );

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -67,3 +67,11 @@
 #wp-admin-bar-notes.active .noticon-bell:before {
     content: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cmVjdCB4PSIwIiBmaWxsPSJub25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiLz48Zz48cGF0aCBmaWxsPSIjMjMyODJkIiBkPSJNNi4xNCAxNC45N2wyLjgyOCAyLjgyN2MtLjM2Mi4zNjItLjg2Mi41ODYtMS40MTQuNTg2LTEuMTA1IDAtMi0uODk1LTItMiAwLS41NTIuMjI0LTEuMDUyLjU4Ni0xLjQxNHptOC44NjcgNS4zMjRMMTQuMyAyMSAzIDkuN2wuNzA2LS43MDcgMS4xMDIuMTU3Yy43NTQuMTA4IDEuNjktLjEyMiAyLjA3Ny0uNTFsMy44ODUtMy44ODRjMi4zNC0yLjM0IDYuMTM1LTIuMzQgOC40NzUgMHMyLjM0IDYuMTM1IDAgOC40NzVsLTMuODg1IDMuODg2Yy0uMzg4LjM4OC0uNjE4IDEuMzIzLS41MSAyLjA3N2wuMTU3IDEuMXoiLz48L2c+PC9zdmc+") !important;
 }
+
+/* Fix changing height issue on hover in pop-up menus */
+#wpadminbar .quicklinks .menupop ul li .ab-item {
+	height: auto !important;
+}
+#wpadminbar .menupop .ab-submenu .ab-submenu-header > .ab-empty-item {
+	line-height: 1 !important;
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/6709

#### Changes proposed in this Pull Request:

* Changes hooks on which Masterbar styles and scripts are loaded in order to avoid unstyled flash of data while they are loading.
* This caused some visual regressions in popup menus, which required new CSS overrides to be introduced.

#### Testing instructions:

1. Activate WordPress.com Toolbar module on your test Jetpack site.
2. Navigate to `wp-admin/index.php` and verify that data flash is no longer occurring.
3. Verify that there are no visual regressions introduced to Masterbar.