### PR TITLE
Fix issue with Nosara aliasing

### DIFF
--- a/_inc/lib/tracks/class.tracks-client.php
+++ b/_inc/lib/tracks/class.tracks-client.php
@@ -158,7 +158,7 @@ class Jetpack_Tracks_Client {
 				$anon_id = 'jetpack:' . base64_encode( $binary );
 
 				if ( ! headers_sent() ) {
-					setcookie( 'tk_ai', $anon_id );
+					setcookie( 'tk_ai', $anon_id, time() + 1000, '/' );
 				}
 			}
 		}

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -88,9 +88,9 @@ function jetpack_tracks_get_identity( $user_id ) {
 
 	// User isn't linked at all.  Fall back to anonymous ID.
 	$anon_id = get_user_meta( $user_id, 'jetpack_tracks_anon_id', true );
-	if ( ! $anon_id ) {
+	if ( ! $anon_id || $anon_id !== $_COOKIE['tk_ai'] ) {
 		$anon_id = Jetpack_Tracks_Client::get_anon_id();
-		add_user_meta( $user_id, 'jetpack_tracks_anon_id', $anon_id, false );
+		update_user_meta( $user_id, 'jetpack_tracks_anon_id', $anon_id );
 	}
 
 	if ( ! isset( $_COOKIE[ 'tk_ai' ] ) && ! headers_sent() ) {

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -88,13 +88,13 @@ function jetpack_tracks_get_identity( $user_id ) {
 
 	// User isn't linked at all.  Fall back to anonymous ID.
 	$anon_id = get_user_meta( $user_id, 'jetpack_tracks_anon_id', true );
-	if ( ! $anon_id || $anon_id !== $_COOKIE['tk_ai'] ) {
+	if ( ! $anon_id || isset($_COOKIE['tk_ai']) && $anon_id !== $_COOKIE['tk_ai'] ) {
 		$anon_id = Jetpack_Tracks_Client::get_anon_id();
 		update_user_meta( $user_id, 'jetpack_tracks_anon_id', $anon_id );
 	}
 
 	if ( ! isset( $_COOKIE[ 'tk_ai' ] ) && ! headers_sent() ) {
-		setcookie( 'tk_ai', $anon_id );
+		setcookie( 'tk_ai', $anon_id, 0, '/' );
 	}
 
 	return array(

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -92,9 +92,13 @@ function jetpack_tracks_get_identity( $user_id ) {
 
 	// User isn't linked at all.  Fall back to anonymous ID.
 	$anon_id = get_user_meta( $user_id, 'jetpack_tracks_anon_id', true );
-	if ( ! $anon_id || isset($_COOKIE['tk_ai']) && $anon_id !== $_COOKIE['tk_ai'] ) {
+	if ( ! $anon_id ) {
 		$anon_id = Jetpack_Tracks_Client::get_anon_id();
 		update_user_meta( $user_id, 'jetpack_tracks_anon_id', $anon_id );
+	}
+
+	if ( isset( $_COOKIE['tk_ai'] ) && $anon_id !== $_COOKIE['tk_ai'] ) {
+		unset( $_COOKIE['tk_ai'] );
 	}
 
 	if ( ! isset( $_COOKIE[ 'tk_ai' ] ) && ! headers_sent() ) {

--- a/_inc/lib/tracks/client.php
+++ b/_inc/lib/tracks/client.php
@@ -86,6 +86,10 @@ function jetpack_tracks_get_identity( $user_id ) {
 		);
 	}
 
+	if ( 0 === $user_id ) {
+		return array();
+	}
+
 	// User isn't linked at all.  Fall back to anonymous ID.
 	$anon_id = get_user_meta( $user_id, 'jetpack_tracks_anon_id', true );
 	if ( ! $anon_id || isset($_COOKIE['tk_ai']) && $anon_id !== $_COOKIE['tk_ai'] ) {

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -13,7 +13,9 @@ class JetpackTracking {
 			return;
 		}
 
-		jetpack_tracks_get_identity( get_current_user_id() );
+		if ( ! defined( 'DOING_AJAX' ) && ! Jetpack::is_user_connected( $user_id = get_current_user_id() ) ) {
+			jetpack_tracks_get_identity( $user_id );
+		}
 
 		// For tracking stuff via js/ajax
 		add_action( 'admin_enqueue_scripts',         array( __CLASS__, 'enqueue_tracks_scripts' ) );

--- a/class.jetpack-tracks.php
+++ b/class.jetpack-tracks.php
@@ -13,6 +13,8 @@ class JetpackTracking {
 			return;
 		}
 
+		jetpack_tracks_get_identity( get_current_user_id() );
+
 		// For tracking stuff via js/ajax
 		add_action( 'admin_enqueue_scripts',         array( __CLASS__, 'enqueue_tracks_scripts' ) );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3209,6 +3209,8 @@ p {
 			add_action( 'jetpack_notices', array( $this, 'alert_auto_ssl_fail' ) );
 		}
 
+		jetpack_tracks_get_identity( get_current_user_id() );
+
 		add_action( 'load-plugins.php', array( $this, 'intercept_plugin_error_scrape_init' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_menu_css' ) );
 		add_filter( 'plugin_action_links_' . plugin_basename( JETPACK__PLUGIN_DIR . 'jetpack.php' ), array( $this, 'plugin_action_links' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3209,8 +3209,6 @@ p {
 			add_action( 'jetpack_notices', array( $this, 'alert_auto_ssl_fail' ) );
 		}
 
-		jetpack_tracks_get_identity( get_current_user_id() );
-
 		add_action( 'load-plugins.php', array( $this, 'intercept_plugin_error_scrape_init' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_menu_css' ) );
 		add_filter( 'plugin_action_links_' . plugin_basename( JETPACK__PLUGIN_DIR . 'jetpack.php' ), array( $this, 'plugin_action_links' ) );


### PR DESCRIPTION
This overwrites the browser's `tk_ai` (anonymous id) cookie with the one stored in user meta. This keeps the id synchronized across all browsers and devices.

#### Changes proposed in this Pull Request:

* Sets the cookie `tk_ai` to the correct parameters to be read from the tracks client
* Updates the user's cookie if it is incorrect
* Calls `jetpack_tracks_get_identity( get_current_user_id() );` asap in plugin initialization in the admin to set the cookie as appropriate, before the js lib can.

#### Testing instructions:

* Login with a user that is not connected
* Navigate to the Jetpack wp-admin with a fresh browser session and check your cookies.
* You should see only one `tk_ai` cookie. If you see more, that's ok. Look for the one with the `/` path, that's your guy.
* Delete your `tk_ai` cookies to simulate using a different/new device and navigate around wp-admin.
* You should have only one `tk_ai` cookie with the previous value.

You can also get creative and set the cookie to a bogus value, it should reset back to the value as before.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
