### PR TITLE
Search: Add Search module

### DIFF
--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-builder.php
@@ -1,0 +1,341 @@
+<?php
+
+
+/**
+ * Provides an interface for easily building a complex search query that
+ * combines multiple ranking signals.
+ *
+ *
+ * $bldr = new Jetpack_WPES_Query_Builder();
+ * $bldr->add_filter( ... );
+ * $bldr->add_filter( ... );
+ * $bldr->add_query( ... );
+ * $es_query = $bldr->build_query();
+ *
+ *
+ * All ES queries take a standard form with main query (with some filters),
+ *  wrapped in a function_score
+ *
+ * Bucketed queries use an aggregation to diversify results. eg a bunch
+ *  of separate filters where to get different sets of results.
+ *
+ */
+
+class Jetpack_WPES_Query_Builder {
+
+	public $es_filters = array();
+
+	// Custom boosting with function_score
+	public $functions = array();
+	public $decays    = array();
+	public $scripts   = array();
+	public $functions_max_boost  = 2.0;
+	public $functions_score_mode = 'multiply';
+	public $query_bool_boost     = null;
+
+	// General aggregations for buckets and metrics
+	public $aggs_query = false;
+	public $aggs       = array();
+
+	// The set of top level text queries to combine
+	public $must_queries    = array();
+	public $should_queries  = array();
+	public $dis_max_queries = array();
+
+	public $diverse_buckets_query = false;
+	public $bucket_filters        = array();
+	public $bucket_sub_aggs       = array();
+
+	////////////////////////////////////
+	// Methods for building a query
+
+	public function add_filter( $filter ) {
+		$this->es_filters[] = $filter;
+	}
+
+	public function add_query( $query, $type = 'must' ) {
+		switch ( $type ) {
+			case 'dis_max':
+				$this->dis_max_queries[] = $query;
+				break;
+
+			case 'should':
+				$this->should_queries[] = $query;
+				break;
+
+			case 'must':
+			default:
+				$this->must_queries[] = $query;
+				break;
+		}
+	}
+
+	/**
+	 * Add a scoring function to the query
+	 *
+	 * NOTE: For decays (linear, exp, or gauss), use Jetpack_WPES_Query_Builder::add_decay() instead
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
+	 *
+	 * @param $function string name of the function
+	 * @param $params array functions parameters
+	 *
+	 * @return void
+	 */
+	public function add_function( $function, $params ) {
+		$this->functions[ $function ][] = $params;
+	}
+
+	/**
+	 * Add a decay function to score results
+	 *
+	 * This method should be used instead of Jetpack_WPES_Query_Builder::add_function() for decays, as the internal  ES structure
+	 * is slightly different for them.
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/guide/current/decay-functions.html
+	 *
+	 * @param $function string name of the decay function - linear, exp, or gauss
+	 * @param $params array The decay functions parameters, passed to ES directly
+	 *
+	 * @return void
+	 */
+	public function add_decay( $function, $params ) {
+		$this->decays[ $function ][] = $params;
+	}
+
+	/**
+	 * Add a scoring mode to the query
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
+	 *
+	 * @param $mode string name of how to score
+	 *
+	 * @return void
+	 */
+	public function add_score_mode_to_functions( $mode='multiply' ) {
+		$this->functions_score_mode = $mode;
+	}
+
+	public function add_max_boost_to_functions( $boost ) {
+		$this->functions_max_boost = $boost;
+	}
+
+	public function add_boost_to_query_bool( $boost ) {
+		$this->query_bool_boost = $boost;
+	}
+
+	public function add_aggs( $aggs_name, $aggs ) {
+		$this->aggs_query = true;
+		$this->aggs[$aggs_name] = $aggs;
+	}
+
+	public function add_aggs_sub_aggs( $aggs_name, $sub_aggs ) {
+		if ( ! array_key_exists( 'aggs', $this->aggs[$aggs_name] ) ) {
+			$this->aggs[$aggs_name]['aggs'] = array();
+		}
+		$this->aggs[$aggs_name]['aggs'] = $sub_aggs;
+	}
+
+	public function add_bucketed_query( $name, $query ) {
+		$this->_add_bucket_filter( $name, $query );
+
+		$this->add_query( $query, 'dis_max' );
+	}
+
+	public function add_bucketed_terms( $name, $field, $terms, $boost = 1 ) {
+		if ( ! is_array( $terms ) ) {
+			$terms = array( $terms );
+		}
+
+		$this->_add_bucket_filter( $name, array(
+			'terms' => array(
+				$field => $terms,
+			),
+		));
+
+		$this->add_query( array(
+			'constant_score' => array(
+				'filter' => array(
+					'terms' => array(
+						$field => $terms,
+					),
+				),
+				'boost' => $boost,
+			),
+		), 'dis_max' );
+	}
+
+	public function add_bucket_sub_aggs( $agg ) {
+		$this->bucket_sub_aggs = array_merge( $this->bucket_sub_aggs, $agg );
+	}
+
+	public function _add_bucket_filter( $name, $filter ) {
+		$this->diverse_buckets_query   = true;
+		$this->bucket_filters[ $name ] = $filter;
+	}
+
+	////////////////////////////////////
+	// Building Final Query
+
+	/**
+	 * Combine all the queries, functions, decays, scripts, and max_boost into an ES query
+	 *
+	 * @return array Array representation of the built ES query
+	 */
+	public function build_query() {
+		$query = array();
+
+		//dis_max queries just become a single must query
+		if ( ! empty( $this->dis_max_queries ) ) {
+			$this->must_queries[] = array(
+				'dis_max' => array(
+					'queries' => $this->dis_max_queries,
+				),
+			);
+		}
+
+		if ( empty( $this->must_queries ) ) {
+			$this->must_queries = array(
+				array(
+					'match_all' => array(),
+				),
+			);
+		}
+
+		if ( empty( $this->should_queries ) ) {
+			if ( 1 == count( $this->must_queries ) ) {
+				$query = $this->must_queries[0];
+			} else {
+				$query = array(
+					'bool' => array(
+						'must' => $this->must_queries,
+					),
+				);
+			}
+		} else {
+			$query = array(
+				'bool' => array(
+					'must'   => $this->must_queries,
+					'should' => $this->should_queries,
+				),
+			);
+		}
+
+		if ( ! is_null( $this->query_bool_boost ) && isset( $query['bool'] ) ) {
+			$query['bool']['boost'] = $this->query_bool_boost;
+		}
+
+		// If there are any function score adjustments, then combine those
+		if ( $this->functions || $this->decays || $this->scripts ) {
+			$weighting_functions = array();
+
+			if ( $this->functions ) {
+				foreach ( $this->functions as $function_type => $configs ) {
+					foreach ( $configs as $config ) {
+						foreach ( $config as $field => $params ) {
+							$func_arr = $params;
+
+							$func_arr['field'] = $field;
+
+							$weighting_functions[] = array(
+								$function_type => $func_arr,
+							);
+						}
+					}
+				}
+			}
+
+			if ( $this->decays ) {
+				foreach ( $this->decays as $decay_type => $configs ) {
+					foreach ( $configs as $config ) {
+						foreach ( $config as $field => $params ) {
+							$weighting_functions[] = array(
+								$decay_type => array(
+									$field => $params,
+								),
+							);
+						}
+					}
+				}
+			}
+
+			if ( $this->scripts ) {
+				foreach ( $this->scripts as $script ) {
+					$weighting_functions[] = array(
+						'script_score' => array(
+							'script' => $script,
+						),
+					);
+				}
+			}
+
+			$query = array(
+				'function_score' => array(
+					'query'     => $query,
+					'functions' => $weighting_functions,
+					'max_boost' => $this->functions_max_boost,
+					'score_mode' => $this->functions_score_mode,
+				),
+			);
+		} // End if().
+
+		return $query;
+	}
+
+	/**
+	 * Assemble the 'filter' portion of an ES query, from all registered filters
+	 *
+	 * @return array|null Combiled ES filters, or null if none have been defined
+	 */
+	public function build_filter() {
+		if ( empty( $this->es_filters ) ) {
+			$filter = null;
+		} elseif ( 1 == count( $this->es_filters ) ) {
+			$filter = $this->es_filters[0];
+		} else {
+			$filter = array(
+				'and' => $this->es_filters,
+			);
+		}
+
+		return $filter;
+	}
+
+	/**
+	 * Assemble the 'aggregation' portion of an ES query, from all general aggregations.
+	 *
+	 * @return an aggregation query as an array of topics, filters, and bucket names
+	 */
+	function build_aggregation() {
+		if ( empty( $this->bucket_sub_aggs ) && empty( $this->aggs_query ) ) {
+			return array();
+		}
+
+		if ( ! $this->diverse_buckets_query && empty( $this->aggs_query ) ) {
+			return $this->bucket_sub_aggs;
+		}
+
+		$aggregations = array(
+			'topics' => array(
+				'filters' => array(
+					'filters' => array(),
+				),
+			),
+		);
+
+		if ( ! empty( $this->bucket_sub_aggs ) ) {
+			$aggregations['topics']['aggs'] = $this->bucket_sub_aggs;
+		}
+
+		foreach ( $this->bucket_filters as $bucket_name => $filter ) {
+			$aggregations['topics']['filters']['filters'][ $bucket_name ] = $filter;
+		}
+
+		if ( ! empty( $this->aggs_query ) ) {
+			$aggregations = $this->aggs;
+		}
+
+		return $aggregations;
+	}
+
+}

--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
@@ -134,10 +134,11 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 		$lst = array();
 		foreach( $langs as $l ) {
 			$l = strtok( $l, '-_' );
-			if (in_array( $l, $this->avail_langs ) )
+			if ( in_array( $l, $this->avail_langs ) ) {
 				$lst[$l] = true;
-			else
+			} else {
 				$lst['default'] = true;
+			}
 		}
 		return array_keys( $lst );
 	}
@@ -190,13 +191,15 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 		foreach( $args['prefixes'] as $p ) {
 			$found = $this->get_fields( $p );
 			if ( $found ) {
-				foreach( $found as $f )
+				foreach( $found as $f ) {
 					$names[] = $f;
+				}
 			}
 		}
 
