### PR TITLE
Fixes sitemaps PHP compatibility issue.

### DIFF
--- a/modules/sitemaps/sitemap-state.php
+++ b/modules/sitemaps/sitemap-state.php
@@ -84,7 +84,8 @@ class Jetpack_Sitemap_State {
 	 */
 	public static function check_in( $state ) {
 		// Get the old max value.
-		$state['max'] = get_option( 'jetpack-sitemap-state', self::initial() )['max'];
+		$sitemap_old = get_option( 'jetpack-sitemap-state', self::initial() );
+		$state['max'] = $sitemap_old['max'];
 
 		// Update the max value of the current type.
 		$state['max'][ $state['sitemap-type'] ]['number']  = $state['number'];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
 			<file>tests/php/test_class.jetpack-constants.php</file>
 			<file>tests/php/test_class.jetpack-connection-banner.php</file>
 			<file>tests/php/test_class.jetpack-options.php</file>
+			<file>tests/php/test_php-lint.php</file>
 		</testsuite>
 		<testsuite name="core-api">
 			<directory phpVersion="5.6.0" phpVersionOperator=">=" prefix="test_" suffix=".php">tests/php/core-api</directory>

--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -1,0 +1,20 @@
+<?php
+
+class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
+
+	/**
+	 * Props to cfinke for the amazing piece of code.
+	 * @author zinigor
+	 * @since 4.8.1
+	 */
+	public function test_php_lint() {
+		$command =
+			'for file in `find . -name "*.php"`; '
+			. 'do php -l "$file" | grep -v "No syntax errors detected"; '
+			. 'done';
+
+		exec( $command, $output );
+
+		$this->assertEmpty( $output );
+	}
+}

--- a/tests/php/test_php-lint.php
+++ b/tests/php/test_php-lint.php
@@ -10,11 +10,15 @@ class WP_Test_Jetpack_PHP_Lint extends WP_UnitTestCase {
 	public function test_php_lint() {
 		$command =
 			'for file in `find . -name "*.php"`; '
-			. 'do php -l "$file" | grep -v "No syntax errors detected"; '
+			. 'do php -l "$file" | '
+			. 'grep -v "No syntax errors detected" | '
+			. 'grep -v "./tools/" | '
+			. 'grep -v "jetpack-cli.php" | '
+			. 'grep -v -e \'^$\'; '
 			. 'done';
 
 		exec( $command, $output );
 
-		$this->assertEmpty( $output );
+		$this->assertEmpty( $output, join( PHP_EOL, $output ) );
 	}
 }


### PR DESCRIPTION
Fixes #6918 

#### Changes proposed in this Pull Request:
* Fixes array dereference in the sitemaps code.
* Adds a unit test to run linting on all PHP files in the plugin, huge props co @cfinke for the suggestion and the code.

#### Testing instructions:
* Make sure Sitemaps work as they did before.
* See if Travis runs OK for all PHP versions.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Made changes to the code to make it compatible with PHP versions older than 5.4.