### PR TITLE
Settings UI: pass property to solve issue with DashStatsBottom

### DIFF
--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -133,6 +133,7 @@ const DashStats = React.createClass( {
 							statsData={ this.props.statsData }
 							siteRawUrl={ this.props.siteRawUrl }
 							siteAdminUrl={ this.props.siteAdminUrl }
+							isLinked={ this.props.isLinked }
 							connectUrl={ this.props.connectUrl }
 						/>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* pass property to solve issue where DashStatsBottom was always rendered as if the user was unlinked

#### Testing instructions:

* link user that can view Stats
* make sure the Stats in Dashboard show the blue button to see more stats in WordPress.com and that the clickable card is not displayed

