### PR TITLE
Sync some unit tests up with WPCOM versions.

### DIFF
--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -7,6 +7,15 @@
  * @package wordpress-plugin-tests
  */
 
+/**
+ * For tests that should be skipped in Jetpack but run in WPCOM (or vice versa), test against this constant.
+ *
+ *	if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
+ *		self::markTestSkipped( 'This test only runs on WPCOM' );
+ *	}
+ */
+define( 'TESTING_IN_JETPACK', true );
+
 // Support for:
 // 1. `WP_DEVELOP_DIR` environment variable
 // 2. Plugin installed inside of WordPress.org developer checkout

--- a/tests/php/modules/shortcodes/test_class.flickr.php
+++ b/tests/php/modules/shortcodes/test_class.flickr.php
@@ -106,6 +106,9 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 	 * Shortcode reversals.
 	 */
 	public function test_shortcodes_flickr_reversal_iframe_to_link() {
+		if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
+			self::markTestSkipped( 'This test only runs on WPCOM' );
+		}
 		$content = '<iframe src="http://www.flickr.com/photos/batmoo/5265478228/player/" height="500" width="375"  frameborder="0" allowfullscreen webkitallowfullscreen mozallowfullscreen oallowfullscreen msallowfullscreen></iframe>';
 
 		$shortcode_content = wp_kses_post( $content );

--- a/tests/php/modules/shortcodes/test_class.flickr.php
+++ b/tests/php/modules/shortcodes/test_class.flickr.php
@@ -3,19 +3,12 @@
 class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
-	 * @author scotchfield
-	 * @covers ::flickr_shortcode_handler
-	 * @since 3.2
+	 * [flickr] shortcode.
 	 */
 	public function test_shortcodes_flickr_exists() {
 		$this->assertEquals( shortcode_exists( 'flickr' ), true );
 	}
 
-	/**
-	 * @author scotchfield
-	 * @covers ::flickr_shortcode_handler
-	 * @since 3.2
-	 */
 	public function test_shortcodes_flickr() {
 		$content = '[flickr]';
 
@@ -24,43 +17,28 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertNotEquals( $content, $shortcode_content );
 	}
 
-	/**
-	 * @author scotchfield
-	 * @covers ::flickr_shortcode_handler
-	 * @since 3.2
-	 */
 	public function test_shortcodes_flickr_video_http() {
-		$user = 'chaddles';
+		$user     = 'chaddles';
 		$video_id = '2402990826';
-		$content = '[flickr video=http://flickr.com/photos/' . $user . '/' . $video_id . '/]';
+		$content  = '[flickr video=http://flickr.com/photos/' . $user . '/' . $video_id . '/]';
 
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( $video_id, $shortcode_content );
 	}
 
-	/**
-	 * @author scotchfield
-	 * @covers ::flickr_shortcode_handler
-	 * @since 3.2
-	 */
 	public function test_shortcodes_flickr_video_id() {
 		$video_id = '2402990826';
-		$content = '[flickr video=' . $video_id . ']';
+		$content  = '[flickr video=' . $video_id . ']';
 
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( $video_id, $shortcode_content );
 	}
 
-	/**
-	 * @author scotchfield
-	 * @covers ::flickr_shortcode_handler
-	 * @since 3.2
-	 */
 	public function test_shortcodes_flickr_video_id_show_info() {
 		$video_id = '2402990826';
-		$content = '[flickr video=' . $video_id . ' show_info=no]';
+		$content  = '[flickr video=' . $video_id . ' show_info=no]';
 
 		$shortcode_content = do_shortcode( $content );
 
@@ -68,16 +46,11 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertContains( 'flickr_show_info_box=false', $shortcode_content );
 	}
 
-	/**
-	 * @author scotchfield
-	 * @covers ::flickr_shortcode_handler
-	 * @since 3.2
-	 */
 	public function test_shortcodes_flickr_video_id_width_height() {
 		$video_id = '2402990826';
-		$width = 200;
-		$height = 150;
-		$content = '[flickr video=' . $video_id . ' w=' . $width . ' h=' . $height . ']';
+		$width    = 200;
+		$height   = 150;
+		$content  = '[flickr video=' . $video_id . ' w=' . $width . ' h=' . $height . ']';
 
 		$shortcode_content = do_shortcode( $content );
 
@@ -86,15 +59,10 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertContains( 'height="' . $height . '"', $shortcode_content );
 	}
 
