### PR TITLE
REST API: Fix object/array assignment issue in request filtering.

### DIFF
--- a/class.json-api.php
+++ b/class.json-api.php
@@ -496,7 +496,11 @@ class WPCOM_JSON_API {
 
 				foreach ( $response[ $key_to_filter ] as $key => $values ) {
 					if ( is_object( $values ) ) {
-						$response[ $key_to_filter ][ $key ] = (object) array_intersect_key( (array) $values, array_flip( $fields ) );
+						if ( is_object( $response[ $key_to_filter ] ) ) {
+							$response[ $key_to_filter ]->$key = (object) array_intersect_key( ( (array) $values ), array_flip( $fields ) );
+						} elseif ( is_array( $response[ $key_to_filter ] ) ) {
+							$response[ $key_to_filter ][ $key ] = (object) array_intersect_key( ( (array) $values ), array_flip( $fields ) );
+						}
 					} elseif ( is_array( $values ) ) {
 						$response[ $key_to_filter ][ $key ] = array_intersect_key( $values, array_flip( $fields ) );
 					}


### PR DESCRIPTION
If the filtered key is an object rather than an array, the request will
fatal because this tries to assign the value using `[ $key ]` rather
than `->$key` notation.

#### Changes proposed in this Pull Request:

* Ensure that the correct assignment syntax is used for a filtered request result.