### PR TITLE
Jetpack Sync: Add sync action for network site enable and disable themes

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -39,16 +39,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 		if ( 'disable-selected' === $action || 'disable' === $action )  {
 			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
-			$disabled_themes = array();
-			foreach ( $disabled_theme_names as $name ) {
-				$theme = wp_get_theme( $name );
-				$disabled_themes[ $name ] = array(
-					'name' => $theme->get( 'Name' ),
-					'version' => $theme->get( 'Version' ),
-					'uri' => $theme->get( 'ThemeURI' ),
-				);
-			}
-
+			$disabled_themes = $this->get_multisite_changed_themes( $disabled_theme_names );
 			/**
 			 * Trigger action to alert $callable sync listener that network themes were disabled
 			 *
@@ -62,16 +53,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 		if ( 'enable-selected' === $action || 'enable' === $action ) {
 			$enabled_theme_names = array_keys( array_diff_key( $value, $old_value ) );
-			$enabled_themes = array();
-			foreach ( $enabled_theme_names as $name ) {
-				$theme = wp_get_theme( $name );
-				$enabled_themes[$name] = array(
-					'name' => $theme->get( 'Name' ),
-					'version' => $theme->get( 'Version' ),
-					'uri' => $theme->get( 'ThemeURI' ),
-				);
-			}
-
+			$enabled_themes = $this->get_multisite_changed_themes( $enabled_theme_names );
 			/**
 			 * Trigger action to alert $callable sync listener that network themes were enabled
 			 *
@@ -81,6 +63,19 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			 */
 			do_action( 'jetpack_network_enabled_themes', $enabled_themes );
 		}
