### PR TITLE
Settings UI: solve Masterbar hamburger overlap with logo

### DIFF
--- a/_inc/client/components/masthead/style.scss
+++ b/_inc/client/components/masthead/style.scss
@@ -4,8 +4,12 @@
 	box-shadow: 0 1px 0 transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 
-	@media (max-width: rem( 720px ) ) {
-		padding: 0 rem( 20px );
+	@media (max-width: rem( 782px ) ) {
+		padding: 0 rem( 24px );
+
+		.jetpack-masterbar & {
+			padding-left: rem( 64px );
+		}
 	}
 }
 

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -50,6 +50,7 @@ class A8C_WPCOM_Masterbar {
 			// Extend core WP_Admin_Bar class in order to add rtl styles
 			add_filter( 'wp_admin_bar_class', array( $this, 'get_rtl_admin_bar_class' ) );
 		}
+		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
 		add_action( 'wp_before_admin_bar_render', array( $this, 'replace_core_masterbar' ), 99999 );
 
@@ -79,6 +80,19 @@ class A8C_WPCOM_Masterbar {
 
 	public function get_rtl_admin_bar_class() {
 		return 'RTL_Admin_Bar';
+	}
+
+	/**
+	 * Adds CSS classes to admin body tag.
+	 *
+	 * @since 5.1
+	 *
+	 * @param string $admin_body_classes CSS classes that will be added.
+	 *
+	 * @return string
+	 */
+	public function admin_body_class( $admin_body_classes ) {
+		return "$admin_body_classes jetpack-masterbar";
 	}
 
 	public function remove_core_styles() {


### PR DESCRIPTION
Fixes #7417
This PR addresses an overlapping issue on the Jetpack side. Note that styles for hamburger icon positioning must be solved in wpcom side.
Fix works for both `admin.php?page=jetpack` and `admin.php?page=jetpack_modules`.

#### Changes proposed in this Pull Request:

* add a CSS class `jetpack-masterbar` to admin `body` tag to identify when it's active
* when Masterbar is active, move Jetpack logo to avoid overlapping

## Before

<img width="358" alt="captura de pantalla 2017-06-30 a las 19 11 02" src="https://user-images.githubusercontent.com/1041600/27759229-6b5575ae-5e01-11e7-8caf-203e33350c48.png">

<img width="488" alt="captura de pantalla 2017-07-01 a las 01 58 25" src="https://user-images.githubusercontent.com/1041600/27759246-b0cd3efa-5e01-11e7-922c-6167cec80a71.png">

## After

<img width="609" alt="captura de pantalla 2017-07-01 a las 01 44 23" src="https://user-images.githubusercontent.com/1041600/27759236-75eddb64-5e01-11e7-842e-6a171bc73b97.png">

<img width="488" alt="captura de pantalla 2017-07-01 a las 01 57 22" src="https://user-images.githubusercontent.com/1041600/27759245-ae5c78de-5e01-11e7-9a83-85c0b39b32ae.png">

* adjust media query so masthead margin kicks in at 782 instead of 720, [fixes this](https://github.com/Automattic/jetpack/issues/7417#issuecomment-312410841).

## Before

<img width="737" alt="captura de pantalla 2017-07-01 a las 00 55 17" src="https://user-images.githubusercontent.com/1041600/27759242-a541ffbc-5e01-11e7-906e-77ad620490b0.png">

## After

<img width="719" alt="captura de pantalla 2017-07-01 a las 01 45 01" src="https://user-images.githubusercontent.com/1041600/27759244-aa813fba-5e01-11e7-91d3-069181c92069.png">

#### Testing instructions:

* activate Masterbar and shrink the viewport until mobile size
* test in mobile device if possible
