### PR TITLE
Sync: Allow detecting active plugins

### DIFF
--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -213,12 +213,24 @@ class Jetpack_Sync_Functions {
 		return $normalized_url;
 	}
 
+	public static function get_plugins_filter( $plugins ) {
+		// todo: make sure this works with network sites
+		$active_plugins = get_option( 'active_plugins' );
+
+		foreach ( $plugins as $plugin_file => &$plugin_meta ) {
+			$plugin_meta['Active'] = in_array( $plugin_file, $active_plugins );
+		}
+
+		return $plugins;
+	}
+
 	public static function get_plugins() {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
 		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
+		add_filter( 'all_plugins', array( 'Jetpack_Sync_Functions', 'get_plugins_filter' ) );
 		return apply_filters( 'all_plugins', get_plugins() );
 	}
 

--- a/sync/class.jetpack-sync-functions.php
+++ b/sync/class.jetpack-sync-functions.php
@@ -214,8 +214,11 @@ class Jetpack_Sync_Functions {
 	}
 
 	public static function get_plugins_filter( $plugins ) {
-		// todo: make sure this works with network sites
 		$active_plugins = get_option( 'active_plugins' );
+
+		if ( is_multisite() ) {
+			$active_plugins = array_merge( get_option( 'active_sitewide_plugins' ) );
+		}
 
 		foreach ( $plugins as $plugin_file => &$plugin_meta ) {
 			$plugin_meta['Active'] = in_array( $plugin_file, $active_plugins );

--- a/tests/php/sync/test_class.jetpack-sync-plugins.php
+++ b/tests/php/sync/test_class.jetpack-sync-plugins.php
@@ -13,6 +13,14 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		parent::tearDown();
 	}
 
+	function filter_plugins( $plugins ) {
+		foreach ( $plugins as $plugin => &$data ) {
+			$data['Active'] = false;
+		}
+
+		return $plugins;
+	}
+
 	public function test_installing_and_removing_plugin_is_synced() {
 		if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID < 50300 ) {
 			$this->markTestIncomplete("Right now this doesn't work on PHP 5.2");	
@@ -47,7 +55,7 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'WP Super Cache', $installed_plugin->args[1]['Name'] );
 
 		$plugins = $this->server_replica_storage->get_callable( 'get_plugins' );
-		$this->assertEquals( get_plugins(), $plugins );
+		$this->assertEquals( $this->filter_plugins( get_plugins() ), $plugins );
 		$this->assertTrue( isset( $plugins['wp-super-cache/wp-cache.php'] ) );
 		// gets called via callable.
 		$this->assertEquals( get_option( 'uninstall_plugins', array() ), $this->server_replica_storage->get_option( 'uninstall_plugins', array() ) );
@@ -57,7 +65,7 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 		$this->remove_plugin();
 		$this->sender->do_sync();
 		$plugins = $this->server_replica_storage->get_callable( 'get_plugins' );
-		$this->assertEquals( get_plugins(), $plugins );
+		$this->assertEquals( $this->filter_plugins( get_plugins() ), $plugins );
 		$this->assertFalse( isset( $plugins['wp-super-cache/wp-cache.php'] ) );
 	}
 
@@ -203,7 +211,7 @@ class WP_Test_Jetpack_Sync_Plugins extends WP_Test_Jetpack_Sync_Base {
 
 	function test_all_plugins_filter_is_respected() {
 		$this->sender->do_sync();
-		$plugins = get_plugins();
+		$plugins = $this->filter_plugins( get_plugins() );
 
 		if ( ! isset( $plugins['hello.php'] ) ) {
 			$this->markTestSkipped( 'Plugin hello dolly is not available' );


### PR DESCRIPTION
While working on something else, it looks like we aren't syncing whether a plugin is active, only that it's installed. This is a simple technique to allow us to get that information.

#### Changes proposed in this Pull Request:

* Adds a filter on the callable: `get_plugins` to report an `Active` state which will be `true` if the plugin is active, and `false` if not.
* Updated unit tests to pass with this new data

#### Testing instructions:

* Make sure unit tests pass
* Verify callable works correctly in multi-site and single-site installs.

<!-- Add the following only if this is meant to be in changelog -->
cc: 
@ebinnion, @enejb since you touched this area of the code last
@eliorivero just because :p
@gravityrail since you asked ;)
