### PR TITLE
WordPress.com Toolbar: remove obsolete CSS overrides

### DIFF
--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -54,11 +54,3 @@
 #wp-admin-bar-notes.active .noticon-bell:before {
     content: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cmVjdCB4PSIwIiBmaWxsPSJub25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiLz48Zz48cGF0aCBmaWxsPSIjMjMyODJkIiBkPSJNNi4xNCAxNC45N2wyLjgyOCAyLjgyN2MtLjM2Mi4zNjItLjg2Mi41ODYtMS40MTQuNTg2LTEuMTA1IDAtMi0uODk1LTItMiAwLS41NTIuMjI0LTEuMDUyLjU4Ni0xLjQxNHptOC44NjcgNS4zMjRMMTQuMyAyMSAzIDkuN2wuNzA2LS43MDcgMS4xMDIuMTU3Yy43NTQuMTA4IDEuNjktLjEyMiAyLjA3Ny0uNTFsMy44ODUtMy44ODRjMi4zNC0yLjM0IDYuMTM1LTIuMzQgOC40NzUgMHMyLjM0IDYuMTM1IDAgOC40NzVsLTMuODg1IDMuODg2Yy0uMzg4LjM4OC0uNjE4IDEuMzIzLS41MSAyLjA3N2wuMTU3IDEuMXoiLz48L2c+PC9zdmc+") !important;
 }
-
-/* Fix changing height issue on hover in pop-up menus */
-#wpadminbar .quicklinks .menupop ul li .ab-item {
-	height: auto !important;
-}
-#wpadminbar .menupop .ab-submenu .ab-submenu-header > .ab-empty-item {
-	line-height: 1 !important;
-}


### PR DESCRIPTION
These overrides were moved to WP.com styles in D6751-code.