### PR TITLE
Moved PHP 7.1 to regular Travis matrix not allowing it to fail anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ matrix:
   - php: "7.1"
 
   allow_failures:
-  - php: "7.1"
 #  - php: "nightly"
 
 # whitelist branches for the "push" build check.


### PR DESCRIPTION
Since WordPress 4.8 came out, we're no longer testing against WordPress 4.6, so it's safe to move PHP 7.1 to the regular matrix and catch failures there.