### PR TITLE
Settings UI: update wording in disconnection dialog

### DIFF
--- a/_inc/client/components/jetpack-disconnect-dialog/index.jsx
+++ b/_inc/client/components/jetpack-disconnect-dialog/index.jsx
@@ -46,7 +46,7 @@ export const JetpackDisconnectDialog = React.createClass( {
 						icon: 'history'
 					},
 					{
-						text: __( 'Priority WordPress and security support' ),
+						text: __( 'Priority support' ),
 						icon: 'chat'
 					},
 					{
@@ -66,7 +66,7 @@ export const JetpackDisconnectDialog = React.createClass( {
 						icon: 'spam'
 					},
 					{
-						text: __( 'Priority WordPress and security support' ),
+						text: __( 'Priority support' ),
 						icon: 'chat'
 					},
 					{
@@ -86,7 +86,7 @@ export const JetpackDisconnectDialog = React.createClass( {
 						icon: 'spam'
 					},
 					{
-						text: __( 'Priority WordPress and security support' ),
+						text: __( 'Priority support' ),
 						icon: 'chat'
 					},
 					{


### PR DESCRIPTION
Fixes #6864

#### Changes proposed in this Pull Request:

* remove reference to WordPress support

**Before**

<img width="461" alt="captura de pantalla 2017-04-04 a las 12 45 04" src="https://cloud.githubusercontent.com/assets/1041600/24665740/ae52a172-1934-11e7-85cd-2acfa82cfc54.png">

**After**

<img width="463" alt="captura de pantalla 2017-04-04 a las 12 44 43" src="https://cloud.githubusercontent.com/assets/1041600/24665745/b0c660ba-1934-11e7-803b-5655f0c4e7d9.png">

#### Testing instructions:

* check the disconnect dialog