### PR TITLE
Store user tokens if returned by Jetpack Start

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -794,6 +794,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				'Authorization' => "Bearer " . $token->access_token,
 				'Host'          => defined( 'JETPACK__WPCOM_JSON_API_HOST_HEADER' ) ? JETPACK__WPCOM_JSON_API_HOST_HEADER : 'public-api.wordpress.com',
 			),
+			'timeout' => 60,
 			'method'  => 'POST',
 			'body'    => json_encode( array( 'site_id' => $blog_id ) )
 		);
@@ -938,6 +939,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				'Authorization' => "Bearer " . $token->access_token,
 				'Host'          => defined( 'JETPACK__WPCOM_JSON_API_HOST_HEADER' ) ? JETPACK__WPCOM_JSON_API_HOST_HEADER : 'public-api.wordpress.com',
 			),
+			'timeout' => 60,
 			'method'  => 'POST',
 			'body'    => json_encode( $request_body )
 		);

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -972,7 +972,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			Jetpack_Options::update_options(
 				array(
 					'master_user'	=> $user->ID,
-					'user_tokens'	=> array($user->ID => $access_token.'.'.$user->ID)
+					'user_tokens'	=> array($user->ID => $body_json->access_token.'.'.$user->ID)
 				)
 			);
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -963,6 +963,15 @@ class Jetpack_CLI extends WP_CLI_Command {
 			}
 		}
 
+		if ( isset( $body_json->access_token ) ) {
+			Jetpack_Options::update_options(
+				array(
+					'master_user'	=> $user->ID,
+					'user_tokens'	=> array($user->ID => $access_token.'.'.$user->ID)
+				)
+			);
+		}
+
 		WP_CLI::log( $body_json->next_url );
 
 		WP_CLI::log( json_encode( $body_json ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -897,6 +897,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			? get_site_icon_url()
 			: false;
 
+		/** This filter is documented in class.jetpack-cli.php */
 		if ( apply_filters( 'jetpack_start_enable_sso', true ) ) {
 			$redirect_uri = add_query_arg(
 				array( 'action' => 'jetpack-sso', 'redirect_to' => urlencode( admin_url() ) ),
@@ -980,6 +981,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 				Jetpack::activate_default_modules( false, false, array(), false );
 			}
 
+			/**
+			 * Auto-enable SSO module for new Jetpack Start connections
+			 *
+			 * @since 5.0.0
+			 *
+			 * @param bool $enable_sso Whether to enable the SSO module. Default to true.
+			 */
 			if ( apply_filters( 'jetpack_start_enable_sso', true ) ) {
 				Jetpack::activate_module( 'sso', false, false );
 			}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -969,12 +969,14 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		if ( isset( $body_json->access_token ) ) {
 			// authorize user and enable SSO
-			Jetpack_Options::update_options(
-				array(
-					'master_user'	=> $user->ID,
-					'user_tokens'	=> array($user->ID => $body_json->access_token.'.'.$user->ID)
-				)
-			);
+			Jetpack::update_user_token( $user->ID, sprintf( '%s.%d', $body_json->access_token, $user->ID ), true );
+
+			if ( $active_modules = Jetpack_Options::get_option( 'active_modules' ) ) {
+				Jetpack::delete_active_modules();
+				Jetpack::activate_default_modules( 999, 1, $active_modules, false );
+			} else {
+				Jetpack::activate_default_modules( false, false, array(), false );
+			}
 
 			if ( apply_filters( 'jetpack_start_enable_sso', true ) ) {
 				Jetpack::activate_module( 'sso', false, false );

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -133,6 +133,7 @@ class Jetpack_Client_Server {
 
 		// If redirect_uri is SSO, ensure SSO module is enabled
 		parse_str( parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
+		/** This filter is documented in class.jetpack-cli.php */
 		if ( isset( $redirect_options['action'] ) && 'jetpack-sso' === $redirect_options['action'] && apply_filters( 'jetpack_start_enable_sso', true ) ) {
 			Jetpack::activate_module( 'sso', false, false );
 		}

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -133,7 +133,7 @@ class Jetpack_Client_Server {
 
 		// If redirect_uri is SSO, ensure SSO module is enabled
 		parse_str( parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
-		if ( isset( $redirect_options['action'] ) && 'jetpack-sso' === $redirect_options['action'] ) {
+		if ( isset( $redirect_options['action'] ) && 'jetpack-sso' === $redirect_options['action'] && apply_filters( 'jetpack_start_enable_sso', true ) ) {
 			Jetpack::activate_module( 'sso', false, false );
 		}
 


### PR DESCRIPTION
In some cases, we want to immediately connect Jetpack Start master users to a specific user on WordPress.com. 

This PR patches the partner-provision process so that if a user can be immediately authorized, the token is returned and inserted into the DB, and appropriate modules are enabled exactly as if they'd gone through the authorize API itself.

This change also adds a new filter, `jetpack_start_enable_sso`, which can be used to prevent auto-enabling SSO for partners who don't want that.

It also increases timeouts as sometimes provisioning can take a while.