### PR TITLE
Simple payments: image

### DIFF
--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -9,7 +9,7 @@
 }
 
 .jetpack-simple-payments-image {
-	magin-right: 15px;
+	margin-right: 15px;
 }
 
 .jetpack-simple-payments-title {

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -3,6 +3,15 @@
 	margin: 0.5em 0;
 }
 
+.jetpack-simple-payments-product {
+	display: flex;
+	flex-direction: row;
+}
+
+.jetpack-simple-payments-image {
+	magin-right: 15px;
+}
+
 .jetpack-simple-payments-title {
 	font-weight: bold;
 	display: block;

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -105,7 +105,7 @@ class Jetpack_Simple_Payments {
 				<input class='${cssPrefix}-items-number' type='number' value='1' id='{$data['dom_id']}_number' />
 			</div>";
 		}
-		$image = get_the_post_thumbnail( $data['id'], 'thumbnail', array( 'class' => "${cssPrefix}-image" ) );
+		$image = get_the_post_thumbnail( $data['id'], 'full', array( 'class' => "${cssPrefix}-image" ) );
 		return "
 <div class='{$data['class']} ${cssPrefix}-wrapper'>
 	<p class='${cssPrefix}-purchase-message'></p>

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -109,13 +109,17 @@ class Jetpack_Simple_Payments {
 		return "
 <div class='{$data['class']} ${cssPrefix}-wrapper'>
 	<p class='${cssPrefix}-purchase-message'></p>
-	{$image}
-	<div class='${cssPrefix}-title'><p>{$data['title']}</p></div>
-	<div class='${cssPrefix}-description'><p>{$data['description']}</p></div>
-	<div class='${cssPrefix}-purchase-box'>
-		<div class='${cssPrefix}-price'><p>{$data['price']}</p></div>
-		{$items}
-		<div class='${cssPrefix}-button' id='{$data['dom_id']}_button'></div>
+	<div class='${cssPrefix}-product'> 
+		{$image}
+		<div class='${cssPrefix}-details'> 
+			<div class='${cssPrefix}-title'><p>{$data['title']}</p></div>
+			<div class='${cssPrefix}-description'><p>{$data['description']}</p></div>
+			<div class='${cssPrefix}-purchase-box'>
+				<div class='${cssPrefix}-price'><p>{$data['price']}</p></div>
+				{$items}
+				<div class='${cssPrefix}-button' id='{$data['dom_id']}_button'></div>
+			</div>
+		</div>
 	</div>
 </div>
 		";

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -86,7 +86,7 @@ class Jetpack_Simple_Payments {
 			get_post_meta( $product->ID, 'spay_currency', true ),
 			$data
 		);
-
+		$data['id'] = $attrs['id'];
 		if ( ! wp_script_is( 'paypal-express-checkout','enqueued' ) ) {
 			wp_enqueue_script( 'paypal-express-checkout' );
 		}

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -105,10 +105,11 @@ class Jetpack_Simple_Payments {
 				<input class='${cssPrefix}-items-number' type='number' value='1' id='{$data['dom_id']}_number' />
 			</div>";
 		}
-
+		$image = get_the_post_thumbnail( $data['id'], 'thumbnail', array( 'class' => "${cssPrefix}-image" ) );
 		return "
 <div class='{$data['class']} ${cssPrefix}-wrapper'>
 	<p class='${cssPrefix}-purchase-message'></p>
+	{$image}
 	<div class='${cssPrefix}-title'><p>{$data['title']}</p></div>
 	<div class='${cssPrefix}-description'><p>{$data['description']}</p></div>
 	<div class='${cssPrefix}-purchase-box'>

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -105,7 +105,10 @@ class Jetpack_Simple_Payments {
 				<input class='${cssPrefix}-items-number' type='number' value='1' id='{$data['dom_id']}_number' />
 			</div>";
 		}
-		$image = get_the_post_thumbnail( $data['id'], 'full', array( 'class' => "${cssPrefix}-image" ) );
+		$image = "";
+		if( has_post_thumbnail( $data['id'] ) ) {
+			$image = "<div class='${cssPrefix}-image'>" . get_the_post_thumbnail( $data['id'], 'full' ) . "</div>";
+		}
 		return "
 <div class='{$data['class']} ${cssPrefix}-wrapper'>
 	<p class='${cssPrefix}-purchase-message'></p>
@@ -114,8 +117,8 @@ class Jetpack_Simple_Payments {
 		<div class='${cssPrefix}-details'> 
 			<div class='${cssPrefix}-title'><p>{$data['title']}</p></div>
 			<div class='${cssPrefix}-description'><p>{$data['description']}</p></div>
+			<div class='${cssPrefix}-price'><p>{$data['price']}</p></div>
 			<div class='${cssPrefix}-purchase-box'>
-				<div class='${cssPrefix}-price'><p>{$data['price']}</p></div>
 				{$items}
 				<div class='${cssPrefix}-button' id='{$data['dom_id']}_button'></div>
 			</div>


### PR DESCRIPTION
Inserts image for simple payments

![zrzut ekranu 2017-07-24 o 18 18 49](https://user-images.githubusercontent.com/3775068/28533239-adea265a-709c-11e7-99d3-d1d3def216c6.png)

It uses get_post_thumnail

## Testing
(before we have calypso pieces, we have to upload manually)

1. Upload media via wp-admin
2. note the media ID
3. Use developer console to update a product (the post id is the same id in shortcode. NOT the post it is embedded in.)

![zrzut ekranu 2017-07-24 o 17 49 16](https://user-images.githubusercontent.com/3775068/28532465-30dcf7ca-709a-11e7-8053-37bbbe7ba8c1.png)

4. use this branch on your JP site obviously
5. Once you update it, your product should have featured image.
6. See what your shortcode renders

