### PR TITLE
WordPress.com Toolbar: Make Sign Out action logout of WordPress.com

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -63,6 +63,13 @@ class A8C_WPCOM_Masterbar {
 			// Override Notification module to include RTL styles
 			add_action( 'a8c_wpcom_masterbar_enqueue_rtl_notification_styles', '__return_true' );
 		}
+
+		add_filter( 'allowed_redirect_hosts', array( $this, 'allow_wpcom_redirect' ) );
+	}
+
+	public function allow_wpcom_redirect( $allowed ) {
+		$allowed[] = 'wordpress.com';
+		return $allowed;
 	}
 
 	public function is_automated_transfer_site() {
@@ -351,7 +358,7 @@ class A8C_WPCOM_Masterbar {
 
 		$settings_url = 'https://wordpress.com/me/account';
 
-		$logout_url = wp_logout_url();
+		$logout_url = wp_logout_url( 'https://wordpress.com/wp-login.php?action=logout' );
 
 		$user_info  = get_avatar( $this->user_email, 128, 'mm', '', array( 'force_display' => true ) );
 		$user_info .= '<span class="display-name">' . $this->display_name . '</span>';

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -64,12 +64,7 @@ class A8C_WPCOM_Masterbar {
 			add_action( 'a8c_wpcom_masterbar_enqueue_rtl_notification_styles', '__return_true' );
 		}
 
-		add_filter( 'allowed_redirect_hosts', array( $this, 'allow_wpcom_redirect' ) );
-	}
-
-	public function allow_wpcom_redirect( $allowed ) {
-		$allowed[] = 'wordpress.com';
-		return $allowed;
+		add_action( 'wp_logout', array( $this, 'maybe_logout_user_from_wpcom' ) );
 	}
 
 	public function is_automated_transfer_site() {
@@ -84,6 +79,12 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		return false;
+	}
+
+	public function maybe_logout_user_from_wpcom() {
+		if ( isset( $_GET['context'] ) && 'masterbar' === $_GET['context'] ) {
+			do_action( 'wp_masterbar_logout' );
+		}
 	}
 
 	public function get_rtl_admin_bar_class() {
@@ -358,7 +359,8 @@ class A8C_WPCOM_Masterbar {
 
 		$settings_url = 'https://wordpress.com/me/account';
 
-		$logout_url = wp_logout_url( 'https://wordpress.com/wp-login.php?action=logout' );
+		$logout_url = wp_logout_url();
+		$logout_url = add_query_arg( 'context', 'masterbar', $logout_url );
 
 		$user_info  = get_avatar( $this->user_email, 128, 'mm', '', array( 'force_display' => true ) );
 		$user_info .= '<span class="display-name">' . $this->display_name . '</span>';

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -42,6 +42,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'wp_login', $callable, 10, 2 );
 		add_action( 'wp_login_failed', $callable, 10, 2 );
 		add_action( 'wp_logout', $callable, 10, 0 );
+		add_action( 'wp_masterbar_logout', $callable, 10, 0 );
 	}
 
 	public function init_full_sync_listeners( $callable ) {


### PR DESCRIPTION
Previously, `Sign Out` action in `Me` menu was just signing out users from their current Jetpack site, and it should be signing them out of WP.com too.

Test with: ~D4938-code~ (deployed)
Fixes https://github.com/Automattic/jetpack/issues/6490

#### Testing instructions:

1. In `Me` sub-menu of WordPress.com Toolbar, click on `Sign Out` button.
2. Verify that you have been logged out of you Jetpack test site.
3. Verify that you have been logged out from WordPress.com.