### PR TITLE
WordPress.com Toolbar: remove duplicate keys

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -425,10 +425,7 @@ class A8C_WPCOM_Masterbar {
 			'title'  => __( 'Get Apps', 'jetpack' ),
 			'href'   => 'https://wordpress.com/me/get-apps',
 			'meta'   => array(
-				'class' => 'user-info-item',
-			),
-			'meta'   => array(
-				'class' => 'mb-icon',
+				'class' => 'mb-icon user-info-item',
 			),
 		) );
 
@@ -438,10 +435,7 @@ class A8C_WPCOM_Masterbar {
 			'title'  => __( 'Next Steps', 'jetpack' ),
 			'href'   => 'https://wordpress.com/me/next',
 			'meta'   => array(
-				'class' => 'user-info-item',
-			),
-			'meta'   => array(
-				'class' => 'mb-icon',
+				'class' => 'mb-icon user-info-item',
 			),
 		) );
 
@@ -457,10 +451,7 @@ class A8C_WPCOM_Masterbar {
 			'title'  => __( 'Help', 'jetpack' ),
 			'href'   => $help_link,
 			'meta'   => array(
-				'class' => 'user-info-item',
-			),
-			'meta'   => array(
-				'class' => 'mb-icon',
+				'class' => 'mb-icon user-info-item',
 			),
 		) );
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/6786

Removes duplicate keys from arrays that are used to build `Me` submenu.

# Testing instructions
1. Verify that `Get Apps`, `Next Steps`, and `Help` in `Me` submenu are rendered correctly.