### PR TITLE
Stats: Confirm value is an array before treating it as one

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -151,7 +151,7 @@ function stats_template_redirect() {
 	// Should we be counting this user's views?
 	if ( ! empty( $current_user->ID ) ) {
 		$count_roles = stats_get_option( 'count_roles' );
-		if ( ! array_intersect( $current_user->roles, $count_roles ) ) {
+		if ( ! is_array( $count_roles ) || ! array_intersect( $current_user->roles, $count_roles ) ) {
 			return;
 		}
 	}


### PR DESCRIPTION
Fixes #204

In some broken cases, `$count_roles` can be an empty string (which I can only think is due to an object cache issues or something is blocking it from setting options since `stats_get_option` calls `stats_get_options`, which runs `stats_upgrade_options` to set the options), so we can check it the var is an array before we use it as such.

Before this, a warning would be thrown and `NULL` returned from `array_intersect`, so the same logic should still happen without the warning.