### PR TITLE
Syncs post endpoint v1.0

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -65,35 +65,6 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 		parent::__construct( $args );
 	}
 
-	function is_metadata_public( $key ) {
-		if ( empty( $key ) )
-			return false;
-
-		// Default whitelisted meta keys.
-		$whitelisted_meta = array( '_thumbnail_id' );
-
-		/**
-		 * Filters the meta keys accessible by the REST API.
-		 * @see https://developer.wordpress.com/2013/04/26/custom-post-type-and-metadata-support-in-the-rest-api/
-		 *
-		 * @module json-api
-		 *
-		 * @since 2.2.3
-		 *
-		 * @param array $whitelisted_meta Array of metadata that is accessible by the REST API.
-		 */
- 		if ( in_array( $key, apply_filters( 'rest_api_allowed_public_metadata', $whitelisted_meta ) ) )
-			return true;
-
-		if ( 0 === strpos( $key, 'geo_' ) )
-			return true;
-
-		if ( 0 === strpos( $key, '_wpas_' ) )
-			return true;
-
- 		return false;
- 	}
-
 	function the_password_form() {
 		return __( 'This post is password protected.', 'jetpack' );
 	}
@@ -449,7 +420,7 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$show = true;
 
 					// Only business plan subscribers can view custom meta description.
-					if ( Jetpack_SEO_Posts::DESCRIPTION_META_KEY == $meta->key && ! Jetpack_SEO_Utils::is_enabled_jetpack_seo() ) {
+					if ( Jetpack_SEO_Posts::DESCRIPTION_META_KEY == $meta['meta_key'] && ! Jetpack_SEO_Utils::is_enabled_jetpack_seo() ) {
 						$show = false;
 					}
 


### PR DESCRIPTION
@vindl  please take a look at this one, because I have changed the way we check the meta key here. When using the object notation I would get `trying to get a property of non-object`.