### PR TITLE
Endpoints: don't always load the module if it's inactive.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2277,7 +2277,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		switch ( $module ) {
 			case 'monitor':
 				// Load the class to use the method. If class can't be found, do nothing.
-				if ( ! class_exists( 'Jetpack_Monitor' ) && ! @include( Jetpack::get_module_path( $module ) ) ) {
+				if ( ! class_exists( 'Jetpack_Monitor' ) && ! include_once( Jetpack::get_module_path( $module ) ) ) {
 					return false;
 				}
 				$value = Jetpack_Monitor::user_receives_notifications( false );
@@ -2285,7 +2285,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 			case 'post-by-email':
 				// Load the class to use the method. If class can't be found, do nothing.
-				if ( ! class_exists( 'Jetpack_Post_By_Email' ) && ! @include( Jetpack::get_module_path( $module ) ) ) {
+				if ( ! class_exists( 'Jetpack_Post_By_Email' ) && ! include_once( Jetpack::get_module_path( $module ) ) ) {
 					return false;
 				}
 				$post_by_email = new Jetpack_Post_By_Email();

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2273,22 +2273,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return false;
 		}
 
-		// If the module is inactive, load the class to use the method.
-		if ( ! did_action( 'jetpack_module_loaded_' . $module ) ) {
-			// Class can't be found so do nothing.
-			if ( ! @include( Jetpack::get_module_path( $module ) ) ) {
-				return false;
-			}
-		}
-
 		// Do what is necessary for each module.
 		switch ( $module ) {
 			case 'monitor':
-				$monitor = new Jetpack_Monitor();
-				$value = $monitor->user_receives_notifications( false );
+				// Load the class to use the method. If class can't be found, do nothing.
+				if ( ! class_exists( 'Jetpack_Monitor' ) && ! @include( Jetpack::get_module_path( $module ) ) ) {
+					return false;
+				}
+				$value = Jetpack_Monitor::user_receives_notifications( false );
 				break;
 
 			case 'post-by-email':
+				// Load the class to use the method. If class can't be found, do nothing.
+				if ( ! class_exists( 'Jetpack_Post_By_Email' ) && ! @include( Jetpack::get_module_path( $module ) ) ) {
+					return false;
+				}
 				$post_by_email = new Jetpack_Post_By_Email();
 				$value = $post_by_email->get_post_by_email_address();
 				if ( $value === null ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1607,7 +1607,7 @@ class Jetpack {
 				continue;
 			}
 
-			if ( ! @include( Jetpack::get_module_path( $module ) ) ) {
+			if ( ! include_once( Jetpack::get_module_path( $module ) ) ) {
 				unset( $modules[ $index ] );
 				self::update_active_modules( array_values( $modules ) );
 				continue;

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -66,7 +66,7 @@ class Jetpack_Monitor {
 						</th>
 						<td>
 							<label for="receive_jetpack_monitor_notification">
-									<input type="checkbox" name="receive_jetpack_monitor_notification" id="receive_jetpack_monitor_notification" value="receive_jetpack_monitor_notification"<?php checked( $this->user_receives_notifications() ); ?> />
+									<input type="checkbox" name="receive_jetpack_monitor_notification" id="receive_jetpack_monitor_notification" value="receive_jetpack_monitor_notification"<?php checked( self::user_receives_notifications() ); ?> />
 								<span><?php _e( 'Receive Monitor Email Notifications.' , 'jetpack'); ?></span>
 							</label>
 							<p class="description"><?php printf( __( 'Emails will be sent to %s (<a href="%s">Edit</a>)', 'jetpack' ), $user_email, 'https://wordpress.com/settings/account/'); ?></p>
@@ -121,7 +121,7 @@ class Jetpack_Monitor {
 	 *
 	 * @return boolean|WP_Error
 	 */
-	public function user_receives_notifications( $die_on_error = true ) {
+	static function user_receives_notifications( $die_on_error = true ) {
 		Jetpack::load_xml_rpc_client();
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()


### PR DESCRIPTION
Fixes #6943

#### Changes proposed in this Pull Request:

* check if class really doesn't exist first.
* convert `Jetpack_Monitor:: user_receives_notifications()` method to static to call it without instancing the class since it's not needed

#### Proposed changelog
Settings: fixed issue that in certain servers caused a gray screen when trying to load the Jetpack admin screen.