### PR TITLE
WP.com API: Allow comment author data to be edited through the `Update_Comment` endpoint.

### DIFF
--- a/json-endpoints.php
+++ b/json-endpoints.php
@@ -1934,8 +1934,11 @@ new WPCOM_JSON_API_Update_Comment_Endpoint( array(
 	),
 
 	'request_format' => array(
-		'date'    => "(ISO 8601 datetime) The comment's creation time.",
-		'content' => '(HTML) The comment text.',
+		'author'       => "(string) The comment author's name.",
+		'author_email' => "(string) The comment author's email.",
+		'author_url'   => "(string) The comment author's URL.",
+		'content'      => '(HTML) The comment text.',
+		'date'         => "(ISO 8601 datetime) The comment's creation time.",
 		'status'  => array(
 			'approved'   => 'Approve the comment.',
 			'unapproved' => 'Remove the comment from public view and send it to the moderation queue.',


### PR DESCRIPTION
This PR will allow a comment author's data (name, email, and website/URL) to be edited through the REST API, just as a user can edit the same information in `wp-admin` now.

See: https://github.com/Automattic/wp-calypso/issues/17164

<img width="1001" alt="screen shot 2017-08-25 at 4 33 10 pm" src="https://user-images.githubusercontent.com/349751/29736096-214857fa-89b3-11e7-84f4-7a55cdb6bf53.png">

D7046-code