### PR TITLE
Update admin UI active modules when Jumpstarting 

### DIFF
--- a/_inc/client/state/settings/reducer.js
+++ b/_inc/client/state/settings/reducer.js
@@ -25,7 +25,8 @@ import {
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 	JETPACK_SETTINGS_UPDATE_FAIL,
 	JETPACK_SETTINGS_SET_UNSAVED_FLAG,
-	JETPACK_SETTINGS_CLEAR_UNSAVED_FLAG
+	JETPACK_SETTINGS_CLEAR_UNSAVED_FLAG,
+	JETPACK_MODULES_LIST_RECEIVE,
 } from 'state/action-types';
 
 export const items = ( state = {}, action ) => {
@@ -34,6 +35,11 @@ export const items = ( state = {}, action ) => {
 			return assign( {}, state, action.initialState.settings );
 		case JETPACK_SETTINGS_FETCH_RECEIVE:
 			return assign( {}, action.settings );
+		case JETPACK_MODULES_LIST_RECEIVE:
+			Object.keys( action.modules ).forEach( key => {
+				action.modules[ key ] = action.modules[ key ].activated;
+			} );
+			return assign( {}, action.modules );
 		case JETPACK_SETTING_UPDATE_SUCCESS:
 			let key = Object.keys( action.updatedOption )[0];
 			return assign( {}, state, {


### PR DESCRIPTION
This fixes an issue that the `settings` state branch was not being updated after Jumpstart.  It does this by listening to the JETPACK_MODULES_LIST_RECEIVE action and updating the `jetpack.settings.items` tree branch with the module activation.  

To Test: 
- Connect Jetpack
- Reset all options in the footer
- Refresh the page when you see Jumpstart prompt to reset UI
- Click `Jumpstart` or `activate recommended features`
- Verify that Photon and other Jumpstarted modules are appearing as active in the dashboard and settings areas.  
