### PR TITLE
WordPress.com Toolbar: add slide in animation for submenus

### DIFF
--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -49,14 +49,6 @@
 #wpadminbar li#wp-admin-bar-newdash.menupop > .ab-sub-wrapper, /* Reader */
 #wpadminbar li#wp-admin-bar-my-account.menupop > .ab-sub-wrapper, /* Me */
 #wpadminbar li#wp-admin-bar-notes.menupop > #wpnt-notes-panel2 { /* Notifications */
-	display: none !important;
-}
-
-/* Show the panels when the item is active */
-#wpadminbar li#wp-admin-bar-blog.menupop.ab-active > .ab-sub-wrapper, /* My Sites */
-#wpadminbar li#wp-admin-bar-newdash.menupop.ab-active > .ab-sub-wrapper, /* Reader */
-#wpadminbar li#wp-admin-bar-my-account.menupop.ab-active > .ab-sub-wrapper, /* Me */
-#wpadminbar li#wp-admin-bar-notes.menupop.wpnt-show > #wpnt-notes-panel2 { /* Notifications */
 	display: block !important;
 }
 


### PR DESCRIPTION
Previously, WordPress.com Toolbar sub-menus were appearing instantly. This restores the slide in animation in order to make it consistent with WP.com side.

Fixes https://github.com/Automattic/jetpack/issues/6966

#### Testing instructions:

1. Use your test Jetpack site with WordPress.com Toolbar module enabled.
2. Navigate to your site's front end or `wp-admin`. 
3. Try opening masterbar's sub-menus (e.g. My Sites, Reader, Me, or Notifications). 
4. Verify that slide in animation is now present.
