### PR TITLE
Widgets: fix border around icons in TwentySeventeen

### DIFF
--- a/modules/widgets/social-media-icons/style.css
+++ b/modules/widgets/social-media-icons/style.css
@@ -3,7 +3,7 @@
     margin-left: 0;
 }
 
-.widget_wpcom_social_media_icons_widget li {
+.widget_wpcom_social_media_icons_widget ul li {
     border: 0 none;
     display: inline;
     margin-right: 0.5em;


### PR DESCRIPTION
Fixes #7452

#### Changes proposed in this Pull Request:

* add specificity to CSS rule

<img width="192" alt="captura de pantalla 2017-08-02 a las 15 25 31" src="https://user-images.githubusercontent.com/1041600/28888431-ea738a52-7796-11e7-8c82-a9c8df528197.png">

#### Testing instructions:

* use TwentySeventeen
* add Social Media Icons widget
* verify there's no border like in the issue #7452

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Remove unwanted border around social media icons with TwentySeventeen theme