### PR TITLE
Separate the action types for declaring fetching state for various actions. 

### DIFF
--- a/_inc/client/state/at-a-glance/reducer.js
+++ b/_inc/client/state/at-a-glance/reducer.js
@@ -48,24 +48,22 @@ const requests = ( state = {}, action ) => {
 
 		case STATS_DATA_FETCH_FAIL:
 		case STATS_DATA_FETCH_SUCCESS:
+			return assign( {}, state, { fetchingStatsData: false } );
 		case AKISMET_DATA_FETCH_FAIL:
 		case AKISMET_DATA_FETCH_SUCCESS:
+			return assign( {}, state, { fetchingAkismetData: false } );
 		case AKISMET_KEY_CHECK_FETCH_FAIL:
 		case AKISMET_KEY_CHECK_FETCH_SUCCESS:
-		case VAULTPRESS_SITE_DATA_FETCH_FAIL:
-		case VAULTPRESS_SITE_DATA_FETCH_SUCCESS:
+			return assign( {}, state, { checkingAkismetKey: false } );
 		case DASHBOARD_PROTECT_COUNT_FETCH_FAIL:
 		case DASHBOARD_PROTECT_COUNT_FETCH_SUCCESS:
+			return assign( {}, state, { fetchingProtectData: false } );
 		case PLUGIN_UPDATES_FETCH_FAIL:
 		case PLUGIN_UPDATES_FETCH_SUCCESS:
-			return assign( {}, state, {
-				fetchingStatsData: false,
-				fetchingAkismetData: false,
-				checkingAkismetKey: false,
-				fetchingVaultPressData: false,
-				fetchingProtectData: false,
-				fetchingPluginUpdates: false
-			} );
+			return assign( {}, state, { fetchingPluginUpdates: false } );
+		case VAULTPRESS_SITE_DATA_FETCH_FAIL:
+		case VAULTPRESS_SITE_DATA_FETCH_SUCCESS:
+			return assign( {}, state, { fetchingVaultPressData: false } );
 
 		default:
 			return state;


### PR DESCRIPTION
This patch is pretty self-explanatory, but before we were acting as if none of these actions were fetching if only one of them succeeded or failed.  This was probably breaking some behavior of some query components, and any other checks that depended on the `fetchingWhatever` state of these features.  