### PR TITLE
Sharing: add toggles to sharing and publicize features

### DIFF
--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -9,64 +9,76 @@ import analytics from 'lib/analytics';
 /**
  * Internal dependencies
  */
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { ModuleToggle } from 'components/module-toggle';
 
-export class Publicize extends Component {
-	trackClickConfigure() {
-		analytics.tracks.recordJetpackClick( {
-			target: 'configure-publicize',
-			page: 'sharing'
-		} );
-	}
+export const Publicize = moduleSettingsForm(
+	class extends Component {
+		trackClickConfigure() {
+			analytics.tracks.recordJetpackClick( {
+				target: 'configure-publicize',
+				page: 'sharing'
+			} );
+		}
 
-	render() {
-		const unavailableInDevMode = this.props.isUnavailableInDevMode( 'publicize' ),
-			isLinked = this.props.isLinked,
-			connectUrl = this.props.connectUrl,
-			siteRawUrl = this.props.siteRawUrl;
+		render() {
+			const unavailableInDevMode = this.props.isUnavailableInDevMode( 'publicize' ),
+				isLinked = this.props.isLinked,
+				connectUrl = this.props.connectUrl,
+				siteRawUrl = this.props.siteRawUrl,
+				isActive = this.props.getOptionValue( 'publicize' );
 
-		const configCard = () => {
-			if ( unavailableInDevMode ) {
-				return;
-			}
-
-			return isLinked
-				? (
-					<Card
-						compact
-						className="jp-settings-card__configure-link"
-						onClick={ this.trackClickConfigure }
-						href={ 'https://wordpress.com/sharing/' + siteRawUrl }>
-						{ __( 'Connect your social media accounts' ) }
-					</Card>
-				)
-				: (
-					<Card
-						compact
-						className="jp-settings-card__configure-link"
-						href={ `${ connectUrl }&from=unlinked-user-connect-publicize` }>
-						{ __( 'Connect your user account to WordPress.com to use this feature' ) }
-					</Card>
-				);
-		};
-
-		return (
-			<SettingsCard
-				{ ...this.props }
-				header={ __( 'Publicize connections', { context: 'Settings header' } ) }
-				module="publicize"
-				hideButton>
-				<SettingsGroup disableInDevMode module={ { module: 'publicize' } } support="https://jetpack.com/support/publicize/">
-					{
-						__( 'Publicize lets you connect your site to various social networking services.  Once connected to a ' +
-							'service, you can share your posts with that service automatically.' )
-					}
-				</SettingsGroup>
-				{
-					configCard()
+			const configCard = () => {
+				if ( unavailableInDevMode ) {
+					return;
 				}
-			</SettingsCard>
-		);
+
+				return isLinked
+					? (
+						<Card
+							compact
+							className="jp-settings-card__configure-link"
+							onClick={ this.trackClickConfigure }
+							href={ 'https://wordpress.com/sharing/' + siteRawUrl }>
+							{ __( 'Connect your social media accounts' ) }
+						</Card>
+					)
+					: (
+						<Card
+							compact
+							className="jp-settings-card__configure-link"
+							href={ `${ connectUrl }&from=unlinked-user-connect-publicize` }>
+							{ __( 'Connect your user account to WordPress.com to use this feature' ) }
+						</Card>
+					);
+			};
+
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Publicize connections', { context: 'Settings header' } ) }
+					module="publicize"
+					hideButton>
+					<SettingsGroup disableInDevMode module={ { module: 'publicize' } } support="https://jetpack.com/support/publicize/">
+						<ModuleToggle
+							slug="publicize"
+							disabled={ unavailableInDevMode }
+							activated={ isActive }
+							toggling={ this.props.isSavingAnyOption( 'publicize' ) }
+							toggleModule={ this.props.toggleModuleNow }>
+							{
+								__( 'Publicize lets you connect your site to various social networking services.  Once connected to a ' +
+									'service, you can share your posts with that service automatically.' )
+							}
+							</ModuleToggle>
+					</SettingsGroup>
+					{
+						isActive && configCard()
+					}
+				</SettingsCard>
+			);
+		}
 	}
-}
+);

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -69,8 +69,7 @@ export const Publicize = moduleSettingsForm(
 							toggling={ this.props.isSavingAnyOption( 'publicize' ) }
 							toggleModule={ this.props.toggleModuleNow }>
 							{
-								__( 'Publicize lets you connect your site to various social networking services.  Once connected to a ' +
-									'service, you can share your posts with that service automatically.' )
+								__( 'Automatically share your posts to social networks' )
 							}
 							</ModuleToggle>
 					</SettingsGroup>

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -56,8 +56,7 @@ export const ShareButtons = moduleSettingsForm(
 							toggling={ this.props.isSavingAnyOption( 'sharedaddy' ) }
 							toggleModule={ this.props.toggleModuleNow }>
 							{
-								__( 'Sharing buttons can be added to your posts so that your users can share your content to their social ' +
-									'networks and show their support.' )
+								__( 'Add sharing buttons to your posts' )
 							}
 							</ModuleToggle>
 					</SettingsGroup>

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -9,52 +9,63 @@ import analytics from 'lib/analytics';
 /**
  * Internal dependencies
  */
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { ModuleToggle } from 'components/module-toggle';
 
-export class ShareButtons extends Component {
-	trackClickConfigure() {
-		analytics.tracks.recordJetpackClick( {
-			target: 'configure-sharing',
-			page: 'sharing'
-		} );
-	}
+export const ShareButtons = moduleSettingsForm(
+	class extends Component {
+		trackClickConfigure() {
+			analytics.tracks.recordJetpackClick( {
+				target: 'configure-sharing',
+				page: 'sharing'
+			} );
+		}
 
-	render() {
-		const isLinked = this.props.isLinked,
-			connectUrl = this.props.connectUrl,
-			siteRawUrl = this.props.siteRawUrl,
-			siteAdminUrl = this.props.siteAdminUrl,
-			isDevMode = this.props.isDevMode;
+		render() {
+			const isLinked = this.props.isLinked,
+				connectUrl = this.props.connectUrl,
+				siteRawUrl = this.props.siteRawUrl,
+				siteAdminUrl = this.props.siteAdminUrl,
+				isDevMode = this.props.isDevMode,
+				isActive = this.props.getOptionValue( 'sharedaddy' );
 
-		const configCard = () => {
-			if ( isDevMode ) {
-				return <Card compact className="jp-settings-card__configure-link" href={ siteAdminUrl + 'options-general.php?page=sharing' }>{ __( 'Configure your sharing buttons' ) }</Card>;
-			}
-
-			if ( isLinked ) {
-				return <Card compact className="jp-settings-card__configure-link" onClick={ this.trackClickConfigure } href={ 'https://wordpress.com/sharing/buttons/' + siteRawUrl }>{ __( 'Configure your sharing buttons' ) }</Card>;
-			}
-
-			return <Card compact className="jp-settings-card__configure-link" href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }>{ __( 'Connect your user account to WordPress.com to use this feature' ) }</Card>;
-		};
-
-		return (
-			<SettingsCard
-				{ ...this.props }
-				header={ __( 'Sharing buttons', { context: 'Settings header' } ) }
-				module="sharing"
-				hideButton>
-				<SettingsGroup disableInDevMode module={ { module: 'sharing' } } support="https://jetpack.com/support/sharing/">
-					{
-						__( 'Sharing buttons can be added to your posts so that your users can share your content to their social ' +
-							'networks and show their support.' )
-					}
-				</SettingsGroup>
-				{
-					configCard()
+			const configCard = () => {
+				if ( isDevMode ) {
+					return <Card compact className="jp-settings-card__configure-link" href={ siteAdminUrl + 'options-general.php?page=sharing' }>{ __( 'Configure your sharing buttons' ) }</Card>;
 				}
-			</SettingsCard>
-		);
+
+				if ( isLinked ) {
+					return <Card compact className="jp-settings-card__configure-link" onClick={ this.trackClickConfigure } href={ 'https://wordpress.com/sharing/buttons/' + siteRawUrl }>{ __( 'Configure your sharing buttons' ) }</Card>;
+				}
+
+				return <Card compact className="jp-settings-card__configure-link" href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }>{ __( 'Connect your user account to WordPress.com to use this feature' ) }</Card>;
+			};
+
+			return (
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Sharing buttons', { context: 'Settings header' } ) }
+					module="sharing"
+					hideButton>
+					<SettingsGroup disableInDevMode module={ { module: 'sharing' } } support="https://jetpack.com/support/sharing/">
+						<ModuleToggle
+							slug="sharedaddy"
+							activated={ isActive }
+							toggling={ this.props.isSavingAnyOption( 'sharedaddy' ) }
+							toggleModule={ this.props.toggleModuleNow }>
+							{
+								__( 'Sharing buttons can be added to your posts so that your users can share your content to their social ' +
+									'networks and show their support.' )
+							}
+							</ModuleToggle>
+					</SettingsGroup>
+					{
+						isActive && configCard()
+					}
+				</SettingsCard>
+			);
+		}
 	}
-}
+);


### PR DESCRIPTION
Add toggles to Share Buttons and Publicize Features: 

![screen shot 2017-04-04 at 10 15 27 am](https://cloud.githubusercontent.com/assets/7129409/24661179/b2e6f2f2-191f-11e7-9731-412c7ae8459b.png)

Make sure the link card at the bottom doesn't show when it's inactive.  