### PR TITLE
Featured Content: Include plugin in REST API theme context action cop…

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -641,4 +641,17 @@ class Featured_Content {
 
 Featured_Content::setup();
 
+/**
+ * Adds the featured content plugin to the set of files for which action 
+ * handlers should be copied when the theme context is loaded by the REST API.
+ *
+ * @param array $copy_dirs Copy paths with actions to be copied
+ * @return array Copy paths with featured content plugin
+ */
+function featured_content_copy_plugin_actions( $copy_dirs ) {
+	$copy_dirs[] = __FILE__;
+	return $copy_dirs;
+}
+add_action( 'restapi_theme_action_copy_dirs', 'featured_content_copy_plugin_actions' );
+
 } // end if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {

--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -648,10 +648,10 @@ Featured_Content::setup();
  * @param array $copy_dirs Copy paths with actions to be copied
  * @return array Copy paths with featured content plugin
  */
-function featured_content_copy_plugin_actions( $copy_dirs ) {
+function wpcom_rest_api_featured_content_copy_plugin_actions( $copy_dirs ) {
 	$copy_dirs[] = __FILE__;
 	return $copy_dirs;
 }
-add_action( 'restapi_theme_action_copy_dirs', 'featured_content_copy_plugin_actions' );
+add_action( 'restapi_theme_action_copy_dirs', 'wpcom_rest_api_featured_content_copy_plugin_actions' );
 
 } // end if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {


### PR DESCRIPTION
…y paths

Theme support for featured content cannot be accurately reflected by REST API until after the theme context is loaded,
so copy theme actions from this file to be re-run after theme has switched in REST API load_theme_functions .

See: https://github.com/Automattic/io/issues/609

This commit syncs r139020-wpcom.