### PR TITLE
Simple payments: remove paragraphs from product content/description

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -45,6 +45,16 @@ class Jetpack_Simple_Payments {
 		$this->register_scripts();
 		$this->register_shortcode();
 		$this->setup_cpts();
+
+		add_filter( 'the_content', array( $this, 'remove_auto_paragraph_from_product_description' ), 0 );
+	}
+
+	function remove_auto_paragraph_from_product_description( $content ) {
+		if ( get_post_type() === self::$post_type_product ) {
+			remove_filter( 'the_content', 'wpautop' );
+		}
+
+		return $content;
 	}
 
 	function parse_shortcode( $attrs, $content = false ) {


### PR DESCRIPTION
Previously, each time user created a new Simple Payments product, its description contained `p` tags. However, we do not support that on the Calypso side (since product description should be short and not contain any HTML). For that, we need to remove the `wpautop` filter from `the_content` if the currently retrieved post is a Simple Payments product.

## Testing

- Checkout `feature/simple-payments` and try to reproduce the bug by adding a new product in Calypso. Do you see the added `p` tags?

![image](https://user-images.githubusercontent.com/4988512/28525522-d5a8941e-7084-11e7-819c-4858257cc241.png)

- Checkout this PR and do the same by creating another new product. Can you still see the `p` tags? You should not.