### PR TITLE
Ensure wp-cli will run even if provisioning is called by root

### DIFF
--- a/bin/partner-cancel.sh
+++ b/bin/partner-cancel.sh
@@ -48,8 +48,7 @@ if [ ! -z "$SITE_URL" ]; then
 fi
 
 # silently ensure Jetpack is active
-wp plugin activate jetpack $ADDITIONAL_ARGS >/dev/null 2>&1
+wp plugin activate jetpack $ADDITIONAL_ARGS >/dev/null 2>&1 --allow-root
 
 # cancel the partner plan
-wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS
-
+wp jetpack partner_cancel "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS --allow-root

--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -61,7 +61,7 @@ if [ ! -z "$SITE_URL" ]; then
 fi
 
 # silently ensure Jetpack is active
-wp plugin activate jetpack $ADDITIONAL_ARGS >/dev/null 2>&1
+wp plugin activate jetpack $ADDITIONAL_ARGS >/dev/null 2>&1 --allow-root
 
 # add extra args if available
 if [ ! -z "$WP_USER" ]; then
@@ -89,4 +89,4 @@ if [ ! -z "$FORCE_CONNECT" ]; then
 fi 
 
 # provision the partner plan
-wp jetpack partner_provision "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS
+wp jetpack partner_provision "$ACCESS_TOKEN_JSON" $ADDITIONAL_ARGS --allow-root


### PR DESCRIPTION
Follow up of #7294, check it for details.
This simply updates the syntax of the command to the traditional one for `wp`.

I checked up with @mjangda and confirmed that syntax didn't make much difference. Let's use this for consistency since it's the most commonly found.