### PR TITLE
Autoupdates: Remove plugin autoupdates from the Jetpack side of things

### DIFF
--- a/class.jetpack-autoupdate.php
+++ b/class.jetpack-autoupdate.php
@@ -32,23 +32,11 @@ class Jetpack_Autoupdate {
 
 	private function __construct() {
 		if ( Jetpack::is_module_active( 'manage' ) ) {
-			add_filter( 'auto_update_plugin', array( $this, 'autoupdate_plugin' ), 10, 2 );
 			add_filter( 'auto_update_theme', array( $this, 'autoupdate_theme' ), 10, 2 );
 			add_filter( 'auto_update_core', array( $this, 'autoupdate_core' ), 10, 2 );
 			add_filter( 'auto_update_translation', array( $this, 'autoupdate_translation' ), 10, 2 );
 			add_action( 'automatic_updates_complete', array( $this, 'automatic_updates_complete' ), 999, 1 );
 		}
-	}
-
-	public function autoupdate_plugin( $update, $item ) {
-		$autoupdate_plugin_list = Jetpack_Options::get_option( 'autoupdate_plugins', array() );
-		if ( in_array( $item->plugin, $autoupdate_plugin_list ) ) {
-			$this->expect( $item->plugin, 'plugin' );
-
-			return true;
-		}
-
-		return $update;
 	}
 
 	public function autoupdate_translation( $update, $item ) {
@@ -187,15 +175,6 @@ class Jetpack_Autoupdate {
 		$instance = Jetpack::init();
 		$log      = array();
 		// Bump numbers
-		if ( ! empty( $this->success['plugin'] ) ) {
-			$instance->stat( 'autoupdates/plugin-success', count( $this->success['plugin'] ) );
-			$log['plugins_success'] = $this->success['plugin'];
-		}
-
-		if ( ! empty( $this->failed['plugin'] ) ) {
-			$instance->stat( 'autoupdates/plugin-fail', count( $this->failed['plugin'] ) );
-			$log['plugins_failed'] = $this->failed['plugin'];
-		}
 
 		if ( ! empty( $this->success['theme'] ) ) {
 			$instance->stat( 'autoupdates/theme-success', count( $this->success['theme'] ) );
@@ -239,9 +218,6 @@ class Jetpack_Autoupdate {
 				switch ( $type ) {
 					case 'theme':
 						$successful_updates[] = $result->item->theme;
-						break;
-					case 'plugin':
-						$successful_updates[] = $result->item->plugin;
 						break;
 					case 'translation':
 						$successful_updates[] = $result->item->type + ':' + $result->item->slug;


### PR DESCRIPTION
Since we are fireing the autoupdated events from .com. Lets only do autoupdates from there. 
This has a number of benefits. 
- We can stop autoupdates from happening if we know that a site will brake due to an autoupdated. 
- Have better events when the autoupdate does happen.

#### Testing instructions:
* Test that the autoupdate doesn't happen for plugins again more.

