### PR TITLE
Sitemaps: generate on activation to solve 404 issue. Add message in settings UI.

### DIFF
--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -33,7 +33,46 @@ export const Sitemaps = moduleSettingsForm(
 		render() {
 			const sitemaps = this.props.getModule( 'sitemaps' ),
 				sitemap_url = get( sitemaps, [ 'extra', 'sitemap_url' ], '' ),
-				news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' );
+				news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' ),
+				isSitemapsActive = this.props.getOptionValue( 'sitemaps' ),
+				isSavingSitemaps = this.props.isSavingAnyOption( 'sitemaps' );
+
+			let sitemapsText = '';
+
+			if ( this.props.isSiteVisibleToSearchEngines ) {
+				if ( isSitemapsActive ) {
+					sitemapsText = (
+						<FormFieldset>
+							<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
+							<p>
+								<ExternalLink onClick={ this.trackSitemapUrl } icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
+								<br />
+								<ExternalLink onClick={ this.trackSitemapNewsUrl } icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+							</p>
+						</FormFieldset>
+					);
+				} else if ( isSavingSitemaps ) {
+					sitemapsText = (
+						<FormFieldset>
+							<p className="jp-form-setting-explanation">{ __( 'Generating sitemap…' ) }</p>
+						</FormFieldset>
+					);
+				}
+			} else {
+				sitemapsText = (
+					<FormFieldset>
+						<p className="jp-form-setting-explanation">
+							{
+								__( 'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.', {
+									components: {
+										a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
+									}
+								} )
+							}
+						</p>
+					</FormFieldset>
+				);
+			}
 
 			return (
 				<SettingsCard
@@ -45,36 +84,14 @@ export const Sitemaps = moduleSettingsForm(
 						<ModuleToggle
 							slug="sitemaps"
 							compact
-							activated={ this.props.getOptionValue( 'sitemaps' ) }
-							toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
+							activated={ isSitemapsActive }
+							disabled={ isSavingSitemaps }
+							toggling={ isSavingSitemaps }
 							toggleModule={ this.props.toggleModuleNow }>
 							{ __( 'Generate XML sitemaps' ) }
 						</ModuleToggle>
 						{
-							this.props.isSiteVisibleToSearchEngines
-								? this.props.getOptionValue( 'sitemaps' ) && (
-									<FormFieldset>
-										<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
-										<p>
-											<ExternalLink onClick={ this.trackSitemapUrl } icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
-											<br />
-											<ExternalLink onClick={ this.trackSitemapNewsUrl } icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
-										</p>
-									</FormFieldset>
-								)
-								: (
-									<FormFieldset>
-											<p className="jp-form-setting-explanation">
-												{
-													__( 'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.', {
-														components: {
-															a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
-														}
-													} )
-												}
-											</p>
-									</FormFieldset>
-								)
+							sitemapsText
 						}
 					</SettingsGroup>
 				</SettingsCard>

--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -13,3 +13,18 @@
 if ( '1' == get_option( 'blog_public' ) ) {
 	include_once 'sitemaps/sitemaps.php';
 }
+
+function jetpack_sitemap_generate_on_activate() {
+	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-constants.php';
+	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-buffer.php';
+	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-stylist.php';
+	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-librarian.php';
+	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-finder.php';
+	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-builder.php';
+
+	wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
+	// Tell build that it's true we're activating this module.
+	$sitemap_builder = new Jetpack_Sitemap_Builder( true );
+	$sitemap_builder->update_sitemap();
+}
+add_action( 'jetpack_activate_module_sitemaps', 'jetpack_sitemap_generate_on_activate' );

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -43,7 +43,7 @@ class Jetpack_Sitemap_Builder {
 	 * @since 4.8.0
 	 * @var $logger Jetpack_Sitemap_Logger
 	 */
-	private $logger;
+	private $logger = false;
 
 	/**
 	 * Finder object for dealing with sitemap URIs.
@@ -55,16 +55,28 @@ class Jetpack_Sitemap_Builder {
 	private $finder;
 
 	/**
+	 * Flag to know if this module is being activated.
+	 *
+	 * @access private
+	 * @since 4.8.0
+	 * @var bool $is_activation
+	 */
+	private $is_activation;
+
+	/**
 	 * Construct a new Jetpack_Sitemap_Builder object.
 	 *
 	 * @access public
-	 * @since 4.8.0
+	 * @since  4.8.0
+	 *
+	 * @param bool $is_activation True if this is this module is being activated.
 	 */
-	public function __construct() {
+	public function __construct( $is_activation = false ) {
+		$this->is_activation = $is_activation;
 		$this->librarian = new Jetpack_Sitemap_Librarian();
 		$this->finder = new Jetpack_Sitemap_Finder();
 
-		if ( defined( 'WP_DEBUG' ) && ( true === WP_DEBUG ) ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && ! $this->is_activation ) {
 			$this->logger = new Jetpack_Sitemap_Logger();
 		}
 
@@ -193,14 +205,20 @@ class Jetpack_Sitemap_Builder {
 					$this->logger->time();
 				}
 
-				die();
+				if ( ! $this->is_activation ) {
+					die();
+				}
+				break;
 
 			default:
 				// Otherwise, reset the state.
 				Jetpack_Sitemap_State::reset(
 					JP_PAGE_SITEMAP_TYPE
 				);
-				die();
+
+				if ( ! $this->is_activation ) {
+					die();
+				}
 		}
 
 		// Unlock the state.

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -963,7 +963,7 @@ FOOTER
 			// Otherwise, loop through each post in the batch.
 			foreach ( $posts as $post ) {
 				// Generate the sitemap XML for the post.
-				$current_item = $this->sitemap_row_to_index_item( $post );
+				$current_item = $this->sitemap_row_to_index_item( (array) $post );
 
 				// Try adding this item to the buffer.
 				if ( true === $buffer->try_to_add_item( $current_item['xml'] ) ) {

--- a/modules/sitemaps/sitemap-constants.php
+++ b/modules/sitemaps/sitemap-constants.php
@@ -130,8 +130,8 @@ if ( ! defined( 'JP_VIDEO_SITEMAP_INDEX_TYPE' ) ) {
  *
  * @return string The filename.
  */
-function jp_sitemap_filename( $type, $number ) {
-	if ( ! is_int( $number ) ) {
+function jp_sitemap_filename( $type, $number = null ) {
+	if ( is_null( $number ) ) {
 		return "error-not-int-$type-$number.xml";
 	} elseif ( JP_MASTER_SITEMAP_TYPE === $type ) {
 		return 'sitemap.xml';

--- a/modules/sitemaps/sitemap-librarian.php
+++ b/modules/sitemaps/sitemap-librarian.php
@@ -171,7 +171,7 @@ class Jetpack_Sitemap_Librarian {
 	 */
 	public function delete_all_stored_sitemap_data() {
 		$this->delete_sitemap_data(
-			jp_sitemap_filename( MASTER_SITEMAP_TYPE ),
+			jp_sitemap_filename( JP_MASTER_SITEMAP_TYPE ),
 			JP_MASTER_SITEMAP_TYPE
 		);
 

--- a/modules/sitemaps/sitemap-logger.php
+++ b/modules/sitemaps/sitemap-logger.php
@@ -61,7 +61,7 @@ class Jetpack_Sitemap_Logger {
 	 * @param string $message The string to be written to the log.
 	 */
 	public function report( $message ) {
-		if ( defined( 'WP_DEBUG' ) && ( true === WP_DEBUG ) ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			error_log( 'jp-sitemap-' . $this->key . ': ' . $message );
 		}
 		return;

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -139,6 +139,13 @@ class Jetpack_Sitemap_Manager {
 
 		if ( '' === $the_content ) {
 			http_response_code( 404 );
+			wp_die(
+				esc_html__( "No sitemap found. Maybe it's being generated. Please try again later.", 'jetpack' ),
+				esc_html__( 'Sitemaps', 'jetpack' ),
+				array(
+					'response' => 404,
+				)
+			);
 		}
 
 		echo $the_content;

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -38,7 +38,7 @@ require_once dirname( __FILE__ ) . '/sitemap-librarian.php';
 require_once dirname( __FILE__ ) . '/sitemap-finder.php';
 require_once dirname( __FILE__ ) . '/sitemap-builder.php';
 
-if ( defined( 'WP_DEBUG' ) && ( true === WP_DEBUG ) ) {
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 	require_once dirname( __FILE__ ) . '/sitemap-logger.php';
 }
 


### PR DESCRIPTION
Fixes #6819

#### Changes proposed in this Pull Request:

- fix wrong data type, add default parameter, wrong constant
- generate master sitemap on activation
- add a way to disable logged messages since otherwise it looks like activation fails since the response is corrupted by the logged messages
- add meaningful error when /sitemaps.xml has no content and end with WP die sending a 404 response.
- when sitemap is being generated
    - disable toggle
    - displaymessage about generation.
    <img width="473" alt="captura de pantalla 2017-03-31 a las 11 52 31" src="https://cloud.githubusercontent.com/assets/1041600/24555729/8a326018-1608-11e7-89c0-77e8f7b62d68.png">

#### Testing instructions:

* activate the module. Verify that the message is displayed and that the module is correctly activated
* go to the sitemaps, verify that they work fine
* to delete the sitemap, go to your DB > `wp_posts` and look for posts of `post_type` equal to `jp_sitemap_master`