### PR TITLE
Widgets: Porting of WP.com's Flickr Widget

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -57,6 +57,7 @@ class Jetpack {
 		'jetpack-my-community-widget',
 		'wordads',
 		'eu-cookie-law-style',
+		'flickr-widget-style',
 	);
 
 	public $plugins_to_deactivate = array(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -290,6 +290,7 @@ frontendcss = [
 	'css/jetpack-idc-admin-bar.css',
 	'modules/wordads/css/style.css',
 	'modules/widgets/eu-cookie-law/style.css',
+	'modules/widgets/flickr/style.css'
 ];
 
 gulp.task( 'old-styles:watch', function() {

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -86,12 +86,12 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 						$src = str_replace( '_m.jpg', $image_size_string, $p[1] );
 					}
 					array_push( $photos, array(
-						'href'  => esc_url( $photo->get_permalink(), array( 'http', 'https' ) ),
-						'src'   => esc_url( $src, array( 'http', 'https' ) ),
-						'title' => esc_attr( $photo->get_title() ),
+						'href'  => $photo->get_permalink(),
+						'src'   => $src,
+						'title' => $photo->get_title(),
 					) );
 				}
-				$flickr_home = esc_url( $rss->get_link(), array( 'http', 'https' ) );
+				$flickr_home = $rss->get_link();
 			}
 
 			echo $args['before_widget'];

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 		 */
 		function __construct() {
 			parent::__construct(
-				'flickr_widget',
+				'flickr',
 				/** This filter is documented in modules/widgets/facebook-likebox.php */
 				apply_filters( 'jetpack_widget_name', esc_html__( 'Flickr', 'jetpack' ) ),
 				array(
@@ -29,16 +29,15 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 			);
 
 			if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
-				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
+				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ) );
 			}
 		}
 
 		/**
-		 * Enqueue scripts and styles.
+		 * Enqueue style.
 		 */
