### PR TITLE
WordPress.com Toolbar: override user setting for hiding the toolbar

### DIFF
--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -17,7 +17,7 @@ import {
 } from 'lib/plans/constants';
 import {
 	getSiteRawUrl,
-	isAutomatedTransfer
+	isAtomicSite,
 } from 'state/initial-state';
 import {
 	getSitePlan,
@@ -92,7 +92,7 @@ const SupportCard = React.createClass( {
 						<p className="jp-support-card__description">
 							<Button
 								onClick={ this.trackAskQuestionClick }
-								href={ this.props.isAutomatedTransfer
+								href={ this.props.isAtomicSite
 									? 'https://wordpress.com/help/contact/'
 									: 'https://jetpack.com/contact-support/'
 								}
@@ -101,7 +101,7 @@ const SupportCard = React.createClass( {
 							</Button>
 							<Button
 								onClick={ this.trackSearchClick }
-								href={ this.props.isAutomatedTransfer
+								href={ this.props.isAtomicSite
 									? 'https://wordpress.com/help/'
 									: 'https://jetpack.com/support/'
 								}
@@ -139,7 +139,7 @@ export default connect(
 			siteRawUrl: getSiteRawUrl( state ),
 			siteConnectionStatus: getSiteConnectionStatus( state ),
 			isFetchingSiteData: isFetchingSiteData( state ),
-			isAutomatedTransfer: isAutomatedTransfer( state )
+			isAtomicSite: isAtomicSite( state )
 		};
 	}
 )( SupportCard );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -203,10 +203,10 @@ export function arePromotionsActive( state ) {
  *
  * @param {Object} state   Global state tree.
  *
- * @return {boolean} True if this is an AT site, false otherwise.
+ * @return {boolean} True if this is an Atomic site, false otherwise.
  */
-export function isAutomatedTransfer( state ) {
-	return get( state.jetpack.initialState.siteData, 'isAutomatedTransfer', false );
+export function isAtomicSite( state ) {
+	return get( state.jetpack.initialState.siteData, 'isAtomicSite', false );
 }
 
 /**

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -302,7 +302,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 * @param bool $are_promotions_active Status of promotions visibility. True by default.
 				 */
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
-				'isAutomatedTransfer' => jetpack_is_atomic_site(),
+				'isAtomicSite' => jetpack_is_atomic_site(),
 			),
 			'themeData' => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -302,7 +302,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 * @param bool $are_promotions_active Status of promotions visibility. True by default.
 				 */
 				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
-				'isAutomatedTransfer' => jetpack_is_automated_transfer_site(),
+				'isAutomatedTransfer' => jetpack_is_atomic_site(),
 			),
 			'themeData' => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/functions.global.php
+++ b/functions.global.php
@@ -17,14 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Determine if this site is an AT site or not looking first at the 'at_options' option.
+ * Determine if this site is an Atomic site or not looking first at the 'at_options' option.
  * As a fallback, check for presence of wpcomsh plugin to determine if a current site has undergone AT.
  *
  * @since 4.8.1
  *
  * @return bool
  */
-function jetpack_is_automated_transfer_site() {
+function jetpack_is_atomic_site() {
 	$at_options = get_option( 'at_options', array() );
 	return ! empty( $at_options ) || defined( 'WPCOMSH__PLUGIN_FILE' );
 }

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -31,6 +31,12 @@ class A8C_WPCOM_Masterbar {
 			return;
 		}
 
+		// Atomic only - override user setting that hides masterbar from site's front.
+		// https://github.com/Automattic/jetpack/issues/7667
+		if ( jetpack_is_atomic_site() ) {
+			add_filter( 'show_admin_bar', '__return_true' );
+		}
+
 		$this->user_data = Jetpack::get_connected_user_data( $this->user_id );
 		$this->user_login = $this->user_data['login'];
 		$this->user_email = $this->user_data['email'];
@@ -66,10 +72,6 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		add_action( 'wp_logout', array( $this, 'maybe_logout_user_from_wpcom' ) );
-	}
-
-	public function is_automated_transfer_site() {
-		return jetpack_is_automated_transfer_site();
 	}
 
 	public function maybe_logout_user_from_wpcom() {
@@ -475,7 +477,7 @@ class A8C_WPCOM_Masterbar {
 
 		$help_link = 'https://jetpack.com/support/';
 
-		if ( $this->is_automated_transfer_site() ) {
+		if ( jetpack_is_atomic_site() ) {
 			$help_link = 'https://wordpress.com/help';
 		}
 
@@ -920,7 +922,7 @@ class A8C_WPCOM_Masterbar {
 				),
 			) );
 
-			if ( $this->is_automated_transfer_site() ) {
+			if ( jetpack_is_atomic_site() ) {
 				$domain_title = $this->create_menu_item_pair(
 					array(
 						'url'   => 'https://wordpress.com/domains/' . esc_attr( $this->primary_site_slug ),


### PR DESCRIPTION
Force the display of WordPress.com Toolbar on Atomic sites regardless of value of `show_admin_bar` user setting. This is done in order to make the experience similar to WP.com where this option has been discontinued.

Fixes https://github.com/Automattic/jetpack/issues/7667

#### Testing instructions:

1. Use a test Jetpack site with WordPress.com toolbar module enabled.
2. Navigate to `/wp-admin/profile.php` of your test site and disable the `Show Toolbar when viewing site` option.
3. Visit the site's front end and verify that the WordPress.com Toolbar is no longer present.
4. In order to simulate the Atomic site environment, mock the `jetpack_is_atomic_site()` function to always return `true`.
5. Visit the site's front end and verify that WordPress.com Toolbar is now visible.
6. Verify that all usages of old `jetpack_is_automated_transfer_site` function have been refactored.