### PR TITLE
Add mechanism to report comment content modifications via sync

### DIFF
--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -24,6 +24,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'untrash_post_comments', $callable );
 		add_action( 'comment_approved_to_unapproved', $callable );
 		add_action( 'comment_unapproved_to_approved', $callable );
+		add_action( 'edit_comment', $callable );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -24,7 +24,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'untrash_post_comments', $callable );
 		add_action( 'comment_approved_to_unapproved', $callable );
 		add_action( 'comment_unapproved_to_approved', $callable );
-		add_action( 'edit_comment', $callable, 10, 2 );
+		add_action( 'wp_update_comment_data', array( $this, 'handle_comment_contents_modification' ), 10, 3 );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data
@@ -39,6 +39,21 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		// listen for meta changes
 		$this->init_listeners_for_meta_type( 'comment', $callable );
 		$this->init_meta_whitelist_handler( 'comment', array( $this, 'filter_meta' ) );
+	}
+
+	/**
+	 * Filters the comment data immediately before it is updated in the database.
+	 *
+	 * Note: data being passed to the filter is already unslashed.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @param array $data       The new, processed comment data.
+	 * @param array $comment    The old, unslashed comment data.
+	 * @param array $commentarr The new, raw comment data.
+	 */
+	public function handle_comment_contents_modification( $new_comment_data, $old_comment_data, $new_raw ) {
+		error_log ("Hello!" );
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -24,7 +24,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'untrash_post_comments', $callable );
 		add_action( 'comment_approved_to_unapproved', $callable );
 		add_action( 'comment_unapproved_to_approved', $callable );
-		add_action( 'wp_update_comment_data', array( $this, 'handle_comment_contents_modification' ), 10, 3 );
+		add_filter( 'wp_update_comment_data', array( $this, 'handle_comment_contents_modification' ), 10, 3 );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -24,8 +24,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'untrash_post_comments', $callable );
 		add_action( 'comment_approved_to_unapproved', $callable );
 		add_action( 'comment_unapproved_to_approved', $callable );
-		add_action( 'jetpack_modified_comment_contents', $callable );
-
+		add_action( 'jetpack_modified_comment_contents', $callable, 10, 2 );
 		add_filter( 'wp_update_comment_data', array( $this, 'handle_comment_contents_modification' ), 10, 3 );
 
 		// even though it's messy, we implement these hooks because
@@ -58,11 +57,16 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		}
 
 		if ( ! empty( $changes ) ) {
-			$action_args = array(
-				$new_comment['comment_ID'],
-				$changes,
-			);
-			do_action( 'jetpack_modified_comment_contents', $action_args );
+			/**
+			 * Signals to the sync listener that this comment's contents were modified and a sync action
+			 * reflecting the change(s) to the content should be sent
+			 *
+			 * @since 4.8.2
+			 *
+			 * @param int $new_comment['comment_ID'] ID of comment whose content was modified
+			 * @param mixed $changes Array of changed comment fields with before and after values
+			 */
+			do_action( 'jetpack_modified_comment_contents', $new_comment['comment_ID'], $changes );
 		}
 		return $new_comment;
 	}

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -42,18 +42,16 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 	}
 
 	/**
-	 * Filters the comment data immediately before it is updated in the database.
-	 *
-	 * Note: data being passed to the filter is already unslashed.
-	 *
-	 * @since 4.7.0
-	 *
 	 * @param array $data       The new, processed comment data.
 	 * @param array $comment    The old, unslashed comment data.
 	 * @param array $commentarr The new, raw comment data.
 	 */
