### PR TITLE
Using directories instead of cache aliases for Travis caching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ env:
     - WP_TRAVISCI=phpunit
 
 cache:
-  - yarn: true
-  - apt: true
+  directories:
+   - $HOME/.composer/cache/files
+   - $HOME/.cache/yarn
 
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,


### PR DESCRIPTION
Fixes #7124 

#### Changes proposed in this Pull Request:
* Using directories instead of cache aliases for Travis caching.
