### PR TITLE
Flickr Widget: Refactor the look and feel to allow for a thumbnail grid

### DIFF
--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 		public function defaults() {
 			return array(
 				'title'             => esc_html__( 'Flickr Photos', 'jetpack' ),
-				'items'             => 3,
+				'items'             => 4,
 				'flickr_image_size' => 'thumbnail',
 				'flickr_rss_url'    => ''
 			);

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -89,9 +89,8 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 					$photos .= '<a href="' . esc_url( $photo->get_permalink(), array( 'http', 'https' ) ) . '">';
 					$photos .= '<img src="' . esc_url( $src, array( 'http', 'https' ) ) . '" ';
 					$photos .= 'alt="' . esc_attr( $photo->get_title() ) . '" ';
-					$photos .= 'border="0" ';
 					$photos .= 'title="' . esc_attr( $photo->get_title() ) . '" ';
-					$photos .= ' /></a><br /><br />';
+					$photos .= ' /></a>';
 				}
 				if ( ! empty( $photos ) && class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' ) ) {
 					$photos = Jetpack_Photon::filter_the_content( $photos );

--- a/modules/widgets/flickr/style.css
+++ b/modules/widgets/flickr/style.css
@@ -1,12 +1,16 @@
-#flickr_badge_uber_wrapper,
-#flickr_badge_wrapper,
-.widget_flickr table td {
-	background-color: transparent;
-	border: 0;
-	margin: 0;
-	padding: 0;
+.flickr-images {
+	text-align: center;
 }
 
-#flickr_badge_uber_wrapper {
-	width: auto;
+.flickr-size-thumbnail .flickr-images {
+	align-content: space-between;
+	align-items: center;
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: center;
+}
+
+.flickr-images img {
+	max-width: 100%;
+	margin: 5px;
 }

--- a/modules/widgets/flickr/widget.php
+++ b/modules/widgets/flickr/widget.php
@@ -1,27 +1,13 @@
 <!-- Start of Flickr Widget -->
-<table
-	border="0"
-	cellpadding="0"
-	cellspacing="0"
-	class="flickr-size-<?php echo esc_attr( $instance['flickr_image_size'] ); ?>"
-	id="flickr_badge_uber_wrapper"
->
-	<tr>
-		<td>
-			<table border="0" cellpadding="0" cellspacing="10" id="flickr_badge_wrapper">
-				<tr>
-					<td align="center">
-						<?php echo $photos; ?>
+<div class="flickr-wrapper flickr-size-<?php echo esc_attr( $instance['flickr_image_size'] ); ?>">
+	<div class="flickr-images">
+		<?php echo $photos; ?>
+	</div>
 
-						<?php if ( isset( $flickr_home ) ) { ?>
-							<a href="<?php echo esc_url( $flickr_home, array( 'http', 'https' ) ); ?>">
-								<?php esc_html_e( 'More Photos', 'jetpack' ); ?>
-							</a>
-						<?php } ?>
-					</td>
-				</tr>
-			</table>
-		</td>
-	</tr>
-</table>
+	<?php if ( isset( $flickr_home ) ) { ?>
+		<a class="flickr-more" href="<?php echo esc_url( $flickr_home, array( 'http', 'https' ) ); ?>">
+			<?php esc_html_e( 'More Photos', 'jetpack' ); ?>
+		</a>
+	<?php } ?>
+</div>
 <!-- End of Flickr Widget -->


### PR DESCRIPTION
Fixes #7089 

#### Changes proposed in this Pull Request:

* Rewrite the front-end of the Flickr widget replacing unnecessary `<table>`s with a flexbox powered `<div>`.
* Center-align the thumbnails, as this was the original intended behaviour (see: `<td align="center">`).

<img width="316" alt="screen shot 2017-04-28 at 19 17 58" src="https://cloud.githubusercontent.com/assets/2070010/25541805/0459d830-2c48-11e7-94cd-225102ac540f.png">

#### Testing instructions:

* Activate the Flickr widget.
* Select size "thumbnail" and check that the photos are displayed in a grid (provided there's enough horizontal space).
* Select size "small" and check that the photos are displayed vertically.