### PR TITLE
Jetpack Sync: Sync term update action type

### DIFF
--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -84,7 +84,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 			 *
 			 * @param object the Term object
 			 */
-			do_action( 'jetpack_sync_add_term', $term_object);
+			do_action( 'jetpack_sync_add_term', $term_object );
 		}
 
 		/**
@@ -94,7 +94,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 		 *
 		 * @param object the Term object
 		 */
-		do_action( 'jetpack_sync_save_term', $term_object);
+		do_action( 'jetpack_sync_save_term', $term_object );
 	}
 
 	function set_taxonomy_whitelist( $taxonomies ) {

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -76,17 +76,6 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 
 		$current_filter = current_filter();
 
-		if ( 'edited_term' === $current_filter ) {
-			/**
-			 * Fires when the client needs to update a term
-			 *
-			 * @since 4.2.0
-			 *
-			 * @param object the Term object
-			 */
-			do_action( 'jetpack_sync_save_term', $term_object);
-		}
-
 		if ( 'created_term' === $current_filter ) {
 			/**
 			 * Fires when the client needs to add a new term
@@ -97,6 +86,15 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 			 */
 			do_action( 'jetpack_sync_add_term', $term_object);
 		}
+
+		/**
+		 * Fires when the client needs to update a term
+		 *
+		 * @since 4.2.0
+		 *
+		 * @param object the Term object
+		 */
+		do_action( 'jetpack_sync_save_term', $term_object);
 	}
 
 	function set_taxonomy_whitelist( $taxonomies ) {

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -84,7 +84,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 			 *
 			 * @param object the Term object
 			 */
-			do_action('jetpack_sync_save_term', $term_object);
+			do_action( 'jetpack_sync_save_term', $term_object);
 		}
 
 		if ( 'created_term' === $current_filter ) {
@@ -95,7 +95,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 			 *
 			 * @param object the Term object
 			 */
-			do_action('jetpack_sync_add_term', $term_object);
+			do_action( 'jetpack_sync_add_term', $term_object);
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -80,7 +80,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 		 *
 		 * @param object the Term object
 		 */
-		do_action( 'jetpack_sync_save_term', $term_object );
+		do_action( 'jetpack_sync_save_term', $term_object, current_filter() );
 	}
 
 	function set_taxonomy_whitelist( $taxonomies ) {

--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -10,7 +10,8 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 	function init_listeners( $callable ) {
 		add_action( 'created_term', array( $this, 'save_term_handler' ), 10, 3 );
 		add_action( 'edited_term', array( $this, 'save_term_handler' ), 10, 3 );
-		add_action( 'jetpack_sync_save_term', $callable, 10, 4 );
+		add_action( 'jetpack_sync_save_term', $callable );
+		add_action( 'jetpack_sync_add_term', $callable );
 		add_action( 'delete_term', $callable, 10, 4 );
 		add_action( 'set_object_terms', $callable, 10, 6 );
 		add_action( 'deleted_term_relationships', $callable, 10, 2 );
@@ -73,14 +74,29 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 			$term_object = get_term_by( 'id', $term_id, $taxonomy );
 		}
 
-		/**
-		 * Fires when the client needs to sync a new term
-		 *
-		 * @since 4.2.0
-		 *
-		 * @param object the Term object
-		 */
-		do_action( 'jetpack_sync_save_term', $term_object, current_filter() );
+		$current_filter = current_filter();
+
+		if ( 'edited_term' === $current_filter ) {
+			/**
+			 * Fires when the client needs to update a term
+			 *
+			 * @since 4.2.0
+			 *
+			 * @param object the Term object
+			 */
+			do_action('jetpack_sync_save_term', $term_object);
+		}
+
+		if ( 'created_term' === $current_filter ) {
+			/**
+			 * Fires when the client needs to add a new term
+			 *
+			 * @since 5.0.0
+			 *
+			 * @param object the Term object
+			 */
+			do_action('jetpack_sync_add_term', $term_object);
+		}
 	}
 
 	function set_taxonomy_whitelist( $taxonomies ) {

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -218,7 +218,8 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			// terms
-			case 'jetpack_sync_save_term':
+			case 'jetpack_sync_save_term': //break intentionally omitted
+			case 'jetpack_sync_add_term':
 				list( $term_object ) = $args;
 				$this->store->update_term( $term_object );
 				break;

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -44,6 +44,9 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$terms        = $this->get_terms();
 		$server_terms = $this->server_replica_storage->get_terms( $this->taxonomy );
 		$this->assertEqualsObject( $terms, $server_terms );
+
+		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_term' );
+		$this->assertEquals( 'created_term', $event_data->args[1] );
 	}
 
 	public function test_update_term_is_synced() {
@@ -57,6 +60,9 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$terms        = $this->get_terms();
 		$server_terms = $this->server_replica_storage->get_terms( $this->taxonomy );
 		$this->assertEqualsObject( $terms, $server_terms );
+
+		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_term' );
+		$this->assertEquals( 'edited_term', $event_data->args[1] );
 	}
 
 	public function test_delete_term_is_synced() {

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -45,8 +45,8 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$server_terms = $this->server_replica_storage->get_terms( $this->taxonomy );
 		$this->assertEqualsObject( $terms, $server_terms );
 
-		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_term' );
-		$this->assertEquals( 'created_term', $event_data->args[1] );
+		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_add_term' );
+		$this->assertTrue( (bool) $event_data );
 	}
 
 	public function test_update_term_is_synced() {
@@ -62,7 +62,6 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEqualsObject( $terms, $server_terms );
 
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_save_term' );
-		$this->assertEquals( 'edited_term', $event_data->args[1] );
 	}
 
 	public function test_delete_term_is_synced() {


### PR DESCRIPTION
This change indicates whether the term save was a creation or an edit/update.

#### Changes proposed in this Pull Request:

This change indicates whether the term save was a creation or an edit/update.

#### Testing instructions:

phpunit

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
