### PR TITLE
Fixed the way i18n exporter handles client strings.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -520,14 +520,16 @@ gulp.task( 'languages:build', [ 'languages:get' ], function( done ) {
 	} );
 
 	rl.on( 'line', function( line ) {
-		var brace_index = line.indexOf( '(' );
+		var brace_index = line.indexOf( '__(' );
 
 		// Skipping lines that do not call translation functions
 		if ( -1 === brace_index ) {
 			return;
 		}
 
-		line = line.slice( brace_index + 1, line.lastIndexOf( ')' ) );
+		line = line
+			.slice( brace_index + 3, line.lastIndexOf( ')' ) )
+			.replace( /[\b\f\n\r\t]/g, ' ' );
 
 		// Making the line look like a JSON array to parse it as such later
 		line = [ '[', line.trim(), ']' ].join( '' );


### PR DESCRIPTION
Before it would have problems when there are special characters, or if there is a translator comment with a placeholder. Now it only looks for gettext calls and replaces tab characters with spaces.

Fixes the problem with `yarn build-languages`.

#### Testing instructions:
* Make sure `yarn build-languages` works without returning an error.