### PR TITLE
Fixes default global options array merging.

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -189,10 +189,10 @@ class Sharing_Service {
 		 * @see https://github.com/Automattic/jetpack/issues/6121
 		 */
 		if ( ! is_array( $options ) || ! isset( $options['button_style'], $options['global'] ) ) {
-			$options = array_merge(
-				is_array( $options ) ? $options : array(),
-				array( 'global' => $this->get_global_options() )
-			);
+			$global_options = array( 'global' => $this->get_global_options() );
+			$options = is_array( $options )
+				? array_merge( $options, $global_options )
+				: $global_options;
 		}
 
 		$global = $options['global'];

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -189,8 +189,10 @@ class Sharing_Service {
 		 * @see https://github.com/Automattic/jetpack/issues/6121
 		 */
 		if ( ! is_array( $options ) || ! isset( $options['button_style'], $options['global'] ) ) {
-			$global_options = $this->get_global_options();
-			$options = array_merge( is_array( $options ) ? $options : array(), $global_options );
+			$options = array_merge(
+				is_array( $options ) ? $options : array(),
+				array( 'global' => $this->get_global_options() )
+			);
 		}
 
 		$global = $options['global'];


### PR DESCRIPTION
A change introduced in #6355 started merging the regular options array with the global options. This has been largely unnoticed, but sometimes resulted in weird errors like this:

```
 PHP Catchable fatal error:  Argument 2 passed to Share_Twitter::__construct() must be of the type array, null given, called in /home/asotestjetpack/main/wp-content/plugins/jetpack-dev/modules/sharedaddy/sharing-service.php on line 227 and defined in /home/asotestjetpack/main/wp-content/plugins/jetpack-dev/modules/sharedaddy/sharing-sources.php on line 562
 PHP Warning:  array_merge(): Argument #1 is not an array in /home/asotestjetpack/main/wp-content/plugins/jetpack-dev/modules/sharedaddy/sharing-service.php on line 227
 PHP Notice:  Undefined index: global in /home/asotestjetpack/main/wp-content/plugins/jetpack-dev/modules/sharedaddy/sharing-service.php on line 196
```

#### Testing instructions:
* I have been able to reproduce the problem when testing Jetpack 5.2 beta1 with doing an options reset. It may have been related to the fact that I was testing PHP 5.2.
