### PR TITLE
Jetpack Notices: fix ugly VaultPress notice

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -7,27 +7,29 @@ const AdminNotices = React.createClass( {
 	componentDidMount() {
 		const $adminNotices = jQuery( this.refs.adminNotices );
 
-		let $vpNotice = jQuery( '.vp-notice' );
+		const $vpNotice = jQuery( '.vp-notice' );
 		if ( $vpNotice.length > 0 ) {
-			$vpNotice.each( function () {
-				let $notice = jQuery( this ).addClass( 'dops-notice is-warning' ).removeClass( 'wrap vp-notice' );
+			$vpNotice.each( function() {
+				let $notice = jQuery( this ).addClass( 'dops-notice is-warning vp-notice-jp' ).removeClass( 'wrap vp-notice' );
+				const icon = '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path></g></svg>';
 				$notice.wrapInner( '<div class="dops-notice__content">' );
-				$notice.find( 'a' ).addClass( 'dops-notice__action' ).appendTo( $notice );
+				$notice.find( '.dops-notice__content' ).before( icon );
 				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );
-				$notice.find( 'h3' ).replaceWith( function () { return jQuery( '<strong />', { html: this.innerHTML } ); } );
-				$notice.find( 'p' ).replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML } ); } );
+				$notice.find( 'h3' ).replaceWith( function() { return jQuery( '<strong />', { html: this.innerHTML } ); } );
+				$notice.find( 'p' ).replaceWith( function() { return jQuery( '<div/>', { html: this.innerHTML } ); } );
+				$notice.find( 'a[href*="admin.php?page=vaultpress"]' ).remove();
 				$notice.prependTo( $adminNotices ).show();
 			} );
 		}
 
-		let $wcNotice = jQuery( '.woocommerce-message' );
+		const $wcNotice = jQuery( '.woocommerce-message' );
 		if ( $wcNotice.length > 0 ) {
-			$wcNotice.each( function () {
-				let $notice = jQuery( this ).addClass( 'dops-notice is-basic' ).removeClass( 'updated wc-connect' );
+			$wcNotice.each( function() {
+				const $notice = jQuery( this ).addClass( 'dops-notice is-basic' ).removeClass( 'updated wc-connect' );
 				$notice.find( '.button-primary' ).addClass( 'dops-notice__action' ).removeClass( 'button-primary' ).detach().appendTo( $notice );
 				$notice.find( 'p' ).not( '.submit' ).wrapAll( '<div class="dops-notice__text"/>' );
-				let $dopsNotice = $notice.find( '.dops-notice__text' );
-				$dopsNotice.find( 'p' ).replaceWith( function () { return jQuery( '<div/>', { html: this.innerHTML, class: 'dops-notice__moved_text' } ); } );
+				const $dopsNotice = $notice.find( '.dops-notice__text' );
+				$dopsNotice.find( 'p' ).replaceWith( function() { return jQuery( '<div/>', { html: this.innerHTML, class: 'dops-notice__moved_text' } ); } );
 				$dopsNotice.find( 'br' ).remove();
 				$notice.find( '.button-secondary' ).removeClass( 'button-secondary' ).detach().appendTo( $dopsNotice );
 				$notice.find( '.submit' ).remove();
@@ -39,7 +41,7 @@ const AdminNotices = React.createClass( {
 	},
 
 	render() {
-		return ( <div ref="adminNotices" aria-live="polite"></div> )
+		return ( <div ref="adminNotices" aria-live="polite"></div> );
 	}
 } );
 

--- a/_inc/client/components/admin-notices/style.scss
+++ b/_inc/client/components/admin-notices/style.scss
@@ -4,6 +4,12 @@
 		display: none;
 	}
 
+	.vp-notice-jp {
+		a {
+			text-decoration: underline;
+		}
+	}
+
 	.woocommerce-message.dops-notice {
 		display: block;
 


### PR DESCRIPTION
Fixes #6960

Manually remove the link to the VaultPress, so there's not two links anymore. 

No more action notices. 

Added an icon. 

Before:
![image](https://cloud.githubusercontent.com/assets/437258/24880003/b1b069ea-1e06-11e7-917b-b1d1eabe2c99.png)

After: 
<img width="776" alt="screen shot 2017-04-11 at 1 05 54 pm" src="https://cloud.githubusercontent.com/assets/7129409/24921445/e05efd9e-1eb8-11e7-904a-84fc78820799.png">
