### PR TITLE
Update/jp plans copy

### DIFF
--- a/_inc/client/components/themes-promo-card/index.jsx
+++ b/_inc/client/components/themes-promo-card/index.jsx
@@ -55,34 +55,34 @@ const ThemesPromoCard = React.createClass( {
 					</div>
 
 					<div className="jp-apps-card__description">
-						<h3 className="jp-apps-card__header">
-							{ __( 'Introducing Unlimited Themes' ) }
-						</h3>
+						<h3 className="jp-apps-card__header">{ __( 'Introducing Unlimited Themes' ) }</h3>
+						{ __(
+							'{{subhead}}Only with Jetpack Professional{{/subhead}}' +
+							'{{p}}Protect your site and work with Jetpack Personal: daily automated backups, unlimited storage, and expert priority support. Security essentials for every WordPress site starting from $3.50.{{/p}}' +
+							'{{p}}Or go Pro with more than 200 Premium Themes, business class security, unlimited video hosting, monetization, marketing automation, and SEO tools.{{/p}}',
+							{
+								components: {
+									subhead: <p className="jp-apps-card__promo_subhead" />,
+									p: <p className="jp-apps-card__paragraph" />
+								}
+							}
+						) }
 
-						<p className="jp-apps-card__promo_subhead">
-							{ __( 'Only with Jetpack Professional' ) }
+						<p>
+							<Button
+								className="is-primary"
+								onClick={ this.trackGetStarted }
+								href={ 'https://jetpack.com/redirect/?source=upgrade-pro-' + urlFriendlyPlan + '&site=' + this.props.siteRawUrl }>
+								{ __( 'Explore Professional' ) }
+							</Button>
+							&nbsp;
+							<Button
+								onClick={ this.trackComparePlans }
+								href={ 'https://jetpack.com/redirect/?source=plans-compare-free' + '&site=' + this.props.siteRawUrl }>
+								{ __( 'Compare All Plans' ) }
+							</Button>
 						</p>
 
-						<p className="jp-apps-card__paragraph">
-							{ __( 'Protect your site and work with Jetpack Personal: daily automated backups, unlimited storage, and expert priority support. Security essentials for every WordPress site starting from $3.50.' ) }
-						</p>
-
-						<p className="jp-apps-card__paragraph">
-							{ __( 'Or go Pro with more than 200 Premium Themes, business class security, unlimited video hosting, monetization, marketing automation, and SEO tools.' ) }
-						</p>
-
-						<Button
-							className="is-primary"
-							onClick={ this.trackGetStarted }
-							href={ 'https://jetpack.com/redirect/?source=upgrade-pro-' + urlFriendlyPlan + '&site=' + this.props.siteRawUrl }>
-							{ __( 'Explore Professional' ) }
-						</Button>
-						<Button
-							onClick={ this.trackComparePlans }
-							href={ 'https://jetpack.com/redirect/?source=plans-compare-free' + '&site=' + this.props.siteRawUrl }>
-							{ __( 'Compare All Plans' ) }
-						</Button>
-						<br />
 						<a
 							onClick={ this.trackGetStarted }
 							href={ 'https://jetpack.com/redirect/?source=upgrade-pro-' + urlFriendlyPlan + '&site=' + this.props.siteRawUrl }
@@ -92,7 +92,7 @@ const ThemesPromoCard = React.createClass( {
 					</div>
 				</Card>
 			</div>
-		);
+						);
 	}
 } );
 

--- a/_inc/client/components/themes-promo-card/index.jsx
+++ b/_inc/client/components/themes-promo-card/index.jsx
@@ -24,6 +24,14 @@ const ThemesPromoCard = React.createClass( {
 		} );
 	},
 
