### PR TITLE
CLI: Properly print list of modules when full syncing

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -654,7 +654,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				// Kick off a full sync
 				if ( Jetpack_Sync_Actions::do_full_sync( $modules ) ) {
 					if ( $modules ) {
-						WP_CLI::log( sprintf( __( 'Initialized a new full sync with modules: ', 'jetpack' ), join( ', ', $modules ) ) );
+						WP_CLI::log( sprintf( __( 'Initialized a new full sync with modules: %s', 'jetpack' ), join( ', ', array_keys( $modules ) ) ) );
 					} else {
 						WP_CLI::log( __( 'Initialized a new full sync', 'jetpack' ) );
 					}


### PR DESCRIPTION
In testing the sync CLI commands, I noticed that the list of modules wasn't being printed correctly. This is because the array of modules is contained in the keys of the array, and not the values of the array.

So, we simply needed to get the array keys from the array for this to print correctly.

To test:

In a Jetpack site, run `wp jetpack sync start --modules=callables` and ensure that you get output like this:

`Initialized a new full sync with modules: callables`