### PR TITLE
WordPress.com Toolbar: add jQuery as a dependency for dotcom script

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -122,7 +122,7 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		wp_enqueue_script( 'jetpack-accessible-focus', plugins_url( '_inc/accessible-focus.js', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
-		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array(), JETPACK__VERSION );
+		wp_enqueue_script( 'a8c_wpcom_masterbar_overrides', $this->wpcom_static_url( '/wp-content/mu-plugins/admin-bar/masterbar-overrides/masterbar.js' ), array( 'jquery' ), JETPACK__VERSION );
 	}
 
 	function wpcom_static_url( $file ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/6993

#### Testing instructions:

I wasn't able to reproduce this bug, but the detailed steps are outlined in https://github.com/Automattic/jetpack/issues/6993. My guess is that for some reason `jquery` is not required on those sites, and it results in an error since the `masterbar-overrides.js` script from WP.com requires it to work.