### PR TITLE
WordPress.com Toolbar: Add View Site item to My Sites menu

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -567,8 +567,8 @@ class A8C_WPCOM_Masterbar {
 		if ( is_admin() ) {
 			$wp_admin_bar->add_menu( array(
 				'parent' => 'blog',
-				'id'     => 'site-preview',
-				'title'  => __( 'Site Preview' ),
+				'id'     => 'site-view',
+				'title'  => __( 'View Site', 'jetpack' ),
 				'href'   => home_url(),
 				'meta'   => array(
 					'class' => 'mb-icon',

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -563,6 +563,20 @@ class A8C_WPCOM_Masterbar {
 			) );
 		}
 
+		// Site Preview
+		if ( is_admin() ) {
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'blog',
+				'id'     => 'site-preview',
+				'title'  => __( 'Site Preview' ),
+				'href'   => home_url(),
+				'meta'   => array(
+					'class' => 'mb-icon',
+					'target' => '_blank',
+				),
+			) );
+		}
+
 		// Stats
 		if ( Jetpack::is_module_active( 'stats' ) ) {
 			$wp_admin_bar->add_menu( array(


### PR DESCRIPTION
Syncing the Masterbar with the Calypso version that now has View Site (for Jetpack sites) item bellow Blog info.

Fixes https://github.com/Automattic/jetpack/issues/6877
Depends on: D6074-code

#### Testing instructions:

WP.com side (needed for styles):

* Apply D6074-code to your sandbox.
* Sandbox `s0.wp.com`, `s1.wp.com`, and `s2.wp.com`.

Jetpack side: 

* Open up `wp-admin` of your test Jetpack site and verify that Site Preview item is present in My Sites menu.
* View the same menu on site's front end and verify that Site Preview is not present.

### Visual changes

Before:

<img alt="before" width="300px" src="https://user-images.githubusercontent.com/1182160/27381885-d3c0a46c-5684-11e7-9423-84a63eb3a065.png" />

After: 

<img alt="before" width="300px" src="https://user-images.githubusercontent.com/1182160/27381893-d862e87c-5684-11e7-8cc0-ff81201e8a7c.png" />

### Proposed changelog
Masterbar: added a View Site item to My Sites menu that launches the front end of the current site.