### PR TITLE
Settings UI: update support block wording and when it should be rendered

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -33,6 +33,10 @@ const SupportCard = React.createClass( {
 		} );
 	},
 
+	shouldComponentUpdate( nextProps ) {
+		return nextProps.sitePlan.product_slug !== this.props.sitePlan.product_slug;
+	},
+
 	trackAskQuestionClick() {
 		analytics.tracks.recordJetpackClick( {
 			target: 'support-card',

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -75,7 +75,7 @@ const SupportCard = React.createClass( {
 							{
 								noPrioritySupport
 									? __( 'Jetpack comes with free, basic support for all users.' )
-									: __( 'Utilize your priority-speed Jetpack support whenever you need it thanks to your paid plan.' )
+									: __( 'Your paid plan gives you access to prioritized Jetpack support.' )
 							}
 						</p>
 						<p className="jp-support-card__description">


### PR DESCRIPTION
Fixes #6808

#### Changes proposed in this Pull Request:

- update support block wording for paid plans

    <img width="740" alt="captura de pantalla 2017-03-29 a las 17 43 38" src="https://cloud.githubusercontent.com/assets/1041600/24475731/43ed7776-14a7-11e7-835b-913b968fc3cd.png">

- don't render the support block on each panel or tab switch.

#### Testing instructions:

* check that the wording is correct


