### PR TITLE
SEO Tools: Suppress output if conflicting SEO plugin is active

### DIFF
--- a/modules/seo-tools.php
+++ b/modules/seo-tools.php
@@ -24,8 +24,8 @@ $jetpack_seo_conflicting_plugins = array(
 	'all-in-one-seo-pack-pro/all_in_one_seo_pack.php',
 );
 
-foreach( $jetpack_seo_conflicting_plugins as $seo_pluging ) {
-	if ( is_plugin_active( $seo_pluging ) ) {
+foreach( $jetpack_seo_conflicting_plugins as $seo_plugin ) {
+	if ( Jetpack::is_plugin_active( $seo_plugin ) ) {
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
 		break;
 	}

--- a/modules/seo-tools.php
+++ b/modules/seo-tools.php
@@ -14,5 +14,21 @@
  */
 
 include dirname( __FILE__ ) . '/seo-tools/jetpack-seo.php';
+include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+// Suppress SEO Tools output if any of the following plugins is active.
+$jetpack_seo_conflicting_plugins = array(
+	'wordpress-seo/wp-seo.php',
+	'wordpress-seo-premium/wp-seo-premium.php',
+	'all-in-one-seo-pack/all_in_one_seo_pack.php',
+	'all-in-one-seo-pack-pro/all_in_one_seo_pack.php',
+);
+
+foreach( $jetpack_seo_conflicting_plugins as $seo_pluging ) {
+	if ( is_plugin_active( $seo_pluging ) ) {
+		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
+		break;
+	}
+}
 
 new Jetpack_SEO;

--- a/modules/seo-tools/jetpack-seo-utils.php
+++ b/modules/seo-tools/jetpack-seo-utils.php
@@ -22,6 +22,19 @@ class Jetpack_SEO_Utils {
 	 * @return bool True if SEO tools are enabled, false otherwise.
 	 */
 	public static function is_enabled_jetpack_seo( $site_id = 0 ) {
+		/**
+		 * Can be used by SEO plugin authors to disable the conflicting output of SEO Tools.
+		 *
+		 * @module seo-tools
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param bool True if SEO Tools should be disabled, false otherwise.
+		 */
+		if ( apply_filters( 'jetpack_disable_seo_tools', false ) ) {
+			return false;
+		}
+
 		if ( function_exists( 'has_blog_sticker' ) ) {
 			// For WPCOM sites
 			if ( empty( $site_id ) ) {

--- a/modules/seo-tools/jetpack-seo-utils.php
+++ b/modules/seo-tools/jetpack-seo-utils.php
@@ -27,7 +27,7 @@ class Jetpack_SEO_Utils {
 		 *
 		 * @module seo-tools
 		 *
-		 * @since 4.9.0
+		 * @since 5.0.0
 		 *
 		 * @param bool True if SEO Tools should be disabled, false otherwise.
 		 */


### PR DESCRIPTION
When SEO plugins like Yoast SEO or All in one SEO are installed on
Jetpack site, SEO Tools should stop modifying the meta tags.

Related PR: https://github.com/Automattic/wp-calypso/pull/14526

#### Testing instructions:

1. Use test Jetpack site with Professional plan and SEO Tools module enabled.
2. In Calypso, navigate to `settings/traffic` and adjust some of the SEO settings.
3. Verify that changes have taken effect on you test site's front end (inspect meta fields).
4. Install Yoast SEO or All in one SEO pack.
5. Verify that changes from step 3 are no longer present.