### PR TITLE
Settings UI: open inline learn more links in new tab

### DIFF
--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -73,7 +73,7 @@ export const SettingsGroup = props => {
 									onClick={ trackLearnMoreClick }
 									icon={ false }
 									href={ support }
-									target="_blank">
+									target="_blank" rel="noopener noreferrer">
 									{ __( 'Learn more' ) }
 								</ExternalLink>
 							</InfoPopover>

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -120,7 +120,9 @@ export const Comments = moduleSettingsForm(
 													{
 														gravatar.description + ' '
 													}
-													<a href={ gravatar.learn_more_button }>{ __( 'Learn more' ) }</a>
+													<a href={ gravatar.learn_more_button } target="_blank" rel="noopener noreferrer">
+														{ __( 'Learn more' ) }
+													</a>
 												</span>
 											</ModuleToggle>
 										</FormFieldset>
@@ -140,7 +142,9 @@ export const Comments = moduleSettingsForm(
 													{
 														__( 'Enable Markdown use for comments.' ) + ' '
 													}
-													<a href={ markdown.learn_more_button }>{ __( 'Learn more' ) }</a>
+													<a href={ markdown.learn_more_button } target="_blank" rel="noopener noreferrer">
+														{ __( 'Learn more' ) }
+													</a>
 												</span>
 											</ModuleToggle>
 										</FormFieldset>
@@ -161,7 +165,7 @@ export const Comments = moduleSettingsForm(
 													{
 														( 'Enable comment likes.' ) + ' '
 													}
-													<a href="https://jetpack.com/support/comment-likes/">
+													<a href="https://jetpack.com/support/comment-likes/" target="_blank" rel="noopener noreferrer">
 														{ __( 'Learn more' ) }
 													</a>
 												</span>

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -56,9 +56,9 @@ export const Sitemaps = moduleSettingsForm(
 									<FormFieldset>
 										<p className="jp-form-setting-explanation">{ __( 'Your sitemap is automatically sent to all major search engines for indexing.' ) }</p>
 										<p>
-											<ExternalLink onClick={ this.trackSitemapUrl } icon={ true } target="_blank" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
+											<ExternalLink onClick={ this.trackSitemapUrl } icon={ true } target="_blank" rel="noopener noreferrer" href={ sitemap_url }>{ sitemap_url }</ExternalLink>
 											<br />
-											<ExternalLink onClick={ this.trackSitemapNewsUrl } icon={ true } target="_blank" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
+											<ExternalLink onClick={ this.trackSitemapNewsUrl } icon={ true } target="_blank" rel="noopener noreferrer" href={ news_sitemap_url }>{ news_sitemap_url }</ExternalLink>
 										</p>
 									</FormFieldset>
 								)

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -38,28 +38,28 @@ export const VerificationServices = moduleSettingsForm(
 										google: (
 											<ExternalLink
 												icon={ true }
-												target="_blank"
+												target="_blank" rel="noopener noreferrer"
 												href="https://www.google.com/webmasters/tools/"
 											/>
 										),
 										bing: (
 											<ExternalLink
 												icon={ true }
-												target="_blank"
+												target="_blank" rel="noopener noreferrer"
 												href="https://www.bing.com/webmaster/"
 											/>
 										),
 										pinterest: (
 											<ExternalLink
 												icon={ true }
-												target="_blank"
+												target="_blank" rel="noopener noreferrer"
 												href="https://pinterest.com/website/verify/"
 											/>
 										),
 										yandex: (
 											<ExternalLink
 												icon={ true }
-												target="_blank"
+												target="_blank" rel="noopener noreferrer"
 												href="https://webmaster.yandex.com/sites/"
 											/>
 										)


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* open inline Learn More links in a new tab to be consistent with info popover links
* comply with ESlint best practices react/jsx-no-target-blank

#### Testing instructions:

* make sure Learn More links in Discussion tab open in a new browser tab.