### PR TITLE
Photon: Defensive coding on filtered function

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -626,7 +626,7 @@ class Jetpack_Photon {
 	 * @uses Jetpack_Photon::strip_image_dimensions_maybe, Jetpack::get_content_width
 	 * @return array An array of Photon image urls and widths.
 	 */
-	public function filter_srcset_array( $sources, $size_array, $image_src, $image_meta ) {
+	public function filter_srcset_array( $sources, $size_array = null, $image_src = null, $image_meta = null ) {
 		$upload_dir = wp_get_upload_dir();
 
 		foreach ( $sources as $i => $source ) {

--- a/class.photon.php
+++ b/class.photon.php
@@ -626,7 +626,10 @@ class Jetpack_Photon {
 	 * @uses Jetpack_Photon::strip_image_dimensions_maybe, Jetpack::get_content_width
 	 * @return array An array of Photon image urls and widths.
 	 */
-	public function filter_srcset_array( $sources, $size_array = null, $image_src = null, $image_meta = null ) {
+	public function filter_srcset_array( $sources = array(), $size_array = array(), $image_src = array(), $image_meta = array() ) {
+		if ( ! is_array( $sources ) ) {
+			return $sources;
+		}
 		$upload_dir = wp_get_upload_dir();
 
 		foreach ( $sources as $i => $source ) {


### PR DESCRIPTION
Pass default values to account for others applying the filter without passing all four args.

Every place we use these variables are already checked to ensure they are set, so there should be no harm in `null`ing them.

Fixes #7075 

#### Testing instructions:

* Use the Fludia theme at https://wordpress.org/themes/fluida/
* Without patch, see PHP Warnings in the error log
* With patch, no errors.
* Verify other image content (on that theme or any other) is still applying Photon values
