### PR TITLE
Add support for VideoPress in core Media Video Widget.

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -164,6 +164,14 @@ class Jetpack_VideoPress {
 				),
 				$this->version
 			);
+
+			wp_enqueue_script(
+				'media-video-widget-extensions',
+				plugins_url( 'js/media-video-widget-extensions.js', __FILE__ ),
+				array(),
+				$this->version,
+				true
+			);
 		}
 
 		/**

--- a/modules/videopress/js/media-video-widget-extensions.js
+++ b/modules/videopress/js/media-video-widget-extensions.js
@@ -8,7 +8,7 @@ window.wp = window.wp || {};
 			return function( mediaFrameProps ) {
 				var newProps, originalProps;
 				originalProps = originalMapMediaToModelProps.call( this, mediaFrameProps );
-				newProps = _.extend( {}, originalProps );;
+				newProps = _.extend( {}, originalProps );
 				
 				if ( mediaFrameProps.videopress && mediaFrameProps.videopress.guid ) {
 					newProps = _.extend( {}, originalProps, {

--- a/modules/videopress/js/media-video-widget-extensions.js
+++ b/modules/videopress/js/media-video-widget-extensions.js
@@ -6,13 +6,23 @@ window.wp = window.wp || {};
 		// Over-ride core media_video#mapMediaToModelProps to set the url based upon videopress_guid if it exists.
 		wp.mediaWidgets.controlConstructors.media_video.prototype.mapMediaToModelProps = ( function( originalMapMediaToModelProps ) {
 			return function( mediaFrameProps ) {
-				var newProps, originalProps;
+				var newProps, originalProps, videoPressGuid;
 				originalProps = originalMapMediaToModelProps.call( this, mediaFrameProps );
 				newProps = _.extend( {}, originalProps );
 				
+				// API response on new media will have the guid at videopress.guid.
 				if ( mediaFrameProps.videopress && mediaFrameProps.videopress.guid ) {
+					videoPressGuid = mediaFrameProps.videopress.guid;
+				}
+
+				// Selecting an existing VideoPress file will have the guid at .videopress_guid[ 0 ].
+				if ( ! videoPressGuid && mediaFrameProps.videopress_guid && mediaFrameProps.videopress_guid.length ) {
+					videoPressGuid = mediaFrameProps.videopress_guid[ 0 ];
+				}
+
+				if ( videoPressGuid ) {
 					newProps = _.extend( {}, originalProps, {
-						url: 'https://videopress.com/v/' + mediaFrameProps.videopress.guid,
+						url: 'https://videopress.com/v/' + videoPressGuid,
 						attachment_id: 0
 					});
 				}

--- a/modules/videopress/js/media-video-widget-extensions.js
+++ b/modules/videopress/js/media-video-widget-extensions.js
@@ -1,0 +1,35 @@
+window.wp = window.wp || {};
+
+( function( wp ) {
+	if ( wp.mediaWidgets ) {
+		
+		// Over-ride core media_video#mapMediaToModelProps to set the url based upon videopress_guid if it exists.
+		wp.mediaWidgets.controlConstructors.media_video.prototype.mapMediaToModelProps = ( function( originalMapMediaToModelProps ) {
+			return function( mediaFrameProps ) {
+				var newProps, originalProps;
+				originalProps = originalMapMediaToModelProps.call( this, mediaFrameProps );
+				newProps = _.extend( {}, originalProps );;
+				
+				if ( mediaFrameProps.videopress && mediaFrameProps.videopress.guid ) {
+					newProps = _.extend( {}, originalProps, {
+						url: 'https://videopress.com/v/' + mediaFrameProps.videopress.guid,
+						attachment_id: 0
+					});
+				}
+				return newProps;
+			};
+		}( wp.mediaWidgets.controlConstructors.media_video.prototype.mapMediaToModelProps ));
+
+		// Over-ride core media_video#isHostedVideo() to add support for videopress oembed urls.
+		wp.mediaWidgets.controlConstructors.media_video.prototype.isHostedVideo = (function( originalIsHostedVideo ) {
+			return function( url ) {
+				var parsedUrl = document.createElement( 'a' );
+				parsedUrl.href = url;
+				if ( 'videopress.com' === parsedUrl.hostname ) {
+					return true;
+				}
+				return originalIsHostedVideo.call( this, url );
+			};
+		}( wp.mediaWidgets.controlConstructors.media_video.prototype.isHostedVideo ));
+	}
+} )( window.wp );

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -184,6 +184,11 @@ class VideoPress_Shortcode {
 						$videopress_guid = $matches[2];
 					}
 
+					// Also test for videopress oembed url, which is used by the Video Media Widget.
+					if ( ! $videopress_guid && preg_match( '@https://videopress.com/v/([a-z0-9]{8})@i', $url, $matches ) ) {
+						$videopress_guid = $matches[1];
+					}
+
 					break;
 				}
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The new Media Widgets are going to be released in WordPress 4.8, and currently VideoPress does not work seamlessly with the new Video Media Widget.  The issue arises when uploading a new video from within the media modal launched by the Video Widget, and the subsequent `url` from the attachment is returned as the attachment page - not the CDN VideoPress file or oembed url.

This PR seeks to fix that problem by extending a few methods on the Video Media Widget, and adding logic to the `wp_video_shortcode` override so VideoPress oembed url's get rendered like they do within the editor for example.

Further details and discussion:
https://core.trac.wordpress.org/ticket/40808
https://github.com/xwp/wp-core-media-widgets/issues/160

#### Testing instructions:

* You must be running trunk, or a nightly build, ~and manually apply [the patch](https://core.trac.wordpress.org/attachment/ticket/40808/40808.2.diff) on the trac ticket if it has yet to be merged in ( at the time of PR creation, the fix has yet to be merged to trunk )~
* Additionally, this PR is dependent upon a minor WPCOM API update that I have been working with @dbtlr on - I will post back here when that has been merged, but until then please ping me for a diff to apply to your sandbox

Hopefully these two steps will be un-needed very soon 😄 

To actually test things out, open up the Customizer | Widgets screen on a site that has a plan with VideoPress enabled.  Add a video widget, and upload a new file.  In the customizer preview, verify that the VideoPress oembed player is shown, and it should show the transcoding progress in real time, and be playable once the video is ready.