### PR TITLE
Settings UI AAG: don't ever hide security dash header for admins

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -35,8 +35,7 @@ const AtAGlance = React.createClass( {
 				siteAdminUrl: this.props.siteAdminUrl,
 				siteRawUrl: this.props.siteRawUrl
 			},
-			securityHeader = this.props.isModuleActivated( 'protect' ) &&
-				<DashSectionHeader
+			securityHeader = <DashSectionHeader
 					label={ __( 'Security' ) }
 					settingsPath="#security"
 					externalLink={
@@ -133,7 +132,7 @@ const AtAGlance = React.createClass( {
 					{ stats	}
 					{
 						// Site Security
-						securityHeader
+						this.props.isModuleActivated( 'protect' ) && securityHeader
 					}
 					{ protect }
 					{ connections }


### PR DESCRIPTION
To reproduce the bug: 
- Deactivate protect
- Look on the AAG Dashboard
- You'll see the security header disappears

To test the fix:
- Deactivate protect
- Make sure the security header is still there for admins 
- Make sure it's not there for non-admins 