### PR TITLE
Sync: Add export event

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -42,6 +42,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		// listen for meta changes
 		$this->init_listeners_for_meta_type( 'post', $callable );
 		$this->init_meta_whitelist_handler( 'post', array( $this, 'filter_meta' ) );
+		add_action( 'export_wp', $callable );
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -960,6 +960,15 @@ That was a cool video.';
 		$this->assertEquals( $events[3]->action, 'jetpack_published_post' );
 	}
 
+	public function test_sync_export_content_event() {
+		// Can't call export_wp directly since it require no headers to be set...
+		do_action( 'export_wp', array( 'content' => 'all' ) );
+		$this->sender->do_sync();
+		$event = $this->server_event_storage->get_most_recent_event( 'export_wp' );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( $event->args[0]['content'], 'all' );
+	}
+
 	function add_a_hello_post_type() {
 		if ( ! $this->test_already  ) {
 			$this->test_already = true;


### PR DESCRIPTION
Adds the export event. Which gets fired when we export data. 

#### Changes proposed in this Pull Request:
*

#### Testing instructions:
* Do the tests pass? 
* Export content and see the event show up. 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
