### PR TITLE
Fix syntax highlight errors in VSCode

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2845,8 +2845,8 @@ p {
 	}
 	/**
 	 * Runs before bumping version numbers up to a new version
-	 * @param  (string) $version    Version:timestamp
-	 * @param  (string) $old_version Old Version:timestamp or false if not set yet.
+	 * @param  string $version    Version:timestamp
+	 * @param  string $old_version Old Version:timestamp or false if not set yet.
 	 * @return null              [description]
 	 */
 	public static function do_version_bump( $version, $old_version ) {
@@ -3635,7 +3635,7 @@ p {
 
 	/**
 	 * Returns the url that the user clicks to remove the notice for the big banner
-	 * @return (string)
+	 * @return string
 	 */
 	function opt_out_jetpack_manage_url() {
 		$referer = '&_wp_http_referer=' . add_query_arg( '_wp_http_referer', null );
@@ -3643,7 +3643,7 @@ p {
 	}
 	/**
 	 * Returns the url that the user clicks to opt in to Jetpack Manage
-	 * @return (string)
+	 * @return string
 	 */
 	function opt_in_jetpack_manage_url() {
 		return wp_nonce_url( Jetpack::admin_url( 'jetpack-notice=jetpack-manage-opt-in' ), 'jetpack_manage_banner_opt_in' );
@@ -3661,7 +3661,7 @@ p {
 	}
 	/**
 	 * Determines whether to show the notice of not true = display notice
-	 * @return (bool)
+	 * @return bool
 	 */
 	function can_display_jetpack_manage_notice() {
 		// never display the notice to users that can't do anything about it anyways

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -156,7 +156,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Collects the necessary information to return for a site's response.
 	 *
-	 * @return (array)
+	 * @return array
 	 */
 	public function build_current_site_response() {
 

--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -588,7 +588,7 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 *
 	 * @param $attachment attachment row
 	 *
-	 * @return (object)
+	 * @return object
 	 */
 	function get_attachment( $attachment ) {
 		$metadata = wp_get_attachment_metadata( $attachment->ID );

--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -53,7 +53,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Determines whether jetpack_relatedposts is supported
 	 *
-	 * @return (bool)
+	 * @return bool
 	 */
 	public function jetpack_relatedposts_supported() {
 		$wpcom_related_posts_theme_blacklist = array(
@@ -68,7 +68,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Returns category details
 	 *
-	 * @return (array)
+	 * @return array
 	 */
 	public function get_category_details( $category ) {
 		return array(
@@ -81,9 +81,9 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * Returns an option value as the result of the callable being applied to
 	 * it if a value is set, otherwise null.
 	 *
-	 * @param (string) $option_name Option name
-	 * @param (callable) $cast_callable Callable to invoke on option value
-	 * @return (int|null) Numeric option value or null
+	 * @param string $option_name Option name
+	 * @param callable $cast_callable Callable to invoke on option value
+	 * @return int|null Numeric option value or null
 	 */
 	protected function get_cast_option_value_or_null( $option_name, $cast_callable ) {
 		$option_value = get_option( $option_name, null );
@@ -97,7 +97,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Collects the necessary information to return for a get settings response.
 	 *
-	 * @return (array)
+	 * @return array
 	 */
 	public function get_settings_response() {
 
@@ -303,7 +303,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Updates site settings for authorized users
 	 *
-	 * @return (array)
+	 * @return array
 	 */
 	public function update_settings() {
 		// $this->input() retrieves posted arguments whitelisted and casted to the $request_format

--- a/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
@@ -63,7 +63,7 @@ class WPCOM_JSON_API_Site_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Updates user data
 	 *
-	 * @return (array)
+	 * @return array
 	 */
 	public function update_user( $user_id, $blog_id ) {
 		$input = $this->input();

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -5,7 +5,7 @@
  * Embed Reversal for Instagram
  *
  * Hooked to pre_kses, converts an embed code from Instagram.com to an oEmbeddable URL.
- * @return (string) the filtered or the original content
+ * @return string The filtered or the original content.
  **/
 function jetpack_instagram_embed_reversal( $content ) {
 	if ( ! is_string( $content ) || false === stripos( $content, 'instagram.com' ) ) {


### PR DESCRIPTION
Very very minor change - noticed that VS Code was getting confused by bracketed `@param` types and highlighting everything below them as a comment.