### PR TITLE
Masterbar: use "Dashboard" instead of "WP Admin" as menu item.

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -939,7 +939,7 @@ class A8C_WPCOM_Masterbar {
 				$wp_admin_bar->add_menu( array(
 					'parent' => 'configuration',
 					'id'     => 'legacy-dashboard',
-					'title'  => __( 'WP Admin', 'jetpack' ),
+					'title'  => __( 'Dashboard', 'jetpack' ),
 					'href'   => admin_url(),
 					'meta'   => array(
 						'class' => 'mb-icon',


### PR DESCRIPTION
I don't think "WP Admin" is actually very user friendly. It won't mean much to new WordPress users imo. I think "Dashboard", like in the default WP admin bar, would be a lot clearer.

Before:

![screen shot 2017-03-31 at 16 03 21](https://cloud.githubusercontent.com/assets/426388/24553779/a06dc516-162b-11e7-8616-fee29df16a77.png)

After:

![screen shot 2017-03-31 at 16 05 56](https://cloud.githubusercontent.com/assets/426388/24553858/f1cc905e-162b-11e7-806a-7bfd70e72fe1.png)
