### PR TITLE
Sync: WooCommerce - Ensure we sync the order_id for order_items in older WooCommerce versions.…

### DIFF
--- a/sync/class.jetpack-sync-module-woocommerce.php
+++ b/sync/class.jetpack-sync-module-woocommerce.php
@@ -81,7 +81,8 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 	}
 
 	public function filter_order_item( $args ) {
-		$args[1] = $this->build_order_item( $args[1] );
+		// Make sure we always have all the data - prior to WooCommerce 3.0 we only have the user supplied data in the second argument and not the full details
+		$args[1] = $this->build_order_item( $args[0] );
 		return $args;
 	}
 
@@ -102,20 +103,9 @@ class Jetpack_Sync_Module_WooCommerce extends Jetpack_Sync_Module {
 		);
 	}
 
-	public function build_order_item( $order_item ) {
-		if ( is_numeric( $order_item ) ) {
-			global $wpdb;
-			return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $this->order_item_table_name WHERE order_item_id = %d", $order_item ) );
-		} elseif ( is_array( $order_item ) ) {
-			return $order_item;
-		} else {
-			return (object)array(
-				'order_item_id'   => $order_item->get_id(),
-				'order_item_type' => $order_item->get_type(),
-				'order_item_name' => $order_item->get_name(),
-				'order_id'        => $order_item->get_order_id(),
-			);
-		}
+	public function build_order_item( $order_item_id ) {
+		global $wpdb;
+		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $this->order_item_table_name WHERE order_item_id = %d", $order_item_id ) );
 	}
 
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {


### PR DESCRIPTION
Prior to WooCommerce 3.0 the second argument to the woocommerce_new_order_item action only contained the order_item_name and order_item_type information and not the order_id.

This meant that incremental syncing of this data would loose the relevant order_ids and the products would not be correctly associated with the orders.

Relevant code in previous major version: https://github.com/woocommerce/woocommerce/blob/2.6.14/includes/wc-order-functions.php#L515