### PR TITLE
Update readme.txt to include new Requires PHP header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-
 Stable tag: 5.2.1
 Requires at least: 4.7
 Tested up to: 4.8
+Requires PHP: 5.6
 
 The one plugin you need for stats, related posts, search engine optimization, social sharing, protection, backups, speed, and email list management.
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Updates readme to include new [Requires PHP header](https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/).

