### PR TITLE
Flickr Widget: Add new large size

### DIFF
--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -79,11 +79,17 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 			$photos = '';
 			if ( ! is_wp_error( $rss ) ) {
 				foreach ( $rss->get_items( 0, $instance['items'] ) as $photo ) {
-					if ( $enclosure = $photo->get_enclosure() ) {
-						$src = str_replace( '_s.jpg', $image_size_string, $enclosure->get_thumbnail() );
-					} else {
-						$src = preg_match( '/src="(.*?)"/i', $photo->get_description(), $p );
-						$src = str_replace( '_m.jpg', $image_size_string, $p[1] );
+					switch ( $instance['flickr_image_size'] ) {
+						case 'thumbnail':
+							$src = $photo->get_enclosure()->get_thumbnail();
+							break;
+						case 'small':
+							$src = preg_match( '/src="(.*?)"/i', $photo->get_description(), $p );
+							$src = $p[1];
+							break;
+						case 'large':
+							$src = $photo->get_enclosure()->get_link();
+							break;
 					}
 
 					$photos .= '<a href="' . esc_url( $photo->get_permalink(), array( 'http', 'https' ) ) . '">';
@@ -139,7 +145,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 
 			if (
 				isset( $new_instance['flickr_image_size'] ) &&
-				in_array( $new_instance['flickr_image_size'], array( 'thumbnail', 'small' ) )
+				in_array( $new_instance['flickr_image_size'], array( 'thumbnail', 'small', 'large' ) )
 			) {
 				$instance['flickr_image_size'] = $new_instance['flickr_image_size'];
 			} else {

--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -52,29 +52,42 @@
 </p>
 
 <p>
-	<label>
+	<div>
 		<?php esc_html_e( 'What size photos would you like to display?', 'jetpack' ); ?>
-	</label>
-	<select name="<?php echo esc_attr( $this->get_field_name( 'flickr_image_size' ) ); ?>">
-		<?php
-		$flickr_sizes = array(
-			array(
-				'size' => 'thumbnail',
-				'text' => esc_html__( 'Thumbnail', 'jetpack' ),
-			),
-			array(
-				'size' => 'small',
-				'text' => esc_html__( 'Small', 'jetpack' ),
-			),
-		);
-		foreach( $flickr_sizes as $flickr_size ) { ?>
-			<option
-				<?php selected( $instance['flickr_image_size'], $flickr_size['size'] ); ?>
-				value="<?php echo esc_attr( $flickr_size['size'] ); ?>"
-			>
-				<?php esc_html_e( $flickr_size['text'] ); ?>
-			</option>
-		<?php }
-		?>
-	</select>
+	</div>
+	<ul>
+		<li>
+			<label>
+				<input
+					<?php checked( $instance['flickr_image_size'], 'thumbnail' ); ?>
+					name="<?php echo esc_attr( $this->get_field_name( 'flickr_image_size' ) ); ?>"
+					type="radio"
+					value="thumbnail"
+				/>
+				<?php esc_html_e( 'Thumbnail', 'jetpack' ); ?>
+			</label>
+		</li>
+		<li>
+			<label>
+				<input
+					<?php checked( $instance['flickr_image_size'], 'small' ); ?>
+					name="<?php echo esc_attr( $this->get_field_name( 'flickr_image_size' ) ); ?>"
+					type="radio"
+					value="small"
+				/>
+				<?php esc_html_e( 'Medium', 'jetpack' ); ?>
+			</label>
+		</li>
+		<li>
+			<label>
+				<input
+					<?php checked( $instance['flickr_image_size'], 'large' ); ?>
+					name="<?php echo esc_attr( $this->get_field_name( 'flickr_image_size' ) ); ?>"
+					type="radio"
+					value="large"
+				/>
+				<?php esc_html_e( 'Large', 'jetpack' ); ?>
+			</label>
+		</li>
+	</ul>
 </p>


### PR DESCRIPTION
Fixes #7085

#### Changes proposed in this Pull Request:

* Add new "Large" size.
* Rename "Small" with "Medium" to be consistent with WordPress media sizes.
* Replace `<select>` with `<input type="radio>`.
* Changes the logic of the image `src` retrieval from the RSS feed.

| Before | After |
| --- | --- |
| <img width="336" alt="screen shot 2017-04-28 at 18 46 40" src="https://cloud.githubusercontent.com/assets/2070010/25540486/229c71ea-2c43-11e7-83f7-a614d1eedf06.png"> | <img width="339" alt="screen shot 2017-04-28 at 18 46 19" src="https://cloud.githubusercontent.com/assets/2070010/25540478/1b72248c-2c43-11e7-9177-baf9104568ef.png"> |

#### Testing instructions:

* Activate the Flickr widget.
* Check that all three sizes output images as expected.

