### PR TITLE
Admin Page: update VaultPress info link.

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -33,7 +33,7 @@ export const BackupsScan = moduleSettingsForm(
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 					action="scan"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://vaultpress.com/jetpack/">
+					<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://help.vaultpress.com/get-to-know/">
 						{
 							__( 'Your site is backed up and threat-free.' )
 						}

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -13,13 +13,7 @@
  *  VaultPress (stub)
  */
 function vaultpress_jetpack_load_more_link() {
-	if ( function_exists( 'is_multisite' ) && is_multisite() ) {
-		$vaultpress_url = 'http://vaultpress.com/jetpack-ms/';
-	} else {
-		$vaultpress_url = 'http://vaultpress.com/jetpack/';
-	}
-
-	echo $vaultpress_url;
+	echo 'https://help.vaultpress.com/get-to-know/';
 }
 add_filter( 'jetpack_learn_more_button_vaultpress', 'vaultpress_jetpack_load_more_link' );
 


### PR DESCRIPTION
The previous link lead to a page advertizing plans, although the info link is only displayed when you already have a plan.

`http://vaultpress.com/jetpack-ms/`, on the other hand, doesn't exist anymore.