### PR TITLE
EU Cookie Law Widget: Remove unnecessary widget border

### DIFF
--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -1,4 +1,5 @@
 .widget_eu_cookie_law_widget.widget {
+	border: none;
 	bottom: 1em;
 	display: none;
 	left: 1em;


### PR DESCRIPTION
Fixes 832-jpop-issues

On some themes `.widget` containers might have borders.
The EU Cookie Law banner logic on close and accept simply removes the _content_ and not the entire `.widget`, therefore the `.widget` border remains visible no matter what.

Particularly odd is the case with the Twenty Sixteen theme, where the `.widget`s have a black upper border.
On large screens, there is a "black frame" that effectively hides the EU Cookie Law banner's border.
On small screens, though, the frame disappears and the border is visible.

Large screen, banner active. Notice the black border.
<img width="858" alt="screen shot 2017-08-22 at 13 13 15" src="https://user-images.githubusercontent.com/2070010/29562942-c9b274a4-873b-11e7-8dce-94fe046590f6.png">

Large screen, banner closed. Notice the black frame of the theme. The closed banner border is actually there, but not visible.
<img width="854" alt="screen shot 2017-08-22 at 13 13 29" src="https://user-images.githubusercontent.com/2070010/29562966-dd0acf42-873b-11e7-813f-561e5421ce1f.png">

Small screen, banner closed. No more black frame, and the widget border is visible again.
<img width="666" alt="screen shot 2017-08-22 at 13 13 36" src="https://user-images.githubusercontent.com/2070010/29563022-1772d0bc-873c-11e7-9f0d-710335d4b648.png">

#### Changes proposed in this Pull Request:

* Remove unnecessary widget border.

#### Testing instructions:

* Activate the EU Cookie Law widget on a site with the Twenty Sixteen theme.
* "Close and Accept" the cookie banner.
* Resize the window until the "black frame" of the theme disappears.
* Make sure that there is no residual black line from the banner.