### PR TITLE
cli: Add info about the primary account owner

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -38,6 +38,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $args[0] ) );
 		}
 
+		$master_user_email = Jetpack::get_master_user_email();
+
 		/*
 		 * Are they asking for all data?
 		 *
@@ -48,6 +50,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::success( __( 'Jetpack is currently connected to WordPress.com', 'jetpack' ) );
 			WP_CLI::line( sprintf( __( "The Jetpack Version is %s", 'jetpack' ), JETPACK__VERSION ) );
 			WP_CLI::line( sprintf( __( "The WordPress.com blog_id is %d", 'jetpack' ), Jetpack_Options::get_option( 'id' ) ) );
+			WP_CLI::line( sprintf( __( 'The WordPress.com account for the primary connection is %s', 'jetpack' ), $master_user_email ) );
 
 			// Heartbeat data
 			WP_CLI::line( "\n" . __( 'Additional data: ', 'jetpack' ) );
@@ -83,6 +86,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::success( __( 'Jetpack is currently connected to WordPress.com', 'jetpack' ) );
 			WP_CLI::line( sprintf( __( 'The Jetpack Version is %s', 'jetpack' ), JETPACK__VERSION ) );
 			WP_CLI::line( sprintf( __( 'The WordPress.com blog_id is %d', 'jetpack' ), Jetpack_Options::get_option( 'id' ) ) );
+			WP_CLI::line( sprintf( __( 'The WordPress.com account for the primary connection is %s', 'jetpack' ), $master_user_email ) );
 			WP_CLI::line( "\n" . _x( "View full status with 'wp jetpack status full'", '"wp jetpack status full" is a command - do not translate', 'jetpack' ) );
 		}
 	}


### PR DESCRIPTION
When running the `jetpack status` command, it's useful to know who the primary connection owner is.

#### Changes proposed in this Pull Request:

* Adds an additional line of output to the `jetpack status` command to include the email of the primary connection owner.

#### Testing instructions:

* When connected, run `wp jetpack status` and `wp jetpack status full`. Verify that the correct connection owner information is displayed.
* When disconnected, verify that this information is not displayed.