### PR TITLE
Widgets: trim white space from email before validating

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				}
 			}
 
-			if ( is_email( $instance['email'] ) ) {
+			if ( is_email( trim( $instance['email'] ) ) ) {
 				printf(
 					'<div class="confit-email"><a href="mailto:%1$s">%1$s</a></div>',
 					esc_html( $instance['email'] )


### PR DESCRIPTION
Fixes an issue where email address doesn't show up in contact widget.

To reproduce:
- add a contact widget to your site
- in the email field, add an email address that has a trailing space
- note that the email address does not get rendered

To test:
- apply this PR to your site, and note that the issue is fixed

Props @BenjaminHilton for reporting issue.