### PR TITLE
Contact Form: Set message content type to restore compat with plugins

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2016,14 +2016,6 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$reply_to_addr = $comment_author_email;
 		}
 
-		/*
-		 * Build the message headers
-		 *
-		 * We don't need to specify a Content-Type header, because PHPMailer will automatically generate the
-		 * proper content-type for each part of the message once it detects that an AltBody is added.
-		 *
-		 * wp_mail() automatically sets the Charset to the site's charset, so we don't need to do that either.
-		 */
 		$headers = 'From: "' . $comment_author . '" <' . $from_email_addr . ">\r\n" .
 					'Reply-To: "' . $comment_author . '" <' . $reply_to_addr . ">\r\n";
 
@@ -2158,6 +2150,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			wp_schedule_event( time() + 250, 'daily', 'grunion_scheduled_delete' );
 		}
 
+		add_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
 		add_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
 		if (
 			$is_spam !== true &&
@@ -2189,6 +2182,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		) { // don't send spam by default.  Filterable.
 			wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 		}
+		remove_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
 		remove_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
@@ -2240,6 +2234,15 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 
 		return $address;
+	}
+
+	/**
+	 * Get the content type that should be assigned to outbound emails
+	 *
+	 * @return string
+	 */
+	static function get_mail_content_type() {
+		return 'text/html';
 	}
 
 	/**


### PR DESCRIPTION
Some plugins override `wp_mail()` and replace PHPMailer with other libraries, like Zend Mail. Previously, we were relying on PHPMailer to correctly set the content type, but that never happens when other libraries are used. Because of that, the message can be sent out with a `text/plain` type, but contain HTML, making it difficult for users to read.

All plugins should respect the value of `wp_mail_content_type`, though, so this is a much more reliable method of setting the type to `text/html`.

Props georgestephanis, jeherve
Fixes #7003


#### Testing instructions:

1. Install the Postman SMTP or Gmail SMTP plugins from the w.org repo
1. Checkout `master`, and submit a contact form. You'll see the raw HTML because the content-type is `text/plain`
1. Checkout this branch and repeat the test. It should display in HTML and have the content-type set to `text/html`