### PR TITLE
JITMS: Remove force=wpcom

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -225,7 +225,6 @@ class Jetpack_JITM {
 
 		// build our jitm request
 		$path = add_query_arg( array(
-			'force'                => 'wpcom',
 			'external_user_id'     => urlencode_deep( $user->ID ),
 			'user_roles'           => urlencode_deep( implode( ',', $user->roles ) ),
 			'query_string'         => urlencode_deep( $query ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removes a misc `force=wpcom` from the jitm api call

#### Testing instructions:

* none

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Remove misc entry from wpcom api call