### PR TITLE
Shortcodes: update Recipe shortcode from WordPress.com

### DIFF
--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -16,7 +16,7 @@ class Jetpack_Recipes {
 	function __construct() {
 		add_action( 'init', array( $this, 'action_init' ) );
 
-		// Add itemprop to allowed tags for wp_kses_post, so we can use it for better Schema compliance.
+		// Add itemprop, itemscope, and itemtype to allowed tags for wp_kses_post, so we can use them for better Schema compliance.
 		global $allowedposttags;
 		$tags = array( 'li', 'ol', 'img' );
 		foreach ( $tags as $tag ) {
@@ -25,6 +25,12 @@ class Jetpack_Recipes {
 			}
 			$allowedposttags[ $tag ]['itemprop'] = array();
 		}
+
+		$allowedposttags['div'] = array(
+			'class'     => array(),
+			'itemscope' => array (),
+			'itemtype'  => array ()
+		);
 	}
 
 	function action_init() {
@@ -102,9 +108,17 @@ class Jetpack_Recipes {
 	 * @return string HTML output
 	 */
 	static function recipe_shortcode_html( $atts, $content = '' ) {
-		// Add itemprop to allowed tags for wp_kses_post, so we can use it for better Schema compliance.
+		// Add itemprop, itemscope, and itemtype to allowed tags for wp_kses_post, so we can use them for better Schema compliance.
 		global $allowedtags;
-		$allowedtags['li'] = array( 'itemprop' => array () );
+		$allowedtags['li'] = array(
+			'itemprop' => array ()
+		);
+
+		$allowedtags['div'] = array(
+			'class'     => array(),
+			'itemscope' => array (),
+			'itemtype'  => array ()
+		);
 
 		$html = '<div class="hrecipe jetpack-recipe" itemscope itemtype="https://schema.org/Recipe">';
 
@@ -154,7 +168,7 @@ class Jetpack_Recipes {
 		// Output the image, if we have one.
 		if ( '' !== $atts['image'] ) {
 			$html .= sprintf(
-				'<img class="jetpack-recipe-image" itemprop="thumbnailUrl" src="%1$s" />',
+				'<img class="jetpack-recipe-image" itemprop="image" src="%1$s" />',
 				esc_url( $atts['image'] )
 			);
 		}

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -16,7 +16,7 @@ class Jetpack_Recipes {
 	function __construct() {
 		add_action( 'init', array( $this, 'action_init' ) );
 
-		// Add itemprop, itemscope, and itemtype to allowed tags for wp_kses_post, so we can use them for better Schema compliance.
+		// Add itemprop to allowed tags for wp_kses_post, so we can use it for better Schema compliance.
 		global $allowedposttags;
 		$tags = array( 'li', 'ol', 'img' );
 		foreach ( $tags as $tag ) {
@@ -25,22 +25,6 @@ class Jetpack_Recipes {
 			}
 			$allowedposttags[ $tag ]['itemprop'] = array();
 		}
-
-		$allowedposttags['p'] = array(
-			'class'    => array(),
-			'itemprop' => array()
-		);
-
-		$allowedposttags['h3'] = array(
-			'class'     => array(),
-			'itemprop' => array ()
-		);
-
-		$allowedposttags['div'] = array(
-			'class'     => array(),
-			'itemscope' => array (),
-			'itemtype'  => array ()
-		);
 	}
 
 	function action_init() {
@@ -118,27 +102,9 @@ class Jetpack_Recipes {
 	 * @return string HTML output
 	 */
 	static function recipe_shortcode_html( $atts, $content = '' ) {
-		// Add itemprop, itemscope, and itemtype to allowed tags for wp_kses_post, so we can use them for better Schema compliance.
+		// Add itemprop to allowed tags for wp_kses_post, so we can use it for better Schema compliance.
 		global $allowedtags;
-		$allowedtags['li'] = array(
-			'itemprop' => array()
-		);
-
-		$allowedtags['p'] = array(
-			'class'    => array(),
-			'itemprop' => array()
-		);
-
-		$allowedtags['h3'] = array(
-			'class'     => array(),
-			'itemprop' => array()
-		);
-
-		$allowedtags['div'] = array(
-			'class'     => array(),
-			'itemscope' => array(),
-			'itemtype'  => array()
-		);
+		$allowedtags['li'] = array( 'itemprop' => array () );
 
 		$html = '<div class="hrecipe jetpack-recipe" itemscope itemtype="https://schema.org/Recipe">';
 
@@ -188,7 +154,7 @@ class Jetpack_Recipes {
 		// Output the image, if we have one.
 		if ( '' !== $atts['image'] ) {
 			$html .= sprintf(
-				'<img class="jetpack-recipe-image" itemprop="image" src="%1$s" />',
+				'<img class="jetpack-recipe-image" itemprop="thumbnailUrl" src="%1$s" />',
 				esc_url( $atts['image'] )
 			);
 		}
@@ -196,7 +162,7 @@ class Jetpack_Recipes {
 		// Output the description, if we have one.
 		if ( '' !== $atts['description'] ) {
 			$html .= sprintf(
-				'<p class="jetpack-recipe-description" itemprop="description">%1$s</p>',
+				'<p class="jetpack-recipe-description">%1$s</p>',
 				esc_html( $atts['description'] )
 			);
 		}

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -41,7 +41,7 @@ class Jetpack_Recipes {
 										'itemtype' => array()
 									) );
 		endif;
-	    return $allowedtags;
+	return $allowedtags;
 	}
 
 	/*
@@ -122,6 +122,8 @@ class Jetpack_Recipes {
 				'time'        => '', //string
 				'difficulty'  => '', //string
 				'print'       => '', //string
+				'source'      => '', //string
+				'sourceurl' => '', //string
 				'image'       => '', //string
 				'description' => '', //string
 			), $atts, 'recipe'
@@ -170,6 +172,30 @@ class Jetpack_Recipes {
 					esc_html_x( 'Difficulty', 'recipe', 'jetpack' ),
 					esc_html( $atts['difficulty'] )
 				);
+			}
+
+			if ( '' !== $atts['source'] ) {
+				$html .= sprintf(
+					'<li class="jetpack-recipe-source"><strong>%1$s: </strong>',
+					esc_html_x( 'Source', 'recipe', 'jetpack' )
+				);
+
+				if ( '' !== $atts['sourceurl'] ) :
+					// Show the link if we have one.
+					$html .= sprintf(
+						'<a href="%2$s">%1$s</a>',
+						esc_html( $atts['source'] ),
+						esc_url( $atts['sourceurl'] )
+					);
+				else :
+					// Skip the link.
+					$html .= sprintf(
+						'%1$s',
+						esc_html( $atts['source'] )
+					);
+				endif;
+
+				$html .= '</li>';
 			}
 
 			if ( 'false' !== $atts['print'] ) {

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -26,6 +26,11 @@ class Jetpack_Recipes {
 			$allowedposttags[ $tag ]['itemprop'] = array();
 		}
 
+		$allowedposttags['p'] = array(
+			'class'    => array(),
+			'itemprop' => array()
+		);
+
 		$allowedposttags['h3'] = array(
 			'class'     => array(),
 			'itemprop' => array ()
@@ -116,18 +121,23 @@ class Jetpack_Recipes {
 		// Add itemprop, itemscope, and itemtype to allowed tags for wp_kses_post, so we can use them for better Schema compliance.
 		global $allowedtags;
 		$allowedtags['li'] = array(
-			'itemprop' => array ()
+			'itemprop' => array()
+		);
+
+		$allowedtags['p'] = array(
+			'class'    => array(),
+			'itemprop' => array()
 		);
 
 		$allowedtags['h3'] = array(
 			'class'     => array(),
-			'itemprop' => array ()
+			'itemprop' => array()
 		);
 
 		$allowedtags['div'] = array(
 			'class'     => array(),
-			'itemscope' => array (),
-			'itemtype'  => array ()
+			'itemscope' => array(),
+			'itemtype'  => array()
 		);
 
 		$html = '<div class="hrecipe jetpack-recipe" itemscope itemtype="https://schema.org/Recipe">';
@@ -186,7 +196,7 @@ class Jetpack_Recipes {
 		// Output the description, if we have one.
 		if ( '' !== $atts['description'] ) {
 			$html .= sprintf(
-				'<p class="jetpack-recipe-description">%1$s</p>',
+				'<p class="jetpack-recipe-description" itemprop="description">%1$s</p>',
 				esc_html( $atts['description'] )
 			);
 		}

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -29,7 +29,7 @@ class Jetpack_Recipes {
 	function add_recipes_kses_rules( $allowedtags, $context ) {
 		if ( in_array( $context, array( '', 'post', 'data' ) ) ) :
 			// Create an array of all the tags we'd like to add the itemprop attribute to.
-			$tags = array( 'li', 'ol', 'ul', 'img', 'p', 'h3' );
+			$tags = array( 'li', 'ol', 'ul', 'img', 'p', 'h3', 'time' );
 			foreach ( $tags as $tag ) {
 				$allowedtags = $this->add_kses_rule(
 					$allowedtags,
@@ -37,6 +37,7 @@ class Jetpack_Recipes {
 					array(
 						'class'    => array(),
 						'itemprop' => array(),
+						'datetime'  => array(),
 					)
 				);
 			}
@@ -192,10 +193,20 @@ class Jetpack_Recipes {
 			}
 
 			if ( '' !== $atts['time'] ) {
+				// Get a time that's supported by Schema.org.
+				$duration = WPCOM_JSON_API_Date::format_duration( $atts['time'] );
+				// If no duration can be calculated, let's output what the user provided.
+				if ( empty( $duration ) ) {
+					$duration = $atts['time'];
+				}
+
 				$html .= sprintf(
-					'<li class="jetpack-recipe-time" itemprop="totalTime"><strong>%1$s: </strong>%2$s</li>',
+					'<li class="jetpack-recipe-time">
+					<time itemprop="totalTime" datetime="%3$s"><strong>%1$s: </strong>%2$s</time>
+					</li>',
 					esc_html_x( 'Time', 'recipe', 'jetpack' ),
-					esc_html( $atts['time'] )
+					esc_html( $atts['time'] ),
+					esc_attr( $duration )
 				);
 			}
 

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -26,6 +26,11 @@ class Jetpack_Recipes {
 			$allowedposttags[ $tag ]['itemprop'] = array();
 		}
 
+		$allowedposttags['h3'] = array(
+			'class'     => array(),
+			'itemprop' => array ()
+		);
+
 		$allowedposttags['div'] = array(
 			'class'     => array(),
 			'itemscope' => array (),
@@ -111,6 +116,11 @@ class Jetpack_Recipes {
 		// Add itemprop, itemscope, and itemtype to allowed tags for wp_kses_post, so we can use them for better Schema compliance.
 		global $allowedtags;
 		$allowedtags['li'] = array(
+			'itemprop' => array ()
+		);
+
+		$allowedtags['h3'] = array(
+			'class'     => array(),
 			'itemprop' => array ()
 		);
 

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -19,41 +19,57 @@ class Jetpack_Recipes {
 		add_filter( 'wp_kses_allowed_html', array( $this, 'add_recipes_kses_rules' ), 10, 2 );
 	}
 
-	/*
+	/**
 	 * Add Schema-specific attributes to our allowed tags in wp_kses,
 	 * so we can have better Schema.org compliance.
+	 *
+	 * @param array $allowedtags Array of allowed HTML tags in recipes.
+	 * @param array $context Context to judge allowed tags by.
 	 */
 	function add_recipes_kses_rules( $allowedtags, $context ) {
 		if ( in_array( $context, array( '', 'post', 'data' ) ) ) :
 			// Create an array of all the tags we'd like to add the itemprop attribute to.
 			$tags = array( 'li', 'ol', 'ul', 'img', 'p', 'h3' );
 			foreach ( $tags as $tag ) {
-				$allowedtags = $this->add_kses_rule( $allowedtags, $tag, array(
-											'class'    => array(),
-											'itemprop' => array()
-										) );
+				$allowedtags = $this->add_kses_rule(
+					$allowedtags,
+					$tag,
+					array(
+						'class'    => array(),
+						'itemprop' => array(),
+					)
+				);
 			}
 
 			// Allow itemscope and itemtype for divs.
-			$allowedtags = $this->add_kses_rule( $allowedtags, 'div', array(
-										'class'    => array(),
-										'itemscope' => array(),
-										'itemtype' => array()
-									) );
+			$allowedtags = $this->add_kses_rule(
+				$allowedtags,
+				'div',
+				array(
+					'class'    => array(),
+					'itemscope' => array(),
+					'itemtype' => array(),
+				)
+			);
 		endif;
-	return $allowedtags;
+
+		return $allowedtags;
 	}
 
-	/*
+	/**
 	 * Function to add a new property rule to our kses array.
 	 * Used by add_recipe_kses_rules() above.
+	 *
+	 * @param array  $all_tags Array of allowed HTML tags in recipes.
+	 * @param string $tag      New HTML tag to add to the array of allowed HTML.
+	 * @param array  $rules    Array of allowed attributes for that HTML tag.
 	 */
 	private function add_kses_rule( $all_tags, $tag, $rules ) {
 
 		// If the tag doesn't already exist, add it.
-		if ( ! isset( $all_tags[ $tag ] ) ) :
+		if ( ! isset( $all_tags[ $tag ] ) ) {
 			$all_tags[ $tag ] = array();
-		endif;
+		}
 
 		// Merge the new tags with existing tags.
 		$all_tags[ $tag ] = array_merge( $all_tags[ $tag ], $rules );
@@ -61,8 +77,11 @@ class Jetpack_Recipes {
 		return $all_tags;
 	}
 
+	/**
+	 * Register our shortcode and enqueue necessary files.
+	 */
 	function action_init() {
-		// Enqueue styles if [recipe] exists
+		// Enqueue styles if [recipe] exists.
 		add_action( 'wp_head', array( $this, 'add_scripts' ), 1 );
 
 		// Render [recipe], along with other shortcodes that can be nested within.
@@ -97,7 +116,8 @@ class Jetpack_Recipes {
 			wp_enqueue_style( 'jetpack-recipes-style', plugins_url( '/css/recipes.css', __FILE__ ), array(), '20130919' );
 		}
 
-		wp_add_inline_style( 'jetpack-recipes-style', self::themecolor_styles() ); // add $themecolors-defined styles
+		// add $themecolors-defined styles.
+		wp_add_inline_style( 'jetpack-recipes-style', self::themecolor_styles() );
 
 		wp_enqueue_script( 'jetpack-recipes-printthis', plugins_url( '/js/recipes-printthis.js', __FILE__ ), array( 'jquery' ), '20170202' );
 		wp_enqueue_script( 'jetpack-recipes-js',        plugins_url( '/js/recipes.js', __FILE__ ), array( 'jquery', 'jetpack-recipes-printthis' ), '20131230' );
@@ -105,27 +125,37 @@ class Jetpack_Recipes {
 		$title_var     = wp_title( '|', false, 'right' );
 		$print_css_var = plugins_url( '/css/recipes-print.css', __FILE__ );
 
-		wp_localize_script( 'jetpack-recipes-js', 'jetpack_recipes_vars', array( 'pageTitle' => $title_var, 'loadCSS' => $print_css_var ) );
+		wp_localize_script(
+			'jetpack-recipes-js',
+			'jetpack_recipes_vars',
+			array(
+				'pageTitle' => $title_var,
+				'loadCSS' => $print_css_var,
+			)
+		);
 	}
 
 	/**
 	 * Our [recipe] shortcode.
 	 * Prints recipe data styled to look good on *any* theme.
 	 *
+	 * @param array  $atts    Array of shortcode attributes.
+	 * @param string $content Post content.
+	 *
 	 * @return string HTML for recipe shortcode.
 	 */
 	static function recipe_shortcode( $atts, $content = '' ) {
 		$atts = shortcode_atts(
 			array(
-				'title'       => '', //string
-				'servings'    => '', //intval
-				'time'        => '', //string
-				'difficulty'  => '', //string
-				'print'       => '', //string
-				'source'      => '', //string
-				'sourceurl' => '', //string
-				'image'       => '', //string
-				'description' => '', //string
+				'title'       => '', // string.
+				'servings'    => '', // intval.
+				'time'        => '', // string.
+				'difficulty'  => '', // string.
+				'print'       => '', // string.
+				'source'      => '', // string.
+				'sourceurl'   => '', // string.
+				'image'       => '', // string.
+				'description' => '', // string.
 			), $atts, 'recipe'
 		);
 
@@ -135,18 +165,21 @@ class Jetpack_Recipes {
 	/**
 	 * The recipe output
 	 *
+	 * @param array  $atts    Array of shortcode attributes.
+	 * @param string $content Post content.
+	 *
 	 * @return string HTML output
 	 */
 	static function recipe_shortcode_html( $atts, $content = '' ) {
 
 		$html = '<div class="hrecipe jetpack-recipe" itemscope itemtype="https://schema.org/Recipe">';
 
-		// Print the recipe title if exists
+		// Print the recipe title if exists.
 		if ( '' !== $atts['title'] ) {
 			$html .= '<h3 class="jetpack-recipe-title" itemprop="name">' . esc_html( $atts['title'] ) . '</h3>';
 		}
 
-		// Print the recipe meta if exists
+		// Print the recipe meta if exists.
 		if ( '' !== $atts['servings'] || '' != $atts['time'] || '' != $atts['difficulty'] || '' != $atts['print'] ) {
 			$html .= '<ul class="jetpack-recipe-meta">';
 
@@ -206,7 +239,7 @@ class Jetpack_Recipes {
 			}
 
 			$html .= '</ul>';
-		}
+		} // End if().
 
 		// Output the image, if we have one.
 		if ( '' !== $atts['image'] ) {
@@ -224,21 +257,21 @@ class Jetpack_Recipes {
 			);
 		}
 
-		// Print content between codes
+		// Print content between codes.
 		$html .= '<div class="jetpack-recipe-content">' . do_shortcode( $content ) . '</div>';
 
-		// Close it up
+		// Close it up.
 		$html .= '</div>';
 
-		// If there is a recipe within a recipe, remove the shortcode
+		// If there is a recipe within a recipe, remove the shortcode.
 		if ( has_shortcode( $html, 'recipe' ) ) {
 			remove_shortcode( 'recipe' );
 		}
 
-		// Sanitize html
+		// Sanitize html.
 		$html = wp_kses_post( $html );
 
-		// Return the HTML block
+		// Return the HTML block.
 		return $html;
 	}
 
@@ -246,14 +279,17 @@ class Jetpack_Recipes {
 	 * Our [recipe-notes] shortcode.
 	 * Outputs ingredients, styled in a div.
 	 *
+	 * @param array  $atts    Array of shortcode attributes.
+	 * @param string $content Post content.
+	 *
 	 * @return string HTML for recipe notes shortcode.
 	 */
 	static function recipe_notes_shortcode( $atts, $content = '' ) {
 		$atts = shortcode_atts( array(
-			'title' => '', //string
+			'title' => '', // string.
 		), $atts, 'recipe-notes' );
 
-		$html ='';
+		$html = '';
 
 		// Print a title if one exists.
 		if ( '' !== $atts['title'] ) {
@@ -278,11 +314,14 @@ class Jetpack_Recipes {
 	 * Our [recipe-ingredients] shortcode.
 	 * Outputs notes, styled in a div.
 	 *
+	 * @param array  $atts    Array of shortcode attributes.
+	 * @param string $content Post content.
+	 *
 	 * @return string HTML for recipe ingredients shortcode.
 	 */
 	static function recipe_ingredients_shortcode( $atts, $content = '' ) {
 		$atts = shortcode_atts( array(
-			'title' => esc_html_x( 'Ingredients', 'recipe', 'jetpack' ), //string
+			'title' => esc_html_x( 'Ingredients', 'recipe', 'jetpack' ), // string.
 		), $atts, 'recipe-ingredients' );
 
 		$html = '<div class="jetpack-recipe-ingredients">';
@@ -313,10 +352,13 @@ class Jetpack_Recipes {
 	 * And we'll magically convert it to a list. This has the added benefit
 	 * of including itemprops for the recipe schema.
 	 *
+	 * @param string $content HTML content.
+	 * @param string $type    Type of list.
+	 *
 	 * @return string content formatted as a list item
 	 */
 	static function output_list_content( $content, $type ) {
-		$html ='';
+		$html = '';
 
 		switch ( $type ) {
 			case 'directions' :
@@ -342,11 +384,11 @@ class Jetpack_Recipes {
 			strpos( $content, '-' )       !== false ||
 			strpos( $content, '*' )       !== false ||
 			strpos( $content, '#' )       !== false ||
-			strpos( $content, '–' )   !== false || // ndash
-			strpos( $content, '—' )   !== false || // mdash
+			strpos( $content, '–' )       !== false || // ndash.
+			strpos( $content, '—' )       !== false || // mdash.
 			preg_match( '/\d+\.\s/', $content )
 		) {
-			// Remove breaks and extra whitespace
+			// Remove breaks and extra whitespace.
 			$content = str_replace( "<br />\n", "\n", $content );
 			$content = trim( $content );
 
@@ -387,11 +429,14 @@ class Jetpack_Recipes {
 	 * Our [recipe-directions] shortcode.
 	 * Outputs directions, styled in a div.
 	 *
+	 * @param array  $atts    Array of shortcode attributes.
+	 * @param string $content Post content.
+	 *
 	 * @return string HTML for recipe directions shortcode.
 	 */
 	static function recipe_directions_shortcode( $atts, $content = '' ) {
 		$atts = shortcode_atts( array(
-				'title' => esc_html_x( 'Directions', 'recipe', 'jetpack' ), //string
+				'title' => esc_html_x( 'Directions', 'recipe', 'jetpack' ), // string.
 		), $atts, 'recipe-directions' );
 
 		$html = '<div class="jetpack-recipe-directions">';

--- a/sal/class.json-api-date.php
+++ b/sal/class.json-api-date.php
@@ -52,4 +52,37 @@ class WPCOM_JSON_API_Date {
 
 		return (string) gmdate( 'Y-m-d\\TH:i:s', $timestamp ) . sprintf( '%s%02d:%02d', $west ? '-' : '+', $hours, $minutes );
 	}
+
+	/**
+	 * Returns ISO 8601 formatted duration interval: P0DT1H10M0S
+	 *
+	 * @param string $time Duration in minutes or hours.
+	 *
+	 * @return null|string
+	 */
+	static function format_duration( $time ) {
+		$timestamp = strtotime( $time, 0 );
+
+		// Bail early if we don't recognize a date.
+		if ( empty( $timestamp ) ) {
+			return;
+		}
+
+		$days = floor( $timestamp / 86400 );
+		$timestamp = $timestamp % 86400;
+
+		$hours = floor( $timestamp / 3600 );
+		$timestamp = $timestamp % 3600;
+
+		$minutes = floor( $timestamp / 60 );
+		$timestamp = $timestamp % 60;
+
+		return (string) sprintf(
+			'P%dDT%dH%dM%dS',
+			$days,
+			$hours,
+			$minutes,
+			$timestamp
+		);
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Bring changes from WordPress.com over to Jetpack to sync the Recipe shortcode.

#### Testing instructions:

* Insert a recipe in a new post, by following the instructions [here](https://en.support.wordpress.com/recipes/)
* Publish your post.
* Run your post through [Google's Rich Snippets testing tool](https://search.google.com/structured-data/testing-tool/u/0/) and make sure no errors are returned. You will see some warnings but those are okay for now.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Shortcodes: update schema.org markup for the Recipe shortcode.