### PR TITLE
Sync: make sure the sidebar index exists before fetching old widgets

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -197,7 +197,9 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			if ( in_array( $sidebar, array( 'array_version', 'wp_inactive_widgets' ) ) ) {
 				continue;
 			}
-			$old_widgets = $old_value[ $sidebar ];
+			$old_widgets = isset( $old_value[ $sidebar ] )
+				? $old_value[ $sidebar ]
+				: array();
 
 			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
 			$moved_to_inactive = array_merge( $moved_to_inactive, $moved_to_inactive_recently );


### PR DESCRIPTION
Fixes issue when activating certain themes

```
Notice: Undefined index: some_sidebar_1 in /jetpack/sync/class.jetpack-sync-module-themes.php on line 200
Warning: array_diff(): Argument #1 is not an array in /jetpack/sync/class.jetpack-sync-module-themes.php on line 135
Warning: array_diff(): Argument #2 is not an array in /jetpack/sync/class.jetpack-sync-module-themes.php on line 114
Warning: array_diff(): Argument #2 is not an array in /jetpack/sync/class.jetpack-sync-module-themes.php on line 164
Warning: array_diff(): Argument #1 is not an array in /jetpack/sync/class.jetpack-sync-module-themes.php on line 168
```

Issue introduced in https://github.com/Automattic/jetpack/pull/6909/files#diff-37af365e9198e952a002bbf543cdcdcfR154

#### Changes proposed in this Pull Request:

* make sure the sidebar index exists before fetching old widgets. If it doesn't pass an empty array to `array_diff` gets the right parameter.

#### Testing instructions:

* activate TwentyFifteen and then TwentySeventeen. There should be no notices.
