### PR TITLE
Widgets: Migrate Image Widget instances to proposed core widget

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -86,6 +86,7 @@ class Jetpack_Options {
 			'jumpstart',                    // (string) A flag for whether or not to show the Jump Start.  Accepts: new_connection, jumpstart_activated, jetpack_action_taken, jumpstart_dismissed.
 			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
+			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget
 		);
 	}
 

--- a/class.photon.php
+++ b/class.photon.php
@@ -51,6 +51,7 @@ class Jetpack_Photon {
 		// Images in post content and galleries
 		add_filter( 'the_content', array( __CLASS__, 'filter_the_content' ), 999999 );
 		add_filter( 'get_post_galleries', array( __CLASS__, 'filter_the_galleries' ), 999999 );
+		add_filter( 'widget_media_image_instance', array( __CLASS__, 'filter_the_image_widget' ), 999999 );
 
 		// Core image retrieval
 		add_filter( 'image_downsize', array( $this, 'filter_image_downsize' ), 10, 3 );
@@ -386,6 +387,24 @@ class Jetpack_Photon {
 		unset( $this_gallery ); // break the reference.
 
 		return $galleries;
+	}
+
+
+	/**
+	 * Runs the image widget through photon.
+	 *
+	 * @param array $instance Image widget instance data.
+	 * @return array
+	 */
+	function filter_the_image_widget( $instance ) {
+		if ( Jetpack::is_module_active( 'photon' ) && ! $instance['attachment_id'] && $instance['url'] ) {
+			jetpack_photon_url( $instance['url'], array(
+				'w' => $instance['width'],
+				'h' => $instance['height'],
+			) );
+		}
+
+		return $instance;
 	}
 
 	/**

--- a/modules/widgets.php
+++ b/modules/widgets.php
@@ -31,6 +31,8 @@ function jetpack_load_widgets() {
 	foreach( $widgets_include as $include ) {
 		include $include;
 	}
+
+	include_once dirname( __FILE__ ) . '/widgets/migrate-to-core/image-widget.php';
 }
 
 add_action( 'jetpack_modules_loaded', 'jetpack_widgets_loaded' );

--- a/modules/widgets/image-widget.php
+++ b/modules/widgets/image-widget.php
@@ -9,8 +9,11 @@
 /**
 * Register the widget for use in Appearance -> Widgets
 */
-add_action( 'widgets_init', 'jetpack_image_widget_init' );
+add_action( 'widgets_init', 'jetpack_image_widget_init', 11 );
 function jetpack_image_widget_init() {
+	if ( class_exists( 'WP_Widget_Media_Image' ) && Jetpack_Options::get_option( 'image_widget_migration' ) ) {
+		return;
+	}
 	register_widget( 'Jetpack_Image_Widget' );
 }
 

--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -42,7 +42,7 @@ function jetpack_migrate_image_widget() {
 	$media_image      = get_option( 'widget_media_image' );
 	$sidebars_widgets = wp_get_sidebars_widgets();
 
-	foreach ( get_option( 'widget_image' ) as $id => $widget ) {
+	foreach ( get_option( 'widget_image', array() ) as $id => $widget ) {
 		if ( is_string( $id ) ) {
 			continue;
 		}
@@ -116,5 +116,14 @@ function jetpack_migrate_image_widget() {
 	wp_set_sidebars_widgets( $sidebars_widgets );
 
 	Jetpack_Options::update_option( 'image_widget_migration', true );
+
+	// We need to refresh on widgets page for changes to take effect.
+	add_action( 'current_screen', 'jetpack_refresh_on_widget_page' );
 }
 add_action( 'widgets_init', 'jetpack_migrate_image_widget' );
+
+function jetpack_refresh_on_widget_page( $current ) {
+	if ( 'widgets' === $current->base ) {
+		wp_safe_redirect( admin_url( 'widgets.php' ) );
+	}
+}

--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -76,7 +76,8 @@ function jetpack_migrate_image_widget() {
 			$image_meta = wp_get_attachment_metadata( $attachment_id );
 
 			// Is it a full size image?
-			if ( $image_basename === array_pop( explode( '/', $image_meta['file'] ) ) ) {
+			$image_path_pieces = explode( '/', $image_meta['file'] );
+			if ( $image_basename === array_pop( $image_path_pieces ) ) {
 				$media_image[ $id ]['attachment_id'] = $attachment_id;
 				$media_image[ $id ]['width']         = $image_meta['width'];
 				$media_image[ $id ]['height']        = $image_meta['height'];

--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -50,6 +50,7 @@ function jetpack_migrate_image_widget() {
 		$media_image[ $id ] = array_merge( $default_data, array_intersect_key( $widget, $default_data ), array(
 			'alt'         => $widget['alt_text'],
 			'height'      => $widget['img_height'],
+			'image_classes' => ! empty( $widget['align'] ) ? 'align' . $widget['align'] : '',
 			'image_title' => $widget['img_title'],
 			'link_url'    => $widget['link'],
 			'url'         => $widget['img_url'],

--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Migration from Jetpack's Image Widget to WordPress' Core Image Widget.
+ *
+ * @since 4.9
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Migrates all active instances of Jetpack's image widget to Core's media image widget.
+ */
+function jetpack_migrate_image_widget() {
+	// Only trigger the migration from wp-admin
+	if ( ! is_admin() ) {
+		return;
+	}
+	// Only migrate if the new widget is available and we haven't yet migrated
+	if ( ! class_exists( 'WP_Widget_Media_Image' ) || Jetpack_Options::get_option( 'image_widget_migration' ) ) {
+		return;
+	}
+
+	$default_data = array(
+		'attachment_id' => 0,
+		'url' => '',
+		'title' => '',
+		'size' => 'full',
+		'width' => 0,
+		'height' => 0,
+		'align' => 'none',
+		'caption' => '',
+		'alt' => '',
+		'link_type' => '',
+		'link_url' => '',
+		'image_classes' => '',
+		'link_classes' => '',
+		'link_rel' => '',
+		'image_title' => '',
+		'link_target_blank' => false,
+	);
+
+	$media_image      = get_option( 'widget_media_image' );
+	$sidebars_widgets = wp_get_sidebars_widgets();
+
+	foreach ( get_option( 'widget_image' ) as $id => $widget ) {
+		if ( is_string( $id ) ) {
+			continue;
+		}
+
+		$media_image[ $id ] = array_merge( $default_data, array_intersect_key( $widget, $default_data ), array(
+			'alt'         => $widget['alt_text'],
+			'height'      => $widget['img_height'],
+			'image_title' => $widget['img_title'],
+			'link_url'    => $widget['link'],
+			'url'         => $widget['img_url'],
+			'width'       => $widget['img_width'],
+		) );
+
+		// Check if the image is in the media library.
+		$image_basename = basename( $widget['img_url'] );
+		$attachment_ids = get_posts( array(
+			'fields'      => 'ids',
+			'meta_query'  => array(
+				array(
+					'value'   => basename( $image_basename ),
+					'compare' => 'LIKE',
+					'key'     => '_wp_attachment_metadata',
+				),
+			),
+			'post_status' => 'inherit',
+			'post_type'   => 'attachment',
+		) );
+
+		foreach ( (array) $attachment_ids as $attachment_id ) {
+			$image_meta = wp_get_attachment_metadata( $attachment_id );
+
+			// Is it a full size image?
+			if ( $image_basename === array_pop( explode( '/', $image_meta['file'] ) ) ) {
+				$media_image[ $id ]['attachment_id'] = $attachment_id;
+				$media_image[ $id ]['width']         = $image_meta['width'];
+				$media_image[ $id ]['height']        = $image_meta['height'];
+				break;
+			}
+
+			// Is it a down-sized image?
+			foreach ( $image_meta['sizes'] as $size => $image ) {
+				if ( false !== array_search( $image_basename, $image ) ) {
+					$media_image[ $id ]['attachment_id'] = $attachment_id;
+					$media_image[ $id ]['size']          = $size;
+					$media_image[ $id ]['width']         = $image['width'];
+					$media_image[ $id ]['height']        = $image['height'];
+					break 2;
+				}
+			}
+		}
+
+		if ( ! empty( $widget['link'] ) ) {
+			$media_image[ $id ]['link_type'] = $widget['link'] === $widget['img_url'] ? 'file' : 'custom';
+		}
+
+		foreach ( $sidebars_widgets as $sidebar => $widgets ) {
+			if ( false !== ( $key = array_search( "image-{$id}", $widgets, true ) ) ) {
+				$sidebars_widgets[ $sidebar ][ $key ] = "media_image-{$id}";
+			}
+		}
+
+		wp_unregister_sidebar_widget( "image-{$id}" );
+		$media_image_widget = new WP_Widget_Media_Image();
+		$media_image_widget->_set( $id );
+		$media_image_widget->_register_one( $id );
+	}
+
+	update_option( 'widget_media_image', $media_image );
+	delete_option( 'widget_image' );
+	wp_set_sidebars_widgets( $sidebars_widgets );
+
+	Jetpack_Options::update_option( 'image_widget_migration', true );
+}
+add_action( 'widgets_init', 'jetpack_migrate_image_widget' );


### PR DESCRIPTION
There's a proposal for a new core image widget in the works, which the core customizer folks want to see merged in WP 4.8. See [the the merge proposal](https://make.wordpress.org/core/2017/04/12/image-widget-merge-proposal/) & https://github.com/xwp/wp-core-media-widgets/issues/43 for more info.

The proposed core widget is a much nicer experience for adding an image, so we should migrate our users' widgets to the new widget (if available), and not register the Jetpack image widget. This PR adds a function that will run once in wp-admin to switch over any Jetpack image widgets to the core image widget.

Additionally this PR adds support for Photon in the widget ⚡️ 

cc @obenland (since the majority of the code came from your comment https://github.com/xwp/wp-core-media-widgets/issues/43#issuecomment-292252925 )

To test:

- Add some (Jetpack) image widgets to your sidebars
- Check out the front end of your site
- Install & activate the [core widgets feature plugin](https://github.com/xwp/wp-core-media-widgets)
- Go back to your widgets
- The images you added should now be using the core widget (the title will be `Image` instead of `Image (Jetpack)`)
- Make sure the front end of your site looks the same

_Note:_ Merging this PR can probably wait until the core widget is merged, but that should be "soon" according to @melchoyce, so I'm dropping this here just to make sure it gets looked at early 🙂 