### PR TITLE
Jetpack Sync: Add theme name and version to theme switch sync data

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -198,6 +198,10 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			}
 		}
 
+		$theme = wp_get_theme();
+		$theme_support['name'] = $theme->name;
+		$theme_support['version'] =  $theme->version;
+
 		return $theme_support;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -39,6 +39,11 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		set_theme_mod( 'foo', 'bar' );
 		$this->sender->do_sync();
 
+		$current_theme = wp_get_theme();
+		$switch_data = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_current_theme_support' );
+		$this->assertEquals( $current_theme->name, $switch_data->args[0]['name']);
+		$this->assertEquals( $current_theme->version, $switch_data->args[0]['version']);
+
 		foreach ( $theme_features as $theme_feature ) {
 			$synced_theme_support_value = $this->server_replica_storage->current_theme_supports( $theme_feature );
 			$this->assertEquals( current_theme_supports( $theme_feature ), $synced_theme_support_value, 'Feature(s) not synced' . $theme_feature );


### PR DESCRIPTION
Add theme name and version to theme switch sync data

#### Changes proposed in this Pull Request:

Add theme name and version to theme switch sync data

#### Testing instructions:

phpunit

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
