### PR TITLE
Settings UI: fix positioning of search icon on mobile screen size

### DIFF
--- a/_inc/client/settings/style.scss
+++ b/_inc/client/settings/style.scss
@@ -11,3 +11,9 @@
 		display: inherit;
 	}
 }
+
+@include breakpoint( "<480px" ) {
+	.dops-search.is-expanded-to-container {
+		height: 46px;
+	}
+}


### PR DESCRIPTION
Fixes #6917

#### Changes proposed in this Pull Request:

Before

<img width="439" alt="captura de pantalla 2017-04-06 a las 15 12 44" src="https://cloud.githubusercontent.com/assets/1041600/24769142/c35f8f5a-1adb-11e7-88f8-caadd339f936.png">

After

<img width="447" alt="captura de pantalla 2017-04-06 a las 15 12 31" src="https://cloud.githubusercontent.com/assets/1041600/24769144/c644da40-1adb-11e7-9f28-a3568cd13a35.png">

#### Testing

Make sure the viewport size is < 480px and check that the icon is correctly positioned.