### PR TITLE
Reintroduce button above editor to add contact forms to posts.

### DIFF
--- a/modules/contact-form/css/editor-ui.css
+++ b/modules/contact-form/css/editor-ui.css
@@ -1,9 +1,11 @@
-i.mce-i-grunion, .jetpack-contact-form-icon {
+i.mce-i-grunion,
+.jetpack-contact-form-icon {
 	font-family: dashicons;
 	font-size: 20px;
 }
 
-i.mce-i-grunion:before, .jetpack-contact-form-icon:before {
+i.mce-i-grunion:before,
+.jetpack-contact-form-icon:before {
 	content: "\f175";
 	vertical-align: top;
 }

--- a/modules/contact-form/css/editor-ui.css
+++ b/modules/contact-form/css/editor-ui.css
@@ -1,5 +1,4 @@
-i.mce-i-grunion,
-.jetpack-contact-form-icon {
+i.mce-i-grunion {
 	font-family: dashicons;
 	font-size: 20px;
 }
@@ -13,4 +12,7 @@ i.mce-i-grunion:before,
 .jetpack-contact-form-icon {
 	opacity: 0.7;
 	vertical-align: text-top;
+	display: inline-block;
+	height: 18px;
+	font: 18px/1 dashicons;
 }

--- a/modules/contact-form/css/editor-ui.css
+++ b/modules/contact-form/css/editor-ui.css
@@ -1,8 +1,14 @@
-i.mce-i-grunion {
+i.mce-i-grunion, .jetpack-contact-form-icon {
 	font-family: dashicons;
 	font-size: 20px;
 }
 
-i.mce-i-grunion:before {
+i.mce-i-grunion:before, .jetpack-contact-form-icon:before {
 	content: "\f175";
+	vertical-align: top;
+}
+
+.jetpack-contact-form-icon {
+	opacity: 0.7;
+	vertical-align: text-top;
 }

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -17,6 +17,21 @@ class Grunion_Editor_View {
 
 	public static function admin_head() {
 		remove_action( 'media_buttons', 'grunion_media_button', 999 );
+		add_action( 'media_buttons', array( __CLASS__, 'grunion_media_button' ), 999 );
+	}
+
+	public static function grunion_media_button() {
+		if ( empty( $GLOBALS['pagenow'] ) || 'press-this.php' === $GLOBALS['pagenow'] ) {
+			return;
+		}
+		$title = __( 'Add Contact Form', 'jetpack' );
+		?>
+
+		<a id="insert-jetpack-contact-form" class="button" title="<?php echo esc_attr( $title ); ?>" href="javascript:;">
+			<?php echo esc_html( $title ); ?>
+		</a>
+
+		<?php
 	}
 
 	public static function mce_external_plugins( $plugin_array ) {

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -28,6 +28,7 @@ class Grunion_Editor_View {
 		?>
 
 		<a id="insert-jetpack-contact-form" class="button" title="<?php echo esc_attr( $title ); ?>" href="javascript:;">
+			<span class="jetpack-contact-form-icon"></span>
 			<?php echo esc_html( $title ); ?>
 		</a>
 

--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -27,10 +27,10 @@ class Grunion_Editor_View {
 		$title = __( 'Add Contact Form', 'jetpack' );
 		?>
 
-		<a id="insert-jetpack-contact-form" class="button" title="<?php echo esc_attr( $title ); ?>" href="javascript:;">
+		<button id="insert-jetpack-contact-form" class="button" title="<?php echo esc_attr( $title ); ?>" href="javascript:;">
 			<span class="jetpack-contact-form-icon"></span>
 			<?php echo esc_html( $title ); ?>
-		</a>
+		</button>
 
 		<?php
 	}

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -206,4 +206,16 @@
 			QTags.insertContent( '[contact-form]' + grunionEditorView.default_form + '[/contact-form]' );
 		}
 	);
+
+	var $wp_content_wrap = $('#wp-content-wrap');
+	$( '#insert-jetpack-contact-form' ).on( 'click', function( e ) {
+		e.preventDefault();
+		if ( $wp_content_wrap.hasClass('tmce-active') ) {
+			tinymce.execCommand( 'grunion_add_form' );
+		} else if ( $wp_content_wrap.hasClass('html-active') ) {
+			QTags.insertContent( '[contact-form]' + grunionEditorView.default_form + '[/contact-form]' );
+		} else {
+			window.console.error( 'Neither TinyMCE nor QuickTags is active. Unable to insert form.' );
+		}
+	} )
 }( jQuery, wp, grunionEditorView ) );

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -207,15 +207,15 @@
 		}
 	);
 
-	var $wp_content_wrap = $('#wp-content-wrap');
+	var $wp_content_wrap = $( '#wp-content-wrap' );
 	$( '#insert-jetpack-contact-form' ).on( 'click', function( e ) {
 		e.preventDefault();
-		if ( $wp_content_wrap.hasClass('tmce-active') ) {
-			tinymce.execCommand( 'grunion_add_form' );
-		} else if ( $wp_content_wrap.hasClass('html-active') ) {
+		if ( $wp_content_wrap.hasClass( 'tmce-active' ) ) {
+			tinyMCE.execCommand( 'grunion_add_form' );
+		} else if ( $wp_content_wrap.hasClass( 'html-active' ) ) {
 			QTags.insertContent( '[contact-form]' + grunionEditorView.default_form + '[/contact-form]' );
 		} else {
 			window.console.error( 'Neither TinyMCE nor QuickTags is active. Unable to insert form.' );
 		}
-	} )
+	} );
 }( jQuery, wp, grunionEditorView ) );


### PR DESCRIPTION
The prior PR #7490 once merged added the button to create forms to the QuickTags and TinyMCE toolbars as a regular button, but a lot of users may not notice the new location and be confused.

Tentatively re-add the prior button back in as well.