### PR TITLE
Docs: add information about beta testing.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Whether you can barely recognize a filter (or don’t know what that means) or y
 
 ### Beta Testing
 
-Beta testers give updates, fixes, and new modules a test run before they’re publicly released, so they’re an important part of the development process. If you'd like to join our Beta group, [sign up to be a Beta tester here](http://jetpack.com/beta/).
+We're always interested in hearing your feedback about existing and upcoming Jetpack features. The easiest way to help test Jetpack is to [join our Beta group.](/docs/testing/beta-testing.md)
 
 ### Create Bug Reports
 

--- a/docs/testing/beta-testing.md
+++ b/docs/testing/beta-testing.md
@@ -1,0 +1,17 @@
+# Join the Beta Program and help test Jetpack
+
+Our Beta program is designed to make it simple for you to test and tell us what we’re doing wrong (and right) in the next version of Jetpack. Your mission as a Beta tester is to help us test the next version of Jetpack and let us know about your experience. Is the UI confusing? Is a feature not working properly? Is there something missing? We need to know!
+
+Beta testers give updates, fixes, and new modules a test run before they’re publicly released, so they’re an important part of the development process.
+
+To join our Beta group, **[download and install the Beta plugin here](http://jetpack.com/beta/).**
+
+## Start testing
+
+Once you've installed and activated the Beta plugin, head over to **Jetpack > Beta** in your dashboard to start testing.
+
+## Found a bug?
+
+If you find an issue or have remarks about a Jetpack feature, you can [send us an email](https://jetpack.com/contact-support/beta-group/), or [create an issue on GitHub.](https://github.com/Automattic/Jetpack/issues/new)
+
+If you’re filing a bug, specific steps to reproduce are helpful. Please include the URL of the page that has the bug, along with what you expected to see and what happened instead. You can [check our recommendations to create great bug reports here](/docs/guides/report-bugs.md).

--- a/docs/testing/testing-tips.md
+++ b/docs/testing/testing-tips.md
@@ -1,0 +1,33 @@
+## Get a testing site
+
+To test out Jetpack, we recommend setting up a publicly accessible test site. Testing locally is limited and isn’t particularly helpful, as most Jetpack features rely on a connection to WordPress.com. You can create a test site from scratch or use a staging environment based on your production site.
+
+**Please only install the Beta plugin on a test site. By their nature, Beta releases could be unstable and should not be used on a site where your data is important.**
+
+## Check for JavaScript errors and enable Debug
+
+During your tests, we encourage you to open your browser's Development Tools and keep the Console open, checking for any errors in the Console and the Network tabs.
+
+To open the Console in Chrome or Firefox, you can press CMD+Alt+i in macOS or F12 in Windows. You can find out more [here](http://codex.wordpress.org/Using_Your_Browser_to_Diagnose_JavaScript_Errors).
+
+We would also recommend that you check your site's `debug.log` as you test.
+To make sure errors are logged on your site, you can add the following to your site's `wp-config.php` file:
+
+```php
+define( 'WP_DEBUG', true );
+
+if ( WP_DEBUG ) {
+
+	@error_reporting( E_ALL );
+	@ini_set( 'log_errors', true );
+	@ini_set( 'log_errors_max_len', '0' );
+
+	define( 'WP_DEBUG_LOG', true );
+	define( 'WP_DEBUG_DISPLAY', false );
+	define( 'CONCATENATE_SCRIPTS', false );
+	define( 'SAVEQUERIES', true );
+
+}
+```
+
+Your `wp-config.php` file may already include a line that says `define('WP_DEBUG', false);`. You can remove it, and replace it by the code above.

--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -68,10 +68,9 @@ NODE_ENV=production BABEL_ENV=production $TARGET_DIR/node_modules/.bin/gulp
 echo "Purging paths included in .svnignore, .gitignore and .git itself"
 # check .svnignore
 for file in $( cat "$TARGET_DIR/.svnignore" 2>/dev/null ); do
-    if [[ $file == "to-test.md" ]]; then
+    if [[ $file == "to-test.md" || $file == "docs/testing/testing-tips.md" ]]; then
         continue
     fi
     rm -rf $TARGET_DIR/$file
 done
 echo "Done!"
-

--- a/tools/deploy-to-master-stable-branch.sh
+++ b/tools/deploy-to-master-stable-branch.sh
@@ -65,8 +65,8 @@ echo "Done!"
 echo "Purging paths included in .svnignore"
 # check .svnignore
 for file in $( cat "$JETPACK_GIT_DIR/.svnignore" 2>/dev/null ); do
-	# We want to commit changes to to-test.md as well.
-	if [ $file == "to-test.md" ]; then
+	# We want to commit changes to to-test.md as well as the testing tips.
+	if [ $file == "to-test.md" || $file == "docs/testing/testing-tips.md" ]; then
 		continue;
 	fi
 	rm -rf $JETPACK_TMP_DIR_2/$file


### PR DESCRIPTION
This info should guide new contributors and help them get started with Beta testing. We'll also pull some of this data directly from the Beta plugin.