### PR TITLE
Subscriptions: Add a check that we don't send the subscription email flag

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -166,6 +166,11 @@ class Jetpack_Subscriptions {
 			return false;
 		}
 
+		// Only posts are currently supported
+		if ( $post->post_type !== 'post' ) {
+			return false;
+		}
+
 		/**
 		 * Array of categories that will never trigger subscription emails.
 		 *
@@ -201,7 +206,6 @@ class Jetpack_Subscriptions {
 		if ( ! empty( $only_these_categories ) && ! in_category( $only_these_categories, $post->ID ) ) {
 			$should_email = false;
 		}
-
 
 		return $should_email;
 	}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -905,7 +905,7 @@ That was a cool video.';
 		$this->assertTrue( $post_flags['send_subscription'] );
 	}
 
-	public function test_sync_jetpack_published_post_should_set_set_send_subscription_to_false_for_post_type_other_then_post() {
+	public function test_sync_jetpack_published_post_should_set_set_send_subscription_to_false_for_post_type_other_than_post() {
 		$this->server_event_storage->reset();
 		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
 		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -905,6 +905,27 @@ That was a cool video.';
 		$this->assertTrue( $post_flags['send_subscription'] );
 	}
 
+	public function test_sync_jetpack_published_post_should_set_set_send_subscription_to_false_for_post_type_other_then_post() {
+		$this->server_event_storage->reset();
+		Jetpack_Options::update_option( 'active_modules', array( 'subscriptions' ) );
+		require_once JETPACK__PLUGIN_DIR . '/modules/subscriptions.php';
+		new Jetpack_Subscriptions; // call instead of Jetpack_Subscriptions::init() so that actions get reinitialized
+
+		$nav_menu_id = wp_insert_post( array(
+			'post_type' => 'nav_menu_item',
+			'post_status' => 'draft',
+		) );
+
+		wp_publish_post( $nav_menu_id );
+
+		$this->sender->do_sync();
+
+		$events = $this->server_event_storage->get_all_events( 'jetpack_published_post' );
+		$this->assertEquals( 1, count( $events ) );
+
+		$post_flags = $events[0]->args[1];
+		$this->assertFalse( $post_flags['send_subscription'] );
+	}
 
 	public function test_sync_jetpack_publish_post_works_with_interjecting_plugins() {
 		$this->server_event_storage->reset();


### PR DESCRIPTION
for post types other then Post

#### Changes proposed in this Pull Request:
* 

#### Testing instructions:

* Do the tests pass? Do Posts still are being sent out to subscriptions.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