-	/**
-	 * @author scotchfield
-	 * @covers ::flickr_shortcode_handler
-	 * @since 3.2
-	 */
 	public function test_shortcodes_flickr_video_id_show_info_secret() {
 		$video_id = '2402990826';
-		$secret = '846d9c1be9';
-		$content = '[flickr video=' . $video_id . ' secret=' . $secret . ']';
+		$secret   = '846d9c1be9';
+		$content  = '[flickr video=' . $video_id . ' secret=' . $secret . ']';
 
 		$shortcode_content = do_shortcode( $content );
 
@@ -102,4 +70,22 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertContains( 'secret=' . $secret, $shortcode_content );
 	}
 
+	/**
+	 * Shortcode reversals.
+	 */
+	public function test_shortcodes_flickr_reversal_iframe_to_link() {
+		$content = '<iframe src="http://www.flickr.com/photos/batmoo/5265478228/player/" height="500" width="375"  frameborder="0" allowfullscreen webkitallowfullscreen mozallowfullscreen oallowfullscreen msallowfullscreen></iframe>';
+
+		$shortcode_content = wp_kses_post( $content );
+
+		$this->assertEquals( $shortcode_content, '<a href="http://www.flickr.com/photos/batmoo/5265478228/player/">http://www.flickr.com/photos/batmoo/5265478228/player/</a>' );
+	}
+
+	public function test_shortcodes_flickr_reversal_embed_to_shortcode() {
+		$content = '<object type="application/x-shockwave-flash" width="400" height="300" data="http://www.flickr.com/apps/video/stewart.swf?v=71377" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000"> <param name="flashvars" value="intl_lang=en-us&photo_secret=846d9c1be9&photo_id=2345938910"></param> <param name="movie" value="http://www.flickr.com/apps/video/stewart.swf?v=71377"></param> <param name="bgcolor" value="#000000"></param> <param name="allowFullScreen" value="true"></param><embed type="application/x-shockwave-flash" src="http://www.flickr.com/apps/video/stewart.swf?v=71377" bgcolor="#000000" allowfullscreen="true" flashvars="intl_lang=en-us&photo_secret=846d9c1be9&photo_id=2345938910" height="300" width="400"></embed></object>';
+
+		$shortcode_content = wp_kses_post( $content );
+
+		$this->assertEquals( $shortcode_content, '[flickr video=2345938910 secret=846d9c1be9 w=400 h=300]' );
+	}
 }

