### PR TITLE
REST API: Settings: fix `jetpack_relatedposts_enabled`

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -148,7 +148,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'settings':
 
-				$jetpack_relatedposts_options = Jetpack_Options::get_option( 'relatedposts' );
+				$jetpack_relatedposts_options = Jetpack_Options::get_option( 'relatedposts', array() );
+				// If the option's enabled key is NOT SET, it is considered enabled by the plugin
+				if ( ! isset( $jetpack_relatedposts_options['enabled'] ) ) {
+					$jetpack_relatedposts_options['enabled'] = true;
+				}
 
 				if ( method_exists( 'Jetpack', 'is_module_active' ) ) {
 					$jetpack_relatedposts_options[ 'enabled' ] = Jetpack::is_module_active( 'related-posts' );


### PR DESCRIPTION
See 69-gh-wp-calypso

The REST API settings endpoint includes a property `jetpack_relatedposts_enabled`, which is true if the Related Posts plugin will display related posts. The value from this endpoint is incorrect, however, when a site has not modified their settings. This is because the `Jetpack_RelatedPosts` plugin defaults the setting to be enabled if it is not set.

This change modifies the endpoint to use the same logic: if the setting is not set, it will default to reporting `jetpack_relatedposts_enabled` as true.

Some sites (VIP and Jetpack) default this setting to `false` instead, but the way this is accomplished is that when the plugin is loaded by `wp-content/mu-plugins/related-posts.php`, it actively changes the option to `false`. Since that loader should still be used by the REST API, that should mean that such sites will continue to have `jetpack_relatedposts_enabled` reported correctly.

This commit syncs r159322-wpcom.

#### Testing instructions:

1. Choose a site which has not changed its Related Posts setting.
2. Visit this wp-admin page on that site: https://[your-site-here]/wp-admin/options-reading.php
3. Verify that the `Related posts` setting reads "Show related content after posts".
4. BEFORE applying this patch...
5. Using a REST API client (eg: the WPCOM developer console), query the following endpoint: GET /rest/v1.1/sites/[your-site-here]/settings
6. Verify that `settings` > `jetpack_relatedposts_enabled` is `false`.
7. Apply this patch and make sure to sandbox the REST API.
8. Using a REST API client (eg: the WPCOM developer console), query the following endpoint: GET /rest/v1.1/sites/[your-site-here]/settings
9. Verify that `settings` > `jetpack_relatedposts_enabled` is `true`.
10. On the wp-admin page, change the setting to read "Hide related content after posts" and click "Save Changes" at the bottom.
11. Using a REST API client (eg: the WPCOM developer console), query the following endpoint: GET /rest/v1.1/sites/[your-site-here]/settings
12. Verify that `settings` > `jetpack_relatedposts_enabled` is `false`.

