### PR TITLE
On theme switch, delete the previous if it was a wpcom theme

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -541,6 +541,7 @@ class Jetpack {
 
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'admin_init', array( $this, 'dismiss_jetpack_notice' ) );
+		add_action( 'switch_theme', array( $this, 'on_theme_switch' ), 10, 3 );
 
 		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
@@ -4307,6 +4308,22 @@ p {
 
 				}
 				break;
+		}
+	}
+
+	/**
+	 * Delete previous theme if it was a WPCOM theme.
+	 *
+	 * @since 5.0
+	 *
+	 * @param string   $new_name  Name of the new theme.
+	 * @param WP_Theme $new_theme WP_Theme instance of the new theme.
+	 * @param WP_Theme $old_theme WP_Theme instance of the old theme.
+	 */
+	function on_theme_switch( $new_name, $new_theme, $old_theme ) {
+		$old_theme = $old_theme->get_stylesheet();
+		if ( false !== stripos( $old_theme, '-wpcom' ) ) {
+			delete_theme( $old_theme );
 		}
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4312,7 +4312,7 @@ p {
 	}
 
 	/**
-	 * Delete previous theme if it was a WPCOM theme.
+	 * Delete previous theme if it was a WPCOM premium theme.
 	 *
 	 * @since 5.0
 	 *
@@ -4322,9 +4322,29 @@ p {
 	 */
 	function on_theme_switch( $new_name, $new_theme, $old_theme ) {
 		$old_theme = $old_theme->get_stylesheet();
-		if ( false !== stripos( $old_theme, '-wpcom' ) ) {
+		if ( false !== stripos( $old_theme, '-wpcom' ) && Jetpack::is_premium_theme( str_replace( '-wpcom', '', $old_theme ) ) ) {
 			delete_theme( $old_theme );
 		}
+	}
+
+	/**
+	 * Checks if a theme is a WPCOM premium theme.
+	 *
+	 * @since 5.0
+	 *
+	 * @param string $theme_slug The slug of the theme to check, like twentyfifteen or mood.
+	 *
+	 * @return bool
+	 */
+	function is_premium_theme( $theme_slug ) {
+		$response_body = wp_remote_retrieve_body( wp_remote_get( 'https://public-api.wordpress.com/rest/v1/themes/theme:' . $theme_slug ) );
+		if ( ! empty( $response_body ) ) {
+			$response_body = json_decode( $response_body );
+			if ( isset( $response_body->stylesheet ) && ( "premium/$theme_slug" === $response_body->stylesheet ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public static function admin_screen_configure_module( $module_id ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* during a theme switch, check if the theme previously active was a wpcom premium theme and delete it if that was the case
* new method `Jetpack::is_premium_theme` that checks if a theme is a wpcom premium theme

#### Testing instructions:

0. mock a wpcom premium theme like Mood and name the folder `mood-wpcom` because that's the name that they get when they're downloaded to a Jetpack site.
1. in WP Admin > Appearance, activate the Mood theme
2. now activate a free wpcom theme like Dara. You can either mock it or do this from Calypso
3. verify that Mood theme was deleted
4. in WP Admin > Appearance, activate any other theme like TwentySeventeen
5. verify that Dara theme was not deleted