### PR TITLE
Added URI decoding to fix escaping search term characters.

### DIFF
--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -54,7 +54,7 @@ export const NavigationSettings = React.createClass( {
 			keyword = term[ 0 ].split( '=' )[ 1 ];
 		}
 
-		this.props.searchForTerm( keyword );
+		this.props.searchForTerm( decodeURIComponent( keyword ) );
 	},
 
 	maybeShowSearch() {


### PR DESCRIPTION
Fixes #6858 

#### Changes proposed in this Pull Request:
* Adds a call to `decodeURIComponent` to fix the escaping of search terms.

#### Testing instructions:
* Try search for things that have spaces in them like "post type".
* Ensure that you can find what you are looking for.
