### PR TITLE
Simple payments: return wpcom blog_id if code is running on wpcom

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -58,6 +58,14 @@ class Jetpack_Simple_Payments {
 		return $content;
 	}
 
+	function get_blog_id() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return get_current_blog_id();
+		}
+
+		return Jetpack_Options::get_option( 'id' );
+	}
+
 	function parse_shortcode( $attrs, $content = false ) {
 		if ( empty( $attrs['id'] ) ) {
 			return;
@@ -72,7 +80,7 @@ class Jetpack_Simple_Payments {
 
 		// We allow for overriding the presentation labels
 		$data = shortcode_atts( array(
-			'blog_id'     => Jetpack_Options::get_option( 'id' ),
+			'blog_id'     => $this->get_blog_id(),
 			'dom_id'      => uniqid( self::$css_classname_prefix . '-' . $product->ID . '_', true ),
 			'class'       => self::$css_classname_prefix . '-' . $product->ID,
 			'title'       => get_the_title( $product ),


### PR DESCRIPTION
In order to properly sync code between WP.com and Jetpack for Simple Payments project, we need to obtain `blog_id` in a different way based on in which environment the code is running.

## Testing

Make sure the functionality of Simple Payments is not broken on Jetpack. For WP.com: does the added code look like it will work fine on WP.com?