### PR TITLE
Fix widget saving

### DIFF
--- a/sync/class.jetpack-sync-module-themes.php
+++ b/sync/class.jetpack-sync-module-themes.php
@@ -33,7 +33,7 @@ class Jetpack_Sync_Module_Themes extends Jetpack_Sync_Module {
 
 	public function sync_widget_edit( $instance, $new_instance, $old_instance, $widget_object ) {
 		if ( empty( $old_instance ) ) {
-			return;
+			return $instance;
 		}
 
 		$widget = array(


### PR DESCRIPTION
Fixes #7570 

In #7487, we tried to improve syncing of widgets for activity log, but manage to break instances where new widgets were added.

Team Poseidon will work on a better method for improving widget syncing.

To test:
Checkout this branch, and ensure you can add a new widget and save it's settings.