### PR TITLE
Plans page: show videopress CTA for correct plan

### DIFF
--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -180,7 +180,7 @@ const PlanBody = React.createClass( {
 					}
 
 					{
-						'is-personal-plan' === planClass && (
+						'is-premium-plan' === planClass && (
 							<div className="jp-landing__plan-features-card">
 								<h3 className="jp-landing__plan-features-title">{ __( 'Video Hosting' ) }</h3>
 								<p>{ __( '13Gb of fast, optimized, and ad-free video hosting for your site (powered by VideoPress).' ) }</p>


### PR DESCRIPTION
Fixes #6865

You should not see a CTA for the free nor personal plan for VideoPress on the `/plans` tab.  

Premium and Pro should show correct text.  