### PR TITLE
Sync: Sync WordPress defined memory limit constants

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -146,6 +146,8 @@ class Jetpack_Sync_Defaults {
 		'ALTERNATE_WP_CRON',
 		'WP_CRON_LOCK_TIMEOUT',
 		'PHP_VERSION',
+		'WP_MEMORY_LIMIT',
+		'WP_MAX_MEMORY_LIMIT'
 	);
 
 	public static function get_constants_whitelist() {


### PR DESCRIPTION
Currently we don't track how much memory sites have available. 
This will allow us to 

#### Changes proposed in this Pull Request:
* Sync WP_MAX_MEMORY_LIMIT and WP_MEMORY_LIMIT so that we know how much memory sites have available to them since low memory limits can sometimes be an indicator of a issues. 

#### Testing instructions:
* Do the test pass? Update the memory limit does the newly defined memory limit get updated on the .com side?