### PR TITLE
Shortcodes: Trigger error when required PHP libraries not included

### DIFF
--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -243,7 +243,7 @@ class Filter_Embedded_HTML_Objects {
 
 	static function get_attrs( $html ) {
 		if ( ! ( function_exists( 'libxml_use_internal_errors' ) && function_exists( 'simplexml_load_string' ) ) ) {
-			trigger_error( 'PHP has been compiled without the libxml or SimpleXML libraries. Please recompile PHP with these libraries.' );
+			trigger_error( __( "PHP's XML extension is not available. Please contact your hosting provider to enable PHP's XML extension." ) );
 			return array();
 		}
 		// We have to go through DOM, since it can load non-well-formed XML (i.e. HTML).  SimpleXML cannot.

--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -242,6 +242,10 @@ class Filter_Embedded_HTML_Objects {
 	}
 
 	static function get_attrs( $html ) {
+		if ( ! ( function_exists( 'libxml_use_internal_errors' ) && function_exists( 'simplexml_load_string' ) ) ) {
+			trigger_error( 'PHP has been compiled without the libxml or SimpleXML libraries. Please recompile PHP with these libraries.' );
+			return array();
+		}
 		// We have to go through DOM, since it can load non-well-formed XML (i.e. HTML).  SimpleXML cannot.
 		$dom = new DOMDocument;
 		// The @ is not enough to suppress errors when dealing with libxml,


### PR DESCRIPTION
When a server lacks `libxml` or `SimpleXML`, we hard fatal. We can be a bit more defensive for a better user experience.

This is coming up since, at least, Ubuntu's de factor PHP 7 package doesn't include all the libraries the PHP5 package did. Core added a similar check in https://core.trac.wordpress.org/changeset/38883