### PR TITLE
WPCOM Widgets Merge -- 22march2017

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -148,40 +148,40 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		?>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>">
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
 				<?php _e( 'Title', 'jetpack' ); ?>
-				<input type="text" name="<?php echo $this->get_field_name( 'title' ); ?>" id="<?php echo $this->get_field_id( 'title' ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" class="widefat" />
+				<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" value="<?php echo esc_attr( $instance['title'] ); ?>" class="widefat" />
 			</label>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'href' ); ?>">
+			<label for="<?php echo esc_attr( $this->get_field_id( 'href' ) ); ?>">
 				<?php _e( 'Facebook Page URL', 'jetpack' ); ?>
-				<input type="text" name="<?php echo $this->get_field_name( 'href' ); ?>" id="<?php echo $this->get_field_id( 'href' ); ?>" value="<?php echo esc_url( $like_args['href'] ); ?>" class="widefat" />
+				<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'href' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'href' ) ); ?>" value="<?php echo esc_url( $like_args['href'] ); ?>" class="widefat" />
 				<br />
 				<small><?php _e( 'The widget only works with Facebook Pages.', 'jetpack' ); ?></small>
 			</label>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'width' ); ?>">
+			<label for="<?php echo esc_attr( $this->get_field_id( 'width' ) ); ?>">
 				<?php _e( 'Width in pixels', 'jetpack' ); ?>
-				<input type="number" class="smalltext" min="<?php echo esc_attr( $this->min_width ); ?>" max="<?php echo esc_attr( $this->max_width ); ?>" maxlength="3" name="<?php echo $this->get_field_name( 'width' ); ?>" id="<?php echo $this->get_field_id( 'width' ); ?>" value="<?php echo esc_attr( $like_args['width'] ); ?>" style="text-align: center;" />
+				<input type="number" class="smalltext" min="<?php echo esc_attr( $this->min_width ); ?>" max="<?php echo esc_attr( $this->max_width ); ?>" maxlength="3" name="<?php echo esc_attr( $this->get_field_name( 'width' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'width' ) ); ?>" value="<?php echo esc_attr( $like_args['width'] ); ?>" style="text-align: center;" />
 				<small><?php echo sprintf( __( 'Minimum: %s', 'jetpack' ), $this->min_width ); ?> / <?php echo sprintf( __( 'Maximum: %s', 'jetpack' ), $this->max_width ); ?></small>
 			</label>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'height' ); ?>">
+			<label for="<?php echo esc_attr( $this->get_field_id( 'height' ) ); ?>">
 				<?php _e( 'Height in pixels', 'jetpack' ); ?>
-				<input type="number" class="smalltext" min="<?php echo esc_attr( $this->min_height ); ?>" max="<?php echo esc_attr( $this->max_height ); ?>" maxlength="3" name="<?php echo $this->get_field_name( 'height' ); ?>" id="<?php echo $this->get_field_id( 'height' ); ?>" value="<?php echo esc_attr( $like_args['height'] ); ?>" style="text-align: center;" />
+				<input type="number" class="smalltext" min="<?php echo esc_attr( $this->min_height ); ?>" max="<?php echo esc_attr( $this->max_height ); ?>" maxlength="3" name="<?php echo esc_attr( $this->get_field_name( 'height' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'height' ) ); ?>" value="<?php echo esc_attr( $like_args['height'] ); ?>" style="text-align: center;" />
 				<small><?php echo sprintf( __( 'Minimum: %s', 'jetpack' ), $this->min_height ); ?> / <?php echo sprintf( __( 'Maximum: %s', 'jetpack' ), $this->max_height ); ?></small>
 			</label>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'show_faces' ); ?>">
-				<input type="checkbox" name="<?php echo $this->get_field_name( 'show_faces' ); ?>" id="<?php echo $this->get_field_id( 'show_faces' ); ?>" <?php checked( $like_args['show_faces'] ); ?> />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'show_faces' ) ); ?>">
+				<input type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'show_faces' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'show_faces' ) ); ?>" <?php checked( $like_args['show_faces'] ); ?> />
 				<?php _e( 'Show Faces', 'jetpack' ); ?>
 				<br />
 				<small><?php _e( 'Show profile photos in the plugin.', 'jetpack' ); ?></small>
