### PR TITLE
Comments: Force https on Facebook/Twitter avatars

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -161,7 +161,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		}
 
 		// Return the FB or Twitter avatar
-		return preg_replace( '#src=([\'"])[^\'"]+\\1#', 'src=\\1' . esc_url( $this->photon_avatar( $foreign_avatar, $size ) ) . '\\1', $avatar );
+		return preg_replace( '#src=([\'"])[^\'"]+\\1#', 'src=\\1' . esc_url( set_url_scheme( $this->photon_avatar( $foreign_avatar, $size ), 'https' ) ) . '\\1', $avatar );
 	}
 
 	/** Output Methods ********************************************************/


### PR DESCRIPTION
In some cases, http is stored in the comment meta for the hc_avatar coming in from Facebook/Twitter. Since FB/Twitter support https, we can force that and avoid mixed content warnings. With Photon on, Twitter likely already worked since Photon uses https, but Facebook would still fail since we skip graph.facebook.com URLs via Photon.

Originally reported in 606687-zen

Fixes https://github.com/Automattic/jetpack/issues/7548