### PR TITLE
VaultPress: fix errors when $vaultpress->contact_service() returned false 

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1329,7 +1329,12 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 		}
 
 		$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
-		if ( is_wp_error( $data ) || ! isset( $data->backups->last_backup ) ) {
+		if ( false == $data ) {
+			return rest_ensure_response( array(
+				'code'    => 'not_registered',
+				'message' => esc_html__( 'Could not connect to VaultPress.', 'jetpack' )
+			) );
+		} else if ( is_wp_error( $data ) || ! isset( $data->backups->last_backup ) ) {
 			return $data;
 		} else if ( empty( $data->backups->last_backup ) ) {
 			return rest_ensure_response( array(


### PR DESCRIPTION
Fixes #6970

To reproduce: 
- Free plan
- With VaultPress active
- Force this to return `false` https://github.com/Automattic/jetpack/pull/7286/files#diff-2ccec9069213650359171727de9a2471R1331

You'll see that the API returns nothing, which our UI can't handle and chokes.  We should be returning something here that the API can handle.  