### PR TITLE
Remove comments from Jumpstart

### DIFF
--- a/modules/comments.php
+++ b/modules/comments.php
@@ -3,13 +3,12 @@
 /**
  * Module Name: Comments
  * Module Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment
- * Jumpstart Description: Let readers use WordPress.com, Twitter, Facebook, or Google+ accounts to comment.
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social
- * Feature: Engagement, Jumpstart
+ * Feature: Engagement
  * Additional Search Queries: comments, comment, facebook, twitter, google+, social
  */
 


### PR DESCRIPTION
After the conversation in #7682, we've decided to omit the Comments feature from Jumpstart, as there is concern that we need to be more defensive.  There are too many plugins/themes out there that customize WP comments and we'd like to minimize the possibility of unintentional conflicts with them.  

