### PR TITLE
The VideoPress mime-type is missing

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -52,6 +52,8 @@ class Jetpack_VideoPress {
 
 		add_filter( 'wp_mime_type_icon', array( $this, 'wp_mime_type_icon' ), 10, 3 );
 
+		add_filter( 'wp_video_extensions', array( $this, 'add_videopress_extenstion' ) );
+
 		$this->add_media_new_notice();
 
 		VideoPress_Scheduler::init();
@@ -296,6 +298,9 @@ class Jetpack_VideoPress {
 			$existing_mimes[ $key ] = $value;
 		}
 
+		// Make sure that videopress mimes are considered videos.
+		$existing_mimes['videopress'] = 'video/videopress';
+
 		return $existing_mimes;
 	}
 
@@ -329,6 +334,17 @@ class Jetpack_VideoPress {
 		}
 
 		return 'https://wordpress.com/wp-content/mu-plugins/videopress/images/media-video-processing-icon.png';
+	}
+
+	/**
+	 * @param array $extensions
+	 *
+	 * @return array
+	 */
+	public function add_videopress_extenstion( $extensions ) {
+		$extensions[] = 'videopress';
+
+		return $extensions;
 	}
 }
 


### PR DESCRIPTION
VideoPress attachments are currently added in as a mime-type of `video/videopress`. This is primarily so that we can delineate the difference between these, virtual entries, and the other types of video files that might be present.

Currently, we do not declare this mime-type as a video file to WordPress so when pulling up the media library for videos projects like the new [Core Media Widgets](https://github.com/xwp/wp-core-media-widgets/issues/160) are having problems seeing and uploading videos when VideoPress is enabled.

This PR adds in the mime type `video/videopress` to the `upload_mimes` and `wp_video_extensions` filters, which fixes this gap.

**Note: This is a blocker for getting the [Core Media Widgets](https://github.com/xwp/wp-core-media-widgets) feature plugin working. Can we please get this out with the next bug fix release?**

## Testing

- After loading this PR, go to the Media Library and view page source.
- Search for the term `mimeTypes`
- You should find the `video/videopress` type now listed, like this:

<img width="1360" alt="screen shot 2017-05-11 at 12 00 23 pm" src="https://cloud.githubusercontent.com/assets/195095/25931912/d2651368-3641-11e7-8a03-6f3a33662a92.png">

