### PR TITLE
WordPress.com Toolbar: remove obsolete CSS override

### DIFF
--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -3,11 +3,6 @@
     min-height: unset !important;
 }
 
-/* Remove icon that appeared before plugins Add link */
-#wpadminbar ul li#wp-admin-bar-plugins a:before {
-    content: none;
-}
-
 /* Overwrite a core style which breaks the overflow for .my-sites in Safari */
 #wpadminbar li.menupop.my-sites {
 	overflow: visible;


### PR DESCRIPTION
This style was updated on WP.com side in D5792-code, so we no longer need to override it in Jetpack.

#### Testing instructions:

* On your test Jetpack site with WordPress.com toolbar module enabled, verify that there are no artifacts displayed before the `Add` button in Plugins section of My Sites menu.