+	}
+
+	private function get_multisite_changed_themes( $theme_names ) {
+		$theme_data = array();
+		foreach ( $theme_names as $name ) {
+			$theme = wp_get_theme( $name );
+			$theme_data[ $name ] = array(
+				'name' => $theme->get( 'Name' ),
+				'version' => $theme->get( 'Version' ),
+				'uri' => $theme->get( 'ThemeURI' ),
+			);
+		}
+		return $theme_data;
 	}
 
 	public function detect_theme_edit( $redirect_url ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -16,8 +16,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_filter( 'wp_redirect', array( $this, 'detect_theme_edit' ) );
 		add_action( 'jetpack_edited_theme', $callable, 10, 2 );
 		add_action( 'update_site_option_allowedthemes', array( $this, 'sync_network_allowed_themes_change' ), 10, 4 );
-		add_action( 'jetpack_network_disabled_themes', $callable );
-		add_action( 'jetpack_network_enabled_themes', $callable );
+		add_action( 'jetpack_network_disabled_themes', $callable, 10, 2 );
+		add_action( 'jetpack_network_enabled_themes', $callable, 10, 2 );
 
 		// Sidebar updates.
 		add_action( 'update_option_sidebars_widgets', array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );
@@ -29,15 +29,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {
-		if ( ! isset( $_REQUEST['action'] ) ||
-			( '-1' === $_REQUEST['action'] && ! isset( $_REQUEST['action2'] ) )
-		) {
-			return;
-		}
-
-		$action = -1 === intval( $_REQUEST['action'] ) ? $_REQUEST['action2'] : $_REQUEST['action'];
-
-		if ( 'disable-selected' === $action || 'disable' === $action )  {
+		if ( count( $old_value ) > count( $value ) )  {
 			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
 			$disabled_themes = $this->get_multisite_changed_themes( $disabled_theme_names );
 			/**
@@ -47,22 +39,20 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			 *
 			 * @param mixed $disabled_themes, Array of info about network disabled themes
 			 */
-			do_action( 'jetpack_network_disabled_themes', $disabled_themes );
+			do_action( 'jetpack_network_disabled_themes', $disabled_themes, array_keys( $value ) );
 			return;
 		}
 
-		if ( 'enable-selected' === $action || 'enable' === $action ) {
-			$enabled_theme_names = array_keys( array_diff_key( $value, $old_value ) );
-			$enabled_themes = $this->get_multisite_changed_themes( $enabled_theme_names );
-			/**
-			 * Trigger action to alert $callable sync listener that network themes were enabled
-			 *
-			 * @since 5.0.0
-			 *
-			 * @param mixed $enabled_themes , Array of info about network enabled themes
-			 */
-			do_action( 'jetpack_network_enabled_themes', $enabled_themes );
-		}
+		$enabled_theme_names = array_keys( array_diff_key( $value, $old_value ) );
+		$enabled_themes = $this->get_multisite_changed_themes( $enabled_theme_names );
+		/**
+		 * Trigger action to alert $callable sync listener that network themes were enabled
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param mixed $enabled_themes , Array of info about network enabled themes
+		 */
+		do_action( 'jetpack_network_enabled_themes', $enabled_themes, array_keys( $value ) );
 	}
 
 	private function get_multisite_changed_themes( $theme_names ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -29,7 +29,11 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {
-		if ( count( $old_value ) > $value )  {
+		if ( ! isset( $_REQUEST['action']) ) {
+			return;
+		}
+
+		if ( 'disable_selected' === $_REQUEST['action'] || 'disable' === $_REQUEST['action'] )  {
 			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
 			$disabled_themes = array();
 			foreach ( $disabled_theme_names as $name ) {
@@ -52,25 +56,27 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$enabled_theme_names = array_keys( array_diff_key( $value, $old_value ) );
-		$enabled_themes = array();
-		foreach ( $enabled_theme_names as $name ) {
-			$theme = wp_get_theme( $name );
-			$enabled_themes[ $name ] = array(
-				'name' => $theme->get('Name'),
-				'version' => $theme->get('Version'),
-				'uri' => $theme->get( 'ThemeURI' ),
-			);
-		}
+		if ( 'enable_selected' === $_REQUEST['action'] || 'enable' === $_REQUEST['action'] ) {
+			$enabled_theme_names = array_keys(array_diff_key($value, $old_value));
+			$enabled_themes = array();
+			foreach ($enabled_theme_names as $name) {
+				$theme = wp_get_theme($name);
+				$enabled_themes[$name] = array(
+					'name' => $theme->get('Name'),
+					'version' => $theme->get('Version'),
+					'uri' => $theme->get('ThemeURI'),
+				);
+			}
 
-		/**
-		 * Trigger action to alert $callable sync listener that network themes were enabled
-		 *
-		 * @since 5.0.0
-		 *
-		 * @param mixed $enabled_themes, Array of info about network enabled themes
-		 */
-		do_action( 'jetpack_network_enabled_themes', $enabled_themes );
+			/**
+			 * Trigger action to alert $callable sync listener that network themes were enabled
+			 *
+			 * @since 5.0.0
+			 *
+			 * @param mixed $enabled_themes , Array of info about network enabled themes
+			 */
+			do_action('jetpack_network_enabled_themes', $enabled_themes);
+		}
 	}
 
 	public function detect_theme_edit( $redirect_url ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -29,7 +29,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {
-		if ( count( $old_value ) > $value )  ) {
+		if ( count( $old_value ) > $value )  {
 			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
 			$disabled_themes = array();
 			foreach ( $disabled_theme_names as $name ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -35,7 +35,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$action = '-1' === $_REQUEST['action'] ? $_REQUEST['action2'] : $_REQUEST['action'];
+		$action = -1 === intval( $_REQUEST['action'] ) ? $_REQUEST['action2'] : $_REQUEST['action'];
 
 		if ( 'disable_selected' === $action || 'disable' === $action )  {
 			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -29,11 +29,15 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {
-		if ( ! isset( $_REQUEST['action']) ) {
+		if ( ! isset( $_REQUEST['action']) ||
+			( '-1' === $_REQUEST['action'] && ! isset( $_REQUEST['action2'] ) )
+		) {
 			return;
 		}
 
-		if ( 'disable_selected' === $_REQUEST['action'] || 'disable' === $_REQUEST['action'] )  {
+		$action = '-1' === $_REQUEST['action'] ? $_REQUEST['action2'] : $_REQUEST['action'];
+
+		if ( 'disable_selected' === $action || 'disable' === $action )  {
 			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
 			$disabled_themes = array();
 			foreach ( $disabled_theme_names as $name ) {
@@ -56,7 +60,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( 'enable_selected' === $_REQUEST['action'] || 'enable' === $_REQUEST['action'] ) {
+		if ( 'enable_selected' === $action || 'enable' === $action ) {
 			$enabled_theme_names = array_keys(array_diff_key($value, $old_value));
 			$enabled_themes = array();
 			foreach ($enabled_theme_names as $name) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -37,7 +37,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 		$action = -1 === intval( $_REQUEST['action'] ) ? $_REQUEST['action2'] : $_REQUEST['action'];
 
-		if ( 'disable_selected' === $action || 'disable' === $action )  {
+		if ( 'disable-selected' === $action || 'disable' === $action )  {
 			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
 			$disabled_themes = array();
 			foreach ( $disabled_theme_names as $name ) {
@@ -60,7 +60,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 
-		if ( 'enable_selected' === $action || 'enable' === $action ) {
+		if ( 'enable-selected' === $action || 'enable' === $action ) {
 			$enabled_theme_names = array_keys(array_diff_key($value, $old_value));
 			$enabled_themes = array();
 			foreach ($enabled_theme_names as $name) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -31,35 +31,37 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {
 		if ( count( $old_value ) > count( $value ) )  {
 			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
-			$disabled_themes = $this->get_multisite_changed_themes( $disabled_theme_names );
+			$disabled_themes = $this->get_theme_details_for_slugs( $disabled_theme_names );
 			/**
 			 * Trigger action to alert $callable sync listener that network themes were disabled
 			 *
 			 * @since 5.0.0
 			 *
 			 * @param mixed $disabled_themes, Array of info about network disabled themes
+			 * @param mixed array_keys( $value ), Array of slugs of all enabled themes
 			 */
 			do_action( 'jetpack_network_disabled_themes', $disabled_themes, array_keys( $value ) );
 			return;
 		}
 
 		$enabled_theme_names = array_keys( array_diff_key( $value, $old_value ) );
-		$enabled_themes = $this->get_multisite_changed_themes( $enabled_theme_names );
+		$enabled_themes = $this->get_theme_details_for_slugs( $enabled_theme_names );
 		/**
 		 * Trigger action to alert $callable sync listener that network themes were enabled
 		 *
 		 * @since 5.0.0
 		 *
 		 * @param mixed $enabled_themes , Array of info about network enabled themes
+		 * @param mixed array_keys( $value ), Array of slugs of all enabled themes
 		 */
 		do_action( 'jetpack_network_enabled_themes', $enabled_themes, array_keys( $value ) );
 	}
 
-	private function get_multisite_changed_themes( $theme_names ) {
+	private function get_theme_details_for_slugs( $theme_slugs ) {
 		$theme_data = array();
-		foreach ( $theme_names as $name ) {
-			$theme = wp_get_theme( $name );
-			$theme_data[ $name ] = array(
+		foreach ( $theme_slugs as $slug ) {
+			$theme = wp_get_theme( $slug );
+			$theme_data[ $slug ] = array(
 				'name' => $theme->get( 'Name' ),
 				'version' => $theme->get( 'Version' ),
 				'uri' => $theme->get( 'ThemeURI' ),

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -29,32 +29,34 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {
+		$all_enabled_theme_slugs = array_keys( $value );
+
 		if ( count( $old_value ) > count( $value ) )  {
-			$disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
-			$disabled_themes = $this->get_theme_details_for_slugs( $disabled_theme_names );
+			$newly_disabled_theme_names = array_keys( array_diff_key( $old_value, $value ) );
+			$newly_disabled_themes = $this->get_theme_details_for_slugs( $newly_disabled_theme_names );
 			/**
 			 * Trigger action to alert $callable sync listener that network themes were disabled
 			 *
 			 * @since 5.0.0
 			 *
-			 * @param mixed $disabled_themes, Array of info about network disabled themes
-			 * @param mixed array_keys( $value ), Array of slugs of all enabled themes
+			 * @param mixed $newly_disabled_themes, Array of info about network disabled themes
+			 * @param mixed $all_enabled_theme_slugs, Array of slugs of all enabled themes
 			 */
-			do_action( 'jetpack_network_disabled_themes', $disabled_themes, array_keys( $value ) );
+			do_action( 'jetpack_network_disabled_themes', $newly_disabled_themes, $all_enabled_theme_slugs );
 			return;
 		}
 
-		$enabled_theme_names = array_keys( array_diff_key( $value, $old_value ) );
-		$enabled_themes = $this->get_theme_details_for_slugs( $enabled_theme_names );
+		$newly_enabled_theme_names = array_keys( array_diff_key( $value, $old_value ) );
+		$newly_enabled_themes = $this->get_theme_details_for_slugs( $newly_enabled_theme_names );
 		/**
 		 * Trigger action to alert $callable sync listener that network themes were enabled
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param mixed $enabled_themes , Array of info about network enabled themes
-		 * @param mixed array_keys( $value ), Array of slugs of all enabled themes
+		 * @param mixed $newly_enabled_themes , Array of info about network enabled themes
+		 * @param mixed $all_enabled_theme_slugs, Array of slugs of all enabled themes
 		 */
-		do_action( 'jetpack_network_enabled_themes', $enabled_themes, array_keys( $value ) );
+		do_action( 'jetpack_network_enabled_themes', $newly_enabled_themes, $all_enabled_theme_slugs );
 	}
 
 	private function get_theme_details_for_slugs( $theme_slugs ) {
@@ -65,6 +67,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 				'name' => $theme->get( 'Name' ),
 				'version' => $theme->get( 'Version' ),
 				'uri' => $theme->get( 'ThemeURI' ),
+				'slug' => $slug,
 			);
 		}
 		return $theme_data;

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -29,7 +29,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {
-		if ( ! isset( $_REQUEST['action']) ||
+		if ( ! isset( $_REQUEST['action'] ) ||
 			( '-1' === $_REQUEST['action'] && ! isset( $_REQUEST['action2'] ) )
 		) {
 			return;
@@ -61,10 +61,10 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		}
 
 		if ( 'enable-selected' === $action || 'enable' === $action ) {
-			$enabled_theme_names = array_keys(array_diff_key($value, $old_value));
+			$enabled_theme_names = array_keys( array_diff_key( $value, $old_value ) );
 			$enabled_themes = array();
-			foreach ($enabled_theme_names as $name) {
-				$theme = wp_get_theme($name);
+			foreach ( $enabled_theme_names as $name ) {
+				$theme = wp_get_theme( $name );
 				$enabled_themes[$name] = array(
 					'name' => $theme->get('Name'),
 					'version' => $theme->get('Version'),
@@ -79,7 +79,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			 *
 			 * @param mixed $enabled_themes , Array of info about network enabled themes
 			 */
-			do_action('jetpack_network_enabled_themes', $enabled_themes);
+			do_action( 'jetpack_network_enabled_themes', $enabled_themes );
 		}
 	}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -15,7 +15,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_deleted_theme', $callable );
 		add_filter( 'wp_redirect', array( $this, 'detect_theme_edit' ) );
 		add_action( 'jetpack_edited_theme', $callable, 10, 2 );
-		add_action( 'update_site_option_allowedthemes', array( $this, 'sync_network_allowed_themes_change' ) );
+		add_action( 'update_site_option_allowedthemes', array( $this, 'sync_network_allowed_themes_change' ), 10, 4 );
 		add_action( 'jetpack_network_disabled_themes', $callable );
 		add_action( 'jetpack_network_enabled_themes', $callable );
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -43,8 +43,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			foreach ( $disabled_theme_names as $name ) {
 				$theme = wp_get_theme( $name );
 				$disabled_themes[ $name ] = array(
-					'name' => $theme->get('Name'),
-					'version' => $theme->get('Version'),
+					'name' => $theme->get( 'Name' ),
+					'version' => $theme->get( 'Version' ),
 					'uri' => $theme->get( 'ThemeURI' ),
 				);
 			}
@@ -66,9 +66,9 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			foreach ( $enabled_theme_names as $name ) {
 				$theme = wp_get_theme( $name );
 				$enabled_themes[$name] = array(
-					'name' => $theme->get('Name'),
-					'version' => $theme->get('Version'),
-					'uri' => $theme->get('ThemeURI'),
+					'name' => $theme->get( 'Name' ),
+					'version' => $theme->get( 'Version' ),
+					'uri' => $theme->get( 'ThemeURI' ),
 				);
 			}
 

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -144,10 +144,10 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			$test_themes[1][0] => 1,
 		);
 
+		$theme_slugs = array_keys( $themes );
+
 		//Test enable multiple themes
 
-		$_REQUEST['action'] = -1;
-		$_REQUEST['action2'] = 'enable-selected';
 		/**
 		 * This filter is already documented in wp-includes/option.php
 		 *
@@ -165,13 +165,12 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}
+		$this->assertEquals( $event_data->args[1], $theme_slugs );
 
 		$this->server_event_storage->reset();
 
 		//Test disable multiple themes
 
-		$_REQUEST['action'] = -1;
-		$_REQUEST['action2'] = 'disable-selected';
 		/**
 		 * This filter is already documented in wp-includes/option.php
 		 *
@@ -189,18 +188,18 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}
+		$this->assertEquals( $event_data->args[1], array() );
 
 		$this->server_event_storage->reset();
 
 		//Prepare for single theme enable and disable tests
 
-		unset( $_REQUEST['action2'] );
 		$test_themes = array( $test_themes[0] );
 		$themes = array( $test_themes[0][0] => 1 );
+		$theme_slugs = array_keys( $themes );
 
 		//Test enable single theme
 
-		$_REQUEST['action'] = 'enable';
 		/**
 		 * This filter is already documented in wp-includes/option.php
 		 *
@@ -218,12 +217,12 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}
+		$this->assertEquals( $event_data->args[1], $theme_slugs );
 
 		$this->server_event_storage->reset();
 
 		//Test disable single theme
 
-		$_REQUEST['action'] = 'disable';
 		/**
 		 * This filter is already documented in wp-includes/option.php
 		 *
@@ -241,10 +240,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}
-
-		//Cleanup
-
-		unset( $_REQUEST['action'] );
+		$this->assertEquals( $event_data->args[1], array() );
 	}
 
 	public function test_install_edit_delete_theme_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -148,6 +148,13 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$_REQUEST['action'] = -1;
 		$_REQUEST['action2'] = 'enable-selected';
+		/**
+		 * This filter is already documented in wp-includes/option.php
+		 *
+		 * Note that 'allowedthemes' is dynamic, i.e. do_action is called on "update_site_option_{$option}"
+		 *
+		 * @since 2.9.0
+		 */
 		do_action( 'update_site_option_allowedthemes', 'allowedthemes', $themes, array(), 0 );
 		$this->sender->do_sync();
 
@@ -165,6 +172,13 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$_REQUEST['action'] = -1;
 		$_REQUEST['action2'] = 'disable-selected';
+		/**
+		 * This filter is already documented in wp-includes/option.php
+		 *
+		 * Note that 'allowedthemes' is dynamic, i.e. do_action is called on "update_site_option_{$option}"
+		 *
+		 * @since 2.9.0
+		 */
 		do_action( 'update_site_option_allowedthemes', 'allowedthemes', array(), $themes, 0 );
 		$this->sender->do_sync();
 
@@ -187,6 +201,13 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		//Test enable single theme
 
 		$_REQUEST['action'] = 'enable';
+		/**
+		 * This filter is already documented in wp-includes/option.php
+		 *
+		 * Note that 'allowedthemes' is dynamic, i.e. do_action is called on "update_site_option_{$option}"
+		 *
+		 * @since 2.9.0
+		 */
 		do_action( 'update_site_option_allowedthemes', 'allowedthemes', $themes, array(), 0 );
 		$this->sender->do_sync();
 
@@ -203,6 +224,13 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		//Test disable single theme
 
 		$_REQUEST['action'] = 'disable';
+		/**
+		 * This filter is already documented in wp-includes/option.php
+		 *
+		 * Note that 'allowedthemes' is dynamic, i.e. do_action is called on "update_site_option_{$option}"
+		 *
+		 * @since 2.9.0
+		 */
 		do_action( 'update_site_option_allowedthemes', 'allowedthemes', array(), $themes, 0 );
 		$this->sender->do_sync();
 

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -147,100 +147,66 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$theme_slugs = array_keys( $themes );
 
 		//Test enable multiple themes
-
 		/**
 		 * This filter is already documented in wp-includes/option.php
 		 *
 		 * Note that 'allowedthemes' is dynamic, i.e. do_action is called on "update_site_option_{$option}"
-		 *
-		 * @since 2.9.0
 		 */
 		do_action( 'update_site_option_allowedthemes', 'allowedthemes', $themes, array(), 0 );
 		$this->sender->do_sync();
-
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_network_enabled_themes' );
-
-		foreach ( $test_themes as $theme ) {
-			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1] );
-			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
-			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
-		}
-		$this->assertEquals( $event_data->args[1], $theme_slugs );
-
+		$this->perform_network_enable_disable_assertions( $test_themes, $event_data, $theme_slugs );
 		$this->server_event_storage->reset();
 
 		//Test disable multiple themes
-
 		/**
 		 * This filter is already documented in wp-includes/option.php
 		 *
 		 * Note that 'allowedthemes' is dynamic, i.e. do_action is called on "update_site_option_{$option}"
-		 *
-		 * @since 2.9.0
 		 */
 		do_action( 'update_site_option_allowedthemes', 'allowedthemes', array(), $themes, 0 );
 		$this->sender->do_sync();
-
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_network_disabled_themes' );
-
-		foreach ( $test_themes as $theme ) {
-			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1] );
-			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
-			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
-		}
-		$this->assertEquals( $event_data->args[1], array() );
-
+		$this->perform_network_enable_disable_assertions( $test_themes, $event_data, array() );
 		$this->server_event_storage->reset();
 
 		//Prepare for single theme enable and disable tests
-
 		$test_themes = array( $test_themes[0] );
 		$themes = array( $test_themes[0][0] => 1 );
 		$theme_slugs = array_keys( $themes );
 
 		//Test enable single theme
-
 		/**
 		 * This filter is already documented in wp-includes/option.php
 		 *
 		 * Note that 'allowedthemes' is dynamic, i.e. do_action is called on "update_site_option_{$option}"
-		 *
-		 * @since 2.9.0
 		 */
 		do_action( 'update_site_option_allowedthemes', 'allowedthemes', $themes, array(), 0 );
 		$this->sender->do_sync();
-
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_network_enabled_themes' );
-
-		foreach ( $test_themes as $theme ) {
-			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1] );
-			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
-			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
-		}
-		$this->assertEquals( $event_data->args[1], $theme_slugs );
-
+		$this->perform_network_enable_disable_assertions( $test_themes, $event_data, $theme_slugs );
 		$this->server_event_storage->reset();
 
 		//Test disable single theme
-
 		/**
 		 * This filter is already documented in wp-includes/option.php
 		 *
 		 * Note that 'allowedthemes' is dynamic, i.e. do_action is called on "update_site_option_{$option}"
-		 *
-		 * @since 2.9.0
 		 */
 		do_action( 'update_site_option_allowedthemes', 'allowedthemes', array(), $themes, 0 );
 		$this->sender->do_sync();
-
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_network_disabled_themes' );
+		$this->perform_network_enable_disable_assertions( $test_themes, $event_data, array() );
+	}
 
+	private function perform_network_enable_disable_assertions( $test_themes, $event_data, $enabled_slugs ) {
 		foreach ( $test_themes as $theme ) {
+			$this->assertEquals( $event_data->args[0][ $theme[0] ]['slug'], $theme[0] );
 			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}
-		$this->assertEquals( $event_data->args[1], array() );
+		$this->assertEquals( $event_data->args[1], $enabled_slugs );
 	}
 
 	public function test_install_edit_delete_theme_sync() {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -161,7 +161,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_network_enabled_themes' );
 
 		foreach ( $test_themes as $theme ) {
-			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1]);
+			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}
@@ -184,7 +184,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_network_disabled_themes' );
 
 		foreach ( $test_themes as $theme ) {
-			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1]);
+			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}
@@ -213,7 +213,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_network_enabled_themes' );
 
 		foreach ( $test_themes as $theme ) {
-			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1]);
+			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}
@@ -236,7 +236,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_network_disabled_themes' );
 
 		foreach ( $test_themes as $theme ) {
-			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1]);
+			$this->assertEquals( $event_data->args[0][ $theme[0] ]['name'], $theme[1] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['version'] );
 			$this->assertTrue( (bool) $event_data->args[0][ $theme[0] ]['uri'] );
 		}


### PR DESCRIPTION
Jetpack Sync: Add sync action for network/multisite enable and disable themes

#### Changes proposed in this Pull Request:

Add sync action for network/multisite enable and disable themes

#### Testing instructions:

phpunit runs new tests when on multisite

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Addition of jetpack_network_disabled_themes and jetpack_network_enabled_themes hooks