### PR TITLE
Add config to run e2e tests against master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - run:
           name: Clone wp-e2e-tests repo
-          command: cd / && git clone https://github.com/Automattic/wp-e2e-tests.git
+          command: cd / && git clone https://github.com/Automattic/wp-e2e-tests.git && cd /wp-e2e-tests && git checkout update/jetpack-CI-script
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
                   else
                     source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
                   fi
-          when: always
+          when: always 
 workflows:
   version: 2
   build_test_destroy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,11 @@ jobs:
     steps:
       - run:
           name: Clone wp-e2e-tests repo
-          command: cd / && git clone https://github.com/Automattic/wp-e2e-tests.git && cd /wp-e2e-tests && git checkout update/jetpack-CI-script
+          command: |
+                  cd /
+                  git clone https://github.com/Automattic/wp-e2e-tests.git
+                  cd /wp-e2e-tests
+                  git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: << checksum "package.json" >>
       - run:
           name: Set name for Jetpack installation
-          command:  echo "export JP_PREFIX=${CIRCLECI_BUILD_NUM}-${CIRCLE_NODE_INDEX}-${RANDOM}" >> $BASH_ENV
+          command:  echo "export JP_PREFIX=${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}-${RANDOM}" >> $BASH_ENV
       - run:
           name: Initialize site on Digital Ocean via ServerPilot
           command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: << checksum "package.json" >>
       - run:
           name: Set name for Jetpack installation
-          command:  echo "export JP_PREFIX=${CIRCLECI_BUILD_NUM}_${CIRCLE_NODE_INDEX}_${RANDOM}" >> $BASH_ENV
+          command:  echo "export JP_PREFIX=${CIRCLECI_BUILD_NUM}-${CIRCLE_NODE_INDEX}-${RANDOM}" >> $BASH_ENV
       - run:
           name: Initialize site on Digital Ocean via ServerPilot
           command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - run:
           name: Clone wp-e2e-tests repo
-          command: cd / && git clone https://github.com/Automattic/wp-e2e-tests.git
+          command: cd /  && git clone https://github.com/Automattic/wp-e2e-tests.git
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - persist_to_workspace:
+          root: /
           paths:
             - /wp-e2e-tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - persist_to_workspace:
-          root: /
+          root: /wp-e2e-tests
           paths:
-            - /wp-e2e-tests
+            - .
       - run:
           name: Initialize site on Digital Ocean via ServerPilot
           command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,22 +54,6 @@ jobs:
       - run:
           name: Run e2e tests
           command: ./run.sh -R -j -H CI -p -x
-      - store_test_results:
-          path: reports/
-      - store_artifacts:
-          path: reports/
-      - store_artifacts:
-          path: screenshots/
-  destroy:
-    working_directory: /wp-e2e-tests
-    docker:
-      - image: automattic/wp-e2e-tests:0.0.5
-        environment:
-                JETPACKHOST: CI
-                NODE_ENV: test
-    steps:
-      - attach_workspace:
-          at: /wp-e2e-tests
       - run:
           name: Run Jetpack deactivation spec
           command: |
@@ -88,6 +72,12 @@ jobs:
                     source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
                   fi
           when: always 
+      - store_test_results:
+          path: reports/
+      - store_artifacts:
+          path: reports/
+      - store_artifacts:
+          path: screenshots/
 workflows:
   version: 2
   build_test_destroy:
@@ -96,7 +86,3 @@ workflows:
       - test:
           requires:
             - build
-      - destroy:
-          requires:
-            - test
-          when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - run:
           name: Clone wp-e2e-tests repo
-          command: cd /  && git clone https://github.com/Automattic/wp-e2e-tests.git
+          command: cd / && git clone https://github.com/Automattic/wp-e2e-tests.git
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install
@@ -34,7 +34,9 @@ jobs:
       - run:
           name: Run Jetpack activation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
-      - run: ./scripts/run-wrapper.sh
+      - run:
+          name: Run e2e tests
+          command: ./run.sh -R -j -H CI -p
       - run:
           name: Run Jetpack deactivation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-deactivate.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
       - run:
           name: Run e2e tests
