### PR TITLE
Settings UI: auto-dismiss Jumpstart and other success notices

### DIFF
--- a/_inc/client/state/connection/actions.js
+++ b/_inc/client/state/connection/actions.js
@@ -32,8 +32,8 @@ export const fetchSiteConnectionStatus = () => {
 				siteConnected: siteConnected
 			} );
 		} );
-	}
-}
+	};
+};
 
 export const fetchConnectUrl = () => {
 	return ( dispatch ) => {
@@ -51,8 +51,8 @@ export const fetchConnectUrl = () => {
 				error: error
 			} );
 		} );
-	}
-}
+	};
+};
 
 export const fetchUserConnectionData = () => {
 	return ( dispatch ) => {
@@ -70,8 +70,8 @@ export const fetchUserConnectionData = () => {
 				error: error
 			} );
 		} );
-	}
-}
+	};
+};
 
 export const disconnectSite = () => {
 	return ( dispatch ) => {
@@ -101,8 +101,8 @@ export const disconnectSite = () => {
 				{ id: 'disconnect-jetpack' }
 			) );
 		} );
-	}
-}
+	};
+};
 
 export const unlinkUser = () => {
 	return ( dispatch ) => {
@@ -116,7 +116,7 @@ export const unlinkUser = () => {
 				userUnlinked: userUnlinked
 			} );
 			dispatch( removeNotice( 'unlink-user' ) );
-			dispatch( createNotice( 'is-success', __( 'Unlinked from WordPress.com.' ), { id: 'unlink-user' } ) );
+			dispatch( createNotice( 'is-success', __( 'Unlinked from WordPress.com.' ), { id: 'unlink-user', duration: 2000 } ) );
 		} ).catch( error => {
 			dispatch( {
 				type: UNLINK_USER_FAIL,
@@ -133,5 +133,5 @@ export const unlinkUser = () => {
 				{ id: 'unlink-user' }
 			) );
 		} );
-	}
-}
+	};
+};

--- a/_inc/client/state/dev-version/actions.js
+++ b/_inc/client/state/dev-version/actions.js
@@ -30,7 +30,7 @@ export const resetOptions = ( options ) => {
 				type: RESET_OPTIONS_SUCCESS
 			} );
 			dispatch( removeNotice( 'reset-options' ) );
-			dispatch( createNotice( 'is-success', __( 'Options reset.' ), { id: 'reset-options' } ) );
+			dispatch( createNotice( 'is-success', __( 'Options reset.' ), { id: 'reset-options', duration: 2000 } ) );
 		} ).catch( error => {
 			dispatch( {
 				type: RESET_OPTIONS_FAIL,
@@ -39,7 +39,7 @@ export const resetOptions = ( options ) => {
 			dispatch( removeNotice( 'reset-options' ) );
 			dispatch( createNotice( 'is-error', __( 'Options failed to reset.' ), { id: 'reset-options' } ) );
 		} );
-	}
+	};
 };
 
 export const enableDevCard = () => {
@@ -47,7 +47,7 @@ export const enableDevCard = () => {
 		dispatch( {
 			type: DEV_CARD_DISPLAY
 		} );
-	}
+	};
 };
 
 export const disableDevCard = () => {
@@ -55,7 +55,7 @@ export const disableDevCard = () => {
 		dispatch( {
 			type: DEV_CARD_HIDE
 		} );
-	}
+	};
 };
 
 export const switchPlanPreview = ( slug ) => {
@@ -64,7 +64,7 @@ export const switchPlanPreview = ( slug ) => {
 			type: JETPACK_SITE_DATA_FETCH_RECEIVE,
 			siteData: { plan: { product_slug: slug } }
 		} );
-	}
+	};
 };
 
 const adminMasterPerms = {
@@ -192,11 +192,10 @@ export const switchUserPermission = ( slug ) => {
 			type: MOCK_SWITCH_USER_PERMISSIONS,
 			initialState: userPerms
 		} );
-	}
+	};
 };
 
 export const switchThreats = count => {
-
 	return ( dispatch ) => {
 		dispatch( {
 			type: MOCK_SWITCH_THREATS,

--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -34,7 +34,7 @@ export const jumpStartActivate = () => {
 			} );
 			analytics.tracks.recordEvent( 'jetpack_wpa_jumpstart_submit', {} );
 			dispatch( removeNotice( 'jumpstart-activate' ) );
-			dispatch( createNotice( 'is-success', __( 'Recommended features active.' ), { id: 'jumpstart-activate' } ) );
+			dispatch( createNotice( 'is-success', __( 'Recommended features active.' ), { id: 'jumpstart-activate', duration: 2000 } ) );
 			dispatch( fetchModules() );
 		} ).catch( error => {
 			dispatch( {
@@ -52,8 +52,8 @@ export const jumpStartActivate = () => {
 				{ id: 'jumpstart-activate' }
 			) );
 		} );
-	}
-}
+	};
+};
 
 const history = createHistory();
 
@@ -75,5 +75,5 @@ export const jumpStartSkip = () => {
 				error: error
 			} );
 		} );
-	}
-}
+	};
+};

--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -99,7 +99,7 @@ export const activateModule = ( slug, reloadAfter = false ) => {
 						slug: getModule( getState(), slug ).name
 					}
 				} ),
-				{ id: 'module-toggle', duration: 3000 }
+				{ id: 'module-toggle', duration: 2000 }
 			) );
 			if ( reloadAfter ) {
 				window.location.reload();
@@ -156,7 +156,7 @@ export const deactivateModule = ( slug, reloadAfter = false ) => {
 						slug: getModule( getState(), slug ).name
 					}
 				} ),
-				{ id: 'module-toggle', duration: 3000 }
+				{ id: 'module-toggle', duration: 2000 }
 			) );
 			if ( reloadAfter ) {
 				window.location.reload();
@@ -218,7 +218,7 @@ export const updateModuleOptions = ( module, newOptionValues ) => {
 						slug: getModule( getState(), slug ).name
 					}
 				} ),
-				{ id: `module-setting-${ slug }` }
+				{ id: `module-setting-${ slug }`, duration: 2000 }
 			) );
 		} ).catch( error => {
 			dispatch( {
@@ -283,7 +283,7 @@ export const regeneratePostByEmailAddress = () => {
 						slug: getModule( getState(), slug ).name
 					}
 				} ),
-				{ id: `module-setting-${ slug }` }
+				{ id: `module-setting-${ slug }`, duration: 2000 }
 			) );
 		} ).catch( error => {
 			dispatch( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* dismiss notice shown after a process ends successfully like other success notices are dismissed:
    - Jumpstart
    - Reset options
    - Unlink user
* solve minor ESLint notices

#### Testing instructions:

**Jumpstart**
- Disconnect Jetpack
- Reset options link in footer
- Connect the site
- Navigate back to the dashboard, you should see Jumpstart
- Click 'Activate recommended features'
- Once it ends, you should see a green success notice that should be automattically hidden after 2 seconds

**Reset options**
- click the link `Reset Options (dev only)`
- the green notice should be auto-dismissed

**Unlink user**
- link a secondary user
- unlink it. The green notice should be auto-dismissed