### PR TITLE
Fixes Travis builds for foreign pull requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,9 @@ cache: yarn
 
 matrix:
   include:
-  - php: "5.6"
-    env: WP_TRAVISCI="yarn lint"
-  - php: "5.6"
-    env: WP_TRAVISCI="yarn test-client"
-  - php: "5.6"
-    env: WP_TRAVISCI="yarn test-gui"
+  - env: WP_TRAVISCI="yarn lint"
+  - env: WP_TRAVISCI="yarn test-client"
+  - env: WP_TRAVISCI="yarn test-gui"
   - php: "5.2"
   - php: "5.3"
   - php: "5.5"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -38,10 +38,9 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
     fi
 else
 
+    npm install -g yarn@0.22.0
     gem install sass
     gem install compass
-    rm -rf ~/.yarn
-    curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.20.3
     yarn
 
     if $WP_TRAVISCI; then


### PR DESCRIPTION
Apparently the problem with foreign pull requests was that we couldn't install yarn by pulling a bash script directly from an URL. So we use `yarn` by installing it from `npm` instead. Hopefully one day Travis will allow using several languages for the same build: https://github.com/travis-ci/travis-ci/issues/4090

#### Changes proposed in this Pull Request:
* Installing `yarn` using `npm`.
