### PR TITLE
Removed the connect link from Publicize in dev mode.

### DIFF
--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -24,17 +24,31 @@ export class Publicize extends Component {
 		const unavailableInDevMode = this.props.isUnavailableInDevMode( 'publicize' ),
 			isLinked = this.props.isLinked,
 			connectUrl = this.props.connectUrl,
-			siteRawUrl = this.props.siteRawUrl,
-			siteAdminUrl = this.props.siteAdminUrl;
+			siteRawUrl = this.props.siteRawUrl;
 
 		const configCard = () => {
-			const settingsLink = unavailableInDevMode
-				? siteAdminUrl + 'wp-admin/options-general.php?page=sharing'
-				: 'https://wordpress.com/sharing/' + siteRawUrl;
+			if ( unavailableInDevMode ) {
+				return;
+			}
 
 			return isLinked
-				? <Card compact className="jp-settings-card__configure-link" onClick={ this.trackClickConfigure } href={ settingsLink }>{ __( 'Connect your social media accounts' ) }</Card>
-				: <Card compact className="jp-settings-card__configure-link" href={ `${ connectUrl }&from=unlinked-user-connect-publicize` }>{ __( 'Connect your user account to WordPress.com to use this feature' ) }</Card>;
+				? (
+					<Card
+						compact
+						className="jp-settings-card__configure-link"
+						onClick={ this.trackClickConfigure }
+						href={ 'https://wordpress.com/sharing/' + siteRawUrl }>
+						{ __( 'Connect your social media accounts' ) }
+					</Card>
+				)
+				: (
+					<Card
+						compact
+						className="jp-settings-card__configure-link"
+						href={ `${ connectUrl }&from=unlinked-user-connect-publicize` }>
+						{ __( 'Connect your user account to WordPress.com to use this feature' ) }
+					</Card>
+				);
 		};
 
 		return (


### PR DESCRIPTION
Fixes the broken link in the Publicize card in development mode. It doesn't make sense to point it anywhere in `wp-admin` because there are no Publicize settings there. So this PR just removes it:

![publicize](https://cloud.githubusercontent.com/assets/374293/24543196/592270f4-1607-11e7-92f5-398314ef3a5c.png)

Note: the `siteAdminUrl` property is no longer needed in the card, but it's still passed down from the `index.js` file. I find this to be a good tradeoff between keeping the code DRY and doing "the right thing".

#### Changes proposed in this Pull Request:
* Removed the connect link from Publicize in dev mode.

#### Testing instructions:
* Make sure the link exists only in connected state, and it's working fine for both linked and unlinked users.
