### PR TITLE
Update tracking props being sent with any upgrade CTA click events.

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -44,7 +44,8 @@ export const SettingsCard = props => {
 	const trackBannerClick = ( feature ) => {
 		analytics.tracks.recordJetpackClick( {
 			target: 'upgrade-banner',
-			feature: feature
+			feature: feature,
+			type: 'upgrade'
 		} );
 	};
 

--- a/_inc/client/components/themes-promo-card/index.jsx
+++ b/_inc/client/components/themes-promo-card/index.jsx
@@ -20,7 +20,8 @@ const ThemesPromoCard = React.createClass( {
 		analytics.tracks.recordJetpackClick( {
 			target: 'themes-card',
 			button: 'themes-get-started',
-			plan: this.props.plan
+			plan: this.props.plan,
+			type: 'upgrade'
 		} );
 	},
 
@@ -28,7 +29,8 @@ const ThemesPromoCard = React.createClass( {
 		analytics.tracks.recordJetpackClick( {
 			target: 'themes-card',
 			button: 'themes-compare-all',
-			plan: this.props.plan
+			plan: this.props.plan,
+			type: 'upgrade'
 		} );
 	},
 


### PR DESCRIPTION
For the purposes of optimized internal tracking, we need to send `type:
upgrade` as a property to any click event attached to a ‘upgrade’ CTA.
Currently, upgrade CTAs on any of the ‘Settings’ cards, as well as the
‘Plans’ tab, lack this property. This PR fixes that.