### PR TITLE
Markdown: Reverse text hashes before restoration

### DIFF
--- a/_inc/lib/markdown/gfm.php
+++ b/_inc/lib/markdown/gfm.php
@@ -234,7 +234,9 @@ class WPCom_GHF_Markdown_Parser extends MarkdownExtra_Parser {
 	 * @return string       Text with hashed preseravtion placeholders replaced by original text
 	 */
 	protected function do_restore( $text ) {
-		foreach( $this->preserve_text_hash as $hash => $value ) {
+		// Reverse hashes to ensure nested blocks are restored.
+		$hashes = array_reverse( $this->preserve_text_hash, true );
+		foreach( $hashes as $hash => $value ) {
 			$placeholder = $this->hash_maker( $hash );
 			$text = str_replace( $placeholder, $value, $text );
 		}


### PR DESCRIPTION
This ensures that nested blocks are replaced first (e.g. code inside shortcodes).

Fixes #7535.

#### Changes proposed in this Pull Request:

* Replace hashes in (roughly) the same order they were added.

#### Testing instructions:

* Follow example from #7535.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Markdown: Fixed bug where code inside shortcodes isn't correctly restored from the hash.