### PR TITLE
JITM: Change activation to priority 9

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -584,7 +584,7 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
 		// A filter to control all just in time messages
-		add_filter( 'jetpack_just_in_time_msgs', '__return_true' );
+		add_filter( 'jetpack_just_in_time_msgs', '__return_true', 9 );
 
 		// Update the Jetpack plan from API on heartbeats
 		add_action( 'jetpack_heartbeat', array( $this, 'refresh_active_plan_from_wpcom' ) );


### PR DESCRIPTION
Plugins/site admins would logically assume `add_filter( 'jetpack_just_in_time_msgs', '__return_false' ); ` would disable JITM, but it may not work depending on load order. We should either update this to 9 so the above works or only activate JITM differently.

Example: https://meta.trac.wordpress.org/changeset/5323
See: https://meta.trac.wordpress.org/ticket/2811

cc: @iandunn @ocean90