### PR TITLE
Settings UI: update support links for AT sites

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -15,7 +15,10 @@ import analytics from 'lib/analytics';
 import {
 	PLAN_JETPACK_PERSONAL
 } from 'lib/plans/constants';
-import { getSiteRawUrl } from 'state/initial-state';
+import {
+	getSiteRawUrl,
+	isAutomatedTransfer
+} from 'state/initial-state';
 import {
 	getSitePlan,
 	isFetchingSiteData
@@ -81,12 +84,20 @@ const SupportCard = React.createClass( {
 						<p className="jp-support-card__description">
 							<Button
 								onClick={ this.trackAskQuestionClick }
-								href="https://jetpack.com/contact-support/">
+								href={ this.props.isAutomatedTransfer
+									? 'https://wordpress.com/help/contact/'
+									: 'https://jetpack.com/contact-support/'
+								}
+							>
 								{ __( 'Ask a question' ) }
 							</Button>
 							<Button
 								onClick={ this.trackSearchClick }
-								href="https://jetpack.com/support/">
+								href={ this.props.isAutomatedTransfer
+									? 'https://wordpress.com/help/'
+									: 'https://jetpack.com/support/'
+								}
+							>
 								{ __( 'Search our support site' ) }
 							</Button>
 						</p>
@@ -117,7 +128,8 @@ export default connect(
 		return {
 			sitePlan: getSitePlan( state ),
 			siteRawUrl: getSiteRawUrl( state ),
-			isFetchingSiteData: isFetchingSiteData( state )
+			isFetchingSiteData: isFetchingSiteData( state ),
+			isAutomatedTransfer: isAutomatedTransfer( state )
 		};
 	}
 )( SupportCard );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -199,6 +199,17 @@ export function arePromotionsActive( state ) {
 }
 
 /**
+ * Check if the site is an Automated Transfer site.
+ *
+ * @param {Object} state   Global state tree.
+ *
+ * @return {boolean} True if this is an AT site, false otherwise.
+ */
+export function isAutomatedTransfer( state ) {
+	return get( state.jetpack.initialState.siteData, 'isAutomatedTransfer', false );
+}
+
+/**
  * Check that theme supports a certain feature
  *
  * @param {Object} state   Global state tree.

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -299,6 +299,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 * @param bool $are_promotions_active Status of promotions visibility. True by default.
 				 */
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
+				'isAutomatedTransfer' => jetpack_is_automated_transfer_site(),
 			),
 			'themeData' => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/functions.global.php
+++ b/functions.global.php
@@ -8,3 +8,23 @@
  * Please namespace with jetpack_
  * Please write docblocks
  */
+
+/**
+ * Disable direct access.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Determine if this site is an AT site or not looking first at the 'at_options' option.
+ * As a fallback, check for presence of wpcomsh plugin to determine if a current site has undergone AT.
+ *
+ * @since 4.8.1
+ *
+ * @return bool
+ */
+function jetpack_is_automated_transfer_site() {
+	$at_options = get_option( 'at_options', array() );
+	return ! empty( $at_options ) || defined( 'WPCOMSH__PLUGIN_FILE' );
+}

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -68,17 +68,7 @@ class A8C_WPCOM_Masterbar {
 	}
 
 	public function is_automated_transfer_site() {
-		$at_options = get_option( 'at_options', array() );
-
-		if ( ! empty( $at_options ) ) {
-			return true;
-		}
-		// As fallback, check for presence of wpcomsh plugin to determine if a current site has undergone AT.
-		if ( defined( 'WPCOMSH__PLUGIN_FILE' ) ) {
-			return true;
-		}
-
-		return false;
+		return jetpack_is_automated_transfer_site();
 	}
 
 	public function maybe_logout_user_from_wpcom() {


### PR DESCRIPTION
Fixes #6874

#### Changes proposed in this Pull Request:

* update support links based on whether the site is an Automated Transfer site or a standalone site
* Initial State: add information about whether the site is an Automated Transfer site or not, and reducer to obtain the info.
* extract code from method 'is_automated_transfer_site' and create a new function visible from everywhere. Preserve the method and call the function in it.

#### Testing instructions:

* make sure support links are correct in standalone sites and in AT site
* make sure Masterbar continues working normally

