### PR TITLE
JITMS: adding new JITM styles

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -347,6 +347,7 @@ class Jetpack_JITM {
 				<div class="jitm-banner__action">
 					<a href="https://jetpack.com/redirect/?source=settings-video-premium&amp;site=golenskijetpack.mystagingwebsite.com" type="button" class="dops-button is-compact is-primary">Upgrade</a>
 				</div>
+				<a href="#" data-module="" class="jitm-banner__dismiss"></a>
 			</div>
 		</div>
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -325,30 +325,33 @@ class Jetpack_JITM {
 		$url = 'https://jetpack.com/redirect/?source=jitm-backup-updates&site=' . $normalized_site_url;
 		$jitm_stats_url = Jetpack::build_stats_url( array( 'x_jetpack-jitm' => 'vaultpress' ) );
 		?>
-		<div class="jp-jitm" data-track="vaultpress-updates" data-stats_url="<?php echo esc_url( $jitm_stats_url ); ?>">
-			<a href="#" data-module="vaultpress" class="dismiss"><span class="genericon genericon-close"></span></a>
-			<?php echo self::get_emblem(); ?>
-			<p class="msg">
-				<?php esc_html_e( 'Backups are recommended to protect your site before you make any changes.', 'jetpack' ); ?>
-			</p>
-			<p>
-				<a href="<?php echo esc_url( $url ); ?>" target="_blank" title="<?php esc_attr_e( 'Enable VaultPress Backups', 'jetpack' ); ?>" data-module="vaultpress" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-vault" class="button button-jetpack launch jptracks"><?php esc_html_e( 'Enable VaultPress Backups', 'jetpack' ); ?></a>
-			</p>
-		</div>
-
-		<? /* ===========   Begin new JITM style EXAMPLES */ ?>
-
-		<div class="jitm-card jitm-banner has-call-to-action is-upgrade-premium">
+		<div class="jitm-card jitm-banner has-call-to-action" data-track="vaultpress-updates" data-stats_url="<?php echo esc_url( $jitm_stats_url ); ?>">
 			<div class="jitm-banner__icon-plan">
 				<?php echo self::get_emblem(); ?>
 			</div>
 			<div class="jitm-banner__content">
 				<div class="jitm-banner__info">
-					<div class="jitm-banner__title"><?php esc_html_e( 'This is a JITM title.', 'jetpack' ); ?></div>
-					<div class="jitm-banner__description"><?php esc_html_e( 'This is a optional JITM description. Super cool, right? We can enter longer strings of text here and it shall flow nicely on all screen sizes.', 'jetpack' ); ?></div>
+					<div class="jitm-banner__title"><?php esc_html_e( 'Backups are recommended to protect your site before you make any changes.', 'jetpack' ); ?></div>
 				</div>
 				<div class="jitm-banner__action">
-					<a href="#" type="button" class="jitm-button is-compact is-primary">Upgrade</a>
+					<a href="<?php echo esc_url( $url ); ?>" target="_blank" title="<?php esc_attr_e( 'Enable Backups', 'jetpack' ); ?>" data-module="vaultpress" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-vault" class="jitm-button is-compact launch jptracks"><?php esc_html_e( 'Enable Backups', 'jetpack' ); ?></a>
+				</div>
+				<a href="#" data-module="vaultpress" class="jitm-banner__dismiss"></a>
+			</div>
+		</div>
+
+		<? /* ===========   Begin new JITM style EXAMPLES */ ?>
+
+		<div class="jitm-card jitm-banner has-call-to-action">
+			<div class="jitm-banner__icon-plan">
+				<?php echo self::get_emblem(); ?>
+			</div>
+			<div class="jitm-banner__content">
+				<div class="jitm-banner__info">
+					<div class="jitm-banner__title"><?php esc_html_e( 'This is a JITM title. Messages go here', 'jetpack' ); ?></div>
+				</div>
+				<div class="jitm-banner__action">
+					<a href="#" type="button" class="jitm-button is-compact">Upgrade</a>
 				</div>
 				<a href="#" data-module="" class="jitm-banner__dismiss"></a>
 			</div>
@@ -362,10 +365,6 @@ class Jetpack_JITM {
 				<div class="jitm-banner__info">
 					<div class="jitm-banner__title"><?php esc_html_e( 'This is a JITM title.', 'jetpack' ); ?></div>
 					<div class="jitm-banner__description"><?php esc_html_e( 'This is a optional JITM description. Super cool, right? We can enter longer strings of text here and it shall flow nicely on all screen sizes.', 'jetpack' ); ?></div>
-					<div class="jitm-banner__list">
-						<li>Testing JITM list</li>
-						<li>Testing JITM list, again!</li>
-					</div>
 				</div>
 				<div class="jitm-banner__action">
 					<a href="#" type="button" class="jitm-button is-compact is-primary">Upgrade</a>

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -336,15 +336,15 @@ class Jetpack_JITM {
 			</p>
 		</div>
 
-		<div class="jitm-card dops-banner has-call-to-action is-upgrade-premium">
-			<div class="dops-banner__icon-plan">
-
+		<div class="jitm-card jitm-banner has-call-to-action is-upgrade-premium">
+			<div class="jitm-banner__icon-plan">
+				<?php echo self::get_emblem(); ?>
 			</div>
-			<div class="dops-banner__content">
-				<div class="dops-banner__info">
-					<div class="dops-banner__title">Testing the new JITM styles.</div>
+			<div class="jitm-banner__content">
+				<div class="jitm-banner__info">
+					<div class="jitm-banner__title">Testing the new JITM styles.</div>
 				</div>
-				<div class="dops-banner__action">
+				<div class="jitm-banner__action">
 					<a href="https://jetpack.com/redirect/?source=settings-video-premium&amp;site=golenskijetpack.mystagingwebsite.com" type="button" class="dops-button is-compact is-primary">Upgrade</a>
 				</div>
 			</div>

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -405,18 +405,23 @@ class Jetpack_JITM {
 		$url = 'https://jetpack.com/redirect/?source=jitm-backup-publish&site=' . $normalized_site_url;
 		$jitm_stats_url = Jetpack::build_stats_url( array( 'x_jetpack-jitm' => 'vaultpress' ) );
 		?>
-		<div class="jp-jitm" data-track="vaultpress-publish" data-stats_url="<?php echo esc_url( $jitm_stats_url ); ?>">
-			<a href="#" data-module="vaultpress" class="dismiss"><span class="genericon genericon-close"></span></a>
-
-			<?php echo self::get_emblem(); ?>
-
-			<p class="msg">
-				<?php esc_html_e( "Great job! Now let's make sure your hard work is never lost, backup everything with VaultPress.", 'jetpack' ); ?>
-			</p>
-			<p>
-				<a href="<?php echo esc_url( $url ); ?>" target="_blank" title="<?php esc_attr_e( 'Enable Backups', 'jetpack' ); ?>" data-module="vaultpress" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-vault-post" class="button button-jetpack launch jptracks"><?php esc_html_e( 'Enable Backups', 'jetpack' ); ?></a>
-			</p>
+		<div class="jitm-card jitm-banner has-call-to-action" data-track="vaultpress-publish" data-stats_url="<?php echo esc_url( $jitm_stats_url ); ?>">
+			<div class="jitm-banner__icon-plan">
+				<?php echo self::get_emblem(); ?>
+			</div>
+			<div class="jitm-banner__content">
+				<div class="jitm-banner__info">
+					<div class="jitm-banner__title"><?php esc_html_e( 'Ensure your work is backed up.', 'jetpack' ); ?></div>
+					<div class="jitm-banner__description"><?php esc_html_e( 'Great work creating that post! Now make sure your hard work is never lost, backup everything with Jetpack Backups.', 'jetpack' ); ?></div>
+				</div>
+				<div class="jitm-banner__action">
+					<a href="<?php echo esc_url( $url ); ?>" target="_blank" title="<?php esc_attr_e( 'Enable Jetpack Backups', 'jetpack' ); ?>" data-module="vaultpress" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-vault-post" class="jitm-button is-compact launch jptracks is-primary"><?php esc_html_e( 'Enable', 'jetpack' ); ?></a>
+				</div>
+				<a href="#" data-module="vaultpress" class="jitm-banner__dismiss"></a>
+			</div>
 		</div>
+
+
 		<?php
 		//jitm is being viewed, track it
 		$jetpack = Jetpack::init();

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -494,22 +494,30 @@ class Jetpack_JITM {
 		$install_url = wp_nonce_url( add_query_arg( array( 'wc-services-action' => $already_installed ? 'activate' : 'install' ) ), 'wc-services-install' );
 
 		?>
-		<div class="jp-jitm woo-jitm">
-			<a href="#"  data-module="wooservices" class="dismiss"><span class="genericon genericon-close"></span></a>
-			<div class="jp-emblem">
-				<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
-					<path d="M18,8h-2V7c0-1.105-0.895-2-2-2H4C2.895,5,2,5.895,2,7v10h2c0,1.657,1.343,3,3,3s3-1.343,3-3h4c0,1.657,1.343,3,3,3s3-1.343,3-3h2v-5L18,8z M7,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S7.828,18.5,7,18.5z M4,14V7h10v7H4z M17,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S17.828,18.5,17,18.5z" />
-				</svg>
+
+		<div class="jitm-card jitm-banner has-call-to-action woo-jitm" data-track="woo-services-activate">
+			<div class="jitm-banner__icon-plan">
+				<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 168 100" xml:space="preserve" enable-background="new 0 0 168 100" width="50" height="30"><style type="text/css">
+					.st0{clip-path:url(#SVGID_2_);enable-background:new    ;}
+					.st1{clip-path:url(#SVGID_4_);}
+					.st2{clip-path:url(#SVGID_6_);}
+					.st3{clip-path:url(#SVGID_8_);fill:#8F567F;}
+					.st4{clip-path:url(#SVGID_10_);fill:#FFFFFE;}
+					.st5{clip-path:url(#SVGID_12_);fill:#FFFFFE;}
+					.st6{clip-path:url(#SVGID_14_);fill:#FFFFFE;}
+				</style><g><defs><polygon id="SVGID_1_" points="83.8 100 0 100 0 0.3 83.8 0.3 167.6 0.3 167.6 100 "/></defs><clipPath id="SVGID_2_"><use xlink:href="#SVGID_1_" overflow="visible"/></clipPath><g class="st0"><g><defs><rect id="SVGID_3_" width="168" height="100"/></defs><clipPath id="SVGID_4_"><use xlink:href="#SVGID_3_" overflow="visible"/></clipPath><g class="st1"><defs><path id="SVGID_5_" d="M15.6 0.3H152c8.6 0 15.6 7 15.6 15.6v52c0 8.6-7 15.6-15.6 15.6h-48.9l6.7 16.4L80.2 83.6H15.6C7 83.6 0 76.6 0 67.9v-52C0 7.3 7 0.3 15.6 0.3"/></defs><clipPath id="SVGID_6_"><use xlink:href="#SVGID_5_" overflow="visible"/></clipPath><g class="st2"><defs><rect id="SVGID_7_" width="168" height="100"/></defs><clipPath id="SVGID_8_"><use xlink:href="#SVGID_7_" overflow="visible"/></clipPath><rect x="-10" y="-9.7" class="st3" width="187.6" height="119.7"/></g></g></g></g></g><g><defs><path id="SVGID_9_" d="M8.4 14.5c1-1.3 2.4-2 4.3-2.1 3.5-0.2 5.5 1.4 6 4.9 2.1 14.3 4.4 26.4 6.9 36.4l15-28.6c1.4-2.6 3.1-3.9 5.2-4.1 3-0.2 4.9 1.7 5.6 5.7 1.7 9.1 3.9 16.9 6.5 23.4 1.8-17.4 4.8-30 9-37.7 1-1.9 2.5-2.9 4.5-3 1.6-0.1 3 0.3 4.3 1.4 1.3 1 2 2.3 2.1 3.9 0.1 1.2-0.1 2.3-0.7 3.3 -2.7 5-4.9 13.2-6.6 24.7 -1.7 11.1-2.3 19.8-1.9 26.1 0.1 1.7-0.1 3.2-0.8 4.5 -0.8 1.5-2 2.4-3.7 2.5 -1.8 0.1-3.6-0.7-5.4-2.5C52.4 66.7 47.4 57 43.7 44.1c-4.4 8.8-7.7 15.3-9.9 19.7 -4 7.7-7.5 11.7-10.3 11.9 -1.9 0.1-3.5-1.4-4.8-4.7 -3.5-9-7.3-26.3-11.3-52C7.1 17.3 7.5 15.8 8.4 14.5"/></defs><clipPath id="SVGID_10_"><use xlink:href="#SVGID_9_" overflow="visible"/></clipPath><rect x="-2.7" y="-0.6" class="st4" width="90.6" height="86.4"/></g><g><defs><path id="SVGID_11_" d="M155.6 25.2c-2.5-4.3-6.1-6.9-11-7.9 -1.3-0.3-2.5-0.4-3.7-0.4 -6.6 0-11.9 3.4-16.1 10.2 -3.6 5.8-5.3 12.3-5.3 19.3 0 5.3 1.1 9.8 3.3 13.6 2.5 4.3 6.1 6.9 11 7.9 1.3 0.3 2.5 0.4 3.7 0.4 6.6 0 12-3.4 16.1-10.2 3.6-5.9 5.3-12.4 5.3-19.4C159 33.4 157.9 28.9 155.6 25.2zM147 44.2c-0.9 4.5-2.7 7.9-5.2 10.1 -2 1.8-3.9 2.5-5.5 2.2 -1.7-0.3-3-1.8-4-4.4 -0.8-2.1-1.2-4.2-1.2-6.2 0-1.7 0.2-3.4 0.5-5 0.6-2.8 1.8-5.5 3.6-8.1 2.3-3.3 4.7-4.8 7.1-4.2 1.7 0.3 3 1.8 4 4.4 0.8 2.1 1.2 4.2 1.2 6.2C147.5 40.9 147.3 42.6 147 44.2z"/></defs><clipPath id="SVGID_12_"><use xlink:href="#SVGID_11_" overflow="visible"/></clipPath><rect x="109.6" y="6.9" class="st5" width="59.4" height="71.4"/></g><g><defs><path id="SVGID_13_" d="M112.7 25.2c-2.5-4.3-6.1-6.9-11-7.9 -1.3-0.3-2.5-0.4-3.7-0.4 -6.6 0-11.9 3.4-16.1 10.2 -3.5 5.8-5.3 12.3-5.3 19.3 0 5.3 1.1 9.8 3.3 13.6 2.5 4.3 6.1 6.9 11 7.9 1.3 0.3 2.5 0.4 3.7 0.4 6.6 0 12-3.4 16.1-10.2 3.5-5.9 5.3-12.4 5.3-19.4C116 33.4 114.9 28.9 112.7 25.2zM104.1 44.2c-0.9 4.5-2.7 7.9-5.2 10.1 -2 1.8-3.9 2.5-5.5 2.2 -1.7-0.3-3-1.8-4-4.4 -0.8-2.1-1.2-4.2-1.2-6.2 0-1.7 0.2-3.4 0.5-5 0.6-2.8 1.8-5.5 3.6-8.1 2.3-3.3 4.7-4.8 7.1-4.2 1.7 0.3 3 1.8 4 4.4 0.8 2.1 1.2 4.2 1.2 6.2C104.6 40.9 104.4 42.6 104.1 44.2z"/></defs><clipPath id="SVGID_14_"><use xlink:href="#SVGID_13_" overflow="visible"/></clipPath><rect x="66.7" y="6.9" class="st6" width="59.4" height="71.4"/></g></svg>
 			</div>
-			<p class="msg">
-				<?php echo esc_html( $message ); ?>
-			</p>
-			<p>
-				<a href="<?php echo esc_url( $install_url ); ?>" title="<?php $already_installed ? esc_attr_e( 'Activate WooCommerce Services', 'jetpack' ) : esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" class="button button-jetpack show-after-enable">
-					<?php $already_installed ? esc_html_e( 'Activate WooCommerce Services', 'jetpack' ) : esc_html_e( 'Install WooCommerce Services', 'jetpack' ); ?>
-				</a>
-			</p>
+			<div class="jitm-banner__content">
+				<div class="jitm-banner__info">
+					<div class="jitm-banner__title"><?php echo esc_html( $message ); ?></div>
+				</div>
+				<div class="jitm-banner__action">
+					<a href="<?php echo esc_url( $install_url ); ?>" target="_blank" title="<?php $already_installed ? esc_attr_e( 'Activate WooCommerce Services', 'jetpack' ) : esc_attr_e( 'Install WooCommerce Services', 'jetpack' ); ?>" data-module="wooservices" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-woo-services" class="jitm-button is-compact launch jptracks is-primary"><?php $already_installed ? esc_html_e( 'Activate', 'jetpack' ) : esc_html_e( 'Install', 'jetpack' ); ?></a>
+				</div>
+				<a href="#" data-module="vaultpress" class="jitm-banner__dismiss"></a>
+			</div>
 		</div>
+
 		<?php
 		//jitm is being viewed, track it
 		$jetpack = Jetpack::init();

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -342,21 +342,6 @@ class Jetpack_JITM {
 
 		<? /* ===========   Begin new JITM style EXAMPLES */ ?>
 
-		<div class="jitm-card jitm-banner has-call-to-action">
-			<div class="jitm-banner__icon-plan">
-				<?php echo self::get_emblem(); ?>
-			</div>
-			<div class="jitm-banner__content">
-				<div class="jitm-banner__info">
-					<div class="jitm-banner__title"><?php esc_html_e( 'This is a JITM title. Messages go here', 'jetpack' ); ?></div>
-				</div>
-				<div class="jitm-banner__action">
-					<a href="#" type="button" class="jitm-button is-compact">Upgrade</a>
-				</div>
-				<a href="#" data-module="" class="jitm-banner__dismiss"></a>
-			</div>
-		</div>
-
 		<div class="jitm-card jitm-banner has-call-to-action is-upgrade-premium">
 			<div class="jitm-banner__icon-plan">
 				<?php echo self::get_emblem(); ?>

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -335,6 +335,22 @@ class Jetpack_JITM {
 				<a href="<?php echo esc_url( $url ); ?>" target="_blank" title="<?php esc_attr_e( 'Enable VaultPress Backups', 'jetpack' ); ?>" data-module="vaultpress" data-jptracks-name="nudge_click" data-jptracks-prop="jitm-vault" class="button button-jetpack launch jptracks"><?php esc_html_e( 'Enable VaultPress Backups', 'jetpack' ); ?></a>
 			</p>
 		</div>
+
+		<div class="jitm-card dops-banner has-call-to-action is-upgrade-premium">
+			<div class="dops-banner__icon-plan">
+
+			</div>
+			<div class="dops-banner__content">
+				<div class="dops-banner__info">
+					<div class="dops-banner__title">Testing the new JITM styles.</div>
+				</div>
+				<div class="dops-banner__action">
+					<a href="https://jetpack.com/redirect/?source=settings-video-premium&amp;site=golenskijetpack.mystagingwebsite.com" type="button" class="dops-button is-compact is-primary">Upgrade</a>
+				</div>
+			</div>
+		</div>
+
+
 		<?php
 		//jitm is being viewed, track it
 		$jetpack = Jetpack::init();

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -336,20 +336,45 @@ class Jetpack_JITM {
 			</p>
 		</div>
 
+		<? /* ===========   Begin new JITM style EXAMPLES */ ?>
+
 		<div class="jitm-card jitm-banner has-call-to-action is-upgrade-premium">
 			<div class="jitm-banner__icon-plan">
 				<?php echo self::get_emblem(); ?>
 			</div>
 			<div class="jitm-banner__content">
 				<div class="jitm-banner__info">
-					<div class="jitm-banner__title">Testing the new JITM styles.</div>
+					<div class="jitm-banner__title"><?php esc_html_e( 'This is a JITM title.', 'jetpack' ); ?></div>
+					<div class="jitm-banner__description"><?php esc_html_e( 'This is a optional JITM description. Super cool, right? We can enter longer strings of text here and it shall flow nicely on all screen sizes.', 'jetpack' ); ?></div>
 				</div>
 				<div class="jitm-banner__action">
-					<a href="https://jetpack.com/redirect/?source=settings-video-premium&amp;site=golenskijetpack.mystagingwebsite.com" type="button" class="dops-button is-compact is-primary">Upgrade</a>
+					<a href="#" type="button" class="jitm-button is-compact is-primary">Upgrade</a>
 				</div>
 				<a href="#" data-module="" class="jitm-banner__dismiss"></a>
 			</div>
 		</div>
+
+		<div class="jitm-card jitm-banner has-call-to-action is-upgrade-premium">
+			<div class="jitm-banner__icon-plan">
+				<?php echo self::get_emblem(); ?>
+			</div>
+			<div class="jitm-banner__content">
+				<div class="jitm-banner__info">
+					<div class="jitm-banner__title"><?php esc_html_e( 'This is a JITM title.', 'jetpack' ); ?></div>
+					<div class="jitm-banner__description"><?php esc_html_e( 'This is a optional JITM description. Super cool, right? We can enter longer strings of text here and it shall flow nicely on all screen sizes.', 'jetpack' ); ?></div>
+					<div class="jitm-banner__list">
+						<li>Testing JITM list</li>
+						<li>Testing JITM list, again!</li>
+					</div>
+				</div>
+				<div class="jitm-banner__action">
+					<a href="#" type="button" class="jitm-button is-compact is-primary">Upgrade</a>
+				</div>
+				<a href="#" data-module="" class="jitm-banner__dismiss"></a>
+			</div>
+		</div>
+
+		<? /* ===========   End new JITM style EXAMPLES */ ?>
 
 
 		<?php

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6448,7 +6448,7 @@ p {
 	 * @return string
 	 */
 	public static function get_jp_emblem() {
-		return '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 172.9 172.9" enable-background="new 0 0 172.9 172.9" xml:space="preserve">	<path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z" /></svg>';
+		return '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" width="20" height="20" viewBox="0 0 172.9 172.9" enable-background="new 0 0 172.9 172.9" xml:space="preserve"><path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z" /></svg>';
 	}
 
 	/*

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -196,7 +196,7 @@
 
 // New JITMS - calypso banner styles
 
-.dops-button {
+.jitm-button {
 	background: $white;
 	border-color: lighten( $gray, 20% );
 	border-style: solid;
@@ -248,7 +248,7 @@
 	&.is-compact {
 		padding: rem( 7px );
 		color: darken( $gray, 10% );
-		font-size: rem( 11px };
+		font-size: rem( 11px );
 		line-height: 1;
 		text-transform: uppercase;
 
@@ -263,7 +263,7 @@
 }
 
 // Primary buttons
-.dops-button.is-primary {
+.jitm-button.is-primary {
 	background: $blue-medium;
 	border-color: $blue-wordpress;
 	color: $white;
@@ -328,6 +328,10 @@
 	position: relative;
 	z-index: 2;
 
+	@include breakpoint( "<480px" ) {
+		display: block;
+	}
+
 	&.is-card-link {
 		padding: rem( 12px ) rem( 48px ) rem( 12px ) rem( 16px );
 	}
@@ -365,6 +369,7 @@
 
 	@include breakpoint( ">480px" ) {
 		padding: rem( 12px ) rem( 16px );
+
 		&.is-dismissible {
 			padding-right: rem( 16px );
 		}
@@ -419,6 +424,21 @@
 		width: rem( 32px );
 	}
 
+	.jp-emblem {
+		position: relative;
+		top: rem( 2px );
+
+		@include breakpoint( "<480px" ) {
+			margin-bottom: rem( 12px );
+		}
+
+		svg {
+			height: rem(  32px );
+			width: rem( 32px );
+			fill: $green-primary;
+		}
+	}
+
 	@include breakpoint( ">480px" ) {
 		align-items: center;
 	}
@@ -453,18 +473,22 @@
 
 	.jitm-banner__description {
 		font-size: rem( 12px );
-		margin-top: rem( 3px );
+		line-height: 1.5;
+		margin-top: rem( 6px );
 	}
 
 	.jitm-banner__list {
 		font-size: rem( 12px );
 		list-style: none;
 		margin: 0;
+
 		li {
 			margin: rem( 6px ) 0;
-			.gridicon {
-				color: $gray;
-				display: none;
+
+			&:before {
+				color: darken($gray, 20%);
+				font: 400 16px/1 dashicons;
+				content: '\f147';
 			}
 		}
 	}
@@ -472,7 +496,7 @@
 	@include breakpoint( ">480px" ) {
 		width: auto;
 
-		.jitm-banner__list li .gridicon {
+		.jitm-banner__list li {
 			display: inline;
 			margin-right: rem( 12px );
 			vertical-align: bottom;

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -216,7 +216,6 @@
 	line-height: rem( 21px );
 	border-radius: rem( 4px );
 	padding: rem( 7px ) rem( 14px ) rem( 9px );
-	-webkit-appearance: none;
 	appearance: none;
 
 	&:hover {
@@ -339,7 +338,7 @@
 		padding-right: rem( 48px );
 	}
 
-	@include jitm-banner-color( $blue-wordpress );
+	@include jitm-banner-color( $alert-green );
 
 	&.is-upgrade-personal {
 		@include jitm-banner-color( $alert-yellow );
@@ -461,8 +460,7 @@
 	width: 100%;
 
 	.jitm-banner__title,
-	.jitm-banner__description,
-	.jitm-banner__list {
+	.jitm-banner__description {
 		color: $gray-dark;
 	}
 
@@ -475,32 +473,6 @@
 		font-size: rem( 12px );
 		line-height: 1.5;
 		margin-top: rem( 6px );
-	}
-
-	.jitm-banner__list {
-		font-size: rem( 12px );
-		list-style: none;
-		margin: 0;
-
-		li {
-			margin: rem( 6px ) 0;
-
-			&:before {
-				color: darken($gray, 20%);
-				font: 400 16px/1 dashicons;
-				content: '\f147';
-			}
-		}
-	}
-
-	@include breakpoint( ">480px" ) {
-		width: auto;
-
-		.jitm-banner__list li {
-			display: inline;
-			margin-right: rem( 12px );
-			vertical-align: bottom;
-		}
 	}
 }
 

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -304,11 +304,16 @@
 	}
 }
 
+// if JITM appears directly below WordPress "help" menu
+#screen-meta-links+.jitm-card {
+	margin: rem( 32px ) 1.5385em 0 auto;
+}
+
 .jitm-card {
 	display: block;
 	position: relative;
-	margin: 2em auto 1em;
-	padding: 16px;
+	margin: rem( 16px ) 1.30rem 0 auto;
+	padding: rem( 16px );
 	box-sizing: border-box;
 	background: $white;
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
@@ -317,8 +322,8 @@
 	@include clear-fix;
 
 	@include breakpoint( ">480px" ) {
-		margin-bottom: 16px;
-		padding: 24px;
+		margin-bottom: rem( 16px );
+		padding: rem( 24px );
 	}
 
 	// Compact Card
@@ -339,15 +344,15 @@
 
 @mixin banner-color( $color ) {
 	border-left-color: $color;
-	.dops-banner__icon {
+	.jitm-banner__icon {
 		color: $color;
 	}
-	.dops-banner__icon-circle {
+	.jitm-banner__icon-circle {
 		background-color: $color;
 	}
 }
 
-.dops-banner.jitm-card {
+.jitm-banner.jitm-card {
 	border-left: 3px solid;
 	display: flex;
 	padding: 12px 6px 12px 12px;
@@ -397,6 +402,155 @@
 	}
 }
 
+.jitm-banner__icons {
+	display: flex;
+
+	.jitm-banner__icon,
+	.jitm-banner__icon-circle {
+		border-radius: 50%;
+		flex-shrink: 0;
+		height: 24px;
+		margin-right: 16px;
+		margin-top: -2px;
+		text-align: center;
+		top: 4px;
+		width: 24px;
+	}
+
+	.jitm-banner__icon {
+		align-self: center;
+		color: $white;
+		display: block;
+	}
+
+	.jitm-banner__icon-circle {
+		color: white;
+		display: none;
+		padding: 3px 4px 4px 3px;
+	}
+
+	@include breakpoint( ">480px" ) {
+		align-items: center;
+
+		.jitm-banner__icon {
+			display: none;
+		}
+		.jitm-banner__icon-circle {
+			display: block;
+		}
+	}
+}
+
+.jitm-banner__icon-plan {
+	display: flex;
+	margin-right: 16px;
+
+	.dops-plan-icon {
+		height: 32px;
+		width: 32px;
+	}
+
+	@include breakpoint( ">480px" ) {
+		align-items: center;
+	}
+}
+
+.jitm-banner__content {
+	align-items: center;
+	display: flex;
+	flex-grow: 1;
+	flex-wrap: wrap;
+
+	@include breakpoint( ">480px" ) {
+		flex-wrap: nowrap;
+	}
+}
+
+.jitm-banner__info {
+	flex-grow: 1;
+	line-height: 1.4;
+	width: 100%;
+
+	.jitm-banner__title,
+	.jitm-banner__description,
+	.jitm-banner__list {
+		color: $gray-dark;
+	}
+
+	.jitm-banner__title {
+		font-size: 14px;
+		font-weight: 500;
+	}
+
+	.jitm-banner__description {
+		font-size: 12px;
+		margin-top: 3px;
+	}
+
+	.jitm-banner__list {
+		font-size: 12px;
+		list-style: none;
+		margin: 0;
+		li {
+			margin: 6px 0;
+			.gridicon {
+				color: $gray;
+				display: none;
+			}
+		}
+	}
+
+	@include breakpoint( ">480px" ) {
+		width: auto;
+
+		.jitm-banner__list li .gridicon {
+			display: inline;
+			margin-right: 12px;
+			vertical-align: bottom;
+		}
+	}
+}
+
+.jitm-banner__action {
+	align-self: center;
+	font-size: 12px;
+	margin: 8px 0 0 0;
+	text-align: left;
+	width: 100%;
+
+	.jitm-banner__prices {
+		display: flex;
+		justify-content: flex-start;
+
+		.dops-plan-price {
+			margin-bottom: 0;
+		}
+
+		.dops-plan-price.is-discounted,
+		.dops-plan-price.is-discounted .dops-plan-price__currency-symbol {
+			color: $gray-dark;
+		}
+
+		.has-call-to-action & .dops-plan-price {
+			margin-bottom: 8px;
+		}
+	}
+
+	@include breakpoint( ">480px" ) {
+		margin: 0 4px 0 8px;
+		text-align: center;
+		width: auto;
+
+		.is-dismissible & {
+			margin-top: 40px;
+		}
+
+		.jitm-banner__prices {
+			justify-content: flex-end;
+			text-align: right;
+		}
+	}
+}
 
 // Large JITMS
 

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -351,7 +351,8 @@
 	&.is-upgrade-premium {
 		@include jitm-banner-color( $alert-green );
 	}
-	&.is-upgrade-business {
+	&.is-upgrade-business,
+	&.woo-jitm {
 		@include jitm-banner-color( $alert-purple );
 	}
 

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -1,5 +1,7 @@
 // Just in Time Messaging - message prompts
 
+@import '_inc/client/scss/functions/rem';
+@import '_inc/client/scss/variables/colors';
 
 // Original JITMs
 .jp-jitm {

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -1,5 +1,7 @@
 // Just in Time Messaging - message prompts
 
+
+// Original JITMs
 .jp-jitm {
 	border-radius: 2px;
 	max-width: 100%;

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -42,15 +42,16 @@
 		fill: #8cc258;
 	}
 
-  	// WooCommerce jitm
-  	&.woo-jitm path {
-	  fill: #96588a;
+	// WooCommerce jitm
+	&.woo-jitm path {
+	 	fill: #96588a;
 	}
 
 	.dismiss {
 		margin: 0;
 		text-decoration: none;
 		float: right;
+
 		&:before {
 			color: #666;
 			font: 400 15px/1 dashicons;
@@ -119,7 +120,9 @@
 
 // update core page
 .update-core-php .jp-jitm {
-	@media (min-width: 1100px) { margin: 3em 2em 0 auto; }
+	@media (min-width: 1100px) { 
+		margin: 3em 2em 0 auto; 
+	}
 }
 
 // when jetpack is connected, we need to move up the upload prompt content so the photo JITM can fit properly.
@@ -173,5 +176,10 @@
 			display: block;
 		}
 	}
-
 }
+
+// New JITMS - calypso banner styles
+
+
+// Large JITMS
+

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -2,12 +2,13 @@
 
 @import '_inc/client/scss/functions/rem';
 @import '_inc/client/scss/variables/colors';
+@import '_inc/client/scss/mixins/breakpoints';
 
 // Original JITMs
 .jp-jitm {
 	border-radius: 2px;
 	max-width: 100%;
-	margin: 2em auto 1em auto;
+	margin: 2em auto 1em;
 	padding: .85em;
 	background: #fcfcfc;
 	border: 1px solid #dedede;
@@ -181,6 +182,220 @@
 }
 
 // New JITMS - calypso banner styles
+
+.dops-button {
+	background: $white;
+	border-color: lighten( $gray, 20% );
+	border-style: solid;
+	border-width: 1px 1px 2px;
+	color: $gray-dark;
+	cursor: pointer;
+	display: inline-block;
+	margin: 0;
+	outline: 0;
+	overflow: hidden;
+	font-size: 14px;
+	font-weight: 500;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	box-sizing: border-box;
+	font-size: 14px;
+	line-height: 21px;
+	border-radius: 4px;
+	padding: 7px 14px 9px;
+	-webkit-appearance: none;
+	appearance: none;
+
+	&:hover {
+		border-color: lighten( $gray, 10% );
+		color: $gray-dark;
+	}
+	&:active {
+		border-width: 2px 1px 1px;
+	}
+	&:visited {
+		color: $gray-dark;
+	}
+	&[disabled],
+	&:disabled {
+		color: lighten( $gray, 30% );
+		background: $white;
+		border-color: lighten( $gray, 30% );
+		cursor: default;
+
+		&:active {
+			border-width: 1px 1px 2px;
+		}
+	}
+	&:focus {
+		outline: 0;
+		border-color: $blue-medium;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+	&.is-compact {
+		padding: 7px;
+		color: darken( $gray, 10% );
+		font-size: 11px;
+		line-height: 1;
+		text-transform: uppercase;
+
+		&:disabled {
+			color: lighten( $gray, 30% );
+		}
+		.gridicon {
+			top: 4px;
+			margin-top: -8px;
+		}
+		// Make the left margin of the small plus icon visually less huge
+		.gridicons-plus-small {
+			margin-left: -4px;
+		}
+		// Reset the left margin if the button contains only the plus icon
+		.gridicons-plus-small:last-of-type {
+			margin-left: 0;
+		}
+		// Make plus icon nudged closer to adjacent icons for add-people and add-plugin type buttons
+		.gridicons-plus-small + .gridicon {
+			margin-left: -4px;
+		}
+	}
+	&.hidden {
+		display: none;
+	}
+	.gridicon {
+		position: relative;
+			top: 4px;
+		margin-top: -2px;
+		width: 18px;
+		height: 18px;
+	}
+}
+
+// Primary buttons
+.dops-button.is-primary {
+	background: $blue-medium;
+	border-color: $blue-wordpress;
+	color: $white;
+
+	&:hover,
+	&:focus {
+		border-color: $blue-dark;
+		color: $white;
+	}
+	&[disabled],
+	&:disabled {
+		background: tint( $blue-light, 50% );
+		border-color: tint( $blue-wordpress, 55% );
+		color: $white;
+	}
+	&.is-compact {
+		color: $white;
+	}
+}
+
+@mixin clear-fix {
+	&:after {
+		content: ".";
+		display: block;
+		height: 0;
+		clear: both;
+		visibility: hidden;
+	}
+}
+
+.jitm-card {
+	display: block;
+	position: relative;
+	margin: 2em auto 1em;
+	padding: 16px;
+	box-sizing: border-box;
+	background: $white;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+
+	@include clear-fix;
+
+	@include breakpoint( ">480px" ) {
+		margin-bottom: 16px;
+		padding: 24px;
+	}
+
+	// Compact Card
+	&.is-compact {
+		margin-bottom: 1px;
+
+		@include breakpoint( ">480px" ) {
+			margin-bottom: 1px;
+			padding: 16px 24px;
+		}
+	}
+
+	&.is-card-link {
+		padding-right: 48px;
+	}
+}
+
+
+@mixin banner-color( $color ) {
+	border-left-color: $color;
+	.dops-banner__icon {
+		color: $color;
+	}
+	.dops-banner__icon-circle {
+		background-color: $color;
+	}
+}
+
+.dops-banner.jitm-card {
+	border-left: 3px solid;
+	display: flex;
+	padding: 12px 6px 12px 12px;
+	position: relative;
+	z-index: 2;
+
+	&.is-card-link {
+		padding: 12px 48px 12px 16px;
+	}
+	&.is-dismissible {
+		padding-right: 48px;
+	}
+
+	@include banner-color( $blue-wordpress );
+
+	&.is-upgrade-personal {
+		@include banner-color( $alert-yellow );
+	}
+	&.is-upgrade-premium {
+		@include banner-color( $alert-green );
+	}
+	&.is-upgrade-business {
+		@include banner-color( $alert-purple );
+	}
+
+	.jitm-card__link-indicator {
+		align-items: center;
+		color: $blue-wordpress;
+		display: flex;
+	}
+
+	&:hover {
+		transition: all 100ms ease-in-out;
+		&.is-card-link {
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
+		}
+		.jitm-card__link-indicator {
+			color: $blue-dark;
+		}
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding: 12px 16px;
+		&.is-dismissible {
+			padding-right: 16px;
+		}
+	}
+}
 
 
 // Large JITMS

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -4,6 +4,26 @@
 @import '_inc/client/scss/variables/colors';
 @import '_inc/client/scss/mixins/breakpoints';
 
+@mixin clear-fix {
+	&:after {
+		content: ".";
+		display: block;
+		height: 0;
+		clear: both;
+		visibility: hidden;
+	}
+}
+
+@mixin jitm-banner-color( $color ) {
+	border-left-color: $color;
+	.jitm-banner__icon {
+		color: $color;
+	}
+	.jitm-banner__icon-circle {
+		background-color: $color;
+	}
+}
+
 // Original JITMs
 .jp-jitm {
 	border-radius: 2px;
@@ -14,14 +34,7 @@
 	border: 1px solid #dedede;
 	text-align: center;
 
-	// clear hack
-	&:before, &:after {
-		content: "";
-		display: table;
-	}
-	&:after {
-		clear: both;
-	}
+	@include clear-fix;
 
 	#screen-meta-links + & {
 	  margin: 3em 1.5385em 0 auto;
@@ -294,17 +307,7 @@
 	}
 }
 
-@mixin clear-fix {
-	&:after {
-		content: ".";
-		display: block;
-		height: 0;
-		clear: both;
-		visibility: hidden;
-	}
-}
-
-// if JITM appears directly below WordPress "help" menu
+// if JITM appears directly below WordPress "help" menu adjust margins
 #screen-meta-links+.jitm-card {
 	margin: rem( 32px ) 1.5385em 0 auto;
 }
@@ -341,17 +344,6 @@
 	}
 }
 
-
-@mixin banner-color( $color ) {
-	border-left-color: $color;
-	.jitm-banner__icon {
-		color: $color;
-	}
-	.jitm-banner__icon-circle {
-		background-color: $color;
-	}
-}
-
 .jitm-banner.jitm-card {
 	border-left: 3px solid;
 	display: flex;
@@ -366,16 +358,16 @@
 		padding-right: 48px;
 	}
 
-	@include banner-color( $blue-wordpress );
+	@include jitm-banner-color( $blue-wordpress );
 
 	&.is-upgrade-personal {
-		@include banner-color( $alert-yellow );
+		@include jitm-banner-color( $alert-yellow );
 	}
 	&.is-upgrade-premium {
-		@include banner-color( $alert-green );
+		@include jitm-banner-color( $alert-green );
 	}
 	&.is-upgrade-business {
-		@include banner-color( $alert-purple );
+		@include jitm-banner-color( $alert-purple );
 	}
 
 	.jitm-card__link-indicator {
@@ -550,6 +542,28 @@
 			text-align: right;
 		}
 	}
+}
+
+.jitm-banner__dismiss {
+	display: block;
+	text-decoration: none;
+	line-height: .5;
+
+	&:before {
+		color: darken($gray, 20%);
+		font: 400 16px/1 dashicons;
+		content: '\f158';
+	}
+
+	@include breakpoint( "<480px" ) {
+		position: absolute;
+		top: rem( 14px );
+		right: rem( 14px );
+	}
+}
+
+.jitm-banner__action + .jitm-banner__dismiss {
+	margin-left: rem( 10px );
 }
 
 // Large JITMS

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -320,6 +320,11 @@
 	}
 }
 
+// remove right margin for jitms in the editor
+.post-php .jitm-card {
+	margin-right: 0;
+}
+
 .jitm-banner.jitm-card {
 	border-left: 3px solid;
 	display: flex;

--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -207,16 +207,15 @@
 	margin: 0;
 	outline: 0;
 	overflow: hidden;
-	font-size: 14px;
 	font-weight: 500;
 	text-overflow: ellipsis;
 	text-decoration: none;
 	vertical-align: top;
 	box-sizing: border-box;
-	font-size: 14px;
-	line-height: 21px;
-	border-radius: 4px;
-	padding: 7px 14px 9px;
+	font-size: rem( 14px );
+	line-height: rem( 21px );
+	border-radius: rem( 4px );
+	padding: rem( 7px ) rem( 14px ) rem( 9px );
 	-webkit-appearance: none;
 	appearance: none;
 
@@ -247,41 +246,19 @@
 		box-shadow: 0 0 0 2px $blue-light;
 	}
 	&.is-compact {
-		padding: 7px;
+		padding: rem( 7px );
 		color: darken( $gray, 10% );
-		font-size: 11px;
+		font-size: rem( 11px };
 		line-height: 1;
 		text-transform: uppercase;
 
 		&:disabled {
 			color: lighten( $gray, 30% );
 		}
-		.gridicon {
-			top: 4px;
-			margin-top: -8px;
-		}
-		// Make the left margin of the small plus icon visually less huge
-		.gridicons-plus-small {
-			margin-left: -4px;
-		}
-		// Reset the left margin if the button contains only the plus icon
-		.gridicons-plus-small:last-of-type {
-			margin-left: 0;
-		}
-		// Make plus icon nudged closer to adjacent icons for add-people and add-plugin type buttons
-		.gridicons-plus-small + .gridicon {
-			margin-left: -4px;
-		}
 	}
+
 	&.hidden {
 		display: none;
-	}
-	.gridicon {
-		position: relative;
-			top: 4px;
-		margin-top: -2px;
-		width: 18px;
-		height: 18px;
 	}
 }
 
@@ -331,31 +308,31 @@
 
 	// Compact Card
 	&.is-compact {
-		margin-bottom: 1px;
+		margin-bottom: rem( 1px );
 
 		@include breakpoint( ">480px" ) {
 			margin-bottom: 1px;
-			padding: 16px 24px;
+			padding: rem( 16px ) rem( 24px );
 		}
 	}
 
 	&.is-card-link {
-		padding-right: 48px;
+		padding-right: rem( 48px );
 	}
 }
 
 .jitm-banner.jitm-card {
 	border-left: 3px solid;
 	display: flex;
-	padding: 12px 6px 12px 12px;
+	padding: rem( 12px ) rem( 6px ) rem( 12px ) rem( 12px );
 	position: relative;
 	z-index: 2;
 
 	&.is-card-link {
-		padding: 12px 48px 12px 16px;
+		padding: rem( 12px ) rem( 48px ) rem( 12px ) rem( 16px );
 	}
 	&.is-dismissible {
-		padding-right: 48px;
+		padding-right: rem( 48px );
 	}
 
 	@include jitm-banner-color( $blue-wordpress );
@@ -387,9 +364,9 @@
 	}
 
 	@include breakpoint( ">480px" ) {
-		padding: 12px 16px;
+		padding: rem( 12px ) rem( 16px );
 		&.is-dismissible {
-			padding-right: 16px;
+			padding-right: rem( 16px );
 		}
 	}
 }
@@ -401,12 +378,12 @@
 	.jitm-banner__icon-circle {
 		border-radius: 50%;
 		flex-shrink: 0;
-		height: 24px;
-		margin-right: 16px;
-		margin-top: -2px;
+		height: rem( 24px );
+		width: rem( 24px );
+		margin-right: rem( 16px );
+		margin-top: rem( -2px );
 		text-align: center;
-		top: 4px;
-		width: 24px;
+		top: rem( 4px );
 	}
 
 	.jitm-banner__icon {
@@ -418,7 +395,7 @@
 	.jitm-banner__icon-circle {
 		color: white;
 		display: none;
-		padding: 3px 4px 4px 3px;
+		padding: rem( 3px ) rem( 4px ) rem( 4px ) rem( 3px );
 	}
 
 	@include breakpoint( ">480px" ) {
@@ -435,11 +412,11 @@
 
 .jitm-banner__icon-plan {
 	display: flex;
-	margin-right: 16px;
+	margin-right: rem( 16px );
 
 	.dops-plan-icon {
-		height: 32px;
-		width: 32px;
+		height: rem(  32px );
+		width: rem( 32px );
 	}
 
 	@include breakpoint( ">480px" ) {
@@ -475,16 +452,16 @@
 	}
 
 	.jitm-banner__description {
-		font-size: 12px;
-		margin-top: 3px;
+		font-size: rem( 12px );
+		margin-top: rem( 3px );
 	}
 
 	.jitm-banner__list {
-		font-size: 12px;
+		font-size: rem( 12px );
 		list-style: none;
 		margin: 0;
 		li {
-			margin: 6px 0;
+			margin: rem( 6px ) 0;
 			.gridicon {
 				color: $gray;
 				display: none;
@@ -497,7 +474,7 @@
 
 		.jitm-banner__list li .gridicon {
 			display: inline;
-			margin-right: 12px;
+			margin-right: rem( 12px );
 			vertical-align: bottom;
 		}
 	}
@@ -505,8 +482,8 @@
 
 .jitm-banner__action {
 	align-self: center;
-	font-size: 12px;
-	margin: 8px 0 0 0;
+	font-size: rem( 12px );
+	margin: rem( 8px ) 0 0;
 	text-align: left;
 	width: 100%;
 
@@ -524,17 +501,17 @@
 		}
 
 		.has-call-to-action & .dops-plan-price {
-			margin-bottom: 8px;
+			margin-bottom: rem( 8px );
 		}
 	}
 
 	@include breakpoint( ">480px" ) {
-		margin: 0 4px 0 8px;
+		margin: 0 rem( 4px ) 0 rem( 8px );
 		text-align: center;
 		width: auto;
 
 		.is-dismissible & {
-			margin-top: 40px;
+			margin-top: rem( 40px );
 		}
 
 		.jitm-banner__prices {

--- a/tests/php/test_class.jetpack-jitm.php
+++ b/tests/php/test_class.jetpack-jitm.php
@@ -29,7 +29,7 @@ class WP_Test_Jetpack_JITM extends WP_UnitTestCase {
 		$jitm = new Mock_JITM();
 
 		$emblem          = $jitm->get_emblem();
-		$expected_emblem = '<div class="jp-emblem"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 172.9 172.9" enable-background="new 0 0 172.9 172.9" xml:space="preserve">	<path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z" /></svg></div>';
+		$expected_emblem = '<div class="jp-emblem"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" width="20" height="20" viewBox="0 0 172.9 172.9" enable-background="new 0 0 172.9 172.9" xml:space="preserve"><path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z" /></svg></div>';
 		$this->assertEquals( $expected_emblem, $emblem );
 	}
 


### PR DESCRIPTION
Adding 2 new JITM styles and cleaning up the original JITM

To do:
- [x] clean up woo commerce JITM (visually)
- [ ] clean up original JITM styles. Update outdated css
- [x] add styles for new JITM banners (calypso styled)

**Current JITM style example:**
<img width="776" alt="old-jitm-style" src="https://cloud.githubusercontent.com/assets/214813/26079357/7ec7639e-3990-11e7-8852-ea2998db6ac6.png">


**New JITM style examples:**
<img width="1085" alt="screen shot 2017-05-15 at 4 59 26 pm" src="https://cloud.githubusercontent.com/assets/214813/26079323/61131032-3990-11e7-8651-e43519e37c04.png">

* Can change border color if desired.
* Can have title + description or just a title
* Can have gray or primary blue CTA button
* JITMs will dynamically resize/realign based on the content. In order words, If you only have a title in the JITM, it'll be vertically centered, and when you add a description, it'll automatically ensure both are vertically centered. ;-)
*Work well on mobile

Important to note that the CTA buttons have a max width in order to be easier to predict and control how they'll be displayed on various screen sizes—which can bump the button text to two lines if its long. We should try and re-word some of the JITMS so the button is one word and most of the verbs are in the description.


**TO TEST:**

1. Get this branch synced up to your sandbox.
2. Visit `yousite.com/wp-admin/update-core.php` where the sample JITMs sit ** Ensure VaultPress is deactivated to see these particular JITMs
3. Sample woo JITM is hanging out at `yoursite.com/wp-admin/edit.php?post_type=shop_order` when woo commerce is installed.

** If you've dismissed JITMs in the past and no longer see them, you'll need to reset your JITM options. Do so by SSH'ing into your sandbox and clearing them with `cd public_html` and then `wp jetpack options delete hide_jitm`

