### PR TITLE
Settings UI: hide settings for unavailable modules

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -185,10 +185,7 @@ export const NavigationSettings = React.createClass( {
 							'protect',
 							'sso',
 							'vaultpress'
-						] ) || (
-							this.props.isPluginActive( 'akismet/akismet.php' ) ||
-							this.props.isPluginActive( 'vaultpress/vaultpress.php' )
-						) ) && (
+						] ) || this.props.isPluginActive( 'akismet/akismet.php' ) ) && (
 							<NavItem
 								path="#security"
 								onClick={ () => this.trackNavClick( 'security' ) }

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -43,13 +43,16 @@ describe( 'NavigationSettings', () => {
 			siteRawUrl: 'example.org',
 			siteAdminUrl: 'https://example.org/wp-admin/',
 			searchForTerm: () => {},
-			isLinked: true
+			isLinked: true,
+			moduleList: { 'omnisearch': true, 'minileven': true, 'contact-form': true, 'sitemaps': true, 'latex': true, 'carousel': true, 'tiled-gallery': true, 'custom-content-types': true, 'verification-tools': true, 'markdown': true, 'infinite-scroll': true, 'gravatar-hovercards': true, 'widget-visibility': true, 'shortcodes': true, 'custom-css': true, 'sharedaddy': true, 'widgets': true, 'notes': true, 'sso': true, 'related-posts': true, 'monitor': true, 'vaultpress': true, 'stats': true, 'masterbar': true, 'google-analytics': true, 'seo-tools': true, 'wordads': true, 'videopress': true, 'subscriptions': true, 'comments': true, 'json-api': true, 'manage': true, 'post-by-email': true, 'after-the-deadline': true, 'enhanced-distribution': true, 'photon': true, 'publicize': true, 'likes': true, 'shortlinks': true },
+			isPluginActive: () => true
 		};
 
 		options = {
 			context: {
 				router: NavigationSettings.contextTypes.router()
-			}
+			},
+			moduleList: [ 'omnisearch', 'minileven', 'contact-form', 'sitemaps', 'latex', 'carousel', 'tiled-gallery', 'custom-content-types', 'verification-tools', 'markdown', 'infinite-scroll', 'gravatar-hovercards', 'widget-visibility', 'shortcodes', 'custom-css', 'sharedaddy', 'widgets', 'notes', 'sso', 'related-posts', 'monitor', 'vaultpress', 'stats', 'masterbar', 'google-analytics', 'seo-tools', 'wordads', 'videopress', 'subscriptions', 'comments', 'json-api', 'manage', 'post-by-email', 'after-the-deadline', 'enhanced-distribution', 'photon', 'publicize', 'likes', 'shortlinks' ]
 		};
 
 		window.location.hash = '#settings';
@@ -123,19 +126,20 @@ describe( 'NavigationSettings', () => {
 		} );
 
 		describe( 'if Publicize is active', () => {
-
-			let publicizeProps = Object.assign( {}, testProps, {
-				userCanManageModules: false,
-				isSubscriber: false,
-				userCanPublish: true,
-				route: {
-					name: 'General',
-					path: '/settings'
-				},
-				isModuleActivated: m => 'publicize' === m
-			} );
-			it( 'show Sharing if user is linked', () => {
-				expect( shallow( <NavigationSettings { ...publicizeProps } />, options ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing', 'Sharing' ].includes( item ) ) ).to.be.true;
+			before( () => {
+				let publicizeProps = Object.assign( {}, testProps, {
+					userCanManageModules: false,
+					isSubscriber: false,
+					userCanPublish: true,
+					route: {
+						name: 'General',
+						path: '/settings'
+					},
+					isModuleActivated: m => 'publicize' === m
+				} );
+				it( 'show Sharing if user is linked', () => {
+					expect( shallow( <NavigationSettings { ...publicizeProps } />, options ).find( 'NavItem' ).children().nodes.filter( item => 'string' === typeof item ).every( item => [ 'Writing', 'Sharing' ].includes( item ) ) ).to.be.true;
+				} );
 			} );
 		} );
 

--- a/_inc/client/components/navigation-settings/test/component.js
+++ b/_inc/client/components/navigation-settings/test/component.js
@@ -44,7 +44,7 @@ describe( 'NavigationSettings', () => {
 			siteAdminUrl: 'https://example.org/wp-admin/',
 			searchForTerm: () => {},
 			isLinked: true,
-			moduleList: { 'omnisearch': true, 'minileven': true, 'contact-form': true, 'sitemaps': true, 'latex': true, 'carousel': true, 'tiled-gallery': true, 'custom-content-types': true, 'verification-tools': true, 'markdown': true, 'infinite-scroll': true, 'gravatar-hovercards': true, 'widget-visibility': true, 'shortcodes': true, 'custom-css': true, 'sharedaddy': true, 'widgets': true, 'notes': true, 'sso': true, 'related-posts': true, 'monitor': true, 'vaultpress': true, 'stats': true, 'masterbar': true, 'google-analytics': true, 'seo-tools': true, 'wordads': true, 'videopress': true, 'subscriptions': true, 'comments': true, 'json-api': true, 'manage': true, 'post-by-email': true, 'after-the-deadline': true, 'enhanced-distribution': true, 'photon': true, 'publicize': true, 'likes': true, 'shortlinks': true },
+			moduleList: { minileven: true, sitemaps: true, carousel: true, 'custom-content-types': true, 'verification-tools': true, markdown: true, 'infinite-scroll': true, 'gravatar-hovercards': true, sharedaddy: true, sso: true, 'related-posts': true, monitor: true, vaultpress: true, stats: true, masterbar: true, 'google-analytics': true, 'seo-tools': true, wordads: true, videopress: true, subscriptions: true, comments: true, 'post-by-email': true, 'after-the-deadline': true, photon: true, publicize: true, likes: true },
 			isPluginActive: () => true
 		};
 
@@ -52,7 +52,7 @@ describe( 'NavigationSettings', () => {
 			context: {
 				router: NavigationSettings.contextTypes.router()
 			},
-			moduleList: [ 'omnisearch', 'minileven', 'contact-form', 'sitemaps', 'latex', 'carousel', 'tiled-gallery', 'custom-content-types', 'verification-tools', 'markdown', 'infinite-scroll', 'gravatar-hovercards', 'widget-visibility', 'shortcodes', 'custom-css', 'sharedaddy', 'widgets', 'notes', 'sso', 'related-posts', 'monitor', 'vaultpress', 'stats', 'masterbar', 'google-analytics', 'seo-tools', 'wordads', 'videopress', 'subscriptions', 'comments', 'json-api', 'manage', 'post-by-email', 'after-the-deadline', 'enhanced-distribution', 'photon', 'publicize', 'likes', 'shortlinks' ]
+			moduleList: []
 		};
 
 		window.location.hash = '#settings';

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -36,88 +36,114 @@ export const Comments = moduleSettingsForm(
 		},
 
 		render() {
-			let comments = this.props.getModule( 'comments' ),
+			const foundComments = this.props.isModuleFound( 'comments' ),
+				foundGravatar = this.props.isModuleFound( 'gravatar-hovercards' ),
+				foundMarkdown = this.props.isModuleFound( 'markdown' );
+
+			if ( ! foundComments && ! foundGravatar && ! foundMarkdown ) {
+				return null;
+			}
+
+			const comments = this.props.getModule( 'comments' ),
 				isCommentsActive = this.props.getOptionValue( 'comments' ),
 				commentsUnavailableInDevMode = this.props.isUnavailableInDevMode( 'comments' ),
 				gravatar = this.props.getModule( 'gravatar-hovercards' ),
 				markdown = this.props.getModule( 'markdown' );
+
 			return (
 				<SettingsCard
 					{ ...this.props }
+					header={ __( 'Comments' ) }
 					module="comments"
 					saveDisabled={ this.props.isSavingAnyOption( [ 'highlander_comment_form_prompt', 'jetpack_comment_form_color_scheme' ] ) }
 				>
-					<SettingsGroup hasChild disableInDevMode module={ comments }>
-						<ModuleToggle
-							slug="comments"
-							compact
-							disabled={ commentsUnavailableInDevMode }
-							activated={ this.props.getOptionValue( 'comments' ) }
-							toggling={ this.props.isSavingAnyOption( 'comments' ) }
-							toggleModule={ this.props.toggleModuleNow }
-						>
+					{
+						foundComments && (
+							<SettingsGroup hasChild disableInDevMode module={ comments }>
+								<ModuleToggle
+									slug="comments"
+									compact
+									disabled={ commentsUnavailableInDevMode }
+									activated={ this.props.getOptionValue( 'comments' ) }
+									toggling={ this.props.isSavingAnyOption( 'comments' ) }
+									toggleModule={ this.props.toggleModuleNow }
+								>
 						<span className="jp-form-toggle-explanation">
 							{
 								comments.description
 							}
 						</span>
-						</ModuleToggle>
-						<FormFieldset>
-							<FormLabel>
-								<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
-								<TextInput
-									name={ 'highlander_comment_form_prompt' }
-									value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
-									disabled={ ! isCommentsActive || commentsUnavailableInDevMode || this.props.isSavingAnyOption( 'highlander_comment_form_prompt' ) }
-									onChange={ this.props.onOptionChange } />
-							</FormLabel>
-							<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
-							<FormLabel>
-								<span className="jp-form-label-wide">{ __( 'Color scheme' ) }</span>
-								<FormSelect
-									name={ 'jetpack_comment_form_color_scheme' }
-									value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
-									disabled={ ! isCommentsActive || commentsUnavailableInDevMode || this.props.isSavingAnyOption( 'jetpack_comment_form_color_scheme' ) }
-									onChange={ this.props.onOptionChange }
-									{ ...this.props }
-									validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
-							</FormLabel>
-						</FormFieldset>
-					</SettingsGroup>
-					<SettingsGroup>
-						<FormFieldset>
-							<ModuleToggle
-								slug="gravatar-hovercards"
-								compact
-								activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
-								toggling={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
-								toggleModule={ this.props.toggleModuleNow }
-								>
-								<span className="jp-form-toggle-explanation">
-									{
-										gravatar.description + ' '
-									}
-									<a href={ gravatar.learn_more_button }>{ __( 'Learn more' ) }</a>
-								</span>
-							</ModuleToggle>
-						</FormFieldset>
-						<FormFieldset>
-							<ModuleToggle
-								slug="markdown"
-								compact
-								activated={ !! this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
-								toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_comments_with_markdown' ] ) }
-								toggleModule={ this.updateFormStateByMarkdown }
-								>
-								<span className="jp-form-toggle-explanation">
-									{
-										__( 'Enable Markdown use for comments.' ) + ' '
-									}
-									<a href={ markdown.learn_more_button }>{ __( 'Learn more' ) }</a>
-								</span>
-							</ModuleToggle>
-						</FormFieldset>
-					</SettingsGroup>
+								</ModuleToggle>
+								<FormFieldset>
+									<FormLabel>
+										<span className="jp-form-label-wide">{ __( 'Comments headline' ) }</span>
+										<TextInput
+											name={ 'highlander_comment_form_prompt' }
+											value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
+											disabled={ ! isCommentsActive || commentsUnavailableInDevMode || this.props.isSavingAnyOption( 'highlander_comment_form_prompt' ) }
+											onChange={ this.props.onOptionChange } />
+									</FormLabel>
+									<span className="jp-form-setting-explanation">{ __( 'A few catchy words to motivate your readers to comment.' ) }</span>
+									<FormLabel>
+										<span className="jp-form-label-wide">{ __( 'Color scheme' ) }</span>
+										<FormSelect
+											name={ 'jetpack_comment_form_color_scheme' }
+											value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
+											disabled={ ! isCommentsActive || commentsUnavailableInDevMode || this.props.isSavingAnyOption( 'jetpack_comment_form_color_scheme' ) }
+											onChange={ this.props.onOptionChange }
+											{ ...this.props }
+											validValues={ this.props.validValues( 'jetpack_comment_form_color_scheme', 'comments' ) }/>
+									</FormLabel>
+								</FormFieldset>
+							</SettingsGroup>
+						)
+					}
+					{
+						( foundGravatar || foundMarkdown ) && (
+							<SettingsGroup>
+								{
+									foundGravatar && (
+										<FormFieldset>
+											<ModuleToggle
+												slug="gravatar-hovercards"
+												compact
+												activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
+												toggling={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
+												toggleModule={ this.props.toggleModuleNow }
+											>
+												<span className="jp-form-toggle-explanation">
+													{
+														gravatar.description + ' '
+													}
+													<a href={ gravatar.learn_more_button }>{ __( 'Learn more' ) }</a>
+												</span>
+											</ModuleToggle>
+										</FormFieldset>
+									)
+								}
+								{
+									foundMarkdown && (
+										<FormFieldset>
+											<ModuleToggle
+												slug="markdown"
+												compact
+												activated={ !! this.props.getOptionValue( 'wpcom_publish_comments_with_markdown', 'markdown' ) }
+												toggling={ this.props.isSavingAnyOption( [ 'markdown', 'wpcom_publish_comments_with_markdown' ] ) }
+												toggleModule={ this.updateFormStateByMarkdown }
+											>
+												<span className="jp-form-toggle-explanation">
+													{
+														__( 'Enable Markdown use for comments.' ) + ' '
+													}
+													<a href={ markdown.learn_more_button }>{ __( 'Learn more' ) }</a>
+												</span>
+											</ModuleToggle>
+										</FormFieldset>
+									)
+								}
+							</SettingsGroup>
+						)
+					}
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -27,38 +27,36 @@ export const Discussion = React.createClass( {
 			isUnavailableInDevMode: this.props.isUnavailableInDevMode
 		};
 
-		let found = {
-			comments: this.props.isModuleFound( 'comments' ),
-			subscriptions: this.props.isModuleFound( 'subscriptions' )
-		};
+		const foundComments = this.props.isModuleFound( 'comments' ),
+			foundMarkdown = this.props.isModuleFound( 'markdown' ),
+			foundGravatar = this.props.isModuleFound( 'gravatar-hovercards' ),
+			foundSubscriptions = this.props.isModuleFound( 'subscriptions' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
-		if ( ! found.comments && ! found.subscriptions ) {
+		if ( ! foundComments && ! foundSubscriptions && ! foundMarkdown && ! foundGravatar ) {
 			return null;
 		}
-
-		let commentsSettings = (
-			<Comments
-				{ ...commonProps }
-			/>
-		);
-		let subscriptionsSettings = (
-			<Subscriptions
-				{ ...commonProps }
-				isLinked={ this.props.isLinked }
-				connectUrl={ this.props.connectUrl }
-				siteRawUrl={ this.props.siteRawUrl }
-			/>
-		);
 
 		return (
 			<div>
 				<QuerySite />
-				{ found.comments && commentsSettings }
-				{ found.subscriptions && subscriptionsSettings }
+				<Comments
+					{ ...commonProps }
+					isModuleFound={ this.props.isModuleFound }
+				/>
+				{
+					foundSubscriptions && (
+						<Subscriptions
+							{ ...commonProps }
+							isLinked={ this.props.isLinked }
+							connectUrl={ this.props.connectUrl }
+							siteRawUrl={ this.props.siteRawUrl }
+						/>
+					)
+				}
 			</div>
 		);
 	}

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -13,7 +13,6 @@ import { isDevMode, isUnavailableInDevMode } from 'state/connection';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { isPluginActive } from 'state/site/plugins';
 import QuerySite from 'components/data/query-site';
-import QuerySitePlugins from 'components/data/query-site-plugins';
 import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
 import { BackupsScan } from './backups-scan';
 import Antispam from './antispam';
@@ -31,54 +30,58 @@ export const Security = React.createClass( {
 			isUnavailableInDevMode: this.props.isUnavailableInDevMode
 		};
 
-		const found = {
-			protect: this.props.isModuleFound( 'protect' ),
-			sso: this.props.isModuleFound( 'sso' )
-		};
+		const foundProtect = this.props.isModuleFound( 'protect' ),
+			foundSso = this.props.isModuleFound( 'sso' ),
+			foundAkismet = this.props.isPluginActive( 'akismet/akismet.php' ),
+			foundBackups = this.props.isPluginActive( 'vaultpress/vaultpress.php' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
-		if ( ! found.sso && ! found.protect ) {
+		if (
+			! foundSso &&
+			! foundProtect &&
+			! foundAkismet &&
+			! foundBackups
+		) {
 			return null;
 		}
 
-		const backupSettings = (
-			<BackupsScan
-				{ ...commonProps }
-			/>
-		);
-
-		let akismetSettings = '';
-		if ( this.props.isPluginActive( 'akismet/akismet.php' ) ) {
-			akismetSettings = (
-				<div>
-					<Antispam
-						{ ...commonProps }
-					/>
-					<QueryAkismetKeyCheck />
-				</div>
-			);
-		}
-		const protectSettings = (
-			<Protect
-				{ ...commonProps }
-			/>
-		);
-		const ssoSettings = (
-			<SSO
-				{ ...commonProps }
-			/>
-		);
 		return (
 			<div>
 				<QuerySite />
-				<QuerySitePlugins />
-				{ ( found.protect || found.sso ) && backupSettings }
-				{ ( found.protect || found.sso ) && akismetSettings }
-				{ found.protect && protectSettings }
-				{ found.sso && ssoSettings }
+				{
+					foundBackups && (
+						<BackupsScan
+							{ ...commonProps }
+						/>
+					)
+				}
+				{
+					foundAkismet && (
+						<div>
+							<Antispam
+								{ ...commonProps }
+							/>
+							<QueryAkismetKeyCheck />
+						</div>
+					)
+				}
+				{
+					foundProtect && (
+						<Protect
+							{ ...commonProps }
+						/>
+					)
+				}
+				{
+					foundSso && (
+						<SSO
+							{ ...commonProps }
+						/>
+					)
+				}
 			</div>
 		);
 	}

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -10,8 +10,8 @@ import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode } from 'state/connection';
-import { isModuleFound as _isModuleFound } from 'state/search';
-import { isPluginActive } from 'state/site/plugins';
+import { isModuleFound } from 'state/search';
+import { isPluginActive, isPluginInstalled } from 'state/site/plugins';
 import QuerySite from 'components/data/query-site';
 import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
 import { BackupsScan } from './backups-scan';
@@ -21,6 +21,31 @@ import { SSO } from './sso';
 
 export const Security = React.createClass( {
 	displayName: 'SecuritySettings',
+
+	/**
+	 * Check if Akismet plugin is being searched and matched.
+	 *
+	 * @returns {boolean} False if the plugin is inactive or if the search doesn't match it. True otherwise.
+	 */
+	isAkismetFound() {
+		if ( ! this.props.isPluginActive( 'akismet/akismet.php' ) ) {
+			return false;
+		}
+
+		if ( this.props.searchTerm ) {
+			const akismetData = this.props.isPluginInstalled( 'akismet/akismet.php' );
+			return [
+				'akismet',
+				'antispam',
+				'spam',
+				'comments',
+				akismetData.Description,
+				akismetData.PluginURI
+			].join( ' ' ).toLowerCase().indexOf( this.props.searchTerm.toLowerCase() ) > -1;
+		}
+
+		return true;
+	},
 
 	render() {
 		const commonProps = {
@@ -32,8 +57,8 @@ export const Security = React.createClass( {
 
 		const foundProtect = this.props.isModuleFound( 'protect' ),
 			foundSso = this.props.isModuleFound( 'sso' ),
-			foundAkismet = this.props.isPluginActive( 'akismet/akismet.php' ),
-			foundBackups = this.props.isPluginActive( 'vaultpress/vaultpress.php' );
+			foundAkismet = this.isAkismetFound(),
+			foundBackups = this.props.isModuleFound( 'vaultpress' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
@@ -94,8 +119,9 @@ export default connect(
 			settings: getSettings( state ),
 			isDevMode: isDevMode( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
-			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug )
+			isModuleFound: ( module_name ) => isModuleFound( state, module_name ),
+			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
+			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
 		};
 	}
 )( Security );

--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -31,48 +31,46 @@ class Sharing extends Component {
 			siteAdminUrl: this.props.siteAdminUrl
 		};
 
-		const found = {
-			publicize: this.props.isModuleFound( 'publicize' ),
-			sharing: this.props.isModuleFound( 'sharedaddy' ),
-			likes: this.props.isModuleFound( 'likes' )
-		};
+		const foundPublicize = this.props.isModuleFound( 'publicize' ),
+			foundSharing = this.props.isModuleFound( 'sharedaddy' ),
+			foundLikes = this.props.isModuleFound( 'likes' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
 		if (
-			! found.publicize &&
-			! found.sharing &&
-			! found.likes
+			! foundPublicize &&
+			! foundSharing &&
+			! foundLikes
 		) {
 			return null;
 		}
 
-		const publicizeSettings = (
-			<Publicize
-				{ ...commonProps }
-			/>
-		);
-
-		const sharingSettings = (
-			<ShareButtons
-				{ ...commonProps }
-			/>
-		);
-
-		const likesSettings = (
-			<Likes
-				{ ...commonProps }
-			/>
-		);
-
 		return (
 			<div>
 				<QuerySite />
-				{ found.publicize && publicizeSettings }
-				{ found.sharing && sharingSettings }
-				{ found.likes && likesSettings }
+				{
+					foundPublicize && (
+						<Publicize
+							{ ...commonProps }
+						/>
+					)
+				}
+				{
+					foundSharing && (
+						<ShareButtons
+							{ ...commonProps }
+						/>
+					)
+				}
+				{
+					foundLikes && (
+						<Likes
+							{ ...commonProps }
+						/>
+					)
+				}
 			</div>
 		);
 	}

--- a/_inc/client/state/search/reducer.js
+++ b/_inc/client/state/search/reducer.js
@@ -45,15 +45,19 @@ export function getSearchTerm( state ) {
  * @return {Boolean}       Whether the module should be in the search results
  */
 export function isModuleFound( state, module ) {
-	let result = get( state, [ 'jetpack', 'modules', 'items' ], {} );
-
-	result = find( result, [ 'module', module ] );
+	const result = find( get( state.jetpack, [ 'modules', 'items' ], {} ), [ 'module', module ] );
 
 	if ( 'undefined' === typeof result ) {
 		return false;
 	}
 
-	let text = [
+	const currentSearchTerm = get( state.jetpack, [ 'search', 'searchTerm' ], false );
+
+	if ( ! currentSearchTerm ) {
+		return true;
+	}
+
+	return [
 		result.module,
 		result.name,
 		result.description,
@@ -63,13 +67,5 @@ export function isModuleFound( state, module ) {
 		result.additional_search_queries,
 		result.short_description,
 		result.feature ? result.feature.toString() : ''
-	].join( ' ' );
-
-	let searchTerm = get( state, [ 'jetpack', 'search', 'searchTerm' ], false );
-
-	if ( ! searchTerm ) {
-		return true;
-	}
-
-	return text.toLowerCase().indexOf( searchTerm.toLowerCase() ) > -1;
+	].join( ' ' ).toLowerCase().indexOf( currentSearchTerm.toLowerCase() ) > -1;
 }

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import { isDevMode, isUnavailableInDevMode } from 'state/connection';
-import { isModuleFound as _isModuleFound } from 'state/search';
+import { isModuleFound } from 'state/search';
 import QuerySite from 'components/data/query-site';
 import { SEO } from './seo';
 import { GoogleAnalytics } from './google-analytics';
@@ -32,88 +32,89 @@ export const Traffic = React.createClass( {
 			isUnavailableInDevMode: this.props.isUnavailableInDevMode
 		};
 
-		const found = {
-			seo: this.props.isModuleFound( 'seo-tools' ),
-			ads: this.props.isModuleFound( 'wordads' ),
-			stats: this.props.isModuleFound( 'stats' ),
-			related: this.props.isModuleFound( 'related-posts' ),
-			verification: this.props.isModuleFound( 'verification-tools' ),
-			sitemaps: this.props.isModuleFound( 'sitemaps' ),
-			analytics: this.props.isModuleFound( 'google-analytics' )
-		};
+		const foundSeo = this.props.isModuleFound( 'seo-tools' ),
+			foundAds = this.props.isModuleFound( 'wordads' ),
+			foundStats = this.props.isModuleFound( 'stats' ),
+			foundRelated = this.props.isModuleFound( 'related-posts' ),
+			foundVerification = this.props.isModuleFound( 'verification-tools' ),
+			foundSitemaps = this.props.isModuleFound( 'sitemaps' ),
+			foundAnalytics = this.props.isModuleFound( 'google-analytics' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
 		if (
-			! found.seo &&
-			! found.ads &&
-			! found.stats &&
-			! found.related &&
-			! found.verification &&
-			! found.sitemaps &&
-			! found.analytics
+			! foundSeo &&
+			! foundAds &&
+			! foundStats &&
+			! foundRelated &&
+			! foundVerification &&
+			! foundSitemaps &&
+			! foundAnalytics
 		) {
 			return null;
 		}
 
-		const seoSettings = (
-			<SEO
-				{ ...commonProps }
-				configureUrl={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl }
-			/>
-		);
-		const adSettings = (
-			<Ads
-				{ ...commonProps }
-				configureUrl={ 'https://wordpress.com/ads/earnings/' + this.props.siteRawUrl }
-			/>
-		);
-		const statsSettings = (
-			<SiteStats
-				{ ...commonProps }
-			/>
-		);
-		const relatedPostsSettings = (
-			<RelatedPosts
-				{ ...commonProps }
-				configureUrl={ this.props.siteAdminUrl +
-					'customize.php?autofocus[section]=jetpack_relatedposts' +
-					'&return=' + encodeURIComponent( this.props.siteAdminUrl + 'admin.php?page=jetpack#/traffic' ) +
-					'&url=' + encodeURIComponent( this.props.lastPostUrl ) }
-			/>
-		);
-
-		const googleAnalyticsSettings = (
-			<GoogleAnalytics
-				{ ...commonProps }
-				configureUrl={ 'https://wordpress.com/settings/analytics/' + this.props.siteRawUrl }
-			/>
-		);
-
-		const sitemaps = (
-			<Sitemaps
-				{ ...commonProps }
-			/>
-		);
-
-		const verificationSettings = (
-			<VerificationServices
-				{ ...commonProps }
-			/>
-		);
-
 		return (
 			<div>
 				<QuerySite />
-				{ found.seo && seoSettings }
-				{ found.ads && adSettings }
-				{ found.stats && statsSettings }
-				{ found.related && relatedPostsSettings }
-				{ found.analytics && googleAnalyticsSettings }
-				{ found.verification && verificationSettings }
-				{ found.sitemaps && sitemaps }
+				{
+					foundSeo && (
+						<SEO
+							{ ...commonProps }
+							configureUrl={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl }
+						/>
+					)
+				}
+				{
+					foundAds && (
+						<Ads
+							{ ...commonProps }
+							configureUrl={ 'https://wordpress.com/ads/earnings/' + this.props.siteRawUrl }
+						/>
+					)
+				}
+				{
+					foundStats && (
+						<SiteStats
+							{ ...commonProps }
+						/>
+					)
+				}
+				{
+					foundRelated && (
+						<RelatedPosts
+							{ ...commonProps }
+							configureUrl={ this.props.siteAdminUrl +
+						'customize.php?autofocus[section]=jetpack_relatedposts' +
+						'&return=' + encodeURIComponent( this.props.siteAdminUrl + 'admin.php?page=jetpack#/traffic' ) +
+						'&url=' + encodeURIComponent( this.props.lastPostUrl ) }
+						/>
+					)
+				}
+				{
+					foundAnalytics && (
+						<GoogleAnalytics
+							{ ...commonProps }
+							configureUrl={ 'https://wordpress.com/settings/analytics/' + this.props.siteRawUrl }
+						/>
+					)
+				}
+				{
+					foundVerification && (
+						<VerificationServices
+							{ ...commonProps }
+						/>
+					)
+				}
+				{
+					foundSitemaps && (
+						<Sitemaps
+							{ ...commonProps }
+						/>
+					)
+				}
 			</div>
 		);
 	}
@@ -126,7 +127,7 @@ export default connect(
 			settings: getSettings( state ),
 			isDevMode: isDevMode( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
+			isModuleFound: ( module_name ) => isModuleFound( state, module_name ),
 			lastPostUrl: getLastPostUrl( state )
 		};
 	}

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -180,11 +180,10 @@ const Composing = moduleSettingsForm(
 		},
 
 		render() {
-			// If we don't have any element to show, return early
-			if (
-				! this.props.isModuleFound( 'markdown' ) &&
-				! this.props.isModuleFound( 'after-the-deadline' )
-			) {
+			const foundAtD = this.props.isModuleFound( 'after-the-deadline' ),
+				foundMarkdown = this.props.isModuleFound( 'markdown' );
+
+			if ( ! foundMarkdown && ! foundAtD ) {
 				return null;
 			}
 
@@ -239,12 +238,14 @@ const Composing = moduleSettingsForm(
 
 			return (
 				<SettingsCard
-					header={ __( 'Composing', { context: 'Settings header' } ) } { ...this.props }
+					{ ...this.props }
+					header={ __( 'Composing', { context: 'Settings header' } ) }
+					hideButton={ ! foundAtD }
 					module="composing"
 					saveDisabled={ this.props.isSavingAnyOption( 'ignored_phrases' ) }
 				>
-					{ this.props.isModuleFound( 'markdown' ) && markdownSettings }
-					{ this.props.isModuleFound( 'after-the-deadline' ) && atdSettings }
+					{ foundMarkdown && markdownSettings }
+					{ foundAtD && atdSettings }
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -65,17 +65,25 @@ export const Writing = React.createClass( {
 		return (
 			<div>
 				<QuerySite />
-				<Masterbar connectUrl={ this.props.connectUrl } { ...commonProps } />
+				{
+					this.props.isModuleFound( 'masterbar' ) && (
+						<Masterbar connectUrl={ this.props.connectUrl } { ...commonProps } />
+					)
+				}
 				{
 					showComposing && (
 						<Composing { ...commonProps } userCanManageModules={ this.props.userCanManageModules } />
 					)
 				}
 				<Media { ...commonProps } />
-				<CustomContentTypes { ...commonProps } />
+				{
+					this.props.isModuleFound( 'custom-content-types' ) && (
+						<CustomContentTypes { ...commonProps } />
+					)
+				}
 				<ThemeEnhancements { ...commonProps } />
 				{
-					showPostByEmail && (
+					( this.props.isModuleFound( 'post-by-email' ) && showPostByEmail ) && (
 						<PostByEmail { ...commonProps }
 							connectUrl={ this.props.connectUrl }
 							isLinked={ this.props.isLinked }

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -70,11 +70,11 @@ const Media = moduleSettingsForm(
 		},
 
 		render() {
-			if (
-				! this.props.isModuleFound( 'photon' ) &&
-				! this.props.isModuleFound( 'carousel' )
-			) {
-				// Nothing to show here
+			const foundPhoton = this.props.isModuleFound( 'photon' ),
+				foundCarousel = this.props.isModuleFound( 'carousel' ),
+				foundVideoPress = this.props.isModuleFound( 'videopress' );
+
+			if ( ! foundCarousel && ! foundPhoton && ! foundVideoPress ) {
 				return null;
 			}
 
@@ -177,12 +177,13 @@ const Media = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Media' ) }
+					hideButton={ ! foundCarousel }
 					feature={ FEATURE_VIDEO_HOSTING_JETPACK }
 					saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }
 				>
-					{ this.props.isModuleFound( 'photon' ) && photonSettings }
-					{ this.props.isModuleFound( 'carousel' ) && carouselSettings }
-					{ this.props.isModuleFound( 'videopress' ) && videoPressSettings }
+					{ foundPhoton && photonSettings }
+					{ foundCarousel && carouselSettings }
+					{ foundVideoPress && videoPressSettings }
 				</SettingsCard>
 			);
 		}

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -14,7 +14,7 @@ import { FormFieldset, FormLabel, FormLegend } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { getModule } from 'state/modules';
 import { currentThemeSupports } from 'state/initial-state';
-import { isModuleFound as _isModuleFound } from 'state/search';
+import { isModuleFound } from 'state/search';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -108,144 +108,152 @@ const ThemeEnhancements = moduleSettingsForm(
 		},
 
 		render() {
-			if ( ! this.props.isModuleFound( 'infinite-scroll' ) && ! this.props.isModuleFound( 'minileven' ) ) {
+			const foundInfiniteScroll = this.props.isModuleFound( 'infinite-scroll' ),
+				foundMinileven = this.props.isModuleFound( 'minileven' );
+
+			if ( ! foundInfiniteScroll && ! foundMinileven ) {
 				return null;
 			}
 
 			return (
 				<SettingsCard
 					{ ...this.props }
-					hideButton={ ! this.props.isInfiniteScrollSupported }
-					header={ __( 'Theme enhancements' ) }>
+					header={ __( 'Theme enhancements' ) }
+					hideButton={ ! foundInfiniteScroll || ! this.props.isInfiniteScrollSupported }
+					>
 					{
-						[ {
-							...this.props.getModule( 'infinite-scroll' ),
-							radios: [
-								{
-									key: 'infinite_default',
-									label: __( 'Load more posts using the default theme behavior' )
-								},
-								{
-									key: 'infinite_button',
-									label: __( 'Load more posts in page with a button' )
-								},
-								{
-									key: 'infinite_scroll',
-									label: __( 'Load more posts as the reader scrolls down' )
-								}
-							]
-						} ].map( item => {
-							if ( ! this.props.isModuleFound( item.module ) ) {
-								return null;
-							}
-
-							return (
-								<SettingsGroup hasChild module={ { module: item.module } } key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
-									<FormLegend className="jp-form-label-wide">
-										{
-											item.name
-										}
-									</FormLegend>
+						foundInfiniteScroll && (
+							[ {
+								...this.props.getModule( 'infinite-scroll' ),
+								radios: [
 									{
-										this.props.isInfiniteScrollSupported
-										? item.radios.map( radio => {
-											return (
-												<FormLabel key={ `${ item.module }_${ radio.key }` }>
-													<input
-														type="radio"
-														name="infinite_mode"
-														value={ radio.key }
-														checked={ radio.key === this.state.infinite_mode }
-														disabled={ this.props.isSavingAnyOption( [ item.module, radio.key ] ) }
-														onChange={ () => this.updateInfiniteMode( radio.key ) }
-													/>
-													<span className="jp-form-toggle-explanation">
-														{
-															radio.label
-														}
-													</span>
-												</FormLabel>
-											);
-										} )
-										: (
-											<span>
-												{
-													__( 'Theme support required.' ) + ' '
-												}
-												<a onClick={ this.trackLearnMoreIS } href={ item.learn_more_button + '#theme' } title={ __( 'Learn more about adding support for Infinite Scroll to your theme.' ) }>
-													{
-														__( 'Learn more' )
-													}
-												</a>
-											</span>
-										)
+										key: 'infinite_default',
+										label: __( 'Load more posts using the default theme behavior' )
+									},
+									{
+										key: 'infinite_button',
+										label: __( 'Load more posts in page with a button' )
+									},
+									{
+										key: 'infinite_scroll',
+										label: __( 'Load more posts as the reader scrolls down' )
 									}
-								</SettingsGroup>
-							);
-						} )
+								]
+							} ].map( item => {
+								if ( ! this.props.isModuleFound( item.module ) ) {
+									return null;
+								}
+
+								return (
+									<SettingsGroup hasChild module={ { module: item.module } } key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
+										<FormLegend className="jp-form-label-wide">
+											{
+												item.name
+											}
+										</FormLegend>
+										{
+											this.props.isInfiniteScrollSupported
+											? item.radios.map( radio => {
+												return (
+													<FormLabel key={ `${ item.module }_${ radio.key }` }>
+														<input
+															type="radio"
+															name="infinite_mode"
+															value={ radio.key }
+															checked={ radio.key === this.state.infinite_mode }
+															disabled={ this.props.isSavingAnyOption( [ item.module, radio.key ] ) }
+															onChange={ () => this.updateInfiniteMode( radio.key ) }
+														/>
+														<span className="jp-form-toggle-explanation">
+															{
+																radio.label
+															}
+														</span>
+													</FormLabel>
+												);
+											} )
+											: (
+												<span>
+													{
+														__( 'Theme support required.' ) + ' '
+													}
+													<a onClick={ this.trackLearnMoreIS } href={ item.learn_more_button + '#theme' } title={ __( 'Learn more about adding support for Infinite Scroll to your theme.' ) }>
+														{
+															__( 'Learn more' )
+														}
+													</a>
+												</span>
+											)
+										}
+									</SettingsGroup>
+								);
+							} )
+						)
 					}
 					{
-						[ {
-							...this.props.getModule( 'minileven' ),
-							checkboxes: [
-								{
-									key: 'wp_mobile_excerpt',
-									label: __( 'Use excerpts instead of full posts on front page and archive pages' )
-								},
-								{
-									key: 'wp_mobile_featured_images',
-									label: __( 'Show featured images' )
-								},
-								{
-									key: 'wp_mobile_app_promos',
-									label: __( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' )
-								}
-							]
-						} ].map( item => {
-							const isItemActive = this.props.getOptionValue( item.module );
-
-							if ( ! this.props.isModuleFound( item.module ) ) {
-								return null;
-							}
-
-							return (
-								<SettingsGroup hasChild module={ { module: item.module } } key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
+						foundMinileven && (
+							[ {
+								...this.props.getModule( 'minileven' ),
+								checkboxes: [
 									{
-										<ModuleToggle
-											slug={ item.module }
-											activated={ isItemActive }
-											toggling={ this.props.isSavingAnyOption( item.module ) }
-											toggleModule={ this.props.toggleModuleNow }
-										>
+										key: 'wp_mobile_excerpt',
+										label: __( 'Use excerpts instead of full posts on front page and archive pages' )
+									},
+									{
+										key: 'wp_mobile_featured_images',
+										label: __( 'Show featured images' )
+									},
+									{
+										key: 'wp_mobile_app_promos',
+										label: __( 'Show an ad for the WordPress mobile apps in the footer of the mobile theme' )
+									}
+								]
+							} ].map( item => {
+								const isItemActive = this.props.getOptionValue( item.module );
+
+								if ( ! this.props.isModuleFound( item.module ) ) {
+									return null;
+								}
+
+								return (
+									<SettingsGroup hasChild module={ { module: item.module } } key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
+										{
+											<ModuleToggle
+												slug={ item.module }
+												activated={ isItemActive }
+												toggling={ this.props.isSavingAnyOption( item.module ) }
+												toggleModule={ this.props.toggleModuleNow }
+											>
 											<span className="jp-form-toggle-explanation">
 												{
 													item.description
 												}
 											</span>
-										</ModuleToggle>
-									}
-									<FormFieldset>
-										{
-											item.checkboxes.map( chkbx => {
-												return (
-													<CompactFormToggle
-														checked={ this.state[ chkbx.key ] }
-														disabled={ ! isItemActive || this.props.isSavingAnyOption( [ item.module, chkbx.key ] ) }
-														onChange={ () => this.updateOptions( chkbx.key, item.module ) }
-														key={ `${ item.module }_${ chkbx.key }` }>
+											</ModuleToggle>
+										}
+										<FormFieldset>
+											{
+												item.checkboxes.map( chkbx => {
+													return (
+														<CompactFormToggle
+															checked={ this.state[ chkbx.key ] }
+															disabled={ ! isItemActive || this.props.isSavingAnyOption( [ item.module, chkbx.key ] ) }
+															onChange={ () => this.updateOptions( chkbx.key, item.module ) }
+															key={ `${ item.module }_${ chkbx.key }` }>
 														<span className="jp-form-toggle-explanation">
 															{
 																chkbx.label
 															}
 														</span>
-													</CompactFormToggle>
-												);
-											} )
-										}
-									</FormFieldset>
-								</SettingsGroup>
-							);
-						} )
+														</CompactFormToggle>
+													);
+												} )
+											}
+										</FormFieldset>
+									</SettingsGroup>
+								);
+							} )
+						)
 					}
 				</SettingsCard>
 			);
@@ -257,8 +265,8 @@ export default connect(
 	( state ) => {
 		return {
 			module: ( module_name ) => getModule( state, module_name ),
-			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
-			isInfiniteScrollSupported: currentThemeSupports( state, 'infinite-scroll' )
+			isInfiniteScrollSupported: currentThemeSupports( state, 'infinite-scroll' ),
+			isModuleFound: ( module_name ) => isModuleFound( state, module_name )
 		};
 	}
 )( ThemeEnhancements );


### PR DESCRIPTION
Hide settings for all modules that are disabled through the `jetpack_get_available_modules` filter.

Fixes #5212

#### Changes proposed in this Pull Request:

- update reducer to initialize once, resolve ambiguity for searchTerm, optimize string matching, fail asap and return
- hide settings for disabled modules. Consolidate calls to avoid running isModuleFound twice since it's expensive.

#### Testing instructions:

* add code to disable modules and check that it's reflected in settings
```
add_filter( 'jetpack_get_available_modules', function( $modules ) {
	unset( $modules['masterbar'] );
	unset( $modules['after-the-deadline'] );
	unset( $modules['carousel'] );
	return $modules;
} );
```
