### PR TITLE
Sync: Separate User Events: Add, Register and Update user events should be different

### DIFF
--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -22,6 +22,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'profile_update', array( $this, 'save_user_handler' ), 10, 2 );
 		add_action( 'add_user_to_blog', array( $this, 'save_user_handler' ) );
 		add_action( 'jetpack_sync_save_user', $callable, 10, 2 );
+		add_action( 'jetpack_sync_register_user', $callable, 10, 2 );
+		add_action( 'jetpack_sync_add_user', $callable, 10, 2 );
+
 		add_action( 'jetpack_sync_user_locale', $callable, 10, 2 );
 		add_action( 'jetpack_sync_user_locale_delete', $callable, 10, 1 );
 
@@ -51,6 +54,8 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_sync_add_user', array( $this, 'expand_user' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_sync_register_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_wp_login', array( $this, 'expand_login_username' ), 10, 1 );
 		add_filter( 'jetpack_sync_before_send_wp_logout', array( $this, 'expand_logout_username' ), 10, 2 );
 
@@ -136,6 +141,30 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			if ( serialize( $old_user ) === serialize( $user->data ) ) {
 				return;
 			}
+		}
+
+		if ( 'user_register' === current_filter() ) {
+			/**
+			 * Fires when a new user is registered on a site
+			 *
+			 * @since 4.9.0
+			 *
+			 * @param object The WP_User object
+			 */
+			do_action( 'jetpack_sync_register_user', $user );
+			return;
+		}
+		/* MU Sites add users instead of register them to sites */
+		if ( 'add_user_to_blog' === current_filter() ) {
+			/**
+			 * Fires when a new user is added to a site. (WordPress Multisite)
+			 *
+			 * @since 4.9.0
+			 *
+			 * @param object The WP_User object
+			 */
+			do_action( 'jetpack_sync_add_user', $user );
+			return;
 		}
 		/**
 		 * Fires when the client needs to sync an updated user

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -21,9 +21,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'user_register', array( $this, 'save_user_handler' ) );
 		add_action( 'profile_update', array( $this, 'save_user_handler' ), 10, 2 );
 		add_action( 'add_user_to_blog', array( $this, 'save_user_handler' ) );
-		add_action( 'jetpack_sync_save_user', $callable, 10, 2 );
-		add_action( 'jetpack_sync_register_user', $callable, 10, 2 );
 		add_action( 'jetpack_sync_add_user', $callable, 10, 2 );
+		add_action( 'jetpack_sync_register_user', $callable, 10, 2 );
+		add_action( 'jetpack_sync_save_user', $callable, 10, 2 );
 
 		add_action( 'jetpack_sync_user_locale', $callable, 10, 2 );
 		add_action( 'jetpack_sync_user_locale_delete', $callable, 10, 1 );
@@ -53,9 +53,9 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	public function init_before_send() {
-		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_add_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_register_user', array( $this, 'expand_user' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_wp_login', array( $this, 'expand_login_username' ), 10, 1 );
 		add_filter( 'jetpack_sync_before_send_wp_logout', array( $this, 'expand_logout_username' ), 10, 2 );
 

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -242,6 +242,8 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			// users
+			case 'jetpack_sync_register_user':
+			case 'jetpack_sync_add_user':
 			case 'jetpack_sync_save_user':
 				list( $user ) = $args;
 				$this->store->upsert_user( $user );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -315,9 +315,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$this->assertNotNull( $this->server_replica_storage->get_user( $mu_blog_user_id ) );
-
-
-		//
+		
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_add_user' );
 
 		$user_sync_module = Jetpack_Sync_Modules::get_module( "users" );

--- a/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/tests/php/sync/test_class.jetpack-sync-users.php
@@ -26,6 +26,24 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		unset( $server_user->data->allowed_mime_types );
 
 		$this->assertEqualsObject( $user, $server_user );
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_register_user' );
+
+		$user_sync_module = Jetpack_Sync_Modules::get_module( "users" );
+		$synced_user = $event->args[0];
+
+		// grab the codec - we need to simulate the stripping of types that comes with encoding/decoding
+		$codec = $this->sender->get_codec();
+
+		$retrieved_user = $codec->decode( $codec->encode(
+			$user_sync_module->get_object_by_id( 'user', $this->user_id )
+		) );
+
+		// TODO: this is to address a testing bug, alas :/
+		unset( $retrieved_user->data->allowed_mime_types );
+
+		$this->assertEquals( $synced_user, $retrieved_user );
+
 	}
 
 	public function test_update_user_url_is_synced() {
@@ -297,6 +315,26 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$this->assertNotNull( $this->server_replica_storage->get_user( $mu_blog_user_id ) );
+
+
+		//
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_add_user' );
+
+		$user_sync_module = Jetpack_Sync_Modules::get_module( "users" );
+		$synced_user = $event->args[0];
+
+		// grab the codec - we need to simulate the stripping of types that comes with encoding/decoding
+		$codec = $this->sender->get_codec();
+
+		$retrieved_user = $codec->decode( $codec->encode(
+			$user_sync_module->get_object_by_id( 'user', $mu_blog_user_id )
+		) );
+
+		// TODO: this is to address a testing bug, alas :/
+		unset( $retrieved_user->data->allowed_mime_types );
+
+		$this->assertEquals( $synced_user, $retrieved_user );
+		
 	}
 
 	public function test_syncs_user_authentication_attempts() {


### PR DESCRIPTION
This will help us know what event took place on the .com side. Instead of just updating the 
#### Changes proposed in this Pull Request:

* Separate the 3 events into separate actions. Add, Register and Update user.


#### Testing instructions:
* Do the tests pass? 
Do the Multi Site tests pass? 
`phpunit -c tests/php.multisite.xml --filter=user`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Seperate the Sync user events. Into more meaningful events.
