### PR TITLE
Settings UI: fix subdirectory install URLs displayed in disconnection dialog

### DIFF
--- a/_inc/client/components/jetpack-disconnect-dialog/index.jsx
+++ b/_inc/client/components/jetpack-disconnect-dialog/index.jsx
@@ -150,7 +150,7 @@ export const JetpackDisconnectDialog = React.createClass( {
 						{
 							__( 'By disconnecting %(siteName)s from WordPress.com you will no longer have access to the following:', {
 								args: {
-									siteName: this.props.siteRawUrl
+									siteName: this.props.siteRawUrl.replace( '::', '/' )
 								}
 							} )
 						}


### PR DESCRIPTION
Fixes #6771

#### Changes proposed in this Pull Request:

* fix subdirectory install URLs displayed in disconnection dialog
This is basically reverting the replacement that `Jetpack::build_raw_urls` does to slashes.

#### Testing instructions:

* use a site located in a subdirectory and verify it doesn't display `::` but `/`.