-		function enqueue_frontend_scripts() {
+		function enqueue_style() {
 			wp_enqueue_style( 'flickr-widget-style', plugins_url( 'flickr/style.css', __FILE__ ), array(), '20170405' );
-			wp_enqueue_script( 'flickr-widget-script', plugins_url( 'flickr/flickr.js', __FILE__ ), array( 'jquery' ), '20170405', true );
 		}
 
 		/**

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -120,6 +120,45 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 		}
 	}
 
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @param  array $new_instance Values just sent to be saved.
+	 * @param  array $old_instance Previously saved values from database.
+	 * @return array Updated safe values to be saved.
+	 */
+	/*public function update( $new_instance, $old_instance ) {
+		$instance = array();
+		$defaults = $this->defaults();
+
+		if ( isset( $new_instance['title'] ) ) {
+			$instance['title'] = wp_kses( $new_instance['title'], array() );
+		}
+
+		if ( isset( $new_instance['items'] ) ) {
+			$instance['items'] = intval( $new_instance['items'] );
+		}
+
+		if (
+			isset( $new_instance['flickr_image_size'] ) &&
+			in_array( $new_instance['flickr_image_size'], array( 'thumbnail', 'small' ) )
+		) {
+			$instance['flickr_image_size'] = $new_instance['flickr_image_size'];
+		} else {
+			$instance['flickr_image_size'] = 'thumbnail';
+		}
+
+		if ( isset( $new_instance['flickr_rss_url'] ) ) {
+			$instance['flickr_rss_url'] = esc_url( $new_instance['flickr_rss_url'], array( 'http', 'https' ) );
+
+			if ( strlen( $instance['flickr_rss_url'] ) < 10 ) {
+				$instance['flickr_rss_url'] = '';
+			}
+		}
+
+		return $instance;
+	}*/
+
 	// Register Jetpack_Flickr_Widget widget.
 	function jetpack_register_flickr_widget() {
 		register_widget( 'Jetpack_Flickr_Widget' );

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 
 			$rss = fetch_feed( $rss_url );
 
-			$photos = array();
+			$photos = '';
 			if ( ! is_wp_error( $rss ) ) {
 				foreach ( $rss->get_items( 0, $instance['items'] ) as $photo ) {
 					if ( $enclosure = $photo->get_enclosure() ) {
@@ -85,12 +85,18 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 						$src = preg_match( '/src="(.*?)"/i', $photo->get_description(), $p );
 						$src = str_replace( '_m.jpg', $image_size_string, $p[1] );
 					}
-					array_push( $photos, array(
-						'href'  => $photo->get_permalink(),
-						'src'   => $src,
-						'title' => $photo->get_title(),
-					) );
+
+					$photos .= '<a href="' . esc_url( $photo->get_permalink(), array( 'http', 'https' ) ) . '">';
+					$photos .= '<img src="' . esc_url( $src, array( 'http', 'https' ) ) . '" ';
+					$photos .= 'alt="' . esc_attr( $photo->get_title() ) . '" ';
+					$photos .= 'border="0" ';
+					$photos .= 'title="' . esc_attr( $photo->get_title() ) . '" ';
+					$photos .= ' /></a><br /><br />';
 				}
+				if ( ! empty( $photos ) && class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
+					$photos = Jetpack_Photon::filter_the_content( $photos );
+				}
+
 				$flickr_home = $rss->get_link();
 			}
 

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Disable direct access/execution to/of the widget code.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
+	/**
+	 * Flickr Widget
+	 *
+	 * Display your recent Flickr photos.
+	 */
+	class Jetpack_Flickr_Widget extends WP_Widget {
+		/**
+		 * Constructor.
+		 */
+		function __construct() {
+			parent::__construct(
+				'flickr_widget',
+				/** This filter is documented in modules/widgets/facebook-likebox.php */
+				apply_filters( 'jetpack_widget_name', esc_html__( 'Flickr', 'jetpack' ) ),
+				array(
+					'description' => esc_html__( 'Display your recent Flickr photos.', 'jetpack' ),
+					'customize_selective_refresh' => true,
+				),
+				array()
+			);
+
+			if ( is_active_widget( false, false, $this->id_base ) || is_customize_preview() ) {
+				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_scripts' ) );
+			}
+		}
+
+		/**
+		 * Enqueue scripts and styles.
+		 */
+		function enqueue_frontend_scripts() {
+			wp_enqueue_style( 'flickr-widget-style', plugins_url( 'flickr/style.css', __FILE__ ), array(), '20170405' );
+			wp_enqueue_script( 'flickr-widget-script', plugins_url( 'flickr/flickr.js', __FILE__ ), array( 'jquery' ), '20170405', true );
+		}
+
+		/**
+		 * Return an associative array of default values.
+		 *
+		 * These values are used in new widgets.
+		 *
+		 * @return array Default values for the widget options.
+		 */
+		public function defaults() {
+			return array(
+				'title'             => esc_html__( 'Flickr Photos', 'jetpack' ),
+				'items'             => 3,
+				'flickr_image_size' => 'thumbnail',
+				'flickr_rss_url'    => ''
+			);
+		}
+
+		/**
+		 * Back-end widget form.
+		 *
+		 * @param array $instance Previously saved values from database.
+		 */
+		public function form( $instance ) {
+			$instance = wp_parse_args( $instance, $this->defaults() );
+			require( dirname( __FILE__ ) . '/flickr/form.php' );
+		}
+	}
+
+	// Register Jetpack_Flickr_Widget widget.
+	function jetpack_register_flickr_widget() {
+		register_widget( 'Jetpack_Flickr_Widget' );
+	}
+	add_action( 'widgets_init', 'jetpack_register_flickr_widget' );
+}

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -117,46 +117,46 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 			$instance = wp_parse_args( $instance, $this->defaults() );
 			require( dirname( __FILE__ ) . '/flickr/form.php' );
 		}
-	}
 
