### PR TITLE
Remove spurious output from JPS

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -993,8 +993,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 			}
 		}
 
-		WP_CLI::log( $body_json->next_url );
-
 		WP_CLI::log( json_encode( $body_json ) );
 	}
 


### PR DESCRIPTION
Removes some debugging output from Jetpack Start's partner-provision command.