### PR TITLE
Fix broken jitms when string is returned

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -69,7 +69,8 @@ jQuery( document ).ready( function( $ ) {
 			query: query,
 			_wpnonce: $el.data( 'nonce' )
 		} ).then( function( response ) {
-			if ( 0 === response.length ) {
+			// properly handle the case of an empty array or no content set
+			if ( 0 === response.length || ! response[ 0 ].content ) {
 				return;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

With nexgen gallery, it will call an invalid url which results in a 402 error page response sent back. So, `response.length` is greater than 0, since it's a string. It then continues as though there's a jitm and it breaks because it's not a jitm, it's a string.

I could check the response code, but that seems like I'd still have to check the content and make sure it's sane. So, I basically just decided to do the simplest and make sure if the length is greater than 0, check that the content is not falsy.

#### Testing instructions:

- Force your webserver to return a string for this api route (you can modify the code to return a string on [this line](https://github.com/Automattic/jetpack/blob/768b0f76d4c17f8dcafd26965ebf398e4d238b56/class.jetpack-jitm.php#L219-L219))
- Verify there's no error in the console.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
