### PR TITLE
WordPress.com Toolbar: add Comments to My Sites menu

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -713,6 +713,19 @@ class A8C_WPCOM_Masterbar {
 			),
 		) );
 
+		// Comments
+		if ( current_user_can( 'moderate_comments' ) ) {
+			$wp_admin_bar->add_menu( array(
+				'parent' => 'publish',
+				'id'     => 'comments',
+				'title'  => __( 'Comments' ),
+				'href'   => 'https://wordpress.com/comments/' . esc_attr( $this->primary_site_slug ),
+				'meta'   => array(
+					'class' => 'mb-icon',
+				),
+			) );
+		}
+
 		// Testimonials
 		if ( Jetpack::is_module_active( 'custom-content-types' ) && get_option( 'jetpack_testimonial' ) ) {
 			$testimonials_title = $this->create_menu_item_pair(


### PR DESCRIPTION
Add Comments to My Sites menu in order to sync it with WP.com masterbar.

Resolves https://github.com/Automattic/jetpack/issues/7651

#### Visual changes:
<img src="https://user-images.githubusercontent.com/1182160/29632114-3545a68a-8842-11e7-8cd3-a5f85dc7e105.png" width="300px">

#### Testing instructions:

1. Use a Jetpack test site with WordPress.com Toolbar module enabled.
2. Visit site's front end and open up My Sites menu.
3. You should see a `Comments` field in `Manage` section.

**_Note:_** In case the icon is not showing up for you, you can try to manually bust the cache [here](https://github.com/Automattic/jetpack/blob/master/modules/masterbar/masterbar.php#L112) for testing purposes. This will happen automatically once the Jetpack version is bumped.