### PR TITLE
Sync: Fix `jetpack_sync_add_term` and `jetpack_sync_save_term` being sent together

### DIFF
--- a/sync/class.jetpack-sync-module-terms.php
+++ b/sync/class.jetpack-sync-module-terms.php
@@ -85,6 +85,7 @@ class Jetpack_Sync_Module_Terms extends Jetpack_Sync_Module {
 			 * @param object the Term object
 			 */
 			do_action( 'jetpack_sync_add_term', $term_object );
+			return;
 		}
 
 		/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Don't send two actions when saving a term.

Previous to this change we were syncing two actions: `jetpack_sync_add_term` and `jetpack_sync_save_term`

#### Testing instructions:

* Add a new term
* Check that only `jetpack_sync_add_term` gets sent.
