### PR TITLE
Widgets: Prevent the caching of the EU Cookie Law Banner cookie

### DIFF
--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -206,24 +206,6 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 		}
 
 		/**
-		 * Set the EU Cookie Law cookie.
-		 */
-		public static function add_consent_cookie() {
-			if ( ! isset( $_POST['eucookielaw'] ) || 'accept' !== $_POST['eucookielaw'] ) {
-				return;
-			}
-
-			if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'eucookielaw' ) ) {
-				return;
-			}
-
-			// Cookie is valid for 30 days, so the user will be shown the banner again after 30 days.
-			setcookie( self::$cookie_name, current_time( 'timestamp' ), time() + self::$cookie_validity, '/' );
-
-			wp_safe_redirect( $_POST['redirect_url'] );
-		}
-
-		/**
 		 * Check if the value is allowed and not empty.
 		 *
 		 * @param  string $value Value to check.
@@ -245,9 +227,5 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 		register_widget( 'Jetpack_EU_Cookie_Law_Widget' );
 	};
 
-  // Only load the widget if we're inside the admin or the user has not given their consent to accept cookies.
-	if ( is_admin() || empty( $_COOKIE[ Jetpack_EU_Cookie_Law_Widget::$cookie_name ] ) ) {
-		add_action( 'widgets_init', 'jetpack_register_eu_cookie_law_widget' );
-		add_action( 'init', array( 'Jetpack_EU_Cookie_Law_Widget', 'add_consent_cookie' ) );
-	}
+	add_action( 'widgets_init', 'jetpack_register_eu_cookie_law_widget' );
 }

--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -1,7 +1,14 @@
 ( function( $ ) {
-	$( '.widget_eu_cookie_law_widget' ).appendTo( 'body' );
+	var cookieValue = document.cookie.replace( /(?:(?:^|.*;\s*)eucookielaw\s*\=\s*([^;]*).*$)|^.*$/, '$1' ),
+		overlay = $( '#eu-cookie-law' ),
+		initialScrollPosition,
+		scrollFunction;
 
-	var overlay = $( '#eu-cookie-law' ), initialScrollPosition, scrollFunction;
+	if ( '' !== cookieValue ) {
+		overlay.remove();
+	}
+
+	$( '.widget_eu_cookie_law_widget' ).appendTo( 'body' ).fadeIn();
 
 	overlay.find( 'form' ).on( 'submit', accept );
 

--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -1,5 +1,6 @@
 .widget_eu_cookie_law_widget.widget {
 	bottom: 1em;
+	display: none;
 	left: 1em;
 	margin: 0;
 	padding: 0;

--- a/modules/widgets/eu-cookie-law/widget.php
+++ b/modules/widgets/eu-cookie-law/widget.php
@@ -5,9 +5,6 @@
 	id="eu-cookie-law"
 >
 	<form method="post">
-		<?php wp_nonce_field( 'eucookielaw' ); ?>
-		<input type="hidden" name="eucookielaw" value="accept" />
-		<input type="hidden" name="redirect_url" value="<?php echo esc_attr( $_SERVER['REQUEST_URI'] ); ?>" />
 		<input type="submit" value="<?php echo esc_attr( $instance['button'] ); ?>" class="accept" />
 	</form>
 


### PR DESCRIPTION
Fixes #7285 

#### Changes proposed in this Pull Request:

* Move all the checks pertaining to the EU Cookie Law Banner cookie to JavaScript.
* Remove the PHP fallbacks for users without JavaScript.
* As the widget is now always loaded in PHP, it starts with `display: none`, and then `fadeIn()` if needed, otherwise it's removed from the DOM.

#### Testing instructions:

* Enable the EU Cookie Law Banner widget.
* Visit a page where the widget is enabled and hit the "Close and accept" button.
* Reload the page and make sure the widget doesn't show up.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Prevent the caching of the EU Cookie Law Banner cookie.