### PR TITLE
oEmbed: add Apple/iCloud Keynote provider.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1531,6 +1531,7 @@ class Jetpack {
 		wp_oembed_add_provider( '#https?://(www\.)?gfycat\.com/.*#i', 'https://api.gfycat.com/v1/oembed', true );
 		wp_oembed_add_provider( '#https?://[^.]+\.(wistia\.com|wi\.st)/(medias|embed)/.*#', 'https://fast.wistia.com/oembed', true );
 		wp_oembed_add_provider( '#https?://sketchfab\.com/.*#i', 'https://sketchfab.com/oembed', true );
+		wp_oembed_add_provider( '#https?://(www\.)?icloud\.com/keynote/.*#i', 'https://iwmb.icloud.com/iwmb/oembed', true );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Apple now offers the option to embed Keynotes via oEmbed. Let's support this in Jetpack until it makes it to WordPress core.

#### Testing instructions:

* See the related discussion here for some examples: p47NkD-BU-p2

#### Proposed changelog entry for your changes:
* oEmbed: add Apple/iCloud Keynote provider.