### PR TITLE
Photon: use Photon for all images in bbPress topics and replies.

### DIFF
--- a/3rd-party/bbpress.php
+++ b/3rd-party/bbpress.php
@@ -13,6 +13,16 @@ function jetpack_bbpress_compat() {
 		add_action( 'bbp_template_after_single_forum', 'jetpack_sharing_bbpress' );
 		add_action( 'bbp_template_after_single_topic', 'jetpack_sharing_bbpress' );
 	}
+
+	/**
+	 * Use Photon for all images in Topics and replies.
+	 *
+	 * @since 4.9.0
+	 */
+	if ( class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+		add_filter( 'bbp_get_topic_content', array( 'Jetpack_Photon', 'filter_the_content' ), 999999 );
+		add_filter( 'bbp_get_reply_content', array( 'Jetpack_Photon', 'filter_the_content' ), 999999 );
+	}
 }
 
 /**

--- a/class.photon.php
+++ b/class.photon.php
@@ -48,9 +48,11 @@ class Jetpack_Photon {
 		if ( ! function_exists( 'jetpack_photon_url' ) )
 			return;
 
-		// Images in post content and galleries
+		// Images in post content, galleries, and bbPress forums.
 		add_filter( 'the_content', array( __CLASS__, 'filter_the_content' ), 999999 );
 		add_filter( 'get_post_galleries', array( __CLASS__, 'filter_the_galleries' ), 999999 );
+		add_filter( 'bbp_get_topic_content', array( __CLASS__, 'filter_the_content' ), 999999 );
+		add_filter( 'bbp_get_reply_content', array( __CLASS__, 'filter_the_content' ), 999999 );
 
 		// Core image retrieval
 		add_filter( 'image_downsize', array( $this, 'filter_image_downsize' ), 10, 3 );

--- a/class.photon.php
+++ b/class.photon.php
@@ -48,11 +48,9 @@ class Jetpack_Photon {
 		if ( ! function_exists( 'jetpack_photon_url' ) )
 			return;
 
-		// Images in post content, galleries, and bbPress forums.
+		// Images in post content and galleries
 		add_filter( 'the_content', array( __CLASS__, 'filter_the_content' ), 999999 );
 		add_filter( 'get_post_galleries', array( __CLASS__, 'filter_the_galleries' ), 999999 );
-		add_filter( 'bbp_get_topic_content', array( __CLASS__, 'filter_the_content' ), 999999 );
-		add_filter( 'bbp_get_reply_content', array( __CLASS__, 'filter_the_content' ), 999999 );
 
 		// Core image retrieval
 		add_filter( 'image_downsize', array( $this, 'filter_image_downsize' ), 10, 3 );


### PR DESCRIPTION
Suggested here:
https://wordpress.org/support/topic/photon-does-not-work/

#### Testing instructions:

1. Install bbPress on your site.
2. Make sure Photon is active.
3. Create a new topic and insert an image into that topic.
4. Post a reply to that topic, also including an image.

All images should then be served by Photon.

#### Proposed changelog entry for your changes:
* Photon: use Photon for all images in bbPress topics and replies.