### PR TITLE
Sync: Send full sync on initial connection. 

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -24,10 +24,6 @@ class Jetpack_Sync_Actions {
 		} else if ( wp_next_scheduled( 'jetpack_sync_cron' ) ) {
 			self::clear_sync_cron_jobs();
 		}
-
-		// On jetpack authorization, schedule a full sync
-		add_action( 'jetpack_client_authorized', array( __CLASS__, 'do_full_sync' ), 10, 0 );
-
 		// When importing via cron, do not sync
 		add_action( 'wp_cron_importer_hook', array( __CLASS__, 'set_is_importing_true' ), 1 );
 
@@ -54,7 +50,6 @@ class Jetpack_Sync_Actions {
 		}
 
 		add_action( 'init', array( __CLASS__, 'add_sender_shutdown' ), 90 );
-
 	}
 
 	static function add_sender_shutdown() {
@@ -202,6 +197,25 @@ class Jetpack_Sync_Actions {
 		);
 
 		self::do_full_sync( $initial_sync_config );
+	}
+
+	static function do_inital_sync_on_site_registration() {
+		$initial_sync_config = array(
+			'options'         => true,
+			'network_options' => true,
+			'functions'       => true,
+			'constants'       => true,
+		);
+
+		$user = wp_get_current_user();
+		if ( isset( $user->ID ) ) {
+			$initial_sync_config['users'] = array( $user->ID );
+		}
+
+		self::initialize_listener();
+		self::initialize_sender();
+		add_action( 'shutdown', array( self::$sender, 'do_full_sync' ) );
+		Jetpack_Sync_Modules::get_module( 'full-sync' )->start( $initial_sync_config );
 	}
 
 	static function do_full_sync( $modules = null ) {
@@ -450,3 +464,5 @@ add_action( 'plugins_loaded', array( 'Jetpack_Sync_Actions', 'init' ), 90 );
 // We need to define this here so that it's hooked before `updating_jetpack_version` is called
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'do_initial_sync' ), 10, 2 );
 add_action( 'updating_jetpack_version', array( 'Jetpack_Sync_Actions', 'cleanup_on_upgrade' ), 10, 2 );
+add_action( 'jetpack_user_authorized', array( 'Jetpack_Sync_Actions', 'do_inital_sync_on_site_registration' ), 10, 0 );
+

--- a/sync/class.jetpack-sync-module-callables.php
+++ b/sync/class.jetpack-sync-module-callables.php
@@ -171,7 +171,13 @@ class Jetpack_Sync_Module_Callables extends Jetpack_Sync_Module {
 
 	public function expand_callables( $args ) {
 		if ( $args[0] ) {
-			return $this->get_all_callables();
+			$callables = $this->get_all_callables();
+			$callables_checksums = array();
+			foreach ( $callables as $name => $value ) {
+				$callables_checksums[ $name ] = $this->get_check_sum( $value );
+			}
+			Jetpack_Options::update_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callables_checksums );
+			return $callables;
 		}
 
 		return $args;

--- a/sync/class.jetpack-sync-module-constants.php
+++ b/sync/class.jetpack-sync-module-constants.php
@@ -112,9 +112,14 @@ class Jetpack_Sync_Module_Constants extends Jetpack_Sync_Module {
 
 	public function expand_constants( $args ) {
 		if ( $args[0] ) {
-			return $this->get_all_constants();
+			$constants = $this->get_all_constants();
+			$constants_checksums = array();
+			foreach ( $constants as $name => $value ) {
+				$constants_checksums[ $name ] = $this->get_check_sum( $value );
+			}
+			update_option( self::CONSTANTS_CHECKSUM_OPTION_NAME, $constants_checksums );
+			return $constants;
 		}
-
 		return $args;
 	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -297,22 +297,22 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function test_full_sync_constants_updates_checksums() {
-		define( 'TEST_SYNC_ALL_CONSTANTS', 'foo' );
+		define( 'FOO_SYNC_ALL_CONSTANTS', 'foo' );
 		$this->resetCallableAndConstantTimeouts();
 		$helper = new Jetpack_Sync_Test_Helper();
-		$helper->array_override = array( 'TEST_SYNC_ALL_CONSTANTS' );
+		$helper->array_override = array( 'FOO_SYNC_ALL_CONSTANTS' );
 		add_filter( 'jetpack_sync_constants_whitelist', array( $helper, 'filter_override_array' ) );
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
 
-		$this->assertEquals( 'foo', $this->server_replica_storage->get_constant( 'TEST_SYNC_ALL_CONSTANTS' ) );
+		$this->assertEquals( 'foo', $this->server_replica_storage->get_constant( 'FOO_SYNC_ALL_CONSTANTS' ) );
 
 		// reset the storage, check value, and do full sync - storage should be set!
 		$this->server_replica_storage->reset();
 		$this->server_event_storage->reset();
 		// Do Sync shouldn't send anything becuase the checksums are up to date.
 		$this->sender->do_sync();
-		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'TEST_SYNC_ALL_CONSTANTS' ) );
+		$this->assertEquals( null, $this->server_replica_storage->get_constant( 'FOO_SYNC_ALL_CONSTANTS' ) );
 		$events = $this->server_event_storage->get_all_events( 'jetpack_sync_constant' );
 		$this->assertTrue( empty( $events ) );
 	}
@@ -1133,13 +1133,13 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 3, $this->server_replica_storage->user_count() );
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
 		Jetpack_Sync_Actions::do_initial_sync( '4.2', '4.1' );
