### PR TITLE
Settings UI: allow to search for and find VideoPress

### DIFF
--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -46,7 +46,8 @@ export const Writing = React.createClass( {
 			'carousel',
 			'post-by-email',
 			'infinite-scroll',
-			'minileven'
+			'minileven',
+			'videopress'
 		].some( this.props.isModuleFound );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {


### PR DESCRIPTION
Fixes #6971 

#### Changes proposed in this Pull Request:

* add VideoPress to list of modules that can be found

#### Testing instructions:

* build and search for `video` for example, it should display videopress

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Settings UI: fix issue where VideoPress wasn't in the results when searching for video