-		if ( empty( $names ) )
+		if ( empty( $names ) ) {
 			return false;
+		}
 
 		foreach( $args['prefixes'] as $p ) {
 			$this->remove_fields( $p );
@@ -211,7 +214,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 			$userdata = get_user_by( 'login', strtolower( $n ) );
 			$filtering = false;
 			if ( $userdata ) {
-				$user_ids[$userdata->ID] = true;
+				$user_ids[ $userdata->ID ] = true;
 				$filtering = true;
 			}
 
@@ -290,13 +293,15 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 		foreach( $args['prefixes'] as $p ) {
 			$found = $this->get_fields( $p );
 			if ( $found ) {
-				foreach( $found as $f )
+				foreach( $found as $f ) {
 					$tags[] = $f;
+				}
 			}
 		}
 
-		if ( empty( $tags ) )
+		if ( empty( $tags ) ) {
 			return false;
+		}
 
 		foreach( $args['prefixes'] as $p ) {
 			$this->remove_fields( $p );
@@ -309,7 +314,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 				$t = preg_replace( '/"/', '', $t );
 			}
 
-			if ( !empty( $args['must_query_fields'] ) ) {
+			if ( ! empty( $args['must_query_fields'] ) ) {
 				if ( $is_phrase ) {
 					$this->add_query( array(
 						'multi_match' => array(
@@ -326,7 +331,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 				}
 			}
 
-			if ( !empty( $args['boost_query_fields'] ) ) {
+			if ( ! empty( $args['boost_query_fields'] ) ) {
 				if ( $is_phrase ) {
 					$this->add_query( array(
 						'multi_match' => array(
@@ -392,10 +397,12 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 			$this->current_query = preg_replace( "/'([^']+)$/", '', $this->current_query );
 		}
 
-		if ( $phrase_prefix )
+		if ( $phrase_prefix ) {
 			$phrases[] = $phrase_prefix;
-		if( empty( $phrases ) )
+		}
+		if ( empty( $phrases ) ) {
 			return false;
+		}
 
 		foreach ( $phrases as $p ) {
 			$this->add_query( array(
@@ -405,7 +412,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 					'type' => 'phrase',
 				) ) );
 
-			if ( !empty( $args['boost_query_fields'] ) ) {
+			if ( ! empty( $args['boost_query_fields'] ) ) {
 				$this->add_query( array(
 					'multi_match' => array(
 						'fields' => $args['boost_query_fields'],
@@ -437,10 +444,11 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 		);
 		$args = wp_parse_args( $args, $defaults );
 
-		if ( empty( $this->current_query ) || ctype_space( $this->current_query ) )
+		if ( empty( $this->current_query ) || ctype_space( $this->current_query ) ) {
 			return;
+		}
 
-		if ( !empty( $args['must_query_fields'] ) ) {
+		if ( ! empty( $args['must_query_fields'] ) ) {
 			$this->add_query( array(
 				'multi_match' => array(
 					'fields' => $args['must_query_fields'],
@@ -449,7 +457,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 			) ) );
 		}
 
-		if ( !empty( $args['boost_query_fields'] ) ) {
+		if ( ! empty( $args['boost_query_fields'] ) ) {
 			$this->add_query( array(
 				'multi_match' => array(
 					'fields' => $args['boost_query_fields'],
@@ -481,8 +489,9 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 		);
 		$args = wp_parse_args( $args, $defaults );
 
-		if ( empty( $this->current_query ) || ctype_space( $this->current_query ) )
+		if ( empty( $this->current_query ) || ctype_space( $this->current_query ) ) {
 			return;
+		}
 
 		//////////////////////////////////
 		// Example cases to think about:
@@ -505,16 +514,18 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 
 		$prefix_word = false;
 		$prefix_remainder = false;
-		if ( preg_match_all( '/([^ ]+)$/', $this->current_query, $matches ) )
+		if ( preg_match_all( '/([^ ]+)$/', $this->current_query, $matches ) ) {
 			$prefix_word = $matches[1][0];
+		}
 
 		$prefix_remainder = preg_replace( '/([^ ]+)$/', '', $this->current_query );
-		if ( ctype_space( $prefix_remainder ) )
+		if ( ctype_space( $prefix_remainder ) ) {
 			$prefix_remainder = false;
+		}
 
-		if ( !$prefix_word ) {
+		if ( ! $prefix_word ) {
 			//Space at the end of the query, so skip using a prefix query
-			if ( !empty( $args['must_query_fields'] ) ) {
+			if ( ! empty( $args['must_query_fields'] ) ) {
 				$this->add_query( array(
 					'multi_match' => array(
 						'fields' => $args['must_query_fields'],
@@ -523,7 +534,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 					) ) );
 			}
 
-			if ( !empty( $args['boost_query_fields'] ) ) {
+			if ( ! empty( $args['boost_query_fields'] ) ) {
 				$this->add_query( array(
 					'multi_match' => array(
 						'fields' => $args['boost_query_fields'],
@@ -535,7 +546,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 		} else {
 
 			//must match the prefix word and the prefix remainder
-			if ( !empty( $args['must_query_fields'] ) ) {
+			if ( ! empty( $args['must_query_fields'] ) ) {
 				//need to do an OR across a few fields to handle all cases
 				$must_q = array( 'bool' => array( 'should' => array( ), 'minimum_should_match' => 1 ) );
 
@@ -587,7 +598,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 			}
 
 			//Now add any boosting of the query
-			if ( !empty( $args['boost_query_fields'] ) ) {
+			if ( ! empty( $args['boost_query_fields'] ) ) {
 				//treat all words as an exact search (boosts complete word like "news"
 				//from prefixes of "newspaper")
 				$this->add_query( array(
@@ -633,7 +644,7 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 	//Get the text after some prefix. eg @gibrown, or @"Greg Brown"
 	protected function get_fields( $field_prefix ) {
 		$regex = '/' . $field_prefix . '(("[^"]+")|([^\\p{Z}]+))/';
-		if( preg_match_all( $regex, $this->current_query, $match ) ) {
+		if ( preg_match_all( $regex, $this->current_query, $match ) ) {
 			return $match[1];
 		}
 		return false;
@@ -647,8 +658,9 @@ class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
 
 	//Best effort string truncation that splits on word breaks
 	function truncate_string( $string, $limit, $break=" " ) {
-		if ( mb_strwidth( $string ) <= $limit )
+		if ( mb_strwidth( $string ) <= $limit ) {
 			return $string;
+		}
 
 		// walk backwards from $limit to find first break
 		$breakpoint = $limit;

--- a/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
+++ b/_inc/lib/jetpack-wpes-query-builder/jetpack-wpes-query-parser.php
@@ -1,0 +1,671 @@
+<?php
+
+/**
+ * Parse a pure text query into WordPress Elasticsearch query. This builds on
+ * the Jetpack_WPES_Query_Builder() to provide search query parsing.
+ *
+ * The key part of this parser is taking a user's query string typed into a box
+ * and converting it into an ES search query.
+ *
+ * This varies by application, but roughly it means extracting some parts of the query
+ * (authors, tags, and phrases) that are treated as a filter. Then taking the
+ * remaining words and building the correct query (possibly with prefix searching
+ * if we are doing search as you type)
+ *
+ * This class only supports ES 2.x+
+ *
+ * This parser builds queries of the form:
+ *   bool:
+ *     must:
+ *       AND match of a single field (ideally an edgengram field)
+ *     filter:
+ *       filter clauses from context (eg @gibrown, #news, etc)
+ *     should:
+ *       boosting of results by various fields
+ *
+ * Features supported:
+ *  - search as you type
+ *  - phrases
+ *  - supports querying across multiple languages at once
+ *
+ * Example usage (from Search on Reader Manage):
+ *
+ *		require_lib( 'jetpack-wpes-query-builder/jetpack-wpes-search-query-parser' );
+ *		$parser = new WPES_Search_Query_Parser( $args['q'], array( $lang ) );
+ *
+ *		//author
+ *		$parser->author_field_filter( array(
+ *			'prefixes' => array( '@' ),
+ *			'wpcom_id_field' => 'author_id',
+ *			'must_query_fields' => array( 'author.engram', 'author_login.engram' ),
+ *			'boost_query_fields' => array( 'author^2', 'author_login^2', 'title.default.engram' ),
+ *		) );
+ *
+ *		//remainder of query
+ *		$match_content_fields = $parser->merge_ml_fields(
+ *			array(
+ *				'all_content' => 0.1,
+ *			),
+ *			array(
+ *				'all_content.default.engram^0.1',
+ *			)
+ *		);
+ *		$boost_content_fields = $parser->merge_ml_fields(
+ *			array(
+ *				'title' => 2,
+ *				'description' => 1,
+ *				'tags' => 1,
+ *			),
+ *			array(
+ *				'author_login^2',
+ *				'author^2',
+ *			)
+ *		);
+ *
+ *		$parser->phrase_filter( array(
+ *			'must_query_fields' => $match_content_fields,
+ *			'boost_query_fields' => $boost_content_fields,
+ *		) );
+ *		$parser->remaining_query( array(
+ *			'must_query_fields' => $match_content_fields,
+ *			'boost_query_fields' => $boost_content_fields,
+ *		) );
+ *
+ *		//Boost on phrases
+ *		$parser->remaining_query( array(
+ *			'boost_query_fields' => $boost_content_fields,
+ *			'boost_query_type'   => 'phrase',
+ *		) );
+ *
+ *		//boosting
+ *		$parser->add_max_boost_to_functions( 20 );
+ *		$parser->add_function( 'field_value_factor', array(
+ *			'follower_count' => array(
+ *				'modifier' => 'sqrt',
+ *				'factor' => 1,
+ *				'missing' => 0,
+ *			) ) );
+ *
+ *		//Filtering
+ *		$parser->add_filter( array(
+ *			'exists' => array( 'field' => 'langs.' . $lang )
+ *		) );
+ *
+ *		//run the query
+ *		$es_query_args = array(
+ *			'name' => 'feeds',
+ *			'blog_id' => false,
+ *			'security_strategy' => 'a8c',
+ *			'type' => 'feed,blog',
+ *			'fields' => array( 'blog_id', 'feed_id' ),
+ *			'query' => $parser->build_query(),
+ *			'filter' => $parser->build_filter(),
+ *			'size' => $size,
+ *			'from' => $from
+ *		);
+ *		$es_results = es_api_search_index( $es_query_args, 'api-feed-find' );
+ *
+ */
+
+jetpack_require_lib( 'jetpack-wpes-query-builder' );
+
+class Jetpack_WPES_Search_Query_Parser extends Jetpack_WPES_Query_Builder {
+
+	var $orig_query = '';
+	var $current_query = '';
+	var $langs;
+	var $avail_langs = array( 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'eu', 'fa', 'fi', 'fr', 'he', 'hi', 'hu', 'hy', 'id', 'it', 'ja', 'ko', 'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr', 'zh' );
+
+	function __construct( $user_query, $langs ) {
+		$this->orig_query = $user_query;
+		$this->current_query = $this->orig_query;
+		$this->langs = $this->norm_langs( $langs );
+	}
+
+	var $extracted_phrases = array();
+
+	///////////////////////////////////////////////////////
+	// Methods for Building arrays of multilingual fields
+
+	/*
+	 * Normalize language codes
+	 */
+	function norm_langs( $langs ) {
+		$lst = array();
+		foreach( $langs as $l ) {
+			$l = strtok( $l, '-_' );
+			if (in_array( $l, $this->avail_langs ) )
+				$lst[$l] = true;
+			else
+				$lst['default'] = true;
+		}
+		return array_keys( $lst );
+	}
+
+	/*
+	 * Take a list of field prefixes and expand them for multi-lingual
+	 * with the provided boostings.
+	 */
+	function merge_ml_fields( $fields2boosts, $additional_fields ) {
+		$flds = array();
+		foreach( $fields2boosts as $f => $b ) {
+			foreach( $this->langs as $l ) {
+				$flds[] = $f . '.' . $l . '^' . $b;
+			}
+		}
+		foreach( $additional_fields as $f ) {
+			$flds[] = $f;
+		}
+		return $flds;
+	}
+
+	////////////////////////////////////
+	// Extract Fields for Filtering on
+
+	/*
+	 * Extract any @mentions from the user query
+	 *  use them as a filter if we can find a wp.com id
+	 *  otherwise use them as a
+	 *
+	 *  args:
+	 *    wpcom_id_field: wp.com id field
+	 *    must_query_fields: array of fields to search for matching results (optional)
+	 *    boost_query_fields: array of fields to search in for boosting results (optional)
+	 *    prefixes: array of prefixes that the user can use to indicate an author
+	 *
+	 *  returns true/false of whether any were found
+	 *
+	 * See also: https://github.com/twitter/twitter-text/blob/master/java/src/com/twitter/Regex.java
+	 */
+	function author_field_filter( $args ) {
+		$defaults = array(
+			'wpcom_id_field' => 'author_id',
+			'must_query_fields' => null,
+			'boost_query_fields' => null,
+			'prefixes' => array( '@' ),
+		);
+		$args = wp_parse_args( $args, $defaults );
+
+		$names = array();
+		foreach( $args['prefixes'] as $p ) {
+			$found = $this->get_fields( $p );
+			if ( $found ) {
+				foreach( $found as $f )
+					$names[] = $f;
+			}
+		}
+
+		if ( empty( $names ) )
+			return false;
+
+		foreach( $args['prefixes'] as $p ) {
+			$this->remove_fields( $p );
+		}
+
+		$user_ids = array();
+		$query_names = array();
+
+		//loop through the matches and separate into filters and queries
+		foreach( $names as $n ) {
+			//check for exact match on login
+			$userdata = get_user_by( 'login', strtolower( $n ) );
+			$filtering = false;
+			if ( $userdata ) {
+				$user_ids[$userdata->ID] = true;
+				$filtering = true;
+			}
+
+			$is_phrase = false;
+			if ( preg_match( '/"/', $n ) ) {
+				$is_phrase = true;
+				$n = preg_replace( '/"/', '', $n );
+			}
+
+			if ( !empty( $args['must_query_fields'] ) && !$filtering ) {
+				if ( $is_phrase ) {
+					$this->add_query( array(
+						'multi_match' => array(
+							'fields' => $args['must_query_fields'],
+							'query' => $n,
+							'type' => 'phrase',
+					) ) );
+				} else {
+					$this->add_query( array(
+						'multi_match' => array(
+							'fields' => $args['must_query_fields'],
+							'query' => $n,
+					) ) );
+				}
+			}
+
+			if ( !empty( $args['boost_query_fields'] ) ) {
+				if ( $is_phrase ) {
+					$this->add_query( array(
+						'multi_match' => array(
+							'fields' => $args['boost_query_fields'],
+							'query' => $n,
+							'type' => 'phrase',
+					) ), 'should' );
+				} else {
+					$this->add_query( array(
+						'multi_match' => array(
+							'fields' => $args['boost_query_fields'],
+							'query' => $n,
+					) ), 'should' );
+				}
+			}
+		}
+
+		if ( ! empty( $user_ids ) ) {
+			$user_ids = array_keys( $user_ids );
+			$this->add_filter( array( 'terms' => array( $args['wpcom_id_field'] => $user_ids ) ) );
+		}
+
+		return true;
+	}
+
+	/*
+	 * Extract any prefix followed by text use them as a must clause,
+	 *   and optionally as a boost to the should query
+	 *   This can be used for hashtags. eg #News, or #"current events",
+	 *   but also works for any arbitrary field. eg from:Greg
+	 *
+	 *  args:
+	 *    must_query_fields: array of fields that must match the tag (optional)
+	 *    boost_query_fields: array of fields to boost search on (optional)
+	 *    prefixes: array of prefixes that the user can use to indicate a tag
+	 *
+	 *  returns true/false of whether any were found
+	 *
+	 */
+	function text_field_filter( $args ) {
+		$defaults = array(
+			'must_query_fields' => array( 'tag.name' ),
+			'boost_query_fields' => array( 'tag.name' ),
+			'prefixes' => array( '#' ),
+		);
+		$args = wp_parse_args( $args, $defaults );
+
+		$tags = array();
+		foreach( $args['prefixes'] as $p ) {
+			$found = $this->get_fields( $p );
+			if ( $found ) {
+				foreach( $found as $f )
+					$tags[] = $f;
+			}
+		}
+
+		if ( empty( $tags ) )
+			return false;
+
+		foreach( $args['prefixes'] as $p ) {
+			$this->remove_fields( $p );
+		}
+
+		foreach( $tags as $t ) {
+			$is_phrase = false;
+			if ( preg_match( '/"/', $t ) ) {
+				$is_phrase = true;
+				$t = preg_replace( '/"/', '', $t );
+			}
+
+			if ( !empty( $args['must_query_fields'] ) ) {
+				if ( $is_phrase ) {
+					$this->add_query( array(
+						'multi_match' => array(
+							'fields' => $args['must_query_fields'],
+							'query' => $t,
+							'type' => 'phrase',
+					) ) );
+				} else {
+					$this->add_query( array(
+						'multi_match' => array(
+							'fields' => $args['must_query_fields'],
+							'query' => $t,
+					) ) );
+				}
+			}
+
+			if ( !empty( $args['boost_query_fields'] ) ) {
+				if ( $is_phrase ) {
+					$this->add_query( array(
+						'multi_match' => array(
+							'fields' => $args['boost_query_fields'],
+							'query' => $t,
+							'type' => 'phrase',
+					) ), 'should' );
+				} else {
+					$this->add_query( array(
+						'multi_match' => array(
+							'fields' => $args['boost_query_fields'],
+							'query' => $t,
+					) ), 'should' );
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/*
+	 * Extract anything surrounded by quotes or if there is an opening quote
+	 *   that is not complete, and add them to the query as a phrase query.
+	 *   Quotes can be either '' or ""
+	 *
+	 *  args:
+	 *    must_query_fields: array of fields that must match the phrases
+	 *    boost_query_fields: array of fields to boost the phrases on (optional)
+	 *
+	 *  returns true/false of whether any were found
+	 *
+	 */
+	function phrase_filter( $args ) {
+		$defaults = array(
+			'must_query_fields' => array( 'all_content' ),
+			'boost_query_fields' => array( 'title' ),
+		);
+		$args = wp_parse_args( $args, $defaults );
+
+		$phrases = array();
+		if ( preg_match_all( '/"([^"]+)"/', $this->current_query, $matches ) ) {
+			foreach ( $matches[1] as $match ) {
+				$phrases[] = $match;
+			}
+			$this->current_query = preg_replace( '/"([^"]+)"/', '', $this->current_query );
+		}
+
+		if ( preg_match_all( "/'([^']+)'/", $this->current_query, $matches ) ) {
+			foreach ( $matches[1] as $match ) {
+				$phrases[] = $match;
+			}
+			$this->current_query = preg_replace( "/'([^']+)'/", '', $this->current_query );
+		}
+
+		//look for a final, uncompleted phrase
+		$phrase_prefix = false;
+		if ( preg_match_all( '/"([^"]+)$/', $this->current_query, $matches ) ) {
+			$phrase_prefix = $matches[1][0];
+			$this->current_query = preg_replace( '/"([^"]+)$/', '', $this->current_query );
+		}
+		if ( preg_match_all( "/'([^']+)$/", $this->current_query, $matches ) ) {
+			$phrase_prefix = $matches[1][0];
+			$this->current_query = preg_replace( "/'([^']+)$/", '', $this->current_query );
+		}
+
+		if ( $phrase_prefix )
+			$phrases[] = $phrase_prefix;
+		if( empty( $phrases ) )
+			return false;
+
+		foreach ( $phrases as $p ) {
+			$this->add_query( array(
+				'multi_match' => array(
+					'fields' => $args['must_query_fields'],
+					'query' => $p,
+					'type' => 'phrase',
+				) ) );
+
+			if ( !empty( $args['boost_query_fields'] ) ) {
+				$this->add_query( array(
+					'multi_match' => array(
+						'fields' => $args['boost_query_fields'],
+						'query' => $p,
+						'operator' => 'and',
+				) ), 'should' );
+			}
+		}
+
+		return true;
+	}
+
+	/*
+	 * Query fields based on the remaining parts of the query
+	 *   This could be the final AND part of the query terms to match, or it
+	 *   could be boosting certain elements of the query
+	 *
+	 *  args:
+	 *    must_query_fields: array of fields that must match the remaining terms (optional)
+	 *    boost_query_fields: array of fields to boost the remaining terms on (optional)
+	 *
+	 */
+	function remaining_query( $args ) {
+		$defaults = array(
+			'must_query_fields' => null,
+			'boost_query_fields' => null,
+			'boost_operator' => 'and',
+			'boost_query_type' => 'best_fields',
+		);
+		$args = wp_parse_args( $args, $defaults );
+
+		if ( empty( $this->current_query ) || ctype_space( $this->current_query ) )
+			return;
+
+		if ( !empty( $args['must_query_fields'] ) ) {
+			$this->add_query( array(
+				'multi_match' => array(
+					'fields' => $args['must_query_fields'],
+					'query' => $this->current_query,
+					'operator' => 'and',
+			) ) );
+		}
+
+		if ( !empty( $args['boost_query_fields'] ) ) {
+			$this->add_query( array(
+				'multi_match' => array(
+					'fields' => $args['boost_query_fields'],
+					'query' => $this->current_query,
+					'operator' => $args['boost_operator'],
+					'type' => $args['boost_query_type'],
+			) ), 'should' );
+		}
+
+	}
+
+	/*
+	 * Query fields using a prefix query (alphabetical expansions on the index).
+	 *   This is not recommended. Slower performance and worse relevancy.
+	 *
+	 *  (UNTESTED! Copied from old prefix expansion code)
+	 *
+	 *  args:
+	 *    must_query_fields: array of fields that must match the remaining terms (optional)
+	 *    boost_query_fields: array of fields to boost the remaining terms on (optional)
+	 *
+	 */
+	function remaining_prefix_query( $args ) {
+		$defaults = array(
+			'must_query_fields' => array( 'all_content' ),
+			'boost_query_fields' => array( 'title' ),
+			'boost_operator' => 'and',
+			'boost_query_type' => 'best_fields',
+		);
+		$args = wp_parse_args( $args, $defaults );
+
+		if ( empty( $this->current_query ) || ctype_space( $this->current_query ) )
+			return;
+
+		//////////////////////////////////
+		// Example cases to think about:
+		// "elasticse"
+		// "elasticsearch"
+		// "elasticsearch "
+		// "elasticsearch lucen"
+		// "elasticsearch lucene"
+		// "the future"  - note the stopword which will match nothing!
+		// "F1" - an exact match that also has tons of expansions
+		// "こんにちは" ja "hello"
+		// "こんにちは友人" ja "hello friend" - we just rely on the prefix phrase and ES to split words
+		//   - this could still be better I bet. Maybe we need to analyze with ES first?
+		//
+
+		/////////////////////////////
+		//extract pieces of query
+		// eg: "PREFIXREMAINDER PREFIXWORD"
+		//     "elasticsearch lucen"
+
+		$prefix_word = false;
+		$prefix_remainder = false;
+		if ( preg_match_all( '/([^ ]+)$/', $this->current_query, $matches ) )
+			$prefix_word = $matches[1][0];
+
+		$prefix_remainder = preg_replace( '/([^ ]+)$/', '', $this->current_query );
+		if ( ctype_space( $prefix_remainder ) )
+			$prefix_remainder = false;
+
+		if ( !$prefix_word ) {
+			//Space at the end of the query, so skip using a prefix query
+			if ( !empty( $args['must_query_fields'] ) ) {
+				$this->add_query( array(
+					'multi_match' => array(
+						'fields' => $args['must_query_fields'],
+						'query' => $this->current_query,
+						'operator' => 'and',
+					) ) );
+			}
+
+			if ( !empty( $args['boost_query_fields'] ) ) {
+				$this->add_query( array(
+					'multi_match' => array(
+						'fields' => $args['boost_query_fields'],
+						'query' => $this->current_query,
+						'operator' => $args['boost_operator'],
+						'type' => $args['boost_query_type'],
+					) ), 'should' );
+			}
+		} else {
+
+			//must match the prefix word and the prefix remainder
+			if ( !empty( $args['must_query_fields'] ) ) {
+				//need to do an OR across a few fields to handle all cases
+				$must_q = array( 'bool' => array( 'should' => array( ), 'minimum_should_match' => 1 ) );
+
+				//treat all words as an exact search (boosts complete word like "news"
+				//from prefixes of "newspaper")
+				$must_q['bool']['should'][] = array( 'multi_match' => array(
+					'fields' => $this->all_fields,
+					'query' => $full_text,
+					'operator' => 'and',
+					'type' => 'cross_fields',
+				) );
+
+				//always optimistically try and match the full text as a phrase
+				//prefix "the futu" should try to match "the future"
+				//otherwise the first stopword kinda breaks
+				//This also works as the prefix match for a single word "elasticsea"
+				$must_q['bool']['should'][] = array( 'multi_match' => array(
+					'fields' => $this->phrase_fields,
+					'query' => $full_text,
+					'operator' => 'and',
+					'type' => 'phrase_prefix',
+					'max_expansions' => 100,
+				) );
+
+				if ( $prefix_remainder ) {
+					//Multiple words found, so treat each word on its own and not just as
+					//a part of a phrase
+					//"elasticsearch lucen" => "elasticsearch" exact AND "lucen" prefix
+					$q['bool']['should'][] = array( 'bool' => array(
+						'must' => array(
+							array( 'multi_match' => array(
+								'fields' => $this->phrase_fields,
+								'query' => $prefix_word,
+								'operator' => 'and',
+								'type' => 'phrase_prefix',
+								'max_expansions' => 100,
+							) ),
+							array( 'multi_match' => array(
+								'fields' => $this->all_fields,
+								'query' => $prefix_remainder,
+								'operator' => 'and',
+								'type' => 'cross_fields',
+							) ),
+						)
+					) );
+				}
+
+				$this->add_query( $must_q );
+			}
+
+			//Now add any boosting of the query
+			if ( !empty( $args['boost_query_fields'] ) ) {
+				//treat all words as an exact search (boosts complete word like "news"
+				//from prefixes of "newspaper")
+				$this->add_query( array(
+					'multi_match' => array(
+						'fields' => $args['boost_query_fields'],
+						'query' => $this->current_query,
+						'operator' => $args['boost_query_operator'],
+						'type' => $args['boost_query_type'],
+					) ), 'should' );
+
+				//optimistically boost the full phrase prefix match
+				$this->add_query( array(
+					'multi_match' => array(
+						'fields' => $args['boost_query_fields'],
+						'query' => $this->current_query,
+						'operator' => 'and',
+						'type' => 'phrase_prefix',
+						'max_expansions' => 100,
+					) ) );
+			}
+		}
+	}
+
+	/*
+	 * Boost results based on the lang probability overlaps
+	 *
+	 *  args:
+	 *    langs2prob: list of languages to search in with associated boosts
+	 */
+	function boost_lang_probs( $langs2prob ) {
+		foreach( $langs2prob as $l => $p ) {
+			$this->add_function( 'field_value_factor', array(
+				'modifier' => 'none',
+				'factor' => $p,
+				'missing' => 0.01, //1% chance doc did not have right lang detected
+			) );
+		}
+	}
+
+	////////////////////////////////////
+	// Helper Methods
+
+	//Get the text after some prefix. eg @gibrown, or @"Greg Brown"
+	protected function get_fields( $field_prefix ) {
+		$regex = '/' . $field_prefix . '(("[^"]+")|([^\\p{Z}]+))/';
+		if( preg_match_all( $regex, $this->current_query, $match ) ) {
+			return $match[1];
+		}
+		return false;
+	}
+
+	//Remove the prefix and text from the query
+	protected function remove_fields( $field_name ) {
+		$regex = '/' . $field_name . '(("[^"]+")|([^\\p{Z}]+))/';
+		$this->current_query = preg_replace( $regex, '', $this->current_query );
+	}
+
+	//Best effort string truncation that splits on word breaks
+	function truncate_string( $string, $limit, $break=" " ) {
+		if ( mb_strwidth( $string ) <= $limit )
+			return $string;
+
+		// walk backwards from $limit to find first break
+		$breakpoint = $limit;
+		$broken = false;
+		while ( $breakpoint > 0 ) {
+			if ( $break === mb_strimwidth( $string, $breakpoint, 1 ) ) {
+				$string = mb_strimwidth( $string, 0, $breakpoint );
+				$broken = true;
+				break;
+			}
+			$breakpoint--;
+		}
+		// if we weren't able to find a break, need to chop mid-word
+		if ( !$broken ) {
+			$string = mb_strimwidth( $string, 0, $limit );
+		}
+		return $string;
+	}
+
+}

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -82,7 +82,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			<# var i = 0;
 			if ( data.items.length ) {
 			_.each( data.items, function( item, key, list ) {
-				if ( item === undefined ) return; #>
+				if ( item === undefined || 'search' == item.module ) return; #>
 				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
 					<th scope="row" class="check-column">
 						<# if ( 'videopress' !== item.module ) { #>

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -143,6 +143,11 @@ function jetpack_get_module_i18n( $key ) {
 				'recommended description' => _x( 'Keep visitors engaged on your blog by highlighting relevant and new content at the bottom of each published post.', 'Jumpstart Description', 'jetpack' ),
 			),
 
+			'search' => array(
+				'name' => _x( 'Search', 'Module Name', 'jetpack' ),
+				'description' => _x( 'Enhanced search, powered by Elasticsearch', 'Module Description', 'jetpack' ),
+			),
+
 			'seo-tools' => array(
 				'name' => _x( 'SEO Tools', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Better results on search engines and social media.', 'Module Description', 'jetpack' ),

--- a/modules/search.php
+++ b/modules/search.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Module Name: Search
+ * Module Description: Enhanced search, powered by Elasticsearch
+ * First Introduced: 5.0
+ * Free: false
+ * Requires Connection: Yes
+ * Auto Activate: No
+ * Feature: Search
+ * Additional Search Queries: search
+ */
+
+require_once( __DIR__ . '/search/class.jetpack-search.php' );

--- a/modules/search.php
+++ b/modules/search.php
@@ -11,4 +11,4 @@
  * Additional Search Queries: search
  */
 
-require_once( __DIR__ . '/search/class.jetpack-search.php' );
+require_once( dirname( __FILE__ ) . '/search/class.jetpack-search.php' );

--- a/modules/search.php
+++ b/modules/search.php
@@ -12,3 +12,5 @@
  */
 
 require_once( dirname( __FILE__ ) . '/search/class.jetpack-search.php' );
+
+Jetpack_Search::instance();

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -124,4 +124,3 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		<?php
 	}
 }
-

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -13,6 +13,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 		parent::__construct(
 			'jetpack-search-filters',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
 			apply_filters( 'jetpack_widget_name', esc_html__( 'Search Filters', 'jetpack' ) ),
 			array(
 				'classname'   => 'jetpack-filters',
@@ -56,6 +57,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 			$title = __( 'Filter By', 'jetpack' );
 		}
 
+		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -40,7 +40,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 		$buckets_found = false;
 
 		foreach ( $filters as $filter ) {
-			if ( count( $filter['buckets'] ) > 1 ) {
+			if ( isset( $filter['buckets'] ) && count( $filter['buckets'] ) > 1 ) {
 				$buckets_found = true;
 
 				break;

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -13,7 +13,7 @@ class Jetpack_Search_Widget_Filters extends WP_Widget {
 
 		parent::__construct(
 			'jetpack-search-filters',
-			apply_filters( 'jetpack_widget_name', esc_html__( 'Search Filters (Jetpack)', 'jetpack' ) ),
+			apply_filters( 'jetpack_widget_name', esc_html__( 'Search Filters', 'jetpack' ) ),
 			array(
 				'classname'   => 'jetpack-filters',
 				'description' => __( 'Displays search result filters when viewing search results.', 'jetpack' ),

--- a/modules/search/class.jetpack-search-widget-filters.php
+++ b/modules/search/class.jetpack-search-widget-filters.php
@@ -1,0 +1,125 @@
+<?php
+
+
+/**
+ * Provides a widget to show available/selected filters on searches
+ */
+class Jetpack_Search_Widget_Filters extends WP_Widget {
+
+	function __construct() {
+		if ( ! class_exists( 'Jetpack_Search' ) ) {
+			return;
+		}
+
+		parent::__construct(
+			'jetpack-search-filters',
+			apply_filters( 'jetpack_widget_name', esc_html__( 'Search Filters (Jetpack)', 'jetpack' ) ),
+			array(
+				'classname'   => 'jetpack-filters',
+				'description' => __( 'Displays search result filters when viewing search results.', 'jetpack' ),
+			)
+		);
+	}
+
+	function widget( $args, $instance ) {
+		if ( ! class_exists( 'Jetpack_Search' ) || ! is_search() ) {
+			return;
+		}
+
+		$search = Jetpack_Search::instance();
+
+		$filters = $search->get_filters();
+
+		$active_buckets = $search->get_active_filter_buckets();
+
+		if ( empty( $filters ) && empty( $active_buckets ) ) {
+			return;
+		}
+
+		$buckets_found = false;
+
+		foreach ( $filters as $filter ) {
+			if ( count( $filter['buckets'] ) > 1 ) {
+				$buckets_found = true;
+
+				break;
+			}
+		}
+
+		if ( ! $buckets_found && empty( $active_buckets ) ) {
+			return;
+		}
+
+		$title = $instance['title'];
+
+		if ( empty( $title ) ) {
+			$title = __( 'Filter By', 'jetpack' );
+		}
+
+		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
+
+		echo $args['before_widget'];
+
+		echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+
+		if ( ! empty( $active_buckets ) ) {
+			echo '<h3>' . esc_html__( 'Current Filters', 'jetpack' ) . '</h3>';
+
+			echo '<ul>';
+
+			foreach ( $active_buckets as $item ) {
+				echo '<li><a href="' . esc_url( $item['remove_url'] ) . '">' . sprintf( _x( '(X) %1$s: %2$s', 'aggregation widget: active filter type and name', 'jetpack' ), esc_html( $item['type_label'] ), esc_html( $item['name'] ) ) . '</a></li>';
+			}
+
+			if ( count( $active_buckets ) > 1 ) {
+				echo '<li><a href="' . esc_url( add_query_arg( 's', get_query_var( 's' ), home_url() ) ) . '">' . esc_html__( 'Remove All Filters', 'jetpack' ) . '</a></li>';
+			}
+
+			echo '</ul>';
+		}
+
+		foreach ( $filters as $label => $filter ) {
+			if ( count( $filter['buckets'] ) < 2 ) {
+				continue;
+			}
+
+			echo '<h3>' . esc_html( $label ) . '</h3>';
+
+			echo '<ul>';
+
+			foreach ( $filter['buckets'] as $item ) {
+				if ( $item['active'] ) {
+					continue;
+				}
+
+				echo '<li><a href="' . esc_url( $item['url'] ) . '">' . esc_html( $item['name'] ) . '</a> (' . number_format_i18n( absint( $item['count'] ) ) . ')</li>';
+			}
+
+			echo '</ul>';
+		}
+
+		echo $args['after_widget'];
+	}
+
+	function update( $new_instance, $old_instance ) {
+		$instance = array();
+
+		$instance['title'] = sanitize_text_field( $new_instance['title'] );
+
+		return $instance;
+	}
+
+	function form( $instance ) {
+		$instance = wp_parse_args( (array) $instance, array(
+			'title' => '',
+		) );
+
+		$title = strip_tags( $instance['title'] );
+
+		?>
+		<p><label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" /></p>
+		<?php
+	}
+}
+

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1255,13 +1255,11 @@ class Jetpack_Search {
 		}
 
 		foreach( $filters as $filter ) {
-			if ( ! is_array( $filter['buckets'] ) ) {
-				continue;
-			}
-
-			foreach( $filter['buckets'] as $item ) {
-				if ( $item['active'] ) {
-					$active_buckets[] = $item;
+			if ( isset( $filters['buckets'] ) && is_array( $filter['buckets'] ) ) {
+				foreach( $filter['buckets'] as $item ) {
+					if ( isset( $item['active'] ) && $item['active'] ) {
+						$active_buckets[] = $item;
+					}
 				}
 			}
 		}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -354,7 +354,7 @@ class Jetpack_Search {
 
 			$taxonomy = $tax_query['taxonomy'];
 
-			if ( ! is_array( $args[ $taxonomy ] ) ) {
+			if ( ! isset( $args[ $taxonomy ] ) || ! is_array( $args[ $taxonomy ] ) ) {
 				$args[ $taxonomy ] = array();
 			}
 

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1250,7 +1250,15 @@ class Jetpack_Search {
 
 		$filters = $this->get_filters();
 
+		if ( ! is_array( $filters ) ) {
+			return $active_buckets;
+		}
+
 		foreach( $filters as $filter ) {
+			if ( ! is_array( $filter['buckets'] ) ) {
+				continue;
+			}
+
 			foreach( $filter['buckets'] as $item ) {
 				if ( $item['active'] ) {
 					$active_buckets[] = $item;

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1009,7 +1009,7 @@ class Jetpack_Search {
 
 			$type = $this->aggregations[ $label ]['type'];
 
-			$aggregations_data[ $label ]['buckets'] = array();
+			$aggregation_data[ $label ]['buckets'] = array();
 
 			$existing_term_slugs = array();
 
@@ -1204,7 +1204,7 @@ class Jetpack_Search {
 				// Need to urlencode param values since add_query_arg doesn't
 				$url_params = urlencode_deep( $query_vars );
 
-				$aggregations_data[ $label ]['buckets'][] = array(
+				$aggregation_data[ $label ]['buckets'][] = array(
 					'url'        => add_query_arg( $url_params ),
 					'query_vars' => $query_vars,
 					'name'       => $name,
@@ -1217,7 +1217,7 @@ class Jetpack_Search {
 			} // End foreach().
 		} // End foreach().
 
-		return $aggregations_data;
+		return $aggregation_data;
 	}
 
 	/**

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1,0 +1,1289 @@
+<?php
+
+class Jetpack_Search {
+
+	protected $found_posts = 0;
+
+	/**
+	 * The maximum offset ('from' param), since deep pages get exponentially slower.
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/guide/current/pagination.html
+	 */
+	protected $max_offset = 200;
+
+	protected $search_result;
+
+	protected $original_blog_id;
+	protected $jetpack_blog_id;
+
+	protected $aggregations = array();
+	protected $max_aggregations_count = 100;
+
+	protected static $instance;
+
+	//Languages with custom analyzers, other languages are supported,
+	// but are analyzed with the default analyzer.
+	public static $analyzed_langs = array( 'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'eu', 'fa', 'fi', 'fr', 'he', 'hi', 'hu', 'hy', 'id', 'it', 'ja', 'ko', 'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr', 'zh' );
+
+	protected function __construct() {
+		/* Don't do anything, needs to be initialized via instance() method */
+	}
+
+	public function __clone() {
+		wp_die( "Please don't __clone Jetpack_Search" );
+	}
+
+	public function __wakeup() {
+		wp_die( "Please don't __wakeup Jetpack_Search" );
+	}
+
+	/**
+	 * Get singleton instance of Jetpack_Search
+	 *
+	 * Instantiates and sets up a new instance if needed, or returns the singleton
+	 *
+	 * @module search
+	 *
+	 * @return Jetpack_Search The Jetpack_Search singleton
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Jetpack_Search();
+
+			self::$instance->setup();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Perform various setup tasks for the class
+	 *
+	 * Checks various pre-requisites and adds hooks
+	 *
+	 * @module search
+	 */
+	public function setup() {
+		if ( ! Jetpack::is_active() ) {
+			return;
+		}
+
+		$this->jetpack_blog_id = Jetpack::get_option( 'id' );
+
+		if ( ! $this->jetpack_blog_id ) {
+			return;
+		}
+
+		$this->init_hooks();
+	}
+
+	/**
+	 * Setup the various hooks needed for the plugin to take over Search duties
+	 *
+	 * @module search
+	 */
+	public function init_hooks() {
+		add_action( 'widgets_init', array( $this, 'action__widgets_init' ) );
+
+		if ( ! is_admin() ) {
+			add_filter( 'posts_pre_query', array( $this, 'filter__posts_pre_query' ), 10, 2 );
+
+			add_filter( 'jetpack_search_es_wp_query_args', array( $this, 'filter__add_date_filter_to_query' ),  10, 2 );
+		}
+	}
+
+	/*
+	 * Run a search on the WP.com public API.
+	 *
+	 * @module search
+	 *
+	 * @param array $es_args Args conforming to the WP.com /sites/<blog_id>/search endpoint
+	 *
+	 * @return object|WP_Error The response from the public api, or a WP_Error
+	 */
+	public function search( array $es_args ) {
+		$service_url = 'https://public-api.wordpress.com/rest/v1/sites/' . $this->jetpack_blog_id . '/search';
+
+		$start_time = microtime( true );
+
+		$request = wp_remote_post( $service_url, array(
+			'headers' => array(
+				'Content-Type' => 'application/json',
+			),
+			'timeout'    => 10,
+			'user-agent' => 'jetpack_search',
+			'body'       => json_encode( $es_args ),
+		) );
+
+		$end_time = microtime( true );
+
+		if ( is_wp_error( $request ) ) {
+			return $request;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $request ), true );
+
+		$took = is_array( $response ) && $response['took'] ? $response['took'] : null;
+
+		$query = array(
+			'args'          => $es_args,
+			'response'      => $response,
+			'response_code' => wp_remote_retrieve_response_code( $request ),
+			'elapsed_time'   => ( $end_time - $start_time ) * 1000, // Convert from float seconds to ms
+			'es_time'       => $took,
+			'url'           => $service_url,
+		);
+
+		do_action( 'did_jetpack_search_query', $query );
+
+		return $response;
+	}
+
+	/**
+	 * Bypass the normal Search query and offload it to Jetpack servers
+	 *
+	 * This is the main hook of the plugin and is responsible for returning the posts that match the search query
+	 *
+	 * @module search
+	 *
+	 * @param array $posts Current array of posts (still pre-query)
+	 * @param WP_Query $query The WP_Query being filtered
+	 *
+	 * @return array Array of matching posts
+	 */
+	public function filter__posts_pre_query( $posts, $query ) {
+		if ( ! $query->is_main_query() || ! $query->is_search() ) {
+			return $posts;
+		}
+
+		$this->do_search( $query );
+
+		if ( ! is_array( $this->search_result ) ) {
+			return $posts;
+		}
+
+		// If no results, nothing to do
+		if ( ! count( $this->search_result['results']['hits'] ) ) {
+			return array();
+		}
+
+		$post_ids = array();
+
+		foreach ( $this->search_result['results']['hits'] as $result ) {
+			$post_ids[] = (int) $result['fields']['post_id'];
+		}
+
+		// Query all posts now
+		$args = array(
+			'post__in' => $post_ids,
+			'perm'     => 'readable',
+		);
+
+		$posts_query = new WP_Query( $args );
+
+		// WP Core doesn't call the set_found_posts and its filters when filtering posts_pre_query like we do, so need to
+		// do these manually
+		$query->found_posts   = $this->found_posts;
+		$query->max_num_pages = ceil( $this->found_posts / $query->get( 'posts_per_page' ) );
+
+		return $posts_query->posts;
+	}
+
+	/**
+	 * Build up the search, then run it against the Jetpack servers
+	 *
+	 * @param WP_Query $query The original WP_Query to use for the parameters of our search
+	 */
+	public function do_search( WP_Query $query ) {
+		global $wpdb;
+
+		if ( ! $query->is_main_query() || ! $query->is_search() ) {
+			return;
+		}
+
+		$page = ( $query->get( 'paged' ) ) ? absint( $query->get( 'paged' ) ) : 1;
+
+		$posts_per_page = $query->get( 'posts_per_page' );
+
+		// ES API does not allow more than 15 results at a time
+		if ( $posts_per_page > 15 ) {
+			$posts_per_page = 15;
+		}
+
+		// Start building the WP-style search query args
+		// They'll be translated to ES format args later
+		$es_wp_query_args = array(
+			'query'          => $query->get( 's' ),
+			'posts_per_page' => $posts_per_page,
+			'paged'          => $page,
+			'orderby'        => $query->get( 'orderby' ),
+			'order'          => $query->get( 'order' ),
+		);
+
+		if ( ! empty( $this->aggregations ) ) {
+			$es_wp_query_args['aggregations'] = $this->aggregations;
+		}
+
+		// Did we query for authors?
+		if ( $query->get( 'author_name' ) ) {
+			$es_wp_query_args['author_name'] = $query->get( 'author_name' );
+		}
+
+		$es_wp_query_args['post_type'] = $this->get_es_wp_query_post_type_for_query( $query );
+
+		$es_wp_query_args['terms']     = $this->get_es_wp_query_terms_for_query( $query );
+
+
+		/**
+		 * Modify the search query parameters, such as controlling the post_type.
+		 *
+		 * These arguments are in the format of WP_Query arguments
+		 *
+		 * @module search
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param array $es_wp_query_args The current query args, in WP_Query format
+		 * @param WP_Query $query The original query object
+		 */
+		$es_wp_query_args = apply_filters( 'jetpack_search_es_wp_query_args', $es_wp_query_args, $query );
+
+		// If page * posts_per_page is greater than our max offset, send a 404. This is necessary because the offset is
+		// capped at $this->max_offset, so a high page would always return the last page of results otherwise
+		if ( ( $es_wp_query_args['paged'] * $es_wp_query_args['posts_per_page'] ) > $this->max_offset ) {
+			$query->set_404();
+
+			return;
+		}
+
+		// If there were no post types returned, then 404 to avoid querying against non-public post types, which could
+		// happen if we don't add the post type restriction to the ES query
+		if ( empty( $es_wp_query_args['post_type'] ) ) {
+			$query->set_404();
+
+			return;
+		}
+
+		// Convert the WP-style args into ES args
+		$es_query_args = $this->convert_wp_es_to_es_args( $es_wp_query_args );
+
+		//Only trust ES to give us IDs, not the content since it is a mirror
+		$es_query_args['fields'] = array(
+			'post_id',
+		);
+
+		/**
+		 * Modify the underlying ES query that is passed to the search endpoint. The returned args must represent a valid ES query
+		 *
+		 * This filter is harder to use if you're unfamiliar with ES, but allows complete control over the query
+		 *
+		 * @module search
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param array $es_query_args The raw ES query args
+		 * @param WP_Query $query The original query object
+		 */
+		$es_query_args = apply_filters( 'jetpack_search_es_query_args', $es_query_args, $query );
+
+		// Do the actual search query!
+		$this->search_result = $this->search( $es_query_args );
+
+		if ( is_wp_error( $this->search_result ) || ! is_array( $this->search_result ) || empty( $this->search_result['results'] ) || empty( $this->search_result['results']['hits'] ) ) {
+			$this->found_posts = 0;
+
+			return;
+		}
+
+		// Total number of results for paging purposes. Capped at $this->>max_offset + $posts_per_page, as deep paging
+		// gets quite expensive
+		$this->found_posts = min( $this->search_result['results']['total'], $this->max_offset + $posts_per_page );
+
+		return;
+	}
+
+	/**
+	 * Given a WP_Query, convert its WP_Tax_Query (if present) into the WP-style ES term arguments for the search
+	 *
+	 * @module search
+	 *
+	 * @param WP_Query $query The original WP_Query object for which to parse the taxonomy query
+	 *
+	 * @return array The new WP-style ES arguments (that will be converted into 'real' ES arguments)
+	 */
+	public function get_es_wp_query_terms_for_query( WP_Query $query ) {
+		$args = array();
+
+		$the_tax_query = $query->tax_query;
+
+		if ( ! $the_tax_query ) {
+			return $args;
+		}
+
+
+		if ( ! $the_tax_query instanceof WP_Tax_Query || empty( $the_tax_query->queried_terms ) || ! is_array( $the_tax_query->queried_terms ) ) {
+			return $args;
+		}
+
+		$args = array();
+
+		foreach ( $the_tax_query->queries as $tax_query ) {
+			// Right now we only support slugs...see note above
+			if ( 'slug' !== $tax_query['field'] ) {
+				continue;
+			}
+
+			$taxonomy = $tax_query['taxonomy'];
+
+			if ( ! is_array( $args[ $taxonomy ] ) ) {
+				$args[ $taxonomy ] = array();
+			}
+
+			$args[ $taxonomy ] = array_merge( $args[ $taxonomy ], $tax_query['terms'] );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Parse out the post type from a WP_Query
+	 *
+	 * Only allows post types that are not marked as 'exclude_from_search'
+	 *
+	 * @module search
+	 *
+	 * @param WP_Query $query Original WP_Query object
+	 *
+	 * @return array Array of searchable post types corresponding to the original query
+	 */
+	public function get_es_wp_query_post_type_for_query( WP_Query $query ) {
+		$post_types = $query->get( 'post_type' );
+
+		// If we're searching 'any', we want to only pass searchable post types to ES
+		if ( 'any' === $post_types ) {
+			$post_types = array_values( get_post_types( array(
+				'exclude_from_search' => false,
+			) ) );
+		}
+
+		if ( ! is_array( $post_types ) ) {
+			$post_types = array( $post_types );
+		}
+
+		$post_types = array_unique( $post_types );
+
+		$sanitized_post_types = array();
+
+		// Make sure the post types are queryable
+		foreach ( $post_types as $post_type ) {
+			if ( ! $post_type ) {
+				continue;
+			}
+
+			$post_type_object = get_post_type_object( $post_type );
+
+			if ( ! $post_type_object || $post_type_object->exclude_from_search ) {
+				continue;
+			}
+
+			$sanitized_post_types[] = $post_type;
+		}
+
+		return $sanitized_post_types;
+	}
+
+	/**
+	 * Initialze widgets for the Search module
+	 *
+	 * @module search
+	 */
+	public function action__widgets_init() {
+		require_once( __DIR__ . '/class.jetpack-search-widget-filters.php' );
+
+		register_widget( 'Jetpack_Search_Widget_Filters' );
+	}
+
+	/**
+	 * Get the Elasticsearch result
+	 *
+	 * @module search
+	 *
+	 * @param bool $raw If true, does not check for WP_Error or return the 'results' array - the JSON decoded HTTP response
+	 *
+	 * @return array|bool The search results, or false if there was a failure
+	 */
+	public function get_search_result( $raw = false ) {
+		if ( $raw ) {
+			return $this->search_result;
+		}
+
+		return ( ! empty( $this->search_result ) && ! is_wp_error( $this->search_result ) && is_array( $this->search_result ) && ! empty( $this->search_result['results'] ) ) ? $this->search_result['results'] : false;
+	}
+
+	/**
+	 * Add the date portion of a WP_Query onto the query args
+	 *
+	 * @param array $es_wp_query_args
+	 * @param $query The original WP_Query
+	 *
+	 * @return array The es wp query args, with date filters added (as needed)
+	 */
+	public function filter__add_date_filter_to_query( array $es_wp_query_args, WP_Query $query ) {
+		if ( $query->get( 'year' ) ) {
+			if ( $query->get( 'monthnum' ) ) {
+				// Padding
+				$date_monthnum = sprintf( '%02d', $query->get( 'monthnum' ) );
+
+				if ( $query->get( 'day' ) ) {
+					// Padding
+					$date_day = sprintf( '%02d', $query->get( 'day' ) );
+
+					$date_start = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $date_day . ' 00:00:00';
+					$date_end   = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $date_day . ' 23:59:59';
+				} else {
+					$days_in_month = date( 't', mktime( 0, 0, 0, $query->get( 'monthnum' ), 14, $query->get( 'year' ) ) ); // 14 = middle of the month so no chance of DST issues
+
+					$date_start = $query->get( 'year' ) . '-' . $date_monthnum . '-01 00:00:00';
+					$date_end   = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $days_in_month . ' 23:59:59';
+				}
+			} else {
+				$date_start = $query->get( 'year' ) . '-01-01 00:00:00';
+				$date_end   = $query->get( 'year' ) . '-12-31 23:59:59';
+			}
+
+			$es_wp_query_args['date_range'] = array(
+				'field' => 'date',
+				'gte'   => $date_start,
+				'lte'   => $date_end,
+			);
+		}
+
+		return $es_wp_query_args;
+	}
+
+	/**
+	 * Converts WP_Query style args to ES args
+	 *
+	 * @module search
+	 *
+	 * @param array $args Array of WP_Query style arguments
+	 *
+	 * @return array Array of ES style query arguments
+	 */
+	function convert_wp_es_to_es_args( array $args ) {
+		jetpack_require_lib( 'jetpack-wpes-query-builder' );
+
+		$builder = new Jetpack_WPES_Query_Builder();
+
+		$defaults = array(
+			'blog_id'        => get_current_blog_id(),
+
+			'query'          => null,    // Search phrase
+			'query_fields'   => array( 'title', 'content', 'author', 'tag', 'category' ),
+
+			'post_type'      => null,  // string or an array
+			'terms'          => array(), // ex: array( 'taxonomy-1' => array( 'slug' ), 'taxonomy-2' => array( 'slug-a', 'slug-b' ) )
+
+			'author'         => null,    // id or an array of ids
+			'author_name'    => array(), // string or an array
+
+			'date_range'     => null,    // array( 'field' => 'date', 'gt' => 'YYYY-MM-dd', 'lte' => 'YYYY-MM-dd' ); date formats: 'YYYY-MM-dd' or 'YYYY-MM-dd HH:MM:SS'
+
+			'orderby'        => null,    // Defaults to 'relevance' if query is set, otherwise 'date'. Pass an array for multiple orders.
+			'order'          => 'DESC',
+
+			'posts_per_page' => 10,
+
+			'offset'         => null,
+			'paged'          => null,
+
+			/**
+			 * Aggregations. Examples:
+			 * array(
+			 *     'Tag'       => array( 'type' => 'taxonomy', 'taxonomy' => 'post_tag', 'count' => 10 ) ),
+			 *     'Post Type' => array( 'type' => 'post_type', 'count' => 10 ) ),
+			 * );
+			 */
+			'aggregations'         => null,
+		);
+
+		$raw_args = $args; // Keep a copy
+
+		$args = wp_parse_args( $args, $defaults );
+
+		$es_query_args = array(
+			'blog_id' => absint( $args['blog_id'] ),
+			'size'    => absint( $args['posts_per_page'] ),
+		);
+
+		// ES "from" arg (offset)
+		if ( $args['offset'] ) {
+			$es_query_args['from'] = absint( $args['offset'] );
+		} elseif ( $args['paged'] ) {
+			$es_query_args['from'] = max( 0, ( absint( $args['paged'] ) - 1 ) * $es_query_args['size'] );
+		}
+
+		// Limit the offset to $this->max_offset posts, as deep pages get exponentially slower
+		// See https://www.elastic.co/guide/en/elasticsearch/guide/current/pagination.html
+		$es_query_args['from'] = min( $es_query_args['from'], $this->max_offset );
+
+		if ( ! is_array( $args['author_name'] ) ) {
+			$args['author_name'] = array( $args['author_name'] );
+		}
+
+		// ES stores usernames, not IDs, so transform
+		if ( ! empty( $args['author'] ) ) {
+			if ( ! is_array( $args['author'] ) ) {
+				$args['author'] = array( $args['author'] );
+			}
+
+			foreach ( $args['author'] as $author ) {
+				$user = get_user_by( 'id', $author );
+
+				if ( $user && ! empty( $user->user_login ) ) {
+					$args['author_name'][] = $user->user_login;
+				}
+			}
+		}
+
+		//////////////////////////////////////////////////
+		// Build the filters from the query elements.
+		// Filters rock because they are cached from one query to the next
+		// but they are cached as individual filters, rather than all combined together.
+		// May get performance boost by also caching the top level boolean filter too.
+		$filters = array();
+
+		if ( $args['post_type'] ) {
+			if ( ! is_array( $args['post_type'] ) ) {
+				$args['post_type'] = array( $args['post_type'] );
+			}
+
+			$filters[] = array(
+				'terms' => array(
+					'post_type' => $args['post_type'],
+				),
+			);
+		}
+
+		if ( $args['author_name'] ) {
+			$filters[] = array(
+				'terms' => array(
+					'author_login' => $args['author_name'],
+				),
+			);
+		}
+
+		if ( ! empty( $args['date_range'] ) && isset( $args['date_range']['field'] ) ) {
+			$field = $args['date_range']['field'];
+
+			unset( $args['date_range']['field'] );
+
+			$filters[] = array(
+				'range' => array(
+					$field => $args['date_range'],
+				),
+			);
+		}
+
+		if ( is_array( $args['terms'] ) ) {
+			foreach ( $args['terms'] as $tax => $terms ) {
+				$terms = (array) $terms;
+
+				if ( count( $terms ) && mb_strlen( $tax ) ) {
+					switch ( $tax ) {
+						case 'post_tag':
+							$tax_fld = 'tag.slug';
+
+							break;
+
+						case 'category':
+							$tax_fld = 'category.slug';
+
+							break;
+
+						default:
+							$tax_fld = 'taxonomy.' . $tax . '.slug';
+
+							break;
+					}
+
+					foreach ( $terms as $term ) {
+						$filters[] = array(
+							'term' => array(
+								$tax_fld => $term,
+							),
+						);
+					}
+				}
+			}
+		}
+
+		if ( $args['query'] ) {
+			$query = array(
+				'multi_match' => array(
+					'query'    => $args['query'],
+					'fields'   => $args['query_fields'],
+					'operator' => 'and',
+					'type'     => 'cross_fields',
+				),
+			);
+
+			$builder->add_query( $query );
+
+			Jetpack_Search::score_query_by_recency( $builder );
+
+			if ( ! $args['orderby'] ) {
+				$args['orderby'] = array( 'relevance' );
+			}
+		} else {
+			if ( ! $args['orderby'] ) {
+				$args['orderby'] = array( 'date' );
+			}
+		}
+
+		// Validate the "order" field
+		switch ( strtolower( $args['order'] ) ) {
+			case 'asc':
+				$args['order'] = 'asc';
+				break;
+
+			case 'desc':
+			default:
+				$args['order'] = 'desc';
+				break;
+		}
+
+		$es_query_args['sort'] = array();
+
+		foreach ( (array) $args['orderby'] as $orderby ) {
+			// Translate orderby from WP field to ES field
+			switch ( $orderby ) {
+				case 'relevance' :
+					//never order by score ascending
+					$es_query_args['sort'][] = array(
+						'_score' => array(
+							'order' => 'desc',
+						),
+					);
+
+					break;
+
+				case 'date' :
+					$es_query_args['sort'][] = array(
+						'date' => array(
+							'order' => $args['order'],
+						),
+					);
+
+					break;
+
+				case 'ID' :
+					$es_query_args['sort'][] = array(
+						'id' => array(
+							'order' => $args['order'],
+						),
+					);
+
+					break;
+
+				case 'author' :
+					$es_query_args['sort'][] = array(
+						'author.raw' => array(
+							'order' => $args['order'],
+						),
+					);
+
+					break;
+			} // End switch().
+		} // End foreach().
+
+		if ( empty( $es_query_args['sort'] ) ) {
+			unset( $es_query_args['sort'] );
+		}
+
+		if ( ! empty( $filters ) && is_array( $filters ) ) {
+			foreach ( $filters as $filter ) {
+				$builder->add_filter( $filter );
+			}
+
+			$es_query_args['filter'] = $builder->build_filter();
+		}
+
+		$es_query_args['query'] = $builder->build_query();
+
+		// Aggregations
+		if ( ! empty( $args['aggregations'] ) ) {
+			$this->add_aggregations_to_es_query_builder( $args['aggregations'], $builder );
+
+			$es_query_args['aggregations'] = $builder->build_aggregation();
+		}
+
+		return $es_query_args;
+	}
+
+	/**
+	 * Given an array of aggregations, parse and add them onto the Jetpack_WPES_Query_Builder object for use in ES
+	 *
+	 * @module search
+	 *
+	 * @param array $aggregations Array of Aggregations (filters) to add to the Jetpack_WPES_Query_Builder
+	 *
+	 * @param Jetpack_WPES_Query_Builder $builder The builder instance that is creating the ES query
+	 */
+	public function add_aggregations_to_es_query_builder( array $aggregations, Jetpack_WPES_Query_Builder $builder ) {
+		foreach ( $aggregations as $label => $aggregation ) {
+			switch ( $aggregation['type'] ) {
+				case 'taxonomy':
+					$this->add_taxonomy_aggregation_to_es_query_builder( $aggregation, $label, $builder );
+
+					break;
+
+				case 'post_type':
+					$this->add_post_type_aggregation_to_es_query_builder( $aggregation, $label, $builder );
+
+					break;
+
+				case 'date_histogram':
+					$this->add_date_histogram_aggregation_to_es_query_builder( $aggregation, $label, $builder );
+
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Given an individual taxonomy aggregation, add it to the Jetpack_WPES_Query_Builder object for use in ES
+	 *
+	 * @module search
+	 *
+	 * @param array $aggregation The aggregation to add to the query builder
+	 * @param $label The 'label' (unique id) for this aggregation
+	 * @param Jetpack_WPES_Query_Builder $builder The builder instance that is creating the ES query
+	 */
+	public function add_taxonomy_aggregation_to_es_query_builder( array $aggregation, $label, Jetpack_WPES_Query_Builder $builder ) {
+		$field = null;
+
+		switch ( $aggregation['taxonomy'] ) {
+			case 'post_tag':
+				$field = 'tag';
+				break;
+
+			case 'category':
+				$field = 'category';
+				break;
+
+			default:
+				$field = 'taxonomy.' . $aggregation['taxonomy'];
+				break;
+		}
+
+		$builder->add_aggs( $label, array(
+			'terms' => array(
+				'field' => $field . '.slug',
+				'size' => min( (int) $aggregation['count'], $this->max_aggregations_count ),
+			),
+		));
+	}
+
+	/**
+	 * Given an individual post_type aggregation, add it to the Jetpack_WPES_Query_Builder object for use in ES
+	 *
+	 * @module search
+	 *
+	 * @param array $aggregation The aggregation to add to the query builder
+	 * @param $label The 'label' (unique id) for this aggregation
+	 * @param Jetpack_WPES_Query_Builder $builder The builder instance that is creating the ES query
+	 */
+	public function add_post_type_aggregation_to_es_query_builder( array $aggregation, $label, Jetpack_WPES_Query_Builder $builder ) {
+		$builder->add_aggs( $label, array(
+			'terms' => array(
+				'field' => 'post_type',
+				'size' => min( (int) $aggregation['count'], $this->max_aggregations_count ),
+			),
+		));
+	}
+
+	/**
+	 * Given an individual date_histogram aggregation, add it to the Jetpack_WPES_Query_Builder object for use in ES
+	 *
+	 * @module search
+	 *
+	 * @param array $aggregation The aggregation to add to the query builder
+	 * @param $label The 'label' (unique id) for this aggregation
+	 * @param Jetpack_WPES_Query_Builder $builder The builder instance that is creating the ES query
+	 */
+	public function add_date_histogram_aggregation_to_es_query_builder( array $aggregation, $label, Jetpack_WPES_Query_Builder $builder ) {
+		$builder->add_aggs( $label, array(
+			'date_histogram' => array(
+				'interval' => $aggregation['interval'],
+				'field'    => ( ! empty( $aggregation['field'] ) && 'post_date_gmt' == $aggregation['field'] ) ? 'date_gmt' : 'date',
+			),
+		));
+	}
+
+	/**
+	 * And an existing filter object with a list of additional filters.
+	 *
+	 * Attempts to optimize the filters somewhat.
+	 *
+	 * @module search
+	 *
+	 * @param array $curr_filter The existing filters to build upon
+	 * @param array $filters The new filters to add
+	 *
+	 * @return array The resulting merged filters
+	 */
+	public static function and_es_filters( array $curr_filter, array $filters ) {
+		if ( ! is_array( $curr_filter ) || isset( $curr_filter['match_all'] ) ) {
+			if ( 1 === count( $filters ) ) {
+				return $filters[0];
+			}
+
+			return array(
+				'and' => $filters,
+			);
+		}
+
+		return array(
+			'and' => array_merge( array( $curr_filter ), $filters ),
+		);
+	}
+
+	/**
+	 * Add a recency score to a given Jetpack_WPES_Query_Builder object, for emphasizing newer posts in results
+	 *
+	 * Internally uses a gauss decay function
+	 *
+	 * @module search
+	 *
+	 * @param Jetpack_WPES_Query_Builder $builder The Jetpack_WPES_Query_Builder to add the recency score to
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-decay
+	 */
+	public static function score_query_by_recency( Jetpack_WPES_Query_Builder &$builder ) {
+		//Newer content gets weighted slightly higher
+		$date_scale  = '360d';
+		$date_decay  = 0.9;
+		$date_origin = date( 'Y-m-d' );
+
+		$builder->add_decay( 'gauss', array(
+			'date_gmt' => array(
+				'origin' => $date_origin,
+				'scale'  => $date_scale,
+				'decay'  => $date_decay,
+			),
+		));
+	}
+
+	/**
+	 * Set the available filters for the search
+	 *
+	 * These get rendered via the Jetpack_Search_Widget_Filters() widget
+	 *
+	 * Behind the scenes, these are implemented using Elasticsearch Aggregations.
+	 *
+	 * If you do not require counts of how many documents match each filter, please consider using regular WP Query
+	 * arguments instead, such as via the jetpack_search_es_wp_query_args filter
+	 *
+	 * @module search
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html
+	 *
+	 * @param array $aggregations Array of filters (aggregations) to apply to the search
+	 */
+	public function set_filters( array $aggregations ) {
+		$this->aggregations = $aggregations;
+	}
+
+	/**
+	 * Set the search's facets (deprecated)
+	 *
+	 * @module search
+	 *
+	 * @deprecated 5.0 Please use Jetpack_Search::set_filters() instead
+	 *
+	 * @see Jetpack_Search::set_filters()
+	 *
+	 * @param array $facets Array of facets to apply to the search
+	 */
+	public function set_facets( array $facets ) {
+		_deprecated_function( __METHOD__, 'jetpack-5.0', 'Jetpack_Search::set_filters()' );
+
+		$this->set_filters( $facets );
+	}
+
+	/**
+	 * Get the raw Aggregation results from the ES response
+	 *
+	 * @module search
+	 *
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html
+	 *
+	 * @return array Array of Aggregations performed on the search
+	 */
+	public function get_search_aggregations_results() {
+		$aggregations = array();
+
+		$search_result = $this->get_search_result();
+
+		if ( ! empty( $search_result ) && ! empty( $search_result['aggregations'] ) ) {
+			$aggregations = $search_result['aggregations'];
+		}
+
+		return $aggregations;
+	}
+
+	/**
+	 * Get the raw Facet results from the ES response
+	 *
+	 * @module search
+	 *
+	 * @deprecated 5.0 Please use Jetpack_Search::get_search_aggregations_results() instead
+	 *
+	 * @see Jetpack_Search::get_search_aggregations_results()
+	 *
+	 * @return array Array of Facets performed on the search
+	 */
+	public function get_search_facets() {
+		_deprecated_function( __METHOD__, 'jetpack-5.0', 'Jetpack_Search::get_search_aggregations_results()' );
+
+		return $this->get_search_aggregations_results();
+	}
+
+	/**
+	 * Get the results of the Filters performed, including the number of matching documents
+	 *
+	 * Returns an array of Filters (keyed by $label, as passed to Jetpack_Search::set_filters()), containing the Filter and all resulting
+	 * matching buckets, the url for applying/removing each bucket, etc.
+	 *
+	 * NOTE - if this is called before the search is performed, an empty array will be returned. Use the $aggregations class
+	 * member if you need to access the raw filters set in Jetpack_Search::set_filters()
+	 *
+	 * @module search
+	 *
+	 * @param WP_Query The optional original WP_Query to use for determining which filters are active. Defaults to the main query
+	 *
+	 * @return array Array of Filters applied and info about them
+	 */
+	public function get_filters( WP_Query $query = null ) {
+		if ( ! $query instanceof WP_Query ) {
+			global $wp_query;
+
+			$query = $wp_query;
+		}
+
+		$aggregation_data = $this->aggregations;
+
+		if ( empty( $aggregation_data ) ) {
+			return $aggregation_data;
+		}
+
+		$aggregation_results = $this->get_search_aggregations_results();
+
+		if ( ! $aggregation_results ) {
+			return $aggregation_data;
+		}
+
+		// NOTE - Looping over the _results_, not the original configured aggregations, so we get the 'real' data from ES
+		foreach ( $aggregation_results as $label => $aggregation ) {
+			if ( empty( $aggregation ) ) {
+				continue;
+			}
+
+			$type = $this->aggregations[ $label ]['type'];
+
+			$aggregations_data[ $label ]['buckets'] = array();
+
+			$existing_term_slugs = array();
+
+			$tax_query_var = null;
+
+			// Figure out which terms are active in the query, for this taxonomy
+			if ( 'taxonomy' === $this->aggregations[ $label ]['type'] ) {
+				$tax_query_var = $this->get_taxonomy_query_var(  $this->aggregations[ $label ]['taxonomy'] );
+
+				if ( ! empty( $query->tax_query ) && ! empty( $query->tax_query->queries ) && is_array( $query->tax_query->queries ) ) {
+					foreach( $query->tax_query->queries as $tax_query ) {
+						if ( $this->aggregations[ $label ]['taxonomy'] === $tax_query['taxonomy'] &&
+						     'slug' === $tax_query['field'] &&
+						     is_array( $tax_query['terms'] ) ) {
+							$existing_term_slugs = array_merge( $existing_term_slugs, $tax_query['terms'] );
+						}
+					}
+				}
+			}
+
+			// Now take the resulting found aggregation items and generate the additional info about them, such as
+			// activation/deactivation url, name, count, etc
+			$buckets = array();
+
+			if ( ! empty( $aggregation['buckets'] ) ) {
+				$buckets = (array) $aggregation['buckets'];
+			}
+
+			// Some aggregation types like date_histogram don't support the max results parameter
+			if ( is_int( $this->aggregations[ $label ]['count'] ) && count( $buckets ) > $this->aggregations[ $label ]['count'] ) {
+				$buckets = array_slice( $buckets, 0, $this->aggregations[ $label ]['count'] );
+			}
+
+			foreach ( $buckets as $item ) {
+				$query_vars = array();
+
+				$active     = false;
+				$remove_url = null;
+
+				// What type was the original aggregation?
+				switch ( $type ) {
+					case 'taxonomy':
+						$taxonomy = $this->aggregations[ $label ]['taxonomy'];
+
+						$term = get_term_by( 'slug', $item['key'], $taxonomy );
+
+						if ( ! $term || ! $tax_query_var ) {
+							continue 2; // switch() is considered a looping structure
+						}
+
+						$query_vars = array(
+							$tax_query_var => implode( '+', array_merge( $existing_term_slugs, array( $term->slug ) ) ),
+						);
+
+						$name = $term->name;
+
+						// Let's determine if this term is active or not
+
+						if ( in_array( $item['key'], $existing_term_slugs, true ) ) {
+							$active = true;
+
+							$slug_count = count( $existing_term_slugs );
+
+							if ( $slug_count > 1 ) {
+								$remove_url = add_query_arg( $tax_query_var, urlencode( implode( '+', array_diff( $existing_term_slugs, array( $item['key'] ) ) ) ) );
+							} else {
+								$remove_url = remove_query_arg( $tax_query_var );
+							}
+						}
+
+						break;
+
+					case 'post_type':
+						$post_type = get_post_type_object( $item['key'] );
+
+						if ( ! $post_type || $post_type->exclude_from_search ) {
+							continue 2;  // switch() is considered a looping structure
+						}
+
+						$query_vars = array(
+							'post_type' => $item['key'],
+						);
+
+						$name = $post_type->labels->singular_name;
+
+						// Is this post type active on this search?
+						$post_types = $query->get( 'post_type' );
+
+						if ( ! is_array( $post_types ) ) {
+							$post_types = array( $post_types );
+						}
+
+						if ( in_array( $item['key'], $post_types ) ) {
+							$active = true;
+
+							$post_type_count = count( $post_types );
+
+							// For the right 'remove filter' url, we need to remove the post type from the array, or remove the param entirely if it's the only one
+							if ( $post_type_count > 1 ) {
+								$remove_url = add_query_arg( 'post_type', urlencode_deep( array_diff( $post_types, array( $item['key'] ) ) ) );
+							} else {
+								$remove_url = remove_query_arg( 'post_type' );
+							}
+						}
+
+						break;
+
+					case 'date_histogram':
+						$timestamp = $item['key'] / 1000;
+
+						switch ( $this->aggregations[ $label ]['interval'] ) {
+							case 'year':
+								$year = (int) date( 'Y', $timestamp );
+
+								$query_vars = array(
+									'year'     => $year,
+									'monthnum' => false,
+									'day'      => false,
+								);
+
+								$name = $year;
+
+								// Is this year currently selected?
+								if ( ! empty( $query->get( 'year' ) ) && $query->get( 'year' ) === $year ) {
+									$active = true;
+
+									$remove_url = remove_query_arg( array( 'year', 'monthnum', 'day' ) );
+								}
+
+								break;
+
+							case 'month':
+								$year  = (int) date( 'Y', $timestamp );
+								$month = (int) date( 'n', $timestamp );
+
+								$query_vars = array(
+									'year'     => $year,
+									'monthnum' => $month,
+									'day'      => false,
+								);
+
+								$name = date( 'F Y', $timestamp );
+
+								// Is this month currently selected?
+								if ( ! empty( $query->get( 'year' ) ) && $query->get( 'year' ) === $year &&
+								     ! empty( $query->get( 'monthnum' ) ) && $query->get( 'monthnum' ) === $month ) {
+									$active = true;
+
+									$remove_url = remove_query_arg( array( 'monthnum', 'day' ) );
+								}
+
+								break;
+
+							case 'day':
+								$year  = (int) date( 'Y', $timestamp );
+								$month = (int) date( 'n', $timestamp );
+								$day   = (int) date( 'j', $timestamp );
+
+								$query_vars = array(
+									'year'     => $year,
+									'monthnum' => $month,
+									'day'      => $day,
+								);
+
+								$name = date( 'F jS, Y', $timestamp );
+
+								// Is this day currently selected?
+								if ( ! empty( $query->get( 'year' ) ) && $query->get( 'year' ) === $year &&
+								     ! empty( $query->get( 'monthnum' ) ) && $query->get( 'month' ) === $month &&
+								     ! empty( $query->get( 'day' ) ) && $query->get( 'day' ) === $day ) {
+									$active = true;
+
+									$remove_url = remove_query_arg( array( 'day' ) );
+								}
+
+								break;
+
+							default:
+								continue 3; // switch() is considered a looping structure
+						} // End switch().
+
+						break;
+
+					default:
+						//continue 2; // switch() is considered a looping structure
+				} // End switch().
+
+				// Need to urlencode param values since add_query_arg doesn't
+				$url_params = urlencode_deep( $query_vars );
+
+				$aggregations_data[ $label ]['buckets'][] = array(
+					'url'        => add_query_arg( $url_params ),
+					'query_vars' => $query_vars,
+					'name'       => $name,
+					'count'      => $item['doc_count'],
+					'active'     => $active,
+					'remove_url' => $remove_url,
+					'type'       => $type,
+					'type_label' => $label,
+				);
+			} // End foreach().
+		} // End foreach().
+
+		return $aggregations_data;
+	}
+
+	/**
+	 * Get the results of the Facets performed
+	 *
+	 * @module search
+	 *
+	 * @deprecated 5.0 Please use Jetpack_Search::get_filters() instead
+	 *
+	 * @see Jetpack_Search::get_filters()
+	 *
+	 * @return array $facets Array of Facets applied and info about them
+	 */
+	public function get_search_facet_data() {
+		_deprecated_function( __METHOD__, 'jetpack-5.0', 'Jetpack_Search::get_filters()' );
+
+		return $this->get_filters();
+	}
+
+	/**
+	 * Get the Filters that are currently applied to this search
+	 *
+	 * @module search
+	 *
+	 * @param WP_Query $query An optional WP_Query object - defaults to global $wp_query
+	 *
+	 * @return array Array if Filters that were applied
+	 */
+	public function get_active_filter_buckets( WP_Query $query = null ) {
+		$active_buckets = array();
+
+		$filters = $this->get_filters();
+
+		foreach( $filters as $filter ) {
+			foreach( $filter['buckets'] as $item ) {
+				if ( $item['active'] ) {
+					$active_buckets[] = $item;
+				}
+			}
+		}
+
+		return $active_buckets;
+	}
+
+	/**
+	 * Get the Filters that are currently applied to this search
+	 *
+	 * @module search
+	 *
+	 * @param WP_Query $query An optional WP_Query object - defaults to global $wp_query
+	 *
+	 * @return array Array if Filters that were applied
+	 */
+	public function get_current_filters( WP_Query $query = null ) {
+		_deprecated_function( __METHOD__, 'jetpack-5.0', 'Jetpack_Search::get_active_filter_buckets()' );
+
+		return $this->get_active_filter_buckets();
+	}
+
+	/**
+	 * Calculate the right query var to use for a given taxonomy
+	 *
+	 * Allows custom code to modify the GET var that is used to represent a given taxonomy, via the jetpack_search_taxonomy_query_var filter
+	 *
+	 * @module search
+	 *
+	 * @param string $taxonomy_name The name of the taxonomy for which to get the query var
+	 *
+	 * @return bool|string The query var to use for this taxonomy, or false if none found
+	 */
+	public function get_taxonomy_query_var( $taxonomy_name ) {
+		$taxonomy = get_taxonomy( $taxonomy_name );
+
+		if ( ! $taxonomy || is_wp_error( $taxonomy ) ) {
+			return false;
+		}
+
+		/**
+		 * Modify the query var to use for a given taxonomy
+		 *
+		 * @module search
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param string $query_var The current query_var for the taxonomy
+		 * @param string $taxonomy_name The taxonomy name
+		 */
+		return apply_filters( 'jetpack_search_taxonomy_query_var', $taxonomy->query_var, $taxonomy_name );
+	}
+}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -134,6 +134,22 @@ class Jetpack_Search {
 			'url'           => $service_url,
 		);
 
+		/**
+		 * Fires after a search request has been performed
+		 *
+		 * Includes the following info in the $query parameter:
+		 *
+		 * array args Array of Elasticsearch arguments for the search
+		 * array response Raw API response, JSON decoded
+		 * int response_code HTTP response code of the request
+		 * float elapsed_time Roundtrip time of the search request, in milliseconds
+		 * float es_time Amount of time Elasticsearch spent running the request, in milliseconds
+		 * string url API url that was queried
+		 *
+		 * @since 5.0
+		 *
+		 * @param array $query Array of information about the query performed
+		 */
 		do_action( 'did_jetpack_search_query', $query );
 
 		return $response;

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -398,7 +398,7 @@ class Jetpack_Search {
 	 * @module search
 	 */
 	public function action__widgets_init() {
-		require_once( __DIR__ . '/class.jetpack-search-widget-filters.php' );
+		require_once( dirname( __FILE__ ) . '/class.jetpack-search-widget-filters.php' );
 
 		register_widget( 'Jetpack_Search_Widget_Filters' );
 	}
@@ -1103,6 +1103,10 @@ class Jetpack_Search {
 					case 'date_histogram':
 						$timestamp = $item['key'] / 1000;
 
+						$current_year  = $query->get( 'year' );
+						$current_month = $query->get( 'monthnum' );
+						$current_day   = $query->get( 'day' );
+
 						switch ( $this->aggregations[ $label ]['interval'] ) {
 							case 'year':
 								$year = (int) date( 'Y', $timestamp );
@@ -1116,7 +1120,7 @@ class Jetpack_Search {
 								$name = $year;
 
 								// Is this year currently selected?
-								if ( ! empty( $query->get( 'year' ) ) && $query->get( 'year' ) === $year ) {
+								if ( ! empty( $current_year ) && (int) $current_year === $year ) {
 									$active = true;
 
 									$remove_url = remove_query_arg( array( 'year', 'monthnum', 'day' ) );
@@ -1137,8 +1141,8 @@ class Jetpack_Search {
 								$name = date( 'F Y', $timestamp );
 
 								// Is this month currently selected?
-								if ( ! empty( $query->get( 'year' ) ) && $query->get( 'year' ) === $year &&
-								     ! empty( $query->get( 'monthnum' ) ) && $query->get( 'monthnum' ) === $month ) {
+								if ( ! empty( $current_year ) && (int) $current_year === $year &&
+								     ! empty( $current_month ) && (int) $current_month === $month ) {
 									$active = true;
 
 									$remove_url = remove_query_arg( array( 'monthnum', 'day' ) );
@@ -1160,9 +1164,9 @@ class Jetpack_Search {
 								$name = date( 'F jS, Y', $timestamp );
 
 								// Is this day currently selected?
-								if ( ! empty( $query->get( 'year' ) ) && $query->get( 'year' ) === $year &&
-								     ! empty( $query->get( 'monthnum' ) ) && $query->get( 'month' ) === $month &&
-								     ! empty( $query->get( 'day' ) ) && $query->get( 'day' ) === $day ) {
+								if ( ! empty( $current_year ) && (int) $current_year === $year &&
+								     ! empty( $current_month ) && (int) $current_month === $month &&
+								     ! empty( $current_day ) && (int) $current_day === $day ) {
 									$active = true;
 
 									$remove_url = remove_query_arg( array( 'day' ) );

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1045,7 +1045,6 @@ class Jetpack_Search {
 
 			foreach ( $buckets as $item ) {
 				$query_vars = array();
-
 				$active     = false;
 				$remove_url = null;
 				$name       = '';

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -216,8 +216,6 @@ class Jetpack_Search {
 	 * @param WP_Query $query The original WP_Query to use for the parameters of our search
 	 */
 	public function do_search( WP_Query $query ) {
-		global $wpdb;
-
 		if ( ! $query->is_main_query() || ! $query->is_search() ) {
 			return;
 		}
@@ -444,8 +442,8 @@ class Jetpack_Search {
 	/**
 	 * Add the date portion of a WP_Query onto the query args
 	 *
-	 * @param array $es_wp_query_args
-	 * @param $query The original WP_Query
+	 * @param array    $es_wp_query_args
+	 * @param WP_Query $query The original WP_Query
 	 *
 	 * @return array The es wp query args, with date filters added (as needed)
 	 */
@@ -527,8 +525,6 @@ class Jetpack_Search {
 			 */
 			'aggregations'         => null,
 		);
-
-		$raw_args = $args; // Keep a copy
 
 		$args = wp_parse_args( $args, $defaults );
 
@@ -778,7 +774,7 @@ class Jetpack_Search {
 	 * @module search
 	 *
 	 * @param array $aggregation The aggregation to add to the query builder
-	 * @param $label The 'label' (unique id) for this aggregation
+	 * @param string $label The 'label' (unique id) for this aggregation
 	 * @param Jetpack_WPES_Query_Builder $builder The builder instance that is creating the ES query
 	 */
 	public function add_taxonomy_aggregation_to_es_query_builder( array $aggregation, $label, Jetpack_WPES_Query_Builder $builder ) {
@@ -812,7 +808,7 @@ class Jetpack_Search {
 	 * @module search
 	 *
 	 * @param array $aggregation The aggregation to add to the query builder
-	 * @param $label The 'label' (unique id) for this aggregation
+	 * @param string $label The 'label' (unique id) for this aggregation
 	 * @param Jetpack_WPES_Query_Builder $builder The builder instance that is creating the ES query
 	 */
 	public function add_post_type_aggregation_to_es_query_builder( array $aggregation, $label, Jetpack_WPES_Query_Builder $builder ) {
@@ -830,7 +826,7 @@ class Jetpack_Search {
 	 * @module search
 	 *
 	 * @param array $aggregation The aggregation to add to the query builder
-	 * @param $label The 'label' (unique id) for this aggregation
+	 * @param string $label The 'label' (unique id) for this aggregation
 	 * @param Jetpack_WPES_Query_Builder $builder The builder instance that is creating the ES query
 	 */
 	public function add_date_histogram_aggregation_to_es_query_builder( array $aggregation, $label, Jetpack_WPES_Query_Builder $builder ) {
@@ -982,7 +978,7 @@ class Jetpack_Search {
 	 *
 	 * @module search
 	 *
-	 * @param WP_Query The optional original WP_Query to use for determining which filters are active. Defaults to the main query
+	 * @param WP_Query $query The optional original WP_Query to use for determining which filters are active. Defaults to the main query
 	 *
 	 * @return array Array of Filters applied and info about them
 	 */
@@ -1246,11 +1242,9 @@ class Jetpack_Search {
 	 *
 	 * @module search
 	 *
-	 * @param WP_Query $query An optional WP_Query object - defaults to global $wp_query
-	 *
 	 * @return array Array if Filters that were applied
 	 */
-	public function get_active_filter_buckets( WP_Query $query = null ) {
+	public function get_active_filter_buckets() {
 		$active_buckets = array();
 
 		$filters = $this->get_filters();
@@ -1279,11 +1273,9 @@ class Jetpack_Search {
 	 *
 	 * @module search
 	 *
-	 * @param WP_Query $query An optional WP_Query object - defaults to global $wp_query
-	 *
 	 * @return array Array if Filters that were applied
 	 */
-	public function get_current_filters( WP_Query $query = null ) {
+	public function get_current_filters() {
 		_deprecated_function( __METHOD__, 'jetpack-5.0', 'Jetpack_Search::get_active_filter_buckets()' );
 
 		return $this->get_active_filter_buckets();

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -120,6 +120,11 @@ class Jetpack_Search {
 		if ( is_wp_error( $request ) ) {
 			return $request;
 		}
+		$response_code = wp_remote_retrieve_response_code( $request );
+
+		if ( ! $response_code || $response_code < 200 || $response_code >= 300 ) {
+			return new WP_Error( 'invalid_search_api_response', 'Invalid response from API - ' . $response_code );
+		}
 
 		$response = json_decode( wp_remote_retrieve_body( $request ), true );
 
@@ -128,7 +133,7 @@ class Jetpack_Search {
 		$query = array(
 			'args'          => $es_args,
 			'response'      => $response,
-			'response_code' => wp_remote_retrieve_response_code( $request ),
+			'response_code' => $response_code,
 			'elapsed_time'   => ( $end_time - $start_time ) * 1000, // Convert from float seconds to ms
 			'es_time'       => $took,
 			'url'           => $service_url,

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -1048,6 +1048,7 @@ class Jetpack_Search {
 
 				$active     = false;
 				$remove_url = null;
+				$name       = '';
 
 				// What type was the original aggregation?
 				switch ( $type ) {

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -196,8 +196,9 @@ class Jetpack_Search {
 
 		// Query all posts now
 		$args = array(
-			'post__in' => $post_ids,
-			'perm'     => 'readable',
+			'post__in'  => $post_ids,
+			'perm'      => 'readable',
+			'post_type' => 'any',
 		);
 
 		$posts_query = new WP_Query( $args );


### PR DESCRIPTION
Adds the Search module, which offloads site search to WordPress.com, powered by Elasticsearch.

Includes Aggregation (Facets) support and corresponding Widget.

Is currently ‘headless’ - no admin UI exists so the module must be enabled manually.