--- a/tests/php/modules/shortcodes/test_class.flickr.php
+++ b/tests/php/modules/shortcodes/test_class.flickr.php
@@ -3,12 +3,19 @@
 class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 	/**
-	 * [flickr] shortcode.
+	 * @author scotchfield
+	 * @covers ::flickr_shortcode_handler
+	 * @since 3.2
 	 */
 	public function test_shortcodes_flickr_exists() {
 		$this->assertEquals( shortcode_exists( 'flickr' ), true );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::flickr_shortcode_handler
+	 * @since 3.2
+	 */
 	public function test_shortcodes_flickr() {
 		$content = '[flickr]';
 
@@ -17,6 +24,11 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertNotEquals( $content, $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::flickr_shortcode_handler
+	 * @since 3.2
+	 */
 	public function test_shortcodes_flickr_video_http() {
 		$user     = 'chaddles';
 		$video_id = '2402990826';
@@ -27,6 +39,11 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertContains( $video_id, $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::flickr_shortcode_handler
+	 * @since 3.2
+	 */
 	public function test_shortcodes_flickr_video_id() {
 		$video_id = '2402990826';
 		$content  = '[flickr video=' . $video_id . ']';
@@ -36,6 +53,11 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertContains( $video_id, $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::flickr_shortcode_handler
+	 * @since 3.2
+	 */
 	public function test_shortcodes_flickr_video_id_show_info() {
 		$video_id = '2402990826';
 		$content  = '[flickr video=' . $video_id . ' show_info=no]';
@@ -46,6 +68,11 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertContains( 'flickr_show_info_box=false', $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::flickr_shortcode_handler
+	 * @since 3.2
+	 */
 	public function test_shortcodes_flickr_video_id_width_height() {
 		$video_id = '2402990826';
 		$width    = 200;
@@ -59,6 +86,11 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 		$this->assertContains( 'height="' . $height . '"', $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::flickr_shortcode_handler
+	 * @since 3.2
+	 */
 	public function test_shortcodes_flickr_video_id_show_info_secret() {
 		$video_id = '2402990826';
 		$secret   = '846d9c1be9';

--- a/tests/php/modules/shortcodes/test_class.slideshare.php
+++ b/tests/php/modules/shortcodes/test_class.slideshare.php
@@ -2,20 +2,10 @@
 
 class WP_Test_Jetpack_Shortcodes_Slideshare extends WP_UnitTestCase {
 
-	/**
-	 * @author scotchfield
-	 * @covers ::slideshare_shortcode
-	 * @since 3.2
-	 */
 	public function test_shortcodes_slideshare_exists() {
 		$this->assertEquals( shortcode_exists( 'slideshare' ), true );
 	}
 
-	/**
-	 * @author scotchfield
-	 * @covers ::slideshare_shortcode
-	 * @since 3.2
-	 */
 	public function test_shortcodes_slideshare() {
 		$content = '[slideshare]';
 
@@ -24,4 +14,35 @@ class WP_Test_Jetpack_Shortcodes_Slideshare extends WP_UnitTestCase {
 		$this->assertNotEquals( $content, $shortcode_content );
 	}
 
+	public function test_shortcodes_slideshare_id() {
+		$content = '[slideshare id=5342235]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertNotEquals( $content, $shortcode_content );
+	}
+
+	public function test_shortcodes_slideshare_id_content() {
+		$content = '[slideshare id=5342235]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals( 0, strpos( $shortcode_content, "<iframe src='https://www.slideshare.net/slideshow/embed_code/5342235'" ) );
+	}
+
+	public function test_shortcodes_slideshare_fb_arg() {
+		$content = '[slideshare id=5342235&amp;fb=0&amp;mw=0&amp;mh=0&amp;sc=no]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals( ! false, strpos( $shortcode_content, 'frameborder' ) );
+	}
+
+	public function test_shortcodes_slideshare_no_fb_arg() {
+		$content = '[slideshare id=5342235&amp;mw=0&amp;mh=0&amp;sc=no]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertEquals( false, strpos( $shortcode_content, 'frameborder' ) );
+	}
 }

--- a/tests/php/modules/shortcodes/test_class.slideshare.php
+++ b/tests/php/modules/shortcodes/test_class.slideshare.php
@@ -2,10 +2,20 @@
 
 class WP_Test_Jetpack_Shortcodes_Slideshare extends WP_UnitTestCase {
 
+	/**
+	 * @author scotchfield
+	 * @covers ::slideshare_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_slideshare_exists() {
 		$this->assertEquals( shortcode_exists( 'slideshare' ), true );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::slideshare_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_slideshare() {
 		$content = '[slideshare]';
 

--- a/tests/php/modules/shortcodes/test_class.slideshow.php
+++ b/tests/php/modules/shortcodes/test_class.slideshow.php
@@ -10,13 +10,13 @@ class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 		}
 
 		// Otherwise, create the two images we're going to be using ourselves!
-		$a1 = self::factory()->attachment->create_object( array(
+		$a1 = self::factory()->attachment->create_object( 'image1.jpg', 0, array(
 			'file'           => 'image1.jpg',
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',
 		) );
 
-		$a2 = self::factory()->attachment->create_object( array(
+		$a2 = self::factory()->attachment->create_object( 'image1.jpg', 0, array(
 			'file'           => 'image2.jpg',
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',

--- a/tests/php/modules/shortcodes/test_class.slideshow.php
+++ b/tests/php/modules/shortcodes/test_class.slideshow.php
@@ -2,6 +2,29 @@
 
 class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 
+	protected function setUp() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			switch_to_blog( 104104364 ); // test.wordpress.com
+			$this->IDs = '161,162';
+			return;
+		}
+
+		// Otherwise, create the two images we're going to be using ourselves!
+		$a1 = self::factory()->attachment->create_object( array(
+			'file'           => 'image1.jpg',
+			'post_mime_type' => 'image/jpeg',
+			'post_type'      => 'attachment',
+		) );
+
+		$a2 = self::factory()->attachment->create_object( array(
+			'file'           => 'image2.jpg',
+			'post_mime_type' => 'image/jpeg',
+			'post_type'      => 'attachment',
+		) );
+
+		$this->IDs = "{$a1},{$a2}";
+	}
+
 	/**
 	 * @author scotchfield
 	 * @covers Jetpack_Slideshow_Shortcode::shortcode_callback
@@ -25,9 +48,7 @@ class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 	}
 
 	public function test_shortcodes_slideshow_no_js() {
-		switch_to_blog( 104104364 ); // test.wordpress.com
-
-		$content = '[gallery type="slideshow" ids="161,162"]';
+		$content = '[gallery type="slideshow" ids="' . $this->IDs . '"]';
 
 		$shortcode_content = do_shortcode( $content );
 
@@ -35,9 +56,7 @@ class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 	}
 
 	public function test_shortcodes_slideshow_html() {
-		switch_to_blog( 104104364 ); // test.wordpress.com
-
-		$content = '[gallery type="slideshow" ids="161,162"]';
+		$content = '[gallery type="slideshow" ids="' . $this->IDs . '"]';
 
 		$shortcode_content = do_shortcode( $content );
 
@@ -45,9 +64,7 @@ class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 	}
 
 	public function test_shortcodes_slideshow_autostart_off() {
-		switch_to_blog( 104104364 ); // test.wordpress.com
-
-		$content = '[gallery type="slideshow" ids="161,162" autostart="false"]';
+		$content = '[gallery type="slideshow" ids="' . $this->IDs . '" autostart="false"]';
 
 		$shortcode_content = do_shortcode( $content );
 
@@ -55,9 +72,7 @@ class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 	}
 
 	public function test_shortcodes_slideshow_autostart_on() {
-		switch_to_blog( 104104364 ); // test.wordpress.com
-
-		$content = '[gallery type="slideshow" ids="161,162" autostart="true"]';
+		$content = '[gallery type="slideshow" ids="' . $this->IDs . '" autostart="true"]';
 
 		$shortcode_content = do_shortcode( $content );
 

--- a/tests/php/modules/shortcodes/test_class.slideshow.php
+++ b/tests/php/modules/shortcodes/test_class.slideshow.php
@@ -3,7 +3,7 @@
 class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 
 	public function setUp() {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		if ( ! defined( 'TESTING_IN_JETPACK' ) || ! TESTING_IN_JETPACK ) {
 			switch_to_blog( 104104364 ); // test.wordpress.com
 			$this->IDs = '161,162';
 			return;

--- a/tests/php/modules/shortcodes/test_class.slideshow.php
+++ b/tests/php/modules/shortcodes/test_class.slideshow.php
@@ -2,7 +2,7 @@
 
 class WP_Test_Jetpack_Shortcodes_Slideshow extends WP_UnitTestCase {
 
-	protected function setUp() {
+	public function setUp() {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			switch_to_blog( 104104364 ); // test.wordpress.com
 			$this->IDs = '161,162';

--- a/tests/php/modules/shortcodes/test_class.soundcloud.php
+++ b/tests/php/modules/shortcodes/test_class.soundcloud.php
@@ -2,20 +2,10 @@
 
 class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 
-	/**
-	 * @author scotchfield
-	 * @covers ::soundcloud_shortcode
-	 * @since 3.2
-	 */
 	public function test_shortcodes_soundcloud_exists() {
 		$this->assertEquals( shortcode_exists( 'soundcloud' ), true );
 	}
 
-	/**
-	 * @author scotchfield
-	 * @covers ::soundcloud_shortcode
-	 * @since 3.2
-	 */
 	public function test_shortcodes_soundcloud() {
 		$content = '[soundcloud]';
 
@@ -24,4 +14,12 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 		$this->assertNotEquals( $content, $shortcode_content );
 	}
 
+	public function test_shortcodes_soundcloud_html() {
+		$content = '[soundcloud url="https://api.soundcloud.com/tracks/156661852" params="auto_play=false&amp;hide_related=false&amp;visual=true" width="100%" height="450" iframe="true" /]';
+
+		$shortcode_content = do_shortcode( $content );
+
+		$this->assertContains( '<iframe width="100%" height="450"', $shortcode_content );
+		$this->assertContains( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&visual=true&auto_play=false&hide_related=false', $shortcode_content );
+	}
 }

--- a/tests/php/modules/shortcodes/test_class.soundcloud.php
+++ b/tests/php/modules/shortcodes/test_class.soundcloud.php
@@ -2,6 +2,9 @@
 
 class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 
+	/**
+	 * Shortcode.
+	 */
 	public function test_shortcodes_soundcloud_exists() {
 		$this->assertEquals( shortcode_exists( 'soundcloud' ), true );
 	}
@@ -21,5 +24,29 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 
 		$this->assertContains( '<iframe width="100%" height="450"', $shortcode_content );
 		$this->assertContains( 'w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F156661852&visual=true&auto_play=false&hide_related=false', $shortcode_content );
+	}
+
+	/**
+	 * Shortcode reversals.
+	 */
+	public function test_shortcodes_soundcloud_reversal_player() {
+		$content = '<iframe width="100%" height="450" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/4142297&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>';
+
+		$shortcode_content = jetpack_soundcloud_embed_reversal( $content );
+		$shortcode_content = str_replace( "\n", '', $shortcode_content );
+
+		$this->assertEquals( $shortcode_content, '[soundcloud url="https://api.soundcloud.com/playlists/4142297" params="auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true" width="100%" height="450" iframe="true" /]' );
+	}
+
+	public function test_shortcodes_soundcloud_reversal_embed() {
+		$content = '<object height="81" width="100%">
+				<param name="movie" value="https://player.soundcloud.com/player.swf?url=http://api.soundcloud.com/tracks/70198773" />
+				<param name="allowscriptaccess" value="always" />
+				<embed allowscriptaccess="always" height="81" src="https://player.soundcloud.com/player.swf?url=http://api.soundcloud.com/tracks/70198773" type="application/x-shockwave-flash" width="100%"></embed>
+			</object>';
+
+		$shortcode_content = wp_kses_post( $content );
+
+		$this->assertEquals( $shortcode_content, '<a href="https://player.soundcloud.com/player.swf?url=http://api.soundcloud.com/tracks/70198773">https://player.soundcloud.com/player.swf?url=http://api.soundcloud.com/tracks/70198773</a>' );
 	}
 }

--- a/tests/php/modules/shortcodes/test_class.soundcloud.php
+++ b/tests/php/modules/shortcodes/test_class.soundcloud.php
@@ -3,12 +3,19 @@
 class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 
 	/**
-	 * Shortcode.
+	 * @author scotchfield
+	 * @covers ::soundcloud_shortcode
+	 * @since 3.2
 	 */
 	public function test_shortcodes_soundcloud_exists() {
 		$this->assertEquals( shortcode_exists( 'soundcloud' ), true );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::soundcloud_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_soundcloud() {
 		$content = '[soundcloud]';
 

--- a/tests/php/modules/shortcodes/test_class.twitter-timeline.php
+++ b/tests/php/modules/shortcodes/test_class.twitter-timeline.php
@@ -14,10 +14,20 @@
  */
 class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 
+	/**
+	 * @author scotchfield
+	 * @covers ::twitter_timeline_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_twitter_timeline_exists() {
 		$this->assertEquals( shortcode_exists( 'twitter-timeline' ), true );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::twitter_timeline_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_twitter_timeline() {
 		$content = '[twitter-timeline]';
 

--- a/tests/php/modules/shortcodes/test_class.twitter-timeline.php
+++ b/tests/php/modules/shortcodes/test_class.twitter-timeline.php
@@ -54,7 +54,7 @@ class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertEquals( $shortcode_content, '<!-- Invalid Twitter Timeline username -->' );
+		$this->assertEquals( '<a class="twitter-timeline" data-partner="jetpack" data-width="450" data-height="282" data-widget-id="297487559557251073">Tweets by @</a>', $shortcode_content );
 	}
 
 	public function test_shortcodes_twitter_timeline_missing_id() {
@@ -62,7 +62,7 @@ class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertEquals( $shortcode_content, '<!-- Invalid Twitter Timeline id -->' );
+		$this->assertEquals( '<a class="twitter-timeline" data-partner="jetpack" data-width="450" data-height="282" href="https://twitter.com/wordpressdotcom">Tweets by @wordpressdotcom</a>', $shortcode_content );
 	}
 
 
@@ -71,7 +71,7 @@ class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertEquals( $shortcode_content, '<a class="twitter-timeline" width="450" height="282" href="https://twitter.com/wordpressdotcom/" data-widget-id="297487559557251073">Tweets by @wordpressdotcom</a>' );
+		$this->assertEquals( '<a class="twitter-timeline" data-partner="jetpack" data-width="450" data-height="282" data-widget-id="297487559557251073" href="https://twitter.com/wordpressdotcom">Tweets by @wordpressdotcom</a>',  $shortcode_content );
 	}
 
 	public function test_shortcodes_twitter_timeline_username() {
@@ -79,7 +79,7 @@ class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertEquals( $shortcode_content, '<a class="twitter-timeline" width="450" height="282" href="https://twitter.com/wordpressdotcom/" data-widget-id="297487559557251073">Tweets by @wordpressdotcom</a>' );
+		$this->assertEquals( '<a class="twitter-timeline" data-partner="jetpack" data-width="450" data-height="282" data-widget-id="297487559557251073" href="https://twitter.com/wordpressdotcom">Tweets by @wordpressdotcom</a>',  $shortcode_content );
 	}
 
 	public function test_shortcodes_twitter_timeline_height_width() {
@@ -87,6 +87,6 @@ class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 
 		$shortcode_content = do_shortcode( $content );
 
-		$this->assertEquals( $shortcode_content, '<a class="twitter-timeline" width="100" height="100" href="https://twitter.com/wordpressdotcom/" data-widget-id="297487559557251073">Tweets by @wordpressdotcom</a>' );
+		$this->assertEquals( '<a class="twitter-timeline" data-partner="jetpack" data-width="100" data-height="100" data-widget-id="297487559557251073" href="https://twitter.com/wordpressdotcom">Tweets by @wordpressdotcom</a>',  $shortcode_content );
 	}
 }

--- a/tests/php/modules/shortcodes/test_class.twitter-timeline.php
+++ b/tests/php/modules/shortcodes/test_class.twitter-timeline.php
@@ -6,11 +6,7 @@
  * Example: [twitter-timeline id="297487559557251073" username="wordpressdotcom"]
  *
  * Expected shortcode output:
- * <a class="twitter-timeline" width="450" height="282" href="https://twitter.com/wordpressdotcom/" data-widget-id="297487559557251073">Tweets by @wordpressdotcom</a>
- *
- * @param
- *
- * @return
+ * <a class="twitter-timeline" data-partner="jetpack" data-width="100" data-height="100" data-widget-id="297487559557251073" href="https://twitter.com/wordpressdotcom">Tweets by @wordpressdotcom</a>
  */
 class WP_Test_Jetpack_Shortcodes_TwitterTimeline extends WP_UnitTestCase {
 

--- a/tests/php/modules/shortcodes/test_class.vimeo.php
+++ b/tests/php/modules/shortcodes/test_class.vimeo.php
@@ -2,10 +2,20 @@
 
 class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 
+	/**
+	 * @author scotchfield
+	 * @covers ::vimeo_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_vimeo_exists() {
 		$this->assertEquals( shortcode_exists( 'vimeo' ), true );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::vimeo_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_vimeo() {
 		$content = '[vimeo]';
 
@@ -14,6 +24,11 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 		$this->assertNotEquals( $content, $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::vimeo_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_vimeo_id() {
 		$video_id = '141358';
 		$content  = '[vimeo ' . $video_id . ']';
@@ -23,6 +38,11 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 		$this->assertContains( 'vimeo.com/video/' . $video_id, $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::vimeo_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_vimeo_url() {
 		$video_id = '141358';
 		$url      = 'http://vimeo.com/' . $video_id;
@@ -33,6 +53,11 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 		$this->assertContains( 'vimeo.com/video/' . $video_id, $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::vimeo_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_vimeo_w_h() {
 		$video_id = '141358';
 		$width    = '350';
@@ -46,6 +71,11 @@ class WP_Test_Jetpack_Shortcodes_Vimeo extends WP_UnitTestCase {
 		$this->assertContains( 'height="' . $height . '"', $shortcode_content );
 	}
 
+	/**
+	 * @author scotchfield
+	 * @covers ::vimeo_shortcode
+	 * @since 3.2
+	 */
 	public function test_shortcodes_vimeo_width_height() {
 		$video_id = '141358';
 		$width    = '350';


### PR DESCRIPTION
This brings some of our unit tests back into sync with the copies that had been synced to wpcom by @enejb some time ago, in r106815-wpcom

Some will need to be tidied or changed before merging back in to Jetpack (some of the wpcom change to blog stuff, for example)