### PR TITLE
Sync: Add actor to sync 

### DIFF
--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -197,13 +197,17 @@ class Jetpack_Sync_Listener {
 			ignore_user_abort( true );
 		}
 
-		if ( 'sync' === $queue->id
-		     || in_array( $current_filter, array(
+		if (
+			'sync' === $queue->id ||
+			in_array(
+				$current_filter,
+				array(
 					'jetpack_full_sync_start',
 					'jetpack_full_sync_end',
 					'jetpack_full_sync_cancel'
-			 ) )
-			) {
+				)
+			)
+		) {
 			$queue->add( array(
 				$current_filter,
 				$args,

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -197,14 +197,30 @@ class Jetpack_Sync_Listener {
 			ignore_user_abort( true );
 		}
 
-		$queue->add( array(
-			$current_filter,
-			$args,
-			get_current_user_id(),
-			microtime( true ),
-			Jetpack_Sync_Settings::is_importing(),
-			$this->get_actor(),
-		) );
+		if ( 'sync' === $queue->id
+		     || in_array( $current_filter, array(
+					'jetpack_full_sync_start',
+					'jetpack_full_sync_end',
+					'jetpack_full_sync_cancel'
+			 ) )
+			) {
+			$queue->add( array(
+				$current_filter,
+				$args,
+				get_current_user_id(),
+				microtime( true ),
+				Jetpack_Sync_Settings::is_importing(),
+				$this->get_actor(),
+			) );
+		} else {
+			$queue->add( array(
+				$current_filter,
+				$args,
+				get_current_user_id(),
+				microtime( true ),
+				Jetpack_Sync_Settings::is_importing()
+			) );
+		}
 
 		// since we've added some items, let's try to load the sender so we can send them as quickly as possible
 		if ( ! Jetpack_Sync_Actions::$sender ) {
@@ -226,9 +242,13 @@ class Jetpack_Sync_Listener {
 			$actor[ 'ip' ] = $_SERVER['REMOTE_ADDR'];
 		}
 
-		$actor[ 'is_cron' ] = defined( 'DOING_CRON' ) ? DOING_CRON : false;
-		$actor[ 'is_wp_admin'] = is_admin();
-		$actor[ 'is_rest'] = defined( 'REST_API_REQUEST' )? REST_API_REQUEST : false;
+		$actor['is_cron'] = defined( 'DOING_CRON' ) ? DOING_CRON : false;
+		$actor['is_wp_admin'] = is_admin();
+		$actor['is_rest'] = defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false;
+		$actor['is_xmlrpc'] = defined( 'XMLRPC_REQUEST' ) ? XMLRPC_REQUEST : false;
+		$actor['is_wp_rest'] = defined( 'REST_API_VERSION' ) ? REST_API_VERSION : false;
+		$actor['is_ajax'] = defined( 'DOING_AJAX' ) ? DOING_AJAX : false;
+
 		return $actor;
 	}
 

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -246,7 +246,7 @@ class Jetpack_Sync_Listener {
 		$actor['is_wp_admin'] = is_admin();
 		$actor['is_rest'] = defined( 'REST_API_REQUEST' ) ? REST_API_REQUEST : false;
 		$actor['is_xmlrpc'] = defined( 'XMLRPC_REQUEST' ) ? XMLRPC_REQUEST : false;
-		$actor['is_wp_rest'] = defined( 'REST_API_VERSION' ) ? REST_API_VERSION : false;
+		$actor['is_wp_rest'] = defined( 'REST_REQUEST' ) ? REST_REQUEST : false;
 		$actor['is_ajax'] = defined( 'DOING_AJAX' ) ? DOING_AJAX : false;
 
 		return $actor;

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -202,7 +202,8 @@ class Jetpack_Sync_Listener {
 			$args,
 			get_current_user_id(),
 			microtime( true ),
-			Jetpack_Sync_Settings::is_importing()
+			Jetpack_Sync_Settings::is_importing(),
+			$this->get_actor(),
 		) );
 
 		// since we've added some items, let's try to load the sender so we can send them as quickly as possible
@@ -212,6 +213,23 @@ class Jetpack_Sync_Listener {
 				Jetpack_Sync_Actions::add_sender_shutdown();
 			}
 		}
+	}
+	function get_actor() {
+		$current_user = wp_get_current_user();
+		$actor = array();
+		if ( $current_user ) {
+			$actor[ 'display_name' ] = $current_user->display_name;
+			$actor[ 'user_email' ] = $current_user->user_email;
+		}
+
+		if ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
+			$actor[ 'ip' ] = $_SERVER['REMOTE_ADDR'];
+		}
+
+		$actor[ 'is_cron' ] = defined( 'DOING_CRON' ) ? DOING_CRON : false;
+		$actor[ 'is_wp_admin'] = is_admin();
+		$actor[ 'is_rest'] = defined( 'REST_API_REQUEST' )? REST_API_REQUEST : false;
+		return $actor;
 	}
 
 	function set_defaults() {

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -77,6 +77,32 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		remove_action( 'my_action', array( $this->listener, 'action_handler' ) );
 	}
 
+	function test_does_listener_add_actor_to_queue() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$this->listener->get_sync_queue()->reset();
+		$queue = $this->listener->get_sync_queue();
+		$queue->reset(); // remove any actions that already got queued
+
+		$this->factory->post->create();
+		$current_user =  wp_get_current_user();
+		$example_actor = array(
+			'display_name' => $current_user->display_name,
+			'user_email'   => $current_user->user_email,
+			'ip'           => $_SERVER['REMOTE_ADDR'],
+			'is_cron'      => defined( 'DOING_CRON' ) ? DOING_CRON : false,
+			'is_wp_admin'  => is_admin(),
+			'is_rest'      => defined( 'REST_API_REQUEST' )? REST_API_REQUEST : false,
+		);
+
+		$all = $queue->get_all();
+		foreach( $all as $queue_item ) {
+			list( $current_filter, $args, $current_user_id, $microtime, $is_importing, $actor ) = $queue_item->value;
+			$this->assertEquals( $actor, $example_actor );
+		}
+	}
+
+
 	function test_does_set_silent_flag_true_while_importing() {
 		Jetpack_Sync_Settings::set_importing( true );
 

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -93,6 +93,9 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 			'is_cron'      => defined( 'DOING_CRON' ) ? DOING_CRON : false,
 			'is_wp_admin'  => is_admin(),
 			'is_rest'      => defined( 'REST_API_REQUEST' )? REST_API_REQUEST : false,
+			'is_xmlrpc'    => defined( 'XMLRPC_REQUEST' ) ? XMLRPC_REQUEST : false,
+			'is_wp_rest'   => defined( 'REST_REQUEST' )? REST_REQUEST : false,
+			'is_ajax'      => defined( 'DOING_AJAX' ) ? DOING_AJAX : false,
 		);
 
 		$all = $queue->get_all();

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -105,7 +105,6 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		}
 	}
 
-
 	function test_does_set_silent_flag_true_while_importing() {
 		Jetpack_Sync_Settings::set_importing( true );
 


### PR DESCRIPTION
The actor data helps up determine who and how the action was triggered. 
Currently when we sync data we only store the current_user_id. 

#### Changes proposed in this Pull Request:
* Add user_email and display name. 
* Add IP address
* Add different environment flag. is_wp_admin, is_wpcom_api, is_cron etc.

#### Testing instructions:
* Do the test pass? 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes: 
Add actor to sync. 
