### PR TITLE
Jetpack Sync: Sync move widget to inactive

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -369,11 +369,6 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
 			$moved_to_inactive_ids = array_merge( $moved_to_inactive_ids, $moved_to_inactive_recently );
-error_log("RECENTLYU:");
-			error_log(print_r($moved_to_inactive_recently, true));
-			error_log("NON:");
-error_log("INACTIVE IDS:");
-error_log(print_r($moved_to_inactive_ids, true));
 
 			$moved_to_sidebar_recently = $this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar );
 			$moved_to_sidebar = array_merge( $moved_to_sidebar, $moved_to_sidebar_recently );

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -352,7 +352,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$moved_to_inactive = array();
+		$moved_to_inactive_ids = array();
 		$moved_to_sidebar = array();
 
 		foreach ( $new_value as $sidebar => $new_widgets ) {
@@ -367,12 +367,11 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 				$new_widgets = array();
 			}
 
-			$moved_to_inactive_recently[] = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
-			$moved_to_inactive_ids[] = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
+			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
+			$moved_to_inactive_ids = array_merge( $moved_to_inactive_ids, $moved_to_inactive_recently );
 error_log("RECENTLYU:");
 			error_log(print_r($moved_to_inactive_recently, true));
 			error_log("NON:");
-error_log(print_r($moved_to_inactive, true));
 error_log("INACTIVE IDS:");
 error_log(print_r($moved_to_inactive_ids, true));
 

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -369,6 +369,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
 			$moved_to_inactive_ids = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
+error_log(print_r($moved_to_inactive_recently, true));
+error_log(print_r($moved_to_inactive, true));
 
 			$moved_to_sidebar_recently = $this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar );
 			$moved_to_sidebar = array_merge( $moved_to_sidebar, $moved_to_sidebar_recently );

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -373,6 +373,8 @@ error_log("RECENTLYU:");
 			error_log(print_r($moved_to_inactive_recently, true));
 			error_log("NON:");
 error_log(print_r($moved_to_inactive, true));
+error_log("INACTIVE IDS:");
+error_log(print_r($moved_to_inactive_ids, true));
 
 			$moved_to_sidebar_recently = $this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar );
 			$moved_to_sidebar = array_merge( $moved_to_sidebar, $moved_to_sidebar_recently );

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -369,7 +369,9 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
 			$moved_to_inactive_ids = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
-error_log(print_r($moved_to_inactive_recently, true));
+error_log("RECENTLYU:");
+			error_log(print_r($moved_to_inactive_recently, true));
+			error_log("NON:");
 error_log(print_r($moved_to_inactive, true));
 
 			$moved_to_sidebar_recently = $this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar );

--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -367,8 +367,8 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 				$new_widgets = array();
 			}
 
-			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
-			$moved_to_inactive_ids = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
+			$moved_to_inactive_recently[] = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
+			$moved_to_inactive_ids[] = array_merge( $moved_to_inactive, $moved_to_inactive_recently );
 error_log("RECENTLYU:");
 			error_log(print_r($moved_to_inactive_recently, true));
 			error_log("NON:");


### PR DESCRIPTION
Sync move widget to inactive

#### Changes proposed in this Pull Request:

Sync move widget to inactive

#### Testing instructions:

phpunit

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
