### PR TITLE
Photon: the new filter_the_image_widget must be static

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -394,7 +394,7 @@ class Jetpack_Photon {
 	 * @param array $instance Image widget instance data.
 	 * @return array
 	 */
-	function filter_the_image_widget( $instance ) {
+	public static function filter_the_image_widget( $instance ) {
 		if ( Jetpack::is_module_active( 'photon' ) && ! $instance['attachment_id'] && $instance['url'] ) {
 			jetpack_photon_url( $instance['url'], array(
 				'w' => $instance['width'],


### PR DESCRIPTION
Fixes warning
```
Deprecated: Non-static method Jetpack_Photon::filter_the_image_widget() should not be called statically in /wp-includes/class-wp-hook.php on line 
```

#### Changes proposed in this Pull Request:

* declare `filter_the_image_widget` as static so it can be called statically

#### Testing instructions:

* make sure you don't get that warning

No changelog required since this is a patch for the image widget migration included in this same version