### PR TITLE
REST API: Add memory limit constants to /sites/$site/ options

### DIFF
--- a/sal/class.json-api-site-jetpack-base.php
+++ b/sal/class.json-api-site-jetpack-base.php
@@ -59,6 +59,8 @@ abstract class Abstract_Jetpack_Site extends SAL_Site {
 
 		$options['software_version'] = (string) $this->wp_version();
 		$options['max_upload_size']  = $this->max_upload_size();
+		$options['wp_memory_limit']  = $this->wp_memory_limit();
+		$options['wp_max_memory_limit']  = $this->wp_max_memory_limit();
 
 		// Sites have to prove that they are not main_network site.
 		// If the sync happends right then we should be able to see that we are not dealing with a network site

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -30,6 +30,14 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return wp_max_upload_size();
 	}
 
+	protected function wp_memory_limit() {
+		return wp_convert_hr_to_bytes( WP_MEMORY_LIMIT );
+	}
+
+	protected function wp_max_memory_limit() {
+		return wp_convert_hr_to_bytes( WP_MAX_MEMORY_LIMIT );
+	}
+
 	protected function is_main_network() {
 		return Jetpack::is_multi_network();
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Exposes the `WP_MEMORY_LIMIT` and `WP_MAX_MEMORY_LIMIT` constants in the `options` list of the `/sites/$site/` JSON API endpoint.

Background: The intended use is for the mobile apps to be able to detect if a Jetpack site's memory limit is too low to support a media item the user is attempting to upload (and prevent it with an error message).

#### Testing instructions:

Verify that `options.wp_memory_limit` and `options.wp_max_memory_limit` exist and reflect the correct values when calling the `/sites/$site/` endpoint.
