### PR TITLE
Flickr Widget: Update description with RSS URL workaround

### DIFF
--- a/modules/widgets/flickr/form.php
+++ b/modules/widgets/flickr/form.php
@@ -23,7 +23,7 @@
 </p>
 <p>
 	<small>
-		<?php esc_html_e( 'To find your Flickr RSS URL, go to your photostream, open the "More" menu and click on "Edit". Scroll down until you see the RSS icon or the "Latest" link. Right click on either and copy the URL. Paste into the box above.', 'jetpack' ); ?>
+		<?php esc_html_e( 'To find your Flickr RSS URL, go to your photostream, add "?details=1" to the URL, and hit enter. Scroll down until you see the RSS icon or the "Latest" link. Right-click on either options and copy the URL. Paste into the box above.', 'jetpack' ); ?>
 	</small>
 </p>
 <p>


### PR DESCRIPTION
Update the Flickr widget description with a workaround to get the RSS URL after the recent Flickr changes.

The copy has already been vetted by the editorial team (hence the couple of unrelated changes in the string).

See: https://www.flickr.com/help/forum/en-us/72157681711158094/page13/#reply72157682795746441