### PR TITLE
Introduce a new bulk post deletion endpoint.

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -69,6 +69,7 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-update-post-v1-1-endpo
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-autosave-v1-1-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-autosave-post-v1-1-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-post-counts-v1-1-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-bulk-delete-post-endpoint.php' );
 
 // Custom Menus
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-menus-v1-1-endpoint.php' );

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -3389,3 +3389,32 @@ new WPCOM_JSON_API_Menus_Delete_Menu_Endpoint( array (
 		'headers' => array( 'authorization' => 'Bearer YOUR_API_TOKEN' ),
 	),
 ) );
+
+new WPCOM_JSON_API_Bulk_Delete_Post_Endpoint( array(
+	'description' => 'Delete multiple posts. Note: If the trash is enabled, this request will send non-trashed posts to the trash. Trashed posts will be permanently deleted.',
+	'group'       => 'posts',
+	'stat'        => 'posts:1:bulk-delete',
+	'min_version' => '1.1',
+	'max_version' => '1.1',
+	'method'      => 'POST',
+	'path'        => '/sites/%s/posts/delete',
+	'path_labels' => array(
+		'$site'    => '(int|string) Site ID or domain',
+	),
+	'request_format' => array(
+		'post_ids' => '(array) An array of Post IDs to delete or trash.',
+	),
+
+	'example_request'      => 'https://public-api.wordpress.com/rest/v1.1/sites/82974409/posts/delete',
+
+	'example_request_data' => array(
+		'headers' => array(
+			'authorization' => 'Bearer YOUR_API_TOKEN'
+		),
+
+		'body' => array(
+			'post_ids' => array( 881, 882 ),
+		),
+
+	)
+) );

--- a/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
@@ -1,0 +1,24 @@
+<?php
+
+class WPCOM_JSON_API_Bulk_Delete_Post_Endpoint extends WPCOM_JSON_API_Update_Post_v1_1_Endpoint {
+	function callback( $path = '', $blog_id = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		$input = $this->input();
+
+		$post_ids = (array) $input['post_ids'];
+
+		$result = array(
+			'results' => array(),
+		);
+
+		foreach( $post_ids as $post_id ) {
+			$result['results'][ $post_id ] = $this->delete_post( $path, $blog_id, $post_id );
+		}
+
+		return $result;
+	}
+}


### PR DESCRIPTION
Summary:
This diff introduces a new bulk post deletion endpoint. The endpoint will be used in the future to enable bulk deletion of posts via Calypso. The endpoint follows the behavior of the current single-delete endpoint: if trash is enabled, the first call will send a post to the trash, and subsequent calls will permanently delete a post. If trash isn't enabled, any call will permanently delete a post.

Differential Revision: D6769-code

This commit syncs r160521-wpcom.
This commit syncs r160522-wpcom.

#### Testing instructions:

* Checkout branch.
* Use the developer console on developer.wordpress.com to make requests against your Jetpack site.
* Verify that the bulk delete endpoint at `/sites/$site/posts/delete` works the same as the single delete endpoint at `/sites/$site/posts/$post_id/delete`, except that it takes an array of `post_ids` as a request parameter as opposed the post_id in the path.