### PR TITLE
Settings UI: make sure Comment Likes option is found through search

### DIFF
--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -41,7 +41,7 @@ export const Comments = moduleSettingsForm(
 				foundMarkdown = this.props.isModuleFound( 'markdown' ),
 				foundCommentLikes = this.props.isModuleFound( 'comment-likes' );
 
-			if ( ! foundComments && ! foundGravatar && ! foundMarkdown ) {
+			if ( ! foundComments && ! foundGravatar && ! foundMarkdown && ! foundCommentLikes ) {
 				return null;
 			}
 

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -30,13 +30,14 @@ export const Discussion = React.createClass( {
 		const foundComments = this.props.isModuleFound( 'comments' ),
 			foundMarkdown = this.props.isModuleFound( 'markdown' ),
 			foundGravatar = this.props.isModuleFound( 'gravatar-hovercards' ),
-			foundSubscriptions = this.props.isModuleFound( 'subscriptions' );
+			foundSubscriptions = this.props.isModuleFound( 'subscriptions' ),
+			foundCommentLikes = this.props.isModuleFound( 'comment-likes' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
 		}
 
-		if ( ! foundComments && ! foundSubscriptions && ! foundMarkdown && ! foundGravatar ) {
+		if ( ! foundComments && ! foundSubscriptions && ! foundMarkdown && ! foundGravatar && ! foundCommentLikes ) {
 			return null;
 		}
 

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -8,7 +8,7 @@
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social
- * Additional Search Queries: like widget, like button
+ * Additional Search Queries: like widget, like button, like, likes
  */
 
 Jetpack::dns_prefetch( array(


### PR DESCRIPTION
Fixes #7393

#### Changes proposed in this Pull Request:

* allow comment likes toggle to be found when searching settings

#### Testing instructions:

* search for `like` or `likes`. The comment likes toggle should show