### PR TITLE
Add pingbacks and trackbacks to the response of the comments tree endpoint.

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1851,8 +1851,12 @@ new WPCOM_JSON_API_Get_Comments_Tree_Endpoint( array(
 		'status' => '(string) Filter returned comments based on this value (allowed values: all, approved, pending, trash, spam).'
 	),
 	'response_format' => array(
-		'comment_count' => '(int) The number of comments returned',
-		'comments_tree' => '(array) Array of arrays representing the comments tree for given site',
+		'comments_count' => '(int) Total number of comments on the site',
+		'comments_tree' => '(array) Array of arrays representing the comments tree for given site (max 50000)',
+		'trackbacks_count' => '(int) Total number of trackbacks on the site',
+		'trackbacks_tree' => '(array) Array of arrays representing the trackbacks tree for given site (max 50000)',
+		'pingbacks_count' => '(int) Total number of pingbacks on the site',
+		'pingbacks_tree' => '(array) Array of arrays representing the pingbacks tree for given site (max 50000)',
 	),
 
 	'example_request' => 'https://public-api.wordpress.com/rest/v1/sites/en.blog.wordpress.com/comments-tree?status=approved'

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -20,7 +20,7 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 				"SELECT comment_ID, comment_post_ID, comment_parent " .
 				"FROM $wpdb->comments AS comments " .
 				"INNER JOIN $wpdb->posts AS posts ON comments.comment_post_ID = posts.ID " .
-				"WHERE comment_type = '' AND comment_ID <= %d AND ( %s = 'all' OR comment_approved = %s ) " .
+				"WHERE comment_ID <= %d AND ( %s = 'all' OR comment_approved = %s ) " .
 				"ORDER BY comment_ID DESC " .
 				"LIMIT %d",
 				(int) $start_at, $db_status, $db_status, $max_comment_count
@@ -55,7 +55,7 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 				"SELECT COUNT(1) " .
 				"FROM $wpdb->comments AS comments " .
 				"INNER JOIN $wpdb->posts AS posts ON comments.comment_post_ID = posts.ID " .
-				"WHERE comment_type = '' AND ( %s = 'all' OR comment_approved = %s )",
+				"WHERE ( %s = 'all' OR comment_approved = %s )",
 				$db_status, $db_status
 			)
 		);

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -9,15 +9,14 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 	 *
 	 * @return array
 	 */
