### PR TITLE
Fixed a spacing issue in Google Analytics card.

### DIFF
--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -28,16 +28,18 @@ export const GoogleAnalytics = moduleSettingsForm(
 					feature={ FEATURE_GOOGLE_ANALYTICS_JETPACK }
 					hideButton>
 					<SettingsGroup disableInDevMode module={ { module: 'google-analytics' } } support="https://jetpack.com/support/google-analytics/">
-						{ __(
-							'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
-							' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
-							'normally show slightly different totals for your visits, views, etc.',
-							{
-								components: {
-									a: <a href={ 'https://wordpress.com/stats/day/' + this.props.siteRawUrl } />
+						<p>
+							{ __(
+								'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
+								' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
+								'normally show slightly different totals for your visits, views, etc.',
+								{
+									components: {
+										a: <a href={ 'https://wordpress.com/stats/day/' + this.props.siteRawUrl } />
+									}
 								}
-							}
-						) }
+							) }
+						</p>
 					</SettingsGroup>
 					{
 						! this.props.isUnavailableInDevMode( 'google-analytics' ) && (


### PR DESCRIPTION
Fixes #7491 

#### Changes proposed in this Pull Request:
* Adds a wrapping paragraph to make inline items behave properly.

#### Testing instructions:
* Open the Traffic tab, switch to the Pro plan and make sure that the link in the Google Analytics card is properly spaced.
