### PR TITLE
Comments management: add Comments tree endpoint from WP.com

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1850,6 +1850,10 @@ new WPCOM_JSON_API_Get_Comments_Tree_Endpoint( array(
 	'query_parameters' => array(
 		'status' => '(string) Filter returned comments based on this value (allowed values: all, approved, pending, trash, spam).'
 	),
+	'response_format' => array(
+		'comment_count' => '(int) The number of comments returned',
+		'comments_tree' => '(array) Array of arrays representing the comments tree for given site',
+	),
 
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments-tree?status=approved'
 ) );

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -20,6 +20,7 @@ require_once( $json_endpoints_dir . 'class.wpcom-json-api-taxonomy-endpoint.php'
 
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-delete-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-comment-endpoint.php' );
+require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-comments-tree-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-media-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-get-post-endpoint.php' );
 require_once( $json_endpoints_dir . 'class.wpcom-json-api-render-endpoint.php' );
@@ -1834,6 +1835,24 @@ new WPCOM_JSON_API_Get_Comment_Endpoint( array(
 	),
 
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments/147564'
+) );
+
+new WPCOM_JSON_API_Get_Comments_Tree_Endpoint( array(
+	'description' => 'Get a comments tree for site.',
+	'group'       => 'comments-tree',
+	'stat'        => 'comments-tree:1',
+
+	'method'      => 'GET',
+	'path'        =>  '/sites/%s/comments-tree',
+	'path_labels' => array(
+		'$site'   => '(int|string) Site ID or domain',
+		'$status' => '(string) Comment status value (allowed values: all, approved, trash, spam)',
+	),
+	'query_parameters' => array(
+		'status' => '(string) Filter returned comments based on this value (allowed values: all, approved, pending, trash, spam).'
+	),
+
+	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments-tree?status=approved'
 ) );
 
 new WPCOM_JSON_API_Update_Comment_Endpoint( array(

--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1846,7 +1846,6 @@ new WPCOM_JSON_API_Get_Comments_Tree_Endpoint( array(
 	'path'        =>  '/sites/%s/comments-tree',
 	'path_labels' => array(
 		'$site'   => '(int|string) Site ID or domain',
-		'$status' => '(string) Comment status value (allowed values: all, approved, trash, spam)',
 	),
 	'query_parameters' => array(
 		'status' => '(string) Filter returned comments based on this value (allowed values: all, approved, pending, trash, spam).'

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -1,0 +1,95 @@
+<?php
+
+class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint {
+	/**
+	 * Retrieves a list of comment data for a given site.
+	 *
+	 * @param   {string} $status   filter by status: 'all' | 'approved' | 'pending' | 'spam' | 'trash'
+	 * @param   {int}    $start_at first comment to search from going back in time
+	 * @returns {array}            list of comment information matching query
+	 */
+	public function get_site_tree( $status, $start_at = PHP_INT_MAX ) {
+		global $wpdb;
+		$max_comment_count = 10000;
+		$total_count = $this->get_site_tree_total_count( $status );
+		$db_status = $this->get_comment_db_status( $status );
+
+		$db_comments = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT comment_ID, comment_post_ID, comment_parent " .
+				"FROM $wpdb->comments AS comments " .
+				"INNER JOIN $wpdb->posts AS posts ON comments.comment_post_ID = posts.ID " .
+				"WHERE comment_type = '' AND comment_ID <= %d AND ( %s = 'all' OR comment_approved = %s ) " .
+				"ORDER BY comment_ID DESC " .
+				"LIMIT %d",
+				(int) $start_at, $db_status, $db_status, $max_comment_count
+			),
+			ARRAY_N
+		);
+
+		return array(
+			$total_count,
+			array_map( function( $comment ) {
+				return array_map( 'intval', $comment );
+			}, $db_comments )
+		);
+	}
+
+	/**
+	 * Retrieves a total count of comments for the given site.
+	 *
+	 * @param   {string} $status   filter by status: 'all' | 'approved' | 'pending' | 'spam' | 'trash'
+	 * @returns {int}              total count of comments for a site
+	 */
+	public function get_site_tree_total_count( $status ) {
+		global $wpdb;
+		$db_status = $this->get_comment_db_status( $status );
+
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(1) " .
+				"FROM $wpdb->comments AS comments " .
+				"INNER JOIN $wpdb->posts AS posts ON comments.comment_post_ID = posts.ID " .
+				"WHERE comment_type = '' AND ( %s = 'all' OR comment_approved = %s )",
+				$db_status, $db_status
+			)
+		);
+	}
+
+	/**
+	 * Ensure a valid status is converted to a database-supported value if necessary.
+	 *
+	 * @param   {string} $status 'all' | 'approved' | 'pending' | 'spam' | 'trash'
+	 * @returns {string}         value that exists in database
+	 */
+	public function get_comment_db_status( $status ) {
+		if ( 'approved' === $status ) {
+			$status = '1';
+		}
+		if ( 'pending' === $status ) {
+			$status = '0';
+		}
+		return $status;
+	}
+
+	public function validate_status_param( $status ) {
+		return in_array( $status, array( 'all', 'approved', 'pending', 'spam', 'trash' ) );
+	}
+
+	// /sites/%s/comments-tree
+	function callback( $path = '', $blog_id = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		$args = $this->query_args();
+		$comment_status = $args['status'];
+
+		if ( ! $this->validate_status_param( $comment_status ) ) {
+			return new WP_Error( 'invalid_status', 'Invalid comment status value provided ', 400 );
+		}
+
+		return $this->get_site_tree( $comment_status );
+	}
+}

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -27,12 +27,12 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 			ARRAY_N
 		);
 
