### PR TITLE
Jumpstart: only display jumpstart if site is connected

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -169,7 +169,7 @@ const Main = React.createClass( {
 			);
 		}
 
-		if ( this.props.jumpStartStatus ) {
+		if ( this.props.isSiteConnected && this.props.jumpStartStatus ) {
 			if ( includes( [ '/', '/dashboard' ], route ) ) {
 				window.location.hash = 'jumpstart';
 				const history = createHistory();


### PR DESCRIPTION
This solves an issue that happens in Dev Mode and Dev Version: if you click Reset Options in the footer, Jumpstart is shown after reset, even though the route correctly points to `/dashboard`.

#### Changes proposed in this Pull Request:

* make sure site is connected before showing Jumpstart

#### Testing instructions:

* in Dev Mode with a Dev Version, click Reset Options at the bottom. You should see the Dashboard, not Jumpstart.