### PR TITLE
API: Force secure endpoints

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -267,11 +267,32 @@ abstract class WPCOM_JSON_API_Endpoint {
 			break;
 		}
 
-		if ( !$cast_and_filter ) {
-			return $return;
+		if ( isset( $this->api->query['force'] ) 
+		    && 'secure' === $this->api->query['force']
+		    && isset( $return['secure_key'] ) ) {
+			$this->api->post_body = $this->get_secure_body( $return['secure_key'] );
+			$this->api->query['force'] = false;
+			return $this->input( $return_default_values, $cast_and_filter );
 		}
 
-		return $this->cast_and_filter( $return, $this->request_format, $return_default_values );
+		if ( $cast_and_filter ) {
+			$return = $this->cast_and_filter( $return, $this->request_format, $return_default_values );
+		}
+		return $return;
+	}
+
+
+	protected function get_secure_body( $secure_key ) {
+		$response =  Jetpack_Client::wpcom_json_api_request_as_blog( 
+			sprintf( '/sites/%d/secure-request', Jetpack_Options::get_option('id' ) ), 
+			'1.1', 
+			array( 'method' => 'POST' ), 
+			array( 'secure_key' => $secure_key ) 
+		);
+		if ( 200 !== $response['response']['code'] ) {
+			return null;
+		}
+		return json_decode( $response['body'], true );
 	}
 
 	function cast_and_filter( $data, $documentation, $return_default_values = false, $for_output = false ) {


### PR DESCRIPTION
When calling endpoints with force=secure enforce the endpoint to relieve the request body by making a secure request to wpcom. 

By doing a secondary call to WordPress.com over https to get the post body. 

#### Changes proposed in this Pull Request:
* 

#### Testing instructions:
*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
