### PR TITLE
REST API: Includes blog_public to the list of returned options from /me/sites

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -49,6 +49,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	protected static $site_options_format = array(
 		'timezone',
 		'gmt_offset',
+		'blog_public',
 		'videopress_enabled',
 		'upgraded_filetypes_enabled',
 		'login_url',
@@ -481,6 +482,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'is_automated_transfer':
 					$options[ $key ] = $site->is_automated_transfer();
+					break;
+				case 'blog_public':
+					$options[ $key ] = $site->get_blog_public();
 					break;
 			}
 		}

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -549,4 +549,8 @@ abstract class SAL_Site {
 		$options = get_option( 'options' );
 		return ! empty ( $options['is_domain_only'] ) ? (bool) $options['is_domain_only'] : false;
 	}
+
+	function get_blog_public() {
+		return (int) get_option( 'blog_public' );
+	}
 }


### PR DESCRIPTION
Differential Revision: D5942-code

This commit syncs r157602-wpcom.

#### Changes proposed in this Pull Request:

Adds the blog_public option to the options returned from the wpcom /me/sites endpoint.  Centralizes the option retrieval to class.json-api-site-base.php for consistency.

#### Testing instructions:

Confirm that the option is properly returned with the list of sites in the /me/sites endpoint. 
