### PR TITLE
WordPress.com Toolbar: add Portfolio and Testimonials when activated

### DIFF
--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -27,6 +27,7 @@ import {
 } from 'state/action-types';
 import { getModule } from 'state/modules/reducer';
 import restApi from 'rest-api';
+import some from 'lodash/some';
 
 export const fetchModules = () => {
 	return ( dispatch ) => {
@@ -309,8 +310,10 @@ export function maybeHideNavMenuItem( module, values ) {
 	}
 }
 
-export function maybeReloadAfterAction( module ) {
-	if ( 'masterbar' in module ) {
+export function maybeReloadAfterAction( newOptionValue ) {
+	const reloadForOptionValues = [ 'masterbar', 'jetpack_testimonial', 'jetpack_portfolio'	];
+
+	if ( some( reloadForOptionValues, ( optionValue ) => optionValue in newOptionValue ) ) {
 		window.location.reload();
 	}
 }

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -3,6 +3,7 @@
  */
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import { translate as __ } from 'i18n-calypso';
+import some from 'lodash/some';
 
 /**
  * Internal dependencies
@@ -103,8 +104,12 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 			newOptionValues = { post_by_email_address: 'regenerate' };
 		}
 
+		// Changes to these options affect WordPress.com Toolbar appearance,
+		// and we need to reload the page for them to take effect.
+		const reloadForOptionValues = [ 'masterbar', 'jetpack_testimonial', 'jetpack_portfolio' ];
+
 		// Adapt message for masterbar toggle, since it needs to reload.
-		if ( 'object' === typeof newOptionValues && 'masterbar' in newOptionValues ) {
+		if ( 'object' === typeof newOptionValues && some( reloadForOptionValues, ( optionValue ) => optionValue in newOptionValues ) ) {
 			messages = {
 				success: __( 'Updated settings. Refreshing page…' )
 			};


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/6836

#### Changes proposed in this Pull Request:

* We need to reload page when Portfolio or Testimonials are activated in order for changes to take effect in the Toolbar.

#### Testing instructions:

1. Navigate to `Writing` pages of your Jetpack settings.
2. Verify that page is reloaded after switching the enabled state for: Masterbar, Portfolio, and Testimonials. 
3. Verify that correct message is displayed when these settings are saved.
4. Verify that we are not reloading when saving other settings.