### PR TITLE
Sync VideoPress API fixes

### DIFF
--- a/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -62,7 +62,7 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 					// More than likely a post has not been created yet, so we pass in the media item we
 					// got back from the Jetpack site.
 					$post       = (object) $media_item['post'];
-					$media_item = $this->get_media_item_v1_1( $media_item['ID'], $post, $media_item['file'] );
+					$media_item = $this->get_media_item_v1_1( $post->ID, $post, $media_item['file'] );
 				}
 			}
 		}


### PR DESCRIPTION
There were some issues with the videopress_guid not return for some Jetpack requests. This attempts to normalize how media items are accessed and add a couple of failure exceptions to help recover if they are encountered.

This commit syncs r159298-wpcom.