+	trackComparePlans() {
+		analytics.tracks.recordJetpackClick( {
+			target: 'themes-card',
+			button: 'themes-compare-all',
+			plan: this.props.plan
+		} );
+	},
+
 	render() {
 		const classes = classNames(
 				this.props.className,
@@ -56,21 +64,30 @@ const ThemesPromoCard = React.createClass( {
 						</p>
 
 						<p className="jp-apps-card__paragraph">
-							{ __( 'Over 200 professionally designed, versatile themes are now available to all Jetpack Professional customers, alongside our advanced security tools and other Professional features.' ) }
+							{ __( 'Protect your site and work with Jetpack Personal: daily automated backups, unlimited storage, and expert priority support. Security essentials for every WordPress site starting from $3.50.' ) }
+						</p>
+
+						<p className="jp-apps-card__paragraph">
+							{ __( 'Or go Pro with more than 200 Premium Themes, business class security, unlimited video hosting, monetization, marketing automation, and SEO tools.' ) }
 						</p>
 
 						<Button
 							className="is-primary"
 							onClick={ this.trackGetStarted }
 							href={ 'https://jetpack.com/redirect/?source=upgrade-pro-' + urlFriendlyPlan + '&site=' + this.props.siteRawUrl }>
-							{ __( 'Get Started' ) }
+							{ __( 'Explore Professional' ) }
+						</Button>
+						<Button
+							onClick={ this.trackComparePlans }
+							href={ 'https://jetpack.com/redirect/?source=plans-compare-free' + '&site=' + this.props.siteRawUrl }>
+							{ __( 'Compare All Plans' ) }
 						</Button>
 						<br />
 						<a
 							onClick={ this.trackGetStarted }
 							href={ 'https://jetpack.com/redirect/?source=upgrade-pro-' + urlFriendlyPlan + '&site=' + this.props.siteRawUrl }
 						>
-							{ __( 'Includes 50% introductory discount' ) }
+							{ __( 'Limited time 50% introductory discount on Jetpack Professional.' ) }
 						</a>
 					</div>
 				</Card>

--- a/_inc/client/plans/plan-body.jsx
+++ b/_inc/client/plans/plan-body.jsx
@@ -301,13 +301,15 @@ const PlanBody = React.createClass( {
 					{
 						'is-personal-plan' === planClass && (
 							<div className="jp-landing__plan-features-card">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Need more? Running a business site?' ) }</h3>
-								<p>{ __( 'If your site is important to you, consider protecting and improving it with some of our advanced features: ' ) }</p>
-								<p> &mdash; { __( 'Daily and on-demand security scanning' ) }</p>
-								<p> &mdash; { __( 'Real-time backups and one-click threat resolution' ) }</p>
-								<p> &mdash; { __( 'Unlimited and ad-free video hosting' ) }</p>
-								<p> &mdash; { __( 'Advanced SEO tools' ) }</p>
-								<p> &mdash; { __( 'Income generation from ads' ) }</p>
+								<h3 className="jp-landing__plan-features-title">{ __( 'Explore Premium and Professional Options' ) }</h3>
+								<p>{ __( 'Learn about Jetpack services used by WordPress professionals. On top of the security essentials you currently enjoy, Jetpack offers you:' ) }</p>
+								<p> &bull; { __( 'Over 200 Premium themes to explore' ) }</p>
+								<p> &bull; { __( 'Business class security: malware scanning, real-time backups, and threat resolution' ) }</p>
+								<p> &bull; { __( 'Social media automation and scheduling' ) }</p>
+								<p> &bull; { __( 'Unlimited and ad-free video hosting' ) }</p>
+								<p> &bull; { __( 'SEO and social media previewing tools' ) }</p>
+								<p> &bull; { __( 'Income generation from a WordPress ad program' ) }</p>
+								<p> &bull; { __( 'Google Analytics integration' ) }</p>
 								<p>
 									<Button onClick={ () => this.trackPlansClick( 'compare_plans' ) } href={ 'https://jetpack.com/redirect/?source=plans-compare-personal&site=' + this.props.siteRawUrl } className="is-primary">
 										{ __( 'Compare Plans' ) }
@@ -320,16 +322,16 @@ const PlanBody = React.createClass( {
 					{
 						'is-premium-plan' === planClass && (
 							<div className="jp-landing__plan-features-card">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Need more? Running a business site?' ) }</h3>
-								<p>{ __( 'If your site is important to you, consider protecting and improving it with some of our advanced features: ' ) }</p>
-								<p> &mdash; { __( 'On-demand security scanning' ) }</p>
-								<p> &mdash; { __( 'Real-time backups' ) }</p>
-								<p> &mdash; { __( 'One-click threat resolution' ) }</p>
-								<p> &mdash; { __( 'Advanced SEO tools' ) }</p>
-								<p> &mdash; { __( 'Income generation from ads' ) }</p>
+								<h3 className="jp-landing__plan-features-title">{ __( 'Explore Jetpack Professional' ) }</h3>
+								<p>{ __( 'Jetpack Professional is the tool used by WordPress professionals. On top of the services you already enjoy, you also benefit from:' ) }</p>
+								<p> &bull; { __( 'Over 200 Premium themes to explore' ) }</p>
+								<p> &bull; { __( 'Business class security: real-time backups and threat resolution' ) }</p>
+								<p> &bull; { __( 'SEO and social media previewing tools' ) }</p>
+								<p> &bull; { __( 'Unlimited ad-free video hosting' ) }</p>
+								<p> &bull; { __( 'Google Analytics integration' ) }</p>
 								<p>
 									<Button onClick={ () => this.trackPlansClick( 'compare_plans' ) } href={ 'https://jetpack.com/redirect/?source=plans-compare-premium&site=' + this.props.siteRawUrl } className="is-primary">
-										{ __( 'Compare Plans' ) }
+										{ __( 'Explore Jetpack Professional' ) }
 									</Button>
 								</p>
 							</div>

--- a/_inc/client/plans/plan-header.jsx
+++ b/_inc/client/plans/plan-header.jsx
@@ -35,7 +35,7 @@ const PlanHeader = React.createClass( {
 							{ __( 'Introducing our most affordable backups and security plan yet' ) }
 						</h2>
 						<p className="jp-landing-plans__header-description">
-							{ __( 'The Personal Plan keeps your data, site, and hard work safe.' ) }
+							{ __( 'Jetpack Personal keeps your data, site, and hard work safe.' ) }
 						</p>
 						<div className="jp-landing-plans__header-img-container">
 							<div className="jp-landing-plans__header-col-left">
@@ -80,8 +80,8 @@ const PlanHeader = React.createClass( {
 							<img src={ imagePath + '/plans/plan-jetpack-premium.svg' } className="jp-landing__plan-icon" alt="" />
 						</div>
 						<div className="jp-landing__plan-card-current">
-							<h3 className="jp-landing__plan-features-title">{ __( 'Your site is on the Jetpack Personal plan' ) }</h3>
-							<p className="jp-landing__plan-features-text">{ __( 'With this plan you are provided with spam-protection, daily backups (up to 30 days), and unlimited storage.' ) }</p>
+							<h3 className="jp-landing__plan-features-title">{ __( 'Welcome to Jetpack Personal' ) }</h3>
+							<p className="jp-landing__plan-features-text">{ __( 'Security essentials (daily backups, spam filtering), and priority support.' ) }</p>
 						</div>
 					</div>
 				);
@@ -94,8 +94,8 @@ const PlanHeader = React.createClass( {
 							<img src={ imagePath + '/plans/plan-jetpack-premium.svg' } className="jp-landing__plan-icon" alt="" />
 						</div>
 						<div className="jp-landing__plan-card-current">
-							<h3 className="jp-landing__plan-features-title">{ __( 'Your site is on the Jetpack Premium plan' ) }</h3>
-							<p className="jp-landing__plan-features-text">{ __( 'With this plan you are provided with spam-protection, daily backups (up to 30 days), unlimited backup storage, security scanning, 13Gb of ad-free video hosting, income generation from ads, and priority support.' ) }</p>
+							<h3 className="jp-landing__plan-features-title">{ __( 'Welcome to Jetpack Premium' ) }</h3>
+							<p className="jp-landing__plan-features-text">{ __( 'Enhanced security (backups, scanning, spam filtering), marketing automation (social scheduling, ad program), 13Gb video hosting, and priority support.' ) }</p>
 						</div>
 					</div>
 				);
@@ -108,8 +108,8 @@ const PlanHeader = React.createClass( {
 							<img src={ imagePath + '/plans/plan-jetpack-pro.svg' } className="jp-landing__plan-icon" alt="" />
 						</div>
 						<div className="jp-landing__plan-card-current">
-							<h3 className="jp-landing__plan-features-title">{ __( 'Your site is on the Jetpack Professional plan' ) }</h3>
-							<p className="jp-landing__plan-features-text">{ __( 'You get spam-protection, real-time backups (unlimited archive), unlimited backup storage, security scanning, unlimited ad-free video hosting, income generation from ads, SEO tools, and priority support.' ) }</p>
+							<h3 className="jp-landing__plan-features-title">{ __( 'Welcome to Jetpack Professional' ) }</h3>
+							<p className="jp-landing__plan-features-text">{ __( 'Unlimited Premium themes, business class security (backups, scanning, spam filtering), marketing automation (social scheduling, SEO tools, ad program), video hosting, and priority support.' ) }</p>
 						</div>
 					</div>
 				);


### PR DESCRIPTION
In time for 5.2:
- Updates to plan header text
- Updates to upgrade pitches at the bottom of the page
- Updates to theme promo card 

The theme promo card should look like this:
<img width="754" alt="jetpack_ _testing_things_ _wordpress" src="https://user-images.githubusercontent.com/2287740/28471031-9a945e7e-6e33-11e7-9a72-6e6eb67838a9.png">
