### PR TITLE
Add support for --url for multisite

### DIFF
--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 cd $SCRIPT_DIR
 
 usage () {
-    echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret"
+    echo "Usage: partner-cancel.sh --partner_id=partner_id --partner_secret=partner_secret [--url=http://example.com]"
 }
 
 for i in "$@"; do
@@ -17,6 +17,9 @@ for i in "$@"; do
                                     shift
                                     ;;
         -s=* | --partner_secret=* ) CLIENT_SECRET="${i#*=}"
+                                    shift
+                                    ;;
+        -u=* | --url=* )            SITE_URL="${i#*=}"
                                     shift
                                     ;;
         -h | --help )               usage
@@ -44,5 +47,5 @@ ACCESS_TOKEN_JSON=`curl https://$JETPACK_START_API_HOST/oauth2/token --silent --
 wp plugin activate jetpack >/dev/null 2>&1
 
 # cancel the partner plan
-wp jetpack partner_cancel "$ACCESS_TOKEN_JSON"
+wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" --url="$SITE_URL"
 

--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -44,7 +44,7 @@ fi
 ACCESS_TOKEN_JSON=`curl https://$JETPACK_START_API_HOST/oauth2/token --silent --header "Host: public-api.wordpress.com" -d "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=jetpack-partner"`
 
 # silently ensure Jetpack is active
-wp plugin activate jetpack >/dev/null 2>&1
+wp plugin activate jetpack --url="$SITE_URL" >/dev/null 2>&1
 
 # cancel the partner plan
 wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" --url="$SITE_URL"

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -57,7 +57,7 @@ fi
 ACCESS_TOKEN_JSON=`curl https://$JETPACK_START_API_HOST/oauth2/token --silent --header "Host: public-api.wordpress.com" -d "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=jetpack-partner"`
 
 # silently ensure Jetpack is active
-wp plugin activate jetpack >/dev/null 2>&1
+wp plugin activate jetpack --url="$SITE_URL" >/dev/null 2>&1
 
 # provision the partner plan
 wp jetpack partner_provision "$ACCESS_TOKEN_JSON" --user_id=$WP_USER_ID --plan=$PLAN_NAME --wpcom_user_id=$WPCOM_USER_ID --url="$SITE_URL"

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 cd $SCRIPT_DIR
 
 usage () {
-    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret --user_id=wp_user_id [--plan=plan_name] [--wpcom_user_id=1234]"
+    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret --user_id=wp_user_id [--plan=plan_name] [--wpcom_user_id=1234] [--url=http://example.com]"
 }
 
 for i in "$@"; do
@@ -30,6 +30,9 @@ for i in "$@"; do
                                     shift
                                     ;;
         -p=* | --plan=* )           PLAN_NAME="${i#*=}"
+                                    shift
+                                    ;;
+        -u=* | --url=* )            SITE_URL="${i#*=}"
                                     shift
                                     ;;
         -h | --help )               usage
@@ -57,5 +60,5 @@ ACCESS_TOKEN_JSON=`curl https://$JETPACK_START_API_HOST/oauth2/token --silent --
 wp plugin activate jetpack >/dev/null 2>&1
 
 # provision the partner plan
-wp jetpack partner_provision "$ACCESS_TOKEN_JSON" --user_id=$WP_USER_ID --plan=$PLAN_NAME --wpcom_user_id=$WPCOM_USER_ID
+wp jetpack partner_provision "$ACCESS_TOKEN_JSON" --user_id=$WP_USER_ID --plan=$PLAN_NAME --wpcom_user_id=$WPCOM_USER_ID --url="$SITE_URL"
 


### PR DESCRIPTION
Allows passing --url to the partner provision and cancel scripts, which helps with provisioning in a multisite environment.