### PR TITLE
Update/info popover

### DIFF
--- a/_inc/client/components/settings-group/README.md
+++ b/_inc/client/components/settings-group/README.md
@@ -11,7 +11,7 @@ var SettingsGroup = require( 'components/settings-group' );
 
 render: function() {
 	return (
-		<SettingsGroup hasChild support={ this.props.getModule( 'related-posts' ).learn_more_button }>
+		<SettingsGroup hasChild module={ this.props.getModule( 'related-posts' ) }>
 			<FormFieldset>
 				// form elements
 			</FormFieldset>
@@ -26,6 +26,25 @@ render: function() {
 * `support` - A custom URL to a support resource. Will be used to render an icon linked to the URL. If no URL is passed but `module` is present, it will fetch the module and use its learn_more_button property as URL.
 ```js
 <SettingsGroup support="https://jetpack.com/support/sso">
+	// form elements
+</SettingsGroup>
+```
+* `supportLabel` - A custom label for the link to be shown in the info popover. If it's not passed, the generic text "Learn more about X" is used where X
+is a module name.
+```js
+<SettingsGroup
+	module={ photon }
+    supportLabel={ __( 'Learn about speeding up images' ) }
+	>
+	// form elements
+</SettingsGroup>
+```
+* `disableInDevMode` - Whether this group will be disabled in Dev Mode.
+```js
+<SettingsGroup
+	module={ photon }
+	disableInDevMode
+	>
 	// form elements
 </SettingsGroup>
 ```

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -53,6 +53,14 @@ export const SettingsGroup = props => {
 		} );
 	};
 
+	const getInfoText = props.supportLabel
+		? props.supportLabel
+		: __( 'Learn more about %(moduleName)s', {
+			args: {
+				moduleName: module.name
+			}
+		} );
+
 	return (
 		<div className="jp-form-settings-group">
 			<Card className={ classNames( {
@@ -67,14 +75,15 @@ export const SettingsGroup = props => {
 						<div className="jp-module-settings__learn-more">
 							<InfoPopover
 								onClick={ trackInfoClick }
-								screenReaderText={ __( 'Learn more' ) }
+								screenReaderText={ getInfoText }
+								position={ 'left' }
 							>
 								<ExternalLink
 									onClick={ trackLearnMoreClick }
-									icon={ false }
+									icon={ true }
 									href={ support }
 									target="_blank">
-									{ __( 'Learn more' ) }
+									{ getInfoText }
 								</ExternalLink>
 							</InfoPopover>
 						</div>
@@ -90,6 +99,7 @@ export const SettingsGroup = props => {
 
 SettingsGroup.propTypes = {
 	support: React.PropTypes.string,
+	supportLabel: React.PropTypes.string,
 	module: React.PropTypes.object,
 	disableInDevMode: React.PropTypes.bool.isRequired,
 	isDevMode: React.PropTypes.bool.isRequired,
@@ -101,6 +111,7 @@ SettingsGroup.propTypes = {
 
 SettingsGroup.defaultProps = {
 	support: '',
+	supportLabel: '',
 	module: {},
 	disableInDevMode: false,
 	isDevMode: false,

--- a/_inc/client/components/settings-group/test/component.js
+++ b/_inc/client/components/settings-group/test/component.js
@@ -84,6 +84,10 @@ describe( 'SettingsGroup', () => {
 		expect( shallow( <SettingsGroup /> ).find( 'InfoPopover' ) ).to.have.length( 0 );
 	} );
 
+	it( 'uses a custom label for info link if one is provided', () => {
+		expect( shallow( <SettingsGroup module={ testProps } supportLabel={ 'Test' } /> ).find( 'ExternalLink' ).props().children ).to.be.equal( 'Test' );
+	} );
+
 	describe( 'has a fading layer', () => {
 
 		it( 'visible in in Dev Mode', () => {

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -72,10 +72,15 @@ export const BackupsScan = moduleSettingsForm(
 			}
 
 			return cardText;
-		};
+		}
 
 		render() {
-			const scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false );
+			const scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false ),
+				backups = {
+					module: 'backups',
+					name: __( 'Backups', { comment: 'A module name' } ),
+					learn_more_button: 'https://help.vaultpress.com/get-to-know/'
+				};
 			return (
 				<SettingsCard
 					feature={ FEATURE_SECURITY_SCANNING_JETPACK }
@@ -85,8 +90,7 @@ export const BackupsScan = moduleSettingsForm(
 					hideButton>
 					<SettingsGroup
 						disableInDevMode
-						module={ { module: 'backups' } }
-						support="https://help.vaultpress.com/get-to-know/">
+						module={ backups }>
 						{
 							this.getCardText()
 						}

--- a/_inc/client/sharing/likes.jsx
+++ b/_inc/client/sharing/likes.jsx
@@ -24,7 +24,7 @@ export const Likes = moduleSettingsForm(
 					header={ __( 'Like buttons', { context: 'Settings header' } ) }
 					module="likes"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'likes' } } support="https://jetpack.com/support/likes/">
+					<SettingsGroup disableInDevMode module={ this.props.getModule( 'likes' ) }>
 						<ModuleToggle
 							slug="likes"
 							disabled={ unavailableInDevMode }

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -61,7 +61,7 @@ export const Publicize = moduleSettingsForm(
 					header={ __( 'Publicize connections', { context: 'Settings header' } ) }
 					module="publicize"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'publicize' } } support="https://jetpack.com/support/publicize/">
+					<SettingsGroup disableInDevMode module={ this.props.getModule( 'publicize' ) }>
 						<ModuleToggle
 							slug="publicize"
 							disabled={ unavailableInDevMode }

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -47,9 +47,9 @@ export const ShareButtons = moduleSettingsForm(
 				<SettingsCard
 					{ ...this.props }
 					header={ __( 'Sharing buttons', { context: 'Settings header' } ) }
-					module="sharing"
+					module="sharedaddy"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'sharing' } } support="https://jetpack.com/support/sharing/">
+					<SettingsGroup disableInDevMode module={ this.props.getModule( 'sharedaddy' ) }>
 						<ModuleToggle
 							slug="sharedaddy"
 							activated={ isActive }

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -61,8 +61,8 @@ export const Ads = moduleSettingsForm(
 					<SettingsGroup
 						disableInDevMode
 						hasChild
-						module={ { module: 'wordads' } }
-						support="https://jetpack.com/support/ads/">
+						module={ this.props.getModule( 'wordads' ) }
+						>
 						<p>
 							{ __( 'Show ads on the first article on your home page or at the end of every page and post. Place additional ads at the top of your site and to any widget area to increase your earnings.' ) }
 							<br />

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -27,7 +27,7 @@ export const GoogleAnalytics = moduleSettingsForm(
 					header={ __( 'Google Analytics', { context: 'Settings header' } ) }
 					feature={ FEATURE_GOOGLE_ANALYTICS_JETPACK }
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'google-analytics' } } support="https://jetpack.com/support/google-analytics/">
+					<SettingsGroup disableInDevMode module={ this.props.getModule( 'google-analytics' ) }>
 						{ __(
 							'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
 							' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -27,7 +27,7 @@ export const SEO = moduleSettingsForm(
 					header={ __( 'Search engine optimization', { context: 'Settings header' } ) }
 					feature={ FEATURE_SEO_TOOLS_JETPACK }
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'seo-tools' } } support="https://jetpack.com/support/seo-tools/">
+					<SettingsGroup disableInDevMode module={ this.props.getModule( 'seo-tools' ) }>
 						<span>
 							{
 								__( "You can tweak these settings if you'd like more advanced control. Read more about what you can do to {{a}}optimize your site's SEO{{/a}}.",

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -41,7 +41,7 @@ export const Sitemaps = moduleSettingsForm(
 					module="sitemaps"
 					hideButton
 				>
-					<SettingsGroup module={ { module: 'sitemaps' } } hasChild support={ sitemaps.learn_more_button }>
+					<SettingsGroup module={ sitemaps } hasChild>
 						<ModuleToggle
 							slug="sitemaps"
 							compact

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -27,7 +27,7 @@ export const VerificationServices = moduleSettingsForm(
 					module="verification-tools"
 					saveDisabled={ this.props.isSavingAnyOption( [ 'google', 'bing', 'pinterest', 'yandex' ] ) }
 				>
-					<SettingsGroup module={ verification } support={ verification.learn_more_button }>
+					<SettingsGroup module={ verification }>
 						<p>
 							{ __(
 								'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order for your site to be indexed by search engines. To use these advanced search engine tools and verify your site with a service, paste the HTML Tag code below. Read the {{support}}full instructions{{/support}} if you are having trouble. Supported verification services: {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}}, {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -55,7 +55,7 @@ const CustomContentTypes = moduleSettingsForm(
 					{ ...this.props }
 					module="custom-content-types"
 					hideButton>
-					<SettingsGroup hasChild module={ module } support={ module.learn_more_button }>
+					<SettingsGroup hasChild module={ module }>
 						<CompactFormToggle
 									checked={ this.state.testimonial }
 									disabled={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) }

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -23,10 +23,9 @@ export const Masterbar = moduleSettingsForm(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'WordPress.com toolbar', { context: 'Settings header' } ) }
 					module="masterbar"
 					hideButton>
-					<SettingsGroup disableInDevMode module={ { module: 'masterbar' } } support="https://jetpack.com/support/masterbar/">
+					<SettingsGroup disableInDevMode module={ this.props.getModule( 'masterbar' ) }>
 						<ModuleToggle
 							slug="masterbar"
 							disabled={ unavailableInDevMode || ! isLinked }

--- a/_inc/client/writing/media.jsx
+++ b/_inc/client/writing/media.jsx
@@ -24,7 +24,6 @@ import { ModuleToggle } from 'components/module-toggle';
 import { ModuleSettingsForm as moduleSettingsForm } from 'components/module-settings/module-settings-form';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { getSitePlan } from 'state/site';
 
@@ -78,17 +77,19 @@ const Media = moduleSettingsForm(
 				return null;
 			}
 
-			const photon = this.props.module( 'photon' ),
-				carousel = this.props.module( 'carousel' ),
+			const photon = this.props.getModule( 'photon' ),
+				carousel = this.props.getModule( 'carousel' ),
 				isCarouselActive = this.props.getOptionValue( 'carousel' ),
-				videoPress = this.props.module( 'videopress' ),
+				videoPress = this.props.getModule( 'videopress' ),
 				planClass = getPlanClass( this.props.sitePlan.product_slug );
 
 			const photonSettings = (
 				<SettingsGroup
 					hasChild
 					disableInDevMode
-					module={ photon }>
+					module={ photon }
+					supportLabel={ __( 'Learn about speeding up images' ) }
+					>
 					<ModuleToggle
 						slug="photon"
 						disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
@@ -113,7 +114,7 @@ const Media = moduleSettingsForm(
 			);
 
 			const carouselSettings = (
-				<SettingsGroup module={ { module: 'carousel' } } hasChild support={ carousel.learn_more_button }>
+				<SettingsGroup module={ carousel } hasChild>
 					<ModuleToggle
 						slug="carousel"
 						activated={ isCarouselActive }
@@ -193,7 +194,6 @@ const Media = moduleSettingsForm(
 export default connect(
 	( state ) => {
 		return {
-			module: ( module_name ) => getModule( state, module_name ),
 			isModuleFound: ( module_name ) => _isModuleFound( state, module_name ),
 			sitePlan: getSitePlan( state )
 		};

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -145,7 +145,7 @@ const ThemeEnhancements = moduleSettingsForm(
 								}
 
 								return (
-									<SettingsGroup hasChild module={ { module: item.module } } key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
+									<SettingsGroup hasChild module={ this.props.getModule( item.module ) } key={ `theme_enhancement_${ item.module }` }>
 										<FormLegend className="jp-form-label-wide">
 											{
 												item.name
@@ -216,7 +216,7 @@ const ThemeEnhancements = moduleSettingsForm(
 								}
 
 								return (
-									<SettingsGroup hasChild module={ { module: item.module } } key={ `theme_enhancement_${ item.module }` } support={ item.learn_more_button }>
+									<SettingsGroup hasChild module={ this.props.getModule( item.module ) } key={ `theme_enhancement_${ item.module }` }>
 										{
 											<ModuleToggle
 												slug={ item.module }


### PR DESCRIPTION
Fixes #7195

#### Changes proposed in this Pull Request:

* update SettingsGroup to receive a supportLabel property that will specify a custom link label. Display the info popover above the info icon. Add tests.
 
* pass complete module information so the module name and info link is correctly fetch. Remove support prop where it was redundant.

#### Testing instructions:

* build and make sure Info Popovers look fine
