### PR TITLE
jspress Javascript lib: fixing bad jQuery selector.

### DIFF
--- a/modules/shortcodes/js/jmpress.js
+++ b/modules/shortcodes/js/jmpress.js
@@ -1438,7 +1438,7 @@
 
 	'use strict';
 	var $jmpress = $.jmpress,
-		hashLink = "a[href^=#]";
+		hashLink = "a[href^='#']";
 
 	/* FUNCTIONS */
 	function randomString() {


### PR DESCRIPTION
props georgestephanis, related GitHub issue and related PR/merge: https://github.com/jmpressjs/jmpress.js/issues/185

This commit syncs r134654-wpcom.
