### PR TITLE
Sitemaps: lower the sitemap byte limit to 1MB.

### DIFF
--- a/modules/sitemaps/sitemap-constants.php
+++ b/modules/sitemaps/sitemap-constants.php
@@ -15,7 +15,7 @@
  * @since 4.8.0
  */
 if ( ! defined( 'JP_SITEMAP_MAX_BYTES' ) ) {
-	define( 'JP_SITEMAP_MAX_BYTES', 10485760 );
+	define( 'JP_SITEMAP_MAX_BYTES', 1048576 );
 }
 
 /**


### PR DESCRIPTION
Storing 10MB blobs in post_content could be dangerous, although it's unlikely we'd hit that limit given the number of items is limited to
2000.

cc @mjangda 