### PR TITLE
Allow 2 hours for authorize secrets rather than 10 minutes

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4229,7 +4229,7 @@ p {
 				$redirect = Jetpack_Network::init()->get_url( 'network_admin_page' );
 			}
 
-			$secrets = Jetpack::generate_secrets( 'authorize', false, DAY_IN_SECONDS );
+			$secrets = Jetpack::generate_secrets( 'authorize', false, 2 * HOUR_IN_SECONDS );
 
 			$site_icon = ( function_exists( 'has_site_icon') && has_site_icon() )
 				? get_site_icon_url()

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4229,7 +4229,7 @@ p {
 				$redirect = Jetpack_Network::init()->get_url( 'network_admin_page' );
 			}
 
-			$secrets = Jetpack::generate_secrets( 'authorize' );
+			$secrets = Jetpack::generate_secrets( 'authorize', DAY_IN_SECONDS );
 
 			$site_icon = ( function_exists( 'has_site_icon') && has_site_icon() )
 				? get_site_icon_url()

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4229,7 +4229,7 @@ p {
 				$redirect = Jetpack_Network::init()->get_url( 'network_admin_page' );
 			}
 
-			$secrets = Jetpack::generate_secrets( 'authorize', DAY_IN_SECONDS );
+			$secrets = Jetpack::generate_secrets( 'authorize', false, DAY_IN_SECONDS );
 
 			$site_icon = ( function_exists( 'has_site_icon') && has_site_icon() )
 				? get_site_icon_url()


### PR DESCRIPTION
The most common error during connect authorization is that the secrets have timed out.

The default timeout is 10 minutes, but it's easy to imagine someone going to make a coffee and coming back and clicking "Accept" more than 10 minutes later.

2 hours feels like a more comfortable number, and it seems that the security implications are probably fairly minor. Interested in feedback on this idea though.

Unfortunately we have not been able to capture the median expiry interval (how long after the timeout is the endpoint getting hit?), so conceivably we could return that with the error and log it to get a better sense of what number to set here.

That said, if no-one has any complaints, I'd rather ship this and then see how it affects the error rate.