### PR TITLE
Add empty stats view for new users

### DIFF
--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -62,7 +62,7 @@ class DashStats extends Component {
 		}
 
 		forEach( props.statsData[ unit ].data, function( v ) {
-			const views = 0;
+			const views = v[ 1 ];
 			let date = v[ 0 ],
 				chartLabel = '',
 				tooltipLabel = '';

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -31,8 +31,16 @@ import {
 	getActiveStatsTab as _getActiveStatsTab
 } from 'state/at-a-glance';
 import { getModules } from 'state/modules';
+import { emptyStatsCardDismissed } from 'state/settings';
 
 class DashStats extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			emptyStatsDismissed: props.isEmptyStatsCardDismissed,
+		};
+	}
+
 	barClick( bar ) {
 		if ( bar.data.link ) {
 			analytics.tracks.recordJetpackClick( 'stats_bar' );
@@ -125,6 +133,10 @@ class DashStats extends Component {
 	}
 
 	renderEmptyStatsCard() {
+		const dismissCard = () => {
+			this.setState( { emptyStatsDismissed: true } );
+			this.props.updateOptions( { dismiss_empty_stats_card: true } );
+		};
 		return (
 			<Card className="jp-at-a-glance__stats-empty">
 				<img src={ imagePath + 'stats.svg' } alt={ __( 'Jetpack Stats Icon' ) } className="jp-at-a-glance__stats-icon" />
@@ -134,6 +146,7 @@ class DashStats extends Component {
 					{ __( 'Just give us a little time to collect data so we can display it for you here.' ) }
 				</p>
 				<Button
+					onClick={ dismissCard }
 					primary={ true }
 				>
 					{ __( 'Okay, got it!' ) }
@@ -166,11 +179,11 @@ class DashStats extends Component {
 			const statsChart = this.statsChart( this.props.activeTab() ),
 				chartData = statsChart.chartData,
 				totalViews = statsChart.totalViews,
-				emptyStats = chartData.length > 0 && totalViews <= 0;
+				showEmptyStats = chartData.length > 0 && totalViews <= 0 && ! this.props.isEmptyStatsCardDismissed && ! this.state.emptyStatsDismissed;
 
 			return (
 				<div className="jp-at-a-glance__stats-container">
-					{ ! emptyStats ? this.renderStatsChart( chartData ) : this.renderEmptyStatsCard() }
+					{ ! showEmptyStats ? this.renderStatsChart( chartData ) : this.renderEmptyStatsCard() }
 				</div>
 			);
 		}
@@ -289,7 +302,8 @@ export default connect(
 			isDevMode: isDevMode( state ),
 			isLinked: isCurrentUserLinked( state ),
 			connectUrl: getConnectUrl( state ),
-			statsData: getStatsData( state ) !== 'N/A' ? getStatsData( state ) : getInitialStateStatsData( state )
+			statsData: getStatsData( state ) !== 'N/A' ? getStatsData( state ) : getInitialStateStatsData( state ),
+			isEmptyStatsCardDismissed: emptyStatsCardDismissed( state ),
 		};
 	},
 	( dispatch ) => {

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -8,6 +8,17 @@
 	padding: 0;
 }
 
+.jp-at-a-glance__stats-empty {
+	padding: rem( 16px );
+	text-align: center;
+	margin-bottom: 0;
+
+	p {
+		font-size: rem( 14px );
+		color: $gray-text-min;
+	}
+}
+
 .jp-at-a-glance__stats-inactive {
 	padding: rem( 16px );
 

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -117,11 +117,15 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 
 		dispatch( removeNotice( 'module-setting-update' ) );
 		dispatch( removeNotice( 'module-setting-update-success' ) );
-		dispatch( createNotice(
-			'is-info',
-			messages.progress,
-			{ id: 'module-setting-update' }
-		) );
+
+		const suppressNoticeFor = [ 'dismiss_dash_app_card', 'dismiss_empty_stats_card' ];
+		if ( 'object' === typeof newOptionValues && ! some( suppressNoticeFor, ( optionValue ) => optionValue in newOptionValues ) ) {
+			dispatch( createNotice(
+				'is-info',
+				messages.progress,
+				{ id: 'module-setting-update' }
+			) );
+		}
 
 		dispatch( {
 			type: JETPACK_SETTINGS_UPDATE,
@@ -139,11 +143,13 @@ export const updateSettings = ( newOptionValues, type = '' ) => {
 
 			dispatch( removeNotice( 'module-setting-update' ) );
 			dispatch( removeNotice( 'module-setting-update-success' ) );
-			dispatch( createNotice(
-				'is-success',
-				messages.success,
-				{ id: 'module-setting-update-success', duration: 2000 }
-			) );
+			if ( 'object' === typeof newOptionValues && ! some( suppressNoticeFor, ( optionValue ) => optionValue in newOptionValues ) ) {
+				dispatch( createNotice(
+					'is-success',
+					messages.success,
+					{ id: 'module-setting-update-success', duration: 2000 }
+				) );
+			}
 		} ).catch( error => {
 			dispatch( {
 				type: JETPACK_SETTINGS_UPDATE_FAIL,

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -192,3 +192,12 @@ export function areThereUnsavedSettings( state ) {
 export function appsCardDismissed( state ) {
 	return get( state.jetpack.settings.items, 'dismiss_dash_app_card', false );
 }
+
+/**
+ * Returns true if Empty Stats card has been dismissed.
+ * @param  {Object}  state Global state tree
+ * @return {Boolean} Whether the card has been dismissed
+ */
+export function emptyStatsCardDismissed( state ) {
+	return get( state.jetpack.settings.items, 'dismiss_empty_stats_card', false );
+}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1679,6 +1679,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
+			// Empty stats card dismiss
+			'dismiss_empty_stats_card' => array(
+				'description'       => '',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'settings',
+			),
+
 		);
 
 		// Add modules to list so they can be toggled

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -862,6 +862,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$updated = get_option( $option ) != $value ? update_option( $option, (bool) $value ) : true;
 					break;
 
+				case 'dismiss_empty_stats_card':
+					// If option value was the same, consider it done.
+					$updated = get_option( $option ) !== $value ? update_option( $option, (bool) $value ) : true;
+					break;
+
 				default:
 					// If option value was the same, consider it done.
 					$updated = get_option( $option ) != $value ? update_option( $option, $value ) : true;


### PR DESCRIPTION
Fixes #7644 

This introduces a more welcoming stats view when there are none to display. 

### Changes proposed
- New option `dismiss_empty_stats_card` for dismissal of card 
- Changed the return of `statsChart()` to an object so we can also get the total # of views for the chart, which makes it easier to decide to show the card
- Update the component state immediately to hide the card, so we're not waiting for the response from the endpoint
- Add conditional checks to suppress the global notices, so it's not showing the "Updating Settings" notice on dismissal. 

To Test: 
- Either test on a site with no stats at all, or manually change [this line](https://github.com/Automattic/jetpack/compare/add/empty-stats-card?expand=1#diff-e07eb47c304f6733548f01181d0416a6L55) to `const views = 0`
- Load the dashboard.  You should see the card. 
- Dismissing the card should not show a notice, and it should not be there on refresh. 
- You should not see the notice if you have any stats.  

Marking as in-progress until we have a better svg cc @MichaelArestad @rickybanister 

Right now it looks like this: 
![screen shot 2017-08-16 at 1 35 03 pm](https://user-images.githubusercontent.com/7129409/29376795-bfa03482-8287-11e7-9df7-2994cd9af7ab.png)
