### PR TITLE
Jetpack Sync: Suppress jetpack_published_post and jetpack_trashed_post when theme customized

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -355,6 +355,8 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			return;
 		}
 
+		error_log(print_r($post, true));
+
 		// Post revisions cause race conditions where this send_published add the action before the actual post gets synced
 		if ( wp_is_post_autosave( $post ) || wp_is_post_revision( $post ) ) {
 			return;

--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -346,6 +346,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		}
 
 		call_user_func( $this->action_handler, $post_ID, $post, $update, $is_auto_save, $just_published );
+
+		if ( 'customize_changeset' === $post->post_type ) {
+			return;
+		}
 		$this->send_published( $post_ID, $post );
 		$this->send_trashed( $post_ID, $post );
 	}
@@ -354,8 +358,6 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		if ( ! in_array( $post_ID, $this->just_published ) ) {
 			return;
 		}
-
-		error_log(print_r($post, true));
 
 		// Post revisions cause race conditions where this send_published add the action before the actual post gets synced
 		if ( wp_is_post_autosave( $post ) || wp_is_post_revision( $post ) ) {


### PR DESCRIPTION
Suppress jetpack_published_post and jetpack_trashed_post when theme customized

#### Changes proposed in this Pull Request:

Suppress jetpack_published_post and jetpack_trashed_post when theme customized

#### Testing instructions:

phpunit

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
