### PR TITLE
Simple Payments: update error message handling

### DIFF
--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -143,7 +143,7 @@ var PaypalExpressCheckout = {
 					env: env
 				};
 
-				return ( new paypal.Promise( function( resolve, reject ) {
+				return new paypal.Promise( function( resolve, reject ) {
 					jQuery.post( PaypalExpressCheckout.getCreatePaymentEndpoint( blogId ), payload )
 						.done( function( paymentResponse ) {
 							resolve( paymentResponse.id );
@@ -153,7 +153,7 @@ var PaypalExpressCheckout = {
 							PaypalExpressCheckout.showError( errorMessage, buttonDomId );
 							reject( new Error( paymentError.responseJSON.code ) );
 						} );
-				} ) ).catch( PaypalExpressCheckout.log );
+				} ).catch( PaypalExpressCheckout.log );
 			},
 
 			onAuthorize: function( onAuthData ) {
@@ -162,7 +162,7 @@ var PaypalExpressCheckout = {
 					payerId: onAuthData.payerID,
 					env: env
 				};
-				return ( new paypal.Promise( function( resolve, reject ) {
+				return new paypal.Promise( function( resolve, reject ) {
 					jQuery.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), payload )
 						.done( function( authResponse ) {
 							PaypalExpressCheckout.showMessage( authResponse.message, buttonDomId );
@@ -172,7 +172,7 @@ var PaypalExpressCheckout = {
 							PaypalExpressCheckout.showError( authError, buttonDomId );
 							reject( new Error( authError.responseJSON.code ) );
 						} );
-				} ) ).catch( PaypalExpressCheckout.log );
+				} ).catch( PaypalExpressCheckout.log );
 			}
 
 		}, buttonDomId );

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -34,10 +34,7 @@ var PaypalExpressCheckout = {
 		}
 		return number;
 	},
