### PR TITLE
Sync: Add Jetpack Post Trashed event

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -241,7 +241,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function save_published( $new_status, $old_status, $post ) {
-		error_log( print_r( array( $new_status, $old_status ) ,1 ));
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
 			$this->just_published[] = $post->ID;
 		}

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -5,6 +5,7 @@ require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 	private $just_published = array();
+	private $just_trashed = array();
 	private $action_handler;
 
 	public function name() {
@@ -33,6 +34,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 
 		add_action( 'deleted_post', $callable, 10 );
 		add_action( 'jetpack_published_post', $callable, 10, 2 );
+		add_action( 'jetpack_trashed_post', $callable, 10, 2 );
+
 		add_action( 'transition_post_status', array( $this, 'save_published' ), 10, 3 );
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_post', array( $this, 'filter_blacklisted_post_types' ) );
 
@@ -238,14 +241,20 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function save_published( $new_status, $old_status, $post ) {
+		error_log( print_r( array( $new_status, $old_status ) ,1 ));
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
 			$this->just_published[] = $post->ID;
+		}
+
+		if ( 'trash' === $new_status && 'trash' !== $old_status ) {
+			$this->just_trashed[] = $post->ID;
 		}
 	}
 
 	public function wp_insert_post( $post_ID, $post, $update ) {
 		call_user_func( $this->action_handler, $post_ID, $post, $update );
 		$this->send_published( $post_ID, $post );
+		$this->send_trashed( $post_ID, $post );
 	}
 
 	public function send_published( $post_ID, $post ) {
@@ -279,6 +288,28 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		do_action( 'jetpack_published_post', $post_ID, $flags );
 
 		$this->just_published = array_diff( $this->just_published, array( $post_ID ) );
+	}
+
+	public function send_trashed( $post_ID, $post ) {
+		if ( ! in_array( $post_ID, $this->just_trashed ) ) {
+			return;
+		}
+
+		// Post revisions cause race conditions where this send_published add the action before the actual post gets synced
+		if ( wp_is_post_autosave( $post ) || wp_is_post_revision( $post ) ) {
+			return;
+		}
+
+		/**
+		 * Action that gets synced when a post type gets trashed.
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param int $post_ID
+		 */
+		do_action( 'jetpack_trashed_post', $post_ID );
+
+		$this->just_trashed = array_diff( $this->just_trashed, array( $post_ID ) );
 	}
 
 	public function expand_post_ids( $args ) {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -49,9 +49,20 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		wp_delete_post( $this->post->ID );
 
 		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_trashed_post' );
+
+		$this->assertTrue( (bool) $event );
+		$this->server_event_storage->reset();
 
 		$this->assertEquals( 0, $this->server_replica_storage->post_count( 'publish' ) );
 		$this->assertEquals( 1, $this->server_replica_storage->post_count( 'trash' ) );
+
+		wp_delete_post( $this->post->ID );
+		$this->sender->do_sync();
+		
+		// Since the post status is not changing here we don't exect the post be trashed again.
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_trashed_post' );
+		$this->assertFalse( (bool) $event );
 	}
 
 	public function test_delete_post_deletes_data() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -60,7 +60,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		wp_delete_post( $this->post->ID );
 		$this->sender->do_sync();
 		
-		// Since the post status is not changing here we don't exect the post be trashed again.
+		// Since the post status is not changing here we don't expect the post to be trashed again.
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_trashed_post' );
 		$this->assertFalse( (bool) $event );
 	}


### PR DESCRIPTION
We current don't have a good way to track when the post is marked as
trashed.

The jetpack_post_trashed follows the same pattern as the published post event.

#### Changes proposed in this Pull Request:
* Adding the jetpack_post_trashed event will let us know when we have
post is marked as trashed.

#### Testing instructions:
* Do the tests pass? 
* Do we get the expected results on the .com side. Do we hear about the event as expected? 
