### PR TITLE
Hide Upgrade banners from non-admins

### DIFF
--- a/_inc/client/components/jetpack-banner/index.jsx
+++ b/_inc/client/components/jetpack-banner/index.jsx
@@ -10,6 +10,7 @@ import Banner from 'components/banner';
  * Internal dependencies
  */
 import { arePromotionsActive } from 'state/initial-state';
+import { userCanManageModules } from 'state/initial-state';
 
 class JetpackBanner extends Banner {
 
@@ -29,10 +30,16 @@ class JetpackBanner extends Banner {
 	};
 
 	static defaultProps = {
-		onClick: noop
+		onClick: noop,
+		plan: false,
 	};
 
 	render() {
+		// Hide promotion banners from non-admins, since they can't upgrade the site.
+		if ( this.props.plan && ! this.props.userCanPurchasePlan ) {
+			return false;
+		}
+
 		return this.props.arePromotionsActive
 			? <Banner { ...this.props } />
 			: null;
@@ -43,7 +50,8 @@ class JetpackBanner extends Banner {
 export default connect(
 	state => {
 		return {
-			arePromotionsActive: arePromotionsActive( state )
+			arePromotionsActive: arePromotionsActive( state ),
+			userCanPurchasePlan: userCanManageModules( state ),
 		};
 	}
 )( JetpackBanner );


### PR DESCRIPTION
Fixes #7235

This makes sure to hide all `JetpackBanners` that are being used to promote paid plans from users that are not able to purchase them.  

I'm doing this by blocking the banner if there is a `plan` prop passed and user is not admin, as the `plan` prop is required for upgrade banners, I figure it's a good indication of whether or not it's being used as such.  

To Test: 
- Make sure you're not seeing any upgrade to purchase a plan as a non-admin. 
- Make sure the non-upgrade JetpackBanners are being rendered
- Make sure you see them correctly as an admin. 