### PR TITLE
Compatibility issues with latest version of WordPress (version 4.8)

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1726,7 +1726,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool
 	 */
 	public static function validate_boolean( $value, $request, $param ) {
-		if ( ! is_bool( $value ) && ! ( ( ctype_digit( $value ) || is_numeric( $value ) ) && in_array( $value, array( 0, 1 ) ) ) ) {
+		if ( ! is_bool( $value ) && ! (  is_numeric( $value ) ) && in_array( $value, array( 0, 1 ) ) ) ) {
 			return new WP_Error( 'invalid_param', sprintf( esc_html__( '%s must be true, false, 0 or 1.', 'jetpack' ), $param ) );
 		}
 		return true;

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -85,7 +85,7 @@ class Jetpack_Client_Server {
 			return new Jetpack_Error( 'no_state', 'Request must include state.', 400 );
 		}
 
-		if ( ! ctype_digit( $data['state'] ) ) {
+		if ( !is_numeric( $data['state'] ) ) {
 			return new Jetpack_Error( $data['error'], 'State must be an integer.', 400 );
 		}
 

--- a/class.jetpack-signature.php
+++ b/class.jetpack-signature.php
@@ -178,7 +178,7 @@ class Jetpack_Signature {
 			}
 		}
 
-		if ( !ctype_digit( "$timestamp" ) || 10 < strlen( $timestamp ) ) { // If Jetpack is around in 275 years, you can blame mdawaffe for the bug.
+		if ( !is_numeric( "$timestamp" ) || 10 < strlen( $timestamp ) ) { // If Jetpack is around in 275 years, you can blame mdawaffe for the bug.
 			return new Jetpack_Error( 'invalid_signature', sprintf( 'The required "%s" parameter is malformed.', 'timestamp' ) );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4887,7 +4887,7 @@ p {
 			$user_id = 0;
 		} else {
 			$token_type = 'user';
-			if ( empty( $user_id ) || ! ctype_digit( $user_id ) ) {
+			if ( empty( $user_id ) || ! is_numeric( $user_id ) ) {
 				return false;
 			}
 			$user_id = (int) $user_id;

--- a/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -772,7 +772,7 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 		$featured_image = (string) $featured_image;
 
 		// if we got a post ID, we can just set it as the thumbnail
-		if ( ctype_digit( $featured_image ) && 'attachment' == get_post_type( $featured_image ) ) {
+		if ( is_numeric( $featured_image ) && 'attachment' == get_post_type( $featured_image ) ) {
 			set_post_thumbnail( $post_id, $featured_image );
 			return $featured_image;
 		}


### PR DESCRIPTION
Fixes # Replaced a few ctype_digits() functions with is_numeric() functions
I am running WordPress 4.8 and the jetpack plugin was having several issues from initial login to updating posts.
I ran a debugger and the line numbers were shown with undefined ctype_digit() function being called. After a few Google searches I though is_numeric function might just work and it did.
https://twitter.com/NonLinearNygma/status/878608299066667008 this tweet is an example of a typical error I was facing regularly.

Some issues still persist, but it is usuable
https://twitter.com/NonLinearNygma/status/879617631560400897
#### Changes proposed in this Pull Request:

*

#### Testing instructions:

* I managed to reproduce this error twice on digitalocean's hosting platform running php5.6 and php7 on different instances.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
