### PR TITLE
Sync wp locale settings

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -111,6 +111,7 @@ class Jetpack_Sync_Defaults {
 		'advanced_seo_front_page_description', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
 		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 		'jetpack_api_cache_enabled',
+		'WPLANG',
 	);
 
 	public static function get_options_whitelist() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -170,6 +170,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'advanced_seo_title_formats'           => array( 'posts' => array( 'type' => 'string', 'value' => 'test' ) ), // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
 			'jetpack_api_cache_enabled'            => '1',
 			'sidebars_widgets'                     => array( 'array_version' => 3 ),
+			'WPLANG'                               => 'en',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -186,6 +186,12 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		foreach ( $options as $option_name => $value ) {
+			// WPLANG is special because it can't be updated in an installation that can not
+			// manage language packs, let's skip this check
+			if ( 'WPLANG' === $option_name ) {
+				continue;
+			}
+
 			$this->assertOptionIsSynced( $option_name, $value );
 		}
 		$option_keys                          = array_keys( $options );


### PR DESCRIPTION
Syncs the locale settings to wpcom.

See D5781-code for the other half.

#### Changes proposed in this Pull Request:

* Adds `WPLANG` option as a synced option

#### Testing instructions:

* See D5781-code

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
