### PR TITLE
Fixed the locale string to work properly with toLocaleString.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -310,7 +310,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				),
 			),
 			'locale' => $this->get_i18n_data(),
-			'localeSlug' => jetpack_get_user_locale(),
+			'localeSlug' => join( '-', explode( '_', jetpack_get_user_locale() ) ),
 			'jetpackStateNotices' => array(
 				'messageCode' => Jetpack::state( 'message' ),
 				'errorCode' => Jetpack::state( 'error' ),


### PR DESCRIPTION
Fixes a bug introduced by #6815. It broke sites that would use a locale with an underscore like `ru_RU`. Using a dash instead of an underscore fixes it.
