### PR TITLE
Flickr Widget: build Feed URLs manually based on user or group ID

### DIFF
--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -68,7 +68,8 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 			$image_size_string = 'small' == $instance['flickr_image_size'] ? '_m.jpg' : '_t.jpg';
 
 			if ( ! empty( $instance['flickr_rss_url'] ) ) {
-				/**
+
+				/*
 				 * Parse the URL, and rebuild a URL that's sure to display images.
 				 * Some Flickr Feeds do not display images by default.
 				 */
@@ -84,9 +85,8 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 
 					// Do we have an ID in the feed? Let's continue.
 					if ( isset( $vars['id'] ) ) {
-						/**
-						 * Flickr Feeds can be used for groups or for individuals.
-						 */
+
+						// Flickr Feeds can be used for groups or for individuals.
 						if (
 							! empty( $flickr_parameters['path'] )
 							&& false !== strpos( $flickr_parameters['path'], 'groups' )


### PR DESCRIPTION
Building the feed ourselves avoids issues when a user enters the wrong RSS format, or URL format.

#### Testing instructions:

With that PR, one can now use the following feed formats, that will all be converted into a compatible Flickr RSS feed:

- https://www.flickr.com/services/feeds/photos_public.gne?id=34430197@N04&lang=en-us&format=rss
- https://api.flickr.com/services/feeds/groups_pool.gne?id=417611@N24&format=rss2
- https://api.flickr.com/services/feeds/groups_pool.gne?id=417611@N24&format=rss_200_enc
- https://api.flickr.com/services/feeds/groups_pool.gne?id=417611@N24
- https://api.flickr.com/services/feeds/groups_pool.gne?id=417611@N24&format=atom
- https://api.flickr.com/services/feeds/groups_pool.gne?id=417611@N24&format=rdf
- https://api.flickr.com/services/feeds/photos_public.gne?id=11023327@N08&lang=fr-fr&format=rss_200

Reported here:
p8oabR-2x-p2