### PR TITLE
Debugger: add link to the old modules list.

### DIFF
--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -292,7 +292,19 @@ class Jetpack_Debugger {
 				<hr />
 				<?php if ( Jetpack::is_active() ) : ?>
 					<div id="connected-user-details">
-						<p><?php printf( /* translators: %s is an e-mail address */ __( 'The primary connection is owned by <strong>%s</strong>\'s WordPress.com account.', 'jetpack' ), esc_html( Jetpack::get_master_user_email() ) ); ?></p>
+						<h3><?php esc_html_e( 'More details about your Jetpack settings', 'jetpack' ); ?></h3>
+						<p><?php printf(
+							/* translators: %s is an e-mail address */
+							__( 'The primary connection is owned by <strong>%s</strong>\'s WordPress.com account.', 'jetpack' ),
+							esc_html( Jetpack::get_master_user_email() )
+						); ?></p>
+						<?php if ( current_user_can( 'jetpack_manage_modules' ) ) {
+							printf(
+								'<p><a href="%1$s">%2$s</a></p>',
+								Jetpack::admin_url( 'page=jetpack_modules' ),
+								esc_html__( 'Access the full list of Jetpack modules available on your site.', 'jetpack' )
+							);
+						} ?>
 					</div>
 				<?php else : ?>
 					<div id="dev-mode-details">
@@ -364,6 +376,7 @@ class Jetpack_Debugger {
 				</form>
 			<?php endif; ?>
 		</div> <!-- contact-message, hidden by default. -->
+		<hr />
 		<div id="toggle_debug_info"><a href="#"><?php _e( 'View Advanced Debug Results', 'jetpack' ); ?></a></div>
 			<div id="debug_info_div" style="display:none">
 			<h4><?php esc_html_e( 'Debug Info', 'jetpack' ); ?></h4>


### PR DESCRIPTION
- Include that link only if user has access to the list.
- Create new section, separated by an horizontal line and including a heading, so the link is easier to locate on the page.

Before:

![screen shot 2017-03-27 at 20 14 48](https://cloud.githubusercontent.com/assets/426388/24371101/0fb5f678-132a-11e7-8f16-1f0128629015.png)

After:

![screen shot 2017-03-27 at 20 14 15](https://cloud.githubusercontent.com/assets/426388/24371072/fc4d606c-1329-11e7-897b-17919af2003f.png)

If you have any feedback on wording or anything, please let me know! I think the wording could be improved, but I'm not really sure how to phrase this.