### PR TITLE
Sync: make sure get_plugins exists before to use it.

### DIFF
--- a/sync/class.jetpack-sync-module-plugins.php
+++ b/sync/class.jetpack-sync-module-plugins.php
@@ -111,6 +111,9 @@ class Jetpack_Sync_Module_Plugins extends Jetpack_Sync_Module {
 		$plugin_path = $args[0];
 		$plugin_data = array();
 
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 		$all_plugins = get_plugins();
 		if ( isset( $all_plugins[ $plugin_path ] ) ) {
 			$all_plugin_data = $all_plugins[ $plugin_path ];


### PR DESCRIPTION
Fixes the Fatal error reported [here](https://wordpress.org/support/topic/php-fatal-error-every-few-minutes/):

```
[17-May-2017 17:05:03 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function get_plugins() in /wp-content/plugins/jetpack/sync/class.jetpack-sync-module-plugins.php:114
Stack trace:
#0 /wp-includes/class-wp-hook.php(300): Jetpack_Sync_Module_Plugins->expand_plugin_data(Array)
#1 /wp-includes/plugin.php(203): WP_Hook->apply_filters(Array, Array)
#2 /wp-content/plugins/jetpack/sync/class.jetpack-sync-sender.php(145): apply_filters('jetpack_sync_be...', Array, 1)
#3 /wp-content/plugins/jetpack/sync/class.jetpack-sync-sender.php(193): Jetpack_Sync_Sender->get_items_to_send(Object(Jetpack_Sync_Queue_Buffer), true)
#4 /wp-content/plugins/jetpack/sync/class.jetpack-sync-sender.php(98): Jetpack_Sync_Sender->do_sync_for_queue(Object(Jetpack_Sync_Queue))
#5 /wp-content/plugins/jetpack/sync/class.jetpack-sync-sender.php(80): Jetpack_Sync_Sender->do_sync_and_set_delays(Object(Jetpac in /wp-content/plugins/jetpack/sync/class.jetpack-sync-module-plugins.php on line 114
```

The problem seems similar to the one we had a little while back in #4233.

What's odd is that the user reports seeing this in their logs every few minutes. Isn't this supposed to be triggered only when activating or deactivating plugins?

cc @enejb and @lezama who worked on the related PR last time, #4238.

#### Proposed changelog entry for your changes:
* Sync: avoid Fatal errors when activating or deactivating plugins.
