### PR TITLE
Jetpack Sync: Adding sync event for plugin edit

### DIFF
--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -55,12 +55,11 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 			do_action( 'jetpack_installed_plugin', $plugin_path, $plugin_info );
 		}
 	}
-	
+
 	public function check_plugin_edit() {
 		$screen = get_current_screen();
 		if ( 'plugin-editor' !== $screen->base ||
-			! isset( $_POST['action'] ) ||
-			'update' !== $_POST['action'] ||
+			! isset( $_POST['new_content'] ) ||
 			! isset( $_POST['plugin'] )
 		) {
 			return;

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -59,7 +59,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 	public function check_plugin_edit() {
 		$screen = get_current_screen();
 		if ( 'plugin-editor' !== $screen->base ||
-			! isset( $_POST['new_content'] ) ||
+			! isset( $_POST['newcontent'] ) ||
 			! isset( $_POST['plugin'] )
 		) {
 			return;

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -18,6 +18,8 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		add_action( 'delete_plugin',  array( $this, 'delete_plugin') );
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
 		add_action( 'jetpack_installed_plugin', $callable, 10, 2 );
+		add_action( 'current_screen', array( $this, 'check_plugin_edit') );
+		add_action( 'jetpack_edited_plugin', $callable, 10, 2 );
 	}
 
 	public function init_before_send() {
@@ -52,6 +54,32 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 			 */
 			do_action( 'jetpack_installed_plugin', $plugin_path, $plugin_info );
 		}
+	}
+
+	public function check_plugin_edit() {
+		$screen = get_current_screen();
+		if ( 'plugin-editor' !== $screen->base ||
+			! 'te' === $_GET['a'] ||
+			! isset( $_GET['plugin'] )
+		) {
+			return;
+		}
+
+		$plugin = $_GET['plugin'];
+		$plugins = get_plugins();
+		if ( ! isset( $plugins[ $plugin ] ) ) {
+			return;
+		}
+
+		/**
+		 * Helps Sync log that a plugin was edited
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param string $plugin, Plugin slug
+		 * @param mixed $plugins[ $plugin ], Array of plugin data
+		 */
+		do_action( 'jetpack_edited_plugin', $plugin, $plugins[ $plugin ] );
 	}
 
 	public function delete_plugin( $plugin_path ) {

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -59,6 +59,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 	public function check_plugin_edit() {
 		$screen = get_current_screen();
 		if ( 'plugin-editor' !== $screen->base ||
+			! isset( $_GET['a'] ) ||
 			! 'te' === $_GET['a'] ||
 			! isset( $_GET['plugin'] )
 		) {

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -18,7 +18,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		add_action( 'delete_plugin',  array( $this, 'delete_plugin') );
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
 		add_action( 'jetpack_installed_plugin', $callable, 10, 2 );
-		add_action( 'wp_admin_update', array( $this, 'check_plugin_edit') );
+		add_action( 'admin_action_update', array( $this, 'check_plugin_edit') );
 		add_action( 'jetpack_edited_plugin', $callable, 10, 2 );
 	}
 

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -18,7 +18,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		add_action( 'delete_plugin',  array( $this, 'delete_plugin') );
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
 		add_action( 'jetpack_installed_plugin', $callable, 10, 2 );
-		add_action( 'current_screen', array( $this, 'check_plugin_edit') );
+		add_action( 'wp_admin_update', array( $this, 'check_plugin_edit') );
 		add_action( 'jetpack_edited_plugin', $callable, 10, 2 );
 	}
 
@@ -56,7 +56,35 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		}
 	}
 
+
 	public function check_plugin_edit() {
+		$screen = get_current_screen();
+		if ( 'plugin-editor' !== $screen->base ||
+			! isset( $_POST['action'] ) ||
+			'update' !== $_POST['action'] ||
+			! isset( $_POST['plugin'] )
+		) {
+			return;
+		}
+
+		$plugin = $_POST['plugin'];
+		$plugins = get_plugins();
+		if ( ! isset( $plugins[ $plugin ] ) ) {
+			return;
+		}
+
+		/**
+		 * Helps Sync log that a plugin was edited
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param string $plugin, Plugin slug
+		 * @param mixed $plugins[ $plugin ], Array of plugin data
+		 */
+		do_action( 'jetpack_edited_plugin', $plugin, $plugins[ $plugin ] );
+	}
+
+	public function check_plugin_edit2() {
 		$screen = get_current_screen();
 		if ( 'plugin-editor' !== $screen->base ||
 			! isset( $_GET['a'] ) ||

--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -55,8 +55,7 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 			do_action( 'jetpack_installed_plugin', $plugin_path, $plugin_info );
 		}
 	}
-
-
+	
 	public function check_plugin_edit() {
 		$screen = get_current_screen();
 		if ( 'plugin-editor' !== $screen->base ||
@@ -68,33 +67,6 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		}
 
 		$plugin = $_POST['plugin'];
-		$plugins = get_plugins();
-		if ( ! isset( $plugins[ $plugin ] ) ) {
-			return;
-		}
-
-		/**
-		 * Helps Sync log that a plugin was edited
-		 *
-		 * @since 4.9.0
-		 *
-		 * @param string $plugin, Plugin slug
-		 * @param mixed $plugins[ $plugin ], Array of plugin data
-		 */
-		do_action( 'jetpack_edited_plugin', $plugin, $plugins[ $plugin ] );
-	}
-
-	public function check_plugin_edit2() {
-		$screen = get_current_screen();
-		if ( 'plugin-editor' !== $screen->base ||
-			! isset( $_GET['a'] ) ||
-			! 'te' === $_GET['a'] ||
-			! isset( $_GET['plugin'] )
-		) {
-			return;
-		}
-
-		$plugin = $_GET['plugin'];
 		$plugins = get_plugins();
 		if ( ! isset( $plugins[ $plugin ] ) ) {
 			return;

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -91,7 +91,7 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		);
 		set_current_screen( 'plugin-editor' );
 
-		do_action( 'wp_admin_update' );
+		do_action( 'admin_action_update' );
 
 		$this->sender->do_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -84,6 +84,24 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( in_array( 'hello', $set_autoupdate_plugin ) );
 	}
 
+	public function test_edit_plugin() {
+		$_GET = array(
+			'a' => 'te',
+			'plugin' => 'hello.php',
+		);
+		set_current_screen( 'plugin-editor' );
+
+		do_action( 'current_screen' );
+
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_edited_plugin' );
+
+		$plugins = get_plugins();
+		$this->assertEquals( 'hello.php', $event->args[0] );
+		$this->assertEquals( $plugins['hello.php'], $event->args[1] );
+	}
+
 	function install_wp_super_cache() {
 		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -88,6 +88,7 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		$_POST = array(
 			'action' => 'update',
 			'plugin' => 'hello.php',
+			'new_content' => 'stuff',
 		);
 		set_current_screen( 'plugin-editor' );
 

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -85,13 +85,13 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_edit_plugin() {
-		$_GET = array(
-			'a' => 'te',
+		$_POST = array(
+			'action' => 'update',
 			'plugin' => 'hello.php',
 		);
 		set_current_screen( 'plugin-editor' );
 
-		do_action( 'current_screen' );
+		do_action( 'wp_admin_update' );
 
 		$this->sender->do_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -88,7 +88,7 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		$_POST = array(
 			'action' => 'update',
 			'plugin' => 'hello.php',
-			'new_content' => 'stuff',
+			'newcontent' => 'stuff',
 		);
 		set_current_screen( 'plugin-editor' );
 


### PR DESCRIPTION
Jetpack Sync: Adding sync event for plugin edit

#### Changes proposed in this Pull Request:

Jetpack Sync: Adding sync event for plugin edit

#### Testing instructions:

phpunit runs new test for this sync action

<!-- Add the following only if this is meant to be in changelog -->

Add new action jetpack_edited_plugin when plugin is saved via editor
