### PR TITLE
WordPress.com Toolbar: Fix unclickable site section and misaligned site icon

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -542,12 +542,11 @@ class A8C_WPCOM_Masterbar {
 				'parent' => 'blog',
 				'id'     => 'blog-info',
 				'title'  => $blog_info,
-				'href'   => esc_url( trailingslashit( $this->primary_site_slug ) ),
+				'href'   => esc_url( trailingslashit( $this->primary_site_url ) ),
 				'meta'   => array(
 					'class' => $class,
 				),
 			) );
-
 		}
 
 		// Stats


### PR DESCRIPTION
_**Note:** this PR is targeted against `fix/add-people-link` branch (https://github.com/Automattic/jetpack/pull/6779)_

This bug occurred in sub-folder installed Jetpack sites because `esc_url` was returning empty string when it encountered a site slug that contains `::`. This resulted in empty `href` field being passed to `add_menu` method, which caused the required `a` tag to be omitted from site section, breaking the layout and functionality.

Fixes https://github.com/Automattic/jetpack/issues/6727, https://github.com/Automattic/jetpack/issues/6724

#### Changes proposed in this Pull Request:

* Converts sub-folder installed site slug to correct URL to be used for site section.

#### Testing instructions:

* On a test Jetpack site installed in sub-folder, verify that site icon is aligned properly, and that all elements of site section are clickable. This includes: site icon, site name, and site slug.
* Verify that functionality is preserved on a regular Jetpack site.