### PR TITLE
Publicize: fix notice when $pages is set to false.

### DIFF
--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -515,7 +515,7 @@ class Publicize extends Publicize_Base {
 
 		if ( ! empty( $connection['connection_data']['meta']['facebook_page'] ) ) {
 			$found = false;
-			if ( is_array( $pages->data ) ) {
+			if ( $pages && is_array( $pages->data ) ) {
 				foreach ( $pages->data as $page ) {
 					if ( $page->id == $connection['connection_data']['meta']['facebook_page'] ) {
 						$found = true;


### PR DESCRIPTION
`[18-May-2017 06:07:11 America/New_York] PHP Notice:  Trying to get property of non-object in
wp-content/plugins/jetpack/modules/publicize/publicize-jetpack.php on line 515`

#### Proposed changelog entry for your changes:
* Publicize: fix potential PHP notice