### PR TITLE
Tracks: use correct hooks for activate/deactivate modules to avoid duplicate events

### DIFF
--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -50,12 +50,12 @@ class JetpackTracking {
 
 	/* Activated module */
 	static function track_activate_module( $module ) {
-		self::record_user_event( 'wpa_module_activated', array( 'module' => $module ) );
+		self::record_user_event( 'module_activated', array( 'module' => $module ) );
 	}
 
 	/* Deactivated module */
 	static function track_deactivate_module( $module ) {
-		self::record_user_event( 'wpa_module_deactivated', array( 'module' => $module ) );
+		self::record_user_event( 'module_deactivated', array( 'module' => $module ) );
 	}
 
 	static function record_user_event( $event_type, $data= array() ) {

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -16,8 +16,8 @@ class JetpackTracking {
 		// For tracking stuff via js/ajax
 		add_action( 'admin_enqueue_scripts',         array( __CLASS__, 'enqueue_tracks_scripts' ) );
 
-		add_action( 'jetpack_pre_activate_module',   array( __CLASS__, 'track_activate_module'), 1, 1 );
-		add_action( 'jetpack_pre_deactivate_module', array( __CLASS__, 'track_deactivate_module'), 1, 1 );
+		add_action( 'jetpack_activate_module',   array( __CLASS__, 'track_activate_module'), 1, 1 );
+		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivate_module'), 1, 1 );
 		add_action( 'jetpack_user_authorized',       array( __CLASS__, 'track_user_linked' ) );
 	}
 


### PR DESCRIPTION
Fixes a bug in Tracks for the following events: 

`jetpack_wpa_module_deactivated`
`jetpack_wpa_module_activated`

The problem with hooking onto the `pre_` version of this, is it doesn't prevent tracking if the module is already active.  

To reproduce the bug, put this `error_log( print_r( $event_obj, 1 ) );` [here](https://github.com/Automattic/jetpack/blob/master/_inc/lib/tracks/client.php#L124), and deactivate a module (`wp jetpack module activate notes` works).  
- Without the patch, you'll see that you can trigger the event multiple times if you run that command multiple times. 
- With this patch, you should only see it once, if the module was active before.  
- Same goes for the activate events.  