### PR TITLE
Simple payments: fix success message styling

### DIFF
--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -108,6 +108,17 @@ var PaypalExpressCheckout = {
 		return '<p>' + ( error.message || defaultMessage ) + '</p>';
 	},
 
+	processSuccessMessage: function( successResponse ) {
+		var message = successResponse.message;
+		var defaultMessage = 'Thank you. Your purchase was successful!';
+
+		if ( ! message ) {
+			return '<p>' + defaultMessage + '</p>';
+		}
+
+		return '<p>' + message + '</p>';
+	},
+
 	cleanAndHideMessage: function( domId ) {
 		var domEl = PaypalExpressCheckout.getMessageContainer( domId );
 		domEl.setAttribute( 'class', PaypalExpressCheckout.messageCssClassName );
@@ -178,7 +189,10 @@ var PaypalExpressCheckout = {
 								return reject( new Error( 'server_error' ) );
 							}
 
-							PaypalExpressCheckout.showMessage( authResponse.message, domId );
+							PaypalExpressCheckout.showMessage(
+								PaypalExpressCheckout.processSuccessMessage( authResponse ),
+								domId
+							);
 							resolve();
 						} )
 						.fail( function( authError ) {

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -13,6 +13,9 @@ class Jetpack_Simple_Payments {
 
 	static $css_classname_prefix = 'jetpack-simple-payments';
 
+	// Increase this number each time there's a change in CSS or JS to bust cache.
+	static $version = '0.23';
+
 	// Classic singleton pattern:
 	private static $instance;
 	private function __construct() {}
@@ -30,7 +33,8 @@ class Jetpack_Simple_Payments {
 		 * @see https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/add-paypal-button/
 		 */
 		wp_register_script( 'paypal-checkout-js', 'https://www.paypalobjects.com/api/checkout.js', array(), null, true );
-		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ) , array( 'jquery', 'paypal-checkout-js' ), '0.21' );
+		wp_register_script( 'paypal-express-checkout', plugins_url( '/paypal-express-checkout.js', __FILE__ ),
+			array( 'jquery', 'paypal-checkout-js' ), self::$version );
 		wp_enqueue_style( 'simple-payments', plugins_url( '/simple-payments.css', __FILE__ ) );
 	}
 	private function register_init_hook() {


### PR DESCRIPTION
Before:

![selection_030](https://user-images.githubusercontent.com/4988512/28581193-ef45b3a6-7161-11e7-8502-45c9e8d067a7.png)

Now:

![selection_031](https://user-images.githubusercontent.com/4988512/28581198-f2a0bf0a-7161-11e7-85d3-dddd8087a866.png)

## Testing

Perform a purchase of some product in Simple Payments. Does the success message text shows in white color?