### PR TITLE
Fixed secret handling in subsite connection.

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -458,8 +458,8 @@ class Jetpack_Network {
 				'gmt_offset'            => $gmt_offset,
 				'timezone_string'       => (string) get_option( 'timezone_string' ),
 				'site_name'             => (string) get_option( 'blogname' ),
-				'secret_1'              => $secret_1,
-				'secret_2'              => $secret_2,
+				'secret_1'              => $secrets['secret_1'],
+				'secret_2'              => $secrets['secret_2'],
 				'site_lang'             => get_locale(),
 				'timeout'               => $timeout,
 				'stats_id'              => $stat_id, // Is this still required?


### PR DESCRIPTION
Fixes multisite subsite automated connection.

#### Changes proposed in this Pull Request:
* Fixes secrets handling in the connection method, changes are pretty self-explanatory.

#### Testing instructions:
* Install Jetpack on a multisite installation.
* Connect a subsite to WordPress.com
* Go to `/wp-admin/network/admin.php?page=jetpack`
* Disconnect a site using the link in the list.
* Try to connect it back, see that it fails.
* Apply this PR.
* Try connecting again, see that it succeeds.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Fixed automated subsite connection for multisite installations.