### PR TITLE
Hide the 'manage security' link on the dashboard from non-admins

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -44,9 +44,9 @@ class AtAGlance extends Component {
 			trackSecurityClick = () => analytics.tracks.recordJetpackClick( 'aag_manage_security_wpcom' ),
 			securityHeader = <DashSectionHeader
 					label={ __( 'Security' ) }
-					settingsPath="#security"
+					settingsPath={ this.props.userCanManageModules && '#security' }
 					externalLink={
-						this.props.isDevMode
+						this.props.isDevMode || ! this.props.userCanManageModules
 						? ''
 						: __( 'Manage security on WordPress.com' )
 					}


### PR DESCRIPTION
![screen shot 2017-08-30 at 11 46 53 am](https://user-images.githubusercontent.com/7129409/29881574-f59911de-8d78-11e7-982b-e3d871c6f1fe.png)


Neither the cog nor the "manage security" text should show to non-admins, as they're unable to manage it in Calypso anyway.  

To Test: 
- Make sure those links don't show for a non-admin 
- Make sure they do show for an admin