### PR TITLE
SSO: Allow redirecting to JETPACK__API_BASE in production

### DIFF
--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -191,10 +191,7 @@ class Jetpack_SSO_Helpers {
 		$hosts[] = 'jetpack.wordpress.com';
 		$hosts[] = 'public-api.wordpress.com';
 
-		if (
-			( Jetpack::is_development_mode() || Jetpack::is_development_version() ) &&
-			( false === strpos( $api_base, 'jetpack.wordpress.com/jetpack' ) )
-		) {
+		if ( false === strpos( $api_base, 'jetpack.wordpress.com/jetpack' ) ) {
 			$base_url_parts = parse_url( esc_url_raw( $api_base ) );
 			if ( $base_url_parts && ! empty( $base_url_parts[ 'host' ] ) ) {
 				$hosts[] = $base_url_parts[ 'host' ];

--- a/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
+++ b/tests/php/modules/sso/test_class.jetpack-sso-helpers.php
@@ -143,23 +143,7 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertContains( 'jetpack.wordpress.com', $hosts );
 	}
 
-	function test_allow_redirect_host_api_base_not_added_when_not_in_dev() {
-		add_filter( 'jetpack_development_version', '__return_false' );
-		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts(
-			array( 'test.com' ),
-			'http://fakesite.com/jetpack.'
-		);
-		$this->assertInternalType( 'array', $hosts );
-		$this->assertCount( 4, $hosts );
-		$this->assertContains( 'test.com', $hosts );
-		$this->assertContains( 'wordpress.com', $hosts );
-		$this->assertContains( 'jetpack.wordpress.com', $hosts );
-		$this->assertNotContains( 'fakesite.com', $hosts );
-		remove_filter( 'jetpack_development_version', '__return_false' );
-	}
-
-	function test_allowed_redirect_hosts_api_base_added_in_dev_mode() {
-		add_filter( 'jetpack_development_mode', '__return_true' );
+	function test_allowed_redirect_hosts_api_base_added() {
 		$hosts = Jetpack_SSO_Helpers::allowed_redirect_hosts(
 			array( 'test.com' ),
 			'http://fakesite.com/jetpack.'
@@ -167,7 +151,6 @@ class WP_Test_Jetpack_SSO_Helpers extends WP_UnitTestCase {
 		$this->assertInternalType( 'array', $hosts );
 		$this->assertCount( 5, $hosts );
 		$this->assertContains( 'fakesite.com', $hosts );
-		remove_filter( 'jetpack_development_mode', '__return_true' );
 	}
 
 	function test_allowed_redirect_hosts_api_base_added_on_dev_version() {


### PR DESCRIPTION
When I initially added this logic, I only wanted to allow the change for sites that were in some form of non-production mode. But, this also has the effect of breaking the auto-authorize redirect for a production site if the the site has defined `JETPACK__API_BASE` to something other than the default.

This change should only affect SSO redirects, and as such, adding the extra URL parsing to requests should not be a performance burden.

To test:

- Checkout branch
- Connect site
- With a user other than the the master user, disconnect, then login via SSO
- After clicking "Log In" on WPCOM, you should end up the auto-authorize flow of JPC
- Try the previous two steps after setting `JETPACK__API_BASE` to your WPCOM sandbox

cc @gravityrail for review.
