### PR TITLE
Add a Jetpack Sync action for theme installation

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -9,6 +9,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'switch_theme', array( $this, 'sync_theme_support' ) );
 		add_action( 'jetpack_sync_current_theme_support', $callable );
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
+		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
 
 		// Sidebar updates.
 		add_action( 'update_option_sidebars_widgets', array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -50,7 +50,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			 * @param string $theme->theme_root Text domain of the theme
 			 * @param mixed $theme_info Array of abbreviated theme info
 			 */
-			do_action( 'jetpack_installed_theme', $theme->theme_root, $theme_info );
+			do_action( 'jetpack_installed_theme', $theme->stylesheet, $theme_info );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -23,31 +23,33 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		error_log(get_class($upgrader));
 		error_log(print_r($details, true));
 
-		return;
-
 		if ( ! isset( $details['type'] ) ||
-			'plugin' !== $details['type'] ||
+			'theme' !== $details['type'] ||
 			is_wp_error( $upgrader->skin->result ) ||
-			! method_exists( $upgrader, 'plugin_info' )
+			! method_exists( $upgrader, 'theme_info' )
 		) {
 			return;
 		}
 
 		if ( 'install' === $details['action'] ) {
-			$plugin_path = $upgrader->plugin_info();
-			$plugins = get_plugins();
-			$plugin_info = $plugins[ $plugin_path ];
+			$theme = $upgrader->theme_info();
+
+			$theme_info = array(
+				'name' => $theme->name,
+				'version' => $theme->version,
+				'uri' => $theme->theme_root_uri,
+			);
 
 			/**
-			 * Signals to the sync listener that a plugin was installed and a sync action
-			 * reflecting the installation and the plugin info should be sent
+			 * Signals to the sync listener that a theme was installed and a sync action
+			 * reflecting the installation and the theme info should be sent
 			 *
 			 * @since 4.9.0
 			 *
-			 * @param string $plugin_path Path of plugin installed
-			 * @param mixed $plugin_info Array of info describing plugin installed
+			 * @param string $theme->theme_root Text domain of the theme
+			 * @param mixed $theme_info Array of abbreviated theme info
 			 */
-			do_action( 'jetpack_installed_plugin', $plugin_path, $plugin_info );
+			do_action( 'jetpack_installed_theme', $theme->theme_root, $theme_info );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -21,9 +21,6 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function check_upgrader( $upgrader, $details) {
-		error_log(get_class($upgrader));
-		error_log(print_r($details, true));
-
 		if ( ! isset( $details['type'] ) ||
 			'theme' !== $details['type'] ||
 			is_wp_error( $upgrader->skin->result ) ||
@@ -34,11 +31,10 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 		if ( 'install' === $details['action'] ) {
 			$theme = $upgrader->theme_info();
-
 			$theme_info = array(
-				'name' => $theme->name,
-				'version' => $theme->version,
-				'uri' => $theme->theme_root_uri,
+				'name' => $theme->get('Name'),
+				'version' => $theme->get('Version'),
+				'uri' => $theme->get('ThemeURI'),
 			);
 
 			/**

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -72,44 +72,35 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_theme_install() {
-			require_once ABSPATH . 'wp-admin/includes/theme-install.php';
-			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		require_once ABSPATH . 'wp-admin/includes/theme-install.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
-			// code from wp-admin/update.php
-			$api = themes_api( 'theme_information', array(
-				'slug'   => 'nordby')    );
+		$theme_stylesheet = 'itek';
+		$theme_name = 'iTek';
 
-			/*,
-				'fields' => array(
-					'short_description' => false,
-					'sections'          => false,
-					'requires'          => false,
-					'rating'            => false,
-					'ratings'           => false,
-					'downloaded'        => false,
-					'last_updated'      => false,
-					'added'             => false,
-					'tags'              => false,
-					'compatibility'     => false,
-					'homepage'          => false,
-					'donate_link'       => false,
-				),
-			) );
-*/
-			if ( is_wp_error( $api ) ) {
-				wp_die( $api );
-			}
+		$api = themes_api(
+			'theme_information',
+			array(
+				'slug'   => $theme_stylesheet,
+			)
+		);
+
+		if ( is_wp_error( $api ) ) {
+			wp_die( $api );
+		}
 
 		$upgrader = new Theme_Upgrader( new Theme_Upgrader_Skin( compact('title', 'nonce', 'url', 'theme') ) );
-			/*
-			$upgrader = new Plugin_Upgrader(
-				new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) )
-			);
-			*/
+		$upgrader->install( $api->download_link );
 
-			$upgrader->install( $api->download_link );
+		$this->sender->do_sync();
+		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_installed_theme' );
 
-		//}
+		$this->assertEquals( $event_data->args[0], $theme_stylesheet );
+		$this->assertEquals( $event_data->args[1]['name'], $theme_name );
+		$this->assertTrue( (bool) $event_data->args[1]['version'] );
+		$this->assertTrue( (bool) $event_data->args[1]['uri'] );
+
+		delete_theme( $theme_stylesheet );
 	}
 
 	public function test_widgets_changes_get_synced() {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -105,11 +105,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			wp_die( $api );
 		}
 
-		//$upgrader = new Theme_Upgrader( new Theme_Upgrader_Skin( compact('title', 'nonce', 'url', 'theme') ) );
-
 		$upgrader = new Theme_Upgrader( new Test_Upgrader_Skin( compact('title', 'nonce', 'url', 'theme') ) );
-
-		// This is noisy, so buffer output so that it doesn't cause test to fail in certain Travis environments
 		$upgrader->install( $api->download_link );
 
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -1,4 +1,20 @@
 <?php
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+// Used to suppress echo'd output from Theme_Upgrader_Skin so that test_theme_install() will pass under Travis environments that failed because of output
+class Test_Upgrader_Skin extends Theme_Upgrader_Skin {
+
+	public function __construct($args = array()) {
+		$defaults = array( 'url' => '', 'theme' => '', 'nonce' => '', 'title' => __('Update Theme') );
+		$args = wp_parse_args($args, $defaults);
+		$this->theme = $args['theme'];
+		parent::__construct($args);
+	}
+	public function feedback($string) {}
+	public function header() {}
+	public function footer() {}
+	public function decrement_update_count( $arg ) {}
+}
 
 /**
  * Testing CRUD on Options
@@ -89,7 +105,11 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			wp_die( $api );
 		}
 
-		$upgrader = new Theme_Upgrader( new Theme_Upgrader_Skin( compact('title', 'nonce', 'url', 'theme') ) );
+		//$upgrader = new Theme_Upgrader( new Theme_Upgrader_Skin( compact('title', 'nonce', 'url', 'theme') ) );
+
+		$upgrader = new Theme_Upgrader( new Test_Upgrader_Skin( compact('title', 'nonce', 'url', 'theme') ) );
+
+		// This is noisy, so buffer output so that it doesn't cause test to fail in certain Travis environments
 		$upgrader->install( $api->download_link );
 
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -71,6 +71,47 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $local_value, $this->server_replica_storage->get_option( 'theme_mods_' . $this->theme ) );
 	}
 
+	public function test_theme_install() {
+			require_once ABSPATH . 'wp-admin/includes/theme-install.php';
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+			// code from wp-admin/update.php
+			$api = themes_api( 'theme_information', array(
+				'slug'   => 'nordby')    );
+
+			/*,
+				'fields' => array(
+					'short_description' => false,
+					'sections'          => false,
+					'requires'          => false,
+					'rating'            => false,
+					'ratings'           => false,
+					'downloaded'        => false,
+					'last_updated'      => false,
+					'added'             => false,
+					'tags'              => false,
+					'compatibility'     => false,
+					'homepage'          => false,
+					'donate_link'       => false,
+				),
+			) );
+*/
+			if ( is_wp_error( $api ) ) {
+				wp_die( $api );
+			}
+
+		$upgrader = new Theme_Upgrader( new Theme_Upgrader_Skin( compact('title', 'nonce', 'url', 'theme') ) );
+			/*
+			$upgrader = new Plugin_Upgrader(
+				new Automatic_Upgrader_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) )
+			);
+			*/
+
+			$upgrader->install( $api->download_link );
+
+		//}
+	}
+
 	public function test_widgets_changes_get_synced() {
 
 		$sidebar_widgets = array(


### PR DESCRIPTION
Adds a Jetpack Sync action for theme installation

#### Changes proposed in this Pull Request:

Adds a Jetpack Sync action for theme installation via the addition of jetpack_installed_theme action

#### Testing instructions:

phpunit to run new test for theme install sync

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

jetpack_installed_theme action added upon theme installation
