### PR TITLE
Settings UI: update Backups/Scan settings card

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -206,7 +206,7 @@ export const SettingsCard = props => {
 
 		switch ( feature ) {
 			case FEATURE_SECURITY_SCANNING_JETPACK:
-				if ( ( 'is-free-plan' === planClass || 'is-personal-plan' === planClass ) && ! scanEnabled ) {
+				if ( ( 'is-free-plan' === planClass ) && ! scanEnabled ) {
 					return false;
 				}
 

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -24,9 +24,10 @@ import {
 	isPluginInstalled
 } from 'state/site/plugins';
 import {
-	getVaultPressScanThreatCount as _getVaultPressScanThreatCount,
-	getVaultPressData as _getVaultPressData,
-	getAkismetData as _getAkismetData
+	getVaultPressScanThreatCount,
+	getVaultPressData,
+	isFetchingVaultPressData,
+	getAkismetData
 } from 'state/at-a-glance';
 import {
 	getSitePlan,
@@ -155,6 +156,9 @@ const ProStatus = React.createClass( {
 			}
 
 			if ( 'scan' === feature ) {
+				if ( this.props.fetchingSiteData || this.props.isFetchingVaultPressData ) {
+					return '';
+				}
 				if ( ( hasFree || hasPersonal ) && ! hasScan ) {
 					if ( this.props.isCompact ) {
 						return this.getProActions( 'free', 'scan' );
@@ -221,9 +225,10 @@ export default connect(
 		return {
 			siteRawUrl: getSiteRawUrl( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
-			getScanThreats: () => _getVaultPressScanThreatCount( state ),
-			getVaultPressData: () => _getVaultPressData( state ),
-			getAkismetData: () => _getAkismetData( state ),
+			getScanThreats: () => getVaultPressScanThreatCount( state ),
+			getVaultPressData: () => getVaultPressData( state ),
+			getAkismetData: () => getAkismetData( state ),
+			isFetchingVaultPressData: isFetchingVaultPressData( state ),
 			sitePlan: () => getSitePlan( state ),
 			fetchingPluginsData: isFetchingPluginsData( state ),
 			pluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -8,6 +8,7 @@ import Button from 'components/button';
 import SimpleNotice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import analytics from 'lib/analytics';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -108,6 +109,26 @@ const ProStatus = React.createClass( {
 		);
 	},
 
+	/**
+	 * Return a button to Set Up a feature.
+	 *
+	 * @param {string} feature Slug of the feature to set up.
+	 *
+	 * @return {component} A Button component.
+	 */
+	getSetUpButton( feature ) {
+		return (
+			<Button
+				onClick={ () => this.trackProStatusClick( 'set_up', feature ) }
+				compact={ true }
+				primary={ true }
+				href={ `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }` }
+			>
+				{ __( 'Set up', { context: 'Caption for a button to set up a feature.' } ) }
+			</Button>
+		);
+	},
+
 	render() {
 		const sitePlan = this.props.sitePlan(),
 			vpData = this.props.getVaultPressData(),
@@ -117,18 +138,8 @@ const ProStatus = React.createClass( {
 
 		const hasPersonal = /jetpack_personal*/.test( sitePlan.product_slug ),
 			hasFree = /jetpack_free*/.test( sitePlan.product_slug ),
-			hasBackups = (
-				'undefined' !== typeof vpData.data &&
-				'undefined' !== typeof vpData.data.features &&
-				'undefined' !== typeof vpData.data.features.backups &&
-				vpData.data.features.backups
-			),
-			hasScan = (
-				'undefined' !== typeof vpData.data &&
-				'undefined' !== typeof vpData.data.features &&
-				'undefined' !== typeof vpData.data.features.security &&
-				vpData.data.features.security
-			);
+			hasBackups = get( vpData, [ 'data', 'features', 'backups' ], false ),
+			hasScan = get( vpData, [ 'data', 'features', 'security' ], false );
 
 		const getStatus = ( feature, active, installed ) => {
 			if ( this.props.isDevMode ) {
@@ -147,6 +158,9 @@ const ProStatus = React.createClass( {
 				if ( ( hasFree || hasPersonal ) && ! hasScan ) {
 					if ( this.props.isCompact ) {
 						return this.getProActions( 'free', 'scan' );
+					} else if ( hasPersonal && ! hasBackups ) {
+						// Personal plans doesn't have scan but it does have backups.
+						return this.getSetUpButton( 'backups' );
 					}
 					return '';
 				}
@@ -180,16 +194,7 @@ const ProStatus = React.createClass( {
 						return this.getProActions( 'active' );
 					}
 
-					return (
-						<Button
-							onClick={ () => this.trackProStatusClick( 'set_up', feature ) }
-							compact={ true }
-							primary={ true }
-							href={ `https://wordpress.com/plugins/setup/${ this.props.siteRawUrl }?only=${ feature }` }
-						>
-							{ __( 'Set up', { context: 'Caption for a button to set up a feature.' } ) }
-						</Button>
-					);
+					return this.getSetUpButton( feature );
 				}
 			}
 

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -2,9 +2,12 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
 import analytics from 'lib/analytics';
+import get from 'lodash/get';
+import { getPlanClass } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
@@ -13,6 +16,9 @@ import { FEATURE_SECURITY_SCANNING_JETPACK } from 'lib/plans/constants';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { getVaultPressData } from 'state/at-a-glance';
+import { getSitePlan } from 'state/site';
+import includes from 'lodash/includes';
 
 export const BackupsScan = moduleSettingsForm(
 	React.createClass( {
@@ -26,6 +32,26 @@ export const BackupsScan = moduleSettingsForm(
 		},
 
 		render() {
+			const backupsAndScansEnabled = (
+					get( this.props.vaultPressData, [ 'data', 'features', 'backups' ], false ) &&
+					get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false )
+				),
+				planClass = getPlanClass( this.props.sitePlan.product_slug );
+			let cardText = '';
+
+			if ( this.props.isDevMode ) {
+				cardText = __( 'Unavailable in Dev Mode.' );
+			} else if ( backupsAndScansEnabled ) {
+				cardText = __( 'Your site is backed up and threat-free.' );
+			} else if ( includes( [ 'is-personal-plan', 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
+				if ( 'is-personal-plan' === planClass ) {
+					cardText = __( "You have paid for backups but they're not yet active." );
+				} else if ( includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
+					cardText = __( 'You have paid for backups and security scanning but they’re not yet active.' );
+				}
+				cardText += ' ' + __( 'Click "Set Up" to finish installation.' );
+			}
+
 			return (
 				<SettingsCard
 					feature={ FEATURE_SECURITY_SCANNING_JETPACK }
@@ -35,11 +61,11 @@ export const BackupsScan = moduleSettingsForm(
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://help.vaultpress.com/get-to-know/">
 						{
-							__( 'Your site is backed up and threat-free.' )
+							cardText
 						}
 					</SettingsGroup>
 					{
-						! this.props.isUnavailableInDevMode( 'backups' ) && (
+						( ! this.props.isUnavailableInDevMode( 'backups' ) && backupsAndScansEnabled ) && (
 							<Card compact className="jp-settings-card__configure-link" onClick={ this.trackConfigureClick } href="https://dashboard.vaultpress.com/">{ __( 'Configure your Security Scans' ) }</Card>
 						)
 					}
@@ -48,3 +74,12 @@ export const BackupsScan = moduleSettingsForm(
 		}
 	} )
 );
+
+export default connect(
+	( state ) => {
+		return {
+			sitePlan: getSitePlan( state ),
+			vaultPressData: getVaultPressData( state )
+		};
+	}
+)( BackupsScan );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -16,8 +16,8 @@ import { FEATURE_SECURITY_SCANNING_JETPACK } from 'lib/plans/constants';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import { getVaultPressData } from 'state/at-a-glance';
-import { getSitePlan } from 'state/site';
+import { getVaultPressData, isFetchingVaultPressData } from 'state/at-a-glance';
+import { getSitePlan, isFetchingSiteData } from 'state/site';
 import includes from 'lodash/includes';
 
 export const BackupsScan = moduleSettingsForm(
@@ -41,15 +41,19 @@ export const BackupsScan = moduleSettingsForm(
 
 			if ( this.props.isDevMode ) {
 				cardText = __( 'Unavailable in Dev Mode.' );
-			} else if ( backupsAndScansEnabled ) {
-				cardText = __( 'Your site is backed up and threat-free.' );
-			} else if ( includes( [ 'is-personal-plan', 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
-				if ( 'is-personal-plan' === planClass ) {
-					cardText = __( "You have paid for backups but they're not yet active." );
-				} else if ( includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
-					cardText = __( 'You have paid for backups and security scanning but they’re not yet active.' );
+			} else if ( ! this.props.isFetchingSiteData && ! this.props.isFetchingVaultPressData ) {
+				if ( backupsAndScansEnabled ) {
+					cardText = __( 'Your site is backed up and threat-free.' );
+				} else if ( includes( [ 'is-personal-plan', 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
+					if ( 'is-personal-plan' === planClass ) {
+						cardText = __( "You have paid for backups but they're not yet active." );
+					} else if ( includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
+						cardText = __( 'You have paid for backups and security scanning but they’re not yet active.' );
+					}
+					cardText += ' ' + __( 'Click "Set Up" to finish installation.' );
 				}
-				cardText += ' ' + __( 'Click "Set Up" to finish installation.' );
+			} else if ( this.props.isFetchingSiteData || this.props.isFetchingVaultPressData ) {
+				cardText += ' ' + __( 'Checking site status…' );
 			}
 
 			return (
@@ -79,7 +83,9 @@ export default connect(
 	( state ) => {
 		return {
 			sitePlan: getSitePlan( state ),
-			vaultPressData: getVaultPressData( state )
+			isFetchingSiteData: isFetchingSiteData( state ),
+			vaultPressData: getVaultPressData( state ),
+			isFetchingVaultPressData: isFetchingVaultPressData( state )
 		};
 	}
 )( BackupsScan );

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -14,7 +14,7 @@ import { isModuleFound } from 'state/search';
 import { isPluginActive, isPluginInstalled } from 'state/site/plugins';
 import QuerySite from 'components/data/query-site';
 import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
-import { BackupsScan } from './backups-scan';
+import BackupsScan from './backups-scan';
 import Antispam from './antispam';
 import { Protect } from './protect';
 import { SSO } from './sso';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* only show card content after data is ready. Fixes #6810 
* Update wording when VP is inactive and site has personal or premium/business plans, and also when it's in dev mode.
* only hide Backups/Scan settings card content in free plans since sites in personal plans have backups
* Update ProStatus so it displays the Set Up blue button when VP is inactive and site has personal plan.
* display content when VP data and site are being fetch
    <img width="734" alt="captura de pantalla 2017-03-31 a las 15 17 26" src="https://cloud.githubusercontent.com/assets/1041600/24563579/40367b94-1625-11e7-83f6-e399e7b0c313.png">

#### Testing instructions:

* make sure the card doesn't display one content when it's loading and then another
* if site is in personal/premium/business plan, if VP is inactive, it should display the Set Up button.
* the card content when site has a personal plan and VP inactive, mentions only backups, while it mentions backups and scans when site has a premium/business plan
* if site is in dev mode, the card content should say "Unavailable in Dev Mode"
