### PR TITLE
General: Update module headings file

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -116,11 +116,6 @@ function jetpack_get_module_i18n( $key ) {
 				'description' => _x( 'Receive instant notifications of site comments and likes.', 'Module Description', 'jetpack' ),
 			),
 
-			'omnisearch' => array(
-				'name' => _x( 'Omnisearch', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Search your entire database from a single field in your dashboard.', 'Module Description', 'jetpack' ),
-			),
-
 			'photon' => array(
 				'name' => _x( 'Photon', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Speed up images and photos', 'Module Description', 'jetpack' ),
@@ -300,7 +295,6 @@ function jetpack_get_module_i18n_tag( $key ) {
 
 			// Modules with `Developers` tag:
 			//  - modules/json-api.php
-			//  - modules/omnisearch.php
 			//  - modules/sso.php
 			'Developers' =>_x( 'Developers', 'Module Tag', 'jetpack' ),
 


### PR DESCRIPTION
After running `yarn build` today against the latest master, I noticed that `modules/module-headings.php` had changed. Since this file is already tracked, we can't `.gitignore` it. So, I'm creating this PR to separately update that file.

My guess is that this happened because we removed omnisearch in #7590.

