### PR TITLE
Settings UI: update wording in Photon dash item

### DIFF
--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -19,7 +19,7 @@ import { isDevMode } from 'state/connection';
 
 const DashPhoton = React.createClass( {
 	getContent: function() {
-		const labelName = __( 'Image Performance %(photon)s', { args: { photon: '(Photon)' } } );
+		const labelName = __( 'Image Performance' );
 
 		if ( this.props.isModuleActivated( 'photon' ) ) {
 			return (
@@ -40,7 +40,7 @@ const DashPhoton = React.createClass( {
 				<p className="jp-dash-item__description">
 					{
 						this.props.isDevMode ? __( 'Unavailable in Dev Mode' ) :
-						__( '{{a}}Activate Photon{{/a}} to enhance the performance and speed of your images.', {
+						__( '{{a}}Activate{{/a}} to enhance the performance and speed of your images.', {
 							components: {
 								a: <a href="javascript:void(0)" onClick={ this.props.activatePhoton } />
 							}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* update wording in Photon dash item to remove the Photon word

<img width="368" alt="captura de pantalla 2017-05-17 a las 09 18 00" src="https://cloud.githubusercontent.com/assets/1041600/26153494/ef4df5c2-3ae1-11e7-8ddd-89b85967c90e.png">

<img width="366" alt="captura de pantalla 2017-05-17 a las 09 21 23" src="https://cloud.githubusercontent.com/assets/1041600/26153551/3fab4db2-3ae2-11e7-9319-bb4194991a62.png">

<img width="363" alt="captura de pantalla 2017-05-17 a las 09 21 15" src="https://cloud.githubusercontent.com/assets/1041600/26153553/4169e050-3ae2-11e7-9094-878e70802291.png">

Note: if you toggle this dash item, you might notice the message "Activating Photon". The Photon word (and the notice itself) will be updated by https://github.com/Automattic/jetpack/pull/7188 and the Photon word removed.