### PR TITLE
Register connect URL: use 'redirect' query parameter when building connect URL

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3715,8 +3715,9 @@ p {
 				}
 
 				$from = isset( $_GET['from'] ) ? $_GET['from'] : false;
+				$redirect = isset( $_GET['redirect'] ) ? $_GET['redirect'] : false;
 
-				wp_redirect( $this->build_connect_url( true, false, $from ) );
+				wp_redirect( $this->build_connect_url( true, $redirect, $from ) );
 				exit;
 			case 'activate' :
 				if ( ! current_user_can( 'jetpack_activate_modules' ) ) {
@@ -4104,6 +4105,14 @@ p {
 
 		if ( $register || ! $token || ! $site_id ) {
 			$url = Jetpack::nonce_url_no_esc( Jetpack::admin_url( 'action=register' ), 'jetpack-register' );
+
+			if ( ! empty( $redirect ) ) {
+				$validated_redirect = wp_validate_redirect( esc_url_raw( $redirect ), false );
+				$url = ! empty( $redirect )
+					? add_query_arg( 'redirect', urlencode( $validated_redirect ), $url )
+					: $url;
+			}
+
 			if( is_network_admin() ) {
 				$url = add_query_arg( 'is_multisite', network_admin_url( 'admin.php?page=jetpack-settings' ), $url );
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4107,10 +4107,11 @@ p {
 			$url = Jetpack::nonce_url_no_esc( Jetpack::admin_url( 'action=register' ), 'jetpack-register' );
 
 			if ( ! empty( $redirect ) ) {
-				$validated_redirect = wp_validate_redirect( esc_url_raw( $redirect ), false );
-				$url = ! empty( $redirect )
-					? add_query_arg( 'redirect', urlencode( $validated_redirect ), $url )
-					: $url;
+				$url = add_query_arg(
+					'redirect',
+					urlencode( wp_validate_redirect( esc_url_raw( $redirect ) ) ),
+					$url
+				);
 			}
 
 			if( is_network_admin() ) {


### PR DESCRIPTION
## The Changes
1. When redirecting from an admin register link, the redirect parameter was ignored. It's now passed in to `build_connect_url()`.

2. When building a register connect URL, the `redirect` query arg wasn't being added, and now it is.

### Use case:
1. Use `Jetpack::init()->build_connect_url` **with a custom redirect parameter** to add a button with the connect URL
2. If the site has not yet been registered, `build_connect_url` returns an admin URL with the query `action=register`, but the redirect param is not passed in
3. After registration, `build_connect_url` is used again, but the redirect parameter is not passed in

This PR makes sure the redirect parameter is used in both places.

## Testing instructions:

### To see the failing case:
1. Install Jetpack on your site (from `master`)
2. Install and activate [WooCommerce](https://wordpress.org/plugins/woocommerce/)
3. Install and activate the `try/add-wc-wizard-step` branch of WooCommerce Services from https://github.com/Automattic/woocommerce-services/pull/1008 (you don't need to run `npm install`, etc, just clone the repo)
4. Deactivate and reactivate Jetpack. This makes sure that you are not connected and your site is not registered.
5. Go to `/wp-admin/index.php?page=wc-setup&step=locale` and select `US` as your store location, and save the page
6. Go to `/wp-admin/index.php?page=wc-setup&step=wcs_shipping`
7. See the Jetpack Connect button. See that the link does not include the redirect parameter. Click on the connect button.
8. See that after you are redirected to Calypso, the custom redirect parameter is missing

### To see the fix:
1. Check out this branch of Jetpack on your site
2. Deactivate and reactivate Jetpack. This makes sure that you are not connected and your site is not registered.
3. Go to `/wp-admin/index.php?page=wc-setup&step=wcs_shipping`
4. See the Jetpack Connect button. See that the link now includes the redirect parameter. Click on the connect button.
5. See that after you are redirected to Calypso, the custom redirect parameter is present
6. After completing the JP connection, see that you are correctly redirected back to `/wp-admin/index.php?page=wc-setup&step=wcs_shipping`