### PR TITLE
Add Tiled Gallery to Jumpstart

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -190,6 +190,7 @@ function jetpack_get_module_i18n( $key ) {
 			'tiled-gallery' => array(
 				'name' => _x( 'Tiled Galleries', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Display image galleries in a variety of elegant arrangements.', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Display image galleries in a variety of elegant arrangements.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'vaultpress' => array(

--- a/modules/tiled-gallery.php
+++ b/modules/tiled-gallery.php
@@ -3,11 +3,12 @@
 /**
  * Module Name: Tiled Galleries
  * Module Description: Display image galleries in a variety of elegant arrangements.
+ * Jumpstart Description: Display image galleries in a variety of elegant arrangements.
  * First Introduced: 2.1
  * Requires Connection: No
  * Auto Activate: No
  * Module Tags: Photos and Videos
- * Feature: Appearance
+ * Feature: Appearance, Jumpstart
  * Sort Order: 24
  * Additional Search Queries: gallery, tiles, tiled, grid, mosaic, images
  */


### PR DESCRIPTION
Currently, if the site was jumpstarted, in order to activate TG a user would have to toggle this OFF and then ON again, which activates both Photon and Tiled Galleries.  

![screen shot 2017-04-04 at 11 30 32 am](https://cloud.githubusercontent.com/assets/7129409/24665028/29ce5c98-192a-11e7-963c-356f7382b2f5.png)

This happens because Photon is a Jumpstart module, and Tiled Gallery is not.  

If we make sure to activate both at the same time, even in Jumpstart, then there will be no disconnect between the two modules.  

To Test **In this order**:
- Disconnect Jetpack
- Reset options link in footer
- Connect the site
- Navigate back to the dashboard, you should see Jumpstart
- Click 'learn more' to view new box for TG
- Activate features
- make sure TG is active

