### PR TITLE
Simple Payments: Style shortcode

### DIFF
--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -97,9 +97,9 @@ var PaypalExpressCheckout = {
 
 		if ( error.additional_errors ) {
 			var messages = [];
-			error.additional_errors.forEach( function() {
-				if ( error.message ) {
-					messages.push( '<p>' + error.message.toString() + '</p>' );
+			error.additional_errors.forEach( function( additionalError) {
+				if ( additionalError.message ) {
+					messages.push( '<p>' + additionalError.message.toString() + '</p>' );
 				}
 			} );
 			return messages.join();

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -102,7 +102,7 @@ var PaypalExpressCheckout = {
 					messages.push( '<p>' + additionalError.message.toString() + '</p>' );
 				}
 			} );
-			return messages.join();
+			return messages.join('');
 		}
 
 		return '<p>' + ( error.message || defaultMessage ) + '</p>';

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -148,8 +148,8 @@ var PaypalExpressCheckout = {
 							resolve( paymentResponse.id );
 						} )
 						.fail( function( paymentError ) {
-							var errorMessage = PaypalExpressCheckout.processErrorMessage( paymentError );
-							PaypalExpressCheckout.showError( errorMessage, domId );
+							var paymentErrorMessage = PaypalExpressCheckout.processErrorMessage( paymentError );
+							PaypalExpressCheckout.showError( paymentErrorMessage, domId );
 							reject( new Error( paymentError.responseJSON.code ) );
 						} );
 				} );
@@ -168,7 +168,8 @@ var PaypalExpressCheckout = {
 							resolve();
 						} )
 						.fail( function( authError ) {
-							PaypalExpressCheckout.showError( authError, domId );
+							var authErrorMessage = PaypalExpressCheckout.processErrorMessage( authError );
+							PaypalExpressCheckout.showError( authErrorMessage, domId );
 							reject( new Error( authError.responseJSON.code ) );
 						} );
 				} );

