### PR TITLE
Jetpack Sync: Update user sync for activity log

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6671,7 +6671,7 @@ p {
 
 		//Do check in linear O(n) time for < PHP5.5 ( using isset at least prevents O(n^2) )
 		foreach ( $backtrace as $call ) {
-			if ( isset( $names[ $call['function'] ] ) ) {
+			if ( isset( $names_as_keys[ $call['function'] ] ) ) {
 				return true;
 			}
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6646,4 +6646,35 @@ p {
 		}
 		return false;
 	}
+
+	/**
+	 * Checks if one or more function names is in debug_backtrace
+	 *
+	 * @param $names Mixed string name of function or array of string names of functions
+	 *
+	 * @return bool
+	 */
+	public static function is_function_in_backtrace( $names ) {
+		$backtrace = debug_backtrace( false );
+		if ( ! is_array( $names ) ) {
+			$names = array( $names );
+		}
+		$names_as_keys = array_flip( $names );
+
+		//Do check in constant O(1) time for PHP5.5+
+		if ( function_exists( 'array_column' ) ) {
+			$backtrace_functions = array_column( $backtrace, 'function' );
+			$backtrace_functions_as_keys = array_flip( $backtrace_functions );
+			$intersection = array_intersect_key( $backtrace_functions_as_keys, $names_as_keys );
+			return ! empty ( $intersection );
+		}
+
+		//Do check in linear O(n) time for < PHP5.5 ( using isset at least prevents O(n^2) )
+		foreach ( $backtrace as $call ) {
+			if ( isset( $names[ $call['function'] ] ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/sync/class.jetpack-sync-module-users.php
+++ b/sync/class.jetpack-sync-module-users.php
@@ -23,13 +23,20 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		add_action( 'add_user_to_blog', array( $this, 'save_user_handler' ) );
 		add_action( 'jetpack_sync_add_user', $callable, 10, 2 );
 		add_action( 'jetpack_sync_register_user', $callable, 10, 2 );
-		add_action( 'jetpack_sync_save_user', $callable, 10, 2 );
+		add_action( 'jetpack_sync_save_user', $callable );
+
+		//Edit user info, see https://github.com/WordPress/WordPress/blob/c05f1dc805bddcc0e76fd90c4aaf2d9ea76dc0fb/wp-admin/user-edit.php#L126
+		add_action( 'personal_options_update', array( $this, 'edited_user_handler' ) );
+		add_action( 'edit_user_profile_update', array( $this, 'edited_user_handler' ) );
+		add_action( 'jetpack_user_edited', $callable );
 
 		add_action( 'jetpack_sync_user_locale', $callable, 10, 2 );
 		add_action( 'jetpack_sync_user_locale_delete', $callable, 10, 1 );
 
-		add_action( 'deleted_user', $callable, 10, 2 );
-		add_action( 'remove_user_from_blog', $callable, 10, 2 );
+		add_action( 'deleted_user', array( $this, 'deleted_user_handler' ), 10, 2 );
+		add_action( 'jetpack_deleted_user', $callable, 10, 3 );
+		add_action( 'remove_user_from_blog', array( $this, 'remove_user_from_blog_handler' ), 10, 2 );
+		add_action( 'jetpack_removed_user_from_blog', $callable, 10, 2 );
 
 		// user roles
 		add_action( 'add_user_role', array( $this, 'save_user_role_handler' ), 10, 2 );
@@ -55,7 +62,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	public function init_before_send() {
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_add_user', array( $this, 'expand_user' ) );
 		add_filter( 'jetpack_sync_before_send_jetpack_sync_register_user', array( $this, 'expand_user' ) );
-		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ) );
+		add_filter( 'jetpack_sync_before_send_jetpack_sync_save_user', array( $this, 'expand_user' ), 10, 2 );
 		add_filter( 'jetpack_sync_before_send_wp_login', array( $this, 'expand_login_username' ), 10, 1 );
 		add_filter( 'jetpack_sync_before_send_wp_logout', array( $this, 'expand_logout_username' ), 10, 2 );
 
@@ -90,6 +97,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 				$user->locale = get_user_locale( $user->ID );
 			}
 		}
+
 		return $user;
 	}
 
@@ -114,13 +122,21 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		$user  = get_userdata( $user_id );
 		$user  = $this->sanitize_user( $user );
 		$login = '';
-		if( is_object( $user ) && is_object( $user->data ) ) {
+		if ( is_object( $user ) && is_object( $user->data ) ) {
 			$login = $user->data->user_login;
 		}
 
 		return array( $login, $user );
 	}
 
+	public function deleted_user_handler( $deleted_user_id, $reassigned_user_id = '' ) {
+		do_action( 'jetpack_deleted_user', $deleted_user_id, $reassigned_user_id, is_multisite() );
+	}
+
+	public function edited_user_handler( $user_id ) {
+		do_action( 'jetpack_user_edited', $user_id );
+	}
+	
 	function save_user_handler( $user_id, $old_user_data = null ) {
 		// ensure we only sync users who are members of the current blog
 		if ( ! is_user_member_of_blog( $user_id, get_current_blog_id() ) ) {
@@ -152,6 +168,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			 * @param object The WP_User object
 			 */
 			do_action( 'jetpack_sync_register_user', $user );
+
 			return;
 		}
 		/* MU Sites add users instead of register them to sites */
@@ -164,8 +181,10 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			 * @param object The WP_User object
 			 */
 			do_action( 'jetpack_sync_add_user', $user );
+
 			return;
 		}
+
 		/**
 		 * Fires when the client needs to sync an updated user
 		 *
@@ -177,8 +196,12 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	function save_user_role_handler( $user_id, $role, $old_roles = null ) {
-		$user = $this->sanitize_user( get_user_by( 'id', $user_id ) );
+		//The jetpack_sync_register_user payload is identical to jetpack_sync_save_user, don't send both
+		if ( $this->is_create_user() || $this->is_add_user_to_blog() ) {
+			return;
+		}
 
+		$user = $this->sanitize_user( get_user_by( 'id', $user_id ) );
 		/**
 		 * Fires when the client needs to sync an updated user
 		 *
@@ -216,6 +239,11 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 	}
 
 	function save_user_cap_handler( $meta_id, $user_id, $meta_key, $capabilities ) {
+		//The jetpack_sync_register_user payload is identical to jetpack_sync_save_user, don't send both
+		if ( $this->is_create_user() || $this->is_add_user_to_blog() ) {
+			return;
+		}
+
 		// if a user is currently being removed as a member of this blog, we don't fire the event
 		if ( current_filter() === 'deleted_user_meta'
 		     &&
@@ -226,7 +254,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 			return;
 		}
 
-		$user =  get_user_by( 'id', $user_id );
+		$user = get_user_by( 'id', $user_id );
 		if ( $meta_key === $user->cap_key ) {
 			/**
 			 * Fires when the client needs to sync an updated user
@@ -241,6 +269,7 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
 		global $wpdb;
+
 		return $this->enqueue_all_ids_as_action( 'jetpack_full_sync_users', $wpdb->usermeta, 'user_id', $this->get_where_sql( $config ), $max_items_to_enqueue, $state );
 	}
 
@@ -291,5 +320,49 @@ class Jetpack_Sync_Module_Users extends Jetpack_Sync_Module {
 		$user_ids = $args[0];
 
 		return array_map( array( $this, 'sanitize_user_and_expand' ), get_users( array( 'include' => $user_ids ) ) );
+	}
+
+	public function remove_user_from_blog_handler( $user_id, $blog_id ) {
+		//User is removed on add, see https://github.com/WordPress/WordPress/blob/0401cee8b36df3def8e807dd766adc02b359dfaf/wp-includes/ms-functions.php#L2114
+		if ( $this->is_add_new_user_to_blog() ) {
+			return;
+		}
+
+		$reassigned_user_id = $this->get_reassigned_network_user_id();
+
+		//Note that we are in the context of the blog the user is removed from, see https://github.com/WordPress/WordPress/blob/473e1ba73bc5c18c72d7f288447503713d518790/wp-includes/ms-functions.php#L233
+		do_action( 'jetpack_removed_user_from_blog', $user_id, $reassigned_user_id );
+	}
+
+	private function is_add_new_user_to_blog() {
+		return Jetpack::is_function_in_backtrace( 'add_new_user_to_blog' );
+	}
+
+	private function is_add_user_to_blog() {
+		return Jetpack::is_function_in_backtrace( 'add_user_to_blog' );
+	}
+
+	private function is_create_user() {
+		$functions = array(
+			'add_new_user_to_blog', // Used to suppress jetpack_sync_save_user in save_user_cap_handler when user registered on multi site
+			'wp_create_user', // Used to suppress jetpack_sync_save_user in save_user_role_handler when user registered on multi site
+			'wp_insert_user', // Used to suppress jetpack_sync_save_user in save_user_cap_handler and save_user_role_handler when user registered on single site
+		);
+
+		return Jetpack::is_function_in_backtrace( $functions );
+	}
+
+	private function get_reassigned_network_user_id() {
+		$backtrace = debug_backtrace( false );
+		foreach ( $backtrace as $call ) {
+			if (
+				'remove_user_from_blog' === $call['function'] &&
+				3 === count( $call['args'] )
+			) {
+				return $call['args'][2];
+			}
+		}
+
+		return false;
 	}
 }

--- a/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -12,7 +12,7 @@ class Jetpack_Sync_Server_Eventstore {
 	}
 
 	function handle_remote_action( $action_name, $args, $user_id, $silent, $timestamp, $sent_timestamp, $queue_id ) {
-		$this->events[] = (object) array(
+		$this->events[ get_current_blog_id() ][] = (object) array(
 			'action'         => $action_name,
 			'args'           => $args,
 			'user_id'        => $user_id,
@@ -23,21 +23,24 @@ class Jetpack_Sync_Server_Eventstore {
 		);
 	}
 
-	function get_all_events( $action_name = null ) {
-		$this->action_name = $action_name;
-		if ( $this->action_name ) {
-			return array_values( array_filter( $this->events, array( $this, 'filter_actions' ) ) );
+	function get_all_events( $action_name = null, $blog_id = null ) {
+		$blog_id = isset( $blog_id ) ? $blog_id : get_current_blog_id();
+
+		if ( $action_name ) {
+			$events = array();
+			foreach ( $this->events[ $blog_id ] as $event ) {
+				if ( $event->action === $action_name ) {
+					$events[] = $event;
+				}
+			}
+			return $events;
 		}
 
-		return $this->events;
+		return $this->events[ $blog_id ];
 	}
 
-	function filter_actions( $event ) {
-		return $event->action === $this->action_name;
-	}
-
-	function get_most_recent_event( $action_name = null ) {
-		$events_list = $this->get_all_events( $action_name );
+	function get_most_recent_event( $action_name = null, $blog_id = null ) {
+		$events_list = $this->get_all_events( $action_name, $blog_id );
 
 		if ( count( $events_list ) > 0 ) {
 			return $events_list[ count( $events_list ) - 1 ];
@@ -47,6 +50,6 @@ class Jetpack_Sync_Server_Eventstore {
 	}
 
 	function reset() {
-		$this->events = array();
+		$this->events[ get_current_blog_id() ] = array();
 	}
 }

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -249,11 +249,11 @@ class Jetpack_Sync_Server_Replicator {
 				list( $user ) = $args;
 				$this->store->upsert_user( $user );
 				break;
-			case 'deleted_user':
+			case 'jetpack_deleted_user':
 				list( $user_id, $reassign ) = $args;
 				$this->store->delete_user( $user_id );
 				break;
-			case 'remove_user_from_blog':
+			case 'jetpack_removed_user_from_blog':
 				list( $user_id, $blog_id ) = $args;
 				$this->store->delete_user( $user_id );
 				break;


### PR DESCRIPTION
Update user sync for activity log

#### Changes proposed in this Pull Request:

This PR modifies the Jetpack User Sync Module to ensure that user related sync actions are sent with the data necessary to populate the Activity Log, and that duplicate/extraneous sync actions are not sent.

#### Testing instructions:

phpunit

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
