### PR TITLE
Add Jetpack Onboarding option for partners

### DIFF
--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
 cd "$SCRIPT_DIR" || exit
 
 usage () {
-    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--wpcom_user_id=1234] [--url=http://example.com]"
+    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com]"
 }
 
 for i in "$@"; do
@@ -29,6 +29,9 @@ for i in "$@"; do
                                     shift
                                     ;;
         -p=* | --plan=* )           PLAN_NAME="${i#*=}"
+                                    shift
+                                    ;;
+        -o=* | --onboarding=* )     ONBOARDING="${i#*=}"
                                     shift
                                     ;;
         -u=* | --url=* )            SITE_URL="${i#*=}"
@@ -63,10 +66,22 @@ fi
 # silently ensure Jetpack is active
 wp plugin activate jetpack $ADDITIONAL_ARGS >/dev/null 2>&1
 
-# add user arg if available
+# add extra args if available
 if [ ! -z "$WP_USER" ]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --user=$WP_USER"
 fi
 
+if [ ! -z "$ONBOARDING" ]; then
+  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --onboarding=$ONBOARDING"
+fi 
+
+if [ ! -z "$PLAN_NAME" ]; then
+  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --plan=$PLAN_NAME"
+fi 
+
+if [ ! -z "$WPCOM_USER_ID" ]; then
+  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --wpcom_user_id=$WPCOM_USER_ID"
+fi 
+
 # provision the partner plan
-wp jetpack partner_provision "$ACCESS_TOKEN_JSON" --plan="$PLAN_NAME" --wpcom_user_id="$WPCOM_USER_ID" --url="$SITE_URL" $ADDITIONAL_ARGS
+wp jetpack partner_provision "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -827,13 +827,15 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * : WordPress.com ID of user to connect as (must be whitelisted against partner key)
 	 * [--force_register=<register>]
 	 * : Whether to force a site to register
+	 * [--onboarding=<onboarding>]
+	 * : Guide the user through an onboarding wizard
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp jetpack partner_provision '{ some: "json" }' premium 1
 	 *     { success: true }
 	 *
-	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--force_register=<register>]
+	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--force_register=<register>] [--onboarding=<onboarding>]
 	 */
 	public function partner_provision( $args, $named_args ) {
 		list( $token_json ) = $args;
@@ -924,6 +926,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		if ( isset( $named_args['plan'] ) && ! empty( $named_args['plan'] ) ) {
 			$request_body['plan'] = $named_args['plan'];
+		}
+
+		if ( isset( $named_args['onboarding'] ) && ! empty( $named_args['onboarding'] ) ) {
+			$request_body['onboarding'] = intval( $named_args['onboarding'] );
 		}
 
 		$request = array(


### PR DESCRIPTION
Partners sometimes want an enhanced onboarding flow that can increase customer success.

This PR provides the foundation for instructing Jetpack Start to direct the user into an onboarding flow during the Jetpack Connect process.

Testing:

- run partner-provision.sh with `--onboarding=1` argument
- when WPCOM redirects you to the Jetpack Connect flow, check that the `onboarding=1` option was passed in the GET params.