### PR TITLE
Sharedaddy: Disable e-mail sharing by default

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2871,7 +2871,7 @@ p {
 				'fallback_no_verify_ssl_certs',
 			)
 		);
-		
+
 		Jetpack_IDC::clear_all_idc_options();
 		Jetpack_Options::delete_raw_option( 'jetpack_secrets' );
 
@@ -6547,5 +6547,18 @@ p {
 				}
 			</style>
 		<?php }
+	}
+
+	/**
+	 * Checks if Akismet is active and working.
+	 *
+	 * @since  5.1.0
+	 * @return bool True = Akismet available. False = Aksimet not available.
+	 */
+	public static function is_akismet_active() {
+		if ( method_exists( 'Akismet' , 'http_post' ) || function_exists( 'akismet_http_post' ) ) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -59,7 +59,7 @@ function sharing_email_send_post( $data ) {
 /* Return $data as it if email about to be send out is not spam. */
 function sharing_email_check_for_spam_via_akismet( $data ) {
 
-	if ( ! function_exists( 'akismet_http_post' ) && ! method_exists( 'Akismet', 'http_post' ) )
+	if ( ! Jetpack::is_akismet_active() )
 		return $data;
 
 	// Prepare the body_request for akismet

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -59,10 +59,6 @@ class Sharing_Service {
 			'skype'             => 'Share_Skype',
 		);
 
-		$email = false;
-		if ( Jetpack::is_akismet_active() ) {
-			$email = true;
-		}
 		/**
 		 * Filters if Email Sharing is enabled.
 		 *
@@ -73,7 +69,7 @@ class Sharing_Service {
 		 *
 		 * @param bool $email Is e-mail sharing enabled? Default false if Akismet is not active or true if Akismet is active.
 		 */
-		if ( apply_filters( 'sharing_services_email', $email ) ) {
+		if ( apply_filters( 'sharing_services_email', Jetpack::is_akismet_active() ) ) {
 			$services['email'] = 'Share_Email';
 		}
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -59,6 +59,10 @@ class Sharing_Service {
 			'skype'             => 'Share_Skype',
 		);
 
+		$email = false;
+		if ( function_exists( 'akismet_http_post' ) || method_exists( 'Akismet', 'http_post' ) ) {
+			$email = true;
+		}
 		/**
 		 * Filters if Email Sharing is enabled.
 		 *
@@ -67,9 +71,9 @@ class Sharing_Service {
 		 *
 		 * @since 5.1.0
 		 *
-		 * @param bool $email Is e-mail sharing enabled? Default false
+		 * @param bool $email Is e-mail sharing enabled? Default false if Akismet is not active or true if Akismet is active.
 		 */
-		if ( apply_filters( 'sharing_services_email', false ) ) {
+		if ( apply_filters( 'sharing_services_email', $email ) ) {
 			$services['email'] = 'Share_Email';
 		}
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -60,7 +60,7 @@ class Sharing_Service {
 		);
 
 		$email = false;
-		if ( function_exists( 'akismet_http_post' ) || method_exists( 'Akismet', 'http_post' ) ) {
+		if ( Jetpack::is_akismet_active() ) {
 			$email = true;
 		}
 		/**

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -44,7 +44,6 @@ class Sharing_Service {
 		// if you update this list, please update the REST API tests
 		// in bin/tests/api/suites/SharingTest.php
 		$services = array(
-			'email'             => 'Share_Email',
 			'print'             => 'Share_Print',
 			'facebook'          => 'Share_Facebook',
 			'linkedin'          => 'Share_LinkedIn',
@@ -59,6 +58,20 @@ class Sharing_Service {
 			'jetpack-whatsapp'  => 'Jetpack_Share_WhatsApp',
 			'skype'             => 'Share_Skype',
 		);
+		
+		/**
+		 * Filters if Email Sharing is enabled.
+		 *
+		 * E-Mail sharing is often problematic due to spam concerns, so this filter enables it to be quickly and simply toggled.
+		 * @module sharedaddy
+		 *
+		 * @since 5.1.0
+		 *
+		 * @param bool $email Is e-mail sharing enabled? Default false
+		 */
+		if ( apply_filters( 'sharing_services_email', false ) ) {
+			$services['email'] = 'Share_Email';
+		}
 
 		if ( $include_custom ) {
 			// Add any custom services in

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -58,7 +58,7 @@ class Sharing_Service {
 			'jetpack-whatsapp'  => 'Jetpack_Share_WhatsApp',
 			'skype'             => 'Share_Skype',
 		);
-		
+
 		/**
 		 * Filters if Email Sharing is enabled.
 		 *


### PR DESCRIPTION
Defers #448 until a longer-term solution can be determined.

This feature has been a bit of a thorn in our side with multiple hosts over time disabling Sharing completely or at least the e-mail service due to spam abuse. While we should fix this, disabling this feature by default and requiring a technically-savvy admin to enable it.

Alternatively, we can disable it for sites that do not have Akismet and rely on Akismet to catch spam.

Opening the PR to continue the discussion.

cc: @csonnek 