### PR TITLE
nova: Change the drag/drop form method to post because the get fails …

### DIFF
--- a/modules/custom-post-types/js/nova-drag-drop.js
+++ b/modules/custom-post-types/js/nova-drag-drop.js
@@ -9,6 +9,7 @@
 		dragMenus();
 		addNonce();
 		addSubmitButton();
+		changeToPost();
 	}
 
 	function dragMenus() {
@@ -41,6 +42,10 @@
 
 	function addNonce() {
 		$('#posts-filter').append('<input type="hidden" name="' + _novaDragDrop.nonceName + '" value="' + _novaDragDrop.nonce + '" />');
+	}
+
+	function changeToPost() {
+		$( '#posts-filter' ).attr( 'method', 'post' );
 	}
 
 	// do it


### PR DESCRIPTION
…because of url length when there are a lot of menu items.

See https://[private link]

Props @southp, @dllh

This commit syncs r136882-wpcom.