### PR TITLE
Add hooks to the masterbar my sites menu

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -633,13 +633,6 @@ class A8C_WPCOM_Masterbar {
 			) );
 		}
 
-		/**
-		 * Fires when menu items are added to the masterbar "My Sites" menu, below the site/plan information.
-		 *
-		 * @since 5.4
-		 */
-		do_action( 'jetpack_masterbar_site_section' );
-
 		// Publish group
 		$wp_admin_bar->add_group( array(
 			'parent' => 'blog',
@@ -801,13 +794,6 @@ class A8C_WPCOM_Masterbar {
 			) );
 		}
 
-		/**
-		 * Fires when menu items are added to the masterbar "My Sites" menu, below the manage section.
-		 *
-		 * @since 5.4
-		 */
-		do_action( 'jetpack_masterbar_manage_section' );
-
 		if ( current_user_can( 'edit_theme_options' ) ) {
 			// Look and Feel group
 			$wp_admin_bar->add_group( array(
@@ -858,13 +844,6 @@ class A8C_WPCOM_Masterbar {
 				'meta'   => $meta
 			) );
 		}
-
-		/**
-		 * Fires when menu items are added to the masterbar "My Sites" menu, below the personalize section.
-		 *
-		 * @since 5.4
-		 */
-		do_action( 'jetpack_masterbar_personalize_section' );
 
 		if ( current_user_can( 'manage_options' ) ) {
 			// Configuration group
@@ -975,13 +954,6 @@ class A8C_WPCOM_Masterbar {
 				),
 			) );
 
-			/**
-			 * Fires when menu items are added to the masterbar "My Sites" menu, below the configure section.
-			 *
-			 * @since 5.4
-			 */
-			do_action( 'jetpack_masterbar_configure_section' );
-
 			if ( ! is_admin() ) {
 				$wp_admin_bar->add_menu( array(
 					'parent' => 'configuration',
@@ -1002,6 +974,13 @@ class A8C_WPCOM_Masterbar {
 				'href'  => '#',
 				) );
 			}
+
+			/**
+			 * Fires when menu items are added to the masterbar "My Sites" menu.
+			 *
+			 * @since 5.4
+			 */
+			do_action( 'jetpack_masterbar' );
 		}
 	}
 }

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -633,6 +633,13 @@ class A8C_WPCOM_Masterbar {
 			) );
 		}
 
+		/**
+		 * Fires when menu items are added to the masterbar "My Sites" menu, below the site/plan information.
+		 *
+		 * @since 5.4
+		 */
+		do_action( 'jetpack_masterbar_site_section' );
+
 		// Publish group
 		$wp_admin_bar->add_group( array(
 			'parent' => 'blog',
@@ -794,6 +801,13 @@ class A8C_WPCOM_Masterbar {
 			) );
 		}
 
+		/**
+		 * Fires when menu items are added to the masterbar "My Sites" menu, below the manage section.
+		 *
+		 * @since 5.4
+		 */
+		do_action( 'jetpack_masterbar_manage_section' );
+
 		if ( current_user_can( 'edit_theme_options' ) ) {
 			// Look and Feel group
 			$wp_admin_bar->add_group( array(
@@ -844,6 +858,13 @@ class A8C_WPCOM_Masterbar {
 				'meta'   => $meta
 			) );
 		}
+
+		/**
+		 * Fires when menu items are added to the masterbar "My Sites" menu, below the personalize section.
+		 *
+		 * @since 5.4
+		 */
+		do_action( 'jetpack_masterbar_personalize_section' );
 
 		if ( current_user_can( 'manage_options' ) ) {
 			// Configuration group
@@ -953,6 +974,13 @@ class A8C_WPCOM_Masterbar {
 					'class' => 'mb-icon',
 				),
 			) );
+
+			/**
+			 * Fires when menu items are added to the masterbar "My Sites" menu, below the configure section.
+			 *
+			 * @since 5.4
+			 */
+			do_action( 'jetpack_masterbar_configure_section' );
 
 			if ( ! is_admin() ) {
 				$wp_admin_bar->add_menu( array(


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/16812.

#### Changes proposed in this Pull Request:

This PR adds a few hooks to the `modules/masterbar/masterbar.php` that make it possible to hook in and add new links to each menu section.

Our proposed usage for this is to add a `Store` link to the menu when applicable, so we can match the menu in Calypso/WordPress.com

#### Testing instructions:

* Go to the front end of your site and open the "My Sites" menu and make sure everything looks correct.
* You can add a test snippet to test adding entries to the menu:

```
add_action( 'jetpack_masterbar', function() {
	global $wp_admin_bar;
	$wp_admin_bar->add_menu( array(
		'parent' => 'blog',
		'id'     => 'store',
		'title'  => esc_html__( 'Store', 'jetpack' ),
		'href'   => 'https://wordpress.com/store',
		'meta'   => array(
			'class' => 'mb-icon-spacer',
		)
	) );
} );
```
