### PR TITLE
Portfolio Shortcode: Remove WordAds

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -677,6 +677,7 @@ class Jetpack_Portfolio {
 				<?php
 				// The content
 				if ( false !== $atts['display_content'] ) {
+					add_filter( 'wordads_inpost_disable', '__return_true', 20 );
 					if ( 'full' === $atts['display_content'] ) {
 					?>
 						<div class="portfolio-entry-content"><?php the_content(); ?></div>
@@ -686,6 +687,7 @@ class Jetpack_Portfolio {
 						<div class="portfolio-entry-content"><?php the_excerpt(); ?></div>
 					<?php
 					}
+					remove_filter( 'wordads_inpost_disable', '__return_true', 20 );
 				}
 				?>
 				</div><!-- close .portfolio-entry -->


### PR DESCRIPTION
With Ads enabled and using the Portfolio shortcode, ads are injected with each portfolio entry. Let's remove this.

This seeks to surgically remove the ads from this instance only purposely set on a non-default priority so we can add/remove the function with a reduced chance of interfering with other plugins or code modifying the ad run.

To test, use a shortcode like `[portfolio display_types="false" include_types="contributing"]`.

![2017-04-10 22_51_55-about brandon kraft](https://cloud.githubusercontent.com/assets/88897/24892236/a8a29f3c-1e40-11e7-9721-7136643df85c.png)
