### PR TITLE
Add `$base_api_path` arg to `Jetpack_Client::wpcom_json_api_request_as_blog`

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -274,9 +274,10 @@ class Jetpack_Client {
 	 * @param string  $version
 	 * @param array   $args
 	 * @param string  $body
+	 * @param string  $base_api_path
 	 * @return array|WP_Error $response Data.
 	 */
-	static function wpcom_json_api_request_as_blog( $path, $version = self::WPCOM_JSON_API_VERSION, $args = array(), $body = null ) {
+	static function wpcom_json_api_request_as_blog( $path, $version = self::WPCOM_JSON_API_VERSION, $args = array(), $body = null, $base_api_path = 'rest' ) {
 		$filtered_args = array_intersect_key( $args, array(
 			'headers'     => 'array',
 			'method'      => 'string',
@@ -302,11 +303,7 @@ class Jetpack_Client {
 		// Use GET by default whereas `remote_request` uses POST
 		$request_method = ( isset( $filtered_args['method'] ) ) ? $filtered_args['method'] : 'GET';
 
-		if ( $version >= 2.0 ) {
-			$url = sprintf( '%s://%s/wpcom/v%s/%s', $proto, JETPACK__WPCOM_JSON_API_HOST, $version, $_path );
-		} else {
-			$url = sprintf( '%s://%s/rest/v%s/%s', $proto, JETPACK__WPCOM_JSON_API_HOST, $version, $_path );
-		}
+		$url = sprintf( '%s://%s/%s/v%s/%s', $proto, JETPACK__WPCOM_JSON_API_HOST, $base_api_path, $version, $_path );
 
 		$validated_args = array_merge( $filtered_args, array(
 			'url'     => $url,

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -247,7 +247,8 @@ class Jetpack_JITM {
 				array(
 					'user_id'    => $user->ID,
 					'user_roles' => implode( ',', $user->roles ),
-				)
+				),
+				'wpcom'
 			);
 
 			// silently fail...might be helpful to track it?


### PR DESCRIPTION
Previously the function was hard-coded to hit the v1 REST API endpoints,
even though there's a `$version` argument, because the v2 endpoints (at
least the most recent ones) are under a different base path (`/wpcom` or `/wp`
instead of `/rest`). This change adds an additional argument that allows
changing that path.
