### PR TITLE
Use the whole locale slug instead of just a prefix.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -206,9 +206,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 
-		$localeSlug = explode( '_', jetpack_get_user_locale() );
-		$localeSlug = $localeSlug[0];
-
 		// Collecting roles that can view site stats
 		$stats_roles = array();
 		$enabled_roles = function_exists( 'stats_get_option' ) ? stats_get_option( 'roles' ) : array( 'administrator' );
@@ -313,7 +310,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				),
 			),
 			'locale' => $this->get_i18n_data(),
-			'localeSlug' => $localeSlug,
+			'localeSlug' => jetpack_get_user_locale(),
 			'jetpackStateNotices' => array(
 				'messageCode' => Jetpack::state( 'message' ),
 				'errorCode' => Jetpack::state( 'error' ),


### PR DESCRIPTION
Fixes the problem with languages where the locale is specified as a combination of two, like `fr_BE` or `de_CH`.

#### Changes proposed in this Pull Request:
* Using the whole locale slug instead of just a prefix.
* Properly recognizing locale slugs like `formal` or `informal` for various languages that support them.

#### Testing instructions:
* To see the difference in the client side you need to run `yarn build-languages`, and to successfully do it you first need to have #6800 merged. Just run the script and see that your client side translations work for languages like `Deutsch (Schweiz, Du)` or `Français de Belgique`. To make sure they do you can check the state tree, the variable `jetpack.initialState.locale` should have locale data in it, even if it's mostly `null` values.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed administrator area translations for several languages.
* Added proper support for Formal/Informal translation versions for languages that support them.