### PR TITLE
Jetpack Sync: Add sync action for widget edit

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -35,12 +35,21 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			! isset( $_REQUEST['action'] ) ||
 			'save-widget' !== $_REQUEST['action'] ||
 			! isset( $_REQUEST['add_new'] ) ||
-			false  !== ( bool ) $_REQUEST['add_new']
+			false  !== ( bool ) $_REQUEST['add_new'] ||
+			! isset( $_REQUEST['id_base'] )
 		) {
 			return;
 		}
+
 		global $wp_registered_widget_updates;
 		$widget_name = $wp_registered_widget_updates[ $_REQUEST['id_base'] ]['callback'][0]->name;
+		/**
+		 * Trigger action to alert $callable sync listener that a widget was edited
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param string $widget_name, Name of edited widget
+		 */
 		do_action( 'jetpack_widget_edited', $widget_name );
 	}
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -31,7 +31,10 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 	}
 
 	public function sync_widget_edit( $instance, $new_instance, $old_instance, $widget_object ) {
-		$widget_name = $widget_object->name;
+		$widget = array(
+			'name' => $widget_object->name,
+			'id' => $widget_object->id,
+		);
 		/**
 		 * Trigger action to alert $callable sync listener that a widget was edited
 		 *
@@ -39,7 +42,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		 *
 		 * @param string $widget_name, Name of edited widget
 		 */
-		do_action( 'jetpack_widget_edited', $widget_name );
+		do_action( 'jetpack_widget_edited', $widget );
 
 		return $instance;
 	}

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -26,6 +26,22 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_widget_moved_to_inactive', $callable );
 		add_action( 'jetpack_cleared_inactive_widgets', $callable );
 		add_action( 'jetpack_widget_reordered', $callable );
+		add_action( 'widgets.php', array( $this, 'detect_widget_edit' ) );
+		add_action( 'jetpack_widget_edited', $callable );
+	}
+
+	public function detect_widget_edit() {
+		if (
+			! isset( $_REQUEST['action'] ) ||
+			'save-widget' !== $_REQUEST['action'] ||
+			! isset( $_REQUEST['add_new'] ) ||
+			false  !== ( bool ) $_REQUEST['add_new']
+		) {
+			return;
+		}
+		global $wp_registered_widget_updates;
+		$widget_name = $wp_registered_widget_updates[ $_REQUEST['id_base'] ]['callback'][0]->name;
+		do_action( 'jetpack_widget_edited', $widget_name );
 	}
 
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -26,14 +26,12 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_widget_moved_to_inactive', $callable );
 		add_action( 'jetpack_cleared_inactive_widgets', $callable );
 		add_action( 'jetpack_widget_reordered', $callable );
-		add_filter( 'widget_update_callback', array( $this, 'sync_widget_edit' ), 10, 3 );
+		add_filter( 'widget_update_callback', array( $this, 'sync_widget_edit' ), 10, 4 );
 		add_action( 'jetpack_widget_edited', $callable );
 	}
 
