### PR TITLE
Webpack: don't overwrite the entire process.env

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,9 +93,7 @@ var webpackConfig = {
 
 			// NODE_ENV is used inside React to enable/disable features that should only
 			// be used in development
-			'process.env': {
-				NODE_ENV: JSON.stringify( NODE_ENV )
-			}
+			'process.env.NODE_ENV': JSON.stringify( NODE_ENV )
 		}),
 		new ExtractTextPlugin( '[name].dops-style.css' )
 	],
@@ -110,10 +108,8 @@ var webpackConfig = {
 if ( NODE_ENV === 'production' ) {
 
 	webpack.DefinePlugin( {
-		"process.env": {
-			// This has effect on the react lib size
-			"NODE_ENV": JSON.stringify(process.env.NODE_ENV) // TODO switch depending on actual environment
-		}
+		// This has effect on the react lib size
+		'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ) // TODO switch depending on actual environment
 	} );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* don't overwrite process.env, only process.env.NODE_ENV
This follows the best practice pointed by Webpack here
https://webpack.js.org/plugins/define-plugin/#feature-flags 

#### Testing instructions:

* verify that NODE_ENV is set as before and things are working like before. A quick one is to check file size of final built files, it should be the same.
