### PR TITLE
Move Calypso redirect option to Jetpack options

### DIFF
--- a/class.jetpack-options.php
+++ b/class.jetpack-options.php
@@ -27,6 +27,7 @@ class Jetpack_Options {
 				'active_modules',
 				'available_modules',
 				'do_activate',
+				'edit_links_calypso_redirect', // (bool) Whether post/page edit links on front end should point to Calypso.
 				'log',
 				'slideshow_background_color',
 				'widget_twitter',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -615,7 +615,7 @@ class Jetpack {
 
 		// If enabled, point edit post and page links to Calypso instead of WP-Admin.
 		// We should make sure to only do this for front end links.
-		if ( get_option( 'jetpack_edit_links_calypso_redirect' ) && ! is_admin() ) {
+		if ( Jetpack_Options::get_option( 'edit_links_calypso_redirect' ) && ! is_admin() ) {
 			add_filter( 'get_edit_post_link', array( $this, 'point_edit_links_to_calypso' ), 1, 2 );
 		}
 


### PR DESCRIPTION
Instead of using a separate site option for Calypso redirect switch, let's utilize existing Jetpack options functionality. This was suggested by @beaulebens in https://github.com/Automattic/jetpack/pull/7702.

#### Testing instructions

1. Use a Jetpack connected test site.
2. Since the option will not be set, change [this line](https://github.com/Automattic/jetpack/compare/update/move-calypso-edit-option?expand=1#diff-9ba9fa5bb52bd6cf36c6c0bdd5ed4830R618) to:
`if ( Jetpack::get_option( 'edit_links_calypso_redirect', true ) && ! is_admin() ) {`
3. Open a post or page from your site's front end and verify that edit links redirect correctly to Calypso.
Test with supported Custom Post Types too (Portfolios and Testimonials).