-	public function sync_widget_edit( $instance, $new_instance, $old_instance ) {
-		$widget_name = $instance->name;
-		error_log(print_r($new_instance, true));
-		error_log(print_r($old_instance, true));
+	public function sync_widget_edit( $instance, $new_instance, $old_instance, $widget_object ) {
+		$widget_name = $widget_object->name;
 		/**
 		 * Trigger action to alert $callable sync listener that a widget was edited
 		 *

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -26,23 +26,14 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		add_action( 'jetpack_widget_moved_to_inactive', $callable );
 		add_action( 'jetpack_cleared_inactive_widgets', $callable );
 		add_action( 'jetpack_widget_reordered', $callable );
-		add_action( 'widgets.php', array( $this, 'detect_widget_edit' ) );
+		add_filter( 'widget_update_callback', array( $this, 'sync_widget_edit' ), 10, 3 );
 		add_action( 'jetpack_widget_edited', $callable );
 	}
 
-	public function detect_widget_edit() {
-		if (
-			! isset( $_REQUEST['action'] ) ||
-			'save-widget' !== $_REQUEST['action'] ||
-			! isset( $_REQUEST['add_new'] ) ||
-			false  !== ( bool ) $_REQUEST['add_new'] ||
-			! isset( $_REQUEST['id_base'] )
-		) {
-			return;
-		}
-
-		global $wp_registered_widget_updates;
-		$widget_name = $wp_registered_widget_updates[ $_REQUEST['id_base'] ]['callback'][0]->name;
+	public function sync_widget_edit( $instance, $new_instance, $old_instance ) {
+		$widget_name = $instance->name;
+		error_log(print_r($new_instance, true));
+		error_log(print_r($old_instance, true));
 		/**
 		 * Trigger action to alert $callable sync listener that a widget was edited
 		 *
@@ -51,6 +42,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		 * @param string $widget_name, Name of edited widget
 		 */
 		do_action( 'jetpack_widget_edited', $widget_name );
+
+		return $instance;
 	}
 
 	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -361,6 +361,35 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( (bool) $event, 'Not fired cleared inacative widgets' );
 	}
 
+	public function test_widget_edited() {
+		$_REQUEST['action'] = 'save-widget';
+		$_REQUEST['add_new'] = '';
+		$_REQUEST['id_base'] = 'search';
+		global $wp_registered_widget_updates;
+		$wp_registered_widget_updates = array(
+			$_REQUEST['id_base'] => array(
+				'callback' => array(
+					(object) array(
+						'name' => 'Search',
+					)
+				)
+			)
+		);
+		/**
+		 * This filter is already documented in wp-admin/includes/ajax-actions.php
+		 */
+		do_action( 'widgets.php' );
+
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_edited' );
+		$this->assertEquals( $event->args[0], 'Search' );
+
+		//Cleanup
+		$_REQUEST = array();
+		$wp_registered_widget_updates = array();
+	}
+
 	private function install_theme( $slug ) {
 		require_once ABSPATH . 'wp-admin/includes/theme-install.php';
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -363,7 +363,8 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_widget_edited() {
 		$object = (object) array(
-			'name' => 'Search'
+			'name' => 'Search',
+			'id' => 'search-1',
 		);
 		/**
 		 * This filter is already documented in wp-includes/class-wp-widget.php
@@ -373,7 +374,8 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_edited' );
-		$this->assertEquals( $event->args[0], 'Search' );
+		$this->assertEquals( $event->args[0]['name'], 'Search' );
+		$this->assertEquals( $event->args[0]['id'], 'search-1' );
 	}
 
 	private function install_theme( $slug ) {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -362,32 +362,18 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_widget_edited() {
-		$_REQUEST['action'] = 'save-widget';
-		$_REQUEST['add_new'] = '';
-		$_REQUEST['id_base'] = 'search';
-		global $wp_registered_widget_updates;
-		$wp_registered_widget_updates = array(
-			$_REQUEST['id_base'] => array(
-				'callback' => array(
-					(object) array(
-						'name' => 'Search',
-					)
-				)
-			)
+		$object = (object) array(
+			'name' => 'Search'
 		);
 		/**
-		 * This filter is already documented in wp-admin/includes/ajax-actions.php
+		 * This filter is already documented in wp-includes/class-wp-widget.php
 		 */
-		do_action( 'widgets.php' );
+		do_action( 'widget_update_callback', array(), array(), array(), $object);
 
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_edited' );
 		$this->assertEquals( $event->args[0], 'Search' );
-
-		//Cleanup
-		$_REQUEST = array();
-		$wp_registered_widget_updates = array();
 	}
 
 	private function install_theme( $slug ) {


### PR DESCRIPTION
Add sync action for widget edit

#### Changes proposed in this Pull Request:

Add sync action for widget edit

#### Testing instructions:

phpunit runs the new test

<!-- Add the following only if this is meant to be in changelog -->
Adds new do_action for 'jetpack_widget_edited'
