### PR TITLE
Point edit post URLs to Calypso

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -614,7 +614,8 @@ class Jetpack {
 		add_filter( 'jetpack_just_in_time_msgs', '__return_true', 9 );
 
 		// If enabled, point edit post and page links to Calypso instead of WP-Admin.
-		if ( get_option( 'jetpack_edit_links_calypso_redirect' ) ) {
+		// We should make sure to only do this for front end links.
+		if ( get_option( 'jetpack_edit_links_calypso_redirect', true ) && ! is_admin() ) {
 			add_filter( 'get_edit_post_link', array( $this, 'point_edit_links_to_calypso' ), 1, 2 );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -659,7 +659,7 @@ class Jetpack {
 
 		$site_slug  = Jetpack::build_raw_urls( get_home_url() );
 
-		return esc_url_raw( sprintf( 'https://wordpress.com/%s/%s/%d', $path_prefix, $site_slug, $post_id ) );
+		return esc_url( sprintf( 'https://wordpress.com/%s/%s/%d', $path_prefix, $site_slug, $post_id ) );
 	}
 
 	function jetpack_track_last_sync_callback( $params ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -639,7 +639,9 @@ class Jetpack {
 	}
 
 	function point_edit_links_to_calypso( $default_url, $post_id ) {
-		if ( ! $post = get_post( $post_id ) ) {
+		$post = get_post( $post_id );
+
+		if ( empty( $post ) ) {
 			return $default_url;
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -615,7 +615,7 @@ class Jetpack {
 
 		// If enabled, point edit post and page links to Calypso instead of WP-Admin.
 		// We should make sure to only do this for front end links.
-		if ( get_option( 'jetpack_edit_links_calypso_redirect', true ) && ! is_admin() ) {
+		if ( get_option( 'jetpack_edit_links_calypso_redirect' ) && ! is_admin() ) {
 			add_filter( 'get_edit_post_link', array( $this, 'point_edit_links_to_calypso' ), 1, 2 );
 		}
 
@@ -648,15 +648,20 @@ class Jetpack {
 
 		$post_type = $post->post_type;
 
-		if ( in_array( $post_type, array( 'post', 'page' ) ) ) {
-			$path_prefix = $post_type;
-		} else if ( in_array( $post_type, apply_filters( 'rest_api_allowed_post_types', array( 'post', 'page', 'revision' ) ) ) ) {
-			$path_prefix = sprintf( 'edit/%s', $post_type );
-		}
+		// Mapping the allowed CPTs on WordPress.com to corresponding paths in Calypso.
+		// https://en.support.wordpress.com/custom-post-types/
+		$allowed_post_types = array(
+			'post' => 'post',
+			'page' => 'page',
+			'jetpack-portfolio' => 'edit/jetpack-portfolio',
+			'jetpack-testimonial' => 'edit/jetpack-testimonial',
+		);
 
-		if ( ! isset( $path_prefix ) ) {
+		if ( ! in_array( $post_type, array_keys( $allowed_post_types ) ) ) {
 			return $default_url;
 		}
+
+		$path_prefix = $allowed_post_types[ $post_type ];
 
 		$site_slug  = Jetpack::build_raw_urls( get_home_url() );
 


### PR DESCRIPTION
Provided that this option is turned on, this will point all front end post edit URLs to Calypso, instead of WP-Admin.

#### Testing instructions
1. Use a Jetpack connected test site.
2. Since the option does not exist yet, change [this line](https://github.com/Automattic/jetpack/compare/add/edit-post-calypso-redirect?expand=1#diff-9ba9fa5bb52bd6cf36c6c0bdd5ed4830R617) to:
`if ( get_option( 'jetpack_edit_links_calypso_redirect', true ) && ! is_admin() ) {`
3. Open a post or page from your site's front end and verify that edit links redirect correctly to Calypso.
4. Test with supported Custom Post Types too (Portfolios and Testimonials).