### PR TITLE
Translate Widget: update layout to be responsive.

### DIFF
--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -84,7 +84,7 @@ class Jetpack_Google_Translate_Widget extends WP_Widget {
 					 *
 					 * @param string $layout layout of the Google Translate Widget.
 					 */
-					'layout' => wp_json_encode( apply_filters( 'jetpack_google_translate_widget_layout', '' ) ),
+					'layout' => esc_js( apply_filters( 'jetpack_google_translate_widget_layout', '' ) ),
 				)
 			);
 			wp_enqueue_script( 'google-translate-init' );

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -66,7 +66,27 @@ class Jetpack_Google_Translate_Widget extends WP_Widget {
 				'title' => $this->default_title,
 			) );
 
-			wp_localize_script( 'google-translate-init', '_wp_google_translate_widget', array( 'lang' => get_locale() ) );
+			wp_localize_script(
+				'google-translate-init',
+				'_wp_google_translate_widget',
+				array(
+					'lang'   => get_locale(),
+					/**
+					 * Filter the layout of the Google Translate Widget.
+					 *
+					 * 3 different values are accepted. Nothing, google.translate.TranslateElement.InlineLayout.SIMPLE, or google.translate.TranslateElement.InlineLayout.HORIZONTAL
+					 *
+					 * @see https://translate.google.com/manager/website/
+					 *
+					 * @module widgets
+					 *
+					 * @since 5.1.0
+					 *
+					 * @param string $layout layout of the Google Translate Widget.
+					 */
+					'layout' => wp_json_encode( apply_filters( 'jetpack_google_translate_widget_layout', '' ) ),
+				)
+			);
 			wp_enqueue_script( 'google-translate-init' );
 			wp_enqueue_script( 'google-translate' );
 

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -66,25 +66,38 @@ class Jetpack_Google_Translate_Widget extends WP_Widget {
 				'title' => $this->default_title,
 			) );
 
+			/**
+			 * Filter the layout of the Google Translate Widget.
+			 *
+			 * 3 different integers are accepted.
+			 * 	0 for the vertical layout.
+			 * 	1 for the horizontal layout.
+			 * 	2 for the dropdown only.
+			 *
+			 * @see https://translate.google.com/manager/website/
+			 *
+			 * @module widgets
+			 *
+			 * @since 5.4.0
+			 *
+			 * @param string $layout layout of the Google Translate Widget.
+			 */
+			$button_layout = apply_filters( 'jetpack_google_translate_widget_layout', 2 );
+
+			if (
+				! is_int( $button_layout )
+				|| 0 > $button_layout
+				|| 2 < $button_layout
+			) {
+				$button_layout = 2;
+			}
+
 			wp_localize_script(
 				'google-translate-init',
 				'_wp_google_translate_widget',
 				array(
 					'lang'   => get_locale(),
-					/**
-					 * Filter the layout of the Google Translate Widget.
-					 *
-					 * 3 different values are accepted. Nothing, google.translate.TranslateElement.InlineLayout.SIMPLE, or google.translate.TranslateElement.InlineLayout.HORIZONTAL
-					 *
-					 * @see https://translate.google.com/manager/website/
-					 *
-					 * @module widgets
-					 *
-					 * @since 5.1.0
-					 *
-					 * @param string $layout layout of the Google Translate Widget.
-					 */
-					'layout' => esc_js( apply_filters( 'jetpack_google_translate_widget_layout', '' ) ),
+					'layout' => intval( $button_layout ),
 				)
 			);
 			wp_enqueue_script( 'google-translate-init' );

--- a/modules/widgets/google-translate.php
+++ b/modules/widgets/google-translate.php
@@ -78,7 +78,7 @@ class Jetpack_Google_Translate_Widget extends WP_Widget {
 			 *
 			 * @module widgets
 			 *
-			 * @since 5.4.0
+			 * @since 5.5.0
 			 *
 			 * @param string $layout layout of the Google Translate Widget.
 			 */

--- a/modules/widgets/google-translate/google-translate.js
+++ b/modules/widgets/google-translate/google-translate.js
@@ -14,7 +14,7 @@ function googleTranslateElementInit() {
 	}
 	new google.translate.TranslateElement( {
 		pageLanguage: lang,
-		layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
+		layout: _wp_google_translate_widget.layout,
 		autoDisplay: false
 	}, 'google_translate_element' );
 }


### PR DESCRIPTION
Fixes #5962

#### Changes proposed in this Pull Request:

This PR includes 2 changes:
1. Change the default layout of the widget displayed by Google. Until now the widget used the "Dropdown Only" mode. It now uses
the "Vertical" mode. This layout is more compatible with mobile devices.
2. Create a new filter, `jetpack_google_translate_widget_layout`, allowing one to switch between layouts if needed:
```php
/**
 * Change the Google Translate Widget layout.
 */
function jeherve_dropdown_only_translate_layout() {
        return 'google.translate.TranslateElement.InlineLayout.SIMPLE';
}
add_filter( 'jetpack_google_translate_widget_layout', 'jeherve_dropdown_only_translate_layout' );
```

Before:

![screenshot 2017-06-02 at 14 35 02](https://cloud.githubusercontent.com/assets/426388/26725847/bdee4a10-47a0-11e7-8c98-010201c05628.png)

After:

![screenshot 2017-06-02 at 14 45 21](https://cloud.githubusercontent.com/assets/426388/26726124/24bb5c64-47a2-11e7-8a90-7a74c813fa09.png)

#### Testing instructions:

1. Make sure the widget is displayed properly on desktop and mobile devices. I'd recommend using an incognito window when switching to the branch to test , as things tend to get cached.
2. Add the snippet above to a functionality plugin and make sure the widget layout can be changed. You can also use the `google.translate.TranslateElement.InlineLayout.HORIZONTAL` string for another layout.

#### Proposed changelog entry for your changes:
* Google Translate Widget: update layout to be responsive.