### PR TITLE
Settings UI: Refine AtD options styling

### DIFF
--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -84,6 +84,10 @@
 	& > .jp-form-setting-explanation {
 		margin-left: rem( 36px );
 	}
+
+	& > .jp-form-fieldset {
+		margin-bottom: rem( 16px );
+	}
 }
 
 .jp-form-block-fade {

--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -1,6 +1,7 @@
 .react-tagsinput {
 	border: 1px solid #e9eff3;
 	padding: rem( 5px );
+	height: rem( 30px );
 }
 
 .react-tagsinput--focused {

--- a/_inc/client/components/tags-input/style.scss
+++ b/_inc/client/components/tags-input/style.scss
@@ -37,11 +37,13 @@
 	content: " \00d7";
 }
 
-.react-tagsinput-input {
-	font-size: 13px;
-	padding: rem( 5px );
+input[type=text].react-tagsinput-input {
 	width: rem( 150px );
-	margin: 0;
 	height: rem( 30px );
-	vertical-align: top;
+	margin: 0;
+	padding: rem( 5px );
+	font-size: 13px;
+	vertical-align: middle;
+	border: none;
+	box-shadow: none;
 }


### PR DESCRIPTION
This PR refines the styling on AtD settings (spelling, style, grammar):

- Increases spacing between subsections.
- Cleans up input inside an input on “Ignored Phrases”

## Before

<img width="388" alt="screen-shot-2017-04-03-at-13-29-57" src="https://cloud.githubusercontent.com/assets/426388/24611785/8720589e-1883-11e7-9e5e-396812e54e53.png">


## After

<img width="751" alt="screen shot 2017-07-28 at 11 44 38" src="https://user-images.githubusercontent.com/390760/28714291-bc09c524-738a-11e7-9638-4fef4089d2b6.png">

## Testing instructions

Visit Writing settings, and expand “Check your spelling, style, and grammar” — `wp-admin/admin.php?page=jetpack#/writing`

Fixes #6868