### PR TITLE
REST: Disable query args for meta expansion

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -126,6 +126,7 @@ new WPCOM_JSON_API_GET_Site_Endpoint( array(
 	'allow_jetpack_site_auth' => true,
 	'query_parameters' => array(
 		'context' => false,
+		'options' => '(string) Optional. Returns specified options only. Comma-separated list. Example: options=login_url,timezone',
 	),
 
 	'response_format' => WPCOM_JSON_API_GET_Site_Endpoint::$site_format,

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -136,10 +136,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return $blog_id;
 		}
 
-		// TODO: enable this when we can do so without being interfered with by
-		// other endpoints that might be wrapping this one.
-		// Uncomment and see failing test: test_jetpack_site_should_have_true_jetpack_property_via_site_meta
-		// $this->filter_fields_and_options();
+		$this->filter_fields_and_options();
 
 		$response = $this->build_current_site_response();
 


### PR DESCRIPTION
Summary: Currently meta expansion can see and use the query args passed to the main request. This doesn't really make sense, especially for things like `fields` and `options`, which can't apply to both the main request and the meta requests equally. Instead, remove the query args when processing meta requests and replace them after.

Reviewers: bluefuton

Differential Revision: D5926-code

This commit syncs r157700-wpcom.
This commit syncs r157706-wpcom.