### PR TITLE
Settings UI - Plans: fix comparison to render the correct link

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -340,7 +340,7 @@ const PlanBody = React.createClass( {
 						</div>
 
 						<p>
-							<Button onClick={ () => this.trackPlansClick( 'compare_plans' ) } href={ 'jetpack_free' === this.props.plans
+							<Button onClick={ () => this.trackPlansClick( 'compare_plans' ) } href={ 'is-free-plan' === planClass
 								? 'https://jetpack.com/redirect/?source=plans-main-bottom&site=' + this.props.siteRawUrl
 								: 'https://jetpack.com/redirect/?source=plans-main-bottom-dev-mode' } className="is-primary">
 								{ __( 'Compare Plans' ) }


### PR DESCRIPTION
This fixes an issue in sites in free plans: the Compare plans button in Plans tab leads user to jetpack.com and it's not redirected, as it should, to WordPress.com.

#### Changes proposed in this Pull Request:

* fix plan slug comparison to render the correct link

#### Testing instructions:

* test with site in free plan. Go to Dashboard > Plans. The button Compare plans should redirect to `https://wordpress.com/plans/%YOUR-SITE%`