-	public function handle_comment_contents_modification( $new_comment_data, $old_comment_data, $new_raw ) {
+	public function handle_comment_contents_modification( $data, $comment, $commentarr ) {
+
+		error_log(print_r($data, true));
 		error_log ("Hello!" );
+		return $data;
+
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -24,7 +24,9 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'untrash_post_comments', $callable );
 		add_action( 'comment_approved_to_unapproved', $callable );
 		add_action( 'comment_unapproved_to_approved', $callable );
-		add_filter( 'wp_update_comment_data', array( $this, 'handle_comment_contents_modification' ), 10, 3 );
+		add_action( 'modified_comment_contents', $callable );
+
+		add_filter( 'wp_update_comment_data', array( $this, 'handle_comment_contents_modification' ), 10, 2 );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data
@@ -44,14 +46,18 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 	/**
 	 * @param array $data       The new, processed comment data.
 	 * @param array $comment    The old, unslashed comment data.
-	 * @param array $commentarr The new, raw comment data.
 	 */
-	public function handle_comment_contents_modification( $data, $comment, $commentarr ) {
+	public function handle_comment_contents_modification( $data, $comment ) {
 
-		error_log(print_r($data, true));
-		error_log ("Hello!" );
+		if ( $data['comment_content'] != $comment['comment_content'] ) {
+			$action_args = array(
+				$data['comment_ID'],
+				$data,
+				$comment['comment_content'],
+			);
+			do_action( 'modified_comment_contents', $action_args );
+		}
 		return $data;
-
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/sync/class.jetpack-sync-module-comments.php
+++ b/sync/class.jetpack-sync-module-comments.php
@@ -24,7 +24,7 @@ class Jetpack_Sync_Module_Comments extends Jetpack_Sync_Module {
 		add_action( 'untrash_post_comments', $callable );
 		add_action( 'comment_approved_to_unapproved', $callable );
 		add_action( 'comment_unapproved_to_approved', $callable );
-		add_action( 'edit_comment', $callable );
+		add_action( 'edit_comment', $callable, 10, 2 );
 
 		// even though it's messy, we implement these hooks because
 		// the edit_comment hook doesn't include the data

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -47,24 +47,108 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( "foo bar baz", $remote_comment->comment_content );
 	}
 
-	public function test_modify_comment_contents() {
-
-		//Confirm that 'modify_comment' action is set after changing comment contents
-		$this->comment->comment_content = "foo bar baz";
-		wp_update_comment( (array) $this->comment );
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'modified_comment_contents' );
-		$this->assertTrue( (bool) $event );
-
-		$this->server_event_storage->reset();
-
-		//Confirm that 'modified_comment_contents' action is not set after unapproving comment
+	public function test_unapprove_comment_does_not_trigger_content_modified_event() {
 		$this->comment->comment_approved = 0;
 		wp_update_comment( (array) $this->comment );
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'modified_comment_contents' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_modified_comment_contents' );
+		$this->assertFalse( (bool) $event );
+	}
+
+	public function test_modify_comment_content() {
+		$comment = clone $this->comment;
+		$comment->comment_content = "Heeeeeeere's Johnny!";
+		$expected_variable = array(
+			'comment_content' => array(
+				$comment->comment_content,
+				$this->comment->comment_content,
+			),
+		);
+		$this->modify_comment_helper( $comment, $expected_variable );
+	}
+
+	public function test_modify_comment_author() {
+		$comment = clone $this->comment;
+		$comment->comment_author = "jollycoder";
+		$expected_variable = array(
+			'comment_author' => array(
+				$comment->comment_author,
+				$this->comment->comment_author,
+			),
+		);
+		$this->modify_comment_helper( $comment, $expected_variable );
+	}
+
+	public function test_modify_comment_author_url() {
+		$comment = clone $this->comment;
+		$comment->comment_author_url = "http://jollycoder.xyz";
+		$expected_variable = array(
+			'comment_author_url' => array(
+				$comment->comment_author_url,
+				$this->comment->comment_author_url,
+			),
+		);
+		$this->modify_comment_helper( $comment, $expected_variable );
+	}
+
+	public function test_modify_comment_author_email() {
+		$comment = clone $this->comment;
+		$comment->comment_author_email = "michael.turk@automattic.com";
+		$expected_variable = array(
+			'comment_author_email' => array(
+				$comment->comment_author_email,
+				$this->comment->comment_author_email,
+			),
+		);
+		$this->modify_comment_helper( $comment, $expected_variable );
+	}
+
+	public function test_modify_comment_multiple_attributes() {
+		$comment = clone $this->comment;
+		$comment->comment_author_email = "michael.turk@automattic.com";
+		$comment->comment_author_url = "http://jollycoder.xyz";
+		$comment->comment_author = "jollycoder";
+		$expected_variable = array(
+			'comment_author_email' => array(
+				$comment->comment_author_email,
+				$this->comment->comment_author_email,
+			),
+			'comment_author_url' => array(
+				$comment->comment_author_url,
+				$this->comment->comment_author_url,
+			),
+			'comment_author' => array(
+				$comment->comment_author,
+				$this->comment->comment_author,
+			),
+		);
+		$this->modify_comment_helper( $comment, $expected_variable );
+	}
+
+	/*
+	 * Updates comment, checks that event args match expected, checks event is not duplicated
+	 */
+	private function modify_comment_helper( $comment, $expected_variable ) {
+		$expected = array(
+			$comment->comment_ID,
+			$expected_variable,
+		);
+
+		wp_update_comment( (array) $comment );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_modified_comment_contents' );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( $expected, $event->args[0] );
+
+		$this->server_event_storage->reset();
+
+		//Confirm that 'modified_comment_contents' action is not set after updating comment with same data
+		wp_update_comment( (array) $comment );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_modified_comment_contents' );
 		$this->assertFalse( (bool) $event );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -57,6 +57,12 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_modify_comment_content() {
+		global $wp_version;
+		if ( version_compare( $wp_version, 4.7, '<' ) ) {
+			$this->markTestSkipped( 'WP 4.7 and up supports required wp_update_comment_data filter' );
+			return;
+		}
+
 		$comment = clone $this->comment;
 		$comment->comment_content = "Heeeeeeere's Johnny!";
 		$expected_variable = array(
@@ -69,6 +75,12 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_modify_comment_author() {
+		global $wp_version;
+		if ( version_compare( $wp_version, 4.7, '<' ) ) {
+			$this->markTestSkipped( 'WP 4.7 and up supports required wp_update_comment_data filter' );
+			return;
+		}
+
 		$comment = clone $this->comment;
 		$comment->comment_author = "jollycoder";
 		$expected_variable = array(
@@ -81,6 +93,12 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_modify_comment_author_url() {
+		global $wp_version;
+		if ( version_compare( $wp_version, 4.7, '<' ) ) {
+			$this->markTestSkipped( 'WP 4.7 and up supports required wp_update_comment_data filter' );
+			return;
+		}
+
 		$comment = clone $this->comment;
 		$comment->comment_author_url = "http://jollycoder.xyz";
 		$expected_variable = array(
@@ -93,6 +111,12 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_modify_comment_author_email() {
+		global $wp_version;
+		if ( version_compare( $wp_version, 4.7, '<' ) ) {
+			$this->markTestSkipped( 'WP 4.7 and up supports required wp_update_comment_data filter' );
+			return;
+		}
+
 		$comment = clone $this->comment;
 		$comment->comment_author_email = "i_prefer_to_remain_anonymous_thanks@example.com";;
 		$expected_variable = array(
@@ -105,6 +129,12 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_modify_comment_multiple_attributes() {
+		global $wp_version;
+		if ( version_compare( $wp_version, 4.7, '<' ) ) {
+			$this->markTestSkipped( 'WP 4.7 and up supports required wp_update_comment_data filter' );
+			return;
+		}
+
 		$comment = clone $this->comment;
 		$comment->comment_author_email = "i_prefer_to_remain_anonymous_thanks@example.com";
 		$comment->comment_author_url = "http://jollycoder.xyz";

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -45,6 +45,10 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$remote_comment = $this->server_replica_storage->get_comment( $this->comment->comment_ID );
 
 		$this->assertEquals( "foo bar baz", $remote_comment->comment_content );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'edit_comment' );
+		$this->assertTrue( (bool) $event );
+
 	}
 
 	public function test_unapprove_comment() {

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -140,7 +140,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_modified_comment_contents' );
 		$this->assertTrue( (bool) $event );
-		$this->assertEquals( $expected, $event->args[0] );
+		$this->assertEquals( $expected, $event->args );
 
 		$this->server_event_storage->reset();
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -54,17 +54,17 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		wp_update_comment( (array) $this->comment );
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'modify_comment_contents' );
+		$event = $this->server_event_storage->get_most_recent_event( 'modified_comment_contents' );
 		$this->assertTrue( (bool) $event );
 
 		$this->server_event_storage->reset();
 
-		//Confirm that 'modify_comment_contents' action is not set after unapproving comment
+		//Confirm that 'modified_comment_contents' action is not set after unapproving comment
 		$this->comment->comment_approved = 0;
 		wp_update_comment( (array) $this->comment );
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'modify_comment_contents' );
+		$event = $this->server_event_storage->get_most_recent_event( 'modified_comment_contents' );
 		$this->assertFalse( (bool) $event );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -94,7 +94,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_modify_comment_author_email() {
 		$comment = clone $this->comment;
-		$comment->comment_author_email = "michael.turk@automattic.com";
+		$comment->comment_author_email = "i_prefer_to_remain_anonymous_thanks@example.com";;
 		$expected_variable = array(
 			'comment_author_email' => array(
 				$comment->comment_author_email,
@@ -106,7 +106,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_modify_comment_multiple_attributes() {
 		$comment = clone $this->comment;
-		$comment->comment_author_email = "michael.turk@automattic.com";
+		$comment->comment_author_email = "i_prefer_to_remain_anonymous_thanks@example.com";
 		$comment->comment_author_url = "http://jollycoder.xyz";
 		$comment->comment_author = "jollycoder";
 		$expected_variable = array(

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -45,10 +45,27 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$remote_comment = $this->server_replica_storage->get_comment( $this->comment->comment_ID );
 
 		$this->assertEquals( "foo bar baz", $remote_comment->comment_content );
+	}
 
-		$event = $this->server_event_storage->get_most_recent_event( 'edit_comment' );
+	public function test_modify_comment_contents() {
+
+		//Confirm that 'modify_comment' action is set after changing comment contents
+		$this->comment->comment_content = "foo bar baz";
+		wp_update_comment( (array) $this->comment );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'modify_comment_contents' );
 		$this->assertTrue( (bool) $event );
 
+		$this->server_event_storage->reset();
+
+		//Confirm that 'modify_comment_contents' action is not set after unapproving comment
+		$this->comment->comment_approved = 0;
+		wp_update_comment( (array) $this->comment );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'modify_comment_contents' );
+		$this->assertFalse( (bool) $event );
 	}
 
 	public function test_unapprove_comment() {


### PR DESCRIPTION
Adds non-sync listener for comment update data, and fires action sync listener is listening for if the comment contents is modified

#### Changes proposed in this Pull Request:

* Adds non-sync listener for comment update data, and fires action sync listener is listening for if the comment contents is modified

#### Testing instructions:

* phpunit --filter comment (added test_modify_comment_contents())

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
