### PR TITLE
API: has_meta returns an array with a meta_key key, not an object

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -449,7 +449,10 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$show = true;
 
 					// Only business plan subscribers can view custom meta description.
-					if ( Jetpack_SEO_Posts::DESCRIPTION_META_KEY == $meta->key && ! Jetpack_SEO_Utils::is_enabled_jetpack_seo() ) {
+					if (
+						Jetpack_SEO_Posts::DESCRIPTION_META_KEY == $meta['meta_key']
+						&& ! Jetpack_SEO_Utils::is_enabled_jetpack_seo()
+					) {
 						$show = false;
 					}
 


### PR DESCRIPTION
Fixes notices like this one:
[18-May-2017 06:16:55 America/New_York] PHP Notice:  Trying to get property of non-object in
wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-endpoint.php on line 452

#### Proposed changelog entry for your changes:
* WordPress.com REST API: avoid PHP notices when getting a post's meta description.