### PR TITLE
Show correct nav item selected after jumpstart

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -141,7 +141,8 @@ const Main = React.createClass( {
 			window.location.hash = 'jumpstart';
 			history.push( window.location.pathname + '?page=jetpack#/jumpstart' );
 		}
-		if ( ! this.props.jumpStartStatus && ! willShowJumpStart && ! willBeJumpstarting ) {
+		if ( this.props.jumpStartStatus && ! willShowJumpStart && ! willBeJumpstarting ) {
+			window.location.hash = 'dashboard';
 			history.push( window.location.pathname + '?page=jetpack#/dashboard' );
 		}
 	},


### PR DESCRIPTION
Fixes an issue where the dashboard nav item was not selected after jumpstart.  

To test: 
- Connect Jeptack
- Click "reset options" in the footer
- when you see jumpstart, make sure to refresh the page to clear css rules
- Click jumpstart or skip 
- The dashboard nav item should be underlined

<img width="228" alt="screen shot 2017-08-24 at 2 09 04 pm" src="https://user-images.githubusercontent.com/7129409/29681490-d12122da-88d5-11e7-827d-10e14fb6c9cc.png">
