### PR TITLE
Content Options: Add a Portfolio option to the Featured Images + fixes

### DIFF
--- a/modules/theme-tools/content-options.php
+++ b/modules/theme-tools/content-options.php
@@ -12,22 +12,24 @@
 		'author-bio-default' => false, // the default setting of the author bio, if it's being displayed or not: true or false (only required if false).
 		'masonry'            => '.site-main', // a CSS selector matching the elements that triggers a masonry refresh if the theme is using a masonry layout.
 		'post-details'       => array(
-			'stylesheet'      => 'themeslug-style', // name of the theme's stylesheet.
-			'date'            => '.posted-on', // a CSS selector matching the elements that display the post date.
-			'categories'      => '.cat-links', // a CSS selector matching the elements that display the post categories.
-			'tags'            => '.tags-links', // a CSS selector matching the elements that display the post tags.
-			'author'          => '.byline', // a CSS selector matching the elements that display the post author.
-			'comment'         => '.comments-link', // a CSS selector matching the elements that display the comment link.
+			'stylesheet'        => 'themeslug-style', // name of the theme's stylesheet.
+			'date'              => '.posted-on', // a CSS selector matching the elements that display the post date.
+			'categories'        => '.cat-links', // a CSS selector matching the elements that display the post categories.
+			'tags'              => '.tags-links', // a CSS selector matching the elements that display the post tags.
+			'author'            => '.byline', // a CSS selector matching the elements that display the post author.
+			'comment'           => '.comments-link', // a CSS selector matching the elements that display the comment link.
 		),
 		'featured-images'    => array(
-			'archive'          => true, // enable or not the featured image check for archive pages: true or false.
-			'archive-default'  => false, // the default setting of the featured image on archive pages, if it's being displayed or not: true or false (only required if false).
-			'post'             => true, // enable or not the featured image check for single posts: true or false.
-			'post-default'     => false, // the default setting of the featured image on single posts, if it's being displayed or not: true or false (only required if false).
-			'page'             => true, // enable or not the featured image check for single pages: true or false.
-			'page-default'     => false, // the default setting of the featured image on single pages, if it's being displayed or not: true or false (only required if false).
-			'fallback'         => true, // enable or not the featured image fallback: true or false.
-			'fallback-default' => true, // the default setting for featured image fallbacks: true or false (only required if false)
+			'archive'           => true, // enable or not the featured image check for archive pages: true or false.
+			'archive-default'   => false, // the default setting of the featured image on archive pages, if it's being displayed or not: true or false (only required if false).
+			'post'              => true, // enable or not the featured image check for single posts: true or false.
+			'post-default'      => false, // the default setting of the featured image on single posts, if it's being displayed or not: true or false (only required if false).
+			'page'              => true, // enable or not the featured image check for single pages: true or false.
+			'page-default'      => false, // the default setting of the featured image on single pages, if it's being displayed or not: true or false (only required if false).
+			'portfolio'         => true, // enable or not the featured image check for single projects: true or false.
+			'portfolio-default' => false, // the default setting of the featured image on single projects, if it's being displayed or not: true or false (only required if false).
+			'fallback'          => true, // enable or not the featured image fallback: true or false.
+			'fallback-default'  => true, // the default setting for featured image fallbacks: true or false (only required if false)
 		),
 	) );
  *