-	public function get_site_tree( $status, $start_at = PHP_INT_MAX ) {
+	function get_site_tree( $status, $start_at = PHP_INT_MAX ) {
 		global $wpdb;
-		$max_comment_count = 10000;
-		$total_count = $this->get_site_tree_total_count( $status );
+		$max_comment_count = 50000;
 		$db_status = $this->get_comment_db_status( $status );
 
 		$db_comment_rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT comment_ID, comment_post_ID, comment_parent " .
+				"SELECT comment_ID, comment_post_ID, comment_parent, comment_type " .
 				"FROM $wpdb->comments AS comments " .
 				"INNER JOIN $wpdb->posts AS posts ON comments.comment_post_ID = posts.ID " .
 				"WHERE comment_ID <= %d AND ( %s = 'all' OR comment_approved = %s ) " .
@@ -28,37 +27,69 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 			ARRAY_N
 		);
 
-		// Avoid using anonymous function bellow in order to preserve PHP 5.2 compatibility.
-		function array_map_all_as_ints( $comments ) {
-			return array_map( 'intval', $comments );
+		$comments = array();
+		$trackbacks = array();
+		$pingbacks = array();
+		foreach ( $db_comment_rows as $row ) {
+			list( $comment_id, $comment_post_id, $comment_parent, $comment_type ) = $row;
+			switch ( $comment_type ) {
+				case 'trackback':
+					$trackbacks[] = array( $comment_id, $comment_post_id, $comment_parent );
+					break;
+				case 'pingback':
+					$pingbacks[] = array( $comment_id, $comment_post_id, $comment_parent );
+					break;
+				default:
+					$comments[] = array( $comment_id, $comment_post_id, $comment_parent );
+			}
 		}
 
 		return array(
-			'comment_count' => intval( $total_count ),
-			'comments_tree' => array_map( 'array_map_all_as_ints', $db_comment_rows ),
+			'comments_count' => $this->get_site_tree_total_count( $status, 'comment' ),
+			'comments_tree' => array_map( array( $this, 'array_map_all_as_ints' ), $comments ),
+			'trackbacks_count' => $this->get_site_tree_total_count( $status, 'trackback' ),
+			'trackbacks_tree' => array_map( array( $this, 'array_map_all_as_ints' ), $trackbacks ),
+			'pingbacks_count' => $this->get_site_tree_total_count( $status, 'pingback' ),
+			'pingbacks_tree' => array_map( array( $this, 'array_map_all_as_ints' ), $pingbacks ),
 		);
 	}
 
 	/**
-	 * Retrieves a total count of comments for the given site.
+	 * Ensure all values are integers.
+	 *
+	 * @param array $comments Collection of comments.
+	 *
+	 * @return array Comments with values as integers.
+	 */
+	function array_map_all_as_ints( $comments ) {
+		return array_map( 'intval', $comments );
+	}
+
+	/**
+	 * Retrieves a total count of comments by type for the given site.
 	 *
 	 * @param string $status Filter by status: all, approved, pending, spam or trash.
+	 * @param string $type Comment type: 'trackback', 'pingback', or 'comment'.
 	 *
 	 * @return int Total count of comments for a site.
 	 */
-	public function get_site_tree_total_count( $status ) {
+	function get_site_tree_total_count( $status, $type ) {
 		global $wpdb;
 		$db_status = $this->get_comment_db_status( $status );
+		$type = $this->get_sanitized_comment_type( $type );
+		// An empty value in the comments_type column denotes a regular comment.
+		$type = ( 'comment' === $type ) ? '' : $type;
 
-		return $wpdb->get_var(
+		$result = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(1) " .
 				"FROM $wpdb->comments AS comments " .
 				"INNER JOIN $wpdb->posts AS posts ON comments.comment_post_ID = posts.ID " .
-				"WHERE ( %s = 'all' OR comment_approved = %s )",
-				$db_status, $db_status
+				"WHERE comment_type = %s AND ( %s = 'all' OR comment_approved = %s )",
+				$type, $db_status, $db_status
 			)
 		);
+		return intval( $result );
 	}
 
 	/**
@@ -68,7 +99,7 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 	 *
 	 * @return string Corresponding value that exists in database.
 	 */
-	public function get_comment_db_status( $status ) {
+	function get_comment_db_status( $status ) {
 		if ( 'approved' === $status ) {
 			return '1';
 		}
@@ -78,11 +109,39 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 		return $status;
 	}
 
-	public function validate_status_param( $status ) {
+	/**
+	 * Determine if the passed comment status is valid or not.
+	 *
+	 * @param string $status
+	 *
+	 * @return boolean
+	 */
+	function validate_status_param( $status ) {
 		return in_array( $status, array( 'all', 'approved', 'pending', 'spam', 'trash' ) );
 	}
 
-	// /sites/%s/comments-tree
+	/**
+	 * Sanitize a given comment type.
+	 *
+	 * @param string Comment type: can be 'trackback', 'pingback', or 'comment'.
+	 *
+	 * @return string Sanitized comment type.
+	 */
+	function get_sanitized_comment_type( $type = 'comment' ) {
+		if ( in_array( $type, array( 'trackback', 'pingback', 'comment' ) ) ) {
+			return $type;
+		}
+		return 'comment';
+	}
+
+	/**
+	 * Endpoint callback for /sites/%s/comments-tree
+	 *
+	 * @param string $path
+	 * @param int    $blog_id
+	 *
+	 * @return array Site tree results by status.
+	 */
 	function callback( $path = '', $blog_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {


### PR DESCRIPTION
Only regular comments are currently included in the comments tree endpoint; by removing the check on the `comments_type` column, we allow pingbacks and trackbacks to be included in the endpoint response also.

#### Testing instructions:

* Make this PR active on a Jetpack site with pingbacks and/or trackbacks. This can be done with the Jetpack Beta plugin too, by selecting `add/comments-tree-endpoint-pingbacks-trackbacks` from Jetpack > Jetpack Beta > Search for a Jetpack feature Branch.
* Hit the WP.com API `comments-tree` endpoint for that site, and verify that any pingbacks and trackbacks are included. This can be done in the [WordPress.com API dev console](https://developer.wordpress.com/docs/api/console/), at `GET
v1/sites/(JP site URL)/comments-tree`.
* If using the dev console, be sure to sandbox the API, and apply D6974-code.
