### PR TITLE
Comments: Revert "Always use https for jetpack.wordpress.com"

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -275,7 +275,8 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		}
 
 		$params['sig']    = $signature;
-		$url              = "https://jetpack.wordpress.com/jetpack-comment/?" . http_build_query( $params );
+		$url_origin       = set_url_scheme( 'http://jetpack.wordpress.com' );
+		$url              = "{$url_origin}/jetpack-comment/?" . http_build_query( $params );
 		$url              = "{$url}#parent=" . urlencode( set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] ) );
 		$this->signed_url = $url;
 		$height           = $params['comment_registration'] || is_user_logged_in() ? '315' : '430'; // Iframe can be shorter if we're not allowing guest commenting
@@ -332,7 +333,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	 * @since JetpackComments (1.4)
 	 */
 	public function watch_comment_parent() {
-		$url_origin = 'https://jetpack.wordpress.com';
+		$url_origin = set_url_scheme( 'http://jetpack.wordpress.com' );
 	?>
 
 		<!--[if IE]>


### PR DESCRIPTION
In Safari, if the site is http and the iframe loads https, it throws a warning about submitting a secure form to an insecure site.

This is because of the following path:

* http site loading an https iframe (no problem)
* https iframe submitting a form (no problem)
* the iframe takes the submission from the https form to the wp-comments-post.php of the http site (this is the problem)

While we should SSL all the things, we may need to rethink this in light of confusion of scary security warnings. 

As reported in 3216198-t