### PR TITLE
Fix what branches Travis CI runs against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ branches:
     - master
     - master-stable
     - /^branch-.*$/
-    - feature/*
+    - /^feature\/.*$/
 
 # Clones WordPress and configures our testing environment.
 before_script:


### PR DESCRIPTION
https://docs.travis-ci.com/user/customizing-the-build#Building-Specific-Branches only mentions the ability to use regex, not plain asterisks. In my testing in my own repository, this does seem to be the case.