### PR TITLE
Comments: adds author email and IP Address to the site's comments endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -127,7 +127,7 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 				);
 				break;
 			case 'author' :
-				$response[$key] = (object) $this->get_author( $comment, in_array( $context, array( 'edit', 'display' ) ) && current_user_can( 'edit_comment', $comment->comment_ID ) );
+				$response[$key] = (object) $this->get_author( $comment, current_user_can( 'edit_comment', $comment->comment_ID ) );
 				break;
 			case 'date' :
 				$response[$key] = (string) $this->format_date( $comment->comment_date_gmt, $comment->comment_date );

--- a/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -127,7 +127,7 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 				);
 				break;
 			case 'author' :
-				$response[$key] = (object) $this->get_author( $comment, 'edit' === $context && current_user_can( 'edit_comment', $comment->comment_ID ) );
+				$response[$key] = (object) $this->get_author( $comment, in_array( $context, array( 'edit', 'display' ) ) && current_user_can( 'edit_comment', $comment->comment_ID ) );
 				break;
 			case 'date' :
 				$response[$key] = (string) $this->format_date( $comment->comment_date_gmt, $comment->comment_date );


### PR DESCRIPTION
Continuation of https://github.com/Automattic/jetpack/pull/7637

#### Changes proposed in this Pull Request:

Add the author IP address to the response of [`GET /sites/$site/comments/$comment_ID`](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/%24comment_ID/), removing the `display` context limitation. Requester must have `edit_comment` capabilities.

#### Testing instructions:

Try the `GET /sites/$site/comments/$comment_ID` endpoint on a Jetpack site here: https://developer.wordpress.com/docs/api/console/

The response's author object must contain both `email` and `ip_address` fields for `display` and `edit` request contexts. Other contexts should return `false` for both fields.

#### References:

https://github.com/Automattic/wp-calypso/pull/17251#issuecomment-322849896
p7jreA-Gv-p2
D6984-code