### PR TITLE
XMLRPC: jetpack.updateRole

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4089,8 +4089,12 @@ p {
 		return self::$capability_translations[$role];
 	}
 
-	static function sign_role( $role ) {
-		if ( ! $user_id = (int) get_current_user_id() ) {
+	static function sign_role( $role, $user_id = null ) {
+		if ( empty( $user_id ) ) {
+			$user_id = (int) get_current_user_id();
+		}
+
+		if ( ! $user_id  ) {
 			return false;
 		}
 

--- a/sync/class.jetpack-sync-users.php
+++ b/sync/class.jetpack-sync-users.php
@@ -41,7 +41,7 @@ class Jetpack_Sync_Users {
 	}
 
 	static function get_signed_role( $user_id ) {
-		return Jetpack::sign_role( self::get_role( $user_id ) );
+		return Jetpack::sign_role( self::get_role( $user_id ), $user_id );
 	}
 
 	static function update_role_on_com( $user_id ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/14490

To test:
- apply this patch to your test site
- in addition to a master user, have an other user who is connected
- logged in as the master user, update the other connected user's role
- log into wordpress.com as the other user, and ensure your new capabilities are reflected

