### PR TITLE
Sitemaps: when module is activated, schedule generation once

### DIFF
--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -33,46 +33,7 @@ export const Sitemaps = moduleSettingsForm(
 		render() {
 			const sitemaps = this.props.getModule( 'sitemaps' ),
 				sitemap_url = get( sitemaps, [ 'extra', 'sitemap_url' ], '' ),
-				news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' ),
-				isSitemapsActive = this.props.getOptionValue( 'sitemaps' ),
-				isSavingSitemaps = this.props.isSavingAnyOption( 'sitemaps' );
-
-			let sitemapsText = '';
-
-			if ( this.props.isSiteVisibleToSearchEngines ) {
-				if ( isSitemapsActive ) {
-					sitemapsText = (
-						<FormFieldset>
-							<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
-							<p>
-								<ExternalLink onClick={ this.trackSitemapUrl } icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
-								<br />
-								<ExternalLink onClick={ this.trackSitemapNewsUrl } icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
-							</p>
-						</FormFieldset>
-					);
-				} else if ( isSavingSitemaps ) {
-					sitemapsText = (
-						<FormFieldset>
-							<p className="jp-form-setting-explanation">{ __( 'Generating sitemap…' ) }</p>
-						</FormFieldset>
-					);
-				}
-			} else {
-				sitemapsText = (
-					<FormFieldset>
-						<p className="jp-form-setting-explanation">
-							{
-								__( 'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.', {
-									components: {
-										a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
-									}
-								} )
-							}
-						</p>
-					</FormFieldset>
-				);
-			}
+				news_sitemap_url = get( sitemaps, [ 'extra', 'news_sitemap_url' ], '' );
 
 			return (
 				<SettingsCard
@@ -84,14 +45,36 @@ export const Sitemaps = moduleSettingsForm(
 						<ModuleToggle
 							slug="sitemaps"
 							compact
-							activated={ isSitemapsActive }
-							disabled={ isSavingSitemaps }
-							toggling={ isSavingSitemaps }
+							activated={ this.props.getOptionValue( 'sitemaps' ) }
+							toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
 							toggleModule={ this.props.toggleModuleNow }>
 							{ __( 'Generate XML sitemaps' ) }
 						</ModuleToggle>
 						{
-							sitemapsText
+							this.props.isSiteVisibleToSearchEngines
+								? this.props.getOptionValue( 'sitemaps' ) && (
+									<FormFieldset>
+										<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
+										<p>
+											<ExternalLink onClick={ this.trackSitemapUrl } icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
+											<br />
+											<ExternalLink onClick={ this.trackSitemapNewsUrl } icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+										</p>
+									</FormFieldset>
+								)
+								: (
+									<FormFieldset>
+											<p className="jp-form-setting-explanation">
+												{
+													__( 'Your site is not currently accessible to search engines. You might have "Search Engine Visibility" disabled in your {{a}}Reading Settings{{/a}}.', {
+														components: {
+															a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />
+														}
+													} )
+												}
+											</p>
+									</FormFieldset>
+								)
 						}
 					</SettingsGroup>
 				</SettingsCard>

--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -39,8 +39,7 @@ function jetpack_sitemap_on_activate() {
 	wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
 	wp_clear_scheduled_hook( 'jetpack_sitemap_generate_on_activate' );
 
-	// Tell builder that it's true we're activating this module.
-	$sitemap_builder = new Jetpack_Sitemap_Builder( true );
+	$sitemap_builder = new Jetpack_Sitemap_Builder();
 	add_action( 'jetpack_sitemap_generate_on_activate', array( $sitemap_builder, 'update_sitemap' ) );
 
 	wp_schedule_single_event( time(), 'jetpack_sitemap_generate_on_activate' );

--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -10,11 +10,25 @@
  * Additional Search Queries: sitemap, traffic, search, site map, seo
  */
 
+/**
+ * Disable direct access and execution.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( '1' == get_option( 'blog_public' ) ) {
 	include_once 'sitemaps/sitemaps.php';
 }
 
-function jetpack_sitemap_generate_on_activate() {
+add_action( 'jetpack_activate_module_sitemaps', 'jetpack_sitemap_on_activate' );
+
+/**
+ * Run when Sitemaps module is activated.
+ *
+ * @since 4.8.0
+ */
+function jetpack_sitemap_on_activate() {
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-constants.php';
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-buffer.php';
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-stylist.php';
@@ -23,8 +37,11 @@ function jetpack_sitemap_generate_on_activate() {
 	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-builder.php';
 
 	wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
-	// Tell build that it's true we're activating this module.
+	wp_clear_scheduled_hook( 'jetpack_sitemap_generate_on_activate' );
+
+	// Tell builder that it's true we're activating this module.
 	$sitemap_builder = new Jetpack_Sitemap_Builder( true );
-	$sitemap_builder->update_sitemap();
+	add_action( 'jetpack_sitemap_generate_on_activate', array( $sitemap_builder, 'update_sitemap' ) );
+
+	wp_schedule_single_event( time(), 'jetpack_sitemap_generate_on_activate' );
 }
-add_action( 'jetpack_activate_module_sitemaps', 'jetpack_sitemap_generate_on_activate' );

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -13,7 +13,7 @@ require_once dirname( __FILE__ ) . '/sitemap-librarian.php';
 require_once dirname( __FILE__ ) . '/sitemap-finder.php';
 require_once dirname( __FILE__ ) . '/sitemap-state.php';
 
-if ( defined( 'WP_DEBUG' ) && ( true === WP_DEBUG ) ) {
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 	require_once dirname( __FILE__ ) . '/sitemap-logger.php';
 }
 
@@ -55,28 +55,16 @@ class Jetpack_Sitemap_Builder {
 	private $finder;
 
 	/**
-	 * Flag to know if this module is being activated.
-	 *
-	 * @access private
-	 * @since 4.8.0
-	 * @var bool $is_activation
-	 */
-	private $is_activation;
-
-	/**
 	 * Construct a new Jetpack_Sitemap_Builder object.
 	 *
 	 * @access public
-	 * @since  4.8.0
-	 *
-	 * @param bool $is_activation True if this is this module is being activated.
+	 * @since 4.8.0
 	 */
-	public function __construct( $is_activation = false ) {
-		$this->is_activation = $is_activation;
+	public function __construct() {
 		$this->librarian = new Jetpack_Sitemap_Librarian();
 		$this->finder = new Jetpack_Sitemap_Finder();
 
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && ! $this->is_activation ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			$this->logger = new Jetpack_Sitemap_Logger();
 		}
 
@@ -205,20 +193,14 @@ class Jetpack_Sitemap_Builder {
 					$this->logger->time();
 				}
 
-				if ( ! $this->is_activation ) {
-					die();
-				}
-				break;
+				die();
 
 			default:
 				// Otherwise, reset the state.
 				Jetpack_Sitemap_State::reset(
 					JP_PAGE_SITEMAP_TYPE
 				);
-
-				if ( ! $this->is_activation ) {
-					die();
-				}
+				die();
 		}
 
 		// Unlock the state.


### PR DESCRIPTION
Fixes #6854

#### Changes proposed in this Pull Request:

* when module is activated, don't generate immediately. Instead, defer it to a cron job to be run once.
* removes message about sitemap being generated

#### Testing instructions:

* make sure the sitemap is generated asap. It won't be generated immediately. Make sure the UI doesn't hang.
