### PR TITLE
General: use include_once to ensure module files are loaded once

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2276,7 +2276,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		// If the module is inactive, load the class to use the method.
 		if ( ! did_action( 'jetpack_module_loaded_' . $module ) ) {
 			// Class can't be found so do nothing.
-			if ( ! @include( Jetpack::get_module_path( $module ) ) ) {
+			if ( ! @include_once( Jetpack::get_module_path( $module ) ) ) {
 				return false;
 			}
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1607,7 +1607,7 @@ class Jetpack {
 				continue;
 			}
 
-			if ( ! @include( Jetpack::get_module_path( $module ) ) ) {
+			if ( ! @include_once( Jetpack::get_module_path( $module ) ) ) {
 				unset( $modules[ $index ] );
 				self::update_active_modules( array_values( $modules ) );
 				continue;


### PR DESCRIPTION
Fixes #6943

#### Changes proposed in this Pull Request:

* use `include_once` instead of `include` to ensure module files are loaded once

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Settings: fixed issue that in certain servers caused a gray screen when trying to load the Jetpack admin screen.