### PR TITLE
Brings back get_avatar_url method.

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1045,7 +1045,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$first_name  = '';
 			$last_name   = '';
 			$URL         = $author->comment_author_url;
-			$avatar_URL  = get_avatar_url( $author );
+			$avatar_URL  = $this->api->get_avatar_url( $author );
 			$profile_URL = 'https://en.gravatar.com/' . md5( strtolower( trim( $email ) ) );
 			$nice        = '';
 			$site_id     = -1;
@@ -1115,7 +1115,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$site_id     = -1;
 			}
 
-			$avatar_URL = get_avatar_url( $email );
+			$avatar_URL = $this->api->get_avatar_url( $email );
 		}
 
 		$email = $show_email ? (string) $email : false;

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -594,8 +594,20 @@ class WPCOM_JSON_API {
 		return '';
 	}
 
+	function get_avatar_url( $email, $avatar_size = null ) {
+		if ( function_exists( 'wpcom_get_avatar_url' ) ) {
+			return null === $avatar_size
+				? wpcom_get_avatar_url( $email )
+				: wpcom_get_avatar_url( $email, $avatar_size );
+		} else {
+			return null === $avatar_size
+				? get_avatar_url( $email )
+				: get_avatar_url( $email, $avatar_size );
+		}
+	}
+
 	/**
-	 * Traps `wp_die()` calls and outputs a JSON response instead.
+	 * traps `wp_die()` calls and outputs a JSON response instead.
 	 * The result is always output, never returned.
 	 *
 	 * @param string|null $error_code  Call with string to start the trapping.  Call with null to stop.


### PR DESCRIPTION
This allows to distinguish between WordPress.com and Jetpack usage in one place.
@singerb tagging you for a review because you have worked on removing the method before.