### PR TITLE
Network: display all sites available in network.

### DIFF
--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -25,9 +25,10 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 		// Deal with bulk actions if any were requested by the user
 		$this->process_bulk_action();
 
-		$sites = get_sites( array( 
+		$sites = get_sites( array(
 			'site__not_in' => array( get_current_blog_id() ),
-			'archived' => false,
+			'archived'     => false,
+			'number'       => 0,
 		) );
 
 		// Setup pagination


### PR DESCRIPTION
By default, `get_sites()` only displays up to 100 sites by default.

Fixes 170-gh-jpop-issues

Before we ship this, it'd be great to test it on large networks. cc @iandunn 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Multisite: display all sites available in network, even on large multisite installations.
