### PR TITLE
Fixed warnings appearing when kses is called on an array

### DIFF
--- a/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -54,7 +54,7 @@ class Filter_Embedded_HTML_Objects {
 	}
 
 	static public function filter( $html ) {
-		if ( ! $html ) {
+		if ( ! $html || ! is_string( $html ) ) {
 			return $html;
 		}
 


### PR DESCRIPTION
Fixes #7629 

To test:
* Activate the shortcodes module
* Install and activate this plugin: https://gist.github.com/marcinbot/14c7fb17c59181f39ebd58fdf2a117c1
* Load any admin page with an array passed in GET params (`arrName[]=e1&arrName[]=e2`)
* Verify no warnings appear 