### PR TITLE
Remove Quotes Around url in style.css

### DIFF
--- a/modules/likes/style.css
+++ b/modules/likes/style.css
@@ -6,12 +6,12 @@
 
 @font-face {
 	font-family: Noticons;
-	src: url("https://wordpress.com/i/noticons/Noticons.woff");
+	src: url(https://wordpress.com/i/noticons/Noticons.woff);
 }
 
 @font-face {
 	font-family: "Open Sans";
-	src: url("https://fonts.googleapis.com/css?family=Open+Sans");
+	src: url(https://fonts.googleapis.com/css?family=Open+Sans);
 }
 
 /* Master container */


### PR DESCRIPTION
Fixes #7488 

Whatever CSS preprocessor or minifier is being used in this project adds another set of quotes around these `url()` statements.