### PR TITLE
Allow passing headers to `Jetpack_Client::wpcom_json_api_request_as_blog`

### DIFF
--- a/class.jetpack-client.php
+++ b/class.jetpack-client.php
@@ -278,6 +278,7 @@ class Jetpack_Client {
 	 */
 	static function wpcom_json_api_request_as_blog( $path, $version = self::WPCOM_JSON_API_VERSION, $args = array(), $body = null ) {
 		$filtered_args = array_intersect_key( $args, array(
+			'headers'     => 'array',
 			'method'      => 'string',
 			'timeout'     => 'int',
 			'redirection' => 'int',


### PR DESCRIPTION
Requests made by `wpcom_json_api_request_as_blog()` do not, by default,
send their data as JSON (despite the name of the function) because there
is no `content-type: application/json` header. This can cause issues in
certain endpoints that expect data as JSON.

This change allows sending additional headers in the `$args` array to
`wpcom_json_api_request_as_blog()`, so that it can be used to specify
`content-type` if necessary.

Related to #6813 as they are both needed to communicate properly with v2 endpoints.

