### PR TITLE
Settings UI: update styling of WooCommerce notices shown here

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -12,30 +12,31 @@ const AdminNotices = React.createClass( {
 			$vpNotice.each( function() {
 				let $notice = jQuery( this ).addClass( 'dops-notice is-warning vp-notice-jp' ).removeClass( 'wrap vp-notice' );
 				const icon = '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path></g></svg>';
-				$notice.wrapInner( '<div class="dops-notice__content">' );
+				$notice.wrapInner( '<span class="dops-notice__content">' );
 				$notice.find( '.dops-notice__content' ).before( icon );
 				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );
 				$notice.find( 'h3' ).replaceWith( function() { return jQuery( '<strong />', { html: this.innerHTML } ); } );
 				$notice.find( 'p' ).replaceWith( function() { return jQuery( '<div/>', { html: this.innerHTML } ); } );
 				$notice.find( 'a[href*="admin.php?page=vaultpress"]' ).remove();
-				$notice.prependTo( $adminNotices ).show();
+				$notice.prependTo( $adminNotices ).css( 'display', 'flex' );
 			} );
 		}
 
 		const $wcNotice = jQuery( '.woocommerce-message' );
 		if ( $wcNotice.length > 0 ) {
 			$wcNotice.each( function() {
-				const $notice = jQuery( this ).addClass( 'dops-notice is-basic' ).removeClass( 'updated wc-connect' );
+				const $notice = jQuery( this ).addClass( 'dops-notice' ).removeClass( 'updated wc-connect' );
 				$notice.find( '.button-primary' ).addClass( 'dops-notice__action' ).removeClass( 'button-primary' ).detach().appendTo( $notice );
-				$notice.find( 'p' ).not( '.submit' ).wrapAll( '<div class="dops-notice__text"/>' );
+				$notice.find( 'p' ).not( '.submit' ).wrapAll( '<span class="dops-notice__text"/>' );
 				const $dopsNotice = $notice.find( '.dops-notice__text' );
 				$dopsNotice.find( 'p' ).replaceWith( function() { return jQuery( '<div/>', { html: this.innerHTML, class: 'dops-notice__moved_text' } ); } );
 				$dopsNotice.find( 'br' ).remove();
 				$notice.find( '.button-secondary' ).removeClass( 'button-secondary' ).detach().appendTo( $dopsNotice );
 				$notice.find( '.submit' ).remove();
-				$notice.find( '.woocommerce-message-close' ).removeClass( 'woocommerce-message-close' ).addClass( 'dops-notice__action' );
-				$notice.prependTo( $adminNotices ).wrapInner( '<div class="dops-notice__content">' ).show();
+				$notice.find( '.woocommerce-message-close' ).removeClass( 'woocommerce-message-close notice-dismiss' ).addClass( 'dops-notice__action' );
+				$notice.wrapInner( '<span class="dops-notice__content">' ).prependTo( $adminNotices ).css( 'display', 'flex' );
 				$notice.find( '.dops-notice__action' ).not( ':first' ).removeClass( 'dops-notice__action' ).detach().appendTo( $notice.find( '.dops-notice__text' ) );
+				$notice.find( '.dops-notice__action:first' ).detach().appendTo( $notice );
 			} );
 		}
 	},

--- a/_inc/client/components/admin-notices/style.scss
+++ b/_inc/client/components/admin-notices/style.scss
@@ -12,18 +12,14 @@
 
 	.woocommerce-message.dops-notice {
 		display: block;
+		padding: 0;
+
+		&::before {
+			content: '';
+		}
 
 		.submit {
 			padding: 0;
-		}
-
-		.skip {
-			color: $gray;
-			opacity: 0.85;
-		}
-
-		.skip:hover {
-			opacity: 1;
 		}
 
 		.notice-dismiss::before {


### PR DESCRIPTION
Fixes issue reported by @keoshi: WooCommerce notices aren't properly stylized and they're cropped on mobile sizes.
The style they had before was due to the `is-basic` modifier. However, Filipe pointed that there are no notices with that style, and indeed there's none in https://wpcalypso.wordpress.com/devdocs/design so I've removed it so they're stylized as any regular notice.

#### Changes proposed in this Pull Request:

* ensure notices aren't cropped in mobile
* update their styling to match the basic notice styling

### Before
<img width="722" alt="captura de pantalla 2017-07-28 a las 15 13 40" src="https://user-images.githubusercontent.com/1041600/28730654-62043f74-73a7-11e7-87f0-313737fe3290.png">

#### Hover

<img width="701" alt="captura de pantalla 2017-07-28 a las 15 24 26" src="https://user-images.githubusercontent.com/1041600/28731080-df477ee6-73a8-11e7-9116-7c8a828ceba4.png">

### After
<img width="735" alt="captura de pantalla 2017-07-28 a las 15 07 10" src="https://user-images.githubusercontent.com/1041600/28730656-63b720e8-73a7-11e7-9c88-682ee0b355cd.png">

#### Hover
<img width="705" alt="captura de pantalla 2017-07-28 a las 15 23 29" src="https://user-images.githubusercontent.com/1041600/28731040-bea37c8a-73a8-11e7-9b16-847fc44fe538.png">

Note: Skip setup has that color because it's slightly faded in WC so I set it in our `$gray` color var.

#### Testing instructions:

* edit this WooCommerce file `woocommerce/includes/admin/class-wc-admin-notices.php` and in method `add_notices()` replace the line
```php
$notices = self::get_notices();
```
with
```php
$notices = array(
			'install',
			'update',
			'template_files',
			'theme_support',
			'legacy_shipping',
			'no_shipping_methods',
			'simplify_commerce',
		);
```

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix styling of WooCommerce notices shown in Jetpack settings page.
