### PR TITLE
Update UI to account for AT plan slugs

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -39,8 +39,8 @@ const DashScan = React.createClass( {
 				&&
 				vpData.data.features.security
 			),
-			hasPremium = /jetpack_premium*/.test( this.props.sitePlan.product_slug ),
-			hasBusiness = /jetpack_business*/.test( this.props.sitePlan.product_slug );
+			hasPremium = /jetpack_premium*/.test( this.props.sitePlan.product_slug ) || 'value_bundle' === this.props.sitePlan.product_slug,
+			hasBusiness = /jetpack_business*/.test( this.props.sitePlan.product_slug ) || 'business-bundle' === this.props.sitePlan.product_slug;
 
 		if ( this.props.isModuleActivated( 'vaultpress' ) ) {
 			if ( vpData === 'N/A' ) {

--- a/_inc/client/engagement/index.jsx
+++ b/_inc/client/engagement/index.jsx
@@ -115,14 +115,17 @@ export const Engagement = ( props ) => {
 		hasBusiness =
 			planLoaded &&
 			( props.sitePlan.product_slug === 'jetpack_business' ||
-				props.sitePlan.product_slug === 'jetpack_business_monthly' );
+				props.sitePlan.product_slug === 'jetpack_business_monthly' ||
+				props.sitePlan.product_slug === 'business-bundle' );
 
 		hasPremiumOrBusiness =
 			planLoaded &&
 			( props.sitePlan.product_slug === 'jetpack_premium' ||
 				props.sitePlan.product_slug === 'jetpack_premium_monthly' ||
 				props.sitePlan.product_slug === 'jetpack_business' ||
-				props.sitePlan.product_slug === 'jetpack_business_monthly' );
+				props.sitePlan.product_slug === 'jetpack_business_monthly' ||
+				props.sitePlan.product_slug === 'business-bundle' ||
+				props.sitePlan.product_slug === 'value_bundle' );
 
 		if ( unavailableInDevMode ) {
 			toggle = __( 'Unavailable in Dev Mode' );

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -44,6 +44,9 @@ const PlanBody = React.createClass( {
 			case 'jetpack_premium_monthly':
 			case 'jetpack_business':
 			case 'jetpack_business_monthly':
+			case 'business-bundle':
+			case 'value_bundle':
+			case 'personal-bundle':
 				planCard = (
 					<div className="jp-landing__plan-features">
 						<div className="jp-landing__plan-features-card">
@@ -66,7 +69,7 @@ const PlanBody = React.createClass( {
 						</div>
 
 					{
-						includes( [ 'jetpack_personal', 'jetpack_personal_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_personal', 'jetpack_personal_monthly', 'personal-bundle' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Backups' ) }</h3>
 								<p>{ __( 'Daily backup of all your site data with unlimited space and one-click restores (powered by VaultPress).' ) }</p>
@@ -89,7 +92,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						includes( [ 'jetpack_premium', 'jetpack_premium_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_premium', 'jetpack_premium_monthly', 'value_bundle' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Backups & Security Scanning' ) }</h3>
 								<p>{ __( 'Daily backup of all your site data with unlimited space, one-click restores, automated security scanning, and priority support (powered by VaultPress).' ) }</p>
@@ -112,7 +115,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						includes( [ 'jetpack_business', 'jetpack_business_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_business', 'jetpack_business_monthly', 'business-bundle' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Backups & Security Scanning' ) }</h3>
 								<p>{ __( 'Real-time backup of all your site data with unlimited space, one-click restores, automated security scanning, one-click threat resolution, and priority support (powered by VaultPress).' ) }</p>
@@ -160,7 +163,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						includes( [ 'jetpack_premium', 'jetpack_premium_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_premium', 'jetpack_premium_monthly', 'value_bundle' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Video Hosting' ) }</h3>
 								<p>{ __( '13Gb of fast, optimized, and ad-free video hosting for your site (powered by VideoPress).' ) }</p>
@@ -185,7 +188,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						includes( [ 'jetpack_business', 'jetpack_business_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_business', 'jetpack_business_monthly', 'business-bundle' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Video Hosting' ) }</h3>
 								<p>{ __( 'Fast, optimized, ad-free, and unlimited video hosting for your site (powered by VideoPress).' ) }</p>
@@ -210,7 +213,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						includes( [ 'jetpack_business', 'jetpack_business_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_business', 'jetpack_business_monthly', 'business-bundle' ], this.props.plan ) ?
 
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'SEO Tools' ) }</h3>
@@ -237,7 +240,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						includes( [ 'jetpack_business', 'jetpack_business_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_business', 'jetpack_business_monthly', 'business-bundle' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Google Analytics' ) }</h3>
 								<p>{ __( 'Track website statistics with Google Analytics for a deeper understanding of your website visitors and customers.' ) }</p>
@@ -263,7 +266,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						includes( [ 'jetpack_personal', 'jetpack_personal_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_personal', 'jetpack_personal_monthly', 'personal-bundle' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Need more? Running a business site?' ) }</h3>
 								<p>{ __( 'If your site is important to you, consider protecting and improving it with some of our advanced features: ' ) }</p>
@@ -282,7 +285,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						includes( [ 'jetpack_premium', 'jetpack_premium_monthly' ], this.props.plan ) ?
+						includes( [ 'jetpack_premium', 'jetpack_premium_monthly', 'value_bundle' ], this.props.plan ) ?
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Need more? Running a business site?' ) }</h3>
 								<p>{ __( 'If your site is important to you, consider protecting and improving it with some of our advanced features: ' ) }</p>
@@ -304,6 +307,7 @@ const PlanBody = React.createClass( {
 			break;
 
 			case 'jetpack_free':
+			case 'free_plan':
 			case 'dev':
 				planCard = (
 					<div className="jp-landing__plan-features">
@@ -323,7 +327,7 @@ const PlanBody = React.createClass( {
 						</div>
 
 						<p>
-							<Button href={ 'jetpack_free' === this.props.plans
+							<Button href={ ( 'jetpack_free' === this.props.plans || 'free_plan' === this.props.plans )
 								? 'https://jetpack.com/redirect/?source=plans-main-bottom&site=' + this.props.siteRawUrl
 								: 'https://jetpack.com/redirect/?source=plans-main-bottom-dev-mode' } className="is-primary">
 								{ __( 'Compare Plans' ) }

--- a/_inc/client/plans/plan-header.jsx
+++ b/_inc/client/plans/plan-header.jsx
@@ -16,6 +16,7 @@ const PlanHeader = React.createClass( {
 			planCard = '';
 		switch ( this.props.plan ) {
 			case 'jetpack_free':
+			case 'free_plan':
 				starrySky = (
 					<div className="jp-landing-plans__header">
 						<h2 className="jp-landing-plans__header-title">
@@ -62,6 +63,7 @@ const PlanHeader = React.createClass( {
 
 			case 'jetpack_personal':
 			case 'jetpack_personal_monthly':
+			case 'personal-bundle':
 				planCard = (
 					<div className="jp-landing__plan-card">
 						<div className="jp-landing__plan-card-img">
@@ -77,6 +79,7 @@ const PlanHeader = React.createClass( {
 
 			case 'jetpack_premium':
 			case 'jetpack_premium_monthly':
+			case 'value_bundle':
 				planCard = (
 					<div className="jp-landing__plan-card">
 						<div className="jp-landing__plan-card-img">
@@ -92,6 +95,7 @@ const PlanHeader = React.createClass( {
 
 			case 'jetpack_business':
 			case 'jetpack_business_monthly':
+			case 'business-bundle':
 				planCard = (
 					<div className="jp-landing__plan-card">
 						<div className="jp-landing__plan-card-img">

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -51,8 +51,10 @@ const ProStatus = React.createClass( {
 			'akismet/akismet.php';
 
 		const hasPersonal = /jetpack_personal*/.test( sitePlan.product_slug ),
-			hasPremium = /jetpack_premium*/.test( sitePlan.product_slug ),
-			hasBusiness = /jetpack_business*/.test( sitePlan.product_slug );
+			hasPremium = /jetpack_premium*/.test( sitePlan.product_slug ) || 'value_bundle' === sitePlan.product_slug,
+			hasBusiness = /jetpack_business*/.test( sitePlan.product_slug ) || 'business-bundle' === sitePlan.product_slug;
+
+		console.log( sitePlan.product_slug );
 
 		let getStatus = ( feature, active, installed ) => {
 			let vpData = this.props.getVaultPressData();
@@ -140,7 +142,7 @@ const ProStatus = React.createClass( {
 
 			if ( sitePlan.product_slug ) {
 				let btnVals = {};
-				if ( 'jetpack_free' !== sitePlan.product_slug ) {
+				if ( 'jetpack_free' !== sitePlan.product_slug && 'free_plan' !== sitePlan.product_slug ) {
 					btnVals = {
 						href: `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }`,
 						text: __( 'Set up' )

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -169,7 +169,7 @@ export const SearchResults = ( {
 		}
 
 		if ( 'videopress' === element[0] ) {
-			if ( ! sitePlan || 'jetpack_free' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
+			if ( ! sitePlan || 'jetpack_free' === sitePlan.product_slug || 'free_plan' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
 				toggle = <Button
 					compact={ true }
 					primary={ true }

--- a/_inc/client/search/index.jsx
+++ b/_inc/client/search/index.jsx
@@ -169,7 +169,7 @@ export const SearchResults = ( {
 		}
 
 		if ( 'videopress' === element[0] ) {
-			if ( ! sitePlan || 'jetpack_free' === sitePlan.product_slug || 'free_plan' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
+			if ( ! sitePlan || 'jetpack_free' === sitePlan.product_slug || 'free_plan' === sitePlan.product_slug || 'personal-bundle' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
 				toggle = <Button
 					compact={ true }
 					primary={ true }

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -98,7 +98,7 @@ export const Writing = ( props ) => {
 		if ( isVideoPress ) {
 			if ( fetchingSiteData ) {
 				toggle = '';
-			} else if ( ! sitePlan || 'free_plan' === sitePlan.product_slug || 'jetpack_free' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
+			} else if ( ! sitePlan || 'free_plan' === sitePlan.product_slug || 'jetpack_free' === sitePlan.product_slug || 'personal-bundle' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
 				toggle = <Button
 					compact={ true }
 					primary={ true }

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -98,7 +98,7 @@ export const Writing = ( props ) => {
 		if ( isVideoPress ) {
 			if ( fetchingSiteData ) {
 				toggle = '';
-			} else if ( ! sitePlan || 'jetpack_free' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
+			} else if ( ! sitePlan || 'free_plan' === sitePlan.product_slug || 'jetpack_free' === sitePlan.product_slug || /jetpack_personal*/.test( sitePlan.product_slug ) ) {
 				toggle = <Button
 					compact={ true }
 					primary={ true }

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -216,14 +216,17 @@ abstract class Jetpack_Admin_Page {
 				$active = Jetpack::get_active_modules();
 				switch ( $current->plan->product_slug ) {
 					case 'jetpack_free':
+					case 'free_plan':
 						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads' );
 						break;
 					case 'jetpack_personal':
 					case 'jetpack_personal_monthly':
+					case 'personal-bundle':
 						$to_deactivate = array( 'seo-tools', 'videopress', 'google-analytics', 'wordads' );
 						break;
 					case 'jetpack_premium':
 					case 'jetpack_premium_monthly':
+					case 'value_bundle':
 						$to_deactivate = array( 'seo-tools', 'google-analytics' );
 						break;
 				}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1287,6 +1287,7 @@ class Jetpack {
 		$personal_plans = array(
 			'jetpack_personal',
 			'jetpack_personal_monthly',
+			'personal-bundle',
 		);
 
 		if ( in_array( $plan['product_slug'], $personal_plans ) ) {
@@ -1300,6 +1301,7 @@ class Jetpack {
 		$premium_plans = array(
 			'jetpack_premium',
 			'jetpack_premium_monthly',
+			'value-bundle',
 		);
 
 		if ( in_array( $plan['product_slug'], $premium_plans ) ) {
@@ -1316,6 +1318,7 @@ class Jetpack {
 		$business_plans = array(
 			'jetpack_business',
 			'jetpack_business_monthly',
+			'business-bundle',
 		);
 
 		if ( in_array( $plan['product_slug'], $business_plans ) ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1301,7 +1301,7 @@ class Jetpack {
 		$premium_plans = array(
 			'jetpack_premium',
 			'jetpack_premium_monthly',
-			'value-bundle',
+			'value_bundle',
 		);
 
 		if ( in_array( $plan['product_slug'], $premium_plans ) ) {

--- a/modules/videopress/class.videopress-options.php
+++ b/modules/videopress/class.videopress-options.php
@@ -6,7 +6,7 @@ class VideoPress_Options {
 	public static $option_name = 'videopress';
 
 	/** @var array */
-	public static $jetpack_plans_with_videopress = array( 'jetpack_premium', 'jetpack_business' );
+	public static $jetpack_plans_with_videopress = array( 'jetpack_premium', 'jetpack_business', 'value_bundle', 'business-bundle' );
 
 	/** @var array */
 	protected static $options = array();


### PR DESCRIPTION
This is meant to only be merged into `branch-4.7`.  

The easiest way to test this is to manually update the state to use these slugs.  I was doing so by adding this 
`action.siteData.plan.product_slug = 'business-bundle';`
Right before the assign in this reducer [here](https://github.com/Automattic/jetpack/blob/branch-4.7/_inc/client/state/site/reducer.js#L20). 

Make sure that you're not shown any upgrade links/CTAs when on the correct plan.  Check the /apps and /plans pages as well, since the content there depends on the current plan.  

New slugs added: 
- BUSINESS = 'business-bundle';
- PREMIUM = 'value_bundle';
- PERSONAL = 'personal-bundle';
- FREE = 'free_plan';