### PR TITLE
Uninstall: Fix fatal due to sync listeners being added for the delete_plugin action

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -27,6 +27,11 @@ delete_option( 'jetpack_was_activated'  );
 delete_option( 'jetpack_auto_installed' );
 delete_transient( 'jetpack_register'    );
 
+// Do not initialize any listeners.
+// Since all the files will be deleted.
+// No need to try to sync anything.
+add_filter( 'jetpack_sync_modules', '__return_empty_array', 100 );
+
 // Jetpack Sync
 require_once JETPACK__PLUGIN_DIR . 'sync/class.jetpack-sync-sender.php';
 Jetpack_Sync_Sender::get_instance()->uninstall();


### PR DESCRIPTION
Fixes #6938 

#### Changes proposed in this Pull Request:

* Do not load any modules and listeners when initialising the sender. 

#### Testing instructions:
* Load branch. Delete plugin notice that there are no fatal error.