### PR TITLE
General: Improved Error Message when static.html is not build

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -139,7 +139,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		if ( false === $static_html ) {
 
 			// If we still have nothing, display an error
-			esc_html_e( 'Error fetching static.html.', 'jetpack' );
+			echo '<p>';
+			esc_html_e( 'Error fetching static.html. Try running: ', 'jetpack' );
+			echo '<code>yarn distclean && yarn build</code>';
+			echo '</p>';
 		} else {
 
 			// We got the static.html so let's display it

--- a/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -24,7 +24,10 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 		// If static.html isn't there, there's nothing else we can do.
 		if ( false === $static_html ) {
-			esc_html_e( 'Error fetching static.html.', 'jetpack' );
+			echo '<p>';
+			esc_html_e( 'Error fetching static.html. Try running: ', 'jetpack' );
+			echo '<code>yarn distclean && yarn build</code>';
+			echo '</p>';
 			return;
 		}
 


### PR DESCRIPTION
Currently when a developer loads up Jetpack but never ran yarn build they see an error message. 

This PR tries to be a bit more helpful and provide a useful error message.


#### Changes proposed in this Pull Request:
* Update error message.

#### Testing instructions:
* Remove the Build folder. 
See the new message. 
<img width="613" alt="screen shot 2017-03-23 at 21 48 00" src="https://cloud.githubusercontent.com/assets/115071/24280995/6c644c0a-1012-11e7-9312-803b8f8479c6.png">


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
