### PR TITLE
Plans page: Fix missing premium theme CTA on Pro plan

### DIFF
--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -7,6 +7,7 @@ import {
 	getPlanClass,
 	FEATURE_UNLIMITED_PREMIUM_THEMES
 } from 'lib/plans/constants';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -55,7 +56,7 @@ export const Plans = React.createClass( {
 		}
 
 		const premiumThemesAvailable = 'undefined' !== typeof this.props.availableFeatures[ FEATURE_UNLIMITED_PREMIUM_THEMES ],
-			premiumThemesActive = 'undefined' !== typeof this.props.activeFeatures[ FEATURE_UNLIMITED_PREMIUM_THEMES ],
+			premiumThemesActive = includes( this.props.activeFeatures, FEATURE_UNLIMITED_PREMIUM_THEMES ),
 			showThemesPromo = premiumThemesAvailable && ! premiumThemesActive;
 
 		if ( showThemesPromo ) {

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -10,6 +10,7 @@ import {
 	getPlanClass,
 	FEATURE_UNLIMITED_PREMIUM_THEMES
 } from 'lib/plans/constants';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -71,7 +72,7 @@ const PlanBody = React.createClass( {
 		const planClass = 'dev' !== this.props.plan
 			? getPlanClass( this.props.plan )
 			: 'dev';
-		const premiumThemesActive = 'undefined' !== typeof this.props.activeFeatures[ FEATURE_UNLIMITED_PREMIUM_THEMES ];
+		const premiumThemesActive = includes( this.props.activeFeatures, FEATURE_UNLIMITED_PREMIUM_THEMES );
 
 		switch ( planClass ) {
 			case 'is-personal-plan':


### PR DESCRIPTION
With D6428-code in place, you should be seeing this CTA in /plans 

![screen shot 2017-07-17 at 2 37 21 pm](https://user-images.githubusercontent.com/7129409/28283938-77fa7f8a-6afd-11e7-83e9-bfb541a6d022.png)

However, currently it's looking for the `premium-themes` Object, when it's actually an array item.  

