### PR TITLE
Don't show upgrade banners for scan/backups if feature is already active

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -7,6 +7,7 @@ import { translate as __ } from 'i18n-calypso';
 import includes from 'lodash/includes';
 import isEmpty from 'lodash/isEmpty';
 import ProStatus from 'pro-status';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/init
 import {
 	isAkismetKeyValid,
 	isCheckingAkismetKey,
-	getVaultPressData as _getVaultPressData
+	getVaultPressData
 } from 'state/at-a-glance';
 import {
 	getSitePlan,
@@ -42,20 +43,8 @@ export const SettingsCard = props => {
 			? props.getModule( props.module )
 			: false,
 		vpData = props.vaultPressData,
-		backupsEnabled = (
-			'undefined' !== typeof vpData &&
-			'undefined' !== typeof vpData.data &&
-			'undefined' !== typeof vpData.data.features &&
-			'undefined' !== typeof vpData.data.features.backups &&
-			vpData.data.features.backups
-		),
-		scanEnabled = (
-			'undefined' !== typeof vpData &&
-			'undefined' !== typeof vpData.data &&
-			'undefined' !== typeof vpData.data.features &&
-			'undefined' !== typeof vpData.data.features.security &&
-			vpData.data.features.security
-		);
+		backupsEnabled = get( vpData, [ 'data', 'features', 'backups' ], false ),
+		scanEnabled = get( vpData, [ 'data', 'features', 'security' ], false );
 
 	// Non admin users only get Publicize, After the Deadline, and Post by Email settings.
 	// composing is not a module slug but it's used so the Composing card is rendered to show AtD.
@@ -292,7 +281,7 @@ export default connect(
 			userCanManageModules: userCanManageModules( state ),
 			isAkismetKeyValid: isAkismetKeyValid( state ),
 			isCheckingAkismetKey: isCheckingAkismetKey( state ),
-			vaultPressData: _getVaultPressData( state )
+			vaultPressData: getVaultPressData( state )
 		};
 	}
 )( SettingsCard );

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -24,7 +24,11 @@ import {
 	getPlanClass
 } from 'lib/plans/constants';
 import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
-import { isAkismetKeyValid, isCheckingAkismetKey } from 'state/at-a-glance';
+import {
+	isAkismetKeyValid,
+	isCheckingAkismetKey,
+	getVaultPressData as _getVaultPressData
+} from 'state/at-a-glance';
 import {
 	getSitePlan,
 	isFetchingSiteData
@@ -36,7 +40,20 @@ import Button from 'components/button';
 export const SettingsCard = props => {
 	const module = props.module
 			? props.getModule( props.module )
-			: false;
+			: false,
+		vpData = props.vaultPressData,
+		backupsEnabled = (
+			'undefined' !== typeof vpData.data &&
+			'undefined' !== typeof vpData.data.features &&
+			'undefined' !== typeof vpData.data.features.security &&
+			vpData.data.features.backups
+		),
+		scanEnabled = (
+			'undefined' !== typeof vpData.data &&
+			'undefined' !== typeof vpData.data.features &&
+			'undefined' !== typeof vpData.data.features.security &&
+			vpData.data.features.security
+		);
 
 	// Non admin users only get Publicize, After the Deadline, and Post by Email settings.
 	// composing is not a module slug but it's used so the Composing card is rendered to show AtD.
@@ -99,7 +116,7 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SECURITY_SCANNING_JETPACK:
-				if ( 'is-business-plan' === planClass ) {
+				if ( backupsEnabled || 'is-business-plan' === planClass ) {
 					return '';
 				}
 
@@ -183,10 +200,7 @@ export const SettingsCard = props => {
 
 		switch ( feature ) {
 			case FEATURE_SECURITY_SCANNING_JETPACK:
-				if (
-					'is-free-plan' === planClass ||
-					'is-personal-plan' === planClass
-				) {
+				if ( ( 'is-free-plan' === planClass || 'is-personal-plan' === planClass ) && ! scanEnabled ) {
 					return false;
 				}
 
@@ -275,7 +289,8 @@ export default connect(
 			siteAdminUrl: getSiteAdminUrl( state ),
 			userCanManageModules: userCanManageModules( state ),
 			isAkismetKeyValid: isAkismetKeyValid( state ),
-			isCheckingAkismetKey: isCheckingAkismetKey( state )
+			isCheckingAkismetKey: isCheckingAkismetKey( state ),
+			vaultPressData: _getVaultPressData( state )
 		};
 	}
 )( SettingsCard );

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -43,12 +43,14 @@ export const SettingsCard = props => {
 			: false,
 		vpData = props.vaultPressData,
 		backupsEnabled = (
+			'undefined' !== typeof vpData &&
 			'undefined' !== typeof vpData.data &&
 			'undefined' !== typeof vpData.data.features &&
-			'undefined' !== typeof vpData.data.features.security &&
+			'undefined' !== typeof vpData.data.features.backups &&
 			vpData.data.features.backups
 		),
 		scanEnabled = (
+			'undefined' !== typeof vpData &&
 			'undefined' !== typeof vpData.data &&
 			'undefined' !== typeof vpData.data.features &&
 			'undefined' !== typeof vpData.data.features.security &&


### PR DESCRIPTION
Sometimes VP will already be installed/active even without a plan.  Don't show the upgrade banner for those instances.  

Fixes #6763