### PR TITLE
Fix path to sharing buttons config to wp.com

### DIFF
--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -25,7 +25,7 @@ export class ShareButtons extends Component {
 			}
 
 			if ( isLinked ) {
-				return <Card compact className="jp-settings-card__configure-link" href={ 'https://wordpress.com/sharing/' + siteRawUrl }>{ __( 'Configure your sharing buttons' ) }</Card>;
+				return <Card compact className="jp-settings-card__configure-link" href={ 'https://wordpress.com/sharing/buttons/' + siteRawUrl }>{ __( 'Configure your sharing buttons' ) }</Card>;
 			}
 
 			return <Card compact className="jp-settings-card__configure-link" href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }>{ __( 'Connect your user account to WordPress.com to use this feature' ) }</Card>;


### PR DESCRIPTION
Point them directly to wordpress.com/sharing/buttons/siteurl.com -- We will be handling the cases where sharing is inactive over in Calypso so that this is not a broken link.  