### PR TITLE
JPS: New params and compatibility fixes

### DIFF
--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 cd $SCRIPT_DIR
 
 usage () {
-    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret"
+    echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret"
 }
 
 for i in "$@"; do

--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+
+# cancel a the plan provided for the current site using the given partner keys
+
+# change to script directory so that wp finds the wordpress install part for this Jetpack instance
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+cd $SCRIPT_DIR
+
+usage () {
+    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret"
+}
+
+for i in "$@"; do
+    key="$1"
+    case $i in
+        -c=* | --partner_id=* )     CLIENT_ID="${i#*=}"
+                                    shift
+                                    ;;
+        -s=* | --partner_secret=* ) CLIENT_SECRET="${i#*=}"
+                                    shift
+                                    ;;
+        -h | --help )               usage
+                                    exit
+                                    ;;
+        * )                         usage
+                                    exit 1
+    esac
+done
+
+if [ "$CLIENT_ID" = "" ] || [ "$CLIENT_SECRET" = "" ]; then
+    usage
+    exit 1
+fi
+
+# default API host that can be overridden
+if [ -z "$JETPACK_START_API_HOST" ]; then
+    JETPACK_START_API_HOST='public-api.wordpress.com'
+fi 
+
+# fetch an access token using our client ID/secret
+ACCESS_TOKEN_JSON=`curl https://$JETPACK_START_API_HOST/oauth2/token --silent --header "Host: public-api.wordpress.com" -d "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=jetpack-partner"`
+
+# silently ensure Jetpack is active
+wp plugin activate jetpack >/dev/null 2>&1
+
+# cancel the partner plan
+wp jetpack partner_cancel "$ACCESS_TOKEN_JSON"
+

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 cd $SCRIPT_DIR
 
 usage () {
-    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret --user_id=wp_user_id --plan=plan_name"
+    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret --user_id=wp_user_id [--plan=plan_name] [--wpcom_user_id=1234]"
 }
 
 for i in "$@"; do
@@ -26,6 +26,9 @@ for i in "$@"; do
         -i=* | --user_id=* )        WP_USER_ID="${i#*=}"
                                     shift
                                     ;;
+        -w=* | --wpcom_user_id=* )  WPCOM_USER_ID="${i#*=}"
+                                    shift
+                                    ;;
         -p=* | --plan=* )           PLAN_NAME="${i#*=}"
                                     shift
                                     ;;
@@ -37,7 +40,7 @@ for i in "$@"; do
     esac
 done
 
-if [ "$CLIENT_ID" = "" ] || [ "$CLIENT_SECRET" = "" ] || [ "$PLAN_NAME" = "" ] || [ "$WP_USER_ID" = "" ]; then
+if [ "$CLIENT_ID" = "" ] || [ "$CLIENT_SECRET" = "" ] || [ "$WP_USER_ID" = "" ]; then
     usage
     exit 1
 fi
@@ -54,5 +57,5 @@ ACCESS_TOKEN_JSON=`curl https://$JETPACK_START_API_HOST/oauth2/token --silent --
 wp plugin activate jetpack >/dev/null 2>&1
 
 # provision the partner plan
-wp jetpack partner_provision "$ACCESS_TOKEN_JSON" --user_id=$WP_USER_ID --plan=$PLAN_NAME
+wp jetpack partner_provision "$ACCESS_TOKEN_JSON" --user_id=$WP_USER_ID --plan=$PLAN_NAME --wpcom_user_id=$WPCOM_USER_ID --force_register=1
 

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -57,5 +57,5 @@ ACCESS_TOKEN_JSON=`curl https://$JETPACK_START_API_HOST/oauth2/token --silent --
 wp plugin activate jetpack >/dev/null 2>&1
 
 # provision the partner plan
-wp jetpack partner_provision "$ACCESS_TOKEN_JSON" --user_id=$WP_USER_ID --plan=$PLAN_NAME --wpcom_user_id=$WPCOM_USER_ID --force_register=1
+wp jetpack partner_provision "$ACCESS_TOKEN_JSON" --user_id=$WP_USER_ID --plan=$PLAN_NAME --wpcom_user_id=$WPCOM_USER_ID
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -838,7 +838,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 		$signed_role = Jetpack::sign_role( $role );
 
 		$secrets = Jetpack::init()->generate_secrets( 'authorize' );
-		@list( $secret ) = explode( ':', $secrets );
 
 		$site_icon = ( function_exists( 'has_site_icon') && has_site_icon() )
 			? get_site_icon_url()
@@ -854,7 +853,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 			// Jetpack auth stuff
 			'scope'         => $signed_role,
-			'secret'        => $secret,			
+			'secret'        => $secrets['secret_1'],			
 
 			// User stuff
 			'user_id'       => $user->ID,

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -802,7 +802,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$this->partner_provision_error( $result );
 		}
 
-		WP_CLI::log( print_r( $result, 1 ) );
+		WP_CLI::log( json_encode( $result ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes some issues with the new return signature of the generate_secrets method, and adds a new parameter that selected partners can use to assign a specific WPCOM user to be the master user for a site.

Also makes the plan parameter optional.