### PR TITLE
Added widget visibility conditions saving to image widget migration script.

### DIFF
--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -102,7 +102,10 @@ function jetpack_migrate_image_widget() {
 		}
 
 		foreach ( $sidebars_widgets as $sidebar => $widgets ) {
-			if ( false !== ( $key = array_search( "image-{$id}", $widgets, true ) ) ) {
+			if (
+				is_array( $widgets )
+				&& false !== ( $key = array_search( "image-{$id}", $widgets, true ) )
+			) {
 				$sidebars_widgets[ $sidebar ][ $key ] = "media_image-{$id}";
 			}
 		}

--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -37,6 +37,7 @@ function jetpack_migrate_image_widget() {
 		'link_rel' => '',
 		'image_title' => '',
 		'link_target_blank' => false,
+		'conditions' => array(),
 	);
 
 	$media_image      = get_option( 'widget_media_image' );


### PR DESCRIPTION
Improves the migration routine proposed in #7103 to include Widget Visibility conditions.

#### Changes proposed in this Pull Request:
* Add widget visibility conditions to the migrated widget.
* Fixes a case where an uninitialized sidebar is not an array.

#### Testing instructions:
* Downgrade to Jetpack 4.9, or forcefully add the old widget class by commenting [a line](https://github.com/Automattic/jetpack/blob/master/modules/widgets/image-widget.php#L15) in the image widget file.
* Delete the flag option by doing `Jetpack_Options::delete_option( 'image_widget_migration' );`
* Create a Jetpack image widget with widget visibility rules, also create one without rules.
* Undo the changes you made to the image widget file, or upgrade to 5.0 depending on what you did in step 1.
* Make sure the widget visibility rules get migrated properly to the newly created widget, and the one without the rules works as expected.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed passing widget visibility rules to the new WordPress Image Widget.