### PR TITLE
Shortcodes: Update inline docs

### DIFF
--- a/modules/shortcodes.php
+++ b/modules/shortcodes.php
@@ -56,6 +56,8 @@ function jetpack_load_shortcodes() {
 	/**
 	 * This filter allows other plugins to override which shortcodes Jetpack loads.
 	 *
+	 * Fires as part of the `plugins_loaded` WP hook, so modifying code needs to be in a plugin, not in a theme's functions.php.
+	 *
 	 * @module shortcodes
 	 *
 	 * @since 2.2.1


### PR DESCRIPTION
Provide indicator that the filter fires before themes are loaded.

Helps to prevent developer grief as seen in #7449. I'm open if there are better ways to indicate this that would get parsed into developer.jetpack.com.

@dereksmart any thoughts?