### PR TITLE
Jetpack Sync: Listen to 'edit_comment' action

### DIFF
--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -24,6 +24,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'untrash_post_comments', $callable );
 		add_action( 'comment_approved_to_unapproved', $callable );
 		add_action( 'comment_unapproved_to_approved', $callable );
+		add_action( 'edit_comment', $callable );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -24,7 +24,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'untrash_post_comments', $callable );
 		add_action( 'comment_approved_to_unapproved', $callable );
 		add_action( 'comment_unapproved_to_approved', $callable );
-		add_action( 'edit_comment', $callable );
+		add_action( 'edit_comment', $callable, 10, 2 );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -45,6 +45,10 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$remote_comment = $this->server_replica_storage->get_comment( $this->comment->comment_ID );
 
 		$this->assertEquals( "foo bar baz", $remote_comment->comment_content );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'edit_comment' );
+		$this->assertTrue( (bool) $event );
+
 	}
 
 	public function test_unapprove_comment() {


### PR DESCRIPTION
Adds a sync listener to the 'edit_comment' action to the Jetpack Sync Comments module so that the Activity Log can report when a comment is edited.

#### Changes proposed in this Pull Request:

* Addition of listener to 'edit_comment' action to Jetpack Sync Comments module

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
