### PR TITLE
Initial State: fix issue detecting Infinite Scroll for default themes

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -242,7 +242,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 		// Get all themes that Infinite Scroll provides support for natively.
 		$inf_scr_support_themes = array();
-		foreach ( Jetpack::glob_php( JETPACK__PLUGIN_DIR . 'modules/infinite-scroll/themes/*.php' ) as $path ) {
+		foreach ( Jetpack::glob_php( JETPACK__PLUGIN_DIR . 'modules/infinite-scroll/themes' ) as $path ) {
 			if ( is_readable( $path ) ) {
 				$inf_scr_support_themes[] = basename( $path, '.php' );
 			}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* fix the issue by calling Jetpack::glob_php() passing only the path and letting it resolve the files

#### Testing instructions:

* `wp theme activate twentyseventeen`
Before this PR, it would show the notice as if theme wasn't supported.
With this PR, it shows the radio buttons since the theme support is provided by Jetpack.
