### PR TITLE
Settings UI: fix Minileven options

### DIFF
--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import CompactFormToggle from 'components/form/form-toggle/compact';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -33,9 +34,9 @@ const ThemeEnhancements = moduleSettingsForm(
 		getInitialState() {
 			return {
 				infinite_mode: this.getInfiniteMode(),
-				wp_mobile_excerpt: this.props.getOptionValue( 'wp_mobile_excerpt', 'minileven' ),
-				wp_mobile_featured_images: this.props.getOptionValue( 'wp_mobile_featured_images', 'minileven' ),
-				wp_mobile_app_promos: this.props.getOptionValue( 'wp_mobile_app_promos', 'minileven' )
+				wp_mobile_excerpt: this.props.getOptionValue( 'wp_mobile_excerpt' ),
+				wp_mobile_featured_images: this.props.getOptionValue( 'wp_mobile_featured_images' ),
+				wp_mobile_app_promos: this.props.getOptionValue( 'wp_mobile_app_promos' )
 			};
 		},
 
@@ -82,19 +83,27 @@ const ThemeEnhancements = moduleSettingsForm(
 			}
 		},
 
+		translateBooleanValue( optionName ) {
+			return includes( [ 'enabled', '1' ], this.state[ optionName ] ) || true === this.state[ optionName ];
+		},
+
 		/**
 		 * Update state so toggles are updated.
 		 *
 		 * @param {string} optionName option slug
-		 * @param {string} module module slug
 		 */
-		updateOptions( optionName, module ) {
+		updateOptions( optionName ) {
+			const booleanValue = this.translateBooleanValue( optionName );
 			this.setState(
 				{
-					[ optionName ]: ! this.state[ optionName ]
-				},
-				this.props.updateFormStateModuleOption( module, optionName )
+					[ optionName ]: ! booleanValue
+				}
 			);
+			this.props.updateOptions( {
+				[ optionName ]: booleanValue
+					? 'disabled'
+					: 'enabled'
+			} );
 		},
 
 		render() {
@@ -205,9 +214,9 @@ const ThemeEnhancements = moduleSettingsForm(
 											item.checkboxes.map( chkbx => {
 												return (
 													<CompactFormToggle
-														checked={ this.state[ chkbx.key ] }
+														checked={ this.translateBooleanValue( chkbx.key ) }
 														disabled={ ! isItemActive || this.props.isSavingAnyOption( [ item.module, chkbx.key ] ) }
-														onChange={ () => this.updateOptions( chkbx.key, item.module ) }
+														onChange={ () => this.updateOptions( chkbx.key ) }
 														key={ `${ item.module }_${ chkbx.key }` }>
 														<span className="jp-form-toggle-explanation">
 															{

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1188,23 +1188,23 @@ class Jetpack_Core_Json_Api_Endpoints {
 			// Mobile Theme
 			'wp_mobile_excerpt' => array(
 				'description'       => esc_html__( 'Excerpts', 'jetpack' ),
-				'type'              => 'boolean',
-				'default'           => 0,
-				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'type'              => 'string',
+				'default'           => 'enabled',
+				'validate_callback' => __CLASS__ . '::validate_enabled',
 				'jp_group'          => 'minileven',
 			),
 			'wp_mobile_featured_images' => array(
 				'description'       => esc_html__( 'Featured Images', 'jetpack' ),
-				'type'              => 'boolean',
-				'default'           => 0,
-				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'type'              => 'string',
+				'default'           => 'enabled',
+				'validate_callback' => __CLASS__ . '::validate_enabled',
 				'jp_group'          => 'minileven',
 			),
 			'wp_mobile_app_promos' => array(
 				'description'       => esc_html__( 'Show a promo for the WordPress mobile apps in the footer of the mobile theme.', 'jetpack' ),
-				'type'              => 'boolean',
-				'default'           => 0,
-				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'type'              => 'string',
+				'default'           => 'enabled',
+				'validate_callback' => __CLASS__ . '::validate_enabled',
 				'jp_group'          => 'minileven',
 			),
 
@@ -1688,6 +1688,24 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function validate_boolean( $value, $request, $param ) {
 		if ( ! is_bool( $value ) && ! ( ( ctype_digit( $value ) || is_numeric( $value ) ) && in_array( $value, array( 0, 1 ) ) ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be true, false, 0 or 1.', 'jetpack' ), $param ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Validates that the parameter is either 'enabled' or 'disabled'.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param string|bool $value Value to check.
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 * @param string $param Name of the parameter passed to endpoint holding $value.
+	 *
+	 * @return bool
+	 */
+	public static function validate_enabled( $value, $request, $param ) {
+		if ( ! in_array( $value, array( 'enabled', 'disabled' ), true ) ) {
+			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be enabled or disabled.', 'jetpack' ), $param ) );
 		}
 		return true;
 	}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -822,6 +822,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$updated = false;
 					break;
 
+				case 'wp_mobile_featured_images':
+				case 'wp_mobile_excerpt':
+					$value = ( 'enabled' === $value ) ? '1' : '0';
+					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;
+					break;
+
 				case 'google_analytics_tracking_id':
 					$grouped_options = $grouped_options_current = (array) get_option( 'jetpack_wga' );
 					$grouped_options[ 'code' ] = $value;


### PR DESCRIPTION
Fixes #6737

#### Changes proposed in this Pull Request:

* revert values accepted by Minileven to previous enabled/disabled for compat with Calypso and backwards compat.
* add translation of these values in the UI so the values sent are always enabled/disabled but values used in UI are booleans.

#### Testing instructions:

* make sure options save and features work