### PR TITLE
Switch Travis CI environment to Trusty - PHP 5.2 to be no longer available Sept 2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 # Tell Travis CI we're using PHP
 language: php
 
+# Tell Travis CI which distro to use
+dist: trusty
+
 # Setup a global environemnt and overide as needed
 env:
   global:
@@ -31,6 +34,7 @@ matrix:
   - env: WP_TRAVISCI="yarn test-client"
   - env: WP_TRAVISCI="yarn test-gui"
   - php: "5.2"
+    dist: precise
   - php: "5.3"
   - php: "5.5"
   - php: "5.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
   - php: "5.2"
     dist: precise
   - php: "5.3"
+    dist: precise
   - php: "5.5"
   - php: "5.6"
   - php: "7.0"


### PR DESCRIPTION
Via [#WP41292](https://core.trac.wordpress.org/ticket/41292)

Travis CI have announced they are switching to Trusty as the default distro come July 18th 2017
> https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

----

The current availability of PHP 5.2 & 5.3 in the Travis CI build environment is the following:

1. ✅ `dist: precise` with `sudo: false` 
2.  ❌  `dist: trusty` with `sudo: false`
3.  ❌  `dist: precise` with `sudo: false`
4.  ❌  `dist: precise` with `sudo: required`

Jetpack's current Travis CI config uses option `1` above
Travis CI will override this configuration with option `2` come July 18th 2017
Workaround to use PHP 5.2 & 5.3 until September 2017 using option `3` for the PHP 5.2 & 5.3 Travis CI job
Come September 2017 Travis CI will overwrite option `3` above with option `4`

I've created the following Travis CI issue on the subject: https://github.com/travis-ci/travis-ci/issues/8072