### PR TITLE
Sync: Update Sync Status Endpoint

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
@@ -5,7 +5,7 @@ class Jetpack_JSON_API_Cron_Endpoint extends Jetpack_JSON_API_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function validate_call( $_blog_id, $capability, $check_manage_active = true ) {
-		parent::validate_call( $_blog_id, $capability, false );
+		return parent::validate_call( $_blog_id, $capability, false );
 	}
 
 	protected function result() {

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -5,7 +5,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 	protected $needed_capabilities = 'manage_options';
 
 	protected function validate_call( $_blog_id, $capability, $check_manage_active = true ) {
-		parent::validate_call( $_blog_id, $capability, false );
+		return parent::validate_call( $_blog_id, $capability, false );
 	}
 
 	protected function result() {

--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -416,8 +416,9 @@ class Jetpack_Sync_Actions {
 		$cron_timestamps = array_keys( _get_cron_array() );
 		$next_cron = $cron_timestamps[0] - time();
 
+		$full_sync_status = ( $sync_module ) ? $sync_module->get_status() : array();
 		return array_merge(
-			$sync_module->get_status(),
+			$full_sync_status,
 			array(
 				'cron_size'             => count( $cron_timestamps ),
 				'next_cron'             => $next_cron,

--- a/sync/class.jetpack-sync-sender.php
+++ b/sync/class.jetpack-sync-sender.php
@@ -58,6 +58,9 @@ class Jetpack_Sync_Sender {
 	}
 
 	public function do_full_sync() {
+		if ( ! Jetpack_Sync_Modules::get_module( 'full-sync' ) ) {
+			return;
+		}
 		$this->continue_full_sync_enqueue();
 		return $this->do_sync_and_set_delays( $this->full_sync_queue );
 	}


### PR DESCRIPTION
Fixes #

Getting sync status when not using the `full_sync` module.

#### Testing instructions:

* request GET /sites/%s/sync/status where the sync module is disable

##### How to disable `full_sync`
```
       add_filter( 'jetpack_sync_modules', array( __CLASS__, 'custom_jetpack_sync_modules' ) );


	/**
	 * Define what Jetpack sync modules to enable
	 * @param  array $modules
	 * @return array
	 */
	public static function custom_jetpack_sync_modules( $modules ) {
		return array(
			//'Jetpack_Sync_Module_Constants',
			//'Jetpack_Sync_Module_Callables',
			//'Jetpack_Sync_Module_Options',
			//'Jetpack_Sync_Module_Network_Options',
			//'Jetpack_Sync_Module_Terms',
			//'Jetpack_Sync_Module_Themes',
			//'Jetpack_Sync_Module_Menus',
			//'Jetpack_Sync_Module_Users',
			'Jetpack_Sync_Module_Posts',
			//'Jetpack_Sync_Module_Comments',
			//'Jetpack_Sync_Module_Updates',
			//'Jetpack_Sync_Module_Attachments',
			//'Jetpack_Sync_Module_Meta',
			//'Jetpack_Sync_Module_Plugins',
			//'Jetpack_Sync_Module_Protect',
			//'Jetpack_Sync_Module_Full_Sync',
			//'Jetpack_Sync_Module_Stats',
			//'Jetpack_Sync_Module_WooCommerce',
		);
	} // End custom_jetpack_sync_modules
```


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Sync: Sync status endpoint fixes