-          command: ./run.sh -R -j -H CI -p -x
+          command: ./run.sh -R -j -H CI -p -x -a 1
       - run:
           name: Run Jetpack deactivation spec
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,14 @@ jobs:
                     source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
                   fi
           when: always
-  workflows:
-    version: 2
-    build_test_destroy:
-      jobs:
-        - build
-        - test
-        - destroy
+workflows:
+  version: 2
+  build_test_destroy:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - destroy:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: Install Jetpack from master
           command: |
                   scp -o "StrictHostKeyChecking no" scripts/jetpack/git-jetpack.sh serverpilot@wp-e2e-tests.pw:~serverpilot/git-jetpack.sh
-                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-${CIRCLE_SHA1:0:30}
+                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-${CIRCLE_SHA1:0:20}
       - run:
           name: Run Jetpack activation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
   destroy:
     working_directory: /wp-e2e-tests
     docker:
-      - image: circleci/node:6.11.1
+      - image: automattic/wp-e2e-tests:0.0.5
     steps:
       - attach_workspace:
           at: /wp-e2e-tests
@@ -72,10 +72,10 @@ jobs:
                     source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
                   fi
           when: always
-workflows:
-  version: 2
-  build_test_destroy:
-    jobs:
-      - build
-      - test
-      - destroy
+  workflows:
+    version: 2
+    build_test_destroy:
+      jobs:
+        - build
+        - test
+        - destroy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
       - run:
           name: Run e2e tests
-          command: ./run.sh -R -j -H CI -p -x -a 1
+          command: ./run.sh -R -j -H CI -p -x
       - run:
           name: Run Jetpack deactivation spec
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
                   cd /
                   git clone https://github.com/Automattic/wp-e2e-tests.git
                   cd /wp-e2e-tests
-                  git checkout origin/${E2E_BRANCH-update/jetpack-CI-new-prefix}
+                  git checkout origin/${E2E_BRANCH-master}
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install
@@ -71,6 +71,15 @@ jobs:
       - attach_workspace:
           at: /wp-e2e-tests
       - run:
+          name: Run Jetpack deactivation spec
+          command: |
+                  if [ "$E2E_DEBUG" == "true" ]; then
+                    echo "Skipping deactivation step for DEBUG purposes"
+                  else
+                    source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-deactivate.js
+                  fi
+          when: always
+      - run:
           name: Delete site from Digital Ocean via ServerPilot
           command: |
                   if [ "$E2E_DEBUG" == "true" ]; then
@@ -90,3 +99,4 @@ workflows:
       - destroy:
           requires:
             - test
+          when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
       - persist_to_workspace:
-          root: /
-          path: wp-e2e-tests
+          paths:
+            - /wp-e2e-tests
       - run:
           name: Initialize site on Digital Ocean via ServerPilot
           command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
                   cd /
                   git clone https://github.com/Automattic/wp-e2e-tests.git
                   cd /wp-e2e-tests
-                  git checkout origin/${E2E_BRANCH-master}
+                  git checkout origin/${E2E_BRANCH-update/jetpack-CI-new-prefix}
       - restore_cache:
           key: << checksum "package.json" >>
       - run: source $HOME/.nvm/nvm.sh && npm install
@@ -30,7 +30,7 @@ jobs:
           name: Install Jetpack from master
           command: |
                   scp -o "StrictHostKeyChecking no" scripts/jetpack/git-jetpack.sh serverpilot@wp-e2e-tests.pw:~serverpilot/git-jetpack.sh
-                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-$CIRCLE_SHA1
+                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-${CIRCLE_SHA1:0:30}
       - run:
           name: Run Jetpack activation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,9 @@
 version: 2
 jobs:
   build:
-    parallelism: 2
     working_directory: /wp-e2e-tests
     docker:
       - image: automattic/wp-e2e-tests:0.0.5
-        environment:
-                JETPACKHOST: CI
-                NODE_ENV: test
     steps:
       - run:
           name: Clone wp-e2e-tests repo
