### PR TITLE
Action: `jetpack_user_authorized`

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -114,7 +114,19 @@ class Jetpack_Client_Server {
 
 		$is_master_user = ! Jetpack::is_active();
 
-		Jetpack::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
+		$token_set = Jetpack::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
+
+		if ( ! $token_set ) {
+			return new Jetpack_Error( 'token_not_saved', 'Error saving token.', 400 );
+		}
+
+		/**
+		 * Fires after user has successfully received an auth token.
+		 *
+		 * @since 3.9.0
+		 */
+		do_action( 'jetpack_user_authorized' );
+
 
 		if ( ! $is_master_user ) {
 			Jetpack::state( 'message', 'linked' );
@@ -260,13 +272,6 @@ class Jetpack_Client_Server {
 		if ( ! current_user_can( $cap ) ) {
 			return new Jetpack_Error( 'scope', 'current_user_cannot', $code );
 		}
-
-		/**
-		 * Fires after user has successfully received an auth token.
-		 *
-		 * @since 3.9.0
-		 */
-		do_action( 'jetpack_user_authorized' );
 
 		return (string) $json->access_token;
 	}


### PR DESCRIPTION
We currently do action `jetpack_user_authorized` before we save the user's token to the database.

Since this action effects JetpackTracking::track_user_linked which requires
a user token, we should only do `jetpack_user_authorized` after the token is saved.

This PR ensures we do `jetpack_user_authorized` after a user token is saved to
the database.

To test:
- Apply this patch to a jetpack site
- Test a few connection flows, and ensure there are no regressions
- Ensure that tracking is logged correctly