### PR TITLE
VideoPress: fix notice when get_current_screen() is null.

### DIFF
--- a/modules/videopress/editor-media-view.php
+++ b/modules/videopress/editor-media-view.php
@@ -107,7 +107,7 @@ function videopress_media_list_table_query( $query ) {
 		return;
 	}
 
-	if ( is_admin() && $query->is_main_query() && ( 'upload' === get_current_screen()->id ) ) {
+	if ( is_admin() && $query->is_main_query() && ( 'upload' === $current_screen->id ) ) {
 		$meta_query = array(
 			array(
 				'key'     => 'videopress_poster_image',

--- a/modules/videopress/editor-media-view.php
+++ b/modules/videopress/editor-media-view.php
@@ -101,6 +101,12 @@ function videopress_ajax_query_attachments_args( $args ) {
  */
 add_action( 'pre_get_posts', 'videopress_media_list_table_query' );
 function videopress_media_list_table_query( $query ) {
+	$current_screen = get_current_screen();
+
+	if ( is_null( $current_screen ) ) {
+		return;
+	}
+
 	if ( is_admin() && $query->is_main_query() && ( 'upload' === get_current_screen()->id ) ) {
 		$meta_query = array(
 			array(


### PR DESCRIPTION
`[18-May-2017 03:45:18 America/New_York] PHP Notice:  Trying to get property of non-object in
wp-content/plugins/jetpack/modules/videopress/editor-media-view.php on line 104`

#### Proposed changelog entry for your changes:
* VideoPress: fix notice when get_current_screen() is null.