### PR TITLE
Filter Infinite Scroll's check for more posts to display

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -305,7 +305,7 @@ class The_Neverending_Home_Page {
 		 *
 		 * @module infinite-scroll
 		 *
-		 * @since 4.8
+		 * @since 4.8.0
 		 *
 		 * @param bool|null null                 Bool if value should be overridden, null to determine from query
 		 * @param object    self::wp_query()     WP_Query object for current request

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -307,7 +307,9 @@ class The_Neverending_Home_Page {
 		 *
 		 * @since 4.8
 		 *
-		 * @param bool|null Bool if value should be overridden, null to determine from query
+		 * @param bool|null null                 Bool if value should be overridden, null to determine from query
+		 * @param object    self::wp_query()     WP_Query object for current request
+		 * @param object    self::get_settings() Infinite Scroll settings
 		 */
 		$override = apply_filters( 'infinite_scroll_is_last_batch', null, self::wp_query(), self::get_settings() );
 		if ( is_bool( $override ) ) {

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -300,6 +300,20 @@ class The_Neverending_Home_Page {
 	 * Is this guaranteed to be the last batch of posts?
 	 */
 	static function is_last_batch() {
+		/**
+		 * Override whether or not this is the last batch for a request
+		 *
+		 * @module infinite-scroll
+		 *
+		 * @since 4.8
+		 *
+		 * @param bool|null Bool if value should be overridden, null to determine from query
+		 */
+		$override = apply_filters( 'infinite_scroll_is_last_batch', null, self::wp_query(), self::get_settings() );
+		if ( is_bool( $override ) ) {
+			return $override;
+		}
+
 		$entries = (int) self::wp_query()->found_posts;
 		$posts_per_page = self::get_settings()->posts_per_page;
 


### PR DESCRIPTION
When the query is manipulated, it may be necessary to filter the check that there are more posts to display, in addition to the query and query arguments.

#### Changes proposed in this Pull Request:

* Adds a new filter to short-circuit the `is_last_batch()` method
