### PR TITLE
REST API: Fix the comment author object for comments whose author info has been edited.

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1061,7 +1061,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 	function get_author( $author, $show_email_and_ip = false ) {
 		$ip_address = isset( $author->comment_author_IP ) ? $author->comment_author_IP : '';
 
-		if ( isset( $author->comment_author_email ) && !$author->user_id ) {
+		if ( isset( $author->comment_author_email ) ) {
 			$ID          = 0;
 			$login       = '';
 			$email       = $author->comment_author_email;
@@ -1069,7 +1069,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$first_name  = '';
 			$last_name   = '';
 			$URL         = $author->comment_author_url;
-			$avatar_URL  = $this->api->get_avatar_url( $author );
+			$avatar_URL  = $this->api->get_avatar_url( $email );
 			$profile_URL = 'https://en.gravatar.com/' . md5( strtolower( trim( $email ) ) );
 			$nice        = '';
 			$site_id     = -1;


### PR DESCRIPTION
`wp-admin` allows a user to edit a comment author's name, email, and URL. This can be done for both logged-out and logged-in users.

<img width="1296" alt="screen shot 2017-08-28 at 4 18 42 pm" src="https://user-images.githubusercontent.com/349751/29797557-a3828802-8c0c-11e7-86ac-1417112d4483.png">

If a comment author is logged-in when commenting, the stored comment will also have the comment author's user ID. The presence of this ID will fail [this check](https://github.com/Automattic/jetpack/blob/b44640a3572b2579e73d6e47c0f7ecb1251f0d30/class.json-api-endpoints.php#L1064) in `get_author()`, and the author object returned by an API call will reflect the user based on that ID; any edited name, email, or URL in the comments table will be bypassed.

This PR seems like the simplest way to get at the edited data: if the "author" passed in is a comment row (as determined by the presence of `comment_author_email`, which is required when commenting), return data from that comment. Note that this will mean losing the original commenter's user ID and associated avatar in the response, but I think this would be desirable. Otherwise, the comment author will be displayed with their edited email, for example, and an avatar associated to another (the original) email.

Another approach would be to have the same data returned for all authors (get rid of the check referenced above), but override any possible edited commenter's data. However, this could change the nature of the response; it will add an (empty) `site_id` to `author`, and `ID` would no longer be `0` in the case of logged-in and edited comment authors. This would be a more consistent shape, but the effect would be more unpredictable – so I've proposed the former for now.

D7075-code