### PR TITLE
Add more consistent instrumentation

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -138,6 +138,19 @@ export const ConnectButton = React.createClass( {
 			<div>
 				<QueryConnectUrl />
 				{ this.renderContent() }
+				{ ! this.props.isSiteConnected && 
+					<p className="jp-banner__tos-blurb">
+					{ __( 
+						'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com',
+						{ 
+							components: {
+								tosLink: <a href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank"/>,
+								shareDetailsLink: <a href="https://jetpack.com/support/what-data-does-jetpack-sync" rel="noopener noreferrer" target="_blank"/>
+							}
+						}
+					) }
+					</p>
+				}
 				<JetpackDisconnectDialog
 					show={ this.state.showModal }
 					toggleModal={ this.toggleVisibility }

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -138,6 +138,7 @@ export const ConnectButton = React.createClass( {
 			<div>
 				<QueryConnectUrl />
 				{ this.renderContent() }
+				{ this.props.children }
 				{ ! this.props.isSiteConnected && 
 					<p className="jp-banner__tos-blurb">
 					{ __( 

--- a/_inc/client/components/connect-button/test/component.js
+++ b/_inc/client/components/connect-button/test/component.js
@@ -68,15 +68,15 @@ describe( 'ConnectButton', () => {
 		const wrapper = shallow( <ConnectButton { ...testProps } /> );
 
 		it( 'does not link to a URL', () => {
-			expect( wrapper.find( 'a' ).props().href ).to.not.exist;
+			expect( wrapper.find( 'a' ).first().props().href ).to.not.exist;
 		} );
 
 		it( 'has an onClick method', () => {
-			expect( wrapper.find( 'a' ).props().onClick ).to.exist;
+			expect( wrapper.find( 'a' ).first().props().onClick ).to.exist;
 		} );
 
 		it( 'when clicked, unlinkUser() is called once', () => {
-			wrapper.find( 'a' ).simulate( 'click' );
+			wrapper.find( 'a' ).first().simulate( 'click' );
 			expect( unlinkUser.calledOnce ).to.be.true;
 		} );
 

--- a/_inc/client/components/jetpack-connect/index.jsx
+++ b/_inc/client/components/jetpack-connect/index.jsx
@@ -29,12 +29,13 @@ const JetpackConnect = React.createClass( {
 					<p className="jp-jetpack-connect__description">
 						{ __( 'Please connect to or create a WordPress.com account to start using Jetpack. This will enable powerful security, traffic, and customization services.' ) }
 					</p>
-					<ConnectButton from="landing-page-top" />
-					<p>
-						<a href={ newAccountUrl } className="jp-jetpack-connect__link">
-							{ __( 'No account? Create one for free' ) }
-						</a>
-					</p>
+					<ConnectButton from="landing-page-top">
+						<p>
+							<a href={ newAccountUrl } className="jp-jetpack-connect__link">
+								{ __( 'No account? Create one for free' ) }
+							</a>
+						</p>
+					</ConnectButton>
 				</Card>
 
 				<Card className="jp-jetpack-connect__feature jp-jetpack-connect__traffic">
@@ -197,12 +198,13 @@ const JetpackConnect = React.createClass( {
 							'We\'re passionate about WordPress and here to make your life easier.'
 						) }
 					</p>
-					<ConnectButton from="landing-page-bottom" />
-					<p>
-						<a href={ newAccountUrl } className="jp-jetpack-connect__link">
-							{ __( 'No account? Create one for free' ) }
-						</a>
-					</p>
+					<ConnectButton from="landing-page-bottom">
+						<p>
+							<a href={ newAccountUrl } className="jp-jetpack-connect__link">
+								{ __( 'No account? Create one for free' ) }
+							</a>
+						</p>
+					</ConnectButton>
 				</Card>
 			</div>
 		);

--- a/_inc/client/components/jetpack-connect/style.scss
+++ b/_inc/client/components/jetpack-connect/style.scss
@@ -9,6 +9,13 @@
 		font-weight: 400;
 		border-bottom: 1px lighten( $gray, 30% ) solid;
 	}
+
+	.jp-banner__tos-blurb {
+		font-size: rem( 11px );
+		color: $gray-dark;
+		margin-bottom: 0;
+		padding-top: 5px;
+	}
 }
 
 .jp-jetpack-connect__cta {

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -20,6 +20,10 @@ class Jetpack_Client_Server {
 		$result = $this->authorize( $data );
 		if ( is_wp_error( $result ) ) {
 			Jetpack::state( 'error', $result->get_error_code() );
+			JetpackTracking::record_user_event( 'jpc_client_authorize_fail', array(
+				'error_code' => $result->get_error_code(),
+				'error_message' => $result->get_error_message()
+			) );
 		} else {
 			/**
 			 * Fires after the Jetpack client is authorized to communicate with WordPress.com.
@@ -29,6 +33,7 @@ class Jetpack_Client_Server {
 			 * @param int Jetpack Blog ID.
 			 */
 			do_action( 'jetpack_client_authorized', Jetpack_Options::get_option( 'id' ) );
+			JetpackTracking::record_user_event( 'jpc_client_authorize_success' );
 		}
 
 		if ( wp_validate_redirect( $redirect ) ) {

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -277,7 +277,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -335,7 +335,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -395,7 +395,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -455,7 +455,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -505,7 +505,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -554,7 +554,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -603,7 +603,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -715,7 +715,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -772,7 +772,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -828,7 +828,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -878,7 +878,7 @@ class Jetpack_Connection_Banner {
 							<span class="jp-banner__tos-blurb">
 							<?php
 								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 									'https://wordpress.com/tos',
 									'https://jetpack.com/support/what-data-does-jetpack-sync'
 								);
@@ -939,7 +939,7 @@ class Jetpack_Connection_Banner {
 					<p class="jp-connect-full__tos-blurb">
 						<?php
 						printf(
-							__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+							__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
 							'https://wordpress.com/tos',
 							'https://jetpack.com/support/what-data-does-jetpack-sync'
 						);

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -129,7 +129,6 @@ class Jetpack_Connection_Banner {
 		// Only fires immediately after plugin activation
 		if ( get_transient( 'activated_jetpack' ) ) {
 			add_action( 'admin_notices', array( $this, 'render_connect_prompt_full_screen' ) );
-			JetpackTracking::record_user_event( 'jpc_prompt_full_screen' );
 			delete_transient( 'activated_jetpack' );
 		}
 	}
@@ -275,6 +274,15 @@ class Jetpack_Connection_Banner {
 								?>">
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 1 -->
 
@@ -650,7 +658,19 @@ class Jetpack_Connection_Banner {
 								?>">
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
+						
+							
+						
 					</div> <!-- end slide 1 -->
 
 					<!-- slide 2: design -->

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -129,6 +129,7 @@ class Jetpack_Connection_Banner {
 		// Only fires immediately after plugin activation
 		if ( get_transient( 'activated_jetpack' ) ) {
 			add_action( 'admin_notices', array( $this, 'render_connect_prompt_full_screen' ) );
+			JetpackTracking::record_user_event( 'jpc_prompt_full_screen' );
 			delete_transient( 'activated_jetpack' );
 		}
 	}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -332,6 +332,15 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 2 -->
 
@@ -383,6 +392,15 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 3 -->
 
@@ -434,6 +452,15 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 3A -->
 
@@ -475,6 +502,15 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 4 -->
 
@@ -515,6 +551,15 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 5 -->
 
@@ -555,6 +600,15 @@ class Jetpack_Connection_Banner {
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 6 -->
 				</div>
@@ -715,6 +769,15 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 2 -->
 
@@ -762,6 +825,15 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 3 -->
 
@@ -803,6 +875,15 @@ class Jetpack_Connection_Banner {
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
+							<span class="jp-banner__tos-blurb">
+							<?php
+								printf(
+									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank" class="jp-connect-full__tos-a">Terms of Service</a> and to <a href="%s" target="_blank" class="jp-connect-full__tos-a">share details</a> with WordPress.com', 'jetpack' ),
+									'https://wordpress.com/tos',
+									'https://jetpack.com/support/what-data-does-jetpack-sync'
+								);
+							?>
+							</span>
 						</p>
 					</div> <!-- end slide 4 -->
 

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -87,19 +87,6 @@ class Jetpack_Connection_Banner {
 	}
 
 	/**
-	 * Prints a TOS blurb used throughout the connection prompts.
-	 *
-	 * @return string
-	 */
-	function render_tos_blurb() {
-		printf(
-			__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-			'https://wordpress.com/tos',
-			'https://jetpack.com/support/what-data-does-jetpack-sync'
-		);
-	}
-
-	/**
 	 * Will initialize hooks to display the new (as of 4.4) connection banner if the current user can
 	 * connect Jetpack, if Jetpack has not been deactivated, and if the current page is the plugins page.
 	 *
@@ -288,7 +275,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 1 -->
@@ -340,7 +327,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 2 -->
@@ -394,7 +381,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 3 -->
@@ -448,7 +435,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 3A -->
@@ -492,7 +479,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 4 -->
@@ -535,7 +522,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 5 -->
@@ -578,7 +565,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 6 -->
@@ -684,7 +671,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 1 -->
@@ -732,7 +719,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 2 -->
@@ -782,7 +769,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 3 -->
@@ -826,7 +813,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-								<?php $this->render_tos_blurb(); ?>
+								<?php jetpack_render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 4 -->
@@ -880,7 +867,7 @@ class Jetpack_Connection_Banner {
 				</div>
 				<div class="jp-connect-full__card-footer">
 					<p class="jp-connect-full__tos-blurb">
-						<?php $this->render_tos_blurb(); ?>
+						<?php jetpack_render_tos_blurb(); ?>
 					</p>
 					<p class="jp-connect-full__button-container">
 						<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'full-screen-prompt' ) ); ?>" class="dops-button is-primary">

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -87,6 +87,19 @@ class Jetpack_Connection_Banner {
 	}
 
 	/**
+	 * Prints a TOS blurb used throughout the connection prompts.
+	 *
+	 * @return string
+	 */
+	function render_tos_blurb() {
+		printf(
+			__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+			'https://wordpress.com/tos',
+			'https://jetpack.com/support/what-data-does-jetpack-sync'
+		);
+	}
+
+	/**
 	 * Will initialize hooks to display the new (as of 4.4) connection banner if the current user can
 	 * connect Jetpack, if Jetpack has not been deactivated, and if the current page is the plugins page.
 	 *
@@ -275,13 +288,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 1 -->
@@ -333,13 +340,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 2 -->
@@ -393,13 +394,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 3 -->
@@ -453,13 +448,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 3A -->
@@ -503,13 +492,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 4 -->
@@ -552,13 +535,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 5 -->
@@ -601,13 +578,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 6 -->
@@ -713,18 +684,9 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
-						
-							
-						
 					</div> <!-- end slide 1 -->
 
 					<!-- slide 2: design -->
@@ -770,13 +732,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 2 -->
@@ -826,13 +782,7 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 3 -->
@@ -876,17 +826,10 @@ class Jetpack_Connection_Banner {
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
 							<span class="jp-banner__tos-blurb">
-							<?php
-								printf(
-									__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-									'https://wordpress.com/tos',
-									'https://jetpack.com/support/what-data-does-jetpack-sync'
-								);
-							?>
+								<?php $this->render_tos_blurb(); ?>
 							</span>
 						</p>
 					</div> <!-- end slide 4 -->
-
 				</div>
 			</div>
 		</div>
@@ -937,13 +880,7 @@ class Jetpack_Connection_Banner {
 				</div>
 				<div class="jp-connect-full__card-footer">
 					<p class="jp-connect-full__tos-blurb">
-						<?php
-						printf(
-							__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-							'https://wordpress.com/tos',
-							'https://jetpack.com/support/what-data-does-jetpack-sync'
-						);
-						?>
+						<?php $this->render_tos_blurb(); ?>
 					</p>
 					<p class="jp-connect-full__button-container">
 						<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, 'full-screen-prompt' ) ); ?>" class="dops-button is-primary">

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -274,9 +274,9 @@ class Jetpack_Connection_Banner {
 								?>">
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 1 -->
 
@@ -326,9 +326,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 2 -->
 
@@ -380,9 +380,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 3 -->
 
@@ -434,9 +434,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 3A -->
 
@@ -478,9 +478,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 4 -->
 
@@ -521,9 +521,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 5 -->
 
@@ -564,9 +564,9 @@ class Jetpack_Connection_Banner {
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 6 -->
 				</div>
@@ -670,9 +670,9 @@ class Jetpack_Connection_Banner {
 								?>">
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 1 -->
 
@@ -718,9 +718,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 2 -->
 
@@ -768,9 +768,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 3 -->
 
@@ -812,9 +812,9 @@ class Jetpack_Connection_Banner {
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
-							<span class="jp-banner__tos-blurb">
+							<p class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</span>
+							</p>
 						</p>
 					</div> <!-- end slide 4 -->
 				</div>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -274,9 +274,9 @@ class Jetpack_Connection_Banner {
 								?>">
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 1 -->
 
@@ -326,9 +326,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 2 -->
 
@@ -380,9 +380,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 3 -->
 
@@ -434,9 +434,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 3A -->
 
@@ -478,9 +478,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 4 -->
 
@@ -521,9 +521,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 5 -->
 
@@ -564,9 +564,9 @@ class Jetpack_Connection_Banner {
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 6 -->
 				</div>
@@ -670,9 +670,9 @@ class Jetpack_Connection_Banner {
 								?>">
 								<?php esc_html_e( 'Start quick tour', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 1 -->
 
@@ -718,9 +718,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 2 -->
 
@@ -768,9 +768,9 @@ class Jetpack_Connection_Banner {
 							<a href="#" class="dops-button next-feature" title="<?php esc_attr_e( 'Jetpack Tour: Next Feature', 'jetpack' ); ?>">
 								<?php esc_html_e( 'Next feature', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 3 -->
 
@@ -812,9 +812,9 @@ class Jetpack_Connection_Banner {
 								class="dops-button is-primary">
 								<?php esc_html_e( 'Connect to WordPress.com', 'jetpack' ); ?>
 							</a>
-							<p class="jp-banner__tos-blurb">
+							<span class="jp-banner__tos-blurb">
 								<?php jetpack_render_tos_blurb(); ?>
-							</p>
+							</span>
 						</p>
 					</div> <!-- end slide 4 -->
 				</div>

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4299,6 +4299,8 @@ p {
 			 */
 			$auth_type = apply_filters( 'jetpack_auth_type', 'calypso' );
 
+			$tracks_identity = jetpack_tracks_get_identity( get_current_user_id() );
+			
 			$args = urlencode_deep(
 				array(
 					'response_type' => 'code',
@@ -4324,6 +4326,9 @@ p {
 					'site_url'      => site_url(),
 					'home_url'      => home_url(),
 					'site_icon'     => $site_icon,
+					'site_lang'     => get_locale(),
+					'_ui'           => $tracks_identity['_ui'],
+					'_ut'           => $tracks_identity['_ut']
 				)
 			);
 
@@ -4870,6 +4875,7 @@ p {
 				'state'           => get_current_user_id(),
 				'_ui'             => $tracks_identity['_ui'],
 				'_ut'             => $tracks_identity['_ut'],
+				'jetpack_version' => JETPACK__VERSION
 			),
 			'headers' => array(
 				'Accept' => 'application/json',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4843,6 +4843,8 @@ p {
 		$stats_options = get_option( 'stats_options' );
 		$stats_id = isset($stats_options['blog_id']) ? $stats_options['blog_id'] : null;
 
+		$tracks_identity = jetpack_tracks_get_identity( get_current_user_id() );
+
 		$args = array(
 			'method'  => 'POST',
 			'body'    => array(
@@ -4857,6 +4859,8 @@ p {
 				'timeout'         => $timeout,
 				'stats_id'        => $stats_id,
 				'state'           => get_current_user_id(),
+				'_ui'             => $tracks_identity['_ui'],
+				'_ut'             => $tracks_identity['_ut'],
 			),
 			'headers' => array(
 				'Accept' => 'application/json',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3823,7 +3823,7 @@ p {
 					$error = $registered->get_error_code();
 					Jetpack::state( 'error', $error );
 					Jetpack::state( 'error', $registered->get_error_message() );
-					JetpackTracking::record_user_event( 'jpc_wpa_register_fail', array(
+					JetpackTracking::record_user_event( 'jpc_register_fail', array(
 						'error_code' => $error,
 						'error_message' => $registered->get_error_message()
 					) );
@@ -3833,7 +3833,7 @@ p {
 				$from = isset( $_GET['from'] ) ? $_GET['from'] : false;
 				$redirect = isset( $_GET['redirect'] ) ? $_GET['redirect'] : false;
 
-				JetpackTracking::record_user_event( 'jpc_wpa_register_success', array(
+				JetpackTracking::record_user_event( 'jpc_register_success', array(
 					'from' => $from
 				) );
 				
@@ -4830,7 +4830,7 @@ p {
 	 * @return bool|WP_Error
 	 */
 	public static function register() {
-		JetpackTracking::record_user_event( 'jpc_wpa_register_begin' );
+		JetpackTracking::record_user_event( 'jpc_register_begin' );
 		add_action( 'pre_update_jetpack_option_register', array( 'Jetpack_Options', 'delete_option' ) );
 		$secrets = Jetpack::generate_secrets( 'register' );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3823,12 +3823,20 @@ p {
 					$error = $registered->get_error_code();
 					Jetpack::state( 'error', $error );
 					Jetpack::state( 'error', $registered->get_error_message() );
+					JetpackTracking::record_user_event( 'jpc_wpa_register_fail', array(
+						'error_code' => $error,
+						'error_message' => $registered->get_error_message()
+					) );
 					break;
 				}
 
 				$from = isset( $_GET['from'] ) ? $_GET['from'] : false;
 				$redirect = isset( $_GET['redirect'] ) ? $_GET['redirect'] : false;
 
+				JetpackTracking::record_user_event( 'jpc_wpa_register_success', array(
+					'from' => $from
+				) );
+				
 				wp_redirect( $this->build_connect_url( true, $redirect, $from ) );
 				exit;
 			case 'activate' :
@@ -4822,6 +4830,7 @@ p {
 	 * @return bool|WP_Error
 	 */
 	public static function register() {
+		JetpackTracking::record_user_event( 'jpc_wpa_register_begin' );
 		add_action( 'pre_update_jetpack_option_register', array( 'Jetpack_Options', 'delete_option' ) );
 		$secrets = Jetpack::generate_secrets( 'register' );
 

--- a/functions.global.php
+++ b/functions.global.php
@@ -90,6 +90,20 @@ function jetpack_get_migration_data( $option_name ) {
 }
 
 /**
+ * Prints a TOS blurb used throughout the connection prompts.
+ *
+ * @since 5.3
+ *
+ * @return string
+ */
+function jetpack_render_tos_blurb() {
+	printf(
+		__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+		'https://wordpress.com/tos',
+		'https://jetpack.com/support/what-data-does-jetpack-sync'
+	);
+}
+/**
  * Intervene upgrade process so Jetpack themes are downloaded with credentials.
  *
  * @since 5.3

--- a/functions.global.php
+++ b/functions.global.php
@@ -103,6 +103,7 @@ function jetpack_render_tos_blurb() {
 		'https://jetpack.com/support/what-data-does-jetpack-sync'
 	);
 }
+
 /**
  * Intervene upgrade process so Jetpack themes are downloaded with credentials.
  *

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -84,6 +84,15 @@ class Publicize extends Publicize_Base {
 							class="button-connector"
 							id="wpcom-connect"><?php esc_html_e( 'Link account with WordPress.com', 'jetpack' ); ?></a>
 					</p>
+					<p class="jetpack-install-blurb">
+					<?php
+						printf(
+							__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+							'https://wordpress.com/tos',
+							'https://jetpack.com/support/what-data-does-jetpack-sync'
+						);
+					?>
+					</p>
 				</div>
 			</div>
 		</div>

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -85,13 +85,7 @@ class Publicize extends Publicize_Base {
 							id="wpcom-connect"><?php esc_html_e( 'Link account with WordPress.com', 'jetpack' ); ?></a>
 					</p>
 					<p class="jetpack-install-blurb">
-					<?php
-						printf(
-							__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-							'https://wordpress.com/tos',
-							'https://jetpack.com/support/what-data-does-jetpack-sync'
-						);
-					?>
+						<?php jetpack_render_tos_blurb(); ?>
 					</p>
 				</div>
 			</div>

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -15,6 +15,14 @@
 
 	.jp-banner__button-container {
 		padding: rem( 12px ) 0 0;
+
+		span.jp-banner__tos-blurb {
+			display: block;
+			font-size: rem( 11px );
+			margin: 0 auto rem( 16px );
+			max-width: rem( 385px );
+			color: $gray-dark;
+		}
 	}
 }
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -19,7 +19,6 @@
 		span.jp-banner__tos-blurb {
 			display: block;
 			font-size: rem( 11px );
-			max-width: rem( 385px );
 			color: $gray-dark;
 		}
 	}
@@ -273,7 +272,7 @@
 .jp-wpcom-connect__content-container .jp-banner__button-container {
 	@include minbreakpoint(tablet) {
 		position: absolute;
-		bottom: 0;
+		bottom: rem(8px);
 	};
 }
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -19,7 +19,6 @@
 		span.jp-banner__tos-blurb {
 			display: block;
 			font-size: rem( 11px );
-			margin: 0 auto rem( 16px );
 			max-width: rem( 385px );
 			color: $gray-dark;
 		}
@@ -274,7 +273,7 @@
 .jp-wpcom-connect__content-container .jp-banner__button-container {
 	@include minbreakpoint(tablet) {
 		position: absolute;
-		bottom: rem( 16px );
+		bottom: 0;
 	};
 }
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -272,7 +272,7 @@
 .jp-wpcom-connect__content-container .jp-banner__button-container {
 	@include minbreakpoint(tablet) {
 		position: absolute;
-		bottom: rem(8px);
+		bottom: rem( 8px );
 	};
 }
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -15,12 +15,12 @@
 
 	.jp-banner__button-container {
 		padding: rem( 12px ) 0 0;
+	}
 
-		span.jp-banner__tos-blurb {
-			display: block;
-			font-size: rem( 11px );
-			color: $gray-dark;
-		}
+	.jp-banner__tos-blurb {
+		clear: both;
+		font-size: rem( 11px );
+		color: $gray-dark;
 	}
 }
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -18,7 +18,9 @@
 	}
 
 	.jp-banner__tos-blurb {
-		clear: both;
+		display: block;
+		padding: rem( 6px ) 0;
+		line-height: 1.5;
 		font-size: rem( 11px );
 		color: $gray-dark;
 	}

--- a/views/admin/must-connect-main-blog.php
+++ b/views/admin/must-connect-main-blog.php
@@ -9,6 +9,15 @@
 			</div>
 			<div class="jetpack-install-container">
 				<p class="submit"><a href="<?php echo esc_url( $data['url'] ); ?>" class="button-connector" id="wpcom-connect"><?php _e( 'Connect to WordPress.com', 'jetpack' ); ?></a></p>
+				<p class="jetpack-install-blurb">
+				<?php
+					printf(
+						__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
+						'https://wordpress.com/tos',
+						'https://jetpack.com/support/what-data-does-jetpack-sync'
+					);
+				?>
+				</p>
 			</div>
 		</div>
 	</div>

--- a/views/admin/must-connect-main-blog.php
+++ b/views/admin/must-connect-main-blog.php
@@ -10,13 +10,7 @@
 			<div class="jetpack-install-container">
 				<p class="submit"><a href="<?php echo esc_url( $data['url'] ); ?>" class="button-connector" id="wpcom-connect"><?php _e( 'Connect to WordPress.com', 'jetpack' ); ?></a></p>
 				<p class="jetpack-install-blurb">
-				<?php
-					printf(
-						__( 'By connecting your site you agree to our fascinating <a href="%s" target="_blank">Terms of Service</a> and to <a href="%s" target="_blank">share details</a> with WordPress.com', 'jetpack' ),
-						'https://wordpress.com/tos',
-						'https://jetpack.com/support/what-data-does-jetpack-sync'
-					);
-				?>
+					<?php jetpack_render_tos_blurb(); ?>
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Right now it's hard to improve quality across the board because of inconsistent identifiers between WPCOM and Jetpack.

This PR aims to include a number of changes to address that.

- ensure informed consent info is present on all connect buttons
- send tracks user_id and type (either anon or wpcom ID) with register and authorize requests
- add a number of new events

Register:
- `jetpack_jpc_register_begin`
- `jetpack_jpc_verify_register_begin`
- `jetpack_jpc_verify_register_success/fail`
- `jetpack_jpc_register_success/fail`

Authorize:
- `jetpack_jpc_remote_authorize_begin`
- `jetpack_jpc_verify_authorize_begin`
- `jetpack_jpc_verify_authorize_success/fail`
- `jetpack_jpc_remote_authorize_success/fail`