### PR TITLE
Fix VaultPress success notice design

### DIFF
--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -7,13 +7,12 @@ const AdminNotices = React.createClass( {
 	componentDidMount() {
 		const $adminNotices = jQuery( this.refs.adminNotices );
 
-		const $vpNotice = jQuery( '.vp-notice' ),
-			$success = jQuery( '#vp-notice' ).hasClass( 'vp-registered' );
-
-		const $warningOrSuccess = $success ? 'is-success' : 'is-warning';
+		const $vpNotice = jQuery( '.vp-notice' );
 
 		if ( $vpNotice.length > 0 ) {
 			$vpNotice.each( function() {
+				const $success = jQuery( this ).hasClass( 'vp-registered' );
+				const $warningOrSuccess = $success ? 'is-success' : 'is-warning';
 				const $notice = jQuery( this ).addClass( 'dops-notice vp-notice-jp ' + $warningOrSuccess ).removeClass( 'wrap vp-notice' );
 				const icon = $success
 					? '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg>'

--- a/_inc/client/components/admin-notices/index.jsx
+++ b/_inc/client/components/admin-notices/index.jsx
@@ -7,11 +7,17 @@ const AdminNotices = React.createClass( {
 	componentDidMount() {
 		const $adminNotices = jQuery( this.refs.adminNotices );
 
-		const $vpNotice = jQuery( '.vp-notice' );
+		const $vpNotice = jQuery( '.vp-notice' ),
+			$success = jQuery( '#vp-notice' ).hasClass( 'vp-registered' );
+
+		const $warningOrSuccess = $success ? 'is-success' : 'is-warning';
+
 		if ( $vpNotice.length > 0 ) {
 			$vpNotice.each( function() {
-				let $notice = jQuery( this ).addClass( 'dops-notice is-warning vp-notice-jp' ).removeClass( 'wrap vp-notice' );
-				const icon = '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path></g></svg>';
+				const $notice = jQuery( this ).addClass( 'dops-notice vp-notice-jp ' + $warningOrSuccess ).removeClass( 'wrap vp-notice' );
+				const icon = $success
+					? '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"/></g></svg>'
+					: '<svg class="gridicon gridicons-notice dops-notice__icon" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"></path></g></svg>';
 				$notice.wrapInner( '<span class="dops-notice__content">' );
 				$notice.find( '.dops-notice__content' ).before( icon );
 				$notice.find( '.vp-message' ).removeClass( 'vp-message' ).addClass( 'dops-notice__text' );


### PR DESCRIPTION
Before, the success notice that comes from VaultPress after plugin setup has the wrong style and icon, making it look not so "successful"

<img width="767" alt="screen shot 2017-08-24 at 2 57 48 pm" src="https://user-images.githubusercontent.com/7129409/29683554-c7a1cb36-88dc-11e7-9bf7-ab40322d0eac.png">

This PR fixes the notice, and now looks like this for success:
<img width="748" alt="screen shot 2017-08-24 at 2 58 08 pm" src="https://user-images.githubusercontent.com/7129409/29683570-d33f2416-88dc-11e7-9323-fe50690b1785.png">

To Test: 
- Add this snippet into a functionality plugin
```
add_action( 'admin_notices', 'show_vp_notice' );
function show_vp_notice() {
	$message = sprintf(
		__( 'VaultPress has been registered and is currently backing up your site. <a href="%1$s">View Backup Status</a>', 'vaultpress' ),
		admin_url( 'admin.php?page=vaultpress' )
	);
	$vp = new VaultPress();
	$vp->ui_message( $message, 'registered',  __( 'VaultPress has been activated!', 'vaultpress' ) );
}
```
- View the Jetpack admin dashboard, it should look good.
- Change the `registered` value in the snippet to anything else.  It should revert back to the `is-warning` styles.  