### PR TITLE
Sync: avoid php warning after switching themes in Calypso or WP Admin

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -359,6 +359,10 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 				? $old_value[ $sidebar ]
 				: array();
 
+			if ( ! is_array( $new_widgets ) ) {
+				$new_widgets = array();
+			}
+
 			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
 			$moved_to_inactive_ids = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
 


### PR DESCRIPTION
Fixes #7380

#### Changes proposed in this Pull Request:

* Sync: avoid php warning by making sure that new widgets to sync are an array

#### Testing instructions:

0. make sure you have `WP_DEBUG` set to `true`
1. in Calypso, activate Dyad 2
2. in WP Admin, add a widget that hasn't been added before
3. in Calypso, activate Lodestar

There should be no PHP warnings.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Sync: fixed a PHP warning after switching themes in Calypso, when new theme had different widgets placed (or none) in its sidebar than old theme.