### PR TITLE
Use standard --user wp-cli argument, and small fixes

### DIFF
--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -42,9 +42,14 @@ fi
 # fetch an access token using our client ID/secret
 ACCESS_TOKEN_JSON=$(curl https://$JETPACK_START_API_HOST/oauth2/token --silent --header "Host: public-api.wordpress.com" -d "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=jetpack-partner")
 
+# set URL arg for multisite compatibility
+if [ ! -z "$SITE_URL" ]; then
+  ADDITIONAL_ARGS="--url=$SITE_URL"
+fi
+
 # silently ensure Jetpack is active
-wp plugin activate jetpack --url="$SITE_URL" >/dev/null 2>&1
+wp plugin activate jetpack $ADDITIONAL_ARGS >/dev/null 2>&1
 
 # cancel the partner plan
-wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" --url="$SITE_URL"
+wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS
 

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -956,7 +956,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 			if ( isset( $body_json->error ) ) {
 				$this->partner_provision_error( new WP_Error( $body_json->error, $body_json->message ) );
 			} else {
-				error_log(print_r($result,1));
 				$this->partner_provision_error( new WP_Error( 'server_error', sprintf( __( "Request failed with code %s" ), $response_code ) ) );
 			}
 		}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -833,15 +833,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *     $ wp jetpack partner_provision '{ some: "json" }' premium 1
 	 *     { success: true }
 	 *
-	 * @synopsis <token_json> --user_id=<user_id> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--force_register=<register>]
+	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--force_register=<register>]
 	 */
 	public function partner_provision( $args, $named_args ) {
 		list( $token_json ) = $args;
-
-		// legacy user_id param
-		if ( $named_args['user_id'] && get_userdata( $named_args['user_id'] ) ) {
-			wp_set_current_user( $named_args['user_id'] );
-		}
 
 		if ( ! $token_json || ! ( $token = json_decode( $token_json ) ) ) {
 			$this->partner_provision_error( new WP_Error( 'missing_access_token',  sprintf( __( 'Invalid token JSON: %s', 'jetpack' ), $token_json ) ) );
@@ -858,19 +853,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$this->partner_provision_error( new WP_Error( 'missing_access_token', __( 'Missing or invalid access token', 'jetpack' ) ) );
 		}
 
-		$user = wp_get_current_user();
-
-		if ( empty( $user ) ) {
-			$this->partner_provision_error( new WP_Error( 'missing_user', __( "No current user", 'jetpack' ) ) );
-		}
-
 		$blog_id    = Jetpack_Options::get_option( 'id' );
 		$blog_token = Jetpack_Options::get_option( 'blog_token' );
-
-		// we need to set the current user because:
-		// 1) register uses it as the "state" variable
-		// 2) authorize uses it to construct state variable and also to check if site is authorized for this user, and to send role
-		// 3) ultimately, it is this user who receives the plan
 
 		if ( ! $blog_id || ! $blog_token || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
 			// this code mostly copied from Jetpack::admin_page_load
@@ -886,11 +870,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$blog_token = Jetpack_Options::get_option( 'blog_token' );
 		}
 
-		// role
-		$role = Jetpack::translate_current_user_to_role();
-		$signed_role = Jetpack::sign_role( $role );
-
-		$secrets = Jetpack::init()->generate_secrets( 'authorize' );
+		// if the user isn't specified, but we have a current master user, then set that to current user
+		if ( ! get_current_user_id() && $master_user_id = Jetpack_Options::get_option( 'master_user' ) ) {
+			wp_set_current_user( $master_user_id );
+		}
 
 		$site_icon = ( function_exists( 'has_site_icon') && has_site_icon() )
 			? get_site_icon_url()
@@ -908,22 +891,31 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		$request_body = array( 
 			'jp_version'    => JETPACK__VERSION,
-
-			// Jetpack auth stuff
-			'scope'         => $signed_role,
-			'secret'        => $secrets['secret_1'],	
-
-			// User stuff
-			'user_id'       => $user->ID,
-			'user_email'    => $user->user_email,
-			'user_login'    => $user->user_login,
-
-			// Blog meta stuff
-			'site_icon'     => $site_icon,
-
-			// Then come back to this URL
 			'redirect_uri'  => $redirect_uri
 		);
+
+		if ( $site_icon ) {
+			$request_body['site_icon'] = $site_icon;
+		}
+
+		if ( get_current_user_id() ) {
+			$user = wp_get_current_user();
+
+			// role
+			$role = Jetpack::translate_current_user_to_role();
+			$signed_role = Jetpack::sign_role( $role );
+
+			$secrets = Jetpack::init()->generate_secrets( 'authorize' );
+
+			// Jetpack auth stuff
+			$request_body['scope']  = $signed_role;
+			$request_body['secret'] = $secrets['secret_1'];
+
+			// User stuff
+			$request_body['user_id']    = $user->ID;
+			$request_body['user_email'] = $user->user_email;
+			$request_body['user_login'] = $user->user_login;
+		}
 
 		// optional additional params
 		if ( isset( $named_args['wpcom_user_id'] ) && ! empty( $named_args['wpcom_user_id'] ) ) {


### PR DESCRIPTION
Previously we used the proprietary `--user-id` flag. This patch uses --user instead, which allows email, login or ID.

In addition, it tries to use the master user for provisioning plans, if available. This makes provisioning plans MUCH easier and more reliable if the Jetpack site is already connected.

Finally, this patch tries to skip non-Jetpack plugins when booting wp-cli. This improves security and reliability.