### PR TITLE
Unit Tests: Remove HHVM from Travis CI job matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache: yarn
 # Test WP trunk/master and two latest versions on minimum (5.2).
 # Test WP latest two versions (4.5, 4.3) on most popular (5.5, 5.6).
 # Test WP latest stable (4.5) on other supported PHP (5.3, 5.4).
-# Test WP trunk/master on edge platforms (7.0, hhvm, PHP nightly).
+# Test WP trunk/master on edge platforms (7.0, PHP nightly).
 
 # WP_VERSION specifies the tag to use. The way these tests are configured to run
 # requires at least WordPress 3.8. Specify "master" to test against SVN trunk.
@@ -36,22 +36,9 @@ matrix:
   - php: "5.6"
   - php: "7.0"
   - php: "7.1"
-#
-#  - php: hhvm
-#    env: WP_VERSION=master
-#    sudo: required
-#    dist: trusty
-#    group: edge
-#    addons:
-#      apt:
-#        packages:
-#        - mysql-server-5.6
-#        - mysql-client-core-5.6
-#        - mysql-client-5.6
 
   allow_failures:
   - php: "7.1"
-#  - php: "hhvm"
 #  - php: "nightly"
 
 # whitelist branches for the "push" build check.


### PR DESCRIPTION
WordPress has now removed HHVM it's Travis CI job matrix:

See https://core.trac.wordpress.org/ticket/40548 https://core.trac.wordpress.org/changeset/40546

https://make.wordpress.org/core/2017/04/23/recent-updates-to-the-unit-testing-infrastructure/