### PR TITLE
Related posts: remove utms from url

### DIFF
--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -48,7 +48,7 @@
 			if ( '' === locationObject.search ) {
 				return pathname + '?' + args;
 			} else {
-				return pathname + locationObject.search + '&' + args;
+				return pathname + (locationObject.search + '&' + args).replace(/utm_.*?(&|$)/g,'');
 			}
 		},
 


### PR DESCRIPTION
Hey, I'm new to Jetpack. I faced problem with 'related-posts' feature. 

Jetpack won't load related posts section for page with url: `http://example.com/posts/id?utm_source=any`, but works well for `http://example.com/posts/id`.

I've tried to find a workaround with this situation, but was unsuccessful. 
So I added code for removing any utm params from `getEndpointURL`. 

As I said, I'm new to Jetpack. If this fix makes no sense, please point how to control this situation with additional url params. Thanks!

#### Changes proposed in this Pull Request:

* removes utm params from endPointURL

#### Testing instructions:

* Go to page with related posts code
* Related Posts section should be same for both links: `http://example.com/posts/id?utm_source=any` and `http://example.com/posts/id`