@@ -23,9 +19,9 @@ jobs:
           paths:
             - /wp-e2e-tests/node_modules
           key: << checksum "package.json" >>
-      - run:
-          name: Set name for Jetpack installation
-          command:  echo "export JP_PREFIX=${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}-${RANDOM}" >> $BASH_ENV
+      - persist_to_workspace:
+          root: /
+          path: wp-e2e-tests
       - run:
           name: Initialize site on Digital Ocean via ServerPilot
           command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js
@@ -33,25 +29,40 @@ jobs:
           name: Install Jetpack from master
           command: |
                   scp -o "StrictHostKeyChecking no" scripts/jetpack/git-jetpack.sh serverpilot@wp-e2e-tests.pw:~serverpilot/git-jetpack.sh
-                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-$JP_PREFIX
+                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-$CIRCLE_BUILD_NUM
+      - run:
+          name: Run Jetpack activation spec
+          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
+  test:
+    parallelism: 2
+    working_directory: /wp-e2e-tests
+    docker:
+      - image: automattic/wp-e2e-tests:0.0.5
+        environment:
+                JETPACKHOST: CI
+                NODE_ENV: test
+    steps:
+      - attach_workspace:
+          at: /wp-e2e-tests
       - run:
           name: Randomize spec execution order
           command: ./scripts/randomize.sh specs
       - run:
-          name: Run Jetpack activation spec
-          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
-      - run:
           name: Run e2e tests
           command: ./run.sh -R -j -H CI -p -x
-      - run:
-          name: Run Jetpack deactivation spec
-          command: |
-                  if [ "$E2E_DEBUG" == "true" ]; then
-                    echo "Skipping deactivation step for DEBUG purposes"
-                  else
-                    source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-deactivate.js
-                  fi
-          when: always
+      - store_test_results:
+          path: reports/
+      - store_artifacts:
+          path: reports/
+      - store_artifacts:
+          path: screenshots/
+  destroy:
+    working_directory: /wp-e2e-tests
+    docker:
+      - image: circleci/node:6.11.1
+    steps:
+      - attach_workspace:
+          at: /wp-e2e-tests
       - run:
           name: Delete site from Digital Ocean via ServerPilot
           command: |
@@ -61,9 +72,10 @@ jobs:
                     source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
                   fi
           when: always
-      - store_test_results:
-          path: reports/
-      - store_artifacts:
-          path: reports/
-      - store_artifacts:
-          path: screenshots/
+workflows:
+  version: 2
+  build_test_destroy:
+    jobs:
+      - build
+      - test
+      - destroy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           name: Install Jetpack from master
           command: |
                   scp -o "StrictHostKeyChecking no" scripts/jetpack/git-jetpack.sh serverpilot@wp-e2e-tests.pw:~serverpilot/git-jetpack.sh
-                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-$CIRCLE_BUILD_NUM
+                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-$CIRCLE_SHA1
       - run:
           name: Run Jetpack activation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
     working_directory: /wp-e2e-tests
     docker:
       - image: automattic/wp-e2e-tests:0.0.5
+        environment:
+                JETPACKHOST: CI
+                NODE_ENV: test
     steps:
       - run:
           name: Clone wp-e2e-tests repo
@@ -61,6 +64,9 @@ jobs:
     working_directory: /wp-e2e-tests
     docker:
       - image: automattic/wp-e2e-tests:0.0.5
+        environment:
+                JETPACKHOST: CI
+                NODE_ENV: test
     steps:
       - attach_workspace:
           at: /wp-e2e-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,15 @@ jobs:
           command: |
                   scp -o "StrictHostKeyChecking no" scripts/jetpack/git-jetpack.sh serverpilot@wp-e2e-tests.pw:~serverpilot/git-jetpack.sh
                   ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-$JP_PREFIX
-      - run: ./scripts/randomize.sh specs
+      - run:
+          name: Randomize spec execution order
+          command: ./scripts/randomize.sh specs
       - run:
           name: Run Jetpack activation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
       - run:
           name: Run e2e tests
