### PR TITLE
Fix the display of listing reasons for being in dev mode

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -86,12 +86,8 @@ export const DevModeNotice = React.createClass( {
 	render() {
 		if ( this.props.siteConnectionStatus === 'dev' ) {
 			const devMode = this.props.siteDevMode,
-				text = __( 'Currently in {{a}}Development Mode{{/a}} (some features are disabled) because:', {
-					components: {
-						a: <a href="https://jetpack.com/support/development-mode/" target="_blank" rel="noopener noreferrer" />
-					}
-				} ),
 				reasons = [];
+
 			if ( devMode.filter ) {
 				reasons.push( __( '{{li}}The jetpack_development_mode filter is active{{/li}}',
 					{
@@ -120,13 +116,19 @@ export const DevModeNotice = React.createClass( {
 				) );
 			}
 
+			const text = __( 'Currently in {{a}}Development Mode{{/a}} (some features are disabled) because: {{reasons/}}', {
+				components: {
+					a: <a href="https://jetpack.com/support/development-mode/" target="_blank" rel="noopener noreferrer" />,
+					reasons: <ul>{ reasons }</ul>
+				}
+			} );
+
 			return (
 				<SimpleNotice
 					showDismiss={ false }
 					status="is-info"
 					text={ text }
 				>
-					<ul>{ reasons }</ul>
 					<NoticeAction
 						href="https://jetpack.com/development-mode/">
 						{ __( 'Learn More' ) }

--- a/_inc/client/components/jetpack-notices/style.scss
+++ b/_inc/client/components/jetpack-notices/style.scss
@@ -1,7 +1,6 @@
 .dops-notice {
 	ul {
 		@include breakpoint( "<480px" ) {
-			margin: 0 rem( 48px ) rem( 8px );
 			font-size: rem( 12px );
 		}
 	}


### PR DESCRIPTION
Fixes #6847

Fixes the awkward/broken list of reasons for being in dev mode.  This style of listing the reasons provides a readable format for when there could be multiple reasons for dev mode.  For example: 

![screen shot 2017-03-31 at 1 46 28 pm](https://cloud.githubusercontent.com/assets/7129409/24562391/a2508a70-1618-11e7-931b-859ed09581e0.png)

