### PR TITLE
API: Add password and status to list of keys to always render before filtering

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -118,10 +118,8 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 			$keys_to_render = array_intersect( $keys_to_render, $limit_to_fields );
 		}
 
-		// always include 'type' because processors require it to validate access
-		if ( ! in_array( 'type', $keys_to_render ) ) {
-			array_push( $keys_to_render, 'type' );
-		}
+		// always include some keys because processors require it to validate access
+		$keys_to_render = array_unique( array_merge( $keys_to_render, array( 'type', 'status', 'password' ) ) );
 
 		$response = $this->render_response_keys( $post, $context, $keys_to_render );
 


### PR DESCRIPTION
This adds the password and status fields to the list of fields that should always render for post objects. These are needed because downstream code looks at the password and status fields to determine if a post should be shown or not. When a request is made and these fields were not included, those checks would always fail and posts would not be returned.

This commit syncs r159288-wpcom.

#### Changes proposed in this Pull Request:

* Always render the password and post status so that API handlers downstream can use them.

#### Testing instructions:

* Make sure posts still render as before and passwords don't appear when specifying `fields=ID,site_ID`
