### PR TITLE
Fix/woocommerce order item meta sync

### DIFF
--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -4,7 +4,7 @@ require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-module.php';
 
 class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 
-	private $meta_whitelist = array(
+	private $order_item_meta_whitelist = array(
 		'_product_id',
 		'_variation_id',
 		'_qty',
@@ -15,6 +15,8 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_line_tax',
 		'_line_tax_data',
 		'_visibility',
+		'discount_amount',
+		'discount_amount_tax',
 	);
 
 	private $order_item_table_name;
@@ -81,7 +83,7 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 
 		return array(
 			$order_items,
-			$this->get_metadata( $order_item_ids, 'order_item', $this->meta_whitelist )
+			$this->get_metadata( $order_item_ids, 'order_item', $this->order_item_meta_whitelist )
 		);
 	}
 

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -17,7 +17,7 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_line_subtotal_tax',
 		'_line_total',
 		'_line_tax',
-		'_line_tax_data'
+		'_line_tax_data',
 		// https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-order-item-shipping-data-store.php#L20
 		'method_id',
 		'cost',

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -5,25 +5,33 @@ require_once JETPACK__PLUGIN_DIR . '/sync/class.jetpack-sync-module.php';
 class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 
 	private $order_item_meta_whitelist = array(
+		// https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-order-item-product-store.php#L20
 		'_product_id',
 		'_variation_id',
 		'_qty',
+		// Tax ones also included in below class
+		// https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-order-item-fee-data-store.php#L20
 		'_tax_class',
+		'_tax_status',
 		'_line_subtotal',
 		'_line_subtotal_tax',
 		'_line_total',
 		'_line_tax',
-		'_line_tax_data',
-		'_visibility',
-		// Coupons
-		'discount_amount',
-		'discount_amount_tax',
-		// Tax on an order
+		'_line_tax_data'
+		// https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-order-item-shipping-data-store.php#L20
+		'method_id',
+		'cost',
+		'total_tax',
+		'taxes',
+		// https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-order-item-tax-data-store.php#L20
 		'rate_id',
 		'label',
 		'compound',
 		'tax_amount',
 		'shipping_tax_amount',
+		// https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-order-item-coupon-data-store.php
+		'discount_amount',
+		'discount_amount_tax',
 	);
 
 	private $order_item_table_name;

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -98,7 +98,7 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 
 		return array(
 			$order_items,
-			$this->get_metadata( $order_item_ids, 'order_item', $this->order_item_meta_whitelist )
+			$this->get_metadata( $order_item_ids, 'order_item', $this->order_item_meta_whitelist ),
 		);
 	}
 

--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -15,8 +15,15 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		'_line_tax',
 		'_line_tax_data',
 		'_visibility',
+		// Coupons
 		'discount_amount',
 		'discount_amount_tax',
+		// Tax on an order
+		'rate_id',
+		'label',
+		'compound',
+		'tax_amount',
+		'shipping_tax_amount',
 	);
 
 	private $order_item_table_name;


### PR DESCRIPTION
Fixes missing item meta data when syncing WooCommerce tables

#### Changes proposed in this Pull Request:

* Updates the order item meta data whitelist name to be clearer
* Adds missing meta data items for coupons and tax

#### Testing instructions:

* Check to see if the extra meta data gets synced

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fixes missing item meta data when syncing WooCommerce tables