### PR TITLE
Settings UI: prevent qTranslate X from redirecting REST API calls

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -11,7 +11,7 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php' );
-require_once JETPACK__PLUGIN_DIR . '3rd-party/qtranslate-x.php';
+require_once( JETPACK__PLUGIN_DIR . '3rd-party/qtranslate-x.php' );
 
 // We can't load this conditionally since polldaddy add the call in class constuctor.
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );

--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -11,6 +11,7 @@ require_once( JETPACK__PLUGIN_DIR . '3rd-party/bitly.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/bbpress.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/woocommerce.php' );
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/domain-mapping.php' );
+require_once JETPACK__PLUGIN_DIR . '3rd-party/qtranslate-x.php';
 
 // We can't load this conditionally since polldaddy add the call in class constuctor.
 require_once( JETPACK__PLUGIN_DIR . '3rd-party/polldaddy.php' );

--- a/3rd-party/qtranslate-x.php
+++ b/3rd-party/qtranslate-x.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Prevent qTranslate X from redirecting REST calls.
+ *
+ * @since 5.3
+ *
+ * @param string $url_lang Language URL to redirect to.
+ * @param string $url_orig Original URL.
+ * @param array $url_info  Pieces of original URL.
+ *
+ * @return bool
+ */
+function jetpack_no_qtranslate_rest_url_redirect( $url_lang, $url_orig, $url_info ) {
+	if ( false !== strpos( $url_info['wp-path'], 'wp-json/jetpack' ) ) {
+		return false;
+	}
+	return $url_lang;
+}
+add_filter( 'qtranslate_language_detect_redirect', 'jetpack_no_qtranslate_rest_url_redirect', 10, 3 );


### PR DESCRIPTION
Fixes #7589

#### Changes proposed in this Pull Request:

* hook into a qTranslate X filter to check the URL. If it's a call to Jetpack REST endpoints, return false so it's not redirected and the settings page can work properly

#### Testing instructions:

1. install qTranslate X without checking this branch
    `wp plugin install qtranslate-x --activate`
2. go to Settings > Languages and set a secondary language as default
3. go to Jetpack dashboard, verify it doesn't work and that REST url calls are prefixed with the language you set as default
4. switch to this PR and verify it's working fine and Jetpack endpoint calls aren't prefixed

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
prevent qTranslate X from redirecting REST API calls to Jetpack endpoints so Jetpack dashboard works properly.