### PR TITLE
Settings UI: add filter 'jetpack_show_promotions' to disable banners when false

### DIFF
--- a/_inc/client/components/jetpack-banner/index.jsx
+++ b/_inc/client/components/jetpack-banner/index.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import noop from 'lodash/noop';
+import Banner from 'components/banner';
+
+/**
+ * Internal dependencies
+ */
+import { arePromotionsActive } from 'state/initial-state';
+
+class JetpackBanner extends Banner {
+
+	static propTypes = {
+		callToAction: React.PropTypes.string,
+		className: React.PropTypes.string,
+		description: React.PropTypes.string,
+		event: React.PropTypes.string,
+		feature: React.PropTypes.string,
+		href: React.PropTypes.string,
+		icon: React.PropTypes.string,
+		list: React.PropTypes.arrayOf( React.PropTypes.string ),
+		onClick: React.PropTypes.func,
+		plan: React.PropTypes.string,
+		siteSlug: React.PropTypes.string,
+		title: React.PropTypes.string.isRequired
+	};
+
+	static defaultProps = {
+		onClick: noop
+	};
+
+	render() {
+		return this.props.arePromotionsActive
+			? <Banner { ...this.props } />
+			: null;
+	}
+
+}
+
+export default connect(
+	state => {
+		return {
+			arePromotionsActive: arePromotionsActive( state )
+		};
+	}
+)( JetpackBanner );

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -30,7 +30,7 @@ import {
 	isFetchingSiteData
 } from 'state/site';
 import SectionHeader from 'components/section-header';
-import Banner from 'components/banner';
+import JetpackBanner from 'components/jetpack-banner';
 import Button from 'components/button';
 
 export const SettingsCard = props => {
@@ -71,7 +71,7 @@ export const SettingsCard = props => {
 				}
 
 				return (
-					<Banner
+					<JetpackBanner
 						title={ __( 'Host fast, high-quality, ad-free video.' ) }
 						callToAction={ upgradeLabel }
 						plan={ PLAN_JETPACK_PREMIUM }
@@ -89,7 +89,7 @@ export const SettingsCard = props => {
 				}
 
 				return (
-					<Banner
+					<JetpackBanner
 						title={ __( 'Generate income with high-quality ads.' ) }
 						callToAction={ upgradeLabel }
 						plan={ PLAN_JETPACK_PREMIUM }
@@ -105,7 +105,7 @@ export const SettingsCard = props => {
 
 				if ( 'is-premium-plan' === planClass ) {
 					return (
-						<Banner
+						<JetpackBanner
 							title={ __( 'Real-time site backups and automatic threat resolution.' ) }
 							plan={ PLAN_JETPACK_BUSINESS }
 							callToAction={ upgradeLabel }
@@ -116,7 +116,7 @@ export const SettingsCard = props => {
 				}
 
 				return (
-					<Banner
+					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __( 'Protect against data loss, malware, and malicious attacks.' ) }
 						plan={ PLAN_JETPACK_PREMIUM }
@@ -130,7 +130,7 @@ export const SettingsCard = props => {
 					return '';
 				}
 				return (
-					<Banner
+					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __( 'Integrate easily with Google Analytics.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
@@ -144,7 +144,7 @@ export const SettingsCard = props => {
 				}
 
 				return (
-					<Banner
+					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __( 'Help your content get found and shared with SEO tools.' ) }
 						plan={ PLAN_JETPACK_BUSINESS }
@@ -160,7 +160,7 @@ export const SettingsCard = props => {
 				}
 
 				return (
-					<Banner
+					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __( 'Protect your site from spam.' ) }
 						plan={ PLAN_JETPACK_PERSONAL }

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -19,7 +19,7 @@ import {
 	getSitePlan,
 	isFetchingSiteData
 } from 'state/site';
-import Banner from 'components/banner';
+import JetpackBanner from 'components/jetpack-banner';
 
 const SupportCard = React.createClass( {
 	displayName: 'SupportCard',
@@ -63,7 +63,7 @@ const SupportCard = React.createClass( {
 				</Card>
 				{
 					noPrioritySupport && (
-						<Banner
+						<JetpackBanner
 							title={ __( 'Get a faster resolution to your support questions.' ) }
 							plan={ PLAN_JETPACK_PERSONAL }
 							callToAction={ __( 'Upgrade' ) }

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -186,3 +186,14 @@ export function getCurrentIp( state ) {
 export function getLastPostUrl( state ) {
 	return get( state.jetpack.initialState, 'lastPostUrl' );
 }
+
+/**
+ * Check if promotions like banners are visible or hidden.
+ *
+ * @param {object} state Global state tree
+ *
+ * @return {boolean} True if promotions are active, false otherwise.
+ */
+export function arePromotionsActive( state ) {
+	return get( state.jetpack.initialState.siteData, 'showPromotions', true );
+}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -285,6 +285,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 					? apply_filters( 'jetpack_photon_url', get_site_icon_url(), array( 'w' => 64 ) )
 					: '',
 				'siteVisibleToSearchEngines' => '1' == get_option( 'blog_public' ),
+				/**
+				 * Whether promotions are visible or not.
+				 *
+				 * @since 4.8.0
+				 *
+				 * @param bool $are_promotions_active Status of promotions visibility. True by default.
+				 */
+				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
 			),
 			'locale' => $this->get_i18n_data(),
 			'localeSlug' => $localeSlug,


### PR DESCRIPTION
Fixes #4537 

#### Changes proposed in this Pull Request:

* introduces a new filter `jetpack_show_promotions` that when set to `false`, hides all banners from settings UI
* introduces a new component `JetpackBanner` that acts as a hub for the banners and displays them based on the result of the `jetpack_show_promotions` filter

#### Testing instructions:

* add `add_filter( 'jetpack_show_promotions', '__return_false' );` in the `functions.php` of a theme or in a plugin. All banners should now be hidden.
