### PR TITLE
Sites: Add options to the query arguments to pick them when limiting

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -126,6 +126,7 @@ new WPCOM_JSON_API_GET_Site_Endpoint( array(
 	'allow_jetpack_site_auth' => true,
 	'query_parameters' => array(
 		'context' => false,
+		'options' => '(string) Optional. Returns specified options only. Comma-separated list. Example: options=login_url,timezone',
 	),
 
 	'response_format' => WPCOM_JSON_API_GET_Site_Endpoint::$site_format,


### PR DESCRIPTION
r157700-wpcom allowed the site endpoint to pre-emptively ignore fields and options passed. This teaches the API to pass along the options value if it is supplied. Fields are special, and specified on the root endpoint class.

This commit syncs r157706-wpcom.

