### PR TITLE
Sync: Add Async Sender

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -78,21 +78,20 @@ class Jetpack_Sync_Actions {
 				defined( 'PHPUNIT_JETPACK_TESTSUITE' )
 			)
 		) ) {
-			if ( isset( $_GET['jetpack_sync_async_sender'] ) ) {
-				if ( ! defined( 'JETPACK_SYNC_DOING_ASYNC_SENDER' ) ) {
-					define( 'JETPACK_SYNC_DOING_ASYNC_SENDER', true );
+			if ( Jetpack_Sync_Settings::get_setting( 'async_sender' ) ) {
+				if ( ! isset( $_GET['jetpack_sync_async_sender'] ) ) {
+					self::async_sender();
+					return;
 				}
+			}
+
+			if ( isset( $_GET['jetpack_sync_async_sender'] ) ) {
 				ignore_user_abort(true );
 			}
 
-			if ( ! defined( 'JETPACK_SYNC_DOING_ASYNC_SENDER' )
-			     && apply_filters( 'jetpack_sync_async_sender', defined( 'REST_REQUEST' ) && REST_REQUEST && ! headers_sent() ) ) {
-				self::async_sender();
-			} else {
-				self::initialize_sender();
-				add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
-				add_action( 'shutdown', array( self::$sender, 'do_full_sync' ) );
-			}
+			self::initialize_sender();
+			add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
+			add_action( 'shutdown', array( self::$sender, 'do_full_sync' ) );
 		}
 	}
 

--- a/sync/class.jetpack-sync-settings.php
+++ b/sync/class.jetpack-sync-settings.php
@@ -24,6 +24,7 @@ class Jetpack_Sync_Settings {
 		'max_queue_size_full_sync'=> true,
 		'sync_via_cron'           => true,
 		'cron_sync_time_limit'    => true,
+		'async_sender'            => false,
 	);
 
 	static $is_importing;


### PR DESCRIPTION
Add the option to load the Jetpack Sync Sender on another request as core does it for cron*. (hat tip @westi).

This feature is Off by default, and can be turned on via a `jetpack_sync_settings_async_sender` filter

*We are avoiding just using `spawn_cron` as we already tried using it in the past, causing troubles with misconfigured cron setups.

**How to test**

turn on the feature(off by default):
- Use the sync settings endpoint to set `async_sender` to `1`
or
- Using a filter: `add_filter('jetpack_sync_settings_async_sender', '__return_true');` 

- on the ngrok console you should see a separate request to admin-ajax.php just for syncing

- alternatively follow @enejb's instructions on https://github.com/Automattic/jetpack/pull/11146 and check that the original request doesn't get delayed