### PR TITLE
Remove Apps card from Jumpstart view

### DIFF
--- a/_inc/client/components/apps-card/index.jsx
+++ b/_inc/client/components/apps-card/index.jsx
@@ -37,7 +37,7 @@ const AppsCard = React.createClass( {
 	},
 
 	render() {
-		if ( this.props.arePromotionsActive && this.props.isAppsCardDismissed ) {
+		if ( ! this.props.arePromotionsActive || this.props.isAppsCardDismissed ) {
 			return null;
 		}
 

--- a/_inc/client/components/apps-card/index.jsx
+++ b/_inc/client/components/apps-card/index.jsx
@@ -14,6 +14,7 @@ import analytics from 'lib/analytics';
  */
 import { imagePath } from 'constants';
 import { updateSettings, appsCardDismissed } from 'state/settings';
+import { arePromotionsActive } from 'state/initial-state';
 
 const AppsCard = React.createClass( {
 	displayName: 'AppsCard',
@@ -36,7 +37,7 @@ const AppsCard = React.createClass( {
 	},
 
 	render() {
-		if ( this.props.isAppsCardDismissed ) {
+		if ( this.props.arePromotionsActive && this.props.isAppsCardDismissed ) {
 			return null;
 		}
 
@@ -90,7 +91,8 @@ AppsCard.propTypes = {
 export default connect(
 	state => {
 		return {
-			isAppsCardDismissed: appsCardDismissed( state )
+			isAppsCardDismissed: appsCardDismissed( state ),
+			arePromotionsActive: arePromotionsActive( state )
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -235,12 +235,8 @@ const Main = React.createClass( {
 						<AdminNotices />
 						<JetpackNotices />
 						{ this.renderMainContent( this.props.route.path ) }
-						{
-							this.props.jumpStartStatus
-								? null
-								: <SupportCard path={ this.props.route.path } />
-						}
-						<AppsCard />
+						{ ! this.props.jumpStartStatus && <SupportCard path={ this.props.route.path } /> }
+						{ ! this.props.jumpStartStatus && <AppsCard /> }
 					</div>
 					<Footer siteAdminUrl={ this.props.siteAdminUrl } />
 				<Tracker analytics={ analytics } />


### PR DESCRIPTION
Reported in p6TEKc-1dr-p2

This removes the apps card from Jumpstart view shown here: 
![apps-jumpstart](https://cloud.githubusercontent.com/assets/7129409/26013125/023eab9c-3725-11e7-8245-74511ef37aa5.png)

It should still show on all other pages. 

To test: 
- Delete the `dismiss_dash_app_card` option `delete_option( 'dismiss_dash_app_card' )` , or start a new site.  
- Click "reset options" in the footer of Jetpack.  Or connect a new site.  
- Make sure there's no card on Jumpstart
- Make sure the card shows on all other pages after jump-starting. 

