### PR TITLE
Sync: Full sync options fix

### DIFF
--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -71,16 +71,22 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 	// Is public so that we don't have to store so much data all the options twice.
 	function get_all_options() {
 		$options = array();
+		$random_string = wp_generate_password();
 		foreach ( $this->options_whitelist as $option ) {
-			$options[ $option ] = get_option( $option );
+			$option_value = get_option( $option, $random_string );
+			if ( $option_value !== $random_string ) {
+				$options[ $option ] = $option_value;
+			}
 		}
 
 		// add theme mods
 		$theme_mods_option = 'theme_mods_'.get_option( 'stylesheet' );
-		$theme_mods_value  = get_option( $theme_mods_option );
+		$theme_mods_value  = get_option( $theme_mods_option, $random_string );
+		if ( $theme_mods_value === $random_string ) {
+			return $options;
+		}
 		$this->filter_theme_mods( $theme_mods_value );
 		$options[ $theme_mods_option ] = $theme_mods_value;
-
 		return $options;
 	}
 
@@ -109,7 +115,6 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 				$this->filter_theme_mods( $args[2] );
 			}
 		}
-
 		return $args;
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -312,7 +312,8 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_sends_all_options() {
-		Jetpack_Sync_Modules::get_module( "options" )->set_options_whitelist( array( 'my_option', 'my_prefix_value' ) );
+		delete_option( 'non_existant' );
+		Jetpack_Sync_Modules::get_module( "options" )->set_options_whitelist( array( 'my_option', 'my_prefix_value', 'non_existant' ) );
 		update_option( 'my_option', 'foo' );
 		update_option( 'my_prefix_value', 'bar' );
 		update_option( 'my_non_synced_option', 'baz' );
@@ -323,19 +324,25 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_option( 'my_option' ) );
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_option( 'my_prefix_value' ) );
 		$this->assertEquals( null, $this->server_replica_storage->get_option( 'my_non_synced_option' ) );
+		$this->assertEquals( null, $this->server_replica_storage->get_option( 'non_existant' )  );
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
 
 		$this->assertEquals( null, $this->server_replica_storage->get_option( 'my_option' ) );
 		$this->assertEquals( null, $this->server_replica_storage->get_option( 'my_prefix_value' ) );
+		$this->assertEquals( null, $this->server_replica_storage->get_option( 'non_existant' )  );
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
 
+		$synced_options_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_options' );
+		$this->assertEquals(  sizeof( $synced_options_event->args ), 2, 'Size of synced potions not as expected' );
+		
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_option( 'my_option' ) );
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_option( 'my_prefix_value' ) );
 		$this->assertEquals( null, $this->server_replica_storage->get_option( 'my_non_synced_option' ) );
+		$this->assertEquals( null, $this->server_replica_storage->get_option( 'non_existant' )  );
 	}
 
 	// to test run phpunit -c tests/php.multisite.xml --filter test_full_sync_sends_all_network_options

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -337,7 +337,9 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$synced_options_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_options' );
-		$this->assertEquals(  sizeof( $synced_options_event->args ), 2, 'Size of synced potions not as expected' );
+		$this->assertEquals(  sizeof( $synced_options_event->args ), 2, 'Size of synced options not as expected' );
+		$this->assertEquals( 'foo', $synced_options_event->args['my_option'] );
+		$this->assertEquals( 'bar', $synced_options_event->args['my_prefix_value'] );
 		
 		$this->assertEquals( 'foo', $this->server_replica_storage->get_option( 'my_option' ) );
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_option( 'my_prefix_value' ) );


### PR DESCRIPTION
Fixes #7199, lets not sync full sync the options that do not exist.

Currently we send the key to with the null value to when options do not exits. Which is not ideal. It would be much better if we just not sent the key at all. This PR fixed #7199.

#### Changes proposed in this Pull Request:
* Remove non-existent options during full sync.

#### Testing instructions:

* Do the unit test pass? 
@nabsul Can you test this to make sure this works for you as expected? 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

