### PR TITLE
Improve the rendering performance of the Follow Button widget.

### DIFF
--- a/modules/widgets/follow-button.php
+++ b/modules/widgets/follow-button.php
@@ -1,7 +1,7 @@
 <?php
 
-// @todo Fix performance issues before shipping.
-//add_action( 'widgets_init', 'follow_button_register_widget' );
+add_action( 'widgets_init', 'follow_button_register_widget' );
+
 function follow_button_register_widget() {
 	if ( Jetpack::is_active() ) {
 		register_widget( 'Jetpack_Follow_Button_Widget' );
@@ -56,6 +56,7 @@ class Jetpack_Follow_Button_Widget extends WP_Widget {
 			class="wordpress-follow-button"
 			href="<?php echo esc_url( home_url() ); ?>"
 			data-blog="<?php echo esc_url( home_url() ); ?>"
+			data-blog-name="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>"
 			data-lang="<?php echo esc_attr( $wpcom_locale ); ?>" <?php if ( ! empty( $attributes ) ) echo implode( ' ', $attributes ); ?>
 		>
 			<?php sprintf( __( 'Follow %s on WordPress.com', 'jetpack' ), get_bloginfo( 'name' ) ); ?>


### PR DESCRIPTION
The follow button can be seriously slowly rendered in dotorg sites
due to one of the batched requests, which heads for `sites/http://foo.com`.

This PR adds `data-blog-name` attribute to the button element,
so the iframed widget can omit the slowest one of the batched requests.
In my test, the widget is rendered 3x faster when it doesn't need to show the subscribers counter.

**Note:** It's still slow when the counter is necessary.

You need D5561-code to see the improvement.

#### Changes proposed in this Pull Request:

* Add `data-blog-name` attribute to the button element to improve the rendering performance of the Follow Button widget when subscribers counter is not in use.

#### Testing instructions:

* Apply D5561-code to your sandbox.
* Sandbox widgets.wp.com
* Add the widget to your test website.