### PR TITLE
Sync: Sidebar changes

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -14,6 +14,7 @@ class Jetpack_Sync_Defaults {
 		'permalink_structure',
 		'category_base',
 		'tag_base',
+		'sidebars_widgets',
 		'comment_moderation',
 		'default_comment_status',
 		'page_on_front',

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -115,11 +115,12 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	function sync_widgets_reordered( $new_widgets, $old_widgets, $sidebar ) {
-		if ( ! empty( array_diff( $old_widgets, $new_widgets ) ) ) {
+		$added_widgets = array_diff( $new_widgets, $old_widgets );
+		if ( ! empty( $added_widgets ) ) {
 			return;
 		}
-
-		if ( ! empty( array_diff( $new_widgets, $old_widgets ) ) ) {
+		$removed_widgets = array_diff( $old_widgets, $new_widgets );
+		if ( ! empty( $removed_widgets ) ) {
 			return;
 		}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -65,7 +65,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	function sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar ) {
-
+		$added_widgets = array_diff( $new_widgets, $old_widgets );
 		if ( empty( $added_widgets ) ) {
 			return array();
 		}
@@ -150,20 +150,16 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			if ( in_array( $sidebar, array( 'array_version', 'wp_inactive_widgets' ) ) ) {
 				continue;
 			}
-
 			$old_widgets = $old_value[ $sidebar ];
 
-			$moved_to_sidebar = array_merge(
-				$moved_to_sidebar,
-				$this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar )
-			);
+			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
+			$moved_to_inactive = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
 
-			$moved_to_inactive = array_merge(
-				$moved_to_inactive,
-				$this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] )
-			);
 
-			$this->sync_widgets_reordered( $new_widgets, $old_widgets );
+			$moved_to_sidebar_recently = $this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar );
+			$moved_to_sidebar = array_merge( $moved_to_sidebar, $moved_to_sidebar_recently );
+
+			$this->sync_widgets_reordered( $new_widgets, $old_widgets, $sidebar );
 
 		}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -10,7 +10,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_sync_current_theme_support', $callable );
 
 		// Sidebar updates.
-		add_action( "update_option_sidebars_widgets", array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );
+		add_action( 'update_option_sidebars_widgets', array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );
 		add_action( 'jetpack_widget_added', $callable, 10, 2 );
 		add_action( 'jetpack_widget_removed', $callable, 10, 2 );
 		add_action( 'jetpack_widget_moved_to_inactive', $callable );
@@ -86,7 +86,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 				foreach( $added_widgets as $added_widget ) {
 					$moved_to_sidebar[] = $added_widget;
 					/**
-					 * Helps Sync log that a widget got add
+					 * Helps Sync log that a widget got added
 					 *
 					 * @since 4.9.0
 					 *
@@ -103,7 +103,6 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 					// lets check if we didn't move the widget to in_active_widgets
 
 					if ( isset( $new_value['wp_inactive_widgets'] ) && ! in_array( $removed_widget, $new_value['wp_inactive_widgets'] ) ) {
-						echo "remove....";
 						/**
 						 * Helps Sync log that a widgte got removed
 						 *

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -169,6 +169,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'advanced_seo_front_page_description'  => 'banana', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 			'advanced_seo_title_formats'           => array( 'posts' => array( 'type' => 'string', 'value' => 'test' ) ), // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 			'jetpack_api_cache_enabled'            => '1',
+			'sidebars_widgets'                     => array(),
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -169,7 +169,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'advanced_seo_front_page_description'  => 'banana', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 			'advanced_seo_title_formats'           => array( 'posts' => array( 'type' => 'string', 'value' => 'test' ) ), // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 			'jetpack_api_cache_enabled'            => '1',
-			'sidebars_widgets'                     => array(),
+			'sidebars_widgets'                     => array( 'array_version' => 3 ),
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
This PR lets us sync changes as they happen to the sidebar.

Currently we don't have enough info that will let us see what is happening to the sidebar.

#### Changes proposed in this Pull Request:
* Add actions that get fired when the widgets get added, removed and reorder a sidebar.
* Also lets us know when we move a widget to the in active widgets as well as when we 

#### Testing instructions:
* Do the test pass? 
* Does it make do the actions get synced on the .com side as expected?
