### PR TITLE
Sync API settings posts_per_page

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -2624,7 +2624,8 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'verification_services_codes'          => '(array) Website verification codes. Allowed keys: google, pinterest, bing, yandex',
 		Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => '(string) The SEO meta description for the site.',
 		Jetpack_SEO_Titles::TITLE_FORMATS_OPTION  => '(array) SEO meta title formats. Allowed keys: front_page, posts, pages, groups, archives',
-		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache'
+		'api_cache'                            => '(bool) Turn on/off the Jetpack JSON API cache',
+		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
 
 	),
 

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -220,6 +220,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => get_option( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION, '' ),
 					Jetpack_SEO_Titles::TITLE_FORMATS_OPTION => get_option( Jetpack_SEO_Titles::TITLE_FORMATS_OPTION, array() ),
 					'api_cache'               => $api_cache,
+					'posts_per_page'          => (int) get_option( 'posts_per_page' ),
 				);
 
 				//allow future versions of this endpoint to support additional settings keys


### PR DESCRIPTION
This pulls the change from r155891-wpcom (which allows setting posts_per_page from the settings endpoint) downstream