### PR TITLE
Flickr Widget: make sure external link opens in a new window.

### DIFF
--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -29,7 +29,7 @@
 <p>
 	<small>
 		<?php printf(
-			__( 'Leave the Flickr RSS URL field blank to display <a href="%s">interesting</a> Flickr photos.', 'jetpack' ),
+			__( 'Leave the Flickr RSS URL field blank to display <a target="_blank" href="%s">interesting</a> Flickr photos.', 'jetpack' ),
 			'http://www.flickr.com/explore/interesting'
 		); ?>
 	</small>


### PR DESCRIPTION
It avoids issues when managing widgets in the customizer; you want to
be able to keep managing your widgets without losing your changes.

![flickr](https://cloud.githubusercontent.com/assets/426388/25531069/cb61c890-2c28-11e7-882b-af2d771d4d13.gif)
