### PR TITLE
Add listeners for comment approval and unapproval actions

### DIFF
--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -23,6 +23,21 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'trashed_post_comments', $callable, 10, 2 );
 		add_action( 'untrash_post_comments', $callable );
 
+		//Comment state transitions for tracking in Activity Log
+		$comment_state_transitions = [
+			'comment_approved_to_unapproved',
+			'comment_approved_to_trash',
+			'comment_approved_to_delete',
+			'comment_approved_to_trash',
+			'comment_approved_to_trash',
+			'comment_trash_to_approved',
+			'comment_approved_to_spam',
+			'comment_approved_to_delete',
+		];
+		foreach ( $comment_state_transitions as $state ) {
+			add_action( $state, $callable );
+		}
+
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data
 		// so this saves us a DB read for every comment event

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -22,21 +22,8 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'spammed_comment', $callable );
 		add_action( 'trashed_post_comments', $callable, 10, 2 );
 		add_action( 'untrash_post_comments', $callable );
-
-		//Comment state transitions for tracking in Activity Log
-		$comment_state_transitions = [
-			'comment_approved_to_unapproved',
-			'comment_approved_to_trash',
-			'comment_approved_to_delete',
-			'comment_approved_to_trash',
-			'comment_approved_to_trash',
-			'comment_trash_to_approved',
-			'comment_approved_to_spam',
-			'comment_approved_to_delete',
-		];
-		foreach ( $comment_state_transitions as $state ) {
-			add_action( $state, $callable );
-		}
+		add_action( 'comment_approved_to_unapproved', $callable );
+		add_action( 'comment_unapproved_to_approved', $callable );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -63,9 +63,13 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( 0, $remote_comment->comment_approved );
 
-		$event = $this->server_event_storage->get_most_recent_event( 'comment_unapproved_' );
+		$comment_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_unapproved_' );
 
-		$this->assertTrue( (bool) $event );
+		$this->assertTrue( (bool) $comment_unapproved_event );
+
+		$comment_approved_to_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_approved_to_unapproved' );
+
+		$this->assertTrue( (bool) $comment_approved_to_unapproved_event );
 
 		//Make sure we don't get the same event about the comment changing state
 
@@ -75,10 +79,13 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'comment_unapproved_' );
+		$comment_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_unapproved_' );
 
-		$this->assertTrue( (bool) $event );
+		$this->assertTrue( (bool) $comment_unapproved_event );
 
+		$comment_approved_to_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_approved_to_unapproved' );
+
+		$this->assertFalse( (bool) $comment_approved_to_unapproved_event );
 	}
 
 	public function test_trash_comment_trashes_data() {

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -50,41 +50,32 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	public function test_unapprove_comment() {
 
 		$this->assertEquals( 1, $this->server_replica_storage->comment_count( 'approve' ) );
-
 		$this->comment->comment_approved = 0;
-
 		wp_update_comment( (array) $this->comment );
 
 		$this->sender->do_sync();
 
+		//Test both sync actions we're expecting
 		$this->assertEquals( 0, $this->server_replica_storage->comment_count( 'approve' ) );
-
 		$remote_comment = $this->server_replica_storage->get_comment( $this->comment->comment_ID );
-
 		$this->assertEquals( 0, $remote_comment->comment_approved );
-
 		$comment_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_unapproved_' );
-
 		$this->assertTrue( (bool) $comment_unapproved_event );
 
 		$comment_approved_to_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_approved_to_unapproved' );
-
 		$this->assertTrue( (bool) $comment_approved_to_unapproved_event );
 
-		//Make sure we don't get the same event about the comment changing state
+		//Test both sync actions again, this time without causing a change in state (comment_unapproved_ remains true despite no state change, while comment_approved_to_unapproved does not)
 
 		$this->server_event_storage->reset();
 
 		wp_update_comment( (array) $this->comment );
-
 		$this->sender->do_sync();
 
 		$comment_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_unapproved_' );
-
 		$this->assertTrue( (bool) $comment_unapproved_event );
 
 		$comment_approved_to_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_approved_to_unapproved' );
-
 		$this->assertFalse( (bool) $comment_approved_to_unapproved_event );
 	}
 


### PR DESCRIPTION
This PR adds sync listeners for the `comment_approved_to_unapproved` and `comment_unapproved_to_approved` actions to the Comments Sync Module for the purpose of reporting these events to the Activity Log.

#### Changes proposed in this Pull Request:

* adds sync listeners for the `comment_approved_to_unapproved` and `comment_unapproved_to_approved` actions to the Comments Sync Module

#### Testing instructions:

* run `phpunit --filter comment`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
