### PR TITLE
Widgets: if widget_media_image exists, flag migration as done

### DIFF
--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -198,11 +198,16 @@ function jetpack_migrate_image_widget() {
 
 		wp_set_sidebars_widgets( $sidebars_widgets );
 
-		Jetpack_Options::update_option( 'image_widget_migration', true );
-
 		// We need to refresh on widgets page for changes to take effect.
 		add_action( 'current_screen', 'jetpack_refresh_on_widget_page' );
+	} else {
+		$widget_media_image = get_option( 'widget_media_image' );
+		if ( is_array( $widget_media_image ) ) {
+			delete_option( 'widget_image' );
+		}
 	}
+	
+	Jetpack_Options::update_option( 'image_widget_migration', true );
 }
 add_action( 'widgets_init', 'jetpack_migrate_image_widget' );
 


### PR DESCRIPTION
Fixes #7595 

#### Changes proposed in this Pull Request:

* if the widget_media_image wasn't updated, maybe it already exists. If so, delete legacy option and set our flag so this code isn't always run

#### Testing instructions:

* delete `image_widget_migration` and test migrating an image widget from a previous WP version
* delete `image_widget_migration`
In both cases, the code should run once instead of every time WP Admin loads as is now

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Widgets: prevent code that migrated legacy Jetpack image widget to WordPress' new image widget from running on every WP Admin load.