### PR TITLE
API: Allow options api endpoint to update and retrieve whitelisted sync whitelisted options

### DIFF
--- a/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
+++ b/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
@@ -21,6 +21,8 @@ class WPCOM_JSON_API_Get_Option_Endpoint extends Jetpack_JSON_API_Endpoint {
 			return new WP_Error( 'option_name_not_set', __( 'You must specify an option_name', 'jetpack' ) );
 		}
 		$this->site_option = isset( $query_args['site_option'] ) ? $query_args['site_option'] : false;
+
+		require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-defaults.php';
 		/**
 		 * Filter the list of options that are manageable via the JSON API.
 		 *
@@ -31,7 +33,7 @@ class WPCOM_JSON_API_Get_Option_Endpoint extends Jetpack_JSON_API_Endpoint {
 		 * @param array The default list of site options.
 		 * @param bool Is the option a site option.
 		 */
-		if ( ! in_array( $this->option_name, apply_filters( 'jetpack_options_whitelist', array(), $this->site_option ) ) ) {
+		if ( ! in_array( $this->option_name, apply_filters( 'jetpack_options_whitelist', Jetpack_Sync_Defaults::$default_options_whitelist, $this->site_option ) ) ) {
 			return new WP_Error( 'option_name_not_in_whitelist', __( 'You must specify a whitelisted option_name', 'jetpack' ) );
 		}
 		return true;


### PR DESCRIPTION
Fixes an issue where we are not able to get and update whitelisted options.