### PR TITLE
Added user matching when adding comments via JSON API.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -102,6 +102,17 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 				if ( !isset( $user->ID ) ) {
 					$user->ID = 0;
 				}
+
+				// If we have a user with an external ID saved, we can use it.
+				if (
+					! $auth_required
+					&& $user->ID
+					&& (
+						$author = get_user_by( 'id', intval( $user->ID ) )
+					)
+				) {
+					$user = $author;
+				}
 			} else {
 				$auth_required = true;
 			}


### PR DESCRIPTION
This will let us attribute comments to authors on the site running Jetpack if a user has successfully connected their account to the actount on WordPress.com.

#### Changes proposed in this Pull Request:
* Adds code that fetches a user based on the external ID stored on WordPress.com

#### Testing instructions:
* Get a site with a user that is not the connection owner.
* Better if you have two users, one of them should be connected to WordPress.com, while the other shouldn't.
* Use the `/sites/%s/posts/%d/replies/new` API endpoint to add comments with both of them.
* Notice how the author is set to a user with 0 ID.
* Apply the PR.
* Notice how in case of a connected user the author field gets properly attributed to the local user.

Tagging @georgestephanis because you worked on the SSO module.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Added user matching when adding comments via JSON API.