### PR TITLE
XMLRPC: remove activateManage method

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -57,7 +57,6 @@ class Jetpack_Options {
 			return array(
 				'register',
 				'authorize',
-				'activate_manage',
 				'blog_token',                  // (string) The Client Secret/Blog Token of this site.
 				'user_token',                  // (string) The User Token of this site. (deprecated)
 				'user_tokens'                  // (array)  User Tokens for each user of this site who has connected to jetpack.wordpress.com.

--- a/class.jetpack-xmlrpc-server.php
+++ b/class.jetpack-xmlrpc-server.php
@@ -80,25 +80,7 @@ class Jetpack_XMLRPC_Server {
 	function authorize_xmlrpc_methods() {
 		return array(
 			'jetpack.remoteAuthorize' => array( $this, 'remote_authorize' ),
-			'jetpack.activateManage'    => array( $this, 'activate_manage' ),
 		);
-	}
-
-	function activate_manage( $request ) {
-		foreach( array( 'secret', 'state' ) as $required ) {
-			if ( ! isset( $request[ $required ] ) || empty( $request[ $required ] ) ) {
-				return $this->error( new Jetpack_Error( 'missing_parameter', 'One or more parameters is missing from the request.', 400 ) );
-			}
-		}
-		$verified = $this->verify_action( array( 'activate_manage', $request['secret'], $request['state'] ) );
-		if ( is_a( $verified, 'IXR_Error' ) ) {
-			return $verified;
-		}
-		$activated = Jetpack::activate_module( 'manage', false, false );
-		if ( false === $activated || ! Jetpack::is_module_active( 'manage' ) ) {
-			return $this->error( new Jetpack_Error( 'activation_error', 'There was an error while activating the module.', 500 ) );
-		}
-		return 'active';
 	}
 
 	function remote_authorize( $request ) {
@@ -130,12 +112,9 @@ class Jetpack_XMLRPC_Server {
 		if ( is_wp_error( $result ) ) {
 			return $this->error( $result );
 		}
-		// Creates a new secret, allowing someone to activate the manage module for up to 1 day after authorization.
-		$secrets = Jetpack::init()->generate_secrets( 'activate_manage', DAY_IN_SECONDS );
-		@list( $secret ) = explode( ':', $secrets );
+
 		$response = array(
 			'result' => $result,
-			'activate_manage' => $secret,
 		);
 		return $response;
 	}


### PR DESCRIPTION
Since Jetpack 4.4, the Manage Module is now activated by default. We no longer need an XMLRPC method for it.

To test:

Add this PR to one of you Jetpack sites.
Test the various Jetpack Connect flows, and ensure there are no regressions.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Removing an no longer necessary XMLRPC method.
