### PR TITLE
Resolve an unnecessary gap at the bottom.

### DIFF
--- a/modules/contact-form/css/editor-style.css
+++ b/modules/contact-form/css/editor-style.css
@@ -535,6 +535,8 @@ input[type="submit"]:focus {
 	min-height: 500px;
 	border: 0;
 	overflow: hidden;
+	margin-bottom: 0;
+	display: block;
 }
 
 .contact-submit.contact-submit {

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -95,16 +95,17 @@
 					$stylesheet = $( '<link rel="stylesheet" href="' + stylesheet_url + '" />' ),
 					$dashicons_css = $( '<link rel="stylesheet" href="' + grunionEditorView.dashicons_css_url + '" />' );
 
-				$editframe.contents().find( 'head' ).append( $stylesheet ).append( $dashicons_css );
 				$stylesheet.on( 'load', function() {
+					$editframe.contents().find( 'body' ).css( 'visibility', 'visible' );
 					$editframe.trigger( 'checkheight' );
 				} );
+				$editframe.contents().find( 'head' ).append( $stylesheet ).append( $dashicons_css );
 
 				$editframe.contents().find( 'body' ).html( wp.mce.grunion_wp_view_renderer.editor_inline( {
 					to      : shortcode.attrs.named.to,
 					subject : shortcode.attrs.named.subject,
 					fields  : fields
-				} ) );
+				} ) ).css( 'visibility', 'hidden' );
 
 				$editframe.contents().find( 'input:first' ).focus();
 


### PR DESCRIPTION
This can be caused by theme editor styles -- in this case, it was caused
by twentyseventeen here:

https://github.com/WordPress/WordPress/blob/be94fa5483dd98667d1fd911d6390ad34387804d/wp-content/themes/twentyseventeen/assets/css/editor-style.css#L343

and looks like this, before the change:

<img width="751" alt="67d9879a532e7363de480b782a8ce320" src="https://user-images.githubusercontent.com/941023/28644311-016b6fec-7227-11e7-9517-37e10fcc35dc.png">
