### PR TITLE
Settings UI: add notice and hide Infinite Scroll controls if theme doesn't support it

### DIFF
--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -197,3 +197,15 @@ export function getLastPostUrl( state ) {
 export function arePromotionsActive( state ) {
 	return get( state.jetpack.initialState.siteData, 'showPromotions', true );
 }
+
+/**
+ * Check that theme supports a certain feature
+ *
+ * @param {Object} state   Global state tree.
+ * @param {string} feature Feature to check if current theme supports. Can be 'infinite-scroll'.
+ *
+ * @return {boolean} URL to last published post.
+ */
+export function currentThemeSupports( state, feature ) {
+	return get( state.jetpack.initialState.themeData, [ 'support', feature ], false );
+}

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import CompactFormToggle from 'components/form/form-toggle/compact';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
@@ -98,6 +99,14 @@ const ThemeEnhancements = moduleSettingsForm(
 			);
 		},
 
+		trackLearnMoreIS() {
+			analytics.tracks.recordJetpackClick( {
+				target: 'learn-more',
+				feature: 'infinite-scroll',
+				extra: 'not-supported-link'
+			} );
+		},
+
 		render() {
 			if ( ! this.props.isModuleFound( 'infinite-scroll' ) && ! this.props.isModuleFound( 'minileven' ) ) {
 				return null;
@@ -163,7 +172,7 @@ const ThemeEnhancements = moduleSettingsForm(
 												{
 													__( 'Theme support required.' ) + ' '
 												}
-												<a href={ item.learn_more_button + '#theme' } title={ __( 'Learn more about adding support for Infinite Scroll to your theme.' ) }>
+												<a onClick={ this.trackLearnMoreIS } href={ item.learn_more_button + '#theme' } title={ __( 'Learn more about adding support for Infinite Scroll to your theme.' ) }>
 													{
 														__( 'Learn more' )
 													}

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -12,6 +12,7 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 import { FormFieldset, FormLabel, FormLegend } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { getModule } from 'state/modules';
+import { currentThemeSupports } from 'state/initial-state';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
@@ -42,7 +43,7 @@ const ThemeEnhancements = moduleSettingsForm(
 		/**
 		 * Translate Infinite Scroll module and option status into our three values for the options.
 		 *
-		 * @returns {string}
+		 * @returns {string} Check the Infinite Scroll and its mode and translate into a string.
 		 */
 		getInfiniteMode() {
 			if ( ! this.props.getOptionValue( 'infinite-scroll' ) ) {
@@ -57,7 +58,7 @@ const ThemeEnhancements = moduleSettingsForm(
 		/**
 		 * Update the state for infinite scroll options and prepare options to submit
 		 *
-		 * @param {string} radio
+		 * @param {string} radio Update options to save when Infinite Scroll options change.
 		 */
 		updateInfiniteMode( radio ) {
 			this.setState(
@@ -105,6 +106,7 @@ const ThemeEnhancements = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
+					hideButton={ ! this.props.isInfiniteScrollSupported }
 					header={ __( 'Theme enhancements' ) }>
 					{
 						[ {
@@ -136,7 +138,8 @@ const ThemeEnhancements = moduleSettingsForm(
 										}
 									</FormLegend>
 									{
-										item.radios.map( radio => {
+										this.props.isInfiniteScrollSupported
+										? item.radios.map( radio => {
 											return (
 												<FormLabel key={ `${ item.module }_${ radio.key }` }>
 													<input
@@ -155,6 +158,18 @@ const ThemeEnhancements = moduleSettingsForm(
 												</FormLabel>
 											);
 										} )
+										: (
+											<span>
+												{
+													__( 'Theme support required.' ) + ' '
+												}
+												<a href={ item.learn_more_button + '#theme' } title={ __( 'Learn more about adding support for Infinite Scroll to your theme.' ) }>
+													{
+														__( 'Learn more' )
+													}
+												</a>
+											</span>
+										)
 									}
 								</SettingsGroup>
 							);
@@ -233,7 +248,8 @@ export default connect(
 	( state ) => {
 		return {
 			module: ( module_name ) => getModule( state, module_name ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name )
+			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
+			isInfiniteScrollSupported: currentThemeSupports( state, 'infinite-scroll' )
 		};
 	}
 )( ThemeEnhancements );

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -237,6 +237,17 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			? get_permalink( $last_post[0]->ID )
 			: get_home_url();
 
+		// Get information about current theme.
+		$current_theme = wp_get_theme();
+
+		// Get all themes that Infinite Scroll provides support for natively.
+		$inf_scr_support_themes = array();
+		foreach ( Jetpack::glob_php( JETPACK__PLUGIN_DIR . 'modules/infinite-scroll/themes/*.php' ) as $path ) {
+			if ( is_readable( $path ) ) {
+				$inf_scr_support_themes[] = basename( $path, '.php' );
+			}
+		}
+
 		// Add objects to be passed to the initial state of the app
 		wp_localize_script( 'react-plugin', 'Initial_State', array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
@@ -293,6 +304,13 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 * @param bool $are_promotions_active Status of promotions visibility. True by default.
 				 */
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
+			),
+			'themeData' => array(
+				'name'      => $current_theme->get( 'Name' ),
+				'hasUpdate' => (bool) get_theme_update_available( $current_theme ),
+				'support'   => array(
+					'infinite-scroll' => current_theme_supports( 'infinite-scroll' ) || in_array( $current_theme->get_stylesheet(), $inf_scr_support_themes ),
+				),
 			),
 			'locale' => $this->get_i18n_data(),
 			'localeSlug' => $localeSlug,


### PR DESCRIPTION
Fixes #5824

#### Changes proposed in this Pull Request:

* introduces a notice and hides the controls if Infinite Scroll is disabled
* "Learn more" link goes to `https://jetpack.com/support/infinite-scroll#theme`
* since there are no settings to save, the Save settings button is hidden

<img width="736" alt="captura de pantalla 2017-03-27 a las 10 58 18" src="https://cloud.githubusercontent.com/assets/1041600/24360010/61a256fa-12dc-11e7-8256-71ca47951628.png">

#### Testing instructions:

1. use a theme that is not one of the Twenty*, for example Ryu.
`wp theme install ryu --activate`
2. go to Jetpack admin and verify that the controls are shown. This is ok, Ryu supports InfScr.
3. edit the file `/wp-content/themes/ryu/inc/jetpack.php`
4. comment or delete the line
`add_action( 'after_setup_theme', 'ryu_infinite_scroll_setup' );`
5. load Jetpack admin again. Controls should not be displayed this time.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Settings UI: if theme doesn't support Infinite Scroll, its controls will be hidden and a notice will be displayed.
