### PR TITLE
Widgets: add missing internet-defense-league widget

### DIFF
--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -48,8 +48,11 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			'shield_badge'   => __( 'Shield Badge', 'jetpack' ),
 			'super_badge'    => __( 'Super Badge', 'jetpack' ),
 			'side_bar_badge' => __( 'Red Cat Badge', 'jetpack' ),
-			'none'           => __( 'Don\'t display a badge (just the campaign)', 'jetpack' ),
 		);
+
+		if ( $this->no_current === false ) {
+			$this->badges[ 'none' ] = __( 'Don\'t display a badge (just the campaign)', 'jetpack' );
+		}
 
 		$this->defaults = array(
 			'campaign' => key( $this->campaigns ),

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -27,23 +27,23 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 
 		// When enabling campaigns other than 'none' or empty, change $no_current to false above.
 		$this->campaigns = array(
-			''       => __( 'All current and future campaigns', 'jetpack' ),
-			'none'   => __( 'None, just display the badge please', 'jetpack' ),
+			''       => esc_html__( 'All current and future campaigns', 'jetpack' ),
+			'none'   => esc_html__( 'None, just display the badge please', 'jetpack' ),
 		);
 
 		$this->variants = array(
-			'banner' => __( 'Banner at the top of my site', 'jetpack' ),
-			'modal'  => __( 'Modal (Overlay Box)', 'jetpack' ),
+			'banner' => esc_html__( 'Banner at the top of my site', 'jetpack' ),
+			'modal'  => esc_html__( 'Modal (Overlay Box)', 'jetpack' ),
 		);
 
 		$this->badges = array(
-			'shield_badge'   => __( 'Shield Badge', 'jetpack' ),
-			'super_badge'    => __( 'Super Badge', 'jetpack' ),
-			'side_bar_badge' => __( 'Red Cat Badge', 'jetpack' ),
+			'shield_badge'   => esc_html__( 'Shield Badge', 'jetpack' ),
+			'super_badge'    => esc_html__( 'Super Badge', 'jetpack' ),
+			'side_bar_badge' => esc_html__( 'Red Cat Badge', 'jetpack' ),
 		);
 
 		if ( $this->no_current === false ) {
-			$this->badges['none'] = __( 'Don\'t display a badge (just the campaign)', 'jetpack' );
+			$this->badges['none'] = esc_html__( 'Don\'t display a badge (just the campaign)', 'jetpack' );
 		}
 
 		$this->defaults = array(
@@ -62,8 +62,9 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			}
 			$badge_url = esc_url( 'https://internetdefenseleague.org/images/badges/final/' . $instance['badge'] . '.png' );
 			$photon_badge_url = jetpack_photon_url( $badge_url );
+			$alt_text = esc_html__( 'Member of The Internet Defense League', 'jetpack' );
 			echo $args['before_widget'];
-			echo '<p><a href="https://internetdefenseleague.org/"><img src="' . $photon_badge_url . '" alt="Member of The Internet Defense League" style="max-width: 100%; height: auto;" /></a></p>';
+			echo '<p><a href="https://internetdefenseleague.org/"><img src="' . $photon_badge_url . '" alt="' . $alt_text .'" style="max-width: 100%; height: auto;" /></a></p>';
 			echo $args['after_widget'];
 		}
 
@@ -107,18 +108,18 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 		// Hide first two form fields if no current campaigns.
 		if ( false === $this->no_current ) {
 			echo '<p><label>';
-			echo __( 'Which Internet Defense League campaign do you want to participate in?', 'jetpack' ) . '<br />';
+			echo esc_html__( 'Which Internet Defense League campaign do you want to participate in?', 'jetpack' ) . '<br />';
 			$this->select( 'campaign', $this->campaigns, $instance['campaign'] );
 			echo '</label></p>';
 
 			echo '<p><label>';
-			echo __( 'How do you want to promote the campaign?', 'jetpack' ) . '<br />';
+			echo esc_html__( 'How do you want to promote the campaign?', 'jetpack' ) . '<br />';
 			$this->select( 'variant', $this->variants, $instance['variant'] );
 			echo '</label></p>';
 		}
 
 		echo '<p><label>';
-		echo __( 'Which badge would you like to display?', 'jetpack' ) . '<br />';
+		echo esc_html__( 'Which badge would you like to display?', 'jetpack' ) . '<br />';
 		$this->select( 'badge', $this->badges, $instance['badge'] );
 		echo '</label></p>';
 
