### PR TITLE
Sync the list media endpoint.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
@@ -98,8 +98,6 @@ class WPCOM_JSON_API_List_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		$response = array();
 
-		$media_posts = $media->posts; 
-
 		// @start-hide-in-jetpack                   
 		// gm2016 - image classification hack
 		// fetches images from image classification and merges results
@@ -107,17 +105,18 @@ class WPCOM_JSON_API_List_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint {
 			jetpack_require_lib( 'classification/class-user-image-classification');
 			if ( User_Image_Classification::is_valid_blog( $blog_id ) ) {
 				$images = User_Image_Classification::get_images_classified( $args['search'] );
-				$media_posts = array_merge( $media_posts, $images );
+				$media->posts = array_merge( $media->posts, $images );
+				$media->found_posts = $media->found_posts + count( $images );
 			}
 		}
 		// @end-hide-in-jetpack 	
 
-		foreach ( $media_posts as $item ) {
+		foreach ( $media->posts as $item ) {
 			$response[] = $this->get_media_item_v1_1( $item->ID );
 		}
 
 		$return = array(
-			'found' => (int) count( $response ),
+			'found' => (int) $media->found_posts,
 			'media' => $response
 		);
 

--- a/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
@@ -97,12 +97,27 @@ class WPCOM_JSON_API_List_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint {
 		}
 
 		$response = array();
-		foreach ( $media->posts as $item ) {
+
+		$media_posts = $media->posts; 
+
+		// @start-hide-in-jetpack                   
+		// gm2016 - image classification hack
+		// fetches images from image classification and merges results
+		if ( ! empty( $args['search'] ) ) { 
+			jetpack_require_lib( 'classification/class-user-image-classification');
+			if ( User_Image_Classification::is_valid_blog( $blog_id ) ) {
+				$images = User_Image_Classification::get_images_classified( $args['search'] );
+				$media_posts = array_merge( $media_posts, $images );
+			}
+		}
+		// @end-hide-in-jetpack 	
+
+		foreach ( $media_posts as $item ) {
 			$response[] = $this->get_media_item_v1_1( $item->ID );
 		}
 
 		$return = array(
-			'found' => (int) $media->found_posts,
+			'found' => (int) count( $response ),
 			'media' => $response
 		);
 

--- a/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
@@ -98,10 +98,9 @@ class WPCOM_JSON_API_List_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		$response = array();
 
-		// @start-hide-in-jetpack                   
 		// gm2016 - image classification hack
 		// fetches images from image classification and merges results
-		if ( ! empty( $args['search'] ) ) { 
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! empty( $args['search'] ) ) {
 			jetpack_require_lib( 'classification/class-user-image-classification');
 			if ( User_Image_Classification::is_valid_blog( $blog_id ) ) {
 				$images = User_Image_Classification::get_images_classified( $args['search'] );
@@ -109,7 +108,6 @@ class WPCOM_JSON_API_List_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$media->found_posts = $media->found_posts + count( $images );
 			}
 		}
-		// @end-hide-in-jetpack 	
 
 		foreach ( $media->posts as $item ) {
 			$response[] = $this->get_media_item_v1_1( $item->ID );


### PR DESCRIPTION
Because an associative array can be converted to an object, ensure that we only return the array values and not keys.

Merges r135464-wpcom.
