### PR TITLE
Contact Form: Send all emails through wrapper to ensure consistency

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -696,7 +696,7 @@ function grunion_ajax_spam() {
 			 */
 			$subject = apply_filters( 'contact_form_subject', $content_fields['_feedback_subject'], $content_fields['_feedback_all_fields'] );
 
-			wp_mail( $to, $subject, $message, $headers );
+			Grunion_Contact_Form::wp_mail( $to, $subject, $message, $headers );
 		}
 	} elseif( $_POST['make_it'] == 'publish' ) {
 		if ( ! current_user_can($post_type_object->cap->delete_post, $post_id) ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2150,8 +2150,6 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			wp_schedule_event( time() + 250, 'daily', 'grunion_scheduled_delete' );
 		}
 
-		add_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
-		add_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
 		if (
 			$is_spam !== true &&
 			/**
@@ -2166,7 +2164,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			 */
 			true === apply_filters( 'grunion_should_send_email', true, $post_id )
 		) {
-			wp_mail( $to, "{$spam}{$subject}", $message, $headers );
+			self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 		} elseif (
 			true === $is_spam &&
 			/**
@@ -2180,10 +2178,8 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			 */
 			apply_filters( 'grunion_still_email_spam', false ) == true
 		) { // don't send spam by default.  Filterable.
-			wp_mail( $to, "{$spam}{$subject}", $message, $headers );
+			self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 		}
-		remove_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
-		remove_action( 'phpmailer_init', __CLASS__ . '::add_plain_text_alternative' );
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return self::success_message( $post_id, $this );
@@ -2215,6 +2211,29 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		wp_safe_redirect( $redirect );
 		exit;
+	}
+
+	/**
+	 * Wrapper for wp_mail() that enables HTML messages with text alternatives
+	 *
+	 * @param string|array $to          Array or comma-separated list of email addresses to send message.
+	 * @param string       $subject     Email subject.
+	 * @param string       $message     Message contents.
+	 * @param string|array $headers     Optional. Additional headers.
+	 * @param string|array $attachments Optional. Files to attach.
+	 *
+	 * @return bool Whether the email contents were sent successfully.
+	 */
+	public static function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
+		add_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
+		add_action( 'phpmailer_init',       __CLASS__ . '::add_plain_text_alternative' );
+
+		$result = wp_mail( $to, $subject, $message, $headers, $attachments );
+
+		remove_filter( 'wp_mail_content_type', __CLASS__ . '::get_mail_content_type' );
+		remove_action( 'phpmailer_init',       __CLASS__ . '::add_plain_text_alternative' );
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7179

#### Changes proposed in this Pull Request:

Send all outbound Grunion messages through a wrapper that ensures they are correctly rendered as HTML.

#### Testing instructions:

1. Add the mu-plugin below to your installation
1. Checkout `master`
1. Send an email. It will be flagged as spam because of the filter.
1. Browse to `Feedback > Spam`
1. Click `Not Spam`
1. View the email. It will have a `text/plain` content type, and show raw HTML in the body

1. Checkout this branch and repeat the steps above. It should have a `text/html` content type and show rendered HTML in the body.
1. Disable the filter and test messages that aren't flagged as spam. They should also have the `text/html` content-type and show rendered HTML.

#### mu-plugin for testing:
```php
add_filter( 'jetpack_contact_form_is_spam', function( $is_spam, $akismet_values ) {
	return true;
}, 10, 2 );
```
