### PR TITLE
Removed an unneeded function call that caused a fatal in PHP 5.2.

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -138,7 +138,6 @@ class Jetpack_Sitemap_Manager {
 		header( 'Content-Type: ' . $the_content_type . '; charset=UTF-8' );
 
 		if ( '' === $the_content ) {
-			http_response_code( 404 );
 			wp_die(
 				esc_html__( "No sitemap found. Maybe it's being generated. Please try again later.", 'jetpack' ),
 				esc_html__( 'Sitemaps', 'jetpack' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Removes a call to `http_response_code`

#### Testing instructions:
* Make sure your sitemap returns a 404 properly if it's not yet generated.
