### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+############################################
+# Please fire off a PR to this file to own #
+#  or disavow any section of the codebase. #
+############################################
+
+# Catch-all owners, the Jetpack Pit Crew
+* @automattic/jetpack
+
+# Individual Modules:
+modules/contact-form*    @georgestephanis
+modules/custom-css*      @georgestephanis
+modules/omnisearch*      @georgestephanis
+
+# Other bits of the Codebase
+


### PR DESCRIPTION
As documented in https://github.com/blog/2392-introducing-code-owners

Defaults to using the [Automattic/Jetpack team in GitHub](https://github.com/orgs/Automattic/teams/jetpack/members), but we may want to list folks manually instead.

Props @eliorivero for mentioning this in Slack, just wanted to get the ball rolling.