### PR TITLE
Fix edit view render for Firefox.

### DIFF
--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -88,7 +88,7 @@
 				this.style.height = '10px';
 				this.style.height = ( 5 + innerDoc.body.scrollHeight ) + 'px';
 				tinyMCE.activeEditor.execCommand( 'wpAutoResize' );
-			} )
+			} );
 
 			$editframe.on( 'load', function() {
 				var stylesheet_url = ( 1 === window.isRtl ) ? grunionEditorView.inline_editing_style_rtl : grunionEditorView.inline_editing_style,

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -67,10 +67,6 @@
 				index = 0,
 				named,
 				fields = '',
-				stylesheet_url = ( 1 === window.isRtl ) ? grunionEditorView.inline_editing_style_rtl : grunionEditorView.inline_editing_style,
-				$stylesheet = $( '<link rel="stylesheet" href="' + stylesheet_url + '" />' ),
-				$dashicons_css = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' ),
-				$editfields,
 				field;
 
 			if ( ! shortcode.content ) {
@@ -87,113 +83,126 @@
 				fields += this.edit_template( named );
 			}
 
-			$view.html( $editframe );
-
-			$editframe.contents().find( 'head' ).append( $stylesheet ).append( $dashicons_css );
-			$stylesheet.on( 'load', function() {
-				$editframe.trigger( 'checkheight' );
-			} );
-
-			$editframe.contents().find( 'body' ).html( this.editor_inline( {
-				to      : shortcode.attrs.named.to,
-				subject : shortcode.attrs.named.subject,
-				fields  : fields
-			} ) );
-
 			$editframe.on( 'checkheight', function() {
+				var innerDoc = ( this.contentDocument ) ? this.contentDocument : this.contentWindow.document;
 				this.style.height = '10px';
-				this.style.height = ( 5 + this.contentWindow.document.body.scrollHeight ) + 'px';
+				this.style.height = ( 5 + innerDoc.body.scrollHeight ) + 'px';
 				tinyMCE.activeEditor.execCommand( 'wpAutoResize' );
-			} ).trigger( 'checkheight' ).hide().fadeIn( 250, function() {
-				$( this ).contents().find( 'input:first' ).focus();
-			} );
+			} )
 
