### PR TITLE
Sync: Update widgets so that we pass in the Widget name and Sidebar name when ever possible

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -360,7 +360,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 				: array();
 
 			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
-			$moved_to_inactive = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
+			$moved_to_inactive_ids = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
 
 			$moved_to_sidebar_recently = $this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar );
 			$moved_to_sidebar = array_merge( $moved_to_sidebar, $moved_to_sidebar_recently );
@@ -370,16 +370,17 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		}
 
 		// Treat inactive sidebar a bit differently
-		if ( ! empty( $moved_to_inactive ) ) {
+		if ( ! empty( $moved_to_inactive_ids ) ) {
+			$moved_to_inactive_name = array_map( array( $this, 'get_widget_name' ), $moved_to_inactive_ids );
 			/**
 			 * Helps Sync log that a widgets IDs got moved to in active
 			 *
 			 * @since 4.9.0
 			 *
-			 * @param array $moved_to_inactive, Array of widgets id that moved to inactive id got changed
-			 * @param array $moved_to_inactive, Array of widgets names that moved to inactive id got changed Since 5.0.0
+			 * @param array $moved_to_inactive_ids, Array of widgets id that moved to inactive id got changed
+			 * @param array $moved_to_inactive_names, Array of widgets names that moved to inactive id got changed Since 5.0.0
 			 */
-			do_action( 'jetpack_widget_moved_to_inactive', $moved_to_inactive, array_map( array( $this, 'get_widget_name' ), $moved_to_inactive ) );
+			do_action( 'jetpack_widget_moved_to_inactive', $moved_to_inactive_ids, $moved_to_inactive_name );
 		} elseif ( empty( $moved_to_sidebar ) &&
 		           empty( $new_value['wp_inactive_widgets']) &&
 		           ! empty( $old_value['wp_inactive_widgets'] ) ) {

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -278,7 +278,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			 * @param string $added_widget_name, Widget id got added Since 5.0.0
 			 *
 			 */
-			do_action( 'jetpack_widget_added', $sidebar, $added_widget,  $sidebar_name, $added_widget_name ); // $this->get_sidebar_name( $sidebar ), $this->get_widget_name( $added_widget ) );
+			do_action( 'jetpack_widget_added', $sidebar, $added_widget,  $sidebar_name, $added_widget_name );
 		}
 		return $moved_to_sidebar;
 	}

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -21,11 +21,12 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 		// Sidebar updates.
 		add_action( 'update_option_sidebars_widgets', array( $this, 'sync_sidebar_widgets_actions' ), 10, 2 );
-		add_action( 'jetpack_widget_added', $callable, 10, 2 );
-		add_action( 'jetpack_widget_removed', $callable, 10, 2 );
-		add_action( 'jetpack_widget_moved_to_inactive', $callable );
+
+		add_action( 'jetpack_widget_added', $callable, 10, 4 );
+		add_action( 'jetpack_widget_removed', $callable, 10, 4 );
+		add_action( 'jetpack_widget_moved_to_inactive', $callable, 10, 2 );
 		add_action( 'jetpack_cleared_inactive_widgets', $callable );
-		add_action( 'jetpack_widget_reordered', $callable );
+		add_action( 'jetpack_widget_reordered', $callable, 10, 2 );
 		add_filter( 'widget_update_callback', array( $this, 'sync_widget_edit' ), 10, 4 );
 		add_action( 'jetpack_widget_edited', $callable );
 	}
@@ -245,14 +246,27 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		return array( $this->get_theme_support_info() );
 	}
 
+	function get_widget_name( $widget_id ) {
+		global $wp_registered_widgets;
+		return ( isset( $wp_registered_widgets[ $widget_id ] ) ? $wp_registered_widgets[ $widget_id ]['name'] : null );
+	}
+
+	function get_sidebar_name( $sidebar_id ) {
+		global $wp_registered_sidebars;
+		return ( isset( $wp_registered_sidebars[ $sidebar_id ] ) ? $wp_registered_sidebars[ $sidebar_id ]['name'] : null );
+	}
+
 	function sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar ) {
 		$added_widgets = array_diff( $new_widgets, $old_widgets );
 		if ( empty( $added_widgets ) ) {
 			return array();
 		}
 		$moved_to_sidebar = array();
+		$sidebar_name = $this->get_sidebar_name( $sidebar );
+
 		foreach ( $added_widgets as $added_widget ) {
 			$moved_to_sidebar[] = $added_widget;
+			$added_widget_name = $this->get_widget_name( $added_widget );
 			/**
 			 * Helps Sync log that a widget got added
 			 *
@@ -260,8 +274,11 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			 *
 			 * @param string $sidebar, Sidebar id got changed
 			 * @param string $added_widget, Widget id got added
+			 * @param string $sidebar_name, Sidebar id got changed Since 5.0.0
+			 * @param string $added_widget_name, Widget id got added Since 5.0.0
+			 *
 			 */
-			do_action( 'jetpack_widget_added', $sidebar, $added_widget );
+			do_action( 'jetpack_widget_added', $sidebar, $added_widget,  $sidebar_name, $added_widget_name ); // $this->get_sidebar_name( $sidebar ), $this->get_widget_name( $added_widget ) );
 		}
 		return $moved_to_sidebar;
 	}
