### PR TITLE
Allow HTTP `PUT` requests sent from Jetpack to WPCOM

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -299,11 +299,7 @@ class Jetpack_Client {
 		$_path = preg_replace( '/^\//', '', $path );
 
 		// Use GET by default whereas `remote_request` uses POST
-		if ( isset( $filtered_args['method'] ) && strtoupper( $filtered_args['method'] === 'POST' ) ) {
-			$request_method = 'POST';
-		} else {
-			$request_method = 'GET';
-		}
+		$request_method = ( isset( $filtered_args['method'] ) ) ? $filtered_args['method'] : 'GET';
 
 		$validated_args = array_merge( $filtered_args, array(
 			'url'     => sprintf( '%s://%s/rest/v%s/%s', $proto, JETPACK__WPCOM_JSON_API_HOST, $version, $_path ),

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -71,7 +71,17 @@ class Jetpack_Signature {
 					$body = $_POST;
 				}
 			}
+		} else if ( 'PUT' == strtoupper( $_SERVER['REQUEST_METHOD'] ) ) {
+			// This is a little strange-looking, but there doesn't seem to be another way to get the PUT body
+			$raw_put_data = file_get_contents( 'php://input' );
+			parse_str( $raw_put_data, $body );
 
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				$put_data = json_decode( $raw_put_data, true );
+				if ( is_array( $put_data ) && count( $put_data ) > 0 ) {
+					$body = $put_data;
+				}
+			}
 		} else {
 			$body = null;
 		}


### PR DESCRIPTION
This has two parts:

## Allow any HTTP method in wpcom_json_api_request_as_blog

Previously, `Jetpack_Client::wpcom_json_api_request_as_blog()` only
supported `GET` and `POST` verbs, but this allows supporting any method
such as `PUT` or `DELETE`.

## Allow HTTP PUT data to be validated by Jetpack_Signature 

HTTP requests made by functions like `Jetpack_Client::remote_request()`
generate signed body hashes for the request content. If the data is sent
via the `PUT` method, however, it was ignored, causing a hash comparison
failure on the server. This change allows `PUT` data to be validated as
well.

Just like the `POST` data, the `PUT` data is taken from the raw
url-encoded input (I don't understand why), but if IS_WPCOM, we assume
the data is JSON-encoded and use the decoded version.
