### PR TITLE
Sharedaddy: Protect against malformed `from` names.

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -22,6 +22,26 @@ function sharing_email_send_post( $data ) {
 	/** This filter is documented in core/src/wp-includes/pluggable.php */
 	$from_email = apply_filters( 'wp_mail_from', 'wordpress@' . $sitename );
 
+	if ( ! empty( $data['name'] ) ) {
+		$s_name = (string) $data['name'];
+		$name_needs_encoding_regex =
+			'/[' .
+				// SpamAssasin's list of characters which "need MIME" encoding
+				'\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\xff' .
+				// Our list of "unsafe" characters
+				'<\r\n' .
+			']/';
+
+		$needs_encoding = preg_match( $name_needs_encoding_regex, $s_name ) ||      // If it contains any blacklisted chars,
+				! function_exists( 'mb_convert_encoding' ) ||           // Or if we can't use `mb_convert_encoding` encode everything,
+				mb_convert_encoding( $data['name'], 'ASCII' ) !== $s_name // Or if it's not already ASCII
+			);
+
+		if ( $needs_encoding ) {
+			$data['name'] = sprintf( '=?UTF-8?B?%s?=', base64_encode( $data['name'] ) );
+		}
+	}
+
 	$headers[] = sprintf( 'From: %1$s <%2$s>', $data['name'], $from_email );
 	$headers[] = sprintf( 'Reply-To: %1$s <%2$s>', $data['name'], $data['source'] );
 

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -32,10 +32,13 @@ function sharing_email_send_post( $data ) {
 				'<\r\n' .
 			']/';
 
-		$needs_encoding = preg_match( $name_needs_encoding_regex, $s_name ) ||      // If it contains any blacklisted chars,
-				! function_exists( 'mb_convert_encoding' ) ||           // Or if we can't use `mb_convert_encoding` encode everything,
-				mb_convert_encoding( $data['name'], 'ASCII' ) !== $s_name // Or if it's not already ASCII
-			);
+		$needs_encoding =
+			// If it contains any blacklisted chars,
+			preg_match( $name_needs_encoding_regex, $s_name ) ||
+			// Or if we can't use `mb_convert_encoding`
+			! function_exists( 'mb_convert_encoding' ) ||
+			// Or if it's not already ASCII
+			mb_convert_encoding( $data['name'], 'ASCII' ) !== $s_name;
 
 		if ( $needs_encoding ) {
 			$data['name'] = sprintf( '=?UTF-8?B?%s?=', base64_encode( $data['name'] ) );


### PR DESCRIPTION
Avoid syntax errors due to unexpected characters in the `from` name by
base64encoding the from name if any blacklisted characters are used
or it's non-ASCII.