### PR TITLE
New API endpoints for backups

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-get-comment-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-comment-backup-endpoint.php
@@ -41,7 +41,7 @@ class Jetpack_JSON_API_Get_Comment_Backup_Endpoint extends Jetpack_JSON_API_Endp
 		);
 
 		$comment = array_intersect_key( $comment->to_array(), array_flip( $allowed_keys ) );
-		$comment_meta = get_comment_meta( $comment->comment_ID );
+		$comment_meta = get_comment_meta( $comment['comment_ID'] );
 
 		return array(
 			'comment' => $comment,

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-comment-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-comment-backup-endpoint.php
@@ -1,0 +1,52 @@
+<?php
+
+class Jetpack_JSON_API_Get_Comment_Backup_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// /sites/%s/comments/%d/backup      -> $blog_id, $comment_id
+
+	protected $needed_capabilities = array(); // This endpoint is only accessible using a site token
+	protected $comment_id;
+
+	function validate_input( $comment_id ) {
+		if ( empty( $comment_id ) || ! is_numeric( $comment_id ) ) {
+			return new WP_Error( 'comment_id_not_specified', __( 'You must specify a Comment ID', 'jetpack' ), 400 );
+		}
+
+		$this->comment_id = intval( $comment_id );
+
+		return true;
+	}
+
+	protected function result() {
+		$comment = get_comment( $this->comment_id );
+		if ( empty( $comment ) ) {
+			return new WP_Error( 'comment_not_found', __( 'Comment not found', 'jetpack' ), 404 );
+		}
+
+		$allowed_keys = array(
+			'comment_ID',
+			'comment_post_ID',
+			'comment_author',
+			'comment_author_email',
+			'comment_author_url',
+			'comment_author_IP',
+			'comment_date',
+			'comment_date_gmt',
+			'comment_content',
+			'comment_karma',
+			'comment_approved',
+			'comment_agent',
+			'comment_type',
+			'comment_parent',
+			'user_id',
+		);
+
+		$comment = array_intersect_key( $comment->to_array(), array_flip( $allowed_keys ) );
+		$comment_meta = get_comment_meta( $comment->comment_ID );
+
+		return array(
+			'comment' => $comment,
+			'meta'    => is_array( $comment_meta ) ? $comment_meta : array(),
+		);
+	}
+
+}

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-option-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-option-backup-endpoint.php
@@ -1,0 +1,35 @@
+<?php
+
+class Jetpack_JSON_API_Get_Option_Backup_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// /sites/%s/options/backup      -> $blog_id
+
+	protected $needed_capabilities = array(); // This endpoint is only accessible using a site token
+	protected $option_names;
+
+	function validate_input( $object ) {
+		$query_args = $this->query_args();		
+
+		if ( empty( $query_args['name'] ) ) {
+			return new WP_Error( 'option_name_not_specified', __( 'You must specify an option name', 'jetpack' ), 400 );
+		}
+
+		if ( is_array( $query_args['name'] ) ) {
+			$this->option_names = $query_args['name'];
+		} else {
+			$this->option_names = array( $query_args['name'] );
+		}
+
+		return true;
+	}
+
+	protected function result() {
+		$options = array_map( array( $this, 'get_option_row' ), $this->option_names );
+		return array( 'options' => $options );
+	}
+
+	private function get_option_row( $name ) {
+		global $wpdb;
+		return $wpdb->get_row( $wpdb->prepare( "select * from `{$wpdb->options}` where option_name = %s", $name ) );
+	}
+
+}

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-post-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-post-backup-endpoint.php
@@ -3,12 +3,12 @@
 class Jetpack_JSON_API_Get_Post_Backup_Endpoint extends Jetpack_JSON_API_Endpoint {
 	// /sites/%s/posts/%d/backup      -> $blog_id, $post_id
 
-	protected $needed_capabilities = array();
+	protected $needed_capabilities = array(); // This endpoint is only accessible using a site token
 	protected $post_id;
 
 	function validate_input( $post_id ) {
 		if ( empty( $post_id ) || ! is_numeric( $post_id ) ) {
-			return new WP_Error( 'post_id_not_specified', __( 'You must specify a Post ID', 'jetpack' ) );
+			return new WP_Error( 'post_id_not_specified', __( 'You must specify a Post ID', 'jetpack' ), 400 );
 		}
 
 		$this->post_id = intval( $post_id );
@@ -19,7 +19,7 @@ class Jetpack_JSON_API_Get_Post_Backup_Endpoint extends Jetpack_JSON_API_Endpoin
 	protected function result() {
 		$post = get_post( $this->post_id );
 		if ( empty( $post ) ) {
-			return new WP_Error( 'post_not_found', __( 'Post not found', 'jetpack' ) );
+			return new WP_Error( 'post_not_found', __( 'Post not found', 'jetpack' ), 404 );
 		}
 
 		return array(

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-term-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-term-backup-endpoint.php
@@ -1,0 +1,32 @@
+<?php
+
+class Jetpack_JSON_API_Get_Term_Backup_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// /sites/%s/terms/%d/backup      -> $blog_id, $term_id
+
+	protected $needed_capabilities = array(); // This endpoint is only accessible using a site token
+	protected $term_id;
+
+	function validate_input( $term_id ) {
+		if ( empty( $term_id ) || ! is_numeric( $term_id ) ) {
+			return new WP_Error( 'term_id_not_specified', __( 'You must specify a Term ID', 'jetpack' ), 400 );
+		}
+
+		$this->term_id = intval( $term_id );
+
+		return true;
+	}
+
+	protected function result() {
+		$term = get_term( $this->term_id );
+		if ( empty( $term ) ) {
+			return new WP_Error( 'term_not_found', __( 'Term not found', 'jetpack' ), 404 );
+		}
+
+		return array(
+			'term' => (array)$term,
+			'meta' => get_term_meta( $this->term_id ),
+		);
+	}
+
+}
+

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-term-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-term-backup-endpoint.php
@@ -23,7 +23,7 @@ class Jetpack_JSON_API_Get_Term_Backup_Endpoint extends Jetpack_JSON_API_Endpoin
 		}
 
 		return array(
-			'term' => (array)$term,
+			'term' => (array) $term,
 			'meta' => get_term_meta( $this->term_id ),
 		);
 	}

--- a/json-endpoints/jetpack/class.jetpack-json-api-get-user-backup-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-get-user-backup-endpoint.php
@@ -1,0 +1,32 @@
+<?php
+
+class Jetpack_JSON_API_Get_User_Backup_Endpoint extends Jetpack_JSON_API_Endpoint {
+	// /sites/%s/users/%d/backup      -> $blog_id, $user_id
+
+	protected $needed_capabilities = array(); // This endpoint is only accessible using a site token
+	protected $user_id;
+
+	function validate_input( $user_id ) {
+		if ( empty( $user_id ) || ! is_numeric( $user_id ) ) {
+			return new WP_Error( 'user_id_not_specified', __( 'You must specify a User ID', 'jetpack' ), 400 );
+		}
+
+		$this->user_id = intval( $user_id );
+
+		return true;
+	}
+
+	protected function result() {
+		$user = get_user_by( 'id', $this->user_id );
+		if ( empty( $user ) ) {
+			return new WP_Error( 'user_not_found', __( 'User not found', 'jetpack' ), 404 );
+		}
+
+		return array(
+			'user' => (array)$user,
+			'meta' => get_user_meta( $user->ID ),
+		);
+	}
+
+}
+

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1134,9 +1134,60 @@ new Jetpack_JSON_API_Cron_Unschedule_Endpoint( array(
 ) );
 
 //	BACKUPS
-require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-get-post-backup-endpoint.php' );
+
+// GET /sites/%s/comments/%d/backup
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-get-comment-backup-endpoint.php' );
+new Jetpack_JSON_API_Get_Comment_Backup_Endpoint( array(
+	'description'    => 'Fetch a backup of a comment, along with all of its metadata',
+	'group'          => '__do_not_document',
+	'method'         => 'GET',
+	'path'           => '/sites/%s/comments/%d/backup',
+	'stat'           => 'comments:1:backup',
+	'allow_jetpack_site_auth' => true,
+	'path_labels'    => array(
+		'$site' => '(int|string) The site ID, The site domain',
+		'$post' => '(int) The comment ID',
+	),
+	'response_format' => array(
+		'comment' => '(array) Comment table row',
+		'meta'    => '(array) Associative array of key/value commentmeta data',
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/comments/1/backup'
+) );
+
+// GET /sites/%s/options/backup
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-get-option-backup-endpoint.php' );
+new Jetpack_JSON_API_Get_Option_Backup_Endpoint( array(
+	'description'    => 'Fetch a backup of an option',
+	'group'          => '__do_not_document',
+	'method'         => 'GET',
+	'path'           => '/sites/%s/options/backup',
+	'stat'           => 'options:backup',
+	'allow_jetpack_site_auth' => true,
+	'path_labels'    => array(
+		'$site' => '(int|string) The site ID, The site domain',
+	),
+	'query_parameters' => array(
+		'name' => '(string|array) One or more option names to include in the backup',
+	),
+	'response_format' => array(
+		'options' => '(array) Associative array of option_name => option_value entries',
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		)
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/options/backup'
+) );
 
 // GET /sites/%s/posts/%d/backup
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-get-post-backup-endpoint.php' );
 new Jetpack_JSON_API_Get_Post_Backup_Endpoint( array(
 	'description'    => 'Fetch a backup of a post, along with all of its metadata',
 	'group'          => '__do_not_document',
@@ -1160,6 +1211,55 @@ new Jetpack_JSON_API_Get_Post_Backup_Endpoint( array(
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/posts/1/backup'
 ) );
 
+// GET /sites/%s/terms/%d/backup
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-get-term-backup-endpoint.php' );
+new Jetpack_JSON_API_Get_Term_Backup_Endpoint( array(
+	'description'    => 'Fetch a backup of a term, along with all of its metadata',
+	'group'          => '__do_not_document',
+	'method'         => 'GET',
+	'path'           => '/sites/%s/terms/%d/backup',
+	'stat'           => 'terms:1:backup',
+	'allow_jetpack_site_auth' => true,
+	'path_labels'    => array(
+		'$site' => '(int|string) The site ID, The site domain',
+		'$term' => '(int) The term ID',
+	),
+	'response_format' => array(
+		'term' => '(array) Term table row',
+		'meta' => '(array) Metadata associated with the term',
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/terms/1/backup'
+) );
+
+// GET /sites/%s/users/%d/backup
+require_once( $json_jetpack_endpoints_dir . 'class.jetpack-json-api-get-user-backup-endpoint.php' );
+new Jetpack_JSON_API_Get_User_Backup_Endpoint( array(
+	'description'    => 'Fetch a backup of a user, along with all of its metadata',
+	'group'          => '__do_not_document',
+	'method'         => 'GET',
+	'path'           => '/sites/%s/users/%d/backup',
+	'stat'           => 'users:1:backup',
+	'allow_jetpack_site_auth' => true,
+	'path_labels'    => array(
+	'$site' => '(int|string) The site ID, The site domain',
+		'$user' => '(int) The user ID',
+	),
+	'response_format' => array(
+		'user' => '(array) User table row',
+		'meta' => '(array) Associative array of key/value usermeta data',
+	),
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+	),
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/users/1/backup'
+) );
 
 // USERS
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add API endpoints for fetching backups of: 
  * Users
  * Comments
  * Options
  * Terms
  * Term taxonomies

#### Testing instructions:

* Using site auth token, GET the following REST paths: 
  * `/sites/$site_id/comments/$comment_id/backup`
  * `/sites/$site_id/options/backup?name=siteurl`
  * `/sites/$site_id/terms/$term_id/backup`
  * `/sites/$site_id/term-taxonomies/backup?name=category`
  * `/sites/$site_id/users/$user_id/backup`

#### Note:

This PR replaces #6758 since I mucked up a merge and muddied it all up. :)