### PR TITLE
Sync: Add import finished event

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -7,6 +7,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	private $just_published = array();
 	private $just_trashed = array();
 	private $action_handler;
+	private $import_end = false;
 
 	public function name() {
 		return 'posts';
@@ -21,6 +22,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	public function set_defaults() {
+		$this->import_end = false;
 	}
 
 	public function init_listeners( $callable ) {
@@ -42,7 +44,85 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		// listen for meta changes
 		$this->init_listeners_for_meta_type( 'post', $callable );
 		$this->init_meta_whitelist_handler( 'post', array( $this, 'filter_meta' ) );
+
 		add_action( 'export_wp', $callable );
+		add_action( 'jetpack_sync_import_end', $callable );
+
+		// Movable type, RSS, Livejournal
+		add_action( 'import_done', array( $this, 'sync_import_done' ) );
+
+		// WordPress, Blogger, Livejournal, woo tax rate
+		add_action( 'import_end', array( $this, 'sync_import_end' ) );
+	}
+
+	public function sync_import_done( $importer ) {
+		// We already ran an send the import
+		if ( $this->import_end ) {
+			return;
+		}
+		/**
+		 * Sync Event that tells that that the import is finished
+		 *
+		 * @since 5.0.0
+		 *
+		 * $param string $importer 
+		 */
+		do_action( 'jetpack_sync_import_end', $importer );
+		$this->import_end = true;
+	}
+
+	public function sync_import_end() {
+		// We already ran an send the import
+		if ( $this->import_end ) {
+			return;
+		}
+
+		$this->import_end = true;
+		$importer = 'unknown';
+		$backtrace = wp_debug_backtrace_summary(null, 0, false );
+		if ( $this->is_blogger_importer( $backtrace ) ) {
+			$importer = 'blogger';
+		}
+
+		if ( 'unknown' === $importer && $this->is_woo_tax_rate_importer( $backtrace ) ) {
+			$importer = 'woo-tax-rate';
+		}
+
+		if ( 'unknown' === $importer && $this->is_wp_importer( $backtrace ) ) {
+			$importer = 'wordpress';
+		}
+
+		/**
+		 * Documented already: Sync Event that tells that that the import is finished
+		 */
+		do_action( 'jetpack_sync_import_end', $importer );
+	}
+	
+	private function is_blogger_importer( $backtrace ) {
+		foreach ( $backtrace as $trace ) {
+			if ( strpos( $trace, 'Blogger_Importer') !== false ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function is_woo_tax_rate_importer( $backtrace ) {
+		foreach ( $backtrace as $trace ) {
+			if ( strpos( $trace, 'WC_Tax_Rate_Importer') !== false ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function is_wp_importer( $backtrace ) {
+		foreach( $backtrace as $trace ) {
+			if ( strpos( $trace, 'WP_Import') !== false ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public function init_full_sync_listeners( $callable ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -61,7 +61,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			return;
 		}
 		/**
-		 * Sync Event that tells that that the import is finished
+		 * Sync Event that tells that the import is finished
 		 *
 		 * @since 5.0.0
 		 *

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -80,51 +80,31 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$this->import_end = true;
 		$importer = 'unknown';
 		$backtrace = wp_debug_backtrace_summary(null, 0, false );
-		if ( $this->is_blogger_importer( $backtrace ) ) {
+		if ( $this->is_importer( $backtrace, 'Blogger_Importer' ) ) {
 			$importer = 'blogger';
 		}
 
-		if ( 'unknown' === $importer && $this->is_woo_tax_rate_importer( $backtrace ) ) {
+		if ( 'unknown' === $importer && $this->is_importer( $backtrace, 'WC_Tax_Rate_Importer' ) ) {
 			$importer = 'woo-tax-rate';
 		}
 
-		if ( 'unknown' === $importer && $this->is_wp_importer( $backtrace ) ) {
+		if ( 'unknown' === $importer && $this->is_importer( $backtrace, 'WP_Import' ) ) {
 			$importer = 'wordpress';
 		}
 
-		/**
-		 * Documented already: Sync Event that tells that that the import is finished
-		 */
+		/** This filter is already documented in sync/class.jetpack-sync-module-posts.php */
 		do_action( 'jetpack_sync_import_end', $importer );
 	}
 	
-	private function is_blogger_importer( $backtrace ) {
+	private function is_importer( $backtrace, $class_name ) {
 		foreach ( $backtrace as $trace ) {
-			if ( strpos( $trace, 'Blogger_Importer') !== false ) {
+			if ( strpos( $trace, $class_name ) !== false ) {
 				return true;
 			}
 		}
 		return false;
 	}
-
-	private function is_woo_tax_rate_importer( $backtrace ) {
-		foreach ( $backtrace as $trace ) {
-			if ( strpos( $trace, 'WC_Tax_Rate_Importer') !== false ) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private function is_wp_importer( $backtrace ) {
-		foreach( $backtrace as $trace ) {
-			if ( strpos( $trace, 'WP_Import') !== false ) {
-				return true;
-			}
-		}
-		return false;
-	}
-
+	
 	public function init_full_sync_listeners( $callable ) {
 		add_action( 'jetpack_full_sync_posts', $callable ); // also sends post meta
 	}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -959,7 +959,7 @@ That was a cool video.';
 		$this->assertEquals( $events[2]->action, 'wp_insert_post' );
 		$this->assertEquals( $events[3]->action, 'jetpack_published_post' );
 	}
-	
+
 	public function test_sync_export_content_event() {
 		// Can't call export_wp directly since it require no headers to be set...
 		do_action( 'export_wp', array( 'content' => 'all' ) );
@@ -974,7 +974,6 @@ That was a cool video.';
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
-		$this->assertTrue( (bool) $event );
 		$this->assertEquals( 'test', $event->args[0] );
 	}
 
@@ -983,7 +982,6 @@ That was a cool video.';
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
-		$this->assertTrue( (bool) $event );
 		$this->assertEquals( 'unknown', $event->args[0] );
 	}
 
@@ -993,7 +991,6 @@ That was a cool video.';
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
-		$this->assertTrue( (bool) $event );
 		$this->assertEquals( 'unknown', $event->args[0] );
 	}
 
@@ -1003,7 +1000,6 @@ That was a cool video.';
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
-		$this->assertTrue( (bool) $event );
 		$this->assertEquals( 'test', $event->args[0] );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -997,7 +997,7 @@ That was a cool video.';
 		$this->assertEquals( 'unknown', $event->args[0] );
 	}
 
-	function test_import_dene_and_import_end_action_syncs_jetpack_sync_import_end() {
+	function test_import_done_and_import_end_action_syncs_jetpack_sync_import_end() {
 		do_action( 'import_done', 'test' );
 		do_action( 'import_end' );
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -959,7 +959,7 @@ That was a cool video.';
 		$this->assertEquals( $events[2]->action, 'wp_insert_post' );
 		$this->assertEquals( $events[3]->action, 'jetpack_published_post' );
 	}
-
+	
 	public function test_sync_export_content_event() {
 		// Can't call export_wp directly since it require no headers to be set...
 		do_action( 'export_wp', array( 'content' => 'all' ) );
@@ -967,6 +967,44 @@ That was a cool video.';
 		$event = $this->server_event_storage->get_most_recent_event( 'export_wp' );
 		$this->assertTrue( (bool) $event );
 		$this->assertEquals( $event->args[0]['content'], 'all' );
+	}
+
+	function test_import_done_action_syncs_jetpack_sync_import_end() {
+		do_action( 'import_done', 'test' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( 'test', $event->args[0] );
+	}
+
+	function test_import_end_action_syncs_jetpack_sync_import_end() {
+		do_action( 'import_end' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( 'unknown', $event->args[0] );
+	}
+
+	function test_import_end_and_import_done_action_syncs_jetpack_sync_import_end() {
+		do_action( 'import_end' );
+		do_action( 'import_done', 'test' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( 'unknown', $event->args[0] );
+	}
+
+	function test_import_dene_and_import_end_action_syncs_jetpack_sync_import_end() {
+		do_action( 'import_done', 'test' );
+		do_action( 'import_end' );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
+		$this->assertTrue( (bool) $event );
+		$this->assertEquals( 'test', $event->args[0] );
 	}
 
 	function add_a_hello_post_type() {


### PR DESCRIPTION
Adds an do_action that gets synced after an import happends.

#### Changes proposed in this Pull Request:
* Start listening to jetpack_sync_import_end that happends after an import has finished.

#### Testing instructions:
* Test different importers:
- WP importer
- Blogger Importer
- Tumblr Importer
- Live journal (I wasn't able to get this one to work )
- RSS
- woo tax importer

Do you see the events as expected? 

Do the test pass? 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
