### PR TITLE
Comments: Allow comment_form_action actions

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -112,11 +112,10 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 
 		// Selfishly remove everything from the existing comment form
 		remove_all_actions( 'comment_form_before' );
-		remove_all_actions( 'comment_form_after' );
 
 		// Selfishly add only our actions back to the comment form
 		add_action( 'comment_form_before', array( $this, 'comment_form_before' ) );
-		add_action( 'comment_form_after', array( $this, 'comment_form_after' ) );
+		add_action( 'comment_form_after',  array( $this, 'comment_form_after'  ), 1 ); // Set very early since we remove everything outputed before our action.
 
 		// Before a comment is posted
 		add_action( 'pre_comment_on_post', array( $this, 'pre_comment_on_post' ), 1 );


### PR DESCRIPTION
Fixes #7357 

A proof of concept to investigate whether we could be less aggressive with the `comment_form_after` hook and get the same effect.

Testing:
Add a plugin that hooks in after the comment form, such as Webmentions ( https://wordpress.org/plugins/webmention/ ).

Before: JP comments override and does not display the Webmentions form.

After: Webmentions form displayed, nothing else changed.