### PR TITLE
CSS minification: remove unexistent stylesheet

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -246,7 +246,6 @@ function doStatic( done ) {
 admincss = [
 	'modules/after-the-deadline/atd.css',
 	'modules/after-the-deadline/tinymce/css/content.css',
-	'modules/contact-form/css/menu-alter.css',
 	'modules/custom-css/csstidy/cssparse.css',
 	'modules/custom-css/csstidy/cssparsed.css',
 	'modules/custom-css/custom-css/css/codemirror.css',


### PR DESCRIPTION
Follow up to #4067

#### Changes proposed in this Pull Request:

* remove unexistent stylesheet from minification

