### PR TITLE
EU Cookie Law Widget: Fix style on themes with specific widgets positioning

### DIFF
--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -1,4 +1,6 @@
 ( function( $ ) {
+	$( '.widget_eu_cookie_law_widget' ).appendTo( 'body' );
+
 	var overlay = $( '#eu-cookie-law' ), initialScrollPosition, scrollFunction;
 
 	overlay.find( 'form' ).on( 'submit', accept );

--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -5,6 +5,7 @@
 	padding: 0;
 	position: fixed;
 	right: 1em;
+	width: auto;
 	z-index: 50001;
 }
 
@@ -16,6 +17,7 @@
 	line-height: 1.5;
 	overflow: hidden;
 	padding: 6px 6px 6px 15px;
+	position: relative;
 }
 
 #eu-cookie-law a,


### PR DESCRIPTION
Fixes 172-gh-customization (comment 299542578) reported by @designsimply 

Some themes applies specific CSS rules over widgets size and positioning.
In these cases it's possible that the EU Cookie Law Banner isn't sized or positioned as expected (which is: as large as the screen, and fixed to the bottom).

#### Changes proposed in this Pull Request:

* Add a `width: auto` to the widget.
This is needed to prevent themes to apply a width to the banner.

* Add a `position: relative` to the widget internal wrapper.
This is needed to keep the "Close" button (which is absolutely positioned) to stay in its correct position, even when the widget positioning is overridden by the theme style.

#### Testing instructions:

* Enable the EU Cookie Law Banner widget.
* Activate a theme with specific widget positioning, such as Twenty Thirteen or Rebalance.
* Check that the banner width spans the entire window at all screen sizes.
* Check that, at small screen sizes, the "Close" button is always positioned after the text, without covering it.

#### Notes

Be aware that the banner is still a widget.

This means that it's added in a sidebar and has to conform to the sidebar's rules.
If a theme, like Twenty Thirteen, uses Masonry to position its widgets (applying `position: absolute` inline), the banner won't be `fixed` anymore.

Some themes, like Twenty Fifteen, hide the sidebar on small screens. This has the side effect of hiding the banner as well.

#### Screenshots

| Before | After |
| --- | --- |
| Twenty Thirteen<br><img width="564" alt="screen shot 2017-05-08 at 14 03 56" src="https://cloud.githubusercontent.com/assets/2070010/25805672/6bd47e40-33f8-11e7-801a-5440ece7a6dc.png"> | Twenty Thirteen<br><img width="565" alt="screen shot 2017-05-08 at 14 04 10" src="https://cloud.githubusercontent.com/assets/2070010/25805677/71cb7eb6-33f8-11e7-8f98-49b970641e1d.png"> |
| Rebalance<br><img width="890" alt="screen shot 2017-05-08 at 14 02 36" src="https://cloud.githubusercontent.com/assets/2070010/25805634/50149186-33f8-11e7-9d3d-2b52ec056263.png"> | Rebalance<br><img width="892" alt="screen shot 2017-05-08 at 14 02 57" src="https://cloud.githubusercontent.com/assets/2070010/25805652/5d00f7d6-33f8-11e7-8739-cb7e9bbe4d7e.png"> |