### PR TITLE
Remove jetpack-deactivate

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -94,8 +94,7 @@ class Jetpack_Connection_Banner {
 	 */
 	function get_dismiss_and_deactivate_url() {
 		return wp_nonce_url(
-			Jetpack::admin_url( '?page=jetpack&jetpack-notice=dismiss' ),
-			'jetpack-deactivate'
+			Jetpack::admin_url( '?page=jetpack&jetpack-notice=dismiss' )
 		);
 	}
 


### PR DESCRIPTION
Dismissing this connection prompt shouldn't deactivate Jetpack. Just dismiss the notice.

<img width="1105" alt="plugins_ _testing_things_ _wordpress" src="https://user-images.githubusercontent.com/2287740/29160082-d5e23922-7da8-11e7-8622-6c83a4e0219f.png">
