### PR TITLE
API: Add connect user endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-user-connect-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-user-connect-endpoint.php
@@ -1,0 +1,31 @@
+<?php
+
+class Jetpack_JSON_API_User_Connect_Endpoint extends Jetpack_JSON_API_Endpoint {
+
+	protected $needed_capabilities = 'create_users';
+
+	private $user_id;
+	private $user_token;
+
+	function result() {
+		Jetpack::update_user_token( $this->user_id, sprintf( '%s.%d', $this->user_token, $this->user_id ), false );
+		return array( 'success' => Jetpack::is_user_connected( $this->user_id ) );
+	}
+
+	function validate_input( $user_id ) {
+		$input = $this->input();
+		if ( ! isset( $user_id ) ) {
+			return new WP_Error( 'input_error', __( 'user_id is required', 'jetpack' ) );
+		}
+		$this->user_id = $user_id;
+		if ( Jetpack::is_user_connected( $this->user_id ) ) {
+			return new WP_Error( 'user_already_connected', __( 'The user is already connected', 'jetpack' ) );
+		}
+		if ( ! isset( $input['user_token'] ) ) {
+			return new WP_Error( 'input_error', __( 'user_token is required', 'jetpack' ) );
+		}
+		$this->user_token = sanitize_text_field( $input[ 'user_token'] );
+		return parent::validate_input( $user_id );
+	}
+
+}

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1159,3 +1159,39 @@ new Jetpack_JSON_API_Get_Post_Backup_Endpoint( array(
 	),
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/posts/1/backup'
 ) );
+
+
+// USERS
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-user-connect-endpoint.php' );
+
+// POST /sites/%s/users/%d/connect
+new Jetpack_JSON_API_User_Connect_Endpoint( array(
+	'description'    => 'Creates or returns a new user given profile data',
+	'group'          => '__do_not_document',
+	'method'         => 'POST',
+	'path'           => '/sites/%s/users/%d/connect',
+	'stat'           => 'users:connect',
+	'allow_jetpack_site_auth' => true,
+	'path_labels'    => array(
+		'$site' => '(int|string) The site ID, The site domain',
+		'$user_id' => '(int) The site user ID to connect',
+	),
+	'request_format' => array(
+		'user_token'        => '(string) The user token',
+	),
+	'response_format' => array(
+		'success' => '(bool) Was the user connected',
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN',
+		),
+		'body' => array(
+			'user_token' => 'XDH55jndskjf3klh3',
+		)
+	),
+	'example_response'     => '{
+       "success" => true
+    }',
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/users/6/connect'
+) );


### PR DESCRIPTION
This will allows us to connect a user after the user accepts an invitation from wpcom. 

#### Changes proposed in this Pull Request:
* Create an api endpoint that will allow set a user 

#### Testing instructions:
Test the api endpoint. 
Does it produce the expected result? 



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