-	/**
-	 * Sanitize widget form values as they are saved.
-	 *
-	 * @param  array $new_instance Values just sent to be saved.
-	 * @param  array $old_instance Previously saved values from database.
-	 * @return array Updated safe values to be saved.
-	 */
-	/*public function update( $new_instance, $old_instance ) {
-		$instance = array();
-		$defaults = $this->defaults();
+		/**
+		 * Sanitize widget form values as they are saved.
+		 *
+		 * @param  array $new_instance Values just sent to be saved.
+		 * @param  array $old_instance Previously saved values from database.
+		 * @return array Updated safe values to be saved.
+		 */
+		public function update( $new_instance, $old_instance ) {
+			$instance = array();
+			$defaults = $this->defaults();
 
-		if ( isset( $new_instance['title'] ) ) {
-			$instance['title'] = wp_kses( $new_instance['title'], array() );
-		}
-
-		if ( isset( $new_instance['items'] ) ) {
-			$instance['items'] = intval( $new_instance['items'] );
-		}
-
-		if (
-			isset( $new_instance['flickr_image_size'] ) &&
-			in_array( $new_instance['flickr_image_size'], array( 'thumbnail', 'small' ) )
-		) {
-			$instance['flickr_image_size'] = $new_instance['flickr_image_size'];
-		} else {
-			$instance['flickr_image_size'] = 'thumbnail';
-		}
-
-		if ( isset( $new_instance['flickr_rss_url'] ) ) {
-			$instance['flickr_rss_url'] = esc_url( $new_instance['flickr_rss_url'], array( 'http', 'https' ) );
-
-			if ( strlen( $instance['flickr_rss_url'] ) < 10 ) {
-				$instance['flickr_rss_url'] = '';
+			if ( isset( $new_instance['title'] ) ) {
+				$instance['title'] = wp_kses( $new_instance['title'], array() );
 			}
-		}
 
-		return $instance;
-	}*/
+			if ( isset( $new_instance['items'] ) ) {
+				$instance['items'] = intval( $new_instance['items'] );
+			}
+
+			if (
+				isset( $new_instance['flickr_image_size'] ) &&
+				in_array( $new_instance['flickr_image_size'], array( 'thumbnail', 'small' ) )
+			) {
+				$instance['flickr_image_size'] = $new_instance['flickr_image_size'];
+			} else {
+				$instance['flickr_image_size'] = 'thumbnail';
+			}
+
+			if ( isset( $new_instance['flickr_rss_url'] ) ) {
+				$instance['flickr_rss_url'] = esc_url( $new_instance['flickr_rss_url'], array( 'http', 'https' ) );
+
+				if ( strlen( $instance['flickr_rss_url'] ) < 10 ) {
+					$instance['flickr_rss_url'] = '';
+				}
+			}
+
+			return $instance;
+		}
+	}
 
 	// Register Jetpack_Flickr_Widget widget.
 	function jetpack_register_flickr_widget() {

--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -12,7 +12,7 @@
 
 <p>
 	<label>
-		<?php esc_html_e( 'Flickr RSS URL:', 'jetpack' ); ?>*
+		<?php esc_html_e( 'Flickr RSS URL:', 'jetpack' ); ?>
 	</label>
 	<input
 		class="widefat"
@@ -20,6 +20,19 @@
 		type="text"
 		value="<?php echo esc_attr( $instance['flickr_rss_url'] ); ?>"
 	/>
+</p>
+<p>
+	<small>
+		<?php esc_html_e( 'To find your Flickr RSS feed, go to your photostream, open the "More" menu and click on "Edit". Scroll down until you see the RSS icon or the Latest link. Right click on either and copy the URL. Paste into the box above.', 'jetpack' ); ?>
+	</small>
+</p>
+<p>
+	<small>
+		<?php printf(
+			__( 'Leave the Flickr RSS URL blank to display <a href="%s">interesting</a> Flickr photos.', 'jetpack' ),
+			'http://www.flickr.com/explore/interesting'
+		); ?>
+	</small>
 </p>
 
 <p>
@@ -64,18 +77,4 @@
 		<?php }
 		?>
 	</select>
-</p>
-
-<p>
-	<small>*
-		<?php esc_html_e( 'To find your Flickr RSS feed, go to your photostream and click the "Edit" tab at the top. Scroll down to the bottom of the page until you see the RSS icon or the Latest link. Right click on either and copy the URL. Paste into the box above.', 'jetpack' ); ?>
-	</small>
-</p>
-<p>
-	<small>
-		<?php printf(
-			__( 'Leave the Flickr RSS URL blank to display <a href="%s">interesting</a> Flickr photos.', 'jetpack' ),
-			'http://www.flickr.com/explore/interesting'
-		); ?>
-	</small>
 </p>

