### PR TITLE
Admin Page: update shortcode name in portfolio card.

### DIFF
--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -92,7 +92,7 @@ const CustomContentTypes = moduleSettingsForm(
 						<FormFieldset>
 							<p className="jp-form-setting-explanation">
 								{
-									__( "Add, organize, and display {{portfolioLink}}portfolios{{/portfolioLink}}. If your theme doesn’t support portfolios yet, you can display them using the shortcode ( [portfolios] ).",
+									__( "Add, organize, and display {{portfolioLink}}portfolios{{/portfolioLink}}. If your theme doesn’t support portfolios yet, you can display them using the shortcode ( [portfolio] ).",
 										{
 											components: {
 												portfolioLink: this.linkIfActiveCPT( 'portfolio' )


### PR DESCRIPTION
The Portfolio shortcode is `portfolio`, not `portfolios`.

Reported here:
https://wordpress.org/support/topic/mistakenly-written-shortcode/

#### Proposed changelog entry for your changes:
* Admin Page: update shortcode name in portfolio card.