### PR TITLE
Protect: Correct HTTP status from math failure

### DIFF
--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				wp_die(
 				__( '<strong>You failed to correctly answer the math problem.</strong>  This is used to combat spam when the Protect API is unavailable.  Please use your browser\'s back button to return to the login form, press the "refresh" button to generate a new math problem, and try to log in again.', 'jetpack' ),
 				'',
-				array ( 'response' => '401' )
+				array ( 'response' => 401 )
 				);
 			} else {
 				return true;
@@ -86,7 +86,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			wp_die(
 				$mathpage,
 				'',
-				array ( 'response' => '401' )
+				array ( 'response' => 401 )
 			);
 		}
 

--- a/modules/protect/math-fallback.php
+++ b/modules/protect/math-fallback.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 				wp_die(
 				__( '<strong>You failed to correctly answer the math problem.</strong>  This is used to combat spam when the Protect API is unavailable.  Please use your browser\'s back button to return to the login form, press the "refresh" button to generate a new math problem, and try to log in again.', 'jetpack' ),
 				'',
-				401
+				array ( 'response' => '401' )
 				);
 			} else {
 				return true;
@@ -86,7 +86,7 @@ if ( ! class_exists( 'Jetpack_Protect_Math_Authenticate' ) ) {
 			wp_die(
 				$mathpage,
 				'',
-				'401'
+				array ( 'response' => '401' )
 			);
 		}
 


### PR DESCRIPTION
I've been seeing the occasional HTTP 500 status code in my web server
log for a long time in response to requests such as 'POST
/wp-login.php'. I finally took the time to track it down to a bug in the
math-fallback.php module. The problem is that the invocation of
`wp_die()` is incorrect. This change fixes that bug. I now see the
expected 401 status in my logs.