### PR TITLE
Sync: check for properties before expanding themes

### DIFF
--- a/sync/class.jetpack-sync-module-updates.php
+++ b/sync/class.jetpack-sync-module-updates.php
@@ -200,6 +200,9 @@ class Jetpack_Sync_Module_Updates extends Jetpack_Sync_Module {
 	}
 
 	public function expand_themes( $args ) {
+		if ( ! isset( $args[0], $args[0]->response ) ) {
+			return $args;
+		}
 		foreach ( $args[0]->response as $stylesheet => &$theme_data ) {
 			$theme = wp_get_theme( $stylesheet );
 			$theme_data['name'] = $theme->name;


### PR DESCRIPTION
Received a report from @richardmtl that a site running Jetpack 5.0 got this error:

```
Warning: Invalid
argument supplied for foreach() in
/wp-content/plugins/jetpack/sync/class.jetpack-sync-module-updates.php on line
203
```

If applied, this patch will check for correct properties before expanding themes. If the properties are not found, the themes will not be expanded.

To test:
phpunit