### PR TITLE
General: Exit after redirecting

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -23,8 +23,10 @@ class Jetpack_Client_Server {
 		}
 
 		if ( wp_validate_redirect( $redirect ) ) {
+			// Exit happens below in $this->do_exit()
 			wp_safe_redirect( $redirect );
 		} else {
+			// Exit happens below in $this->do_exit()
 			wp_safe_redirect( Jetpack::admin_url() );
 		}
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -24,10 +24,8 @@ class Jetpack_Client_Server {
 
 		if ( wp_validate_redirect( $redirect ) ) {
 			wp_safe_redirect( $redirect );
-			exit;
 		} else {
 			wp_safe_redirect( Jetpack::admin_url() );
-			exit;
 		}
 
 		/**

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -24,8 +24,10 @@ class Jetpack_Client_Server {
 
 		if ( wp_validate_redirect( $redirect ) ) {
 			wp_safe_redirect( $redirect );
+			exit;
 		} else {
 			wp_safe_redirect( Jetpack::admin_url() );
+			exit;
 		}
 
 		/**

--- a/class.jetpack-debugger.php
+++ b/class.jetpack-debugger.php
@@ -55,6 +55,7 @@ class Jetpack_Debugger {
 			if ( Jetpack::is_active() ) {
 				Jetpack::disconnect();
 				wp_redirect( Jetpack::admin_url() );
+				exit;
 			}
 		}
 	}

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -334,7 +334,6 @@ class Jetpack_Network {
 
 					wp_safe_redirect( $url );
 					exit;
-					break;
 
 				case 'subsitedisconnect':
 					Jetpack::log( 'subsitedisconnect' );

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -333,6 +333,7 @@ class Jetpack_Network {
 					}
 
 					wp_safe_redirect( $url );
+					exit;
 					break;
 
 				case 'subsitedisconnect':

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3787,6 +3787,7 @@ p {
 				if ( ! isset( $_GET['calypso_env'] ) ) {
 					Jetpack::state( 'message', 'already_authorized' );
 					wp_safe_redirect( Jetpack::admin_url() );
+					exit;
 				} else {
 					$connect_url = $this->build_connect_url( true, false, 'iframe' );
 					$connect_url .= '&already_authorized=true';

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3791,6 +3791,7 @@ p {
 					$connect_url = $this->build_connect_url( true, false, 'iframe' );
 					$connect_url .= '&already_authorized=true';
 					wp_redirect( $connect_url );
+					exit;
 				}
 			}
 		}

--- a/modules/custom-css/custom-css-4.7.php
+++ b/modules/custom-css/custom-css-4.7.php
@@ -137,6 +137,7 @@ class Jetpack_Custom_CSS_Enhancements {
 		wp_safe_redirect( self::customizer_link( array(
 			'return_url' => wp_get_referer(),
 		) ) );
+		exit;
 	}
 
 	/**

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -45,6 +45,7 @@ class Jetpack_Monitor {
 			$this->update_option_receive_jetpack_monitor_notification( isset( $_POST['receive_jetpack_monitor_notification'] ) );
 			Jetpack::state( 'message', 'module_configured' );
 			wp_safe_redirect( Jetpack::module_configuration_url( $this->module ) );
+			exit;
 		}
 	}
 

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -597,6 +597,7 @@ class Jetpack_Protect_Module {
 			// If it fails we need access to $this->api_key_error
 			if ( $result ) {
 				wp_safe_redirect( Jetpack::module_configuration_url( 'protect' ) );
+				exit;
 			}
 		}
 

--- a/modules/widgets/migrate-to-core/image-widget.php
+++ b/modules/widgets/migrate-to-core/image-widget.php
@@ -214,5 +214,6 @@ add_action( 'widgets_init', 'jetpack_migrate_image_widget' );
 function jetpack_refresh_on_widget_page( $current ) {
 	if ( 'widgets' === $current->base ) {
 		wp_safe_redirect( admin_url( 'widgets.php' ) );
+		exit;
 	}
 }


### PR DESCRIPTION
@gravityrail was auditing the connection flow today, and found that a missing exit after a redirect was causing stats to be double counted in cases. 

This sparked an audit by @georgestephanis of the Jetpack code base for `wp_redirect()` without an exit and I followed up with an audit of `wp_safe_redirect()` without an exit.

This PR fixes cases of `wp_redirect` and `wp_safe_redirect` without an exit or die afterwards.

Test steps TBD.