### PR TITLE
Settings UI: new card for Sitemaps

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -59,8 +59,7 @@ export const SettingsCard = props => {
 
 	const getBanner = () => {
 		const planClass = getPlanClass( props.sitePlan.product_slug ),
-			upgradeLabel = __( 'Upgrade', { context: 'A caption for a button to upgrade an existing paid feature to a higher tier.' } ),
-			activateLabel = __( 'Activate', { context: 'A caption for a button to activate a paid feature.' } );
+			upgradeLabel = __( 'Upgrade', { context: 'A caption for a button to upgrade an existing paid feature to a higher tier.' } );
 
 		switch ( feature ) {
 			case FEATURE_VIDEO_HOSTING_JETPACK:

--- a/_inc/client/components/settings-group/style.scss
+++ b/_inc/client/components/settings-group/style.scss
@@ -7,6 +7,9 @@
 		margin-top: 0;
 		margin-bottom: rem( 24px );
 	}
+	fieldset p:last-child {
+		margin-bottom: 8px;
+	}
 	.form-toggle__label {
 		margin-top: rem( 4px );
 		margin-bottom: rem( 4px );

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -17,7 +17,8 @@ import { GoogleAnalytics } from './google-analytics';
 import { Ads } from './ads';
 import { SiteStats } from './site-stats';
 import { RelatedPosts } from './related-posts';
-import VerificationServices from './verification-services';
+import { VerificationServices } from './verification-services';
+import Sitemaps from './sitemaps';
 import { getLastPostUrl } from 'state/initial-state';
 
 export const Traffic = React.createClass( {
@@ -83,15 +84,23 @@ export const Traffic = React.createClass( {
 					'&url=' + encodeURIComponent( this.props.lastPostUrl ) }
 			/>
 		);
-		const verificationSettings = (
-			<VerificationServices
-				{ ...commonProps }
-			/>
-		);
+
 		const googleAnalyticsSettings = (
 			<GoogleAnalytics
 				{ ...commonProps }
 				configureUrl={ 'https://wordpress.com/settings/analytics/' + this.props.siteRawUrl }
+			/>
+		);
+
+		const sitemaps = (
+			<Sitemaps
+				{ ...commonProps }
+			/>
+		);
+
+		const verificationSettings = (
+			<VerificationServices
+				{ ...commonProps }
 			/>
 		);
 
@@ -103,7 +112,8 @@ export const Traffic = React.createClass( {
 				{ found.stats && statsSettings }
 				{ found.related && relatedPostsSettings }
 				{ found.analytics && googleAnalyticsSettings }
-				{ ( found.verification || found.sitemaps ) && verificationSettings }
+				{ found.verification && verificationSettings }
+				{ found.sitemaps && sitemaps }
 			</div>
 		);
 	}

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+import ExternalLink from 'components/external-link';
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import {
+	FormFieldset
+} from 'components/forms';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { ModuleToggle } from 'components/module-toggle';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { getSiteAdminUrl, isSiteVisibleToSearchEngines } from 'state/initial-state';
+
+export const Sitemaps = moduleSettingsForm(
+	React.createClass( {
+
+		render() {
+			const sitemaps = this.props.getModule( 'sitemaps' ),
+				sitemap_url = get( sitemaps, [ 'extra', 'sitemap_url' ], '' ),
+				news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' );
+
+			return (
+				<SettingsCard
+					{ ...this.props }
+					module="sitemaps"
+					hideButton
+				>
+					<SettingsGroup hasChild support={ sitemaps.learn_more_button }>
+						<ModuleToggle
+							slug="sitemaps"
+							compact
+							activated={ this.props.getOptionValue( 'sitemaps' ) }
+							toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
+							toggleModule={ this.props.toggleModuleNow }>
+							{ __( 'Generate XML sitemaps' ) }
+						</ModuleToggle>
+						{
+							this.props.isSiteVisibleToSearchEngines
+								? this.props.getOptionValue( 'sitemaps' ) && (
+									<FormFieldset>
+										<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
+										<p>
+											<ExternalLink icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
+											<br />
+											<ExternalLink icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+										</p>
+									</FormFieldset>
+								)
+								: (
+									<FormFieldset>
+											<p className="jp-form-setting-explanation">
+												{
+													__( 'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.', {
+														components: {
+															a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
+														}
+													} )
+												}
+											</p>
+									</FormFieldset>
+								)
+						}
+					</SettingsGroup>
+				</SettingsCard>
+			);
+		}
+	} )
+);
+
+export default connect(
+	state => {
+		return {
+			isSiteVisibleToSearchEngines: isSiteVisibleToSearchEngines( state ),
+			siteAdminUrl: getSiteAdminUrl( state )
+		};
+	}
+)( Sitemaps );

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -2,11 +2,9 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import TextInput from 'components/text-input';
 import ExternalLink from 'components/external-link';
-import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -16,19 +14,13 @@ import {
 	FormLabel
 } from 'components/forms';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
-import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import { getSiteAdminUrl, isSiteVisibleToSearchEngines } from 'state/initial-state';
 
 export const VerificationServices = moduleSettingsForm(
 	React.createClass( {
-
 		render() {
-			let verification     = this.props.getModule( 'verification-tools' ),
-				sitemaps         = this.props.getModule( 'sitemaps' ),
-				sitemap_url      = get( sitemaps, [ 'extra', 'sitemap_url' ], '' ),
-				news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' );
+			const verification = this.props.getModule( 'verification-tools' );
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -115,51 +107,9 @@ export const VerificationServices = moduleSettingsForm(
 							}
 						</FormFieldset>
 					</SettingsGroup>
-					<SettingsGroup support={ sitemaps.learn_more_button }>
-						<ModuleToggle
-							slug="sitemaps"
-							compact
-							activated={ this.props.getOptionValue( 'sitemaps' ) }
-							toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
-							toggleModule={ this.props.toggleModuleNow }>
-							{ __( 'Generate XML sitemaps' ) }
-						</ModuleToggle>
-						{
-							this.props.isSiteVisibleToSearchEngines
-								? this.props.getOptionValue( 'sitemaps' ) && (
-									<FormFieldset>
-										<p>
-											<ExternalLink icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
-											<br />
-											<ExternalLink icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
-										</p>
-										<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
-									</FormFieldset>
-								)
-								: (
-									<p className="jp-form-setting-explanation">
-										{
-											__( 'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.', {
-												components: {
-													a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
-												}
-											} )
-										}
-									</p>
-								)
-						}
-					</SettingsGroup>
 				</SettingsCard>
 			);
 		}
 	} )
 );
 
-export default connect(
-	state => {
-		return {
-			isSiteVisibleToSearchEngines: isSiteVisibleToSearchEngines( state ),
-			siteAdminUrl: getSiteAdminUrl( state )
-		};
-	}
-)( VerificationServices );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Sitemaps now has its own card 
* card is above Site Verification as per p1HpG7-3Sm-jetpackp2
* setting explanation is indented below toggle

<img width="754" alt="captura de pantalla 2017-03-24 a las 15 23 14" src="https://cloud.githubusercontent.com/assets/1041600/24308203/d6006372-10a5-11e7-85a2-8eab14b92144.png">

<img width="739" alt="captura de pantalla 2017-03-24 a las 17 47 52" src="https://cloud.githubusercontent.com/assets/1041600/24313037/07920d46-10ba-11e7-8ff8-09c1a53d5350.png">

#### Testing instructions:

* render and assert that Sitemaps is in a new card above Site Verification

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
