### PR TITLE
Sync: Stop syncing Customizer changesets

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -206,15 +206,16 @@ class Jetpack_Sync_Defaults {
 
 	static $blacklisted_post_types = array(
 		'ai1ec_event',
-		'snitch',
-		'secupress_log_action',
-		'http',
-		'bwg_gallery',
 		'bwg_album',
+		'bwg_gallery',
+		'customize_changeset', // WP built-in post type for Customizer changesets
+		'http',
 		'idx_page',
 		'postman_sent_mail',
-		'rssmi_feed_item',
 		'rssap-feed',
+		'rssmi_feed_item',
+		'secupress_log_action',
+		'snitch',
 		'wp_automatic',
 	);
 


### PR DESCRIPTION
Customizer changesets can be used to store for a week pending changes via the Customizer. There is no work done on our site regarding this data and is not useful at this time.

If we're using this data for anything, we can close this PR, but I'm not aware of anything.

Additionally, orders the list of post types.

cc: @david-binda 