### PR TITLE
VideoPress: avoid Fatal when get_current_screen() isn't defined

### DIFF
--- a/modules/videopress/editor-media-view.php
+++ b/modules/videopress/editor-media-view.php
@@ -101,13 +101,15 @@ function videopress_ajax_query_attachments_args( $args ) {
  */
 add_action( 'pre_get_posts', 'videopress_media_list_table_query' );
 function videopress_media_list_table_query( $query ) {
-	$current_screen = get_current_screen();
 
-	if ( is_null( $current_screen ) ) {
+	if (
+		! function_exists( 'get_current_screen' )
+		|| is_null( get_current_screen() )
+	) {
 		return;
 	}
 
-	if ( is_admin() && $query->is_main_query() && ( 'upload' === $current_screen->id ) ) {
+	if ( is_admin() && $query->is_main_query() && ( 'upload' === get_current_screen()->id ) ) {
 		$meta_query = array(
 			array(
 				'key'     => 'videopress_poster_image',


### PR DESCRIPTION
Issue introduced in #7229

Reported in p8oabR-3s-p2