### PR TITLE
Fix Multi-Site Connections

### DIFF
--- a/sync/class.jetpack-sync-actions.php
+++ b/sync/class.jetpack-sync-actions.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname( __FILE__ ) . '/class.jetpack-sync-modules.php';
+
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
  * when to send, when to perform a full sync, etc.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Connecting from a fresh MU installation fails due to lacking the sync modules class, this requires it in the sync actions class, since it's used here and any file could pull it in.

#### Testing instructions:

* Create MU site, connect from network admin

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
