### PR TITLE
Endpoints: ensure that parameter is an array before checking an item exists

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -34,7 +34,9 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param string|WP_REST_Request $request {
+	 * @param string|WP_REST_Request $request It's a WP_REST_Request when called from endpoint /module/<slug>/*
+	 *                                        and a string when called from Jetpack_Core_API_Data->update_data.
+	 * {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Module slug.
@@ -43,7 +45,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
 	public function activate_module( $request ) {
-		$module_slug = isset( $request['slug'] )
+		$module_slug = is_array( $request ) && isset( $request['slug'] )
 			? $request['slug']
 			: $request;
 
@@ -74,7 +76,9 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param string|WP_REST_Request $request {
+	 * @param string|WP_REST_Request $request It's a WP_REST_Request when called from endpoint /module/<slug>/*
+	 *                                        and a string when called from Jetpack_Core_API_Data->update_data.
+	 * {
 	 *     Array of parameters received by request.
 	 *
 	 *     @type string $slug Module slug.
@@ -83,7 +87,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
 	public function deactivate_module( $request ) {
-		$module_slug = isset( $request['slug'] )
+		$module_slug = is_array( $request ) && isset( $request['slug'] )
 			? $request['slug']
 			: $request;
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -45,9 +45,19 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
 	public function activate_module( $request ) {
-		$module_slug = is_array( $request ) && isset( $request['slug'] )
-			? $request['slug']
-			: $request;
+		$module_slug = '';
+
+		if (
+			(
+				is_array( $request )
+				|| is_object( $request )
+			)
+			&& isset( $request['slug'] )
+		) {
+			$module_slug = $request['slug'];
+		} else {
+			$module_slug = $request;
+		}
 
 		if ( ! Jetpack::is_module( $module_slug ) ) {
 			return new WP_Error(
@@ -87,9 +97,19 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 	 * @return bool|WP_Error True if module was activated. Otherwise, a WP_Error instance with the corresponding error.
 	 */
 	public function deactivate_module( $request ) {
-		$module_slug = is_array( $request ) && isset( $request['slug'] )
-			? $request['slug']
-			: $request;
+		$module_slug = '';
+
+		if (
+			(
+				is_array( $request )
+				|| is_object( $request )
+			)
+			&& isset( $request['slug'] )
+		) {
+			$module_slug = $request['slug'];
+		} else {
+			$module_slug = $request;
+		}
 
 		if ( ! Jetpack::is_module( $module_slug ) ) {
 			return new WP_Error(


### PR DESCRIPTION
Fixes #6932

props @cfinke for finding, explaining and suggesting a patch.

#### Changes proposed in this Pull Request:

* add checking to ensure that the parameter is an array before checking the existence of an item

#### Testing instructions:

* make sure modules can be activated/deactivated in PHP 5.2, 5.3, 5.4 and later.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Endpoints: fixed an issue that could prevent module activation in PHP versions lower than 5.4