### PR TITLE
Surface all modules on search and allow "one-way" activation.  

### DIFF
--- a/_inc/client/components/settings-card/style.scss
+++ b/_inc/client/components/settings-card/style.scss
@@ -96,3 +96,9 @@
 		}
 	}
 }
+
+.jp-searchable-banner {
+	.gridicon {
+		margin-bottom: -7px;
+	}
+}

--- a/_inc/client/searchable-modules/README.md
+++ b/_inc/client/searchable-modules/README.md
@@ -1,0 +1,26 @@
+Searchable Modules
+==============
+
+This component is meant to be a searchable container which will surface the modules that do not have any
+UI in any of the other primary settings tabs.
+
+The results rendered will either show a Banner, with a prop to activate, or if the module is already active,
+it will show a standard info card about the feature.  The content in the 'active' cards is pulled from
+the module headers themselves from the {module-slug}.php files.
+
+It is connected to the Redux store, which is where it gets the module data from.
+It only needs to be fed search terms (string) as a prop.
+
+#### How to use:
+
+```js
+
+import SearchableModules from 'searchable-modules/index.jsx';
+render: function() {
+    return (
+        <SearchableModules searchTerm={ this.props.searchTerm } />
+    );
+}
+
+}
+```

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import forEach from 'lodash/forEach';
+import includes from 'lodash/includes';
+import { translate as __ } from 'i18n-calypso';
+import Banner from 'components/banner';
+
+/**
+ * Internal dependencies
+ */
+import { getModules, isModuleActivated, activateModule } from 'state/modules';
+import { isModuleFound } from 'state/search';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { userCanManageModules } from 'state/initial-state';
+import { isDevMode, isUnavailableInDevMode } from 'state/connection';
+
+class SearchableModules extends Component {
+	render() {
+		// Only admins plz
+		if ( ! this.props.canManageModules ) {
+			return null;
+		}
+
+		// Only render if search terms present
+		const searchTerms = this.props.searchTerm;
+		if ( searchTerms.length < 3 ) {
+			return null;
+		}
+
+		// Only should be features that don't already have a UI, and we want to reveal in search.
+		const whitelist = [
+			'contact-form',
+			'custom-css',
+			'enhanced-distribution',
+			'json-api',
+			'latex',
+			'notes',
+			'omnisearch',
+			'shortcodes',
+			'shortlinks',
+			'widget-visibility',
+			'widgets'
+		];
+
+		const allModules = this.props.modules,
+			results = [];
+		forEach( allModules, ( moduleData, slug ) => {
+			if (
+				this.props.isModuleFound( slug ) &&
+				includes( whitelist, slug )
+			) {
+				// Not available in dev mode
+				if ( this.props.isDevMode && this.props.isUnavailableInDevMode( moduleData.module ) ) {
+					return results.push( <ActiveCard key={ slug } moduleData={ moduleData } devMode={ true } /> );
+				}
+
+				if ( this.props.isModuleActive( moduleData.module ) ) {
+					results.push( <ActiveCard key={ slug } moduleData={ moduleData } /> );
+				} else {
+					results.push(
+						<Banner
+							className="jp-searchable-banner"
+							key={ slug }
+							callToAction={ __( 'Activate' ) }
+							description={ moduleData.description }
+							href="javascript:void( 0 )"
+							icon="cog"
+							onClick={ this.props.activateModule.bind( null, moduleData.module ) }
+							title={ moduleData.name }
+						/>
+					);
+				}
+			}
+		} );
+
+		return (
+			<div>{ results }</div>
+		);
+	}
+}
+
+SearchableModules.propTypes = {
+	searchTerm: React.PropTypes.string
+};
+
+SearchableModules.defaultProps = {
+	searchTerm: ''
+};
+
+class ActiveCard extends Component {
+	render() {
+		const m = this.props.moduleData,
+			devMode = this.props.devMode;
+
+		return (
+			<SettingsCard
+				header={ m.name }
+				action={ m.module }
+				hideButton>
+				<SettingsGroup
+					disableInDevMode={ devMode }
+					module={ { module: m.module } }
+					support={ m.learn_more_button }
+				>
+					{ m.description }
+				</SettingsGroup>
+			</SettingsCard>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		return {
+			modules: getModules( state ),
+			isModuleFound: ( module_name ) => isModuleFound( state, module_name ),
+			isModuleActive: ( module_name ) => isModuleActivated( state, module_name ),
+			canManageModules: userCanManageModules( state ),
+			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+			isDevMode: isDevMode( state )
+		};
+	},
+	( dispatch ) => {
+		return {
+			activateModule: ( slug ) => {
+				return dispatch( activateModule( slug ) );
+			}
+		};
+	}
+)( SearchableModules );

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -12,77 +12,81 @@ import Banner from 'components/banner';
 /**
  * Internal dependencies
  */
-import { getModules, isModuleActivated, activateModule } from 'state/modules';
+import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import { getModules } from 'state/modules';
 import { isModuleFound } from 'state/search';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { userCanManageModules } from 'state/initial-state';
 import { isDevMode, isUnavailableInDevMode } from 'state/connection';
 
-class SearchableModules extends Component {
-	render() {
-		// Only admins plz
-		if ( ! this.props.canManageModules ) {
-			return null;
-		}
-
-		// Only render if search terms present
-		const searchTerms = this.props.searchTerm;
-		if ( searchTerms.length < 3 ) {
-			return null;
-		}
-
-		// Only should be features that don't already have a UI, and we want to reveal in search.
-		const whitelist = [
-			'contact-form',
-			'custom-css',
-			'enhanced-distribution',
-			'json-api',
-			'latex',
-			'notes',
-			'omnisearch',
-			'shortcodes',
-			'shortlinks',
-			'widget-visibility',
-			'widgets'
-		];
-
-		const allModules = this.props.modules,
-			results = [];
-		forEach( allModules, ( moduleData, slug ) => {
-			if (
-				this.props.isModuleFound( slug ) &&
-				includes( whitelist, slug )
-			) {
-				// Not available in dev mode
-				if ( this.props.isDevMode && this.props.isUnavailableInDevMode( moduleData.module ) ) {
-					return results.push( <ActiveCard key={ slug } moduleData={ moduleData } devMode={ true } /> );
-				}
-
-				if ( this.props.isModuleActive( moduleData.module ) ) {
-					results.push( <ActiveCard key={ slug } moduleData={ moduleData } /> );
-				} else {
-					results.push(
-						<Banner
-							className="jp-searchable-banner"
-							key={ slug }
-							callToAction={ __( 'Activate' ) }
-							description={ moduleData.description }
-							href="javascript:void( 0 )"
-							icon="cog"
-							onClick={ this.props.activateModule.bind( null, moduleData.module ) }
-							title={ moduleData.name }
-						/>
-					);
-				}
+export const SearchableModules = moduleSettingsForm(
+	class extends Component {
+		render() {
+			// Only admins plz
+			if ( ! this.props.canManageModules ) {
+				return null;
 			}
-		} );
 
-		return (
-			<div>{ results }</div>
-		);
+			// Only render if search terms present
+			const searchTerms = this.props.searchTerm;
+			if ( searchTerms.length < 3 ) {
+				return null;
+			}
+
+			// Only should be features that don't already have a UI, and we want to reveal in search.
+			const whitelist = [
+				'contact-form',
+				'custom-css',
+				'enhanced-distribution',
+				'json-api',
+				'latex',
+				'monitor',
+				'notes',
+				'omnisearch',
+				'shortcodes',
+				'shortlinks',
+				'widget-visibility',
+				'widgets'
+			];
+
+			const allModules = this.props.modules,
+				results = [];
+			forEach( allModules, ( moduleData, slug ) => {
+				if (
+					this.props.isModuleFound( slug ) &&
+					includes( whitelist, slug )
+				) {
+					// Not available in dev mode
+					if ( this.props.isDevMode && this.props.isUnavailableInDevMode( moduleData.module ) ) {
+						return results.push( <ActiveCard key={ slug } moduleData={ moduleData } devMode={ true } /> );
+					}
+
+					if ( this.props.getOptionValue( moduleData.module ) ) {
+						results.push( <ActiveCard key={ slug } moduleData={ moduleData } /> );
+					} else {
+						results.push(
+							<Banner
+								className="jp-searchable-banner"
+								key={ slug }
+								callToAction={ __( 'Activate' ) }
+								description={ moduleData.description }
+								href="javascript:void( 0 )"
+								icon="cog"
+								onClick={ this.props.updateOptions.bind( null, { [ moduleData.module ]: true } ) }
+								title={ moduleData.name }
+							/>
+						);
+					}
+				}
+			} );
+
+			return (
+				<div>{ results }</div>
+			);
+		}
 	}
-}
+);
 
 SearchableModules.propTypes = {
 	searchTerm: React.PropTypes.string
@@ -119,17 +123,9 @@ export default connect(
 		return {
 			modules: getModules( state ),
 			isModuleFound: ( module_name ) => isModuleFound( state, module_name ),
-			isModuleActive: ( module_name ) => isModuleActivated( state, module_name ),
 			canManageModules: userCanManageModules( state ),
 			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
 			isDevMode: isDevMode( state )
-		};
-	},
-	( dispatch ) => {
-		return {
-			activateModule: ( slug ) => {
-				return dispatch( activateModule( slug ) );
-			}
 		};
 	}
 )( SearchableModules );

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -12,6 +12,7 @@ import Security from 'security/index.jsx';
 import Traffic from 'traffic';
 import Writing from 'writing/index.jsx';
 import Sharing from 'sharing/index.jsx';
+import SearchableModules from 'searchable-modules/index.jsx';
 
 export default React.createClass( {
 	displayName: 'SearchableSettings',
@@ -66,6 +67,7 @@ export default React.createClass( {
 					active={ ( '/sharing' === this.props.route.path ) }
 					{ ...commonProps }
 				/>
+				<SearchableModules searchTerm={ this.props.searchTerm } />
 			</div>
 		);
 	}


### PR DESCRIPTION
Implements @MichaelArestad "one-way activation" suggestion in #6788 

This PR adds a new component, `<SearchableModules />`, which has a hard-coded list of modules available for search.  It's hard-coded, because search already inherits the cards from existing tabs, and has specific settings configs.  These features will all be surfaced with the same card style for each, in order to simplify this code.  

The card is populated with the Name/descriptions from the module headers themselves.  We can change the copy of them, if so desired. 

If the module is not active, it will show a banner like this: 
![screen shot 2017-05-15 at 8 56 05 am](https://cloud.githubusercontent.com/assets/7129409/26058569/69898b9a-394c-11e7-8ecd-146f18314ea0.png)

If the module is active, we'll continue to show the card with the learn more link:
![screen shot 2017-05-15 at 8 56 18 am](https://cloud.githubusercontent.com/assets/7129409/26058576/72a589cc-394c-11e7-9856-6e53c99edfef.png)

Please test the following (hard-coded) modules that will now appear in search: 
- 'contact-form',
- 'custom-css',
- 'enhanced-distribution',
- 'json-api',
- 'latex',
- 'notes',
- 'omnisearch',
- 'shortcodes',
- 'shortlinks',
- 'widget-visibility',
- 'widgets'

Please make sure that you're not able to search these as a non-admin. 

Please make sure that they show a disabled card if in dev mode, and the feature requires a connection, JSON API. 