### PR TITLE
Add Grunion Editor View.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 # Tell Travis CI we're using PHP
 language: php
 
+# Tell Travis CI which distro to use
+dist: trusty
+
 # Setup a global environemnt and overide as needed
 env:
   global:
@@ -31,6 +34,7 @@ matrix:
   - env: WP_TRAVISCI="yarn test-client"
   - env: WP_TRAVISCI="yarn test-gui"
   - php: "5.2"
+    dist: precise
   - php: "5.3"
   - php: "5.5"
   - php: "5.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
   - php: "5.2"
     dist: precise
   - php: "5.3"
+    dist: precise
   - php: "5.5"
   - php: "5.6"
   - php: "7.0"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -246,6 +246,9 @@ function doStatic( done ) {
 admincss = [
 	'modules/after-the-deadline/atd.css',
 	'modules/after-the-deadline/tinymce/css/content.css',
+	'modules/contact-form/css/editor-inline-editing-style.css',
+	'modules/contact-form/css/editor-style.css',
+	'modules/contact-form/css/editor-ui.css',
 	'modules/custom-css/csstidy/cssparse.css',
 	'modules/custom-css/csstidy/cssparsed.css',
 	'modules/custom-css/custom-css/css/codemirror.css',

--- a/modules/contact-form.php
+++ b/modules/contact-form.php
@@ -14,3 +14,7 @@
  */
 
 include dirname( __FILE__ ) . '/contact-form/grunion-contact-form.php';
+
+if ( is_admin() ) {
+	require_once dirname( __FILE__ ) . '/contact-form/grunion-editor-view.php';
+}

--- a/modules/contact-form.php
+++ b/modules/contact-form.php
@@ -14,7 +14,17 @@
  */
 
 include dirname( __FILE__ ) . '/contact-form/grunion-contact-form.php';
-
-if ( is_admin() ) {
+/*
+ * Filters if the new Contact Form Editor View should be used.
+ *
+ * A temporary filter to disable the new Editor View for the older UI.
+ * Please note this filter and the old UI will be removed in the future.
+ * Expected to be removed in Jetpack 5.8 or if a security issue merits removing the old code sooner.
+ *
+ * @since 5.2.0
+ * 
+ * @param boolean $view Use new Editor View. Default true.
+ */
+if ( is_admin() && apply_filters( 'tmp_grunion_allow_editor_view', true ) ) {
 	require_once dirname( __FILE__ ) . '/contact-form/grunion-editor-view.php';
 }

--- a/modules/contact-form/css/editor-inline-editing-style.css
+++ b/modules/contact-form/css/editor-inline-editing-style.css
@@ -1,0 +1,746 @@
+/* ==========================================================================
+** Normalize
+** ======================================================================== */
+
+body {
+	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+	font-size: 16px;
+	line-height: 1.4em;
+	margin: 0;
+	padding: 0 1em;
+}
+
+/* Links */
+a,
+a:visited {
+	color: #0087be;
+	text-decoration: none;
+}
+
+a:hover,
+a:focus,
+a:active {
+	color: $link-highlight;
+}
+
+/* ==========================================================================
+** Card
+** ======================================================================= */
+
+.card {
+	display: block;
+	position: relative;
+	margin: 0 auto 10px auto;
+	padding: 16px;
+	box-sizing: border-box;
+	background: white;
+	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+}
+
+.card:after {
+	content: ".";
+	display: block;
+	height: 0;
+	clear: both;
+	visibility: hidden;
+}
+
+.card .delete-field {
+	display: block;
+	float: right;
+}
+
+@media ( min-width: 481px ) {
+	.card {
+		margin-bottom: 16px;
+		padding: 24px;
+	}
+}
+
+.card.is-compact {
+	margin-bottom: 1px;
+}
+
+@media ( min-width: 481px ) {
+	.card.is-compact {
+		margin-bottom: 1px;
+		padding: 16px 24px;
+	}
+}
+
+.card > div {
+	margin-top: 24px;
+}
+
+.card > div:first-child {
+	margin-top: 0;
+}
+
+
+/* ==========================================================================
+** Labels
+** ======================================================================= */
+
+label {
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 5px;
+	margin-top: 24px;
+}
+
+label:first-of-type {
+	margin-top: 7px;
+}
+
+
+/* ==========================================================================
+** Text Inputs
+** ======================================================================= */
+
+input[type="text"],
+input[type="tel"],
+input[type="email"] {
+	border-radius: 0;
+	appearance: none;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 7px 14px;
+	width: 100%;
+	color: #2e4453;
+	font-size: 16px;
+	line-height: 1.5;
+	border: 1px solid #c8d7e1;
+	background-color: #fff;
+	transition: all .15s ease-in-out;
+	box-shadow: none;
+}
+
+input[type="text"]::placeholder,
+input[type="tel"]::placeholder,
+input[type="email"]::placeholder {
+	color: #87a6bc;
+}
+
+input[type="text"]:hover,
+input[type="tel"]:hover,
+input[type="email"]:hover {
+	border-color: #a8bece;
+}
+
+input[type="text"]:focus,
+input[type="tel"]:focus,
+input[type="email"]:focus {
+	border-color: #0087be;
+	outline: none;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+input[type="text"]:focus::-ms-clear,
+input[type="tel"]:focus::-ms-clear,
+input[type="email"]:focus::-ms-clear {
+	display: none;
+}
+
+input[type="text"]:disabled,
+input[type="tel"]:disabled,
+input[type="email"]:disabled {
+	background: #f3f6f8;
+	border-color: #e9eff3;
+	color: #a8bece;
+	-webkit-text-fill-color: #a8bece;
+}
+
+input[type="text"]:disabled:hover,
+input[type="tel"]:disabled:hover,
+input[type="email"]:disabled:hover {
+	cursor: default;
+}
+
+input[type="text"]:disabled::placeholder,
+input[type="tel"]:disabled::placeholder,
+input[type="email"]:disabled::placeholder {
+	color: #a8bece;
+}
+
+
+/* ==========================================================================
+** Textareas
+** ======================================================================= */
+
+textarea {
+	border-radius: 0;
+	appearance: none;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 7px 14px;
+	height: 92px;
+	width: 100%;
+	color: #2e4453;
+	font-size: 16px;
+	line-height: 1.5;
+	border: 1px solid #c8d7e1;
+	background-color: #fff;
+	transition: all .15s ease-in-out;
+	box-shadow: none;
+}
+
+textarea::placeholder {
+	color: #87a6bc;
+}
+
+textarea:hover {
+	border-color: #a8bece;
+}
+
+textarea:focus {
+	border-color: #0087be;
+	outline: none;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+textarea:focus::-ms-clear {
+	display: none;
+}
+
+textarea:disabled {
+	background: #f3f6f8;
+	border-color: #e9eff3;
+	color: #a8bece;
+	-webkit-text-fill-color: #a8bece;
+}
+
+textarea:disabled:hover {
+	cursor: default;
+}
+
+textarea:disabled::placeholder {
+	color: #a8bece;
+}
+
+
+/* ==========================================================================
+** Checkboxes
+** ======================================================================= */
+
+.checkbox,
+input[type="checkbox"] {
+	-webkit-appearance: none;
+	display: inline-block;
+	box-sizing: border-box;
+	margin: 2px 0 0;
+	padding: 7px 14px;
+	width: 16px;
+	height: 16px;
+	float: left;
+	outline: 0;
+	padding: 0;
+	box-shadow: none;
+	background-color: #fff;
+	border: 1px solid #c8d7e1;
+	color: #2e4453;
+	font-size: 16px;
+	line-height: 0;
+	text-align: center;
+	vertical-align: middle;
+	appearance: none;
+	transition: all .15s ease-in-out;
+	clear: none;
+	cursor: pointer;
+}
+
+.checkbox:checked:before,
+input[type="checkbox"]:checked:before {
+	content: '\f147';
+	font-family: Dashicons;
+	margin: -3px 0 0 -4px;
+	float: left;
+	display: inline-block;
+	vertical-align: middle;
+	width: 16px;
+	font-size: 20px;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	speak: none;
+	color: #00aadc;
+}
+
+.checkbox:disabled:checked:before,
+input[type="checkbox"]:disabled:checked:before {
+	color: #a8bece;
+}
+
+.checkbox:hover,
+input[type="checkbox"]:hover {
+	border-color: #a8bece;
+}
+
+.checkbox:focus,
+input[type="checkbox"]:focus {
+	border-color: #0087be;
+	outline: none;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+.checkbox:disabled,
+input[type="checkbox"]:disabled {
+	background: #f3f6f8;
+	border-color: #e9eff3;
+	color: #a8bece;
+	opacity: 1;
+}
+
+.checkbox:disabled:hover,
+input[type="checkbox"]:disabled:hover {
+	cursor: default;
+}
+
+.checkbox + span,
+input[type="checkbox"] + span {
+	display: block;
+	font-weight: normal;
+	margin-left: 24px;
+}
+
+
+/* ==========================================================================
+** Radio buttons
+** ======================================================================== */
+
+.radio-button,
+input[type=radio] {
+	color: #2e4453;
+	font-size: 16px;
+	border: 1px solid #c8d7e1;
+	background-color: #fff;
+	transition: all .15s ease-in-out;
+	box-sizing: border-box;
+	-webkit-appearance: none;
+	clear: none;
+	cursor: pointer;
+	display: inline-block;
+	line-height: 0;
+	height: 16px;
+	margin: 2px 4px 0 0;
+	float: left;
+	outline: 0;
+	padding: 0;
+	text-align: center;
+	vertical-align: middle;
+	width: 16px;
+	min-width: 16px;
+	appearance: none;
+	border-radius: 50%;
+	line-height: 10px;
+}
+
+.radio-button:hover,
+input[type="radio"]:hover {
+	border-color: #a8bece;
+}
+
+.radio-button:focus,
+input[type="radio"]:focus {
+	border-color: #0087be;
+	outline: none;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+.radio-button:focus::-ms-clear,
+input[type="radio"]:focus::-ms-clear {
+	display: none;
+}
+
+.radio-button:checked:before,
+input[type="radio"]:checked:before {
+	float: left;
+	display: inline-block;
+	content: '\2022';
+	margin: 3px;
+	width: 8px;
+	height: 8px;
+	text-indent: -9999px;
+	background: #00aadc;
+	vertical-align: middle;
+	border-radius: 50%;
+	animation: grow .2s ease-in-out;
+}
+
+.radio-button:disabled,
+input[type="radio"]:disabled {
+	background: #f3f6f8;
+	border-color: #e9eff3;
+	color: #a8bece;
+	opacity: 1;
+	-webkit-text-fill-color: #a8bece;
+}
+
+.radio-button:disabled:hover,
+input[type="radio"]:disabled:hover {
+	cursor: default;
+}
+
+.radio-button:disabled::placeholder,
+input[type="radio"]:disabled::placeholder {
+	color: #a8bece;
+}
+
+.radio-button:disabled:checked::before,
+input[type="radio"]:disabled:checked:before {
+	background: #e9eff3;
+}
+
+.radio-button + span,
+input[type="radio"] + span {
+	display: block;
+	font-weight: normal;
+	margin-left: 24px;
+}
+
+@keyframes grow {
+	0% {
+		transform: scale(0.3);
+	}
+
+	60% {
+		transform: scale(1.15);
+	}
+
+	100% {
+		transform: scale(1);
+	}
+}
+
+@keyframes grow {
+	0% {
+		transform: scale(0.3);
+	}
+
+	60% {
+		transform: scale(1.15);
+	}
+
+	100% {
+		transform: scale(1);
+	}
+}
+
+
+/* ==========================================================================
+** Selects
+** ======================================================================== */
+
+select {
+	background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
+	border-color: #c8d7e1;
+	border-style: solid;
+	border-radius: 4px;
+	border-width: 1px 1px 2px;
+	color: #2e4453;
+	cursor: pointer;
+	display: inline-block;
+	margin: 0;
+	outline: 0;
+	overflow: hidden;
+	font-size: 14px;
+	line-height: 21px;
+	font-weight: 600;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	white-space: nowrap;
+	box-sizing: border-box;
+	padding: 7px 32px 9px 14px; // Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow.
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+}
+
+select:hover {
+	background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjYThiZWNlIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==);
+}
+
+select:focus {
+	background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiA8dGl0bGU+YXJyb3ctZG93bjwvdGl0bGU+IDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiA8ZGVmcz48L2RlZnM+IDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHNrZXRjaDp0eXBlPSJNU1BhZ2UiPiA8ZyBpZD0iYXJyb3ctZG93biIgc2tldGNoOnR5cGU9Ik1TQXJ0Ym9hcmRHcm91cCIgZmlsbD0iIzJlNDQ1MyI+IDxwYXRoIGQ9Ik0xNS41LDYgTDE3LDcuNSBMMTAuMjUsMTQuMjUgTDMuNSw3LjUgTDUsNiBMMTAuMjUsMTEuMjUgTDE1LjUsNiBaIiBpZD0iRG93bi1BcnJvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=);
+	border-color: #00aadc;
+	box-shadow: 0 0 0 2px #78dcfa;
+	outline: 0;
+	-moz-outline:none;
+	-moz-user-focus:ignore;
+}
+
+select:disabled,
+select:hover:disabled {
+	background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjZTllZmYzIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;;
+}
+
+select.is-compact {
+	min-width: 0;
+	padding: 0 20px 2px 6px;
+	margin: 0 4px;
+	background-position:  right 5px center;
+	background-size: 12px 12px;
+}
+
+/* Make it display:block when it follows a label */
+label select,
+label + select {
+	display: block;
+	min-width: 200px;
+}
+
+label select.is-compact,
+label + select.is-compact {
+	display: inline-block;
+	min-width: 0;
+}
+
+/* IE: Remove the default arrow */
+select::-ms-expand {
+	display: none;
+}
+
+/* IE: Remove default background and color styles on focus */
+select::-ms-value {
+	background: none;
+	color: #2e4453;
+}
+
+/* Firefox: Remove the focus outline, see http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002 */
+select:-moz-focusring {
+	color: transparent;
+	text-shadow: 0 0 0 #2e4453;
+}
+
+
+/* ==========================================================================
+** Buttons
+** ======================================================================== */
+
+input[type="submit"] {
+	padding: 0;
+	font-size: 14px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	vertical-align: baseline;
+	background: white;
+	border-color: #c8d7e1;
+	border-style: solid;
+	border-width: 1px 1px 2px;
+	color: #2e4453;
+	cursor: pointer;
+	display: inline-block;
+	margin: 24px 0 0;
+	outline: 0;
+	overflow: hidden;
+	font-weight: 500;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	box-sizing: border-box;
+	font-size: 14px;
+	line-height: 21px;
+	border-radius: 4px;
+	padding: 7px 14px 9px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+}
+
+input[type="submit"]:hover {
+	border-color: #a8bece;
+	color: #2e4453;
+}
+
+input[type="submit"]:active {
+	border-width: 2px 1px 1px;
+}
+
+input[type="submit"]:visited {
+	color: #2e4453;
+}
+
+input[type="submit"][disabled],
+input[type="submit"]:disabled {
+	color: #e9eff3;
+	background: white;
+	border-color: #e9eff3;
+	cursor: default;
+}
+
+input[type="submit"][disabled]:active,
+input[type="submit"]:disabled:active {
+	border-width: 1px 1px 2px;
+}
+
+input[type="submit"]:focus {
+	border-color: #00aadc;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+input[type="submit"].is-compact {
+	padding: 7px;
+	color: #668eaa;
+	font-size: 11px;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
+input[type="submit"].is-compact:disabled {
+	color: #e9eff3;
+}
+
+input[type="submit"].is-compact .gridicon {
+	top: 4px;
+	margin-top: -8px;
+}
+
+input[type="submit"].is-compact .gridicons-plus-small {
+	margin-left: -4px;
+}
+
+input[type="submit"].is-compact .gridicons-plus-small:last-of-type {
+	margin-left: 0;
+}
+
+input[type="submit"].is-compact .gridicons-plus-small + .gridicon {
+	margin-left: -4px;
+}
+
+input[type="submit"].hidden {
+	display: none;
+}
+
+input[type="submit"] .gridicon {
+	position: relative;
+	top: 4px;
+	margin-top: -2px;
+	width: 18px;
+	height: 18px;
+}
+
+input[type="submit"].is-primary {
+	background: #00aadc;
+	border-color: #008ab3;
+	color: white;
+}
+
+input[type="submit"].is-primary:hover,
+input[type="submit"].is-primary:focus {
+	border-color: #005082;
+	color: white;
+}
+
+input[type="submit"].is-primary[disabled],
+input[type="submit"].is-primary:disabled {
+	background: #bceefd;
+	border-color: #8cc9e2;
+	color: white;
+}
+
+input[type="submit"].is-primary {
+	color: white;
+}
+
+
+/* ==========================================================================
+** Inline editor styles
+** ======================================================================== */
+
+.card.grunion-form-settings {
+	background: #f5f5f5;
+}
+
+.card.grunion-field-edit {
+	margin-bottom: 0.5em;
+	background: #f5f5f5;
+}
+
+.ui-sortable-helper.card{
+	background: #e9eff3;
+}
+
+.grunion-section-header {
+	font-size: 21px;
+	margin-top: 32px;
+}
+
+.grunion-type {
+	float: left;
+	width: 60%;
+}
+
+.grunion-type select {
+	width: 100%;
+}
+
+.grunion-required {
+	float: right;
+	width: 30%;
+	padding-top: 2em;
+}
+
+.grunion-options {
+	clear: both;
+}
+
+.grunion-options ol {
+	list-style: none;
+	padding: 0;
+	margin: 8px 0 0;
+}
+
+.grunion-options li {
+	display: flex;
+	margin-bottom: 16px;
+}
+
+.grunion-field-edit .grunion-options {
+	display: none;
+}
+
+.delete-option,
+.delete-field {
+	color: #0087be;
+	text-decoration: none;
+	width: 40px;
+	line-height: 40px;
+	font-size: 21px;
+	text-align: center;
+	font-weight: 600;
+}
+
+.delete-field {
+	position: absolute;
+	top: 0;
+	right: 0;
+}
+
+.delete-option:before,
+.delete-field:before {
+	font-family: Dashicons;
+/*	content: "\f158"; /* This is the bolder X */
+	content: "\f335"; /* This is the thinner X */
+	display: inline-block;
+	speak: none;
+}
+
+.grunion-field-edit.grunion-field-checkbox-multiple .grunion-options,
+.grunion-field-edit.grunion-field-radio .grunion-options,
+.grunion-field-edit.grunion-field-select .grunion-options {
+	display: block;
+}
+
+.screen-reader-text {
+	position: absolute;
+	margin: -1px;
+	padding: 0;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	border: 0;
+	word-wrap: normal !important; /* many screen reader and browser combinations announce broken words as they would appear visually */
+}

--- a/modules/contact-form/css/editor-inline-editing-style.css
+++ b/modules/contact-form/css/editor-inline-editing-style.css
@@ -2,6 +2,10 @@
 ** Normalize
 ** ======================================================================== */
 
+html {
+	direction: ltr;
+}
+
 body {
 	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 	font-size: 16px;

--- a/modules/contact-form/css/editor-inline-editing-style.css
+++ b/modules/contact-form/css/editor-inline-editing-style.css
@@ -11,7 +11,6 @@ body {
 	font-size: 16px;
 	line-height: 1.4em;
 	margin: 0;
-	padding: 0 1em;
 }
 
 /* Links */
@@ -31,7 +30,8 @@ a:active {
 ** Card
 ** ======================================================================= */
 
-.card {
+.card,
+body {
 	display: block;
 	position: relative;
 	margin: 0 auto 10px auto;
@@ -39,6 +39,11 @@ a:active {
 	box-sizing: border-box;
 	background: white;
 	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+}
+
+body {
+	margin: 0;
+	background: #f5f5f5;
 }
 
 .card:after {
@@ -49,6 +54,11 @@ a:active {
 	visibility: hidden;
 }
 
+.card:hover,
+.card:focus {
+	box-shadow: 0 0 0 1px #999, 0 1px 2px #e9eff3;
+}
+
 .card .delete-field {
 	display: block;
 	float: right;
@@ -57,6 +67,9 @@ a:active {
 @media ( min-width: 481px ) {
 	.card {
 		margin-bottom: 16px;
+		padding: 24px;
+	}
+	body {
 		padding: 24px;
 	}
 }
@@ -90,11 +103,11 @@ label {
 	font-size: 14px;
 	font-weight: 600;
 	margin-bottom: 5px;
-	margin-top: 24px;
+	margin-top: 8px;
 }
 
 label:first-of-type {
-	margin-top: 7px;
+	margin-top: 4px;
 }
 
 
@@ -584,35 +597,6 @@ input[type="submit"]:focus {
 	box-shadow: 0 0 0 2px #78dcfa;
 }
 
-input[type="submit"].is-compact {
-	padding: 7px;
-	color: #668eaa;
-	font-size: 11px;
-	line-height: 1;
-	text-transform: uppercase;
-}
-
-input[type="submit"].is-compact:disabled {
-	color: #e9eff3;
-}
-
-input[type="submit"].is-compact .gridicon {
-	top: 4px;
-	margin-top: -8px;
-}
-
-input[type="submit"].is-compact .gridicons-plus-small {
-	margin-left: -4px;
-}
-
-input[type="submit"].is-compact .gridicons-plus-small:last-of-type {
-	margin-left: 0;
-}
-
-input[type="submit"].is-compact .gridicons-plus-small + .gridicon {
-	margin-left: -4px;
-}
-
 input[type="submit"].hidden {
 	display: none;
 }
@@ -625,26 +609,26 @@ input[type="submit"] .gridicon {
 	height: 18px;
 }
 
-input[type="submit"].is-primary {
+input[type="submit"].button-primary {
 	background: #00aadc;
 	border-color: #008ab3;
 	color: white;
 }
 
-input[type="submit"].is-primary:hover,
-input[type="submit"].is-primary:focus {
+input[type="submit"].button-primary:hover,
+input[type="submit"].button-primary:focus {
 	border-color: #005082;
 	color: white;
 }
 
-input[type="submit"].is-primary[disabled],
-input[type="submit"].is-primary:disabled {
+input[type="submit"].button-primary[disabled],
+input[type="submit"].button-primary:disabled {
 	background: #bceefd;
 	border-color: #8cc9e2;
 	color: white;
 }
 
-input[type="submit"].is-primary {
+input[type="submit"].button-primary {
 	color: white;
 }
 
@@ -653,17 +637,9 @@ input[type="submit"].is-primary {
 ** Inline editor styles
 ** ======================================================================== */
 
-.card.grunion-form-settings {
-	background: #f5f5f5;
-}
 
-.card.grunion-field-edit {
-	margin-bottom: 0.5em;
-	background: #f5f5f5;
-}
-
-.ui-sortable-helper.card{
-	background: #e9eff3;
+.ui-sortable-handle {
+	cursor: move;
 }
 
 .grunion-section-header {
@@ -671,9 +647,18 @@ input[type="submit"].is-primary {
 	margin-top: 32px;
 }
 
+.grunion-section-header:first-child {
+	margin-top: 0;
+}
+
+.grunion-type-options {
+	display: flex;
+	flex-wrap: wrap;
+}
+
 .grunion-type {
-	float: left;
-	width: 60%;
+	flex-grow: 0;
+	flex-shrink: 0;
 }
 
 .grunion-type select {
@@ -681,13 +666,13 @@ input[type="submit"].is-primary {
 }
 
 .grunion-required {
-	float: right;
-	width: 30%;
-	padding-top: 2em;
+	padding: 27px 0 0 16px;
+	flex-grow: 0;
+	flex-shrink: 0;
 }
 
 .grunion-options {
-	clear: both;
+	padding-top: 16px;
 }
 
 .grunion-options ol {

--- a/modules/contact-form/css/editor-style.css
+++ b/modules/contact-form/css/editor-style.css
@@ -526,70 +526,6 @@ input[type="submit"]:focus {
 	box-shadow: 0 0 0 2px #78dcfa;
 }
 
-input[type="submit"].is-compact {
-	padding: 7px;
-	color: #668eaa;
-	font-size: 11px;
-	line-height: 1;
-	text-transform: uppercase;
-}
-
-input[type="submit"].is-compact:disabled {
-	color: #e9eff3;
-}
-
-input[type="submit"].is-compact .gridicon {
-	top: 4px;
-	margin-top: -8px;
-}
-
-input[type="submit"].is-compact .gridicons-plus-small {
-	margin-left: -4px;
-}
-
-input[type="submit"].is-compact .gridicons-plus-small:last-of-type {
-	margin-left: 0;
-}
-
-input[type="submit"].is-compact .gridicons-plus-small + .gridicon {
-	margin-left: -4px;
-}
-
-input[type="submit"].hidden {
-	display: none;
-}
-
-input[type="submit"] .gridicon {
-	position: relative;
-	top: 4px;
-	margin-top: -2px;
-	width: 18px;
-	height: 18px;
-}
-
-input[type="submit"].is-primary {
-	background: #00aadc;
-	border-color: #008ab3;
-	color: white;
-}
-
-input[type="submit"].is-primary:hover,
-input[type="submit"].is-primary:focus {
-	border-color: #005082;
-	color: white;
-}
-
-input[type="submit"].is-primary[disabled],
-input[type="submit"].is-primary:disabled {
-	background: #bceefd;
-	border-color: #8cc9e2;
-	color: white;
-}
-
-input[type="submit"].is-primary {
-		color: white;
-}
-
 /* ==========================================================================
 ** Preview styles
 ** ======================================================================== */
@@ -599,4 +535,9 @@ input[type="submit"].is-primary {
 	min-height: 500px;
 	border: 0;
 	overflow: hidden;
+}
+
+.contact-submit.contact-submit {
+	margin-top: 0;
+	margin-bottom: 0;
 }

--- a/modules/contact-form/css/editor-style.css
+++ b/modules/contact-form/css/editor-style.css
@@ -1,0 +1,602 @@
+/* ==========================================================================
+** Normalize
+** ======================================================================== */
+
+body,
+label {
+	font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+	font-size: 16px;
+	line-height: 1.4em;
+}
+
+/* ==========================================================================
+** Card
+** ======================================================================= */
+
+.card {
+	display: block;
+	position: relative;
+	margin: 0 auto;
+	padding: 16px;
+	box-sizing: border-box;
+	background: white;
+	box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+}
+
+.card:after {
+	content: ".";
+	display: block;
+	height: 0;
+	clear: both;
+	visibility: hidden;
+}
+
+@media ( min-width: 481px ) {
+	.card {
+		padding: 24px;
+	}
+}
+
+.card > div {
+	margin-top: 24px;
+}
+
+.card > div:first-child {
+	margin-top: 0;
+}
+
+
+/* ==========================================================================
+** Labels
+** ======================================================================= */
+
+label {
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 5px;
+}
+
+
+/* ==========================================================================
+** Text Inputs
+** ======================================================================= */
+
+input[type="text"],
+input[type="tel"],
+input[type="email"] {
+	border-radius: 0;
+	appearance: none;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 7px 14px;
+	width: 100%;
+	color: #2e4453;
+	font-size: 16px;
+	line-height: 1.5;
+	border: 1px solid #c8d7e1;
+	background-color: #fff;
+	transition: all .15s ease-in-out;
+	box-shadow: none;
+}
+
+input[type="text"]::placeholder,
+input[type="tel"]::placeholder,
+input[type="email"]::placeholder {
+	color: #87a6bc;
+}
+
+input[type="text"]:hover,
+input[type="tel"]:hover,
+input[type="email"]:hover {
+	border-color: #a8bece;
+}
+
+input[type="text"]:focus,
+input[type="tel"]:focus,
+input[type="email"]:focus {
+	border-color: #0087be;
+	outline: none;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+input[type="text"]:focus::-ms-clear,
+input[type="tel"]:focus::-ms-clear,
+input[type="email"]:focus::-ms-clear {
+	display: none;
+}
+
+input[type="text"]:disabled,
+input[type="tel"]:disabled,
+input[type="email"]:disabled {
+	background: #f3f6f8;
+	border-color: #e9eff3;
+	color: #a8bece;
+	-webkit-text-fill-color: #a8bece;
+}
+
+input[type="text"]:disabled:hover,
+input[type="tel"]:disabled:hover,
+input[type="email"]:disabled:hover {
+	cursor: default;
+}
+
+input[type="text"]:disabled::placeholder,
+input[type="tel"]:disabled::placeholder,
+input[type="email"]:disabled::placeholder {
+	color: #a8bece;
+}
+
+
+/* ==========================================================================
+** Textareas
+** ======================================================================= */
+
+textarea {
+	border-radius: 0;
+	appearance: none;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 7px 14px;
+	height: 92px;
+	width: 100%;
+	color: #2e4453;
+	font-size: 16px;
+	line-height: 1.5;
+	border: 1px solid #c8d7e1;
+	background-color: #fff;
+	transition: all .15s ease-in-out;
+	box-shadow: none;
+}
+
+textarea::placeholder {
+	color: #87a6bc;
+}
+
+textarea:hover {
+	border-color: #a8bece;
+}
+
+textarea:focus {
+	border-color: #0087be;
+	outline: none;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+textarea:focus::-ms-clear {
+	display: none;
+}
+
+textarea:disabled {
+	background: #f3f6f8;
+	border-color: #e9eff3;
+	color: #a8bece;
+	-webkit-text-fill-color: #a8bece;
+}
+
+textarea:disabled:hover {
+	cursor: default;
+}
+
+textarea:disabled::placeholder {
+	color: #a8bece;
+}
+
+
+/* ==========================================================================
+** Checkboxes
+** ======================================================================= */
+
+input[type="checkbox"] {
+	-webkit-appearance: none;
+	display: inline-block;
+	box-sizing: border-box;
+	margin: 2px 0 0;
+	padding: 7px 14px;
+	width: 16px;
+	height: 16px;
+	float: left;
+	outline: 0;
+	padding: 0;
+	box-shadow: none;
+	background-color: #fff;
+	border: 1px solid #c8d7e1;
+	color: #2e4453;
+	font-size: 16px;
+	line-height: 0;
+	text-align: center;
+	vertical-align: middle;
+	appearance: none;
+	transition: all .15s ease-in-out;
+	clear: none;
+	cursor: pointer;
+}
+
+input[type="checkbox"]:checked:before {
+	content: '\f147';
+	font-family: Dashicons;
+	margin: -3px 0 0 -4px;
+	float: left;
+	display: inline-block;
+	vertical-align: middle;
+	width: 16px;
+	font-size: 20px;
+	line-height: 1;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	speak: none;
+	color: #00aadc;
+}
+
+input[type="checkbox"]:disabled:checked:before {
+	color: #a8bece;
+}
+
+input[type="checkbox"]:hover {
+	border-color: #a8bece;
+}
+
+input[type="checkbox"]:focus {
+	border-color: #0087be;
+	outline: none;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+input[type="checkbox"]:disabled {
+	background: #f3f6f8;
+	border-color: #e9eff3;
+	color: #a8bece;
+	opacity: 1;
+}
+
+input[type="checkbox"]:disabled:hover {
+	cursor: default;
+}
+
+input[type="checkbox"] + span {
+	display: block;
+	font-weight: normal;
+	margin-left: 24px;
+}
+
+
+/* ==========================================================================
+** Radio buttons
+** ======================================================================== */
+
+input[type=radio] {
+	color: #2e4453;
+	font-size: 16px;
+	border: 1px solid #c8d7e1;
+	background-color: #fff;
+	transition: all .15s ease-in-out;
+	box-sizing: border-box;
+	-webkit-appearance: none;
+	clear: none;
+	cursor: pointer;
+	display: inline-block;
+	line-height: 0;
+	height: 16px;
+	margin: 2px 4px 0 0;
+	float: left;
+	outline: 0;
+	padding: 0;
+	text-align: center;
+	vertical-align: middle;
+	width: 16px;
+	min-width: 16px;
+	appearance: none;
+	border-radius: 50%;
+	line-height: 10px;
+}
+
+input[type="radio"]:hover {
+	border-color: #a8bece;
+}
+
+input[type="radio"]:focus {
+	border-color: #0087be;
+	outline: none;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+input[type="radio"]:focus::-ms-clear {
+	display: none;
+}
+
+input[type="radio"]:checked:before {
+	float: left;
+	display: inline-block;
+	content: '\2022';
+	margin: 3px;
+	width: 8px;
+	height: 8px;
+	text-indent: -9999px;
+	background: #00aadc;
+	vertical-align: middle;
+	border-radius: 50%;
+	animation: grow .2s ease-in-out;
+}
+
+input[type="radio"]:disabled {
+	background: #f3f6f8;
+	border-color: #e9eff3;
+	color: #a8bece;
+	opacity: 1;
+	-webkit-text-fill-color: #a8bece;
+}
+
+input[type="radio"]:disabled:hover {
+	cursor: default;
+}
+
+input[type="radio"]:disabled::placeholder {
+	color: #a8bece;
+}
+
+input[type="radio"]:disabled:checked:before {
+	background: #e9eff3;
+}
+
+input[type="radio"] + span {
+	display: block;
+	font-weight: normal;
+	margin-left: 24px;
+}
+
+@keyframes grow {
+	0% {
+		transform: scale(0.3);
+	}
+
+	60% {
+		transform: scale(1.15);
+	}
+
+	100% {
+		transform: scale(1);
+	}
+}
+
+@keyframes grow {
+	0% {
+		transform: scale(0.3);
+	}
+
+	60% {
+		transform: scale(1.15);
+	}
+
+	100% {
+		transform: scale(1);
+	}
+}
+
+
+/* ==========================================================================
+** Selects
+** ======================================================================== */
+
+select {
+	background: #fff url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
+	border-color: #c8d7e1;
+	border-style: solid;
+	border-radius: 4px;
+	border-width: 1px 1px 2px;
+	color: #2e4453;
+	cursor: pointer;
+	display: inline-block;
+	margin: 0;
+	outline: 0;
+	overflow: hidden;
+	font-size: 14px;
+	line-height: 21px;
+	font-weight: 600;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	white-space: nowrap;
+	box-sizing: border-box;
+	padding: 7px 32px 9px 14px; // Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow.
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+}
+
+select:hover {
+	background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjYThiZWNlIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==);
+}
+
+select:focus {
+	background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiA8dGl0bGU+YXJyb3ctZG93bjwvdGl0bGU+IDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiA8ZGVmcz48L2RlZnM+IDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHNrZXRjaDp0eXBlPSJNU1BhZ2UiPiA8ZyBpZD0iYXJyb3ctZG93biIgc2tldGNoOnR5cGU9Ik1TQXJ0Ym9hcmRHcm91cCIgZmlsbD0iIzJlNDQ1MyI+IDxwYXRoIGQ9Ik0xNS41LDYgTDE3LDcuNSBMMTAuMjUsMTQuMjUgTDMuNSw3LjUgTDUsNiBMMTAuMjUsMTEuMjUgTDE1LjUsNiBaIiBpZD0iRG93bi1BcnJvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=);
+	border-color: #00aadc;
+	box-shadow: 0 0 0 2px #78dcfa;
+	outline: 0;
+	-moz-outline:none;
+	-moz-user-focus:ignore;
+}
+
+select:disabled,
+select:hover:disabled {
+	background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjZTllZmYzIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;;
+}
+
+select.is-compact {
+	min-width: 0;
+	padding: 0 20px 2px 6px;
+	margin: 0 4px;
+	background-position:  right 5px center;
+	background-size: 12px 12px;
+}
+
+/* Make it display:block when it follows a label */
+label select,
+label + select {
+	display: block;
+	min-width: 200px;
+}
+
+label select.is-compact,
+label + select.is-compact {
+	display: inline-block;
+	min-width: 0;
+}
+
+/* IE: Remove the default arrow */
+select::-ms-expand {
+	display: none;
+}
+
+/* IE: Remove default background and color styles on focus */
+select::-ms-value {
+	background: none;
+	color: #2e4453;
+}
+
+/* Firefox: Remove the focus outline, see http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002 */
+select:-moz-focusring {
+	color: transparent;
+	text-shadow: 0 0 0 #2e4453;
+}
+
+
+/* ==========================================================================
+** Buttons
+** ======================================================================== */
+
+input[type="submit"] {
+	padding: 0;
+	font-size: 14px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+			 appearance: none;
+	vertical-align: baseline;
+	background: white;
+	border-color: #c8d7e1;
+	border-style: solid;
+	border-width: 1px 1px 2px;
+	color: #2e4453;
+	cursor: pointer;
+	display: inline-block;
+	margin: 24px 0 0;
+	outline: 0;
+	overflow: hidden;
+	font-weight: 500;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	box-sizing: border-box;
+	font-size: 14px;
+	line-height: 21px;
+	border-radius: 4px;
+	padding: 7px 14px 9px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+			 appearance: none;
+}
+
+input[type="submit"]:hover {
+	border-color: #a8bece;
+	color: #2e4453;
+}
+
+input[type="submit"]:active {
+	border-width: 2px 1px 1px;
+}
+
+input[type="submit"]:visited {
+	color: #2e4453;
+}
+
+input[type="submit"][disabled],
+input[type="submit"]:disabled {
+	color: #e9eff3;
+	background: white;
+	border-color: #e9eff3;
+	cursor: default;
+}
+
+input[type="submit"][disabled]:active,
+input[type="submit"]:disabled:active {
+	border-width: 1px 1px 2px;
+}
+
+input[type="submit"]:focus {
+	border-color: #00aadc;
+	box-shadow: 0 0 0 2px #78dcfa;
+}
+
+input[type="submit"].is-compact {
+	padding: 7px;
+	color: #668eaa;
+	font-size: 11px;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
+input[type="submit"].is-compact:disabled {
+	color: #e9eff3;
+}
+
+input[type="submit"].is-compact .gridicon {
+	top: 4px;
+	margin-top: -8px;
+}
+
+input[type="submit"].is-compact .gridicons-plus-small {
+	margin-left: -4px;
+}
+
+input[type="submit"].is-compact .gridicons-plus-small:last-of-type {
+	margin-left: 0;
+}
+
+input[type="submit"].is-compact .gridicons-plus-small + .gridicon {
+	margin-left: -4px;
+}
+
+input[type="submit"].hidden {
+	display: none;
+}
+
+input[type="submit"] .gridicon {
+	position: relative;
+	top: 4px;
+	margin-top: -2px;
+	width: 18px;
+	height: 18px;
+}
+
+input[type="submit"].is-primary {
+	background: #00aadc;
+	border-color: #008ab3;
+	color: white;
+}
+
+input[type="submit"].is-primary:hover,
+input[type="submit"].is-primary:focus {
+	border-color: #005082;
+	color: white;
+}
+
+input[type="submit"].is-primary[disabled],
+input[type="submit"].is-primary:disabled {
+	background: #bceefd;
+	border-color: #8cc9e2;
+	color: white;
+}
+
+input[type="submit"].is-primary {
+		color: white;
+}
+
+/* ==========================================================================
+** Preview styles
+** ======================================================================== */
+
+.wpview.wpview-wrap[data-wpview-type=contact-form] iframe.inline-edit-contact-form {
+	width: 100%;
+	min-height: 500px;
+	border: 0;
+	overflow: hidden;
+}

--- a/modules/contact-form/css/editor-ui.css
+++ b/modules/contact-form/css/editor-ui.css
@@ -1,0 +1,8 @@
+i.mce-i-grunion {
+	font-family: dashicons;
+	font-size: 20px;
+}
+
+i.mce-i-grunion:before {
+	content: "\f175";
+}

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -47,9 +47,11 @@ class Grunion_Editor_View {
 		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'editor_view_js_templates' ), 1 );
 
 		wp_enqueue_style( 'grunion-editor-ui', plugins_url( 'css/editor-ui.css', __FILE__ ) );
+		wp_style_add_data( 'grunion-editor-ui', 'rtl', 'replace' );
 		wp_enqueue_script( 'grunion-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'jquery', 'quicktags' ), false, true );
 		wp_localize_script( 'grunion-editor-view', 'grunionEditorView', array(
 			'inline_editing_style' => plugins_url( 'css/editor-inline-editing-style.css', __FILE__ ),
+			'inline_editing_style_rtl' => plugins_url( 'css/editor-inline-editing-style-rtl.css', __FILE__ ),
 			'dashicons_css_url'    => includes_url( 'css/dashicons.css' ),
 			'default_form'  => '[contact-field label="' . __( 'Name', 'jetpack' ) . '" type="name"  required="true" /]' .
 								'[contact-field label="' . __( 'Email', 'jetpack' )   . '" type="email" required="true" /]' .

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -57,6 +57,7 @@ class Grunion_Editor_View {
 								'[contact-field label="' . __( 'Message', 'jetpack' ) . '" type="textarea" /]',
 			'labels'      => array(
 				'submit_button_text'  => __( 'Submit', 'jetpack' ),
+				/** This filter is documented in modules/contact-form/grunion-contact-form.php */
 				'required_field_text' => apply_filters( 'jetpack_required_field_text', __( '(required)', 'jetpack' ) ),
 				'edit_close_ays'      => __( 'Are you sure you\'d like to stop editing this form without saving your changes?', 'jetpack' ),
 				'quicktags_label'     => __( 'contact form', 'jetpack' ),

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -1,0 +1,252 @@
+<?php
+
+/*
+ * A prototype to allow inline editing / editor views for contact forms.\
+ *
+ * Originally developed in: http://github.com/automattic/gm2016-grunion-editor
+ * Authors: Michael Arestad, Andrew Ozz, and George Stephanis
+ */
+
+class Grunion_Editor_View {
+	public static function add_hooks() {
+		add_action( 'admin_notices', array( __CLASS__, 'handle_editor_view_js' ) );
+		add_filter( 'mce_external_plugins', array( __CLASS__, 'mce_external_plugins' ) );
+		add_filter( 'mce_buttons', array( __CLASS__, 'mce_buttons' ) );
+		add_action( 'admin_head', array( __CLASS__, 'admin_head' ) );
+	}
+
+	public static function admin_head() {
+		remove_action( 'media_buttons', 'grunion_media_button', 999 );
+	}
+
+	public static function mce_external_plugins( $plugin_array ) {
+		$plugin_array['grunion_form'] =  plugins_url( 'js/tinymce-plugin-form-button.js', __FILE__ );
+		return $plugin_array;
+	}
+
+	public static function mce_buttons( $buttons ) {
+		$size = sizeof( $buttons );
+		$buttons1 = array_slice( $buttons, 0, $size - 1 );
+		$buttons2 = array_slice( $buttons, $size - 1 );
+		return array_merge(
+			$buttons1,
+			array( 'grunion' ),
+			$buttons2
+		);
+	}
+
+	/**
+	 * WordPress Shortcode Editor View JS Code
+	 */
+	public static function handle_editor_view_js() {
+		$current_screen = get_current_screen();
+		if ( ! isset( $current_screen->id ) || $current_screen->base !== 'post' ) {
+			return;
+		}
+
+		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'editor_view_js_templates' ), 1 );
+
+		wp_enqueue_style( 'grunion-editor-ui', plugins_url( 'css/editor-ui.css', __FILE__ ) );
+		wp_enqueue_script( 'grunion-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'jquery', 'quicktags' ), false, true );
+		wp_localize_script( 'grunion-editor-view', 'grunionEditorView', array(
+			'inline_editing_style' => plugins_url( 'css/editor-inline-editing-style.css', __FILE__ ),
+			'dashicons_css_url'    => includes_url( 'css/dashicons.css' ),
+			'default_form'  => '[contact-field label="' . __( 'Name', 'jetpack' ) . '" type="name"  required="true" /]' .
+								'[contact-field label="' . __( 'Email', 'jetpack' )   . '" type="email" required="true" /]' .
+								'[contact-field label="' . __( 'Website', 'jetpack' ) . '" type="url" /]' .
+								'[contact-field label="' . __( 'Message', 'jetpack' ) . '" type="textarea" /]',
+			'labels'      => array(
+				'submit_button_text'  => __( 'Submit', 'jetpack' ),
+				'required_field_text' => apply_filters( 'jetpack_required_field_text', __( '(required)', 'jetpack' ) ),
+				'edit_close_ays'      => __( 'Are you sure you\'d like to stop editing this form without saving your changes?', 'jetpack' ),
+				'quicktags_label'     => __( 'contact form', 'jetpack' ),
+				'tinymce_label'       => __( 'Add contact form', 'jetpack' ),
+			)
+		) );
+
+		add_editor_style( plugins_url( 'css/editor-style.css', __FILE__ ) );
+	}
+
+	/**
+	 * JS Templates.
+	 */
+	public static function editor_view_js_templates() {
+		?>
+<script type="text/html" id="tmpl-grunion-contact-form">
+	<form class="card" action='#' method='post' class='contact-form commentsblock' onsubmit="return false;">
+		{{{ data.body }}}
+		<p class='contact-submit'>
+			<input type='submit' value='{{ data.submit_button_text }}' class='pushbutton-wide'/>
+		</p>
+	</form>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-email">
+	<div>
+		<label for='{{ data.id }}' class='grunion-field-label email'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<input type='email' name='{{ data.id }}' id='{{ data.id }}' value='{{ data.value }}' class='{{ data.class }}' placeholder='{{ data.placeholder }}' />
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-telephone">
+	<div>
+		<label for='{{ data.id }}' class='grunion-field-label telephone'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<input type='tel' name='{{ data.id }}' id='{{ data.id }}' value='{{ data.value }}' class='{{ data.class }}' placeholder='{{ data.placeholder }}' />
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-textarea">
+	<div>
+		<label for='contact-form-comment-{{ data.id }}' class='grunion-field-label textarea'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<textarea name='{{ data.id }}' id='contact-form-comment-{{ data.id }}' rows='20' class='{{ data.class }}' placeholder='{{ data.placeholder }}'>{{ data.value }}</textarea>
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-radio">
+	<div>
+		<label class='grunion-field-label'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<# _.each( data.options, function( option ) { #>
+			<label class='grunion-radio-label radio'>
+				<input type='radio' name='{{ data.id }}' value='{{ option }}' class="{{ data.class }}" <# if ( option === data.value ) print( "checked='checked'" ) #> />
+				<span>{{ option }}</span>
+			</label>
+		<# }); #>
+		<div class='clear-form'></div>
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-checkbox">
+	<div>
+		<label class='grunion-field-label checkbox'>
+			<input type='checkbox' name='{{ data.id }}' value='<?php esc_attr__( 'Yes', 'jetpack' ); ?>' class="{{ data.class }}" <# if ( data.value ) print( 'checked="checked"' ) #> />
+				<span>{{ data.label }}</span><# if ( data.required ) print( " <span>" + data.required + "</span>" ) #>
+		</label>
+		<div class='clear-form'></div>
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-checkbox-multiple">
+	<div>
+		<label class='grunion-field-label'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<# _.each( data.options, function( option ) { #>
+			<label class='grunion-checkbox-multiple-label checkbox-multiple'>
+				<input type='checkbox' name='{{ data.id }}[]' value='{{ option }}' class="{{ data.class }}" <# if ( option === data.value || _.contains( data.value, option ) ) print( "checked='checked'" ) #> />
+				<span>{{ option }}</span>
+			</label>
+		<# }); #>
+		<div class='clear-form'></div>
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-select">
+	<div>
+		<label for='{{ data.id }}' class='grunion-field-label select'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<select name='{{ data.id }}' id='{{ data.id }}' class="{{ data.class }}">
+			<# _.each( data.options, function( option ) { #>
+				<option <# if ( option === data.value ) print( "selected='selected'" ) #>>{{ option }}</option>
+			<# }); #>
+		</select>
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-date">
+	<div>
+		<label for='{{ data.id }}' class='grunion-field-label {{ data.type }}'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<input type='date' name='{{ data.id }}' id='{{ data.id }}' value='{{ data.value }}' class="{{ data.class }}" />
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-text">
+	<div>
+		<label for='{{ data.id }}' class='grunion-field-label {{ data.type }}'>{{ data.label }}<# if ( data.required ) print( " <span>" + data.required + "</span>" ) #></label>
+		<input type='text' name='{{ data.id }}' id='{{ data.id }}' value='{{ data.value }}' class='{{ data.class }}' placeholder='{{ data.placeholder }}' />
+	</div>
+</script>
+
+
+<script type="text/html" id="tmpl-grunion-field-edit">
+	<div class="card is-compact grunion-field-edit grunion-field-{{ data.type }}" aria-label="<?php esc_attr_e( 'Form Field', 'jetpack' ); ?>">
+		<label class="grunion-name">
+			<span><?php esc_html_e( 'Field Label', 'jetpack' ); ?></span>
+			<input type="text" name="label" placeholder="<?php esc_attr_e( 'Label', 'jetpack' ); ?>" value="{{ data.label }}"/>
+		</label>
+
+		<?php
+		$grunion_field_types = array(
+			'text'              => __( 'Text', 'jetpack' ),
+			'name'              => __( 'Name', 'jetpack' ),
+			'email'             => __( 'Email', 'jetpack' ),
+			'url'               => __( 'Website', 'jetpack' ),
+			'textarea'          => __( 'Textarea', 'jetpack' ),
+			'checkbox'          => __( 'Checkbox', 'jetpack' ),
+			'checkbox-multiple' => __( 'Checkbox with Multiple Items', 'jetpack' ),
+			'select'            => __( 'Drop down', 'jetpack' ),
+			'radio'             => __( 'Radio', 'jetpack' ),
+		);
+		?>
+		<label class="grunion-type">
+			<?php esc_html_e( 'Field Type', 'jetpack' ); ?>
+			<select name="type">
+				<?php foreach ( $grunion_field_types as $type => $label ) : ?>
+				<option <# if ( '<?php echo esc_js( $type ); ?>' === data.type ) print( "selected='selected'" ) #> value="<?php echo esc_attr( $type ); ?>">
+					<?php echo esc_html( $label ); ?>
+				</option>
+				<?php endforeach; ?>
+			</select>
+		</label>
+
+		<label class="grunion-required">
+			<input type="checkbox" name="required" value="1" <# if ( data.required ) print( 'checked="checked"' ) #> />
+			<span><?php esc_html_e( 'Required?', 'jetpack' ); ?></span>
+		</label>
+
+		<label class="grunion-options">
+			<?php esc_html_e( 'Options', 'jetpack' ); ?>
+			<ol>
+				<# if ( data.options ) { #>
+					<# _.each( data.options, function( option ) { #>
+						<li><input type="text" name="option" value="{{ option }}" /> <a class="delete-option" href="javascript:;"><span class="screen-reader-text"><?php esc_html_e( 'Delete Option', 'jetpack' ); ?></span></a></li>
+					<# }); #>
+				<# } else { #>
+					<li><input type="text" name="option" /> <a class="delete-option" href="javascript:;"><span class="screen-reader-text"><?php esc_html_e( 'Delete Option', 'jetpack' ); ?></span></a></li>
+					<li><input type="text" name="option" /> <a class="delete-option" href="javascript:;"><span class="screen-reader-text"><?php esc_html_e( 'Delete Option', 'jetpack' ); ?></span></a></li>
+					<li><input type="text" name="option" /> <a class="delete-option" href="javascript:;"><span class="screen-reader-text"><?php esc_html_e( 'Delete Option', 'jetpack' ); ?></span></a></li>
+				<# } #>
+				<li><a class="add-option" href="javascript:;"><?php esc_html_e( 'Add new option...', 'jetpack' ); ?></a></li>
+			</ol>
+		</label>
+
+		<a href="javascript:;" class="delete-field"><span class="screen-reader-text"><?php esc_html_e( 'Delete Field', 'jetpack' ); ?></span></a>
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-field-edit-option">
+	<li><input type="text" name="option" /> <a class="delete-option" href="javascript:;"><span class="screen-reader-text"><?php esc_html_e( 'Delete Option', 'jetpack' ); ?></span></a></li>
+</script>
+
+<script type="text/html" id="tmpl-grunion-editor-inline">
+			<h1 id="form-settings-header" class="grunion-section-header"><?php esc_html_e( 'Form Settings', 'jetpack' ); ?></h1>
+			<section class="card grunion-form-settings" aria-labelledby="form-settings-header">
+				<label><?php esc_html_e( 'What would you like the subject of the email to be?', 'jetpack' ); ?>
+					<input type="text" name="subject" value="{{ data.subject }}" />
+				</label>
+				<label><?php esc_html_e( 'Which email address should we send the submissions to?', 'jetpack' ); ?>
+					<input type="text" name="to" value="{{ data.to }}" />
+				</label>
+			</section>
+			<h1 id="form-fields-header" class="grunion-section-header"><?php esc_html_e( 'Form Fields', 'jetpack' ); ?></h1>
+			<section class="grunion-fields" aria-labelledby="form-fields-header">
+				{{{ data.fields }}}
+			</section>
+			<section class="buttons">
+				<?php submit_button( esc_html__( 'Add Field', 'jetpack' ), 'secondary', 'add-field', false ); ?>
+				<?php submit_button( esc_html__( 'Update Form', 'jetpack' ), 'primary', 'submit', false ); ?>
+				<?php submit_button( esc_html__( 'Cancel', 'jetpack' ), 'delete', 'cancel', false ); ?>
+			</section>
+</script>
+	<?php
+	}
+}
+
+
+Grunion_Editor_View::add_hooks();

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -187,21 +187,23 @@ class Grunion_Editor_View {
 			'radio'             => __( 'Radio', 'jetpack' ),
 		);
 		?>
-		<label class="grunion-type">
-			<?php esc_html_e( 'Field Type', 'jetpack' ); ?>
-			<select name="type">
-				<?php foreach ( $grunion_field_types as $type => $label ) : ?>
-				<option <# if ( '<?php echo esc_js( $type ); ?>' === data.type ) print( "selected='selected'" ) #> value="<?php echo esc_attr( $type ); ?>">
-					<?php echo esc_html( $label ); ?>
-				</option>
-				<?php endforeach; ?>
-			</select>
-		</label>
+		<div class="grunion-type-options">
+			<label class="grunion-type">
+				<?php esc_html_e( 'Field Type', 'jetpack' ); ?>
+				<select name="type">
+					<?php foreach ( $grunion_field_types as $type => $label ) : ?>
+					<option <# if ( '<?php echo esc_js( $type ); ?>' === data.type ) print( "selected='selected'" ) #> value="<?php echo esc_attr( $type ); ?>">
+						<?php echo esc_html( $label ); ?>
+					</option>
+					<?php endforeach; ?>
+				</select>
+			</label>
 
-		<label class="grunion-required">
-			<input type="checkbox" name="required" value="1" <# if ( data.required ) print( 'checked="checked"' ) #> />
-			<span><?php esc_html_e( 'Required?', 'jetpack' ); ?></span>
-		</label>
+			<label class="grunion-required">
+				<input type="checkbox" name="required" value="1" <# if ( data.required ) print( 'checked="checked"' ) #> />
+				<span><?php esc_html_e( 'Required?', 'jetpack' ); ?></span>
+			</label>
+		</div>
 
 		<label class="grunion-options">
 			<?php esc_html_e( 'Options', 'jetpack' ); ?>
@@ -243,10 +245,12 @@ class Grunion_Editor_View {
 			</section>
 			<section class="buttons">
 				<?php submit_button( esc_html__( 'Add Field', 'jetpack' ), 'secondary', 'add-field', false ); ?>
-				<?php submit_button( esc_html__( 'Update Form', 'jetpack' ), 'primary', 'submit', false ); ?>
 				<?php submit_button( esc_html__( 'Cancel', 'jetpack' ), 'delete', 'cancel', false ); ?>
+				<?php submit_button( esc_html__( 'Update Form', 'jetpack' ), 'primary', 'submit', false ); ?>
 			</section>
 </script>
+
+</div>
 	<?php
 	}
 }

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -1,5 +1,5 @@
-/* global grunionEditorView, tinyMCE, QTags */
-(function( $, wp, grunionEditorView ){
+/* global grunionEditorView, tinyMCE, QTags, wp */
+( function( $, wp, grunionEditorView ) {
 	wp.mce = wp.mce || {};
 	if ( 'undefined' === typeof wp.mce.views ) {
 		return;
@@ -34,7 +34,7 @@
 			}
 
 			// Render the fields.
-			while ( field = wp.shortcode.next( 'contact-field', content, index ) ) {
+			while ( ( field = wp.shortcode.next( 'contact-field', content, index ) ) ) {
 				index = field.index + field.content.length;
 				named = field.shortcode.attrs.named;
 				if ( ! named.type || ! this.field_templates[ named.type ] ) {
@@ -44,7 +44,7 @@
 					named.required = grunionEditorView.labels.required_field_text;
 				}
 				if ( named.options && 'string' === typeof named.options ) {
-					named.options = named.options.split(',');
+					named.options = named.options.split( ',' );
 				}
 				body += this.field_templates[ named.type ]( named );
 			}
@@ -60,138 +60,142 @@
 			var shortcode_data = wp.shortcode.next( this.shortcode_string, data ),
 				shortcode = shortcode_data.shortcode,
 				$tinyMCE_document = $( tinyMCE.activeEditor.getDoc() ),
-				$view = $tinyMCE_document.find('.wpview.wpview-wrap').filter(function(){
-					return $(this).attr('data-mce-selected');
-				}),
-				$editframe = $('<iframe scrolling="no" class="inline-edit-contact-form" />'),
+				$view = $tinyMCE_document.find( '.wpview.wpview-wrap' ).filter( function() {
+					return $( this ).attr( 'data-mce-selected' );
+				} ),
+				$editframe = $( '<iframe scrolling="no" class="inline-edit-contact-form" />' ),
 				index = 0,
 				named,
 				fields = '',
-				stylesheet_url = ( 1 === window.isRtl ) ? grunionEditorView.inline_editing_style_rtl : grunionEditorView.inline_editing_style,
+				stylesheet_url = ( 1 === window.isRtl )
+					? grunionEditorView.inline_editing_style_rtl
+					: grunionEditorView.inline_editing_style,
 				$stylesheet = $( '<link rel="stylesheet" href="' + stylesheet_url + '" />' ),
-				$dashicons_css  = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' ),
-				$editfields, field;
+				$dashicons_css = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' ),
+				$editfields,
+				field;
 
 			if ( ! shortcode.content ) {
 				shortcode.content = grunionEditorView.default_form;
 			}
 
 			// Render the fields.
-			while ( field = wp.shortcode.next( 'contact-field', shortcode.content, index ) ) {
+			while ( ( field = wp.shortcode.next( 'contact-field', shortcode.content, index ) ) ) {
 				index = field.index + field.content.length;
 				named = field.shortcode.attrs.named;
 				if ( named.options && 'string' === typeof named.options ) {
-					named.options = named.options.split(',');
+					named.options = named.options.split( ',' );
 				}
 				fields += this.edit_template( named );
 			}
 
 			$view.html( $editframe );
 
-			$editframe.contents().find('head').append( $stylesheet ).append( $dashicons_css );
-			$stylesheet.on( 'load', function(){
-				$editframe.trigger('checkheight');
-			});
+			$editframe.contents().find( 'head' ).append( $stylesheet ).append( $dashicons_css );
+			$stylesheet.on( 'load', function() {
+				$editframe.trigger( 'checkheight' );
+			} );
 
-			$editframe.contents().find('body').html( this.editor_inline( {
+			$editframe.contents().find( 'body' ).html( this.editor_inline( {
 				to      : shortcode.attrs.named.to,
 				subject : shortcode.attrs.named.subject,
 				fields  : fields
-			}) );
+			} ) );
 
-			$editframe.on('checkheight', function(){
+			$editframe.on( 'checkheight', function() {
 				this.style.height = '10px';
 				this.style.height = ( 5 + this.contentWindow.document.body.scrollHeight ) + 'px';
-				tinyMCE.activeEditor.execCommand('wpAutoResize');
-			}).trigger('checkheight').hide().fadeIn(250, function(){
-				$(this).contents().find('input:first').focus();
-			});
+				tinyMCE.activeEditor.execCommand( 'wpAutoResize' );
+			} ).trigger( 'checkheight' ).hide().fadeIn( 250, function() {
+				$( this ).contents().find( 'input:first' ).focus();
+			} );
 
-			$editfields = $editframe.contents().find('.grunion-fields');
+			$editfields = $editframe.contents().find( '.grunion-fields' );
 			$editfields.sortable();
-			$editfields.on( 'change select', 'select[name=type]', function(){
-				$(this).closest('.grunion-field-edit')[0].className = 'card is-compact grunion-field-edit grunion-field-' + $(this).val();
-				$editframe.trigger('checkheight');
-			});
+			$editfields.on( 'change select', 'select[name=type]', function() {
+				$( this ).closest( '.grunion-field-edit' )[ 0 ].className =
+					'card is-compact grunion-field-edit grunion-field-' + $( this ).val();
+				$editframe.trigger( 'checkheight' );
+			} );
 
-			var $buttons = $editframe.contents().find('.buttons');
+			var $buttons = $editframe.contents().find( '.buttons' );
 
 			// The 'save' listener.
-			$buttons.find('input[name=submit]').on( 'click', function(){
+			$buttons.find( 'input[name=submit]' ).on( 'click', function(){
 				var new_data = shortcode;
 
 				new_data.type = 'closed';
 				new_data.attrs = {};
 				new_data.content = '';
 
-				$editfields.children().each( function(){
+				$editfields.children().each( function() {
 					var field_shortcode = {
 							tag   : 'contact-field',
 							type  : 'single',
 							attrs : {
-								label : $(this).find('input[name=label]').val(),
-								type  : $(this).find('select[name=type]').val()
+								label : $( this ).find( 'input[name=label]' ).val(),
+								type  : $( this ).find( 'select[name=type]' ).val()
 							}
 						},
 						options = [];
 
-					if ( $(this).find('input[name=required]:checked').length ) {
+					if ( $( this ).find( 'input[name=required]:checked' ).length ) {
 						field_shortcode.attrs.required = '1';
 					}
 
-					$(this).find('input[name=option]').each( function(){
-						if ( $(this).val() ) {
-							options.push( $(this).val() );
+					$( this ).find( 'input[name=option]' ).each( function() {
+						if ( $( this ).val() ) {
+							options.push( $( this ).val() );
 						}
-					});
+					} );
 					if ( options.length ) {
-						field_shortcode.attrs.options = options.join(',');
+						field_shortcode.attrs.options = options.join( ',' );
 					}
 
 					new_data.content += wp.shortcode.string( field_shortcode );
 				} );
 
-				if ( $editframe.contents().find('input[name=to]').val() ) {
-					new_data.attrs.to = $editframe.contents().find('input[name=to]').val();
+				if ( $editframe.contents().find( 'input[name=to]' ).val() ) {
+					new_data.attrs.to = $editframe.contents().find( 'input[name=to]' ).val();
 				}
-				if ( $editframe.contents().find('input[name=subject]').val() ) {
-					new_data.attrs.subject = $editframe.contents().find('input[name=subject]').val();
+				if ( $editframe.contents().find( 'input[name=subject]' ).val() ) {
+					new_data.attrs.subject = $editframe.contents().find( 'input[name=subject]' ).val();
 				}
 
 				update_callback( wp.shortcode.string( new_data ) );
-			});
+			} );
 
-			$buttons.find('input[name=cancel]').on( 'click', function(){
+			$buttons.find( 'input[name=cancel]' ).on( 'click', function() {
 				update_callback( wp.shortcode.string( shortcode ) );
-			});
+			} );
 
-			$buttons.find('input[name=add-field]').on( 'click', function(){
-				var $new_field = $( wp.mce.grunion_wp_view_renderer.edit_template({}) );
+			$buttons.find( 'input[name=add-field]' ).on( 'click', function() {
+				var $new_field = $( wp.mce.grunion_wp_view_renderer.edit_template( {} ) );
 				$editfields.append( $new_field );
-				$editfields.sortable('refresh');
-				$editframe.trigger('checkheight');
-				$new_field.find('input:first').focus();
-			});
+				$editfields.sortable( 'refresh' );
+				$editframe.trigger( 'checkheight' );
+				$new_field.find( 'input:first' ).focus();
+			} );
 
-			$editfields.on( 'click', '.delete-option', function(e){
+			$editfields.on( 'click', '.delete-option', function( e ) {
 				e.preventDefault();
-				$(this).closest('li').remove();
-				$editframe.trigger('checkheight');
-			});
+				$( this ).closest( 'li' ).remove();
+				$editframe.trigger( 'checkheight' );
+			} );
 
-			$editfields.on( 'click', '.add-option', function(e){
+			$editfields.on( 'click', '.add-option', function( e ) {
 				var $new_option = $( wp.mce.grunion_wp_view_renderer.editor_option() );
 				e.preventDefault();
-				$(this).closest('li').before( $new_option );
-				$editframe.trigger('checkheight');
-				$new_option.find('input:first').focus();
-			});
+				$( this ).closest( 'li' ).before( $new_option );
+				$editframe.trigger( 'checkheight' );
+				$new_option.find( 'input:first' ).focus();
+			} );
 
-			$editfields.on( 'click', '.delete-field', function(e){
+			$editfields.on( 'click', '.delete-field', function( e ) {
 				e.preventDefault();
-				$(this).closest('.card').remove();
-				$editframe.trigger('checkheight');
-			});
+				$( this ).closest( '.card' ).remove();
+				$editframe.trigger( 'checkheight' );
+			} );
 		}
 	};
 	wp.mce.views.register( 'contact-form', wp.mce.grunion_wp_view_renderer );
@@ -200,9 +204,8 @@
 	QTags.addButton(
 		'grunion_shortcode',
 		grunionEditorView.labels.quicktags_label,
-		function(){
+		function() {
 			QTags.insertContent( '[contact-form]' + grunionEditorView.default_form + '[/contact-form]' );
 		}
 	);
-
-}( jQuery, wp, grunionEditorView ));
+}( jQuery, wp, grunionEditorView ) );

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -67,9 +67,7 @@
 				index = 0,
 				named,
 				fields = '',
-				stylesheet_url = ( 1 === window.isRtl )
-					? grunionEditorView.inline_editing_style_rtl
-					: grunionEditorView.inline_editing_style,
+				stylesheet_url = ( 1 === window.isRtl ) ? grunionEditorView.inline_editing_style_rtl : grunionEditorView.inline_editing_style,
 				$stylesheet = $( '<link rel="stylesheet" href="' + stylesheet_url + '" />' ),
 				$dashicons_css = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' ),
 				$editfields,

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -67,7 +67,8 @@
 				index = 0,
 				named,
 				fields = '',
-				$stylesheet = $( '<link rel="stylesheet" href="' + grunionEditorView.inline_editing_style + '" />' ),
+				stylesheet_url = ( 1 === window.isRtl ) ? grunionEditorView.inline_editing_style_rtl : grunionEditorView.inline_editing_style;
+				$stylesheet = $( '<link rel="stylesheet" href="' + stylesheet_url + '" />' ),
 				$dashicons_css  = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' ),
 				$editfields, field;
 

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -14,7 +14,7 @@
 			textarea            : wp.template( 'grunion-field-textarea' ),
 			radio               : wp.template( 'grunion-field-radio' ),
 			checkbox            : wp.template( 'grunion-field-checkbox' ),
-			"checkbox-multiple" : wp.template( 'grunion-field-checkbox-multiple' ),
+			'checkbox-multiple' : wp.template( 'grunion-field-checkbox-multiple' ),
 			select              : wp.template( 'grunion-field-select' ),
 			date                : wp.template( 'grunion-field-date' ),
 			text                : wp.template( 'grunion-field-text' )
@@ -49,7 +49,7 @@
 				body += this.field_templates[ named.type ]( named );
 			}
 
-			options = {
+			var options = {
 				body : body,
 				submit_button_text : grunionEditorView.labels.submit_button_text
 			};
@@ -69,7 +69,7 @@
 				fields = '',
 				$stylesheet = $( '<link rel="stylesheet" href="' + grunionEditorView.inline_editing_style + '" />' ),
 				$dashicons_css  = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' ),
-				$editfields;
+				$editfields, field;
 
 			if ( ! shortcode.content ) {
 				shortcode.content = grunionEditorView.default_form;
@@ -129,7 +129,7 @@
 							type  : 'single',
 							attrs : {
 								label : $(this).find('input[name=label]').val(),
-								type  : $(this).find('select[name=type]').val(),
+								type  : $(this).find('select[name=type]').val()
 							}
 						},
 						options = [];

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -67,7 +67,7 @@
 				index = 0,
 				named,
 				fields = '',
-				stylesheet_url = ( 1 === window.isRtl ) ? grunionEditorView.inline_editing_style_rtl : grunionEditorView.inline_editing_style;
+				stylesheet_url = ( 1 === window.isRtl ) ? grunionEditorView.inline_editing_style_rtl : grunionEditorView.inline_editing_style,
 				$stylesheet = $( '<link rel="stylesheet" href="' + stylesheet_url + '" />' ),
 				$dashicons_css  = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' ),
 				$editfields, field;

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -1,0 +1,207 @@
+/* global grunionEditorView, tinyMCE, QTags */
+(function( $, wp, grunionEditorView ){
+	wp.mce = wp.mce || {};
+	if ( 'undefined' === typeof wp.mce.views ) {
+		return;
+	}
+
+	wp.mce.grunion_wp_view_renderer = {
+		shortcode_string : 'contact-form',
+		template       : wp.template( 'grunion-contact-form' ),
+		field_templates: {
+			email               : wp.template( 'grunion-field-email' ),
+			telephone           : wp.template( 'grunion-field-telephone' ),
+			textarea            : wp.template( 'grunion-field-textarea' ),
+			radio               : wp.template( 'grunion-field-radio' ),
+			checkbox            : wp.template( 'grunion-field-checkbox' ),
+			"checkbox-multiple" : wp.template( 'grunion-field-checkbox-multiple' ),
+			select              : wp.template( 'grunion-field-select' ),
+			date                : wp.template( 'grunion-field-date' ),
+			text                : wp.template( 'grunion-field-text' )
+		},
+		edit_template  : wp.template( 'grunion-field-edit' ),
+		editor_inline  : wp.template( 'grunion-editor-inline' ),
+		editor_option  : wp.template( 'grunion-field-edit-option' ),
+		getContent     : function() {
+			var content = this.shortcode.content,
+				index = 0,
+				field, named,
+				body = '';
+
+			// If it's the legacy `[contact-form /]` syntax, populate default fields.
+			if ( ! content ) {
+				content = grunionEditorView.default_form;
+			}
+
+			// Render the fields.
+			while ( field = wp.shortcode.next( 'contact-field', content, index ) ) {
+				index = field.index + field.content.length;
+				named = field.shortcode.attrs.named;
+				if ( ! named.type || ! this.field_templates[ named.type ] ) {
+					named.type = 'text';
+				}
+				if ( named.required ) {
+					named.required = grunionEditorView.labels.required_field_text;
+				}
+				if ( named.options && 'string' === typeof named.options ) {
+					named.options = named.options.split(',');
+				}
+				body += this.field_templates[ named.type ]( named );
+			}
+
+			options = {
+				body : body,
+				submit_button_text : grunionEditorView.labels.submit_button_text
+			};
+
+			return this.template( options );
+		},
+		edit: function( data, update_callback ) {
+			var shortcode_data = wp.shortcode.next( this.shortcode_string, data ),
+				shortcode = shortcode_data.shortcode,
+				$tinyMCE_document = $( tinyMCE.activeEditor.getDoc() ),
+				$view = $tinyMCE_document.find('.wpview.wpview-wrap').filter(function(){
+					return $(this).attr('data-mce-selected');
+				}),
+				$editframe = $('<iframe scrolling="no" class="inline-edit-contact-form" />'),
+				index = 0,
+				named,
+				fields = '',
+				$stylesheet = $( '<link rel="stylesheet" href="' + grunionEditorView.inline_editing_style + '" />' ),
+				$dashicons_css  = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' ),
+				$editfields;
+
+			if ( ! shortcode.content ) {
+				shortcode.content = grunionEditorView.default_form;
+			}
+
+			// Render the fields.
+			while ( field = wp.shortcode.next( 'contact-field', shortcode.content, index ) ) {
+				index = field.index + field.content.length;
+				named = field.shortcode.attrs.named;
+				if ( named.options && 'string' === typeof named.options ) {
+					named.options = named.options.split(',');
+				}
+				fields += this.edit_template( named );
+			}
+
+			$view.html( $editframe );
+
+			$editframe.contents().find('head').append( $stylesheet ).append( $dashicons_css );
+			$stylesheet.on( 'load', function(){
+				$editframe.trigger('checkheight');
+			});
+
+			$editframe.contents().find('body').html( this.editor_inline( {
+				to      : shortcode.attrs.named.to,
+				subject : shortcode.attrs.named.subject,
+				fields  : fields
+			}) );
+
+			$editframe.on('checkheight', function(){
+				this.style.height = '10px';
+				this.style.height = ( 5 + this.contentWindow.document.body.scrollHeight ) + 'px';
+				tinyMCE.activeEditor.execCommand('wpAutoResize');
+			}).trigger('checkheight').hide().fadeIn(250, function(){
+				$(this).contents().find('input:first').focus();
+			});
+
+			$editfields = $editframe.contents().find('.grunion-fields');
+			$editfields.sortable();
+			$editfields.on( 'change select', 'select[name=type]', function(){
+				$(this).closest('.grunion-field-edit')[0].className = 'card is-compact grunion-field-edit grunion-field-' + $(this).val();
+				$editframe.trigger('checkheight');
+			});
+
+			var $buttons = $editframe.contents().find('.buttons');
+
+			// The 'save' listener.
+			$buttons.find('input[name=submit]').on( 'click', function(){
+				var new_data = shortcode;
+
+				new_data.type = 'closed';
+				new_data.attrs = {};
+				new_data.content = '';
+
+				$editfields.children().each( function(){
+					var field_shortcode = {
+							tag   : 'contact-field',
+							type  : 'single',
+							attrs : {
+								label : $(this).find('input[name=label]').val(),
+								type  : $(this).find('select[name=type]').val(),
+							}
+						},
+						options = [];
+
+					if ( $(this).find('input[name=required]:checked').length ) {
+						field_shortcode.attrs.required = '1';
+					}
+
+					$(this).find('input[name=option]').each( function(){
+						if ( $(this).val() ) {
+							options.push( $(this).val() );
+						}
+					});
+					if ( options.length ) {
+						field_shortcode.attrs.options = options.join(',');
+					}
+
+					new_data.content += wp.shortcode.string( field_shortcode );
+				} );
+
+				if ( $editframe.contents().find('input[name=to]').val() ) {
+					new_data.attrs.to = $editframe.contents().find('input[name=to]').val();
+				}
+				if ( $editframe.contents().find('input[name=subject]').val() ) {
+					new_data.attrs.subject = $editframe.contents().find('input[name=subject]').val();
+				}
+
+				update_callback( wp.shortcode.string( new_data ) );
+			});
+
+			$buttons.find('input[name=cancel]').on( 'click', function(){
+				update_callback( wp.shortcode.string( shortcode ) );
+			});
+
+			$buttons.find('input[name=add-field]').on( 'click', function(){
+				var $new_field = $( wp.mce.grunion_wp_view_renderer.edit_template({}) );
+				$editfields.append( $new_field );
+				$editfields.sortable('refresh');
+				$editframe.trigger('checkheight');
+				$new_field.find('input:first').focus();
+			});
+
+			$editfields.on( 'click', '.delete-option', function(e){
+				e.preventDefault();
+				$(this).closest('li').remove();
+				$editframe.trigger('checkheight');
+			});
+
+			$editfields.on( 'click', '.add-option', function(e){
+				var $new_option = $( wp.mce.grunion_wp_view_renderer.editor_option() );
+				e.preventDefault();
+				$(this).closest('li').before( $new_option );
+				$editframe.trigger('checkheight');
+				$new_option.find('input:first').focus();
+			});
+
+			$editfields.on( 'click', '.delete-field', function(e){
+				e.preventDefault();
+				$(this).closest('.card').remove();
+				$editframe.trigger('checkheight');
+			});
+		}
+	};
+	wp.mce.views.register( 'contact-form', wp.mce.grunion_wp_view_renderer );
+
+	// Add the 'text' editor button.
+	QTags.addButton(
+		'grunion_shortcode',
+		grunionEditorView.labels.quicktags_label,
+		function(){
+			QTags.insertContent( '[contact-form]' + grunionEditorView.default_form + '[/contact-form]' );
+		}
+	);
+
+}( jQuery, wp, grunionEditorView ));

--- a/modules/contact-form/js/tinymce-plugin-form-button.js
+++ b/modules/contact-form/js/tinymce-plugin-form-button.js
@@ -1,4 +1,4 @@
-/* global grunionEditorView */
+/* global grunionEditorView, tinymce */
 (function() {
 	tinymce.create( 'tinymce.plugins.grunion_form', {
 

--- a/modules/contact-form/js/tinymce-plugin-form-button.js
+++ b/modules/contact-form/js/tinymce-plugin-form-button.js
@@ -1,0 +1,34 @@
+/* global grunionEditorView */
+(function() {
+	tinymce.create( 'tinymce.plugins.grunion_form', {
+
+		init : function( editor ) {
+			editor.addButton( 'grunion', {
+				title : grunionEditorView.labels.tinymce_label,
+				cmd   : 'grunion_add_form',
+				icon  : 'grunion'
+			});
+			editor.addCommand('grunion_add_form', function() {
+				if ( grunionEditorView.default_form ) {
+					editor.execCommand( 'mceInsertContent', 0, '[contact-form]' + grunionEditorView.default_form + '[/contact-form]' );
+				} else {
+					editor.execCommand( 'mceInsertContent', 0, '[contact-form /]' );
+				}
+			});
+		},
+
+		createControl : function() {
+			return null;
+		},
+
+		getInfo : function() {
+			return {
+				longname : 'Grunion Contact Form',
+				author   : 'Automattic',
+				version  : '1'
+			};
+		}
+	});
+
+	tinymce.PluginManager.add( 'grunion_form', tinymce.plugins.grunion_form );
+})();


### PR DESCRIPTION
Closes #6685

Fixes #7063
Fixes #1849
Fixes #1055
Fixes #642
Fixes #604
Fixes #254

This is a redo of #6685 because I seem to have made that ugly by rebasing it. :\

The diff to implement this on wpcom is at D6457

![contact-form](https://cloud.githubusercontent.com/assets/941023/23999347/841afec8-0a2e-11e7-8415-70d59b48efbb.gif)


This is currently just adding the overrides -- I'm intentionally not removing the old legacy code yet, to ease the transition on any users that prefer the old method.  They can just disable the new include line, and the old way will be back again.

Props @MichaelArestad @azaozz and @georgestephanis for building this at the 2016 a8c GM.

#### Changes proposed in this Pull Request:

* Add a visual interface for Contact Forms.

#### Testing instructions:

* Add a contact form to a post.
* Edit an existing contact form in a post.
* Switch to the html editor.  Back again!
* Add a second or third contact form to a post.
* Open multiple forms to editing mode at the same time.