### PR TITLE
Build: suppress for now the a11y errors since DOPS needs a few fixes.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
 	"parser": "babel-eslint",
-	"extends": "wpcalypso/react-a11y",
+	"extends": "wpcalypso/react",
 	"env": {
 		"browser": true,
 		"es6": true,


### PR DESCRIPTION
We're getting a lot of issues regarding accessibility from DOPS components that are preventing us from building. For now, let's revert to the previous eslint and when the issues in DOPS are addressed, let's enable this again.

#### Changes proposed in this Pull Request:

* restore previous

#### Testing instructions:

* try to build or watch, it should work without errors

cc @ryelle 