### PR TITLE
CSS: Enqueue Open Sans if we're going to use it.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6163,7 +6163,9 @@ p {
 
 		$version = Jetpack::is_development_version() ? filemtime( JETPACK__PLUGIN_DIR . 'css/jetpack.css' ) : JETPACK__VERSION;
 
-		wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), $version );
+		if ( ! wp_style_is( 'open-sans', 'registered' ) ) {
+			wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), $version );
+		}
 		wp_enqueue_style( 'jetpack_css', plugins_url( 'css/jetpack.css', __FILE__ ), array( 'open-sans' ), $version );
 		wp_style_add_data( 'jetpack_css', 'rtl', 'replace' );
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6163,7 +6163,7 @@ p {
 
 		$version = Jetpack::is_development_version() ? filemtime( JETPACK__PLUGIN_DIR . 'css/jetpack.css' ) : JETPACK__VERSION;
 
-		wp_enqueue_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), $version );
+		wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), $version );
 		wp_enqueue_style( 'jetpack_css', plugins_url( 'css/jetpack.css', __FILE__ ), array( 'open-sans' ), $version );
 		wp_style_add_data( 'jetpack_css', 'rtl', 'replace' );
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6163,7 +6163,8 @@ p {
 
 		$version = Jetpack::is_development_version() ? filemtime( JETPACK__PLUGIN_DIR . 'css/jetpack.css' ) : JETPACK__VERSION;
 
-		wp_enqueue_style( 'jetpack_css', plugins_url( 'css/jetpack.css', __FILE__ ), array(), $version );
+		wp_enqueue_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), $version );
+		wp_enqueue_style( 'jetpack_css', plugins_url( 'css/jetpack.css', __FILE__ ), array( 'open-sans' ), $version );
 		wp_style_add_data( 'jetpack_css', 'rtl', 'replace' );
 	}
 

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -119,7 +119,7 @@ class Jetpack_Comment_Likes {
 	}
 
 	public function load_styles_register_scripts() {
-		wp_enqueue_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
+		wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
 		wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array( 'open-sans' ), JETPACK__VERSION );
 		wp_enqueue_script( 'postmessage', plugins_url( '_inc/postmessage.js', dirname(__FILE__) ), array( 'jquery' ), JETPACK__VERSION, false );
 		wp_enqueue_script( 'jetpack_resize', plugins_url( '_inc/jquery.jetpack-resize.js' , dirname(__FILE__) ), array( 'jquery' ), JETPACK__VERSION, false );

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -119,7 +119,9 @@ class Jetpack_Comment_Likes {
 	}
 
 	public function load_styles_register_scripts() {
-		wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
+		if ( ! wp_style_is( 'open-sans', 'registered' ) ) {
+			wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
+		}
 		wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array( 'open-sans' ), JETPACK__VERSION );
 		wp_enqueue_script( 'postmessage', plugins_url( '_inc/postmessage.js', dirname(__FILE__) ), array( 'jquery' ), JETPACK__VERSION, false );
 		wp_enqueue_script( 'jetpack_resize', plugins_url( '_inc/jquery.jetpack-resize.js' , dirname(__FILE__) ), array( 'jquery' ), JETPACK__VERSION, false );

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -119,7 +119,8 @@ class Jetpack_Comment_Likes {
 	}
 
 	public function load_styles_register_scripts() {
-		wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array(), JETPACK__VERSION );
+		wp_enqueue_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
+		wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array( 'open-sans' ), JETPACK__VERSION );
 		wp_enqueue_script( 'postmessage', plugins_url( '_inc/postmessage.js', dirname(__FILE__) ), array( 'jquery' ), JETPACK__VERSION, false );
 		wp_enqueue_script( 'jetpack_resize', plugins_url( '_inc/jquery.jetpack-resize.js' , dirname(__FILE__) ), array( 'jquery' ), JETPACK__VERSION, false );
 		wp_enqueue_script( 'jetpack_likes_queuehandler', plugins_url( 'likes/queuehandler.js' , __FILE__ ), array( 'jquery', 'postmessage', 'jetpack_resize' ), JETPACK__VERSION, true );

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -135,7 +135,7 @@ class Jetpack_Likes {
 	 */
 	function load_styles_register_scripts() {
 		if ( $this->in_jetpack ) {
-			wp_enqueue_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
+			wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
 			wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array( 'open-sans' ), JETPACK__VERSION );
 			$this->register_scripts();
 		}

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -135,7 +135,9 @@ class Jetpack_Likes {
 	 */
 	function load_styles_register_scripts() {
 		if ( $this->in_jetpack ) {
-			wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
+			if ( ! wp_style_is( 'open-sans', 'registered' ) ) {
+				wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
+			}
 			wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array( 'open-sans' ), JETPACK__VERSION );
 			$this->register_scripts();
 		}

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -135,7 +135,8 @@ class Jetpack_Likes {
 	 */
 	function load_styles_register_scripts() {
 		if ( $this->in_jetpack ) {
-			wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array(), JETPACK__VERSION );
+			wp_enqueue_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
+			wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array( 'open-sans' ), JETPACK__VERSION );
 			$this->register_scripts();
 		}
 	}

--- a/modules/likes/style.css
+++ b/modules/likes/style.css
@@ -1,17 +1,10 @@
 /**
  * Like Button toolbar button, loading text & container styles
- *
- * @todo: doesn't look like "style.css" is used anymore.
  */
 
 @font-face {
 	font-family: Noticons;
-	src: url("https://wordpress.com/i/noticons/Noticons.woff");
-}
-
-@font-face {
-	font-family: "Open Sans";
-	src: url("https://fonts.googleapis.com/css?family=Open+Sans");
+	src: url(https://wordpress.com/i/noticons/Noticons.woff);
 }
 
 /* Master container */


### PR DESCRIPTION
Aren't needed and the double-quote isn't getting picked up by the concatenation build.

Fixes #7435