### PR TITLE
Admin Page: Es6ify and use prettier on security components

### DIFF
--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -20,70 +20,74 @@ import analytics from 'lib/analytics';
  * Internal dependencies
  */
 import { FormFieldset, FormLabel } from 'components/forms';
-import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import {
+	ModuleSettingsForm as moduleSettingsForm,
+} from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const Antispam = moduleSettingsForm(
-	React.createClass( {
+	class extends React.Component {
+		state = {
+			apiKey: this.props.getOptionValue( 'wordpress_api_key' ),
+			delayKeyCheck: false,
+			currentEvent: {},
+		};
 
-		getInitialState() {
-			return {
-				apiKey: this.props.getOptionValue( 'wordpress_api_key' ),
-				delayKeyCheck: false,
-				currentEvent: {}
-			};
-		},
-
-		keyChanged: false,
+		keyChanged = false;
 
 		componentWillMount() {
 			this.debouncedCheckApiKeyTyped = debounce( this.checkApiKeyTyped, 500 );
-		},
+		}
 
-		checkApiKeyTyped( event ) {
+		checkApiKeyTyped = event => {
 			if ( 0 < event.currentTarget.value.length ) {
 				this.props.checkAkismetKey( event.currentTarget.value );
 			}
 			this.keyChanged = true;
 			this.setState( {
-				delayKeyCheck: false
+				delayKeyCheck: false,
 			} );
-		},
+		};
 
-		updateText( event ) {
+		updateText = event => {
 			const currentEvent = assign( {}, event );
 			currentEvent.currentTarget.value = trim( currentEvent.currentTarget.value );
 			this.setState(
 				{
 					apiKey: currentEvent.currentTarget.value,
 					delayKeyCheck: true,
-					currentEvent: currentEvent
+					currentEvent: currentEvent,
 				},
 				this.debouncedCheckApiKeyTyped( currentEvent )
 			);
-		},
+		};
 
 		componentDidUpdate() {
-			if ( ! this.props.isCheckingAkismetKey && this.props.isAkismetKeyValid && this.keyChanged && ! isEmpty( this.state.currentEvent ) ) {
+			if (
+				! this.props.isCheckingAkismetKey &&
+				this.props.isAkismetKeyValid &&
+				this.keyChanged &&
+				! isEmpty( this.state.currentEvent )
+			) {
 				this.keyChanged = false;
 				this.props.onOptionChange( this.state.currentEvent );
 			}
-		},
+		}
 
-		trackOpenCard() {
+		trackOpenCard = () => {
 			analytics.tracks.recordJetpackClick( {
 				target: 'foldable-settings-open',
-				feature: 'anti-spam'
+				feature: 'anti-spam',
 			} );
-		},
+		};
 
 		render() {
 			const textProps = {
 				name: 'wordpress_api_key',
 				value: this.state.apiKey,
 				disabled: this.props.isSavingAnyOption( 'wordpress_api_key' ),
-				onChange: this.updateText
+				onChange: this.updateText,
 			};
 			let akismetStatus = '',
 				foldableHeader = __( 'Checking your spam protection…' ),
@@ -98,12 +102,16 @@ export const Antispam = moduleSettingsForm(
 				foldableHeader = __( 'Your site needs an Antispam key.' );
 			} else if ( ! this.state.delayKeyCheck && ! this.props.isCheckingAkismetKey ) {
 				if ( false === this.props.isAkismetKeyValid ) {
-					akismetStatus = <FormInputValidation isError text={
-							__( "There's a problem with your Antispam API key. {{a}}Learn more{{/a}}.", {
+					akismetStatus = (
+						<FormInputValidation
+							isError
+							text={ __( "There's a problem with your Antispam API key. {{a}}Learn more{{/a}}.", {
 								components: {
-									a: <a href={ 'https://docs.akismet.com/getting-started/api-key/' } />
-								}
-							} ) } />;
+									a: <a href={ 'https://docs.akismet.com/getting-started/api-key/' } />,
+								},
+							} ) }
+						/>
+					);
 					textProps.isError = true;
 					foldableHeader = __( 'Your site is not protected from spam.' );
 				} else {
@@ -128,53 +136,44 @@ export const Antispam = moduleSettingsForm(
 					saveDisabled={ this.props.isSavingAnyOption( 'wordpress_api_key' ) }
 					feature={ FEATURE_SPAM_AKISMET_PLUS }
 				>
-					<FoldableCard
-						onOpen={ this.trackOpenCard }
-						header={ foldableHeader }
-					>
+					<FoldableCard onOpen={ this.trackOpenCard } header={ foldableHeader }>
 						<SettingsGroup support="https://akismet.com/jetpack/">
 							<FormFieldset>
 								<FormLabel>
 									<span className="jp-form-label-wide">{ __( 'Your API key' ) }</span>
-									<TextInput
-										{ ...textProps }
-									/>
-									{
-										akismetStatus
-									}
+									<TextInput { ...textProps } />
+									{ akismetStatus }
 								</FormLabel>
-								{
-									explanation && (
-										<p className="jp-form-setting-explanation" >
+								{ explanation &&
+									<p className="jp-form-setting-explanation">
+										{ __(
+											"If you don't already have an API key, then {{a}}get your API key here{{/a}}, and you'll be guided through the process of getting one.",
 											{
-												__( "If you don't already have an API key, then {{a}}get your API key here{{/a}}, and you'll be guided through the process of getting one.", {
-													components: {
-														a: <a href={ 'https://akismet.com/wordpress/' } />
-													}
-												} )
+												components: {
+													a: <a href={ 'https://akismet.com/wordpress/' } />,
+												},
 											}
-										</p>
-									)
-								}
+										) }
+									</p> }
 							</FormFieldset>
 						</SettingsGroup>
 					</FoldableCard>
 				</SettingsCard>
 			);
 		}
-	} )
+	}
 );
 
 export default connect(
 	state => {
 		return {
 			isAkismetKeyValid: isAkismetKeyValid( state ),
-			isCheckingAkismetKey: isCheckingAkismetKey( state )
+			isCheckingAkismetKey: isCheckingAkismetKey( state ),
 		};
 	},
 	dispatch => {
 		return {
-			checkAkismetKey: ( apiKey = '' ) => dispatch( checkAkismetKey( apiKey ) )
+			checkAkismetKey: ( apiKey = '' ) => dispatch( checkAkismetKey( apiKey ) ),
 		};
 	}
 )( Antispam );

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import TextInput from 'components/text-input';
@@ -27,7 +27,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const Antispam = moduleSettingsForm(
-	class extends React.Component {
+	class extends Component {
 		state = {
 			apiKey: this.props.getOptionValue( 'wordpress_api_key' ),
 			delayKeyCheck: false,

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import Card from 'components/card';
@@ -23,7 +23,7 @@ import { getSitePlan, isFetchingSiteData } from 'state/site';
 import includes from 'lodash/includes';
 
 export const BackupsScan = moduleSettingsForm(
-	class extends React.Component {
+	class extends Component {
 		toggleModule = ( name, value ) => {
 			this.props.updateFormStateOptionValue( name, ! value );
 		};

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -13,7 +13,9 @@ import { getPlanClass } from 'lib/plans/constants';
  * Internal dependencies
  */
 import { FEATURE_SECURITY_SCANNING_JETPACK } from 'lib/plans/constants';
-import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import {
+	ModuleSettingsForm as moduleSettingsForm,
+} from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { getVaultPressData, isFetchingVaultPressData } from 'state/at-a-glance';
@@ -21,21 +23,19 @@ import { getSitePlan, isFetchingSiteData } from 'state/site';
 import includes from 'lodash/includes';
 
 export const BackupsScan = moduleSettingsForm(
-	React.createClass( {
-
-		toggleModule( name, value ) {
+	class extends React.Component {
+		toggleModule = ( name, value ) => {
 			this.props.updateFormStateOptionValue( name, ! value );
-		},
+		};
 
-		trackConfigureClick() {
+		trackConfigureClick = () => {
 			analytics.tracks.recordJetpackClick( 'configure-scan' );
-		},
+		};
 
 		render() {
-			const backupsAndScansEnabled = (
-					get( this.props.vaultPressData, [ 'data', 'features', 'backups' ], false ) &&
-					get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false )
-				),
+			const backupsAndScansEnabled =
+				get( this.props.vaultPressData, [ 'data', 'features', 'backups' ], false ) &&
+				get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false ),
 				planClass = getPlanClass( this.props.sitePlan.product_slug );
 			let cardText = '';
 
@@ -44,11 +44,15 @@ export const BackupsScan = moduleSettingsForm(
 			} else if ( ! this.props.isFetchingSiteData && ! this.props.isFetchingVaultPressData ) {
 				if ( backupsAndScansEnabled ) {
 					cardText = __( 'Your site is backed up and threat-free.' );
-				} else if ( includes( [ 'is-personal-plan', 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
+				} else if (
+					includes( [ 'is-personal-plan', 'is-premium-plan', 'is-business-plan' ], planClass )
+				) {
 					if ( 'is-personal-plan' === planClass ) {
 						cardText = __( "You have paid for backups but they're not yet active." );
 					} else if ( includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) ) {
-						cardText = __( 'You have paid for backups and security scanning but they’re not yet active.' );
+						cardText = __(
+							'You have paid for backups and security scanning but they’re not yet active.'
+						);
 					}
 					cardText += ' ' + __( 'Click "Set Up" to finish installation.' );
 				}
@@ -62,30 +66,36 @@ export const BackupsScan = moduleSettingsForm(
 					{ ...this.props }
 					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
 					action="scan"
-					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'backups' } } support="https://help.vaultpress.com/get-to-know/">
-						{
-							cardText
-						}
+					hideButton
+				>
+					<SettingsGroup
+						disableInDevMode
+						module={ { module: 'backups' } }
+						support="https://help.vaultpress.com/get-to-know/"
+					>
+						{ cardText }
 					</SettingsGroup>
-					{
-						( ! this.props.isUnavailableInDevMode( 'backups' ) && backupsAndScansEnabled ) && (
-							<Card compact className="jp-settings-card__configure-link" onClick={ this.trackConfigureClick } href="https://dashboard.vaultpress.com/">{ __( 'Configure your Security Scans' ) }</Card>
-						)
-					}
+					{ ! this.props.isUnavailableInDevMode( 'backups' ) &&
+						backupsAndScansEnabled &&
+						<Card
+							compact
+							className="jp-settings-card__configure-link"
+							onClick={ this.trackConfigureClick }
+							href="https://dashboard.vaultpress.com/"
+						>
+							{ __( 'Configure your Security Scans' ) }
+						</Card> }
 				</SettingsCard>
 			);
 		}
-	} )
+	}
 );
 
-export default connect(
-	( state ) => {
-		return {
-			sitePlan: getSitePlan( state ),
-			isFetchingSiteData: isFetchingSiteData( state ),
-			vaultPressData: getVaultPressData( state ),
-			isFetchingVaultPressData: isFetchingVaultPressData( state )
-		};
-	}
-)( BackupsScan );
+export default connect( state => {
+	return {
+		sitePlan: getSitePlan( state ),
+		isFetchingSiteData: isFetchingSiteData( state ),
+		vaultPressData: getVaultPressData( state ),
+		isFetchingVaultPressData: isFetchingVaultPressData( state ),
+	};
+} )( BackupsScan );

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -19,7 +19,7 @@ import Antispam from './antispam';
 import { Protect } from './protect';
 import { SSO } from './sso';
 
-export class Security extends React.Component {
+export class Security extends Component {
 	static displayName = 'SecuritySettings';
 
 	/**

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -19,40 +19,45 @@ import Antispam from './antispam';
 import { Protect } from './protect';
 import { SSO } from './sso';
 
-export const Security = React.createClass( {
-	displayName: 'SecuritySettings',
+export class Security extends React.Component {
+	static displayName = 'SecuritySettings';
 
 	/**
 	 * Check if Akismet plugin is being searched and matched.
 	 *
 	 * @returns {boolean} False if the plugin is inactive or if the search doesn't match it. True otherwise.
 	 */
-	isAkismetFound() {
+	isAkismetFound = () => {
 		if ( ! this.props.isPluginActive( 'akismet/akismet.php' ) ) {
 			return false;
 		}
 
 		if ( this.props.searchTerm ) {
 			const akismetData = this.props.isPluginInstalled( 'akismet/akismet.php' );
-			return [
-				'akismet',
-				'antispam',
-				'spam',
-				'comments',
-				akismetData.Description,
-				akismetData.PluginURI
-			].join( ' ' ).toLowerCase().indexOf( this.props.searchTerm.toLowerCase() ) > -1;
+			return (
+				[
+					'akismet',
+					'antispam',
+					'spam',
+					'comments',
+					akismetData.Description,
+					akismetData.PluginURI,
+				]
+					.join( ' ' )
+					.toLowerCase()
+					.indexOf( this.props.searchTerm.toLowerCase() ) > -1
+			);
 		}
 
 		return true;
-	},
+	};
 
 	render() {
 		const commonProps = {
 			settings: this.props.settings,
 			getModule: this.props.module,
 			isDevMode: this.props.isDevMode,
-			isUnavailableInDevMode: this.props.isUnavailableInDevMode
+			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
 		};
 
 		const foundProtect = this.props.isModuleFound( 'protect' ),
@@ -64,64 +69,34 @@ export const Security = React.createClass( {
 			return null;
 		}
 
-		if (
-			! foundSso &&
-			! foundProtect &&
-			! foundAkismet &&
-			! foundBackups
-		) {
+		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups ) {
 			return null;
 		}
 
 		return (
 			<div>
 				<QuerySite />
-				{
-					foundBackups && (
-						<BackupsScan
-							{ ...commonProps }
-						/>
-					)
-				}
-				{
-					foundAkismet && (
-						<div>
-							<Antispam
-								{ ...commonProps }
-							/>
-							<QueryAkismetKeyCheck />
-						</div>
-					)
-				}
-				{
-					foundProtect && (
-						<Protect
-							{ ...commonProps }
-						/>
-					)
-				}
-				{
-					foundSso && (
-						<SSO
-							{ ...commonProps }
-						/>
-					)
-				}
+				{ foundBackups && <BackupsScan { ...commonProps } /> }
+				{ foundAkismet &&
+					<div>
+						<Antispam { ...commonProps } />
+						<QueryAkismetKeyCheck />
+					</div> }
+				{ foundProtect && <Protect { ...commonProps } /> }
+				{ foundSso && <SSO { ...commonProps } /> }
 			</div>
 		);
 	}
-} );
+}
 
-export default connect(
-	( state ) => {
-		return {
-			module: module_name => getModule( state, module_name ),
-			settings: getSettings( state ),
-			isDevMode: isDevMode( state ),
-			isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
-			isModuleFound: ( module_name ) => isModuleFound( state, module_name ),
-			isPluginActive: ( plugin_slug ) => isPluginActive( state, plugin_slug ),
-			isPluginInstalled: ( plugin_slug ) => isPluginInstalled( state, plugin_slug )
-		};
-	}
-)( Security );
+export default connect( state => {
+	return {
+		module: module_name => getModule( state, module_name ),
+		settings: getSettings( state ),
+		isDevMode: isDevMode( state ),
+		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+		isModuleFound: module_name => isModuleFound( state, module_name ),
+		isPluginActive: plugin_slug => isPluginActive( state, plugin_slug ),
+		isPluginInstalled: plugin_slug => isPluginInstalled( state, plugin_slug ),
+	};
+} )( Security );

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -13,68 +13,66 @@ import analytics from 'lib/analytics';
 /**
  * Internal dependencies
  */
-import {
-	FormFieldset,
-	FormLegend,
-	FormLabel
-} from 'components/forms';
+import { FormFieldset, FormLegend, FormLabel } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
-import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import {
+	ModuleSettingsForm as moduleSettingsForm,
+} from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const Protect = moduleSettingsForm(
-	React.createClass( {
+	class extends React.Component {
+		state = {
+			whitelist: this.props.getOptionValue( 'jetpack_protect_global_whitelist' )
+				? this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local
+				: '',
+		};
 
-		getInitialState() {
-			return {
-				whitelist: this.props.getOptionValue( 'jetpack_protect_global_whitelist' )
-					? this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local
-					: ''
-			};
-		},
-
-		currentIpIsWhitelisted() {
+		currentIpIsWhitelisted = () => {
 			// get current whitelist in textarea from this.state.whitelist;
 			return !! includes( this.state.whitelist, this.props.currentIp );
-		},
+		};
 
-		updateText( event ) {
+		updateText = event => {
 			// Enable button if IP is not in the textarea
 			this.currentIpIsWhitelisted();
 
 			// Update textarea value
 			this.setState( {
-				whitelist: event.target.value
+				whitelist: event.target.value,
 			} );
 
 			// Add textarea content to form values to save
 			this.props.onOptionChange( event );
-		},
+		};
 
-		addToWhitelist() {
-			const newWhitelist = this.state.whitelist + ( 0 >= this.state.whitelist.length ? '' : '\n' ) + this.props.currentIp;
+		addToWhitelist = () => {
+			const newWhitelist =
+				this.state.whitelist +
+				( 0 >= this.state.whitelist.length ? '' : '\n' ) +
+				this.props.currentIp;
 
 			// Update form value manually
 			this.props.updateFormStateOptionValue( 'jetpack_protect_global_whitelist', newWhitelist );
 
 			// add to current state this.state.whitelist;
 			this.setState( {
-				whitelist: newWhitelist
+				whitelist: newWhitelist,
 			} );
 
 			analytics.tracks.recordJetpackClick( {
 				target: 'add-to-whitelist',
-				feature: 'protect'
+				feature: 'protect',
 			} );
-		},
+		};
 
-		trackOpenCard() {
+		trackOpenCard = () => {
 			analytics.tracks.recordJetpackClick( {
 				target: 'foldable-settings-open',
-				feature: 'protect'
+				feature: 'protect',
 			} );
-		},
+		};
 
 		render() {
 			const isProtectActive = this.props.getOptionValue( 'protect' ),
@@ -107,40 +105,52 @@ export const Protect = moduleSettingsForm(
 					>
 						<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'protect' ) }>
 							<FormFieldset>
-								{
-									this.props.currentIp && (
-										<div>
-											<div className="jp-form-label-wide">
-												{
-													__( 'Your current IP: %(ip)s', { args: { ip: this.props.currentIp } } )
-												}
-											</div>
-											{
-												<Button
-													disabled={ ! isProtectActive || unavailableInDevMode || this.currentIpIsWhitelisted() || this.props.isSavingAnyOption( [ 'protect', 'jetpack_protect_global_whitelist' ] ) }
-													onClick={ this.addToWhitelist }
-													>{ __( 'Add to whitelist' ) }</Button>
-											}
+								{ this.props.currentIp &&
+									<div>
+										<div className="jp-form-label-wide">
+											{ __( 'Your current IP: %(ip)s', { args: { ip: this.props.currentIp } } ) }
 										</div>
-									)
-								}
+										{
+											<Button
+												disabled={
+													! isProtectActive ||
+														unavailableInDevMode ||
+														this.currentIpIsWhitelisted() ||
+														this.props.isSavingAnyOption(
+															[ 'protect', 'jetpack_protect_global_whitelist' ]
+														)
+												}
+												onClick={ this.addToWhitelist }
+											>
+												{ __( 'Add to whitelist' ) }
+											</Button>
+										}
+									</div> }
 								<FormLabel>
 									<FormLegend>{ __( 'Whitelisted IP addresses' ) }</FormLegend>
 									<Textarea
-										disabled={ ! isProtectActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'protect', 'jetpack_protect_global_whitelist' ] ) }
+										disabled={
+											! isProtectActive ||
+												unavailableInDevMode ||
+												this.props.isSavingAnyOption(
+													[ 'protect', 'jetpack_protect_global_whitelist' ]
+												)
+										}
 										name={ 'jetpack_protect_global_whitelist' }
 										placeholder={ 'Example: 12.12.12.1-12.12.12.100' }
 										onChange={ this.updateText }
-										value={ this.state.whitelist } />
+										value={ this.state.whitelist }
+									/>
 								</FormLabel>
 								<span className="jp-form-setting-explanation">
-									{
-										__( 'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100', {
+									{ __(
+										'You may whitelist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100',
+										{
 											components: {
-												br: <br />
-											}
-										} )
-									}
+												br: <br />,
+											},
+										}
+									) }
 								</span>
 							</FormFieldset>
 						</SettingsGroup>
@@ -148,5 +158,5 @@ export const Protect = moduleSettingsForm(
 				</SettingsCard>
 			);
 		}
-	} )
+	}
 );

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
 import Button from 'components/button';
 import Textarea from 'components/textarea';
@@ -22,7 +22,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const Protect = moduleSettingsForm(
-	class extends React.Component {
+	class extends Component {
 		state = {
 			whitelist: this.props.getOptionValue( 'jetpack_protect_global_whitelist' )
 				? this.props.getOptionValue( 'jetpack_protect_global_whitelist' ).local

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -10,38 +10,40 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
  */
 import { FormFieldset } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
-import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
+import {
+	ModuleSettingsForm as moduleSettingsForm,
+} from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const SSO = moduleSettingsForm(
-	React.createClass( {
+	class extends React.Component {
+		/**
+     * Get options for initial state.
+     *
+     * @returns {{jetpack_sso_match_by_email: *, jetpack_sso_require_two_step: *}}
+     */
+		state = {
+			jetpack_sso_match_by_email: this.props.getOptionValue( 'jetpack_sso_match_by_email', 'sso' ),
+			jetpack_sso_require_two_step: this.props.getOptionValue(
+				'jetpack_sso_require_two_step',
+				'sso'
+			),
+		};
 
 		/**
-		 * Get options for initial state.
-		 *
-		 * @returns {{jetpack_sso_match_by_email: *, jetpack_sso_require_two_step: *}}
-		 */
-		getInitialState() {
-			return {
-				jetpack_sso_match_by_email: this.props.getOptionValue( 'jetpack_sso_match_by_email', 'sso' ),
-				jetpack_sso_require_two_step: this.props.getOptionValue( 'jetpack_sso_require_two_step', 'sso' )
-			};
-		},
-
-		/**
-		 * Update state so toggles are updated.
-		 *
-		 * @param {string} optionName
-		 */
-		updateOptions( optionName ) {
+     * Update state so toggles are updated.
+     *
+     * @param {string} optionName
+     */
+		updateOptions = optionName => {
 			this.setState(
 				{
-					[ optionName ]: ! this.state[ optionName ]
+					[ optionName ]: ! this.state[ optionName ],
 				},
 				this.props.updateFormStateModuleOption( 'sso', optionName )
 			);
-		},
+		};
 
 		render() {
 			let isSSOActive = this.props.getOptionValue( 'sso' ),
@@ -51,40 +53,46 @@ export const SSO = moduleSettingsForm(
 					{ ...this.props }
 					hideButton
 					module="sso"
-					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }>
+					header={ __( 'WordPress.com log in', { context: 'Settings header' } ) }
+				>
 					<SettingsGroup hasChild disableInDevMode module={ this.props.getModule( 'sso' ) }>
 						<ModuleToggle
 							slug="sso"
 							disabled={ unavailableInDevMode }
-							activated={ isSSOActive }F
+							activated={ isSSOActive }
+							F
 							toggling={ this.props.isSavingAnyOption( 'sso' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
-						<span className="jp-form-toggle-explanation">
-							{
-								this.props.getModule( 'sso' ).description
-							}
-						</span>
+							<span className="jp-form-toggle-explanation">
+								{ this.props.getModule( 'sso' ).description }
+							</span>
 						</ModuleToggle>
 						<FormFieldset>
 							<CompactFormToggle
 								checked={ this.state.jetpack_sso_match_by_email }
-								disabled={ ! isSSOActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_match_by_email' ] ) }
-								onChange={ () => this.updateOptions( 'jetpack_sso_match_by_email' ) }>
+								disabled={
+									! isSSOActive ||
+										unavailableInDevMode ||
+										this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_match_by_email' ] )
+								}
+								onChange={ () => this.updateOptions( 'jetpack_sso_match_by_email' ) }
+							>
 								<span className="jp-form-toggle-explanation">
-									{
-										__( 'Match accounts using email addresses' )
-									}
+									{ __( 'Match accounts using email addresses' ) }
 								</span>
 							</CompactFormToggle>
 							<CompactFormToggle
 								checked={ this.state.jetpack_sso_require_two_step }
-								disabled={ ! isSSOActive || unavailableInDevMode || this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_require_two_step' ] ) }
-								onChange={ () => this.updateOptions( 'jetpack_sso_require_two_step' ) }>
+								disabled={
+									! isSSOActive ||
+										unavailableInDevMode ||
+										this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_require_two_step' ] )
+								}
+								onChange={ () => this.updateOptions( 'jetpack_sso_require_two_step' ) }
+							>
 								<span className="jp-form-toggle-explanation">
-									{
-										__( 'Require accounts to use WordPress.com Two-Step Authentication' )
-									}
+									{ __( 'Require accounts to use WordPress.com Two-Step Authentication' ) }
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>
@@ -92,5 +100,5 @@ export const SSO = moduleSettingsForm(
 				</SettingsCard>
 			);
 		}
-	} )
+	}
 );

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -60,7 +60,6 @@ export const SSO = moduleSettingsForm(
 							slug="sso"
 							disabled={ unavailableInDevMode }
 							activated={ isSSOActive }
-							F
 							toggling={ this.props.isSavingAnyOption( 'sso' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { translate as __ } from 'i18n-calypso';
 import CompactFormToggle from 'components/form/form-toggle/compact';
 
@@ -17,7 +17,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 
 export const SSO = moduleSettingsForm(
-	class extends React.Component {
+	class extends Component {
 		/**
      * Get options for initial state.
      *

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -19,10 +19,10 @@ import SettingsGroup from 'components/settings-group';
 export const SSO = moduleSettingsForm(
 	class extends Component {
 		/**
-     * Get options for initial state.
-     *
-     * @returns {{jetpack_sso_match_by_email: *, jetpack_sso_require_two_step: *}}
-     */
+		 * Get options for initial state.
+		 *
+		 * @returns {{jetpack_sso_match_by_email: *, jetpack_sso_require_two_step: *}}
+		 */
 		state = {
 			jetpack_sso_match_by_email: this.props.getOptionValue( 'jetpack_sso_match_by_email', 'sso' ),
 			jetpack_sso_require_two_step: this.props.getOptionValue(
@@ -32,10 +32,10 @@ export const SSO = moduleSettingsForm(
 		};
 
 		/**
-     * Update state so toggles are updated.
-     *
-     * @param {string} optionName
-     */
+		 * Update state so toggles are updated.
+		 *
+		 * @param {string} optionName
+		 */
 		updateOptions = optionName => {
 			this.setState(
 				{


### PR DESCRIPTION
Applies the `class` react-codemod and Calypso-tuned prettier to use ES6 classes and Calypso styleguides.


#### How this was achieved:

```sh
# Install jscodeshift (the codemod runner)
npm i -g jscodeshift
# Get the react-codemods
git clone https://github.com/reactjs/react-codemod ~/react-codemod

cd jetpack
# Install prettier locally (no saving)
npm i "git+https://github.com/Automattic/calypso-prettier.git#calypso-1.1"

# Run codemod
jscodeshift -t ~/react-codemod/transforms/class.js  _inc/client/security/*jsx
# Run prettier
node_modules/.bin/prettier --write _inc/client/security/* 

git commit -a -m 'Es6ify and run prettier on security components'
```

#### Testing instructions

1. With a Professional plan active on the site, check that the security tab components render properly and work as expected
