### PR TITLE
WordPress.com Toolbar: restore access to wp-admin menu items on mobile

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -924,6 +924,15 @@ class A8C_WPCOM_Masterbar {
 					),
 				) );
 			}
+
+			// Restore dashboard menu toggle that is needed on mobile views.
+			if ( is_admin() ) {
+				$wp_admin_bar->add_menu( array(
+				'id'    => 'menu-toggle',
+				'title' => '<span class="ab-icon"></span><span class="screen-reader-text">' . __( 'Menu', 'jetpack' ) . '</span>',
+				'href'  => '#',
+				) );
+			}
 		}
 	}
 }

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -67,3 +67,34 @@
 #wpadminbar .menupop .ab-submenu .ab-submenu-header > .ab-empty-item {
 	line-height: 1 !important;
 }
+
+@media screen and ( max-width: 782px ) {
+	.wp-admin .wrap h1 {
+		padding-left: 50px;
+	}
+
+	#wpadminbar #wp-admin-bar-menu-toggle {
+		position: absolute;
+		top: 53px;
+	}
+
+	#wpadminbar #wp-admin-bar-menu-toggle a {
+		padding: 0 8px !important;
+	}
+
+	#wpadminbar #wp-admin-bar-menu-toggle .ab-icon:before {
+		color: #333;
+	}
+
+	.wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle .ab-icon:before {
+		color: #00b9eb !important;
+	}
+
+	.wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle {
+		left: 190px;
+	}
+
+	.wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle .ab-item {
+		background-color: transparent;
+	}
+}


### PR DESCRIPTION
Previously, Masterbar was removing the dashboard menu item that was used
to enable access to wp-admin menu items on smaller screen sizes. Now that
menu item is restored, with some additional styling fixes that are needed to
resolve incorrect positioning on screens larger than 480px.

Fixes https://github.com/Automattic/jetpack/issues/6914

#### Testing instructions:

1. On a Jetpack site, enable the WordPress.com toolbar.
2. Navigate to `wp-admin` and view it in smaller screen size (<780px).
3. Verify that you see the icon to toggle the `wp-admin` menu items.

#### Visual changes:

<img alt="toggle-off" src="https://user-images.githubusercontent.com/1182160/27184086-3cd16930-51e1-11e7-9c2a-ee79a5064e52.png" width="300px" />

<img alt="toggle-on" src="https://user-images.githubusercontent.com/1182160/27184088-3cf6fe70-51e1-11e7-8f66-566341d45dd2.png" width="300px" />