### PR TITLE
Sync: avoid busting cache too often

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -235,8 +235,8 @@ class Jetpack_JITM {
 		$envelopes  = get_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ) );
 
 		// if something is in the cache and it was put in the cache after the last sync we care about, use it
-		$last_sync = (int) get_transient( 'jetpack_last_sync' );
-		$from_cache = $envelopes && $last_sync < $envelopes[ 'response_time' ];
+		$last_sync = (int) get_transient( 'jetpack_last_plugin_sync' );
+		$from_cache = $envelopes && $last_sync > 0 && $last_sync < $envelopes[ 'last_response_time' ];
 
 		// otherwise, ask again
 		if ( ! $from_cache ) {
@@ -261,13 +261,13 @@ class Jetpack_JITM {
 			}
 
 			$expiration                 = isset( $envelopes[0] ) ? $envelopes[0]->ttl : 300;
-			$envelopes['response_time'] = time();
+			$envelopes['last_response_time'] = time();
 
 			set_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ), $envelopes, $expiration );
 		}
 
 		$hidden_jitms = Jetpack_Options::get_option( 'hide_jitm' );
-		unset( $envelopes['response_time'] );
+		unset( $envelopes['last_response_time'] );
 
 		foreach ( $envelopes as $idx => &$envelope ) {
 

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -236,7 +236,7 @@ class Jetpack_JITM {
 
 		// if something is in the cache and it was put in the cache after the last sync we care about, use it
 		$last_sync = (int) get_transient( 'jetpack_last_plugin_sync' );
-		$from_cache = $envelopes && $last_sync > 0 && $last_sync < $envelopes[ 'last_response_time' ];
+		$from_cache = $envelopes && $last_sync > 0 && $last_sync < $envelopes['last_response_time'];
 
 		// otherwise, ask again
 		if ( ! $from_cache ) {

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -233,16 +233,13 @@ class Jetpack_JITM {
 
 		// attempt to get from cache
 		$envelopes  = get_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ) );
-		$from_cache = false;
 
-		// if something is in the cache and it was put in the cache after the last heartbeat, use it
-		if ( $envelopes && Jetpack_Options::get_option( 'last_heartbeat', time() ) < $envelopes['response_time'] ) {
-			$from_cache = true;
-		}
+		// if something is in the cache and it was put in the cache after the last sync we care about, use it
+		$last_sync = (int) get_transient( 'jetpack_last_sync' );
+		$from_cache = $envelopes && $last_sync < $envelopes[ 'response_time' ];
 
 		// otherwise, ask again
 		if ( ! $from_cache ) {
-			$from_cache     = false;
 			$wpcom_response = Jetpack_Client::wpcom_json_api_request_as_blog(
 				$path,
 				'2',

--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -235,15 +235,14 @@ class Jetpack_JITM {
 		$envelopes  = get_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ) );
 		$from_cache = false;
 
-		// if something is in the cache and it was put in the cache after the last heartbeat or sync, use it
-		$last_heartbeat = Jetpack_Options::get_option( 'last_heartbeat', time() );
-		$last_sync      = Jetpack_Options::get_option( 'last_sync', time() );
-		if ( $envelopes && $last_heartbeat < $envelopes['response_time'] || $last_sync < $envelopes['response_time'] ) {
+		// if something is in the cache and it was put in the cache after the last heartbeat, use it
+		if ( $envelopes && Jetpack_Options::get_option( 'last_heartbeat', time() ) < $envelopes['response_time'] ) {
 			$from_cache = true;
 		}
 
 		// otherwise, ask again
 		if ( ! $from_cache ) {
+			$from_cache     = false;
 			$wpcom_response = Jetpack_Client::wpcom_json_api_request_as_blog(
 				$path,
 				'2',

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -84,7 +84,6 @@ class Jetpack_Options {
 			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
 			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget
-			'last_sync',                    // (int)    The last time a sync was performed
 		);
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -607,10 +607,12 @@ class Jetpack {
 	}
 
 	function jetpack_track_last_sync_callback( $params ) {
-		$option = $params[ 0 ];
-		if ( $option === 'active_plugins' ) {
-			// use the cache if we can, but not terribly important if it gets evicted
-			set_transient( 'jetpack_last_sync', time(), 3600 );
+		if ( is_array( $params ) && isset( $params[0] ) ) {
+			$option = $params[0];
+			if ( 'active_plugins' === $option ) {
+				// use the cache if we can, but not terribly important if it gets evicted
+				set_transient( 'jetpack_last_plugin_sync', time(), 3600 );
+			}
 		}
 
 		return $params;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -599,6 +599,21 @@ class Jetpack {
 			add_action( 'wp_print_styles', array( $this, 'implode_frontend_css' ), -1 ); // Run first
 			add_action( 'wp_print_footer_scripts', array( $this, 'implode_frontend_css' ), -1 ); // Run first to trigger before `print_late_styles`
 		}
+
+		/**
+		 * These are sync actions that we need to keep track of for jitms
+		 */
+		add_filter( 'jetpack_sync_before_send_updated_option', array( $this, 'jetpack_track_last_sync_callback' ), 99 );
+	}
+
+	function jetpack_track_last_sync_callback( $params ) {
+		$option = $params[ 0 ];
+		if ( $option === 'active_plugins' ) {
+			// use the cache if we can, but not terribly important if it gets evicted
+			set_transient( 'jetpack_last_sync', time(), 3600 );
+		}
+
+		return $params;
 	}
 
 	function jetpack_admin_ajax_tracks_callback() {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -611,7 +611,7 @@ class Jetpack {
 			$option = $params[0];
 			if ( 'active_plugins' === $option ) {
 				// use the cache if we can, but not terribly important if it gets evicted
-				set_transient( 'jetpack_last_plugin_sync', time(), 3600 );
+				set_transient( 'jetpack_last_plugin_sync', time(), HOUR_IN_SECONDS );
 			}
 		}
 

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -155,7 +155,6 @@ class Jetpack_Sync_Actions {
 		) );
 
 		$result = $rpc->query( 'jetpack.syncActions', $data );
-		Jetpack_Options::update_option( 'last_sync', time() );
 
 		if ( ! $result ) {
 			return $rpc->get_jetpack_error();


### PR DESCRIPTION
See p1496182959940456-slack-jpop-growth for some background. We basically want to not bust the cache too often and cause a degraded experience for users, or use up all their db queries if they have a quota.

#### Changes proposed in this Pull Request:

This reverts an earlier commit (that made caching super-passive aggressive) and makes the caching logic much more aggressive (only bust the cache if a plugin activation changes). It also uses transients to avoid hitting the database at all, when the site has a caching layer.

The fact that any of these keys may be evicted at any time doesn't really affect much. Also, the values are going to be fairly small, so they'd be in smaller slabs than most options, which makes them less likely to be evicted. (In theory...) But like I said, won't affect much if they are evicted.

#### Testing instructions:

The easiest way to test is to drop an xdebug breakpoint (or `error_log` statement) right after the `$from_cache` and verify that it makes sense.

Values of `$from_cache`:
- First page load on `/wp-admin/plugins.php`: could be anything, most likely `false`
- Refresh: `true`
- (De)Activate a plugin: `false`
- Refresh: `true`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