@@ -274,10 +291,12 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		}
 
 		$moved_to_inactive = array();
+		$sidebar_name = $this->get_sidebar_name( $sidebar );
 
 		foreach( $removed_widgets as $removed_widget ) {
 			// Lets check if we didn't move the widget to in_active_widgets
 			if ( isset( $inactive_widgets ) && ! in_array( $removed_widget, $inactive_widgets ) ) {
+				$removed_widget_name = $this->get_widget_name( $removed_widget );
 				/**
 				 * Helps Sync log that a widgte got removed
 				 *
@@ -285,8 +304,10 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 				 *
 				 * @param string $sidebar, Sidebar id got changed
 				 * @param string $removed_widget, Widget id got removed
+				 * @param string $sidebar_name, Name of the sidebar that changed  Since 5.0.0
+				 * @param string $removed_widget_name, Name of the widget that got removed Since 5.0.0
 				 */
-				do_action( 'jetpack_widget_removed', $sidebar, $removed_widget );
+				do_action( 'jetpack_widget_removed', $sidebar, $removed_widget, $sidebar_name, $removed_widget_name );
 			} else {
 				$moved_to_inactive[] = $removed_widget;
 			}
@@ -306,14 +327,16 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 		}
 
 		if ( serialize( $old_widgets ) !== serialize( $new_widgets ) ) {
+			$sidebar_name = $this->get_sidebar_name( $sidebar );
 			/**
 			 * Helps Sync log that a sidebar id got reordered
 			 *
 			 * @since 4.9.0
 			 *
 			 * @param string $sidebar, Sidebar id got changed
+			 * @param string $sidebar_name, Name of the sidebar that changed  Since 5.0.0
 			 */
-			do_action( 'jetpack_widget_reordered', $sidebar );
+			do_action( 'jetpack_widget_reordered', $sidebar, $sidebar_name );
 		}
 
 	}
@@ -339,7 +362,6 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
 			$moved_to_inactive = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
 
-
 			$moved_to_sidebar_recently = $this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar );
 			$moved_to_sidebar = array_merge( $moved_to_sidebar, $moved_to_sidebar_recently );
 
@@ -354,9 +376,10 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			 *
 			 * @since 4.9.0
 			 *
-			 * @param array $sidebar, Sidebar id got changed
+			 * @param array $moved_to_inactive, Array of widgets id that moved to inactive id got changed
+			 * @param array $moved_to_inactive, Array of widgets names that moved to inactive id got changed Since 5.0.0
 			 */
