### PR TITLE
Plans: if there's no plan known or if it's Jetpack Free, add 'free' class item

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1291,15 +1291,15 @@ class Jetpack {
 	 * @return array Active Jetpack plan details
 	 */
 	public static function get_active_plan() {
-		$plan = get_option( 'jetpack_active_plan' );
+		$plan = get_option( 'jetpack_active_plan', array() );
 
 		// Set the default options
-		if ( ! $plan ) {
-			$plan = array(
+		if ( empty( $plan ) || ( isset( $plan['product_slug'] ) && 'jetpack_free' === $plan['product_slug'] ) ) {
+			$plan = wp_parse_args( $plan, array(
 				'product_slug' => 'jetpack_free',
 				'supports'     => array(),
 				'class'        => 'free',
-			);
+			) );
 		}
 
 		// Define what paid modules are supported by personal plans


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* when the `jetpack_active_plan` option is fetch, set an empty array as the default to be returned, instead of a boolean false
* if there's no plan stored or if it's Jetpack Free, add a 'class' item set to 'free' to the array to be returned.
    This solves an undefined string in `admin.php?page=jetpack-debugger` screen when Jetpack site is in Free plan.

Before:
<img width="316" alt="captura de pantalla 2017-06-23 a las 23 56 13" src="https://user-images.githubusercontent.com/1041600/27505213-bd2dc746-5870-11e7-8e37-e7f477e0c328.png">

After:
<img width="341" alt="captura de pantalla 2017-06-23 a las 23 56 00" src="https://user-images.githubusercontent.com/1041600/27505212-bcfb9afa-5870-11e7-9453-070ec06e32fb.png">

#### Testing instructions:

* make sure a site with Jetpack Free plan doesn't show undefined as shown in the image above.
