### PR TITLE
JITM classname change

### DIFF
--- a/scss/jetpack-admin-jitm.scss
+++ b/scss/jetpack-admin-jitm.scss
@@ -114,7 +114,7 @@
 }
 
 // if JITM appears directly below WordPress "help" menu adjust margins
-#screen-meta-links+.jetpack-jitm-message {
+#screen-meta-links+.jitm-card {
 	margin: rem( 40px ) 1.5385em 0 auto;
 }
 


### PR DESCRIPTION
Had to make a classname change after @withinboredom [refactor](https://github.com/Automattic/jetpack/pull/7289) to make some styles from [this former PR](https://github.com/Automattic/jetpack/pull/7268) work again. This PR ensures a proper margin is applied to the JITM

:shakes fist: applies label: `cleanup-after-rob` haha

After: 
Everything appears as it should as seen [in this PR](https://github.com/Automattic/jetpack/pull/7268)