--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -53,28 +53,11 @@ var PaypalExpressCheckout = {
 	 * Get the DOM element-placeholder used to show message
 	 * about the transaction. If it doesn't exist then the function will create a new one.
 	 *
-	 * @param  string buttonDomId id of the payment button placeholder
+	 * @param  string domId id of the payment button placeholder
 	 * @return Element the dom element to print the message
 	 */
-	getMessageElement: function( buttonDomId ) {
-		var messageDomId = buttonDomId + '_message';
-
-		// DOM Elements
-		var buttonDomElement = document.getElementById( buttonDomId );
-		var messageDomElement = document.getElementById( messageDomId );
-
-		if ( messageDomElement ) {
-			return messageDomElement;
-		}
-
-		// create dom message element
-		messageDomElement = document.createElement( 'div' );
-		messageDomElement.setAttribute( 'id', messageDomId );
-
-		// inject into the DOM Tree
-		buttonDomElement.appendChild( messageDomElement );
-
-		return messageDomElement;
+	getMessageContainer: function( domId ) {
+		return document.getElementById( domId + '-message-container' );
 	},
 
 	/**
@@ -86,8 +69,8 @@ var PaypalExpressCheckout = {
 	 * @param  {String} domId paypal-button element dom identifier
 	 * @param  {Boolean} [error] defines if it's a message error. Not TRUE as default.
 	 */
-	showMessage: function( message, buttonDomId, isError ) {
-		var domEl = PaypalExpressCheckout.getMessageElement( buttonDomId );
+	showMessage: function( message, domId, isError ) {
+		var domEl = PaypalExpressCheckout.getMessageContainer( domId );
 
 		// set css classes
 		var cssClasses = PaypalExpressCheckout.messageCssClassName + ' show ';
@@ -100,8 +83,8 @@ var PaypalExpressCheckout = {
 		}, 1000 );
 	},
 
-	showError: function( message, buttonDomId ) {
-		PaypalExpressCheckout.showMessage( message, buttonDomId, true );
+	showError: function( message, domId ) {
+		PaypalExpressCheckout.showMessage( message, domId, true );
 	},
 
 	processErrorMessage: function( errorResponse ) {
@@ -125,14 +108,15 @@ var PaypalExpressCheckout = {
 		return '<p>' + ( error.message || defaultMessage ) + '</p>';
 	},
 
-	cleanAndHideMessage: function( buttonDomId ) {
-		var domEl = PaypalExpressCheckout.getMessageElement( buttonDomId );
+	cleanAndHideMessage: function( domId ) {
+		var domEl = PaypalExpressCheckout.getMessageContainer( domId );
 		domEl.setAttribute( 'class', PaypalExpressCheckout.messageCssClassName );
 		domEl.innerHTML = '';
 	},
 
 	renderButton: function( blogId, buttonId, domId, enableMultiple ) {
 		var env = PaypalExpressCheckout.getEnvironment();
+
 		if ( ! paypal ) {
 			throw new Error( 'PayPal module is required by PaypalExpressCheckout' );
 		}
@@ -150,7 +134,7 @@ var PaypalExpressCheckout = {
 			},
 
 			payment: function() {
-				PaypalExpressCheckout.cleanAndHideMessage( buttonDomId );
+				PaypalExpressCheckout.cleanAndHideMessage( domId );
 
 				var payload = {
 					number: PaypalExpressCheckout.getNumberOfItems( domId + '_number', enableMultiple ),
@@ -165,7 +149,7 @@ var PaypalExpressCheckout = {
 						} )
 						.fail( function( paymentError ) {
 							var errorMessage = PaypalExpressCheckout.processErrorMessage( paymentError );
-							PaypalExpressCheckout.showError( errorMessage, buttonDomId );
+							PaypalExpressCheckout.showError( errorMessage, domId );
 							reject( new Error( paymentError.responseJSON.code ) );
 						} );
 				} );
@@ -180,11 +164,11 @@ var PaypalExpressCheckout = {
 				return new paypal.Promise( function( resolve, reject ) {
 					jQuery.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), payload )
 						.done( function( authResponse ) {
-							PaypalExpressCheckout.showMessage( authResponse.message, buttonDomId );
+							PaypalExpressCheckout.showMessage( authResponse.message, domId );
 							resolve();
 						} )
 						.fail( function( authError ) {
-							PaypalExpressCheckout.showError( authError, buttonDomId );
+							PaypalExpressCheckout.showError( authError, domId );
 							reject( new Error( authError.responseJSON.code ) );
 						} );
 				} );

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -4,7 +4,7 @@
 
 /* Higher specificity in order to reset paragraph style */
 body .jetpack-simple-payments-wrapper .jetpack-simple-payments-details p {
-	margin: 0 0 1.5em 0;
+	margin: 0 0 1.5em;
 	padding: 0;
 }
 
@@ -66,12 +66,19 @@ input[type="number"].jetpack-simple-payments-items-number {
 
 .jetpack-simple-payments-purchase-message {
 	display: none;
-	padding: 1em;
+	padding: 0.5em 1em;
+	margin-bottom: 1.5em;
 }
 
 /* Higher specificity in order to set the text color */
-body .jetpack-simple-payments-wrapper p.jetpack-simple-payments-purchase-message {
+body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message p {
 	color: #fff;
+	margin: 0 0 0.5em;
+	padding: 0;
+}
+
+body .jetpack-simple-payments-wrapper .jetpack-simple-payments-purchase-message p:last-child {
+	margin: 0;
 }
 
 .jetpack-simple-payments-purchase-message.show {

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -64,6 +64,10 @@ input[type="number"].jetpack-simple-payments-items-number {
 	padding: 4px 8px;
 }
 
+.jetpack-simple-payments-button iframe {
+	margin: 0;
+}
+
 .jetpack-simple-payments-purchase-message {
 	display: none;
 	padding: 0.5em 1em;

--- a/modules/simple-payments/simple-payments.css
+++ b/modules/simple-payments/simple-payments.css
@@ -1,46 +1,67 @@
-
 .jetpack-simple-payments-wrapper {
-	margin: 0.5em 0;
+	margin-bottom: 1.5em;
+}
+
+/* Higher specificity in order to reset paragraph style */
+body .jetpack-simple-payments-wrapper .jetpack-simple-payments-details p {
+	margin: 0 0 1.5em 0;
+	padding: 0;
 }
 
 .jetpack-simple-payments-product {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
+}
+
+.jetpack-simple-payments-product-image {
+	flex: 0 0 30%;
+	margin-bottom: 1.5em;
 }
 
 .jetpack-simple-payments-image {
-	margin-right: 15px;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	box-sizing: border-box;
+	min-width: 70px;
+	padding-top: calc(100% - 2px);
+	position: relative;
 }
 
-.jetpack-simple-payments-title {
+/* Higher specificity in order to trump theme's style */
+body .jetpack-simple-payments-wrapper .jetpack-simple-payments-product-image .jetpack-simple-payments-image img.size-full {
+	border: 0;
+	border-radius: 0;
+	height: auto;
+	left: 50%;
+	margin: 0;
+	max-height: 100%;
+	max-width: 100%;
+	padding: 0;
+	position: absolute;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	width: auto;
+}
+
+.jetpack-simple-payments-title p,
+.jetpack-simple-payments-price p {
 	font-weight: bold;
-	display: block;
-	margin-bottom: 0.3em;
 }
 
-.jetpack-simple-payments-payment-row {
-	margin-top: 0.3em;
-}
-
-.jetpack-simple-payments-price {
-	font-weight: bold;
-	display: inline-block;
-	float: left;
-	margin-right: 15px;
+.jetpack-simple-payments-purchase-box {
+	align-items: flex-start;
+	display: flex;
 }
 
 .jetpack-simple-payments-items {
-	display:inline-block;
-	margin-right: 15px;
+	flex: 0 0 auto;
+	margin-right: 10px;
 }
 
-.jetpack-simple-payments-items input {
-	width: 30px;
-}
-
-.jetpack-simple-payments-button {
-	display: inline-block;
-	float: left;
+input[type="number"].jetpack-simple-payments-items-number {
+	font-size: 16px;
+	line-height: 1;
+	max-width: 60px;
+	padding: 4px 8px;
 }
 
 .jetpack-simple-payments-purchase-message {
@@ -48,7 +69,7 @@
 	padding: 1em;
 }
 
-/* stronger rule in order to set the text color */
+/* Higher specificity in order to set the text color */
 body .jetpack-simple-payments-wrapper p.jetpack-simple-payments-purchase-message {
 	color: #fff;
 }
@@ -63,4 +84,15 @@ body .jetpack-simple-payments-wrapper p.jetpack-simple-payments-purchase-message
 
 .jetpack-simple-payments-purchase-message.error {
 	background-color: #d94f4f;
+}
+
+@media screen and (min-width: 400px) {
+	.jetpack-simple-payments-product {
+		flex-direction: row;
+	}
+
+	.jetpack-simple-payments-product-image + .jetpack-simple-payments-details {
+		flex-basis: 70%;
+		padding-left: 1em;
+	}
 }

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -111,7 +111,7 @@ class Jetpack_Simple_Payments {
 		}
 		return "
 <div class='{$data['class']} ${css_prefix}-wrapper'>
-	<p class='${css_prefix}-purchase-message' id='{$data['dom_id']}-message-container'></p>
+	<div class='${css_prefix}-purchase-message' id='{$data['dom_id']}-message-container'></div>
 	<div class='${css_prefix}-product'>
 		{$image}
 		<div class='${css_prefix}-details'>

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -111,7 +111,7 @@ class Jetpack_Simple_Payments {
 		}
 		return "
 <div class='{$data['class']} ${css_prefix}-wrapper'>
-	<p class='${css_prefix}-purchase-message'></p>
+	<p class='${css_prefix}-purchase-message' id='{$data['dom_id']}-message-container'></p>
 	<div class='${css_prefix}-product'>
 		{$image}
 		<div class='${css_prefix}-details'>

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -107,14 +107,14 @@ class Jetpack_Simple_Payments {
 		}
 		$image = "";
 		if( has_post_thumbnail( $data['id'] ) ) {
-			$image = "<div class='${css_prefix}-image'>" . get_the_post_thumbnail( $data['id'], 'full' ) . "</div>";
+			$image = "<div class='${css_prefix}-product-image'><div class='${css_prefix}-image'>" . get_the_post_thumbnail( $data['id'], 'full' ) . "</div></div>";
 		}
 		return "
 <div class='{$data['class']} ${css_prefix}-wrapper'>
 	<p class='${css_prefix}-purchase-message'></p>
-	<div class='${css_prefix}-product'> 
+	<div class='${css_prefix}-product'>
 		{$image}
-		<div class='${css_prefix}-details'> 
+		<div class='${css_prefix}-details'>
 			<div class='${css_prefix}-title'><p>{$data['title']}</p></div>
 			<div class='${css_prefix}-description'><p>{$data['description']}</p></div>
 			<div class='${css_prefix}-price'><p>{$data['price']}</p></div>


### PR DESCRIPTION
Styling simple payments shortcode for the site front-end. I've tested all default themes and some themes.

**Twenty Seventeen Desktop:**
![image](https://user-images.githubusercontent.com/908665/28548283-01e9935c-70cb-11e7-8f07-35dece22b678.png)

**Twenty Seventeen Mobile:**
![image](https://user-images.githubusercontent.com/908665/28548294-15b324fc-70cb-11e7-84a7-50537e09e0f6.png)
