### PR TITLE
Try to set longer timeouts for Register() in connect

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -401,9 +401,10 @@ class Jetpack_Network {
 		// Figure out what site we are working on
 		$site_id = ( is_null( $site_id ) ) ? $_GET['site_id'] : $site_id;
 
-		// Remote query timeout limit
-		$timeout = $jp->get_remote_query_timeout_limit();
-
+		// better to try (and fail) to set a higher timeout than this system
+		// supports than to have register fail for more users than it should
+		$timeout = Jetpack::set_min_time_limit( 60 ) / 2;
+		
 		// The blog id on WordPress.com of the primary network site
 		$network_wpcom_blog_id = Jetpack_Options::get_option( 'id' );
 

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -404,7 +404,7 @@ class Jetpack_Network {
 		// better to try (and fail) to set a higher timeout than this system
 		// supports than to have register fail for more users than it should
 		$timeout = Jetpack::set_min_time_limit( 60 ) / 2;
-		
+
 		// The blog id on WordPress.com of the primary network site
 		$network_wpcom_blog_id = Jetpack_Options::get_option( 'id' );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4776,11 +4776,25 @@ p {
 	 * @since 2.6
 	 * @return int
 	 **/
-	public function get_remote_query_timeout_limit() {
+	public static function get_max_execution_time() {
 	    $timeout = (int) ini_get( 'max_execution_time' );
 	    if ( ! $timeout ) // Ensure exec time set in php.ini
-				$timeout = 30;
-	    return intval( $timeout / 2 );
+			$timeout = 30;
+	    return $timeout;
+	}
+
+	/**
+	 * Sets a minimum request timeout, and returns the current timeout
+	 *
+	 * @since 5.3
+	 **/
+	public static function set_min_time_limit( $min_timeout ) {
+		$timeout = self::get_max_execution_time();
+		if ( $timeout < $min_timeout ) {
+			$timeout = $min_timeout;
+			set_time_limit( $timeout );
+		}
+		return $timeout;
 	}
 
 
@@ -4847,7 +4861,9 @@ p {
 			return new Jetpack_Error( 'missing_secrets' );
 		}
 
-		$timeout = Jetpack::init()->get_remote_query_timeout_limit();
+		// better to try (and fail) to set a higher timeout than this system
+		// supports than to have register fail for more users than it should
+		$timeout = Jetpack::set_min_time_limit( 60 ) / 2;
 
 		$gmt_offset = get_option( 'gmt_offset' );
 		if ( ! $gmt_offset ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4775,18 +4775,35 @@ p {
 	 *
 	 * @since 2.6
 	 * @return int
+	 * @deprecated
+	 **/
+	public function get_remote_query_timeout_limit() {
+		_deprecated_function( __METHOD__, 'jetpack-5.4' );
+		return Jetpack::get_max_execution_time();
+	}
+
+	/**
+	 * Builds the timeout limit for queries talking with the wpcom servers.
+	 *
+	 * Based on local php max_execution_time in php.ini
+	 *
+	 * @since 5.4
+	 * @return int
 	 **/
 	public static function get_max_execution_time() {
-	    $timeout = (int) ini_get( 'max_execution_time' );
-	    if ( ! $timeout ) // Ensure exec time set in php.ini
+		$timeout = (int) ini_get( 'max_execution_time' );
+
+		// Ensure exec time set in php.ini
+		if ( ! $timeout ) {
 			$timeout = 30;
-	    return $timeout;
+		}
+		return $timeout;
 	}
 
 	/**
 	 * Sets a minimum request timeout, and returns the current timeout
 	 *
-	 * @since 5.3
+	 * @since 5.4
 	 **/
 	public static function set_min_time_limit( $min_timeout ) {
 		$timeout = self::get_max_execution_time();


### PR DESCRIPTION
When users connect Jetpack, the very first step is registration.

A couple of hundred sites a day fail registration because of timeouts, and of these the vast majority are sending us a timeout of 15 seconds or less (the timeout sent by Jetpack is 50% of the `max_execution_time`, to allow for multiple connection attempts). 

This is because in order to register the site, WPCOM must make a couple of requests, and some Jetpack sites are pretty slow.

Some sites appear to have execution timeouts as short as 10 seconds, which is not anywhere near enough to register a lot of the time.

This change tells PHP to increase the local `max_execution_time` for the duration of the register() step so that WPCOM has more time to register the site. If the request timeout is already longer than 60 seconds, it leaves it unaltered.

To test:
- set max_execution_time to < 60 seconds in php.ini
- add logging of $args for register step
- register Jetpack site
- observe that timeout sent to WPCOM is 30 seconds