### PR TITLE
Dev Tools: enable a11y check for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
 	"parser": "babel-eslint",
-	"extends": "wpcalypso/react",
+	"extends": "wpcalypso/react-a11y",
 	"env": {
 		"browser": true,
 		"es6": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,7 +11,7 @@
 
 "@automattic/dops-components@automattic/dops-components":
   version "0.0.1"
-  resolved "https://codeload.github.com/automattic/dops-components/tar.gz/27810dcb44795a9ab9b2dfc7119f82ab7e70cf56"
+  resolved "https://codeload.github.com/automattic/dops-components/tar.gz/8749714fb6b534367b3823f2ab6763971f2f178f"
   dependencies:
     bounding-client-rect "^1.0.5"
     classnames "^2.1.3"
@@ -1394,8 +1394,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.3.0"
 
 caniuse-db@^1.0.30000346, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000641"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000641.tgz#4810fc75fbb3f5b3bd75c2d6a94d894a7c709873"
+  version "1.0.30000644"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000644.tgz#9d7eccf1ef1d11cbd6741b9fb390f9923ff42261"
 
 cardinal@^1.0.0:
   version "1.0.0"
@@ -1886,8 +1886,8 @@ content-type@~1.0.2:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
 
 convert-source-map@1.X, convert-source-map@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.4.0.tgz#e3dad195bf61bfe13a7a3c73e9876ec14a0268f3"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -7757,8 +7757,8 @@ uglify-js@2.6.x, uglify-js@~2.6.0:
     yargs "~3.10.0"
 
 uglify-js@~2.8.10:
-  version "2.8.16"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.16.tgz#d286190b6eefc6fd65eb0ecac6551e0b0e8839a4"
+  version "2.8.17"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.17.tgz#b68ea00a1cef853960bc99b8dec7740d2553f20b"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"
@@ -8139,13 +8139,13 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1, which@^1.2.12, which@^1.2.9, which@~1.2.10:
+which@1, which@^1.0.5, which@^1.2.12, which@^1.2.9, which@~1.2.10:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
     isexe "^2.0.0"
 
-which@^1.0.5, which@~1.0.5:
+which@~1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/which/-/which-1.0.9.tgz#460c1da0f810103d0321a9b633af9e575e64486f"
 


### PR DESCRIPTION
Now that https://github.com/Automattic/dops-components/pull/106 is merged, `yarn build` ends correctly so this PR restores the a11y checkings in Jetpack.

#### Changes proposed in this Pull Request:

* enable a11y check for eslint
* update `yarn.lock`

#### Testing instructions:

* `gulp eslint` should end with only warnings, no errors
* `yarn build` should end correctly
