### PR TITLE
SimplePayments: implement button styles composition

### DIFF
--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -126,6 +126,17 @@ var PaypalExpressCheckout = {
 		domEl.innerHTML = '';
 	},
 
+	getButtonStyle: function( domId ) {
+		var buttonEl = document.getElementById( domId );
+		var dataset = buttonEl ? ( buttonEl.dataset || {} ) : {};
+
+		return {
+			label: dataset.buttonStyleLabel || 'pay',
+			shape: dataset.buttonStyleShape || 'rect',
+			color: dataset.buttonStyleColor || 'silver'
+		};
+	},
+
 	renderButton: function( blogId, buttonId, domId, enableMultiple ) {
 		var env = PaypalExpressCheckout.sandbox ? 'sandbox' : 'production';
 		if ( ! paypal ) {
@@ -138,11 +149,7 @@ var PaypalExpressCheckout = {
 			env: env,
 			commit: true,
 
-			style: {
-				label: 'pay',
-				shape: 'rect',
-				color: 'silver'
-			},
+			style: PaypalExpressCheckout.getButtonStyle( buttonDomId ),
 
 			payment: function() {
 				PaypalExpressCheckout.cleanAndHideMessage( buttonDomId );

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -73,13 +73,17 @@ class Jetpack_Simple_Payments {
 
 		// We allow for overriding the presentation labels
 		$data = shortcode_atts( array(
-			'blog_id'     => Jetpack_Options::get_option( 'id' ),
-			'dom_id'      => uniqid( self::$css_classname_prefix . '-' . $product->ID . '_', true ),
-			'class'       => self::$css_classname_prefix . '-' . $product->ID,
-			'title'       => get_the_title( $product ),
-			'description' => $product->post_content,
-			'cta'         => get_post_meta( $product->ID, 'spay_cta', true ),
-			'multiple'    => get_post_meta( $product->ID, 'spay_multiple', true ) || '0'
+			'blog_id'            => Jetpack_Options::get_option( 'id' ),
+			'dom_id'             => uniqid( self::$css_classname_prefix . '-' . $product->ID . '_', true ),
+			'class'              => self::$css_classname_prefix . '-' . $product->ID,
+			'title'              => get_the_title( $product ),
+			'description'        => $product->post_content,
+			'cta'                => get_post_meta( $product->ID, 'spay_cta', true ),
+			'multiple'           => get_post_meta( $product->ID, 'spay_multiple', true ) || '0',
+
+			'button_style_label' => get_post_meta( $product->ID, 'spay_button_style_label', true ),
+			'button_style_shape' => get_post_meta( $product->ID, 'spay_button_style_shape', true ),
+			'button_style_color' => get_post_meta( $product->ID, 'spay_button_style_color', true ),
 		), $attrs );
 		$data['price'] = $this->format_price(
 			get_post_meta( $product->ID, 'spay_price', true ),
@@ -109,6 +113,12 @@ class Jetpack_Simple_Payments {
 		if( has_post_thumbnail( $data['id'] ) ) {
 			$image = "<div class='${css_prefix}-image'>" . get_the_post_thumbnail( $data['id'], 'full' ) . "</div>";
 		}
+
+		$button_style_markup = '';
+		$button_style_markup .= ' data-button-style-label="' . ( $data['button_style_label'] ? $data['button_style_label'] : 'pay' ) . '"';
+		$button_style_markup .= ' data-button-style-shape="' . ( $data['button_style_shape'] ? $data['button_style_shape'] : 'rect' ) . '"';
+		$button_style_markup .= ' data-button-style-color="' . ( $data['button_style_color'] ? $data['button_style_color'] : 'silver' ) . '"';
+
 		return "
 <div class='{$data['class']} ${css_prefix}-wrapper'>
 	<p class='${css_prefix}-purchase-message'></p>
@@ -120,7 +130,12 @@ class Jetpack_Simple_Payments {
 			<div class='${css_prefix}-price'><p>{$data['price']}</p></div>
 			<div class='${css_prefix}-purchase-box'>
 				{$items}
-				<div class='${css_prefix}-button' id='{$data['dom_id']}_button'></div>
+				<div
+					class='${css_prefix}-button'
+					id='{$data['dom_id']}_button'
+					{$button_style_markup}
+				>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -156,7 +171,10 @@ class Jetpack_Simple_Payments {
 			'spay_currency',
 			'spay_cta',
 			'spay_email',
-			'spay_multiple'
+			'spay_multiple',
+			'button_style_label',
+			'button_style_shape',
+			'button_style_color',
 		) );
 	}
 


### PR DESCRIPTION
### This patch implements the composition of the button styles. 

First of all, the styles are stored in the meta data of the post using `button_style_label`, `button_style_shape` and `button_style_color`.
Then these values are added as data attribute passing a default value just in case.
Finally, those data are [gotten in the client-side](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) and mapped into the `style` property of the button instance.
The patch applies default values on both sides so this changes shouldn't affect the correct behavior of the rendering process.

The code is passed into the HTML markup:

<img src="https://user-images.githubusercontent.com/77539/28540741-c7bca7ca-708c-11e7-9fb8-faed300677d9.png" width="500px" />

<img src="https://user-images.githubusercontent.com/77539/28540689-9e5a503a-708c-11e7-9c7a-cd771e306cc9.png" width="400px" />
