### PR TITLE
Sync: Add sync actions when core updates

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -34,9 +34,10 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 		// Send data when update completes
 		add_action( '_core_updated_successfully', array( $this, 'update_core' ) );
-		add_action( 'jetpack_sync_update_core_successful', $callable, 10, 2 );
-		add_action( 'jetpack_sync_autoupdate_core_successful', $callable, 10, 2 );
-		add_action( 'jetpack_sync_reinstall_core_successful', $callable );
+		add_action( 'jetpack_sync_core_reinstalled_successfully', $callable );
+		add_action( 'jetpack_sync_core_autoupdated_successfully', $callable, 10, 2 );
+		add_action( 'jetpack_sync_core_updated_successfully', $callable, 10, 2 );
+
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -52,17 +53,39 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		global $pagenow;
 
 		if ( isset( $_GET[ 'action' ] ) && 'do-core-reinstall' == $_GET[ 'action' ] ) {
-			do_action( 'jetpack_sync_reinstall_core_successful', $new_wp_version );
+			/**
+			 * Sync event that is fires when the core reinstall was successful
+			 *
+			 * @since 5.0.0
+			 *
+			 * @param string $new_wp_version the updated WordPress version
+			 */
+			do_action( 'jetpack_sync_core_reinstalled_successfully', $new_wp_version );
 			return;
 		}
 
 		// Core was autoudpated
 		if ( 'update-core.php' !== $pagenow ) {
-			do_action( 'jetpack_sync_autoupdate_core_successful', $new_wp_version, $this->old_wp_version );
+			/**
+			 * Sync event that is fires when the core autoupdate was successful
+			 *
+			 * @since 5.0.0
+			 *
+			 * @param string $new_wp_version the updated WordPress version
+			 * @param string $old_wp_version the previous WordPress version
+			 */
+			do_action( 'jetpack_sync_core_autoupdated_successfully', $new_wp_version, $this->old_wp_version );
 			return;
 		}
