### PR TITLE
JITM: Remove obsolete videopress warning

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -54,8 +54,6 @@ class Jetpack_VideoPress {
 
 		add_filter( 'wp_video_extensions', array( $this, 'add_videopress_extenstion' ) );
 
-		$this->add_media_new_notice();
-
 		VideoPress_Scheduler::init();
 		VideoPress_XMLRPC::init();
 	}
@@ -111,22 +109,6 @@ class Jetpack_VideoPress {
 		$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 
 		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
-	}
-
-	/**
-	 * Add a notice to the top of the media-new.php to let the user know how to upload a video.
-	 */
-	public function add_media_new_notice() {
-		global $pagenow;
-
-		if ( $pagenow != 'media-new.php' ) {
-			return;
-		}
-
-		$jitm = Jetpack_JITM::init();
-
-		add_action( 'admin_enqueue_scripts', array( $jitm, 'jitm_enqueue_files' ) );
-		add_action( 'admin_notices', array( $jitm, 'videopress_media_upload_warning_msg' ) );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Removes some jitm code that was hiding outside of the original jitm class
* The original warning is replaced by D5960-code

#### Testing instructions:

* No PHP warning appears on `/wp-admin/media-new.php`

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
