### PR TITLE
Settings UI: link to a release post in the welcome notice

### DIFF
--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -167,12 +167,13 @@ const JetpackStateNotices = React.createClass( {
 		switch ( key ) {
 			// This is the message that is shown on first page load after a Jetpack plugin update.
 			case 'modules_activated' :
-				message = __( 'Welcome to {{s}}Jetpack %(jetpack_version)s{{/s}}!',
+				message = __( "Welcome to {{s}}Jetpack %(jetpack_version)s{{/s}}! {{a}}Learn about what's new{{/a}}.",
 					{
 						args: {
 							jetpack_version: this.props.currentVersion
 						},
 						components: {
+							a: <a href="https://jetpack.com/?p=20888" />,
 							s: <strong />
 						}
 					}

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -167,13 +167,13 @@ const JetpackStateNotices = React.createClass( {
 		switch ( key ) {
 			// This is the message that is shown on first page load after a Jetpack plugin update.
 			case 'modules_activated' :
-				message = __( "Welcome to {{s}}Jetpack %(jetpack_version)s{{/s}}! {{a}}Learn about what's new{{/a}}.",
+				message = __( "Welcome to {{s}}Jetpack %(jetpack_version)s{{/s}}! {{a}}Learn what's new{{/a}}.",
 					{
 						args: {
 							jetpack_version: this.props.currentVersion
 						},
 						components: {
-							a: <a href="https://jetpack.com/?p=20888" />,
+							a: <a href="https://jetpack.com/?p=22509" />,
 							s: <strong />
 						}
 					}

--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -27,6 +27,10 @@
 	text-decoration: none;
 }
 
+.dops-notice__text a {
+	text-decoration: underline;
+}
+
 // Hello Dolly positioning overwrite
 .jetpack-pagestyles #dolly {
 	float: none;


### PR DESCRIPTION
I'd prefer if we get this https://github.com/Automattic/jetpack/issues/7375 in, but just in case, here's this PR that addresses this issue in the UI.
If we get that one in, let's close this one and add a PR that entirely deletes this notice instead.

❗️❗️ Before merging this, let's add the proper link to the release post ❗️❗️ 

#### Changes proposed in this Pull Request:

* underline links in notice text, following Notices section example at https://wpcalypso.wordpress.com/devdocs/design
* display a link to the release post
<img width="750" alt="captura de pantalla 2017-07-25 a las 13 43 16" src="https://user-images.githubusercontent.com/1041600/28583405-6a1b00e0-713f-11e7-9d4c-e60f6cb34f53.png">

#### Testing instructions:

* update version and make sure the link is shown