### PR TITLE
Sync: Adda a way to distinguish between an added and an updated attachment

### DIFF
--- a/sync/class.jetpack-sync-module-attachments.php
+++ b/sync/class.jetpack-sync-module-attachments.php
@@ -9,21 +9,35 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 		add_action( 'edit_attachment', array( $this, 'send_attachment_info' ) );
 		// Once we don't have to support 4.3 we can start using add_action( 'attachment_updated', $handler, 10, 3 ); instead
 		add_action( 'add_attachment', array( $this, 'send_attachment_info' ) );
-		add_action( 'jetpack_sync_save_add_attachment', $callable, 10, 3 );
+		add_action( 'jetpack_sync_save_update_attachment', $callable, 10, 2 );
+		add_action( 'jetpack_sync_save_add_attachment', $callable, 10, 2 );
 	}
 
 	function send_attachment_info( $attachment_id ) {
 		$attachment = get_post( $attachment_id );
+		if ( 'add_attachment' === current_filter() ) {
+			/**
+			 * Fires when the client needs to sync an new attachment
+			 *
+			 * @since 4.2.0
+			 *
+			 * @param int The attachment ID
+			 * @param object The attachment
+			 */
+			do_action( 'jetpack_sync_save_add_attachment', $attachment_id, $attachment );
+		} else {
+			/**
+			 * Fires when the client needs to sync an updated attachment
+			 *
+			 * @since 4.9.0
+			 *
+			 * @param int The attachment ID
+			 * @param object The attachment
+			 *
+			 * Previously this action was synced using jetpack_sync_save_add_attachment action.
+			 */
+			do_action( 'jetpack_sync_save_update_attachment', $attachment_id, $attachment );
+		}
 
-		/**
-		 * Fires when the client needs to sync an attachment for a post
-		 *
-		 * @since 4.2.0
-		 *
-		 * @param int The attachment ID
-		 * @param object The attachment
-		 */
-		$filter = current_filter();
-		do_action( 'jetpack_sync_save_add_attachment', $attachment_id, $attachment, $filter );
 	}
 }

--- a/sync/class.jetpack-sync-module-attachments.php
+++ b/sync/class.jetpack-sync-module-attachments.php
@@ -9,7 +9,7 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 		add_action( 'edit_attachment', array( $this, 'send_attachment_info' ) );
 		// Once we don't have to support 4.3 we can start using add_action( 'attachment_updated', $handler, 10, 3 ); instead
 		add_action( 'add_attachment', array( $this, 'send_attachment_info' ) );
-		add_action( 'jetpack_sync_save_add_attachment', $callable, 10, 2 );
+		add_action( 'jetpack_sync_save_add_attachment', $callable, 10, 3 );
 	}
 
 	function send_attachment_info( $attachment_id ) {
@@ -23,6 +23,7 @@ class Jetpack_Sync_Module_Attachments extends Jetpack_Sync_Module {
 		 * @param int The attachment ID
 		 * @param object The attachment
 		 */
-		do_action( 'jetpack_sync_save_add_attachment', $attachment_id, $attachment );
+		$filter = current_filter();
+		do_action( 'jetpack_sync_save_add_attachment', $attachment_id, $attachment, $filter );
 	}
 }

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -33,6 +33,7 @@ class Jetpack_Sync_Server_Replicator {
 				list( $post_id, $post, $post_before ) = $args;
 				$this->store->upsert_post( $post, $silent );
 				break;
+			case 'jetpack_sync_save_update_attachment':
 			case 'jetpack_sync_save_add_attachment':
 				list( $attachment_id, $attachment ) = $args;
 				$this->store->upsert_post( $attachment, $silent );

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -161,7 +161,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$meta_thumbnail_id = $this->server_replica_storage->get_metadata( 'post', $this->post->ID, '_thumbnail_id', true );
 		$this->assertEquals( get_post_meta( $this->post->ID, '_thumbnail_id', true ), $meta_thumbnail_id );
-
 	}
 
 	public function test_sync_attachment_update_is_synced() {
@@ -184,7 +183,14 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		// Insert the attachment.
 		$attach_id = wp_insert_attachment( $attachment, $filename, $this->post->ID );
+		
 		$this->sender->do_sync();
+		
+		// Test that the first event is add_attachment
+		$attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_add_attachment' );
+		$this->assertEquals( 'add_attachment', $attachment_event->args[2] );
+		$this->server_event_storage->reset();
+		
 
 		$this->assertAttachmentSynced( $attach_id );
 
@@ -208,6 +214,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( $attachment, $remote_attachment );
 
+		$attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_add_attachment' );
+		$this->assertEquals( 'edit_attachment', $attachment_event->args[2] );
 	}
 
 	public function test_sync_attachment_delete_is_synced() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -187,8 +187,11 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		
 		// Test that the first event is add_attachment
-		$attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_add_attachment' );
-		$this->assertEquals( 'add_attachment', $attachment_event->args[2] );
+		$update_attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_update_attachment' );
+		$add_attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_add_attachment' );
+		$this->assertTrue( (bool) $add_attachment_event );
+		$this->assertFalse( (bool) $update_attachment_event );
+
 		$this->server_event_storage->reset();
 		
 
@@ -214,8 +217,10 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( $attachment, $remote_attachment );
 
-		$attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_add_attachment' );
-		$this->assertEquals( 'edit_attachment', $attachment_event->args[2] );
+		$update_attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_update_attachment' );
+		$add_attachment_event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_add_attachment' );
+		$this->assertTrue( (bool) $update_attachment_event );
+		$this->assertFalse( (bool) $add_attachment_event );
 	}
 
 	public function test_sync_attachment_delete_is_synced() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Current we can't tell if an user added or updated an attachment. 
This PR tries so solve this by adding the current filter to the action being synced. 

#### Testing instructions:
* Do the tests pass? 
* Notice when you add an attachment that the add_attachment action is being send to .com and that the edit_attachment action is being send to .com when you update the attachment info. 

