### PR TITLE
SEO Tools: remove obsolete meta title tag

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5933,6 +5933,7 @@ p {
 			'jetpack_sync_all_registered_options'                    => null,
 			'jetpack_has_identity_crisis'                            => 'jetpack_sync_error_idc_validation',
 			'jetpack_is_post_mailable'                               => null,
+			'jetpack_seo_site_host'                                  => null,
 		);
 
 		// This is a silly loop depth. Better way?

--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -105,17 +105,6 @@ class Jetpack_SEO {
 			return;
 		}
 
-		/**
-		 * Can be used to insert custom site host that will used for meta title.
-		 *
-		 * @module seo-tools
-		 *
-		 * @since 4.4.0
-		 * @deprecated 5.0.0 This filter is no longer used. Meta tags that used site host are now obsolete.
-		 *
-		 * @param string Name of the site host. Defaults to empty string.
-		 */
-
 		$front_page_meta     = Jetpack_SEO_Utils::get_front_page_meta_description();
 		$description         = $front_page_meta ? $front_page_meta : get_bloginfo( 'description' );
 		$meta['description'] = trim( $description );

--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -114,17 +114,7 @@ class Jetpack_SEO {
 		 *
 		 * @param string Name of the site host. Defaults to empty string.
 		 */
-		$site_host     = apply_filters( 'jetpack_seo_site_host', '' );
-
-		$meta['title'] = sprintf( _x( '%1$s', 'Site Title', 'jetpack' ), get_bloginfo( 'title' ) );
-
-		if ( ! empty( $site_host ) ) {
-			$meta['title'] = sprintf(
-				_x( '%1$s on %2$s', 'Site Title on WordPress', 'jetpack' ),
-				get_bloginfo( 'title' ),
-				$site_host
-			);
-		}
+		$site_host = apply_filters( 'jetpack_seo_site_host', '' );
 
 		$front_page_meta     = Jetpack_SEO_Utils::get_front_page_meta_description();
 		$description         = $front_page_meta ? $front_page_meta : get_bloginfo( 'description' );
@@ -132,12 +122,6 @@ class Jetpack_SEO {
 
 		// Try to target things if we're on a "specific" page of any kind.
 		if ( is_singular() ) {
-			$meta['title'] = sprintf(
-				_x( '%1$s | %2$s', 'Post Title | Site Title on WordPress', 'jetpack' ),
-				get_the_title(),
-				$meta['title']
-			);
-
 			// Business users can overwrite the description.
 			if ( ! ( is_front_page() && Jetpack_SEO_Utils::get_front_page_meta_description() ) ) {
 				$description = Jetpack_SEO_Posts::get_post_description( get_post() );
@@ -151,12 +135,6 @@ class Jetpack_SEO {
 		} elseif ( is_author() ) {
 			$obj = get_queried_object();
 
-			$meta['title'] = sprintf(
-				_x( 'Posts by %1$s | %2$s', 'Posts by Author Name | Blog Title on WordPress', 'jetpack' ),
-				$obj->display_name,
-				$meta['title']
-			);
-
 			$meta['description'] = sprintf(
 				_x( 'Read all of the posts by %1$s on %2$s', 'Read all of the posts by Author Name on Blog Title', 'jetpack' ),
 				$obj->display_name,
@@ -164,12 +142,6 @@ class Jetpack_SEO {
 			);
 		} elseif ( is_tag() || is_category() || is_tax() ) {
 			$obj = get_queried_object();
-
-			$meta['title'] = sprintf(
-				_x( 'Posts about %1$s on %2$s', 'Posts about Category on Blog Title', 'jetpack' ),
-				single_term_title( '', false ),
-				get_bloginfo( 'title' )
-			);
 
 			$description = get_term_field( 'description', $obj->term_id, $obj->taxonomy, 'raw' );
 
@@ -220,20 +192,8 @@ class Jetpack_SEO {
 				);
 			}
 
-			$meta['title'] = sprintf(
-				_x( 'Posts from %1$s on %2$s', 'Posts from May 2012 on Blog Title', 'jetpack' ),
-				$period,
-				get_bloginfo( 'title' )
-			);
-
 			$authors             = $this->get_authors();
 			$meta['description'] = wp_sprintf( $template, count( $wp_query->posts ), $authors, $period );
-		}
-
-		$custom_title = Jetpack_SEO_Titles::get_custom_title();
-
-		if ( ! empty( $custom_title ) ) {
-			$meta['title'] = $custom_title;
 		}
 
 		/**

--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -105,17 +105,6 @@ class Jetpack_SEO {
 			return;
 		}
 
-		/**
-		 * Can be used to insert custom site host that will used for meta title.
-		 *
-		 * @module seo-tools
-		 *
-		 * @since 4.4.0
-		 *
-		 * @param string Name of the site host. Defaults to empty string.
-		 */
-		$site_host = apply_filters( 'jetpack_seo_site_host', '' );
-
 		$front_page_meta     = Jetpack_SEO_Utils::get_front_page_meta_description();
 		$description         = $front_page_meta ? $front_page_meta : get_bloginfo( 'description' );
 		$meta['description'] = trim( $description );

--- a/modules/seo-tools/jetpack-seo.php
+++ b/modules/seo-tools/jetpack-seo.php
@@ -105,6 +105,17 @@ class Jetpack_SEO {
 			return;
 		}
 
+		/**
+		 * Can be used to insert custom site host that will used for meta title.
+		 *
+		 * @module seo-tools
+		 *
+		 * @since 4.4.0
+		 * @deprecated 5.0.0 This filter is no longer used. Meta tags that used site host are now obsolete.
+		 *
+		 * @param string Name of the site host. Defaults to empty string.
+		 */
+
 		$front_page_meta     = Jetpack_SEO_Utils::get_front_page_meta_description();
 		$description         = $front_page_meta ? $front_page_meta : get_bloginfo( 'description' );
 		$meta['description'] = trim( $description );


### PR DESCRIPTION
Since we are already setting the `<title>` tags correctly, we no longer need to use the `<meta name="title" ...>` tag.

Fixes #7190

#### Testing instructions:

1. Use Jetpack test site with a professional plan. 
2. In Calypso, navigate to `settings/traffic/{siteSlug}`.
3. Set custom title formats for that site.
4. Verify that those custom title formats are no longer included in `<meta name="title" ...>` tags. 