### PR TITLE
Related Posts: Fix fatal when the exclusion parameter is not a string

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -125,7 +125,13 @@ class Jetpack_RelatedPosts {
 		if ( isset( $_GET['relatedposts'] ) ) {
 			$excludes = array();
 			if ( isset( $_GET['relatedposts_exclude'] ) ) {
-				$excludes = explode( ',', $_GET['relatedposts_exclude'] );
+				if ( is_string( $_GET['relatedposts_exclude'] ) ) {
+					$excludes = explode( ',', $_GET['relatedposts_exclude'] );
+				} elseif ( is_array( $_GET['relatedposts_exclude'] ) ) {
+					$excludes = array_values( $_GET['relatedposts_exclude'] );
+				}
+
+				$excludes = array_unique( array_filter( array_map( 'absint', $excludes ) ) );
 			}
 
 			$this->_action_frontend_init_ajax( $excludes );


### PR DESCRIPTION
Some requests for related posts are using a malformed URL where the
`relatedposts_exclude` parameter is of type array, not of type string, causing
`explode()` to fatal.

This change checks the type of the `relatedpost_exclude` parameter, and will
perform the original `explode()` if it is a string; or extract the values if
it's an array. We sanitize the values to ensure they are valid ints for use as
`$excludes`.

Props @jmdodd

Fixes #N/A

#### Changes proposed in this Pull Request:

* Sanitize values and handle both comma delimited values as well as url arrays

#### Testing instructions:

* Check that the URL param `relatedposts_exclude[]=X` and `relatedposts_exclude=X` both exclude post_id X.
