### PR TITLE
WordAds: Do not try to inject ad when in a feed

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -191,7 +191,7 @@ HTML;
 	 */
 	function insert_ad( $content ) {
 		// Ad JS won't work in XML feeds.
-		if ( is_feed() ){
+		if ( is_feed() ) {
 			return $content;
 		}
 		/**

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -190,6 +190,10 @@ HTML;
 	 * @since 4.5.0
 	 */
 	function insert_ad( $content ) {
+		// Ad JS won't work in XML feeds.
+		if ( is_feed() ){
+			return $content;
+		}
 		/**
 		 * Allow third-party tools to disable the display of in post ads.
 		 *


### PR DESCRIPTION
WordAds will inject the inline JS into `the_content` and `the_excerpt`. This won't work very well since it's XML and none of the header or scripts hooks are firing :)

The PR will bail early if being ran while `is_feed()` is true.

Real like failure (from https://micro.blog/bjk , powered via RSS feed from kraft.blog):
![screen shot 2017-04-30 at 22 04 14](https://cloud.githubusercontent.com/assets/88897/25571060/fdfc968a-2df0-11e7-87c0-c1c463b2c57a.png)

XML before patch:
![screen shot 2017-04-30 at 21 59 10](https://cloud.githubusercontent.com/assets/88897/25571063/118cc210-2df1-11e7-9051-9d556834cb84.png)

XML after patch:
![screen shot 2017-04-30 at 22 00 00](https://cloud.githubusercontent.com/assets/88897/25571066/19da7d5e-2df1-11e7-9edc-8e38007657e7.png)
