### PR TITLE
Settings UI: if user is not linked, display clickable card to link account under Stats

### DIFF
--- a/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import Button from 'components/button';
 import analytics from 'lib/analytics';
+import Card from 'components/card';
 
 /**
  * Internal dependencies
@@ -11,6 +12,22 @@ import analytics from 'lib/analytics';
 import { numberFormat, moment, translate as __ } from 'i18n-calypso';
 
 const DashStatsBottom = React.createClass( {
+	propTypes: {
+		siteRawUrl: React.PropTypes.string.isRequired,
+		siteAdminUrl: React.PropTypes.string.isRequired,
+		statsData: React.PropTypes.object.isRequired,
+		isLinked: React.PropTypes.bool.isRequired
+	},
+
+	getDefaultProps: function() {
+		return {
+			siteRawUrl: '',
+			siteAdminUrl: '',
+			statsData: {},
+			isLinked: false
+		};
+	},
+
 	statsBottom: function() {
 		let generalStats;
 		if ( 'object' === typeof this.props.statsData.general ) {
@@ -22,7 +39,7 @@ const DashStatsBottom = React.createClass( {
 				views_today: '-',
 				views_best_day: '-',
 				views_best_day_total: '-'
-			}
+			};
 		}
 		return [
 			{
@@ -40,7 +57,7 @@ const DashStatsBottom = React.createClass( {
 	},
 
 	render: function() {
-		const s = this.statsBottom()[0];
+		const s = this.statsBottom()[ 0 ];
 		return (
 		<div>
 			<div className="jp-at-a-glance__stats-summary">
@@ -52,8 +69,9 @@ const DashStatsBottom = React.createClass( {
 					<p className="jp-at-a-glance__stat-details">{ __( 'Best overall day', { comment: 'Referring to a number of page views' } ) }</p>
 					<h3 className="jp-at-a-glance__stat-number">
 						{
-							'-' === s.bestDay.count ? '-' :
-							__( '%(number)s View', '%(number)s Views',
+							'-' === s.bestDay.count
+							? '-'
+							: __( '%(number)s View', '%(number)s Views',
 								{
 									count: s.bestDay.count,
 									args: {
@@ -92,7 +110,7 @@ const DashStatsBottom = React.createClass( {
 				<div className="jp-at-a-glance__stats-cta-description">
 				</div>
 				<div className="jp-at-a-glance__stats-cta-buttons">
-					{ __( '{{button}}View Detailed Stats{{/button}}', {
+					{ __( '{{button}}View detailed stats{{/button}}', {
 						components: {
 							button:
 								<Button
@@ -101,18 +119,35 @@ const DashStatsBottom = React.createClass( {
 								/>
 						}
 					} ) }
-					{ __( '{{button}}View More Stats on WordPress.com {{/button}}', {
-						components: {
-							button:
-								<Button
-									onClick={ () => analytics.tracks.recordEvent( 'jetpack_wpa_aag_stats_wpcom_click', {} ) }
-									className="is-primary"
-									href={ 'https://wordpress.com/stats/insights/' + this.props.siteRawUrl }
-								/>
-						}
-					} ) }
+					{
+						this.props.isLinked && (
+							__( '{{button}}View more stats on WordPress.com {{/button}}', {
+								components: {
+									button:
+										<Button
+											onClick={ () => analytics.tracks.recordEvent( 'jetpack_wpa_aag_stats_wpcom_click', {} ) }
+											className="is-primary"
+											href={ 'https://wordpress.com/stats/insights/' + this.props.siteRawUrl }
+										/>
+								}
+							} )
+						)
+					}
 				</div>
 			</div>
+			{
+				! this.props.isLinked && (
+					<Card
+						compact
+						className="jp-settings-card__configure-link"
+						href={ `${ this.props.connectUrl }&from=unlinked-user-connect` }
+					>
+						{
+							__( 'Connect your account to WordPress.com to view more stats' )
+						}
+					</Card>
+				)
+			}
 		</div>
 		);
 	}

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -18,13 +18,12 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import { imagePath } from 'constants';
-import { isDevMode } from 'state/connection';
+import { isDevMode, isCurrentUserLinked, getConnectUrl } from 'state/connection';
 import {
 	getInitialStateStatsData
 } from 'state/initial-state';
 import QueryStatsData from 'components/data/query-stats-data';
 import DashStatsBottom from './dash-stats-bottom';
-
 import {
 	getStatsData,
 	statsSwitchTab,
@@ -134,6 +133,7 @@ const DashStats = React.createClass( {
 							statsData={ this.props.statsData }
 							siteRawUrl={ this.props.siteRawUrl }
 							siteAdminUrl={ this.props.siteAdminUrl }
+							connectUrl={ this.props.connectUrl }
 						/>
 					</div>
 				</div>
@@ -174,7 +174,7 @@ const DashStats = React.createClass( {
 
 	maybeShowStatsTabs: function() {
 		if ( this.props.isModuleActivated( 'stats' ) && ! this.statsErrors() ) {
-			return(
+			return (
 				<ul className="jp-at-a-glance__stats-views">
 					<li tabIndex="0" className="jp-at-a-glance__stats-view">
 						<a href="javascript:void(0)" onClick={ this.handleSwitchStatsView.bind( this, 'day' ) }
@@ -244,6 +244,8 @@ export default connect(
 			isFetchingModules: () => _isFetchingModulesList( state ),
 			activeTab: () => _getActiveStatsTab( state ),
 			isDevMode: isDevMode( state ),
+			isLinked: isCurrentUserLinked( state ),
+			connectUrl: getConnectUrl( state ),
 			statsData: getStatsData( state ) !== 'N/A' ? getStatsData( state ) : getInitialStateStatsData( state )
 		};
 	},


### PR DESCRIPTION
Fixes #5145

#### Changes proposed in this Pull Request:

* if user with permission to see stats is unlinked, the buttons to view more stats and stats on WordPress.com will be replaced by a clickable card that prompts them to link their account

<img width="760" alt="captura de pantalla 2017-03-27 a las 17 15 34" src="https://cloud.githubusercontent.com/assets/1041600/24376083/04c96236-1311-11e7-972b-6ec3a9227711.png">

#### Testing instructions:

* test Jetpack admin with an unlinked user that can view stats

