### PR TITLE
Jetpack Connect: Add REST fallback for connect endpoints

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -75,6 +75,18 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'callback' => __CLASS__ . '::delete_jitm_message'
 		) );
 
+		// Register a site
+		register_rest_route( 'jetpack/v4', '/verify_registration', array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => __CLASS__ . '::verify_registration',
+		) );
+
+		// Authorize a remote user
+		register_rest_route( 'jetpack/v4', '/remote_authorize', array(
+			'methods' => WP_REST_Server::EDITABLE,
+			'callback' => __CLASS__ . '::remote_authorize',
+		) );
+
 		// Get current connection status of Jetpack
 		register_rest_route( 'jetpack/v4', '/connection', array(
 			'methods' => WP_REST_Server::READABLE,
@@ -342,6 +354,48 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		return $jitm->dismiss( $request['id'], $request['feature_class'] );
 	}
+
+	/**
+	 * Handles verification that a site is registered
+	 *
+	 * @since 4.9.0
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return array|wp-error
+	 */
+	public static function verify_registration( $request ) {
+		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-xmlrpc-server.php';
+		$xmlrpc_server = new Jetpack_XMLRPC_Server();
+		$result = $xmlrpc_server->verify_registration( array( $request['secret_1'], $request['state'] ) );
+
+		if ( is_a( $result, 'IXR_Error' ) ) {
+			$result = new WP_Error( $result->code, $result->message );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Handles verification that a site is registered
+	 *
+	 * @since 4.9.0
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return array|wp-error
+	 */
+	 public static function remote_authorize( $request ) {
+		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-xmlrpc-server.php';
+		$xmlrpc_server = new Jetpack_XMLRPC_Server();
+		$result = $xmlrpc_server->remote_authorize( $request );
+
+		if ( is_a( $result, 'IXR_Error' ) ) {
+			$result = new WP_Error( $result->code, $result->message );
+		}
+
+		return $result;
+	 }
 
 	/**
 	 * Handles dismissing of Jetpack Notices

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -358,7 +358,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Handles verification that a site is registered
 	 *
-	 * @since 4.9.0
+	 * @since 5.4.0
 	 *
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
@@ -379,7 +379,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Handles verification that a site is registered
 	 *
-	 * @since 4.9.0
+	 * @since 5.4.0
 	 *
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *


### PR DESCRIPTION
If sites have XMLRPC blocked for security reasons, Jetpack will fail to connect.

This PR adds REST versions of the two most critical XMLRPC methods so that we can still connect, even though other things will also fail. This at least allows us to get users started with Jetpack so that we can help them make their site compatible.

To test:

- Block XMLRPC on your server like this (nginx example):

```
    location = /xmlrpc.php {
        deny all;
        access_log off;
        log_not_found off;
    }
```

- Attempt to connect
- You should be able to connect! But things like auto-installing VaultPress/Akismet will fail later.

Here's a screenshot of ngrok logged requets during Jetpack Connect.

<img width="449" alt="ngrok-requests" src="https://user-images.githubusercontent.com/51896/30037641-cf582062-9171-11e7-9fdd-1829310eab77.png">