-			do_action( 'jetpack_widget_moved_to_inactive', $moved_to_inactive );
+			do_action( 'jetpack_widget_moved_to_inactive', $moved_to_inactive, array_map( array( $this, 'get_widget_name' ), $moved_to_inactive ) );
 		} elseif ( empty( $moved_to_sidebar ) &&
 		           empty( $new_value['wp_inactive_widgets']) &&
 		           ! empty( $old_value['wp_inactive_widgets'] ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -283,6 +283,11 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_widgets_changes_get_synced() {
+		global $wp_registered_sidebars;
+
+		$sidebar_id = 'sidebar-1';
+		$sidebar_name = $wp_registered_sidebars[ $sidebar_id ]['name'];
+		
 		$sidebar_widgets = array(
 			'wp_inactive_widgets' => array( 'author-1' ),
 			'sidebar-1' => array( 'nav_menu-1' ),
@@ -308,9 +313,9 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_added' );
 
-		$this->assertEquals( $event->args[0], 'sidebar-1', 'Added to sidebar not found' );
+		$this->assertEquals( $event->args[0], $sidebar_id, 'Added to sidebar not found' );
 		$this->assertEquals( $event->args[1], 'calendar-1', 'Added widget not found' );
-		$this->assertEquals( $event->args[2], 'Sidebar 1', 'Added sidebar name not found' );
+		$this->assertEquals( $event->args[2], $sidebar_name, 'Added sidebar name not found' );
 		$this->assertEquals( $event->args[3], 'Calendar', 'Added widget name not found' );
 
 		// Reorder widget
@@ -324,8 +329,8 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_reordered' );
 
-		$this->assertEquals( $event->args[0], 'sidebar-1', 'Reordered sidebar not found' );
-		$this->assertEquals( $event->args[1], 'Sidebar 1', 'Reordered sidebar name not found' );
+		$this->assertEquals( $event->args[0], $sidebar_id, 'Reordered sidebar not found' );
+		$this->assertEquals( $event->args[1], $sidebar_name, 'Reordered sidebar name not found' );
 
 		// Deleted widget
 		$sidebar_widgets  = array(
@@ -338,10 +343,10 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_removed' );
 
-		$this->assertEquals( $event->args[0], 'sidebar-1', 'Sidebar not found' );
+		$this->assertEquals( $event->args[0], $sidebar_id, 'Sidebar not found' );
 		$this->assertEquals( $event->args[1], 'nav_menu-1', 'Recent removed widget not found' );
 
-		$this->assertEquals( $event->args[2], 'Sidebar 1', 'Added sidebar name not found' );
+		$this->assertEquals( $event->args[2], $sidebar_name, 'Added sidebar name not found' );
 		$this->assertEquals( $event->args[3], 'Custom Menu', 'Added widget name not found' );
 
 		// Moved to inactive

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -283,10 +283,9 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_widgets_changes_get_synced() {
-
 		$sidebar_widgets = array(
 			'wp_inactive_widgets' => array( 'author-1' ),
-			'sidebar-1' => array( 'recent-posts-2' ),
+			'sidebar-1' => array( 'nav_menu-1' ),
 			'array_version' => 3
 		);
 		wp_set_sidebars_widgets( $sidebar_widgets );
@@ -300,7 +299,7 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		// Add widget
 		$sidebar_widgets = array(
 			'wp_inactive_widgets' => array( 'author-1' ),
-			'sidebar-1' => array( 'recent-posts-2', 'calendar-2'),
+			'sidebar-1' => array( 'nav_menu-1', 'calendar-1' ),
 			'array_version' => 3
 		);
 		wp_set_sidebars_widgets( $sidebar_widgets );
@@ -308,37 +307,46 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_added' );
+
 		$this->assertEquals( $event->args[0], 'sidebar-1', 'Added to sidebar not found' );
-		$this->assertEquals( $event->args[1], 'calendar-2', 'Added widget not found' );
+		$this->assertEquals( $event->args[1], 'calendar-1', 'Added widget not found' );
+		$this->assertEquals( $event->args[2], 'Sidebar 1', 'Added sidebar name not found' );
+		$this->assertEquals( $event->args[3], 'Calendar', 'Added widget name not found' );
 
 		// Reorder widget
 		$sidebar_widgets  = array(
 			'wp_inactive_widgets' => array( 'author-1' ),
-			'sidebar-1' => array( 'calendar-2', 'recent-posts-2' ),
+			'sidebar-1' => array( 'calendar-1', 'nav_menu-1' ),
 			'array_version' => 3
 		);
 		wp_set_sidebars_widgets( $sidebar_widgets );
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_reordered' );
+
 		$this->assertEquals( $event->args[0], 'sidebar-1', 'Reordered sidebar not found' );
+		$this->assertEquals( $event->args[1], 'Sidebar 1', 'Reordered sidebar name not found' );
 
 		// Deleted widget
 		$sidebar_widgets  = array(
 			'wp_inactive_widgets' => array( 'author-1' ),
-			'sidebar-1' => array( 'calendar-2' ),
+			'sidebar-1' => array( 'calendar-1' ),
 			'array_version' => 3
 		);
 		wp_set_sidebars_widgets( $sidebar_widgets );
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_removed' );
+
 		$this->assertEquals( $event->args[0], 'sidebar-1', 'Sidebar not found' );
-		$this->assertEquals( $event->args[1], 'recent-posts-2', 'Recent removed widget not found' );
+		$this->assertEquals( $event->args[1], 'nav_menu-1', 'Recent removed widget not found' );
+
+		$this->assertEquals( $event->args[2], 'Sidebar 1', 'Added sidebar name not found' );
+		$this->assertEquals( $event->args[3], 'Custom Menu', 'Added widget name not found' );
 
 		// Moved to inactive
 		$sidebar_widgets  = array(
-			'wp_inactive_widgets' => array( 'author-1', 'calendar-2' ),
+			'wp_inactive_widgets' => array( 'author-1', 'calendar-1' ),
 			'sidebar-1' => array(),
 			'array_version' => 3
 		);
@@ -346,7 +354,8 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_widget_moved_to_inactive' );
-		$this->assertEquals( $event->args[0], array( 'calendar-2' ), 'Moved to inactive not present' );
+		$this->assertEquals( $event->args[0], array( 'calendar-1' ), 'Moved to inactive not present' );
+		$this->assertEquals( $event->args[1], array( 'Calendar' ), 'Moved to inactive not present' );
 		
 		// Cleared inavite
 		$sidebar_widgets  = array(


### PR DESCRIPTION
Previously we were no passing in the widget name and the sidebar name. but instead were just passing in the ids. Which are not enough to build a user friendly Activity log. 

We are adding the names the way we are so that they are backwards compatible if someone else is using the do_actions already. 

#### Changes proposed in this Pull Request:
* In this pr we are adding the names of the sidebar and the widget whenever possible 

#### Testing instructions:
* Do the test pass? Do it pass when testing things manually

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
