### PR TITLE
Shortcodes: fix recipe time display to be compatible with Schema.org

### DIFF
--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -29,7 +29,7 @@ class Jetpack_Recipes {
 	function add_recipes_kses_rules( $allowedtags, $context ) {
 		if ( in_array( $context, array( '', 'post', 'data' ) ) ) :
 			// Create an array of all the tags we'd like to add the itemprop attribute to.
-			$tags = array( 'li', 'ol', 'ul', 'img', 'p', 'h3' );
+			$tags = array( 'li', 'ol', 'ul', 'img', 'p', 'h3', 'time' );
 			foreach ( $tags as $tag ) {
 				$allowedtags = $this->add_kses_rule(
 					$allowedtags,
@@ -37,6 +37,7 @@ class Jetpack_Recipes {
 					array(
 						'class'    => array(),
 						'itemprop' => array(),
+						'datetime'  => array(),
 					)
 				);
 			}
@@ -192,10 +193,20 @@ class Jetpack_Recipes {
 			}
 
 			if ( '' !== $atts['time'] ) {
+				// Get a time that's supported by Schema.org.
+				$duration = WPCOM_JSON_API_Date::format_duration( $atts['time'] );
+				// If no duration can be calculated, let's output what the user provided.
+				if ( empty( $duration ) ) {
+					$duration = $atts['time'];
+				}
+
 				$html .= sprintf(
-					'<li class="jetpack-recipe-time" itemprop="totalTime"><strong>%1$s: </strong>%2$s</li>',
+					'<li class="jetpack-recipe-time">
+					<time itemprop="totalTime" datetime="%3$s"><strong>%1$s: </strong>%2$s</time>
+					</li>',
 					esc_html_x( 'Time', 'recipe', 'jetpack' ),
-					esc_html( $atts['time'] )
+					esc_html( $atts['time'] ),
+					esc_attr( $duration )
 				);
 			}
 

--- a/sal/class.json-api-date.php
+++ b/sal/class.json-api-date.php
@@ -52,4 +52,37 @@ class WPCOM_JSON_API_Date {
 
 		return (string) gmdate( 'Y-m-d\\TH:i:s', $timestamp ) . sprintf( '%s%02d:%02d', $west ? '-' : '+', $hours, $minutes );
 	}
+
+	/**
+	 * Returns ISO 8601 formatted duration interval: P0DT1H10M0S
+	 *
+	 * @param string $time Duration in minutes or hours.
+	 *
+	 * @return null|string
+	 */
+	static function format_duration( $time ) {
+		$timestamp = strtotime( $time, 0 );
+
+		// Bail early if we don't recognize a date.
+		if ( empty( $timestamp ) ) {
+			return;
+		}
+
+		$days = floor( $timestamp / 86400 );
+		$timestamp = $timestamp % 86400;
+
+		$hours = floor( $timestamp / 3600 );
+		$timestamp = $timestamp % 3600;
+
+		$minutes = floor( $timestamp / 60 );
+		$timestamp = $timestamp % 60;
+
+		return (string) sprintf(
+			'P%dDT%dH%dM%dS',
+			$days,
+			$hours,
+			$minutes,
+			$timestamp
+		);
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR is set to be merged into `update/recipe-shortcode-wpcom-merge`, as it relies on the changes proposed in #7125. I'll update the base branch if #7125 gets merged.

We previously displayed the total recipe time as the user provided it in the shortcode.
While that works on the site, that format isn't compatible with Schema.org.
Search engines relying on Schema.org to display recipe previews expect the recipe time to use ISO 8601 formatted duration interval.

This PR does 2 things:
- It adds a new shared function allowing you to convert any user-inputted duration into ISO 8601 formatted duration.
- It uses the shared function to output a new `time` tag in the recipe output, where that formatted duration is added as a
datetime attribute.

Reported here:
https://wordpress.org/support/topic/recipe-shortcode-lacks-css-class/

#### Testing instructions:

* Insert a recipe in a new post, by following the instructions [here](https://en.support.wordpress.com/recipes/). Provide a `time` attribute in your shortcode.
* Publish your post.
* Run your post through [Google's Rich Snippets testing tool](https://search.google.com/structured-data/testing-tool/u/0/) and make sure no errors are returned. Pay extra attention to warnings about time; there shouldn't be any. You will see some other warnings but those are okay for now.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Shortcodes: fix recipe time display to be compatible with Schema.org, so your recipes' previews can appear in Google search results.