### PR TITLE
WordPress.com Toolbar: Fix custom post types related menu items display conditions

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -667,37 +667,73 @@ class A8C_WPCOM_Masterbar {
 			),
 		) );
 
-		// Portfolio
-		$portfolios_title = $this->create_menu_item_pair(
-			array(
-				'url'   => 'https://wordpress.com/types/jetpack-portfolio/' . esc_attr( $this->primary_site_slug ),
-				'id'    => 'wp-admin-bar-edit-portfolio',
-				'label' => __( 'Portfolio', 'jetpack' ),
-			),
-			array(
-				'url'   => 'https://wordpress.com/edit/jetpack-portfolio/' . esc_attr( $this->primary_site_slug ),
-				'id'    => 'wp-admin-bar-new-portfolio',
-				'label' => _x( 'Add', 'admin bar menu new item label', 'jetpack' ),
-			)
-		);
-
-		if ( ! current_user_can( 'edit_pages' ) ) {
-			$portfolios_title = $this->create_menu_item_anchor(
-				'ab-item ab-primary mb-icon',
-				'https://wordpress.com/types/jetpack-portfolio/' . esc_attr( $this->primary_site_slug ),
-				__( 'Portfolio', 'jetpack' ),
-				'wp-admin-bar-edit-portfolio'
+		// Testimonials
+		if ( Jetpack::is_module_active( 'custom-content-types' ) && get_option( 'jetpack_testimonial' ) ) {
+			$testimonials_title = $this->create_menu_item_pair(
+				array(
+					'url'   => 'https://wordpress.com/types/jetpack-testimonial/' . esc_attr( $this->primary_site_slug ),
+					'id'    => 'wp-admin-bar-edit-testimonial',
+					'label' => __( 'Testimonials', 'jetpack' ),
+				),
+				array(
+					'url'   => 'https://wordpress.com/edit/jetpack-testimonial/' . esc_attr( $this->primary_site_slug ),
+					'id'    => 'wp-admin-bar-new-testimonial',
+					'label' => _x( 'Add', 'admin bar menu new item label', 'jetpack' ),
+				)
 			);
+
+			if ( ! current_user_can( 'edit_pages' ) ) {
+				$testimonials_title = $this->create_menu_item_anchor(
+					'ab-item ab-primary mb-icon',
+					'https://wordpress.com/types/jetpack-testimonial/' . esc_attr( $this->primary_site_slug ),
+					__( 'Testimonials', 'jetpack' ),
+					'wp-admin-bar-edit-testimonial'
+				);
+			}
+
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'publish',
+				'id'     => 'new-jetpack-testimonial',
+				'title'  => $testimonials_title,
+				'meta'   => array(
+					'class' => 'inline-action',
+				),
+			) );
 		}
 
-		$wp_admin_bar->add_menu( array(
-			'parent' => 'publish',
-			'id'     => 'new-jetpack-portfolio',
-			'title'  => $portfolios_title,
-			'meta'   => array(
-				'class' => 'inline-action',
-			),
-		) );
+		// Portfolio
+		if ( Jetpack::is_module_active( 'custom-content-types' ) && get_option( 'jetpack_portfolio' ) ) {
+			$portfolios_title = $this->create_menu_item_pair(
+				array(
+					'url'   => 'https://wordpress.com/types/jetpack-portfolio/' . esc_attr( $this->primary_site_slug ),
+					'id'    => 'wp-admin-bar-edit-portfolio',
+					'label' => __( 'Portfolio', 'jetpack' ),
+				),
+				array(
+					'url'   => 'https://wordpress.com/edit/jetpack-portfolio/' . esc_attr( $this->primary_site_slug ),
+					'id'    => 'wp-admin-bar-new-portfolio',
+					'label' => _x( 'Add', 'admin bar menu new item label', 'jetpack' ),
+				)
+			);
+
+			if ( ! current_user_can( 'edit_pages' ) ) {
+				$portfolios_title = $this->create_menu_item_anchor(
+					'ab-item ab-primary mb-icon',
+					'https://wordpress.com/types/jetpack-portfolio/' . esc_attr( $this->primary_site_slug ),
+					__( 'Portfolio', 'jetpack' ),
+					'wp-admin-bar-edit-portfolio'
+				);
+			}
+
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'publish',
+				'id'     => 'new-jetpack-portfolio',
+				'title'  => $portfolios_title,
+				'meta'   => array(
+					'class' => 'inline-action',
+				),
+			) );
+		}
 
 		if ( current_user_can( 'edit_theme_options' ) ) {
 			// Look and Feel group

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -678,7 +678,7 @@ class A8C_WPCOM_Masterbar {
 				array(
 					'url'   => 'https://wordpress.com/edit/jetpack-testimonial/' . esc_attr( $this->primary_site_slug ),
 					'id'    => 'wp-admin-bar-new-testimonial',
-					'label' => _x( 'Add', 'admin bar menu new item label', 'jetpack' ),
+					'label' => _x( 'Add', 'Button label for adding a new item via the toolbar menu', 'jetpack' ),
 				)
 			);
 
@@ -712,7 +712,7 @@ class A8C_WPCOM_Masterbar {
 				array(
 					'url'   => 'https://wordpress.com/edit/jetpack-portfolio/' . esc_attr( $this->primary_site_slug ),
 					'id'    => 'wp-admin-bar-new-portfolio',
-					'label' => _x( 'Add', 'admin bar menu new item label', 'jetpack' ),
+					'label' => _x( 'Add', 'Button label for adding a new item via the toolbar menu', 'jetpack' ),
 				)
 			);
 


### PR DESCRIPTION
Previously, Portfolio item was shown in My Sites menu irregardless of Custom Content Types module or Portfolio content type state. These changes prevent showing Portfolio menu item when above settings are not enabled, and adds Testimonials item with similar constraints.

Fixes https://github.com/Automattic/jetpack/issues/6761

#### Changes proposed in this Pull Request:

* Don't display Portfolio menu item if Custom Content Types module is not enabled, or if Portfolio content type is not enabled.
* Add Testimonials menu item with similar display constraints as for Portfolio.

#### Testing instructions:

1. Disable Custom Content Types and verify that Portfolio and Testimonials are not shown in My Sites menu.
2. Enable Custom Content Types, and check `Enable Portfolio Projects for this site` option.
3. Refresh page and verify that Portfolio item is displayed in My Sites menu. 
4. Back in Jetpack module settings, check `Enable Testimonials for this site` option.
5. Refresh page and verify that Testimonials are displayed in My Sites menu too. 