### PR TITLE
Added a mechanism to check the existing token.

### DIFF
--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -633,12 +633,17 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		$response->data = parse_url( $response->data );
 		parse_str( $response->data['query'], $response->data['query'] );
+
+		// Because dotcom will not respond to a fake token, the method
+		// generates a register URL
+		$this->assertContains( 'register', $response->data['query'] );
+
 		unset( $response->data['query'] );
 		$this->assertResponseData(
 			array(
-				'scheme' => 'https',
-				'host'   => 'jetpack.wordpress.com',
-				'path'   => '/jetpack.authorize/1/',
+				'scheme' => 'http',
+				'host'   => 'example.org',
+				'path'   => '/wp-admin/admin.php'
 			), $response
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds a mechanism that checks the existing token and generates a registration URL if it doesn't work.

#### Testing instructions:
* Disconnect your Jetpack, make sure it appears as disconnected both in wp-admin and in Calypso.
* Click the connect link.
* In the approval screen just leave it without clicking "Approve".
* Intentionally garble your token to simulate a non-functional Jetpack connection on the client side, you can do it by running this code as a filter once:
```
add_action( 'noop_wp_loaded', function() {
	$token = Jetpack_Options::get_option( 'blog_token' ) . 'garbage';
	Jetpack_Options::update_option( 'blog_token', $token );
} );
```
* You shouldn't be able to connect from wp-admin at all. Broken tokens result in different errors, most notorious of which is the following:
```
Invalid request, please go back and try again.
Error Code: invalid_client
Error Message: Unknown client_id.
```
* Update to this PR.
* Now you'll be able to connect even if you have a broken token - it will get re-requested.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Added a mechanism to detect broken connection states and resolve them.