### PR TITLE
Protect: Stop showing multisite network activation warning on beta installs

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -133,7 +133,7 @@ class Jetpack_Protect_Module {
 				require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
 			}
 
-			if ( ! is_plugin_active_for_network( 'jetpack/jetpack.php' ) ) {
+			if ( ! ( is_plugin_active_for_network( 'jetpack/jetpack.php' ) || is_plugin_active_for_network( 'jetpack-dev/jetpack.php' ) ) {
 				add_action( 'load-index.php', array ( $this, 'prepare_jetpack_protect_multisite_notice' ) );
 			}
 		}

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -133,7 +133,7 @@ class Jetpack_Protect_Module {
 				require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
 			}
 
-			if ( ! ( is_plugin_active_for_network( 'jetpack/jetpack.php' ) || is_plugin_active_for_network( 'jetpack-dev/jetpack.php' ) ) {
+			if ( ! ( is_plugin_active_for_network( 'jetpack/jetpack.php' ) || is_plugin_active_for_network( 'jetpack-dev/jetpack.php' ) ) ) {
 				add_action( 'load-index.php', array ( $this, 'prepare_jetpack_protect_multisite_notice' ) );
 			}
 		}


### PR DESCRIPTION
On beta plugin installs, the path of the plugin is `jetpack-dev/jetpack.php` which currently displays a warning to network activate whether or not it is active. Adding it here to better mimic production.