### PR TITLE
Sync all the options at least once and keep track of them

### DIFF
--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -375,6 +375,19 @@ class Jetpack_Sync_Defaults {
 		'active_sitewide_plugins',
 	);
 
+	static function get_network_options_whitelist() {
+		/**
+		 * Filter the list of WordPress network options that are can be synced.
+		 *
+		 * @module sync
+		 *
+		 * @since 5.3.0
+		 *
+		 * @param array The default list of network options.
+		 */
+		return apply_filters( 'jetpack_sync_network_options_whitelist', self::$default_network_options_whitelist );
+	}
+
 	static $default_taxonomy_whitelist = array();
 	static $default_dequeue_max_bytes = 500000; // very conservative value, 1/2 MB
 	static $default_upload_max_bytes = 600000; // a little bigger than the upload limit to account for serialization

--- a/sync/class.jetpack-sync-defaults.php
+++ b/sync/class.jetpack-sync-defaults.php
@@ -395,6 +395,7 @@ class Jetpack_Sync_Defaults {
 	static $default_max_queue_size_full_sync = 1000; // max number of total items in the full sync queue
 	static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again
 	static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again
+	static $default_sync_options_wait_time = DAY_IN_SECONDS;
 	static $default_sync_queue_lock_timeout = 120; // 2 minutes
 	static $default_cron_sync_time_limit = 30; // 30 seconds
 }

--- a/sync/class.jetpack-sync-module-options.php
+++ b/sync/class.jetpack-sync-module-options.php
@@ -49,7 +49,7 @@ class Jetpack_Sync_Module_Options extends Jetpack_Sync_Module {
 				/**
 				 * Tells the client to sync an option to the server
 				 *
-				 * @since 5.2.0
+				 * @since 5.3.0
 				 *
 				 * @param string The name of the constant
 				 * @param mixed The value of the constant

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -68,6 +68,7 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			// options
+			case 'jetpack_sync_option':
 			case 'added_option':
 				list( $option, $value ) = $args;
 				$this->store->update_option( $option, $value );

--- a/tests/php/sync/server/class.jetpack-sync-server-replicator.php
+++ b/tests/php/sync/server/class.jetpack-sync-server-replicator.php
@@ -131,6 +131,7 @@ class Jetpack_Sync_Server_Replicator {
 				break;
 
 			// network options
+			case 'jetpack_sync_network_option':
 			case 'add_site_option':
 				list( $option, $value ) = $args;
 				$this->store->update_site_option( $option, $value );

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -67,6 +67,7 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
 		delete_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );
 		delete_transient( Jetpack_Sync_Module_Options::OPTIONS_AWAIT_TRANSIENT_NAME );
+		delete_transient( Jetpack_Sync_Module_Network_Options::OPTIONS_AWAIT_TRANSIENT_NAME );
 	}
 
 	public function test_pass() {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -61,13 +61,19 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		// don't sync callables or constants every time - slows down tests
 		set_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME, 60 );
 		set_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME, 60 );
+		set_transient( Jetpack_Sync_Module_Options::OPTIONS_AWAIT_TRANSIENT_NAME, 60 );
+		if ( is_multisite() ) {
+			set_site_transient( Jetpack_Sync_Module_Network_Options::OPTIONS_AWAIT_TRANSIENT_NAME, 60 );
+		}
 	}
 
 	protected function resetCallableAndConstantTimeouts() {
 		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
 		delete_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );
 		delete_transient( Jetpack_Sync_Module_Options::OPTIONS_AWAIT_TRANSIENT_NAME );
-		delete_transient( Jetpack_Sync_Module_Network_Options::OPTIONS_AWAIT_TRANSIENT_NAME );
+		if ( is_multisite() ) {
+			delete_site_transient( Jetpack_Sync_Module_Network_Options::OPTIONS_AWAIT_TRANSIENT_NAME );
+		}
 	}
 
 	public function test_pass() {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -65,7 +65,8 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 	protected function resetCallableAndConstantTimeouts() {
 		delete_transient( Jetpack_Sync_Module_Callables::CALLABLES_AWAIT_TRANSIENT_NAME );
-		delete_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );	
+		delete_transient( Jetpack_Sync_Module_Constants::CONSTANTS_AWAIT_TRANSIENT_NAME );
+		delete_transient( Jetpack_Sync_Module_Options::OPTIONS_AWAIT_TRANSIENT_NAME );
 	}
 
 	public function test_pass() {

--- a/tests/php/sync/test_class.jetpack-sync-network-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-network-options.php
@@ -23,6 +23,29 @@ class WP_Test_Jetpack_Sync_Network_Options extends WP_Test_Jetpack_Sync_Base {
 		parent::tearDown();
 	}
 
+	function test_white_listed_option_is_synced() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Run it in multi site mode' );
+		}
+
+		$this->resetCallableAndConstantTimeouts();
+		add_site_option('banana', 'phone' );
+		add_site_option( 'coffee','white' );
+
+		$helper = new Jetpack_Sync_Test_Helper();
+		$helper->array_override = array( 'banana' );
+		add_filter( 'jetpack_sync_network_options_whitelist', array( $helper, 'filter_override_array' ) );
+		$this->network_options_module->set_defaults(); // Reset the
+
+		$this->sender->do_sync();
+
+		$synced_foo_value = $this->server_replica_storage->get_site_option( 'banana' );
+		$synced_bar_value = $this->server_replica_storage->get_site_option( 'coffee' );
+
+		$this->assertEquals( 'phone', $synced_foo_value );
+		$this->assertNotEquals( 'white', $synced_bar_value );
+	}
+
 	public function test_added_network_option_is_synced() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Run it in multisite mode' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -19,6 +19,25 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 	}
 
+	function test_white_listed_option_is_synced() {
+		$this->resetCallableAndConstantTimeouts();
+		add_option('banana', 'phone' );
+		add_option( 'coffee','white' );
+
+		$helper = new Jetpack_Sync_Test_Helper();
+		$helper->array_override = array( 'banana' );
+		add_filter( 'jetpack_sync_options_whitelist', array( $helper, 'filter_override_array' ) );
+		$this->options_module->set_defaults(); // Reset the
+
+		$this->sender->do_sync();
+
+		$synced_foo_value = $this->server_replica_storage->get_option( 'banana' );
+		$synced_bar_value = $this->server_replica_storage->get_option( 'coffee' );
+
+		$this->assertEquals( 'phone', $synced_foo_value );
+		$this->assertNotEquals( 'white', $synced_bar_value );
+	}
+
 	public function test_added_option_is_synced() {
 		$synced_option_value = $this->server_replica_storage->get_option( 'test_option' );
 		$this->assertEquals( 'foo', $synced_option_value );
@@ -213,8 +232,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 		$options[] = 'foo_option_bar';
 		return $options;
 	}
-
-
 
 	function add_option_on_89() {
 		add_filter( 'jetpack_options_whitelist', array( $this, 'add_jetpack_options_whitelist_filter' ) );


### PR DESCRIPTION
Fixes #7680

Currently we sync options but we don't sync all the options at lease once untill a full sync is requested. Which doesn't happen as often. 

This PR add syncing of all options and network options which works the same way as callables and constants. We keep track of the checksum and send only things that have changed. We have a really large interval here (once a day) Since most of the time options are synced anyways via the add / update and delete hooks. 

This Fixe
#### Changes proposed in this Pull Request:

*

#### Testing instructions:
* Do the tests pass? 
Does it fix issue #7680?

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Improve options and network options syncing.