### PR TITLE
Add:  Core Update Network sync action

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -48,7 +48,7 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	public function update_core_network_event( $option, $wp_db_version, $old_wp_db_version ) {
 		global $wp_version;
 		/**
-		 * Sync Event for when core wp network updated happends.
+		 * Sync event for when core wp network updates to a new db version
 		 *
 		 * @since 5.0.0
 		 *

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -68,7 +68,8 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		 *
 		 */
 		do_action( 'jetpack_sync_core_update_network', $wp_db_version, $old_wp_db_version, $wp_version );
-
+	}
+	
 	public function update_core( $new_wp_version ) {
 		global $pagenow;
 

--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -28,6 +28,12 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 		), 10, 2 );
 
 		add_action( 'automatic_updates_complete', $callable );
+
+		if ( is_multisite() ) {
+			add_action( 'update_site_option_wpmu_upgrade_site', array ( $this, 'update_core_network_event' ), 10, 3 );
+			add_action( 'jetpack_sync_core_update_network', $callable, 10, 3 );
+		}
+
 	}
 
 	public function init_full_sync_listeners( $callable ) {
@@ -37,6 +43,21 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_full_sync_updates', array( $this, 'expand_updates' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_update_themes_change', array( $this, 'expand_themes' ) );
+	}
+
+	public function update_core_network_event( $option, $wp_db_version, $old_wp_db_version ) {
+		global $wp_version;
+		/**
+		 * Sync Event for when core wp network updated happends.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param int $wp_db_version the latest wp_db_version
+		 * @param int $old_wp_db_version previous wp_db_version
+		 * @param string $wp_version the latest wp_version
+		 *
+		 */
+		do_action( 'jetpack_sync_core_update_network', $wp_db_version, $old_wp_db_version, $wp_version );
 	}
 
 	public function get_update_checksum( $value ) {

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -77,4 +77,19 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( (bool) $event );
 	}
 
+	public function test_network_core_update_sync_action() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not compatible with single site mode' );
+		}
+
+		global $wp_db_version, $wp_version;
+		update_site_option( 'wpmu_upgrade_site', (int)$wp_db_version + 1 );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_core_update_network' );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( $event->args[0], $wp_db_version + 1 );
+		$this->assertEquals( $event->args[1], $wp_db_version );
+		$this->assertEquals( $event->args[2], $wp_version );
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -145,6 +145,4 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0], 'foo' ); // New version
 	}
-
-
 }


### PR DESCRIPTION
When the WP Mu Network updates it sets the wp db version is udpated in the DB.
This PR added an event that gets called when this happends.

#### Changes proposed in this Pull Request:
* Sync when a mu site updates core across the whole network.

#### Testing instructions:
* Do the test pass? 
* update the value of wp_db_version in wp-includes/version.php 
* Go to the Network tab and update all the sites.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
