### PR TITLE
Set is_feed/feed so sitemap can be identified later in shutdown

### DIFF
--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -137,6 +137,10 @@ class Jetpack_Sitemap_Manager {
 	private function serve_raw_and_die( $the_content_type, $the_content ) {
 		header( 'Content-Type: ' . $the_content_type . '; charset=UTF-8' );
 
+		global $wp_query;
+		$wp_query->is_feed = true;
+		set_query_var( 'feed', 'sitemap' );
+
 		if ( '' === $the_content ) {
 			wp_die(
 				esc_html__( "No sitemap found. Maybe it's being generated. Please try again later.", 'jetpack' ),


### PR DESCRIPTION
Identify sitemaps as a "sitemap" feed for the purposes of caching or further analysis of an output buffer.

Caching plugins use output buffering to capture the page so even though the sitemap function dies immediately after the content is pushed out, the content is still captured. However, in my testing the Content-Type header was not captured (even when using `apache_get_header_list` or `headers_list`) in the output buffer callback. With this change the caching plugin can identify a sitemap and then use the right caching and/or content type. [This](https://github.com/Automattic/wp-super-cache/blob/master/wp-cache-phase2.php#L1050) is how WP Super Cache does that.
See https://github.com/Automattic/wp-super-cache/issues/237 for further
discussion.
