### PR TITLE
Settings UI: fix disconnection dialog latency

### DIFF
--- a/_inc/client/components/jetpack-disconnect-dialog/index.jsx
+++ b/_inc/client/components/jetpack-disconnect-dialog/index.jsx
@@ -20,7 +20,6 @@ import {
 	isDisconnectingSite,
 } from 'state/connection';
 import { getSiteRawUrl } from 'state/initial-state';
-import QuerySite from 'components/data/query-site';
 
 export const JetpackDisconnectDialog = React.createClass( {
 	propTypes: {
@@ -122,7 +121,6 @@ export const JetpackDisconnectDialog = React.createClass( {
 				className="jp-connection-settings__modal"
 				onRequestClose={ this.props.toggleModal }
 				>
-				<QuerySite />
 				<Card className="jp-connection-settings__modal-body">
 					<h2>
 						{


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* don't initiate a new site data query since there's already one started by AtAGlance component where disconnection dialog lives. This solves the issue of feature text replaced after the site data is received

#### Testing instructions:

* verify that when disconnection dialog opens, the text about features is not quickly replaced
