### PR TITLE
Add email field to error on social account create

### DIFF
--- a/class.json-api.php
+++ b/class.json-api.php
@@ -437,16 +437,22 @@ class WPCOM_JSON_API {
 
 		$status_code = $error->get_error_data();
 
-		if ( is_array( $status_code ) )
+		if ( is_array( $status_code ) ) {
 			$status_code = $status_code['status_code'];
+		}
 
 		if ( !$status_code ) {
 			$status_code = 400;
 		}
-		$response = array(
+		$response = [
 			'error'   => $error->get_error_code(),
 			'message' => $error->get_error_message(),
-		);
+		];
+		
+		if ( $additional_data = $error->get_error_data( 'additional_data' ) ) {
+			$response['data'] = $additional_data;
+		}		
+
 		return array(
 			'status_code' => $status_code,
 			'errors' => $response

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -444,10 +444,10 @@ class WPCOM_JSON_API {
 		if ( !$status_code ) {
 			$status_code = 400;
 		}
-		$response = [
+		$response = array(
 			'error'   => $error->get_error_code(),
 			'message' => $error->get_error_message(),
-		];
+		);
 		
 		if ( $additional_data = $error->get_error_data( 'additional_data' ) ) {
 			$response['data'] = $additional_data;


### PR DESCRIPTION
This is part of https://github.com/Automattic/wp-calypso/pull/16638

Differential Revision: D6588

This commit syncs r160556-wpcom.

Fixes #

#### Changes proposed in this Pull Request:

*

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
