### PR TITLE
Jetpack Sync: Sending $_SERVER['REQUEST_URI'] with wp_insert_post action

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -94,7 +94,12 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	 * @return array
 	 */
 	function expand_wp_insert_post( $args ) {
-		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2], $_SERVER['REQUEST_URI'] );
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			$is_auto_save = true;
+		} else {
+			$is_auto_save = false;
+		}
+		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2], $is_auto_save );
 	}
 
 	function filter_blacklisted_post_types( $args ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -94,12 +94,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	 * @return array
 	 */
 	function expand_wp_insert_post( $args ) {
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			$is_auto_save = true;
-		} else {
-			$is_auto_save = false;
-		}
-		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2], $is_auto_save );
+		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2], $args[3] );
 	}
 
 	function filter_blacklisted_post_types( $args ) {
@@ -260,7 +255,14 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( ! is_numeric( $post_ID ) || is_null( $post ) ) {
 			return;
 		}
-		call_user_func( $this->action_handler, $post_ID, $post, $update );
+
+		if ( Jetpack_Constants::get_constant( 'DOING_AUTOSAVE' ) ) {
+			$is_auto_save = true;
+		} else {
+			$is_auto_save = false;
+		}
+
+		call_user_func( $this->action_handler, $post_ID, $post, $update, $is_auto_save );
 		$this->send_published( $post_ID, $post );
 		$this->send_trashed( $post_ID, $post );
 	}

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -94,7 +94,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	 * @return array
 	 */
 	function expand_wp_insert_post( $args ) {
-		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2] );
+		return array( $args[0], $this->filter_post_content_and_add_links( $args[1] ), $args[2], $_SERVER['REQUEST_URI'] );
 	}
 
 	function filter_blacklisted_post_types( $args ) {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -54,7 +54,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
 		$this->assertEquals( 'my_URI', $event->args[3] );
-
 	}
 
 	public function test_trash_post_trashes_data() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -47,8 +47,8 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		//Sync from setup should not be auto save
 		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
 		$this->assertFalse( $event->args[3] );
-
-		define( 'DOING_AUTOSAVE', true );
+		
+		Jetpack_Constants::set_constant( 'DOING_AUTOSAVE', true );//define( 'DOING_AUTOSAVE', true );
 
 		//Performing sync here (even though setup() does it) to sync REQUEST_URI
 		$user_id = $this->factory->user->create();

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -43,17 +43,20 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $this->post, $this->server_replica_storage->get_post( $this->post->ID ) );
 	}
 
-	public function test_add_post_syncs_request_uri() {
-		$_SERVER['REQUEST_URI'] = 'my_URI';
+	public function test_add_post_syncs_request_is_auto_save() {
+		//Sync from setup should not be auto save
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$this->assertFalse( $event->args[3] );
+
+		define( 'DOING_AUTOSAVE', true );
 
 		//Performing sync here (even though setup() does it) to sync REQUEST_URI
 		$user_id = $this->factory->user->create();
-		$post_id    = $this->factory->post->create( array( 'post_author' => $user_id ) );
-		$this->post = get_post( $post_id );
+		$this->factory->post->create( array( 'post_author' => $user_id ) );
 		$this->sender->do_sync();
 
 		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
-		$this->assertEquals( 'my_URI', $event->args[3] );
+		$this->assertTrue( $event->args[3] );
 	}
 
 	public function test_trash_post_trashes_data() {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -43,6 +43,20 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $this->post, $this->server_replica_storage->get_post( $this->post->ID ) );
 	}
 
+	public function test_add_post_syncs_request_uri() {
+		$_SERVER['REQUEST_URI'] = 'my_URI';
+
+		//Performing sync here (even though setup() does it) to sync REQUEST_URI
+		$user_id = $this->factory->user->create();
+		$post_id    = $this->factory->post->create( array( 'post_author' => $user_id ) );
+		$this->post = get_post( $post_id );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_post' );
+		$this->assertEquals( 'my_URI', $event->args[3] );
+
+	}
+
 	public function test_trash_post_trashes_data() {
 		$this->assertEquals( 1, $this->server_replica_storage->post_count( 'publish' ) );
 


### PR DESCRIPTION
Jetpack Sync sending whether is_auto_save with wp_insert_post sync_action

#### Changes proposed in this Pull Request:

Addition of is_auto_save in wp_insert_post payload

#### Testing instructions:

* Run phpunit

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
