### PR TITLE
Readme: Update links to `https`

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -2,11 +2,11 @@
 
 /*
  * Plugin Name: Jetpack by WordPress.com
- * Plugin URI: http://jetpack.com
+ * Plugin URI: https://jetpack.com
  * Description: Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.
  * Author: Automattic
  * Version: 5.1-alpha
- * Author URI: http://jetpack.com
+ * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
  * Domain Path: /languages/

--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,19 @@
 # Jetpack
 
-[![License](https://poser.pugx.org/automattic/jetpack/license.svg)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![License](https://poser.pugx.org/automattic/jetpack/license.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
 [![Code Climate](https://codeclimate.com/github/Automattic/jetpack/badges/gpa.svg)](https://codeclimate.com/github/Automattic/jetpack)
 
-[Jetpack](http://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of WordPress.com.
+[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of WordPress.com.
 
-For more information, check out [jetpack.com](http://jetpack.com/).
+For more information, check out [jetpack.com](https://jetpack.com/).
 
 ## Get Help
 
-Do you need help installing Jetpack, or do you have questions about one of the Jetpack modules? You can [search through our documentation here](http://jetpack.com/support/). If you don't find the answers you're looking for, you can [send us an email](http://jetpack.com/contact-support/) or [start a new thread in the WordPress.org support forums](https://wordpress.org/support/plugin/jetpack#new-post).
+Do you need help installing Jetpack, or do you have questions about one of the Jetpack modules? You can [search through our documentation here](https://jetpack.com/support/). If you don't find the answers you're looking for, you can [send us an email](https://jetpack.com/contact-support/) or [start a new thread in the WordPress.org support forums](https://wordpress.org/support/plugin/jetpack#new-post).
 
 ## Get Started
 
-To install the Jetpack plugin on your site, [follow the instructions on this page](http://jetpack.com/install/).
+To install the Jetpack plugin on your site, [follow the instructions on this page](https://jetpack.com/install/).
 
 ### Installation From Git Repo
 
@@ -35,7 +35,7 @@ To build your own version of Jetpack, you can [follow the instructions here.](./
 
 Developers of all levels can help — whether you can barely recognize a filter (or don’t know what that means) or you’ve already authored your own plugins, there are ways for you to pitch in. Blast off:
 
-- [Join our Jetpack Beta program](http://jetpack.com/beta/).
+- [Join our Jetpack Beta program](https://jetpack.com/beta/).
 - If you found a bug, [file a report here](https://github.com/Automattic/jetpack/issues/new). You can [check our recommendations to create great bug reports here](./docs/guides/report-bugs.md).
 - [Translate Jetpack in your language](./docs/translations.md).
 - [Write and submit patches](./.github/CONTRIBUTING.md#write-and-submit-a-patch).
@@ -64,4 +64,4 @@ Contributions have been and continue to be made by dozens of other Automattician
 
 Our _awesome_ happiness engineers are @aheckler, @annezazuu, @bikedorkjon, @cena, @chaselivingston, @codestor4, @csonnek, @danjjohnson, @davoraltman, @drpottex, @gaurav1984, @gregwp, @jamilabreu, @jeherve, @jenhooks, @joendotcom, @kraftbj, @lamdayap, @lschuyler, @macmanx2,  @madhattermattic, @mbhthompson, @NujabesSoul, @ntpixels, @pmciano, @rachelsquirrel, @rcowles, @richardmtl, @seejacobscott, @stefmattana, and @tmmbecker.
 
-Interested in working on awesome open-source code all day? [Join us](http://automattic.com/work-with-us/)!
+Interested in working on awesome open-source code all day? [Join us](https://automattic.com/work-with-us/)!

--- a/readme.txt
+++ b/readme.txt
@@ -62,7 +62,7 @@ Installation is free, quick, and easy. Set up <a href="https://jetpack.com/insta
 Installation is free, quick, and easy. [Install Jetpack from our site](https://jetpack.com/install?from=wporg) in minutes.
 
 = Manual Alternatives =
-Alternatively, install Jetpack via the plugin directory, or upload the files manually to your server and follow the on-screen instructions. If you need additional help [read our detailed instructions](http://jetpack.com/support/installing-jetpack/).
+Alternatively, install Jetpack via the plugin directory, or upload the files manually to your server and follow the on-screen instructions. If you need additional help [read our detailed instructions](https://jetpack.com/support/installing-jetpack/).
 
 == Frequently Asked Questions ==
 
@@ -132,7 +132,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 = 5.0 =
 
 * Release date: June 6th, 2017
-* Release post: http://jetpack.com/2017/06/06/jetpack-5-0-spring-clean/
+* Release post: https://jetpack.com/2017/06/06/jetpack-5-0-spring-clean/
 
 **Enhancements**
 


### PR DESCRIPTION
Since `jetpack.com` and all other URLs we're referencing have `https` versions.

No functional changes here