### PR TITLE
Settings UI: reorder cards

### DIFF
--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -60,10 +60,9 @@ export const Traffic = React.createClass( {
 			<div>
 				<QuerySite />
 				{
-					foundSeo && (
-						<SEO
+					foundStats && (
+						<SiteStats
 							{ ...commonProps }
-							configureUrl={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl }
 						/>
 					)
 				}
@@ -72,13 +71,6 @@ export const Traffic = React.createClass( {
 						<Ads
 							{ ...commonProps }
 							configureUrl={ 'https://wordpress.com/ads/earnings/' + this.props.siteRawUrl }
-						/>
-					)
-				}
-				{
-					foundStats && (
-						<SiteStats
-							{ ...commonProps }
 						/>
 					)
 				}
@@ -94,6 +86,14 @@ export const Traffic = React.createClass( {
 					)
 				}
 				{
+					foundSeo && (
+						<SEO
+							{ ...commonProps }
+							configureUrl={ 'https://wordpress.com/settings/seo/' + this.props.siteRawUrl }
+						/>
+					)
+				}
+				{
 					foundAnalytics && (
 						<GoogleAnalytics
 							{ ...commonProps }
@@ -102,15 +102,15 @@ export const Traffic = React.createClass( {
 					)
 				}
 				{
-					foundVerification && (
-						<VerificationServices
+					foundSitemaps && (
+						<Sitemaps
 							{ ...commonProps }
 						/>
 					)
 				}
 				{
-					foundSitemaps && (
-						<Sitemaps
+					foundVerification && (
+						<VerificationServices
 							{ ...commonProps }
 						/>
 					)


### PR DESCRIPTION
Based on task from post p1HpG7-3St-jetpackp2 by @rickybanister 

> Reorder the cards to be Stats, Ads, Related Posts, SEO, Google Analytics, XML Sitemaps, Site verification

#### Changes proposed in this Pull Request:

* reorders the cards to match the desired order

#### Testing instructions:

* make sure the cards are in the proper order

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
