### PR TITLE
XHTML compliance

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6385,7 +6385,7 @@ p {
 		if ( empty( $new_urls ) && ! empty( $prefetch_urls ) ) {
 			echo "\r\n";
 			foreach ( $prefetch_urls as $this_prefetch_url ) {
-				printf( "<link rel='dns-prefetch' href='%s'>\r\n", esc_attr( $this_prefetch_url ) );
+				printf( "<link rel='dns-prefetch' href='%s'/>\r\n", esc_attr( $this_prefetch_url ) );
 			}
 		} elseif ( ! empty( $new_urls ) ) {
 			if ( ! has_action( 'wp_head', array( __CLASS__, __FUNCTION__ ) ) ) {

--- a/tests/php/test_class.jetpack.php
+++ b/tests/php/test_class.jetpack.php
@@ -207,9 +207,9 @@ EXPECTED;
 		Jetpack::dns_prefetch( 'https://example2.com' );
 
 		$expected = "\r\n" .
-		            "<link rel='dns-prefetch' href='//example1.com'>\r\n" .
-		            "<link rel='dns-prefetch' href='//example2.com'>\r\n" .
-		            "<link rel='dns-prefetch' href='//example3.com'>\r\n";
+		            "<link rel='dns-prefetch' href='//example1.com'/>\r\n" .
+		            "<link rel='dns-prefetch' href='//example2.com'/>\r\n" .
+		            "<link rel='dns-prefetch' href='//example3.com'/>\r\n";
 
 		$this->assertEquals( $expected, str_replace( $remove_this, "\r\n", get_echo( array( 'Jetpack', 'dns_prefetch' ) ) ) );
 	}


### PR DESCRIPTION
Fixes dns_prefetch to output a self-closing tag

#### Changes proposed in this Pull Request:

`Jetpack::dns_prefetch` is updated to output a self closing tag in order to be used in a blog that strives for XHTML compliance. 