### PR TITLE
WordPress.com Toolbar: bring back WP Admin link

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -915,8 +915,7 @@ class A8C_WPCOM_Masterbar {
 					),
 				) );
 			}
-
-
+			
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'configuration',
 				'id'     => 'blog-settings',
@@ -927,17 +926,15 @@ class A8C_WPCOM_Masterbar {
 				),
 			) );
 
-			if ( $this->is_automated_transfer_site() ) {
-				$wp_admin_bar->add_menu( array(
-					'parent' => 'configuration',
-					'id'     => 'legacy-dashboard',
-					'title'  => __( 'WP Admin', 'jetpack' ),
-					'href'   => '//' . esc_attr( $this->primary_site_url ) . '/wp-admin/',
-					'meta'   => array(
-						'class' => 'mb-icon',
-					),
-				) );
-			}
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'configuration',
+				'id'     => 'legacy-dashboard',
+				'title'  => __( 'WP Admin', 'jetpack' ),
+				'href'   => '//' . esc_attr( $this->primary_site_url ) . '/wp-admin/',
+				'meta'   => array(
+					'class' => 'mb-icon',
+				),
+			) );
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/6818

#### Changes proposed in this Pull Request:

* Restores WP Admin link in WordPress.com Toolbar's My sites menu.

#### Testing instructions:

1. Enable WordPress.com Toolbar module on your test Jetpack site.
2. Verify that WP Admin link is displayed as last item in My Sites menu.