### PR TITLE
JITM: Include the user ID in the URL of the CTA so that we can better customize the experience.

### DIFF
--- a/class.jetpack-jitm.php
+++ b/class.jetpack-jitm.php
@@ -283,7 +283,7 @@ class Jetpack_JITM {
 			}
 
 			$normalized_site_url      = Jetpack::build_raw_urls( get_home_url() );
-			$envelope->url            = 'https://jetpack.com/redirect/?source=jitm-' . $envelope->id . '&site=' . $normalized_site_url;
+			$envelope->url            = 'https://jetpack.com/redirect/?source=jitm-' . $envelope->id . '&site=' . $normalized_site_url . '&u=' . $user->ID;
 			$envelope->jitm_stats_url = Jetpack::build_stats_url( array( 'x_jetpack-jitm' => $envelope->id ) );
 
 			if ( $envelope->CTA->hook ) {


### PR DESCRIPTION
This change simply updates the params sent over via the JITM CTA URL.
Providing the user ID will allow us to better customize the experience
from there for the particular individual.

To test:

1) Trigger any JITM in your wp-admin.
2) Click on the CTA and make sure that the user ID param is correctly included in the destination URL.