### PR TITLE
adding back the tax filter for the widget visibility module

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -125,16 +125,16 @@ class Jetpack_Widget_Conditions {
 
 		$taxonomies = get_taxonomies(
 			/**
-			* Filters args passed to get_taxonomies.
-			*
-			* @see https://developer.wordpress.org/reference/functions/get_taxonomies/
-			*
-			* @since 4.4.0
-			*
-			* @module widget-visibility
-			*
-			* @param array $args Widget Visibility taxonomy arguments.
-			*/
+			 * Filters args passed to get_taxonomies.
+			 *
+			 * @see https://developer.wordpress.org/reference/functions/get_taxonomies/
+			 *
+			 * @since 5.3.0
+			 *
+			 * @module widget-visibility
+			 *
+			 * @param array $args Widget Visibility taxonomy arguments.
+			 */
 			apply_filters( 'jetpack_widget_visibility_tax_args', array( '_builtin' => false ) ),
 			'objects'
 		);

--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -123,7 +123,22 @@ class Jetpack_Widget_Conditions {
 		$widget_conditions_data['taxonomy'] = array();
 		$widget_conditions_data['taxonomy'][] = array( '', __( 'All taxonomy pages', 'jetpack' ) );
 
-		$taxonomies = get_taxonomies( array( '_builtin' => false ), 'objects' );
+		$taxonomies = get_taxonomies(
+			/**
+			* Filters args passed to get_taxonomies.
+			*
+			* @see https://developer.wordpress.org/reference/functions/get_taxonomies/
+			*
+			* @since 4.4.0
+			*
+			* @module widget-visibility
+			*
+			* @param array $args Widget Visibility taxonomy arguments.
+			*/
+			apply_filters( 'jetpack_widget_visibility_tax_args', array( '_builtin' => false ) ),
+			'objects'
+		);
+
 		usort( $taxonomies, array( __CLASS__, 'strcasecmp_name' ) );
 
 		foreach ( $taxonomies as $taxonomy ) {


### PR DESCRIPTION
Fixes #5221

#### Changes proposed in this Pull Request:
I had originally added this filter in this PR: https://github.com/Automattic/jetpack/pull/5222 but it was later erased when this module was refactored here: https://github.com/Automattic/jetpack/commit/0c510aaa0c8fb362657ec8ca6f0195506e214fe2#diff-deea61a2ffe944e4c0f7e2bc0d534be2L157

This pull request re-adds the filter again.

#### Testing instructions:
Add a an arg with the following:
```php
add_filter( 'jetpack_widget_visibility_tax_args', function( $args ) {
    $args['public'] = true;
    return $args;
} );
```
