### PR TITLE
Add connection banner to Dashboard

### DIFF
--- a/_inc/jetpack-connection-banner.js
+++ b/_inc/jetpack-connection-banner.js
@@ -5,7 +5,14 @@
 		contentContainer = $( '.jp-wpcom-connect__content-container' ),
 		nextFeatureButtons = $( '.jp-banner__button-container .next-feature' ),
 		fullScreenContainer = $( '.jp-connect-full__container' ),
-		fullScreenDismiss = $( '.jp-connect-full__dismiss' );
+		fullScreenDismiss = $( '.jp-connect-full__dismiss' ),
+		wpWelcomeNotice = $( '#welcome-panel' ),
+		connectionBanner = $( '#message' );
+
+	// Move the banner below the WP Welcome notice on the dashboard
+	$( window ).on( 'load', function() {
+		wpWelcomeNotice.insertBefore( connectionBanner );
+	} );
 
 	nav.on( 'click', '.vertical-menu__feature-item:not( .vertical-menu__feature-item-is-selected )', function() {
 		transitionSlideToIndex( $( this ).index() );

--- a/_inc/jetpack-connection-banner.js
+++ b/_inc/jetpack-connection-banner.js
@@ -1,4 +1,4 @@
-/* jQuery */
+/* jQuery, jp_banner */
 
 ( function( $ ) {
 	var nav = $( '.jp-wpcom-connect__vertical-nav-container' ),
@@ -7,11 +7,29 @@
 		fullScreenContainer = $( '.jp-connect-full__container' ),
 		fullScreenDismiss = $( '.jp-connect-full__dismiss' ),
 		wpWelcomeNotice = $( '#welcome-panel' ),
-		connectionBanner = $( '#message' );
+		connectionBanner = $( '#message' ),
+		connectionBannerDismiss = $( '.connection-banner-dismiss' );
 
 	// Move the banner below the WP Welcome notice on the dashboard
 	$( window ).on( 'load', function() {
 		wpWelcomeNotice.insertBefore( connectionBanner );
+	} );
+
+	// Dismiss the connection banner via AJAX
+	connectionBannerDismiss.on( 'click', function() {
+		$( connectionBanner ).hide();
+
+		var data = {
+			action: 'jetpack_connection_banner',
+			nonce: jp_banner.connectionBannerNonce,
+			dismissBanner: true,
+		};
+
+		$.post( jp_banner.ajax_url, data, function( response ) {
+			if ( true !== response.success ) {
+				$( connectionBanner ).show();
+			}
+		} );
 	} );
 
 	nav.on( 'click', '.vertical-menu__feature-item:not( .vertical-menu__feature-item-is-selected )', function() {

--- a/_inc/jetpack-connection-banner.js
+++ b/_inc/jetpack-connection-banner.js
@@ -1,4 +1,4 @@
-/* jQuery, jp_banner */
+/* global jQuery, jp_banner */
 
 ( function( $ ) {
 	var nav = $( '.jp-wpcom-connect__vertical-nav-container' ),
@@ -22,7 +22,7 @@
 		var data = {
 			action: 'jetpack_connection_banner',
 			nonce: jp_banner.connectionBannerNonce,
-			dismissBanner: true,
+			dismissBanner: true
 		};
 
 		$.post( jp_banner.ajax_url, data, function( response ) {

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -44,6 +44,11 @@ class Jetpack_Connection_Banner {
 	 * @param $current_screen
 	 */
 	function maybe_initialize_hooks( $current_screen ) {
+		// Kill if banner has been dismissed
+		if ( Jetpack_Options::get_option( 'dismissed_connection_banner' ) ) {
+			return;
+		}
+
 		// Don't show the connect notice anywhere but the plugins.php after activating
 		if ( 'plugins' !== $current_screen->base && 'dashboard' !== $current_screen->base ) {
 			return;
@@ -83,19 +88,14 @@ class Jetpack_Connection_Banner {
 			JETPACK__VERSION,
 			true
 		);
-	}
 
-	/**
-	 * Returns a URL that will dismiss allow the current user to dismiss the connection banner.
-	 *
-	 * @since 4.4.0
-	 *
-	 * @return string
-	 */
-	function get_dismiss_and_deactivate_url() {
-		return wp_nonce_url(
-			Jetpack::admin_url( '?page=jetpack&jetpack-notice=dismiss' ),
-			'jetpack-deactivate'
+		wp_localize_script(
+			'jetpack-connection-banner-js',
+			'jp_banner',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'connectionBannerNonce' => wp_create_nonce( 'jp-connection-banner-nonce' ),
+			)
 		);
 	}
 
@@ -111,7 +111,6 @@ class Jetpack_Connection_Banner {
 			<a
 				href="<?php echo esc_url( $this->get_dismiss_and_deactivate_url() ); ?>"
 				class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
-
 			</a>
 			<div class="jp-banner__description-container">
 				<h2 class="jp-banner__header"><?php esc_html_e( 'Your Jetpack is almost ready!', 'jetpack' ); ?></h2>
@@ -154,11 +153,10 @@ class Jetpack_Connection_Banner {
 	function render_banner() { ?>
 		<div id="message" class="updated jp-wpcom-connect__container">
 			<div class="jp-wpcom-connect__inner-container">
-				<a
-					href="<?php echo esc_url( $this->get_dismiss_and_deactivate_url() ); ?>"
-					class="notice-dismiss"
+				<span
+					class="notice-dismiss connection-banner-dismiss"
 					title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
-				</a>
+				</span>
 
 				<div class="jp-wpcom-connect__vertical-nav">
 					<div class="jp-wpcom-connect__vertical-nav-container">

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -100,52 +100,6 @@ class Jetpack_Connection_Banner {
 	}
 
 	/**
-	 * Renders the legacy connection banner.
-	 */
-	function render_legacy_banner() {
-		$legacy_banner_from = self::check_ab_test_not_expired()
-			? 'banner-legacy'
-			: 'banner';
-		?>
-		<div id="message" class="updated jp-banner">
-			<a
-				href="<?php echo esc_url( $this->get_dismiss_and_deactivate_url() ); ?>"
-				class="notice-dismiss" title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
-			</a>
-			<div class="jp-banner__description-container">
-				<h2 class="jp-banner__header"><?php esc_html_e( 'Your Jetpack is almost ready!', 'jetpack' ); ?></h2>
-				<p class="jp-banner__description">
-					<?php
-					esc_html_e(
-						'Please connect to or create a WordPress.com account to enable Jetpack, including
-								powerful security, traffic, and customization services.',
-						'jetpack'
-					);
-					?>
-				</p>
-				<p class="jp-banner__button-container">
-					<a
-						href="<?php echo Jetpack::init()->build_connect_url( false, false, $legacy_banner_from ) ?>"
-						class="button button-primary">
-						<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
-					</a>
-					<a
-						href="<?php echo Jetpack::admin_url( 'admin.php?page=jetpack' ) ?>"
-						class="button"
-						title="<?php
-						esc_attr_e(
-							'Learn about the benefits you receive when you connect Jetpack to WordPress.com',
-							'jetpack'
-						);
-						?> ">
-						<?php esc_html_e( 'Learn more', 'jetpack' ); ?>
-					</a>
-				</p>
-			</div>
-		</div>
-	<?php }
-
-	/**
 	 * Renders the new connection banner.
 	 *
 	 * @since 4.4.0

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -104,7 +104,9 @@ class Jetpack_Connection_Banner {
 	 *
 	 * @since 4.4.0
 	 */
-	function render_banner() { ?>
+	function render_banner() {
+		global $current_screen;
+		?>
 		<div id="message" class="updated jp-wpcom-connect__container">
 			<div class="jp-wpcom-connect__inner-container">
 				<span
@@ -198,7 +200,7 @@ class Jetpack_Connection_Banner {
 
 						<p class="jp-banner__button-container">
 							<a
-								href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-1' ) ); ?>"
+								href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-1-' . $current_screen->base ) ); ?>"
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
@@ -252,7 +254,7 @@ class Jetpack_Connection_Banner {
 						</p>
 
 						<p class="jp-banner__button-container">
-							<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-2' ) ); ?>" class="dops-button is-primary">
+							<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-2-' . $current_screen->base ) ); ?>" class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
@@ -298,7 +300,7 @@ class Jetpack_Connection_Banner {
 
 						<p class="jp-banner__button-container">
 							<a
-								href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-3' ) ); ?>"
+								href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-3-' . $current_screen->base ) ); ?>"
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
@@ -335,7 +337,7 @@ class Jetpack_Connection_Banner {
 						</p>
 
 						<p class="jp-banner__button-container">
-							<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-4' ) ); ?>" class="dops-button is-primary">
+							<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-4-' . $current_screen->base ) ); ?>" class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
@@ -371,7 +373,7 @@ class Jetpack_Connection_Banner {
 						</p>
 
 						<p class="jp-banner__button-container">
-							<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-5' ) ); ?>" class="dops-button is-primary">
+							<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-5-' . $current_screen->base ) ); ?>" class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
@@ -409,7 +411,7 @@ class Jetpack_Connection_Banner {
 
 						<p class="jp-banner__button-container">
 							<a
-								href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-6' ) ); ?>"
+								href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'banner-44-slide-6-' . $current_screen->base ) ); ?>"
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -45,7 +45,7 @@ class Jetpack_Connection_Banner {
 	 */
 	function maybe_initialize_hooks( $current_screen ) {
 		// Don't show the connect notice anywhere but the plugins.php after activating
-		if ( 'plugins' !== $current_screen->base ) {
+		if ( 'plugins' !== $current_screen->base && 'dashboard' !== $current_screen->base ) {
 			return;
 		}
 

--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -50,6 +50,7 @@ class Jetpack_Options {
 				'sync_error_idc',              // (bool|array) false or array containing the site's home and siteurl at time of IDC error
 				'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 				'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
+				'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
 			);
 
 		case 'private' :

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6413,10 +6413,6 @@ p {
 	}
 
 	public function wp_dashboard_setup() {
-		if ( ! self::is_active() ) {
-			return;
-		}
-
 		if ( self::is_active() ) {
 			add_action( 'jetpack_dashboard_widget', array( __CLASS__, 'dashboard_widget_footer' ), 999 );
 			$widget_title = __( 'Site Stats', 'jetpack' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2862,6 +2862,7 @@ p {
 		Jetpack::load_modules();
 
 		Jetpack_Options::delete_option( 'do_activate' );
+		Jetpack_Options::delete_option( 'dismissed_connection_banner' );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6399,6 +6399,10 @@ p {
 	}
 
 	public function wp_dashboard_setup() {
+		if ( ! self::is_active() ) {
+			return;
+		}
+
 		if ( self::is_active() ) {
 			add_action( 'jetpack_dashboard_widget', array( __CLASS__, 'dashboard_widget_footer' ), 999 );
 			$widget_title = __( 'Site Stats', 'jetpack' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6420,9 +6420,6 @@ p {
 		if ( self::is_active() ) {
 			add_action( 'jetpack_dashboard_widget', array( __CLASS__, 'dashboard_widget_footer' ), 999 );
 			$widget_title = __( 'Site Stats', 'jetpack' );
-		} elseif ( ! self::is_development_mode() && current_user_can( 'jetpack_connect' ) ) {
-			add_action( 'jetpack_dashboard_widget', array( $this, 'dashboard_widget_connect_to_wpcom' ) );
-			$widget_title = __( 'Please Connect Jetpack', 'jetpack' );
 		}
 
 		if ( has_action( 'jetpack_dashboard_widget' ) ) {
@@ -6515,29 +6512,6 @@ p {
 		</div>
 
 		</footer>
-		<?php
-	}
-
-	public function dashboard_widget_connect_to_wpcom() {
-		if ( Jetpack::is_active() || Jetpack::is_development_mode() || ! current_user_can( 'jetpack_connect' ) ) {
-			return;
-		}
-		?>
-		<div class="wpcom-connect">
-			<div class="jp-emblem">
-			<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0" y="0" viewBox="0 0 172.9 172.9" enable-background="new 0 0 172.9 172.9" xml:space="preserve">
-				<path d="M86.4 0C38.7 0 0 38.7 0 86.4c0 47.7 38.7 86.4 86.4 86.4s86.4-38.7 86.4-86.4C172.9 38.7 134.2 0 86.4 0zM83.1 106.6l-27.1-6.9C49 98 45.7 90.1 49.3 84l33.8-58.5V106.6zM124.9 88.9l-33.8 58.5V66.3l27.1 6.9C125.1 74.9 128.4 82.8 124.9 88.9z"/>
-			</svg>
-			</div>
-			<h3><?php esc_html_e( 'Please Connect Jetpack', 'jetpack' ); ?></h3>
-			<p><?php echo wp_kses( __( 'Connecting Jetpack will show you <strong>stats</strong> about your traffic, <strong>protect</strong> you from brute force attacks, <strong>speed up</strong> your images and photos, and enable other <strong>traffic and security</strong> features.', 'jetpack' ), 'jetpack' ) ?></p>
-
-			<div class="actions">
-				<a href="<?php echo $this->build_connect_url( false, false, 'widget-btn' ); ?>" class="button button-primary">
-					<?php esc_html_e( 'Connect Jetpack', 'jetpack' ); ?>
-				</a>
-			</div>
-		</div>
 		<?php
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -563,6 +563,8 @@ class Jetpack {
 		// Universal ajax callback for all tracking events triggered via js
 		add_action( 'wp_ajax_jetpack_tracks', array( $this, 'jetpack_admin_ajax_tracks_callback' ) );
 
+		add_action( 'wp_ajax_jetpack_connection_banner', array( $this, 'jetpack_connection_banner_callback' ) );
+
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'devicepx' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'devicepx' ) );
@@ -621,6 +623,17 @@ class Jetpack {
 		return $params;
 	}
 
+	function jetpack_connection_banner_callback() {
+		check_ajax_referer( 'jp-connection-banner-nonce', 'nonce' );
+
+		if ( isset( $_REQUEST['dismissBanner'] ) ) {
+			Jetpack_Options::update_option( 'dismissed_connection_banner', 1 );
+			wp_send_json_success();
+		}
+		
+		wp_die();
+	}
+	
 	function jetpack_admin_ajax_tracks_callback() {
 		// Check for nonce
 		if ( ! isset( $_REQUEST['tracksNonce'] ) || ! wp_verify_nonce( $_REQUEST['tracksNonce'], 'jp-tracks-ajax-nonce' ) ) {

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -196,6 +196,7 @@
 }
 
 .updated .notice-dismiss {
+	z-index: 1;
 	text-decoration: none;
 }
 // end overrides


### PR DESCRIPTION
Fixes #7567 and #7447

This PR adds the connection banner to the wp-admin dashboard as well as the plugins screen.  It replaces the connection widget that was there before, so you should not see that widget unless the site is connected.  It uses some custom JS to sit below the welcome message: 

![screen shot 2017-08-07 at 11 04 36 am](https://user-images.githubusercontent.com/7129409/29032716-7c0742e8-7b60-11e7-9f59-b77544b3ff69.png)

This PR also changes the behavior of the dismiss, which now sets an option via AJAX and does NOT dismiss the plugin.  This option is cleared on the next plugin_initialize, so that we make sure to show the banner if they deactivate/enable Jetpack again for whatever reason.  

To Test: 
- Disconnect Jetpack
- Visit your wp-admin dashboard `/wp-admin/index.php?welcome=true` and see the connection banner
- Dismiss should remove the banner persistently
- Deactivating/reactivating the plugin should show the banner again
- The wp-admin dashboard stats widget should still show when Jetpack is connected.  