### PR TITLE
Jetpack Sync: Add sync event for theme deletion

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -11,7 +11,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
 		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
 		add_action( 'jetpack_updated_theme', $callable, 10, 2 );
-		add_action( 'delete_site_transient_update_themes', array($this, 'detect_theme_deletion') );
+		add_action( 'delete_site_transient_update_themes', array( $this, 'detect_theme_deletion') );
 		add_action( 'jetpack_deleted_theme', $callable );
 
 		// Sidebar updates.

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -12,7 +12,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
 		add_action( 'jetpack_updated_theme', $callable, 10, 2 );
 		add_action( 'delete_site_transient_update_themes', array($this, 'detect_theme_deletion') );
-		add_action( 'jetpack_delete_theme', $callable );
+		add_action( 'jetpack_deleted_theme', $callable );
 
 		// Sidebar updates.
 		add_action( 'update_option_sidebars_widgets', array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );
@@ -36,9 +36,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$data = array(
-			'slug' => $delete_theme_call['args'][0],
-		);
+		$slug = $delete_theme_call['args'][0];
 
 		/**
 		 * Signals to the sync listener that a theme was deleted and a sync action
@@ -46,10 +44,9 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		 *
 		 * @since 4.9.0
 		 *
-		 * @param string $theme->theme_root Text domain of the theme
-		 * @param mixed $theme_info Array of abbreviated theme info
+		 * @param string $slug Theme slug
 		 */
-		do_action( 'jetpack_delete_theme', $data );
+		do_action( 'jetpack_deleted_theme', $slug );
 	}
 
 	public function check_upgrader( $upgrader, $details) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -12,6 +12,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
 		add_action( 'jetpack_updated_theme', $callable, 10, 2 );
 		add_action( 'delete_site_transient_update_themes', array($this, 'detect_theme_deletion') );
+		add_action( 'jetpack_delete_theme', $callable );
 
 		// Sidebar updates.
 		add_action( 'update_option_sidebars_widgets', array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );
@@ -34,9 +35,21 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		if ( empty( $delete_theme_call ) ) {
 			return;
 		}
-		error_log(print_r($delete_theme_call, true));
-		$name = $delete_theme_call['args'][0];
-		error_log($name);
+
+		$data = array(
+			'slug' => $delete_theme_call['args'][0],
+		);
+
+		/**
+		 * Signals to the sync listener that a theme was deleted and a sync action
+		 * reflecting the deletion and theme slug should be sent
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param string $theme->theme_root Text domain of the theme
+		 * @param mixed $theme_info Array of abbreviated theme info
+		 */
+		do_action( 'jetpack_delete_theme', $data );
 	}
 
 	public function check_upgrader( $upgrader, $details) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -11,6 +11,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'upgrader_process_complete', array( $this, 'check_upgrader'), 10, 2 );
 		add_action( 'jetpack_installed_theme', $callable, 10, 2 );
 		add_action( 'jetpack_updated_theme', $callable, 10, 2 );
+		add_action( 'delete_site_transient_update_themes', array($this, 'detect_theme_deletion') );
 
 		// Sidebar updates.
 		add_action( 'update_option_sidebars_widgets', array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );
@@ -19,6 +20,22 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_widget_moved_to_inactive', $callable );
 		add_action( 'jetpack_cleared_inactive_widgets', $callable );
 		add_action( 'jetpack_widget_reordered', $callable );
+	}
+
+	public function detect_theme_deletion() {
+		$backtrace = debug_backtrace();
+		$delete_theme_call = null;
+		foreach ( $backtrace as $call ) {
+			if ( isset( $call['function'] ) && 'delete_theme' === $call['function'] ) {
+				$delete_theme_call = $call;
+				break;
+			}
+		}
+		if ( empty( $delete_theme_call ) ) {
+			return;
+		}
+		error_log(print_r($delete_theme_call, true));
+		$name = $delete_theme_call['args'][0];
 	}
 
 	public function check_upgrader( $upgrader, $details) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -35,12 +35,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 		error_log(print_r($delete_theme_call, true));
-//error_log(print_r($_POST, true));
-//error_log(print_r($_GET, true));
-//error_log(print_r($_REQUEST, true));
 		$name = $delete_theme_call['args'][0];
 		error_log($name);
-
 	}
 
 	public function check_upgrader( $upgrader, $details) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -42,7 +42,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		 * Signals to the sync listener that a theme was deleted and a sync action
 		 * reflecting the deletion and theme slug should be sent
 		 *
-		 * @since 4.9.0
+		 * @since 5.0.0
 		 *
 		 * @param string $slug Theme slug
 		 */

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -35,7 +35,12 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 		error_log(print_r($delete_theme_call, true));
+//error_log(print_r($_POST, true));
+//error_log(print_r($_GET, true));
+//error_log(print_r($_REQUEST, true));
 		$name = $delete_theme_call['args'][0];
+		error_log($name);
+
 	}
 
 	public function check_upgrader( $upgrader, $details) {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -123,7 +123,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $local_value, $this->server_replica_storage->get_option( 'theme_mods_' . $this->theme ) );
 	}
 
-	public function test_theme_install() {
+	public function test_theme_install_and_delete() {
 		require_once ABSPATH . 'wp-admin/includes/theme-install.php';
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
@@ -153,6 +153,12 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( (bool) $event_data->args[1]['uri'] );
 
 		delete_theme( $theme_stylesheet );
+
+		$this->sender->do_sync();
+
+		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_deleted_theme' );
+
+		$this->assertEquals( 'itek', $event_data->args[0] );
 	}
 
 	public function test_theme_update() {
@@ -177,6 +183,10 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			)
 		);
 		$this->assertEquals( $expected, $event_data->args );
+	}
+
+	public function test_theme_deletion() {
+
 	}
 
 	public function test_widgets_changes_get_synced() {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -185,10 +185,6 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $expected, $event_data->args );
 	}
 
-	public function test_theme_deletion() {
-
-	}
-
 	public function test_widgets_changes_get_synced() {
 
 		$sidebar_widgets = array(


### PR DESCRIPTION
This PR adds a Jetpack sync event for theme deletion, primarily for use by the Activity log.

#### Changes proposed in this Pull Request:

Addition of  'jetpack_deleted_theme' action, which triggers sync action upon theme deletion.

#### Testing instructions:

phpunit tests new functionality

<!-- Add the following only if this is meant to be in changelog -->
Addition of  'jetpack_deleted_theme' action
