### PR TITLE
Jetpack Sync: Adding name of importer to sync details for activity log

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -1,4 +1,4 @@
-<?php
+<?php 
 
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 require_once dirname( __FILE__ ) . '/class.jetpack-sync-settings.php';
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -102,6 +102,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 	}
 
 	private function get_importer_name( $importer ) {
+		$importers = get_importers();
 		return isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
 	}
 

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -61,9 +61,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			return;
 		}
 
-		//Identify importer
-		$importers = get_importers();
-		$importer_name = isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
+		$importer_name = $this->get_importer_name( $importer );
 
 		/**
 		 * Sync Event that tells that the import is finished
@@ -97,12 +95,14 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$importer = 'wordpress';
 		}
 
-		//Identify importer
-		$importers = get_importers();
-		$importer_name = isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
+		$importer_name = $this->get_importer_name( $importer );
 
 		/** This filter is already documented in sync/class.jetpack-sync-module-posts.php */
 		do_action( 'jetpack_sync_import_end', $importer, $importer_name );
+	}
+
+	private function get_importer_name( $importer ) {
+		return isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
 	}
 
 	private function is_importer( $backtrace, $class_name ) {

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -46,7 +46,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		$this->init_meta_whitelist_handler( 'post', array( $this, 'filter_meta' ) );
 
 		add_action( 'export_wp', $callable );
-		add_action( 'jetpack_sync_import_end', $callable );
+		add_action( 'jetpack_sync_import_end', $callable, 10, 2 );
 
 		// Movable type, RSS, Livejournal
 		add_action( 'import_done', array( $this, 'sync_import_done' ) );
@@ -60,6 +60,11 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( $this->import_end ) {
 			return;
 		}
+
+		//Identify importer
+		$importers = get_importers();
+		$importer_name = isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
+
 		/**
 		 * Sync Event that tells that the import is finished
 		 *
@@ -67,7 +72,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 *
 		 * $param string $importer
 		 */
-		do_action( 'jetpack_sync_import_end', $importer );
+		do_action( 'jetpack_sync_import_end', $importer, $importer_name );
 		$this->import_end = true;
 	}
 
@@ -92,8 +97,12 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			$importer = 'wordpress';
 		}
 
+		//Identify importer
+		$importers = get_importers();
+		$importer_name = isset( $importers[ $importer ] ) ? $importers[ $importer ][0] : 'Unknown Importer';
+
 		/** This filter is already documented in sync/class.jetpack-sync-module-posts.php */
-		do_action( 'jetpack_sync_import_end', $importer );
+		do_action( 'jetpack_sync_import_end', $importer, $importer_name );
 	}
 
 	private function is_importer( $backtrace, $class_name ) {

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -991,6 +991,7 @@ That was a cool video.';
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
 		$this->assertEquals( 'test', $event->args[0] );
+		$this->assertEquals( 'Unknown Importer', $event->args[1] );
 	}
 
 	function test_import_end_action_syncs_jetpack_sync_import_end() {
@@ -999,6 +1000,7 @@ That was a cool video.';
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_import_end' );
 		$this->assertEquals( 'unknown', $event->args[0] );
+		$this->assertEquals( 'Unknown Importer', $event->args[1] );
 	}
 
 	function test_import_end_and_import_done_action_syncs_jetpack_sync_import_end() {


### PR DESCRIPTION
Fixes #7451 

Adding name of importer to sync details for activity log

#### Changes proposed in this Pull Request:

Adding name of importer to sync details for activity log

#### Testing instructions:

phpunit

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
