### PR TITLE
Settings: Add trailing period

### DIFF
--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -92,7 +92,7 @@ const CustomContentTypes = moduleSettingsForm(
 						<FormFieldset>
 							<p className="jp-form-setting-explanation">
 								{
-									__( "Add, organize, and display {{portfolioLink}}portfolios{{/portfolioLink}}. If your theme doesn’t support portfolios yet, you can display them using the shortcode ( [portfolios] )",
+									__( "Add, organize, and display {{portfolioLink}}portfolios{{/portfolioLink}}. If your theme doesn’t support portfolios yet, you can display them using the shortcode ( [portfolios] ).",
 										{
 											components: {
 												portfolioLink: this.linkIfActiveCPT( 'portfolio' )


### PR DESCRIPTION
Just adding a dot there so that description for portofolios matches the description for testimonials. :-)