### PR TITLE
Simple payments/show messages response

### DIFF
--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -11,7 +11,7 @@
  * @param  string buttonDomId id of the payment button placeholder
  * @return Element the dom element to print the message
  */
-var getButtonMessageElement = function ( buttonDomId ) {
+var getButtonMessageElement = function( buttonDomId ) {
 	var messageDomId = buttonDomId + '_message';
 
 	var domButtonElement = document.getElementById( buttonDomId );
@@ -32,6 +32,11 @@ var getButtonMessageElement = function ( buttonDomId ) {
 
 	return domMessageElement;
 }
+
+var cleanAndHideMessage = function( el ) {
+	el.style.display = 'none';
+	el.innerHTML = '';
+};
 
 var showMessage = function( message, el ) {
 	// show message 500ms after Paypal popup is closed
@@ -88,6 +93,7 @@ var PaypalExpressCheckout = {
 			},
 			payment: function( paymentData ) {
 				paypalMessagePlaceholder = getButtonMessageElement( domId + '_button' );
+				cleanAndHideMessage( paypalMessagePlaceholder );
 
 				var payload = {
 					number: PaypalExpressCheckout.getNumberOfItems( domId + '_number', enableMultiple ),
@@ -104,6 +110,8 @@ var PaypalExpressCheckout = {
 				} );
 			},
 			onAuthorize: function( onAuthData ) {
+				cleanAndHideMessage( paypalMessagePlaceholder );
+
 				return paypal.request.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), {
 					buttonId: buttonId,
 					payerId: onAuthData.payerID,

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -140,11 +140,11 @@ var PaypalExpressCheckout = {
 					var payerInfo = authResponse.payer.payer_info;
 
 					var message =
-						'<strong>Thank you for your purchase, ' + payerInfo.first_name + '!</strong>' +
+						'<strong>Thank you, ' + payerInfo.first_name + '!</strong>' +
 						'<br />' +
-						'The purchase has been successful. <br />' +
-						'For more details, an email has been sent to your email address ' +
-						'<a href="mailto:' + payerInfo.email + '"><em>' + payerInfo.email + '</em></a>.';
+						'Your purchase was successful. <br />' +
+						'We just sent you a confirmation email to ' +
+						'<em>' + payerInfo.email + '</em>.';
 
 					PaypalExpressCheckout.showMessage( message, buttonDomId );
 				} )

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -34,19 +34,22 @@ var PaypalExpressCheckout = {
 		return number;
 	},
 	togglePurchaseMessage: function( message, successOrError ) {
-		if ( ! this.$purchaseMessageContainer ) {
-			this.$purchaseMessageContainer = jQuery( '.jetpack-simple-payments__purchase-message' );
+		if ( ! PaypalExpressCheckout.$purchaseMessageContainer ) {
+			PaypalExpressCheckout.$purchaseMessageContainer = jQuery( '.jetpack-simple-payments__purchase-message' );
 		}
 
-		if ( this.$purchaseMessageContainer.hasClass( 'show' ) ) {
-			this.$purchaseMessageContainer
-				.removeClass( 'show' )
+		if ( PaypalExpressCheckout.$purchaseMessageContainer.hasClass( 'show' ) ) {
+			PaypalExpressCheckout.$purchaseMessageContainer
+				.removeClass( 'show success error' )
 				.html( '' )
-				.removeClass( 'success error' );
 		} else {
-			this.$purchaseMessageContainer
+			PaypalExpressCheckout.$purchaseMessageContainer
 				.html( message )
-				.addClass( 'show ' + successOrError );
+				.addClass( 'show' );
+
+			if ( typeof successOrError !== 'undefined' ) {
+				PaypalExpressCheckout.$purchaseMessageContainer.addClass( successOrError );
+			}
 		}
 	},
 	renderButton: function( blogId, buttonId, domId, enableMultiple ) {
@@ -63,7 +66,12 @@ var PaypalExpressCheckout = {
 				color: 'blue'
 			},
 			payment: function( paymentData ) {
-				PaypalExpressCheckout.togglePurchaseMessage();
+				if (
+					PaypalExpressCheckout.$purchaseMessageContainer &&
+					PaypalExpressCheckout.$purchaseMessageContainer.hasClass( 'show' )
+				) {
+					PaypalExpressCheckout.togglePurchaseMessage();
+				}
 
 				var payload = {
 					number: PaypalExpressCheckout.getNumberOfItems( domId + '_number', enableMultiple ),
@@ -77,7 +85,6 @@ var PaypalExpressCheckout = {
 				} );
 			},
 			onAuthorize: function( onAuthData ) {
-				PaypalExpressCheckout.togglePurchaseMessage();
 
 				return paypal.request.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), {
 					buttonId: buttonId,

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -55,9 +55,6 @@ var PaypalExpressCheckout = {
 			throw new Error( 'PayPal module is required by PaypalExpressCheckout' );
 		}
 
-		// message DOM element instance
-		var paypalMessagePlaceholder;
-
 		paypal.Button.render( {
 			env: env,
 			commit: true,

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -41,11 +41,11 @@ var PaypalExpressCheckout = {
 		if ( this.$purchaseMessageContainer.hasClass( 'show' ) ) {
 			this.$purchaseMessageContainer
 				.removeClass( 'show' )
-				.text( '' )
+				.html( '' )
 				.removeClass( 'success error' );
 		} else {
 			this.$purchaseMessageContainer
-				.text( message )
+				.html( message )
 				.addClass( 'show ' + successOrError );
 		}
 	},

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -33,7 +33,7 @@ var PaypalExpressCheckout = {
 		}
 		return number;
 	},
-	togglePurcahseMessage: function( message, successOrError ) {
+	togglePurchaseMessage: function( message, successOrError ) {
 		if ( ! this.$purchaseMessageContainer ) {
 			this.$purchaseMessageContainer = jQuery( '.jetpack-simple-payments__purchase-message' );
 		}
@@ -63,7 +63,7 @@ var PaypalExpressCheckout = {
 				color: 'blue'
 			},
 			payment: function( paymentData ) {
-				PaypalExpressCheckout.togglePurcahseMessage();
+				PaypalExpressCheckout.togglePurchaseMessage();
 
 				var payload = {
 					number: PaypalExpressCheckout.getNumberOfItems( domId + '_number', enableMultiple ),
@@ -76,11 +76,11 @@ var PaypalExpressCheckout = {
 					return paymentResponse.id;
 				} )
 				.catch( function( paymentError ) {
-					PaypalExpressCheckout.togglePurcahseMessage( paymentError, 'error' );
+					PaypalExpressCheckout.togglePurchaseMessage( paymentError, 'error' );
 				} );
 			},
 			onAuthorize: function( onAuthData ) {
-				PaypalExpressCheckout.togglePurcahseMessage();
+				PaypalExpressCheckout.togglePurchaseMessage();
 
 				return paypal.request.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), {
 					buttonId: buttonId,
@@ -95,14 +95,14 @@ var PaypalExpressCheckout = {
 						'The purchase has been successful. <br />' +
 						'For more details, an email has been sent to your email address <em>' + payerInfo.email + '<em>.';
 
-					PaypalExpressCheckout.togglePurcahseMessage( message, 'success' );
+					PaypalExpressCheckout.togglePurchaseMessage( message, 'success' );
 
 					// TODO: handle success, errors, messaging, etc, etc.
 					/* jshint ignore:start */
 					/* jshint ignore:end */
 				} )
 				.catch( function( authError ) {
-					PaypalExpressCheckout.togglePurcahseMessage( 'Error!', 'error' );
+					PaypalExpressCheckout.togglePurchaseMessage( 'Error!', 'error' );
 					// console.log( 'authError: %o', authError );
 				} );
 			}

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -6,7 +6,7 @@
 
 /* global paypal */
 /* exported PaypalExpressCheckout */
-/* jshint unused:false */
+/* jshint unused:false, es3:false, esversion:5 */
 var PaypalExpressCheckout = {
 	sandbox: true,
 	$purchaseMessageContainer: null,
@@ -37,7 +37,7 @@ var PaypalExpressCheckout = {
 	/**
 	 * Get the DOM element-placeholder used to show message
 	 * about the transaction. If it doesn't exist then the function will create a new one.
-	 * 
+	 *
 	 * @param  string buttonDomId id of the payment button placeholder
 	 * @return Element the dom element to print the message
 	 */
@@ -66,7 +66,7 @@ var PaypalExpressCheckout = {
 	 * Show a messange close to the Paypal button.
 	 * Use this function to give feedback to the user according
 	 * to the transaction result.
-	 * 
+	 *
 	 * @param  {String} message message to show
 	 * @param  {String} domId paypal-button element dom identifier
 	 * @param  {Boolean} [error] defines if it's a message error. Not TRUE as default.

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -74,9 +74,6 @@ var PaypalExpressCheckout = {
 				return paypal.request.post( PaypalExpressCheckout.getCreatePaymentEndpoint( blogId ), payload )
 				.then( function( paymentResponse ) {
 					return paymentResponse.id;
-				} )
-				.catch( function( paymentError ) {
-					PaypalExpressCheckout.togglePurchaseMessage( paymentError, 'error' );
 				} );
 			},
 			onAuthorize: function( onAuthData ) {

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -4,6 +4,44 @@
  * of simple-payments module.
  */
 
+/**
+ * Get the DOM element-placeholder used to show message
+ * about the transaction. If it doesn't exist then the function will create a new one.
+ * 
+ * @param  string buttonDomId id of the payment button placeholder
+ * @return Element the dom element to print the message
+ */
+var getButtonMessageElement = function ( buttonDomId ) {
+	var messageDomId = buttonDomId + '_message';
+
+	var domButtonElement = document.getElementById( buttonDomId );
+	var domMessageElement = document.getElementById( messageDomId );
+
+	if ( domMessageElement ) {
+		return domMessageElement;
+	}
+
+	// create dom message element
+	domMessageElement = document.createElement( 'div' );
+	domMessageElement.setAttribute( 'class', 'jetpack-simple-payments-message-placeholder' );
+	domMessageElement.setAttribute( 'id', messageDomId );
+	domMessageElement.style.display = 'none';
+
+	// inject into the DOM Tree
+	domButtonElement.appendChild( domMessageElement );
+
+	return domMessageElement;
+}
+
+var showMessage = function( message, el ) {
+	// show message 500ms after Paypal popup is closed
+	setTimeout( function() {
+		el.style.display = 'block';
+		el.style.color = '#06F';
+		el.innerHTML = message;
+	}, 1000 );
+}
+
 /* global paypal */
 /* exported PaypalExpressCheckout */
 /* jshint unused:false */
@@ -37,6 +75,10 @@ var PaypalExpressCheckout = {
 		if ( ! paypal ) {
 			throw new Error( 'PayPal module is required by PaypalExpressCheckout' );
 		}
+
+		// message DOM element instance
+		var paypalMessagePlaceholder;
+
 		paypal.Button.render( {
 			env: env,
 			commit: true,
@@ -44,26 +86,43 @@ var PaypalExpressCheckout = {
 				label: 'pay',
 				color: 'blue'
 			},
-			payment: function() {
+			payment: function( paymentData ) {
+				paypalMessagePlaceholder = getButtonMessageElement( domId + '_button' );
+
 				var payload = {
 					number: PaypalExpressCheckout.getNumberOfItems( domId + '_number', enableMultiple ),
 					buttonId: buttonId,
 					env: env
 				};
-				return paypal.request.post( PaypalExpressCheckout.getCreatePaymentEndpoint( blogId ), payload ).then( function( data ) {
-					return data.id;
+
+				return paypal.request.post( PaypalExpressCheckout.getCreatePaymentEndpoint( blogId ), payload )
+				.then( function( paymentResponse ) {
+					return paymentResponse.id;
+				} )
+				.catch( function( paymentError ) {
+					showMessage( paymentError, paypalMessagePlaceholder );
 				} );
 			},
-			onAuthorize: function( data ) {
-				return paypal.request.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, data.paymentID ), {
+			onAuthorize: function( onAuthData ) {
+				return paypal.request.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), {
 					buttonId: buttonId,
-					payerId: data.payerID,
+					payerId: onAuthData.payerID,
 					env: env
-				} ).then( function() {
+				} )
+				.then( function( authResponse ) {
+					var payerInfo = authResponse.payer.payer_info;
+					var message = 'Thanks <strong>' + payerInfo.first_name + '</strong>! ' +
+						'The purchase has been successful.<br />' +
+						'For more details, an email has been sent to the <em>' + payerInfo.email + '<em>.';
+
+					showMessage( message, paypalMessagePlaceholder );
+
 					// TODO: handle success, errors, messaging, etc, etc.
 					/* jshint ignore:start */
-					alert( 'success!' );
 					/* jshint ignore:end */
+				} )
+				.catch( function( authError ) {
+					// console.log( 'authError: %o', authError );
 				} );
 			}
 

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -2,7 +2,6 @@
 	display: none;
 	color: #fff;
 	padding: 1em;
-	margin: 20px 0;
 }
 
 .jetpack-simple-payments__purchase-message.show {

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -2,9 +2,13 @@
 	display: none;
 	color: #fff;
 	padding: 1em;
-
 	margin: 20px 0;
 }
+
+.jetpack-simple-payments__purchase-message.show {
+	display: block;
+}
+
 .jetpack-simple-payments__purchase-message.success {
 	background-color: #4ab866;
 }

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -1,17 +1,21 @@
-.jetpack-simple-payments__purchase-message {
+body .jetpack-simple-payments__wrapper div.jetpack-simple-payments__purchase-message {
 	display: none;
+}
+
+body .jetpack-simple-payments__wrapper div.jetpack-simple-payments__purchase-message,
+body .jetpack-simple-payments__wrapper div.jetpack-simple-payments__purchase-message a {
 	color: #fff;
 	padding: 1em;
 }
 
-.jetpack-simple-payments__purchase-message.show {
+body .jetpack-simple-payments__wrapper div.jetpack-simple-payments__purchase-message.show {
 	display: block;
 }
 
-.jetpack-simple-payments__purchase-message.success {
+body .jetpack-simple-payments__wrapper div.jetpack-simple-payments__purchase-message.success {
 	background-color: #4ab866;
 }
 
-.jetpack-simple-payments__purchase-message.error {
+body .jetpack-simple-payments__wrapper div.jetpack-simple-payments__purchase-message.error {
 	background-color: #d94f4f;
 }

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -1,0 +1,14 @@
+.jetpack-simple-payments__purchase-message {
+	display: none;
+	color: #fff;
+	padding: 1em;
+
+	margin: 20px 0;
+}
+.jetpack-simple-payments__purchase-message.success {
+	background-color: #4ab866;
+}
+
+.jetpack-simple-payments__purchase-message.error {
+	background-color: #d94f4f;
+}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -93,8 +93,8 @@ class Jetpack_Simple_Payments {
 		}
 		$output = "
 <div class='{$data[ 'class' ]} jetpack-simple-payments__wrapper'>
-	<div class='jetpack-simple-payments__purchase-message'>
-	</div>
+	<p class='jetpack-simple-payments__purchase-message'>
+	</p>
 	<div class='jetpack-simple-payments__title'>{$data['title']}</div>
 	<div class='jetpack-simple-payments__description'>{$data['description']}</div>
 	<div class='jetpack-simple-payments__price'>{$data['price']}</div>

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -29,7 +29,7 @@ class Jetpack_Simple_Payments {
 		 * @see https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/add-paypal-button/
 		 */
 		wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js' );
-		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ) , array( 'paypal-checkout-js' ), '0.21' );
+		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ) , array( 'jquery', 'paypal-checkout-js' ), '0.21' );
 		wp_enqueue_style( 'simple-payments', plugins_url( '/simple-payments.css', __FILE__ ) );
 	}
 	private function register_init_hook() {
@@ -93,10 +93,7 @@ class Jetpack_Simple_Payments {
 		}
 		$output = "
 <div class='{$data[ 'class' ]} jetpack-simple-payments__wrapper'>
-	<div class='jetpack-simple-payments__purchase-message success'>
-		<strong>Thank you for your purchase!</strong>
-		<br />
-		More info and exact copies TBD.
+	<div class='jetpack-simple-payments__purchase-message'>
 	</div>
 	<div class='jetpack-simple-payments__title'>{$data['title']}</div>
 	<div class='jetpack-simple-payments__description'>{$data['description']}</div>

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -28,7 +28,7 @@ class Jetpack_Simple_Payments {
 		 * Paypal heavily discourages putting that script in your own server:
 		 * @see https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/add-paypal-button/
 		 */
-		wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js' );
+		wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
 		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ) , array( 'jquery', 'paypal-checkout-js' ), '0.21' );
 		wp_enqueue_style( 'simple-payments', plugins_url( '/simple-payments.css', __FILE__ ) );
 	}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -30,6 +30,7 @@ class Jetpack_Simple_Payments {
 		 */
 		wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js' );
 		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ) , array( 'paypal-checkout-js' ), '0.21' );
+		wp_enqueue_style( 'simple-payments', plugins_url( '/simple-payments.css', __FILE__ ) );
 	}
 	private function register_init_hook() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
@@ -91,12 +92,17 @@ class Jetpack_Simple_Payments {
 		       </div>";
 		}
 		$output = "
-<div class='{$data[ 'class' ]} jetpack-simple-payments-wrapper'>
-	<div class='jetpack-simple-payments-title'>{$data['title']}</div>
-	<div class='jetpack-simple-payments-description'>{$data['description']}</div>
-	<div class='jetpack-simple-payments-price'>{$data['price']}</div>
+<div class='{$data[ 'class' ]} jetpack-simple-payments__wrapper'>
+	<div class='jetpack-simple-payments__purchase-message success'>
+		<strong>Thank you for your purchase!</strong>
+		<br />
+		More info and exact copies TBD.
+	</div>
+	<div class='jetpack-simple-payments__title'>{$data['title']}</div>
+	<div class='jetpack-simple-payments__description'>{$data['description']}</div>
+	<div class='jetpack-simple-payments__price'>{$data['price']}</div>
 	{$items}
-	<div class='jetpack-simple-payments-button' id='{$data['dom_id']}_button'></div>
+	<div class='jetpack-simple-payments__button' id='{$data['dom_id']}_button'></div>
 </div>
 ";
 		return $output;


### PR DESCRIPTION
This PR depending on #7409
-----------------------

This PR implements the ability to print the message when a transaction ends.

![image](https://user-images.githubusercontent.com/4988512/28475331-fd94610a-6e4b-11e7-88ee-dc9d39e0df0d.png)

![simple-payments-message-5](https://user-images.githubusercontent.com/77539/28483911-fc10c054-6e45-11e7-8bca-79ab92e0dccf.gif)

## Testing

With Paypal sandbox account, click on the "Buy" button. After successful purchase, do you get a green success message? Try buying again. Does the message disappear when you click on the "buy" button again? Do you get the green success message after the second purchase?

