### PR TITLE
Simple Payments: pass order ID to the execute endpoint

### DIFF
--- a/modules/simple-payments/paypal-express-checkout.js
+++ b/modules/simple-payments/paypal-express-checkout.js
@@ -11,7 +11,7 @@
 var PaypalExpressCheckout = {
 	primaryCssClassName: 'jetpack-simple-payments',
 	messageCssClassName: 'jetpack-simple-payments-purchase-message',
-
+	spayOrderId: null,
 	wpRestAPIHost: 'https://public-api.wordpress.com',
 	wpRestAPIVersion: '/wpcom/v2',
 
@@ -161,14 +161,16 @@ var PaypalExpressCheckout = {
 								return reject( new Error( 'server_error' ) );
 							}
 
+							PaypalExpressCheckout.spayOrderId = paymentResponse.order_id;
 							resolve( paymentResponse.id );
 						} )
 						.fail( function( paymentError ) {
 							var paymentErrorMessage = PaypalExpressCheckout.processErrorMessage( paymentError );
 							PaypalExpressCheckout.showError( paymentErrorMessage, domId );
 
-							var code = paymentError.responseJSON && paymentError.responseJSON.code ?
-								paymentError.responseJSON.code : 'server_error';
+							var code = paymentError.responseJSON && paymentError.responseJSON.code
+								? paymentError.responseJSON.code
+								: 'server_error';
 
 							reject( new Error( code ) );
 						} );
@@ -179,8 +181,10 @@ var PaypalExpressCheckout = {
 				var payload = {
 					buttonId: buttonId,
 					payerId: onAuthData.payerID,
-					env: env
+					env: env,
+					spayOrderId: PaypalExpressCheckout.spayOrderId,
 				};
+
 				return new paypal.Promise( function( resolve, reject ) {
 					jQuery.post( PaypalExpressCheckout.getExecutePaymentEndpoint( blogId, onAuthData.paymentID ), payload )
 						.done( function( authResponse ) {


### PR DESCRIPTION
This PR takes the simple payment order ID from the `create` endpoint response thus later be passed to the `execute` endpoint request into its body.

### Testing

After updating your testing site, make the purchasing process. It takes two steps.

You should pay attention especially to the second one which is known as `execute`, taking a look at the body request. The `spayOrderId` field should be defined there.

![image](https://user-images.githubusercontent.com/77539/29423687-10a9ad2e-8353-11e7-8209-079f91b09a59.png)

If you wanna see how it works you could use my sandbox: https://retrofocs.wpsandbox.me/2017/08/17/cubba/