### PR TITLE
Jetpack Start: Allow force_connect to ignore existing token on WPCOM

### DIFF
--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -3,15 +3,12 @@
 # accepts: partner client ID and secret key, and some site info
 # executes wp-cli command to provision Jetpack site for given partner
 
-# TODO:
-# - allow user_email instead of user_id, automatically lookup/provision an admin on site (maybe rename user_id param to user?)
-
 # change to script directory so that wp finds the wordpress install part for this Jetpack instance
 SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
 cd "$SCRIPT_DIR" || exit
 
 usage () {
-    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com]"
+    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_reconnect=1] [--force_register=1]"
 }
 
 for i in "$@"; do
@@ -81,6 +78,14 @@ fi
 
 if [ ! -z "$WPCOM_USER_ID" ]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --wpcom_user_id=$WPCOM_USER_ID"
+fi 
+
+if [ ! -z "$FORCE_REGISTER" ]; then
+  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_register=$FORCE_REGISTER"
+fi
+
+if [ ! -z "$FORCE_CONNECT" ]; then
+  ADDITIONAL_ARGS="$ADDITIONAL_ARGS --force_connect=$FORCE_CONNECT"
 fi 
 
 # provision the partner plan

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
 cd "$SCRIPT_DIR" || exit
 
 usage () {
-    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_reconnect=1] [--force_register=1]"
+    echo "Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_connect=1] [--force_register=1]"
 }
 
 for i in "$@"; do

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -831,17 +831,19 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 * : Slug of the requested plan, e.g. premium
 	 * [--wpcom_user_id=<user_id>]
 	 * : WordPress.com ID of user to connect as (must be whitelisted against partner key)
-	 * [--force_register=<register>]
-	 * : Whether to force a site to register
 	 * [--onboarding=<onboarding>]
 	 * : Guide the user through an onboarding wizard
+	 * [--force_register=<register>]
+	 * : Whether to force a site to register
+	 * [--force_connect=<force_connect>]
+	 * : Force JPS to not reuse existing credentials
 	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp jetpack partner_provision '{ some: "json" }' premium 1
 	 *     { success: true }
 	 *
-	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--force_register=<register>] [--onboarding=<onboarding>]
+	 * @synopsis <token_json> [--wpcom_user_id=<user_id>] [--plan=<plan_name>] [--onboarding=<onboarding>] [--force_register=<register>] [--force_connect=<force_connect>]
 	 */
 	public function partner_provision( $args, $named_args ) {
 		list( $token_json ) = $args;
@@ -936,6 +938,10 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		if ( isset( $named_args['onboarding'] ) && ! empty( $named_args['onboarding'] ) ) {
 			$request_body['onboarding'] = intval( $named_args['onboarding'] );
+		}
+
+		if ( isset( $named_args['force_connect'] ) && ! empty( $named_args['force_connect'] ) ) {
+			$request_body['force_connect'] = intval( $named_args['force_connect'] );
 		}
 
 		$request = array(


### PR DESCRIPTION
If a Jetpack site is restored to a pre-connected state and we want to re-provision, then we also want to ignore (and if necessary regenerate) existing credentials on WordPress.com.

This patch allows passing the `force_connect` parameter to accomplish this.