### PR TITLE
Settings UI: add underline to links in notices

### DIFF
--- a/_inc/client/scss/shared/_main.scss
+++ b/_inc/client/scss/shared/_main.scss
@@ -27,6 +27,10 @@
 	text-decoration: none;
 }
 
+.dops-notice__text a {
+	text-decoration: underline;
+}
+
 // Hello Dolly positioning overwrite
 .jetpack-pagestyles #dolly {
 	float: none;


### PR DESCRIPTION
Taken from #7516

#### Changes proposed in this Pull Request:

* add underline to links inside notice texts, following Calypso and DOPS