--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -1,0 +1,81 @@
+<p>
+	<label>
+		<?php esc_html_e( 'Title:', 'jetpack' ); ?>
+	</label>
+	<input
+		class="widefat"
+		name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+		type="text"
+		value="<?php echo esc_attr( $instance['title'] ); ?>"
+	/>
+</p>
+
+<p>
+	<label>
+		<?php esc_html_e( 'Flickr RSS URL:', 'jetpack' ); ?>*
+	</label>
+	<input
+		class="widefat"
+		name="<?php echo esc_attr( $this->get_field_name( 'flickr_rss_url' ) ); ?>"
+		type="text"
+		value="<?php echo esc_attr( $instance['flickr_rss_url'] ); ?>"
+	/>
+</p>
+
+<p>
+	<label>
+		<?php esc_html_e( 'How many photos would you like to display?', 'jetpack' ); ?>
+	</label>
+	<select name="<?php echo esc_attr( $this->get_field_name( 'items' ) ); ?>">
+		<?php for ( $i = 1; $i <= 10; ++$i ) { ?>
+			<option
+				<?php selected( $instance['items'], $i ); ?>
+				value="<?php echo $i; ?>"
+			>
+				<?php echo $i; ?>
+			</option>
+		<?php } ?>
+	</select>
+</p>
+
+<p>
+	<label>
+		<?php esc_html_e( 'What size photos would you like to display?', 'jetpack' ); ?>
+	</label>
+	<select name="<?php echo esc_attr( $this->get_field_name( 'flickr_image_size' ) ); ?>">
+		<?php
+		$flickr_sizes = array(
+			array(
+				'size' => 'thumbnail',
+				'text' => esc_html__( 'Thumbnail', 'jetpack' ),
+			),
+			array(
+				'size' => 'small',
+				'text' => esc_html__( 'Small', 'jetpack' ),
+			),
+		);
+		foreach( $flickr_sizes as $flickr_size ) { ?>
+			<option
+				<?php selected( $instance['flickr_image_size'], $flickr_size['size'] ); ?>
+				value="<?php echo esc_attr( $flickr_size['size'] ); ?>"
+			>
+				<?php esc_html_e( $flickr_size['text'] ); ?>
+			</option>
+		<?php }
+		?>
+	</select>
+</p>
+
+<p>
+	<small>*
+		<?php esc_html_e( 'To find your Flickr RSS feed, go to your photostream and click the "Edit" tab at the top. Scroll down to the bottom of the page until you see the RSS icon or the Latest link. Right click on either and copy the URL. Paste into the box above.', 'jetpack' ); ?>
+	</small>
+</p>
+<p>
+	<small>
+		<?php printf(
+			__( 'Leave the Flickr RSS URL blank to display <a href="%s">interesting</a> Flickr photos.', 'jetpack' ),
+			'http://www.flickr.com/explore/interesting'
+		); ?>
+	</small>
+</p>

--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -23,13 +23,13 @@
 </p>
 <p>
 	<small>
-		<?php esc_html_e( 'To find your Flickr RSS feed, go to your photostream, open the "More" menu and click on "Edit". Scroll down until you see the RSS icon or the Latest link. Right click on either and copy the URL. Paste into the box above.', 'jetpack' ); ?>
+		<?php esc_html_e( 'To find your Flickr RSS URL, go to your photostream, open the "More" menu and click on "Edit". Scroll down until you see the RSS icon or the "Latest" link. Right click on either and copy the URL. Paste into the box above.', 'jetpack' ); ?>
 	</small>
 </p>
 <p>
 	<small>
 		<?php printf(
-			__( 'Leave the Flickr RSS URL blank to display <a href="%s">interesting</a> Flickr photos.', 'jetpack' ),
+			__( 'Leave the Flickr RSS URL field blank to display <a href="%s">interesting</a> Flickr photos.', 'jetpack' ),
 			'http://www.flickr.com/explore/interesting'
 		); ?>
 	</small>

--- a/modules/widgets/flickr/style.css
+++ b/modules/widgets/flickr/style.css
@@ -10,11 +10,3 @@
 #flickr_badge_uber_wrapper {
 	width: auto;
 }
-
-#flickr_badge_uber_wrapper a,
-#flickr_badge_uber_wrapper a:hover,
-#flickr_badge_uber_wrapper a:active,
-#flickr_badge_uber_wrapper a:visited {
-	color: #3993ff;
-	text-decoration: none;
-}

--- a/modules/widgets/flickr/style.css
+++ b/modules/widgets/flickr/style.css
@@ -1,0 +1,20 @@
+#flickr_badge_uber_wrapper,
+#flickr_badge_wrapper,
+.widget_flickr table td {
+	background-color: transparent;
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+
+#flickr_badge_uber_wrapper {
+	width: auto;
+}
+
+#flickr_badge_uber_wrapper a,
+#flickr_badge_uber_wrapper a:hover,
+#flickr_badge_uber_wrapper a:active,
+#flickr_badge_uber_wrapper a:visited {
+	color: #3993ff;
+	text-decoration: none;
+}

--- a/modules/widgets/flickr/widget.php
+++ b/modules/widgets/flickr/widget.php
@@ -11,14 +11,8 @@
 			<table border="0" cellpadding="0" cellspacing="10" id="flickr_badge_wrapper">
 				<tr>
 					<td align="center">
