### PR TITLE
Small updates to changelog and to-test for 5.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -132,7 +132,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 * Fixed compatibility issues with plugins using TinyMCE.
 * Updating WordPress.com themes will no longer have any problems.
 * The Sitemaps feature will no longer error with posts/images with special characters in the title.
-* There are more conflicts with the ACF plugin when adding a new custom field.
+* There are no more conflicts with the ACF plugin when adding a new custom field.
 * Fixed a bug that would cause some plugins to throw warnings with the Shortcode feature.
 * We're no longer loading a font on the front-end for the Likes feature, which will also have some performance benefits.
 * The Jetpack admin UI had some bugs that were causing some features to not display the correct active status, which are squashed now.

--- a/to-test.md
+++ b/to-test.md
@@ -78,5 +78,5 @@ There were a few small changes to the connection process that is aimed at fixing
 The site should now fully sync on every Jetpack connection.
 
 - Disconnect jetpack
-- Update an option such as site_icon.
+- Update an option such as Site Title or Site Description.
 - Connect the site. Check that the option was saved right away and reflects correctly in Calypso


### PR DESCRIPTION
Brings over 6f60c5566aa40e815c0c00eb08ca68105651c226 and 2bb2ce1e856837516ae5fa7ba2b6a555ff0a6dc0 from branch-5.3, already committed there.  