### PR TITLE
Backups/scan card: Fix broken status for personal plan.

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -172,6 +172,10 @@ const ProStatus = React.createClass( {
 					return '';
 				}
 				if ( 'N/A' !== vpData ) {
+					if ( ! hasScan ) {
+						return this.getSetUpButton( 'scan' );
+					}
+
 					const threatsCount = this.props.getScanThreats();
 					if ( 0 !== threatsCount ) {
 						return this.getProActions( 'threats', 'scan' );

--- a/modules/omnisearch/omnisearch-rtl.css
+++ b/modules/omnisearch/omnisearch-rtl.css
@@ -1,5 +1,4 @@
-/* This file was automatically generated on Sep 29 2014 23:28:15 */
-
+/* Do not modify this file directly.  It is concatenated from individual module CSS files. */
 
 h2.page-title small {
 	font-size: 0.6em;


### PR DESCRIPTION
Fixes #6995

# This is not testable with the dev tools plan switcher.  You must actually change the plan to test this.  

The dev tools won't work in testing, because the dev tools only changes the plan class, and it's possible to have these features active without a Jetpack plan.  

This fixes an issue when we were showing the wrong text on personal plan.  It also re-writes the logic to show the content to make it more readable.

It also fixes an issue where we were not showing the `set up` button on professional plans if scan was not enabled for some reason.

To test: You should see the following statuses
**Free plan, no features active**
![screen shot 2017-05-19 at 10 28 00 am](https://cloud.githubusercontent.com/assets/7129409/26252949/b2ef0c02-3c7f-11e7-89d1-b3b30feb06c0.png)

**Backups only enabled, (personal plan)**
![screen shot 2017-05-19 at 10 29 07 am](https://cloud.githubusercontent.com/assets/7129409/26252978/ca431ae2-3c7f-11e7-9dad-5b909e3a3afc.png)

**Backups and scan enabled (premium/business)**
![screen shot 2017-05-19 at 10 27 44 am](https://cloud.githubusercontent.com/assets/7129409/26253012/e0248742-3c7f-11e7-97cf-55e6f4b89e7e.png)

**Personal plan, not enabled yet**
![screen shot 2017-05-19 at 10 45 03 am](https://cloud.githubusercontent.com/assets/7129409/26253125/3faf26fe-3c80-11e7-81a5-0576852bf6d8.png)


**Premium/business plan, but not enabled yet**
![screen shot 2017-05-19 at 10 38 24 am](https://cloud.githubusercontent.com/assets/7129409/26253040/f76a4496-3c7f-11e7-9610-f06a2c1b5bc0.png)


