### PR TITLE
Comment likes: refactor code

### DIFF
--- a/modules/comment-likes/admin-style.css
+++ b/modules/comment-likes/admin-style.css
@@ -1,11 +1,3 @@
-.vers img {
-    display: none;
-}
-
-.metabox-prefs .vers img {
-    display: inline;
-}
-
 .fixed .column-comment_likes {
     width: 5.5em;
     padding: 8px 0;
@@ -17,8 +9,6 @@
 }
 
 .fixed .column-comment_likes .comment-like-count {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
     display: inline-block;
     padding: 0 8px;
@@ -26,18 +16,18 @@
     margin-top: 5px;
     -webkit-border-radius: 5px;
     border-radius: 5px;
-    background-color: #72777C;
-    color: #FFF;
+    background-color: #72777c;
+    color: #fff;
     font-size: 11px;
     line-height: 21px;
 }
 
 .fixed .column-comment_likes .comment-like-count:after {
-    border: none !important;
+    border: none;
 }
 
 .fixed .column-comment_likes .comment-like-count:hover {
-    background-color: #0073AA;
+    background-color: #0073aa;
 }
 
 .fixed .column-comment_likes .vers:before {

--- a/modules/comment-likes/comment-like-count.js
+++ b/modules/comment-likes/comment-like-count.js
@@ -10,44 +10,27 @@ jQuery( document ).ready( function( $ ) {
 			APIqueue.push( '/sites/' + blogId + '/comments/' + commentId + '/likes' );
 		} );
 
-		fetchCounts();
-	}
-
-	function showCount( commentId, count ) {
-		if ( count < 1 ) {
-			return;
-		}
-
-		$( '#comment-like-count-' + commentId ).find( '.like-count' ).hide().text( count ).fadeIn();
-	}
-
-	function fetchCounts() {
-		var batchRequest = {
-			path: '/batch',
+		return $.ajax( {
+			type: 'GET',
+			url: jsonAPIbase + '/batch',
+			dataType: 'jsonp',
 			data: 'urls[]=' + APIqueue.map( encodeURIComponent ).join( '&urls[]=' ),
 			success: function( response ) {
 				for ( var path in response ) {
 					if ( ! response[ path ].error_data ) {
 						var urlPieces = path.split( '/' ),
-							commentId = urlPieces[ 4 ];
-						showCount( commentId, response[ path ].found );
+							commentId = urlPieces[ 4 ],
+							likeCount = response[ path ].found;
+
+						if ( likeCount < 1 ) {
+							return;
+						}
+
+						$( '#comment-like-count-' + commentId ).find( '.like-count' ).hide().text( likeCount ).fadeIn();
 					}
 				}
 			},
 			error: function() {}
-		};
-
-		request( batchRequest );
-	}
-
-	function request( options ) {
-		return $.ajax( {
-			type: 'GET',
-			url: jsonAPIbase + options.path,
-			dataType: 'jsonp',
-			data: options.data,
-			success: options.success,
-			error: options.error
 		} );
 	}
 


### PR DESCRIPTION
Refactoring parts of the module code in order to comply with coding standards and address new feedback from https://github.com/Automattic/jetpack/pull/7175. 

#### Testing instructions:

  1. Run `yarn build` in your Jetpack folder.
  2. Navigate to `Discussion` tab in Jetpack settings, and enable Comment likes module.
  3. Test liking and un-liking comments. 
  4. Visit `wp-admin/edit-comments.php` and verify that comment like counts are displayed correctly.
  5. Make sure that post likes still work as expected.