### PR TITLE
Settings UI: fix blank dashboard when non-admin had Stats access

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -123,7 +123,7 @@ class AtAGlance extends Component {
          */
 		let stats = '';
 		if ( this.props.userCanViewStats ) {
-			stats = <DashStats { ...urls } />;
+			stats = <DashStats { ...settingsProps } { ...urls } />;
 		}
 
 		let protect = '';


### PR DESCRIPTION
Fixes #7462

#### Changes proposed in this Pull Request:

* pass props so getOptionValue() method is available for usage in the component

#### Testing instructions:

* test as Adam points here https://github.com/Automattic/jetpack/issues/7462#issue-242747877

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
An issue that resulted in a blank dashboard for non admins when they had access to Stats has been fixed.