### PR TITLE
Fixed empty sitemap YSOD.

### DIFF
--- a/modules/sitemaps/sitemap-buffer.php
+++ b/modules/sitemaps/sitemap-buffer.php
@@ -114,7 +114,7 @@ abstract class Jetpack_Sitemap_Buffer {
 		$this->doc = new DOMDocument( '1.0', 'UTF-8' );
 
 		$this->item_capacity = max( 1, intval( $item_limit ) );
-		$this->byte_capacity = max( 1, intval( $byte_limit ) ) - strlen( $this->contents() );
+		$this->byte_capacity = max( 1, intval( $byte_limit ) ) - strlen( $this->doc->saveXML() );
 	}
 
 	/**
@@ -189,6 +189,10 @@ abstract class Jetpack_Sitemap_Buffer {
 	 * @return string The contents of the buffer (with the footer included).
 	 */
 	public function contents() {
+		if( $this->is_empty() ) {
+			// The sitemap should have at least the root element added to the DOM
+			$this->get_root_element();
+		}
 		return $this->doc->saveXML();
 	}
 

--- a/tests/php/modules/sitemaps/test_class.sitemap-buffer.php
+++ b/tests/php/modules/sitemaps/test_class.sitemap-buffer.php
@@ -26,7 +26,11 @@ class WP_Test_Jetpack_Sitemap_Buffer extends WP_UnitTestCase {
 	 */
 	public function test_sitemap_buffer_constructor() {
 		$buffer = new Jetpack_Sitemap_Buffer_Dummy( 1, 10, '1970-01-01 00:00:00' );
-		$this->assertEquals( $buffer->contents(), '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL );
+		$this->assertEquals(
+			'<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL
+			. '<dummy/>' . PHP_EOL,
+			 $buffer->contents()
+		);
 	}
 
 	/**


### PR DESCRIPTION
If a site has no posts in a while a news sitemap can be empty. Previously it didn't contain a root element in this case, now it does. This fixes a yellow screen of death (at least on Firefox).

#### Changes proposed in this Pull Request:
* Always generate a root element no matter if the sitemap has not had any items added.

#### Testing instructions:
* Get a site with no recent posts to test or modify the code to [empty the recent posts array](https://github.com/Automattic/jetpack/blob/master/modules/sitemaps/sitemap-builder.php#L943).
* You may want to tweak the conditional to disregard [existing cache entries](https://github.com/Automattic/jetpack/blob/master/modules/sitemaps/sitemap-builder.php#L918), it will be easier to test this way.
* Open the news sitemap.
* Observe the XML element without a root element, which should give you an error.
* Use this PR, visit the sitemap again.
* See the sitemap with an empty root element.
