### PR TITLE
Add Epoch plugin to incompatible plugin list for comment-likes module

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -110,6 +110,9 @@ class Jetpack {
 			'Google+ Comments'                     => 'google-plus-comments/google-plus-comments.php',
 			'WP-SpamShield Anti-Spam'              => 'wp-spamshield/wp-spamshield.php',
 		),
+		'comment-likes' => array(
+			'Epoch'                                => 'epoch/plugincore.php',
+		),
 		'contact-form'      => array(
 			'Contact Form 7'                       => 'contact-form-7/wp-contact-form-7.php',
 			'Gravity Forms'                        => 'gravityforms/gravityforms.php',


### PR DESCRIPTION
addresses #7568

The actual fix for this would require a change in the epoch plugin as well as Jetpack.  For now, we're adding it to the incompatible list for comment-likes module.  