### PR TITLE
VideoPress: Only loop if specifically indicated

### DIFF
--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -127,7 +127,7 @@ class VideoPress_Shortcode {
 		$options = apply_filters( 'videopress_shortcode_options', array(
 			'at'              => (int) $attr['at'],
 			'hd'              => $attr['hd'],
-			'loop'            => $attr['autoplay'] || $attr['loop'],
+			'loop'            => $attr['loop'],
 			'freedom'         => $attr['freedom'],
 			'autoplay'        => $attr['autoplay'],
 			'permalink'       => $attr['permalink'],


### PR DESCRIPTION
Fixes #7303 

Testing:
Add an autoplay arg to a VideoPress shortcode. It should autoplay but not loop.

cc: @dbtlr