### PR TITLE
Masterbar: fix admin URL and make sure the WP admin link is only displayed when necessary

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -328,7 +328,7 @@ class A8C_WPCOM_Masterbar {
 		if ( empty( $user_id ) ) {
 			return;
 		}
-		
+
 		$avatar = get_avatar( $this->user_email, 32, 'mm', '', array( 'force_display' => true ) );
 		$class  = empty( $avatar ) ? '' : 'with-avatar';
 
@@ -853,7 +853,7 @@ class A8C_WPCOM_Masterbar {
 					'label' => __( 'People', 'jetpack' ),
 				),
 				array(
-					'url'   => '//' . esc_attr( $this->primary_site_url ) . '/wp-admin/user-new.php',
+					'url'   => admin_url( 'user-new.php' ),
 					'id'    => 'wp-admin-bar-people-add',
 					'label' => _x( 'Add', 'admin bar people item label', 'jetpack' ),
 				)
@@ -915,7 +915,7 @@ class A8C_WPCOM_Masterbar {
 					),
 				) );
 			}
-			
+
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'configuration',
 				'id'     => 'blog-settings',
@@ -930,7 +930,7 @@ class A8C_WPCOM_Masterbar {
 				'parent' => 'configuration',
 				'id'     => 'legacy-dashboard',
 				'title'  => __( 'WP Admin', 'jetpack' ),
-				'href'   => '//' . esc_attr( $this->primary_site_url ) . '/wp-admin/',
+				'href'   => admin_url(),
 				'meta'   => array(
 					'class' => 'mb-icon',
 				),

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -926,15 +926,17 @@ class A8C_WPCOM_Masterbar {
 				),
 			) );
 
-			$wp_admin_bar->add_menu( array(
-				'parent' => 'configuration',
-				'id'     => 'legacy-dashboard',
-				'title'  => __( 'WP Admin', 'jetpack' ),
-				'href'   => admin_url(),
-				'meta'   => array(
-					'class' => 'mb-icon',
-				),
-			) );
+			if ( ! is_admin() ) {
+				$wp_admin_bar->add_menu( array(
+					'parent' => 'configuration',
+					'id'     => 'legacy-dashboard',
+					'title'  => __( 'WP Admin', 'jetpack' ),
+					'href'   => admin_url(),
+					'meta'   => array(
+						'class' => 'mb-icon',
+					),
+				) );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Part 2 of #6823

1. Use `admin_url()` to always return the right admin URL.
- On some sites, the admin URL may be filtered.
- On others, WordPress may live in a subdirectory.
2. Only display WP Admin link when not in the dashboard. The menu item isn't useful when you're already in the dashboard.

P.S.: I'm wondering if "WP Admin" is actually very user friendly. It won't mean much to new WordPress users imo. How about just "Dashboard", like in the default WP admin bar?