### PR TITLE
WordPress.com Toolbar: Fix broken links to WP Admin on sites with sub-folder install

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -28,7 +28,13 @@ class A8C_WPCOM_Masterbar {
 		$this->user_email = $this->user_data['email'];
 		$this->display_name = $this->user_data['display_name'];
 		$this->user_site_count = $this->user_data['site_count'];
+
+		// Used to build menu links that point directly to Calypso.
 		$this->primary_site_slug = Jetpack::build_raw_urls( get_home_url() );
+
+		// Used for display purposes and for building WP Admin links.
+		$this->primary_site_url = str_replace( '::', '/', $this->primary_site_slug );
+
 		// We need to use user's setting here, instead of relying on current blog's text direction
 		$this->user_text_direction = $this->user_data['text_direction'];
 
@@ -539,10 +545,9 @@ class A8C_WPCOM_Masterbar {
 				$class = 'has-blavatar';
 			}
 
-			$site_link = str_replace( '::', '/', $this->primary_site_slug );
 			$blog_info = '<div class="ab-site-icon">' . $blavatar . '</div>';
 			$blog_info .= '<span class="ab-site-title">' . esc_html( $blog_name ) . '</span>';
-			$blog_info .= '<span class="ab-site-description">' . esc_html( $site_link ) . '</span>';
+			$blog_info .= '<span class="ab-site-description">' . esc_html( $this->primary_site_url ) . '</span>';
 
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'blog',
@@ -845,7 +850,7 @@ class A8C_WPCOM_Masterbar {
 					'label' => __( 'People', 'jetpack' ),
 				),
 				array(
-					'url'   => '//' . esc_attr( $this->primary_site_slug ) . '/wp-admin/user-new.php',
+					'url'   => '//' . esc_attr( $this->primary_site_url ) . '/wp-admin/user-new.php',
 					'id'    => 'wp-admin-bar-people-add',
 					'label' => _x( 'Add', 'admin bar people item label', 'jetpack' ),
 				)
@@ -924,7 +929,7 @@ class A8C_WPCOM_Masterbar {
 					'parent' => 'configuration',
 					'id'     => 'legacy-dashboard',
 					'title'  => __( 'WP Admin', 'jetpack' ),
-					'href'   => '//' . esc_attr( $this->primary_site_slug ) . '/wp-admin/',
+					'href'   => '//' . esc_attr( $this->primary_site_url ) . '/wp-admin/',
 					'meta'   => array(
 						'class' => 'mb-icon',
 					),

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -553,12 +553,11 @@ class A8C_WPCOM_Masterbar {
 				'parent' => 'blog',
 				'id'     => 'blog-info',
 				'title'  => $blog_info,
-				'href'   => esc_url( trailingslashit( $this->primary_site_slug ) ),
+				'href'   => esc_url( trailingslashit( $this->primary_site_url ) ),
 				'meta'   => array(
 					'class' => $class,
 				),
 			) );
-
 		}
 
 		// Stats


### PR DESCRIPTION
For sites with sub-folder install, links to WP Admin were broken because of `::` that was present in generated URLs, instead of slashes.

Fixes https://github.com/Automattic/jetpack/issues/6725

#### Changes proposed in this Pull Request:

* Replaces `::` with `/` in generated site URL in order to correct link to WP Admin pages.

#### Testing instructions:

* Using a test Jetpack site that is installed in sub-folder, verify that `Add` People button works correctly.
* Verify that button works as expected on regular Jetpack sites.
