### PR TITLE
Comment likes: set the right URL to look for assets

### DIFF
--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -126,8 +126,8 @@ class Jetpack_Comment_Likes {
 			wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
 		}
 		wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array( 'open-sans' ), JETPACK__VERSION );
-		wp_enqueue_script( 'postmessage', plugins_url( '_inc/postmessage.js', JETPACK__PLUGIN_DIR ), array( 'jquery' ), JETPACK__VERSION, false );
-		wp_enqueue_script( 'jetpack_resize', plugins_url( '_inc/jquery.jetpack-resize.js' , JETPACK__PLUGIN_DIR ), array( 'jquery' ), JETPACK__VERSION, false );
+		wp_enqueue_script( 'postmessage', plugins_url( '_inc/postmessage.js', JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION, false );
+		wp_enqueue_script( 'jetpack_resize', plugins_url( '_inc/jquery.jetpack-resize.js' , JETPACK__PLUGIN_FILE ), array( 'jquery' ), JETPACK__VERSION, false );
 		wp_enqueue_script( 'jetpack_likes_queuehandler', plugins_url( 'likes/queuehandler.js' , __FILE__ ), array( 'jquery', 'postmessage', 'jetpack_resize' ), JETPACK__VERSION, true );
 	}
 


### PR DESCRIPTION
Fixes issue reported by @keoshi 
<img width="588" alt="screen-shot-2017-07-27-at-18-24-06" src="https://user-images.githubusercontent.com/1041600/28685301-ba78bfba-72dd-11e7-9a44-014bc9f992f6.png">

#### Changes proposed in this Pull Request:

* set the correct path to resolve URL for assets

#### Testing instructions:

* make sure Comment likes work on the front end 

