### PR TITLE
Comments: Add checks on the `moderate_comments` capabilities

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -67,7 +67,7 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 			return new WP_Error( 'unauthorized', 'User cannot create comments', 403 );
 		}
 
-		if ( ! current_user_can( 'moderate_comments' ) && ! comments_open( $post->ID ) ) {
+		if ( ! ( comments_open( $post->ID ) || current_user_can( 'moderate_comments' ) ) ) {
 			return new WP_Error( 'unauthorized', 'Comments on this post are closed', 403 );
 		}
 

--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -67,7 +67,7 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 			return new WP_Error( 'unauthorized', 'User cannot create comments', 403 );
 		}
 
-		if ( !comments_open( $post->ID ) ) {
+		if ( ! current_user_can( 'moderate_comments' ) && ! comments_open( $post->ID ) ) {
 			return new WP_Error( 'unauthorized', 'Comments on this post are closed', 403 );
 		}
 

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -362,6 +362,7 @@ abstract class SAL_Site {
 			'list_users'          => current_user_can( 'list_users' ),
 			'manage_categories'   => current_user_can( 'manage_categories' ),
 			'manage_options'      => current_user_can( 'manage_options' ),
+			'moderate_comments'   => current_user_can( 'moderate_comments' ),
 			'activate_wordads'    => wpcom_get_blog_owner() === (int) get_current_user_id(),
 			'promote_users'       => current_user_can( 'promote_users' ),
 			'publish_posts'       => current_user_can( 'publish_posts' ),


### PR DESCRIPTION
Replicates the changes introduced in D6713-code and D6726-code

#### Changes proposed in this Pull Request:

* Add the `moderate_comments` capability to those returned from the sites endpoint.
* Allow comments to posts with closed comments if the author has the `moderate_comments` capability.

#### Testing instructions:

Part 1
* Login as an Author.
* Go to `https://wpcalypso.wordpress.com/comments/`, and make sure to be redirected to the Stats page.

Part 2
* Login as an Admin.
* Create a new post, add a comment to this post, and disable the comments for this post.
* Go to `https://wpcalypso.wordpress.com/comments/`, select the site, locate the new comment and reply to it.
* The reply should be approved. Wait for a couple of seconds and make sure that the reply pops up in the comments list and no error notice is displayed.