-	/**
-	 * To overwrite for debugging needs.
-	 */
-	log: function() {},
+
 	/**
 	 * Get the DOM element-placeholder used to show message
 	 * about the transaction. If it doesn't exist then the function will create a new one.
@@ -119,6 +116,7 @@ var PaypalExpressCheckout = {
 		domEl.setAttribute( 'class', 'jetpack-simple-payments__purchase-message' );
 		domEl.innerHTML = '';
 	},
+
 	renderButton: function( blogId, buttonId, domId, enableMultiple ) {
 		var env = PaypalExpressCheckout.sandbox ? 'sandbox' : 'production';
 		if ( ! paypal ) {
@@ -153,7 +151,7 @@ var PaypalExpressCheckout = {
 							PaypalExpressCheckout.showError( errorMessage, buttonDomId );
 							reject( new Error( paymentError.responseJSON.code ) );
 						} );
-				} ).catch( PaypalExpressCheckout.log );
+				} );
 			},
 
 			onAuthorize: function( onAuthData ) {
@@ -172,7 +170,7 @@ var PaypalExpressCheckout = {
 							PaypalExpressCheckout.showError( authError, buttonDomId );
 							reject( new Error( authError.responseJSON.code ) );
 						} );
-				} ).catch( PaypalExpressCheckout.log );
+				} );
 			}
 
 		}, buttonDomId );

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -143,7 +143,7 @@ var PaypalExpressCheckout = {
 					env: env
 				};
 
-				return new paypal.Promise( function( resolve, reject ) {
+				return ( new paypal.Promise( function( resolve, reject ) {
 					jQuery.post( PaypalExpressCheckout.getCreatePaymentEndpoint( blogId ), payload )
 						.done( function( paymentResponse ) {
 							resolve( paymentResponse.id );
@@ -153,7 +153,7 @@ var PaypalExpressCheckout = {
 							PaypalExpressCheckout.showError( errorMessage, buttonDomId );
 							reject( new Error( paymentError.responseJSON.code ) );
 						} );
-				} ).catch( PaypalExpressCheckout.log );
+				} ) ).catch( PaypalExpressCheckout.log );
 			},
 
 			onAuthorize: function( onAuthData ) {
@@ -162,7 +162,7 @@ var PaypalExpressCheckout = {
 					payerId: onAuthData.payerID,
 					env: env
 				};
-				return new paypal.Promise( function( resolve, reject ) {
+				return ( new paypal.Promise( function( resolve, reject ) {
 					jQuery.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), payload )
 						.done( function( authResponse ) {
 							PaypalExpressCheckout.showMessage( authResponse.message, buttonDomId );
@@ -172,7 +172,7 @@ var PaypalExpressCheckout = {
 							PaypalExpressCheckout.showError( authError, buttonDomId );
 							reject( new Error( authError.responseJSON.code ) );
 						} );
-				} ).catch( PaypalExpressCheckout.log );
+				} ) ).catch( PaypalExpressCheckout.log );
 			}
 
 		}, buttonDomId );

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -34,7 +34,10 @@ var PaypalExpressCheckout = {
 		}
 		return number;
 	},
-
+	/**
+	 * To overwrite for debugging needs.
+	 */
+	log: function() {},
 	/**
 	 * Get the DOM element-placeholder used to show message
 	 * about the transaction. If it doesn't exist then the function will create a new one.
@@ -116,7 +119,6 @@ var PaypalExpressCheckout = {
 		domEl.setAttribute( 'class', 'jetpack-simple-payments__purchase-message' );
 		domEl.innerHTML = '';
 	},
-
 	renderButton: function( blogId, buttonId, domId, enableMultiple ) {
 		var env = PaypalExpressCheckout.sandbox ? 'sandbox' : 'production';
 		if ( ! paypal ) {
@@ -151,7 +153,7 @@ var PaypalExpressCheckout = {
 							PaypalExpressCheckout.showError( errorMessage, buttonDomId );
 							reject( new Error( paymentError.responseJSON.code ) );
 						} );
-				} );
+				} ).catch( PaypalExpressCheckout.log );
 			},
 
 			onAuthorize: function( onAuthData ) {
@@ -170,7 +172,7 @@ var PaypalExpressCheckout = {
 							PaypalExpressCheckout.showError( authError, buttonDomId );
 							reject( new Error( authError.responseJSON.code ) );
 						} );
-				} );
+				} ).catch( PaypalExpressCheckout.log );
 			}
 
 		}, buttonDomId );

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -133,7 +133,7 @@ var PaypalExpressCheckout = {
 				label: 'pay',
 				color: 'blue'
 			},
-			payment: function( paymentData ) {
+			payment: function() {
 				PaypalExpressCheckout.cleanAndHideMessage( buttonDomId );
 
 				var payload = {
@@ -148,7 +148,7 @@ var PaypalExpressCheckout = {
 							resolve( paymentResponse.id );
 						} )
 						.fail( function( paymentError ) {
-							var errorMessage = PaypalExpressCheckout.processErrorMessage( paymentError ) ;
+							var errorMessage = PaypalExpressCheckout.processErrorMessage( paymentError );
 							PaypalExpressCheckout.showError( errorMessage, buttonDomId );
 							reject( new Error( paymentError.responseJSON.code ) );
 						} );
@@ -164,18 +164,10 @@ var PaypalExpressCheckout = {
 				return new paypal.Promise( function( resolve, reject ) {
 					jQuery.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), payload )
 						.done( function( authResponse ) {
-							var payerInfo = authResponse.payer.payer_info;
-							var message =
-								'<strong>Thank you, ' + payerInfo.first_name + '!</strong>' +
-								'<br />' +
-								'Your purchase was successful. <br />' +
-								'We just sent you a confirmation email to ' +
-								'<em>' + payerInfo.email + '</em>.';
-							PaypalExpressCheckout.showMessage( message, buttonDomId );
+							PaypalExpressCheckout.showMessage( authResponse.message, buttonDomId );
 							resolve();
 						} )
 						.fail( function( authError ) {
-							var errorMessage = PaypalExpressCheckout.processErrorResponse( paymentError ) ;
 							PaypalExpressCheckout.showError( authError, buttonDomId );
 							reject( new Error( authError.responseJSON.code ) );
 						} );

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -89,6 +89,25 @@ var PaypalExpressCheckout = {
 		PaypalExpressCheckout.showMessage( message, buttonDomId, true );
 	},
 
+	processErrorMessage( errorResponse ) {
+		var error = errorResponse.responseJSON;
+		var defaultMessage = 'There was an issue processing your payment.';
+
+		if ( ! error ) {
+			return defaultMessage;
+		}
+
+		if ( error.additional_errors ) {
+			var messages = [];
+			error.additional_errors.forEach( function( error ) {
+				messages.push( error.message );
+			} );
+			return messages.join( '<br />' );
+		}
+
+		return error.message || defaultMessage;
+	},
+
 	cleanAndHideMessage: function( buttonDomId ) {
 		var domEl = PaypalExpressCheckout.getMessageElement( buttonDomId );
 		domEl.setAttribute( 'class', 'jetpack-simple-payments__purchase-message' );

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -149,7 +149,7 @@ var PaypalExpressCheckout = {
 						.fail( function( paymentError ) {
 							var errorMessage = PaypalExpressCheckout.processErrorMessage( paymentError );
 							PaypalExpressCheckout.showError( errorMessage, buttonDomId );
-							reject( new Error( paymentError.responseJSON.code ) );
+							reject();
 						} );
 				} );
 			},

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -149,7 +149,7 @@ var PaypalExpressCheckout = {
 						.fail( function( paymentError ) {
 							var errorMessage = PaypalExpressCheckout.processErrorMessage( paymentError );
 							PaypalExpressCheckout.showError( errorMessage, buttonDomId );
-							reject();
+							reject( new Error( paymentError.responseJSON.code ) );
 						} );
 				} );
 			},
@@ -168,7 +168,7 @@ var PaypalExpressCheckout = {
 						} )
 						.fail( function( authError ) {
 							PaypalExpressCheckout.showError( authError, buttonDomId );
-							reject();
+							reject( new Error( authError.responseJSON.code ) );
 						} );
 				} );
 			}

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -5,6 +5,7 @@
  */
 
 /* global paypal */