-          command: ./run.sh -R -j -H CI -p
+          command: ./run.sh -R -j -H CI -p -x
       - run:
           name: Run Jetpack deactivation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-deactivate.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: << checksum "package.json" >>
       - run:
           name: Set name for Jetpack installation
-          command:  echo "export JP_PREFIX=$(date +'%s')$RANDOM" >> $BASH_ENV
+          command:  echo "export JP_PREFIX=${CIRCLECI_BUILD_NUM}_${CIRCLE_NODE_INDEX}_${RANDOM}" >> $BASH_ENV
       - run:
           name: Initialize site on Digital Ocean via ServerPilot
           command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js
@@ -41,11 +41,21 @@ jobs:
           command: ./run.sh -R -j -H CI -p -x
       - run:
           name: Run Jetpack deactivation spec
-          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-deactivate.js
+          command: |
+                  if [ "$E2E_DEBUG" == "true" ]; then
+                    echo "Skipping deactivation step for DEBUG purposes"
+                  else
+                    source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-deactivate.js
+                  fi
           when: always
       - run:
           name: Delete site from Digital Ocean via ServerPilot
-          command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
+          command: |
+                  if [ "$E2E_DEBUG" == "true" ]; then
+                    echo "Skipping delete step for DEBUG purposes"
+                  else
+                    source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
+                  fi
           when: always
       - store_test_results:
           path: reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+version: 2
+jobs:
+  build:
+    parallelism: 2
+    working_directory: /wp-e2e-tests
+    docker:
+      - image: automattic/wp-e2e-tests:0.0.5
+        environment:
+                JETPACKHOST: CI
+                NODE_ENV: test
+    steps:
+      - run:
+          name: Clone wp-e2e-tests repo
+          command: cd / && git clone https://github.com/Automattic/wp-e2e-tests.git
+      - restore_cache:
+          key: << checksum "package.json" >>
+      - run: source $HOME/.nvm/nvm.sh && npm install
+      - save_cache:
+          paths:
+            - /wp-e2e-tests/node_modules
+          key: << checksum "package.json" >>
+      - run:
+          name: Set name for Jetpack installation
+          command:  echo "export JP_PREFIX=$(date +'%s')$RANDOM" >> $BASH_ENV
+      - run:
+          name: Initialize site on Digital Ocean via ServerPilot
+          command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js
+      - run:
+          name: Install Jetpack from master
+          command: |
+                  scp -o "StrictHostKeyChecking no" scripts/jetpack/git-jetpack.sh serverpilot@wp-e2e-tests.pw:~serverpilot/git-jetpack.sh
+                  ssh -o "StrictHostKeyChecking no" serverpilot@wp-e2e-tests.pw ~serverpilot/git-jetpack.sh wordpress-$JP_PREFIX
+      - run: ./scripts/randomize.sh specs
+      - run:
+          name: Run Jetpack activation spec
+          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
+      - run: ./scripts/run-wrapper.sh
+      - run:
+          name: Run Jetpack deactivation spec
+          command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-deactivate.js
+          when: always
+      - run:
+          name: Delete site from Digital Ocean via ServerPilot
+          command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
+          when: always
+      - store_test_results:
+          path: reports/
+      - store_artifacts:
+          path: reports/
+      - store_artifacts:
+          path: screenshots/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,9 @@ jobs:
             - .
       - run:
           name: Initialize site on Digital Ocean via ServerPilot
-          command: source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js
+          command: |
+                  source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js # In case of a rebuild
+                  source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-init.js
       - run:
           name: Install Jetpack from master
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,22 @@ jobs:
       - run:
           name: Run e2e tests
           command: ./run.sh -R -j -H CI -p -x
+      - store_test_results:
+          path: reports/
+      - store_artifacts:
+          path: reports/
+      - store_artifacts:
+          path: screenshots/
+  destroy:
+    working_directory: /wp-e2e-tests
+    docker:
+      - image: automattic/wp-e2e-tests:0.0.5
+        environment:
+                JETPACKHOST: CI
+                NODE_ENV: test
+    steps:
+      - attach_workspace:
+          at: /wp-e2e-tests
       - run:
           name: Run Jetpack deactivation spec
           command: |
