### PR TITLE
iCalendar: use WP time constant instead of non-existing constant.

### DIFF
--- a/_inc/lib/icalendar-reader.php
+++ b/_inc/lib/icalendar-reader.php
@@ -97,7 +97,7 @@ class iCalendarReader {
 			// If the timezone isn't set then the GMT offset must be set.
 			// generate a DateInterval object from the timezone offset
 			$gmt_offset = get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
-			$timezone_offset_interval = date_interval_create_from_date_string( "{$gmt_offset} minutes" );
+			$timezone_offset_interval = date_interval_create_from_date_string( "{$gmt_offset} seconds" );
 			$timezone = new DateTimeZone( 'UTC' );
 		}
 

--- a/_inc/lib/icalendar-reader.php
+++ b/_inc/lib/icalendar-reader.php
@@ -96,7 +96,7 @@ class iCalendarReader {
 		} else {
 			// If the timezone isn't set then the GMT offset must be set.
 			// generate a DateInterval object from the timezone offset
-			$gmt_offset = get_option( 'gmt_offset' ) * HOUR_IN_MINUTES;
+			$gmt_offset = get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
 			$timezone_offset_interval = date_interval_create_from_date_string( "{$gmt_offset} minutes" );
 			$timezone = new DateTimeZone( 'UTC' );
 		}
@@ -113,7 +113,7 @@ class iCalendarReader {
 				$end_time = preg_replace( '/Z$/', '', $event['DTEND'] );
 				$end_time = new DateTime( $end_time, $this->timezone );
 				$end_time->setTimeZone( $timezone );
-				
+
 				if ( $timezone_offset_interval ) {
 					$start_time->add( $timezone_offset_interval );
 					$end_time->add( $timezone_offset_interval );
@@ -137,7 +137,7 @@ class iCalendarReader {
 		 * This filter allows any time to be passed in for testing or changing timezones, etc...
 		 *
 		 * @module widgets
-		 * 
+		 *
 		 * @since 3.4.0
 		 *
 		 * @param object time() A time object.


### PR DESCRIPTION
Fixes #7162

WordPress defines a few specific time constants:
https://github.com/WordPress/WordPress/blob/4.7.4/wp-includes/default-constants.php#L120-L125

`HOUR_IN_MINUTES` is not one of them and is only defined on WordPress.com. Let's not use it.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Upcoming Events: use correct time constant to define an hour.