### PR TITLE
Contact Forms: use current_screen hook to specify when to add actions

### DIFF
--- a/modules/contact-form/grunion-editor-view.php
+++ b/modules/contact-form/grunion-editor-view.php
@@ -8,11 +8,20 @@
  */
 
 class Grunion_Editor_View {
-	public static function add_hooks() {
-		add_action( 'admin_notices', array( __CLASS__, 'handle_editor_view_js' ) );
-		add_filter( 'mce_external_plugins', array( __CLASS__, 'mce_external_plugins' ) );
-		add_filter( 'mce_buttons', array( __CLASS__, 'mce_buttons' ) );
-		add_action( 'admin_head', array( __CLASS__, 'admin_head' ) );
+
+	/**
+	 * Add hooks according to screen.
+	 *
+	 * @param WP_Screen $screen Data about current screen.
+	 */
+	public static function add_hooks( $screen ) {
+		if ( isset( $screen->base ) && 'post' === $screen->base ) {
+			add_filter( 'mce_external_plugins', array( __CLASS__, 'mce_external_plugins' ) );
+			add_filter( 'mce_buttons', array( __CLASS__, 'mce_buttons' ) );
+			add_action( 'admin_notices', array( __CLASS__, 'handle_editor_view_js' ) );
+			add_action( 'admin_print_footer_scripts', array( __CLASS__, 'editor_view_js_templates' ), 1 );
+			add_action( 'admin_head', array( __CLASS__, 'admin_head' ) );
+		}
 	}
 
 	public static function admin_head() {
@@ -21,9 +30,6 @@ class Grunion_Editor_View {
 	}
 
 	public static function grunion_media_button() {
-		if ( empty( $GLOBALS['pagenow'] ) || 'press-this.php' === $GLOBALS['pagenow'] ) {
-			return;
-		}
 		$title = __( 'Add Contact Form', 'jetpack' );
 		?>
 
@@ -55,13 +61,6 @@ class Grunion_Editor_View {
 	 * WordPress Shortcode Editor View JS Code
 	 */
 	public static function handle_editor_view_js() {
-		$current_screen = get_current_screen();
-		if ( ! isset( $current_screen->id ) || $current_screen->base !== 'post' ) {
-			return;
-		}
-
-		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'editor_view_js_templates' ), 1 );
-
 		wp_enqueue_style( 'grunion-editor-ui', plugins_url( 'css/editor-ui.css', __FILE__ ) );
 		wp_style_add_data( 'grunion-editor-ui', 'rtl', 'replace' );
 		wp_enqueue_script( 'grunion-editor-view', plugins_url( 'js/editor-view.js', __FILE__ ), array( 'wp-util', 'jquery', 'quicktags' ), false, true );
@@ -274,5 +273,4 @@ class Grunion_Editor_View {
 	}
 }
 
-
-Grunion_Editor_View::add_hooks();
+add_action( 'current_screen', array( 'Grunion_Editor_View', 'add_hooks' ) );


### PR DESCRIPTION
Relevant for #7598 and #7617

#### Changes proposed in this Pull Request:

* use current_screen hook to delegate actions for other screens

#### Testing instructions:

* make sure editor actions are only added to post editing screen

