### PR TITLE
JSON API: replace deprecated method

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
@@ -45,8 +45,7 @@ class WPCOM_JSON_API_List_Roles_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		$roles = array();
 
-		global $wp_roles;
-		$wp_roles->reinit();
+		$wp_roles= new WP_Roles();
 		$role_names = $wp_roles->get_names();
 		$role_keys = array_keys( $role_names );
 


### PR DESCRIPTION
I think the it's stats card is trying to poll roles. 

Anyway, this method that's used now has been deprecated since WP 4.7.  

To reproduce the error: 
```
[03-May-2017 18:44:02 UTC] PHP Stack trace:
[03-May-2017 18:44:02 UTC] PHP   1. {main}() /home/dereksma/public_html/xmlrpc.php:0
[03-May-2017 18:44:02 UTC] PHP   2. wp_xmlrpc_server->serve_request() /home/dereksma/public_html/xmlrpc.php:84
[03-May-2017 18:44:02 UTC] PHP   3. IXR_Server->IXR_Server() /home/dereksma/public_html/wp-includes/class-wp-xmlrpc-server.php:197
[03-May-2017 18:44:02 UTC] PHP   4. IXR_Server->__construct() /home/dereksma/public_html/wp-includes/IXR/class-IXR-server.php:35
[03-May-2017 18:44:02 UTC] PHP   5. IXR_Server->serve() /home/dereksma/public_html/wp-includes/IXR/class-IXR-server.php:27
[03-May-2017 18:44:02 UTC] PHP   6. IXR_Server->call() /home/dereksma/public_html/wp-includes/IXR/class-IXR-server.php:65
[03-May-2017 18:44:02 UTC] PHP   7. IXR_Server->multiCall() /home/dereksma/public_html/wp-includes/IXR/class-IXR-server.php:115
[03-May-2017 18:44:02 UTC] PHP   8. IXR_Server->call() /home/dereksma/public_html/wp-includes/IXR/class-IXR-server.php:212
[03-May-2017 18:44:02 UTC] PHP   9. Jetpack_XMLRPC_Server->json_api() /home/dereksma/public_html/wp-includes/IXR/class-IXR-server.php:127
[03-May-2017 18:44:02 UTC] PHP  10. WPCOM_JSON_API->serve() /home/dereksma/public_html/wp-content/plugins/jetpack/class.jetpack-xmlrpc-server.php:478
[03-May-2017 18:44:02 UTC] PHP  11. WPCOM_JSON_API->process_request() /home/dereksma/public_html/wp-content/plugins/jetpack/class.json-api.php:316
[03-May-2017 18:44:02 UTC] PHP  12. WPCOM_JSON_API_List_Roles_Endpoint->callback() /home/dereksma/public_html/wp-content/plugins/jetpack/class.json-api.php:332
[03-May-2017 18:44:02 UTC] PHP  13. WP_Roles->reinit() /home/dereksma/public_html/wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php:49
[03-May-2017 18:44:02 UTC] PHP  14. _deprecated_function() /home/dereksma/public_html/wp-includes/class-wp-roles.php:152
[03-May-2017 18:44:02 UTC] PHP  15. trigger_error() /home/dereksma/public_html/wp-includes/functions.php:3831
```

- Turn on `DEBUG_LOG`
- Watch wp-content/debug.log
- Load https://wordpress.com/settings/traffic/YOURSITE.COM