### PR TITLE
Contact Form: Fix problem sending mail from SiteGround

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2264,7 +2264,8 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	function add_name_to_address( $address ) {
 		// If it's just the address, without a display name
 		if ( is_email( $address ) ) {
-			$address = sprintf( '"%s" <%s>', $address, $address );
+			$address_parts = explode( '@', $address );
+			$address = sprintf( '"%s" <%s>', $address_parts[0], $address );
 		}
 
 		return $address;

--- a/tests/php/modules/contact-form/test_class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test_class.grunion-contact-form.php
@@ -86,7 +86,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		// Default metadata should be saved
 		$submission = $feedback[0];
 		$email = get_post_meta( $submission->ID, '_feedback_email', true );
-		$this->assertEquals( '"john@example.com" <john@example.com>', $email['to'][0] );
+		$this->assertEquals( '"john" <john@example.com>', $email['to'][0] );
 		$this->assertContains( 'IP Address: 127.0.0.1', $email['message'] );
 	}
 
@@ -323,12 +323,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		// Initialize a form with name, dropdown and radiobutton (first, second
 		// and third option), text field
-		$form = new Grunion_Contact_Form( array( 'to' => '"john@example.com" <john@example.com>', 'subject' => 'Hello there!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
+		$form = new Grunion_Contact_Form( array( 'to' => '"john" <john@example.com>', 'subject' => 'Hello there!' ), "[contact-field label='Name' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
 		$form->process_submission();
 	}
 
 	public function pre_test_process_submission_sends_correct_single_email( $args ){
-		$this->assertContains( '"john@example.com" <john@example.com>', $args['to'] );
+		$this->assertContains( '"john" <john@example.com>', $args['to'] );
 		$this->assertEquals( 'Hello there!', $args['subject'] );
 
 		$expected = '<b>Name:</b> John Doe<br /><br />';
@@ -365,7 +365,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	}
 
 	public function pre_test_process_submission_sends_correct_multiple_email( $args ){
-		$this->assertEquals( array( '"john@example.com" <john@example.com>','"jane@example.com" <jane@example.com>'), $args['to'] );
+		$this->assertEquals( array( '"john" <john@example.com>','"jane" <jane@example.com>'), $args['to'] );
 	}
 
 	/**


### PR DESCRIPTION
This PR takes a different approach from #7367 to avoid the need for any escaping.

Currently in the To: field we use:
`"foo.bar@example.com" <foo.bar@example.com>`

To avoid any need to escape the @ char in the display name part, instead use:
`"foo.bar" <foo.bar@example.com>`

Fixes #7276 

**To Test**
* Use testing instructions in #7276 
