### PR TITLE
Settings UI: update support block

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -4,120 +4,111 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import sample from 'lodash/sample';
+import sampleSize from 'lodash/sampleSize';
 import { translate as __ } from 'i18n-calypso';
+import Card from 'components/card';
+import Button from 'components/button';
 
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import {
+	PLAN_JETPACK_PERSONAL
+} from 'lib/plans/constants';
+import { getSiteRawUrl } from 'state/initial-state';
+import {
+	getSitePlan,
+	isFetchingSiteData
+} from 'state/site';
 import { getHappinessGravatarIds } from 'state/initial-state';
+import Banner from 'components/banner';
 
 const SupportCard = React.createClass( {
 	displayName: 'SupportCard',
 
 	render() {
 		const classes = classNames(
-			this.props.className,
-			'jp-support-card'
-		);
-
-		const randomGravID = sample( this.props.happinessGravatarIds );
+				this.props.className,
+				'jp-support-card'
+			),
+			gravIds = sampleSize( this.props.happinessGravatarIds, 3 ),
+			noPrioritySupport = 'undefined' === typeof this.props.sitePlan.product_slug || 'jetpack_free' === this.props.sitePlan.product_slug;
 
 		return (
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
-					<div className="jp-support-card__happiness-engineer">
-						<img
-							src={ 'https://secure.gravatar.com/avatar/' + randomGravID }
-							alt={ __( 'Jetpack Happiness Engineer' ) }
-							className="jp-support-card__happiness-engineer-img"
-							width="72"
-							height="72"
-						/>
-					</div>
 					<div className="jp-support-card__happiness-contact">
-						<h4 className="jp-support-card__header">
-							{ __( 'Need help? The Jetpack team is here for you.' ) }
-						</h4>
+						<h3 className="jp-support-card__header">
+							{ __( "We're here to help." ) }
+						</h3>
 						<p className="jp-support-card__description">
-							{ __( 'We offer free, full support to all of our Jetpack users. Our support team is always around to help you.' ) }
+							{
+								noPrioritySupport
+									? __( 'Utilize your free Jetpack support whenever you need.' )
+									: __( 'Utilize your priority-speed Jetpack support whenever you need it thanks to your paid plan.' )
+							}
 						</p>
 						<p className="jp-support-card__description">
-							{ __(
-								'{{supportLink}}View our support page{{/supportLink}}{{hideOnMobile}},{{/hideOnMobile}} ' +
-								'{{forumLink}}check the forums for answers{{/forumLink}}{{hideOnMobile}}, or{{/hideOnMobile}} ' +
-								'{{contactLink}}contact us directly{{/contactLink}}{{hideOnMobile}}.{{/hideOnMobile}}', {
-									components: {
-										hideOnMobile: <span className="jp-hidden-on-mobile" />,
-										supportLink: (
-											<a
-												className="jp-support-card__link"
-												href="https://jetpack.com/support/"
-												title={ __( 'Go to Jetpack.com/support' ) }
-											/>
-										),
-										forumLink: (
-											<a
-												className="jp-support-card__link"
-												href="https://wordpress.org/support/plugin/jetpack"
-												title={ __( 'Go to the WordPress.org support forums' ) }
-											/>
-										),
-										contactLink: (
-											<a
-												className="jp-support-card__link"
-												href="https://jetpack.com/contact-support/"
-												title={ __( 'Contact Jetpack support staff directly' ) }
-											/>
-										)
-									}
-								}
-							) }
+							<Button
+								href="https://jetpack.com/contact-support/">
+								{ __( 'Ask a question' ) }
+							</Button>
+							<Button
+								href="https://jetpack.com/support/">
+								{ __( 'Search our support site' ) }
+							</Button>
 						</p>
 					</div>
+					<div className="jp-support-card__happiness-engineer">
+						<ul>
+							<li>
+								<img
+									src={ 'https://secure.gravatar.com/avatar/' + gravIds[ 0 ].avatar }
+									alt={ __( 'Jetpack Happiness Engineer' ) }
+									className="jp-support-card__happiness-engineer-img"
+									width="72"
+									height="72"
+								/>
+								<div>
+									<em className="jp-support-card__happiness-engineer-name">{ gravIds[ 0 ].name }</em>
+								</div>
+							</li>
+							<li>
+								<img
+									src={ 'https://secure.gravatar.com/avatar/' + gravIds[ 1 ].avatar }
+									alt={ __( 'Jetpack Happiness Engineer' ) }
+									className="jp-support-card__happiness-engineer-img"
+									width="72"
+									height="72"
+								/>
+								<div>
+									<em className="jp-support-card__happiness-engineer-name">{ gravIds[ 1 ].name }</em>
+								</div>
+							</li>
+							<li>
+								<img
+									src={ 'https://secure.gravatar.com/avatar/' + gravIds[ 2 ].avatar }
+									alt={ __( 'Jetpack Happiness Engineer' ) }
+									className="jp-support-card__happiness-engineer-img"
+									width="72"
+									height="72"
+								/>
+								<div>
+									<em className="jp-support-card__happiness-engineer-name">{ gravIds[ 2 ].name }</em>
+								</div>
+							</li>
+						</ul>
+					</div>
 				</Card>
-				<Card className="jp-support-card__social">
-					<p className="jp-support-card__description">
-						{ __(
-							'{{hideOnMobile}}Enjoying Jetpack or have feedback?{{/hideOnMobile}} ' +
-							'{{reviewLink}}Leave us a review{{/reviewLink}}{{hideOnMobile}},{{/hideOnMobile}} ' +
-							'{{twitterLink}}follow us on Twitter{{/twitterLink}}{{hideOnMobile}}, and{{/hideOnMobile}} ' +
-							'{{facebookLink}}like us on Facebook{{/facebookLink}}{{hideOnMobile}}.{{/hideOnMobile}}', {
-								components: {
-									hideOnMobile: <span className="jp-hidden-on-mobile" />,
-									reviewLink: (
-										<a
-											className="jp-support-card__link"
-											href="https://wordpress.org/support/view/plugin-reviews/jetpack"
-											title={ __( 'Leave a Jetpack review' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-									twitterLink: (
-										<a
-											className="jp-support-card__link"
-											href="http://twitter.com/jetpack"
-											title={ __( 'Follow Jetpack on Twitter' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-									facebookLink: (
-										<a
-											className="jp-support-card__link"
-											href="https://www.facebook.com/jetpackme"
-											title={ __( 'Like us on Facebook' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									)
-								}
-							}
-						) }
-					</p>
-				</Card>
+				{
+					( ! this.props.fetchingSiteData && noPrioritySupport ) && (
+						<Banner
+							title={ __( 'Need help quicker? Upgrade for priority support' ) }
+							plan={ PLAN_JETPACK_PERSONAL }
+							href={ 'https://jetpack.com/redirect/?source=support&site=' + this.props.siteRawUrl }
+						/>
+					)
+				}
 			</div>
 		);
 	}
@@ -131,7 +122,10 @@ SupportCard.propTypes = {
 export default connect(
 	state => {
 		return {
+			sitePlan: getSitePlan( state ),
+			siteRawUrl: getSiteRawUrl( state ),
+			fetchingSiteData: isFetchingSiteData( state ),
 			happinessGravatarIds: getHappinessGravatarIds( state )
-		}
+		};
 	}
 )( SupportCard );

--- a/_inc/client/components/support-card/style.scss
+++ b/_inc/client/components/support-card/style.scss
@@ -4,13 +4,24 @@
 }
 
 .jp-support-card__description {
-	margin: 0;
 	font-size: rem( 14px);
 	line-height: 1.65;
-	color: $wpui-dark-medium-gray;
+	color: $blue-text;
 
-	@include breakpoint( "<660px" ) {
+	&:first-of-type {
+		margin-top: 4px;
+	}
+
+	&:last-of-type {
 		margin-bottom: 0;
+	}
+
+	.dops-button {
+		margin: 0 16px 0 0;
+
+		@include breakpoint( "<960px" ) {
+			margin: 0 16px 8px 0;
+		}
 	}
 }
 
@@ -19,7 +30,6 @@
 
 	@include breakpoint( "<660px" ) {
 		display: block;
-		width: 100%;
 		width: 100%;
 		padding: rem( 10px ) 0;
 		border-top: 1px transparentize( lighten( $gray, 20% ), .5 ) solid;
@@ -39,8 +49,6 @@
 	flex-flow: row nowrap;
 
 	@include breakpoint( "<660px" ) {
-		padding-bottom: 0;
-
 		.jp-support-card__description:first-of-type {
 			margin-bottom: rem( 16px );
 		}
@@ -60,34 +68,64 @@
 }
 
 .jp-support-card__header {
-	margin: 0 0 rem( 16px ) 0;
+	color: $blue-heading;
+	font-weight: 400;
+	font-size: rem( 21px );
+	margin: 0;
 }
 
 .jp-support-card__happiness-engineer {
 
-	@include breakpoint( ">660px" ) {
-		flex-basis: 15%;
-		flex-shrink: 1;
-		flex-grow: 1;
+	ul {
+		display: flex;
+		margin-bottom: 0;
+		text-align: right;
+
+		@include breakpoint( "<660px" ) {
+			display: block;
+		}
+	}
+	li {
+		margin-left: rem( 16px );
+		display: none;
+		@include breakpoint( "<660px" ) {
+			&:first-child {
+				display: inline-block;
+			}
+		}
+		@include breakpoint( ">660px" ) {
+			display: inline-block;
+		}
+	}
+	img + div {
+		text-align: center;
 	}
 
+	flex-shrink: 1;
+	flex-grow: 1;
+	flex-basis: 40%;
+
 	@include breakpoint( "<660px" ) {
-		display: none;
+		flex-basis: 20%;
 	}
 }
 
 .jp-support-card__happiness-engineer-img {
 	width: rem( 72px );
 	height: rem( 72px );
-	margin-right: rem( 24px );
 	border-radius: 50%;
 }
 
-.jp-support-card__happiness-contact {
+.jp-support-card__happiness-engineer-name {
+	color: $blue-heading;
+}
 
-	@include breakpoint( ">660px" ) {
-		flex-basis: 85%;
-		flex-shrink: 1;
-		flex-grow: 1;
+.jp-support-card__happiness-contact {
+	flex-shrink: 1;
+	flex-grow: 1;
+	flex-basis: 60%;
+
+	@include breakpoint( "<660px" ) {
+		flex-basis: 80%;
 	}
 }

--- a/_inc/client/scss/variables/_colors.scss
+++ b/_inc/client/scss/variables/_colors.scss
@@ -15,6 +15,10 @@ $gray:                   #87a6bc;
 $gray-light:             lighten( $gray, 33% ); //#f3f6f8
 $gray-dark:              darken( $gray, 38% ); //#2e4453
 
+// Text blues
+$blue-heading:           #668eaa;
+$blue-text:              #537994;
+
 // $gray-text: ideal for standard, non placeholder text
 // $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
 $gray-text:              $gray-dark;

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -319,25 +319,82 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
  */
 function jetpack_get_happiness_gravatar_ids() {
 	return array(
-		'623f42e878dbd146ddb30ebfafa1375b',
-		'561be467af56cefa58e02782b7ac7510',
-		'd8ad409290a6ae7b60f128a0b9a0c1c5',
-		'790618302648bd80fa8a55497dfd8ac8',
-		'6e238edcb0664c975ccb9e8e80abb307',
-		'4e6c84eeab0a1338838a9a1e84629c1a',
-		'9d4b77080c699629e846d3637b3a661c',
-		'4626de7797aada973c1fb22dfe0e5109',
-		'190cf13c9cd358521085af13615382d5',
-		'f7006d10e9f7dd7bea89a001a2a2fd59',
-		'16acbc88e7aa65104ed289d736cb9698',
-		'4d5ad4219c6f676ea1e7d40d2e8860e8',
-		'e301f7d01b09e7578fdfc1b1ec1bc08d',
-		'42f4c73f5337486e199f6e3b3910f168',
-		'e7b26de48e76498cff880abca1eed8da',
-		'764fb02aaae2ff64c0625c763d82b74e',
-		'4988305772319fb9bc8fce0a7acb3aa1',
-		'5d8695c4b81592f1255721d2644627ca',
-		'0e2249a7de3404bc6d5207a45e911187',
+		array(
+			'avatar' => '623f42e878dbd146ddb30ebfafa1375b',
+			'name'   => 'Chase',
+		),
+		array(
+			'avatar' => '561be467af56cefa58e02782b7ac7510',
+			'name'   => 'Carolyn',
+		),
+		array(
+			'avatar' => 'd8ad409290a6ae7b60f128a0b9a0c1c5',
+			'name'   => 'Jeremy',
+		),
+		array(
+			'avatar' => '790618302648bd80fa8a55497dfd8ac8',
+			'name'   => 'Jennifer',
+		),
+		array(
+			'avatar' => '6e238edcb0664c975ccb9e8e80abb307',
+			'name'   => 'Brandon',
+		),
+		array(
+			'avatar' => '4e6c84eeab0a1338838a9a1e84629c1a',
+			'name'   => 'Nancy',
+		),
+		array(
+			'avatar' => '9d4b77080c699629e846d3637b3a661c',
+			'name'   => 'Richard',
+		),
+		array(
+			'avatar' => '4626de7797aada973c1fb22dfe0e5109',
+			'name'   => 'Ryan',
+		),
+		array(
+			'avatar' => '190cf13c9cd358521085af13615382d5',
+			'name'   => 'James',
+		),
+		array(
+			'avatar' => 'f7006d10e9f7dd7bea89a001a2a2fd59',
+			'name'   => 'Jacob',
+		),
+		array(
+			'avatar' => '16acbc88e7aa65104ed289d736cb9698',
+			'name'   => 'Davor',
+		),
+		array(
+			'avatar' => '4d5ad4219c6f676ea1e7d40d2e8860e8',
+			'name'   => 'Lamda',
+		),
+		array(
+			'avatar' => 'e301f7d01b09e7578fdfc1b1ec1bc08d',
+			'name'   => 'Diana',
+		),
+		array(
+			'avatar' => '42f4c73f5337486e199f6e3b3910f168',
+			'name'   => 'Rachel',
+		),
+		array(
+			'avatar' => 'e7b26de48e76498cff880abca1eed8da',
+			'name'   => 'Stefan',
+		),
+		array(
+			'avatar' => '764fb02aaae2ff64c0625c763d82b74e',
+			'name'   => 'Stef',
+		),
+		array(
+			'avatar' => '4988305772319fb9bc8fce0a7acb3aa1',
+			'name'   => 'Dan',
+		),
+		array(
+			'avatar' => '5d8695c4b81592f1255721d2644627ca',
+			'name'   => 'Jon',
+		),
+		array(
+			'avatar' => '0e2249a7de3404bc6d5207a45e911187',
+			'name'   => 'Anne',
+		),
 	);
 }
 


### PR DESCRIPTION
<img width="739" alt="captura de pantalla 2017-03-22 a las 13 30 42" src="https://cloud.githubusercontent.com/assets/1041600/24209216/6e3e6178-0f04-11e7-8ac7-eaf16d6b1b1f.png">

<img width="734" alt="captura de pantalla 2017-03-22 a las 14 15 08" src="https://cloud.githubusercontent.com/assets/1041600/24211155/fae9ac54-0f09-11e7-8b7a-e42f71884487.png">

#### Changes proposed in this Pull Request:

* in addition to the UI changes, the info for HEs gravatars now includes the names since they're used below the image.