### PR TITLE
Add/jetpack publish post type

### DIFF
--- a/sync/class.jetpack-sync-module-posts.php
+++ b/sync/class.jetpack-sync-module-posts.php
@@ -360,6 +360,10 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 			return;
 		}
 
+		$post_flags = array(
+			'post_type' => $post->post_type
+		);
+
 		/**
 		 * Filter that is used to add to the post flags ( meta data ) when a post gets published
 		 *
@@ -368,7 +372,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 * @param mixed array post flags that are added to the post
 		 * @param mixed $post WP_POST object
 		 */
-		$flags = apply_filters( 'jetpack_published_post_flags', array(), $post );
+		$flags = apply_filters( 'jetpack_published_post_flags', $post_flags, $post );
 
 		/**
 		 * Action that gets synced when a post type gets published.
@@ -400,7 +404,7 @@ class Jetpack_Sync_Module_Posts extends Jetpack_Sync_Module {
 		 *
 		 * @param int $post_ID
 		 */
-		do_action( 'jetpack_trashed_post', $post_ID );
+		do_action( 'jetpack_trashed_post', $post_ID, $post->post_type );
 
 		$this->just_trashed = array_diff( $this->just_trashed, array( $post_ID ) );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -67,6 +67,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_trashed_post' );
 
+		$this->assertEquals( 'post', $event->args[1] );
 		$this->assertTrue( (bool) $event );
 		$this->server_event_storage->reset();
 
@@ -872,6 +873,7 @@ That was a cool video.';
 
 		$this->assertEquals( 'jetpack_published_post', $event->action );
 		$this->assertEquals( $post_id, $event->args[0] );
+		$this->assertEquals( 'post', $event->args[1]['post_type']);
 	}
 
 	public function test_sync_jetpack_update_post_to_draft_shouldnt_publish() {


### PR DESCRIPTION
Adding post type to jetpack_published_post and jetpack_trashed_post sync actions

#### Changes proposed in this Pull Request:

Adding post type to jetpack_published_post and jetpack_trashed_post sync actions

#### Testing instructions:

phpunit

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
