### PR TITLE
Jetpack Sync: Adding 'since' comment to do_action invocation in plugi…

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -93,7 +93,7 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		set_current_screen( 'plugin-editor' );
 
 		/**
-		 * Used to signal that a plugin was updated
+		 * This action is already documented in wp-admin/admin.php as a dynamic action that fires upon admin update
 		 *
 		 * @since 2.6.0
 		 */

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -92,6 +92,11 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		);
 		set_current_screen( 'plugin-editor' );
 
+		/**
+		 * Used to signal that a plugin was updated
+		 *
+		 * @since 2.6.0
+		 */
 		do_action( 'admin_action_update' );
 
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -93,7 +93,10 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		set_current_screen( 'plugin-editor' );
 
 		/**
-		 * This action is already documented in wp-admin/admin.php as a dynamic action that fires upon admin update
+		 * This action is already documented in wp-admin/admin.php
+		 *
+		 * The 'update' portion of the hook name is from `$_REQUEST['action']`,
+		 * e.g. 'admin_action_' . $_REQUEST['action']
 		 *
 		 * @since 2.6.0
 		 */


### PR DESCRIPTION
Jetpack Sync: Adding 'since' comment to do_action invocation

#### Changes proposed in this Pull Request:

Adding 'since' comment to do_action invocation

#### Testing instructions:

n/a

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
