### PR TITLE
CLI: Fix potential undefined property issue when provisioning partner key

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -844,7 +844,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 		}
 
 		if ( isset( $token->error ) ) {
-			$this->partner_provision_error( new WP_Error( $token->error, $token->message ) );
+			$message = isset( $token->message )
+				? $token->message
+				: '';
+			$this->partner_provision_error( new WP_Error( $token->error, $message ) );
 		}
 
 		if ( ! isset( $token->access_token ) ) {


### PR DESCRIPTION
While testing D5777 with the following:

```
bash partner-provision.sh --partner_id=.... --partner_secret=.... --user_id=... --plan=premium
```

I got the following warning:

```
Notice: Undefined property: stdClass::$message in .....public/wordpress/wp-content/plugins/jetpack/class.jetpack-cli.php on line 847
```

This PR ensures that `$token->message` is set before we try and use it, and if it's not set, we use empty string.

To test, you could follow instructions on D5777, or ping @gravityrail or myself.