### PR TITLE
fix / Full Screen Connection clash with akismet banner

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -41,7 +41,7 @@
 			right: 0;
 			bottom: 0;
 			left: 0;
-			z-index: 999; // to sit over other elements
+		z-index: 9999; // to sit over other elements
 		background: rgba($gray-light, .95);
 		text-align: center;
 		padding: rem( 32px );


### PR DESCRIPTION
Adjusting full screen connection banner to avoid visual clash with the akismet banner. Text from the akismet banner sits above the full screen connection banner within jetpack.

Fixes: https://github.com/Automattic/jetpack/issues/7173

**Before:**
![screen shot 2017-05-11 at 22 13 39](https://cloud.githubusercontent.com/assets/426388/25969994/633512d0-3697-11e7-820f-1f008748c733.png)

**After:**
<img width="1121" alt="screen shot 2017-05-31 at 12 11 26 pm" src="https://cloud.githubusercontent.com/assets/214813/26642166/be40a58c-45fa-11e7-9cd8-dedf2c2b44ff.png">


To Test:
1. Install the Akismet plugin on your site. Do not configure it. You'll see this banner in the Plugins page:

![screen shot 2017-05-11 at 22 15 54](https://cloud.githubusercontent.com/assets/426388/25970004/6b83e344-3697-11e7-8414-1ca5bec6520b.png)

2. Install and activate the Jetpack plugin.
3. Some of the text from the Akismet banner appears in Jetpack's full connection banner.