@@ -146,9 +147,7 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 }
 
 function jetpack_internet_defense_league_init() {
-	if ( Jetpack::is_active() ) {
-		register_widget( 'Jetpack_Internet_Defense_League_Widget' );
-	}
+	register_widget( 'Jetpack_Internet_Defense_League_Widget' );
 }
 
 add_action( 'widgets_init', 'jetpack_internet_defense_league_init' );

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -30,6 +30,7 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			apply_filters( 'jetpack_widget_name_widget', esc_html__( 'Internet Defense League', 'jetpack' ) ),
 			array(
 				'description' => __( 'Show your support for the Internet Defense League.', 'jetpack' ),
+				'customize_selective_refresh' => true,
 			)
 		);
 

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -1,0 +1,154 @@
+<?php /*
+
+**************************************************************************
+
+Plugin Name:  Internet Defense League
+Description:  Displays your support for the Internet Defense League.
+Author:       Automattic Inc.
+Author URI:   https://automattic.com/
+
+**************************************************************************/
+
+class Internet_Defense_League_Widget extends WP_Widget {
+
+	public $defaults = array();
+
+	public $variant;
+	public $variants = array();
+
+	public $campaign;
+	public $campaigns  = array();
+	public $no_current = true;
+
+	public $badge;
+	public $badges = array();
+
+	function __construct() {
+		parent::__construct(
+			'internet_defense_league_widget',
+			apply_filters( 'jetpack_widget_name_widget', esc_html__( 'Internet Defense League', 'jetpack' ) ),
+			array(
+				'description' => __( 'Show your support for the Internet Defense League.', 'internetdefenseleague' ),
+			)
+		);
+
+		// When enabling campaigns other than 'none' or empty, change $no_current to false above.
+		$this->campaigns = array(
+			''       => __( 'All current and future campaigns', 'internetdefenseleague' ),
+			// 'nsa' => __( 'NSA Protest on July 4th, 2013', 'internetdefenseleague' ),
+			'none'   => __( 'None, just display the badge please', 'internetdefenseleague' ),
+		);
+
+		$this->variants = array(
+			'banner' => __( 'Banner at the top of my site', 'internetdefenseleague' ),
+			'modal'  => __( 'Modal (Overlay Box)', 'internetdefenseleague' ),
+		);
+
+		$this->badges = array(
+			'shield_badge'   => __( 'Shield Badge', 'internetdefenseleague' ),
+			'super_badge'    => __( 'Super Badge', 'internetdefenseleague' ),
+			'side_bar_badge' => __( 'Red Cat Badge', 'internetdefenseleague' ),
+			'none'           => __( 'Don\'t display a badge (just the campaign)', 'internetdefenseleague' ),
+		);
+
+		$this->defaults = array(
+			'campaign' => key( $this->campaigns ),
+			'variant'  => key( $this->variants ),
+			'badge'    => key( $this->badges ),
+		);
+	}
+
+	public function widget( $args, $instance ) {
+		$instance = wp_parse_args( $instance, $this->defaults );
+
+		if ( 'none' != $instance['badge'] ) {
+			if ( ! isset( $this->badges[ $instance['badge'] ] ) ) {
+				$instance['badge'] = $this->defaults['badge'];
+			}
+			echo $args['before_widget'];
+			echo '<p><a href="https://internetdefenseleague.org/"><img src="' . esc_url( 'https://internetdefenseleague.org/images/badges/final/' . $instance['badge'] . '.png' ) . '" alt="Member of The Internet Defense League" style="max-width: 100%; height: auto;" /></a></p>';
+			echo $args['after_widget'];
+			do_action( 'jetpack_stats_extra', 'widget_view', 'internet_defense_league' );
+		}
+
+		if ( 'none' != $instance['campaign'] ) {
+			$this->campaign = $instance['campaign'];
+			$this->variant  = $instance['variant'];
+			add_action( 'wp_footer', array( $this, 'footer_script' ) );
+			do_action( 'jetpack_stats_extra', 'widget_view', 'internet_defense_league' );
+		}
+	}
+
+	public function footer_script() {
+		if ( ! isset( $this->campaigns[ $this->campaign ] ) )
+			$this->campaign = $this->defaults['campaign'];
+
+		if ( ! isset( $this->variants[ $this->variant ] ) )
+			$this->variant = $this->defaults['variant'];
+		?>
+		<script type="text/javascript">
+			window._idl = {};
+			_idl.campaign = "<?php echo esc_js( $this->campaign ); ?>";
+			_idl.variant = "<?php echo esc_js( $this->variant ); ?>";
+			(function() {
+				var idl = document.createElement('script');
+				idl.type = 'text/javascript';
+				idl.async = true;
+				idl.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'members.internetdefenseleague.org/include/?url=' + (_idl.url || '') + '&campaign=' + (_idl.campaign || '') + '&variant=' + (_idl.variant || 'banner');
+				document.getElementsByTagName('body')[0].appendChild(idl);
+			})();
+		</script>
+		<?php
+	}
+
+	public function form( $instance ) {
+		$instance = wp_parse_args( $instance, $this->defaults );
+
+		// Hide first two form fields if no current campaigns.
+		if ( false === $this->no_current ) {
+			echo '<p><label>';
+			echo __( 'Which Internet Defense League campaign do you want to participate in?', 'internetdefenseleague' ) . '<br />';
+			$this->select( 'campaign', $this->campaigns, $instance['campaign'] );
+			echo '</label></p>';
+
+			echo '<p><label>';
+			echo __( 'How do you want to promote the campaign?', 'internetdefenseleague' ) . '<br />';
+			$this->select( 'variant', $this->variants, $instance['variant'] );
+			echo '</label></p>';
+		}
+
+		echo '<p><label>';
+		echo __( 'Which badge would you like to display?', 'internetdefenseleague' ) . '<br />';
+		$this->select( 'badge', $this->badges, $instance['badge'] );
+		echo '</label></p>';
+
+		/* translators: %s is a name of an internet campaign called the "Internet Defense League" */
+		echo '<p>' . sprintf( _x( 'Learn more about the %s', 'the Internet Defense League', 'internetdefenseleague' ), '<a href="https://www.internetdefenseleague.org/">Internet Defense League</a>' ) . '</p>';
+	}
+
+	public function select( $field_name, $options, $default = null ) {
+		echo '<select class="widefat" name="' . $this->get_field_name( $field_name ) . '">';
+		foreach ( $options as $option_slug => $option_name ) {
+			echo '<option value="' . esc_attr( $option_slug ) . '"' . selected( $option_slug, $default, false ) . '>' . esc_html( $option_name ) . '</option>';
+		}
+		echo '</select>';
+	}
+
+	public function update( $new_instance, $old_instance ) {
+		$instance = array();
+
+		$instance['campaign'] = ( isset( $new_instance['campaign'] ) && isset( $this->campaigns[ $new_instance['campaign'] ] ) ) ? $new_instance['campaign'] : $this->defaults['campaign'];
+		$instance['variant']  = ( isset( $new_instance['variant'] )  && isset( $this->variants[  $new_instance['variant']  ] ) ) ? $new_instance['variant']  : $this->defaults['variant'];
+		$instance['badge']    = ( isset( $new_instance['badge'] )    && isset( $this->badges[    $new_instance['badge'] ] ) )    ? $new_instance['badge']    : $this->defaults['badge'];
+
+		return $instance;
+	}
+}
+
+function jetpack_internet_defense_league_init() {
+	if ( Jetpack::is_active() ) {
+		register_widget( 'Internet_Defense_League_Widget' );
+	}
+}
+
+add_action( 'widgets_init', 'jetpack_internet_defense_league_init' );

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -29,27 +29,26 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name_widget', esc_html__( 'Internet Defense League', 'jetpack' ) ),
 			array(
-				'description' => __( 'Show your support for the Internet Defense League.', 'internetdefenseleague' ),
+				'description' => __( 'Show your support for the Internet Defense League.', 'jetpack' ),
 			)
 		);
 
 		// When enabling campaigns other than 'none' or empty, change $no_current to false above.
 		$this->campaigns = array(
-			''       => __( 'All current and future campaigns', 'internetdefenseleague' ),
-			// 'nsa' => __( 'NSA Protest on July 4th, 2013', 'internetdefenseleague' ),
-			'none'   => __( 'None, just display the badge please', 'internetdefenseleague' ),
+			''       => __( 'All current and future campaigns', 'jetpack' ),
+			'none'   => __( 'None, just display the badge please', 'jetpack' ),
 		);
 
 		$this->variants = array(
-			'banner' => __( 'Banner at the top of my site', 'internetdefenseleague' ),
-			'modal'  => __( 'Modal (Overlay Box)', 'internetdefenseleague' ),
+			'banner' => __( 'Banner at the top of my site', 'jetpack' ),
+			'modal'  => __( 'Modal (Overlay Box)', 'jetpack' ),
 		);
 
 		$this->badges = array(
-			'shield_badge'   => __( 'Shield Badge', 'internetdefenseleague' ),
-			'super_badge'    => __( 'Super Badge', 'internetdefenseleague' ),
-			'side_bar_badge' => __( 'Red Cat Badge', 'internetdefenseleague' ),
-			'none'           => __( 'Don\'t display a badge (just the campaign)', 'internetdefenseleague' ),
+			'shield_badge'   => __( 'Shield Badge', 'jetpack' ),
+			'super_badge'    => __( 'Super Badge', 'jetpack' ),
+			'side_bar_badge' => __( 'Red Cat Badge', 'jetpack' ),
+			'none'           => __( 'Don\'t display a badge (just the campaign)', 'jetpack' ),
 		);
 
 		$this->defaults = array(
@@ -108,23 +107,23 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 		// Hide first two form fields if no current campaigns.
 		if ( false === $this->no_current ) {
 			echo '<p><label>';
-			echo __( 'Which Internet Defense League campaign do you want to participate in?', 'internetdefenseleague' ) . '<br />';
+			echo __( 'Which Internet Defense League campaign do you want to participate in?', 'jetpack' ) . '<br />';
 			$this->select( 'campaign', $this->campaigns, $instance['campaign'] );
 			echo '</label></p>';
 
 			echo '<p><label>';
-			echo __( 'How do you want to promote the campaign?', 'internetdefenseleague' ) . '<br />';
+			echo __( 'How do you want to promote the campaign?', 'jetpack' ) . '<br />';
 			$this->select( 'variant', $this->variants, $instance['variant'] );
 			echo '</label></p>';
 		}
 
 		echo '<p><label>';
-		echo __( 'Which badge would you like to display?', 'internetdefenseleague' ) . '<br />';
+		echo __( 'Which badge would you like to display?', 'jetpack' ) . '<br />';
 		$this->select( 'badge', $this->badges, $instance['badge'] );
 		echo '</label></p>';
 
 		/* translators: %s is a name of an internet campaign called the "Internet Defense League" */
-		echo '<p>' . sprintf( _x( 'Learn more about the %s', 'the Internet Defense League', 'internetdefenseleague' ), '<a href="https://www.internetdefenseleague.org/">Internet Defense League</a>' ) . '</p>';
+		echo '<p>' . sprintf( _x( 'Learn more about the %s', 'the Internet Defense League', 'jetpack' ), '<a href="https://www.internetdefenseleague.org/">Internet Defense League</a>' ) . '</p>';
 	}
 
 	public function select( $field_name, $options, $default = null ) {

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -68,8 +68,10 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			if ( ! isset( $this->badges[ $instance['badge'] ] ) ) {
 				$instance['badge'] = $this->defaults['badge'];
 			}
+			$badge_url = esc_url( 'https://internetdefenseleague.org/images/badges/final/' . $instance['badge'] . '.png' );
+			$photon_badge_url = jetpack_photon_url( $badge_url );
 			echo $args['before_widget'];
-			echo '<p><a href="https://internetdefenseleague.org/"><img src="' . esc_url( 'https://internetdefenseleague.org/images/badges/final/' . $instance['badge'] . '.png' ) . '" alt="Member of The Internet Defense League" style="max-width: 100%; height: auto;" /></a></p>';
+			echo '<p><a href="https://internetdefenseleague.org/"><img src="' . $photon_badge_url . '" alt="Member of The Internet Defense League" style="max-width: 100%; height: auto;" /></a></p>';
 			echo $args['after_widget'];
 			do_action( 'jetpack_stats_extra', 'widget_view', 'internet_defense_league' );
 		}

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -1,13 +1,4 @@
-<?php /*
-
-**************************************************************************
-
-Plugin Name:  Internet Defense League
-Description:  Displays your support for the Internet Defense League.
-Author:       Automattic Inc.
-Author URI:   https://automattic.com/
-
-**************************************************************************/
+<?php
 
 class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 
