### PR TITLE
SEO Tools: Allow empty string to be passed as title format

### DIFF
--- a/modules/seo-tools/jetpack-seo-titles.php
+++ b/modules/seo-tools/jetpack-seo-titles.php
@@ -246,6 +246,10 @@ class Jetpack_SEO_Titles {
 				return false;
 			}
 
+			if ( $format_array === "" ) {
+				continue;
+			}
+			
 			if ( ! is_array( $format_array ) ) {
 				return false;
 			}

--- a/modules/seo-tools/jetpack-seo-titles.php
+++ b/modules/seo-tools/jetpack-seo-titles.php
@@ -246,7 +246,7 @@ class Jetpack_SEO_Titles {
 				return false;
 			}
 
-			if ( $format_array === "" ) {
+			if ( '' === $format_array ) {
 				continue;
 			}
 			


### PR DESCRIPTION
Previously, only arrays were considered as valid title formats, and
in case of deletion we needed to provide empty array. Now, we are also
allowing empty string to be passed in that case instead. This is needed
to resolve the bug that prevented title deletion in Calypso.

Fixes https://github.com/Automattic/wp-calypso/issues/10003

#### Testing instructions:

1. Test with https://github.com/Automattic/wp-calypso/pull/13327.
2. On your test Jetpack site with a Professional plan, navigate to `settings/traffic`.
3. Verify that custom title formats can now be deleted.