### PR TITLE
New Feature: add size => thumbnail to the portfolio shortcode

### DIFF
--- a/modules/custom-post-types/css/portfolio-shortcode.css
+++ b/modules/custom-post-types/css/portfolio-shortcode.css
@@ -7,7 +7,7 @@
 
 .portfolio-entry {
 	float: left;
-	margin: 0 0 3em;
+	margin: 0em;
 	padding: 0;
 	width: 100%;
 }

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -505,6 +505,7 @@ class Jetpack_Portfolio {
 			'showposts'       => -1,
 			'order'           => 'asc',
 			'orderby'         => 'date',
+			'size'		      => 'thumbnail',
 		), $atts, 'portfolio' );
 
 		// A little sanitization
@@ -564,6 +565,7 @@ class Jetpack_Portfolio {
 				$atts['orderby'] = implode( ' ', $parsed );
 			}
 		}
+        	$atts['size'] = sanitize_html_class( $atts['size'] );
 
 		// enqueue shortcode styles when shortcode is used
 		wp_enqueue_style( 'jetpack-portfolio-style', plugins_url( 'css/portfolio-shortcode.css', __FILE__ ), array(), '20140326' );
@@ -651,7 +653,7 @@ class Jetpack_Portfolio {
 					<header class="portfolio-entry-header">
 					<?php
 					// Featured image
-					echo self::get_portfolio_thumbnail_link( $post_id );
+					echo self::get_portfolio_thumbnail_link( $post_id, $atts['size'] );
 					?>
 
 					<h2 class="portfolio-entry-title"><a href="<?php echo esc_url( get_permalink() ); ?>" title="<?php echo esc_attr( the_title_attribute( ) ); ?>"><?php the_title(); ?></a></h2>
@@ -840,7 +842,7 @@ class Jetpack_Portfolio {
 	 *
 	 * @return html
 	 */
-	static function get_portfolio_thumbnail_link( $post_id ) {
+	static function get_portfolio_thumbnail_link( $post_id, $size = 'thumbnail' ) {
 		if ( has_post_thumbnail( $post_id ) ) {
 			/**
 			 * Change the Portfolio thumbnail size.
@@ -851,7 +853,7 @@ class Jetpack_Portfolio {
 			 *
 			 * @param string|array $var Either a registered size keyword or size array.
 			 */
-			return '<a class="portfolio-featured-image" href="' . esc_url( get_permalink( $post_id ) ) . '">' . get_the_post_thumbnail( $post_id, apply_filters( 'jetpack_portfolio_thumbnail_size', 'large' ) ) . '</a>';
+			return '<a class="portfolio-featured-image" href="' . esc_url( get_permalink( $post_id ) ) . '">' . get_the_post_thumbnail( $post_id, apply_filters( 'jetpack_portfolio_thumbnail_size', $size ) ) . '</a>';
 		}
 	}
 }


### PR DESCRIPTION
Fixes #7040

#### Changes proposed in this Pull Request:

* Adds the shortcode option "size" which can be "thumbnail, medium, large" from the wordpress settings. 
* defaults to thumbnail in order for the shortcode to more closely resemble the default portfolio template setting
* change to .portfolio-entry css code to create a equal grid. This is a less important change.

#### Testing instructions:

* In order for the thumbnail changes to take effect you may have to reapply the featured image so it pushes to the jetpack backend server. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