+/* global jQuery */
 /* exported PaypalExpressCheckout */
 /* jshint unused:false, es3:false, esversion:5 */
 var PaypalExpressCheckout = {
@@ -89,7 +90,7 @@ var PaypalExpressCheckout = {
 		PaypalExpressCheckout.showMessage( message, buttonDomId, true );
 	},
 
-	processErrorMessage( errorResponse ) {
+	processErrorMessage: function( errorResponse ) {
 		var error = errorResponse.responseJSON;
 		var defaultMessage = 'There was an issue processing your payment.';
 
@@ -100,12 +101,12 @@ var PaypalExpressCheckout = {
 		if ( error.additional_errors ) {
 			var messages = [];
 			error.additional_errors.forEach( function( error ) {
-				messages.push( error.message );
+				messages.push( '<p>' + error.message.toString() + '</p>' );
 			} );
-			return messages.join( '<br />' );
+			return messages.join();
 		}
 
-		return error.message || defaultMessage;
+		return '<p>' + ( error.message || defaultMessage ) + '</p>';
 	},
 
 	cleanAndHideMessage: function( buttonDomId ) {
@@ -119,8 +120,11 @@ var PaypalExpressCheckout = {
 		if ( ! paypal ) {
 			throw new Error( 'PayPal module is required by PaypalExpressCheckout' );
 		}
+		if ( ! jQuery ) {
+			throw new Error( 'jQuery library is required by PaypalExpressCheckout' );
+		}
 
-		var buttonDomId = domId+ '_button';
+		var buttonDomId = domId + '_button';
 
 		paypal.Button.render( {
 			env: env,

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -101,7 +101,9 @@ var PaypalExpressCheckout = {
 		if ( error.additional_errors ) {
 			var messages = [];
 			error.additional_errors.forEach( function( error ) {
-				messages.push( '<p>' + error.message.toString() + '</p>' );
+				if ( error.message ) {
+					messages.push( '<p>' + error.message.toString() + '</p>' );
+				}
 			} );
 			return messages.join();
 		}
@@ -119,9 +121,6 @@ var PaypalExpressCheckout = {
 		var env = PaypalExpressCheckout.sandbox ? 'sandbox' : 'production';
 		if ( ! paypal ) {
 			throw new Error( 'PayPal module is required by PaypalExpressCheckout' );
-		}
-		if ( ! jQuery ) {
-			throw new Error( 'jQuery library is required by PaypalExpressCheckout' );
 		}
 
 		var buttonDomId = domId + '_button';
@@ -169,7 +168,7 @@ var PaypalExpressCheckout = {
 						} )
 						.fail( function( authError ) {
 							PaypalExpressCheckout.showError( authError, buttonDomId );
-							reject( new Error( authError.responseJSON.code ) );
+							reject();
 						} );
 				} );
 			}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -88,7 +88,7 @@ class Jetpack_Simple_Payments {
 		$items = '';
 		if ( $data['multiple'] ) {
 		       $items="<div class='jetpack-simple-payments-items'>
-		       <input class='jetpack-simple-payments-items-number' type='number' value='1' id='{$data['dom_id']}_number'>
+		       <input class='jetpack-simple-payments-items-number' type='number' min='1' value='1' id='{$data['dom_id']}_number'>
 		       </div>";
 		}
 		$output = "


### PR DESCRIPTION
This updates how we handle error messaging from the wpcom REST api.
It replaces `paypal.request.post` with `JQuery.post`. The change allows better api error handling such as paypal REST api errors or disabled buttons. The way `paypal.request.post` handles response errors is too specific and only exposes errors as strings ([ including stringifying json data](https://github.com/paypal/paypal-checkout/blob/master/src/lib/http.js#L78)).

**Screenshots**
Custom error message from wpcom api ( in this case , the button did not have a valid currency )
![screen shot 2017-07-23 at 12 02 58 pm](https://user-images.githubusercontent.com/744755/28503753-1b35b31e-6fc1-11e7-8e10-ddc1a40d45d5.png)

Displaying multiple errors from calling `WP_Error::add`
![screen shot 2017-07-23 at 12 06 32 pm](https://user-images.githubusercontent.com/744755/28503755-33266e28-6fc1-11e7-9df6-2ae1c9b5d536.png)

Default error message. The message is from the client
![screen shot 2017-07-23 at 12 03 05 pm](https://user-images.githubusercontent.com/744755/28503764-48cb33e4-6fc1-11e7-9e23-30c9443ae63c.png)

**Testing**
1. Apply D6514-code , sandbox
1. Verify no regression errors for valid payment flows
1. Introduce a paypal api error ( suggestion: set the currency code on a button to null )
1. The error message displayed should be from the wpcom rest api.
1. Try buying with a free JP site as well