@@ -74,21 +76,24 @@ function jetpack_featured_images_get_settings() {
 	$featured_images = ( ! empty( $options[0]['featured-images'] ) ) ? $options[0]['featured-images'] : null;
 
 	$settings        = array(
-		'archive'          => ( ! empty( $featured_images['archive'] ) ) ? $featured_images['archive'] : null,
-		'post'             => ( ! empty( $featured_images['post'] ) ) ? $featured_images['post'] : null,
-		'page'             => ( ! empty( $featured_images['page'] ) ) ? $featured_images['page'] : null,
-		'archive-default'  => ( isset( $featured_images['archive-default'] ) && false === $featured_images['archive-default'] ) ? '' : 1,
-		'post-default'     => ( isset( $featured_images['post-default'] ) && false === $featured_images['post-default'] ) ? '' : 1,
-		'page-default'     => ( isset( $featured_images['page-default'] ) && false === $featured_images['page-default'] ) ? '' : 1,
-		'fallback'         => ( ! empty( $featured_images['fallback'] ) ) ? $featured_images['fallback'] : null,
-		'fallback-default' => ( isset( $featured_images['fallback-default'] ) && false === $featured_images['fallback-default'] ) ? '' : 1,
+		'archive'           => ( ! empty( $featured_images['archive'] ) ) ? $featured_images['archive'] : null,
+		'post'              => ( ! empty( $featured_images['post'] ) ) ? $featured_images['post'] : null,
+		'page'              => ( ! empty( $featured_images['page'] ) ) ? $featured_images['page'] : null,
+		'portfolio'         => ( ! empty( $featured_images['portfolio'] ) ) ? $featured_images['portfolio'] : null,
+		'archive-default'   => ( isset( $featured_images['archive-default'] ) && false === $featured_images['archive-default'] ) ? '' : 1,
+		'post-default'      => ( isset( $featured_images['post-default'] ) && false === $featured_images['post-default'] ) ? '' : 1,
+		'page-default'      => ( isset( $featured_images['page-default'] ) && false === $featured_images['page-default'] ) ? '' : 1,
+		'portfolio-default' => ( isset( $featured_images['portfolio-default'] ) && false === $featured_images['portfolio-default'] ) ? '' : 1,
+		'fallback'          => ( ! empty( $featured_images['fallback'] ) ) ? $featured_images['fallback'] : null,
+		'fallback-default'  => ( isset( $featured_images['fallback-default'] ) && false === $featured_images['fallback-default'] ) ? '' : 1,
 	);
 
 	$settings        = array_merge( $settings, array(
-		'archive-option'  => get_option( 'jetpack_content_featured_images_archive', $settings['archive-default'] ),
-		'post-option'     => get_option( 'jetpack_content_featured_images_post', $settings['post-default'] ),
-		'page-option'     => get_option( 'jetpack_content_featured_images_page', $settings['page-default'] ),
-		'fallback-option' => get_option( 'jetpack_content_featured_images_fallback', $settings['fallback-default'] ),
+		'archive-option'   => get_option( 'jetpack_content_featured_images_archive', $settings['archive-default'] ),
+		'post-option'      => get_option( 'jetpack_content_featured_images_post', $settings['post-default'] ),
+		'page-option'      => get_option( 'jetpack_content_featured_images_page', $settings['page-default'] ),
+		'portfolio-option' => get_option( 'jetpack_content_featured_images_portfolio', $settings['portfolio-default'] ),
+		'fallback-option'  => get_option( 'jetpack_content_featured_images_fallback', $settings['fallback-default'] ),
 	) );
 
 	return $settings;

--- a/modules/theme-tools/content-options/customizer.php
+++ b/modules/theme-tools/content-options/customizer.php
@@ -5,29 +5,31 @@
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
  */
 function jetpack_content_options_customize_register( $wp_customize ) {
-	$options             = get_theme_support( 'jetpack-content-options' );
-	$blog_display        = ( ! empty( $options[0]['blog-display'] ) ) ? $options[0]['blog-display'] : null;
-	$blog_display        = preg_grep( '/^(content|excerpt)$/', (array) $blog_display );
+	$options              = get_theme_support( 'jetpack-content-options' );
+	$blog_display         = ( ! empty( $options[0]['blog-display'] ) ) ? $options[0]['blog-display'] : null;
+	$blog_display         = preg_grep( '/^(content|excerpt)$/', (array) $blog_display );
 	sort( $blog_display );
-	$blog_display        = implode( ', ', $blog_display );
-	$blog_display        = ( 'content, excerpt' === $blog_display ) ? 'mixed' : $blog_display;
-	$author_bio          = ( ! empty( $options[0]['author-bio'] ) ) ? $options[0]['author-bio'] : null;
-	$author_bio_default  = ( isset( $options[0]['author-bio-default'] ) && false === $options[0]['author-bio-default'] ) ? '' : 1;
-	$post_details        = ( ! empty( $options[0]['post-details'] ) ) ? $options[0]['post-details'] : null;
-	$date                = ( ! empty( $post_details['date'] ) ) ? $post_details['date'] : null;
-	$categories          = ( ! empty( $post_details['categories'] ) ) ? $post_details['categories'] : null;
-	$tags                = ( ! empty( $post_details['tags'] ) ) ? $post_details['tags'] : null;
-	$author              = ( ! empty( $post_details['author'] ) ) ? $post_details['author'] : null;
-	$comment             = ( ! empty( $post_details['comment'] ) ) ? $post_details['comment'] : null;
-	$featured_images     = ( ! empty( $options[0]['featured-images'] ) ) ? $options[0]['featured-images'] : null;
-	$fi_archive          = ( ! empty( $featured_images['archive'] ) ) ? $featured_images['archive'] : null;
-	$fi_post             = ( ! empty( $featured_images['post'] ) ) ? $featured_images['post'] : null;
-	$fi_page             = ( ! empty( $featured_images['page'] ) ) ? $featured_images['page'] : null;
-	$fi_archive_default  = ( isset( $featured_images['archive-default'] ) && false === $featured_images['archive-default'] ) ? '' : 1;
-	$fi_post_default     = ( isset( $featured_images['post-default'] ) && false === $featured_images['post-default'] ) ? '' : 1;
-	$fi_page_default     = ( isset( $featured_images['page-default'] ) && false === $featured_images['page-default'] ) ? '' : 1;
-	$fi_fallback         = ( ! empty( $featured_images['fallback'] ) ) ? $featured_images['fallback'] : null;
-	$fi_fallback_default = ( isset( $featured_images['fallback-default'] ) && false === $featured_images['fallback-default'] ) ? '' : 1;
+	$blog_display         = implode( ', ', $blog_display );
+	$blog_display         = ( 'content, excerpt' === $blog_display ) ? 'mixed' : $blog_display;
+	$author_bio           = ( ! empty( $options[0]['author-bio'] ) ) ? $options[0]['author-bio'] : null;
+	$author_bio_default   = ( isset( $options[0]['author-bio-default'] ) && false === $options[0]['author-bio-default'] ) ? '' : 1;
+	$post_details         = ( ! empty( $options[0]['post-details'] ) ) ? $options[0]['post-details'] : null;
+	$date                 = ( ! empty( $post_details['date'] ) ) ? $post_details['date'] : null;
+	$categories           = ( ! empty( $post_details['categories'] ) ) ? $post_details['categories'] : null;
+	$tags                 = ( ! empty( $post_details['tags'] ) ) ? $post_details['tags'] : null;
+	$author               = ( ! empty( $post_details['author'] ) ) ? $post_details['author'] : null;
+	$comment              = ( ! empty( $post_details['comment'] ) ) ? $post_details['comment'] : null;
+	$featured_images      = ( ! empty( $options[0]['featured-images'] ) ) ? $options[0]['featured-images'] : null;
+	$fi_archive           = ( ! empty( $featured_images['archive'] ) ) ? $featured_images['archive'] : null;
+	$fi_post              = ( ! empty( $featured_images['post'] ) ) ? $featured_images['post'] : null;
+	$fi_page              = ( ! empty( $featured_images['page'] ) ) ? $featured_images['page'] : null;
+	$fi_portfolio         = ( ! empty( $featured_images['portfolio'] ) ) ? $featured_images['portfolio'] : null;
+	$fi_fallback          = ( ! empty( $featured_images['fallback'] ) ) ? $featured_images['fallback'] : null;
+	$fi_archive_default   = ( isset( $featured_images['archive-default'] ) && false === $featured_images['archive-default'] ) ? '' : 1;
+	$fi_post_default      = ( isset( $featured_images['post-default'] ) && false === $featured_images['post-default'] ) ? '' : 1;
+	$fi_page_default      = ( isset( $featured_images['page-default'] ) && false === $featured_images['page-default'] ) ? '' : 1;
+	$fi_portfolio_default = ( isset( $featured_images['portfolio-default'] ) && false === $featured_images['portfolio-default'] ) ? '' : 1;
+	$fi_fallback_default  = ( isset( $featured_images['fallback-default'] ) && false === $featured_images['fallback-default'] ) ? '' : 1;
 
 	// If the theme doesn't support 'jetpack-content-options[ 'blog-display' ]', 'jetpack-content-options[ 'author-bio' ]', 'jetpack-content-options[ 'post-details' ]' and 'jetpack-content-options[ 'featured-images' ]', don't continue.
 	if ( ( ! in_array( $blog_display, array( 'content', 'excerpt', 'mixed' ) ) )
@@ -38,7 +40,7 @@ function jetpack_content_options_customize_register( $wp_customize ) {
 				|| empty( $tags )
 				|| empty( $author )
 				|| empty( $comment ) ) )
-		&& ( true !== $fi_archive && true !== $fi_post && true !== $fi_page && true !== $fi_fallback ) ) {
+		&& ( true !== $fi_archive && true !== $fi_post && true !== $fi_page && true !== $fi_portfolio && true !== $fi_fallback ) ) {
 	    return;
 	}
 
@@ -48,7 +50,7 @@ function jetpack_content_options_customize_register( $wp_customize ) {
 
 		public function render_content() {
 		?>
-			<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+			<span class="customize-control-title"><?php echo wp_kses_post( $this->label ); ?></span>
 		<?php
 		}
 	}
@@ -220,12 +222,12 @@ function jetpack_content_options_customize_register( $wp_customize ) {
 	}
 
 	// Add Featured Images options.
-	if ( true === $fi_archive || true === $fi_post || true === $fi_page || true === $fi_fallback ) {
+	if ( true === $fi_archive || true === $fi_post || true === $fi_page || true === $fi_portfolio || true === $fi_fallback ) {
 		$wp_customize->add_setting( 'jetpack_content_featured_images_title' );
 
 		$wp_customize->add_control( new Jetpack_Customize_Control_Title( $wp_customize, 'jetpack_content_featured_images_title', array(
 			'section'                  => 'jetpack_content_options',
-			'label'                    => esc_html__( 'Featured Images', 'jetpack' ),
+			'label'                    => esc_html__( 'Featured Images', 'jetpack' ) . sprintf( '<a href="https://en.support.wordpress.com/featured-images/" class="customize-help-toggle dashicons dashicons-editor-help" title="%1$s" target="_blank"><span class="screen-reader-text">%1$s</span></a>', esc_html__( 'Learn more about Featured Images', 'jetpack' ) ),
 			'type'                     => 'title',
 			'active_callback'          => 'jetpack_post_thumbnail_supports',
 		) ) );
@@ -235,7 +237,6 @@ function jetpack_content_options_customize_register( $wp_customize ) {
 			$wp_customize->add_setting( 'jetpack_content_featured_images_archive', array(
 				'default'              => $fi_archive_default,
 				'type'                 => 'option',
-				'transport'            => 'refresh',
 				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
 			) );
 
@@ -252,7 +253,6 @@ function jetpack_content_options_customize_register( $wp_customize ) {
 			$wp_customize->add_setting( 'jetpack_content_featured_images_post', array(
 				'default'              => $fi_post_default,
 				'type'                 => 'option',
-				'transport'            => 'refresh',
 				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
 			) );
 
@@ -269,7 +269,6 @@ function jetpack_content_options_customize_register( $wp_customize ) {
 			$wp_customize->add_setting( 'jetpack_content_featured_images_page', array(
 				'default'              => $fi_page_default,
 				'type'                 => 'option',
-				'transport'            => 'refresh',
 				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
 			) );
 
@@ -280,13 +279,28 @@ function jetpack_content_options_customize_register( $wp_customize ) {
 				'active_callback'      => 'jetpack_post_thumbnail_supports',
 			) );
 		}
+		
+		// Featured Images: Portfolio
+		if ( true === $fi_portfolio && post_type_exists( 'jetpack-portfolio' ) ) {
+			$wp_customize->add_setting( 'jetpack_content_featured_images_portfolio', array(
+				'default'              => $fi_portfolio_default,
+				'type'                 => 'option',
+				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
+			) );
+
+			$wp_customize->add_control( 'jetpack_content_featured_images_portfolio', array(
+				'section'              => 'jetpack_content_options',
+				'label'                => esc_html__( 'Display on single projects', 'jetpack' ),
+				'type'                 => 'checkbox',
+				'active_callback'      => 'jetpack_post_thumbnail_supports',
+			) );
+		}
 
 		// Featured Images: Fallback
 		if ( true === $fi_fallback ) {
 			$wp_customize->add_setting( 'jetpack_content_featured_images_fallback', array(
 				'default'              => $fi_fallback_default,
 				'type'                 => 'option',
-				'transport'            => 'refresh',
 				'sanitize_callback'    => 'jetpack_content_options_sanitize_checkbox',
 			) );
 

--- a/modules/theme-tools/content-options/featured-images-fallback.php
+++ b/modules/theme-tools/content-options/featured-images-fallback.php
@@ -20,7 +20,7 @@ function jetpack_featured_images_fallback_get_image( $html, $post_id, $post_thum
 	}
 
 	if ( jetpack_featured_images_should_load() ) {
-		if ( 
+		if (
 			( true === $opts['archive'] && ( is_home() || is_archive() || is_search() ) && ! $opts['archive-option'] )
 			|| ( true === $opts['post'] && is_single() && ! $opts['post-option'] )
 			|| ! $opts['fallback-option']
@@ -152,7 +152,7 @@ function jetpack_featured_images_post_class( $classes, $class, $post_id ) {
 	$post_password_required = post_password_required( $post_id );
 	$opts                   = jetpack_featured_images_get_settings();
 
-	if ( jetpack_has_featured_image( $post_id ) && (bool) 1 === (bool) $opts['fallback-option'] && ! is_attachment() && ! $post_password_required ) {
+	if ( jetpack_has_featured_image( $post_id ) && (bool) 1 === (bool) $opts['fallback-option'] && ! is_attachment() && ! $post_password_required && 'post' === get_post_type() ) {
 		$classes[] = 'has-post-thumbnail';
 	}
 

--- a/modules/theme-tools/content-options/featured-images.php
+++ b/modules/theme-tools/content-options/featured-images.php
@@ -8,7 +8,8 @@ function jetpack_featured_images_remove_post_thumbnail( $metadata, $object_id, $
 	// Returns false if the archive option or singular option is unticked.
 	if ( ( true === $opts['archive'] && ( is_home() || is_archive() || is_search() ) && ! $opts['archive-option'] && ( isset( $meta_key ) && '_thumbnail_id' === $meta_key ) && in_the_loop() )
 		|| ( true === $opts['post'] && is_single() && ! jetpack_is_product() && ! $opts['post-option'] && ( isset( $meta_key ) && '_thumbnail_id' === $meta_key ) && in_the_loop() )
-		|| ( true === $opts['page'] && is_singular() && is_page() && ! $opts['page-option'] && ( isset( $meta_key ) && '_thumbnail_id' === $meta_key ) && in_the_loop() ) ) {
+		|| ( true === $opts['page'] && is_singular() && is_page() && ! $opts['page-option'] && ( isset( $meta_key ) && '_thumbnail_id' === $meta_key ) && in_the_loop() )
+		|| ( true === $opts['portfolio'] && post_type_exists( 'jetpack-portfolio' ) && is_singular( 'jetpack-portfolio' ) && ! $opts['portfolio-option'] && ( isset( $meta_key ) && '_thumbnail_id' === $meta_key ) && in_the_loop() ) ) {
 		return false;
 	} else {
 		return $metadata;


### PR DESCRIPTION
Similar to Post, Page, and Archives, a new option can be added to the
themes using the Portfolio CPT.
This update also adds a link to learn more about featured images for
users unsure about what it is.
Finally, a small tweak is added to Featured Images fallback to make
sure only Posts can get the “fake” `has-post-thumbnail` class