### PR TITLE
Settings UI: Don't hide the dashboard for non-admins

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -35,7 +35,7 @@ const AtAGlance = React.createClass( {
 				siteAdminUrl: this.props.siteAdminUrl,
 				siteRawUrl: this.props.siteRawUrl
 			},
-			securityHeader =
+			securityHeader = this.props.isModuleActivated( 'protect' ) &&
 				<DashSectionHeader
 					label={ __( 'Security' ) }
 					settingsPath="#security"
@@ -121,31 +121,24 @@ const AtAGlance = React.createClass( {
 				protect = <DashProtect />;
 			}
 
-			let nonAdminAAG = '';
-			if ( '' !== stats || '' !== protect ) {
-				nonAdminAAG = this.props.userIsSubscriber
+			const nonAdminAAG = this.props.userIsSubscriber
 				? (
-					<div>
-						{ stats	}
-						{
-							connections
-						}
-					</div>
-				)
+				<div>
+					{ stats	}
+					{ connections }
+				</div>
+			)
 				: (
-					<div>
-						{ stats	}
-						{
-							// Site Security
-							securityHeader
-						}
-						{ protect }
-						{
-							connections
-						}
-					</div>
-				);
-			}
+				<div>
+					{ stats	}
+					{
+						// Site Security
+						securityHeader
+					}
+					{ protect }
+					{ connections }
+				</div>
+			);
 
 			return nonAdminAAG;
 		}

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -52,22 +52,13 @@ export const Navigation = React.createClass( {
 				</NavTabs>
 			);
 		} else {
-			let dashboard = '';
-			if ( this.props.userCanViewStats || this.props.isModuleActivated( 'protect' ) ) {
-				dashboard = (
+			navTabs = (
+				<NavTabs selectedText={ this.props.route.name }>
 					<NavItem
 						path="#/dashboard"
 						selected={ ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) }>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
-				);
-			} else if ( ( this.props.route.path === '/dashboard' ) || ( this.props.route.path === '/' ) ) {
-				this.props.route.path = '/apps';
-				this.props.route.name = 'Apps';
-			}
-			navTabs = (
-				<NavTabs selectedText={ this.props.route.name }>
-					{ dashboard }
 					<NavItem
 						path="#/apps"
 						selected={ this.props.route.path === '/apps' }>

--- a/_inc/client/components/navigation/test/component.js
+++ b/_inc/client/components/navigation/test/component.js
@@ -35,22 +35,13 @@ describe( 'Navigation', () => {
 			expect( wrapper.find( 'NavTabs' ) ).to.exist;
 		} );
 
-		it( 'renders 1 NavItem component', () => {
-			expect( wrapper.find( 'NavItem' ) ).to.have.length( 1 );
+		it( 'renders 2 NavItem components', () => {
+			expect( wrapper.find( 'NavItem' ) ).to.have.length( 2 );
 		} );
 
-		it( 'renders only one tab: Apps', () => {
-			expect( wrapper.find( 'NavItem' ).children().text() ).to.be.equal( 'Apps' );
+		it( 'renders tabs with At a Glance, Apps', () => {
+			expect( wrapper.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance,Apps' );
 		} );
-
-		it( 'does not have At a Glance as selectedText', () => {
-			expect( wrapper.find( 'NavTabs' ).props().selectedText ).to.not.equal( 'At a Glance' );
-		} );
-
-		it( 'has Apps as selectedText, despite having At a Glance initially', () => {
-			expect( wrapper.find( 'NavTabs' ).props().selectedText ).to.be.equal( 'Apps' );
-		} );
-
 	} );
 
 	describe( "User can't view Stats or manage modules but Protect is active", () => {

--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -31,12 +31,7 @@ const NonAdminView = React.createClass( {
 		switch ( route ) {
 			case '/dashboard':
 			default:
-				if ( this.props.userCanViewStats || this.props.isModuleActivated( 'protect' ) ) {
-					pageComponent = <AtAGlance { ...this.props } />;
-				} else {
-					// If routing took us to Dashboard but user can't view anything, fallback to Apps
-					pageComponent = <Apps { ...this.props } />;
-				}
+				pageComponent = <AtAGlance { ...this.props } />;
 				break;
 			case '/apps':
 				pageComponent = <Apps { ...this.props } />;

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -51,10 +51,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	function jetpack_add_dashboard_sub_nav_item() {
 		if ( Jetpack::is_development_mode() || Jetpack::is_active() ) {
 			global $submenu;
-			if ( current_user_can( 'jetpack_manage_modules' ) || Jetpack::is_module_active( 'protect' ) || current_user_can( 'view_stats' ) ) {
+			if ( current_user_can( 'jetpack_admin_page' ) ) {
 				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/dashboard' );
-			} elseif ( current_user_can( 'jetpack_admin_page' ) ) {
-				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/apps' );
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #6842

This ensures that all users will have access to the dashboard, regardless of which modules are active, so that they can disconnect from wpcom if they so choose.  

This patch also fixes the security header showing for non-admins, even if protect wasn't active.

To Test: 
- Follow steps in the issue linked to reproduce
- Log in as non-admin 
- Make sure you have access to the dashboard
- Make sure the security header doesn't show when protect isn't active
- make sure it does show when active.  

Looks like this 
![screen shot 2017-03-31 at 10 33 02 am](https://cloud.githubusercontent.com/assets/7129409/24554983/7672bdd0-15fd-11e7-86a6-7bcc183530f0.png)