### PR TITLE
Connection: Fire jetpack_client_authorized action if no error

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -20,6 +20,15 @@ class Jetpack_Client_Server {
 		$result = $this->authorize( $data );
 		if ( is_wp_error( $result ) ) {
 			Jetpack::state( 'error', $result->get_error_code() );
+		} else {
+			/**
+			 * Fires after the Jetpack client is authorized to communicate with WordPress.com.
+			 *
+			 * @since 4.2.0
+			 *
+			 * @param int Jetpack Blog ID.
+			 */
+			do_action( 'jetpack_client_authorized', Jetpack_Options::get_option( 'id' ) );
 		}
 
 		if ( wp_validate_redirect( $redirect ) ) {
@@ -27,15 +36,6 @@ class Jetpack_Client_Server {
 		} else {
 			wp_safe_redirect( Jetpack::admin_url() );
 		}
-
-		/**
-		 * Fires after the Jetpack client is authorized to communicate with WordPress.com.
-		 *
-		 * @since 4.2.0
-		 *
-		 * @param int Jetpack Blog ID.
-		 */
-		do_action( 'jetpack_client_authorized', Jetpack_Options::get_option( 'id' ) );
 
 		$this->do_exit();
 	}


### PR DESCRIPTION
After stepping through some connection code today, @beaulebens pointed out a potential issue where it seems like we were firing the `jetpack_client_authorized` inappropriately. Before this patch, it seems like we fire the `jetpack_client_authorized` action on both successful and errored authorizations.

It looks like this hook was added in #4347 to handle kicking off a full sync after connecting a site to WordPress.com.

I don't imagine this is causing much of an issue in production since it's only hooked in `class.jetpack-sync-actions.php` to start a full sync, and even then, the method that kicks off the full sync short-circuits if sync is not allowed. But, we should fix it all the same.