### PR TITLE
Fix `force_*` params for partner provision script

### DIFF
--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -34,6 +34,12 @@ for i in "$@"; do
         -u=* | --url=* )            SITE_URL="${i#*=}"
                                     shift
                                     ;;
+        --force_register=* )        FORCE_REGISTER="${i#*=}"
+                                    shift
+                                    ;;
+        --force_connect=* )         FORCE_CONNECT="${i#*=}"
+                                    shift
+                                    ;;
         -h | --help )               usage
                                     exit
                                     ;;


### PR DESCRIPTION
We need to add the params to the parsing block otherwise they are not recognized as valid params and the command bails with usage instructions.

#### Testing instructions:

* Without patch, call the script with either the `--force_connect=1` or `--force_register=1` flag, or both:

```
$ ./bin/partner-provision.sh --partner_id=1 --partner_secret=2 --wpcom_user_id=1 --force_register=1
Usage: partner-provision.sh --partner_id=partner_id --partner_secret=partner_secret [--user=wp_user_id] [--plan=plan_name] [--onboarding=1] [--wpcom_user_id=1234] [--url=http://example.com] [--force_connect=1] [--force_register=1]
``` 

This will output the Usage instructions.

* Apply patch and run again and verify that the script actually executes (it may still fail unless you provide valid data)

```
$ ./bin/partner-provision.sh --partner_id=1 --partner_secret=2 --wpcom_user_id=1 --force_register=1 --force_connect=1
{"error":"invalid_client","error_description":"Unknown partner key."}
```