### PR TITLE
Milestone Widget: allow target attribute in custom links.

### DIFF
--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -287,7 +287,7 @@ class Milestone_Widget extends WP_Widget {
 		) );
 
 		$allowed_tags = array(
-			'a'      => array( 'title' => array(), 'href' => array() ),
+			'a'      => array( 'title' => array(), 'href' => array(), 'target' => array() ),
 			'em'     => array( 'title' => array() ),
 			'strong' => array( 'title' => array() ),
 		);


### PR DESCRIPTION
Site owners should be able to allow links to open in a new window when adding custom links in the Milestone widget.

WordPress itself allows the `target` attribute in kses, so I think it's safe to allow it here as well.

Reported here:
https://wordpress.org/support/topic/html-anchors-in-milestone/

#### Proposed changelog entry for your changes:
* Widgets: allow links to open in a new window when adding custom links in the Milestone widget.