### PR TITLE
Update NodeJS required version to `6.10.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,6 @@
     "webpack-dev-server": "1.14.0"
   },
   "engines": {
-    "node": ">=5.11.1"
+    "node": ">=6.10.2"
   }
 }


### PR DESCRIPTION
Calypso requires `6.10.2` -> https://github.com/Automattic/wp-calypso/blob/master/package.json#L141