-
-		do_action( 'jetpack_sync_update_core_successful', $new_wp_version, $this->old_wp_version );
+		/**
+		 * Sync event that is fires when the core update was successful
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param string $new_wp_version the updated WordPress version
+		 * @param string $old_wp_version the previous WordPress version
+		 */
+		do_action( 'jetpack_sync_core_updated_successfully', $new_wp_version, $this->old_wp_version );
 		return;
 	}
 

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -54,7 +54,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 		if ( isset( $_GET[ 'action' ] ) && 'do-core-reinstall' == $_GET[ 'action' ] ) {
 			/**
-			 * Sync event that is fires when the core reinstall was successful
+			 * Sync event that fires when core reinstall was successful
 			 *
 			 * @since 5.0.0
 			 *
@@ -67,7 +67,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		// Core was autoudpated
 		if ( 'update-core.php' !== $pagenow ) {
 			/**
-			 * Sync event that is fires when the core autoupdate was successful
+			 * Sync event that fires when core autoupdate was successful
 			 *
 			 * @since 5.0.0
 			 *
@@ -78,7 +78,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 			return;
 		}
 		/**
-		 * Sync event that is fires when the core update was successful
+		 * Sync event that fires when core update was successful
 		 *
 		 * @since 5.0.0
 		 *

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -4,7 +4,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 	const UPDATES_CHECKSUM_OPTION_NAME = 'jetpack_updates_sync_checksum';
 
-	private $old_version = null;
+	private $old_wp_version = null;
 
 	function name() {
 		return 'updates';
@@ -12,7 +12,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 	public function init_listeners( $callable ) {
 		global $wp_version;
-		$this->old_version = $wp_version;
+		$this->old_wp_version = $wp_version;
 		add_action( 'set_site_transient_update_plugins', array( $this, 'validate_update_change' ), 10, 3 );
 		add_action( 'set_site_transient_update_themes', array( $this, 'validate_update_change' ), 10, 3 );
 		add_action( 'set_site_transient_update_core', array( $this, 'validate_update_change' ), 10, 3 );
@@ -36,7 +36,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_action( '_core_updated_successfully', array( $this, 'update_core' ) );
 		add_action( 'jetpack_sync_update_core_successfull', $callable, 10, 2 );
 		add_action( 'jetpack_sync_autoupdate_core_successfull', $callable, 10, 2 );
-		add_action( 'jetpack_sync_reinstall_core_successfull', $callable, 10, 1 );
+		add_action( 'jetpack_sync_reinstall_core_successfull', $callable );
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -48,21 +48,21 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		add_filter( 'jetpack_sync_before_send_jetpack_update_themes_change', array( $this, 'expand_themes' ) );
 	}
 
-	public function update_core( $new_version ) {
+	public function update_core( $new_wp_version ) {
 		global $pagenow;
 
 		if ( isset( $_GET[ 'action' ] ) && 'do-core-reinstall' == $_GET[ 'action' ] ) {
-			do_action( 'jetpack_sync_reinstall_core_successfull', $new_version );
+			do_action( 'jetpack_sync_reinstall_core_successful', $new_wp_version );
 			return;
 		}
 
 		// Core was autoudpated
 		if ( 'update-core.php' !== $pagenow ) {
-			do_action( 'jetpack_sync_autoupdate_core_successfull', $new_version, $this->old_version );
+			do_action( 'jetpack_sync_autoupdate_core_successful', $new_wp_version, $this->old_wp_version );
 			return;
 		}
 
-		do_action( 'jetpack_sync_update_core_successfull', $new_version, $this->old_version );
+		do_action( 'jetpack_sync_update_core_successful', $new_wp_version, $this->old_wp_version );
 		return;
 	}
 

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -52,7 +52,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	public function update_core( $new_wp_version ) {
 		global $pagenow;
 
-		if ( isset( $_GET[ 'action' ] ) && 'do-core-reinstall' == $_GET[ 'action' ] ) {
+		if ( isset( $_GET[ 'action' ] ) && 'do-core-reinstall' === $_GET[ 'action' ] ) {
 			/**
 			 * Sync event that fires when core reinstall was successful
 			 *

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -34,7 +34,9 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 		// Send data when update completes
 		add_action( '_core_updated_successfully', array( $this, 'update_core' ) );
-		add_action( 'jetpack_sync_update_core_successfull', $callable, 10, 4 );
+		add_action( 'jetpack_sync_update_core_successfull', $callable, 10, 2 );
+		add_action( 'jetpack_sync_autoupdate_core_successfull', $callable, 10, 2 );
+		add_action( 'jetpack_sync_reinstall_core_successfull', $callable, 10, 1 );
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -49,13 +51,21 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	public function update_core( $new_version ) {
 		global $pagenow;
 
-		$auto_updated = (bool) ( 'update-core.php' !== $pagenow );
+		if ( isset( $_GET[ 'action' ] ) && 'do-core-reinstall' == $_GET[ 'action' ] ) {
+			do_action( 'jetpack_sync_reinstall_core_successfull', $new_version );
+			return;
+		}
 
-		$reinstall = isset( $_GET[ 'action' ] ) && 'do-core-reinstall' == $_GET[ 'action' ] ? true : false ;
+		// Core was autoudpated
+		if ( 'update-core.php' !== $pagenow ) {
+			do_action( 'jetpack_sync_autoupdate_core_successfull', $new_version, $this->old_version );
+			return;
+		}
 
-		do_action( 'jetpack_sync_update_core_successfull', $this->old_version, $new_version, $auto_updated, $reinstall );
+		do_action( 'jetpack_sync_update_core_successfull', $new_version, $this->old_version );
+		return;
 	}
-	
+
 	public function get_update_checksum( $value ) {
 		// Create an new array so we don't modify the object passed in.
 		$a_value = (array) $value;

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -34,9 +34,9 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 
 		// Send data when update completes
 		add_action( '_core_updated_successfully', array( $this, 'update_core' ) );
-		add_action( 'jetpack_sync_update_core_successfull', $callable, 10, 2 );
-		add_action( 'jetpack_sync_autoupdate_core_successfull', $callable, 10, 2 );
-		add_action( 'jetpack_sync_reinstall_core_successfull', $callable );
+		add_action( 'jetpack_sync_update_core_successful', $callable, 10, 2 );
+		add_action( 'jetpack_sync_autoupdate_core_successful', $callable, 10, 2 );
+		add_action( 'jetpack_sync_reinstall_core_successful', $callable );
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -55,14 +55,14 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_sync_wp_version() {
 		global $wp_version;
-		$previews_version = $wp_version;
+		$previous_version = $wp_version;
 		$this->assertEquals( $wp_version, $this->server_replica_storage->get_callable( 'wp_version' ) );
 
 		// Lets pretend that we updated the wp_version to bar.
 		$wp_version = 'bar';
 		do_action( 'upgrader_process_complete', null, array( 'action' => 'update', 'type' => 'core' ) );
 		$this->sender->do_sync();
-		$wp_version = $previews_version;
+		$wp_version = $previous_version;
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_callable( 'wp_version' ) );
 	}
 
@@ -90,7 +90,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$pagenow = $current_page; // revert page now
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_update_core_successful' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_core_updated_successfully' );
 
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // Old Version
@@ -105,7 +105,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		do_action( '_core_updated_successfully', 'foo' );
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_autoupdate_core_successful' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_core_autoupdated_successfully' );
 
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // Old Version
@@ -123,7 +123,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 		unset( $_GET['action'] );
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_reinstall_core_successful' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_core_reinstalled_successfully' );
 
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // New version

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -67,7 +67,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 	public function test_automatic_updates_complete_sync_action() {
 		// wp_maybe_auto_update();
 		do_action( 'automatic_updates_complete', array( 'core' => array(
-			'item'     => array('somedata'),
+			'item'     => array( 'somedata' ),
 			'result'   => 'some more data',
 			'name'     => 'WordPress 4.7',
 			'messages' => array('it worked.') ) ) );
@@ -75,6 +75,23 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'automatic_updates_complete' );
 		$this->assertTrue( (bool) $event );
+	}
+
+	public function test_update_core_successfully_sync_action() {
+		global $wp_version;
+		// Remove the _redirect_to_about_wordpress action
+		remove_action( '_core_updated_successfully', '_redirect_to_about_wordpress' );
+		do_action( '_core_updated_successfully', 'foo' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_update_core_successfull' );
+
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( $event->args[0], $wp_version ); // Old Version
+		$this->assertEquals( $event->args[1], 'foo' ); // New version
+		$this->assertTrue( $event->args[2] ); // Autoupdated
+		$this->assertFalse( $event->args[3] ); // is Reinstall?
+
 	}
 
 }

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -76,7 +76,6 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'automatic_updates_complete' );
-		var_dump($event);
 		$this->assertTrue( (bool) $event );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -90,7 +90,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$pagenow = $current_page; // revert page now
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_update_core_successfull' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_update_core_successful' );
 
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // Old Version
@@ -105,7 +105,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		do_action( '_core_updated_successfully', 'foo' );
 		$this->sender->do_sync();
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_autoupdate_core_successfull' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_autoupdate_core_successful' );
 
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // Old Version
@@ -123,7 +123,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 		unset( $_GET['action'] );
 
-		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_reinstall_core_successfull' );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_reinstall_core_successful' );
 
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // New version


### PR DESCRIPTION
The new action lets us know when core gets updated to a specific
version and it was autoupdated and if it was reinstalled.

#### Changes proposed in this Pull Request:
* Send specific events that would allow us know when a site has autoupdated, updated or reinstalled core.

#### Testing instructions:
* Go to the wp-admin/update-core.php and click on the update core button. 
.com should get the `jetpack_sync_update_core_successfull` action with 4 arguments. 

* Update the core verions to help trigger the core update links. 
Do the same. And notice that we get jetpack_sync_update_core_successfull again but with different arguments. 

Let autoupdate update core and notice the same action. 

To the phpunit tests pass? 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
