### PR TITLE
Settings UI: restore blue notices that indicate progress

### DIFF
--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -46,8 +46,8 @@ export const fetchModules = () => {
 				error: error
 			} );
 		} );
-	}
-}
+	};
+};
 
 export const fetchModule = () => {
 	return ( dispatch ) => {
@@ -66,8 +66,8 @@ export const fetchModule = () => {
 				error: error
 			} );
 		} );
-	}
-}
+	};
+};
 
 export const activateModule = ( slug, reloadAfter = false ) => {
 	return ( dispatch, getState ) => {
@@ -75,6 +75,16 @@ export const activateModule = ( slug, reloadAfter = false ) => {
 			type: JETPACK_MODULE_ACTIVATE,
 			module: slug
 		} );
+		dispatch( removeNotice( 'module-toggle' ) );
+		dispatch( createNotice(
+			'is-info',
+			__( 'Activating %(slug)s…', {
+				args: {
+					slug: getModule( getState(), slug ).name
+				}
+			} ),
+			{ id: 'module-toggle' }
+		) );
 		return restApi.activateModule( slug ).then( () => {
 			dispatch( {
 				type: JETPACK_MODULE_ACTIVATE_SUCCESS,
@@ -113,8 +123,8 @@ export const activateModule = ( slug, reloadAfter = false ) => {
 				{ id: 'module-toggle' }
 			) );
 		} );
-	}
-}
+	};
+};
 
 export const deactivateModule = ( slug, reloadAfter = false ) => {
 	return ( dispatch, getState ) => {
@@ -122,6 +132,16 @@ export const deactivateModule = ( slug, reloadAfter = false ) => {
 			type: JETPACK_MODULE_DEACTIVATE,
 			module: slug
 		} );
+		dispatch( removeNotice( 'module-toggle' ) );
+		dispatch( createNotice(
+			'is-info',
+			__( 'Deactivating %(slug)s…', {
+				args: {
+					slug: getModule( getState(), slug ).name
+				}
+			} ),
+			{ id: 'module-toggle' }
+		) );
 		return restApi.deactivateModule( slug ).then( () => {
 			dispatch( {
 				type: JETPACK_MODULE_DEACTIVATE_SUCCESS,
@@ -160,11 +180,11 @@ export const deactivateModule = ( slug, reloadAfter = false ) => {
 				{ id: 'module-toggle' }
 			) );
 		} );
-	}
-}
+	};
+};
 
 export const updateModuleOptions = ( module, newOptionValues ) => {
-	let slug = module.module;
+	const slug = module.module;
 
 	return ( dispatch, getState ) => {
 		dispatch( {
@@ -220,8 +240,8 @@ export const updateModuleOptions = ( module, newOptionValues ) => {
 				{ id: `module-setting-${ slug }` }
 			) );
 		} );
-	}
-}
+	};
+};
 
 export const regeneratePostByEmailAddress = () => {
 	const slug = 'post-by-email';
@@ -285,8 +305,8 @@ export const regeneratePostByEmailAddress = () => {
 				{ id: `module-setting-${ slug }` }
 			) );
 		} );
-	}
-}
+	};
+};
 
 export function maybeHideNavMenuItem( module, values ) {
 	switch ( module ) {

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -116,6 +116,7 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 		}
 
 		dispatch( removeNotice( 'module-setting-update' ) );
+		dispatch( removeNotice( 'module-setting-update-success' ) );
 		dispatch( createNotice(
 			'is-info',
 			messages.progress,
@@ -137,10 +138,11 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 			maybeReloadAfterAction( newOptionValues );
 
 			dispatch( removeNotice( 'module-setting-update' ) );
+			dispatch( removeNotice( 'module-setting-update-success' ) );
 			dispatch( createNotice(
 				'is-success',
 				messages.success,
-				{ id: 'module-setting-update', duration: 2000 }
+				{ id: 'module-setting-update-success', duration: 2000 }
 			) );
 		} ).catch( error => {
 			dispatch( {

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -112,9 +112,7 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 
 		// Adapt message for masterbar toggle, since it needs to reload.
 		if ( 'object' === typeof newOptionValues && some( reloadForOptionValues, ( optionValue ) => optionValue in newOptionValues ) ) {
-			messages = {
-				success: __( 'Updated settings. Refreshing page…' )
-			};
+			messages.success = __( 'Updated settings. Refreshing page…' );
 		}
 
 		dispatch( removeNotice( 'module-setting-update' ) );

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -85,6 +85,7 @@ export const updateSetting = ( updatedOption ) => {
 export const updateSettings = ( newOptionValues, type = '' ) => {
 	return ( dispatch ) => {
 		let messages = {
+				progress: __( 'Updating settings…' ),
 				success: __( 'Updated settings.' ),
 				error: error => __( 'Error updating settings. %(error)s', { args: { error: error } } )
 			},
@@ -93,6 +94,7 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 		// Adapt messages and data when regenerating Post by Email address
 		if ( 'regeneratePbE' === type ) {
 			messages = {
+				progress: __( 'Updating Post by Email address…' ),
 				success: __( 'Regenerated Post by Email address.' ),
 				error: error => __( 'Error regenerating Post by Email address. %(error)s', { args: { error: error } } )
 			};
@@ -114,6 +116,13 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 				success: __( 'Updated settings. Refreshing page…' )
 			};
 		}
+
+		dispatch( removeNotice( 'module-setting-update' ) );
+		dispatch( createNotice(
+			'is-info',
+			messages.progress,
+			{ id: 'module-setting-update' }
+		) );
 
 		dispatch( {
 			type: JETPACK_SETTINGS_UPDATE,


### PR DESCRIPTION
Fixes #6869

#### Changes proposed in this Pull Request:

* restore blue notices after toggling a feature or saving a setting
* these are restored in At a Glance and Settings

#### Testing instructions:

* toggle something in At a Glance. Make sure the blue notice shows up
* toggle some module and save some setting. The blue notice should show up
* regenerate PbE address. Its blue notice with custom text should show up
