### PR TITLE
Settings UI: fix support block triple render

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -33,6 +33,10 @@ const SupportCard = React.createClass( {
 	},
 
 	render() {
+		if ( 'undefined' === typeof this.props.sitePlan.product_slug && this.props.isFetchingSiteData ) {
+			return <div />;
+		}
+
 		const classes = classNames(
 				this.props.className,
 				'jp-support-card'
@@ -106,7 +110,7 @@ const SupportCard = React.createClass( {
 					</div>
 				</Card>
 				{
-					( ! this.props.fetchingSiteData && noPrioritySupport ) && (
+					noPrioritySupport && (
 						<Banner
 							title={ __( 'Need help quicker? Upgrade for priority support' ) }
 							plan={ PLAN_JETPACK_PERSONAL }
@@ -129,7 +133,7 @@ export default connect(
 		return {
 			sitePlan: getSitePlan( state ),
 			siteRawUrl: getSiteRawUrl( state ),
-			fetchingSiteData: isFetchingSiteData( state ),
+			isFetchingSiteData: isFetchingSiteData( state ),
 			happinessGravatarIds: getHappinessGravatarIds( state )
 		};
 	}

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -26,12 +26,17 @@ import Banner from 'components/banner';
 const SupportCard = React.createClass( {
 	displayName: 'SupportCard',
 
+	getInitialState() {
+		return {
+			gravIds: sampleSize( this.props.happinessGravatarIds, 3 )
+		};
+	},
+
 	render() {
 		const classes = classNames(
 				this.props.className,
 				'jp-support-card'
 			),
-			gravIds = sampleSize( this.props.happinessGravatarIds, 3 ),
 			noPrioritySupport = 'undefined' === typeof this.props.sitePlan.product_slug || 'jetpack_free' === this.props.sitePlan.product_slug;
 
 		return (
@@ -63,38 +68,38 @@ const SupportCard = React.createClass( {
 						<ul>
 							<li>
 								<img
-									src={ 'https://secure.gravatar.com/avatar/' + gravIds[ 0 ].avatar }
+									src={ 'https://secure.gravatar.com/avatar/' + this.state.gravIds[ 0 ].avatar }
 									alt={ __( 'Jetpack Happiness Engineer' ) }
 									className="jp-support-card__happiness-engineer-img"
 									width="72"
 									height="72"
 								/>
 								<div>
-									<em className="jp-support-card__happiness-engineer-name">{ gravIds[ 0 ].name }</em>
+									<em className="jp-support-card__happiness-engineer-name">{ this.state.gravIds[ 0 ].name }</em>
 								</div>
 							</li>
 							<li>
 								<img
-									src={ 'https://secure.gravatar.com/avatar/' + gravIds[ 1 ].avatar }
+									src={ 'https://secure.gravatar.com/avatar/' + this.state.gravIds[ 1 ].avatar }
 									alt={ __( 'Jetpack Happiness Engineer' ) }
 									className="jp-support-card__happiness-engineer-img"
 									width="72"
 									height="72"
 								/>
 								<div>
-									<em className="jp-support-card__happiness-engineer-name">{ gravIds[ 1 ].name }</em>
+									<em className="jp-support-card__happiness-engineer-name">{ this.state.gravIds[ 1 ].name }</em>
 								</div>
 							</li>
 							<li>
 								<img
-									src={ 'https://secure.gravatar.com/avatar/' + gravIds[ 2 ].avatar }
+									src={ 'https://secure.gravatar.com/avatar/' + this.state.gravIds[ 2 ].avatar }
 									alt={ __( 'Jetpack Happiness Engineer' ) }
 									className="jp-support-card__happiness-engineer-img"
 									width="72"
 									height="72"
 								/>
 								<div>
-									<em className="jp-support-card__happiness-engineer-name">{ gravIds[ 2 ].name }</em>
+									<em className="jp-support-card__happiness-engineer-name">{ this.state.gravIds[ 2 ].name }</em>
 								</div>
 							</li>
 						</ul>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* avoid re-rendering the support block unnecessarily
* don't render the support block until we have the plan data so we know which text to display: the one for priority support or the regular one
* once it's rendered, don't re-render when switching tabs if we already have plan information available.

#### Testing instructions:

* make sure there are no multiple calls for HE avatars
* make sure the support block is rendered once