### PR TITLE
Tiled Gallery: resize galleries passing a parameter to a custom event

### DIFF
--- a/modules/tiled-gallery/tiled-gallery/tiled-gallery.js
+++ b/modules/tiled-gallery/tiled-gallery/tiled-gallery.js
@@ -142,8 +142,12 @@
 	$( document ).ready( function() {
 		var tiledGalleries = new TiledGalleryCollection();
 
-		$( 'body' ).on( 'post-load', function() {
-			tiledGalleries.findAndSetupNewGalleries();
+		$( 'body' ).on( 'post-load', function( e, maybeResize ) {
+			if ( 'string' === typeof maybeResize && 'resize' === maybeResize ) {
+				tiledGalleries.resizeAll();
+			} else {
+				tiledGalleries.findAndSetupNewGalleries();
+			}
 		} );
 		$( document ).on( 'page-rendered.wpcom-newdash', function() {
 			tiledGalleries.findAndSetupNewGalleries();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* allow `post-load` custom event to pass a parameter so that when it's `resize`, the galleries are resized. When it's not passed or is different from `resize`, it will perform the usual task: find and setup new galleries.


#### Testing instructions:

* setup a tiled gallery and execute this in JS console:
    `jQuery( 'body' ).trigger( 'post-load', ['resize'] );`

    you can verify that it worked by altering first the inline dimensions like these and checking that the image is ok after running the code in console
    <img width="658" alt="captura de pantalla 2017-08-17 a la s 13 13 45" src="https://user-images.githubusercontent.com/1041600/29422233-fb89ebc0-834d-11e7-8ea3-5f9c08d78cc2.png">

    or you can add a `console.log` [here](https://github.com/Automattic/jetpack/pull/7652/files#diff-4f9b83c204105157a58e1d538ab4925fR147).

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Tiled Gallery: allow to resize galleries already loaded by passing 'resize' to the 'post-load' custom event.