### PR TITLE
Sync: Add actor to wp_login sync action

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4103,6 +4103,16 @@ p {
 		return false;
 	}
 
+	static function translate_user_to_role( $user ) {
+		foreach ( self::$capability_translations as $role => $cap ) {
+			if ( user_can( $user, $role ) || user_can( $user, $cap ) ) {
+				return $role;
+			}
+		}
+
+		return false;
+    }
+
 	static function translate_role_to_cap( $role ) {
 		if ( ! isset( self::$capability_translations[$role] ) ) {
 			return false;

--- a/sync/class.jetpack-sync-listener.php
+++ b/sync/class.jetpack-sync-listener.php
@@ -214,7 +214,7 @@ class Jetpack_Sync_Listener {
 				get_current_user_id(),
 				microtime( true ),
 				Jetpack_Sync_Settings::is_importing(),
-				$this->get_actor(),
+				$this->get_actor( $current_filter, $args ),
 			) );
 		} else {
 			$queue->add( array(
@@ -235,9 +235,14 @@ class Jetpack_Sync_Listener {
 		}
 	}
 
-	function get_actor() {
-		$user = wp_get_current_user();
-		$translated_role = Jetpack::translate_current_user_to_role();
+	function get_actor( $current_filter, $args ) {
+		if ( 'wp_login' === $current_filter  ) {
+			$user = get_user_by( 'ID', $args[1]->data->ID );
+		} else {
+			$user = wp_get_current_user();
+		}
+
+		$translated_role = Jetpack::translate_user_to_role( $user );
 
 		$actor = array(
 			'wpcom_user_id'    => null,


### PR DESCRIPTION
Currently the current user is not set to during the wp_login action.
This PR fixes this by updating the setting the actor.

#### Changes proposed in this Pull Request:
* Set the actor information as expected. 

#### Testing instructions:
* E2E test that when you login you see the activity log as expected.
