### PR TITLE
Settings UI: make the QuerySite component fetch data only once

### DIFF
--- a/_inc/client/components/data/query-site/index.jsx
+++ b/_inc/client/components/data/query-site/index.jsx
@@ -1,40 +1,55 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * Internal dependencies
  */
 import {
 	fetchSiteData,
-	isFetchingSiteData
+	isFetchingSiteData,
+	getSitePlan
 } from 'state/site';
 import { isDevMode } from 'state/connection';
 
-export const QuerySite = React.createClass( {
-	componentDidMount() {
-		if ( ! ( this.props.isFetchingSiteData || this.props.isDevMode ) ) {
+class QuerySite extends Component {
+	static propTypes = {
+		isFetchingSiteData: PropTypes.bool,
+		isDevMode: PropTypes.bool,
+		sitePlan: PropTypes.object
+	};
+
+	static defaultProps = {
+		isFetchingSiteData: false,
+		isDevMode: false,
+		sitePlan: {}
+	};
+
+	componentWillMount() {
+		if ( ! this.props.isFetchingSiteData && ! this.props.isDevMode && isEmpty( this.props.sitePlan ) ) {
 			this.props.fetchSiteData();
 		}
-	},
+	}
 
 	render() {
 		return null;
 	}
-} );
+}
 
 export default connect(
 	( state ) => {
 		return {
 			isFetchingSiteData: isFetchingSiteData( state ),
-			isDevMode: isDevMode( state )
+			isDevMode: isDevMode( state ),
+			sitePlan: getSitePlan( state )
 		};
 	},
 	( dispatch ) => {
 		return {
 			fetchSiteData: () => dispatch( fetchSiteData() )
-		}
+		};
 	}
 )( QuerySite );


### PR DESCRIPTION
Fixes issue where `/jetpack/v4/site` is queried on every tab switch.

#### Changes proposed in this Pull Request:

* check that we already have site data, in which case we won't fetch it again
* declare prop types and defaults
* convert to ES6 class syntax
* fix minor ESLint issues

#### Testing instructions:

* load Jetpack admin. Everything should work normally as before
* there should be only one query to `/jetpack/v4/site` regardless of the panel or tab that is first loaded when you start the app