### PR TITLE
Remove shiv for REST API

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -27,31 +27,6 @@ defined( 'JETPACK__API_BASE' )               or define( 'JETPACK__API_BASE', 'ht
 defined( 'JETPACK_PROTECT__API_HOST' )       or define( 'JETPACK_PROTECT__API_HOST', 'https://api.bruteprotect.com/' );
 defined( 'JETPACK__WPCOM_JSON_API_HOST' )    or define( 'JETPACK__WPCOM_JSON_API_HOST', 'public-api.wordpress.com' );
 
-add_filter( 'rest_url_prefix', 'jetpack_index_permalinks_rest_api_url', 999 );
-/**
- * Fix the REST API URL for sites using index permalinks
- *
- * @todo   Remove when 4.7 is minimum version
- * @see    https://core.trac.wordpress.org/ticket/38182
- * @see    https://github.com/Automattic/jetpack/issues/5216
- * @author kraftbj
- *
- * @param string $prefix REST API endpoint URL base prefix.
- *
- * @return string
- */
-function jetpack_index_permalinks_rest_api_url( $prefix ){
-	global $wp_rewrite, $wp_version;
-	if ( version_compare( $wp_version, '4.7-alpha-38790', '<' )
-		&& isset( $wp_rewrite ) && $wp_rewrite instanceof WP_Rewrite
-		&& method_exists( $wp_rewrite, 'using_index_permalinks' )
-		&& $wp_rewrite->using_index_permalinks() ) {
-		$prefix = $wp_rewrite->index . '/' . $prefix;
-	}
-
-	return $prefix;
-}
-
 /**
  * Returns the location of Jetpack's lib directory. This filter is applied
  * in require_lib().


### PR DESCRIPTION
Removes a pre-WP 4.7 hack needed to handle a core bug with the REST API on sites using a particular permalink structure.