### PR TITLE
Settings UI: don't show Sitemaps settings if site discourages search engines indexing

### DIFF
--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -149,12 +149,25 @@ export function userCanViewStats( state ) {
 }
 
 /**
- * Returns the site icon as an image URL
+ * Returns the site icon as an image URL.
  *
- * @param state
+ * @param {object} state Global state tree
+ *
+ * @return string
  */
 export function getSiteIcon( state ) {
 	return get( state.jetpack.initialState.siteData, [ 'icon' ] );
+}
+
+/**
+ * Check whether the site is accessible by search engines or not. It's true by default in an initial WP installation.
+ *
+ * @param {object} state Global state tree
+ *
+ * @return {boolean} False if site is set to discourage search engines from indexing it. True otherwise.
+ */
+export function isSiteVisibleToSearchEngines( state ) {
+	return get( state.jetpack.initialState.siteData, [ 'siteVisibleToSearchEngines' ], true );
 }
 
 export function getApiNonce( state ) {

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -17,7 +17,7 @@ import { GoogleAnalytics } from './google-analytics';
 import { Ads } from './ads';
 import { SiteStats } from './site-stats';
 import { RelatedPosts } from './related-posts';
-import { VerificationServices } from './verification-services';
+import VerificationServices from './verification-services';
 import { getLastPostUrl } from 'state/initial-state';
 
 export const Traffic = React.createClass( {

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import TextInput from 'components/text-input';
 import ExternalLink from 'components/external-link';
@@ -18,6 +19,7 @@ import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-sett
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { getSiteAdminUrl, isSiteVisibleToSearchEngines } from 'state/initial-state';
 
 export const VerificationServices = moduleSettingsForm(
 	React.createClass( {
@@ -123,16 +125,28 @@ export const VerificationServices = moduleSettingsForm(
 							{ __( 'Generate XML sitemaps' ) }
 						</ModuleToggle>
 						{
-							this.props.getOptionValue( 'sitemaps' ) && (
-								<FormFieldset>
-									<p>
-										<ExternalLink icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
-										<br />
-										<ExternalLink icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+							this.props.isSiteVisibleToSearchEngines
+								? this.props.getOptionValue( 'sitemaps' ) && (
+									<FormFieldset>
+										<p>
+											<ExternalLink icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
+											<br />
+											<ExternalLink icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+										</p>
+										<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
+									</FormFieldset>
+								)
+								: (
+									<p className="jp-form-setting-explanation">
+										{
+											__( 'Your site must be accessible by search engines for this feature to work properly. You can change this in {{a}}Reading Settings{{/a}}.', {
+												components: {
+													a: <a href={ this.props.siteAdminUrl + 'options-reading.php#blog_public' } />
+												}
+											} )
+										}
 									</p>
-									<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
-								</FormFieldset>
-							)
+								)
 						}
 					</SettingsGroup>
 				</SettingsCard>
@@ -140,3 +154,12 @@ export const VerificationServices = moduleSettingsForm(
 		}
 	} )
 );
+
+export default connect(
+	state => {
+		return {
+			isSiteVisibleToSearchEngines: isSiteVisibleToSearchEngines( state ),
+			siteAdminUrl: getSiteAdminUrl( state )
+		};
+	}
+)( VerificationServices );

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -139,9 +139,9 @@ export const VerificationServices = moduleSettingsForm(
 								: (
 									<p className="jp-form-setting-explanation">
 										{
-											__( 'Your site must be accessible by search engines for this feature to work properly. You can change this in {{a}}Reading Settings{{/a}}.', {
+											__( 'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.', {
 												components: {
-													a: <a href={ this.props.siteAdminUrl + 'options-reading.php#blog_public' } />
+													a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
 												}
 											} )
 										}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -282,6 +282,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'icon' => has_site_icon()
 					? apply_filters( 'jetpack_photon_url', get_site_icon_url(), array( 'w' => 64 ) )
 					: '',
+				'siteVisibleToSearchEngines' => '1' == get_option( 'blog_public' ),
 			),
 			'locale' => $this->get_i18n_data(),
 			'localeSlug' => $localeSlug,


### PR DESCRIPTION
Fixes #6736

#### Changes proposed in this Pull Request:

<img width="738" alt="captura de pantalla 2017-03-24 a las 09 57 10" src="https://cloud.githubusercontent.com/assets/1041600/24295343/18422838-1079-11e7-8173-d4cc4fbe1947.png">

* instead of the sitemap URLs, a message will be displayed

#### Testing instructions:

* in Settings > Reading, set `Discourage search engines from indexing this site` to true 
* view Jetpack admin > Traffic > Sitemaps and it should display a message when the feature is active

