### PR TITLE
SimplePayments: add formatted price meta data

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -80,11 +80,17 @@ class Jetpack_Simple_Payments {
 			'cta'         => get_post_meta( $product->ID, 'spay_cta', true ),
 			'multiple'    => get_post_meta( $product->ID, 'spay_multiple', true ) || '0'
 		), $attrs );
-		$data['price'] = $this->format_price(
-			get_post_meta( $product->ID, 'spay_price', true ),
-			get_post_meta( $product->ID, 'spay_currency', true ),
-			$data
-		);
+
+		if ( $formatted_price = get_post_meta( $product->ID, 'spay_formatted_price', true ) ) {
+			$data['price'] = $formatted_price;
+		} else {
+			$data['price'] = $this->format_price(
+				get_post_meta( $product->ID, 'spay_price', true ),
+				get_post_meta( $product->ID, 'spay_currency', true ),
+				$data
+			);
+		}
+
 		$data['id'] = $attrs['id'];
 		if ( ! wp_script_is( 'paypal-express-checkout', 'enqueued' ) ) {
 			wp_enqueue_script( 'paypal-express-checkout' );
@@ -161,7 +167,8 @@ class Jetpack_Simple_Payments {
 			'spay_currency',
 			'spay_cta',
 			'spay_email',
-			'spay_multiple'
+			'spay_multiple',
+			'spay_formatted_price',
 		) );
 	}
 

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -81,15 +81,12 @@ class Jetpack_Simple_Payments {
 			'multiple'    => get_post_meta( $product->ID, 'spay_multiple', true ) || '0'
 		), $attrs );
 
-		if ( $formatted_price = get_post_meta( $product->ID, 'spay_formatted_price', true ) ) {
-			$data['price'] = $formatted_price;
-		} else {
-			$data['price'] = $this->format_price(
-				get_post_meta( $product->ID, 'spay_price', true ),
-				get_post_meta( $product->ID, 'spay_currency', true ),
-				$data
-			);
-		}
+		$data['price'] = $this->format_price(
+			get_post_meta( $product->ID, 'spay_formatted_price', true ),
+			get_post_meta( $product->ID, 'spay_price', true ),
+			get_post_meta( $product->ID, 'spay_currency', true ),
+			$data
+		);
 
 		$data['id'] = $attrs['id'];
 		if ( ! wp_script_is( 'paypal-express-checkout', 'enqueued' ) ) {
@@ -139,8 +136,10 @@ class Jetpack_Simple_Payments {
 		";
 	}
 
-	function format_price( $price, $currency, $all_data ) {
-		// TODO: better price formatting logic. Extracting from woocmmerce is not a solution since its bound with woo site options.
+	function format_price( $formatted_price, $price, $currency, $all_data ) {
+		if ( $formatted_price ) {
+			return $formatted_price;
+		}
 		return "$price $currency";
 	}
 
@@ -226,6 +225,7 @@ class Jetpack_Simple_Payments {
 		 * thumbnail - image
 		 * metadata:
 		 * spay_price - price
+		 * spay_formatted_price
 		 * spay_currency - currency code
 		 * spay_cta - text with "Buy" or other CTA
 		 * spay_email - paypal email


### PR DESCRIPTION
This PR will show the formatted price of the product if it's defined in the meta data of the paypal-button post.
It will try to get this value from the `spay_formatted_price` metadata. If it's defined then the price will show this value. If not the price will be defined by the currency and price metadata.

![image](https://user-images.githubusercontent.com/77539/28553722-bd1e1026-70cb-11e7-9555-c4141d406b7c.png)
