### PR TITLE
EU Cookie Law Widget: Fix minimum height when content is a single line.

### DIFF
--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -14,7 +14,7 @@
 	color: #2e4467;
 	font-size: 12px;
 	line-height: 1.5;
-	min-height: 53px;
+	overflow: hidden;
 	padding: 6px 6px 6px 15px;
 }
 

--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -14,6 +14,7 @@
 	color: #2e4467;
 	font-size: 12px;
 	line-height: 1.5;
+	min-height: 53px;
 	padding: 6px 6px 6px 15px;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds a `min-height` (equals to the sum of the button's height and the banner's paddings and borders) to the banner in order to keep the button inside, even when there's not enough content in the banner.

| Before | After |
| --- | --- |
| <img width="733" alt="screen shot 2017-04-28 at 14 02 34" src="https://cloud.githubusercontent.com/assets/2070010/25529995/6af23e92-2c1c-11e7-9d9c-a15dddb5f429.png"> | <img width="734" alt="screen shot 2017-04-28 at 14 04 45" src="https://cloud.githubusercontent.com/assets/2070010/25530001/71ef8542-2c1c-11e7-9baf-0386a07cd6c5.png"> |

#### Testing instructions:

* Add the EU Cookie Law widget and set all radios to "Custom" and all fields to 1 character long strings.
* Check that the banner height is now big enough that the button is _inside_ the banner.

Reported here: p8oabR-2x-p2