### PR TITLE
Jumpstart: Adding Comments, Likes, and Monitor to Jumpstart features

### DIFF
--- a/_inc/client/state/jumpstart/actions.js
+++ b/_inc/client/state/jumpstart/actions.js
@@ -19,6 +19,7 @@ import {
 } from 'state/action-types';
 import restApi from 'rest-api';
 import { fetchModules } from 'state/modules';
+import { fetchSettings } from 'state/settings';
 
 export const jumpStartActivate = () => {
 	return ( dispatch ) => {
@@ -36,6 +37,7 @@ export const jumpStartActivate = () => {
 			dispatch( removeNotice( 'jumpstart-activate' ) );
 			dispatch( createNotice( 'is-success', __( 'Recommended features active.' ), { id: 'jumpstart-activate', duration: 2000 } ) );
 			dispatch( fetchModules() );
+			dispatch( fetchSettings() );
 		} ).catch( error => {
 			dispatch( {
 				type: JUMPSTART_ACTIVATE_FAIL,

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -25,8 +25,7 @@ import {
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 	JETPACK_SETTINGS_UPDATE_FAIL,
 	JETPACK_SETTINGS_SET_UNSAVED_FLAG,
-	JETPACK_SETTINGS_CLEAR_UNSAVED_FLAG,
-	JETPACK_MODULES_LIST_RECEIVE,
+	JETPACK_SETTINGS_CLEAR_UNSAVED_FLAG
 } from 'state/action-types';
 
 export const items = ( state = {}, action ) => {
@@ -35,11 +34,6 @@ export const items = ( state = {}, action ) => {
 			return assign( {}, state, action.initialState.settings );
 		case JETPACK_SETTINGS_FETCH_RECEIVE:
 			return assign( {}, action.settings );
-		case JETPACK_MODULES_LIST_RECEIVE:
-			Object.keys( action.modules ).forEach( key => {
-				action.modules[ key ] = action.modules[ key ].activated;
-			} );
-			return assign( {}, action.modules );
 		case JETPACK_SETTING_UPDATE_SUCCESS:
 			let key = Object.keys( action.updatedOption )[0];
 			return assign( {}, state, {

--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -25,7 +25,8 @@ import {
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 	JETPACK_SETTINGS_UPDATE_FAIL,
 	JETPACK_SETTINGS_SET_UNSAVED_FLAG,
-	JETPACK_SETTINGS_CLEAR_UNSAVED_FLAG
+	JETPACK_SETTINGS_CLEAR_UNSAVED_FLAG,
+	JETPACK_MODULES_LIST_RECEIVE,
 } from 'state/action-types';
 
 export const items = ( state = {}, action ) => {
@@ -34,6 +35,11 @@ export const items = ( state = {}, action ) => {
 			return assign( {}, state, action.initialState.settings );
 		case JETPACK_SETTINGS_FETCH_RECEIVE:
 			return assign( {}, action.settings );
+		case JETPACK_MODULES_LIST_RECEIVE:
+			Object.keys( action.modules ).forEach( key => {
+				action.modules[ key ] = action.modules[ key ].activated;
+			} );
+			return assign( {}, action.modules );
 		case JETPACK_SETTING_UPDATE_SUCCESS:
 			let key = Object.keys( action.updatedOption )[0];
 			return assign( {}, state, {

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -3,7 +3,7 @@
 /**
  * Module Name: Comments
  * Module Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment
- * Jumpstart Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment
+ * Jumpstart Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment.
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes

--- a/modules/comments.php
+++ b/modules/comments.php
@@ -3,12 +3,13 @@
 /**
  * Module Name: Comments
  * Module Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment
+ * Jumpstart Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social
- * Feature: Engagement
+ * Feature: Engagement, Jumpstart
  * Additional Search Queries: comments, comment, facebook, twitter, google+, social
  */
 

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -2,12 +2,13 @@
 /**
  * Module Name: Likes
  * Module Description: Give visitors an easy way to show they appreciate your content.
+ * Jumpstart Description: Give visitors an easy way to show they appreciate your content.
  * First Introduced: 2.2
  * Sort Order: 23
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social
- * Feature: Engagement
+ * Feature: Engagement, Jumpstart
  * Additional Search Queries: like, likes, wordpress.com
  */
 

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -31,6 +31,7 @@ function jetpack_get_module_i18n( $key ) {
 			'comments' => array(
 				'name' => _x( 'Comments', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'contact-form' => array(
@@ -83,6 +84,7 @@ function jetpack_get_module_i18n( $key ) {
 			'likes' => array(
 				'name' => _x( 'Likes', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Give visitors an easy way to show they appreciate your content.', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Give visitors an easy way to show they appreciate your content.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'manage' => array(
@@ -109,6 +111,7 @@ function jetpack_get_module_i18n( $key ) {
 			'monitor' => array(
 				'name' => _x( 'Monitor', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Receive immediate notifications if your site goes down, 24/7.', 'Module Description', 'jetpack' ),
+				'recommended description' => _x( 'Receive immediate notifications if your site goes down, 24/7.', 'Jumpstart Description', 'jetpack' ),
 			),
 
 			'notes' => array(

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -2,13 +2,14 @@
 /**
  * Module Name: Monitor
  * Module Description: Receive immediate notifications if your site goes down, 24/7.
+ * Jumpstart Description: Receive immediate notifications if your site goes down, 24/7.
  * Sort Order: 28
  * Recommendation Order: 10
  * First Introduced: 2.6
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Recommended
- * Feature: Security
+ * Feature: Security, Jumpstart
  * Additional Search Queries: monitor, uptime, downtime, monitoring
  */
 


### PR DESCRIPTION
Suggested by @beaulebens in p2JiWH-29g-p2:

> I think we should include Monitor, Likes and Comments into the Jumpstart Features.

I just copied the descriptions from what was already there, but could use a review.  

This also fixes a bug where Photon and the other Jumpstart modules did not display as active in the UI.  it just needed a state update to the `settings` branch of the tree.  

**To Test:**
- Connect Jetpack
- Click "reset options (dev)" in the footer
- Jumpstart your site
- Verify the modules were activated.

<img width="566" alt="screen shot 2017-08-24 at 12 28 58 pm" src="https://user-images.githubusercontent.com/7129409/29677155-3fadeaa2-88c8-11e7-8e37-8f76b3fb4c0a.png">