@@ -189,8 +189,8 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'stream' ); ?>">
-				<input type="checkbox" name="<?php echo $this->get_field_name( 'stream' ); ?>" id="<?php echo $this->get_field_id( 'stream' ); ?>" <?php checked( $like_args['stream'] ); ?> />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'stream' ) ); ?>">
+				<input type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'stream' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'stream' ) ); ?>" <?php checked( $like_args['stream'] ); ?> />
 				<?php _e( 'Show Stream', 'jetpack' ); ?>
 				<br />
 				<small><?php _e( 'Show Page Posts.', 'jetpack' ); ?></small>
@@ -198,8 +198,8 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'cover' ); ?>">
-				<input type="checkbox" name="<?php echo $this->get_field_name( 'cover' ); ?>" id="<?php echo $this->get_field_id( 'cover' ); ?>" <?php checked( $like_args['cover'] ); ?> />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'cover' ) ); ?>">
+				<input type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'cover' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'cover' ) ); ?>" <?php checked( $like_args['cover'] ); ?> />
 				<?php _e( 'Show Cover Photo', 'jetpack' ); ?>
 				<br />
 			</label>
@@ -304,5 +304,3 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		Jetpack::$instance->get_locale();
 	}
 }
-
-// END

--- a/modules/widgets/gallery.php
+++ b/modules/widgets/gallery.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: Gallery
 Description: Gallery widget
-Author: Automattic, Inc.
+Author: Automattic Inc.
 Version: 1.0
 Author URI: http://automattic.com
 */

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Social Media Icons Widget
 Description: A simple widget that displays social media icons
-Author: Chris Rudzki
+Author: Automattic Inc.
 */
 
 

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -68,6 +68,16 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Enqueue script to improve admin UI
+	 */
+	public function admin_scripts( $hook ) {
+		// This is still 'widgets.php' when managing widgets via the Customizer.
+		if ( 'widgets.php' === $hook ) {
+			wp_enqueue_script( 'twitter-timeline-admin', plugins_url( 'twitter-timeline-admin.js', __FILE__ ) );
+		}
+	}
+
+	/**
 	 * Front-end display of widget.
 	 *
 	 * @see WP_Widget::widget()

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -68,16 +68,6 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Enqueue script to improve admin UI
-	 */
-	public function admin_scripts( $hook ) {
-		// This is still 'widgets.php' when managing widgets via the Customizer.
-		if ( 'widgets.php' === $hook ) {
-			wp_enqueue_script( 'twitter-timeline-admin', plugins_url( 'twitter-timeline-admin.js', __FILE__ ) );
-		}
-	}
-
-	/**
 	 * Front-end display of widget.
 	 *
 	 * @see WP_Widget::widget()

--- a/modules/widgets/upcoming-events.php
+++ b/modules/widgets/upcoming-events.php
@@ -112,43 +112,13 @@ class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 		do_action( 'jetpack_stats_extra', 'widget_view', 'grofile' );
 	}
 
+	// Left this function here for backward compatibility
+	// just incase a site using jetpack is also using this function
 	function apply_timezone_offset( $events ) {
-		if ( ! $events ) {
-			return $events;
-		}
+		jetpack_require_lib( 'icalendar-reader' );
 
-		// get timezone offset from the timezone name.
-		$timezone_name = get_option( 'timezone_string' );
-		if ( $timezone_name ) {
-			$timezone = new DateTimeZone( $timezone_name );
-			$offset = $timezone->getOffset( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) );
-		} else {
-			// fallback - gmt_offset option
-			$offset = get_option( 'gmt_offset' ) * 3600;
-		}
-
-		// generate a DateInterval object from the timezone offset
-		$interval_string = sprintf( '%d minutes', $offset / 60 );
-		$interval = date_interval_create_from_date_string( $interval_string );
-
-		$offsetted_events = array();
-
-		foreach ( $events as $event ) {
-			// Don't handle all-day events
-			if ( 8 < strlen( $event['DTSTART'] ) ) {
-				$start_time = new DateTime( $event['DTSTART'] );
-				$start_time->add( $interval );
-				$end_time = new DateTime( $event['DTEND'] );
-				$end_time->add( $interval );
-
-				$event['DTSTART'] = $start_time->format( 'YmdHis\Z' );
-				$event['DTEND'] = $end_time->format( 'YmdHis\Z' );
-			}
-
-			$offsetted_events[] = $event;
-		}
-
-		return $offsetted_events;
+		$ical = new iCalendarReader();
+		return $ical->apply_timezone_offset( $events );
 	}
 }
 


### PR DESCRIPTION
This handles the sync of wpcom changes to Jetpack, but explicitly omits the `wordpress-post-widget` because of the huge overhaul merged in #3207