-			$editfields = $editframe.contents().find( '.grunion-fields' );
-			$editfields.sortable();
-			$editfields.on( 'change select', 'select[name=type]', function() {
-				$( this ).closest( '.grunion-field-edit' )[ 0 ].className =
-					'card is-compact grunion-field-edit grunion-field-' + $( this ).val();
-				$editframe.trigger( 'checkheight' );
-			} );
+			$editframe.on( 'load', function() {
+				var stylesheet_url = ( 1 === window.isRtl ) ? grunionEditorView.inline_editing_style_rtl : grunionEditorView.inline_editing_style,
+					$stylesheet = $( '<link rel="stylesheet" href="' + stylesheet_url + '" />' ),
+					$dashicons_css = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' );
 
-			var $buttons = $editframe.contents().find( '.grunion-controls' );
-
-			// The 'save' listener.
-			$buttons.find( 'input[name=submit]' ).on( 'click', function(){
-				var new_data = shortcode;
-
-				new_data.type = 'closed';
-				new_data.attrs = {};
-				new_data.content = '';
-
-				$editfields.children().each( function() {
-					var field_shortcode = {
-							tag   : 'contact-field',
-							type  : 'single',
-							attrs : {
-								label : $( this ).find( 'input[name=label]' ).val(),
-								type  : $( this ).find( 'select[name=type]' ).val()
-							}
-						},
-						options = [];
-
-					if ( $( this ).find( 'input[name=required]:checked' ).length ) {
-						field_shortcode.attrs.required = '1';
-					}
-
-					$( this ).find( 'input[name=option]' ).each( function() {
-						if ( $( this ).val() ) {
-							options.push( $( this ).val() );
-						}
-					} );
-					if ( options.length ) {
-						field_shortcode.attrs.options = options.join( ',' );
-					}
-
-					new_data.content += wp.shortcode.string( field_shortcode );
+				$editframe.contents().find( 'head' ).append( $stylesheet ).append( $dashicons_css );
+				$stylesheet.on( 'load', function() {
+					$editframe.trigger( 'checkheight' );
 				} );
 
-				if ( $editframe.contents().find( 'input[name=to]' ).val() ) {
-					new_data.attrs.to = $editframe.contents().find( 'input[name=to]' ).val();
-				}
-				if ( $editframe.contents().find( 'input[name=subject]' ).val() ) {
-					new_data.attrs.subject = $editframe.contents().find( 'input[name=subject]' ).val();
-				}
+				$editframe.contents().find( 'body' ).html( wp.mce.grunion_wp_view_renderer.editor_inline( {
+					to      : shortcode.attrs.named.to,
+					subject : shortcode.attrs.named.subject,
+					fields  : fields
+				} ) );
 
-				update_callback( wp.shortcode.string( new_data ) );
+				$editframe.contents().find( 'input:first' ).focus();
+
+				setTimeout( function(){
+					$editframe.trigger( 'checkheight' );
+				}, 250 );
+
+				var $editfields = $editframe.contents().find( '.grunion-fields' ),
+					$buttons = $editframe.contents().find( '.buttons' );
+
+				$editfields.sortable();
+
+				// Now, add all the listeners!
+
+				$editfields.on( 'change select', 'select[name=type]', function() {
+					$( this ).closest( '.grunion-field-edit' )[ 0 ].className =
+						'card is-compact grunion-field-edit grunion-field-' + $( this ).val();
+					$editframe.trigger( 'checkheight' );
+				} );
+
+				$editfields.on( 'click', '.delete-option', function( e ) {
+					e.preventDefault();
+					$( this ).closest( 'li' ).remove();
+					$editframe.trigger( 'checkheight' );
+				} );
+
+				$editfields.on( 'click', '.add-option', function( e ) {
+					var $new_option = $( wp.mce.grunion_wp_view_renderer.editor_option() );
+					e.preventDefault();
+					$( this ).closest( 'li' ).before( $new_option );
+					$editframe.trigger( 'checkheight' );
+					$new_option.find( 'input:first' ).focus();
+				} );
+
+				$editfields.on( 'click', '.delete-field', function( e ) {
+					e.preventDefault();
+					$( this ).closest( '.card' ).remove();
+					$editframe.trigger( 'checkheight' );
+				} );
+
+				$buttons.find( 'input[name=submit]' ).on( 'click', function(){
+					var new_data = shortcode;
+
+					new_data.type = 'closed';
+					new_data.attrs = {};
+					new_data.content = '';
+
+					$editfields.children().each( function() {
+						var field_shortcode = {
+								tag   : 'contact-field',
+								type  : 'single',
+								attrs : {
+									label : $( this ).find( 'input[name=label]' ).val(),
+									type  : $( this ).find( 'select[name=type]' ).val()
+								}
+							},
+							options = [];
+
+						if ( $( this ).find( 'input[name=required]:checked' ).length ) {
+							field_shortcode.attrs.required = '1';
+						}
+
+						$( this ).find( 'input[name=option]' ).each( function() {
+							if ( $( this ).val() ) {
+								options.push( $( this ).val() );
+							}
+						} );
+						if ( options.length ) {
+							field_shortcode.attrs.options = options.join( ',' );
+						}
+
+						new_data.content += wp.shortcode.string( field_shortcode );
+					} );
+
+					if ( $editframe.contents().find( 'input[name=to]' ).val() ) {
+						new_data.attrs.to = $editframe.contents().find( 'input[name=to]' ).val();
+					}
+					if ( $editframe.contents().find( 'input[name=subject]' ).val() ) {
+						new_data.attrs.subject = $editframe.contents().find( 'input[name=subject]' ).val();
+					}
+
+					update_callback( wp.shortcode.string( new_data ) );
+				} );
+
+				$buttons.find( 'input[name=cancel]' ).on( 'click', function() {
+					update_callback( wp.shortcode.string( shortcode ) );
+				} );
+
+				$buttons.find( 'input[name=add-field]' ).on( 'click', function() {
+					var $new_field = $( wp.mce.grunion_wp_view_renderer.edit_template( {} ) );
+					$editfields.append( $new_field );
+					$editfields.sortable( 'refresh' );
+					$editframe.trigger( 'checkheight' );
+					$new_field.find( 'input:first' ).focus();
+				} );
 			} );
 
-			$buttons.find( 'input[name=cancel]' ).on( 'click', function() {
-				update_callback( wp.shortcode.string( shortcode ) );
-			} );
-
-			$buttons.find( 'input[name=add-field]' ).on( 'click', function() {
-				var $new_field = $( wp.mce.grunion_wp_view_renderer.edit_template( {} ) );
-				$editfields.append( $new_field );
-				$editfields.sortable( 'refresh' );
-				$editframe.trigger( 'checkheight' );
-				$new_field.find( 'input:first' ).focus();
-			} );
-
-			$editfields.on( 'click', '.delete-option', function( e ) {
-				e.preventDefault();
-				$( this ).closest( 'li' ).remove();
-				$editframe.trigger( 'checkheight' );
-			} );
-
-			$editfields.on( 'click', '.add-option', function( e ) {
-				var $new_option = $( wp.mce.grunion_wp_view_renderer.editor_option() );
-				e.preventDefault();
-				$( this ).closest( 'li' ).before( $new_option );
-				$editframe.trigger( 'checkheight' );
-				$new_option.find( 'input:first' ).focus();
-			} );
-
-			$editfields.on( 'click', '.delete-field', function( e ) {
-				e.preventDefault();
-				$( this ).closest( '.card' ).remove();
-				$editframe.trigger( 'checkheight' );
-			} );
+			$view.html( $editframe );
 		}
 	};
 	wp.mce.views.register( 'contact-form', wp.mce.grunion_wp_view_renderer );

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -113,7 +113,7 @@
 				}, 250 );
 
 				var $editfields = $editframe.contents().find( '.grunion-fields' ),
-					$buttons = $editframe.contents().find( '.buttons' );
+					$buttons = $editframe.contents().find( '.grunion-controls' );
 
 				$editfields.sortable();
 


### PR DESCRIPTION
We were writing the contents too quickly after adding the empty iframe
to the dom -- so when load ran, the contents got wiped out.

Instead let's do our stuff on the load event.

The downside is that there's a brief flash of unstyled content, will
look at addressing seperately -- as that's gloss, not functionality.

Props @petitphp for the find!

https://twitter.com/petitphp/status/889968381994160128