### PR TITLE
CLI: Fixes undefined warning when provisioning a partner plan

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -872,7 +872,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$this->partner_provision_error( new WP_Error( 'missing_user', sprintf( __( "User %s doesn't exist", 'jetpack' ), $user_id ) ) );
 		}
 
-		if ( ! $blog_id || ! $blog_token || intval( $named_args['force_register'] ) ) {
+		if ( ! $blog_id || ! $blog_token || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
 			// this code mostly copied from Jetpack::admin_page_load
 			Jetpack::maybe_set_version_option();
 			$registered = Jetpack::try_registration();


### PR DESCRIPTION
While testing D5777 some more, I hit an undefined index notice:

```
Notice: Undefined index: force_register in ....wordpress/wp-content/plugins/jetpack/class.jetpack-cli.php on line 875
```

To test this PR, you can follow the instructions in D5777 to setup the WPCOM side or you can ping @gravityrail or myself for assistance with testing steps.

You'll then use something like this to test on the Jetpack side:

```
bash partner-provision.sh --partner_id=.... --partner_secret=.... --user_id=... --plan=premium
```