@@ -72,12 +88,6 @@ jobs:
                     source $HOME/.nvm/nvm.sh && ./scripts/jetpack/wp-serverpilot-delete.js
                   fi
           when: always 
-      - store_test_results:
-          path: reports/
-      - store_artifacts:
-          path: reports/
-      - store_artifacts:
-          path: screenshots/
 workflows:
   version: 2
   build_test_destroy:
@@ -86,3 +96,6 @@ workflows:
       - test:
           requires:
             - build
+      - destroy:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ workflows:
   version: 2
   build_test_destroy:
     jobs:
-      - build
+      - build:
           filters:
              branches:
                 only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
              branches:
                 only:
                   - master
-                  - /*e2e*/
+                  - /.*e2e.*/
       - test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,4 +95,4 @@ workflows:
             - test
     filters:
        branches:
-          only: master
+          only: add/e2e-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,12 +87,14 @@ workflows:
   build_test_destroy:
     jobs:
       - build
+          filters:
+             branches:
+                only:
+                  - master
+                  - /*e2e*/
       - test:
           requires:
             - build
       - destroy:
           requires:
             - test
-    filters:
-       branches:
-          only: add/e2e-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,14 @@
-version: 2
-jobs:
-  build:
+defaults: &defaults
     working_directory: /wp-e2e-tests
     docker:
       - image: automattic/wp-e2e-tests:0.0.5
         environment:
                 JETPACKHOST: CI
                 NODE_ENV: test
+version: 2
+jobs:
+  build:
+    <<: *defaults          
     steps:
       - run:
           name: Clone wp-e2e-tests repo
@@ -40,13 +42,8 @@ jobs:
           name: Run Jetpack activation spec
           command: source $HOME/.nvm/nvm.sh && xvfb-run ./node_modules/.bin/mocha scripts/jetpack/wp-jetpack-activate.js
   test:
+    <<: *defaults          
     parallelism: 2
-    working_directory: /wp-e2e-tests
-    docker:
-      - image: automattic/wp-e2e-tests:0.0.5
-        environment:
-                JETPACKHOST: CI
-                NODE_ENV: test
     steps:
       - attach_workspace:
           at: /wp-e2e-tests
@@ -63,12 +60,7 @@ jobs:
       - store_artifacts:
           path: screenshots/
   destroy:
-    working_directory: /wp-e2e-tests
-    docker:
-      - image: automattic/wp-e2e-tests:0.0.5
-        environment:
-                JETPACKHOST: CI
-                NODE_ENV: test
+    <<: *defaults          
     steps:
       - attach_workspace:
           at: /wp-e2e-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,3 +101,6 @@ workflows:
       - destroy:
           requires:
             - test
+    filters:
+       branches:
+          only: master


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds a config to run the [e2e tests](https://github.com/Automattic/wp-e2e-tests) against a dynamically created / activated Jetpack site.
* Uses a webhook to CircleCI to run the tests

1) You merge a change into Jetpack master, and a CircleCI webhook fires (it actually fires on every branch, but the Circle config restricts it to only run against master or branches with “e2e” in the name)
2) On the CircleCI container it does a git clone of the latest wp-e2e-tests master. I debated making it a submodule, but I didn’t want to add any unnecessary dependencies to the repo.
3) A new WP site is built via the ServerPilot API on a DigitalOcean droplet
4) It SSHes in and installs the latest Jetpack master on the site. (I have a clone of the repo already on the server, and it just copies it into the plugins directory and does a git pull to refresh. So one limitation here will be if we need to do a yarn rebuild or anything like that. It was just too slow to do that all from scratch on every run, but that’s an option if the functionality is needed)
5) A Selenium script opens a Chrome browser and activates / connects the plugin to an existing wpcom account (e2eflowtestingjetpackmulti)
6) The e2e tests are run in Desktop and Mobile screen sizes against that site
7) A Selenium script disconnects Jetpack from the Calypso site settings page
8) The site is deleted via the ServerPilot API