@@ -27,7 +18,7 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 		parent::__construct(
 			'internet_defense_league_widget',
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
-			apply_filters( 'jetpack_widget_name_widget', esc_html__( 'Internet Defense League', 'jetpack' ) ),
+			apply_filters( 'jetpack_widget_name', esc_html__( 'Internet Defense League', 'jetpack' ) ),
 			array(
 				'description' => __( 'Show your support for the Internet Defense League.', 'jetpack' ),
 				'customize_selective_refresh' => true,
@@ -52,7 +43,7 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 		);
 
 		if ( $this->no_current === false ) {
-			$this->badges[ 'none' ] = __( 'Don\'t display a badge (just the campaign)', 'jetpack' );
+			$this->badges['none'] = __( 'Don\'t display a badge (just the campaign)', 'jetpack' );
 		}
 
 		$this->defaults = array(

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -73,15 +73,16 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			echo $args['before_widget'];
 			echo '<p><a href="https://internetdefenseleague.org/"><img src="' . $photon_badge_url . '" alt="Member of The Internet Defense League" style="max-width: 100%; height: auto;" /></a></p>';
 			echo $args['after_widget'];
-			do_action( 'jetpack_stats_extra', 'widget_view', 'internet_defense_league' );
 		}
 
 		if ( 'none' != $instance['campaign'] ) {
 			$this->campaign = $instance['campaign'];
 			$this->variant  = $instance['variant'];
 			add_action( 'wp_footer', array( $this, 'footer_script' ) );
-			do_action( 'jetpack_stats_extra', 'widget_view', 'internet_defense_league' );
 		}
+
+		/** This action is already documented in modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'widget_view', 'internet_defense_league' );
 	}
 
 	public function footer_script() {

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -20,7 +20,7 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', esc_html__( 'Internet Defense League', 'jetpack' ) ),
 			array(
-				'description' => __( 'Show your support for the Internet Defense League.', 'jetpack' ),
+				'description' => esc_html__( 'Show your support for the Internet Defense League.', 'jetpack' ),
 				'customize_selective_refresh' => true,
 			)
 		);

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -9,7 +9,7 @@ Author URI:   https://automattic.com/
 
 **************************************************************************/
 
-class Internet_Defense_League_Widget extends WP_Widget {
+class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 
 	public $defaults = array();
 
@@ -147,7 +147,7 @@ class Internet_Defense_League_Widget extends WP_Widget {
 
 function jetpack_internet_defense_league_init() {
 	if ( Jetpack::is_active() ) {
-		register_widget( 'Internet_Defense_League_Widget' );
+		register_widget( 'Jetpack_Internet_Defense_League_Widget' );
 	}
 }
 

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -26,6 +26,7 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 	function __construct() {
 		parent::__construct(
 			'internet_defense_league_widget',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name_widget', esc_html__( 'Internet Defense League', 'jetpack' ) ),
 			array(
 				'description' => __( 'Show your support for the Internet Defense League.', 'internetdefenseleague' ),

--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -86,11 +86,13 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 	}
 
 	public function footer_script() {
-		if ( ! isset( $this->campaigns[ $this->campaign ] ) )
+		if ( ! isset( $this->campaigns[ $this->campaign ] ) ) {
 			$this->campaign = $this->defaults['campaign'];
+		}
 
-		if ( ! isset( $this->variants[ $this->variant ] ) )
+		if ( ! isset( $this->variants[ $this->variant ] ) ) {
 			$this->variant = $this->defaults['variant'];
+		}
 		?>
 		<script type="text/javascript">
 			window._idl = {};


### PR DESCRIPTION
This is part of 185-gh-customization

#### Changes proposed in this Pull Request:

This adds a wpcom widget to Jetpack. This is copied mostly verbatim from wpcom, with some small modifications for stats and the registration of the module.

#### Testing instructions:

* In your test sandbox, navigate to your Jetpack plugin and checkout this branch
* Navigate to the customizer /wp-admin/customize.php
* Click on widgets
* Then select a widget area
* Click add a widget
* With a connected Jetpack site, you should be able to search for Internet Defense League
![screen shot 2017-04-21 at 1 03 06 pm](https://cloud.githubusercontent.com/assets/1270189/25294178/e4bdd34c-2692-11e7-8f2c-70815bf3f328.png)
* Add it to your sidebar
* The widget options should work, (different img types/visibility)
![screen shot 2017-04-21 at 1 04 59 pm](https://cloud.githubusercontent.com/assets/1270189/25294239/26be78fa-2693-11e7-9db8-9a1365c9fd9c.png)
* Publish your page
* We should see that the Jetpack site now has an option of `widget_internet_defense_league_widget` which might have a shape like
![screen shot 2017-04-21 at 1 09 13 pm](https://cloud.githubusercontent.com/assets/1270189/25294392/d2e5b9a4-2693-11e7-96d9-37c505d2ace2.png)