-
+		$current_user = wp_get_current_user();
 		$expected_sync_config = array( 
 			'options' => true, 
 			'network_options' => true,
 			'functions' => true, 
 			'constants' => true, 
-			'users' => 'initial'
+			'users' => array( $current_user->ID )
 		);
 
 		$full_sync_status = $this->full_sync->get_status();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1134,13 +1134,17 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// finally, let's make sure that the initial sync method actually invokes our initial sync user config
 		Jetpack_Sync_Actions::do_initial_sync( '4.2', '4.1' );
 		$current_user = wp_get_current_user();
+
 		$expected_sync_config = array( 
-			'options' => true, 
-			'network_options' => true,
+			'options' => true,
 			'functions' => true, 
 			'constants' => true, 
 			'users' => array( $current_user->ID )
 		);
+
+		if ( is_multisite() ) {
+			$expected_sync_config['network_options'] = true;
+		}
 
 		$full_sync_status = $this->full_sync->get_status();
 		$this->assertEquals(

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -103,8 +103,8 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Jetpack_Sync_Actions::DEFAULT_SYNC_CRON_INTERVAL_NAME, wp_get_schedule( 'jetpack_sync_full_cron' ) );
 	}
 
-	function test_starts_full_sync_on_client_authorized() {
-		do_action( 'jetpack_client_authorized', 'abcd1234' );
+	function test_starts_full_sync_on_user_authorized() {
+		do_action( 'jetpack_user_authorized', 'abcd1234' );
 		$this->assertTrue( Jetpack_Sync_Modules::get_module( 'full-sync' )->is_started() );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -23,11 +23,13 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 		global $wpdb;
 
+		$current_user = wp_get_current_user();
+
 		$expected_sync_config = array( 
 			'options' => true,
 			'functions' => true, 
 			'constants' => true, 
-			'users' => 'initial'
+			'users' => array( $current_user->ID )
 		);
 
 		if ( is_multisite() ) {

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -24,22 +24,33 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		global $wpdb;
 
 		$expected_sync_config = array( 
-			'options' => true, 
-			'network_options' => true,
+			'options' => true,
 			'functions' => true, 
 			'constants' => true, 
 			'users' => 'initial'
 		);
 
+		if ( is_multisite() ) {
+			$expected_sync_config['network_options'] = true;
+		}
 		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
 		
 		$this->assertEquals( $sync_status['config'], $expected_sync_config );
 	}
 
 	function test_upgrading_from_42_plus_does_not_start_an_initial_sync() {
+		$current_user = wp_get_current_user();
 
-		$initial_sync_with_users_config = array( 'options' => true, 'functions' => true, 'constants' => true, 'network_options' => true, 'users' => 'initial' );
+		$initial_sync_with_users_config = array(
+			'options' => true,
+			'functions' => true,
+			'constants' => true,
+			'users' => array( $current_user->ID )
+		);
 
+		if ( is_multisite() ) {
+			$initial_sync_with_users_config['network_options'] = true;
+		}
 		do_action( 'updating_jetpack_version', '4.3', '4.2' );
 		$sync_status = Jetpack_Sync_Modules::get_module( 'full-sync' )->get_status();
 		$sync_config = $sync_status[ 'config' ];


### PR DESCRIPTION
Send options, network_options, functions, constans, updates and the initial users on connection.

Fixes #7680
We used to send all this information before. but it seems that we lost the info when we switched to the new authorize endpoint. 

#### Changes proposed in this Pull Request:
* Re add sending full sync info on site autorization. 

#### Testing instructions:
* Disconnect jetpack, update an option such as site_icon. 
Connect the site. Check that the option was saved right away. 

Does it work you can see it as expected. 

Do the tests pass? 

cc: @lezama, @withinboredom 
<!-- Add the following only if this is meant to be in changelog -->

From my testing I can see that the full sync happends on the api request that request Autorization. 
see 
```
[29-Aug-2017 03:46:53 UTC] message:START ======  PID:16476
[29-Aug-2017 03:46:53 UTC] message:/aaa/xmlrpc.php?for=jetpack PID:16476
[29-Aug-2017 03:46:53 UTC] message:"<?xml version=\"1.0\"?>\n<methodCall>\n<methodName>jetpack.remoteAuthorize<\/methodName>\n<params>\n<param><value><struct>\n  <member><name>code<\/name><value><string>ddWAhquOG6<\/string><\/value><\/member>\n  <member><name>state<\/name><value><string>10<\/string><\/value><\/member>\n  <member><name>redirect_uri<\/name><value><string>https:\/\/enej.wpsandbox.me\/aaa\/wp-admin\/admin.php?page=jetpack&amp;action=authorize&amp;_wpnonce=46140ca383&amp;redirect=https%3A%2F%2Fenej.wpsandbox.me%2Faaa%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack<\/string><\/value><\/member>\n  <member><name>secret<\/name><value><string>UIdXPxzF3bmcyBE8kX9KNqcfQhEJvfxK<\/string><\/value><\/member>\n  <member><name>jp_version<\/name><value><string>5.3-alpha<\/string><\/value><\/member>\n  <member><name>auth_type<\/name><value><string>calypso<\/string><\/value><\/member>\n<\/struct><\/value><\/param>\n<\/params><\/methodCall>" PID:16476
[29-Aug-2017 03:46:53 UTC] message:Sync Actions init PID:16476
[29-Aug-2017 03:46:54 UTC] message:Remote authorize function... PID:16476
[29-Aug-2017 03:46:55 UTC] message:do_inital_sync_on_site_registration PID:16476
[29-Aug-2017 03:46:55 UTC] message:initialize_listener() PID:16476
[29-Aug-2017 03:46:55 UTC] message:init_full_sync_listeners PID:16476
[29-Aug-2017 03:46:55 UTC] message:initialize_sender() PID:16476
[29-Aug-2017 03:46:56 UTC] message:full sync started PID:16476
[29-Aug-2017 03:46:56 UTC] action:jetpack_full_sync_start PID:16476
[29-Aug-2017 03:46:56 UTC] message:continue_enqueuing PID:16476
[29-Aug-2017 03:46:56 UTC] action:jetpack_full_sync_end PID:16476
[29-Aug-2017 03:46:56 UTC] action:jetpack_client_authorized PID:16476
[29-Aug-2017 03:46:56 UTC] message:Remote authorize function...END... PID:16476
[29-Aug-2017 03:46:56 UTC] message:Sender DO_full_sync PID:16476
[29-Aug-2017 03:46:56 UTC] message:do_sync_for_queue PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_start PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_constants PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_callables PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_options PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_users PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_users PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_users PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_users PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_updates PID:16476
[29-Aug-2017 03:46:56 UTC] message:Item to sendjetpack_full_sync_end PID:16476
[29-Aug-2017 03:46:57 UTC] action:jetpack_sync_processed_actions PID:16476
[29-Aug-2017 03:46:57 UTC] message:Items were sent PID:16476
[29-Aug-2017 03:46:57 UTC] action:shutdown PID:16476
```

#### Proposed changelog entry for your changes:
Improve initial connection syncing