-		return array(
-			$total_count,
-			array_map( function( $comment ) {
-				return array_map( 'intval', $comment );
-			}, $db_comments )
-		);
+		// Avoid using anonymous function bellow in order to preserve PHP 5.2 compatibility.
+		function intval_array_map( $comments ) {
+			return array_map( 'intval', $comments );
+		}
+
+		return array( $total_count, intval_array_map( $db_comments ) );
 	}
 
 	/**

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -93,7 +93,7 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 		$comment_status = empty( $args['status'] ) ? 'all' : $args['status'];
 
 		if ( ! $this->validate_status_param( $comment_status ) ) {
-			return new WP_Error( 'invalid_status', "Invalid comment status value provided: '$comment_status''.", 400 );
+			return new WP_Error( 'invalid_status', "Invalid comment status value provided: '$comment_status'.", 400 );
 		}
 
 		return $this->get_site_tree( $comment_status );

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -32,7 +32,7 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 			return array_map( 'intval', $comments );
 		}
 
-		return array( $total_count, intval_array_map( $db_comments ) );
+		return array( $total_count, array_map( 'intval_array_map', $db_comments ) );
 	}
 
 	/**

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -32,7 +32,10 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 			return array_map( 'intval', $comments );
 		}
 
-		return array( $total_count, array_map( 'intval_array_map', $db_comments ) );
+		return array(
+			'comment_count' => intval( $total_count ),
+			'comments_tree' => array_map( 'intval_array_map', $db_comments ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Introducing the Comments tree endpoint in Jetpack. This endpoint is already available on WordPress.com side, and the changes presented here are a verbatim copy of D6862-code.

#### Testing instructions
1. Apply D6862-code on your sandbox.
2. Sandbox the WP.com API.
3. Send `GET` request to `https://public-api.wordpress.com/rest/v1/sites/{$blog_id}/comments-tree/?status=all`, where `$blog_id` is the `id` of your test Jetpack site.
4. Results should be similar to the one that you can obtain by performing a `GET` request for: `https://public-api.wordpress.com/wpcom/v2/sites/{$blog_id}/comments-tree?status=all`