### PR TITLE
Social Links: pass an argument to get_services() to avoid errors.

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -354,11 +354,16 @@ class Publicize extends Publicize_Base {
 		), menu_page_url( 'sharing', false ) );
 	}
 
-	function get_services( $filter ) {
-		if ( ! in_array( $filter, array( 'all', 'connected' ) ) ) {
-			$filter = 'all';
-		}
-
+	/**
+	 * Get social networks, either all available or only those that the site is connected to.
+	 *
+	 * @since 2.0
+	 *
+	 * @param string $filter Select the list of services that will be returned. Defaults to 'all', accepts 'connected'.
+	 *
+	 * @return array List of social networks.
+	 */
+	function get_services( $filter = 'all' ) {
 		$services = array(
 			'facebook'    => array(),
 			'twitter'     => array(),
@@ -378,7 +383,6 @@ class Publicize extends Publicize_Base {
 					$connected_services[ $service ] = $connections;
 				}
 			}
-
 			return $connected_services;
 		}
 	}

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -119,7 +119,7 @@ abstract class Publicize_Base {
 	abstract function connect_url( $service_name );
 	abstract function disconnect_url( $service_name, $id );
 	abstract function get_connection_meta( $connection );
-	abstract function get_services( $filter );
+	abstract function get_services( $filter = 'all' );
 	abstract function get_connections( $service, $_blog_id = false, $_user_id = false );
 	abstract function get_connection( $service, $id, $_blog_id = false, $_user_id = false );
 	abstract function flag_post_for_publicize( $new_status, $old_status, $post );

--- a/modules/theme-tools/social-links.php
+++ b/modules/theme-tools/social-links.php
@@ -122,7 +122,7 @@ class Social_Links {
 			'priority' => 35,
 		) );
 
-		foreach ( array_keys( $this->publicize->get_services() ) as $service ) {
+		foreach ( array_keys( $this->publicize->get_services( 'connected' ) ) as $service ) {
 			$choices = $this->get_customize_select( $service );
 
 			if ( empty( $choices ) ) {

--- a/modules/theme-tools/social-links.php
+++ b/modules/theme-tools/social-links.php
@@ -122,7 +122,7 @@ class Social_Links {
 			'priority' => 35,
 		) );
 
-		foreach ( array_keys( $this->publicize->get_services( 'connected' ) ) as $service ) {
+		foreach ( array_keys( $this->publicize->get_services( 'all' ) ) as $service ) {
 			$choices = $this->get_customize_select( $service );
 
 			if ( empty( $choices ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

PHP 7.1 returns a Fatal Error if get_services() is invoked without any argument.
Providing an argument should fix that.

Reported here:
https://wordpress.org/support/topic/publicize-and-wordpress-customizer/

- Related: 3bbf0603784f5eab435316e49cb7d2fb64f88abe where the change was introduced.
- Master issue: #6106

#### Testing instructions:

1. On a server running PHP 7.1, enable a theme using Social Links, like [Ryu](https://wordpress.org/themes/ryu/).
2. Go to Appearance > Customize.
3. Make sure you can set up Social Links without creating any errors.

#### Proposed changelog entry for your changes:
* Social Links: avoid Fatal Errors on sites running PHP 7.1.