### PR TITLE
Flickr Widget: do not display widget table when there are no images

### DIFF
--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -103,7 +103,11 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 			echo $args['before_widget'];
 			if ( empty( $photos ) ) {
 				if ( current_user_can( 'edit_theme_options' ) ) {
-					echo '<p>' . esc_html__( 'There are no photos to display. Make sure your Flickr feed URL is correct, and that your pictures are publicly accessible.', 'jetpack' ) . '</p>';
+					printf(
+						'<p>%1$s<br />%2$s</p>',
+						esc_html__( 'There are no photos to display. Make sure your Flickr feed URL is correct, and that your pictures are publicly accessible.', 'jetpack' ),
+						esc_html__( '(Only admins can see this message)', 'jetpack' )
+					);
 				}
 			} else {
 				echo $args['before_title'] . esc_html( $instance['title'] ) . $args['after_title'];

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -101,8 +101,14 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 			}
 
 			echo $args['before_widget'];
-			echo $args['before_title'] . esc_html( $instance['title'] ) . $args['after_title'];
-			require( dirname( __FILE__ ) . '/flickr/widget.php' );
+			if ( empty( $photos ) ) {
+				if ( current_user_can( 'edit_theme_options' ) ) {
+					echo '<p>' . esc_html__( 'There are no photos to display. Make sure your Flickr feed URL is correct, and that your pictures are publicly accessible.', 'jetpack' ) . '</p>';
+				}
+			} else {
+				echo $args['before_title'] . esc_html( $instance['title'] ) . $args['after_title'];
+				require( dirname( __FILE__ ) . '/flickr/widget.php' );
+			}
 			echo $args['after_widget'];
 			/** This action is already documented in modules/widgets/gravatar-profile.php */
 			do_action( 'jetpack_stats_extra', 'widget_view', 'flickr' );


### PR DESCRIPTION
Instead, we will display a warning message to site admins to let them know
their widget doesn't work properly.

#### Testing instructions:

Try entering a Flickr Feed URL where all images are marked as private ([example](https://href.li/?https://api.flickr.com/services/feeds/photos_public.gne?id=154104018@N06&lang=en-us&format=rss_200)).

Here is how it currently looks:

![screen shot 2017-04-28 at 14 23 35](https://cloud.githubusercontent.com/assets/426388/25528459/4a29eb40-2c1e-11e7-98dd-10c003b47147.png)
(the link redirects to Flickr but no images are displayed there)

Here is how it looks for admins with this PR:

![screen shot 2017-04-28 at 14 19 56](https://cloud.githubusercontent.com/assets/426388/25528468/5e2a6e94-2c1e-11e7-95c9-9e8d3df4d5b2.png)


Reported here:
p8oabR-2x-p2