### PR TITLE
Add REST API cache busting mechanism.

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -10,242 +10,203 @@ import assign from 'lodash/assign';
  */
 
 function JetpackRestApiClient( root, nonce ) {
-	let apiRoot = root;
-	let apiNonce = nonce;
+	let apiRoot = root,
+		headers = {
+			'X-WP-Nonce': nonce
+		},
+		getParams = {
+			credentials: 'same-origin',
+			headers: headers
+		},
+		postParams = {
+			method: 'post',
+			credentials: 'same-origin',
+			headers: assign( {}, headers, {
+				'Content-type': 'application/json'
+			} )
+		};
 
 	const methods = {
 		setApiRoot( newRoot ) {
 			apiRoot = newRoot;
 		},
 		setApiNonce( newNonce ) {
-			apiNonce = newNonce;
+			headers = {
+				'X-WP-Nonce': newNonce
+			};
+			getParams = {
+				credentials: 'same-origin',
+				headers: headers
+			};
+			postParams = {
+				method: 'post',
+				credentials: 'same-origin',
+				headers: assign( {}, headers, {
+					'Content-type': 'application/json'
+				} )
+			};
 		},
-		fetchSiteConnectionStatus: () => fetch( `${ apiRoot }jetpack/v4/connection`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( response => response.json() ),
-		fetchUserConnectionData: () => fetch( `${ apiRoot }jetpack/v4/connection/data`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( response => response.json() ),
-		disconnectSite: () => fetch( `${ apiRoot }jetpack/v4/connection`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( { isActive: false } )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		fetchConnectUrl: () => fetch( `${ apiRoot }jetpack/v4/connection/url`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		unlinkUser: () => fetch( `${ apiRoot }jetpack/v4/connection/user`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( { linked: false } )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
+
+		fetchSiteConnectionStatus: () => fetch( `${ apiRoot }jetpack/v4/connection`, getParams )
+			.then( response => response.json() ),
+
+		fetchUserConnectionData: () => fetch( `${ apiRoot }jetpack/v4/connection/data`, getParams )
+			.then( response => response.json() ),
+
+		disconnectSite: () => fetch(
+			`${ apiRoot }jetpack/v4/connection`,
+			assign( {}, postParams, {
+				body: JSON.stringify( { isActive: false } )
+			} )
+		)
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		fetchConnectUrl: () => fetch( `${ apiRoot }jetpack/v4/connection/url`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		unlinkUser: () => fetch(
+			`${ apiRoot }jetpack/v4/connection/user`,
+			assign( {}, postParams, {
+				body: JSON.stringify( { linked: false } )
+			} )
+		)
+			.then( checkStatus )
+			.then( response => response.json() ),
+
 		jumpStart: ( action ) => {
 			let active;
 			if ( action === 'activate' ) {
-				active = true
+				active = true;
 			}
 			if ( action === 'deactivate' ) {
-				active = false
+				active = false;
 			}
-			return fetch( `${ apiRoot }jetpack/v4/jumpstart`, {
-				method: 'post',
-				credentials: 'same-origin',
-				headers: {
-					'X-WP-Nonce': apiNonce,
-					'Content-type': 'application/json'
-				},
-				body: JSON.stringify( { active } )
-			} )
-			.then( checkStatus ).then( response => response.json() )
+			return fetch(
+				`${ apiRoot }jetpack/v4/jumpstart`,
+				assign( {}, postParams, {
+					body: JSON.stringify( { active } )
+				} )
+			)
+				.then( checkStatus )
+				.then( response => response.json() );
 		},
-		fetchModules: () => fetch( `${ apiRoot }jetpack/v4/module/all`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		fetchModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		activateModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( { active: true } )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		deactivateModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( { active: false } )
-		} ),
-		updateModuleOptions: ( slug, newOptionValues ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( newOptionValues )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		updateSettings: ( newOptionValues ) => fetch( `${ apiRoot }jetpack/v4/settings`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( newOptionValues )
-		} )
-			.then( checkStatus ).then( response => response.json() ),
-		getProtectCount: () => fetch( `${ apiRoot }jetpack/v4/module/protect/data`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		resetOptions: ( options ) => fetch( `${ apiRoot }jetpack/v4/options/${ options }`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( { reset: true } )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		getVaultPressData: () => fetch( `${ apiRoot }jetpack/v4/module/vaultpress/data`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		getAkismetData: () => fetch( `${ apiRoot }jetpack/v4/module/akismet/data`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		checkAkismetKey: () => fetch( `${ apiRoot }jetpack/v4/module/akismet/key/check`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		checkAkismetKeyTyped: apiKey => fetch( `${ apiRoot }jetpack/v4/module/akismet/key/check`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( { api_key: apiKey } )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		fetchStatsData: ( range ) => fetch(
-			statsDataUrl( range ),
-			{
-				credentials: 'same-origin',
-				headers: {
-					'X-WP-Nonce': apiNonce
-				}
-			}
+
+		fetchModules: () => fetch( `${ apiRoot }jetpack/v4/module/all`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		fetchModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		activateModule: ( slug ) => fetch(
+			`${ apiRoot }jetpack/v4/module/${ slug }/active`,
+			assign( {}, postParams, {
+				body: JSON.stringify( { active: true } )
+			} )
 		)
-		.then( checkStatus ).then( response => response.json() ),
-		getPluginUpdates: () => fetch( `${ apiRoot }jetpack/v4/updates/plugins`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		fetchSettings: () => fetch( `${ apiRoot }jetpack/v4/settings`, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		updateSetting: ( updatedSetting ) => fetch( `${ apiRoot }jetpack/v4/settings`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( updatedSetting )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		fetchSiteData: () => {
-			return fetch( `${ apiRoot }jetpack/v4/site`, {
-				method: 'get',
-				credentials: 'same-origin',
-				headers: {
-					'X-WP-Nonce': apiNonce
-				}
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		deactivateModule: ( slug ) => fetch(
+			`${ apiRoot }jetpack/v4/module/${ slug }/active`,
+			assign( {}, postParams, {
+				body: JSON.stringify( { active: false } )
 			} )
-			.then( checkStatus ).then( response => response.json() )
-			.then( body => {
-				return JSON.parse( body.data );
-			} );
-		},
-		dismissJetpackNotice: ( notice ) => fetch( `${ apiRoot }jetpack/v4/notice/${ notice }`, {
-			method: 'post',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce,
-				'Content-type': 'application/json'
-			},
-			body: JSON.stringify( { dismissed: true } )
-		} )
-		.then( checkStatus ).then( response => response.json() ),
-		fetchPluginsData: () => fetch( `${ apiRoot }jetpack/v4/plugins`, {
-			method: 'get',
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': apiNonce
-			}
-		} )
-		.then( checkStatus ).then( response => response.json() )
+		),
+
+		updateModuleOptions: ( slug, newOptionValues ) => fetch(
+			`${ apiRoot }jetpack/v4/module/${ slug }`,
+			assign( {}, postParams, {
+				body: JSON.stringify( newOptionValues )
+			} )
+		)
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		updateSettings: ( newOptionValues ) => fetch(
+			`${ apiRoot }jetpack/v4/settings`,
+			assign( {}, postParams, {
+				body: JSON.stringify( newOptionValues )
+			} )
+		)
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		getProtectCount: () => fetch( `${ apiRoot }jetpack/v4/module/protect/data`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		resetOptions: ( options ) => fetch(
+			`${ apiRoot }jetpack/v4/options/${ options }`,
+			assign( {}, postParams, {
+				body: JSON.stringify( { reset: true } )
+			} )
+		)
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		getVaultPressData: () => fetch( `${ apiRoot }jetpack/v4/module/vaultpress/data`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		getAkismetData: () => fetch( `${ apiRoot }jetpack/v4/module/akismet/data`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		checkAkismetKey: () => fetch( `${ apiRoot }jetpack/v4/module/akismet/key/check`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		checkAkismetKeyTyped: apiKey => fetch(
+			`${ apiRoot }jetpack/v4/module/akismet/key/check`,
+			assign( {}, postParams, {
+				body: JSON.stringify( { api_key: apiKey } )
+			} )
+		)
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		fetchStatsData: ( range ) => fetch( statsDataUrl( range ), getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		getPluginUpdates: () => fetch( `${ apiRoot }jetpack/v4/updates/plugins`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		fetchSettings: () => fetch( `${ apiRoot }jetpack/v4/settings`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		updateSetting: ( updatedSetting ) => fetch(
+			`${ apiRoot }jetpack/v4/settings`,
+			assign( {}, postParams, {
+				body: JSON.stringify( updatedSetting )
+			} )
+		)
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		fetchSiteData: () => fetch( `${ apiRoot }jetpack/v4/site`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() )
+			.then( body => JSON.parse( body.data ) ),
+
+		dismissJetpackNotice: ( notice ) => fetch(
+			`${ apiRoot }jetpack/v4/notice/${ notice }`,
+			assign( {}, postParams, {
+				body: JSON.stringify( { dismissed: true } )
+			} )
+		)
+			.then( checkStatus )
+			.then( response => response.json() ),
+
+		fetchPluginsData: () => fetch( `${ apiRoot }jetpack/v4/plugins`, getParams )
+			.then( checkStatus )
+			.then( response => response.json() )
 	};
 
 	function statsDataUrl( range ) {

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -47,31 +47,25 @@ function JetpackRestApiClient( root, nonce ) {
 			};
 		},
 
-		fetchSiteConnectionStatus: () => fetch( `${ apiRoot }jetpack/v4/connection`, getParams )
+		fetchSiteConnectionStatus: () => getRequest( `${ apiRoot }jetpack/v4/connection` )
 			.then( response => response.json() ),
 
-		fetchUserConnectionData: () => fetch( `${ apiRoot }jetpack/v4/connection/data`, getParams )
+		fetchUserConnectionData: () => getRequest( `${ apiRoot }jetpack/v4/connection/data` )
 			.then( response => response.json() ),
 
-		disconnectSite: () => fetch(
-			`${ apiRoot }jetpack/v4/connection`,
-			assign( {}, postParams, {
-				body: JSON.stringify( { isActive: false } )
-			} )
-		)
+		disconnectSite: () => postRequest( `${ apiRoot }jetpack/v4/connection`, {
+			body: JSON.stringify( { isActive: false } )
+		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchConnectUrl: () => fetch( `${ apiRoot }jetpack/v4/connection/url`, getParams )
+		fetchConnectUrl: () => getRequest( `${ apiRoot }jetpack/v4/connection/url` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		unlinkUser: () => fetch(
-			`${ apiRoot }jetpack/v4/connection/user`,
-			assign( {}, postParams, {
-				body: JSON.stringify( { linked: false } )
-			} )
-		)
+		unlinkUser: () => postRequest( `${ apiRoot }jetpack/v4/connection/user`, {
+			body: JSON.stringify( { linked: false } )
+		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
@@ -83,131 +77,130 @@ function JetpackRestApiClient( root, nonce ) {
 			if ( action === 'deactivate' ) {
 				active = false;
 			}
-			return fetch(
-				`${ apiRoot }jetpack/v4/jumpstart`,
-				assign( {}, postParams, {
-					body: JSON.stringify( { active } )
-				} )
-			)
+			return postRequest( `${ apiRoot }jetpack/v4/jumpstart`, {
+				body: JSON.stringify( { active } )
+			} )
 				.then( checkStatus )
 				.then( response => response.json() );
 		},
 
-		fetchModules: () => fetch( `${ apiRoot }jetpack/v4/module/all`, getParams )
+		fetchModules: () => getRequest( `${ apiRoot }jetpack/v4/module/all` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchModule: ( slug ) => fetch( `${ apiRoot }jetpack/v4/module/${ slug }`, getParams )
+		fetchModule: ( slug ) => getRequest( `${ apiRoot }jetpack/v4/module/${ slug }` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		activateModule: ( slug ) => fetch(
-			`${ apiRoot }jetpack/v4/module/${ slug }/active`,
-			assign( {}, postParams, {
-				body: JSON.stringify( { active: true } )
-			} )
-		)
+		activateModule: ( slug ) => postRequest( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
+			body: JSON.stringify( { active: true } )
+		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		deactivateModule: ( slug ) => fetch(
-			`${ apiRoot }jetpack/v4/module/${ slug }/active`,
-			assign( {}, postParams, {
-				body: JSON.stringify( { active: false } )
-			} )
-		),
+		deactivateModule: ( slug ) => postRequest( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
+			body: JSON.stringify( { active: false } )
+		} ),
 
-		updateModuleOptions: ( slug, newOptionValues ) => fetch(
+		updateModuleOptions: ( slug, newOptionValues ) => postRequest(
 			`${ apiRoot }jetpack/v4/module/${ slug }`,
-			assign( {}, postParams, {
+			{
 				body: JSON.stringify( newOptionValues )
-			} )
+			}
 		)
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		updateSettings: ( newOptionValues ) => fetch(
-			`${ apiRoot }jetpack/v4/settings`,
-			assign( {}, postParams, {
-				body: JSON.stringify( newOptionValues )
-			} )
-		)
+		updateSettings: ( newOptionValues ) => postRequest( `${ apiRoot }jetpack/v4/settings`, {
+			body: JSON.stringify( newOptionValues )
+		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		getProtectCount: () => fetch( `${ apiRoot }jetpack/v4/module/protect/data`, getParams )
+		getProtectCount: () => getRequest( `${ apiRoot }jetpack/v4/module/protect/data` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		resetOptions: ( options ) => fetch(
-			`${ apiRoot }jetpack/v4/options/${ options }`,
-			assign( {}, postParams, {
-				body: JSON.stringify( { reset: true } )
-			} )
-		)
+		resetOptions: ( options ) => postRequest( `${ apiRoot }jetpack/v4/options/${ options }`, {
+			body: JSON.stringify( { reset: true } )
+		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		getVaultPressData: () => fetch( `${ apiRoot }jetpack/v4/module/vaultpress/data`, getParams )
+		getVaultPressData: () => getRequest( `${ apiRoot }jetpack/v4/module/vaultpress/data` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		getAkismetData: () => fetch( `${ apiRoot }jetpack/v4/module/akismet/data`, getParams )
+		getAkismetData: () => getRequest( `${ apiRoot }jetpack/v4/module/akismet/data` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		checkAkismetKey: () => fetch( `${ apiRoot }jetpack/v4/module/akismet/key/check`, getParams )
+		checkAkismetKey: () => getRequest( `${ apiRoot }jetpack/v4/module/akismet/key/check` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		checkAkismetKeyTyped: apiKey => fetch(
+		checkAkismetKeyTyped: apiKey => postRequest(
 			`${ apiRoot }jetpack/v4/module/akismet/key/check`,
-			assign( {}, postParams, {
+			{
 				body: JSON.stringify( { api_key: apiKey } )
-			} )
+			}
 		)
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchStatsData: ( range ) => fetch( statsDataUrl( range ), getParams )
+		fetchStatsData: ( range ) => getRequest( statsDataUrl( range ) )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		getPluginUpdates: () => fetch( `${ apiRoot }jetpack/v4/updates/plugins`, getParams )
+		getPluginUpdates: () => getRequest( `${ apiRoot }jetpack/v4/updates/plugins` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchSettings: () => fetch( `${ apiRoot }jetpack/v4/settings`, getParams )
+		fetchSettings: () => getRequest( `${ apiRoot }jetpack/v4/settings` )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		updateSetting: ( updatedSetting ) => fetch(
-			`${ apiRoot }jetpack/v4/settings`,
-			assign( {}, postParams, {
-				body: JSON.stringify( updatedSetting )
-			} )
-		)
+		updateSetting: ( updatedSetting ) => postRequest( `${ apiRoot }jetpack/v4/settings`, {
+			body: JSON.stringify( updatedSetting )
+		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchSiteData: () => fetch( `${ apiRoot }jetpack/v4/site`, getParams )
+		fetchSiteData: () => getRequest( `${ apiRoot }jetpack/v4/site` )
 			.then( checkStatus )
 			.then( response => response.json() )
 			.then( body => JSON.parse( body.data ) ),
 
-		dismissJetpackNotice: ( notice ) => fetch(
-			`${ apiRoot }jetpack/v4/notice/${ notice }`,
-			assign( {}, postParams, {
-				body: JSON.stringify( { dismissed: true } )
-			} )
-		)
+		dismissJetpackNotice: ( notice ) => postRequest( `${ apiRoot }jetpack/v4/notice/${ notice }`, {
+			body: JSON.stringify( { dismissed: true } )
+		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchPluginsData: () => fetch( `${ apiRoot }jetpack/v4/plugins`, getParams )
+		fetchPluginsData: () => getRequest( `${ apiRoot }jetpack/v4/plugins` )
 			.then( checkStatus )
 			.then( response => response.json() )
 	};
+
+	function addCacheBuster( route ) {
+		const parts = route.split( '?' ),
+			query = parts.length > 1
+				? parts[ 1 ]
+				: '',
+			args = query.split( '&' );
+
+		args.push( '_rnd=' + ( 10e9 * Math.random() ) );
+
+		return parts[ 0 ] + '?' + args.join( '&' );
+	}
+
+	function getRequest( route ) {
+		return fetch( addCacheBuster( route ), getParams );
+	}
+
+	function postRequest( route, body ) {
+		return fetch( addCacheBuster( route ), assign( {}, postParams, body ) );
+	}
 
 	function statsDataUrl( range ) {
 		let url = `${ apiRoot }jetpack/v4/module/stats/data`;

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -47,23 +47,23 @@ function JetpackRestApiClient( root, nonce ) {
 			};
 		},
 
-		fetchSiteConnectionStatus: () => getRequest( `${ apiRoot }jetpack/v4/connection` )
+		fetchSiteConnectionStatus: () => getRequest( `${ apiRoot }jetpack/v4/connection`, getParams )
 			.then( response => response.json() ),
 
-		fetchUserConnectionData: () => getRequest( `${ apiRoot }jetpack/v4/connection/data` )
+		fetchUserConnectionData: () => getRequest( `${ apiRoot }jetpack/v4/connection/data`, getParams )
 			.then( response => response.json() ),
 
-		disconnectSite: () => postRequest( `${ apiRoot }jetpack/v4/connection`, {
+		disconnectSite: () => postRequest( `${ apiRoot }jetpack/v4/connection`, postParams, {
 			body: JSON.stringify( { isActive: false } )
 		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchConnectUrl: () => getRequest( `${ apiRoot }jetpack/v4/connection/url` )
+		fetchConnectUrl: () => getRequest( `${ apiRoot }jetpack/v4/connection/url`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		unlinkUser: () => postRequest( `${ apiRoot }jetpack/v4/connection/user`, {
+		unlinkUser: () => postRequest( `${ apiRoot }jetpack/v4/connection/user`, postParams, {
 			body: JSON.stringify( { linked: false } )
 		} )
 			.then( checkStatus )
@@ -77,33 +77,42 @@ function JetpackRestApiClient( root, nonce ) {
 			if ( action === 'deactivate' ) {
 				active = false;
 			}
-			return postRequest( `${ apiRoot }jetpack/v4/jumpstart`, {
+			return postRequest( `${ apiRoot }jetpack/v4/jumpstart`, postParams, {
 				body: JSON.stringify( { active } )
 			} )
 				.then( checkStatus )
 				.then( response => response.json() );
 		},
 
-		fetchModules: () => getRequest( `${ apiRoot }jetpack/v4/module/all` )
+		fetchModules: () => getRequest( `${ apiRoot }jetpack/v4/module/all`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchModule: ( slug ) => getRequest( `${ apiRoot }jetpack/v4/module/${ slug }` )
+		fetchModule: ( slug ) => getRequest( `${ apiRoot }jetpack/v4/module/${ slug }`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		activateModule: ( slug ) => postRequest( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
-			body: JSON.stringify( { active: true } )
-		} )
+		activateModule: ( slug ) => postRequest(
+			`${ apiRoot }jetpack/v4/module/${ slug }/active`,
+			postParams,
+			{
+				body: JSON.stringify( { active: true } )
+			}
+		)
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		deactivateModule: ( slug ) => postRequest( `${ apiRoot }jetpack/v4/module/${ slug }/active`, {
-			body: JSON.stringify( { active: false } )
-		} ),
+		deactivateModule: ( slug ) => postRequest(
+			`${ apiRoot }jetpack/v4/module/${ slug }/active`,
+			postParams,
+			{
+				body: JSON.stringify( { active: false } )
+			}
+		),
 
 		updateModuleOptions: ( slug, newOptionValues ) => postRequest(
 			`${ apiRoot }jetpack/v4/module/${ slug }`,
+			postParams,
 			{
 				body: JSON.stringify( newOptionValues )
 			}
@@ -111,36 +120,45 @@ function JetpackRestApiClient( root, nonce ) {
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		updateSettings: ( newOptionValues ) => postRequest( `${ apiRoot }jetpack/v4/settings`, {
-			body: JSON.stringify( newOptionValues )
-		} )
+		updateSettings: ( newOptionValues ) => postRequest(
+			`${ apiRoot }jetpack/v4/settings`,
+			postParams,
+			{
+				body: JSON.stringify( newOptionValues )
+			}
+		)
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		getProtectCount: () => getRequest( `${ apiRoot }jetpack/v4/module/protect/data` )
+		getProtectCount: () => getRequest( `${ apiRoot }jetpack/v4/module/protect/data`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		resetOptions: ( options ) => postRequest( `${ apiRoot }jetpack/v4/options/${ options }`, {
-			body: JSON.stringify( { reset: true } )
-		} )
+		resetOptions: ( options ) => postRequest(
+			`${ apiRoot }jetpack/v4/options/${ options }`,
+			postParams,
+			{
+				body: JSON.stringify( { reset: true } )
+			}
+		)
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		getVaultPressData: () => getRequest( `${ apiRoot }jetpack/v4/module/vaultpress/data` )
+		getVaultPressData: () => getRequest( `${ apiRoot }jetpack/v4/module/vaultpress/data`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		getAkismetData: () => getRequest( `${ apiRoot }jetpack/v4/module/akismet/data` )
+		getAkismetData: () => getRequest( `${ apiRoot }jetpack/v4/module/akismet/data`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		checkAkismetKey: () => getRequest( `${ apiRoot }jetpack/v4/module/akismet/key/check` )
+		checkAkismetKey: () => getRequest( `${ apiRoot }jetpack/v4/module/akismet/key/check`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
 		checkAkismetKeyTyped: apiKey => postRequest(
 			`${ apiRoot }jetpack/v4/module/akismet/key/check`,
+			postParams,
 			{
 				body: JSON.stringify( { api_key: apiKey } )
 			}
@@ -148,36 +166,40 @@ function JetpackRestApiClient( root, nonce ) {
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchStatsData: ( range ) => getRequest( statsDataUrl( range ) )
+		fetchStatsData: ( range ) => getRequest( statsDataUrl( range ), getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		getPluginUpdates: () => getRequest( `${ apiRoot }jetpack/v4/updates/plugins` )
+		getPluginUpdates: () => getRequest( `${ apiRoot }jetpack/v4/updates/plugins`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchSettings: () => getRequest( `${ apiRoot }jetpack/v4/settings` )
+		fetchSettings: () => getRequest( `${ apiRoot }jetpack/v4/settings`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		updateSetting: ( updatedSetting ) => postRequest( `${ apiRoot }jetpack/v4/settings`, {
+		updateSetting: ( updatedSetting ) => postRequest( `${ apiRoot }jetpack/v4/settings`, postParams, {
 			body: JSON.stringify( updatedSetting )
 		} )
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchSiteData: () => getRequest( `${ apiRoot }jetpack/v4/site` )
+		fetchSiteData: () => getRequest( `${ apiRoot }jetpack/v4/site`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() )
 			.then( body => JSON.parse( body.data ) ),
 
-		dismissJetpackNotice: ( notice ) => postRequest( `${ apiRoot }jetpack/v4/notice/${ notice }`, {
-			body: JSON.stringify( { dismissed: true } )
-		} )
+		dismissJetpackNotice: ( notice ) => postRequest(
+			`${ apiRoot }jetpack/v4/notice/${ notice }`,
+			postParams,
+			{
+				body: JSON.stringify( { dismissed: true } )
+			}
+		)
 			.then( checkStatus )
 			.then( response => response.json() ),
 
-		fetchPluginsData: () => getRequest( `${ apiRoot }jetpack/v4/plugins` )
+		fetchPluginsData: () => getRequest( `${ apiRoot }jetpack/v4/plugins`, getParams )
 			.then( checkStatus )
 			.then( response => response.json() )
 	};
@@ -187,19 +209,21 @@ function JetpackRestApiClient( root, nonce ) {
 			query = parts.length > 1
 				? parts[ 1 ]
 				: '',
-			args = query.split( '&' );
+			args = query.length
+				? query.split( '&' )
+				: [];
 
-		args.push( '_rnd=' + ( 10e9 * Math.random() ) );
+		args.push( '_cacheBuster=' + new Date().getTime() );
 
 		return parts[ 0 ] + '?' + args.join( '&' );
 	}
 
-	function getRequest( route ) {
-		return fetch( addCacheBuster( route ), getParams );
+	function getRequest( route, params ) {
+		return fetch( addCacheBuster( route ), params );
 	}
 
-	function postRequest( route, body ) {
-		return fetch( addCacheBuster( route ), assign( {}, postParams, body ) );
+	function postRequest( route, params, body ) {
+		return fetch( route, assign( {}, params, body ) );
 	}
 
 	function statsDataUrl( range ) {


### PR DESCRIPTION
Fixes #5217 

#### Changes proposed in this Pull Request:
* Refactored the REST API component to make it more DRY.
* Adds a cache busting mechanism to address the problem of requests being cached.

#### Testing instructions:
* I had a really hard time reproducing the problem on my own server, but it could be reproduced on SiteGround shared hosting. If you enable the browser console and allow browser caching in the settings, you will see that some requests come back with `304 Not Modified`. My guess is that it's because the server sends back the `Last-Modified` header with the zero epoch time every time. If you can't reproduce it, try adding the header to API responses manually with this:
```
add_filter( 'rest_post_dispatch', function( $response, $server, $request ) {
	$response->set_headers(
		array_merge(
			$response->get_headers(),
			array(
				'Last-Modified' => date( 'r', 0 )
			)
		)
	);
	return $response;
}, 3, 10 );
```
* See that the requests are cached.
* Update to this PR.
* See that the cache busting mechanism defeats the problem.

#### Proposed changelog entry for your changes:
* Fixed the problem of API requests being cached on some hosts.