-						<?php foreach ( $photos as $key => $photo ) { ?>
-							<a href="<?php echo esc_url( $photo['href'], array( 'http', 'https' ) ); ?>"><img
-									alt="<?php echo esc_attr( $photo['title'] ); ?>"
-									border="0"
-									src="<?php echo esc_url( $photo['src'], array( 'http', 'https' ) ); ?>"
-									title="<?php echo esc_attr( $photo['title'] ); ?>"
-								/></a><br /><br />
-						<?php } ?>
+						<?php echo $photos; ?>
+
 						<?php if ( isset( $flickr_home ) ) { ?>
 							<a href="<?php echo esc_url( $flickr_home, array( 'http', 'https' ) ); ?>">
 								<?php esc_html_e( 'More Photos', 'jetpack' ); ?>

--- a/modules/widgets/flickr/widget.php
+++ b/modules/widgets/flickr/widget.php
@@ -1,0 +1,33 @@
+<!-- Start of Flickr Widget -->
+<table
+	border="0"
+	cellpadding="0"
+	cellspacing="0"
+	class="flickr-size-<?php echo esc_attr( $instance['flickr_image_size'] ); ?>"
+	id="flickr_badge_uber_wrapper"
+>
+	<tr>
+		<td>
+			<table border="0" cellpadding="0" cellspacing="10" id="flickr_badge_wrapper">
+				<tr>
+					<td align="center">
+						<?php foreach ( $photos as $key => $photo ) { ?>
+							<a href="<?php echo $photo['link']; ?>">
+								<img
+									alt="<?php echo $photo['title']; ?>"
+									border="0"
+									src="<?php echo $photo['src']; ?>"
+									title="<?php echo $photo['title']; ?>"
+								/>
+							</a><br /><br />
+						<?php } ?>
+						<a href="<?php echo $flickr_home; ?>">
+							<?php esc_html_e( 'More Photos', 'jetpack' ); ?>
+						</a>
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+<!-- End of Flickr Widget -->

--- a/modules/widgets/flickr/widget.php
+++ b/modules/widgets/flickr/widget.php
@@ -12,15 +12,15 @@
 				<tr>
 					<td align="center">
 						<?php foreach ( $photos as $key => $photo ) { ?>
-							<a href="<?php echo $photo['href']; ?>"><img
-									alt="<?php echo $photo['title']; ?>"
+							<a href="<?php echo esc_url( $photo['href'], array( 'http', 'https' ) ); ?>"><img
+									alt="<?php echo esc_attr( $photo['title'] ); ?>"
 									border="0"
-									src="<?php echo $photo['src']; ?>"
-									title="<?php echo $photo['title']; ?>"
+									src="<?php echo esc_url( $photo['src'], array( 'http', 'https' ) ); ?>"
+									title="<?php echo esc_attr( $photo['title'] ); ?>"
 								/></a><br /><br />
 						<?php } ?>
 						<?php if ( isset( $flickr_home ) ) { ?>
-							<a href="<?php echo $flickr_home; ?>">
+							<a href="<?php echo esc_url( $flickr_home, array( 'http', 'https' ) ); ?>">
 								<?php esc_html_e( 'More Photos', 'jetpack' ); ?>
 							</a>
 						<?php } ?>

--- a/modules/widgets/flickr/widget.php
+++ b/modules/widgets/flickr/widget.php
@@ -12,18 +12,18 @@
 				<tr>
 					<td align="center">
 						<?php foreach ( $photos as $key => $photo ) { ?>
-							<a href="<?php echo $photo['link']; ?>">
-								<img
+							<a href="<?php echo $photo['href']; ?>"><img
 									alt="<?php echo $photo['title']; ?>"
 									border="0"
 									src="<?php echo $photo['src']; ?>"
 									title="<?php echo $photo['title']; ?>"
-								/>
-							</a><br /><br />
+								/></a><br /><br />
 						<?php } ?>
-						<a href="<?php echo $flickr_home; ?>">
-							<?php esc_html_e( 'More Photos', 'jetpack' ); ?>
-						</a>
+						<?php if ( isset( $flickr_home ) ) { ?>
+							<a href="<?php echo $flickr_home; ?>">
+								<?php esc_html_e( 'More Photos', 'jetpack' ); ?>
+							</a>
+						<?php } ?>
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
This is my second PR in the effort of filling the gaps between Jetpack and WP.com, to smooth the AT process out.

#### Changes proposed in this Pull Request:

* Adds the Flickr widget as already available on WP.com.

#### Testing instructions:

* Add the widget to a sidebar and check if the widget shows up.
* Check if the photos are retrieved from the correct RSS feed.