### PR TITLE
API: Update Plugin use the bulk_upgrade

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -200,8 +200,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			$upgrader = new Plugin_Upgrader( $skin );
 			$upgrader->init();
 			// This avoids the plugin to be deactivated.
-			defined( 'DOING_CRON' ) or define( 'DOING_CRON', true );
-			$result = $upgrader->upgrade( $plugin );
+			// Using bulk upgrade puts the site into maintenance mode during the upgrades
+			$result = $upgrader->bulk_upgrade( array( $plugin ) );
 
 			$this->log[ $plugin ] = $upgrader->skin->get_upgrade_messages();
 		}


### PR DESCRIPTION
Using the bulk upgrade which puts the site into maintenance mode during
updates.

#### Changes proposed in this Pull Request:
* Use the bulk_update function to update plugins via the api. 
This puts site into the maintenance mode and prevents errors during updates.

#### Testing instructions:
* Use the api to update a plugin. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
