### PR TITLE
JSON API: Fix encoding of action links

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -211,7 +211,7 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		 if ( count( $action_links ) > 0 ) {
 			 $dom_doc = new DOMDocument;
 			 foreach( $action_links as $action_link ) {
-				 $dom_doc->loadHTML( $action_link );
+				 $dom_doc->loadHTML( mb_convert_encoding( $action_link, 'HTML-ENTITIES', 'UTF-8' ) );
 				 $link_elements = $dom_doc->getElementsByTagName( 'a' );
 				 if ( $link_elements->length == 0 ) {
 					 continue;


### PR DESCRIPTION
Fixes #7127

#### Changes proposed in this Pull Request:

* Convert encoding of action link markup to UTF-8. This prevents from encoding issues occurring with non-latin characters. See #7127 for details.

#### Testing instructions:

* Change the language of your site to Bulgarian.
* Connect your site to WordPress.com.
* Go to `/plugins/jetpack/$site` in WordPress.com.
* Verify the plugins endpoint retrieves the non-latin copy properly:
![](https://cldup.com/JG4UmQ5MuD.png)
* Verify the action link texts now appear properly:
![](https://cldup.com/1p325fI3bF.png)

