### PR TITLE
Install yarn using apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,5 +88,12 @@ notifications:
        - secure: "WQdTdmYuifSW0hiJGXpQGKystMASC50QvxHlyUL5SM3h5GP8aCgeSsHuXvKPe3dT3Pffhk0dSHBfDtdWFwSHW/upURhg0vs4dm7+nxxvGZiTPzKcuAIjgvCoqWM7teyda/XqFGNSnv+XsT34uoyPhhFgd45T3oS+QQ3aNCruFak="
 
 addons:
+  addons:
+  apt:
+    sources:
+      - sourceline: 'deb https://dl.yarnpkg.com/debian/ stable main'
+        key_url: 'https://dl.yarnpkg.com/debian/pubkey.gpg'
+    packages:
+      - yarn
   code_climate:
     repo_token: 683bd559e5214ca3b721092af177893f05765ba90d2589fcf35d7e85c6ea01e8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ env:
   global:
     - WP_TRAVISCI=phpunit
 
-cache: yarn
+cache:
+  - yarn: true
+  - apt: true
 
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -38,7 +38,6 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
     fi
 else
 
-    npm install -g yarn@0.22.0
     gem install sass
     gem install compass
     yarn


### PR DESCRIPTION
Whilst testing #7065 and merging changes from #7074 I noticed this:

> https://travis-ci.org/Automattic/jetpack/jobs/226607567#L227
> _"npm WARN deprecated yarn@0.22.0: It is recommended to install Yarn using the native installation method for your environment. See https://yarnpkg.com/en/docs/install"_

So, per the above instructions is this PR using apt to install yarn

It also installs "stable main" so isn't locked to the yarn version `0.22.0` that was being used with npm previously, not sure what the reason was to pin to yarn 0.22.0?