### PR TITLE
Added array initialization to fix PHP 7.1 notices.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -1043,8 +1043,16 @@ add_shortcode( 'jetpack_subscription_form', 'jetpack_do_subscription_form' );
 add_shortcode( 'blog_subscription_form', 'jetpack_do_subscription_form' );
 
 function jetpack_do_subscription_form( $instance ) {
+	if ( empty( $instance ) || ! is_array( $instance ) ) {
+		$instance = array();
+	}
 	$instance['show_subscribers_total'] = empty( $instance['show_subscribers_total'] ) ? false : true;
-	$instance = shortcode_atts( Jetpack_Subscriptions_Widget::defaults(), $instance, 'jetpack_subscription_form' );
+
+	$instance = shortcode_atts(
+		Jetpack_Subscriptions_Widget::defaults(),
+		$instance,
+		'jetpack_subscription_form'
+	);
 	$args = array(
 		'before_widget' => sprintf( '<div class="%s">', 'jetpack_subscription_widget' ),
 	);


### PR DESCRIPTION
Fixes #6101 

#### Changes proposed in this Pull Request:
* Adds array initialization to fix a notice in PHP 7.1.

#### Testing instructions:
* Use a WordPress installation running on PHP 7.1.
* Add some code that outputs a default subscriptions widget without any settings, like this:
```
add_action( 'wp_footer', function() {
	do_shortcode( '[jetpack_subscription_form]' );
} );
```
* Observe the notice in the error log.
* Update to this PR.
* Observe no notice and verify that the shortcode works as it should.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed a notice in the subscription widget in PHP 7.1